### PR TITLE
test(telegram): add regression test for forum topic message_thread_id with streamed reasoning

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -568,6 +568,23 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
   }
 
+  function createReasoningForumTopicContext(): TelegramMessageContext {
+    loadSessionStore.mockReturnValue({
+      s1: { reasoningLevel: "stream" },
+    });
+    return createContext({
+      ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+      msg: {
+        chat: { id: -100123, type: "supergroup", is_forum: true },
+        message_id: 456,
+        message_thread_id: 88,
+      } as unknown as TelegramMessageContext["msg"],
+      chatId: -100123,
+      isGroup: true,
+      threadSpec: { id: 88, scope: "forum" },
+    });
+  }
+
   it("skips general understanding after describing a first-seen non-vision sticker", async () => {
     describeStickerImage.mockResolvedValueOnce("A curious sticker");
     const ctxPayload = {
@@ -3518,6 +3535,37 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(reasoningDraftStream.update).toHaveBeenCalledWith("Thinking\n\n_Thinking_");
     expect(answerDraftStream.update).toHaveBeenCalledWith("Answer");
     expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("preserves forum topic message_thread_id across streamed reasoning and final answer", async () => {
+    const { answerDraftStream, reasoningDraftStream } = setupDraftStreams({
+      answerMessageId: 2001,
+      reasoningMessageId: 3001,
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onReasoningStream?.({ text: "<think>Thinking</think>" });
+        await dispatcherOptions.deliver({ text: "Answer" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context: createReasoningForumTopicContext() });
+
+    expect(reasoningDraftStream.update).toHaveBeenCalledWith("Thinking\n\n_Thinking_");
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Answer");
+    expect(answerDraftStream.stop).toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expectRecordFields(mockCallArg(emitInternalMessageSentHook), {
+      content: "Answer",
+      messageId: 2001,
+    });
+    expectRecordFields(mockCallArg(recordOutboundMessageForPromptContext), {
+      chatId: "-100123",
+      messageId: 2001,
+      text: "Answer",
+      messageThreadId: 88,
+    });
   });
 
   it("replaces reasoning snapshots on the reasoning lane", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3566,6 +3566,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
       text: "Answer",
       messageThreadId: 88,
     });
+    expectDraftStreamParams({ thread: { id: 88, scope: "forum" } });
+    expectRecordFields(mockCallArg(createTelegramDraftStream, 1), {
+      thread: { id: 88, scope: "forum" },
+    });
   });
 
   it("replaces reasoning snapshots on the reasoning lane", async () => {


### PR DESCRIPTION
## What Problem This Solves

Issue #89352 reports that Telegram forum topic `message_thread_id` can be dropped when a bot reply involves streamed reasoning (`<think>...</think>`) followed by a final answer. After code tracing of all delivery paths in the current main branch (draft streams, `deliverInboundReplyWithMessageSendContext`, `deliverReplies`, `emitPreviewFinalizedHook`), `message_thread_id` is correctly passed through all paths. The gap was in test coverage for the combined reasoning-stream + final-delivery scenario in forum topics.

## Why This Change Was Made

Adds a focused regression test covering forum thread context (`threadSpec: { id: 88, scope: "forum" }`) with both `onReasoningStream` and `deliver({ kind: "final" })`. Asserts `message_thread_id` propagation at the `createTelegramDraftStream` boundary for both answer and reasoning lanes, not only at the prompt-context record.

## User Impact

No user-facing changes. Test-only PR that prevents regression where forum topic `message_thread_id` could be lost between the prompt-context record and the actual send path during streamed reasoning + final answer delivery.

## Evidence

### Unit Tests

```console
$ pnpm test extensions/telegram/src/bot-message-dispatch.test.ts -t "preserves forum topic"
 ✓ extensions/telegram/src/bot-message-dispatch.test.ts (1 test) 1 passed

$ pnpm test extensions/telegram/src/bot-message-dispatch.test.ts
 ✓ extensions/telegram/src/bot-message-dispatch.test.ts (143 tests) 143 passed

  Tests  143 passed (143)

$ pnpm check:test-types
✔ tsgo test:types passed
```

### Live Telegram Forum Topic Proof

Real environment: Linux, Node 24, `@xialong_devBOT`, branch `fix/issue-89352-telegram-forum-topic-streaming`.

**Step 1: Gateway log** showing bot received messages in topic:4 (forum topic id=4, non-General), and **outbound `message_thread_id=4`** confirmed via diagnostic probe at `buildTelegramThreadParams`:

```console
$ pnpm openclaw gateway
...
[telegram] Inbound message telegram:group:-1004357306494:topic:4 -> @xialong_devBOT (group, 36 chars)
[PROOF] buildTelegramThreadParams: thread={id:4, scope:"forum"} → api params: message_thread_id=4
[PROOF] buildTelegramThreadParams: thread={id:4, scope:"forum"} → api params: message_thread_id=4
[PROOF] buildTelegramThreadParams: thread={id:4, scope:"forum"} → api params: message_thread_id=4

# Topic 1 (General): correctly omits thread param
[telegram] Inbound message telegram:group:-1004357306494:topic:1 -> @xialong_devBOT (group, 18 chars)
[PROOF] buildTelegramThreadParams: General topic, omitting thread
```

The three `message_thread_id=4` calls correspond to the reasoning draft stream, answer draft stream, and `sendMessage` API call — all in the same forum topic as the inbound message.

**Observed result:** Bot sent streamed reasoning and final answer to topic 4 with `message_thread_id=4` in the outbound API params. General topic (id=1) correctly omitted `message_thread_id` per Telegram API requirements. No content leaked across topics.

### Screenshots

Send calc question to topic 4 (topic name: xialonglee_test):

<img width="1080" height="2403" alt="topic4_calc" src="https://github.com/user-attachments/assets/8583c570-210d-4c1f-bc0c-f32a18ccdcf6" />
<img width="424" height="386" alt="image" src="https://github.com/user-attachments/assets/0c5c1742-63dc-4b21-bfe4-1127c0afc74c" />


Topic 1 (General), no leakage of topic4 answer:

<img width="1080" height="2403" alt="two_topic_forum" src="https://github.com/user-attachments/assets/e77d7496-3294-45c4-b8c9-ec75166c8a84" />

<img width="1080" height="2403" alt="no_leakage" src="https://github.com/user-attachments/assets/864149e0-d12e-46f2-9f24-9cf9482317b0" />

Fixes #89352