### PR TITLE
fix(anthropic): strip thinking blocks from completed prior assistant turns

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -1712,17 +1712,10 @@ describe("anthropic transport stream", () => {
       latestAnthropicRequest().payload.messages,
       (record) => record.role === "assistant",
     );
+    // Thinking blocks from completed turns (no active tool-use cycle) are
+    // stripped to prevent stale signatures from bricking long threads (#94228).
     expect(assistantMessage.content).toEqual([
-      {
-        type: "thinking",
-        thinking: signedThinking,
-        signature: "sig_1",
-      },
-      {
-        type: "thinking",
-        thinking: "",
-        signature: "sig_omitted",
-      },
+      { type: "text", text: "[assistant reasoning omitted]" },
     ]);
   });
 

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -379,9 +379,8 @@ function convertAnthropicMessages(
   const allowReasoningContentReplay = options?.allowReasoningContentReplay === true;
   const replayThinkingEnabled = options?.replayThinkingEnabled !== false;
   const transformedMessages = transformTransportMessages(messages, model, normalizeToolCallId);
-  const activeToolTurnAssistantIndex = replayThinkingEnabled
-    ? -1
-    : findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
+  const activeToolTurnAssistantIndex =
+    findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
   for (let i = 0; i < transformedMessages.length; i += 1) {
     const msg = transformedMessages[i];
     if (msg.role === "user") {
@@ -447,7 +446,12 @@ function convertAnthropicMessages(
         if (block.type === "thinking") {
           const thinkingSignature = block.thinkingSignature?.trim();
           const isReasoningContent = thinkingSignature === "reasoning_content";
-          if (!replayThinkingEnabled && i !== activeToolTurnAssistantIndex && !isReasoningContent) {
+          // Strip thinking blocks from completed prior assistant turns.
+          // Only the active tool-use cycle needs preserved thinking signatures
+          // for tool-result continuity. Completed turns without pending tool
+          // calls do not need signatures, and re-emitting stale signatures
+          // can cause 400 "Invalid signature in thinking block" (#94228).
+          if (i !== activeToolTurnAssistantIndex && !isReasoningContent) {
             omittedThinking = true;
             continue;
           }

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -235,6 +235,78 @@ describe("Anthropic provider", () => {
     expect(result.responseModel).toBe("claude-fable-5");
   });
 
+  it("strips thinking from completed turns while preserving active tool-turn thinking (#94228)", async () => {
+    // Multi-turn session with tool calls. The active tool turn (assistant
+    // with tool_use + pending tool_result) must keep its thinking signatures
+    // for signature continuity. The earlier completed assistant turn must
+    // have its thinking stripped to prevent stale signature 400 errors.
+    let capturedPayload: unknown;
+    const client = {
+      messages: {
+        create: vi.fn(() => ({
+          asResponse: () =>
+            Promise.resolve(
+              createSseResponse([
+                {
+                  type: "message_start",
+                  message: { id: "msg_1", model: "claude-sonnet-4-6", usage: { input_tokens: 1, output_tokens: 0 } },
+                },
+                { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { input_tokens: 1, output_tokens: 1 } },
+                { type: "message_stop" },
+              ]),
+            ),
+        })),
+      },
+    };
+
+    const stream = streamAnthropic(
+      makeAnthropicModel({ id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" }),
+      {
+        messages: [
+          { role: "user", content: "task 1", timestamp: 0 },
+          {
+            role: "assistant",
+            provider: "anthropic", api: "anthropic-messages", model: "claude-sonnet-4-6",
+            stopReason: "tool_use", timestamp: 0,
+            usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+            content: [
+              { type: "thinking", thinking: "old reasoning", thinkingSignature: "sig_old" },
+              { type: "text", text: "Done." },
+            ],
+          },
+          { role: "user", content: "task 2", timestamp: 0 },
+          {
+            role: "assistant",
+            provider: "anthropic", api: "anthropic-messages", model: "claude-sonnet-4-6",
+            stopReason: "tool_use", timestamp: 0,
+            usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+            content: [
+              { type: "thinking", thinking: "active reasoning", thinkingSignature: "sig_active" },
+              { type: "toolCall", id: "tool_1", name: "bash", arguments: {} },
+            ],
+          },
+          { role: "toolResult", toolCallId: "tool_1", content: "ok", isError: false },
+        ],
+      },
+      { apiKey: "sk-ant-provider", client: client as never, onPayload: (p) => { capturedPayload = p; } },
+    );
+
+    await stream.result();
+    const payload = capturedPayload as { messages: Array<{ role: string; content: unknown[] }> };
+    const assistantMessages = payload.messages.filter((m) => m.role === "assistant");
+    expect(assistantMessages).toHaveLength(2);
+
+    // Completed turn: thinking stripped → [assistant reasoning omitted]
+    const firstBlocks = assistantMessages[0].content as Array<{ type: string }>;
+    expect(firstBlocks.find((b) => b.type === "thinking")).toBeUndefined();
+
+    // Active tool turn: thinking preserved for signature continuity
+    const secondBlocks = assistantMessages[1].content as Array<{ type: string; thinking?: string; signature?: string }>;
+    const activeThinking = secondBlocks.find((b) => b.type === "thinking");
+    expect(activeThinking).toBeDefined();
+    expect(activeThinking?.signature).toBe("sig_active");
+  });
+
   it.each([
     {
       label: "omitted",

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -227,17 +227,10 @@ describe("Anthropic provider", () => {
     const payload = capturedPayload as { messages: Array<{ role: string; content: unknown[] }> };
     const assistantMessage = payload.messages.find((message) => message.role === "assistant");
     expect(JSON.stringify(assistantMessage?.content)).not.toContain("reasoning_content");
+    // Thinking blocks from completed turns (no active tool-use cycle) are
+    // stripped to prevent stale signatures from bricking long threads.
     expect(assistantMessage?.content).toEqual([
-      {
-        type: "thinking",
-        thinking: signedThinking,
-        signature: "sig_1",
-      },
-      {
-        type: "thinking",
-        thinking: "",
-        signature: "sig_omitted",
-      },
+      { type: "text", text: "[assistant reasoning omitted]" },
     ]);
     expect(result.responseModel).toBe("claude-fable-5");
   });

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1247,14 +1247,13 @@ function convertMessages(
             text: sanitizeSurrogates(block.text),
           });
         } else if (block.type === "thinking") {
-          // Strip thinking blocks from completed prior assistant turns.
-          // When replayThinkingEnabled is true, only keep thinking for the
-          // active tool-use cycle (signatures are needed for tool-result
-          // continuity). When false, strip all thinking. Completed turns
-          // without pending tool calls do not need preserved signatures and
-          // re-emitting stale signatures can cause 400 "Invalid signature
-          // in thinking block" on long multi-turn sessions.
-          if (!replayThinkingEnabled || i !== activeToolTurnAssistantIndex) {
+          // Strip thinking blocks from completed prior assistant turns:
+          // only the active tool-use cycle needs preserved signatures for
+          // tool-result continuity. Completed turns without pending tool
+          // calls do not need signatures, and re-emitting stale signatures
+          // can cause 400 "Invalid signature in thinking block" on long
+          // multi-turn sessions (#94228).
+          if (i !== activeToolTurnAssistantIndex) {
             omittedThinking = true;
             continue;
           }

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1188,9 +1188,8 @@ function convertMessages(
 
   // Transform messages for cross-provider compatibility
   const transformedMessages = transformMessages(messages, model, normalizeToolCallId);
-  const activeToolTurnAssistantIndex = replayThinkingEnabled
-    ? -1
-    : findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
+  const activeToolTurnAssistantIndex =
+    findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
 
   for (let i = 0; i < transformedMessages.length; i++) {
     const msg = transformedMessages[i];
@@ -1248,7 +1247,14 @@ function convertMessages(
             text: sanitizeSurrogates(block.text),
           });
         } else if (block.type === "thinking") {
-          if (!replayThinkingEnabled && i !== activeToolTurnAssistantIndex) {
+          // Strip thinking blocks from completed prior assistant turns.
+          // When replayThinkingEnabled is true, only keep thinking for the
+          // active tool-use cycle (signatures are needed for tool-result
+          // continuity). When false, strip all thinking. Completed turns
+          // without pending tool calls do not need preserved signatures and
+          // re-emitting stale signatures can cause 400 "Invalid signature
+          // in thinking block" on long multi-turn sessions.
+          if (!replayThinkingEnabled || i !== activeToolTurnAssistantIndex) {
             omittedThinking = true;
             continue;
           }


### PR DESCRIPTION
## Summary

Fixes #94228: on the native Anthropic provider path, long-lived multi-turn tool-use sessions eventually brick permanently with HTTP 400 `"Invalid signature in thinking block"`. The same stored history is replayed on every retry, so the thread can never recover.

## Root cause

The Anthropic request-builder re-emits **every** stored thinking block from **all** prior assistant turns on every request, with its persisted signature. On long threads, the replayed multi-turn structure no longer matches the per-turn context each signature was minted against. Anthropic guidance states thinking blocks from already-closed turns may be omitted on replay.

## Changes

**SDK provider path** (`src/llm/providers/anthropic.ts`):
1. Always compute the active tool-turn assistant index
2. Strip thinking blocks from non-active turns only

**Managed transport path** (`src/agents/anthropic-transport-stream.ts`):
3. Mirrored the same fix — both replay surfaces now consistent

```diff
- const activeToolTurnAssistantIndex = replayThinkingEnabled
-     ? -1
-     : findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
+ const activeToolTurnAssistantIndex =
+     findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
```

```diff
- if (!replayThinkingEnabled && i !== activeToolTurnAssistantIndex) {
+ if (i !== activeToolTurnAssistantIndex) {
```

### v3: Sibling path coverage (ClawSweeper rank-up)

Per ClawSweeper review: the managed Anthropic transport (`anthropic-transport-stream.ts`) had the same stale-signature replay behavior. Both paths now use identical stripping logic — only the active tool-use cycle preserves thinking signatures.

## Real behavior proof

- **Behavior addressed**: Long multi-turn Anthropic tool-use sessions brick with HTTP 400 `"Invalid signature in thinking block"` because all historical thinking blocks with stale signatures are replayed on every request.
- **Real environment tested**: Linux Node 24, full repository checkout, both SDK and managed transport test suites
- **Exact steps or command run after this patch**:
  ```shell
  $ node scripts/run-vitest.mjs src/llm/providers/anthropic.test.ts --run
  $ node scripts/run-vitest.mjs src/agents/anthropic-transport-stream.test.ts --run
  ```
- **Evidence after fix**: Terminal output:
  ```
  ✓ src/llm/providers/anthropic.test.ts (35 tests) 35 passed
  ✓ src/agents/anthropic-transport-stream.test.ts (74 tests) 74 passed
  ```
  Total: 109/109 tests pass across both replay surfaces. Key invariants:
  - Active tool-use cycle: thinking blocks with signatures preserved
  - Completed prior turns: thinking stripped, replaced with `[assistant reasoning omitted]`
  - `replayThinkingEnabled: false`: active tool-turn thinking preserved (no regression)
  - **Both SDK and managed transport paths are now consistent**
- **Observed result after fix**: Both replay surfaces strip completed-turn thinking. Sibling-path poison loop eliminated — managed transport users are no longer left on the original 400 behavior while SDK users get the fix.
- **What was not tested**: Live Anthropic API multi-turn session (requires API access)

## Related

- #84002: same failure pattern on OpenAI-responses path
- #92373: merged PR that established the active-tool-turn preservation helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)