### PR TITLE
fix(tui): map DEL (0x7f) as backspace in addition to BS (0x08)

### DIFF
--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -370,7 +370,7 @@ describe("createBackspaceDeduper", () => {
   it("suppresses duplicate backspace events within the dedupe window", () => {
     const { dedupe, advance } = createTimedDedupe();
 
-    expect(dedupe("\x7f")).toBe("\x7f");
+    expect(dedupe("\x7f")).toBe("\x08");
     advance(1);
     expect(dedupe("\x08")).toBe("");
   });
@@ -378,9 +378,9 @@ describe("createBackspaceDeduper", () => {
   it("preserves backspace events outside the dedupe window", () => {
     const { dedupe, advance } = createTimedDedupe();
 
-    expect(dedupe("\x7f")).toBe("\x7f");
+    expect(dedupe("\x7f")).toBe("\x08");
     advance(10);
-    expect(dedupe("\x7f")).toBe("\x7f");
+    expect(dedupe("\x7f")).toBe("\x08");
   });
 
   it("treats ASCII BS as backspace when it is the first event", () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -233,7 +233,8 @@ export function createBackspaceDeduper(params?: { dedupeWindowMs?: number; now?:
   let lastBackspaceAt = -1;
 
   return (data: string): string => {
-    if (data !== "\x08" && !matchesKey(data, Key.backspace)) {
+    const isBackspace = data === "\x08" || data === "\x7f" || matchesKey(data, Key.backspace);
+    if (!isBackspace) {
       return data;
     }
     const ts = now();
@@ -241,7 +242,7 @@ export function createBackspaceDeduper(params?: { dedupeWindowMs?: number; now?:
       return "";
     }
     lastBackspaceAt = ts;
-    return data;
+    return "\x08";
   };
 }
 


### PR DESCRIPTION
## Summary

- WSL2/Ubuntu terminals send `0x7f` (DEL) when the backspace key is pressed, but the TUI only recognized `0x08` (BS / `^H`)
- `createBackspaceDeduper` now normalizes both `0x7f` and `0x08` to `0x08`, and the editor always receives a normalized BS character
- All 62 existing TUI tests pass

Fixes #92777

## Test plan

- [x] Unit tests updated and passing (62 tests, 0 failures)
- [ ] Manual verification on WSL2/Ubuntu (not possible in this CI-only environment)

## Risk checklist

- [x] Did user-visible behavior change? (Yes — backspace now works on terminals that send DEL instead of BS)
- [x] Did config, environment, or migration behavior change? (No)
- [x] Did security, auth, secrets, network, or tool execution behavior change? (No)