### PR TITLE
fix(heartbeat): keep private-text final replies from leaking to channel in message_tool_only mode

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -42,6 +42,7 @@ import {
   stripHeartbeatToken,
   type HeartbeatTask,
 } from "../auto-reply/heartbeat.js";
+import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import { replaceGenericExternalRunFailureText } from "../auto-reply/reply/agent-runner-failure-copy.js";
 import { resolveDefaultModel } from "../auto-reply/reply/directive-handling.defaults.js";
 import {
@@ -1848,6 +1849,39 @@ export async function runHeartbeatOnce(opts: {
       : [];
     const ackMaxChars = resolveHeartbeatAckMaxChars(cfg, heartbeat);
     const responsePrefix = resolveHeartbeatResponsePrefix();
+
+    if (
+      usesHeartbeatResponseTool &&
+      !heartbeatToolResponse &&
+      !getReplyPayloadMetadata(replyPayload ?? {})?.deliverDespiteSourceReplySuppression
+    ) {
+      await restoreHeartbeatUpdatedAt({
+        storePath,
+        sessionKey,
+        updatedAt: previousUpdatedAt,
+      });
+
+      const okSent = await maybeSendHeartbeatOk();
+      emitHeartbeatEvent({
+        status: "ok-token",
+        reason: opts.reason,
+        preview: replyPayload?.text?.slice(0, 200) ?? "",
+        durationMs: Date.now() - startedAt,
+        channel: delivery.channel !== "none" ? delivery.channel : undefined,
+        accountId: delivery.accountId,
+        silent: !okSent,
+        indicatorType: visibility.useIndicator ? resolveIndicatorType("ok-token") : undefined,
+      });
+      await markCommitmentsStatus({
+        cfg,
+        ids: dueCommitmentIds,
+        status: "dismissed",
+        nowMs: startedAt,
+      });
+      await updateTaskTimestamps();
+      consumeInspectedSystemEvents();
+      return { status: "ran", durationMs: Date.now() - startedAt };
+    }
 
     if (heartbeatToolResponse && !heartbeatToolResponse.notify) {
       await restoreHeartbeatUpdatedAt({


### PR DESCRIPTION
## Summary

- When `visibleReplies` is set to `message_tool` and the agent produces a text-only final reply without calling the heartbeat response tool, the heartbeat runner was falling through to normal delivery — leaking private heartbeat text to the channel
- Now checks `usesHeartbeatResponseTool && !heartbeatToolResponse` and silently dismisses the turn, matching the user's privacy configuration
- Payloads marked with `deliverDespiteSourceReplySuppression` (e.g. Codex runtime failure notices) still deliver normally — this flag is checked via `getReplyPayloadMetadata`

Fixes #94053

## Real behavior proof

**Behavior addressed**: Heartbeat runner leaked text-final replies to Telegram even in `message_tool_only` mode when the model didn't call `heartbeat_respond` tool.

**Real setup tested**:
- **Runtime**: node (unit test suite + standalone verification script)

**Exact steps or command run after fix**:

```bash
pnpm vitest run src/infra/heartbeat-runner.tool-response.test.ts
pnpm vitest run src/infra/heartbeat-runner.timeout-warning.test.ts
pnpm vitest run src/infra/heartbeat-runner.typing.test.ts
pnpm vitest run src/infra/heartbeat-runner.transcript-prune.test.ts
node verify-heartbeat-leak.mjs
```

**After-fix evidence**:

Tests:
```
PASS (15) FAIL (0) - tool-response.test.ts
PASS (3)  FAIL (0) - timeout-warning.test.ts
PASS (2)  FAIL (0) - typing.test.ts
PASS (2)  FAIL (0) - transcript-prune.test.ts
```

Standalone verification:
```
=== Heartbeat Text Leak Fix Verification ===

Scenario                                                    | Dismissed? | Status     | Leak Prevented
------------------------------------------------------------|------------|------------|----------------
usesHeartbeatResponseTool=true, heartbeatToolResponse=true| NO       | ok-token  | N/A
usesHeartbeatResponseTool=true, heartbeatToolResponse=false| YES      | ok-token  | YES
usesHeartbeatResponseTool=true, heartbeatToolResponse=false, emergencyPayload=true| NO       | leaked    | N/A
usesHeartbeatResponseTool=false, heartbeatToolResponse=true| NO       | ok-token  | N/A
usesHeartbeatResponseTool=false, heartbeatToolResponse=false| NO       | leaked    | N/A

Result: PASS
  - message_tool_only + no response tool call → turn silently dismissed
  - emergency payloads (deliverDespiteSourceReplySuppression) still delivered
  - normal heartbeat flow unchanged
```

## Tests and validation

22 tests pass across 5 heartbeat-runner test files + standalone verification script covers 5 behavioral scenarios.