### PR TITLE
feat #94529: auto-derive session title in sidebar

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -389,6 +389,28 @@ describe("resolveSessionDisplayName", () => {
     ).toBe("General");
   });
 
+  it("falls back to derivedTitle when label and displayName are absent", () => {
+    expect(
+      resolveSessionDisplayName(
+        "agent:main:dashboard:abc",
+        row({ key: "agent:main:dashboard:abc", derivedTitle: "Project plan" }),
+      ),
+    ).toBe("Project plan");
+  });
+
+  it("prefers label over derivedTitle when both are present", () => {
+    expect(
+      resolveSessionDisplayName(
+        "agent:main:dashboard:abc",
+        row({
+          key: "agent:main:dashboard:abc",
+          label: "My label",
+          derivedTitle: "Generated title",
+        }),
+      ),
+    ).toBe("My label");
+  });
+
   it("falls back to displayName when label is absent", () => {
     expect(
       resolveSessionDisplayName(

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -1778,7 +1778,12 @@ function resolveSessionScopedOptionLabel(
 
   const label = normalizeOptionalString(row.label) ?? "";
   const displayName = normalizeOptionalString(row.displayName) ?? "";
-  if ((label && label !== key) || (displayName && displayName !== key)) {
+  const derivedTitle = normalizeOptionalString(row.derivedTitle) ?? "";
+  if (
+    (label && label !== key) ||
+    (displayName && displayName !== key) ||
+    (derivedTitle && derivedTitle !== key)
+  ) {
     return resolveSessionDisplayName(key, row);
   }
 

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -291,6 +291,7 @@ function createChatSessionPickerRequestParams(
     includeGlobal: overrides.includeGlobal,
     includeUnknown: overrides.includeUnknown,
     configuredAgentsOnly: overrides.configuredAgentsOnly,
+    includeDerivedTitles: true,
     limit: overrides.limit,
   };
   const activeAgentSession = parseAgentSessionKey(state.sessionKey);

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -335,6 +335,7 @@ describe("createSessionAndRefresh", () => {
       parentSessionKey: "agent:main:main",
     });
     expect(request).toHaveBeenNthCalledWith(2, "sessions.list", {
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       configuredAgentsOnly: true,
@@ -398,6 +399,7 @@ describe("deleteSessionsAndRefresh", () => {
       deleteTranscript: true,
     });
     expect(request).toHaveBeenNthCalledWith(3, "sessions.list", {
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       configuredAgentsOnly: true,
@@ -430,6 +432,7 @@ describe("deleteSessionsAndRefresh", () => {
       deleteTranscript: true,
     });
     expect(request).toHaveBeenNthCalledWith(2, "sessions.list", {
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       configuredAgentsOnly: true,
@@ -525,6 +528,7 @@ describe("deleteSessionsAndRefresh", () => {
     expect(deleted).toEqual(["key-a"]);
     expect(request).toHaveBeenCalledTimes(2);
     expect(request).toHaveBeenNthCalledWith(2, "sessions.list", {
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       configuredAgentsOnly: true,
@@ -549,6 +553,7 @@ describe("patchSession", () => {
       fastMode: true,
     });
     expect(request).toHaveBeenNthCalledWith(2, "sessions.list", {
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       configuredAgentsOnly: true,
@@ -799,6 +804,7 @@ describe("loadSessions", () => {
     await loadSessions(state);
 
     expect(request).toHaveBeenCalledWith("sessions.list", {
+      includeDerivedTitles: true,
       limit: 50,
       includeGlobal: true,
       includeUnknown: true,
@@ -828,6 +834,7 @@ describe("loadSessions", () => {
     await loadSessions(state);
 
     expect(request).toHaveBeenCalledWith("sessions.list", {
+      includeDerivedTitles: true,
       activeMinutes: 120,
       limit: 50,
       includeGlobal: true,
@@ -858,6 +865,7 @@ describe("loadSessions", () => {
     await loadSessions(state);
 
     expect(request).toHaveBeenCalledWith("sessions.list", {
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       configuredAgentsOnly: true,
@@ -887,6 +895,7 @@ describe("loadSessions", () => {
     });
 
     expect(request).toHaveBeenCalledWith("sessions.list", {
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       configuredAgentsOnly: true,
@@ -917,6 +926,7 @@ describe("loadSessions", () => {
     });
 
     expect(request).toHaveBeenCalledWith("sessions.list", {
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       configuredAgentsOnly: true,
@@ -954,6 +964,7 @@ describe("loadSessions", () => {
     });
 
     expect(request).toHaveBeenCalledWith("sessions.list", {
+      includeDerivedTitles: true,
       limit: 1,
       offset: 2,
       search: "telegram",
@@ -1055,6 +1066,7 @@ describe("loadSessions", () => {
 
     expect(request).toHaveBeenCalledTimes(2);
     expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {
+      includeDerivedTitles: true,
       activeMinutes: 30,
       limit: 10,
       includeGlobal: true,
@@ -1062,6 +1074,7 @@ describe("loadSessions", () => {
       configuredAgentsOnly: true,
     });
     expect(request).toHaveBeenNthCalledWith(2, "sessions.list", {
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       configuredAgentsOnly: true,
@@ -1145,6 +1158,7 @@ describe("loadSessions", () => {
     await loadSessions(state);
 
     expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       configuredAgentsOnly: true,
@@ -1205,6 +1219,7 @@ describe("loadSessions", () => {
       checkpointId: "checkpoint-1",
     });
     expect(request).toHaveBeenNthCalledWith(2, "sessions.list", {
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       configuredAgentsOnly: true,
@@ -1216,6 +1231,7 @@ describe("loadSessions", () => {
       checkpointId: "checkpoint-1",
     });
     expect(request).toHaveBeenNthCalledWith(4, "sessions.list", {
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       configuredAgentsOnly: true,

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -1126,6 +1126,7 @@ async function loadSessionsOnce(
       includeGlobal,
       includeUnknown,
       configuredAgentsOnly,
+      includeDerivedTitles: true,
     };
     const agentId = overrides?.agentId?.trim();
     const resultAgentId = agentId ? normalizeAgentId(agentId) : null;

--- a/ui/src/ui/session-display.ts
+++ b/ui/src/ui/session-display.ts
@@ -84,6 +84,7 @@ export function resolveSessionDisplayName(
 ): string {
   const label = normalizeOptionalString(row?.label) ?? "";
   const displayName = normalizeOptionalString(row?.displayName) ?? "";
+  const derivedTitle = normalizeOptionalString(row?.derivedTitle) ?? "";
   const { prefix, fallbackName } = parseSessionKey(key);
 
   const applyTypedPrefix = (name: string): string => {
@@ -99,6 +100,9 @@ export function resolveSessionDisplayName(
   }
   if (displayName && displayName !== key) {
     return applyTypedPrefix(displayName);
+  }
+  if (derivedTitle) {
+    return applyTypedPrefix(derivedTitle);
   }
   return fallbackName;
 }

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -472,6 +472,7 @@ export type GatewaySessionRow = {
   kind: "cron" | "direct" | "group" | "global" | "unknown";
   label?: string;
   displayName?: string;
+  derivedTitle?: string;
   surface?: string;
   subject?: string;
   room?: string;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -2971,6 +2971,39 @@ describe("chat session controls", () => {
     expect(onSwitchSession).toHaveBeenCalledWith(state, targetSessionKey);
   });
 
+  it("renders derived-title-only rows as friendly picker option labels", () => {
+    const { state } = createChatHeaderState();
+    state.sessionKey = "agent:main:main";
+    state.settings.sessionKey = state.sessionKey;
+    state.sessionsIncludeGlobal = false;
+    state.sessionsIncludeUnknown = false;
+    state.chatSessionPickerOpen = true;
+    state.chatSessionPickerSurface = "desktop";
+    state.chatSessionPickerResult = createSessionsResultFromRows([
+      {
+        key: "agent:main:main",
+        kind: "direct",
+        derivedTitle: "Main generated title",
+        updatedAt: 2,
+      },
+      {
+        key: "agent:main:derived-only",
+        kind: "direct",
+        derivedTitle: "Planning thread",
+        updatedAt: 1,
+      },
+    ]);
+    const container = document.createElement("div");
+
+    render(renderChatSessionSelect(state), container);
+
+    const labels = [...container.querySelectorAll(".chat-session-picker__option-label")].map(
+      (node) => node.textContent?.trim(),
+    );
+    expect(labels).toContain("Planning thread");
+    expect(labels).not.toContain("derived-only");
+  });
+
   it("clears applied chat session picker search when the input is cleared", async () => {
     const { state } = createChatHeaderState();
     state.sessionsIncludeGlobal = false;
@@ -3296,6 +3329,7 @@ describe("chat session controls", () => {
     expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {
       agentId: "main",
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
@@ -3304,6 +3338,7 @@ describe("chat session controls", () => {
     expect(request).toHaveBeenNthCalledWith(2, "sessions.list", {
       agentId: "main",
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
@@ -3375,6 +3410,7 @@ describe("chat session controls", () => {
     expect(request).toHaveBeenCalledWith("sessions.list", {
       agentId: "main",
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
@@ -3383,6 +3419,7 @@ describe("chat session controls", () => {
     expect(request).toHaveBeenCalledWith("sessions.list", {
       agentId: "main",
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -2845,6 +2845,7 @@ describe("chat session controls", () => {
     expect(request).toHaveBeenCalledWith("sessions.list", {
       agentId: "main",
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
@@ -2910,6 +2911,7 @@ describe("chat session controls", () => {
     expect(request).toHaveBeenCalledWith("sessions.list", {
       agentId: "main",
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
@@ -3058,6 +3060,7 @@ describe("chat session controls", () => {
     expect(request).toHaveBeenCalledWith("sessions.list", {
       agentId: "main",
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
@@ -3102,6 +3105,7 @@ describe("chat session controls", () => {
     expect(request).toHaveBeenCalledWith("sessions.list", {
       agentId: "main",
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
@@ -3114,6 +3118,7 @@ describe("chat session controls", () => {
     expect(request).toHaveBeenCalledWith("sessions.list", {
       agentId: "main",
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
@@ -3201,6 +3206,7 @@ describe("chat session controls", () => {
     expect(request).toHaveBeenCalledWith("sessions.list", {
       agentId: "main",
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
@@ -3465,6 +3471,7 @@ describe("chat session controls", () => {
     expect(request).toHaveBeenCalledWith("sessions.list", {
       agentId: "main",
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
@@ -3472,6 +3479,7 @@ describe("chat session controls", () => {
     expect(request).toHaveBeenCalledWith("sessions.list", {
       agentId: "main",
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
@@ -3521,6 +3529,7 @@ describe("chat session controls", () => {
 
     expect(request).toHaveBeenCalledWith("sessions.list", {
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
@@ -3601,6 +3610,7 @@ describe("chat session controls", () => {
     expect(request).toHaveBeenCalledWith("sessions.list", {
       agentId: "main",
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,
@@ -3608,6 +3618,7 @@ describe("chat session controls", () => {
     expect(request).toHaveBeenCalledWith("sessions.list", {
       agentId: "ops",
       configuredAgentsOnly: true,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: 50,


### PR DESCRIPTION
## Summary

Control UI session lists now request derived titles from the gateway and fall back to them when a session has no user-set label or display name. This makes the sidebar and chat session picker distinguishable after opening multiple sessions.

## Root Cause

`sessions.list` already supports `includeDerivedTitles`, but the Control UI frontend never requested it, so the sidebar showed generic labels such as "New Session" for fresh sessions. The chat session picker also received derived titles but did not render them when no `label`/`displayName` was present.

## Changes

- `ui/src/ui/controllers/sessions.ts`: include `includeDerivedTitles: true` in sidebar session list requests.
- `ui/src/ui/chat/session-controls.ts`: include `includeDerivedTitles: true` in chat session picker requests; `resolveSessionScopedOptionLabel()` now treats a non-key `derivedTitle` like `label` / `displayName` and calls `resolveSessionDisplayName()` instead of falling back to the parsed key rest.
- `ui/src/ui/types.ts`: add `derivedTitle?: string` to `GatewaySessionRow`.
- `ui/src/ui/session-display.ts`: use `derivedTitle` as a fallback after explicit `label` and `displayName`.

## Regression Test Plan

- Updated `ui/src/ui/controllers/sessions.test.ts` to assert `includeDerivedTitles: true` in expected `sessions.list` params.
- Updated `ui/src/ui/views/chat.test.ts` for chat session picker params and added derived-title-only picker render coverage.
- Added `resolveSessionDisplayName` tests in `ui/src/ui/app-render.helpers.node.test.ts` covering `derivedTitle` fallback and precedence over explicit labels.

## Real behavior proof

Behavior addressed: Control UI sidebar and chat session picker showed generic labels for fresh sessions instead of derived titles.

Real environment tested: Linux development checkout running the Control UI test harness.

Exact steps or command run after this patch:
```bash
pnpm test ui/src/ui/controllers/sessions.test.ts ui/src/ui/views/chat.test.ts ui/src/ui/app-render.helpers.node.test.ts --run
```

Evidence after fix:
```
✓ ui/ui/src/ui/controllers/sessions.test.ts (78 tests)
✓ ui/ui/src/ui/app-render.helpers.node.test.ts (77 tests)
✓ unit-ui/ui/src/ui/views/chat.test.ts (111 tests)

Test Files 3 passed (3)
Tests 266 passed (266)
```

These tests verify that the frontend now requests `includeDerivedTitles: true`, that `derivedTitle` is used as a fallback display name, and that the chat session picker renders `derivedTitle` for rows that have no explicit `label`/`displayName`.

Observed result after fix: `sessions.list` calls from the sidebar and chat session picker include `includeDerivedTitles: true`; `resolveSessionDisplayName` returns the derived title when no explicit label/displayName exists; `resolveSessionScopedOptionLabel` no longer falls back to the parsed key rest for derived-title-only rows.

What was not tested: A live browser screenshot of the Control UI sidebar rendering multiple sessions with distinct derived titles (requires a running gateway and browser). Requesting maintainer `proof:` override for the missing live UI screenshot.

Closes #94529.