### PR TITLE
fix(tools): emit process warning for empty allOf/anyOf availability groups

### DIFF
--- a/src/tools/availability.test.ts
+++ b/src/tools/availability.test.ts
@@ -1,5 +1,5 @@
 // Covers tool availability evaluation and disabled-tool reasons.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { evaluateToolAvailability } from "./availability.js";
 import type { ToolDescriptor } from "./types.js";
 
@@ -254,5 +254,35 @@ describe("evaluateToolAvailability", () => {
         context: { authProviderIds: new Set(["openai"]) },
       }).map((entry) => entry.reason),
     ).toEqual(["unsupported-signal"]);
+  });
+
+  it("emits a process warning for empty allOf availability", () => {
+    const warnings: string[] = [];
+    const orig = process.emitWarning.bind(process);
+    process.emitWarning = vi.fn((...args: unknown[]) => {
+      warnings.push(String(args[0]));
+    });
+
+    evaluateToolAvailability({
+      descriptor: { ...baseDescriptor, availability: { allOf: [] } },
+    });
+
+    process.emitWarning = orig;
+    expect(warnings).toContain("Empty availability allOf group");
+  });
+
+  it("emits a process warning for empty anyOf availability", () => {
+    const warnings: string[] = [];
+    const orig = process.emitWarning.bind(process);
+    process.emitWarning = vi.fn((...args: unknown[]) => {
+      warnings.push(String(args[0]));
+    });
+
+    evaluateToolAvailability({
+      descriptor: { ...baseDescriptor, availability: { anyOf: [] } },
+    });
+
+    process.emitWarning = orig;
+    expect(warnings).toContain("Empty availability anyOf group");
   });
 });

--- a/src/tools/availability.ts
+++ b/src/tools/availability.ts
@@ -131,6 +131,7 @@ function evaluateExpression(
   }
   if ("allOf" in expression) {
     if (expression.allOf.length === 0) {
+      process.emitWarning("Empty availability allOf group", "ToolAvailabilityWarning");
       return [
         {
           reason: "unsupported-signal",
@@ -142,6 +143,7 @@ function evaluateExpression(
   }
   if ("anyOf" in expression) {
     if (expression.anyOf.length === 0) {
+      process.emitWarning("Empty availability anyOf group", "ToolAvailabilityWarning");
       return [
         {
           reason: "unsupported-signal",


### PR DESCRIPTION
## Summary

- Empty `allOf`/`anyOf` arrays in tool descriptors previously produced a hidden `unsupported-signal` diagnostic that was never surfaced to callers or logs — tools disappeared silently with no actionable error
- Now emits `process.emitWarning` so the mistake is visible at descriptor registration time (gateway startup)
- Existing behavior preserved: the tool is still hidden, but now with a visible warning

Fixes #92361

## Real behavior proof (required for external PRs)

**Behavior addressed**: When a ToolDescriptor has `availability: { anyOf: [] }` or `{ allOf: [] }`, the old code moved it to the hidden plan with no log output. The fix adds `process.emitWarning` so the malformed descriptor is immediately visible.

**Real setup tested**:
- **Runtime**: node (unit test suite)

**Exact steps or command run after fix**:

```
pnpm vitest run src/tools/availability.test.ts src/tools/planner.test.ts
```

**After-fix evidence**:

```
PASS (17) FAIL (0) - availability.test.ts + planner.test.ts
```

**Observed result after the fix**: All 17 tests pass (11 existing + 2 new warning-emission tests, 4 planner tests). `process.emitWarning` fires with "Empty availability allOf group" / "Empty availability anyOf group" when these malformed descriptors are evaluated.

**What was not tested**: Manual verification of the warning output at gateway startup (covered by unit test via mock).

**Proof limitations or environment constraints**: Unit-tested via mock on `process.emitWarning`.

## Tests and validation

Both test files pass (17 tests total):
- `availability.test.ts` — 13 tests including 2 new warning-emission tests for empty allOf and anyOf
- `planner.test.ts` — 4 tests

## Risk checklist

Did user-visible behavior change? (No)
- Behaviorally identical: malformed descriptors still hide the tool; only now a warning is emitted

Did config, environment, or migration behavior change? (No)

Did security, auth, secrets, network, or tool execution behavior change? (No)

What is the highest-risk area?
- Gateway startup log output — warning is emitted only for actually malformed descriptors

How is that risk mitigated?
- Warning is a passive signal (process.emitWarning), does not change control flow

## Current review state

What is the next action?
- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?
- N/A

Which bot or reviewer comments were addressed?
- N/A