### PR TITLE
chore: sync yuanbao plugin catalog to 2.15.0

### DIFF
--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -76,9 +76,9 @@
           }
         },
         "install": {
-          "npmSpec": "openclaw-plugin-yuanbao@2.13.1",
+          "npmSpec": "openclaw-plugin-yuanbao@2.15.0",
           "defaultChoice": "npm",
-          "expectedIntegrity": "sha512-lH2I9/nsmrg7l0YJJSQhOSpWMEFBAa6FwKbZcRLDFHDT2+mOZkHa44XE+8KYN4VmorlUdAxHzpZQmVr7C98IuA=="
+          "expectedIntegrity": "sha512-3GD+mf3EjTSUTOAREjTHAyp/deXdpgqB+q+xE0b19Qtat4ADhUV1mHDwFkVCRqTCBY5ATFKtKcipoDejqFj/+w=="
         }
       }
     },

--- a/src/channels/plugins/catalog.test.ts
+++ b/src/channels/plugins/catalog.test.ts
@@ -33,7 +33,7 @@ describe("channel plugin catalog", () => {
     expect(yuanbao?.id).toBe("yuanbao");
     expect(yuanbao?.pluginId).toBe("openclaw-plugin-yuanbao");
     expect(yuanbao?.trustedSourceLinkedOfficialInstall).toBe(true);
-    expect(yuanbao?.install?.npmSpec).toBe("openclaw-plugin-yuanbao@2.13.1");
+    expect(yuanbao?.install?.npmSpec).toBe("openclaw-plugin-yuanbao@2.15.0");
   });
 
   it("excludes only the rejected origin/plugin pair when resolving fallback copies", () => {

--- a/src/channels/plugins/contracts/channel-catalog.contract.test.ts
+++ b/src/channels/plugins/contracts/channel-catalog.contract.test.ts
@@ -46,6 +46,6 @@ describeChannelCatalogEntryContract({
 
 describeChannelCatalogEntryContract({
   channelId: "yuanbao",
-  npmSpec: "openclaw-plugin-yuanbao@2.13.1",
+  npmSpec: "openclaw-plugin-yuanbao@2.15.0",
   alias: "yb",
 });

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -846,7 +846,7 @@ describe("config plugin validation", () => {
 
     expect(res.ok).toBe(true);
     const message =
-      "plugin not installed: yuanbao — install the official external plugin with: openclaw plugins install openclaw-plugin-yuanbao@2.13.1";
+      "plugin not installed: yuanbao — install the official external plugin with: openclaw plugins install openclaw-plugin-yuanbao@2.15.0";
     expectPathMessage(res.warnings, "plugins.entries.yuanbao", message);
     expect((res.warnings ?? []).filter((warning) => warning.message === message)).toHaveLength(1);
   });

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -28,7 +28,7 @@ describe("official external plugin catalog", () => {
     );
     expect(resolveOfficialExternalPluginId(yuanbaoByChannel)).toBe("openclaw-plugin-yuanbao");
     expect(resolveOfficialExternalPluginInstall(yuanbaoByChannel)?.npmSpec).toBe(
-      "openclaw-plugin-yuanbao@2.13.1",
+      "openclaw-plugin-yuanbao@2.15.0",
     );
   });
 

--- a/test/official-channel-catalog.test.ts
+++ b/test/official-channel-catalog.test.ts
@@ -171,10 +171,10 @@ describe("buildOfficialChannelCatalog", () => {
         aliases: ["yuanbao", "yb", "tencent-yuanbao", "元宝"],
       },
       install: {
-        npmSpec: "openclaw-plugin-yuanbao@2.13.1",
+        npmSpec: "openclaw-plugin-yuanbao@2.15.0",
         defaultChoice: "npm",
         expectedIntegrity:
-          "sha512-lH2I9/nsmrg7l0YJJSQhOSpWMEFBAa6FwKbZcRLDFHDT2+mOZkHa44XE+8KYN4VmorlUdAxHzpZQmVr7C98IuA==",
+          "sha512-3GD+mf3EjTSUTOAREjTHAyp/deXdpgqB+q+xE0b19Qtat4ADhUV1mHDwFkVCRqTCBY5ATFKtKcipoDejqFj/+w==",
       },
     });
     expect(


### PR DESCRIPTION
## Summary

- Sync the Yuanbao official external channel catalog pin from `openclaw-plugin-yuanbao@2.13.1` to `@2.15.0`, with the matching `expectedIntegrity` updated to the 2.15.0 npm registry value.
- Keep the catalog the single source of truth for trusted official Yuanbao install/update resolution; this is a routine upstream package-pin sync, not a behavior/code change.
- Update the five catalog tests that hard-code the pinned spec/integrity so they assert the new `2.15.0` values.
- Intentionally out of scope: no workflow, lockfile, secret-handling, or runtime code changes.
- Success: a real OpenClaw install path resolves Yuanbao to `openclaw-plugin-yuanbao@2.15.0` and the catalog integrity check passes.
- Reviewers should focus on the single changed install pin (`scripts/lib/official-external-channel-catalog.json`) and confirm the integrity matches the npm registry value for 2.15.0.

## Linked context

Routine upstream package-pin sync for the Tencent Yuanbao channel plugin. No issue/maintainer request is linked; this tracks the published `openclaw-plugin-yuanbao@2.15.0` release on npm.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: the official catalog pinned Yuanbao to `2.13.1`; npm now publishes `2.15.0`, so trusted official install/update should resolve to `2.15.0`.
- Real environment tested: macOS (darwin), Node v22, OpenClaw built from this PR head (`2f6784d`), isolated `--dev` profile under `~/.openclaw-dev` to avoid touching real state.
- Exact steps or command run after this patch:
  ```
  node openclaw.mjs --dev plugins install openclaw-plugin-yuanbao@2.15.0
  ```
- Evidence after fix (copied live terminal output):
  ```
  Installing openclaw-plugin-yuanbao@2.15.0 into /Users/<redacted>/.openclaw-dev/npm…
  Installed plugin: openclaw-plugin-yuanbao
  Restart the gateway to load plugins.
  ```
  Post-install version confirmation from the managed npm root:
  ```
  $ node -p "require('.../.openclaw-dev/npm/node_modules/openclaw-plugin-yuanbao/package.json').version"
  2.15.0
  ```
- Observed result after fix: the real `plugins install` path resolved Yuanbao through the official catalog, the catalog `expectedIntegrity` drift check passed (no integrity-drift abort), and `2.15.0` was installed successfully onto disk.
- What was not tested: live end-to-end Yuanbao channel messaging (out of scope for a catalog pin); only install/resolution behavior was validated.
- Proof limitations or environment constraints: install was run in an isolated `--dev` profile; user-specific home path is redacted.

## Tests and validation

Commands run: `node openclaw.mjs --dev plugins install openclaw-plugin-yuanbao@2.15.0` (real install proof above). The five updated catalog tests assert the new `2.15.0` spec/integrity. Nothing failed before in a behavioral sense; this is a forward version sync, and the tests were updated to track the new pin.

## Risk checklist

- Did user-visible behavior change? No (install resolves to a newer published version).
- Did config, environment, or migration behavior change? No.
- Did security, auth, secrets, network, or tool execution behavior change? No.
- Highest-risk area: the trusted official install pin can affect fresh installs and trusted-source update/sync.
- How is that risk mitigated: `expectedIntegrity` was updated to the npm registry integrity for `2.15.0` and verified by a real install run (above) where the catalog integrity check passed.

## Current review state

Next action: re-review. Real behavior proof has been added per ClawSweeper P1 guidance. Waiting on: ClawSweeper automatic re-review (or `@clawsweeper re-review`). Addressed: ClawSweeper "needs real behavior proof before merge" by adding a real OpenClaw install path resolving Yuanbao to `2.15.0`.
