### PR TITLE
fix: keep trusted policies with hook registry

### DIFF
--- a/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
@@ -5,7 +5,11 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setEmbeddedMode } from "../infra/embedded-mode.js";
-import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import {
+  getGlobalHookRunner,
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugins/hook-runner-global.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
@@ -69,6 +73,7 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
   let runBeforeToolCallMock: ReturnType<typeof vi.fn<HookRunner["runBeforeToolCall"]>>;
 
   beforeEach(() => {
+    resetGlobalHookRunner();
     runBeforeToolCallMock = vi.fn<HookRunner["runBeforeToolCall"]>();
     hookRunner = {
       hasHooks: vi.fn<HookRunner["hasHooks"]>().mockReturnValue(true),
@@ -82,6 +87,7 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
   afterEach(() => {
     setEmbeddedMode(false);
     setActivePluginRegistry(createEmptyPluginRegistry());
+    resetGlobalHookRunner();
   });
 
   it("blocks approval-required tools in embedded mode when no gateway approval route exists", async () => {
@@ -442,6 +448,46 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
       params: { action: "apply", proposal_id: "weather-20260530-a1b2c3d4e5" },
     });
     expect(mockCallGatewayTool).not.toHaveBeenCalled();
+    expect(runBeforeToolCallMock).not.toHaveBeenCalled();
+  });
+
+  it("runs trusted policies from the global hook registry after the active registry changes", async () => {
+    const evaluatePolicy = vi.fn(() => ({
+      block: true,
+      blockReason: "gateway registry policy blocked",
+    }));
+    const gatewayRegistry = createEmptyPluginRegistry();
+    gatewayRegistry.trustedToolPolicies = [
+      {
+        pluginId: "gateway-policy",
+        pluginName: "Gateway Policy",
+        source: "test",
+        policy: {
+          id: "gateway-block",
+          description: "Gateway policy",
+          evaluate: evaluatePolicy,
+        },
+      },
+    ];
+    initializeGlobalHookRunner(gatewayRegistry);
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    runBeforeToolCallMock.mockResolvedValue(undefined);
+
+    const result = await runBeforeToolCallHook({
+      toolName: "bash",
+      params: { command: "deploy" },
+      toolCallId: "call-gateway-policy",
+      ctx: { agentId: "main", sessionKey: "main" },
+    });
+
+    expect(result).toEqual({
+      blocked: true,
+      kind: "veto",
+      deniedReason: "plugin-before-tool-call",
+      reason: "gateway registry policy blocked",
+      params: { command: "deploy" },
+    });
+    expect(evaluatePolicy).toHaveBeenCalledTimes(1);
     expect(runBeforeToolCallMock).not.toHaveBeenCalled();
   });
 

--- a/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
@@ -12,7 +12,11 @@ import {
 } from "../plugins/hook-runner-global.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
-import { setActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  pinActivePluginChannelRegistry,
+  releasePinnedPluginChannelRegistry,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
 import { PluginApprovalResolutions } from "../plugins/types.js";
 import { runBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -489,6 +493,54 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
     });
     expect(evaluatePolicy).toHaveBeenCalledTimes(1);
     expect(runBeforeToolCallMock).not.toHaveBeenCalled();
+  });
+
+  it("runs pinned gateway trusted policies after a later global runner initialization", async () => {
+    const evaluatePolicy = vi.fn(() => ({
+      block: true,
+      blockReason: "pinned gateway policy blocked",
+    }));
+    const gatewayRegistry = createEmptyPluginRegistry();
+    gatewayRegistry.trustedToolPolicies = [
+      {
+        pluginId: "gateway-policy",
+        pluginName: "Gateway Policy",
+        source: "test",
+        policy: {
+          id: "gateway-block",
+          description: "Gateway policy",
+          evaluate: evaluatePolicy,
+        },
+      },
+    ];
+    setActivePluginRegistry(gatewayRegistry);
+    initializeGlobalHookRunner(gatewayRegistry);
+    pinActivePluginChannelRegistry(gatewayRegistry);
+    try {
+      const laterRegistry = createEmptyPluginRegistry();
+      setActivePluginRegistry(laterRegistry);
+      initializeGlobalHookRunner(laterRegistry);
+      runBeforeToolCallMock.mockResolvedValue(undefined);
+
+      const result = await runBeforeToolCallHook({
+        toolName: "bash",
+        params: { command: "deploy" },
+        toolCallId: "call-pinned-gateway-policy",
+        ctx: { agentId: "main", sessionKey: "main" },
+      });
+
+      expect(result).toEqual({
+        blocked: true,
+        kind: "veto",
+        deniedReason: "plugin-before-tool-call",
+        reason: "pinned gateway policy blocked",
+        params: { command: "deploy" },
+      });
+      expect(evaluatePolicy).toHaveBeenCalledTimes(1);
+      expect(runBeforeToolCallMock).not.toHaveBeenCalled();
+    } finally {
+      releasePinnedPluginChannelRegistry(gatewayRegistry);
+    }
   });
 
   it("does not require skill_workshop lifecycle approval in auto mode", async () => {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -37,7 +37,7 @@ import {
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { redactToolDetail } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { getGlobalHookRunner, getGlobalPluginRegistry } from "../plugins/hook-runner-global.js";
 import { deriveToolParams } from "../plugins/host-tool-param-parsers.js";
 import { copyPluginToolMeta, getPluginToolMeta } from "../plugins/tools.js";
 import {
@@ -206,9 +206,10 @@ export type BeforeToolCallPolicyDiagnosticState = {
 
 /** Return whether before_tool_call hooks or trusted policies are active. */
 export function getBeforeToolCallPolicyDiagnosticState(): BeforeToolCallPolicyDiagnosticState {
+  const policyRegistry = getGlobalPluginRegistry() ?? undefined;
   return {
     hasBeforeToolCallHook: getGlobalHookRunner()?.hasHooks("before_tool_call") === true,
-    trustedToolPolicies: getTrustedToolPolicyDiagnosticEntries(),
+    trustedToolPolicies: getTrustedToolPolicyDiagnosticEntries(policyRegistry),
   };
 }
 
@@ -1113,7 +1114,8 @@ export async function runBeforeToolCallHook(args: {
   const hookRunner = getGlobalHookRunner();
   try {
     const hasBeforeToolCallHooks = hookRunner?.hasHooks("before_tool_call") === true;
-    const shouldRunTrustedPolicies = hasTrustedToolPolicies();
+    const policyRegistry = getGlobalPluginRegistry() ?? undefined;
+    const shouldRunTrustedPolicies = hasTrustedToolPolicies(policyRegistry);
     const normalizedParams = isPlainObject(params) ? params : {};
     const initialCorePolicyResult = resolveSkillWorkshopToolApproval({
       toolName,
@@ -1165,6 +1167,7 @@ export async function runBeforeToolCallHook(args: {
           },
           toolContext,
           {
+            ...(policyRegistry ? { registry: policyRegistry } : {}),
             ...(args.ctx?.config ? { config: args.ctx.config } : {}),
             deriveEvent: deriveToolEventParams,
             normalizeEvent(eventValue) {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -37,7 +37,7 @@ import {
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { redactToolDetail } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { getGlobalHookRunner, getGlobalPluginRegistry } from "../plugins/hook-runner-global.js";
+import { getGlobalHookRunner, getGlobalHookRunnerRegistry } from "../plugins/hook-runner-global.js";
 import { deriveToolParams } from "../plugins/host-tool-param-parsers.js";
 import { copyPluginToolMeta, getPluginToolMeta } from "../plugins/tools.js";
 import {
@@ -206,7 +206,7 @@ export type BeforeToolCallPolicyDiagnosticState = {
 
 /** Return whether before_tool_call hooks or trusted policies are active. */
 export function getBeforeToolCallPolicyDiagnosticState(): BeforeToolCallPolicyDiagnosticState {
-  const policyRegistry = getGlobalPluginRegistry() ?? undefined;
+  const policyRegistry = getGlobalHookRunnerRegistry() ?? undefined;
   return {
     hasBeforeToolCallHook: getGlobalHookRunner()?.hasHooks("before_tool_call") === true,
     trustedToolPolicies: getTrustedToolPolicyDiagnosticEntries(policyRegistry),
@@ -1114,7 +1114,7 @@ export async function runBeforeToolCallHook(args: {
   const hookRunner = getGlobalHookRunner();
   try {
     const hasBeforeToolCallHooks = hookRunner?.hasHooks("before_tool_call") === true;
-    const policyRegistry = getGlobalPluginRegistry() ?? undefined;
+    const policyRegistry = getGlobalHookRunnerRegistry() ?? undefined;
     const shouldRunTrustedPolicies = hasTrustedToolPolicies(policyRegistry);
     const normalizedParams = isPlainObject(params) ? params : {};
     const initialCorePolicyResult = resolveSkillWorkshopToolApproval({

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -37,7 +37,8 @@ import {
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { redactToolDetail } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { getGlobalHookRunner, getGlobalHookRunnerRegistry } from "../plugins/hook-runner-global.js";
+import { getGlobalHookRunnerRegistry } from "../plugins/hook-runner-global-state.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { deriveToolParams } from "../plugins/host-tool-param-parsers.js";
 import { copyPluginToolMeta, getPluginToolMeta } from "../plugins/tools.js";
 import {

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: () => mocks.hookRunner,
+  getGlobalHookRunnerRegistry: () => null,
 }));
 
 vi.mock("../infra/shell-env.js", () => ({

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -355,6 +355,22 @@ describe("runtime api guardrails", () => {
     }
   });
 
+  it("keeps the composed hook-runner registry internal", () => {
+    const pluginRuntime = readFileSync(resolve(ROOT_DIR, "plugin-sdk/plugin-runtime.ts"), "utf8");
+    const hookRunnerGlobal = readFileSync(
+      resolve(ROOT_DIR, "plugins/hook-runner-global.ts"),
+      "utf8",
+    );
+    const hookRegistryTypes = readFileSync(
+      resolve(ROOT_DIR, "plugins/hook-registry.types.ts"),
+      "utf8",
+    );
+
+    expect(pluginRuntime).toContain('export * from "../plugins/hook-runner-global.js";');
+    expect(hookRunnerGlobal).not.toContain("getGlobalHookRunnerRegistry");
+    expect(hookRegistryTypes).not.toContain("trustedToolPolicies");
+  });
+
   it("keeps Slack's narrow runtime-setter entrypoint pinned to a single export", () => {
     // Regression for #69317. The bundled channel entry's runtime.specifier
     // now points at runtime-setter-api.ts. The whole point of that file is

--- a/src/plugins/hook-registry.types.ts
+++ b/src/plugins/hook-registry.types.ts
@@ -1,6 +1,7 @@
 // Defines plugin hook registry entry and dispatch types.
 import type { HookEntry } from "../hooks/types.js";
 import type { PluginHookRegistration as TypedPluginHookRegistration } from "./hook-types.js";
+import type { PluginTrustedToolPolicyRegistryRegistration } from "./registry-types.js";
 
 /** Legacy hook registration stored by the global hook runner registry. */
 export type PluginLegacyHookRegistration = {
@@ -23,4 +24,5 @@ export type GlobalHookRunnerRegistry = HookRunnerRegistry & {
     id: string;
     status: "loaded" | "disabled" | "error";
   }>;
+  trustedToolPolicies?: PluginTrustedToolPolicyRegistryRegistration[];
 };

--- a/src/plugins/hook-registry.types.ts
+++ b/src/plugins/hook-registry.types.ts
@@ -1,7 +1,6 @@
 // Defines plugin hook registry entry and dispatch types.
 import type { HookEntry } from "../hooks/types.js";
 import type { PluginHookRegistration as TypedPluginHookRegistration } from "./hook-types.js";
-import type { PluginTrustedToolPolicyRegistryRegistration } from "./registry-types.js";
 
 /** Legacy hook registration stored by the global hook runner registry. */
 export type PluginLegacyHookRegistration = {
@@ -24,5 +23,4 @@ export type GlobalHookRunnerRegistry = HookRunnerRegistry & {
     id: string;
     status: "loaded" | "disabled" | "error";
   }>;
-  trustedToolPolicies?: PluginTrustedToolPolicyRegistryRegistration[];
 };

--- a/src/plugins/hook-runner-global-state.ts
+++ b/src/plugins/hook-runner-global-state.ts
@@ -1,0 +1,213 @@
+// Internal state and composed-registry view for the global hook runner.
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type { GlobalHookRunnerRegistry } from "./hook-registry.types.js";
+import type { HookRunner } from "./hooks.js";
+import { isPluginRegistryRetired } from "./registry-lifecycle.js";
+import type {
+  PluginRegistry,
+  PluginTrustedToolPolicyRegistryRegistration,
+} from "./registry-types.js";
+import { collectLivePluginRegistries } from "./runtime.js";
+
+type TrustedPolicyHookRunnerRegistry = GlobalHookRunnerRegistry & {
+  trustedToolPolicies?: PluginTrustedToolPolicyRegistryRegistration[];
+};
+
+export type HookRunnerGlobalState = {
+  hookRunner: HookRunner | null;
+  registry: TrustedPolicyHookRunnerRegistry | null;
+};
+
+const hookRunnerGlobalStateKey = Symbol.for("openclaw.plugins.hook-runner-global-state");
+
+export function getHookRunnerGlobalState(): HookRunnerGlobalState {
+  return resolveGlobalSingleton<HookRunnerGlobalState>(hookRunnerGlobalStateKey, () => ({
+    hookRunner: null,
+    registry: null,
+  }));
+}
+
+function collectHookRegistrySources(
+  lastInitialized: TrustedPolicyHookRunnerRegistry | null,
+): TrustedPolicyHookRunnerRegistry[] {
+  const ordered: TrustedPolicyHookRunnerRegistry[] = [];
+  const seen = new Set<TrustedPolicyHookRunnerRegistry>();
+  const add = (registry: TrustedPolicyHookRunnerRegistry | null) => {
+    if (!registry || seen.has(registry)) {
+      return;
+    }
+    // Retired registries were superseded by a newer activation; dispatching
+    // their hooks would resurrect stale config closures. Only lastInitialized
+    // can be retired here (the live registries below are active/pinned, never
+    // retired); SDK-supplied registries are not PluginRegistry and never match.
+    if (isPluginRegistryRetired(registry as PluginRegistry)) {
+      return;
+    }
+    seen.add(registry);
+    ordered.push(registry);
+  };
+  // Precedence: the explicitly initialized registry wins so an SDK caller that
+  // initializes an isolated registry stays authoritative; in the gateway it is
+  // the same object as the active registry, so this just dedupes.
+  add(lastInitialized);
+  for (const registry of collectLivePluginRegistries()) {
+    add(registry);
+  }
+  return ordered;
+}
+
+function composeLiveHookRegistry(
+  lastInitialized: TrustedPolicyHookRunnerRegistry | null,
+): TrustedPolicyHookRunnerRegistry {
+  const sources = collectHookRegistrySources(lastInitialized);
+  // One source registry owns a plugin's entire contribution (status + hooks),
+  // so handlers never double-fire across registries and a plugin's hooks stay
+  // paired with the status the inbound-claim path reads.
+  const ownerSourceIndexByPluginId = new Map<string, number>();
+  const claimOwner = (pluginId: string, index: number) => {
+    if (!ownerSourceIndexByPluginId.has(pluginId)) {
+      ownerSourceIndexByPluginId.set(pluginId, index);
+    }
+  };
+  // pluginIds each source actually contributes a hook for, so ownership can
+  // prefer a source that carries the plugin's hooks over a same-plugin record
+  // that loaded without any (e.g. a setup-runtime channel load registers the
+  // channel but not the plugin's api.on(...) hooks).
+  const hookPluginIdsBySource = sources.map((registry) => {
+    const ids = new Set<string>();
+    for (const hook of registry.typedHooks) {
+      ids.add(hook.pluginId);
+    }
+    for (const hook of registry.hooks) {
+      ids.add(hook.pluginId);
+    }
+    return ids;
+  });
+  // Prefer the highest-precedence source where the plugin loaded AND actually
+  // contributes a hook, so a loaded-but-hookless record (failed/disabled scoped
+  // reload, or a setup-runtime channel load) cannot shadow a lower-precedence
+  // registration that still carries a fail-closed tool-call gate.
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      if (plugin.status === "loaded" && hookPluginIdsBySource[index].has(plugin.id)) {
+        claimOwner(plugin.id, index);
+      }
+    }
+  });
+  // Then a loaded record owns the plugin's status when no live source
+  // contributes a hook for it, keeping status paired with a single owner.
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      if (plugin.status === "loaded") {
+        claimOwner(plugin.id, index);
+      }
+    }
+  });
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      claimOwner(plugin.id, index);
+    }
+  });
+  // Defensive: claim any hook whose plugin record is absent from .plugins so a
+  // malformed registry never silently drops a registered hook.
+  sources.forEach((registry, index) => {
+    for (const hook of registry.typedHooks) {
+      claimOwner(hook.pluginId, index);
+    }
+    for (const hook of registry.hooks) {
+      claimOwner(hook.pluginId, index);
+    }
+  });
+  const policyOwnerSourceIndexByPluginId = new Map<string, number>();
+  const claimPolicyOwner = (pluginId: string, index: number) => {
+    if (!policyOwnerSourceIndexByPluginId.has(pluginId)) {
+      policyOwnerSourceIndexByPluginId.set(pluginId, index);
+    }
+  };
+  const trustedPolicyPluginIdsBySource = sources.map((registry) => {
+    const ids = new Set<string>();
+    for (const registration of registry.trustedToolPolicies ?? []) {
+      ids.add(registration.pluginId);
+    }
+    return ids;
+  });
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      if (plugin.status === "loaded" && trustedPolicyPluginIdsBySource[index].has(plugin.id)) {
+        claimPolicyOwner(plugin.id, index);
+      }
+    }
+  });
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      if (plugin.status === "loaded") {
+        claimPolicyOwner(plugin.id, index);
+      }
+    }
+  });
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      claimPolicyOwner(plugin.id, index);
+    }
+  });
+  sources.forEach((registry, index) => {
+    for (const registration of registry.trustedToolPolicies ?? []) {
+      claimPolicyOwner(registration.pluginId, index);
+    }
+  });
+  const trustedToolPolicies = sources
+    .flatMap((registry, index) =>
+      (registry.trustedToolPolicies ?? []).filter(
+        (registration) => policyOwnerSourceIndexByPluginId.get(registration.pluginId) === index,
+      ),
+    )
+    // Preserve the trusted-policy tier contract across composed registries:
+    // bundled policies run before installed policies, and same-tier entries
+    // keep the source/plugin-load order selected above.
+    .toSorted((left, right) => {
+      const leftRank = left.origin === "bundled" ? 0 : 1;
+      const rightRank = right.origin === "bundled" ? 0 : 1;
+      return leftRank - rightRank;
+    });
+  return {
+    hooks: sources.flatMap((registry, index) =>
+      registry.hooks.filter((hook) => ownerSourceIndexByPluginId.get(hook.pluginId) === index),
+    ),
+    typedHooks: sources.flatMap((registry, index) =>
+      registry.typedHooks.filter((hook) => ownerSourceIndexByPluginId.get(hook.pluginId) === index),
+    ),
+    plugins: sources.flatMap((registry, index) =>
+      registry.plugins.filter((plugin) => ownerSourceIndexByPluginId.get(plugin.id) === index),
+    ),
+    trustedToolPolicies,
+  };
+}
+
+export function createComposedHookRegistryFacade(
+  state: HookRunnerGlobalState,
+): TrustedPolicyHookRunnerRegistry {
+  // Live getters: createHookRunner reads these on every hasHooks/getHooksForName
+  // call, so the runner always dispatches the current live registry set rather
+  // than a snapshot captured at initialization. Composition is bounded by the
+  // small live registry set and runs on hook-paced events, not tight loops.
+  return {
+    get hooks() {
+      return composeLiveHookRegistry(state.registry).hooks;
+    },
+    get typedHooks() {
+      return composeLiveHookRegistry(state.registry).typedHooks;
+    },
+    get plugins() {
+      return composeLiveHookRegistry(state.registry).plugins;
+    },
+    get trustedToolPolicies() {
+      return composeLiveHookRegistry(state.registry).trustedToolPolicies;
+    },
+  };
+}
+
+/** Get the composed registry that backs global hook dispatch. */
+export function getGlobalHookRunnerRegistry(): TrustedPolicyHookRunnerRegistry | null {
+  const state = getHookRunnerGlobalState();
+  return state.registry ? createComposedHookRegistryFacade(state) : null;
+}

--- a/src/plugins/hook-runner-global.compose.test.ts
+++ b/src/plugins/hook-runner-global.compose.test.ts
@@ -6,6 +6,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  getGlobalHookRunnerRegistry,
   getGlobalHookRunner,
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
@@ -17,6 +18,7 @@ import {
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "./runtime.js";
+import { createPluginRecord } from "./status.test-helpers.js";
 
 function runner() {
   const value = getGlobalHookRunner();
@@ -91,6 +93,55 @@ describe("global hook runner composition (#91918)", () => {
 
     expect(runner().hasHooks("subagent_ended")).toBe(true);
     expect(runner().hasHooks("message_sent")).toBe(true);
+  });
+
+  it("keeps bundled trusted policies before installed policies across live registries", () => {
+    const pinnedBundled = createMockPluginRegistry([
+      { hookName: "before_tool_call", handler: vi.fn(), pluginId: "bundled-policy" },
+    ]);
+    pinnedBundled.plugins = [createPluginRecord({ id: "bundled-policy", origin: "bundled" })];
+    pinnedBundled.trustedToolPolicies = [
+      {
+        pluginId: "bundled-policy",
+        pluginName: "Bundled Policy",
+        origin: "bundled",
+        source: "test",
+        policy: {
+          id: "bundled-first",
+          description: "bundled policy",
+          evaluate: () => undefined,
+        },
+      },
+    ];
+    const activeInstalled = createMockPluginRegistry([]);
+    activeInstalled.plugins = [createPluginRecord({ id: "installed-policy", origin: "workspace" })];
+    activeInstalled.trustedToolPolicies = [
+      {
+        pluginId: "installed-policy",
+        pluginName: "Installed Policy",
+        origin: "workspace",
+        source: "test",
+        policy: {
+          id: "installed-second",
+          description: "installed policy",
+          evaluate: () => undefined,
+        },
+      },
+    ];
+
+    pinActivePluginChannelRegistry(pinnedBundled);
+    setActivePluginRegistry(activeInstalled);
+    initializeGlobalHookRunner(activeInstalled);
+
+    expect(
+      getGlobalHookRunnerRegistry()?.trustedToolPolicies?.map((registration) => [
+        registration.origin,
+        registration.policy.id,
+      ]),
+    ).toEqual([
+      ["bundled", "bundled-first"],
+      ["workspace", "installed-second"],
+    ]);
   });
 
   it("lets an explicitly initialized registry win ownership over the active registry", () => {

--- a/src/plugins/hook-runner-global.compose.test.ts
+++ b/src/plugins/hook-runner-global.compose.test.ts
@@ -5,8 +5,8 @@
  * loader.hook-runner-live-view.test.ts.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { getGlobalHookRunnerRegistry } from "./hook-runner-global-state.js";
 import {
-  getGlobalHookRunnerRegistry,
   getGlobalHookRunner,
   initializeGlobalHookRunner,
   resetGlobalHookRunner,

--- a/src/plugins/hook-runner-global.test.ts
+++ b/src/plugins/hook-runner-global.test.ts
@@ -1,6 +1,13 @@
 /** Verifies global hook runner sequencing, mutation, and error behavior. */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createMockPluginRegistry } from "./hooks.test-helpers.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import {
+  pinActivePluginChannelRegistry,
+  releasePinnedPluginChannelRegistry,
+  setActivePluginRegistry,
+} from "./runtime.js";
+import { createPluginRecord } from "./status.test-helpers.js";
 
 async function importHookRunnerGlobalModule() {
   return import("./hook-runner-global.js");
@@ -31,6 +38,7 @@ async function expectGlobalRunnerState(expected: { hasRunner: boolean; registry?
 afterEach(async () => {
   const mod = await importHookRunnerGlobalModule();
   mod.resetGlobalHookRunner();
+  setActivePluginRegistry(createEmptyPluginRegistry());
 });
 
 describe("hook-runner-global", () => {
@@ -68,5 +76,54 @@ describe("hook-runner-global", () => {
     vi.resetModules();
 
     await expectGlobalRunnerState({ hasRunner: false });
+  });
+
+  it("exposes trusted policies from the same live registry set as hooks", async () => {
+    const mod = await importHookRunnerGlobalModule();
+    const gatewayRegistry = createMockPluginRegistry([
+      {
+        hookName: "before_tool_call",
+        pluginId: "rovoclaw",
+        handler: vi.fn(),
+      },
+    ]);
+    gatewayRegistry.plugins = [createPluginRecord({ id: "rovoclaw" })];
+    gatewayRegistry.trustedToolPolicies = [
+      {
+        pluginId: "rovoclaw",
+        pluginName: "RovoClaw",
+        source: "test",
+        policy: {
+          id: "atl-sec-core",
+          description: "trusted policy",
+          evaluate: () => undefined,
+        },
+      },
+    ];
+
+    setActivePluginRegistry(gatewayRegistry);
+    mod.initializeGlobalHookRunner(gatewayRegistry);
+    pinActivePluginChannelRegistry(gatewayRegistry);
+    try {
+      const laterRegistry = createEmptyPluginRegistry();
+      laterRegistry.plugins = [createPluginRecord({ id: "openai" })];
+      setActivePluginRegistry(laterRegistry);
+      mod.initializeGlobalHookRunner(laterRegistry);
+
+      expect(expectGlobalHookRunner(mod.getGlobalHookRunner()).hasHooks("before_tool_call")).toBe(
+        true,
+      );
+      expect(mod.getGlobalPluginRegistry()).toBe(laterRegistry);
+      expect(
+        mod
+          .getGlobalHookRunnerRegistry()
+          ?.trustedToolPolicies?.map((registration) => [
+            registration.pluginId,
+            registration.policy.id,
+          ]),
+      ).toEqual([["rovoclaw", "atl-sec-core"]]);
+    } finally {
+      releasePinnedPluginChannelRegistry(gatewayRegistry);
+    }
   });
 });

--- a/src/plugins/hook-runner-global.test.ts
+++ b/src/plugins/hook-runner-global.test.ts
@@ -13,6 +13,10 @@ async function importHookRunnerGlobalModule() {
   return import("./hook-runner-global.js");
 }
 
+async function importHookRunnerGlobalStateModule() {
+  return import("./hook-runner-global-state.js");
+}
+
 type HookRunnerGlobalModule = Awaited<ReturnType<typeof importHookRunnerGlobalModule>>;
 type HookRunner = NonNullable<ReturnType<HookRunnerGlobalModule["getGlobalHookRunner"]>>;
 
@@ -114,8 +118,9 @@ describe("hook-runner-global", () => {
         true,
       );
       expect(mod.getGlobalPluginRegistry()).toBe(laterRegistry);
+      const stateMod = await importHookRunnerGlobalStateModule();
       expect(
-        mod
+        stateMod
           .getGlobalHookRunnerRegistry()
           ?.trustedToolPolicies?.map((registration) => [
             registration.pluginId,

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -165,6 +165,20 @@ function composeLiveHookRegistry(
       claimPolicyOwner(registration.pluginId, index);
     }
   });
+  const trustedToolPolicies = sources
+    .flatMap((registry, index) =>
+      (registry.trustedToolPolicies ?? []).filter(
+        (registration) => policyOwnerSourceIndexByPluginId.get(registration.pluginId) === index,
+      ),
+    )
+    // Preserve the trusted-policy tier contract across composed registries:
+    // bundled policies run before installed policies, and same-tier entries
+    // keep the source/plugin-load order selected above.
+    .toSorted((left, right) => {
+      const leftRank = left.origin === "bundled" ? 0 : 1;
+      const rightRank = right.origin === "bundled" ? 0 : 1;
+      return leftRank - rightRank;
+    });
   return {
     hooks: sources.flatMap((registry, index) =>
       registry.hooks.filter((hook) => ownerSourceIndexByPluginId.get(hook.pluginId) === index),
@@ -175,11 +189,7 @@ function composeLiveHookRegistry(
     plugins: sources.flatMap((registry, index) =>
       registry.plugins.filter((plugin) => ownerSourceIndexByPluginId.get(plugin.id) === index),
     ),
-    trustedToolPolicies: sources.flatMap((registry, index) =>
-      (registry.trustedToolPolicies ?? []).filter(
-        (registration) => policyOwnerSourceIndexByPluginId.get(registration.pluginId) === index,
-      ),
-    ),
+    trustedToolPolicies,
   };
 }
 

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -15,204 +15,15 @@
  */
 
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import type { GlobalHookRunnerRegistry } from "./hook-registry.types.js";
+import {
+  createComposedHookRegistryFacade,
+  getHookRunnerGlobalState,
+} from "./hook-runner-global-state.js";
 import type { PluginHookGatewayContext, PluginHookGatewayStopEvent } from "./hook-types.js";
 import { createHookRunner, type HookRunner } from "./hooks.js";
-import { isPluginRegistryRetired } from "./registry-lifecycle.js";
-import type { PluginRegistry } from "./registry-types.js";
-import { collectLivePluginRegistries } from "./runtime.js";
-
-type HookRunnerGlobalState = {
-  hookRunner: HookRunner | null;
-  registry: GlobalHookRunnerRegistry | null;
-};
-
-const hookRunnerGlobalStateKey = Symbol.for("openclaw.plugins.hook-runner-global-state");
-const getState = () =>
-  resolveGlobalSingleton<HookRunnerGlobalState>(hookRunnerGlobalStateKey, () => ({
-    hookRunner: null,
-    registry: null,
-  }));
 
 const getLog = () => createSubsystemLogger("plugins");
-
-function collectHookRegistrySources(
-  lastInitialized: GlobalHookRunnerRegistry | null,
-): GlobalHookRunnerRegistry[] {
-  const ordered: GlobalHookRunnerRegistry[] = [];
-  const seen = new Set<GlobalHookRunnerRegistry>();
-  const add = (registry: GlobalHookRunnerRegistry | null) => {
-    if (!registry || seen.has(registry)) {
-      return;
-    }
-    // Retired registries were superseded by a newer activation; dispatching
-    // their hooks would resurrect stale config closures. Only lastInitialized
-    // can be retired here (the live registries below are active/pinned, never
-    // retired); SDK-supplied registries are not PluginRegistry and never match.
-    if (isPluginRegistryRetired(registry as PluginRegistry)) {
-      return;
-    }
-    seen.add(registry);
-    ordered.push(registry);
-  };
-  // Precedence: the explicitly initialized registry wins so an SDK caller that
-  // initializes an isolated registry stays authoritative; in the gateway it is
-  // the same object as the active registry, so this just dedupes.
-  add(lastInitialized);
-  for (const registry of collectLivePluginRegistries()) {
-    add(registry);
-  }
-  return ordered;
-}
-
-function composeLiveHookRegistry(
-  lastInitialized: GlobalHookRunnerRegistry | null,
-): GlobalHookRunnerRegistry {
-  const sources = collectHookRegistrySources(lastInitialized);
-  // One source registry owns a plugin's entire contribution (status + hooks),
-  // so handlers never double-fire across registries and a plugin's hooks stay
-  // paired with the status the inbound-claim path reads.
-  const ownerSourceIndexByPluginId = new Map<string, number>();
-  const claimOwner = (pluginId: string, index: number) => {
-    if (!ownerSourceIndexByPluginId.has(pluginId)) {
-      ownerSourceIndexByPluginId.set(pluginId, index);
-    }
-  };
-  // pluginIds each source actually contributes a hook for, so ownership can
-  // prefer a source that carries the plugin's hooks over a same-plugin record
-  // that loaded without any (e.g. a setup-runtime channel load registers the
-  // channel but not the plugin's api.on(...) hooks).
-  const hookPluginIdsBySource = sources.map((registry) => {
-    const ids = new Set<string>();
-    for (const hook of registry.typedHooks) {
-      ids.add(hook.pluginId);
-    }
-    for (const hook of registry.hooks) {
-      ids.add(hook.pluginId);
-    }
-    return ids;
-  });
-  // Prefer the highest-precedence source where the plugin loaded AND actually
-  // contributes a hook, so a loaded-but-hookless record (failed/disabled scoped
-  // reload, or a setup-runtime channel load) cannot shadow a lower-precedence
-  // registration that still carries a fail-closed tool-call gate.
-  sources.forEach((registry, index) => {
-    for (const plugin of registry.plugins) {
-      if (plugin.status === "loaded" && hookPluginIdsBySource[index].has(plugin.id)) {
-        claimOwner(plugin.id, index);
-      }
-    }
-  });
-  // Then a loaded record owns the plugin's status when no live source
-  // contributes a hook for it, keeping status paired with a single owner.
-  sources.forEach((registry, index) => {
-    for (const plugin of registry.plugins) {
-      if (plugin.status === "loaded") {
-        claimOwner(plugin.id, index);
-      }
-    }
-  });
-  sources.forEach((registry, index) => {
-    for (const plugin of registry.plugins) {
-      claimOwner(plugin.id, index);
-    }
-  });
-  // Defensive: claim any hook whose plugin record is absent from .plugins so a
-  // malformed registry never silently drops a registered hook.
-  sources.forEach((registry, index) => {
-    for (const hook of registry.typedHooks) {
-      claimOwner(hook.pluginId, index);
-    }
-    for (const hook of registry.hooks) {
-      claimOwner(hook.pluginId, index);
-    }
-  });
-  const policyOwnerSourceIndexByPluginId = new Map<string, number>();
-  const claimPolicyOwner = (pluginId: string, index: number) => {
-    if (!policyOwnerSourceIndexByPluginId.has(pluginId)) {
-      policyOwnerSourceIndexByPluginId.set(pluginId, index);
-    }
-  };
-  const trustedPolicyPluginIdsBySource = sources.map((registry) => {
-    const ids = new Set<string>();
-    for (const registration of registry.trustedToolPolicies ?? []) {
-      ids.add(registration.pluginId);
-    }
-    return ids;
-  });
-  sources.forEach((registry, index) => {
-    for (const plugin of registry.plugins) {
-      if (plugin.status === "loaded" && trustedPolicyPluginIdsBySource[index].has(plugin.id)) {
-        claimPolicyOwner(plugin.id, index);
-      }
-    }
-  });
-  sources.forEach((registry, index) => {
-    for (const plugin of registry.plugins) {
-      if (plugin.status === "loaded") {
-        claimPolicyOwner(plugin.id, index);
-      }
-    }
-  });
-  sources.forEach((registry, index) => {
-    for (const plugin of registry.plugins) {
-      claimPolicyOwner(plugin.id, index);
-    }
-  });
-  sources.forEach((registry, index) => {
-    for (const registration of registry.trustedToolPolicies ?? []) {
-      claimPolicyOwner(registration.pluginId, index);
-    }
-  });
-  const trustedToolPolicies = sources
-    .flatMap((registry, index) =>
-      (registry.trustedToolPolicies ?? []).filter(
-        (registration) => policyOwnerSourceIndexByPluginId.get(registration.pluginId) === index,
-      ),
-    )
-    // Preserve the trusted-policy tier contract across composed registries:
-    // bundled policies run before installed policies, and same-tier entries
-    // keep the source/plugin-load order selected above.
-    .toSorted((left, right) => {
-      const leftRank = left.origin === "bundled" ? 0 : 1;
-      const rightRank = right.origin === "bundled" ? 0 : 1;
-      return leftRank - rightRank;
-    });
-  return {
-    hooks: sources.flatMap((registry, index) =>
-      registry.hooks.filter((hook) => ownerSourceIndexByPluginId.get(hook.pluginId) === index),
-    ),
-    typedHooks: sources.flatMap((registry, index) =>
-      registry.typedHooks.filter((hook) => ownerSourceIndexByPluginId.get(hook.pluginId) === index),
-    ),
-    plugins: sources.flatMap((registry, index) =>
-      registry.plugins.filter((plugin) => ownerSourceIndexByPluginId.get(plugin.id) === index),
-    ),
-    trustedToolPolicies,
-  };
-}
-
-function createComposedHookRegistryFacade(state: HookRunnerGlobalState): GlobalHookRunnerRegistry {
-  // Live getters: createHookRunner reads these on every hasHooks/getHooksForName
-  // call, so the runner always dispatches the current live registry set rather
-  // than a snapshot captured at initialization. Composition is bounded by the
-  // small live registry set and runs on hook-paced events, not tight loops.
-  return {
-    get hooks() {
-      return composeLiveHookRegistry(state.registry).hooks;
-    },
-    get typedHooks() {
-      return composeLiveHookRegistry(state.registry).typedHooks;
-    },
-    get plugins() {
-      return composeLiveHookRegistry(state.registry).plugins;
-    },
-    get trustedToolPolicies() {
-      return composeLiveHookRegistry(state.registry).trustedToolPolicies;
-    },
-  };
-}
 
 /**
  * Initialize the global hook runner with a plugin registry.
@@ -221,7 +32,7 @@ function createComposedHookRegistryFacade(state: HookRunnerGlobalState): GlobalH
  * hooks; the passed registry becomes the highest-precedence composition source.
  */
 export function initializeGlobalHookRunner(registry: GlobalHookRunnerRegistry): void {
-  const state = getState();
+  const state = getHookRunnerGlobalState();
   const log = getLog();
   state.registry = registry;
   if (!state.hookRunner) {
@@ -251,7 +62,7 @@ export function initializeGlobalHookRunner(registry: GlobalHookRunnerRegistry): 
  * Returns null if plugins haven't been loaded yet.
  */
 export function getGlobalHookRunner(): HookRunner | null {
-  return getState().hookRunner;
+  return getHookRunnerGlobalState().hookRunner;
 }
 
 /**
@@ -260,23 +71,14 @@ export function getGlobalHookRunner(): HookRunner | null {
  * this single registry; the runner resolves hooks from the live composed view.
  */
 export function getGlobalPluginRegistry(): GlobalHookRunnerRegistry | null {
-  return getState().registry;
-}
-
-/**
- * Get the composed registry that backs global hook dispatch.
- * Returns null if plugins haven't been loaded yet.
- */
-export function getGlobalHookRunnerRegistry(): GlobalHookRunnerRegistry | null {
-  const state = getState();
-  return state.registry ? createComposedHookRegistryFacade(state) : null;
+  return getHookRunnerGlobalState().registry;
 }
 
 /**
  * Check if any hooks are registered for a given hook name.
  */
 export function hasGlobalHooks(hookName: Parameters<HookRunner["hasHooks"]>[0]): boolean {
-  return getState().hookRunner?.hasHooks(hookName) ?? false;
+  return getHookRunnerGlobalState().hookRunner?.hasHooks(hookName) ?? false;
 }
 
 export async function runGlobalGatewayStopSafely(params: {
@@ -304,7 +106,7 @@ export async function runGlobalGatewayStopSafely(params: {
  * Reset the global hook runner (for testing).
  */
 export function resetGlobalHookRunner(): void {
-  const state = getState();
+  const state = getHookRunnerGlobalState();
   state.hookRunner = null;
   state.registry = null;
 }

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -128,6 +128,43 @@ function composeLiveHookRegistry(
       claimOwner(hook.pluginId, index);
     }
   });
+  const policyOwnerSourceIndexByPluginId = new Map<string, number>();
+  const claimPolicyOwner = (pluginId: string, index: number) => {
+    if (!policyOwnerSourceIndexByPluginId.has(pluginId)) {
+      policyOwnerSourceIndexByPluginId.set(pluginId, index);
+    }
+  };
+  const trustedPolicyPluginIdsBySource = sources.map((registry) => {
+    const ids = new Set<string>();
+    for (const registration of registry.trustedToolPolicies ?? []) {
+      ids.add(registration.pluginId);
+    }
+    return ids;
+  });
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      if (plugin.status === "loaded" && trustedPolicyPluginIdsBySource[index].has(plugin.id)) {
+        claimPolicyOwner(plugin.id, index);
+      }
+    }
+  });
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      if (plugin.status === "loaded") {
+        claimPolicyOwner(plugin.id, index);
+      }
+    }
+  });
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      claimPolicyOwner(plugin.id, index);
+    }
+  });
+  sources.forEach((registry, index) => {
+    for (const registration of registry.trustedToolPolicies ?? []) {
+      claimPolicyOwner(registration.pluginId, index);
+    }
+  });
   return {
     hooks: sources.flatMap((registry, index) =>
       registry.hooks.filter((hook) => ownerSourceIndexByPluginId.get(hook.pluginId) === index),
@@ -137,6 +174,11 @@ function composeLiveHookRegistry(
     ),
     plugins: sources.flatMap((registry, index) =>
       registry.plugins.filter((plugin) => ownerSourceIndexByPluginId.get(plugin.id) === index),
+    ),
+    trustedToolPolicies: sources.flatMap((registry, index) =>
+      (registry.trustedToolPolicies ?? []).filter(
+        (registration) => policyOwnerSourceIndexByPluginId.get(registration.pluginId) === index,
+      ),
     ),
   };
 }
@@ -155,6 +197,9 @@ function createComposedHookRegistryFacade(state: HookRunnerGlobalState): GlobalH
     },
     get plugins() {
       return composeLiveHookRegistry(state.registry).plugins;
+    },
+    get trustedToolPolicies() {
+      return composeLiveHookRegistry(state.registry).trustedToolPolicies;
     },
   };
 }
@@ -206,6 +251,15 @@ export function getGlobalHookRunner(): HookRunner | null {
  */
 export function getGlobalPluginRegistry(): GlobalHookRunnerRegistry | null {
   return getState().registry;
+}
+
+/**
+ * Get the composed registry that backs global hook dispatch.
+ * Returns null if plugins haven't been loaded yet.
+ */
+export function getGlobalHookRunnerRegistry(): GlobalHookRunnerRegistry | null {
+  const state = getState();
+  return state.registry ? createComposedHookRegistryFacade(state) : null;
 }
 
 /**

--- a/src/plugins/trusted-tool-policy.ts
+++ b/src/plugins/trusted-tool-policy.ts
@@ -18,6 +18,7 @@ import type {
 import { getActivePluginRegistry } from "./runtime.js";
 
 type TrustedPolicyRegistration = PluginTrustedToolPolicyRegistryRegistration;
+type TrustedToolPolicyRegistry = Pick<PluginRegistry, "trustedToolPolicies"> | null | undefined;
 
 /** Diagnostic entry for an installed trusted tool policy. */
 export type TrustedToolPolicyDiagnosticEntry = {
@@ -26,9 +27,11 @@ export type TrustedToolPolicyDiagnosticEntry = {
   pluginName?: string;
 };
 
-/** True when the active plugin registry has trusted tool policies. */
-export function hasTrustedToolPolicies(): boolean {
-  return copyTrustedPolicyRegistrations(getActivePluginRegistry()).length > 0;
+/** True when the supplied or active plugin registry has trusted tool policies. */
+export function hasTrustedToolPolicies(
+  registry: TrustedToolPolicyRegistry = getActivePluginRegistry(),
+): boolean {
+  return copyTrustedPolicyRegistrations(registry).length > 0;
 }
 
 function unreadableTrustedPolicyRegistration(): TrustedPolicyRegistration {
@@ -42,7 +45,7 @@ function unreadableTrustedPolicyRegistration(): TrustedPolicyRegistration {
 }
 
 function copyTrustedPolicyRegistrations(
-  registry: PluginRegistry | null | undefined,
+  registry: TrustedToolPolicyRegistry,
 ): TrustedPolicyRegistration[] {
   let policies: unknown;
   try {
@@ -131,8 +134,10 @@ function trustedPolicyFailureResult(
 }
 
 /** Lists trusted tool policies for status and diagnostics. */
-export function getTrustedToolPolicyDiagnosticEntries(): TrustedToolPolicyDiagnosticEntry[] {
-  return copyTrustedPolicyRegistrations(getActivePluginRegistry()).map((registration) => {
+export function getTrustedToolPolicyDiagnosticEntries(
+  registry: TrustedToolPolicyRegistry = getActivePluginRegistry(),
+): TrustedToolPolicyDiagnosticEntry[] {
+  return copyTrustedPolicyRegistrations(registry).map((registration) => {
     const entry: TrustedToolPolicyDiagnosticEntry = {
       id: readTrustedPolicyId(registration),
       pluginId: trustedPolicyDiagnosticPluginId(registration),
@@ -184,9 +189,10 @@ export async function runTrustedToolPolicies(
           ctx?: Pick<PluginHookToolContext, "toolKind" | "toolInputKind">;
         }
       | undefined;
+    registry?: TrustedToolPolicyRegistry;
   },
 ): Promise<PluginHookBeforeToolCallResult | undefined> {
-  const policies = copyTrustedPolicyRegistrations(getActivePluginRegistry());
+  const policies = copyTrustedPolicyRegistrations(options?.registry ?? getActivePluginRegistry());
   let adjustedParams = event.params;
   let hasAdjustedParams = false;
   let approval: PluginHookBeforeToolCallResult["requireApproval"];


### PR DESCRIPTION
## Summary
- Fix `before_tool_call` trusted-policy lookup so it uses the same composed live plugin registry view as the global hook runner.
- Keep the composed registry getter internal, outside the public plugin SDK barrel.
- Preserve trusted-policy tier order across composed registries: bundled policies still run before installed policies.
- Add regression coverage for active-registry drift, later global-runner reinitialization, pinned Gateway registries, cross-registry policy ordering, SDK export guardrails, and the existing exec-env hook mock path.

## What Changed
A Gateway run can keep plugin hooks live through the global hook runner while a later scoped/default registry becomes the active registry. Current `main` composes hook dispatch from the latest initialized registry plus live active/pinned registries. Before this change, trusted policies were still read from a single active/latest registry path, so a hook from a pinned Gateway registry could run while that registry's trusted policy was invisible.

The fixed path exposes an internal composed registry view and passes that registry into trusted-policy diagnostics and evaluation. `src/plugins/hook-runner-global.ts` stays the public hook-runner module; `src/plugins/hook-runner-global-state.ts` owns the internal composed-registry state.

The composed policy list is owner-filtered across live registries, then ordered by the existing trusted-policy contract: bundled policies first, installed policies after. That matters because trusted-policy blocks are terminal and policy parameter rewrites feed later policies.

## Flow
```mermaid
flowchart TD
  A[Tool call enters before_tool_call path] --> B[Read composed hook-runner registry]
  B --> C{Trusted policies present?}
  C -- yes --> D[Run trusted policies from same live registry as hooks]
  C -- no --> E[Skip trusted policy phase]
  D --> F{Policy blocks or rewrites?}
  F -- block --> G[Stop before ordinary hook]
  F -- rewrite --> H[Pass adjusted params onward]
  F -- allow --> H
  E --> H
  H --> I{before_tool_call hooks present?}
  I -- yes --> J[Run ordinary plugin hooks]
  I -- no --> K[Execute tool]
  J --> K
```

## Behavior Addressed
| Case | Before | After |
| --- | --- | --- |
| Pinned Gateway registry has `atl-sec-core`, later registry becomes active | Hook can still run, but trusted policy lookup may miss the pinned registry | Hook and trusted policy use the same composed live registry view |
| Later active registry has an installed policy, pinned registry has a bundled policy | Raw live-source order can put installed policy first | Bundled policy remains first, matching the registry/docs contract |
| Public SDK barrel re-exports hook-runner helpers | A new composed-registry getter could leak internal trusted-policy state | Internal getter lives in `hook-runner-global-state.ts`, with guardrail coverage |
| Existing tests mock only `getGlobalHookRunner()` | New registry getter can be missing from the mock and fail closed in unrelated coverage | Focused mock now returns `null` for the internal registry lookup so resolve-exec-env tests stay scoped |

## Real behavior proof
Behavior addressed: split-registry trusted-policy bypass in `runBeforeToolCallHook(...)`, including the current composed global hook-runner path, trusted-policy ordering across live registries, SDK export boundaries, and the existing exec-env hook path that uses a mocked hook runner.

Real environment tested: local OpenClaw worktree on current `origin/main`, branch `jesse/fix-trusted-policy-registry`, commit `e5314c0272619d109e3c6fd767200c2a6d68d61a`.

Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts src/agents/agent-tools.before-tool-call.embedded-mode.test.ts src/agents/bash-tools.exec.resolve-env-hook.test.ts src/plugins/hook-runner-global.test.ts src/plugins/hook-runner-global.compose.test.ts src/plugins/contracts/host-hooks.contract.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo
git diff --check
mmdc -i /tmp/pr-94545-flow.mmd -o /tmp/pr-94545-flow.svg
```

Evidence after fix:

```text
focused Vitest: 3 shards passed, 6 files passed, 98 tests passed
core tsgo: passed
source-test tsgo: passed
git diff --check: passed
Mermaid diagram validation: passed

Native review: 3 consecutive clean `codex review --base origin/main` passes on e5314c0272619d109e3c6fd767200c2a6d68d61a
Cold review: 3 consecutive clean independent cold-review passes on the same tree
```

Observed result after fix: the before-tool-call tests create a Gateway registry with a trusted policy, replace/reinitialize later registries, and confirm the trusted policy still blocks before the ordinary hook runs. The hook-runner-global tests verify the composed registry exposes the pinned Gateway trusted policy after later initialization and keeps bundled policies before installed policies across live registries. The SDK guardrail test verifies the internal composed-registry getter and trusted-policy field do not leak through the public runtime barrel. The resolve-exec-env test verifies existing before-tool-call mocked-hook coverage still reaches the exec host instead of failing closed on the new registry lookup.

What was not tested: a rebuilt ASSP/RovoClaw container using this patched OpenClaw commit was not run after the code change. Upstream Codex tests were not run; Codex source was inspected for the PreToolUse contract.

## Verification
```text
node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts src/agents/agent-tools.before-tool-call.embedded-mode.test.ts src/agents/bash-tools.exec.resolve-env-hook.test.ts src/plugins/hook-runner-global.test.ts src/plugins/hook-runner-global.compose.test.ts src/plugins/contracts/host-hooks.contract.test.ts
[test] passed 3 Vitest shards in 11.86s

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
passed

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo
passed

git diff --check
passed
```
