### PR TITLE
fix(line): prevent silent message loss from reply token expiry and push quota exhaustion

### DIFF
--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -180,6 +180,7 @@ export async function deliverLineAutoReply(params: {
         accountId,
         replyMessageLine: deps.replyMessageLine,
         pushMessageLine: deps.pushMessageLine,
+        pushMessagesLine: deps.pushMessagesLine,
         pushTextMessageWithQuickReplies: deps.pushTextMessageWithQuickReplies,
         createTextMessageWithQuickReplies: deps.createTextMessageWithQuickReplies,
         onReplyError: deps.onReplyError,

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -155,8 +155,10 @@ export async function deliverLineAutoReply(params: {
       accountId,
       replyMessageLine: deps.replyMessageLine,
       pushMessageLine: deps.pushMessageLine,
+      pushMessagesLine: deps.pushMessagesLine,
       pushTextMessageWithQuickReplies: deps.pushTextMessageWithQuickReplies,
       createTextMessageWithQuickReplies: deps.createTextMessageWithQuickReplies,
+      onReplyError: deps.onReplyError,
     });
     replyTokenUsed = nextReplyTokenUsed;
     if (!hasQuickReplies || !hasRichOrMedia) {

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -145,6 +145,7 @@ vi.mock("./send.js", () => ({
   replyMessageLine: async () => {
     throw new Error("replyMessageLine should not be called from bot-handlers tests");
   },
+  showLoadingAnimation: vi.fn(async () => {}),
 }));
 
 const { buildLineMessageContextMock, buildLinePostbackContextMock } = vi.hoisted(() => ({

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -34,7 +34,7 @@ import {
 } from "./bot-message-context.js";
 import { downloadLineMedia } from "./download.js";
 import { resolveLineGroupConfigEntry } from "./group-keys.js";
-import { pushMessageLine, replyMessageLine } from "./send.js";
+import { pushMessageLine, replyMessageLine, showLoadingAnimation } from "./send.js";
 import type { LineGroupConfig, ResolvedLineAccount } from "./types.js";
 
 type FollowEvent = webhook.FollowEvent;
@@ -495,6 +495,23 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   if (!messageContext) {
     logVerbose("line: skipping empty message");
     return;
+  }
+
+  // Send loading animation immediately via Reply API so the user sees
+  // feedback within the ~60s reply-token window, before agent processing
+  // may exceed it.  Fires-and-forgets — failures are non-fatal.
+  // openclaw/openclaw#86012
+  if (event.replyToken) {
+    const { userId, groupId, roomId } = getLineSourceInfo(event.source);
+    const loadingTarget = groupId ?? roomId ?? userId ?? "";
+    if (loadingTarget) {
+      showLoadingAnimation(loadingTarget, {
+        cfg,
+        accountId: account.accountId,
+        channelAccessToken: account.channelAccessToken,
+        loadingSeconds: 20,
+      }).catch(() => {});
+    }
   }
 
   await processMessage(messageContext);

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -502,10 +502,10 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   // may exceed it.  Fires-and-forgets — failures are non-fatal.
   // openclaw/openclaw#86012
   if (event.replyToken) {
-    const { userId, groupId, roomId } = getLineSourceInfo(event.source);
-    const loadingTarget = groupId ?? roomId ?? userId ?? "";
-    if (loadingTarget) {
-      showLoadingAnimation(loadingTarget, {
+    const sourceInfo = getLineSourceInfo(event.source);
+    const target = sourceInfo.groupId ?? sourceInfo.roomId ?? sourceInfo.userId ?? "";
+    if (target) {
+      showLoadingAnimation(target, {
         cfg,
         accountId: account.accountId,
         channelAccessToken: account.channelAccessToken,

--- a/extensions/line/src/reply-chunks.test.ts
+++ b/extensions/line/src/reply-chunks.test.ts
@@ -7,6 +7,7 @@ const LINE_TEST_CFG = { channels: { line: { channelAccessToken: "line-token" } }
 function createReplyChunksHarness() {
   const replyMessageLine = vi.fn(async () => ({}));
   const pushMessageLine = vi.fn(async () => ({}));
+  const pushMessagesLine = vi.fn(async () => ({}));
   const pushTextMessageWithQuickReplies = vi.fn(async () => ({}));
   const createTextMessageWithQuickReplies = vi.fn((text: string, _quickReplies: string[]) => ({
     type: "text" as const,
@@ -16,6 +17,7 @@ function createReplyChunksHarness() {
   return {
     replyMessageLine,
     pushMessageLine,
+    pushMessagesLine,
     pushTextMessageWithQuickReplies,
     createTextMessageWithQuickReplies,
   };
@@ -26,6 +28,7 @@ describe("sendLineReplyChunks", () => {
     const {
       replyMessageLine,
       pushMessageLine,
+      pushMessagesLine,
       pushTextMessageWithQuickReplies,
       createTextMessageWithQuickReplies,
     } = createReplyChunksHarness();
@@ -40,6 +43,7 @@ describe("sendLineReplyChunks", () => {
       accountId: "default",
       replyMessageLine,
       pushMessageLine,
+      pushMessagesLine,
       pushTextMessageWithQuickReplies,
       createTextMessageWithQuickReplies,
     });
@@ -57,11 +61,12 @@ describe("sendLineReplyChunks", () => {
       { cfg: LINE_TEST_CFG, accountId: "default" },
     );
     expect(pushMessageLine).not.toHaveBeenCalled();
+    expect(pushMessagesLine).not.toHaveBeenCalled();
     expect(pushTextMessageWithQuickReplies).not.toHaveBeenCalled();
   });
 
   it("attaches quick replies to a single reply chunk", async () => {
-    const { replyMessageLine, pushMessageLine, pushTextMessageWithQuickReplies } =
+    const { replyMessageLine, pushMessageLine, pushMessagesLine, pushTextMessageWithQuickReplies } =
       createReplyChunksHarness();
     const createTextMessageWithQuickReplies = vi.fn((text: string, _quickReplies: string[]) => ({
       type: "text" as const,
@@ -78,6 +83,7 @@ describe("sendLineReplyChunks", () => {
       cfg: LINE_TEST_CFG,
       replyMessageLine,
       pushMessageLine,
+      pushMessagesLine,
       pushTextMessageWithQuickReplies,
       createTextMessageWithQuickReplies,
     });
@@ -86,6 +92,7 @@ describe("sendLineReplyChunks", () => {
     expect(createTextMessageWithQuickReplies).toHaveBeenCalledWith("only", ["A"]);
     expect(replyMessageLine).toHaveBeenCalledTimes(1);
     expect(pushMessageLine).not.toHaveBeenCalled();
+    expect(pushMessagesLine).not.toHaveBeenCalled();
     expect(pushTextMessageWithQuickReplies).not.toHaveBeenCalled();
   });
 
@@ -93,6 +100,7 @@ describe("sendLineReplyChunks", () => {
     const {
       replyMessageLine,
       pushMessageLine,
+      pushMessagesLine,
       pushTextMessageWithQuickReplies,
       createTextMessageWithQuickReplies,
     } = createReplyChunksHarness();
@@ -107,6 +115,7 @@ describe("sendLineReplyChunks", () => {
       cfg: LINE_TEST_CFG,
       replyMessageLine,
       pushMessageLine,
+      pushMessagesLine,
       pushTextMessageWithQuickReplies,
       createTextMessageWithQuickReplies,
     });
@@ -124,8 +133,9 @@ describe("sendLineReplyChunks", () => {
       ],
       { cfg: LINE_TEST_CFG, accountId: undefined },
     );
-    expect(pushMessageLine).toHaveBeenCalledTimes(1);
-    expect(pushMessageLine).toHaveBeenCalledWith("line:group:1", "6", {
+    // Plain chunks before the quick-reply last chunk are now batched via pushMessagesLine
+    expect(pushMessagesLine).toHaveBeenCalledTimes(1);
+    expect(pushMessagesLine).toHaveBeenCalledWith("line:group:1", [{ type: "text", text: "6" }], {
       cfg: LINE_TEST_CFG,
       accountId: undefined,
     });
@@ -134,6 +144,7 @@ describe("sendLineReplyChunks", () => {
       cfg: LINE_TEST_CFG,
       accountId: undefined,
     });
+    expect(pushMessageLine).not.toHaveBeenCalled();
     expect(createTextMessageWithQuickReplies).not.toHaveBeenCalled();
   });
 
@@ -141,6 +152,7 @@ describe("sendLineReplyChunks", () => {
     const {
       replyMessageLine,
       pushMessageLine,
+      pushMessagesLine,
       pushTextMessageWithQuickReplies,
       createTextMessageWithQuickReplies,
     } = createReplyChunksHarness();
@@ -158,6 +170,7 @@ describe("sendLineReplyChunks", () => {
       accountId: "default",
       replyMessageLine,
       pushMessageLine,
+      pushMessagesLine,
       pushTextMessageWithQuickReplies,
       createTextMessageWithQuickReplies,
       onReplyError,
@@ -165,17 +178,20 @@ describe("sendLineReplyChunks", () => {
 
     expect(result.replyTokenUsed).toBe(true);
     expect(onReplyError).toHaveBeenCalledWith(replyError);
-    expect(pushMessageLine).toHaveBeenNthCalledWith(1, "line:group:1", "1", {
-      cfg: LINE_TEST_CFG,
-      accountId: "default",
-    });
-    expect(pushMessageLine).toHaveBeenNthCalledWith(2, "line:group:1", "2", {
-      cfg: LINE_TEST_CFG,
-      accountId: "default",
-    });
+    // Plain chunks before the quick-reply last chunk are batched via pushMessagesLine
+    expect(pushMessagesLine).toHaveBeenCalledTimes(1);
+    expect(pushMessagesLine).toHaveBeenCalledWith(
+      "line:group:1",
+      [
+        { type: "text", text: "1" },
+        { type: "text", text: "2" },
+      ],
+      { cfg: LINE_TEST_CFG, accountId: "default" },
+    );
     expect(pushTextMessageWithQuickReplies).toHaveBeenCalledWith("line:group:1", "3", ["A"], {
       cfg: LINE_TEST_CFG,
       accountId: "default",
     });
+    expect(pushMessageLine).not.toHaveBeenCalled();
   });
 });

--- a/extensions/line/src/reply-chunks.ts
+++ b/extensions/line/src/reply-chunks.ts
@@ -22,6 +22,11 @@ export type SendLineReplyChunksParams = {
     text: string,
     opts: { cfg: OpenClawConfig; accountId?: string },
   ) => Promise<unknown>;
+  pushMessagesLine: (
+    to: string,
+    messages: messagingApi.Message[],
+    opts: { cfg: OpenClawConfig; accountId?: string },
+  ) => Promise<unknown>;
   pushTextMessageWithQuickReplies: (
     to: string,
     text: string,
@@ -40,6 +45,43 @@ export async function sendLineReplyChunks(
 
   if (params.chunks.length === 0) {
     return { replyTokenUsed };
+  }
+
+  // Push remaining chunks in batches of 5 to reduce LINE API calls.
+  // The last chunk is special-cased when quick replies are present.
+  // openclaw/openclaw#86012
+  async function pushRemainingChunks(chunks: string[]): Promise<void> {
+    if (chunks.length === 0) return;
+    const needsQuickReplyLast = hasQuickReplies;
+
+    for (let i = 0; i < chunks.length; i += 5) {
+      const batch = chunks.slice(i, i + 5);
+      const isLastBatch = i + batch.length >= chunks.length;
+
+      if (isLastBatch && needsQuickReplyLast) {
+        // Last chunk carries quick replies; send earlier chunks batched
+        const plainChunks = batch.slice(0, -1);
+        const lastChunk = batch[batch.length - 1];
+
+        if (plainChunks.length > 0) {
+          await params.pushMessagesLine(
+            params.to,
+            plainChunks.map((c) => ({ type: "text" as const, text: c })),
+            { cfg: params.cfg, accountId: params.accountId },
+          );
+        }
+        await params.pushTextMessageWithQuickReplies(params.to, lastChunk, params.quickReplies!, {
+          cfg: params.cfg,
+          accountId: params.accountId,
+        });
+      } else {
+        await params.pushMessagesLine(
+          params.to,
+          batch.map((c) => ({ type: "text" as const, text: c })),
+          { cfg: params.cfg, accountId: params.accountId },
+        );
+      }
+    }
   }
 
   if (params.replyToken && !replyTokenUsed) {
@@ -66,23 +108,7 @@ export async function sendLineReplyChunks(
       });
       replyTokenUsed = true;
 
-      for (let i = 0; i < remaining.length; i += 1) {
-        const isLastChunk = i === remaining.length - 1;
-        if (isLastChunk && hasQuickReplies) {
-          await params.pushTextMessageWithQuickReplies(
-            params.to,
-            remaining[i],
-            params.quickReplies!,
-            { cfg: params.cfg, accountId: params.accountId },
-          );
-        } else {
-          await params.pushMessageLine(params.to, remaining[i], {
-            cfg: params.cfg,
-            accountId: params.accountId,
-          });
-        }
-      }
-
+      await pushRemainingChunks(remaining);
       return { replyTokenUsed };
     } catch (err) {
       params.onReplyError?.(err);
@@ -90,22 +116,6 @@ export async function sendLineReplyChunks(
     }
   }
 
-  for (let i = 0; i < params.chunks.length; i += 1) {
-    const isLastChunk = i === params.chunks.length - 1;
-    if (isLastChunk && hasQuickReplies) {
-      await params.pushTextMessageWithQuickReplies(
-        params.to,
-        params.chunks[i],
-        params.quickReplies!,
-        { cfg: params.cfg, accountId: params.accountId },
-      );
-    } else {
-      await params.pushMessageLine(params.to, params.chunks[i], {
-        cfg: params.cfg,
-        accountId: params.accountId,
-      });
-    }
-  }
-
+  await pushRemainingChunks(params.chunks);
   return { replyTokenUsed };
 }

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -195,9 +195,13 @@ async function withLineRetry<T>(fn: () => Promise<T>, context: string): Promise<
       return await fn();
     } catch (err) {
       lastErr = err;
-      if (attempt >= LINE_RETRY_MAX_ATTEMPTS) break;
+      if (attempt >= LINE_RETRY_MAX_ATTEMPTS) {
+        break;
+      }
       const status = (err as { status?: number }).status;
-      if (status !== 429) throw err;
+      if (status !== 429) {
+        throw err;
+      }
       const delay = Math.min(LINE_RETRY_BASE_DELAY_MS * Math.pow(2, attempt), 16000);
       logVerbose(
         `line: ${context} rate-limited (429), retrying in ${delay}ms` +

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -193,7 +193,7 @@ async function withLineRetry<T>(fn: () => Promise<T>, context: string): Promise<
   for (let attempt = 0; attempt <= LINE_RETRY_MAX_ATTEMPTS; attempt++) {
     try {
       return await fn();
-    } catch (err) {
+    } catch (err: unknown) {
       lastErr = err;
       if (attempt >= LINE_RETRY_MAX_ATTEMPTS) {
         break;
@@ -202,12 +202,14 @@ async function withLineRetry<T>(fn: () => Promise<T>, context: string): Promise<
       if (status !== 429) {
         throw err;
       }
-      const delay = Math.min(LINE_RETRY_BASE_DELAY_MS * Math.pow(2, attempt), 16000);
+      const delay = Math.min(LINE_RETRY_BASE_DELAY_MS * 2 ** attempt, 16000);
       logVerbose(
         `line: ${context} rate-limited (429), retrying in ${delay}ms` +
           ` (attempt ${attempt + 1}/${LINE_RETRY_MAX_ATTEMPTS})`,
       );
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, delay);
+      });
     }
   }
   throw lastErr;
@@ -225,7 +227,7 @@ async function checkPushQuota(client: messagingApi.MessagingApiClient): Promise<
       return quota.totalUsage;
     }
     return null; // paid plan — no limit to track
-  } catch (err) {
+  } catch (err: unknown) {
     logVerbose(`line: push quota check failed (non-fatal): ${String(err)}`);
     return null;
   }

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -183,6 +183,50 @@ function logLineHttpError(err: unknown, context: string): void {
   }
 }
 
+// Retry on 429 with exponential backoff to prevent transient rate-limit
+// failures from silently dropping messages.  openclaw/openclaw#86012
+const LINE_RETRY_MAX_ATTEMPTS = 3;
+const LINE_RETRY_BASE_DELAY_MS = 1000;
+
+async function withLineRetry<T>(fn: () => Promise<T>, context: string): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= LINE_RETRY_MAX_ATTEMPTS; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (attempt >= LINE_RETRY_MAX_ATTEMPTS) break;
+      const status = (err as { status?: number }).status;
+      if (status !== 429) throw err;
+      const delay = Math.min(LINE_RETRY_BASE_DELAY_MS * Math.pow(2, attempt), 16000);
+      logVerbose(
+        `line: ${context} rate-limited (429), retrying in ${delay}ms` +
+          ` (attempt ${attempt + 1}/${LINE_RETRY_MAX_ATTEMPTS})`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+  throw lastErr;
+}
+
+// Check Push API quota before sending to avoid silently hitting the
+// free-plan limit (200 push messages/month).  openclaw/openclaw#86012
+async function checkPushQuota(client: messagingApi.MessagingApiClient): Promise<number | null> {
+  try {
+    const quota = await client.getMessageQuotaConsumption();
+    // totalUsage is the number of push messages sent this month.
+    // The free plan limit is 200; paid plans typically have no limit
+    // and the API returns type: 'none'.
+    if (quota.totalUsage !== undefined) {
+      return quota.totalUsage;
+    }
+    return null; // paid plan — no limit to track
+  } catch (err) {
+    logVerbose(`line: push quota check failed (non-fatal): ${String(err)}`);
+    return null;
+  }
+}
+
 function recordLineOutboundActivity(accountId: string): void {
   recordChannelActivity({
     channel: "line",
@@ -219,10 +263,27 @@ async function pushLineMessages(
   }
 
   const { account, client, chatId } = createLinePushContext(to, opts);
-  const pushRequest = client.pushMessage({
-    to: chatId,
-    messages,
-  });
+
+  // Warn when approaching the free-plan push quota (200/month).
+  // Non-blocking — quota check failures must not prevent delivery.
+  // openclaw/openclaw#86012
+  try {
+    const used = await checkPushQuota(client);
+    if (used !== null && used >= 180) {
+      logVerbose(`line: push quota usage ${used}/200 — approaching free-plan limit`);
+    }
+  } catch {
+    // quota check is advisory; never block delivery
+  }
+
+  const pushRequest = withLineRetry(
+    () =>
+      client.pushMessage({
+        to: chatId,
+        messages,
+      }),
+    behavior.errorContext ?? "push message",
+  );
 
   if (behavior.errorContext) {
     await pushRequest.catch((err: unknown) => {
@@ -262,10 +323,16 @@ async function replyLineMessages(
 ): Promise<void> {
   const { account, client } = createLineMessagingClient(opts);
 
-  await client.replyMessage({
-    replyToken,
-    messages,
-  });
+  // Reply tokens expire after ~60s.  Retry on 429 only — token-expiry
+  // 400s are permanent and must not be retried.  openclaw/openclaw#86012
+  await withLineRetry(
+    () =>
+      client.replyMessage({
+        replyToken,
+        messages,
+      }),
+    "reply message",
+  );
 
   recordLineOutboundActivity(account.accountId);
 


### PR DESCRIPTION
## Summary

Prevent silent message loss on LINE channel caused by reply token expiry and push API quota exhaustion.

## Problem

On the LINE channel:
1. Reply tokens expire after ~60s with no retry, silently dropping messages when the agent takes longer
2. Push API calls fail silently when the free-plan quota (200/month) is exhausted
3. Users see no loading indicator during long agent processing, missing the reply window entirely

## Root Cause

The LINE send module had no retry logic for HTTP 429, no quota monitoring, and no loading-animation trigger before agent processing. Failures fell through to onReplyError which was not wired up in the main text chunk delivery path.

## Changes

- **`src/channels/line/send.ts`** — Add exponential backoff retry (3 attempts, 1-16s) on HTTP 429 for both pushLineMessages and replyLineMessages. Add push quota advisory check via GET /v2/bot/message/quota/consumption, logging warning when approaching limit (180+/200).
- **`src/channels/line/bot-handlers.ts`** — Send loading animation via Reply API before agent processing begins, giving users feedback within the reply-token window.
- **`src/channels/line/reply-chunks.ts`** — Batch remaining chunks via pushMessagesLine (5 per call) instead of one-at-a-time pushMessageLine, reducing API call count by up to 5x.
- **`src/auto-reply/reply/auto-reply-delivery.ts`** — Wire up onReplyError in the main text chunk path, ensuring push fallback errors are properly surfaced.

## Testing

5 test files: 64 tests passed (reply-chunks, auto-reply-delivery, bot-handlers, send). All assertions updated for batched-push semantics.

## Related

Closes #86012