### PR TITLE
Stabilize OpenClaw frontier candidate checks

### DIFF
--- a/extensions/browser/src/browser/server-context.remote-profile-tab-ops.test-helpers.ts
+++ b/extensions/browser/src/browser/server-context.remote-profile-tab-ops.test-helpers.ts
@@ -2,6 +2,7 @@
  * Lazy-loaded dependency bundle for remote-profile tab operation tests.
  */
 import { afterEach, beforeEach, vi } from "vitest";
+import "../test-support/browser-security.mock.js";
 
 /** Modules and helpers shared by remote-profile tab operation tests. */
 export type RemoteProfileTestDeps = {

--- a/extensions/browser/src/browser/server.control-server.test-harness.ts
+++ b/extensions/browser/src/browser/server.control-server.test-harness.ts
@@ -5,6 +5,7 @@
 import { afterEach, beforeEach, vi } from "vitest";
 import { deriveDefaultBrowserCdpPortRange } from "../config/port-defaults.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
+import "../test-support/browser-security.mock.js";
 import type { MockFn } from "../test-utils/vitest-mock-fn.js";
 import { installChromeUserDataDirHooks } from "./chrome-user-data-dir.test-harness.js";
 import { getFreePort } from "./test-port.js";

--- a/extensions/codex/src/app-server/protocol-generated/json/v2/ThreadResumeResponse.json
+++ b/extensions/codex/src/app-server/protocol-generated/json/v2/ThreadResumeResponse.json
@@ -1055,6 +1055,14 @@
           "description": "Usually the first user message in the thread, if available.",
           "type": "string"
         },
+        "recencyAt": {
+          "description": "Unix timestamp (in seconds) used for thread recency ordering.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "sessionId": {
           "description": "Session id shared by threads that belong to the same session tree.",
           "type": "string"

--- a/extensions/codex/src/app-server/protocol-generated/json/v2/ThreadStartResponse.json
+++ b/extensions/codex/src/app-server/protocol-generated/json/v2/ThreadStartResponse.json
@@ -1055,6 +1055,14 @@
           "description": "Usually the first user message in the thread, if available.",
           "type": "string"
         },
+        "recencyAt": {
+          "description": "Unix timestamp (in seconds) used for thread recency ordering.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "sessionId": {
           "description": "Session id shared by threads that belong to the same session tree.",
           "type": "string"

--- a/scripts/report-test-temp-creations.mjs
+++ b/scripts/report-test-temp-creations.mjs
@@ -7,6 +7,8 @@ import { runAsScript } from "./lib/ts-guard-utils.mjs";
 
 const DEFAULT_BASE_REF = "origin/main";
 const DEFAULT_HEAD_REF = "HEAD";
+const DEFAULT_DIFF_MAX_BUFFER_BYTES = 256 * 1024 * 1024;
+const DIFF_MAX_BUFFER_ENV = "OPENCLAW_TEST_TEMP_REPORT_DIFF_MAX_BUFFER_BYTES";
 const TEMP_DIR_HELPER_PATH = "test/helpers/temp-dir.ts";
 const FINDING_PATTERNS = [
   {
@@ -120,7 +122,7 @@ function parseArgs(argv) {
   ]);
 }
 
-function readDiff(args, cwd = process.cwd()) {
+function readDiff(args, cwd = process.cwd(), env = process.env) {
   const range = args.noMergeBase ? `${args.base}..${args.head}` : `${args.base}...${args.head}`;
   const diffArgs = args.staged
     ? ["diff", "--cached", "--unified=0", "--diff-filter=ACMR", "--"]
@@ -128,9 +130,31 @@ function readDiff(args, cwd = process.cwd()) {
   return execFileSync("git", diffArgs, {
     cwd,
     encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
+    maxBuffer: readDiffMaxBufferBytes(env),
     stdio: ["ignore", "pipe", "pipe"],
   });
+}
+
+function readDiffMaxBufferBytes(env = process.env) {
+  const raw = env[DIFF_MAX_BUFFER_ENV];
+  if (raw === undefined || raw === "") {
+    return DEFAULT_DIFF_MAX_BUFFER_BYTES;
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`invalid ${DIFF_MAX_BUFFER_ENV}: ${raw}`);
+  }
+  return value;
+}
+
+function isDiffBufferOverflow(error) {
+  return error?.code === "ENOBUFS" || error?.errno === -105;
+}
+
+function formatDiffBufferOverflowWarning(error, env = process.env) {
+  const maxBuffer = readDiffMaxBufferBytes(env);
+  const detail = error?.message ? ` ${error.message}` : "";
+  return `[test-temp-report] git diff exceeded ${maxBuffer} bytes; skipping warning-only temp creation report.${detail}\n`;
 }
 
 export function collectTempCreationFindingsFromDiff(diffText) {
@@ -205,7 +229,19 @@ export async function main(argv, io) {
     return 0;
   }
 
-  const findings = collectTempCreationFindingsFromDiff(readDiff(args));
+  let findings;
+  try {
+    findings = collectTempCreationFindingsFromDiff(readDiff(args, process.cwd(), env));
+  } catch (error) {
+    if (!isDiffBufferOverflow(error)) {
+      throw error;
+    }
+    if (args.json) {
+      stdout.write("[]\n");
+    }
+    stderr.write(formatDiffBufferOverflowWarning(error, env));
+    return args.failOnFindings ? 1 : 0;
+  }
   if (args.json) {
     stdout.write(`${JSON.stringify(findings, null, 2)}\n`);
   } else if (findings.length === 0) {

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -145,6 +145,12 @@ const GATEWAY_CORE_VITEST_CONFIG = "test/vitest/vitest.gateway-core.config.ts";
 const GATEWAY_METHODS_VITEST_CONFIG = "test/vitest/vitest.gateway-methods.config.ts";
 const GATEWAY_SERVER_VITEST_CONFIG = "test/vitest/vitest.gateway-server.config.ts";
 const GATEWAY_VITEST_CONFIG = "test/vitest/vitest.gateway.config.ts";
+const GATEWAY_PROJECT_VITEST_CONFIGS = [
+  GATEWAY_CORE_VITEST_CONFIG,
+  GATEWAY_CLIENT_VITEST_CONFIG,
+  GATEWAY_METHODS_VITEST_CONFIG,
+  GATEWAY_SERVER_VITEST_CONFIG,
+];
 const HOOKS_VITEST_CONFIG = "test/vitest/vitest.hooks.config.ts";
 const INFRA_VITEST_CONFIG = "test/vitest/vitest.infra.config.ts";
 const MEDIA_VITEST_CONFIG = "test/vitest/vitest.media.config.ts";
@@ -1436,6 +1442,63 @@ function isGatewayServerFullSuiteTarget(relative) {
       path.posix.basename(relative).includes("server") &&
       relative.endsWith(".test.ts"))
   );
+}
+
+function isGatewayMethodsTarget(relative) {
+  return relative.startsWith("src/gateway/server-methods/") && relative.endsWith(".test.ts");
+}
+
+function isGatewayClientTarget(relative) {
+  if (!relative.startsWith("src/gateway/") || !relative.endsWith(".test.ts")) {
+    return false;
+  }
+  const basename = path.posix.basename(relative);
+  return (
+    !basename.includes("server") &&
+    (basename.includes("client") ||
+      basename.includes("reconnect") ||
+      basename.includes("android-node") ||
+      basename.includes("gateway-cli-backend"))
+  );
+}
+
+function isGatewayCoreTarget(relative) {
+  return (
+    relative.startsWith("src/gateway/") &&
+    relative.endsWith(".test.ts") &&
+    !GATEWAY_SERVER_EXCLUDED_TEST_TARGETS.has(relative) &&
+    !isGatewayMethodsTarget(relative) &&
+    !isGatewayClientTarget(relative) &&
+    !isGatewayServerFullSuiteTarget(relative)
+  );
+}
+
+function partitionGatewayIncludePatterns(includePatterns) {
+  if (
+    !Array.isArray(includePatterns) ||
+    includePatterns.some((pattern) => isGlobTarget(pattern) || !pattern.startsWith("src/gateway/"))
+  ) {
+    return null;
+  }
+  const partitions = [
+    {
+      config: GATEWAY_CORE_VITEST_CONFIG,
+      includePatterns: includePatterns.filter(isGatewayCoreTarget),
+    },
+    {
+      config: GATEWAY_CLIENT_VITEST_CONFIG,
+      includePatterns: includePatterns.filter(isGatewayClientTarget),
+    },
+    {
+      config: GATEWAY_METHODS_VITEST_CONFIG,
+      includePatterns: includePatterns.filter(isGatewayMethodsTarget),
+    },
+    {
+      config: GATEWAY_SERVER_VITEST_CONFIG,
+      includePatterns: includePatterns.filter(isGatewayServerFullSuiteTarget),
+    },
+  ];
+  return partitions.filter((partition) => partition.includePatterns.length > 0);
 }
 
 function resolveGatewayServerFullSuiteTargets(cwd) {
@@ -2938,9 +3001,9 @@ export function buildVitestRunPlans(
       const configs = watchMode
         ? [FULL_EXTENSIONS_VITEST_CONFIG]
         : listFullExtensionVitestProjectConfigs();
-      for (const config of configs) {
+      for (const projectConfig of configs) {
         plans.push({
-          config,
+          config: projectConfig,
           forwardedArgs: nonTargetArgs,
           includePatterns: null,
           watchMode,
@@ -2956,6 +3019,22 @@ export function buildVitestRunPlans(
     const useWholeConfigTarget = grouped.some((targetArg) =>
       shouldUseWholeConfigTarget(kind, targetArg, cwd),
     );
+    const useBroadGatewayTarget =
+      kind === "gateway" &&
+      grouped.some(
+        (targetArg) => toRepoRelativeTarget(targetArg, cwd).replace(/\/+$/u, "") === "src/gateway",
+      );
+    if (kind === "gateway" && !watchMode && (useWholeConfigTarget || useBroadGatewayTarget)) {
+      for (const gatewayConfig of GATEWAY_PROJECT_VITEST_CONFIGS) {
+        plans.push({
+          config: gatewayConfig,
+          forwardedArgs: nonTargetArgs,
+          includePatterns: null,
+          watchMode,
+        });
+      }
+      continue;
+    }
     const includePatterns = useCliTargetArgs
       ? null
       : useWholeConfigTarget
@@ -3191,7 +3270,7 @@ export function createVitestRunSpecs(args, params = {}) {
   const plans = filterPlansForContractIncludeFile(
     buildVitestRunPlans(args, cwd, listChangedPathsFromGit, { env: baseEnv }),
     baseEnv,
-  );
+  ).flatMap(expandBroadGatewayVitestPlan);
   return plans.map((plan, index) => {
     const includeFilePath = plan.includePatterns
       ? path.join(
@@ -3213,6 +3292,35 @@ export function createVitestRunSpecs(args, params = {}) {
       watchMode: plan.watchMode,
     };
   });
+}
+
+function expandBroadGatewayVitestPlan(plan) {
+  if (plan.watchMode || plan.config !== GATEWAY_VITEST_CONFIG) {
+    return [plan];
+  }
+  const includePatterns = plan.includePatterns;
+  const broadGatewayInclude =
+    Array.isArray(includePatterns) &&
+    includePatterns.length === 1 &&
+    includePatterns[0] === "src/gateway/**/*.test.ts";
+  if (includePatterns !== null && !broadGatewayInclude) {
+    const partitions = partitionGatewayIncludePatterns(includePatterns);
+    if (!partitions) {
+      return [plan];
+    }
+    return partitions.map((partition) =>
+      Object.assign({}, plan, {
+        config: partition.config,
+        includePatterns: partition.includePatterns,
+      }),
+    );
+  }
+  return GATEWAY_PROJECT_VITEST_CONFIGS.map((config) =>
+    Object.assign({}, plan, {
+      config,
+      includePatterns: null,
+    }),
+  );
 }
 
 function loadIncludePatternsForSpecFilter(env) {

--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -153,6 +153,7 @@ vi.mock("../infra/is-main.js", () => ({
 }));
 
 vi.mock("../logging/console.js", () => ({
+  getConsoleSettings: () => ({ level: "silent", style: "compact" }),
   routeLogsToStderr: () => mockState.routeLogsToStderr(),
 }));
 

--- a/src/agents/compaction-planning-worker.ts
+++ b/src/agents/compaction-planning-worker.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 /**
  * Runs CPU-heavy compaction planning in a worker thread when histories are
  * large enough to risk starving the main event loop.
@@ -28,6 +29,7 @@ const COMPACTION_PLANNING_WORKER_TIMEOUT_MS = 60_000;
 // Worker startup is more expensive than local planning for tiny histories.
 // Keep small compactions synchronous; move only starvation-sized plans off-thread.
 const COMPACTION_PLANNING_WORKER_MIN_MESSAGES = 64;
+const requireFromHere = createRequire(import.meta.url);
 
 class CompactionPlanningWorkerError extends Error {
   constructor(
@@ -52,6 +54,29 @@ function resolveCompactionPlanningWorkerUrl(currentModuleUrl = import.meta.url):
   return new URL(`./compaction-planning.worker${extension}`, currentModuleUrl);
 }
 
+function createSourceWorkerBootstrapUrl(workerUrl: URL): URL {
+  const tsxApiUrl = pathToFileURL(requireFromHere.resolve("tsx/esm/api")).href;
+  const source = [
+    `import { tsImport } from ${JSON.stringify(tsxApiUrl)};`,
+    `await tsImport(${JSON.stringify(workerUrl.href)}, { parentURL: ${JSON.stringify(workerUrl.href)} });`,
+  ].join("\n");
+  return new URL(`data:text/javascript,${encodeURIComponent(source)}`);
+}
+
+function createCompactionPlanningWorkerLaunch(workerUrl: URL): {
+  execArgv?: string[];
+  url: URL;
+} {
+  if (workerUrl.pathname.endsWith(".ts")) {
+    // Worker threads do not install tsx's ESM resolver from execArgv in source
+    // checkout mode, so bootstrap the TypeScript worker through tsx's API.
+    return {
+      url: createSourceWorkerBootstrapUrl(workerUrl),
+    };
+  }
+  return { url: workerUrl };
+}
+
 function runCompactionPlanningWorker(params: {
   input: CompactionPlanningWorkerInput;
   signal?: AbortSignal;
@@ -68,12 +93,12 @@ function runCompactionPlanningWorker(params: {
   }
 
   const workerUrl = params.workerUrl ?? resolveCompactionPlanningWorkerUrl();
-  const sourceWorkerExecArgv = workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : undefined;
   let worker: Worker;
   try {
-    worker = new Worker(workerUrl, {
+    const launch = createCompactionPlanningWorkerLaunch(workerUrl);
+    worker = new Worker(launch.url, {
       workerData: params.input,
-      execArgv: sourceWorkerExecArgv,
+      execArgv: launch.execArgv,
     });
   } catch (error) {
     return Promise.reject(

--- a/src/cli/command-execution-startup.test.ts
+++ b/src/cli/command-execution-startup.test.ts
@@ -10,6 +10,7 @@ vi.mock("./banner.js", () => ({
 }));
 
 vi.mock("../logging/console.js", () => ({
+  getConsoleSettings: () => ({ level: "silent", style: "compact" }),
   routeLogsToStderr: routeLogsToStderrMock,
 }));
 

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -233,6 +233,7 @@ vi.mock("../../infra/supervisor-markers.js", async (importOriginal) => {
 });
 
 vi.mock("../../logging/console.js", () => ({
+  getConsoleSettings: () => ({ level: "silent", style: "compact" }),
   setConsoleSubsystemFilter: (filters: string[]) => setConsoleSubsystemFilter(filters),
   setConsoleTimestampPrefix: () => undefined,
 }));

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -45,6 +45,7 @@ vi.mock("../banner.js", () => ({
 }));
 
 vi.mock("../../logging/console.js", () => ({
+  getConsoleSettings: () => ({ level: "silent", style: "compact" }),
   routeLogsToStderr: routeLogsToStderrMock,
 }));
 

--- a/test/scripts/ensure-playwright-chromium.test.ts
+++ b/test/scripts/ensure-playwright-chromium.test.ts
@@ -7,6 +7,9 @@ import {
 } from "../../scripts/ensure-playwright-chromium.mjs";
 
 describe("ensurePlaywrightChromium", () => {
+  const envWithoutPnpm = { PATH: "/openclaw-test-no-pnpm" };
+  const ciEnvWithoutPnpm = { CI: "1", PATH: "/openclaw-test-no-pnpm" };
+
   it("does nothing when the browser binary exists and runs", () => {
     const spawnSync = vi.fn(() => ({ status: 0 }));
 
@@ -83,7 +86,7 @@ describe("ensurePlaywrightChromium", () => {
       ensurePlaywrightChromium({
         cwd: "/repo",
         ensureFfmpeg: true,
-        env: { PATH: "/bin" },
+        env: envWithoutPnpm,
         executablePath: "/cache/chromium/chrome",
         existsSync: (path: string) => path === "/usr/bin/chromium-browser",
         log: (line: string) => logs.push(line),
@@ -99,7 +102,7 @@ describe("ensurePlaywrightChromium", () => {
       ["--dir", "ui", "exec", "playwright", "install", "ffmpeg"],
       {
         cwd: "/repo",
-        env: { PATH: "/bin" },
+        env: envWithoutPnpm,
         shell: false,
         stdio: "pipe",
         windowsVerbatimArguments: undefined,
@@ -156,7 +159,7 @@ describe("ensurePlaywrightChromium", () => {
     expect(
       ensurePlaywrightChromium({
         cwd: "/repo",
-        env: { PATH: "/bin" },
+        env: envWithoutPnpm,
         executablePath: "/cache/chromium/chrome",
         existsSync: () => ++existsCalls > 1,
         platform: "linux",
@@ -170,7 +173,7 @@ describe("ensurePlaywrightChromium", () => {
       ["--dir", "ui", "exec", "playwright", "install", "chromium"],
       {
         cwd: "/repo",
-        env: { PATH: "/bin" },
+        env: envWithoutPnpm,
         shell: false,
         stdio: "pipe",
         windowsVerbatimArguments: undefined,
@@ -190,7 +193,7 @@ describe("ensurePlaywrightChromium", () => {
     expect(
       ensurePlaywrightChromium({
         cwd: "/repo",
-        env: { PATH: "/bin" },
+        env: envWithoutPnpm,
         executablePath: "/cache/chromium/chrome",
         existsSync: () => true,
         getuid: () => 0,
@@ -206,7 +209,7 @@ describe("ensurePlaywrightChromium", () => {
       ["--dir", "ui", "exec", "playwright", "install", "chromium"],
       {
         cwd: "/repo",
-        env: { PATH: "/bin" },
+        env: envWithoutPnpm,
         shell: false,
         stdio: "pipe",
         windowsVerbatimArguments: undefined,
@@ -218,7 +221,7 @@ describe("ensurePlaywrightChromium", () => {
       ["--dir", "ui", "exec", "playwright", "install", "--with-deps", "chromium"],
       {
         cwd: "/repo",
-        env: { PATH: "/bin" },
+        env: envWithoutPnpm,
         shell: false,
         stdio: "pipe",
         windowsVerbatimArguments: undefined,
@@ -238,7 +241,7 @@ describe("ensurePlaywrightChromium", () => {
     expect(
       ensurePlaywrightChromium({
         cwd: "/repo",
-        env: { CI: "1", PATH: "/bin" },
+        env: ciEnvWithoutPnpm,
         executablePath: "/cache/chromium/chrome",
         existsSync: () => ++existsCalls > 1,
         getuid: () => 501,
@@ -255,7 +258,7 @@ describe("ensurePlaywrightChromium", () => {
       ["--dir", "ui", "exec", "playwright", "install", "chromium"],
       {
         cwd: "/repo",
-        env: { CI: "1", PATH: "/bin" },
+        env: ciEnvWithoutPnpm,
         shell: false,
         stdio: "pipe",
         windowsVerbatimArguments: undefined,
@@ -267,7 +270,7 @@ describe("ensurePlaywrightChromium", () => {
       ["--dir", "ui", "exec", "playwright", "install", "--with-deps", "chromium"],
       {
         cwd: "/repo",
-        env: { CI: "1", PATH: "/bin" },
+        env: ciEnvWithoutPnpm,
         shell: false,
         stdio: "pipe",
         windowsVerbatimArguments: undefined,
@@ -286,7 +289,7 @@ describe("ensurePlaywrightChromium", () => {
     expect(
       ensurePlaywrightChromium({
         cwd: "/repo",
-        env: { PATH: "/bin" },
+        env: envWithoutPnpm,
         executablePath: "/cache/chromium/chrome",
         existsSync: () => true,
         getuid: () => 501,
@@ -309,7 +312,7 @@ describe("ensurePlaywrightChromium", () => {
     expect(
       ensurePlaywrightChromium({
         cwd: "/repo",
-        env: { PATH: "/bin" },
+        env: envWithoutPnpm,
         executablePath: "/cache/chromium/chrome",
         existsSync: () => true,
         platform: "linux",
@@ -327,7 +330,7 @@ describe("ensurePlaywrightChromium", () => {
       ["--dir", "ui", "exec", "playwright", "install", "chromium"],
       {
         cwd: "/repo",
-        env: { PATH: "/bin" },
+        env: envWithoutPnpm,
         shell: false,
         stdio: "pipe",
         windowsVerbatimArguments: undefined,

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -174,10 +174,10 @@ describe("package-mac-app plist stamping", () => {
     writeFileSync(
       corepackPath,
       [
-        "#!/usr/bin/env bash",
-        "set -euo pipefail",
+        "#!/bin/sh",
+        "set -eu",
         'printf \'%s|%s\\n\' "$PWD" "$*" >> "$OPENCLAW_TEST_LOG"',
-        'if [[ "${1:-}" == "pnpm" && "${2:-}" == "--version" ]]; then',
+        'if [ "${1:-}" = "pnpm" ] && [ "${2:-}" = "--version" ]; then',
         "  echo '11.2.2'",
         "fi",
         "",
@@ -191,7 +191,7 @@ describe("package-mac-app plist stamping", () => {
       ROOT_DIR=${JSON.stringify(tempRoot)}
       OPENCLAW_TEST_LOG=${JSON.stringify(logPath)}
       export OPENCLAW_TEST_LOG
-      PATH=${JSON.stringify(`${toolsDir}:/usr/bin:/bin`)}
+      PATH=${JSON.stringify(toolsDir)}
       ${helperBlock}
       run_pnpm install --frozen-lockfile --config.node-linker=hoisted
       run_pnpm build
@@ -214,7 +214,7 @@ describe("package-mac-app plist stamping", () => {
     const result = runHelper(`
       set -euo pipefail
       ROOT_DIR=${JSON.stringify(tempRoot)}
-      PATH=${JSON.stringify(`${toolsDir}:/usr/bin:/bin`)}
+      PATH=${JSON.stringify(toolsDir)}
       ${helperBlock}
       run_pnpm build
     `);

--- a/test/scripts/report-test-temp-creations.test.ts
+++ b/test/scripts/report-test-temp-creations.test.ts
@@ -196,6 +196,72 @@ describe("report-test-temp-creations", () => {
     );
   });
 
+  it("skips the warning-only report when the branch diff exceeds the configured buffer", () => {
+    const root = tempDirs.make("openclaw-temp-report-");
+    const env = {
+      ...createNestedGitEnv(),
+      OPENCLAW_TEST_TEMP_REPORT_DIFF_MAX_BUFFER_BYTES: "64",
+    };
+    execFileSync("git", ["init", "-q", "--initial-branch=main"], { cwd: root, env });
+    fs.mkdirSync(path.join(root, "test", "helpers"), { recursive: true });
+    fs.writeFileSync(path.join(root, "test", "helpers", "case.ts"), "const value = 1;\n", "utf8");
+    execFileSync("git", ["add", "test/helpers/case.ts"], { cwd: root, env });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=Test User",
+        "commit",
+        "-q",
+        "-m",
+        "initial",
+      ],
+      { cwd: root, env },
+    );
+    execFileSync("git", ["checkout", "-q", "-b", "feature"], { cwd: root, env });
+    fs.appendFileSync(
+      path.join(root, "test", "helpers", "case.ts"),
+      `const huge = "${"x".repeat(2048)}";\n`,
+      "utf8",
+    );
+    execFileSync("git", ["add", "test/helpers/case.ts"], { cwd: root, env });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=Test User",
+        "commit",
+        "-q",
+        "-m",
+        "huge diff",
+      ],
+      { cwd: root, env },
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(repoRoot, "scripts", "report-test-temp-creations.mjs"),
+        "--base",
+        "main",
+        "--head",
+        "HEAD",
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env,
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("skipping warning-only temp creation report");
+  });
+
   it("exits non-zero for staged findings when requested", () => {
     const root = tempDirs.make("openclaw-temp-report-");
     const env = createNestedGitEnv();

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1309,6 +1309,20 @@ describe("scripts/test-projects changed-target routing", () => {
         watchMode: false,
       },
     ]);
+    expect(
+      createVitestRunSpecs(["src/gateway/server-startup-early.ts"], {
+        baseEnv: {},
+        cwd: process.cwd(),
+      }).map((spec) => ({
+        config: spec.config,
+        includePatterns: spec.includePatterns,
+      })),
+    ).toEqual([
+      {
+        config: "test/vitest/vitest.gateway-server.config.ts",
+        includePatterns: ["src/gateway/server-startup-early.test.ts"],
+      },
+    ]);
     expect(buildVitestRunPlans(["src/commands/onboarding-plugin-install.ts"])).toEqual([
       {
         config: "test/vitest/vitest.commands.config.ts",
@@ -1655,7 +1669,6 @@ describe("scripts/test-projects changed-target routing", () => {
       ["src/config", "test/vitest/vitest.runtime-config.config.ts"],
       ["src/cron", "test/vitest/vitest.cron.config.ts"],
       ["src/daemon", "test/vitest/vitest.daemon.config.ts"],
-      ["src/gateway", "test/vitest/vitest.gateway.config.ts"],
       ["src/hooks", "test/vitest/vitest.hooks.config.ts"],
       ["src/infra", "test/vitest/vitest.infra.config.ts"],
       ["src/logging", "test/vitest/vitest.logging.config.ts"],
@@ -1681,6 +1694,44 @@ describe("scripts/test-projects changed-target routing", () => {
         watchMode: false,
       });
     }
+
+    expect(buildVitestRunPlans(["src/gateway"], process.cwd())).toEqual([
+      {
+        config: "test/vitest/vitest.gateway-core.config.ts",
+        forwardedArgs: [],
+        includePatterns: null,
+        watchMode: false,
+      },
+      {
+        config: "test/vitest/vitest.gateway-client.config.ts",
+        forwardedArgs: [],
+        includePatterns: null,
+        watchMode: false,
+      },
+      {
+        config: "test/vitest/vitest.gateway-methods.config.ts",
+        forwardedArgs: [],
+        includePatterns: null,
+        watchMode: false,
+      },
+      {
+        config: "test/vitest/vitest.gateway-server.config.ts",
+        forwardedArgs: [],
+        includePatterns: null,
+        watchMode: false,
+      },
+    ]);
+    expect(
+      createVitestRunSpecs(["src/gateway"], { baseEnv: {}, cwd: process.cwd() }).map((spec) => ({
+        config: spec.config,
+        includePatterns: spec.includePatterns,
+      })),
+    ).toEqual([
+      { config: "test/vitest/vitest.gateway-core.config.ts", includePatterns: null },
+      { config: "test/vitest/vitest.gateway-client.config.ts", includePatterns: null },
+      { config: "test/vitest/vitest.gateway-methods.config.ts", includePatterns: null },
+      { config: "test/vitest/vitest.gateway-server.config.ts", includePatterns: null },
+    ]);
 
     expect(buildVitestRunPlans(["src/plugin-sdk"], process.cwd())).toEqual([
       expect.objectContaining({


### PR DESCRIPTION
## Summary

Stabilizes the OpenClaw frontier candidate checks after rebasing onto current `upstream/main`.

This package includes:

- regenerated Codex app-server protocol JSON for `recencyAt`
- changed-test planner hardening for gateway umbrella configs
- temp-directory report buffer hardening and coverage
- source-mode compaction worker bootstrap repair
- Browser test DNS/SSRF mock wiring for inert `example.com` navigation
- direct console mock drift repairs
- fixture test isolation updates

Dependency lockfile/shrinkwrap changes were removed from this PR so it does not change the resolved dependency graph.

## Local Proof

Base: `openclaw/openclaw@5b7cf461ac03b41d937152dc4c6b19b69d7b84bc`

Head: `308d682a5d9927f64d31cb1e90df9495be3f7953`

Passed locally:

- `pnpm check:changed --timed --base upstream/main --head HEAD -- $(git diff --name-only upstream/main...HEAD)`
- `node scripts/test-projects.mjs --changed upstream/main`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-browser.config.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts`
- `pnpm codex-app-server:protocol:check` with `OPENCLAW_CODEX_REPO=/home/spryguy/openclaw-workspace/repos/codex`
- `pnpm plugins:inventory:check`

## Real behavior proof

- **Behavior or issue addressed:** The Codex app-server generated protocol mirrors in OpenClaw must match the current Codex exporter output after adding the `recencyAt` field to thread start/resume responses.

- **Real environment tested:** Local OpenClaw source checkout at `/home/spryguy/openclaw-workspace/repos/openclaw-frontier-update-20260617T230204Z`, local `openai/codex` checkout at `/home/spryguy/openclaw-workspace/repos/codex`, Linux shell, Rust/Cargo exporter build, and OpenClaw's protocol comparison script.

- **Exact steps or command run after this patch:**

```text
SYSROOT=/home/spryguy/.local/cyborgclaw-openclaw-s04e-sysroot
OPENCLAW_CODEX_REPO=/home/spryguy/openclaw-workspace/repos/codex \
PATH="$SYSROOT/usr/bin:$HOME/.cargo/bin:$PATH" \
LD_LIBRARY_PATH="$SYSROOT/usr/lib/x86_64-linux-gnu:$SYSROOT/usr/lib" \
PKG_CONFIG="$SYSROOT/usr/bin/pkgconf" \
PKG_CONFIG_PATH="$SYSROOT/usr/lib/x86_64-linux-gnu/pkgconfig:$SYSROOT/usr/lib/pkgconfig:$SYSROOT/usr/share/pkgconfig" \
PKG_CONFIG_SYSROOT_DIR="$SYSROOT" \
CFLAGS="-I$SYSROOT/usr/include/x86_64-linux-gnu" \
CPPFLAGS="-I$SYSROOT/usr/include/x86_64-linux-gnu" \
PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false \
pnpm codex-app-server:protocol:check
```

- **Evidence after fix:** Copied console output from the real protocol exporter/comparison run:

```text
$ node --import tsx scripts/check-codex-app-server-protocol.ts
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.36s
     Running `codex-rs/target/debug/export --out /home/spryguy/openclaw-workspace/repos/openclaw-frontier-update-20260617T230204Z/.tmp-codex-app-server-protocol-RmzTf6/generated --experimental`
Finished in 47ms on 647 files using 1 threads.
Codex app-server generated protocol matches OpenClaw bridge assumptions: /home/spryguy/openclaw-workspace/repos/codex
```

- **Observed result after fix:** The real Codex Rust exporter completed and OpenClaw's protocol comparison reported that the generated app-server protocol matches the OpenClaw bridge assumptions for the local Codex checkout.

- **What was not tested:** GitHub Actions all-green, upstream maintainer acceptance, release/deploy readiness, production runtime adoption, and model-readiness were not tested or claimed.

Supplemental test evidence:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-browser.config.ts
Test Files 122 passed (122)
Tests 1398 passed | 1 skipped (1399)

node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts
Test Files 90 passed (90)
Tests 1628 passed (1628)

node scripts/test-projects.mjs --changed upstream/main
[test] passed 6 Vitest shards in 37.49s
```

## Notes

The Codex protocol check used a local checkout of `openai/codex` at `c274a83f8bb0f9b5520a3f1d475060bebbe3b728`.

This PR claims local source/test readiness for review only. It does not claim release, deploy, production, runtime adoption, or model-readiness status.