### PR TITLE
chore(extensions): bump tokenjuice to 0.8.1

### DIFF
--- a/extensions/tokenjuice/manifest.test.ts
+++ b/extensions/tokenjuice/manifest.test.ts
@@ -18,7 +18,7 @@ describe("tokenjuice package manifest", () => {
       fs.readFileSync(new URL("./package.json", import.meta.url), "utf8"),
     ) as TokenjuicePackageManifest;
 
-    expect(packageJson.dependencies?.tokenjuice).toBe("0.8.0");
+    expect(packageJson.dependencies?.tokenjuice).toBe("0.8.1");
   });
 
   it("declares runtime-neutral tool result middleware ownership in the manifest contract", () => {

--- a/extensions/tokenjuice/npm-shrinkwrap.json
+++ b/extensions/tokenjuice/npm-shrinkwrap.json
@@ -8,7 +8,7 @@
       "name": "@openclaw/tokenjuice",
       "version": "2026.6.8",
       "dependencies": {
-        "tokenjuice": "0.8.0"
+        "tokenjuice": "0.8.1"
       },
       "peerDependencies": {
         "openclaw": ">=2026.6.8"
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/tokenjuice": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/tokenjuice/-/tokenjuice-0.8.0.tgz",
-      "integrity": "sha512-8jSOhyW3NzYNx7HbbGDkNVltQPiGaZB10Tty5Ovqpsw1VOBw7y+FikykNZ4+Gp9Ze94UubtcPDak7kkyv6F2cg==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/tokenjuice/-/tokenjuice-0.8.1.tgz",
+      "integrity": "sha512-/CnrgVI7zm7P4yphNe2Ypqm4vOwzdIob4ki9nRdT8P1NAOgsWGv0ciTDLly4cyAaKIhLd0H3swLNn2R5FCDpYw==",
       "license": "MIT",
       "bin": {
         "tokenjuice": "dist/cli/main.js"

--- a/extensions/tokenjuice/package.json
+++ b/extensions/tokenjuice/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "tokenjuice": "0.8.0"
+    "tokenjuice": "0.8.1"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1580,8 +1580,8 @@ importers:
   extensions/tokenjuice:
     dependencies:
       tokenjuice:
-        specifier: 0.8.0
-        version: 0.8.0
+        specifier: 0.8.1
+        version: 0.8.1
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -7241,8 +7241,8 @@ packages:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
 
-  tokenjuice@0.8.0:
-    resolution: {integrity: sha512-8jSOhyW3NzYNx7HbbGDkNVltQPiGaZB10Tty5Ovqpsw1VOBw7y+FikykNZ4+Gp9Ze94UubtcPDak7kkyv6F2cg==}
+  tokenjuice@0.8.1:
+    resolution: {integrity: sha512-/CnrgVI7zm7P4yphNe2Ypqm4vOwzdIob4ki9nRdT8P1NAOgsWGv0ciTDLly4cyAaKIhLd0H3swLNn2R5FCDpYw==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -13769,7 +13769,7 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
-  tokenjuice@0.8.0: {}
+  tokenjuice@0.8.1: {}
 
   totalist@3.0.1: {}
 


### PR DESCRIPTION
## Summary
- update the bundled tokenjuice dependency to the published 0.8.1 release
- regenerate the extension npm shrinkwrap and align its manifest assertion

## Validation
- `node scripts/run-vitest.mjs extensions/tokenjuice/manifest.test.ts src/plugins/source-checkout-runtime.test.ts test/scripts/bundled-plugin-build-entries.test.ts test/package-manager-config.test.ts`
- `node scripts/generate-npm-shrinkwrap.mjs --changed --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `OPENCLAW_TESTBOX=1 pnpm check:changed` (queued as `tbx_01kvd6a5ssmmp9w4zjnvbwbx6w`)

## Release impact
- follows tokenjuice v0.8.1, published from tag `v0.8.1`.