### PR TITLE
fix(docs-i18n): detect and retry Chinese mojibake output from AI translation

### DIFF
--- a/scripts/docs-i18n/translator.go
+++ b/scripts/docs-i18n/translator.go
@@ -63,14 +63,14 @@ func NewCodexTranslator(srcLang, tgtLang string, glossary []GlossaryEntry, think
 }
 
 func (t *CodexTranslator) Translate(ctx context.Context, text, srcLang, tgtLang string) (string, error) {
-	return t.translate(ctx, text, t.translateMasked)
+	return t.translate(ctx, text, tgtLang, t.translateMasked)
 }
 
 func (t *CodexTranslator) TranslateRaw(ctx context.Context, text, srcLang, tgtLang string) (string, error) {
-	return t.translate(ctx, text, t.translateRaw)
+	return t.translate(ctx, text, tgtLang, t.translateRaw)
 }
 
-func (t *CodexTranslator) translate(ctx context.Context, text string, run func(context.Context, string) (string, error)) (string, error) {
+func (t *CodexTranslator) translate(ctx context.Context, text, tgtLang string, run func(context.Context, string) (string, error)) (string, error) {
 	prefix, core, suffix := splitWhitespace(text)
 	if core == "" {
 		return text, nil
@@ -84,7 +84,11 @@ func (t *CodexTranslator) translate(ctx context.Context, text string, run func(c
 	if err != nil {
 		return "", err
 	}
-	return prefix + translated + suffix, nil
+	result := prefix + translated + suffix
+	if validationErr := validateTargetLanguageOutput(result, tgtLang); validationErr != nil {
+		return "", validationErr
+	}
+	return result, nil
 }
 
 func exactGlossaryMappings(glossary []GlossaryEntry) map[string]string {
@@ -181,7 +185,7 @@ func isRetryableTranslateError(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return false
 	}
-	if errors.Is(err, errEmptyTranslation) {
+	if errors.Is(err, errEmptyTranslation) || errors.Is(err, errSuspectedMojibake) {
 		return true
 	}
 	message := strings.ToLower(err.Error())

--- a/scripts/docs-i18n/translator_test.go
+++ b/scripts/docs-i18n/translator_test.go
@@ -363,3 +363,54 @@ func TestPreviewCommandOutputRetainsStderrTail(t *testing.T) {
 		t.Fatalf("expected retained stderr tail, got %q", preview)
 	}
 }
+
+func TestCodexTranslatorRetriesOnMojibakeOutput(t *testing.T) {
+	previousDelay := translateRetryDelay
+	translateRetryDelay = func(int) time.Duration { return 0 }
+	defer func() { translateRetryDelay = previousDelay }()
+
+	// Simulate first response is mojibake, second is correct
+	attempts := 0
+	mojibakeText := "éç½®æåææ¡£æµè¯ä¸­æç¿»è¯"
+	translator := &CodexTranslator{
+		systemPrompt: "Translate from English to Chinese.",
+		thinking:     "high",
+		runPrompt: func(context.Context, codexPromptRequest) (string, error) {
+			attempts++
+			if attempts == 1 {
+				return mojibakeText, nil
+			}
+			return "配置指南文档测试中文翻译", nil
+		},
+	}
+
+	got, err := translator.TranslateRaw(context.Background(), "Configuration guide doc test Chinese translation", "en", "zh-CN")
+	if err != nil {
+		t.Fatalf("TranslateRaw returned error: %v", err)
+	}
+	if got != "配置指南文档测试中文翻译" {
+		t.Fatalf("unexpected translation %q", got)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts (mojibake + retry), got %d", attempts)
+	}
+}
+
+func TestCodexTranslatorSkipsMojibakeValidationForNonChinese(t *testing.T) {
+	// Non-Chinese targets should not trigger mojibake validation
+	translator := &CodexTranslator{
+		systemPrompt: "Translate from English to German.",
+		thinking:     "high",
+		runPrompt: func(context.Context, codexPromptRequest) (string, error) {
+			return "Konfigurationsleitfaden", nil
+		},
+	}
+
+	got, err := translator.TranslateRaw(context.Background(), "Configuration guide", "en", "de")
+	if err != nil {
+		t.Fatalf("TranslateRaw returned unexpected error: %v", err)
+	}
+	if got != "Konfigurationsleitfaden" {
+		t.Fatalf("unexpected translation %q", got)
+	}
+}

--- a/scripts/docs-i18n/util.go
+++ b/scripts/docs-i18n/util.go
@@ -119,6 +119,46 @@ func validateNoTranslationTranscriptArtifacts(source, translated string) error {
 	return nil
 }
 
+var errSuspectedMojibake = fmt.Errorf("suspected mojibake in translated output")
+
+func validateTargetLanguageOutput(text, tgtLang string) error {
+	if !strings.EqualFold(tgtLang, "zh-CN") && !strings.EqualFold(tgtLang, "zh-TW") {
+		return nil
+	}
+	cjkCount := 0
+	latin1SupplCount := 0
+	total := 0
+	for _, r := range text {
+		total++
+		if isCJK(r) {
+			cjkCount++
+		}
+		if r >= 0x0080 && r <= 0x00FF {
+			latin1SupplCount++
+		}
+	}
+	if total == 0 {
+		return nil
+	}
+	// Latin-1 Supplement characters present but zero CJK characters strongly
+	// indicates MOJIBAKE: UTF-8 multi-byte sequences interpreted as Latin-1.
+	// A single short untranslated English snippet would have latin1SupplCount=0.
+	if latin1SupplCount >= 4 && cjkCount == 0 && total >= 12 {
+		return fmt.Errorf("%w: latin1-suppl=%d cjk=%d total=%d", errSuspectedMojibake, latin1SupplCount, cjkCount, total)
+	}
+	// High ratio of Latin-1 Supplement to CJK characters indicates partial mojibake.
+	if latin1SupplCount >= 8 && cjkCount < latin1SupplCount && total >= 20 {
+		return fmt.Errorf("%w: latin1-suppl=%d cjk=%d total=%d", errSuspectedMojibake, latin1SupplCount, cjkCount, total)
+	}
+	return nil
+}
+
+func isCJK(r rune) bool {
+	return (r >= 0x4E00 && r <= 0x9FFF) ||
+		(r >= 0x3400 && r <= 0x4DBF) ||
+		(r >= 0xF900 && r <= 0xFAFF)
+}
+
 func fatal(err error) {
 	if err == nil {
 		return

--- a/scripts/docs-i18n/util_test.go
+++ b/scripts/docs-i18n/util_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestDocsI18nProviderUsesOpenAI(t *testing.T) {
 	t.Setenv(envDocsI18nProvider, "anthropic")
@@ -24,5 +27,87 @@ func TestDocsI18nModelPrefersExplicitOverride(t *testing.T) {
 
 	if got := docsI18nModel(); got != "__test_model_override__" {
 		t.Fatalf("expected explicit model override, got %q", got)
+	}
+}
+
+func TestIsCJK(t *testing.T) {
+	tests := []struct {
+		r    rune
+		want bool
+	}{
+		{'中', true},
+		{'文', true},
+		{'日', true},
+		{'本', true},
+		{'A', false},
+		{'1', false},
+		{' ', false},
+		{'ä', false},
+		{'é', false},
+		{'ç', false},
+		{'à', false},
+		{'—', false}, // em dash
+		{'·', false}, // middle dot (Latin-1 Supplement)
+	}
+	for _, tt := range tests {
+		if got := isCJK(tt.r); got != tt.want {
+			t.Errorf("isCJK(%q) = %v, want %v", tt.r, got, tt.want)
+		}
+	}
+}
+
+func TestValidateTargetLanguageOutputChinese_OK(t *testing.T) {
+	validTexts := []string{
+		"本文档描述了当前首次运行设置流程",
+		"OpenClaw Gateway 网关配置",
+		"",
+		"Hello World",          // English-only is fine for short snippets
+		"API v2.0 配置指南",      // Mixed with digits and Latin chars
+	}
+	for _, text := range validTexts {
+		if err := validateTargetLanguageOutput(text, "zh-CN"); err != nil {
+			t.Errorf("validateTargetLanguageOutput(%q, zh-CN) unexpected error: %v", text, err)
+		}
+	}
+}
+
+func TestValidateTargetLanguageOutputChinese_Mojibake(t *testing.T) {
+	// Classic UTF-8→Latin-1 mojibake: Chinese "配置指南" (UTF-8: E9 85 8D E7 BD AE E6 8C 87 E5 8D 97)
+	// interpreted as Latin-1: éç½®æå
+	mojibakeTexts := []string{
+		"éç½®æåææ¡£",  // "配置指南文档" as mojibake
+		"ä¸­æä¹±ç æ£æµ",    // "中文乱码检测" as mojibake
+	}
+	for _, text := range mojibakeTexts {
+		err := validateTargetLanguageOutput(text, "zh-CN")
+		if err == nil {
+			t.Errorf("validateTargetLanguageOutput(%q, zh-CN) expected error, got nil", text)
+		}
+		if !errors.Is(err, errSuspectedMojibake) {
+			t.Errorf("validateTargetLanguageOutput(%q, zh-CN) error should wrap errSuspectedMojibake, got: %v", text, err)
+		}
+	}
+}
+
+func TestValidateTargetLanguageOutputNonChinese_Skipped(t *testing.T) {
+	// Non-Chinese targets should not be validated
+	text := "éç½®æå"
+	for _, lang := range []string{"ja-JP", "ko", "es", "en", ""} {
+		if err := validateTargetLanguageOutput(text, lang); err != nil {
+			t.Errorf("validateTargetLanguageOutput(%q, %s) should skip, got error: %v", text, lang, err)
+		}
+	}
+}
+
+func TestValidateTargetLanguageOutputShortText_NoFalsePositive(t *testing.T) {
+	// Short text with a few Latin-1 Supplement chars but under threshold
+	shortTexts := []string{
+		"OK",                         // too short to trigger
+		"© 2026 OpenClaw",           // Latin-1 but under threshold
+	}
+	for _, text := range shortTexts {
+		if err := validateTargetLanguageOutput(text, "zh-CN"); err != nil {
+			t.Errorf("validateTargetLanguageOutput(%q, zh-CN) unexpected error on short text: %v", text, err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

The AI translation pipeline (`scripts/docs-i18n`) lacked validation for Chinese character encoding in translated output. When the AI model (Codex/OpenAI) occasionally produced Mojibake text (UTF-8 bytes interpreted as Latin-1, showing garbled characters like `é…ç½®æŒ‡å—` instead of proper Chinese), the garbled output passed through to the published docs site without detection or retry.

This PR adds post-translation encoding validation for Chinese (`zh-CN`/`zh-TW`) target languages that detects common Mojibake patterns and triggers automatic retry (up to 3 attempts).

Fixes #94504

## Real behavior proof

**Behavior addressed**: Chinese character encoding issues (Mojibake) on docs.openclaw.ai pages served under /zh-CN/

**Real environment tested**: Page headers confirm `content-type: text/html; charset=utf-8`. The page at `/zh-CN/start/onboarding` currently renders correctly (self-healed by subsequent re-translation), but the root cause — lack of output validation — remained unaddressed.

**Exact steps or command run after fix**:

```bash
cd scripts/docs-i18n
go test -v -count=1 -run "TestValidate|TestIsCJK|TestCodexTranslatorRetries|TestCodexTranslatorSkips" ./...
```

**After-fix evidence**:

The new `validateTargetLanguageOutput()` function correctly:
- Detects Mojibake patterns (Latin-1 Supplement >= 4, CJK == 0, total >= 12 chars) in zh-CN/zh-TW output
- Allows valid Chinese text (CJK characters present)
- Skips validation for non-Chinese target languages
- Preserves short English snippets (under detection thresholds)

**Observed result after the fix**: When Mojibake is detected in translated output, `errSuspectedMojibake` is returned, which triggers `translateWithRetry` to re-run the translation (up to 3 attempts). Non-Chinese targets are unaffected.

**What was not tested**: Live end-to-end translation with actual Codex/OpenAI API was not performed (requires API key and model access). Unit tests simulate the mojibake detection and retry behavior with injected prompt runners.

## Tests and validation

| Test | Status | Description |
|------|--------|-------------|
| `TestValidateTargetLanguageOutputChinese_OK` | New | Valid Chinese text passes validation |
| `TestValidateTargetLanguageOutputChinese_Mojibake` | New | Mojibake patterns correctly detected and return errSuspectedMojibake |
| `TestValidateTargetLanguageOutputNonChinese_Skipped` | New | Non-Chinese targets skip validation |
| `TestValidateTargetLanguageOutputShortText_NoFalsePositive` | New | Short text with Latin-1 chars not falsely flagged |
| `TestIsCJK` | New | CJK character classification correct |
| `TestCodexTranslatorRetriesOnMojibakeOutput` | New | Translator retries when mojibake detected |
| `TestCodexTranslatorSkipsMojibakeValidationForNonChinese` | New | Non-Chinese targets skip mojibake validation |
| All existing tests | Regression | No changes to existing test expectations |

## Risk checklist

Did user-visible behavior change? **No** — only adds validation and retry for currently-unvalidated output

Did config, environment, or migration behavior change? **No**

Did security, auth, secrets, network, or tool execution behavior change? **No**

What is the highest-risk area?
- False positive detection causing unnecessary retries on short valid text

How is that risk mitigated?
- Conservative thresholds: text must be >= 12 characters with >= 4 Latin-1 Supplement characters and zero CJK characters to trigger detection. Short English snippets, mixed content, and valid Chinese text are all excluded.

## Current review state

What is the next action?
- Maintainer review
