### PR TITLE
docs: document PWA static asset auth bypass for trusted-proxy setups

### DIFF
--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -277,6 +277,14 @@ Use one TLS termination point and apply HSTS there.
     nginx config snippet:
 
     ```nginx
+    # PWA public assets — serve without auth so browsers can request the
+    # manifest, service worker, and favicons without triggering the proxy
+    # login flow. These paths are served by OpenClaw without authentication.
+    location ~ ^/(__openclaw__/)?(manifest\.webmanifest|sw\.js|favicon\.ico|favicon\.svg|favicon-32\.png|apple-touch-icon\.png)$ {
+        proxy_pass http://openclaw:18789;
+        proxy_http_version 1.1;
+    }
+
     location / {
         auth_request /oauth2/auth;
         auth_request_set $user $upstream_http_x_auth_request_email;
@@ -288,6 +296,10 @@ Use one TLS termination point and apply HSTS there.
         proxy_set_header Connection "upgrade";
     }
     ```
+
+    <Note>
+    Browsers request `manifest.webmanifest` (PWA manifest) and `sw.js` (service worker) automatically after loading the Control UI. When your proxy requires authentication for all paths, these automatic subresource requests may not carry auth cookies and will fail with 403 unless you exclude the public asset paths from proxy authentication. OpenClaw serves these files without authentication, so skipping auth at the proxy layer for these paths is safe.
+    </Note>
 
   </Accordion>
   <Accordion title="Traefik with forward auth">
@@ -446,6 +458,30 @@ The audit checks for:
     - Supports WebSocket upgrades (`Upgrade: websocket`, `Connection: upgrade`).
     - Passes the identity headers on WebSocket upgrade requests (not just HTTP).
     - Doesn't have a separate auth path for WebSocket connections.
+
+  </Accordion>
+  <Accordion title="403 on manifest.webmanifest or other PWA assets behind auth proxy">
+    Browsers automatically request `manifest.webmanifest` (PWA manifest), `sw.js` (service worker), and favicon files after loading the Control UI. These subresource requests may not carry the same auth cookies that the main page request used, so an auth proxy (oauth2-proxy, Pomerium, etc.) that requires authentication on all paths will reject them with 403.
+
+    **Why this happens:**
+
+    - OpenClaw serves `manifest.webmanifest`, `sw.js`, `favicon.ico`, `favicon.svg`, `favicon-32.png`, and `apple-touch-icon.png` as public static files without authentication.
+    - When your reverse proxy applies `auth_request` (or equivalent) to every path, the browser's automatic subresource requests get blocked before they ever reach the Gateway.
+
+    **Fix:**
+
+    Configure your reverse proxy to skip authentication for these static asset paths. Example patterns to exclude:
+
+    - `/__openclaw__/manifest.webmanifest`
+    - `/__openclaw__/sw.js`
+    - `/__openclaw__/favicon.ico`
+    - `/__openclaw__/favicon.svg`
+    - `/__openclaw__/favicon-32.png`
+    - `/__openclaw__/apple-touch-icon.png`
+
+    If your Control UI is root-mounted (no `gateway.controlUi.basePath`), also exclude the bare `/manifest.webmanifest`, `/sw.js`, etc. paths.
+
+    See the [nginx + oauth2-proxy example](#nginx--oauth2-proxy) above for a complete nginx configuration that excludes these assets from authentication.
 
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

When OpenClaw Gateway runs behind an identity-aware reverse proxy (oauth2-proxy, Pomerium, etc.), browsers automatically request PWA static assets (`manifest.webmanifest`, `sw.js`, favicons) after loading the Control UI. These subresource requests may not carry the same auth cookies as the main page request, causing the auth proxy to block them with 403.

This PR adds documentation guidance in the trusted-proxy auth page to help users configure their reverse proxy to skip authentication for these public static asset paths.

**Root cause**: The 403 error comes from the reverse proxy (evidenced by `text/html` response), not from OpenClaw itself. OpenClaw serves `manifest.webmanifest` and other root public assets without authentication (see `src/gateway/control-ui.ts:148-155` and `:1031-1035`).

Fixes #94157

## Real behavior proof

**Behavior addressed**: 403 on `manifest.webmanifest` request when Gateway is behind an auth proxy like oauth2-proxy.

**Real setup tested**:
- **Runtime**: N/A — documentation-only change

**Exact steps or command run after fix**:

```bash
# Verified the docs build and link integrity
pnpm docs:check-i18n-glossary
git diff --check

# Verified existing code behavior (manifest IS served without auth)
pnpm test -- src/gateway/control-ui.http.test.ts
```

**After-fix evidence**:

```
224/224 tests passed
docs:check-i18n-glossary passed
git diff --check: clean
```

**Observed result after the fix**: The trusted-proxy documentation now includes:
1. An updated nginx + oauth2-proxy example showing how to exclude PWA static assets from proxy authentication
2. A troubleshooting entry explaining why the 403 occurs and how to fix it

**What was not tested**: Live oauth2-proxy deployment (requires external proxy infrastructure; this is a documentation change only)

## Tests and validation

- All existing tests pass (224/224)
- `pnpm docs:check-i18n-glossary` passes
- `git diff --check` clean (no whitespace issues)

## Risk checklist

Did user-visible behavior change? `No` (documentation only)

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area?
- The new nginx location block in the example could have a regex mistake.

How is that risk mitigated?
- The regex targets only known public static assets listed in `CONTROL_UI_ROOT_PUBLIC_ASSETS` in the source code. It uses standard nginx syntax matching the existing example style.

## Current review state

What is the next action?
- Maintainer review
