### PR TITLE
[codex] fix(copilot): tolerate missing runtime state API

### DIFF
--- a/extensions/copilot/index.test.ts
+++ b/extensions/copilot/index.test.ts
@@ -160,4 +160,26 @@ describe("copilot plugin", () => {
     });
     expect(createHarness).toHaveBeenCalledWith(expect.objectContaining({ sessionStore }));
   });
+
+  it("registers without durable session bindings when the host runtime lacks state APIs", () => {
+    const createHarness = vi.mocked(createCopilotAgentHarness);
+    createHarness.mockClear();
+    const registerAgentHarness = vi.fn();
+
+    plugin.register(
+      createTestPluginApi({
+        id: "copilot",
+        name: "GitHub Copilot agent runtime",
+        source: "test",
+        config: {},
+        pluginConfig: {},
+        runtime: {} as never,
+        registerAgentHarness,
+      }),
+    );
+
+    expect(registerAgentHarness).toHaveBeenCalledTimes(1);
+    expect(createHarness).toHaveBeenCalledTimes(1);
+    expect(createHarness.mock.calls[0]?.[0]).not.toHaveProperty("sessionStore");
+  });
 });

--- a/extensions/copilot/index.ts
+++ b/extensions/copilot/index.ts
@@ -30,16 +30,20 @@ export default definePluginEntry({
   description: "Registers the GitHub Copilot agent runtime.",
   register(api) {
     const poolOptions = readPoolOptions(api.pluginConfig);
-    const sessionStore = api.runtime.state.openSyncKeyedStore<CopilotSessionBinding>({
-      namespace: "sdk-sessions",
-      maxEntries: 5000,
-      defaultTtlMs: 90 * 24 * 60 * 60 * 1000,
-    });
+    const openSyncKeyedStore = api.runtime.state?.openSyncKeyedStore;
+    const sessionStore =
+      typeof openSyncKeyedStore === "function"
+        ? openSyncKeyedStore<CopilotSessionBinding>({
+            namespace: "sdk-sessions",
+            maxEntries: 5000,
+            defaultTtlMs: 90 * 24 * 60 * 60 * 1000,
+          })
+        : undefined;
 
     api.registerAgentHarness(
       createCopilotAgentHarness({
         ...(poolOptions ? { poolOptions } : {}),
-        sessionStore,
+        ...(sessionStore ? { sessionStore } : {}),
       }),
     );
   },


### PR DESCRIPTION
## Summary

- Prevent the `copilot` plugin from failing registration when the host runtime object does not expose `runtime.state.openSyncKeyedStore`.
- Keep durable Copilot SDK session bindings when the state API is available.
- Fall back to the existing non-persistent harness behavior when the state API is absent.
- Intentionally does not catch errors thrown by `openSyncKeyedStore`, so trusted-plugin enforcement remains unchanged.
- Review focus: whether the compatibility fallback is acceptable for older/incomplete host API surfaces.

## Linked context

Closes #94516

Related #88064

This was not directly requested by a maintainer; it follows the user report in #94516.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `@openclaw/copilot` registration can throw `TypeError: Cannot read properties of undefined (reading 'openSyncKeyedStore')` when `api.runtime.state` is missing.
- Real environment tested: local OpenClaw source checkout at `95c256fa98` on macOS, using the actual copilot plugin entrypoint with focused Vitest coverage for both available and missing state API surfaces.
- Exact steps or command run after this patch:
  - `./node_modules/.bin/vitest run extensions/copilot/index.test.ts`
  - `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm tsgo:extensions:test`
  - `./node_modules/.bin/oxfmt --check extensions/copilot/index.ts extensions/copilot/index.test.ts`
  - `./node_modules/.bin/oxlint extensions/copilot/index.ts extensions/copilot/index.test.ts`
  - `git diff --check`
  - `rg -n '<<<<<<<|=======|>>>>>>>' extensions/copilot/index.ts extensions/copilot/index.test.ts`
- Evidence after fix: focused Vitest output: `Test Files 1 passed (1)`, `Tests 6 passed (6)`.
- Observed result after fix: the copilot plugin still opens the durable `sdk-sessions` store when `openSyncKeyedStore` exists, and registers the harness without a `sessionStore` when `runtime.state` is absent.
- What was not tested: a live installed OpenClaw `2026.6.8 (844f405)` environment matching the reporter's system.
- Proof limitations or environment constraints: I could not reproduce the reporter's exact installed host/plugin state locally; this PR is draft until maintainers decide whether the compatibility fallback is sufficient or provide/confirm live repro evidence.
- Before evidence (optional but encouraged): prior code unconditionally accessed `api.runtime.state.openSyncKeyedStore(...)`, so a missing `state` namespace fails during plugin registration before the harness can be registered.

## Tests and validation

- `./node_modules/.bin/vitest run extensions/copilot/index.test.ts` passes.
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm tsgo:extensions:test` passes.
- `./node_modules/.bin/oxfmt --check extensions/copilot/index.ts extensions/copilot/index.test.ts` passes.
- `./node_modules/.bin/oxlint extensions/copilot/index.ts extensions/copilot/index.test.ts` passes.
- `git diff --check` passes.
- Manual conflict-marker scan passes.

Regression coverage added: `extensions/copilot/index.test.ts` now covers registration when the host runtime lacks state APIs.

`node scripts/check-changed.mjs` could not complete locally because the default Blacksmith/crabbox delegation failed its binary sanity check; local child mode identified the expected `extensions` and `extensionTests` lanes but failed because `corepack` is not installed on PATH.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Copilot plugin registration can now continue without durable session bindings when the host runtime lacks the state API.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No. The patch does not catch or suppress `openSyncKeyedStore` errors when the API exists, so trusted-plugin enforcement remains intact.

What is the highest-risk area?

Older hosts without the state API lose durable Copilot SDK session binding persistence.

How is that risk mitigated?

Persistence was already optional in the harness; the fallback omits `sessionStore` only when the host API is absent, preserving the current durable path everywhere the API exists.

## Current review state

What is the next action?

Maintainer review, especially on whether draft can be marked ready without live reporter-environment proof.

What is still waiting on author, maintainer, CI, or external proof?

External/live proof for the reporter's installed `2026.6.8` environment is still missing.

Which bot or reviewer comments were addressed?

None yet.
