### PR TITLE
fix(web-fetch): respect NO_PROXY when useTrustedEnvProxy is enabled

### DIFF
--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -169,9 +169,12 @@ pinning. Enable this only when the proxy is operator-controlled and enforces
 outbound policy after DNS resolution.
 
 <Note>
-  If no HTTP(S) proxy env var is configured, or the target host is excluded by
-  `NO_PROXY`, `web_fetch` falls back to the normal strict path with local DNS
-  pinning.
+  If no HTTP(S) proxy env var is configured, `web_fetch` falls back to the
+  normal strict path with local DNS pinning. When a proxy is configured but
+  the target host is excluded by `NO_PROXY`, the request gets exact-host
+  trust — private and local addresses (RFC1918, tailnet, localhost) are
+  allowed directly without going through the proxy, but metadata and
+  link-local addresses (169.254.x.x, cloud metadata IPs) remain blocked.
 </Note>
 
 ## Limits and safety

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -2203,6 +2203,62 @@ describe("fetchWithSsrFGuard hardening", () => {
     expect(lookupFn).toHaveBeenCalledOnce();
     await result.release();
   });
+
+  it("blocks link-local resolved addresses for NO_PROXY-matched hosts (metadata guard)", async () => {
+    clearProxyEnv();
+    vi.stubEnv("http_proxy", "http://proxy.corp:8080");
+    vi.stubEnv("no_proxy", "");
+    vi.stubEnv("NO_PROXY", "");
+    vi.stubEnv("NO_PROXY", "*.internal");
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: agentCtor,
+      EnvHttpProxyAgent: envHttpProxyAgentCtor,
+      ProxyAgent: proxyAgentCtor,
+      fetch: vi.fn(async () => okResponse()),
+    };
+    // DNS rebinding: hostname matches NO_PROXY but resolves to 169.254.x.x
+    const lookupFn = vi.fn(async () => [
+      { address: "169.254.169.254", family: 4 },
+    ]) as unknown as LookupFn;
+    const fetchImpl = vi.fn(async () => okResponse());
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "http://api.internal:8080/status",
+        fetchImpl,
+        lookupFn,
+        mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+      }),
+    ).rejects.toThrow("Blocked");
+  });
+
+  it("blocks cloud metadata resolved addresses for NO_PROXY-matched hosts (metadata guard)", async () => {
+    clearProxyEnv();
+    vi.stubEnv("http_proxy", "http://proxy.corp:8080");
+    vi.stubEnv("no_proxy", "");
+    vi.stubEnv("NO_PROXY", "");
+    vi.stubEnv("NO_PROXY", "*.internal");
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: agentCtor,
+      EnvHttpProxyAgent: envHttpProxyAgentCtor,
+      ProxyAgent: proxyAgentCtor,
+      fetch: vi.fn(async () => okResponse()),
+    };
+    // DNS rebinding: resolves to cloud metadata IP
+    const lookupFn = vi.fn(async () => [
+      { address: "100.100.100.200", family: 4 },
+    ]) as unknown as LookupFn;
+    const fetchImpl = vi.fn(async () => okResponse());
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "http://api.internal:8080/status",
+        fetchImpl,
+        lookupFn,
+        mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+      }),
+    ).rejects.toThrow("Blocked");
+  });
 });
 
 function toLintErrorObject(value: unknown, fallbackMessage: string): Error {

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -2111,6 +2111,98 @@ describe("fetchWithSsrFGuard hardening", () => {
     expect(lookupFn).toHaveBeenCalledOnce();
     await result.release();
   });
+
+  it("allows NO_PROXY-matched private IP direct access in trusted env-proxy mode", async () => {
+    clearProxyEnv();
+    // clearProxyEnv sets lowercase http_proxy="" which shadows uppercase.
+    // Undici semantics: empty lowercase shadows uppercase, so stub
+    // lowercase with the real proxy value instead.
+    vi.stubEnv("http_proxy", "http://proxy.corp:8080");
+    vi.stubEnv("no_proxy", "");
+    vi.stubEnv("NO_PROXY", "");
+    vi.stubEnv("NO_PROXY", "192.168.*");
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: agentCtor,
+      EnvHttpProxyAgent: envHttpProxyAgentCtor,
+      ProxyAgent: proxyAgentCtor,
+      fetch: vi.fn(async () => okResponse()),
+    };
+    const lookupFn = vi.fn(async () => [
+      { address: "192.168.1.100", family: 4 },
+    ]) as unknown as LookupFn;
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const requestInit = init as RequestInit & { dispatcher?: unknown };
+      expectDispatcherAttached(requestInit.dispatcher);
+      expect(getDispatcherClassName(requestInit.dispatcher)).not.toBe("EnvHttpProxyAgent");
+      return okResponse();
+    });
+
+    const result = await fetchWithSsrFGuard({
+      url: "http://192.168.1.100:8123/status",
+      fetchImpl,
+      lookupFn,
+      mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(lookupFn).toHaveBeenCalledOnce();
+    await result.release();
+  });
+
+  it("blocks non-NO_PROXY private IP even in trusted env-proxy mode", async () => {
+    clearProxyEnv();
+    vi.stubEnv("http_proxy", "http://proxy.corp:8080");
+    vi.stubEnv("no_proxy", "");
+    vi.stubEnv("NO_PROXY", "");
+    vi.stubEnv("NO_PROXY", "other.host");
+    const lookupFn = vi.fn(async () => [
+      { address: "192.168.1.100", family: 4 },
+    ]) as unknown as LookupFn;
+    const fetchImpl = vi.fn(async () => okResponse());
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "http://192.168.1.100:8123/status",
+        fetchImpl,
+        lookupFn,
+        mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+      }),
+    ).rejects.toThrow("Blocked");
+  });
+
+  it("allows NO_PROXY-matched localhost direct access in trusted env-proxy mode", async () => {
+    clearProxyEnv();
+    vi.stubEnv("http_proxy", "http://proxy.corp:8080");
+    vi.stubEnv("no_proxy", "");
+    vi.stubEnv("NO_PROXY", "");
+    vi.stubEnv("NO_PROXY", "localhost,127.0.0.1");
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: agentCtor,
+      EnvHttpProxyAgent: envHttpProxyAgentCtor,
+      ProxyAgent: proxyAgentCtor,
+      fetch: vi.fn(async () => okResponse()),
+    };
+    const lookupFn = vi.fn(async () => [
+      { address: "127.0.0.1", family: 4 },
+    ]) as unknown as LookupFn;
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const requestInit = init as RequestInit & { dispatcher?: unknown };
+      expectDispatcherAttached(requestInit.dispatcher);
+      expect(getDispatcherClassName(requestInit.dispatcher)).not.toBe("EnvHttpProxyAgent");
+      return okResponse();
+    });
+
+    const result = await fetchWithSsrFGuard({
+      url: "http://localhost:8080/api",
+      fetchImpl,
+      lookupFn,
+      mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(lookupFn).toHaveBeenCalledOnce();
+    await result.release();
+  });
 });
 
 function toLintErrorObject(value: unknown, fallbackMessage: string): Error {

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -518,14 +518,13 @@ async function fetchWithSsrFGuardInternal(
       // When trusted-env-proxy mode is active but NO_PROXY excludes this URL,
       // the request bypasses the proxy and goes direct through pinned DNS.
       //
-      // Relax SSRF private-network checks for NO_PROXY-matched hosts because:
-      // 1. useTrustedEnvProxy is an explicit operator opt-in — the user already
-      //    trusted the proxy with ALL traffic, including private-network targets.
-      // 2. NO_PROXY is an explicit per-host exclusion — the operator chose to
-      //    bypass the proxy for these specific addresses. Direct access does not
-      //    add risk the proxy would not have already accepted.
-      // 3. SSRF hostname allowlist and DNS pinning still apply; only the
-      //    private-network address block is relaxed, and only for the matched host.
+      // Use exact-host trust via allowedHostnames so NO_PROXY-matched private
+      // and local addresses (RFC1918, tailnet, localhost) can be reached
+      // directly without going through the proxy. This approach intentionally
+      // does NOT set allowPrivateNetwork because that would skip the
+      // metadata/link-local resolved-address guard in
+      // resolvePinnedHostnameWithPolicy — exact-host trust still blocks
+      // 169.254.x.x and cloud metadata IPs after DNS resolution.
       const resolvedProtocol = parsedUrl.protocol === "https:" ? "https" : "http";
       const trustedNoProxyBypass =
         mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY &&
@@ -535,11 +534,7 @@ async function fetchWithSsrFGuardInternal(
       const effectivePolicy = trustedNoProxyBypass
         ? {
             ...policyForUrl,
-            allowPrivateNetwork: true,
-            allowedHostnames: [
-              ...(policyForUrl?.allowedHostnames ?? []),
-              parsedUrl.hostname,
-            ],
+            allowedHostnames: [...(policyForUrl?.allowedHostnames ?? []), parsedUrl.hostname],
           }
         : policyForUrl;
       const canUseMockedFetchWithoutDns =

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -11,7 +11,12 @@ import {
   shouldUseConfiguredLocalOriginManagedProxyBypass,
   type ConfiguredLocalOriginManagedProxyBypass,
 } from "./configured-local-origin-bypass.js";
-import { hasProxyEnvConfigured, shouldUseEnvHttpProxyForUrl } from "./proxy-env.js";
+import {
+  hasEnvHttpProxyConfigured,
+  hasProxyEnvConfigured,
+  matchesNoProxy,
+  shouldUseEnvHttpProxyForUrl,
+} from "./proxy-env.js";
 import { retainSafeHeadersForCrossOriginRedirect as retainSafeRedirectHeaders } from "./redirect-headers.js";
 import {
   fetchWithRuntimeDispatcher,
@@ -509,6 +514,34 @@ async function fetchWithSsrFGuardInternal(
           (params.useEnvProxyForEligibleUrls === true && !canUseManagedProxy)) &&
         !dispatcherPolicy &&
         shouldUseEnvHttpProxyForUrl(parsedUrl.toString());
+
+      // When trusted-env-proxy mode is active but NO_PROXY excludes this URL,
+      // the request bypasses the proxy and goes direct through pinned DNS.
+      //
+      // Relax SSRF private-network checks for NO_PROXY-matched hosts because:
+      // 1. useTrustedEnvProxy is an explicit operator opt-in — the user already
+      //    trusted the proxy with ALL traffic, including private-network targets.
+      // 2. NO_PROXY is an explicit per-host exclusion — the operator chose to
+      //    bypass the proxy for these specific addresses. Direct access does not
+      //    add risk the proxy would not have already accepted.
+      // 3. SSRF hostname allowlist and DNS pinning still apply; only the
+      //    private-network address block is relaxed, and only for the matched host.
+      const resolvedProtocol = parsedUrl.protocol === "https:" ? "https" : "http";
+      const trustedNoProxyBypass =
+        mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY &&
+        !canUseTrustedEnvProxy &&
+        hasEnvHttpProxyConfigured(resolvedProtocol) &&
+        matchesNoProxy(parsedUrl.toString());
+      const effectivePolicy = trustedNoProxyBypass
+        ? {
+            ...policyForUrl,
+            allowPrivateNetwork: true,
+            allowedHostnames: [
+              ...(policyForUrl?.allowedHostnames ?? []),
+              parsedUrl.hostname,
+            ],
+          }
+        : policyForUrl;
       const canUseMockedFetchWithoutDns =
         isUsingMockedFetch &&
         params.lookupFn === undefined &&
@@ -521,7 +554,7 @@ async function fetchWithSsrFGuardInternal(
       // Trusted env-proxy and pinDns=false can skip local DNS pinning, so keep
       // the pre-DNS hostname/IP policy checks from the pinned path.
       if (canUseTrustedEnvProxy || params.pinDns === false) {
-        assertHostnameAllowedWithPolicy(parsedUrl.hostname, policyForUrl);
+        assertHostnameAllowedWithPolicy(parsedUrl.hostname, effectivePolicy);
       }
 
       if (canUseTrustedEnvProxy) {
@@ -529,36 +562,38 @@ async function fetchWithSsrFGuardInternal(
       } else if (canUseManagedProxy) {
         const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
           lookupFn: params.lookupFn,
-          policy: policyForUrl,
+          policy: effectivePolicy,
         });
         dispatcher = shouldUseConfiguredLocalOriginManagedProxyBypass({
           url: parsedUrl,
           managedProxyBypass: params.managedProxyBypass,
           resolvedAddresses: pinned.addresses,
         })
-          ? createPinnedDispatcher(pinned, dispatcherPolicy, policyForUrl, timeoutMs)
+          ? createPinnedDispatcher(pinned, dispatcherPolicy, effectivePolicy, timeoutMs)
           : createHttp1EnvHttpProxyAgent(undefined, timeoutMs);
       } else if (usesTrustedExplicitProxyMode) {
         // Explicit proxy targets are still checked against the caller's hostname
         // policy, but the proxy does the DNS resolution for the final target.
-        assertHostnameAllowedWithPolicy(parsedUrl.hostname, policyForUrl);
+        assertHostnameAllowedWithPolicy(parsedUrl.hostname, effectivePolicy);
         dispatcher = createPolicyDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
       } else if (canUseMockedFetchWithoutDns) {
         // Test-installed fetch mocks should stay hermetic. Host/IP policy still runs;
         // real fetches continue through pinned DNS below.
-        assertHostnameAllowedWithPolicy(parsedUrl.hostname, policyForUrl);
+        assertHostnameAllowedWithPolicy(parsedUrl.hostname, effectivePolicy);
       } else if (params.pinDns === false) {
         await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
           lookupFn: params.lookupFn,
-          policy: policyForUrl,
+          policy: effectivePolicy,
         });
-        dispatcher = createPolicyDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
+        dispatcher = trustedNoProxyBypass
+          ? createHttp1Agent(undefined, timeoutMs)
+          : createPolicyDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
       } else {
         const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
           lookupFn: params.lookupFn,
-          policy: policyForUrl,
+          policy: effectivePolicy,
         });
-        dispatcher = createPinnedDispatcher(pinned, dispatcherPolicy, policyForUrl, timeoutMs);
+        dispatcher = createPinnedDispatcher(pinned, dispatcherPolicy, effectivePolicy, timeoutMs);
       }
 
       const init: DispatcherAwareRequestInit = {


### PR DESCRIPTION
## Summary

When `tools.web.fetch.useTrustedEnvProxy: true` is set and `NO_PROXY` excludes a target host, `web_fetch` should bypass the proxy and connect directly. The proxy bypass logic in `shouldUseEnvHttpProxyForUrl()` already detects NO_PROXY matches, but after skipping proxy creation the request falls through to the strict SSRF pinned-DNS path which blocks private/internal IP addresses — making NO_PROXY exclusions ineffective for local services.

Fix: use exact-host trust via `allowedHostnames` for NO_PROXY-matched hosts. This allows private and local addresses (RFC1918, tailnet, localhost) to be reached directly without the proxy, while metadata and link-local addresses (169.254.x.x, cloud metadata IPs) remain blocked by the resolved-address guard in `resolvePinnedHostnameWithPolicy`. Does NOT set `allowPrivateNetwork: true` which would skip all SSRF checks.

Fixes #93807.

## Changes

- `src/infra/net/fetch-guard.ts`: exact-host trust via `allowedHostnames` for NO_PROXY hosts, preserving metadata/link-local guard
- `src/infra/net/fetch-guard.ssrf.test.ts`: +2 metadata/link-local regression tests for NO_PROXY-matched hosts
- `docs/tools/web-fetch.md`: updated NO_PROXY behavior description

## Real behavior proof (required for external PRs)

**Behavior addressed**: `web_fetch` with `useTrustedEnvProxy: true` ignores `NO_PROXY` exclusions for private-network targets. After fix, NO_PROXY-matched hosts use exact-host trust (private IPs allowed, metadata/link-local still blocked).

**Real environment tested**: Linux, Node 24, OpenClaw PR branch 149e5470c4

**Exact steps or command run after fix**:

```bash
node scripts/run-vitest.mjs run src/infra/net/fetch-guard.ssrf.test.ts
```

**Evidence after fix**:

```
Test Files  1 passed (1)
     Tests  90 passed (90)
```

Includes 2 new metadata/link-local regression tests:
- `blocks link-local resolved addresses for NO_PROXY-matched hosts (metadata guard)` — DNS rebinding to 169.254.169.254 is blocked
- `blocks cloud metadata resolved addresses for NO_PROXY-matched hosts (metadata guard)` — DNS rebinding to 100.100.100.200 is blocked

Private IPs (192.168.x.x) and localhost are allowed for NO_PROXY-matched hosts, proving exact-host trust works.

**Observed result after fix**: NO_PROXY-matched hosts can reach private networks directly. Metadata/link-local IPs remain blocked. The `allowPrivateNetwork: true` flag is NOT used — exact-host trust via `allowedHostnames` preserves the resolved-address guard.

**What was not tested**: A live web_fetch call against a real private NO_PROXY target was not tested — requires a production proxy setup.

## Tests and validation

- `fetch-guard.ssrf.test.ts`: 90/90 passed ✅ (incl. 2 metadata guard tests)
- Docs: `web-fetch.md` updated

## Risk checklist

Did user-visible behavior change? `Yes` — NO_PROXY hosts can now reach private IPs directly.
Did config, environment, or migration behavior change? `No`.
Did security, auth, secrets, network, or tool execution behavior change? `Yes` — SSRF security boundary: exact-host trust replaces full `allowPrivateNetwork`, preserving metadata/link-local blocking.
