### PR TITLE
fix(secrets): commit auth-stores before config to prevent half-migrated credentials

### DIFF
--- a/src/secrets/apply.test.ts
+++ b/src/secrets/apply.test.ts
@@ -1085,4 +1085,270 @@ describe("secrets apply", () => {
       mode: "json",
     });
   });
+
+  it("leaves config un-migrated when a per-agent auth-store commit fails (issue #88012)", async () => {
+    // One `secrets apply` migrates both an inline config provider key and an agent auth-store to
+    // SecretRefs. openclaw.json is the manifest that declares the migration, so it is committed
+    // last: a fault while committing the auth-store must abort before config is touched, and even
+    // if the best-effort rollback also fails, config must never be left claiming SecretRefs while a
+    // plaintext credential survives on disk (the cross-store divergence in issue #88012).
+    await writeJsonFile(fixture.configPath, {
+      models: { providers: { openai: createOpenAiProviderConfig("sk-openai-plaintext") } }, // pragma: allowlist secret
+    });
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {
+        "openai:default": { type: "api_key", provider: "openai", key: "sk-ope...text" }, // pragma: allowlist secret
+      },
+    });
+    const plan = createPlan({
+      targets: [
+        createOpenAiProviderTarget(),
+        {
+          type: "auth-profiles.api_key.key",
+          path: "profiles.openai:default.key",
+          pathSegments: ["profiles", "openai:default", "key"],
+          agentId: "main",
+          ref: OPENAI_API_KEY_ENV_REF,
+        },
+      ],
+      options: {
+        scrubEnv: false,
+        scrubAuthProfilesForProviderTargets: false,
+        scrubLegacyAuthJson: false,
+      },
+    });
+
+    // Model a mid-commit IO fault: the per-agent SQLite auth-store commit throws, and the
+    // best-effort config rollback restore throws too (same sticky disk fault). This is the
+    // persistence condition from issue #88012 / PROOF-CAND-057.
+    const storeModule = await import("../agents/auth-profiles/store.js");
+    const sharedModule = await import("./shared.js");
+    const actualWriteTextFileAtomic = sharedModule.writeTextFileAtomic;
+    const saveSpy = vi.spyOn(storeModule, "saveAuthProfileStore").mockImplementationOnce(() => {
+      throw new Error("simulated auth-store commit fault");
+    });
+    const rollbackSpy = vi
+      .spyOn(sharedModule, "writeTextFileAtomic")
+      .mockImplementation((targetPath, content, mode) => {
+        if (path.basename(targetPath) === "openclaw.json") {
+          throw new Error("simulated config rollback restore fault");
+        }
+        return actualWriteTextFileAtomic(targetPath, content, mode);
+      });
+
+    try {
+      await expect(runSecretsApply({ plan, env: fixture.env, write: true })).rejects.toThrow(
+        /Secrets apply failed/,
+      );
+
+      // config must still hold the plaintext key, never a SecretRef object: committing config last
+      // means a failed auth-store commit never publishes a config that falsely claims migration.
+      const config = JSON.parse(await fs.readFile(fixture.configPath, "utf8")) as {
+        models: { providers: { openai: { apiKey: unknown } } };
+      };
+      expect(config.models.providers.openai.apiKey).toBe("sk-openai-plaintext");
+    } finally {
+      rollbackSpy.mockRestore();
+      saveSpy.mockRestore();
+    }
+  });
+
+  it("commits a new provider definition before the auth-store ref that uses it (issue #88012, no orphaned provider ref)", async () => {
+    // A single apply defines a new secrets provider (providerUpserts), points an auth-store profile's
+    // ref at that new alias, and migrates an inline config key. The provider definition must commit
+    // before the auth-store, so that even if the final config write and its rollback both fail, a
+    // persisted store ref to the new alias still resolves against committed config (no dangling ref).
+    await writeJsonFile(fixture.configPath, {
+      models: { providers: { openai: createOpenAiProviderConfig("sk-openai-plaintext") } }, // pragma: allowlist secret
+    });
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {
+        "openai:default": { type: "api_key", provider: "openai", key: "sk-ope...text" }, // pragma: allowlist secret
+      },
+    });
+    const plan = createPlan({
+      providerUpserts: { newprov: { source: "env" } },
+      targets: [
+        createOpenAiProviderTarget(),
+        {
+          type: "auth-profiles.api_key.key",
+          path: "profiles.openai:default.key",
+          pathSegments: ["profiles", "openai:default", "key"],
+          agentId: "main",
+          ref: { source: "env", provider: "newprov", id: "OPENAI_API_KEY" },
+        },
+      ],
+      options: {
+        scrubEnv: false,
+        scrubAuthProfilesForProviderTargets: false,
+        scrubLegacyAuthJson: false,
+      },
+    });
+
+    const mutateModule = await import("../config/mutate.js");
+    const storeModule = await import("../agents/auth-profiles/store.js");
+    const actualReplaceConfigFile = mutateModule.replaceConfigFile;
+    const actualSaveAuthProfileStore = storeModule.saveAuthProfileStore;
+    // Fail the FULL config write (the openai key is migrated to a SecretRef) but let the
+    // provider-definitions write (key still plaintext) succeed - i.e. fail config-last, keep Phase 0.
+    const replaceSpy = vi
+      .spyOn(mutateModule, "replaceConfigFile")
+      .mockImplementation(async (args) => {
+        const next = args.nextConfig as {
+          models?: { providers?: { openai?: { apiKey?: unknown } } };
+        };
+        const apiKey = next.models?.providers?.openai?.apiKey;
+        if (apiKey && typeof apiKey === "object") {
+          throw new Error("simulated config write fault");
+        }
+        return actualReplaceConfigFile(args);
+      });
+    // Let the store commit succeed but fail its best-effort rollback, so the store keeps the ref.
+    let saveCalls = 0;
+    const saveSpy = vi
+      .spyOn(storeModule, "saveAuthProfileStore")
+      .mockImplementation((store, agentDir, opts) => {
+        saveCalls += 1;
+        if (saveCalls === 1) {
+          return actualSaveAuthProfileStore(store, agentDir, opts);
+        }
+        throw new Error("simulated auth-store rollback fault");
+      });
+
+    try {
+      await expect(runSecretsApply({ plan, env: fixture.env, write: true })).rejects.toThrow(
+        /Secrets apply failed/,
+      );
+
+      // The auth-store kept its ref to the new provider alias...
+      const store = (await readAuthStore(fixture)) as unknown as {
+        profiles: { "openai:default": { keyRef?: { provider?: string } } };
+      };
+      expect(store.profiles["openai:default"].keyRef?.provider).toBe("newprov");
+      // ...and committed config defines that provider, so the ref resolves (no orphaned reference).
+      const config = JSON.parse(await fs.readFile(fixture.configPath, "utf8")) as {
+        secrets?: { providers?: Record<string, unknown> };
+      };
+      expect(config.secrets?.providers?.newprov).toBeDefined();
+    } finally {
+      saveSpy.mockRestore();
+      replaceSpy.mockRestore();
+    }
+  });
+
+  it("does not delete a provider before the final config write that moves refs off it", async () => {
+    // config defines provider "oldprov" and an auth-store profile still references it. A plan deletes
+    // oldprov while migrating an inline config key. The delete must ride the final config write (not a
+    // Phase 0 pre-commit), so a fault on that write leaves oldprov defined and the existing store ref
+    // resolvable - the alias is never removed before the store moves off it.
+    await writeJsonFile(fixture.configPath, {
+      secrets: { providers: { oldprov: { source: "env" } } },
+      models: { providers: { openai: createOpenAiProviderConfig("sk-openai-plaintext") } }, // pragma: allowlist secret
+    });
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          keyRef: { source: "env", provider: "oldprov", id: "OPENAI_API_KEY" },
+        },
+      },
+    });
+    const plan = createPlan({
+      providerDeletes: ["oldprov"],
+      targets: [createOpenAiProviderTarget()],
+      options: {
+        scrubEnv: false,
+        scrubAuthProfilesForProviderTargets: false,
+        scrubLegacyAuthJson: false,
+      },
+    });
+
+    const mutateModule = await import("../config/mutate.js");
+    const actualReplaceConfigFile = mutateModule.replaceConfigFile;
+    // Fail the config write that carries the migration (openai key migrated to a ref); a pure
+    // additions pre-commit (key still plaintext) is allowed through.
+    const replaceSpy = vi
+      .spyOn(mutateModule, "replaceConfigFile")
+      .mockImplementation(async (args) => {
+        const next = args.nextConfig as {
+          models?: { providers?: { openai?: { apiKey?: unknown } } };
+        };
+        const apiKey = next.models?.providers?.openai?.apiKey;
+        if (apiKey && typeof apiKey === "object") {
+          throw new Error("simulated config write fault");
+        }
+        return actualReplaceConfigFile(args);
+      });
+
+    try {
+      await expect(runSecretsApply({ plan, env: fixture.env, write: true })).rejects.toThrow(
+        /Secrets apply failed/,
+      );
+      // oldprov must still be defined: the delete rode the failed final write and never landed early.
+      const config = JSON.parse(await fs.readFile(fixture.configPath, "utf8")) as {
+        secrets?: { providers?: Record<string, unknown> };
+      };
+      expect(config.secrets?.providers?.oldprov).toBeDefined();
+    } finally {
+      replaceSpy.mockRestore();
+    }
+  });
+
+  it("rejects a concurrent openclaw.json edit made between the provider pre-commit and the final write", async () => {
+    // A providerUpserts plan triggers the Phase 0 pre-commit. If another writer edits openclaw.json
+    // between Phase 0 and the final config write, the final write must compare-and-set against Phase 0's
+    // hash and reject the stale write rather than silently overwrite the concurrent edit.
+    await writeJsonFile(fixture.configPath, {
+      models: { providers: { openai: createOpenAiProviderConfig("sk-openai-plaintext") } }, // pragma: allowlist secret
+    });
+    const plan = createPlan({
+      providerUpserts: { addedprov: { source: "env" } },
+      targets: [createOpenAiProviderTarget()],
+      options: {
+        scrubEnv: false,
+        scrubAuthProfilesForProviderTargets: false,
+        scrubLegacyAuthJson: false,
+      },
+    });
+
+    const mutateModule = await import("../config/mutate.js");
+    const actualReplaceConfigFile = mutateModule.replaceConfigFile;
+    const replaceSpy = vi
+      .spyOn(mutateModule, "replaceConfigFile")
+      .mockImplementation(async (args) => {
+        const next = args.nextConfig as {
+          models?: { providers?: { openai?: { apiKey?: unknown } } };
+        };
+        const apiKey = next.models?.providers?.openai?.apiKey;
+        const isFinalWrite = apiKey && typeof apiKey === "object";
+        if (!isFinalWrite) {
+          // Phase 0 pre-commit (additions, key still plaintext): let it land, then simulate a
+          // concurrent writer changing openclaw.json before the final write re-reads it.
+          const result = await actualReplaceConfigFile(args);
+          const cfg = JSON.parse(await fs.readFile(fixture.configPath, "utf8")) as {
+            models: { providers: { openai: { baseUrl?: string } } };
+          };
+          cfg.models.providers.openai.baseUrl = "https://concurrent-edit.example/v1";
+          await fs.writeFile(fixture.configPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf8");
+          return result;
+        }
+        return actualReplaceConfigFile(args);
+      });
+
+    try {
+      // The final write's compare-and-set must reject the stale projected config.
+      await expect(runSecretsApply({ plan, env: fixture.env, write: true })).rejects.toThrow();
+      // The concurrent edit survives - it was not silently overwritten by the stale final write.
+      const config = JSON.parse(await fs.readFile(fixture.configPath, "utf8")) as {
+        models: { providers: { openai: { baseUrl?: string } } };
+      };
+      expect(config.models.providers.openai.baseUrl).toBe("https://concurrent-edit.example/v1");
+    } finally {
+      replaceSpy.mockRestore();
+    }
+  });
 });

--- a/src/secrets/apply.ts
+++ b/src/secrets/apply.ts
@@ -68,6 +68,12 @@ type AuthStoreSnapshot = {
 
 type ProjectedState = {
   nextConfig: OpenClawConfig;
+  // Config with only the provider *additions* (providerUpserts) applied, before any provider delete
+  // or target migration. Non-null only when there are upserts; committed first (Phase 0) so that
+  // auth-store SecretRefs pointing at a newly-defined provider alias always resolve. Provider deletes
+  // are deliberately excluded here - they ride the final config write so a store ref is never left
+  // pointing at an alias removed before the store moved off it.
+  providerMutationConfig: OpenClawConfig | null;
   configSnapshot: ConfigFileSnapshot;
   configPath: string;
   configWriteOptions: ConfigWriteOptions;
@@ -236,12 +242,22 @@ async function projectPlanState(params: {
   const warnings: string[] = [];
   const configPath = resolveUserPath(snapshot.path);
 
-  const providerConfigChanged = applyProviderPlanMutations({
+  // Provider additions (upserts) may be referenced by new auth-store refs, so they commit first
+  // (Phase 0). Provider deletes must NOT precede the stores - an alias a store still references must
+  // outlive the store rewrite - so they are applied after the snapshot below and ride the final
+  // config write (Phase B). Apply upserts, snapshot the additions-only config, then apply deletes.
+  const providerUpsertsChanged = applyProviderPlanMutations({
     config: nextConfig,
     upserts: params.plan.providerUpserts,
+    deletes: undefined,
+  });
+  const providerMutationConfig = providerUpsertsChanged ? structuredClone(nextConfig) : null;
+  const providerDeletesChanged = applyProviderPlanMutations({
+    config: nextConfig,
+    upserts: undefined,
     deletes: params.plan.providerDeletes,
   });
-  if (providerConfigChanged) {
+  if (providerUpsertsChanged || providerDeletesChanged) {
     changedFiles.add(configPath);
   }
 
@@ -295,6 +311,7 @@ async function projectPlanState(params: {
 
   return {
     nextConfig,
+    providerMutationConfig,
     configSnapshot: snapshot,
     configPath,
     configWriteOptions: writeOptions,
@@ -890,13 +907,32 @@ export async function runSecretsApply(params: {
   }
 
   try {
-    await replaceConfigFile({
-      nextConfig: projected.nextConfig,
-      snapshot: projected.configSnapshot,
-      writeOptions: projected.configWriteOptions,
-      io,
-      afterWrite: { mode: "auto" },
-    });
+    // There is no cross-store transaction across the config file and the N per-agent SQLite
+    // databases, so the commit is ordered by dependency to keep every persisted SecretRef resolvable
+    // and to never publish a config that falsely claims migration:
+    //
+    //   Phase 0  provider *additions* (providerUpserts) into openclaw.json, if any. Committed first
+    //            so an auth-store SecretRef pointing at a newly-defined provider alias can always
+    //            resolve, even if a later write fails - the ref never outruns its definition.
+    //   Phase A  satellite files + per-agent SQLite auth-stores.
+    //   Phase B  the full config (additions + deletes + target migrations), committed last so the
+    //            manifest only flips a credential to a SecretRef once every store it points at has
+    //            committed (prevents config=ref while an auth-store stays plaintext, issue #88012),
+    //            and a provider delete never lands before the store that still references it.
+    let configBaseHashAfterPhase0: string | undefined;
+    if (projected.providerMutationConfig) {
+      const phase0 = await replaceConfigFile({
+        nextConfig: projected.providerMutationConfig,
+        snapshot: projected.configSnapshot,
+        writeOptions: projected.configWriteOptions,
+        io,
+        afterWrite: { mode: "auto" },
+      });
+      configBaseHashAfterPhase0 = phase0.persistedHash ?? undefined;
+      // Re-snapshot config at the additions state so a later rollback restores to here (keeping the
+      // additions) instead of to the original, which would orphan committed store refs.
+      snapshots.set(projected.configPath, captureFileSnapshot(projected.configPath));
+    }
     for (const writeLocal of writes) {
       writeTextFileAtomic(writeLocal.path, writeLocal.content, writeLocal.mode);
     }
@@ -906,6 +942,25 @@ export async function runSecretsApply(params: {
       if (agentDir && store) {
         saveAuthProfileStore(store, agentDir);
       }
+    }
+    if (projected.providerMutationConfig) {
+      // Phase 0 advanced config past configSnapshot. Re-read for this write but assert against
+      // Phase 0's persisted hash, so a concurrent edit to openclaw.json between Phase 0 and Phase B
+      // is rejected (compare-and-set) instead of being silently overwritten.
+      await replaceConfigFile({
+        nextConfig: projected.nextConfig,
+        io,
+        baseHash: configBaseHashAfterPhase0,
+        afterWrite: { mode: "auto" },
+      });
+    } else {
+      await replaceConfigFile({
+        nextConfig: projected.nextConfig,
+        snapshot: projected.configSnapshot,
+        writeOptions: projected.configWriteOptions,
+        io,
+        afterWrite: { mode: "auto" },
+      });
     }
   } catch (err) {
     // Apply can touch multiple files; restore captured snapshots so partial writes do not leave


### PR DESCRIPTION
## Summary

- `secrets apply` (write mode) migrates plaintext credentials to `SecretRef`s across `openclaw.json` and the per-agent SQLite auth-stores in one commit block with no cross-store transaction, committing config first. If a per-agent auth-store commit threw after config (a real IO fault: EPERM / ENOSPC / EIO / read-only db), config was left declaring the credentials migrated to refs while the auth-store still held plaintext, and the best-effort rollback could not recover under a sticky fault: a credential source-of-truth divergence (issue #88012).
- Why now: upstream #89102 (`e16ac04330`) moved auth profiles from `auth-profiles.json` to per-agent SQLite (`openclaw-agent.sqlite`); the divergence survives the move (config + N agent databases, still no cross-database transaction).
- Fix: order the commit by dependency. **Phase 0** commits provider *additions* (`providerUpserts`) into config first, so an auth-store ref to a newly-defined provider alias always resolves even if a later write fails. **Phase A** commits satellite files and per-agent SQLite auth-stores. **Phase B** commits the full config (additions + deletes + target migrations) last, so config only claims a credential migrated once its store has committed, and a provider *delete* never lands before the store that still references the alias. The projected next-state is computed in memory before the commit block, so this only reorders writes; stores never read config at write time. When Phase 0 runs, the rollback snapshot is re-captured at the additions state (so a rollback keeps the additions and never orphans a committed store ref), and Phase B's compare-and-set asserts against Phase 0's persisted hash, so a concurrent `openclaw.json` edit between Phase 0 and Phase B is rejected instead of overwritten.
- Out of scope: full cross-store atomicity (store-to-store partial migration is still possible after a sticky rollback failure, but each artifact stays internally consistent, no config falsely claims migration, no store ref is left unresolvable, and `secrets apply` is idempotent so a re-run completes it). The concurrent-writer lost-update axis on the auth-store itself (`AUTH_STORE_LOCK`) is a separate follow-up.
- Reviewer focus: the dependency-ordered commit in `runSecretsApply` (`src/secrets/apply.ts`) - additions precommit, deletes ride the final write, and the final write keeps compare-and-set against the Phase 0 hash.

## Linked context

Closes #88012

Related: #88013 (the earlier file-based fix for this same issue; closed after #89102 moved the store to SQLite, since its staged file rename did not port to the SQLite store owner).

Was this requested by a maintainer or owner? No - found by a reliability audit of the credential-migration path.

## Real behavior proof

- **Behavior or issue addressed**: Without this patch, runSecretsApply (src/secrets/apply.ts:892-934) commits one logical credential-migration transaction (plaintext credential -> SecretRef) as a non-atomic three-phase sequence with no cross-store boundary: Phase 1 replaceConfigFile for openclaw.json, Phase 2 a writeTextFileAtomic loop over legacy auth.json / .env, and Phase 3 a saveAuthProfileStore loop that commits each per-agent SQLite auth-store (openclaw-agent.sqlite). Auth profiles were moved from auth-profiles.json to per-agent SQLite by upstream #89102 (e16ac04330), but the commit block still has no cross-file or cross-database transaction. If a Phase 3 store write throws after config already committed, the catch block runs a best-effort rollback (restoreFileSnapshot and a restore saveAuthProfileStore, each wrapped in try/catch that swallows failures, "Best effort only"). When the same fault also fails the config rollback restore, the partial migration persists: config is left migrated to a SecretRef while one or more auth-stores stay plaintext, diverging the credential source-of-truth (issue #88012). With this patch, a mid-commit fault leaves no partial migration (config and the auth-stores converge to the same state).
- **Real environment tested**: macOS (darwin arm64), Node 24.x (node:sqlite DatabaseSync; the per-agent auth-store is SQLite, which requires Node 24+). OpenClaw worktrees checked out at the base and head shas (base = 4106794ff5, current upstream/main). tsx executes src/secrets/apply.ts directly (--skip-build). Each trial builds a fresh isolated temp HOME via fs.mkdtempSync (os.tmpdir()); production ~/.openclaw and real credentials are never touched, and the temp HOME is removed after each trial. No external dependencies (no OAuth / LLM / network). Two real OS-level faults are injected (not vi.fn stubs): (A) the second agent's SQLite db file is made immutable with chflags(uchg), so ensureOpenClawAgentDatabasePermissions' chmod throws EPERM and the Phase 3 store commit fails (a read-only / EPERM I/O fault; plain chmod 0o400 is defeated because the same ensure-perms chmods it back at open); (B) the config rollback restore write is failed through @openclaw/fs-safe's test-only DI seam (__setFsSafeTestHooksForTest.beforeFileStoreSyncPrivateWrite, gated on NODE_ENV=test), modeling ENOSPC/EIO on the rollback. The config commit does not pass through that seam, so only the rollback restore is failed.
- **Exact steps or command run after this patch**:

```text
$ pnpm install --frozen-lockfile                      (both worktrees, --skip-build)
$ node_modules/.bin/tsx <probe.ts>                    (Node 24, worktree-relative)
  Control trial : runSecretsApply(write) with no fault -> expect full migration, no divergence.
  Defect trial  : beta SQLite db immutable (Phase 3 commit throws) AND config rollback restore throws.
                  Measures config (ref/plaintext) and each per-agent store (ref/plaintext/missing).
```

- **Evidence after fix**:

Live Node.js (v24) measurement of config + per-agent SQLite store final state after a mid-commit throw:

```text
[Build A] without this patch (base sha):
  control trial: config=ref stores={"store#1-alpha": "ref", "store#2-beta": "ref"} diverged=False
  defect  trial: threw=True config=ref stores={"store#1-alpha": "plaintext", "store#2-beta": "plaintext"}
                 plaintextStores=2/2 diverged=True  (config migrated to ref while an auth-store stayed plaintext)

[Build B] with this patch (head sha):
  control trial: config=ref stores={"store#1-alpha": "ref", "store#2-beta": "ref"} diverged=False
  defect  trial: threw=True config=plaintext stores={"store#1-alpha": "plaintext", "store#2-beta": "plaintext"}
                 plaintextStores=2/2 diverged=False  (config and stores converge; no partial migration)
```

- **Observed result after fix**: Without patch, a mid-commit throw leaves config=ref while 2/2 auth-stores stay plaintext (diverged=True): the credential source-of-truth is split. With patch, the same injected faults yield config=plaintext with diverged=False (config and stores converge). The control trial reports diverged=False/False on both builds, confirming the healthy full-migration path is not flagged.
- **What was not tested**: SECURITY-SENSITIVE PATH: src/secrets/apply.ts and src/agents/auth-profiles/ touch the credential source-of-truth and are owned by @openclaw/openclaw-secops in .github/CODEOWNERS. Any fix that introduces a cross-store transaction/journal or reorders the commit must be reviewed under that gate before merge. Not tested here: (1) the concurrent-writer lost-update axis (FIND-secrets-apply-cross-store-consistency-002, AUTH_STORE_LOCK bypass), a separate child task; (2) production-scale fault timing under real ENOSPC/EIO (modeled deterministically via an immutable db file + the fs-safe DI seam rather than real disk exhaustion); (3) the legacy auth.json and .env satellite writes (same loop, not exercised by this plan); (4) store-internal atomicity of a single saveAuthProfileStore (which runOpenClawAgentWriteTransaction already provides) -- the gap proven here is strictly cross-store / config-vs-store.

- **Proof limitations or environment constraints**: The per-agent auth-store is SQLite, which requires Node 24+ (`node:sqlite`). The two injected faults are real OS-level faults (an immutable db file via `chflags(uchg)` so `ensureOpenClawAgentDatabasePermissions`' `chmod` throws EPERM, and the `@openclaw/fs-safe` test-only DI seam for the rollback write), used to deterministically model production ENOSPC/EIO/read-only conditions rather than exhausting a real disk. macOS host (`chflags`); the divergence and the fix are platform-independent (the gap is the missing cross-store boundary, not the fault mechanism). The proof above exercises the issue #88012 direction; the provider-alias ordering (upserts, deletes) and the Phase 0/Phase B compare-and-set are covered by the unit regressions below.
- **Before evidence (optional but encouraged)**: shown above as "Build A (without this patch)" in the same run - config=ref while both auth-stores stayed plaintext, diverged=True.

## Tests and validation

Which commands did you run? (Node 24)
- `pnpm vitest run src/secrets/apply.test.ts` - 25/25 pass (includes four new regression tests).
- `pnpm check` - exit 0. `pnpm build` - exit 0.

What regression coverage was added or updated? Four tests in `src/secrets/apply.test.ts`:
1. An auth-store commit fault plus a failing config rollback restore leaves config with its plaintext key, not a `SecretRef` (issue #88012, no false migrated claim).
2. A `providerUpserts` + auth-profile plan whose config write and auth-store rollback fail still leaves the new provider defined in committed config, so the persisted store ref resolves (no orphaned reference).
3. A `providerDeletes` plan does not remove a provider before the final config write that moves refs off it (the delete rides the failed final write, so the alias stays defined).
4. A concurrent `openclaw.json` edit made between the Phase 0 pre-commit and the final write is rejected by compare-and-set rather than silently overwritten.

What failed before this fix, if known? Reverting to config-first fails test 1; reverting to plain config-last fails test 2; committing provider deletes in Phase 0 fails test 3; dropping the Phase 0 hash from the final compare-and-set fails test 4. With the dependency-ordered fix all four pass.

## Risk checklist

Did user-visible behavior change? No - on success the migration result is identical; only the on-disk commit order during a mid-commit fault changes.

Did config, environment, or migration behavior change? Yes - the order in which `secrets apply` commits provider additions, auth-stores, deletes, and config. The projected next-state is unchanged (computed in memory before the commit block); only the write order changes.

Did security, auth, secrets, network, or tool execution behavior change? Yes - this is the credential source-of-truth migration path (`/src/secrets/`, `/src/agents/auth-profiles/`). No new permissions, network calls, or secret values are introduced; the change narrows the windows in which a failed apply leaves plaintext under a migrated config or leaves a store ref pointing at an undefined or removed provider alias.

What is the highest-risk area? Splitting the config write into a provider-additions pre-commit and a final write. Mitigation: the projected config/stores are precomputed in memory (`projectPlanState`); stores do not read config at write time; provider deletes are kept in the final write; the rollback snapshot is re-captured after Phase 0 so a rollback never orphans a committed store ref; and the final write keeps compare-and-set against Phase 0's hash so a concurrent edit is rejected. Full `apply.test.ts` (25/25), `check`, and `build` are green.

@openclaw/openclaw-secops - this PR touches the credential source-of-truth commit path under your CODEOWNERS gate (`/src/secrets/`, `/src/agents/auth-profiles/`); requesting your review. No plaintext credentials are committed in tests or fixtures (`pragma: allowlist secret` retained).

## Current review state

What is the next action? Maintainer / secops review.

What is still waiting? secops (`@openclaw/openclaw-secops`) review of the credential commit-path change.

Which bot or reviewer comments were addressed? ClawSweeper's first P1 (a store ref could outrun a `providerUpserts` definition) and second-round P1s (provider deletes committed too early, and the final config write losing compare-and-set) are all addressed: additions precommit in Phase 0, deletes ride the final write, and the final write keeps compare-and-set against the Phase 0 hash. Regressions cover each case, and the real behavior proof is refreshed against the current head.

---

AI-assisted: this change was prepared with AI assistance (analysis, fix, regression tests, and the real-behavior proof harness). A human reviewed the diff, the gates, and the proof before opening this PR.
