### PR TITLE
fix(macos): allowlist Homebrew Node + git checkout gateway in PortGuardian

### DIFF
--- a/apps/macos/Sources/OpenClaw/PortGuardian.swift
+++ b/apps/macos/Sources/OpenClaw/PortGuardian.swift
@@ -382,6 +382,15 @@ actor PortGuardian {
             {
                 return true
             }
+            // Homebrew Node + git checkout: /opt/homebrew/... /node /...openclaw/dist/index.js gateway
+            if full.contains("dist/index.js gateway") || full.contains("dist/index.cjs gateway") {
+                return true
+            }
+            // Any process whose full command references both openclaw and gateway
+            // (covers npm global, pnpm dev, and other install paths)
+            if full.contains("openclaw") && full.contains("gateway") {
+                return true
+            }
             // If args are unavailable, treat a CLI listener as expected.
             if cmd.contains("openclaw"), full == cmd { return true }
             return false

--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
@@ -178,6 +178,18 @@ struct LowCoverageHelperTests {
             command: "node",
             fullCommand: "node /path/to/gateway-daemon",
             port: 18789, mode: .local) == true)
+
+        // Homebrew Node + git checkout: dist/index.js gateway
+        #expect(PortGuardian._testIsExpected(
+            command: "node",
+            fullCommand: "/opt/homebrew/opt/node/bin/node /Users/user/openclaw/dist/index.js gateway --port 18789",
+            port: 18789, mode: .local) == true)
+
+        // openclaw + gateway anywhere in full command (covers npm global, pnpm dev)
+        #expect(PortGuardian._testIsExpected(
+            command: "node",
+            fullCommand: "node /usr/local/lib/node_modules/@anthropic/openclaw/dist/index.cjs gateway --port 18789",
+            port: 18789, mode: .local) == true)
     }
 
     @Test func `port guardian remote mode report accepts any listener`() {


### PR DESCRIPTION
## Summary

Fix PortGuardian.isExpected() terminating valid launchd-managed gateways when using Homebrew Node and git checkout install paths.

## Problem

On macOS, PortGuardian.sweep(mode: .local) SIGTERMs valid launchd-managed Gateway processes, interrupting active assistant turns. The process appears as a regular node process under Homebrew paths and is not recognized as an expected gateway listener.

## Root Cause

PortGuardian.isExpected() in local mode only recognizes gateway-daemon (legacy) and openclaw-gateway (service title). When the Gateway runs via Homebrew Node from a git checkout, the full command is:

/opt/homebrew/opt/node/bin/node /Users/<user>/openclaw/dist/index.js gateway --port 18789

This does not match any existing allowlist pattern.

## Changes

- **`apps/macos/Sources/OpenClaw/PortGuardian.swift`** — Add two allowlist patterns to the .local case:
  1. dist/index.js (or .cjs) gateway — explicit match for git checkout dev path
  2. openclaw + gateway anywhere in full command — covers npm global, pnpm dev, and other install paths
- **`apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift`** — Add test cases for Homebrew Node + dist/index.js gateway and npm global install paths

## Testing

Two new test cases verify the new patterns pass isExpected(). Existing port guardian tests continue to pass. CI validation pending.

## Related

Closes #94476