### PR TITLE
fix(agents): make global loop breaker session-wide

### DIFF
--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -235,7 +235,7 @@ describe("before_tool_call loop detection behavior", () => {
   function expectCriticalLoopEvent(
     loopEvent: DiagnosticToolLoopEvent | undefined,
     params: {
-      detector: "ping_pong" | "known_poll_no_progress";
+      detector: "ping_pong" | "known_poll_no_progress" | "global_circuit_breaker";
       toolName: string;
       count?: number;
     },
@@ -383,6 +383,63 @@ describe("before_tool_call loop detection behavior", () => {
 
     const result = await tool.execute(`read-${CRITICAL_THRESHOLD}`, params, undefined, undefined);
     expectToolLoopBlockedResult(result, "identical outcomes");
+  });
+
+  it("blocks a different wrapped tool when aggregate no-progress reaches the global breaker", async () => {
+    const crossToolLoopContext = {
+      agentId: "main",
+      sessionKey: "cross-tool-global-breaker",
+      loopDetection: {
+        enabled: true,
+        warningThreshold: 1,
+        criticalThreshold: 3,
+        globalCircuitBreakerThreshold: 4,
+        detectors: { genericRepeat: false, knownPollNoProgress: false, pingPong: false },
+      },
+    };
+    const readTool = createWrappedTool(
+      "read",
+      vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "same read output" }],
+        details: { ok: true },
+      }),
+      crossToolLoopContext,
+    );
+    const listTool = createWrappedTool(
+      "list",
+      vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "same list output" }],
+        details: { ok: true },
+      }),
+      crossToolLoopContext,
+    );
+    const execExecute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "should not execute" }],
+      details: { ok: true },
+    });
+    const execTool = createWrappedTool("exec", execExecute, crossToolLoopContext);
+
+    await expectUnblockedToolExecution(readTool, "read-1", { path: "/tmp/a.txt" });
+    await expectUnblockedToolExecution(listTool, "list-1", { path: "/tmp" });
+    await expectUnblockedToolExecution(readTool, "read-2", { path: "/tmp/a.txt" });
+    await expectUnblockedToolExecution(listTool, "list-2", { path: "/tmp" });
+
+    await withToolLoopEvents(async (emitted) => {
+      const result = await execTool.execute(
+        "exec-after-cross-tool-loop",
+        { command: "date" },
+        undefined,
+        undefined,
+      );
+
+      expectToolLoopBlockedResult(result, "global circuit breaker");
+      expect(execExecute).not.toHaveBeenCalled();
+      expectCriticalLoopEvent(emitted.at(-1), {
+        detector: "global_circuit_breaker",
+        toolName: "exec",
+        count: 4,
+      });
+    });
   });
 
   it("does not carry loop history across run ids", async () => {

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -569,6 +569,154 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("blocks a different next tool after aggregate cross-tool no-progress reaches the global breaker", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 1,
+        criticalThreshold: 3,
+        globalCircuitBreakerThreshold: 4,
+        detectors: { genericRepeat: false, knownPollNoProgress: false, pingPong: false },
+      };
+
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/tmp/a.txt" },
+        { content: [{ type: "text", text: "same read output" }], details: { status: "ok" } },
+        0,
+      );
+      recordSuccessfulCall(
+        state,
+        "list",
+        { path: "/tmp" },
+        { content: [{ type: "text", text: "same list output" }], details: { status: "ok" } },
+        1,
+      );
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/tmp/a.txt" },
+        { content: [{ type: "text", text: "same read output" }], details: { status: "ok" } },
+        2,
+      );
+      recordSuccessfulCall(
+        state,
+        "list",
+        { path: "/tmp" },
+        { content: [{ type: "text", text: "same list output" }], details: { status: "ok" } },
+        3,
+      );
+
+      const loopResult = detectToolCallLoop(state, "exec", { command: "date" }, config);
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("global_circuit_breaker");
+        expect(loopResult.count).toBe(4);
+        expect(loopResult.warningKey).toMatch(/^global:session:2:/);
+      }
+    });
+
+    it("does not count one-off successful calls as aggregate no-progress", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 1,
+        criticalThreshold: 3,
+        globalCircuitBreakerThreshold: 4,
+        detectors: { genericRepeat: false, knownPollNoProgress: false, pingPong: false },
+      };
+
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/tmp/a.txt" },
+        { content: [{ type: "text", text: "read output" }], details: { status: "ok" } },
+        0,
+      );
+      recordSuccessfulCall(
+        state,
+        "list",
+        { path: "/tmp" },
+        { content: [{ type: "text", text: "list output" }], details: { status: "ok" } },
+        1,
+      );
+      recordSuccessfulCall(
+        state,
+        "exec",
+        { command: "pwd" },
+        {
+          content: [{ type: "text", text: "/workspace" }],
+          details: { status: "completed", exitCode: 0, aggregated: "/workspace" },
+        },
+        2,
+      );
+      recordSuccessfulCall(
+        state,
+        "search",
+        { query: "openclaw" },
+        { content: [{ type: "text", text: "search output" }], details: { status: "ok" } },
+        3,
+      );
+
+      const loopResult = detectToolCallLoop(state, "message", { action: "send" }, config);
+
+      expect(loopResult.stuck).toBe(false);
+    });
+
+    it("resets aggregate no-progress when a repeated tool pattern starts progressing", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 1,
+        criticalThreshold: 3,
+        globalCircuitBreakerThreshold: 4,
+        detectors: { genericRepeat: false, knownPollNoProgress: false, pingPong: false },
+      };
+
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/tmp/a.txt" },
+        { content: [{ type: "text", text: "same read output" }], details: { status: "ok" } },
+        0,
+      );
+      recordSuccessfulCall(
+        state,
+        "list",
+        { path: "/tmp" },
+        { content: [{ type: "text", text: "same list output" }], details: { status: "ok" } },
+        1,
+      );
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/tmp/a.txt" },
+        { content: [{ type: "text", text: "same read output" }], details: { status: "ok" } },
+        2,
+      );
+      recordSuccessfulCall(
+        state,
+        "list",
+        { path: "/tmp" },
+        { content: [{ type: "text", text: "same list output" }], details: { status: "ok" } },
+        3,
+      );
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/tmp/a.txt" },
+        { content: [{ type: "text", text: "new read output" }], details: { status: "ok" } },
+        4,
+      );
+
+      const loopResult = detectToolCallLoop(state, "exec", { command: "date" }, config);
+
+      expect(loopResult.stuck).toBe(false);
+    });
+
     it("blocks repeated completed exec calls despite volatile runtime details", () => {
       const state = createState();
       const params = { command: "grafana-api.sh datasources" };

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -449,6 +449,46 @@ function getNoProgressStreak(
   return { count: streak, latestResultHash };
 }
 
+function getAggregateNoProgressStreak(
+  history: Array<{ toolName: string; argsHash: string; resultHash?: string }>,
+): { count: number; patternCount: number; latestResultHash?: string } {
+  const signatures = new Map<string, { count: number; latestResultHash: string }>();
+
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const record = history[i];
+    if (!record || typeof record.resultHash !== "string" || !record.resultHash) {
+      break;
+    }
+
+    const existing = signatures.get(record.argsHash);
+    if (!existing) {
+      signatures.set(record.argsHash, { count: 1, latestResultHash: record.resultHash });
+      continue;
+    }
+    if (existing.latestResultHash !== record.resultHash) {
+      break;
+    }
+    existing.count += 1;
+  }
+
+  let count = 0;
+  let patternCount = 0;
+  let latestResultHash: string | undefined;
+  for (const signature of signatures.values()) {
+    if (signature.count < 2) {
+      continue;
+    }
+    count += signature.count;
+    patternCount += 1;
+    latestResultHash ??= signature.latestResultHash;
+    if (latestResultHash !== signature.latestResultHash) {
+      latestResultHash = "mixed";
+    }
+  }
+
+  return { count, patternCount, latestResultHash };
+}
+
 function getPingPongStreak(
   history: Array<{ toolName: string; argsHash: string; resultHash?: string }>,
   currentSignature: string,
@@ -575,6 +615,7 @@ export function detectToolCallLoop(
   const unknownToolStreak = getUnknownToolRepeatStreak(history, toolName);
   const noProgress = getNoProgressStreak(history, toolName, currentHash);
   const noProgressStreak = noProgress.count;
+  const aggregateNoProgress = getAggregateNoProgressStreak(history);
   const knownPollTool = isKnownPollToolCall(toolName, params);
   const pingPong = getPingPongStreak(history, currentHash);
 
@@ -589,17 +630,17 @@ export function detectToolCallLoop(
     };
   }
 
-  if (noProgressStreak >= resolvedConfig.globalCircuitBreakerThreshold) {
+  if (aggregateNoProgress.count >= resolvedConfig.globalCircuitBreakerThreshold) {
     log.error(
-      `Global circuit breaker triggered: ${toolName} repeated ${noProgressStreak} times with no progress`,
+      `Global circuit breaker triggered: session repeated ${aggregateNoProgress.count} no-progress outcomes across ${aggregateNoProgress.patternCount} tool patterns`,
     );
     return {
       stuck: true,
       level: "critical",
       detector: "global_circuit_breaker",
-      count: noProgressStreak,
-      message: `CRITICAL: ${toolName} has repeated identical no-progress outcomes ${noProgressStreak} times. Session execution blocked by global circuit breaker to prevent runaway loops.`,
-      warningKey: `global:${toolName}:${currentHash}:${noProgress.latestResultHash ?? "none"}`,
+      count: aggregateNoProgress.count,
+      message: `CRITICAL: Recent tool calls have repeated identical no-progress outcomes ${aggregateNoProgress.count} times across ${aggregateNoProgress.patternCount} tool patterns. Session execution blocked by global circuit breaker to prevent runaway loops.`,
+      warningKey: `global:session:${aggregateNoProgress.patternCount}:${aggregateNoProgress.latestResultHash ?? "none"}`,
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes #79252.

The global loop breaker now watches the recent session tail for repeated no-progress outcomes across stable tool patterns, instead of only counting repeats for the tool that is about to run. That closes the gap where a loop like `read -> list -> read -> list` could keep making no progress and still allow a different next tool to run.

I also added detector-level coverage and before-tool-call wrapper coverage so the same behavior is checked both in the pure detector and at the runtime boundary.

## Real behavior proof

Behavior addressed: alternating stable no-progress tool calls could evade `globalCircuitBreakerThreshold` because the detector only counted repeats for the current tool/args pair.

Real environment tested: macOS local checkout on branch `fix/global-loop-breaker`, rebased on `origin/main` at `c1a414bf28`.

Exact steps or command run after this patch:

```sh
node --import tsx - <<'EOF'
import {
  detectToolCallLoop,
  recordToolCall,
  recordToolCallOutcome,
} from './src/agents/tool-loop-detection.ts';

const state = {};
const config = {
  enabled: true,
  warningThreshold: 1,
  criticalThreshold: 3,
  globalCircuitBreakerThreshold: 4,
  detectors: {
    genericRepeat: false,
    knownPollNoProgress: false,
    pingPong: false,
  },
};

function complete(toolName, toolParams, result) {
  recordToolCall(state, toolName, toolParams, undefined, config);
  recordToolCallOutcome(state, {
    toolName,
    toolParams,
    result,
    config,
  });
}

complete('read', { path: '/tmp/a.txt' }, { ok: true, content: 'same' });
complete('list', { path: '/tmp' }, { ok: true, entries: ['a.txt'] });
complete('read', { path: '/tmp/a.txt' }, { ok: true, content: 'same' });
complete('list', { path: '/tmp' }, { ok: true, entries: ['a.txt'] });

const result = detectToolCallLoop(state, 'exec', { command: 'date' }, config);
console.log(JSON.stringify(result, null, 2));
EOF
```

Evidence after fix:

```json
{
  "stuck": true,
  "level": "critical",
  "detector": "global_circuit_breaker",
  "count": 4,
  "message": "CRITICAL: Recent tool calls have repeated identical no-progress outcomes 4 times across 2 tool patterns. Session execution blocked by global circuit breaker to prevent runaway loops.",
  "warningKey": "global:session:2:d945f533f0d17914232880903bfb9369d59cd75ef12afe84c409d1fb88e9b775"
}
```

Observed result after fix: after two stable `read` outcomes and two stable `list` outcomes, the next `exec` call is blocked by `global_circuit_breaker` with count `4`.

What was not tested: no live Gateway or Feishu replay. The changed behavior is inside the shared loop detector and before-tool-call wrapper, and both paths are covered by focused tests.

## Verification

```sh
node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts
node scripts/run-vitest.mjs src/agents/agent-tools.before-tool-call.e2e.test.ts
./node_modules/.bin/oxfmt --check src/agents/tool-loop-detection.ts src/agents/tool-loop-detection.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/tool-loop-detection.ts src/agents/tool-loop-detection.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts
git diff --check
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs
```
