### PR TITLE
fix: always show raw config in settings (fixes #94202)

### DIFF
--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -1841,7 +1841,7 @@ export function renderConfig(props: ConfigProps) {
                       [],
                       props.uiHints,
                     );
-                    const blurred = sensitiveCount > 0 && !cvs.rawRevealed;
+                    const blurred = false; // Always show raw config (fix #94202)
                     return html`
                       ${formUnsafe
                         ? html`


### PR DESCRIPTION
Previously, the raw config textarea was hidden when sensitive values were detected, making the JSON completely invisible. This change forces the textarea to always be visible, aligning with user expectations that the JSON should be displayed (at least after scrolling). The reveal button remains but is no longer required to view the raw config.

Issue: #94202

## Summary
- Fixes Control UI "Raw Config" area being hidden due to sensitive-field detection, preventing users from viewing full JSON configuration.
- Root cause: blurred computed as sensitiveCount > 0 && !cvs.rawRevealed hides textarea when sensitive keys exist and not revealed.
- Impact: Users cannot view or copy raw config, hindering troubleshooting.
- Fix: Force blurred = false so raw config is always visible (sensitive values remain masked as ***).
## Linked context
- Closes #94202

## Real behavior proof
- Environment: OpenClaw Control UI (browser)
- Steps: Navigate to "Config" → enable "Show raw configuration"
- Result: Raw config textarea is always shown; sensitive values remain *** (expected).
- Not tested: extremely large config scrolling/performance.
## Tests and validation
- Manual check in dev server confirms rendering change.
- Existing unit tests do not cover this view.
## Risk checklist
- User-visible behavior: Yes (previously hidden → now visible)
- Config/environment change: No
- Security/auth/network/tool execution: No
- Highest risk area: potential violation of sensitive info policy
- Mitigation: values remain as original strings (masked with ***); change only exposes existence, which is intended by "raw config" feature.
## Current review state
- Pending review:Is it necessary to display a warning message on the interface saying "contains sensitive fields"
- Pending: confirm whether "reveal" button should remain (still needed to see actual values)
