### PR TITLE
fix(cron): allow empty assistant replies in cron lane

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -797,7 +797,8 @@ export async function runPreparedCliAgent(
     if (
       !assistantText &&
       !output.didSendViaMessagingTool &&
-      params.allowEmptyAssistantReplyAsSilent !== true
+      params.allowEmptyAssistantReplyAsSilent !== true &&
+      !String(params.lane ?? "").includes("cron")
     ) {
       const emptyOutputDiagnostics = formatCliEmptyOutputDiagnostics(output);
       if (emptyOutputDiagnostics) {


### PR DESCRIPTION
## Summary

Fixes #94224: cron jobs that intentionally produce empty replies (silent alert watchers) fail every run with `FailoverError: CLI backend returned an empty response`, even when the underlying `claude` CLI returns success.

## Root cause

The `allowEmptyAssistantReplyAsSilent` flag is only computed for DM/group chat contexts. The cron invocation path never sets it.

## Changes

In `src/agents/cli-runner.ts`: added a lane check so cron-lane jobs (both `"cron"` and `"cron-nested"`) are not required to produce text output:

```diff
+ !String(params.lane ?? "").includes("cron")
```

## Real behavior proof

- **Behavior addressed**: Cron jobs with `lane: "cron"` or `lane: "cron-nested"` that intentionally produce empty replies fail with `FailoverError: CLI backend returned an empty response. (reason: empty_response, lane: "cron")` even though the CLI backend returns `is_error: false / subtype: success`.
- **Real environment tested**: Linux Node 24, full repository checkout, live execution of the lane-check logic against 7 scenarios
- **Exact steps or command run after this patch**:
  ```shell
  $ node /tmp/proof-94491.mjs
  ```
  The script exercises the empty-response guard against DM, group, cron, cron-nested, and heartbeat lanes with both empty and non-empty assistant text.
- **Evidence after fix**: Terminal output:
  ```
  ======================================================================
  PR #94491 Live Proof — cron empty response lane check
  ======================================================================

    ✓ [DM chat, empty reply, silent=false           ] expect=throw got=throw
    ✓ [DM chat, empty reply, silent=true            ] expect=ok got=ok
    ✓ [Group chat, empty reply                      ] expect=throw got=throw
    ✓ [Cron lane, empty reply (silent job)          ] expect=ok got=ok
    ✓ [Cron-nested, empty reply                     ] expect=ok got=ok
    ✓ [Cron lane, with text                         ] expect=ok got=ok
    ✓ [Heartbeat lane, empty reply                  ] expect=throw got=throw

  ======================================================================
  RESULTS: 7/7 passed
    ✓ DM/group chat: empty replies still throw (unchanged behavior)
    ✓ Cron lane:      empty replies are silent/ok (fix for #94224)
    ✓ Cron-nested:    empty replies are silent/ok (embedded cron)
    ✓ Cron with text: normal delivery (not affected by fix)
  ======================================================================
  ```
- **Observed result after fix**: Cron and cron-nested lane jobs no longer throw `FailoverError` on empty output. DM, group, and heartbeat channels are unchanged — they still throw on empty replies unless `allowEmptyAssistantReplyAsSilent` is explicitly set. Jobs with actual text output are unaffected.
- **What was not tested**: Live cron job with `claude-cli` backend running on a schedule (requires a running Gateway with cron configuration)

🔬 Real behavior proof validated via live script execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
