### PR TITLE
fix: Tailscale serve creates redundant entries on gateway startup

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,5 +1,0 @@
-# CodeGraph data files — local to each machine, not for committing.
-# Ignore everything in .codegraph/ except this file itself, so transient
-# files (the database, daemon.pid, sockets, logs) never show up in git.
-*
-!.gitignore

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -218,17 +218,22 @@ describe("tailscale helpers", () => {
   it("enableTailscaleServe attempts normal first, then sudo", async () => {
     const exec = vi
       .fn()
-      .mockRejectedValueOnce(new Error("permission denied"))
-      .mockResolvedValueOnce({ stdout: "" });
+      .mockResolvedValueOnce({ stdout: "" }) // reset succeeds
+      .mockRejectedValueOnce(new Error("permission denied")) // serve fails
+      .mockResolvedValueOnce({ stdout: "" }); // sudo serve succeeds
 
     await enableTailscaleServe(3000, exec as never);
 
-    expect(exec).toHaveBeenCalledTimes(2);
-    expectExecCall(exec, 1, tailscaleBin, ["serve", "--bg", "--yes", "3000"], {
+    expect(exec).toHaveBeenCalledTimes(3);
+    expectExecCall(exec, 1, tailscaleBin, ["serve", "reset"], {
       maxBuffer: 200_000,
       timeoutMs: 15_000,
     });
-    expectExecCall(exec, 2, "sudo", ["-n", tailscaleBin, "serve", "--bg", "--yes", "3000"], {
+    expectExecCall(exec, 2, tailscaleBin, ["serve", "--bg", "--yes", "3000"], {
+      maxBuffer: 200_000,
+      timeoutMs: 15_000,
+    });
+    expectExecCall(exec, 3, "sudo", ["-n", tailscaleBin, "serve", "--bg", "--yes", "3000"], {
       maxBuffer: 200_000,
       timeoutMs: 15_000,
     });
@@ -239,8 +244,12 @@ describe("tailscale helpers", () => {
 
     await enableTailscaleServe(3000, exec as never);
 
-    expect(exec).toHaveBeenCalledTimes(1);
-    expectExecCall(exec, 1, tailscaleBin, ["serve", "--bg", "--yes", "3000"], {
+    expect(exec).toHaveBeenCalledTimes(2);
+    expectExecCall(exec, 1, tailscaleBin, ["serve", "reset"], {
+      maxBuffer: 200_000,
+      timeoutMs: 15_000,
+    });
+    expectExecCall(exec, 2, tailscaleBin, ["serve", "--bg", "--yes", "3000"], {
       maxBuffer: 200_000,
       timeoutMs: 15_000,
     });
@@ -251,10 +260,14 @@ describe("tailscale helpers", () => {
 
     await enableTailscaleServe(3000, exec as never, "svc:openclaw");
 
-    expect(exec).toHaveBeenCalledTimes(1);
+    expect(exec).toHaveBeenCalledTimes(2);
+    expectExecCall(exec, 1, tailscaleBin, ["serve", "clear", "svc:openclaw"], {
+      maxBuffer: 200_000,
+      timeoutMs: 15_000,
+    });
     expectExecCall(
       exec,
-      1,
+      2,
       tailscaleBin,
       ["serve", "--service=svc:openclaw", "--bg", "--yes", "3000"],
       {

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -218,14 +218,14 @@ describe("tailscale helpers", () => {
   it("enableTailscaleServe attempts normal first, then sudo", async () => {
     const exec = vi
       .fn()
-      .mockResolvedValueOnce({ stdout: "" }) // reset succeeds
+      .mockResolvedValueOnce({ stdout: "" }) // previous route cleanup succeeds
       .mockRejectedValueOnce(new Error("permission denied")) // serve fails
       .mockResolvedValueOnce({ stdout: "" }); // sudo serve succeeds
 
     await enableTailscaleServe(3000, exec as never);
 
     expect(exec).toHaveBeenCalledTimes(3);
-    expectExecCall(exec, 1, tailscaleBin, ["serve", "reset"], {
+    expectExecCall(exec, 1, tailscaleBin, ["serve", "--https=443", "off"], {
       maxBuffer: 200_000,
       timeoutMs: 15_000,
     });
@@ -245,7 +245,7 @@ describe("tailscale helpers", () => {
     await enableTailscaleServe(3000, exec as never);
 
     expect(exec).toHaveBeenCalledTimes(2);
-    expectExecCall(exec, 1, tailscaleBin, ["serve", "reset"], {
+    expectExecCall(exec, 1, tailscaleBin, ["serve", "--https=443", "off"], {
       maxBuffer: 200_000,
       timeoutMs: 15_000,
     });

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -411,6 +411,18 @@ export async function enableTailscaleServe(
   serviceName?: string,
 ) {
   const tailscaleBin = await getTailscaleBinary();
+  // tailscale serve is append-only — stale entries accumulated across gateway
+  // restarts cause duplicate proxies and eventually ERR_SSL_PROTOCOL_ERROR /
+  // ERR_CONNECTION_REFUSED. Reset before configuring so each start is clean.
+  await execWithSudoFallback(
+    exec,
+    tailscaleBin,
+    serviceName ? ["serve", "clear", serviceName] : ["serve", "reset"],
+    {
+      maxBuffer: 200_000,
+      timeoutMs: 15_000,
+    },
+  );
   await execWithSudoFallback(
     exec,
     tailscaleBin,

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -413,11 +413,12 @@ export async function enableTailscaleServe(
   const tailscaleBin = await getTailscaleBinary();
   // tailscale serve is append-only — stale entries accumulated across gateway
   // restarts cause duplicate proxies and eventually ERR_SSL_PROTOCOL_ERROR /
-  // ERR_CONNECTION_REFUSED. Reset before configuring so each start is clean.
+  // ERR_CONNECTION_REFUSED. Clear only OpenClaw's route before configuring so
+  // operator-managed Serve entries survive gateway restarts.
   await execWithSudoFallback(
     exec,
     tailscaleBin,
-    serviceName ? ["serve", "clear", serviceName] : ["serve", "reset"],
+    serviceName ? ["serve", "clear", serviceName] : ["serve", "--https=443", "off"],
     {
       maxBuffer: 200_000,
       timeoutMs: 15_000,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `gateway.tailscale.mode: "serve"` could accumulate duplicate Tailscale Serve handlers across gateway restarts because `tailscale serve --bg --yes <port>` re-applies Serve state instead of cleaning stale entries first.

Fixes #93936

## Why This Change Was Made

Startup cleanup now removes only the OpenClaw-owned Serve route before re-enabling it. The default node route uses `tailscale serve --https=443 off`, while configured service routes use `tailscale serve clear <serviceName>`, avoiding the previous broad `tailscale serve reset` behavior that could delete unrelated operator-managed Serve routes.

The unrelated `.codegraph/.gitignore` file was removed from this branch.

## User Impact

Gateway restarts can refresh OpenClaw's Tailscale Serve route without wiping other Serve configuration on the same node.

## Real behavior proof

**Behavior addressed**: Tailscale Serve startup cleanup is scoped to OpenClaw's route instead of resetting all Serve config.

**Real environment tested**: macOS local checkout, Node 24.13.1.

**Exact steps or command run after this patch**:

```bash
node scripts/run-vitest.mjs src/infra/tailscale.test.ts src/gateway/server-tailscale.test.ts
node --import tsx /Users/yangjiajun/projects/auto-pr/workspace/openclaw/outputs/issue-93936-pr-94496/verify-scoped-serve-cleanup.mjs
```

**Evidence after fix**:

```text
[test] passed 2 Vitest shards in 9.43s

Tests       55 passed (55)
```

The scoped-cleanup proof runs the real `enableTailscaleServe()` helper against a local fake Tailscale CLI and records the exact CLI arguments:

```json
{
  "commands": [
    "serve --https=443 off",
    "serve --bg --yes 3000",
    "serve clear svc:openclaw",
    "serve --service=svc:openclaw --bg --yes 3000"
  ],
  "globalResetUsed": false
}
```

**Observed result after fix**: The default no-service path no longer calls `tailscale serve reset`; it clears only the default HTTPS Serve route before re-adding OpenClaw's route. The service-name path remains scoped to the configured service.

**What was not tested**: A live Tailscale tailnet restart loop with `tailscale serve status --json`. The command contract was checked against Tailscale upstream source: `serve reset` clears the full Serve config, `serve clear <service>` clears one service, and `serve --https=443 off` unsets the default node HTTPS route.

AI-assisted: built with Codex
