### PR TITLE
fix(macos): open native file picker for Control UI file inputs

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -19,7 +19,7 @@ private final class DashboardWindowDragRegionView: NSView {
 }
 
 @MainActor
-final class DashboardWindowController: NSWindowController, WKNavigationDelegate, NSWindowDelegate {
+final class DashboardWindowController: NSWindowController, WKNavigationDelegate, WKUIDelegate, NSWindowDelegate {
     private let webView: WKWebView
     private var currentURL: URL
     private var auth: DashboardWindowAuth
@@ -44,6 +44,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         super.init(window: window)
 
         self.webView.navigationDelegate = self
+        self.webView.uiDelegate = self
         self.window?.delegate = self
     }
 
@@ -265,6 +266,29 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         }
         NSWorkspace.shared.open(url)
         decisionHandler(.cancel)
+    }
+
+    func webView(
+        _: WKWebView,
+        runOpenPanelWith parameters: WKOpenPanelParameters,
+        initiatedByFrame _: WKFrameInfo,
+        completionHandler: @escaping ([URL]?) -> Void)
+    {
+        let panel = Self.makeOpenPanel(
+            allowsDirectories: parameters.allowsDirectories,
+            allowsMultipleSelection: parameters.allowsMultipleSelection)
+        panel.begin { result in
+            completionHandler(result == .OK ? panel.urls : nil)
+        }
+    }
+
+    static func makeOpenPanel(allowsDirectories: Bool, allowsMultipleSelection: Bool) -> NSOpenPanel {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = allowsDirectories
+        panel.allowsMultipleSelection = allowsMultipleSelection
+        panel.resolvesAliases = true
+        return panel
     }
 
     func webView(_: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -1,5 +1,7 @@
+import AppKit
 import Foundation
 import Testing
+import WebKit
 @testable import OpenClaw
 
 @Suite(.serialized)
@@ -36,6 +38,34 @@ struct DashboardWindowSmokeTests {
     @Test func `dashboard origin brackets ipv6 literals`() throws {
         let url = try #require(URL(string: "http://[fd12:3456:789a::1]:18789/control/"))
         #expect(DashboardWindowController.originString(for: url) == "http://[fd12:3456:789a::1]:18789")
+    }
+
+    @Test func `dashboard controller is wired as the webview ui delegate`() throws {
+        let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let controller = DashboardWindowController(
+            url: url,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+        // Without a WKUIDelegate, HTML `<input type="file">` clicks (e.g. the avatar
+        // image picker) never open a native panel. Conformance + wiring is the fix.
+        #expect(controller is WKUIDelegate)
+    }
+
+    @Test func `open panel allows files and honors single selection parameters`() {
+        let panel = DashboardWindowController.makeOpenPanel(
+            allowsDirectories: false,
+            allowsMultipleSelection: false)
+        #expect(panel.canChooseFiles)
+        #expect(!panel.canChooseDirectories)
+        #expect(!panel.allowsMultipleSelection)
+    }
+
+    @Test func `open panel honors directory and multiple selection parameters`() {
+        let panel = DashboardWindowController.makeOpenPanel(
+            allowsDirectories: true,
+            allowsMultipleSelection: true)
+        #expect(panel.canChooseFiles)
+        #expect(panel.canChooseDirectories)
+        #expect(panel.allowsMultipleSelection)
     }
 
     @Test func `dashboard failure state opens in dashboard window`() throws {


### PR DESCRIPTION
## Summary

- Conform `DashboardWindowController` to `WKUIDelegate` and implement `runOpenPanelWith` so the embedded Control UI can open the native macOS file picker.
- User-facing impact: the Personal Settings avatar **Choose image** button (and any other Control UI `<input type="file">`) now opens an `NSOpenPanel` instead of silently doing nothing.

## Motivation

Closes #94468.

The Control UI is hosted in a `WKWebView` (`DashboardWindowController`) that set only `navigationDelegate`, never `uiDelegate`. WebKit routes HTML file-input clicks through the `WKUIDelegate.webView(_:runOpenPanelWith:initiatedByFrame:completionHandler:)` callback; with no UI delegate, the click is dropped and no panel appears. This matches the issue reporter's binary investigation (found `WKNavigationDelegate` methods but no `runOpenPanel` callback). The fix sets `webView.uiDelegate = self` and presents an `NSOpenPanel` honoring the requested directory / multiple-selection parameters.

## Real behavior proof

- **Behavior addressed:** Control UI file inputs (avatar **Choose image**) opened no native picker because the hosting `WKWebView` had no `WKUIDelegate`. After the fix the controller is wired as the WebView UI delegate and presents an `NSOpenPanel`.
- **Real environment tested:** macOS, Apple Swift 6.3.2, the real `apps/macos` SwiftPM package (not a mock harness) — `DashboardWindowController`/`WKWebView` exercised directly.
- **Exact steps or command run after the patch:**
  ```
  cd apps/macos
  swift build --disable-keychain
  swift test  --disable-keychain --filter DashboardWindowSmokeTests
  ```
- **Evidence after fix:** copied live terminal output from the commands above, run against the patched package:
  ```
  ◇ Suite DashboardWindowSmokeTests started.
  ✔ Test "dashboard window controller shows and closes" passed after 0.245 seconds.
  ✔ Test "dashboard navigation stays on same endpoint" passed after 0.018 seconds.
  ✔ Test "dashboard origin brackets ipv6 literals" passed after 0.001 seconds.
  ✔ Test "dashboard controller is wired as the webview ui delegate" passed after 0.017 seconds.
  ✔ Test "open panel allows files and honors single selection parameters" passed after 0.770 seconds.
  ✔ Test "open panel honors directory and multiple selection parameters" passed after 0.225 seconds.
  ✔ Test "dashboard failure state opens in dashboard window" passed after 0.325 seconds.
  ✔ Suite DashboardWindowSmokeTests passed after 1.602 seconds.
  ✔ Test run with 7 tests in 1 suite passed after 1.603 seconds.
  ```
- **Observed result after fix:** the controller now reports as a `WKUIDelegate` (the `dashboard controller is wired as the webview ui delegate` assertion is red before this change, green after), and the `open panel ...` runs confirm the `NSOpenPanel` is built with the correct `canChooseFiles`/`canChooseDirectories`/`allowsMultipleSelection` mapping for the file-input request. Before the patch the same Choose-image click produced no panel and no callback at all.
- **What was not tested:** the live `NSOpenPanel.begin` presentation + `completionHandler` round-trip is not exercised in a headless run (it requires a real WebKit file-input event + window-server interaction); the panel construction it depends on is covered by the `open panel ...` assertions above.
