### PR TITLE
fix(agents): keep lane-task timeout alive during long-running tools (fixes #94033)

### DIFF
--- a/scripts/repro/issue-94033-cron-lane-timeout.mts
+++ b/scripts/repro/issue-94033-cron-lane-timeout.mts
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// Standalone real-environment proof for #94033.
+//
+// Reproduces the lane-task timeout sliding window from
+// `src/process/command-queue.ts`. A task that takes longer than the
+// configured `taskTimeoutMs` without reporting progress triggers
+// `CommandLaneTaskTimeoutError`.
+//
+// With the fix (heartbeat helper applied), `noteProgress` is invoked
+// periodically while the task is in flight, so the sliding window
+// stays fresh and the task completes successfully.
+//
+// Without the fix, the task exceeds `taskTimeoutMs` and the timeout
+// fires.
+//
+// Run: node --import tsx scripts/repro/issue-94033-cron-lane-timeout.mts
+import assert from "node:assert/strict";
+import {
+  CommandLaneTaskTimeoutError,
+  enqueueCommandInLane,
+  resetCommandLane,
+} from "../../src/process/command-queue.ts";
+import { startLaneTaskProgressHeartbeat } from "../../src/agents/embedded-agent-runner/lane-heartbeat.ts";
+
+const LANE = "repro-cron-94033";
+const TASK_TIMEOUT_MS = 600; // Short timeout for fast reproduction
+const HEARTBEAT_INTERVAL_MS = 100; // < grace window, similar pattern to real prod
+const TASK_DURATION_MS = 1_500; // > TASK_TIMEOUT_MS, would trigger timeout without heartbeat
+
+async function runScenario({
+  withHeartbeat,
+  label,
+}: {
+  withHeartbeat: boolean;
+  label: string;
+}) {
+  resetCommandLane(LANE);
+  let progressNotes = 0;
+  // The progress-at timestamp mirrors the production pattern:
+  // `let laneTaskProgressAtMs = Date.now(); noteProgress = () => { laneTaskProgressAtMs = Date.now() }`
+  // The lane-task timeout callback reads this same closure variable.
+  let lastProgressAtMs = Date.now();
+  const noteProgress = () => {
+    lastProgressAtMs = Date.now();
+    progressNotes += 1;
+  };
+  const taskPromise = enqueueCommandInLane(
+    LANE,
+    async () => {
+      const heartbeat = withHeartbeat
+        ? startLaneTaskProgressHeartbeat(noteProgress, HEARTBEAT_INTERVAL_MS)
+        : undefined;
+      try {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, TASK_DURATION_MS);
+        });
+        return "completed";
+      } finally {
+        heartbeat?.stop();
+      }
+    },
+    {
+      taskTimeoutMs: TASK_TIMEOUT_MS,
+      taskTimeoutProgressAtMs: () => lastProgressAtMs,
+    },
+  );
+
+  const started = Date.now();
+  let outcome: "completed" | "timed-out";
+  try {
+    await taskPromise;
+    outcome = "completed";
+  } catch (err) {
+    if (err instanceof CommandLaneTaskTimeoutError) {
+      outcome = "timed-out";
+    } else {
+      throw err;
+    }
+  }
+  const elapsedMs = Math.round(Date.now() - started);
+
+  console.log(`[${label}] outcome=${outcome} elapsedMs=${elapsedMs} noteProgressCalls=${progressNotes}`);
+  return { outcome, elapsedMs, progressNotes };
+}
+
+console.log("=== Reproduction for issue #94033 ===");
+console.log(`Lane: ${LANE}`);
+console.log(`Configured taskTimeoutMs: ${TASK_TIMEOUT_MS}`);
+console.log(`Task runs for: ${TASK_DURATION_MS}ms (longer than timeout)`);
+console.log("");
+
+const without = await runScenario({ withHeartbeat: false, label: "without-heartbeat" });
+console.log("");
+const withFix = await runScenario({ withHeartbeat: true, label: "with-heartbeat " });
+
+console.log("");
+console.log("=== Results ===");
+console.log(
+  `Without heartbeat (pre-fix): timed-out after ${without.elapsedMs}ms (timeout fired as expected)`,
+);
+console.log(
+  `With heartbeat    (post-fix): ${withFix.outcome} after ${withFix.elapsedMs}ms (noteProgress called ${withFix.progressNotes} times)`,
+);
+
+assert.equal(without.outcome, "timed-out", "pre-fix scenario should time out");
+assert.equal(withFix.outcome, "completed", "post-fix scenario should complete");
+assert.ok(
+  withFix.progressNotes >= 10,
+  `heartbeat should fire many times during ${TASK_DURATION_MS}ms at ${HEARTBEAT_INTERVAL_MS}ms interval, got ${withFix.progressNotes}`,
+);
+
+console.log("");
+console.log("PASS: heartbeat keeps the lane-task sliding window alive during long-running work.");

--- a/src/agents/embedded-agent-runner/lane-heartbeat.test.ts
+++ b/src/agents/embedded-agent-runner/lane-heartbeat.test.ts
@@ -1,0 +1,103 @@
+// Focused tests for the lane-task progress heartbeat helper.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { startLaneTaskProgressHeartbeat, withLaneTaskProgressHeartbeat } from "./lane-heartbeat.js";
+
+describe("startLaneTaskProgressHeartbeat", () => {
+  it("calls noteProgress at the requested interval", () => {
+    vi.useFakeTimers();
+    const noteProgress = vi.fn();
+    const handle = startLaneTaskProgressHeartbeat(noteProgress, 1_000);
+    expect(noteProgress).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1_000);
+    expect(noteProgress).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(2_000);
+    expect(noteProgress).toHaveBeenCalledTimes(3);
+    handle.stop();
+    vi.useRealTimers();
+  });
+
+  it("stops calling noteProgress after stop()", () => {
+    vi.useFakeTimers();
+    const noteProgress = vi.fn();
+    const handle = startLaneTaskProgressHeartbeat(noteProgress, 1_000);
+    vi.advanceTimersByTime(1_000);
+    expect(noteProgress).toHaveBeenCalledTimes(1);
+    handle.stop();
+    vi.advanceTimersByTime(5_000);
+    expect(noteProgress).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it("stop() is idempotent", () => {
+    vi.useFakeTimers();
+    const noteProgress = vi.fn();
+    const handle = startLaneTaskProgressHeartbeat(noteProgress, 1_000);
+    handle.stop();
+    handle.stop();
+    vi.advanceTimersByTime(5_000);
+    expect(noteProgress).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("uses a 20s default interval", () => {
+    vi.useFakeTimers();
+    const noteProgress = vi.fn();
+    const handle = startLaneTaskProgressHeartbeat(noteProgress);
+    vi.advanceTimersByTime(19_999);
+    expect(noteProgress).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(noteProgress).toHaveBeenCalledTimes(1);
+    handle.stop();
+    vi.useRealTimers();
+  });
+});
+
+describe("withLaneTaskProgressHeartbeat", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stops the heartbeat when the task resolves", async () => {
+    const noteProgress = vi.fn();
+    const task = Promise.resolve("done");
+    const wrapped = withLaneTaskProgressHeartbeat(noteProgress, task, 1_000);
+    // Let the microtask queue drain so the finally block runs.
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(wrapped).resolves.toBe("done");
+    expect(noteProgress).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(5_000);
+    expect(noteProgress).not.toHaveBeenCalled();
+  });
+
+  it("stops the heartbeat when the task rejects", async () => {
+    const noteProgress = vi.fn();
+    const failure = new Error("boom");
+    let rejectTask!: (err: Error) => void;
+    const task = new Promise<string>((_resolve, reject) => {
+      rejectTask = reject;
+    });
+    const wrapped = withLaneTaskProgressHeartbeat(noteProgress, task, 1_000);
+    rejectTask(failure);
+    await expect(wrapped).rejects.toBe(failure);
+    vi.advanceTimersByTime(5_000);
+    expect(noteProgress).not.toHaveBeenCalled();
+  });
+
+  it("keeps ticking noteProgress until the task settles", async () => {
+    const noteProgress = vi.fn();
+    let resolveTask!: (value: string) => void;
+    const task = new Promise<string>((resolve) => {
+      resolveTask = resolve;
+    });
+    const wrapped = withLaneTaskProgressHeartbeat(noteProgress, task, 1_000);
+    vi.advanceTimersByTime(2_500);
+    expect(noteProgress).toHaveBeenCalledTimes(2);
+    resolveTask("done");
+    await expect(wrapped).resolves.toBe("done");
+    vi.advanceTimersByTime(5_000);
+    expect(noteProgress).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/agents/embedded-agent-runner/lane-heartbeat.ts
+++ b/src/agents/embedded-agent-runner/lane-heartbeat.ts
@@ -1,0 +1,65 @@
+// Lane-task progress heartbeat.
+//
+// The command-queue lane-task timeout uses a sliding window: every
+// `armTimeout()` cycle re-reads `lastProgressAtMs` (provided by
+// `taskTimeoutProgressAtMs` in the queue entry) and rejects with
+// `CommandLaneTaskTimeoutError` if `Date.now() - lastProgressAtMs > taskTimeoutMs`.
+//
+// The embedded runner only refreshes `lastProgressAtMs` via the
+// `noteLaneTaskProgress` callback, which fires from
+// `notifyExecutionPhase` / `notifyRunProgress` during the runner's own
+// lifecycle. Long-running tool execution (e.g. an `exec` that runs for
+// several minutes) happens *inside* the embedded attempt and emits no
+// runner callbacks, so the sliding window expires even though the task
+// is making progress.
+//
+// This helper bridges that gap by periodically calling a `noteProgress`
+// callback while a task is in flight. The default interval is 20s —
+// well under the 30s grace window in `command-queue.ts:265`
+// (`taskTimeoutMs + 30s`), so at least one `armTimeout` cycle always
+// sees fresh progress before deciding to fire.
+//
+// The interval is `.unref()`'d so the heartbeat never blocks process
+// exit. Callers must always invoke `stop()` once the task settles
+// (success, error, or abort) so the timer cannot outlive the task it
+// is observing.
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 20_000;
+
+export type LaneTaskProgressHeartbeat = { stop: () => void };
+
+/**
+ * Start a periodic heartbeat that calls `noteProgress` every
+ * `intervalMs` (default 20s). Returns a handle whose `stop()` clears
+ * the underlying timer; safe to call multiple times.
+ *
+ * The interval is `.unref()`'d so the timer never keeps the Node event
+ * loop alive on its own.
+ */
+export function startLaneTaskProgressHeartbeat(
+  noteProgress: () => void,
+  intervalMs: number = DEFAULT_HEARTBEAT_INTERVAL_MS,
+): LaneTaskProgressHeartbeat {
+  const handle = setInterval(noteProgress, intervalMs);
+  handle.unref?.();
+  return {
+    stop: () => {
+      clearInterval(handle);
+    },
+  };
+}
+
+/**
+ * Run `task` under a periodic progress heartbeat. The heartbeat is
+ * stopped once the task settles (success or failure), so callers can
+ * safely `await` the returned promise and never leak the interval.
+ */
+export function withLaneTaskProgressHeartbeat<T>(
+  noteProgress: () => void,
+  task: Promise<T>,
+  intervalMs: number = DEFAULT_HEARTBEAT_INTERVAL_MS,
+): Promise<T> {
+  const heartbeat = startLaneTaskProgressHeartbeat(noteProgress, intervalMs);
+  return task.finally(() => {
+    heartbeat.stop();
+  });
+}

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -146,6 +146,7 @@ import {
   hasOutboundDeliveryEvidence,
 } from "./delivery-evidence.js";
 import { resolveEmbeddedRunFailureSignal } from "./failure-signal.js";
+import { startLaneTaskProgressHeartbeat } from "./lane-heartbeat.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { resolveModelAsync } from "./model.js";
@@ -1853,6 +1854,11 @@ async function runEmbeddedAgentInternal(
           } else {
             parentAbortSignal?.addEventListener("abort", relayParentAbort, { once: true });
           }
+          // Keep the lane-task sliding window alive while the embedded attempt
+          // is in flight (notably during long-running tool execution such as
+          // `exec` commands). Without this heartbeat the lane-task timeout
+          // expires even though the attempt is still making progress. See #94033.
+          const laneHeartbeat = startLaneTaskProgressHeartbeat(noteLaneTaskProgress);
           const rawAttempt = await runEmbeddedAttemptWithBackend({
             sessionId: activeSessionId,
             sessionKey: resolvedSessionKey,
@@ -2011,6 +2017,7 @@ async function runEmbeddedAgentInternal(
               throw postCompactionAbortError ?? err;
             })
             .finally(() => {
+              laneHeartbeat.stop();
               parentAbortSignal?.removeEventListener?.("abort", relayParentAbort);
               if (postCompactionAbortController === attemptAbortController) {
                 postCompactionAbortController = undefined;


### PR DESCRIPTION
## Summary

Cron jobs with `isolated: true` fail with `CommandLaneTaskTimeoutError` when tool execution exceeds ~10 minutes. Root cause: the embedded runner only refreshes the lane-task sliding-window timestamp via `noteLaneTaskProgress`, which fires from the runner's own `notifyExecutionPhase` / `notifyRunProgress` callbacks. Long-running tool execution (e.g. an `exec` running for several minutes) happens *inside* the embedded attempt and emits no runner callbacks, so the sliding window expires even though the task is making progress.

This PR adds a periodic heartbeat that keeps the sliding window fresh while the embedded attempt is in flight, and applies it at the single production call site.

This is the same root-cause fix as the open PRs (#94060, #94082, #94090). Differences vs those competitors:

- **Packaged as a tested helper** (`startLaneTaskProgressHeartbeat`) with focused unit coverage of start/stop/idempotency/cleanup-on-settle. Competitors inline `setInterval` and ship zero tests.
- **20s default interval**, not 30s. The 30s grace window in `command-queue.ts:265` (`taskTimeoutMs + 30s`) sits exactly at the timeout boundary — a 30s heartbeat could race the grace check. 20s leaves headroom while staying below the grace threshold.
- **`.unref()` on the interval** so the heartbeat never blocks process exit on its own. Competitors' bare `setInterval` keeps the event loop alive.
- **Standalone real-environment proof** that drives the actual lane-task sliding window in `command-queue.ts` with the production timeout logic, not a vitest mock.

## Changes

- `src/agents/embedded-agent-runner/lane-heartbeat.ts` (new, 65 lines): exports `startLaneTaskProgressHeartbeat` and `withLaneTaskProgressHeartbeat`. Default interval 20s; intervals are `.unref()`'d; both helpers stop the heartbeat deterministically.
- `src/agents/embedded-agent-runner/lane-heartbeat.test.ts` (new, 103 lines): 7 focused tests — heartbeat fires at requested interval; `stop()` halts calls; `stop()` is idempotent; default interval is 20s; `withLaneTaskProgressHeartbeat` stops on resolve / reject / slow resolution.
- `src/agents/embedded-agent-runner/run.ts` (+7 / -0): add `startLaneTaskProgressHeartbeat(noteLaneTaskProgress)` before the `runEmbeddedAttemptWithBackend(...)` call (line 1856, the only call site) and call `.stop()` inside the existing `.finally()` block. No reformatting; the integration is two adjacent insertions.
- `scripts/repro/issue-94033-cron-lane-timeout.mts` (new, 113 lines): standalone proof that runs the production `enqueueCommandInLane` / `CommandLaneTaskTimeoutError` path with and without the heartbeat, prints outcomes, and asserts the heartbeat scenario completes while the no-heartbeat scenario times out.

## Real behavior proof

- **Behavior addressed**: `CommandLaneTaskTimeoutError` fires during long-running tool execution inside an embedded attempt because no progress is reported for the lane-task sliding window.
- **Real environment tested**: Linux x86_64 local checkout, Node 22.19+, pnpm workspace.
- **Exact steps or command run after this patch**:
  - `node --import tsx scripts/repro/issue-94033-cron-lane-timeout.mts`
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/embedded-agent-runner/lane-heartbeat.test.ts`
  - `npx oxlint --import-plugin --config .oxlintrc.json src/agents/embedded-agent-runner/lane-heartbeat.ts src/agents/embedded-agent-runner/lane-heartbeat.test.ts src/agents/embedded-agent-runner/run.ts scripts/repro/issue-94033-cron-lane-timeout.mts`
- **Evidence after fix (standalone repro — terminal output from real Node process)**:
  ```text
  === Reproduction for issue #94033 ===
  Lane: repro-cron-94033
  Configured taskTimeoutMs: 600
  Task runs for: 1500ms (longer than timeout)

  [diagnostic] lane task error: lane=repro-cron-94033 durationMs=602 error="CommandLaneTaskTimeoutError: Command lane \"repro-cron-94033\" task timed out after 600ms"
  [without-heartbeat] outcome=timed-out elapsedMs=724 noteProgressCalls=0

  [with-heartbeat ] outcome=completed elapsedMs=1502 noteProgressCalls=14

  === Results ===
  Without heartbeat (pre-fix): timed-out after 724ms (timeout fired as expected)
  With heartbeat    (post-fix): completed after 1502ms (noteProgress called 14 times)

  PASS: heartbeat keeps the lane-task sliding window alive during long-running work.
  ```
  This is real console output from `node --import tsx scripts/repro/issue-94033-cron-lane-timeout.mts`. The repro drives the actual lane-task sliding window logic from `src/process/command-queue.ts` (`enqueueCommandInLane`, `runQueueEntryTask`, `CommandLaneTaskTimeoutError`) using real timers and real `setInterval`. The pre-fix scenario times out exactly as observed in production; the post-fix scenario completes and the heartbeat fires 14 times during the 1.5s task.
- **Evidence of necessity (revert test — terminal output from real Node process)**: temporarily skipping the heartbeat call reproduces the pre-fix failure on the same task:
  ```text
  [diagnostic] lane task error: lane=revert-test durationMs=602 error="CommandLaneTaskTimeoutError: Command lane \"revert-test\" task timed out after 600ms"
  REVERT-TEST: timed out as expected (pre-fix behavior confirmed)
  ```
  Real stdout from running the repro without the heartbeat wrapper. Confirms the fix is necessary, not redundant. The fix was restored after this revert test.
- **Evidence after fix (unit tests — vitest run stdout)**:
  ```text
  RUN  v4.1.8 /home/0668000666/0668000666/AI/OpenClaw/new_open_claw

   ✓ src/agents/embedded-agent-runner/lane-heartbeat.test.ts > startLaneTaskProgressHeartbeat > calls noteProgress at the requested interval
   ✓ src/agents/embedded-agent-runner/lane-heartbeat.test.ts > startLaneTaskProgressHeartbeat > stops calling noteProgress after stop()
   ✓ src/agents/embedded-agent-runner/lane-heartbeat.test.ts > startLaneTaskProgressHeartbeat > stop() is idempotent
   ✓ src/agents/embedded-agent-runner/lane-heartbeat.test.ts > startLaneTaskProgressHeartbeat > uses a 20s default interval
   ✓ src/agents/embedded-agent-runner/lane-heartbeat.test.ts > withLaneTaskProgressHeartbeat > stops the heartbeat when the task resolves
   ✓ src/agents/embedded-agent-runner/lane-heartbeat.test.ts > withLaneTaskProgressHeartbeat > stops the heartbeat when the task rejects
   ✓ src/agents/embedded-agent-runner/lane-heartbeat.test.ts > withLaneTaskProgressHeartbeat > keeps ticking noteProgress until the task settles

   Test Files  1 passed (1)
        Tests  7 passed (7)
  ```
  This is supplemental unit-test coverage — the primary real behavior proof is the standalone repro above, not these tests.
- **Observed result after fix**: when an embedded attempt's tool execution exceeds the configured `taskTimeoutMs`, the lane-task sliding window stays fresh and the task completes normally. The standalone repro confirms the production behavior under the same parameters used in the issue.
- **What was not tested**: a full packaged OpenClaw desktop/manual cron run. The fix is scoped to the lane-task progress refresh; no surface outside the embedded runner was touched.

## Verification

- `node --import tsx scripts/repro/issue-94033-cron-lane-timeout.mts` → PASS (pre-fix timeout fires; post-fix task completes with 14 progress notes).
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/embedded-agent-runner/lane-heartbeat.test.ts` → **7/7 tests pass**.
- Revert test (skip heartbeat) on the same repro path → `CommandLaneTaskTimeoutError` fires (pre-fix behavior).
- `npx oxlint --import-plugin --config .oxlintrc.json <changed files>` → clean (no errors).

## Notes for maintainers

- The fix is the single call site in `run.ts:1856`. No other locations call `runEmbeddedAttemptWithBackend`, so this one insertion covers the whole runner.
- The 20s interval rationale is in the helper's doc comment. The 30s grace window in `command-queue.ts:265` is the upper bound — a heartbeat at 30s would race the grace check on every cycle. 20s leaves headroom.
- `setInterval` is `.unref()`'d so a leftover timer (e.g. in a failure path that bypasses `.finally`) cannot prevent the Node process from exiting. The `.stop()` call inside the existing `.finally()` is the primary defense; `.unref()` is a belt-and-suspenders guarantee.
- The helper is intentionally minimal (two exports, one with promise-wrapping). Callers can use either form; the embedded runner uses the start/stop form so the existing `.finally()` block can be reused without restructuring the inline `runEmbeddedAttemptWithBackend({...}).catch().finally()` chain.

## Related

- Fixes #94033

🤖 Generated with [Claude Code](https://claude.com/claude-code)