### PR TITLE
fix(telegram): stop clearing registered webhook on channel restart

### DIFF
--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -1043,7 +1043,7 @@ describe("startTelegramWebhook", () => {
     );
   });
 
-  it("de-registers webhook when shutting down", async () => {
+  it("does not de-register webhook when shutting down", async () => {
     deleteWebhookSpy.mockClear();
     const abort = new AbortController();
     await startTelegramWebhook({
@@ -1055,7 +1055,10 @@ describe("startTelegramWebhook", () => {
     });
 
     abort.abort();
-    expect(deleteWebhookSpy).toHaveBeenCalledTimes(1);
-    expect(deleteWebhookSpy).toHaveBeenCalledWith({ drop_pending_updates: false });
+    // Webhook should persist across restarts so transient channel lifecycle
+    // events (config reload, health-check restart) do not clear the Telegram
+    // webhook and cause message loss. The next startup calls setWebhook,
+    // which replaces the old webhook URL on Telegram's side.
+    expect(deleteWebhookSpy).toHaveBeenCalledTimes(0);
   });
 });

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -1055,10 +1055,6 @@ describe("startTelegramWebhook", () => {
     });
 
     abort.abort();
-    // Webhook should persist across restarts so transient channel lifecycle
-    // events (config reload, health-check restart) do not clear the Telegram
-    // webhook and cause message loss. The next startup calls setWebhook,
-    // which replaces the old webhook URL on Telegram's side.
     expect(deleteWebhookSpy).toHaveBeenCalledTimes(0);
   });
 });

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -415,13 +415,6 @@ export async function startTelegramWebhook(opts: {
       return;
     }
     shutDown = true;
-    void withTelegramApiErrorLogging({
-      operation: "deleteWebhook",
-      runtime,
-      fn: () => bot.api.deleteWebhook({ drop_pending_updates: false }),
-    }).catch(() => {
-      // withTelegramApiErrorLogging has already emitted the failure.
-    });
     server.close();
     void bot.stop();
     status.noteWebhookStop();


### PR DESCRIPTION
## Root Cause

The `startTelegramWebhook` shutdown handler unconditionally called `deleteWebhook()` on the `abortSignal`, clearing the Telegram webhook URL during transient channel restarts (config reload, health-check restart, error recovery). Each restart triggered `deleteWebhook`, causing inbound message loss until the next `setWebhook` succeeded.

The ~32s clear cadence reported by the user was caused by a restart loop: `deleteWebhook` clears webhook → `monitorTelegramProvider` returns → channel framework restarts account → next transient event triggers `deleteWebhook` again.

## Summary

- When a Telegram webhook channel restarts transiently, the shutdown handler was deleting the registered webhook, causing message loss every ~32s until the guard timer re-asserted it.
- Removes the `deleteWebhook` call from the webhook shutdown path so the webhook URL persists across restarts.
- On the next startup, `setWebhook` naturally replaces any old webhook URL on Telegram's side, so no stale registration remains.
- The polling transport's `deleteWebhook` (on startup when switching to polling mode) is unaffected — it runs in a different code path.
- Fixes #90254

## Verification

- `pnpm test extensions/telegram/src/webhook.test.ts` — 20/20 passed
- `pnpm test extensions/telegram/src/monitor.test.ts` — 34/34 passed
- `pnpm test extensions/telegram/src/channel.gateway.test.ts` — 18/18 passed
- Autoreview: Clean (no actionable findings)

## Real behavior proof

Behavior addressed: Telegram webhook cleared on every transient channel restart, causing ~32s message loss cadence. Now webhook persists across restarts.
Real environment tested: Linux, Node 22, branch `fix/issue-90254-telegram-webhook-deletewebhook`
Exact steps or command run after this patch:
```bash
pnpm test extensions/telegram/src/webhook.test.ts
pnpm test extensions/telegram/src/monitor.test.ts
pnpm test extensions/telegram/src/channel.gateway.test.ts
```
Evidence after fix:
```console
✓ webhook.test.ts (20 tests) 11.33s
✓ monitor.test.ts (34 tests) 21.74s  
✓ channel.gateway.test.ts (18 tests) 24.36s
```
Observed result after fix: Test `"does not de-register webhook when shutting down"` asserts `deleteWebhook` is NOT called on abort, confirming the fix. All 72 related tests pass. No regressions.
What was not tested: Live Telegram E2E (requires bot token and public endpoint). The change is purely about removing an API call in the shutdown code path; the functional behavior (webhook registration, message handling) is covered by existing tests.
