### PR TITLE
fix #94479: Control UI: User message not rendered until assistant response starts streaming

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -2566,6 +2566,48 @@ describe("handleSendChat", () => {
     expect(host.chatQueueBySession?.["agent:a"]).toBeUndefined();
   });
 
+  it("rolls back cached optimistic messages after switching sessions before reconnect", async () => {
+    const sent = createDeferred<unknown>();
+    const request = vi.fn((method: string) => {
+      if (method === "chat.send") {
+        return sent.promise;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "retry from session A",
+      sessionKey: "agent:a:main",
+    });
+
+    const send = handleSendChat(host);
+    await Promise.resolve();
+
+    expect(host.chatMessages).toHaveLength(1);
+    expect(host.chatMessages[0]).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "retry from session A" }],
+      __openclaw: { kind: "submitted-send" },
+    });
+
+    host.chatMessagesBySession = new Map([["agent:a:main", [...host.chatMessages]]]);
+    host.chatQueueBySession = { "agent:a:main": [...host.chatQueue] };
+    host.chatMessages = [];
+    host.chatQueue = [];
+    host.sessionKey = "agent:b:main";
+
+    sent.reject(new Error("gateway closed (1006): network lost"));
+    await send;
+
+    expect(host.sessionKey).toBe("agent:b:main");
+    expect(host.chatMessages).toStrictEqual([]);
+    expect(host.chatMessagesBySession?.get("agent:a:main") ?? []).toStrictEqual([]);
+    expect(host.chatQueueBySession?.["agent:a:main"]?.[0]).toMatchObject({
+      text: "retry from session A",
+      sendState: "waiting-reconnect",
+    });
+  });
+
   it("keeps a pre-ack socket close recoverable with the same run id", async () => {
     const request = vi.fn((method: string) => {
       if (method === "chat.send") {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -2332,7 +2332,11 @@ describe("handleSendChat", () => {
     expect(host.chatQueue).toHaveLength(1);
     expect(host.chatQueue[0]?.text).toBe("same prompt");
     expect(host.chatQueue[0]?.sendState).toBe("sending");
-    expect(host.chatMessages).toStrictEqual([]);
+    expect(host.chatMessages).toHaveLength(1);
+    expect(host.chatMessages[0]).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "same prompt" }],
+    });
 
     const queuedRunId = host.chatQueue[0]?.sendRunId;
     sent.resolve({ runId: queuedRunId, status: "started" });
@@ -2343,7 +2347,7 @@ describe("handleSendChat", () => {
     expect(host.chatMessages).toHaveLength(1);
   });
 
-  it("keeps normal prompt text visible as pending until chat.send is acknowledged", async () => {
+  it("renders the user message before chat.send is acknowledged", async () => {
     const sent = createDeferred<unknown>();
     const request = vi.fn((method: string) => {
       if (method === "chat.send") {
@@ -2360,7 +2364,11 @@ describe("handleSendChat", () => {
     await Promise.resolve();
 
     expect(host.chatMessage).toBe("");
-    expect(host.chatMessages).toStrictEqual([]);
+    expect(host.chatMessages).toHaveLength(1);
+    expect(host.chatMessages[0]).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "do not lose this" }],
+    });
     expect(host.chatQueue).toHaveLength(1);
     expect(host.chatQueue[0]).toMatchObject({
       text: "do not lose this",

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -24,7 +24,12 @@ import {
   type ChatInputHistoryState,
 } from "./chat/input-history.ts";
 import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
-import { clearChatMessagesFromCache, type ChatMessageCache } from "./chat/session-message-cache.ts";
+import {
+  cacheChatMessages,
+  clearChatMessagesFromCache,
+  readChatMessagesFromCache,
+  type ChatMessageCache,
+} from "./chat/session-message-cache.ts";
 import type { ChatSideResult } from "./chat/side-result.ts";
 import { executeSlashCommand } from "./chat/slash-command-executor.ts";
 import {
@@ -1045,11 +1050,30 @@ async function sendQueuedChatMessage(
   recordChatSendTiming(host, sendingItem, "request-start", sendingItem.sendSubmittedAtMs);
   host.chatSending = true;
   const isVisibleSession = () => visibleSessionMatches(host, sessionKey, prepared.agentId);
+  const submittedSessionTarget = { sessionKey, agentId: prepared.agentId };
+  const readSubmittedSessionChatMessages = (): ChatState["chatMessages"] => {
+    if (isVisibleSession()) {
+      return host.chatMessages;
+    }
+    return host.chatMessagesBySession
+      ? readChatMessagesFromCache(host.chatMessagesBySession, host, submittedSessionTarget)
+      : [];
+  };
+  const writeSubmittedSessionChatMessages = (messages: ChatState["chatMessages"]) => {
+    if (isVisibleSession()) {
+      host.chatMessages = messages;
+      return;
+    }
+    if (host.chatMessagesBySession) {
+      cacheChatMessages(host.chatMessagesBySession, host, submittedSessionTarget, messages);
+      host.requestUpdate?.();
+    }
+  };
   let previousChatMessages: ChatState["chatMessages"] | null = null;
   let appendedUserMessage = false;
   const rollbackAppendedUserMessage = () => {
-    if (appendedUserMessage && previousChatMessages && isVisibleSession()) {
-      host.chatMessages = previousChatMessages;
+    if (appendedUserMessage && previousChatMessages) {
+      writeSubmittedSessionChatMessages(previousChatMessages);
     }
     appendedUserMessage = false;
   };
@@ -1057,16 +1081,19 @@ async function sendQueuedChatMessage(
     if (!appendedUserMessage) {
       return;
     }
-    host.chatMessages = host.chatMessages.map((entry) => {
-      const record = entry as Record<string, unknown>;
-      const marker = record.__openclaw as Record<string, unknown> | undefined;
-      if (marker?.kind !== "submitted-send" || marker.id !== id) {
-        return entry;
-      }
-      const next = { ...record };
-      delete next.__openclaw;
-      return next;
-    });
+    const messages = readSubmittedSessionChatMessages();
+    writeSubmittedSessionChatMessages(
+      messages.map((entry) => {
+        const record = entry as Record<string, unknown>;
+        const marker = record.__openclaw as Record<string, unknown> | undefined;
+        if (marker?.kind !== "submitted-send" || marker.id !== id) {
+          return entry;
+        }
+        const next = { ...record };
+        delete next.__openclaw;
+        return next;
+      }),
+    );
   };
   if (isVisibleSession()) {
     setChatError(host, null);

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1045,11 +1045,43 @@ async function sendQueuedChatMessage(
   recordChatSendTiming(host, sendingItem, "request-start", sendingItem.sendSubmittedAtMs);
   host.chatSending = true;
   const isVisibleSession = () => visibleSessionMatches(host, sessionKey, prepared.agentId);
+  let previousChatMessages: ChatState["chatMessages"] | null = null;
+  let appendedUserMessage = false;
+  const rollbackAppendedUserMessage = () => {
+    if (appendedUserMessage && previousChatMessages && isVisibleSession()) {
+      host.chatMessages = previousChatMessages;
+    }
+    appendedUserMessage = false;
+  };
+  const clearSubmittedSendMarker = () => {
+    if (!appendedUserMessage) {
+      return;
+    }
+    host.chatMessages = host.chatMessages.map((entry) => {
+      const record = entry as Record<string, unknown>;
+      const marker = record.__openclaw as Record<string, unknown> | undefined;
+      if (marker?.kind !== "submitted-send" || marker.id !== id) {
+        return entry;
+      }
+      const next = { ...record };
+      delete next.__openclaw;
+      return next;
+    });
+  };
   if (isVisibleSession()) {
     setChatError(host, null);
     reconcileChatRunLifecycle(host as unknown as Parameters<typeof reconcileChatRunLifecycle>[0], {
       clearRunStatus: true,
     });
+    previousChatMessages = host.chatMessages;
+    appendUserChatMessage(
+      host as unknown as ChatState,
+      message,
+      hasAttachments ? attachments : undefined,
+      startedAt,
+      { kind: "submitted-send", id },
+    );
+    appendedUserMessage = true;
   }
 
   try {
@@ -1078,13 +1110,17 @@ async function sendQueuedChatMessage(
       ...chatSendAckServerTimingEventFields(ack),
     });
     removeQueuedMessageWithoutReleasing(host, id, sessionKey);
+    clearSubmittedSendMarker();
     if (isVisibleSession()) {
-      appendUserChatMessage(
-        host as unknown as ChatState,
-        message,
-        hasAttachments ? attachments : undefined,
-        startedAt,
-      );
+      if (!appendedUserMessage) {
+        appendUserChatMessage(
+          host as unknown as ChatState,
+          message,
+          hasAttachments ? attachments : undefined,
+          startedAt,
+        );
+        appendedUserMessage = true;
+      }
       if (ack.status === "ok") {
         reconcileChatRunLifecycle(
           host as unknown as Parameters<typeof reconcileChatRunLifecycle>[0],
@@ -1133,6 +1169,7 @@ async function sendQueuedChatMessage(
     discardChatAttachmentDataUrls(excludeComposerAttachments(host, attachments));
     return "sent";
   } catch (err) {
+    rollbackAppendedUserMessage();
     const error = formatConnectError(err);
     if (isRecoverableChatSendError(err, error)) {
       updateQueuedMessageForSession(host, sessionKey, id, (item) => ({

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -456,6 +456,21 @@ function queuedSendThreadMessage(item: ChatQueueItem): Record<string, unknown> |
   };
 }
 
+function submittedSendMessageIds(messages: unknown[]): Set<string> {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    const marker = asRecord(asRecord(message)?.["__openclaw"]);
+    if (marker?.kind !== "submitted-send") {
+      continue;
+    }
+    const id = typeof marker.id === "string" ? marker.id.trim() : "";
+    if (id) {
+      ids.add(id);
+    }
+  }
+  return ids;
+}
+
 function rawMessageTimestamp(message: unknown): number | null {
   const timestamp = asRecord(message)?.timestamp;
   return typeof timestamp === "number" && Number.isFinite(timestamp) ? timestamp : null;
@@ -725,8 +740,9 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     });
   }
   const queuedSends = Array.isArray(props.queue) ? props.queue : [];
+  const submittedSendIds = submittedSendMessageIds(history);
   for (const queued of queuedSends) {
-    if (!shouldRenderQueuedSendInThread(queued)) {
+    if (submittedSendIds.has(queued.id) || !shouldRenderQueuedSendInThread(queued)) {
       continue;
     }
     const message = queuedSendThreadMessage(queued);

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1185,6 +1185,7 @@ export function appendUserChatMessage(
   message: string,
   attachments?: ChatAttachment[],
   timestamp = Date.now(),
+  openclawMetadata?: Record<string, unknown>,
 ) {
   state.chatMessages = [
     ...state.chatMessages,
@@ -1192,6 +1193,7 @@ export function appendUserChatMessage(
       role: "user",
       content: buildUserChatMessageContentBlocks(message, attachments),
       timestamp,
+      ...(openclawMetadata ? { __openclaw: openclawMetadata } : {}),
     },
   ];
 }

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -724,6 +724,23 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
           timeout: 10_000,
         })
         .toBe("");
+      await expect
+        .poll(
+          () =>
+            page.evaluate(() => {
+              const app = document.querySelector("openclaw-app") as
+                | (Element & {
+                    chatMessages?: Array<{ role?: unknown; content?: Array<{ text?: unknown }> }>;
+                  })
+                | null;
+              return (app?.chatMessages ?? []).map((message) => ({
+                role: message.role,
+                text: message.content?.[0]?.text,
+              }));
+            }),
+          { timeout: 10_000 },
+        )
+        .toEqual([{ role: "user", text: prompt }]);
       const params = requireRecord(sendRequest.params);
       const runId = requireString(params.idempotencyKey, "chat send idempotency key");
 


### PR DESCRIPTION
Fixes #94479

## Summary
- Render the submitted user turn into `chatMessages` before waiting for the `chat.send` ACK, so the Control UI transcript state updates immediately after Send.
- Keep the queued send for idempotency, retry, and duplicate-submit coalescing, while rolling the optimistic message back on request failure.
- Filter the matching pending-send thread item while the optimistic user message is present, so delayed ACKs do not render the same user text twice.
- Clean the temporary optimistic marker in the submitted session cache when users switch sessions before ACK or reconnect handling completes.

## Root Cause
- **Fix classification:** Root cause fix.
- **Maintainer-ready confidence:** High. The failing unit assertions reproduced the delayed-ACK state gap before the production change, the follow-up unit regression reproduced the session-cache marker lifecycle gap before the cache-aware cleanup, and the browser E2E exercises the real Control UI send path with `chat.send` held open until after the user message is observed in `openclaw-app.chatMessages`.
- **Root cause:** `sendQueuedChatMessage()` previously appended the user message only after `requestChatSend()` resolved. During a slow or delayed Gateway ACK, the composer cleared and the queue entered `sending`, but the transcript source of truth (`chatMessages`) still did not contain the submitted user turn. The first optimistic-render patch also only rolled back or cleared the temporary `submitted-send` marker through the currently visible `host.chatMessages`, so switching sessions before a delayed failure/reconnect could leave a stale marker in the original session cache.
- **Why this is root-cause fix:** The change updates the transcript owner at the source of the send lifecycle: a visible submitted send now enters `chatMessages` immediately, before the asynchronous ACK boundary. The queue item stays in place for retry/coalescing state, failures restore the previous message array, and ACK/failure marker cleanup now targets the submitted session whether it is still visible or has been saved into `chatMessagesBySession`.
- **Patch quality notes:** Patch-quality warnings are expected because this is a message-delivery UI path and the code uses the existing `host as unknown as ChatState` pattern already present in this function. The new timeout is inside an existing E2E `expect.poll` guard and matches the surrounding 10s browser assertions; it does not change product retry or timeout behavior.

## Competition / linked PR analysis
- PR #94497 also targets #94479 by moving the user-message append earlier in `sendQueuedChatMessage()`.
- This patch additionally handles the duplicate-rendering edge exposed by the existing delayed-ACK browser path: once the optimistic message is present, `buildChatItems()` skips the matching pending-send thread item by queue id, so the transcript and queue lifecycle do not render two copies of the same user text.
- This patch also handles the session-switch lifecycle edge for the temporary optimistic marker: rollback/ACK cleanup reads and writes the submitted session cache when that session is no longer visible.
- The PR body proof here includes a browser E2E assertion for the actual Control UI custom element state before the ACK resolves; the linked PR body explicitly did not include a full Control UI browser/manual E2E run.

## Origin / follow-up
N/A — independent root-cause issue fix. The #94497 reference above is linked-PR competition analysis for the same issue, not a follow-up to a merged origin PR.

## Review findings addressed
- **RF-001 status: fixed by this update.** The PR was waiting on author action; this update adds the requested code change, regression coverage, refreshed local proof, and updated PR body.
- **RF-002 status: fixed.** `sendQueuedChatMessage()` now reads and writes the submitted session message list through `chatMessagesBySession` when the original session is off-screen, so failure/reconnect cleanup is not limited to visible `host.chatMessages`.
- **RF-003 status: fixed.** Added `ui/src/ui/app-chat.test.ts` coverage that starts a send in `agent:a:main`, caches the optimistic message, switches to `agent:b:main`, rejects `chat.send` as recoverable, and verifies the cached optimistic message is gone while the original queue item remains `waiting-reconnect`.
- **RF-004 status: fixed.** The stale marker no longer remains in the cached original session after a recoverable failure, so the queued retry state is not hidden by `buildChatItems()` when that session is restored.
- **RF-005 status: maintainer-decision disclosed.** There is still another open candidate PR for the same issue; this PR documents the linked PR gap and provides the additional duplicate-rendering and session-cache lifecycle coverage for maintainers to choose the canonical fix path.
- **RF-006 status: fixed.** The repair stays narrow: it only changes the optimistic message rollback/marker cleanup target and one focused regression test.
- **RF-007 status: fixed.** The rollback helper now restores `previousChatMessages` to the submitted session even after a session switch, using the existing session message cache helpers.
- **RF-008 status: fixed with proof.** Ran `node scripts/run-vitest.mjs ui/src/ui/app-chat.test.ts ui/src/ui/chat/build-chat-items.test.ts`; result: 2 files passed, 138 tests passed.
- **RF-009 status: fixed with proof.** Ran `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/google-chrome node scripts/run-vitest.mjs ui/src/ui/e2e/chat-flow.e2e.test.ts`; result: 1 file passed, 14 tests passed.
- **RF-010 status: fixed with proof.** Ran `pnpm --dir ui build`; result: production UI build passed with the existing large chunk warning.

## Real behavior proof
- **Behavior or issue addressed:** Control UI user messages should appear in the chat transcript state immediately after Send, before the Gateway starts streaming or resolves the `chat.send` ACK. If the user switches sessions before a delayed failure/reconnect, the original session cache should not keep a stale `submitted-send` marker that hides the queued retry row.
- **Real environment tested:** Local Linux worktree for `openclaw/openclaw`, Control UI browser E2E in Chromium via `/usr/bin/google-chrome`, existing local Gateway fixture, and production UI build.
- **Exact steps or command run after this patch:**
```bash
node scripts/run-vitest.mjs ui/src/ui/app-chat.test.ts ui/src/ui/chat/build-chat-items.test.ts
PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/google-chrome node scripts/run-vitest.mjs ui/src/ui/e2e/chat-flow.e2e.test.ts
pnpm --dir ui build
```
- **Evidence after fix:**
```text
RED follow-up regression:
  ui/src/ui/app-chat.test.ts failed because cached messages for agent:a:main still contained the optimistic user message with __openclaw.kind = submitted-send after switching sessions before a recoverable chat.send rejection.

GREEN unit:
  Test Files  2 passed (2)
  Tests       138 passed (138)

GREEN browser E2E:
  Test Files  1 passed (1)
  Tests       14 passed (14)
  Covered path: delayed chat.send ACK keeps the ACK unresolved after Send and verifies openclaw-app.chatMessages already contains [{ role: "user", text: prompt }].

GREEN build:
  vite v8.0.16 building client environment for production...
  ✓ 921 modules transformed.
  ✓ built in 3.63s
```
- **Observed result after fix:** With `chat.send` deferred, the Control UI browser test clears the composer, records the `chat.send` request, and observes the submitted user message in `openclaw-app.chatMessages` before the ACK is resolved. The same delayed-ACK thread renders only one copy of the user text while the queue item remains available for send lifecycle state. The follow-up session-cache unit test switches away from the submitted session before a recoverable `chat.send` rejection and confirms the cached original session message list is rolled back while the queued item remains in `waiting-reconnect`.
- **What was not tested:** I did not test the Windows desktop shell or the qclaw/minimax provider route from the issue report. The local proof uses the repository's Control UI browser E2E harness and local Gateway fixture to isolate the client-side delayed-ACK behavior.

## Regression Test Plan
- **Target test file:** `ui/src/ui/app-chat.test.ts`, `ui/src/ui/chat/build-chat-items.test.ts`, and `ui/src/ui/e2e/chat-flow.e2e.test.ts`.
- **Scenario locked in:** A queued send whose `chat.send` request is not acknowledged immediately must clear the composer and place the submitted user turn in `chatMessages` before ACK; the pending queue item must not create a second thread copy while that optimistic message is present; and switching sessions before a recoverable rejection must roll back the cached optimistic message without losing the queued retry state.
- **Why this is the smallest reliable guardrail:** The app-chat unit tests catch the source state invariant and the session-cache lifecycle edge, the build-chat-items test suite guards the thread builder touched by the de-dupe, and the browser E2E proves the user-facing Control UI path across the composer, Gateway request, transcript state, and delayed ACK boundary.

## Merge risk
- **Risk labels considered:** `merge-risk:message-delivery` and a public-contract/protocol scanner signal around the `chat.send` text in the PR body.
- **Risk explanation:** The change is in the Control UI client-side send lifecycle only. It does not alter the Gateway method name, request payload, provider/model routing, server protocol, or persisted session format; it changes when the visible UI transcript state receives the already-submitted user turn and ensures the temporary client-only marker follows the submitted session cache lifecycle.
- **Why acceptable:** Existing queued retry/coalescing state is preserved, recoverable and validation failures roll back the optimistic message, session-cache cleanup prevents stale markers from hiding retry rows after session switches, and browser E2E covers delayed ACK behavior so the queue and transcript do not double-render the same user send.

## Scope and architecture boundaries
- **Why it matters / User impact:** Users get immediate visual confirmation that their message was sent instead of waiting for the assistant stream or ACK timing. This directly addresses the issue report's delayed user-message rendering in Control UI.
- **What did NOT change:** No Gateway API, `chat.send` payload, provider route, model selection, session key selection, desktop shell behavior, or server-side message delivery code changed.
- **Architecture / source-of-truth check:** `chatMessages` remains the transcript source of truth for rendered conversation turns, while `chatQueue` remains the send lifecycle source for retry/coalescing. The temporary `submitted-send` marker is client-internal, removed after ACK or rolled back on failure in the submitted session whether visible or cached, and only used to suppress the matching pending-send thread item. Related open PR scan found #94497 for the same issue; this patch keeps compatibility/default behavior unchanged and leaves Windows desktop/provider-specific live proof out of scope.
