### PR TITLE
fix: macOS embedded Control UI avatar image picker opens native file …

### DIFF
--- a/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
@@ -5,7 +5,7 @@ import OpenClawKit
 import WebKit
 
 @MainActor
-final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NSWindowDelegate {
+final class CanvasWindowController: NSWindowController, WKNavigationDelegate, WKUIDelegate, NSWindowDelegate {
     let sessionKey: String
     private let root: URL
     private let sessionDir: URL
@@ -121,6 +121,7 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NS
         self.webView = WKWebView(frame: .zero, configuration: config)
         // Canvas scaffold is a fully self-contained HTML page; avoid relying on transparency underlays.
         self.webView.setValue(true, forKey: "drawsBackground")
+        self.webView.uiDelegate = self
 
         let sessionDir = self.sessionDir
         let webView = self.webView
@@ -257,6 +258,23 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NS
         self.debugStatusTitle = title
         self.debugStatusSubtitle = subtitle
         self.applyDebugStatusIfNeeded()
+    }
+
+    // MARK: - WKUIDelegate
+    func webView(
+        _ webView: WKWebView,
+        runOpenPanelWith parameters: WKOpenPanelParameters,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping ([URL]?) -> Void
+    ) {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = parameters.allowsDirectories
+        panel.allowsMultipleSelection = parameters.allowsMultipleSelection
+
+        panel.begin { result in
+            completionHandler(result == .OK ? panel.urls : nil)
+        }
     }
 
     func applyDebugStatusIfNeeded() {


### PR DESCRIPTION
…picker\n\nThis implements WKUIDelegate in CanvasWindowController and sets the uiDelegate\non the WKWebView, enabling the native macOS NSOpenPanel for HTML file inputs.\n\nFixes #94468

## Summary

- Fixes macOS Control UI avatar editor: clicking the image picker did not open the native file selector.
- Root cause: CanvasWindowController did not set WKUIDelegate and lacked file picker callback.
- Impact: macOS users cannot upload custom avatars.
- Fix: Set webView.uiDelegate = self and implement webView(_:runOpenPanelWith:initiatedByFrame:completionHandler:) to call NSOpenPanel.

## Linked context

- Closes #94468

## Real behavior proof (required for external PRs)

- Environment: macOS OpenClaw app (embedded Control UI)
- Steps: Settings → tap avatar → choose "Upload image"
- Result: Native file selector opens; selected image displays correctly as preview.
- Not tested: multi-select scenario (single-select only currently).

## Tests and validation

- Manual verification on macOS app confirms file picker opens and returns selected file.
- No automated tests added.

## Risk checklist

- User-visible behavior: Yes (new file picker interaction)
- Config/environment change: No
- Security/auth/network/tool execution: No
- Highest risk area: UI delegate misimplementation regression
- Mitigation: code review + manual verification

## Current review state

- Awaiting review: Swift implementation alignment with OpenClaw macOS standards
- Pending: decide whether multi-select support is required
