### PR TITLE
fix(qqbot): add exponential backoff, jitter, and circuit breaker to token refresh retry

### DIFF
--- a/extensions/qqbot/src/engine/api/token.test.ts
+++ b/extensions/qqbot/src/engine/api/token.test.ts
@@ -21,6 +21,33 @@ function mockGuardedTokenResponse(body: BodyInit, init?: ResponseInit): ReturnTy
   return release;
 }
 
+function cancelTrackedResponse(
+  text: string,
+  init: ResponseInit,
+): {
+  release: ReturnType<typeof vi.fn>;
+  response: Response;
+  wasCanceled: () => boolean;
+} {
+  let canceled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  const release = vi.fn(async () => {});
+  const response = new Response(stream, init);
+  fetchWithSsrFGuardMock.mockResolvedValueOnce({ response, release });
+  return {
+    release,
+    response,
+    wasCanceled: () => canceled,
+  };
+}
+
 describe("QQBot token manager", () => {
   beforeEach(() => {
     fetchWithSsrFGuardMock.mockReset();
@@ -57,6 +84,25 @@ describe("QQBot token manager", () => {
       },
     });
     expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds access token responses without using response.text()", async () => {
+    const logger = { debug: vi.fn(), info: vi.fn(), error: vi.fn() };
+    const tracked = cancelTrackedResponse(`${"qqbot token unavailable ".repeat(1024)}tail`, {
+      status: 503,
+      headers: { "content-type": "text/plain" },
+    });
+    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
+
+    await expect(new TokenManager({ logger }).getAccessToken("app-id", "secret")).rejects.toThrow(
+      "QQBot access_token response was malformed JSON",
+    );
+
+    expect(tracked.wasCanceled()).toBe(true);
+    expect(textSpy).not.toHaveBeenCalled();
+    expect(tracked.release).toHaveBeenCalledTimes(1);
+    expect(logger.debug.mock.calls.join("\n")).toContain("qqbot token unavailable");
+    expect(logger.debug.mock.calls.join("\n")).not.toContain("tail");
   });
 
   it("passes the RFC2544 SSRF allowance to the token fetch (regression for #88984)", async () => {
@@ -113,42 +159,60 @@ describe("QQBot token manager", () => {
 
   describe("resolveRetryDelayMs", () => {
     it("applies exponential backoff with jitter on consecutive failures", () => {
-      const p1 = { retryDelayMs: 1000, maxRetryDelayMs: 32000, circuitBreakerThreshold: 6, circuitBreakerCooldownMs: 300000, consecutiveRetries: 1 };
+      const p1 = {
+        retryDelayMs: 1000,
+        maxRetryDelayMs: 32000,
+        circuitBreakerThreshold: 6,
+        circuitBreakerCooldownMs: 300000,
+        consecutiveRetries: 1,
+      };
       for (let i = 0; i < 50; i++) {
         const r = resolveRetryDelayMs(p1);
-        expect(r).toBeGreaterThanOrEqual(700);   // 1000 * 0.7
-        expect(r).toBeLessThanOrEqual(1300);      // 1000 * 1.3
+        expect(r).toBeGreaterThanOrEqual(700); // 1000 * 0.7
+        expect(r).toBeLessThanOrEqual(1300); // 1000 * 1.3
       }
 
       const p2 = { ...p1, consecutiveRetries: 2 };
       for (let i = 0; i < 50; i++) {
         const r = resolveRetryDelayMs(p2);
-        expect(r).toBeGreaterThanOrEqual(1400);  // 2000 * 0.7
-        expect(r).toBeLessThanOrEqual(2600);     // 2000 * 1.3
+        expect(r).toBeGreaterThanOrEqual(1400); // 2000 * 0.7
+        expect(r).toBeLessThanOrEqual(2600); // 2000 * 1.3
       }
 
       const p3 = { ...p1, consecutiveRetries: 3 };
       for (let i = 0; i < 50; i++) {
         const r = resolveRetryDelayMs(p3);
-        expect(r).toBeGreaterThanOrEqual(2800);  // 4000 * 0.7
-        expect(r).toBeLessThanOrEqual(5200);     // 4000 * 1.3
+        expect(r).toBeGreaterThanOrEqual(2800); // 4000 * 0.7
+        expect(r).toBeLessThanOrEqual(5200); // 4000 * 1.3
       }
     });
 
     it("caps backoff at maxRetryDelayMs", () => {
-      const params = { retryDelayMs: 1000, maxRetryDelayMs: 5000, circuitBreakerThreshold: 10, circuitBreakerCooldownMs: 300000, consecutiveRetries: 8 };
+      const params = {
+        retryDelayMs: 1000,
+        maxRetryDelayMs: 5000,
+        circuitBreakerThreshold: 10,
+        circuitBreakerCooldownMs: 300000,
+        consecutiveRetries: 8,
+      };
       // 8 < 10 threshold, so 1000 * 2^(8-1) = 128000, capped at 5000
       for (let i = 0; i < 50; i++) {
         const r = resolveRetryDelayMs(params);
-        expect(r).toBeGreaterThanOrEqual(3500);  // 5000 * 0.7
-        expect(r).toBeLessThanOrEqual(6500);     // 5000 * 1.3
+        expect(r).toBeGreaterThanOrEqual(3500); // 5000 * 0.7
+        expect(r).toBeLessThanOrEqual(6500); // 5000 * 1.3
       }
     });
 
     it("trips circuit breaker after threshold", () => {
-      const params = { retryDelayMs: 1000, maxRetryDelayMs: 32000, circuitBreakerThreshold: 6, circuitBreakerCooldownMs: 300000, consecutiveRetries: 7 };
+      const params = {
+        retryDelayMs: 1000,
+        maxRetryDelayMs: 32000,
+        circuitBreakerThreshold: 6,
+        circuitBreakerCooldownMs: 300000,
+        consecutiveRetries: 7,
+      };
       const result = resolveRetryDelayMs(params);
-      expect(result).toBe(300000);  // Exact cooldown, no jitter
+      expect(result).toBe(300000); // Exact cooldown, no jitter
     });
   });
 

--- a/extensions/qqbot/src/engine/api/token.test.ts
+++ b/extensions/qqbot/src/engine/api/token.test.ts
@@ -1,6 +1,6 @@
 // Qqbot tests cover token plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { TokenManager } from "./token.js";
+import { resolveRetryDelayMs, TokenManager } from "./token.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
 
@@ -108,6 +108,46 @@ describe("QQBot token manager", () => {
     expect(manager.getStatus("app-id")).toEqual({
       status: "expired",
       expiresAt: Date.now(),
+    });
+  });
+
+  describe("resolveRetryDelayMs", () => {
+    it("applies exponential backoff with jitter on consecutive failures", () => {
+      const p1 = { retryDelayMs: 1000, maxRetryDelayMs: 32000, circuitBreakerThreshold: 6, circuitBreakerCooldownMs: 300000, consecutiveRetries: 1 };
+      for (let i = 0; i < 50; i++) {
+        const r = resolveRetryDelayMs(p1);
+        expect(r).toBeGreaterThan(700);   // 1000 * 0.7
+        expect(r).toBeLessThan(1300);      // 1000 * 1.3
+      }
+
+      const p2 = { ...p1, consecutiveRetries: 2 };
+      for (let i = 0; i < 50; i++) {
+        const r = resolveRetryDelayMs(p2);
+        expect(r).toBeGreaterThan(1400);  // 2000 * 0.7
+        expect(r).toBeLessThan(2600);     // 2000 * 1.3
+      }
+
+      const p3 = { ...p1, consecutiveRetries: 3 };
+      for (let i = 0; i < 50; i++) {
+        const r = resolveRetryDelayMs(p3);
+        expect(r).toBeGreaterThan(2800);  // 4000 * 0.7
+        expect(r).toBeLessThan(5200);     // 4000 * 1.3
+      }
+    });
+
+    it("caps backoff at maxRetryDelayMs", () => {
+      const params = { retryDelayMs: 1000, maxRetryDelayMs: 5000, circuitBreakerThreshold: 6, circuitBreakerCooldownMs: 300000, consecutiveRetries: 10 };
+      for (let i = 0; i < 50; i++) {
+        const r = resolveRetryDelayMs(params);
+        expect(r).toBeGreaterThan(3500);  // 5000 * 0.7
+        expect(r).toBeLessThan(6500);     // 5000 * 1.3
+      }
+    });
+
+    it("trips circuit breaker after threshold", () => {
+      const params = { retryDelayMs: 1000, maxRetryDelayMs: 32000, circuitBreakerThreshold: 6, circuitBreakerCooldownMs: 300000, consecutiveRetries: 7 };
+      const result = resolveRetryDelayMs(params);
+      expect(result).toBe(300000);  // Exact cooldown, no jitter
     });
   });
 

--- a/extensions/qqbot/src/engine/api/token.test.ts
+++ b/extensions/qqbot/src/engine/api/token.test.ts
@@ -116,31 +116,32 @@ describe("QQBot token manager", () => {
       const p1 = { retryDelayMs: 1000, maxRetryDelayMs: 32000, circuitBreakerThreshold: 6, circuitBreakerCooldownMs: 300000, consecutiveRetries: 1 };
       for (let i = 0; i < 50; i++) {
         const r = resolveRetryDelayMs(p1);
-        expect(r).toBeGreaterThan(700);   // 1000 * 0.7
-        expect(r).toBeLessThan(1300);      // 1000 * 1.3
+        expect(r).toBeGreaterThanOrEqual(700);   // 1000 * 0.7
+        expect(r).toBeLessThanOrEqual(1300);      // 1000 * 1.3
       }
 
       const p2 = { ...p1, consecutiveRetries: 2 };
       for (let i = 0; i < 50; i++) {
         const r = resolveRetryDelayMs(p2);
-        expect(r).toBeGreaterThan(1400);  // 2000 * 0.7
-        expect(r).toBeLessThan(2600);     // 2000 * 1.3
+        expect(r).toBeGreaterThanOrEqual(1400);  // 2000 * 0.7
+        expect(r).toBeLessThanOrEqual(2600);     // 2000 * 1.3
       }
 
       const p3 = { ...p1, consecutiveRetries: 3 };
       for (let i = 0; i < 50; i++) {
         const r = resolveRetryDelayMs(p3);
-        expect(r).toBeGreaterThan(2800);  // 4000 * 0.7
-        expect(r).toBeLessThan(5200);     // 4000 * 1.3
+        expect(r).toBeGreaterThanOrEqual(2800);  // 4000 * 0.7
+        expect(r).toBeLessThanOrEqual(5200);     // 4000 * 1.3
       }
     });
 
     it("caps backoff at maxRetryDelayMs", () => {
-      const params = { retryDelayMs: 1000, maxRetryDelayMs: 5000, circuitBreakerThreshold: 6, circuitBreakerCooldownMs: 300000, consecutiveRetries: 10 };
+      const params = { retryDelayMs: 1000, maxRetryDelayMs: 5000, circuitBreakerThreshold: 10, circuitBreakerCooldownMs: 300000, consecutiveRetries: 8 };
+      // 8 < 10 threshold, so 1000 * 2^(8-1) = 128000, capped at 5000
       for (let i = 0; i < 50; i++) {
         const r = resolveRetryDelayMs(params);
-        expect(r).toBeGreaterThan(3500);  // 5000 * 0.7
-        expect(r).toBeLessThan(6500);     // 5000 * 1.3
+        expect(r).toBeGreaterThanOrEqual(3500);  // 5000 * 0.7
+        expect(r).toBeLessThanOrEqual(6500);     // 5000 * 1.3
       }
     });
 

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -12,12 +12,14 @@ import {
   resolveExpiresAtMsFromDurationSeconds,
   resolveTimestampMsToIsoString,
 } from "openclaw/plugin-sdk/number-runtime";
+import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { EngineLogger } from "../types.js";
 import { formatErrorMessage } from "../utils/format.js";
 
 const TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken";
 const DEFAULT_TOKEN_EXPIRES_IN_SECONDS = 7200;
+const QQBOT_TOKEN_RESPONSE_LIMIT_BYTES = 8 * 1024;
 
 /**
  * Host-scoped SSRF policy for the QQ Bot token endpoint.
@@ -339,7 +341,7 @@ export class TokenManager {
 
       let rawBody: string;
       try {
-        rawBody = await response.text();
+        rawBody = await readResponseTextLimited(response, QQBOT_TOKEN_RESPONSE_LIMIT_BYTES);
       } catch (err) {
         throw new Error(`Failed to read access_token response: ${formatErrorMessage(err)}`, {
           cause: err,

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -48,6 +48,12 @@ interface BackgroundRefreshOptions {
   randomOffsetMs?: number;
   minRefreshIntervalMs?: number;
   retryDelayMs?: number;
+  /** Maximum delay between retries after exponential backoff (default: 120s). */
+  maxRetryDelayMs?: number;
+  /** Consecutive failures before circuit breaker pauses retries (default: 6). */
+  circuitBreakerThreshold?: number;
+  /** Duration to pause retry loop after circuit breaker trips (default: 5min). */
+  circuitBreakerCooldownMs?: number;
 }
 
 function resolveTokenExpiresInSeconds(value: unknown): number {
@@ -59,6 +65,47 @@ function resolveTokenExpiresInSeconds(value: unknown): number {
     return DEFAULT_TOKEN_EXPIRES_IN_SECONDS;
   }
   return 0;
+}
+
+/**
+ * Calculate retry delay with exponential backoff, jitter, and circuit breaker.
+ *
+ * - Exponential backoff: `baseDelayMs * 2^(retry-1)`, capped at `maxRetryDelayMs`.
+ * - Jitter: ±30% (random 70%-130%) to avoid thundering herd.
+ * - Circuit breaker: after `circuitBreakerThreshold` consecutive failures, pause
+ *   for `circuitBreakerCooldownMs` to reduce server load and log noise.
+ *
+ * Exported for testing.
+ */
+export function resolveRetryDelayMs(params: {
+  retryDelayMs: number;
+  maxRetryDelayMs: number;
+  circuitBreakerThreshold: number;
+  circuitBreakerCooldownMs: number;
+  consecutiveRetries: number;
+}): number {
+  const {
+    retryDelayMs,
+    maxRetryDelayMs,
+    circuitBreakerThreshold,
+    circuitBreakerCooldownMs,
+    consecutiveRetries,
+  } = params;
+
+  // Circuit breaker: after threshold, pause for cooldown (no jitter)
+  if (consecutiveRetries > circuitBreakerThreshold) {
+    return circuitBreakerCooldownMs;
+  }
+
+  // Exponential backoff: baseDelay * 2^(retry-1), capped at max
+  const exponentialDelay = Math.min(
+    retryDelayMs * Math.pow(2, consecutiveRetries - 1),
+    maxRetryDelayMs,
+  );
+
+  // Jitter: ±30% (random 70%-130%)
+  const jitter = 0.7 + Math.random() * 0.6;
+  return Math.round(exponentialDelay * jitter);
 }
 
 /**
@@ -165,6 +212,9 @@ export class TokenManager {
       randomOffsetMs = 30 * 1000,
       minRefreshIntervalMs = 60 * 1000,
       retryDelayMs = 5 * 1000,
+      maxRetryDelayMs = 120 * 1000,
+      circuitBreakerThreshold = 6,
+      circuitBreakerCooldownMs = 5 * 60 * 1000,
     } = options ?? {};
 
     const controller = new AbortController();
@@ -172,11 +222,13 @@ export class TokenManager {
     const { signal } = controller;
 
     const loop = async () => {
+      let consecutiveRetries = 0;
       this.logger?.info?.(`[qqbot:token:${appId}] Background refresh started`);
 
       while (!signal.aborted) {
         try {
           await this.getAccessToken(appId, clientSecret);
+          consecutiveRetries = 0;
           const cached = this.cache.get(appId);
 
           if (cached) {
@@ -197,10 +249,18 @@ export class TokenManager {
           if (signal.aborted) {
             break;
           }
+          consecutiveRetries++;
+          const delayMs = resolveRetryDelayMs({
+            retryDelayMs,
+            maxRetryDelayMs,
+            circuitBreakerThreshold,
+            circuitBreakerCooldownMs,
+            consecutiveRetries,
+          });
           this.logger?.error?.(
-            `[qqbot:token:${appId}] Background refresh failed: ${formatErrorMessage(err)}`,
+            `[qqbot:token:${appId}] Background refresh failed (retry ${consecutiveRetries} in ${Math.round(delayMs / 1000)}s): ${formatErrorMessage(err)}`,
           );
-          await this.abortableSleep(retryDelayMs, signal);
+          await this.abortableSleep(delayMs, signal);
         }
       }
 


### PR DESCRIPTION
### Description

The token background refresh loop (`startBackgroundRefresh`) currently retries with a fixed 5-second delay on every failure. When `bots.qq.com` returns a transient 503 (STGW gateway), this creates a tight retry storm.

While the cross-plugin network isolation was already fixed in v2026.6.8 (PR #89015 made token fetch use per-request dispatchers via `fetchWithSsrFGuard`), this PR addresses the remaining QQBot self-preservation concern:

- **API politeness**: hammering Tencent's API every 5s during a sustained outage is bad practice and may trigger rate limiting
- **Self-recovery**: exponential backoff lets the service recover naturally when the endpoint comes back
- **Log hygiene**: fewer error log entries during transient failures

### Changes

**`extensions/qqbot/src/engine/api/token.ts`**:

1. `BackgroundRefreshOptions` interface — added 3 optional fields (backward-compatible):
   - `maxRetryDelayMs` (default: 120s)
   - `circuitBreakerThreshold` (default: 6)
   - `circuitBreakerCooldownMs` (default: 5min)

2. New exported pure function `resolveRetryDelayMs()` — calculates retry delay with:
   - **Exponential backoff**: `baseDelayMs * 2^(retry-1)`, capped at `maxRetryDelayMs`
   - **Jitter**: ±30% (random 70%-130%) to avoid thundering herd
   - **Circuit breaker**: after threshold, pauses for cooldown (no jitter, exact value)

3. `startBackgroundRefresh` loop body — tracks `consecutiveRetries` counter:
   - Reset to 0 on every successful token refresh
   - On failure, uses `resolveRetryDelayMs()` instead of hardcoded 5s

**`extensions/qqbot/src/engine/api/token.test.ts`** — 3 new test cases for `resolveRetryDelayMs`, each running 50 iterations to verify jitter bounds.

### Retry timing

| Consecutive failures | Delay (approx) | Cumulative |
|---------------------|----------------|------------|
| 1 | ~5s | ~5s |
| 2 | ~10s | ~15s |
| 3 | ~20s | ~35s |
| 4 | ~40s | ~75s |
| 5 | ~80s | ~2.5min |
| 6 | ~120s (capped) | ~4.5min |
| 7+ | 5min (circuit breaker) | — |

### Backward compatibility

All new fields are optional with sensible defaults. The single call site (`gateway-connection.ts:209`) passes `{ log }` only, so it will use all defaults without changes.
