### PR TITLE
fix: #94482 normalize cacheRetention 'standard' to 'short'

### DIFF
--- a/src/agents/embedded-agent-runner/prompt-cache-retention.test.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-retention.test.ts
@@ -121,6 +121,29 @@ describe("prompt cache retention", () => {
     ).toBeUndefined();
   });
 
+  it("normalizes standard cacheRetention to short for Anthropic family providers", () => {
+    // Anthropic direct API accepts "standard" as a cache retention mode.
+    // normalize it to "short" so it survives the family gate.
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "standard" },
+        "anthropic",
+        "anthropic-messages",
+        "claude-sonnet-4-6",
+      ),
+    ).toBe("short");
+    // For non-Anthropic-direct families (e.g. Bedrock), "standard" also maps
+    // to "short" instead of falling through to undefined.
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "standard" },
+        "amazon-bedrock",
+        "bedrock-converse-stream",
+        "us.anthropic.claude-sonnet-4-6",
+      ),
+    ).toBe("short");
+  });
+
   it("identifies supported direct Google cache families", () => {
     expect(
       isGooglePromptCacheEligible({

--- a/src/agents/embedded-agent-runner/prompt-cache-retention.test.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-retention.test.ts
@@ -144,6 +144,33 @@ describe("prompt cache retention", () => {
     ).toBe("short");
   });
 
+  it("does not normalize standard cacheRetention for Google providers", () => {
+    // "standard" is an Anthropic-specific alias; Google Gemini providers
+    // should not receive the normalization.
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "standard" },
+        "google",
+        "google-generative-ai",
+        "gemini-3.1-pro-preview",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("does not normalize standard cacheRetention for prompt-cache-key providers", () => {
+    // "standard" is an Anthropic-specific alias; openai-completions
+    // providers with supportsPromptCacheKey should not receive it.
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "standard" },
+        "omlx-local",
+        "openai-completions",
+        "local_model",
+        true,
+      ),
+    ).toBeUndefined();
+  });
+
   it("identifies supported direct Google cache families", () => {
     expect(
       isGooglePromptCacheEligible({

--- a/src/agents/embedded-agent-runner/prompt-cache-retention.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-retention.ts
@@ -50,6 +50,13 @@ export function resolveCacheRetention(
   if (newVal === "none" || newVal === "short" || newVal === "long") {
     return newVal;
   }
+  // Anthropic direct API accepts "standard" as a cache retention mode; normalize
+  // it to "short" so the value survives the family gate instead of falling
+  // through to undefined. Fixes Bedrock Claude models where the family is not
+  // "anthropic-direct" and the explicit setting was silently discarded.
+  if (newVal === "standard") {
+    return "short";
+  }
 
   const legacy = extraParams?.cacheControlTtl;
   if (legacy === "5m" && (family || googleEligible)) {

--- a/src/agents/embedded-agent-runner/prompt-cache-retention.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-retention.ts
@@ -50,11 +50,10 @@ export function resolveCacheRetention(
   if (newVal === "none" || newVal === "short" || newVal === "long") {
     return newVal;
   }
-  // Anthropic direct API accepts "standard" as a cache retention mode; normalize
-  // it to "short" so the value survives the family gate instead of falling
-  // through to undefined. Fixes Bedrock Claude models where the family is not
-  // "anthropic-direct" and the explicit setting was silently discarded.
-  if (newVal === "standard") {
+  // Anthropic API docs accept "standard" as a cache retention synonym for
+  // "short". Normalize it only within the Anthropic family gate so Google and
+  // prompt-cache-key providers are unaffected.
+  if (newVal === "standard" && family) {
     return "short";
   }
 


### PR DESCRIPTION
## What Problem This Solves

`resolveCacheRetention()` in `src/agents/embedded-agent-runner/prompt-cache-retention.ts` is the central gate for all cache retention values. It only recognized `"none"`, `"short"`, and `"long"`. When a user set `cacheRetention: "standard"` (valid in Anthropic API docs), the value fell through the family gate for non-`anthropic-direct` providers (e.g. `amazon-bedrock`) and was silently discarded — the explicit user config was treated as if unset.

## Why This Change Was Made

Add `"standard"` → `"short"` normalization at the central gate, **scoped to the Anthropic cache family only** (`&& family` gate). This fixes the issue for Anthropic-family providers (Bedrock Claude, direct Anthropic, Anthropic Vertex) while Google Gemini and prompt-cache-key providers are unaffected.

## Revisions (addressing ClawSweeper feedback)

- **[P1]** Scoped `standard` → `"short"` alias to `family` (Anthropic/Bedrock cache family) only — Google and prompt-cache-key providers no longer accept the alias.
- **[P1]** Added negative tests proving the alias does not leak to Google or prompt-cache-key providers.

## Evidence

### Unit tests (fresh run on PR branch `f48dc42`)

```
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/prompt-cache-retention.test.ts

 RUN  v4.1.8

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  10:29:21
   Duration  483ms
```

All 11 tests pass (9 existing + 2 new negative tests for Google and prompt-cache-key).

### Real behavior proof: built dist verification

Built binary commit: `f48dc42b4c`, Node v24.13.1, Linux 4.19.112.

```
$ node -e "import('./dist/extra-params-BzroSmEY.js').then(m => { const fn = m.s; ... })"

=== cacheRetention: "standard" — Anthropic family ===
Bedrock Claude Sonnet 4.6  -> "short"  (expected: "short")
Bedrock Claude Opus 4.6    -> "short"  (expected: "short")
Direct Anthropic Claude    -> "short"  (expected: "short")
Vertex Anthropic Claude    -> "short"  (expected: "short")

=== Non-Anthropic providers (expect undefined) ===
Google Gemini              -> undefined  (expected: undefined)
prompt-cache-key (omlx)    -> undefined  (expected: undefined)
Bedrock Nova (non-Claude)  -> undefined  (expected: undefined)

=== Regression: existing values ===
Bedrock + short: "short"
Bedrock + long: "long"
Bedrock + none: "none"
```

The `standard` alias correctly maps to `"short"` for all Anthropic-family providers and correctly returns `undefined` for Google, prompt-cache-key, and non-Claude Bedrock models. Existing `short`/`long`/`none` values are unaffected.

## User Impact

Users who set `cacheRetention: "standard"` for Bedrock Claude / Anthropic-family models (following Anthropic API documentation) will now have their cache retention honored instead of silently discarded. Google Gemini and prompt-cache-key providers are unaffected by this change. No impact on existing `"short"`/`"long"`/`"none"` users.

## 变更类型

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Code refactor
- [ ] Test update
- [ ] Dependency update

Closes #94482

🤖 Generated with [Claude Code](https://claude.com/claude-code)
