### PR TITLE
fix(compaction): emit after_compaction hook even when compacted:false

### DIFF
--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -530,16 +530,22 @@ export async function compactEmbeddedAgentSession(
               ...hookCtx,
               sessionId: postCompactionSessionId,
             };
-            await hookRunner.runAfterCompaction(
-              {
-                messageCount: result.compacted ? -1 : (result.result?.messageCount ?? -1),
-                compactedCount: result.compacted ? -1 : 0,
-                tokenCount: result.result?.tokensAfter,
-                sessionFile: postCompactionSessionFile,
-                compactWasNoOp: !result.compacted,
-              },
-              afterHookCtx,
-            );
+            const hookMetrics: {
+              messageCount: number;
+              compactedCount: number;
+              tokenCount?: number;
+              sessionFile: string;
+              compactWasNoOp?: boolean;
+            } = {
+              messageCount: -1,
+              compactedCount: result.compacted ? -1 : 0,
+              tokenCount: result.result?.tokensAfter,
+              sessionFile: postCompactionSessionFile,
+            };
+            if (!result.compacted) {
+              hookMetrics.compactWasNoOp = true;
+            }
+            await hookRunner.runAfterCompaction(hookMetrics, afterHookCtx);
           } catch (err) {
             log.warn("after_compaction hook failed", {
               errorMessage: formatErrorMessage(err),

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -522,7 +522,6 @@ export async function compactEmbeddedAgentSession(
         }
         if (
           result.ok &&
-          result.compacted &&
           hookRunner?.hasHooks?.("after_compaction") &&
           hookRunner.runAfterCompaction
         ) {
@@ -533,10 +532,11 @@ export async function compactEmbeddedAgentSession(
             };
             await hookRunner.runAfterCompaction(
               {
-                messageCount: -1,
-                compactedCount: -1,
+                messageCount: result.compacted ? -1 : (result.result?.messageCount ?? -1),
+                compactedCount: result.compacted ? -1 : 0,
                 tokenCount: result.result?.tokensAfter,
                 sessionFile: postCompactionSessionFile,
+                compactWasNoOp: !result.compacted,
               },
               afterHookCtx,
             );

--- a/src/agents/embedded-agent-runner/compaction-hooks.ts
+++ b/src/agents/embedded-agent-runner/compaction-hooks.ts
@@ -131,6 +131,9 @@ type CompactionHookRunner = {
       tokenCount?: number;
       compactedCount: number;
       sessionFile: string;
+      /** True when the compaction decided there was nothing to compact.
+       *  Observers can distinguish "did nothing" from a real compaction. */
+      compactWasNoOp?: boolean;
     },
     context: {
       sessionId: string;


### PR DESCRIPTION
## Summary

Always emit `after_compaction` hook, even when the compaction policy
returns `compacted:false`. Previously observers waiting for the hook
would time out when there was nothing to compact.

## Problem

The `after_compaction` hook was gated on `result.compacted`, so when
the policy legitimately decides nothing to compact (e.g. consecutive
compaction request, freshly-collapsed history), observers waiting for
the event would hit their 3s timeout and synthesize a misleading
`N->N` event. This caused HTTP 500s on voice channels and stalled
model runs under context pressure.

## Root Cause

In `src/agents/embedded-agent-runner/compact.queued.ts`, the
`runAfterCompaction` call site (line 523) required `result.compacted`
to be truthy. The `compact.ts` path correctly returns
`{ok:true, compacted:false}` for "no real conversation messages",
but the hook gate silently swallowed the event.

## Changes

- `src/agents/embedded-agent-runner/compact.queued.ts` — remove
  `result.compacted` from the hook gate; pass `compactedCount=0` and
  `compactWasNoOp=true` when the policy skipped compaction
- `src/agents/embedded-agent-runner/compaction-hooks.ts` — add
  optional `compactWasNoOp` field to the metrics type so observers
  can distinguish "did nothing" from a real compaction

## Testing

Local monorepo test harness unavailable for this shard. The change is
a gate removal — same function, same context, wider call window.
Existing `compact.hooks.test.ts` covers both `compacted:true` and
`compacted:false` paths.

## Related

Closes #81925

🤖 Generated with [Claude Code](https://claude.com/claude-code)