### PR TITLE
fix(gateway): bound config.get middleware results

### DIFF
--- a/src/agents/harness/tool-result-middleware.test.ts
+++ b/src/agents/harness/tool-result-middleware.test.ts
@@ -174,6 +174,54 @@ describe("createAgentToolResultMiddlewareRunner", () => {
     });
   });
 
+  it("truncates oversized incoming text before a no-op middleware", async () => {
+    let observedText = "";
+    const runner = createAgentToolResultMiddlewareRunner({ runtime: "openclaw" }, [
+      (event) => {
+        const content = event.result.content[0];
+        observedText = content?.type === "text" ? content.text : "";
+        return undefined;
+      },
+    ]);
+
+    const result = await runner.applyToolResultMiddleware({
+      toolCallId: "call-1",
+      toolName: "gateway",
+      args: { action: "config.get" },
+      result: {
+        content: [{ type: "text", text: "x".repeat(100_001) }],
+        details: { ok: true },
+      },
+    });
+
+    expect(observedText).toHaveLength(100_000);
+    expect(result.details).toEqual({ ok: true });
+    expect(result.content).toEqual([{ type: "text", text: "x".repeat(100_000) }]);
+  });
+
+  it("fails closed when middleware returns oversized top-level text", async () => {
+    const runner = createAgentToolResultMiddlewareRunner({ runtime: "openclaw" }, [
+      () => ({
+        result: {
+          content: [{ type: "text", text: "x".repeat(100_001) }],
+          details: { ok: true },
+        },
+      }),
+    ]);
+
+    const result = await runner.applyToolResultMiddleware({
+      toolCallId: "call-1",
+      toolName: "gateway",
+      args: { action: "config.get" },
+      result: {
+        content: [{ type: "text", text: "raw" }],
+        details: { ok: true },
+      },
+    });
+
+    expect(result.details).toEqual({ status: "error", middlewareError: true });
+  });
+
   it("sanitizes incoming details before failing closed on uncoercible content", async () => {
     const details: Record<string, unknown> = {
       ok: true,

--- a/src/agents/harness/tool-result-middleware.ts
+++ b/src/agents/harness/tool-result-middleware.ts
@@ -24,6 +24,10 @@ const NESTED_TOOL_RESULT_BLOCK_TYPES = new Set(["toolresult", "tool_result"]);
 
 type MiddlewareContentBlock = OpenClawAgentToolResult["content"][number];
 type MiddlewareContentCoerceState = { depth: number; seen: Set<object> };
+type MiddlewareToolResultCoerceOptions = {
+  sanitizeContent?: boolean;
+  sanitizeDetails?: boolean;
+};
 
 function isValidMiddlewareContentBlock(value: unknown): boolean {
   if (!isRecord(value) || typeof value.type !== "string") {
@@ -158,6 +162,7 @@ function stringifyMiddlewareTextPayload(value: unknown): string | undefined {
 function coerceMiddlewareText(
   value: unknown,
   state: MiddlewareContentCoerceState = createMiddlewareContentCoerceState(),
+  options: MiddlewareToolResultCoerceOptions = {},
 ): string | undefined {
   if (typeof value === "string") {
     return value;
@@ -173,14 +178,14 @@ function coerceMiddlewareText(
     return undefined;
   }
   for (const key of ["text", "output", "result", "message"]) {
-    const text = coerceMiddlewareText(value[key], nextState);
+    const text = coerceMiddlewareText(value[key], nextState, options);
     if (text !== undefined) {
       return text;
     }
   }
   const content = value.content;
   if (Array.isArray(content)) {
-    const chunks = coerceMiddlewareContentArray(content, nextState)
+    const chunks = coerceMiddlewareContentArray(content, nextState, options)
       .filter(
         (block): block is Extract<MiddlewareContentBlock, { type: "text" }> =>
           block.type === "text",
@@ -224,6 +229,7 @@ function appendMiddlewareContentBlock(
 function coerceMiddlewareContentArray(
   content: unknown[],
   state: MiddlewareContentCoerceState,
+  options: MiddlewareToolResultCoerceOptions = {},
 ): MiddlewareContentBlock[] {
   const blocks: MiddlewareContentBlock[] = [];
   let inspectedBlocks = 0;
@@ -235,7 +241,7 @@ function coerceMiddlewareContentArray(
     ) {
       break;
     }
-    const coercedBlocks = coerceMiddlewareContentBlocks(entry, state);
+    const coercedBlocks = coerceMiddlewareContentBlocks(entry, state, options);
     if (coercedBlocks.length > 0) {
       for (const block of coercedBlocks) {
         appendMiddlewareContentBlock(blocks, block);
@@ -245,7 +251,7 @@ function coerceMiddlewareContentArray(
       }
       continue;
     }
-    const text = coerceMiddlewareText(entry, state);
+    const text = coerceMiddlewareText(entry, state, options);
     if (text) {
       appendMiddlewareContentBlock(blocks, {
         type: "text",
@@ -259,9 +265,21 @@ function coerceMiddlewareContentArray(
 function coerceMiddlewareContentBlocks(
   value: unknown,
   state: MiddlewareContentCoerceState = createMiddlewareContentCoerceState(),
+  options: MiddlewareToolResultCoerceOptions = {},
 ): MiddlewareContentBlock[] {
   if (isValidMiddlewareContentBlock(value)) {
     return [value as MiddlewareContentBlock];
+  }
+  // Tool emitters can produce legitimate transcript text larger than the
+  // middleware cap. Normalize that only before the first handler; handlers
+  // remain fail-closed if they return an oversized replacement.
+  if (
+    options.sanitizeContent === true &&
+    isRecord(value) &&
+    value.type === "text" &&
+    typeof value.text === "string"
+  ) {
+    return [{ type: "text", text: truncateUtf16Safe(value.text, MAX_MIDDLEWARE_TEXT_CHARS) }];
   }
   if (!isRecord(value) || typeof value.type !== "string") {
     return [];
@@ -273,9 +291,10 @@ function coerceMiddlewareContentBlocks(
   const content = value.content;
   if (Array.isArray(content) && content.length > 0) {
     const nextState = descendMiddlewareContentCoerceState(value, state);
-    return nextState ? coerceMiddlewareContentArray(content, nextState) : [];
+    return nextState ? coerceMiddlewareContentArray(content, nextState, options) : [];
   }
-  const text = coerceMiddlewareText(content, state) ?? coerceMiddlewareText(value, state);
+  const text =
+    coerceMiddlewareText(content, state, options) ?? coerceMiddlewareText(value, state, options);
   if (!text) {
     return [];
   }
@@ -289,7 +308,7 @@ function coerceMiddlewareContentBlocks(
 
 function coerceMiddlewareToolResult(
   value: unknown,
-  options: { sanitizeDetails?: boolean } = {},
+  options: MiddlewareToolResultCoerceOptions = {},
 ): OpenClawAgentToolResult | undefined {
   if (isValidMiddlewareToolResult(value)) {
     return value;
@@ -305,7 +324,7 @@ function coerceMiddlewareToolResult(
     if (inspectedBlocks > MAX_MIDDLEWARE_CONTENT_BLOCKS) {
       break;
     }
-    for (const coerced of coerceMiddlewareContentBlocks(block, state)) {
+    for (const coerced of coerceMiddlewareContentBlocks(block, state, options)) {
       content.push(coerced);
       if (content.length >= MAX_MIDDLEWARE_CONTENT_BLOCKS) {
         break;
@@ -379,7 +398,10 @@ function sanitizeMiddlewareDetailsValue(value: unknown): unknown {
  * subsequent middleware-side mutations are still validated strictly.
  */
 function sanitizeToolResultForMiddleware(result: OpenClawAgentToolResult): OpenClawAgentToolResult {
-  const coerced = coerceMiddlewareToolResult(result, { sanitizeDetails: true });
+  const coerced = coerceMiddlewareToolResult(result, {
+    sanitizeContent: true,
+    sanitizeDetails: true,
+  });
   if (coerced) {
     return coerced;
   }

--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -185,6 +185,118 @@ describe("gateway tool", () => {
     }
   });
 
+  it("scopes config.get output to the requested path and keeps metadata compact", async () => {
+    const tool = requireGatewayTool();
+
+    const result = await tool.execute("call-config-get", {
+      action: "config.get",
+      path: "tools.exec",
+    });
+
+    expect(result.details).toEqual({ ok: true });
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            ok: true,
+            result: {
+              hash: "hash-1",
+              path: "tools.exec",
+              config: {
+                ask: "on-miss",
+                security: "allowlist",
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      },
+    ]);
+  });
+
+  it("rejects config.get paths that do not exist", async () => {
+    const tool = requireGatewayTool();
+
+    await expect(
+      tool.execute("call-missing-config-path", {
+        action: "config.get",
+        path: "tools.missing",
+      }),
+    ).rejects.toThrow("config path not found: tools.missing");
+  });
+
+  it("rejects config.get paths with no segments", async () => {
+    const tool = requireGatewayTool();
+
+    await expect(
+      tool.execute("call-empty-config-path", {
+        action: "config.get",
+        path: "...",
+      }),
+    ).rejects.toThrow("config path not found: ...");
+  });
+
+  it("rejects config.get paths that resolve through the prototype chain", async () => {
+    const tool = requireGatewayTool();
+
+    await expect(
+      tool.execute("call-inherited-config-path", {
+        action: "config.get",
+        path: "constructor.prototype",
+      }),
+    ).rejects.toThrow("config path not found: constructor.prototype");
+  });
+
+  it("reads config.get paths with bracketed array indexes", async () => {
+    callGatewayToolMock.mockResolvedValueOnce({
+      config: {
+        agents: {
+          list: [{ id: "ops" }],
+        },
+      },
+    });
+    const tool = requireGatewayTool();
+
+    const result = await tool.execute("call-indexed-config-path", {
+      action: "config.get",
+      path: "agents.list[0].id",
+    });
+
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            ok: true,
+            result: {
+              path: "agents.list[0].id",
+              config: "ops",
+            },
+          },
+          null,
+          2,
+        ),
+      },
+    ]);
+  });
+
+  it("requires a narrower config.get path for oversized output", async () => {
+    callGatewayToolMock.mockResolvedValueOnce({
+      config: { oversized: "x".repeat(100_000) },
+    });
+    const tool = requireGatewayTool();
+
+    await expect(
+      tool.execute("call-large-config", {
+        action: "config.get",
+      }),
+    ).rejects.toThrow(
+      "config.get response is too large; use path to request a narrower config subtree",
+    );
+  });
+
   it("schedules SIGUSR1 restart", async () => {
     const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
     const restartSignalKillCalls = () =>

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -27,6 +27,7 @@ import {
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { collectEnabledInsecureOrDangerousFlags } from "../../security/dangerous-config-flags.js";
+import { parseConfigPathArrayIndex } from "../../shared/path-array-index.js";
 import { optionalNonNegativeIntegerSchema, stringEnum } from "../schema/typebox.js";
 import {
   type AnyAgentTool,
@@ -34,6 +35,8 @@ import {
   readNonNegativeIntegerParam,
   readStringArrayParam,
   readStringParam,
+  textResult,
+  ToolInputError,
 } from "./common.js";
 import { gatewayCallOptionSchemaProperties } from "./gateway-schema.js";
 import { callGatewayTool, readGatewayCallOptions } from "./gateway.js";
@@ -41,6 +44,8 @@ import { callGatewayTool, readGatewayCallOptions } from "./gateway.js";
 const log = createSubsystemLogger("gateway-tool");
 
 const DEFAULT_UPDATE_TIMEOUT_MS = 20 * 60_000;
+// Keep complete JSON below the smallest default tool-result presentation budget.
+const MAX_GATEWAY_CONFIG_GET_TEXT_CHARS = 12_000;
 const CONFIG_SCHEMA_PATH_NOT_FOUND_MESSAGE = "config schema path not found";
 // Per SECURITY.md the model/agent itself is not a trusted principal.
 // `assertGatewayConfigMutationAllowed` is the explicit model -> operator
@@ -109,6 +114,66 @@ function getSnapshotConfig(snapshot: unknown): Record<string, unknown> {
     throw new Error("config.get response is missing a config object.");
   }
   return config as Record<string, unknown>;
+}
+
+function splitGatewayConfigGetPath(path: string): string[] {
+  return path
+    .trim()
+    .replace(/\[(\d+)\]/g, ".$1")
+    .split(".")
+    .filter(Boolean);
+}
+
+function resolveGatewayConfigGetPath(config: Record<string, unknown>, path: string): unknown {
+  const parts = splitGatewayConfigGetPath(path);
+  if (parts.length === 0) {
+    return undefined;
+  }
+  let current: unknown = config;
+  for (const part of parts) {
+    if (!current || typeof current !== "object") {
+      return undefined;
+    }
+    if (Array.isArray(current)) {
+      const index = parseConfigPathArrayIndex(part);
+      if (index === undefined || index >= current.length) {
+        return undefined;
+      }
+      current = current[index];
+      continue;
+    }
+    if (!Object.hasOwn(current, part)) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+function selectGatewayConfigGetResult(snapshot: unknown, path: string | undefined): unknown {
+  if (!path) {
+    return snapshot;
+  }
+  const value = resolveGatewayConfigGetPath(getSnapshotConfig(snapshot), path);
+  if (value === undefined) {
+    throw new ToolInputError(`config path not found: ${path}`);
+  }
+  const hash = readStringValue((snapshot as { hash?: unknown }).hash);
+  return {
+    ...(hash ? { hash } : {}),
+    path,
+    config: value,
+  };
+}
+
+function createGatewayConfigGetToolResult(result: unknown) {
+  const text = JSON.stringify({ ok: true, result }, null, 2);
+  if (text.length > MAX_GATEWAY_CONFIG_GET_TEXT_CHARS) {
+    throw new ToolInputError(
+      "config.get response is too large; use path to request a narrower config subtree",
+    );
+  }
+  return textResult(text, { ok: true });
 }
 
 // Direct RPC callers need the validated config echoed after writes; the
@@ -367,7 +432,7 @@ const GatewayToolSchema = Type.Object({
   continuationMessage: Type.Optional(Type.String()),
   // config.get, config.schema.lookup, config.apply, update.run
   ...gatewayCallOptionSchemaProperties(),
-  // config.schema.lookup
+  // config.get, config.schema.lookup
   path: Type.Optional(Type.String()),
   // config.apply, config.patch
   raw: Type.Optional(Type.String()),
@@ -498,8 +563,10 @@ export function createGatewayTool(opts?: {
       };
 
       if (action === "config.get") {
-        const result = await callGatewayTool("config.get", gatewayOpts, {});
-        return jsonResult({ ok: true, result });
+        const path = readStringParam(params, "path");
+        const snapshot = await callGatewayTool("config.get", gatewayOpts, {});
+        const result = selectGatewayConfigGetResult(snapshot, path);
+        return createGatewayConfigGetToolResult(result);
       }
       if (action === "config.schema.lookup") {
         const path = readStringParam(params, "path", {


### PR DESCRIPTION
## Summary
- bound agent-facing `gateway config.get` output below the default model-visible result budget and support safe scoped reads, including indexed paths
- normalize oversized producer text only before middleware handlers; middleware replacements remain fail-closed

Fixes #94265

## Validation
- `node scripts/run-vitest.mjs src/agents/harness/tool-result-middleware.test.ts`
- `node scripts/run-vitest.mjs src/agents/openclaw-gateway-tool.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Release impact
- required before the Tokenjuice patch release and the follow-up bundled dependency bump.