### PR TITLE
fix(cron): default runMode to "due" instead of "force"

### DIFF
--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -1086,7 +1086,7 @@ Use jobId canonical; id accepted compat. contextMessages (0-10) adds previous me
             throw new Error("jobId required (id accepted for backward compatibility)");
           }
           const runMode =
-            params.runMode === "due" || params.runMode === "force" ? params.runMode : "force";
+            params.runMode === "due" || params.runMode === "force" ? params.runMode : "due";
           return jsonResult(await callGateway("cron.run", gatewayOpts, { id, mode: runMode }));
         }
         case "runs": {


### PR DESCRIPTION
## Summary

Fixes #94270: when the `mcp__openclaw__cron` tool `action=run` caller omits `runMode`, the MCP router previously defaulted to `"force"` mode, silently bypassing all schedule guards — `isJobEnabled`, the cron expression day-of-week/time check, and `nextRunAtMs`.

## Changes

One-line change in `src/agents/tools/cron-tool.ts`: the fallback default for `runMode` is changed from `"force"` to `"due"`.

```diff
- params.runMode === "due" || params.runMode === "force" ? params.runMode : "force"
+ params.runMode === "due" || params.runMode === "force" ? params.runMode : "due"
```

Callers who explicitly pass `runMode: "force"` are unaffected. Callers who omit the parameter now get schedule-respecting behavior instead of bypassing all guards by default.

## Real behavior proof

- **Behavior addressed**: Omitted `runMode` parameter in `mcp__openclaw__cron action=run` previously defaulted to `"force"`, causing jobs to fire immediately regardless of cron expression, `isJobEnabled`, or `nextRunAtMs` schedule guards.
- **Real environment tested**: Linux Node 24, full repository checkout
- **Exact steps or command run after this patch**:
  ```shell
  $ node scripts/run-vitest.mjs src/agents/tools/cron-tool.test.ts --run
  ```
- **Evidence after fix**:
  ```
  ✓ src/agents/tools/cron-tool.test.ts (110 tests) 110 passed
  ```
  All 110 cron-tool tests pass. The fallback is now `"due"` — callers who omit `runMode` get schedule-respecting behavior. Explicit `runMode: "force"` still works via the ternary check.
- **Observed result after fix**: Default behavior respects schedule guards. Explicit `runMode: "force"` still works.
- **What was not tested**: Live cron job firing on a production deployment (requires a running Gateway with cron jobs configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)