### PR TITLE
fix: prevent heartbeat runner from leaking private replies when respo…

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1849,6 +1849,34 @@ export async function runHeartbeatOnce(opts: {
     const ackMaxChars = resolveHeartbeatAckMaxChars(cfg, heartbeat);
     const responsePrefix = resolveHeartbeatResponsePrefix();
 
+    if (usesHeartbeatResponseTool && !heartbeatToolResponse) {
+      await restoreHeartbeatUpdatedAt({
+        storePath,
+        sessionKey,
+        updatedAt: previousUpdatedAt,
+      });
+      const okSent = await maybeSendHeartbeatOk();
+      emitHeartbeatEvent({
+        status: "ok-***",
+        reason: opts.reason,
+        preview: replyPayload?.text?.slice(0, 200) ?? "",
+        durationMs: Date.now() - startedAt,
+        channel: delivery.channel !== "none" ? delivery.channel : undefined,
+        accountId: delivery.accountId,
+        silent: !okSent,
+        indicatorType: visibility.useIndicator ? resolveIndicatorType("ok-***") : undefined,
+      });
+      await markCommitmentsStatus({
+        cfg,
+        ids: dueCommitmentIds,
+        status: "dismissed",
+        nowMs: startedAt,
+      });
+      await updateTaskTimestamps();
+      consumeInspectedSystemEvents();
+      return { status: "ran", durationMs: Date.now() - startedAt };
+    }
+
     if (heartbeatToolResponse && !heartbeatToolResponse.notify) {
       await restoreHeartbeatUpdatedAt({
         storePath,


### PR DESCRIPTION
…nse tool not used (fixes #94053)

Add early return when usesHeartbeatResponseTool is true but heartbeatToolResponse is falsy. Treat as silent heartbeat to comply with message_tool_only privacy mode.

## Summary
- Fixes Heartbeat runner leaking final text replies to Telegram when messages.visibleReplies: "message_tool" and heartbeat_respond tool is not invoked.
- Root cause: When usesHeartbeatResponseTool is true but heartbeatToolResponse is falsy, code fell back to sending raw reply payload, bypassing privacy mode.
- Impact: Heartbeat text meant to be private (e.g., HEARTBEAT_OK) was sent to public channel, leaking context.
## Linked context
- Closes #94053

## Real behavior proof
- Config: messages.visibleReplies: "message_tool"
- Trigger: cron/wake event, model outputs HEARTBEAT_OK only, no heartbeat_respond tool call
- Result: no text sent to channel; only background silent processing (update updatedAt, emit ok-*** event, clear commitments).
- Validation: check Telegram for absence of extra messages; review logs for event records.
## Tests and validation
- Related tests: src/infra/heartbeat-runner.tool-response.test.ts needs new case covering this branch.
- Manual verification via logs confirms silent flow.
## Risk checklist
- User-visible behavior: No (background process change)
- Config/environment change: No
- Security/auth/network/tool execution: Yes (affects message visibility)
- Highest risk area: over-silencing might drop important signals
- Mitigation: silent mode only when configuration explicitly requires "tool-only" and no response tool used; aligns with documented expectations.
## Current review state
- Pending: add unit test for new branch
- Pending review: silent-processing logic matches existing !notify branch (reused same steps)