### PR TITLE
fix(msteams): route attachment proactive sends through channel threads (fixes #88836)

### DIFF
--- a/extensions/msteams/src/send.test.ts
+++ b/extensions/msteams/src/send.test.ts
@@ -444,6 +444,50 @@ describe("sendMessageMSTeams", () => {
     expect(uploadPayload.chatId).toBe(botFrameworkConversationId);
     expect(uploadPayload.siteId).toBe("site-456");
   });
+
+  it("passes threadActivityId to proactive attachment sends for channel thread routing", async () => {
+    const threadRootId = "thread-root-msg-1";
+    mockState.resolveMSTeamsSendContext.mockResolvedValue({
+      app: createMockApp(),
+      appId: "app-id",
+      conversationId: "19:channel@thread.tacv2",
+      ref: {
+        user: { id: "user-1" },
+        agent: { id: "agent-1" },
+        conversation: { id: "19:channel@thread.tacv2", conversationType: "channel" },
+        channelId: "msteams",
+        threadId: threadRootId,
+      },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      conversationType: "channel",
+      replyStyle: "thread",
+      sdkCloudOptions: { cloud: "Public" },
+      tokenProvider: { getAccessToken: vi.fn(async () => "token") },
+      mediaMaxBytes: 8 * 1024 * 1024,
+      sharePointSiteId: "site-789",
+    });
+    mockSharePointPdfUpload({
+      bufferSize: 50,
+      fileName: "threaded-report.pdf",
+      itemId: "item-3",
+      uniqueId: "{GUID-789}",
+    });
+
+    await sendMessageMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: "conversation:19:channel@thread.tacv2",
+      text: "threaded file",
+      mediaUrl: "https://example.com/threaded-report.pdf",
+    });
+
+    // The proactive activity send for the SharePoint file card must include
+    // threadActivityId so the message lands inside the channel thread.
+    const calls = mockState.sendMSTeamsActivityWithReference.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    // sendMSTeamsActivityWithReference(app, baseRef, activity, options)
+    const options = calls[0]?.[3] as Record<string, unknown> | undefined;
+    expect(options?.threadActivityId).toBe(threadRootId);
+  });
 });
 
 describe("MSTeams continueConversation failure handling", () => {

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -167,6 +167,13 @@ export async function sendMessageMSTeams(
     sdkCloudOptions,
   } = ctx;
 
+  // Resolve the thread root message ID for channel thread routing.
+  // Mirrors the resolution in sendMSTeamsMessages so proactive activity sends
+  // (consent cards, SharePoint file cards, OneDrive fallback links) honor the
+  // configured replyStyle instead of always posting at the top level.
+  const resolvedThreadId =
+    conversationType === "channel" ? (ref.threadId ?? ref.activityId) : undefined;
+
   log.debug?.("sending proactive message", {
     conversationId,
     conversationType,
@@ -223,6 +230,7 @@ export async function sendMessageMSTeams(
         activity,
         errorPrefix: "msteams consent card send",
         serviceUrlBoundary: sdkCloudOptions,
+        threadActivityId: resolvedThreadId,
       });
 
       // Store the activity ID so the accept handler can replace the consent
@@ -308,6 +316,7 @@ export async function sendMessageMSTeams(
           ref,
           activity,
           serviceUrlBoundary: sdkCloudOptions,
+          threadActivityId: resolvedThreadId,
         });
 
         log.info("sent native file card", {
@@ -352,6 +361,7 @@ export async function sendMessageMSTeams(
         ref,
         activity,
         serviceUrlBoundary: sdkCloudOptions,
+        threadActivityId: resolvedThreadId,
       });
 
       log.info("sent message with OneDrive file link", {
@@ -447,6 +457,8 @@ type ProactiveActivityParams = {
   activity: Record<string, unknown>;
   errorPrefix: string;
   serviceUrlBoundary: MSTeamsProactiveContext["sdkCloudOptions"];
+  /** Thread root activity ID for channel thread routing (only for channel conversations). */
+  threadActivityId?: string;
 };
 
 type ProactiveActivityRawParams = Omit<ProactiveActivityParams, "errorPrefix">;
@@ -456,9 +468,12 @@ async function sendProactiveActivityRaw({
   ref,
   activity,
   serviceUrlBoundary,
+  threadActivityId,
 }: ProactiveActivityRawParams): Promise<string> {
   const baseRef = buildConversationReference(ref);
+  const isChannel = ref.conversation?.conversationType === "channel";
   const response = await sendMSTeamsActivityWithReference(app, baseRef, activity, {
+    threadActivityId: isChannel ? threadActivityId : undefined,
     serviceUrlBoundary,
   });
   return extractMessageId(response) ?? "unknown";
@@ -470,9 +485,16 @@ async function sendProactiveActivity({
   activity,
   errorPrefix,
   serviceUrlBoundary,
+  threadActivityId,
 }: ProactiveActivityParams): Promise<string> {
   try {
-    return await sendProactiveActivityRaw({ app, ref, activity, serviceUrlBoundary });
+    return await sendProactiveActivityRaw({
+      app,
+      ref,
+      activity,
+      serviceUrlBoundary,
+      threadActivityId,
+    });
   } catch (err) {
     const classification = classifyMSTeamsSendError(err);
     const hint = formatMSTeamsSendErrorHint(classification);


### PR DESCRIPTION
### Summary

- **Problem**: In Microsoft Teams channels with `replyStyle: thread`, messages containing file attachments arrive as new top-level messages instead of inside the channel thread they belong to.
- **Root Cause**: `sendProactiveActivityRaw` (used for all three attachment send paths — FileConsentCard, SharePoint native file card, OneDrive fallback link) calls `sendMSTeamsActivityWithReference` without passing `threadActivityId`. The text-only path (`sendTextWithMedia` → `sendMSTeamsMessages`) correctly passes it, but the attachment paths bypass that function and lose the thread routing.
- **Fix**: Resolve the thread root ID (`ref.threadId ?? ref.activityId`) in `sendMessageMSTeams` for channel conversations and pass it through `sendProactiveActivityRaw` → `sendMSTeamsActivityWithReference`, following the same pattern already used in `sendMSTeamsMessages`.
- **What changed**:
  - `extensions/msteams/src/send.ts` — add `threadActivityId` to `ProactiveActivityParams`/`ProactiveActivityRawParams` types; wire it through `sendProactiveActivityRaw` and `sendProactiveActivity`; resolve and pass `resolvedThreadId` from `sendMessageMSTeams` for the three attachment paths
- **What did NOT change (scope boundary)**:
  - Poll and Adaptive Card proactive sends — these are standalone features that follow the same pattern but are not attachment sends; keeping scope focused on the reported bug

### Reproduction

1. Configure a Teams channel with `channels.msteams.replyStyle: thread`
2. Ask the agent to create a file and send it to the channel
3. **Before this PR**: The file card / link message posts at the top level of the channel, losing the thread relationship
4. **After this PR**: The file card / link message lands inside the same channel thread as the text reply

### Real behavior proof

**Behavior or issue addressed (#88836)**: In `sendMessageMSTeams`, attachment proactive sends (FileConsentCard, SharePoint file card, OneDrive fallback link) now carry `threadActivityId` so they route into the correct channel thread. Before this fix, `sendProactiveActivityRaw` always omitted `threadActivityId` — the attachment message would post at the top level even when `replyStyle` is `thread`.

**Real environment tested**: Linux, Node 22 — msteams extension test runner via `test/vitest/vitest.extension-msteams.config.ts`

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs extensions/msteams/src/send.test.ts`

**Evidence before fix**:
```text
[test] starting test/vitest/vitest.extension-msteams.config.ts
 RUN  v4.1.8
 Test Files  1 passed (1)
      Tests  11 passed (11)
```
The existing 11 tests all pass because none of them verify thread routing for proactive attachment sends. The missing coverage is the bug — `sendProactiveActivityRaw` was never tested for `threadActivityId` passthrough.

**Evidence after fix**:
```text
[test] starting test/vitest/vitest.extension-msteams.config.ts
 RUN  v4.1.8
 Test Files  1 passed (1)
      Tests  12 passed (12)
```
The new test ("passes threadActivityId to proactive attachment sends for channel thread routing") sets up a channel conversation with `threadId: "thread-root-msg-1"`, sends a message with a SharePoint file attachment, and asserts that `sendMSTeamsActivityWithReference` receives `options.threadActivityId === "thread-root-msg-1"`.

**Observed result after fix**: `sendMSTeamsActivityWithReference` is called with `threadActivityId` set to the resolved thread root ID when the conversation is a channel. The new test assertion passes, confirming the fix routes attachment messages into the correct channel thread.

**What was not tested**: Live Microsoft Teams round-trip with an actual Bot Framework conversation reference — the test uses mocked SDK calls. The `sendProactiveActivityRaw` logic mirroring `sendMSTeamsMessages`'s existing channel guard (`isChannel ? threadActivityId : undefined`) was verified through code-path analysis rather than a separate test case.

**Repro confirmation**: The new test case verifies the fix by asserting `options.threadActivityId` equals the expected thread root on the `sendMSTeamsActivityWithReference` mock. Before the fix, this assertion would fail because `threadActivityId` was never passed through `sendProactiveActivityRaw`.

### Risk / Mitigation

- **Risk**: The resolved `threadActivityId` could be stale or incorrect for some edge-case conversations.
  **Mitigation**: Uses the same resolution pattern (`ref.threadId ?? ref.activityId`) already battle-tested in `sendMSTeamsMessages` lines 534-536. The `isChannel` guard mirrors the same condition used in the messenger.
- **Risk**: Poll and Adaptive Card sends still lack thread routing — they use the same `sendProactiveActivity` path.
  **Mitigation**: Those are separate features not covered by this bug report. The fix pattern is the same (add `threadActivityId` to the call), so they can be addressed in a follow-up if bugs are reported.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] msteams extension

### Regression Test Plan

- `node scripts/run-vitest.mjs extensions/msteams/src/send.test.ts` — 12 tests including the new thread routing assertion

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #88836
