### PR TITLE
fix(update): isolate post-core finalizer env

### DIFF
--- a/src/infra/update-post-core-finalize.test.ts
+++ b/src/infra/update-post-core-finalize.test.ts
@@ -123,6 +123,38 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
     expect(env.OPENCLAW_GATEWAY_SERVICE_PID).toBeUndefined();
   });
 
+  it("does not inherit a stale source-config handoff path without a fresh payload", async () => {
+    const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>(async () => ({ code: 0 }));
+    await runPostCoreFinalizeAfterGatewayUpdate({
+      result: gitOkResult(),
+      resolveEntrypoint: resolveEntrypointOk,
+      spawnFinalize,
+      env: {
+        PATH: "/usr/bin",
+        OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH: "/tmp/stale-source-config.json",
+      },
+    });
+
+    const { env } = spawnFinalize.mock.calls[0][0];
+    expect(env.OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH).toBeUndefined();
+  });
+
+  it("does not inherit a stale compatibility host version when the update result has none", async () => {
+    const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>(async () => ({ code: 0 }));
+    await runPostCoreFinalizeAfterGatewayUpdate({
+      result: gitOkResult({ after: undefined }),
+      resolveEntrypoint: resolveEntrypointOk,
+      spawnFinalize,
+      env: {
+        PATH: "/usr/bin",
+        OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.1.1",
+      },
+    });
+
+    const { env } = spawnFinalize.mock.calls[0][0];
+    expect(env.OPENCLAW_COMPATIBILITY_HOST_VERSION).toBeUndefined();
+  });
+
   it("carries effective git/dev channel via env without --channel for a no-config update", async () => {
     const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>(async () => ({ code: 0 }));
     await runPostCoreFinalizeAfterGatewayUpdate({

--- a/src/infra/update-post-core-finalize.ts
+++ b/src/infra/update-post-core-finalize.ts
@@ -45,8 +45,9 @@ import type { UpdateRunResult } from "./update-runner.js";
 const FINALIZE_PROCESS_TIMEOUT_FLOOR_MS = 30 * 60_000;
 const FINALIZE_PROCESS_STEP_BUDGET_MULTIPLIER = 6;
 
-// Strip the running gateway's service identity from the finalizer child so it is
-// not mistaken for the managed service process (matches the CLI post-core spawn).
+// Strip the running gateway's service identity and stale finalizer handoff
+// context from the child; each finalize run must receive only this update's
+// source-config path and host-version context.
 // Also carry the effective update channel so convergence runs on the channel the
 // core update actually used (git/dev for an unconfigured source update) — passed
 // as the *effective* channel, never a *requested* one, so `update finalize` does
@@ -61,6 +62,8 @@ function buildFinalizeEnv(
   delete env.OPENCLAW_SERVICE_MARKER;
   delete env.OPENCLAW_SERVICE_KIND;
   delete env[GATEWAY_SERVICE_RUNTIME_PID_ENV];
+  delete env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+  delete env[POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV];
   env[UPDATE_EFFECTIVE_CHANNEL_ENV] = effectiveChannel;
   if (compatHostVersion) {
     env.OPENCLAW_COMPATIBILITY_HOST_VERSION = compatHostVersion;


### PR DESCRIPTION
## Summary

Fixes #94559.

The RPC post-core finalizer now clears stale internal finalizer handoff env vars before setting the context for the current update run. That keeps `openclaw update finalize` from inheriting an old `OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH` or compatibility host version from the running gateway process.

The change is intentionally narrow: it only affects the environment passed to the finalizer child and adds focused regression coverage for both stale values.

## Real behavior proof

Behavior addressed: `runPostCoreFinalizeAfterGatewayUpdate` could pass a stale inherited `OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH` to the finalizer child when the current RPC update did not have a fresh pre-update config payload.

Real environment tested: macOS local checkout on branch `fix/finalize-env-isolation`, based on `origin/main` at `bba1d0204c`.

Exact steps or command run after this patch:

```sh
tmpdir=$(mktemp -d /tmp/openclaw-finalize-proof-helper-XXXXXX)
config="$tmpdir/openclaw.json"
printf '{"channels":{"slack":{"enabled":true}}}\n' > "$config"
printf '{"sourceConfig":{"channels":{"telegram":{"enabled":true}}},"authoredConfig":{"channels":{"telegram":{"enabled":true}}}}\n' > "$tmpdir/stale-source-config.json"

TMPDIR_PROOF="$tmpdir" CONFIG_PROOF="$config" node --import tsx - <<'EOF' > "$tmpdir/out.txt" 2> "$tmpdir/err.txt"
import fs from 'node:fs/promises';
import { runPostCoreFinalizeAfterGatewayUpdate } from './src/infra/update-post-core-finalize.ts';

const tmpdir = process.env.TMPDIR_PROOF;
const config = process.env.CONFIG_PROOF;
if (!tmpdir || !config) throw new Error('missing proof env');

const outcome = await runPostCoreFinalizeAfterGatewayUpdate({
  result: {
    status: 'ok',
    mode: 'git',
    root: process.cwd(),
    after: { version: '2026.6.8' },
    steps: [],
    durationMs: 1,
  },
  timeoutMs: 1000,
  env: {
    PATH: process.env.PATH,
    HOME: tmpdir,
    OPENCLAW_HOME: tmpdir,
    OPENCLAW_CONFIG_PATH: config,
    OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH: `${tmpdir}/stale-source-config.json`,
  },
});

const parsed = JSON.parse(await fs.readFile(config, 'utf-8'));
console.log(JSON.stringify({
  outcome,
  slackEnabled: parsed.channels?.slack?.enabled ?? null,
  telegramRestoredFromStaleEnv: parsed.channels?.telegram?.enabled === true,
}, null, 2));
EOF

exit_code=$?
printf 'status=%s\n' "$exit_code"
printf 'stdout='
cat "$tmpdir/out.txt"
printf '\nconfig_channels='
node -e "const fs=require('fs'); const c=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(JSON.stringify(c.channels ?? null))" "$config"
```

This proof does not pass a test `spawnFinalize` or `resolveEntrypoint`; the helper uses its normal subprocess path and launches the real built `openclaw update finalize` child.

Evidence after fix:

```text
status=0
stdout={
  "outcome": {
    "status": "ok",
    "entrypoint": "<repo>/dist/index.js"
  },
  "slackEnabled": true,
  "telegramRestoredFromStaleEnv": false
}

config_channels={"slack":{"enabled":true}}
```

The same stale source-config file would restore `telegram` if passed directly to `openclaw update finalize`:

```json
{
  "channels": {
    "slack": {
      "enabled": true
    },
    "telegram": {
      "enabled": true
    }
  },
}
```

Observed result after fix: the real helper-spawned `openclaw update finalize` child completed successfully, preserved the current `slack` config, and did not restore `telegram` from the stale inherited source-config path.

What was not tested: a live gateway self-update/restart. The changed behavior is isolated to finalizer child env construction and is covered by focused tests plus a real helper-spawned finalizer child run in an isolated temp config.

## Verification

```sh
node scripts/run-vitest.mjs src/infra/update-post-core-finalize.test.ts
./node_modules/.bin/oxfmt --check src/infra/update-post-core-finalize.ts src/infra/update-post-core-finalize.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/infra/update-post-core-finalize.ts src/infra/update-post-core-finalize.test.ts
git diff --check
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs
```
