### PR TITLE
feat(gateway-cli): scope usage-cost by agent

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -181,11 +181,19 @@ Fetch usage-cost summaries from session logs.
 ```bash
 openclaw gateway usage-cost
 openclaw gateway usage-cost --days 7
+openclaw gateway usage-cost --agent work --json
+openclaw gateway usage-cost --all-agents
 openclaw gateway usage-cost --json
 ```
 
 <ParamField path="--days <days>" type="number" default="30">
   Number of days to include.
+</ParamField>
+<ParamField path="--agent <id>" type="string">
+  Scope the cost summary to one configured agent id.
+</ParamField>
+<ParamField path="--all-agents" type="boolean">
+  Aggregate the cost summary across all configured agents. Cannot be combined with `--agent`.
 </ParamField>
 
 ### `gateway stability`

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -213,6 +213,55 @@ describe("gateway-cli coverage", () => {
     });
   });
 
+  it("scopes usage-cost to a specific agent via --agent", async () => {
+    callGateway.mockClear();
+
+    await runGatewayCommand(["gateway", "usage-cost", "--agent", "alpha", "--days", "7", "--json"]);
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    const costCall = firstMockArg(callGateway) as { method?: string; params?: unknown };
+    expect(costCall?.method).toBe("usage.cost");
+    expect(costCall?.params).toEqual({ days: 7, agentId: "alpha" });
+  });
+
+  it("omits agentId from usage-cost when --agent is absent or blank", async () => {
+    callGateway.mockClear();
+
+    await runGatewayCommand(["gateway", "usage-cost", "--agent", "  ", "--days", "7", "--json"]);
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    const costCall = firstMockArg(callGateway) as { method?: string; params?: unknown };
+    expect(costCall?.method).toBe("usage.cost");
+    expect(costCall?.params).toEqual({ days: 7 });
+  });
+
+  it("aggregates usage-cost across agents via --all-agents", async () => {
+    callGateway.mockClear();
+
+    await runGatewayCommand(["gateway", "usage-cost", "--all-agents", "--days", "7", "--json"]);
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    const costCall = firstMockArg(callGateway) as { method?: string; params?: unknown };
+    expect(costCall?.method).toBe("usage.cost");
+    expect(costCall?.params).toEqual({ days: 7, agentScope: "all" });
+  });
+
+  it("rejects combining --agent with --all-agents for usage-cost", async () => {
+    callGateway.mockClear();
+
+    await expectGatewayExit([
+      "gateway",
+      "usage-cost",
+      "--agent",
+      "alpha",
+      "--all-agents",
+      "--json",
+    ]);
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(runtimeErrors.join("\n")).toContain("Use --agent or --all-agents, not both");
+  });
+
   it("writes JSON for gateway health transport failures in JSON mode", async () => {
     const error = new Error("gateway closed (1006)");
     const payload = {

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -556,12 +556,24 @@ export function registerGatewayCli(program: Command) {
       .command("usage-cost")
       .description("Fetch usage cost summary from session logs")
       .option("--days <days>", "Number of days to include", "30")
+      .option("--agent <id>", "Scope the cost summary to a specific agent id")
+      .option("--all-agents", "Aggregate the cost summary across all agents", false)
       .action(async (opts, command) => {
         await runGatewayCommand(
           async () => {
             const rpcOpts = resolveGatewayRpcOptions(opts, command);
             const days = parseDaysOption(opts.days);
-            const result = await callGatewayCli("usage.cost", rpcOpts, { days });
+            const agentId = typeof opts.agent === "string" ? opts.agent.trim() : undefined;
+            // The gateway honors agentScope only when no agentId is set, so reject the
+            // ambiguous combination here instead of silently dropping --all-agents.
+            if (agentId && opts.allAgents) {
+              throw new Error("Use --agent or --all-agents, not both");
+            }
+            const result = await callGatewayCli("usage.cost", rpcOpts, {
+              days,
+              ...(agentId ? { agentId } : {}),
+              ...(opts.allAgents ? { agentScope: "all" } : {}),
+            });
             if (rpcOpts.json) {
               defaultRuntime.writeJson(result);
               return;


### PR DESCRIPTION
## Summary

`openclaw gateway usage-cost` only sent `{ days }` to the `usage.cost` gateway RPC (`src/cli/gateway-cli/register.ts:535`), even though the handler already accepts agent scoping (`src/gateway/server-methods/usage.ts:982-990`): `params.agentId` narrows the summary to one agent, and `params.agentScope: "all"` aggregates every agent. The Control UI uses both, but the CLI could only ever report the **default agent**, so operators running multiple agents had no way to see per-agent or all-agent cost from the terminal.

This adds the two missing agent-scoping flags to the CLI command:

- `--agent <id>` → forwards `agentId` (cost for that one agent).
- `--all-agents` → forwards `agentScope: "all"` (cost across every agent).

They are mutually exclusive: the gateway honors `agentScope` only when no `agentId` is set (`usage.ts:983`), so passing both now errors instead of silently dropping `--all-agents`. With no flag the wire payload stays exactly `{ days }`, so existing default-agent behavior is unchanged. `--days` (the existing date-range flag) is intentionally left as-is; only the agent dimension is added.

### Changes
- `src/cli/gateway-cli/register.ts` — add `--agent`/`--all-agents` options, a mutual-exclusion guard, and forward `agentId`/`agentScope` to the RPC.
- `src/cli/gateway-cli.coverage.test.ts` — 4 tests: `--agent` forwards `agentId`; blank `--agent` is omitted; `--all-agents` forwards `agentScope: "all"`; `--agent` + `--all-agents` errors before any RPC call.

## Real behavior proof

Behavior addressed: the `gateway usage-cost` CLI could not scope cost by agent (the RPC supports it; the CLI never sent `agentId`/`agentScope`). It now exposes `--agent <id>` and `--all-agents`, mutually exclusive.

Real environment tested: Node 22.22.1, macOS. A dev gateway built from source and run with `gateway run --dev --auth none --port 7799` against an isolated `OPENCLAW_HOME`/`OPENCLAW_STATE_DIR`; the real `openclaw gateway usage-cost` CLI was run against it (no model, no network egress). "BEFORE" is the same CLI rebuilt from `origin/main` (the flags absent).

Exact steps or command run after this patch:
```bash
# isolated dev gateway (auth=none), then the real CLI against it:
node scripts/run-node.mjs gateway run --dev --auth none --port 7799 --force   # background
node scripts/run-node.mjs gateway usage-cost --agent alpha --days 7 --json
node scripts/run-node.mjs gateway usage-cost --all-agents --days 7 --json
node scripts/run-node.mjs gateway usage-cost --agent alpha --all-agents --json
# BEFORE: same CLI rebuilt from origin/main (flags do not exist):
git stash && rm -f dist/.buildstamp
node scripts/run-node.mjs gateway usage-cost --agent alpha --days 7 --json
```

Evidence after fix:
```
BEFORE (origin/main): gateway usage-cost --agent alpha
  -> OpenClaw does not recognize option "--agent".

AFTER --agent alpha --days 7 --json
  -> { "updatedAt": ..., "days": 8, "totals": { "totalCost": 0, ... }, "cacheStatus": { "status": "fresh", ... } }   (valid summary, RPC round-trip OK)

AFTER --all-agents --days 7 --json
  -> { "updatedAt": ..., "days": 8, "totals": { "totalCost": 0, ... }, "cacheStatus": {...} }   (all-agents path, RPC round-trip OK)

AFTER --agent alpha --all-agents
  -> Gateway usage cost failed: Error: Use --agent or --all-agents, not both   (guard fires; no RPC sent)
```

Observed result after fix: `--agent` and `--all-agents` are accepted and complete a real `usage.cost` RPC round-trip returning a valid `CostUsageSummary`; on `origin/main` the same flags are rejected as unknown options. The mutually-exclusive combination is rejected before any RPC call.

What was not tested: per-agent cost *differentiation* with seeded session-log cost data — the isolated env has no usage history, so every summary is zero. The exact wire payload the CLI sends for each flag (`{ days, agentId }`, `{ days, agentScope: "all" }`, blank-omitted `{ days }`, and the conflict rejection) is asserted by the colocated tests in `gateway-cli.coverage.test.ts`; the RPC's agent-scoping logic itself is pre-existing and covered by `src/infra/session-cost-usage.test.ts`.

## Additional checks
- `pnpm test src/cli/gateway-cli.coverage.test.ts` — 27 pass (incl. the 4 new cases). `register.option-collisions.test.ts` — green (`--agent`/`--all-agents` collide with no global gateway option).
- Formatter (`oxfmt`), static analysis (`oxlint`), and `tsgo:core` typecheck pass for the changed files.
- Sibling check: `usage-cost` is the only CLI command in the usage/cost RPC family — `sessions.usage` / `sessions.usage.timeseries` / `sessions.usage.logs` have no CLI command — so no parallel CLI surface is left unscoped.
