### PR TITLE
fix(control-ui): render user message immediately on send (#94479)

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -2332,7 +2332,12 @@ describe("handleSendChat", () => {
     expect(host.chatQueue).toHaveLength(1);
     expect(host.chatQueue[0]?.text).toBe("same prompt");
     expect(host.chatQueue[0]?.sendState).toBe("sending");
-    expect(host.chatMessages).toStrictEqual([]);
+    // FIX #94479: User message is now appended before the network request.
+    expect(host.chatMessages).toHaveLength(1);
+    expect(host.chatMessages[0]).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "same prompt" }],
+    });
 
     const queuedRunId = host.chatQueue[0]?.sendRunId;
     sent.resolve({ runId: queuedRunId, status: "started" });
@@ -2360,7 +2365,8 @@ describe("handleSendChat", () => {
     await Promise.resolve();
 
     expect(host.chatMessage).toBe("");
-    expect(host.chatMessages).toStrictEqual([]);
+    // FIX #94479: User message is now appended before the network request.
+    expect(host.chatMessages).toHaveLength(1);
     expect(host.chatQueue).toHaveLength(1);
     expect(host.chatQueue[0]).toMatchObject({
       text: "do not lose this",
@@ -2375,6 +2381,7 @@ describe("handleSendChat", () => {
 
     expect(host.chatQueue).toStrictEqual([]);
     expect(host.chatRunId).toBe(runId);
+    // User message should still be present (no rollback since send succeeded).
     expect(host.chatMessages).toHaveLength(1);
     const userMessage = requireRecord(host.chatMessages[0], "user message");
     expect(userMessage.role).toBe("user");
@@ -2648,6 +2655,9 @@ describe("handleSendChat", () => {
     );
     expect(payload.sessionKey).toBe("global");
     expect(payload.agentId).toBe("work");
+    // FIX #94479: User message is NOT appended here because the session is
+    // no longer visible (agent switched from "work" to "main"). The message
+    // will appear when the user switches back to the "work" global session.
     expect(host.chatMessages).toStrictEqual([]);
     expect(host.chatRunId).toBeNull();
     expect(host.chatStream).toBeNull();

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1052,6 +1052,21 @@ async function sendQueuedChatMessage(
     });
   }
 
+  // FIX #94479: Append user message before the network request so it appears
+  // immediately in the chat, without waiting for the ACK or streaming response.
+  let userMessageAppended = false;
+  let previousChatMessages: unknown[] | null = null;
+  if (isVisibleSession()) {
+    previousChatMessages = host.chatMessages;
+    appendUserChatMessage(
+      host as unknown as ChatState,
+      message,
+      hasAttachments ? attachments : undefined,
+      startedAt,
+    );
+    userMessageAppended = true;
+  }
+
   try {
     const ack = prepared.skillWorkshopRevision
       ? await requestSkillWorkshopRevisionChatSend(host as unknown as ChatState, {
@@ -1078,13 +1093,11 @@ async function sendQueuedChatMessage(
       ...chatSendAckServerTimingEventFields(ack),
     });
     removeQueuedMessageWithoutReleasing(host, id, sessionKey);
+    // FIX #94479: Only process ACK effects if the session is still visible.
+    // The user message was already appended before the network request above,
+    // so this guard only prevents stale ACK state (e.g. chatRunId) from
+    // leaking into a different session the user has since switched to.
     if (isVisibleSession()) {
-      appendUserChatMessage(
-        host as unknown as ChatState,
-        message,
-        hasAttachments ? attachments : undefined,
-        startedAt,
-      );
       if (ack.status === "ok") {
         reconcileChatRunLifecycle(
           host as unknown as Parameters<typeof reconcileChatRunLifecycle>[0],
@@ -1115,7 +1128,7 @@ async function sendQueuedChatMessage(
             startedAt;
         }
       }
-    }
+    } // end if (isVisibleSession()) — guard ACK effects to current session
     if (prepared.refreshSessions) {
       const refreshTarget = {
         sessionKey,
@@ -1133,6 +1146,12 @@ async function sendQueuedChatMessage(
     discardChatAttachmentDataUrls(excludeComposerAttachments(host, attachments));
     return "sent";
   } catch (err) {
+    // FIX #94479: Rollback the user message if the send failed, so the queue
+    // item (pending-send) continues to represent the pending message without
+    // a duplicate in chatMessages.
+    if (userMessageAppended && previousChatMessages !== null) {
+      host.chatMessages = previousChatMessages;
+    }
     const error = formatConnectError(err);
     if (isRecoverableChatSendError(err, error)) {
       updateQueuedMessageForSession(host, sessionKey, id, (item) => ({


### PR DESCRIPTION
## Summary

Moves `appendUserChatMessage()` before the network request in `sendQueuedChatMessage()` so the user message appears immediately in the chat view, without waiting for the ACK or streaming response. Includes rollback on failure.

Fixes #94479

## Real behavior proof (required for external PRs)

**Behavior addressed**: User message not rendered until assistant response starts streaming.

**Real setup tested**:
- **Runtime**: Node.js v24.13.1, Linux 4.19.112

**Exact steps or command run after fix**:

```bash
npx vitest run --config test/vitest/vitest.unit-ui.config.ts
```

**After-fix evidence**:

```
 ✓ |unit-ui| ui/src/ui/app-chat.test.ts (94 tests) 1256ms
 Test Files  1 failed | 32 passed (33)
      Tests  1 failed | 739 passed (740)
```

The 1 failure is a pre-existing locale-dependent AM/PM format test in `grouped-render.test.ts`, unrelated to this change.

**Observed result after the fix**: All 94 app-chat tests pass. Key behavioral changes verified:
- User message appears in `chatMessages` immediately (before network request)
- On send failure, user message is rolled back via `previousChatMessages` restore
- Session-scoped ACK isolation preserved: ACKs from non-visible sessions do not leak state

**What was not tested**: Manual E2E in the browser (requires running the full Control UI).

## Tests and validation

- 94 app-chat tests pass
- Pre-existing unrelated failure: grouped-render locale test (AM/PM format)
- Test coverage includes: normal send, dedup, session switch, recoverable error, reconnect retry

## Risk checklist

Did user-visible behavior change? (`Yes`)
- **Positive**: user message now appears immediately on send

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?
- Error recovery: ensuring rollback works correctly when network fails mid-send

How is that risk mitigated?
- `previousChatMessages` reference-based rollback in the catch block
- Existing test coverage for recoverable and non-recoverable send errors

## Current review state

What is the next action?
- Maintainer review
