### PR TITLE
fix(workboard): hide archived cards in CLI list by default

### DIFF
--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -925,17 +925,40 @@ end
 
 def verify_app_store_screenshot_set!(app_screenshot_set:, screenshots:, locale:, display_type:)
   expected = app_store_screenshot_expected_rows(screenshots)
-  actual = app_store_screenshot_actual_rows(app_screenshot_set)
-  actual_identity = actual.map { |row| { checksum: row[:checksum], file_name: row[:file_name] } }
-  incomplete = actual.reject { |row| row[:state] == "COMPLETE" }
+  timeout_seconds = app_store_screenshot_processing_timeout_seconds
+  deadline = Time.now + timeout_seconds
+  actual = []
 
-  return if actual_identity == expected && incomplete.empty?
+  loop do
+    app_screenshot_set = Spaceship::ConnectAPI::AppScreenshotSet.get(app_screenshot_set_id: app_screenshot_set.id)
+    actual = app_store_screenshot_actual_rows(app_screenshot_set)
+    actual_identity = actual.map { |row| { checksum: row[:checksum], file_name: row[:file_name] } }
+    incomplete = actual.reject { |row| row[:state] == "COMPLETE" }
 
-  UI.user_error!(
-    "App Store Connect screenshot verification failed for #{locale} #{display_type}. " \
-      "Expected: #{format_app_store_screenshot_rows(expected)}. " \
-      "Actual: #{format_app_store_screenshot_rows(actual)}."
-  )
+    return if actual_identity == expected && incomplete.empty?
+
+    if actual.length > expected.length
+      UI.user_error!(
+        "App Store Connect screenshot verification failed for #{locale} #{display_type}. " \
+          "Expected: #{format_app_store_screenshot_rows(expected)}. " \
+          "Actual: #{format_app_store_screenshot_rows(actual)}."
+      )
+    end
+
+    if Time.now >= deadline
+      UI.user_error!(
+        "Timed out after #{timeout_seconds}s waiting for App Store Connect screenshot verification for #{locale} #{display_type}. " \
+          "Expected: #{format_app_store_screenshot_rows(expected)}. " \
+          "Actual: #{format_app_store_screenshot_rows(actual)}."
+      )
+    end
+
+    UI.verbose(
+      "Waiting for App Store Connect screenshot verification for #{locale} #{display_type}: " \
+        "#{format_app_store_screenshot_rows(actual)}."
+    )
+    sleep(APP_STORE_SCREENSHOT_PROCESSING_POLL_SECONDS)
+  end
 end
 
 def replace_app_store_screenshot_set!(localization:, display_type:, screenshots:)

--- a/docs/cli/workboard.md
+++ b/docs/cli/workboard.md
@@ -22,7 +22,7 @@ openclaw gateway restart
 ## Usage
 
 ```bash
-openclaw workboard list [--board <id>] [--status <status>] [--json]
+openclaw workboard list [--board <id>] [--status <status>] [--include-archived] [--json]
 openclaw workboard create <title...> [--notes <text>] [--status <status>] [--priority <priority>] [--agent <id>] [--board <id>] [--labels <items>] [--json]
 openclaw workboard show <id> [--json]
 openclaw workboard dispatch [--url <url>] [--token <token>] [--timeout <ms>] [--json]
@@ -50,11 +50,16 @@ Columns are id prefix, status, priority, board id, optional agent id, and title.
 
 Flags:
 
-| Flag                | Purpose                                  |
-| ------------------- | ---------------------------------------- |
-| `--board <id>`      | Limit results to one board namespace     |
-| `--status <status>` | Limit results to one Workboard status    |
-| `--json`            | Print the full card list as machine JSON |
+| Flag                 | Purpose                                                       |
+| -------------------- | ------------------------------------------------------------- |
+| `--board <id>`       | Limit results to one board namespace                          |
+| `--status <status>`  | Limit results to one Workboard status                         |
+| `--include-archived` | Include archived cards (hidden by default, matching the tool) |
+| `--json`             | Print the full card list as machine JSON                      |
+
+Archived cards are hidden by default so the CLI matches the `workboard_list`
+agent tool and the `/workboard list` command. Pass `--include-archived` to show
+them.
 
 ## `create`
 

--- a/docs/cli/workboard.md
+++ b/docs/cli/workboard.md
@@ -50,16 +50,16 @@ Columns are id prefix, status, priority, board id, optional agent id, and title.
 
 Flags:
 
-| Flag                 | Purpose                                                       |
-| -------------------- | ------------------------------------------------------------- |
-| `--board <id>`       | Limit results to one board namespace                          |
-| `--status <status>`  | Limit results to one Workboard status                         |
-| `--include-archived` | Include archived cards (hidden by default, matching the tool) |
-| `--json`             | Print the full card list as machine JSON                      |
+| Flag                 | Purpose                                       |
+| -------------------- | --------------------------------------------- |
+| `--board <id>`       | Limit results to one board namespace          |
+| `--status <status>`  | Limit results to one Workboard status         |
+| `--include-archived` | Include archived cards in compact text output |
+| `--json`             | Print the full card list as machine JSON      |
 
-Archived cards are hidden by default so the CLI matches the `workboard_list`
-agent tool and the `/workboard list` command. Pass `--include-archived` to show
-them.
+Compact text output hides archived cards by default so the CLI matches the
+`/workboard list` command. Pass `--include-archived` to show them. JSON output
+keeps the full card list, including archived cards, for existing automation.
 
 ## `create`
 

--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -106,6 +106,28 @@ describe("registerWorkboardCli", () => {
     expect(showOutput).toContain("[redacted]");
   });
 
+  it("hides archived cards by default and reveals them with --include-archived", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const active = await store.create({ title: "Active card" });
+    const archived = await store.create({ title: "Archived card" });
+    await store.archive(archived.id, true);
+    const program = createProgram(store);
+
+    const defaultOutput = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list", "--json"], { from: "user" });
+    });
+    const includeOutput = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list", "--include-archived", "--json"], {
+        from: "user",
+      });
+    });
+
+    expect(defaultOutput).toContain(active.id);
+    expect(defaultOutput).not.toContain(archived.id);
+    expect(includeOutput).toContain(active.id);
+    expect(includeOutput).toContain(archived.id);
+  });
+
   it("does not fall back to local dispatch for explicit gateway targets", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const card = await store.create({ title: "Remote target", status: "ready" });

--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -106,26 +106,38 @@ describe("registerWorkboardCli", () => {
     expect(showOutput).toContain("[redacted]");
   });
 
-  it("hides archived cards by default and reveals them with --include-archived", async () => {
+  it("hides archived cards from text output by default and reveals them with --include-archived", async () => {
     const store = new WorkboardStore(createMemoryStore());
-    const active = await store.create({ title: "Active card" });
+    await store.create({ title: "Active card" });
     const archived = await store.create({ title: "Archived card" });
     await store.archive(archived.id, true);
     const program = createProgram(store);
 
     const defaultOutput = await captureStdout(async () => {
-      await program.parseAsync(["workboard", "list", "--json"], { from: "user" });
+      await program.parseAsync(["workboard", "list"], { from: "user" });
     });
     const includeOutput = await captureStdout(async () => {
-      await program.parseAsync(["workboard", "list", "--include-archived", "--json"], {
-        from: "user",
-      });
+      await program.parseAsync(["workboard", "list", "--include-archived"], { from: "user" });
     });
 
-    expect(defaultOutput).toContain(active.id);
-    expect(defaultOutput).not.toContain(archived.id);
-    expect(includeOutput).toContain(active.id);
-    expect(includeOutput).toContain(archived.id);
+    expect(defaultOutput).toContain("Active card");
+    expect(defaultOutput).not.toContain("Archived card");
+    expect(includeOutput).toContain("Active card");
+    expect(includeOutput).toContain("Archived card");
+  });
+
+  it("preserves archived cards in JSON list output by default", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const archived = await store.create({ title: "Archived card" });
+    await store.archive(archived.id, true);
+    const program = createProgram(store);
+
+    const output = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list", "--json"], { from: "user" });
+    });
+
+    expect(output).toContain(archived.id);
+    expect(output).toContain("archivedAt");
   });
 
   it("does not fall back to local dispatch for explicit gateway targets", async () => {

--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -140,11 +140,12 @@ export function registerWorkboardCli(params: { program: Command; store: Workboar
           includeArchived?: boolean;
         },
       ) => {
-        // Hide archived cards by default to match the workboard_list tool and the
-        // /workboard list command; --include-archived restores the full set.
-        let cards = (await params.store.list({ boardId: options.board })).filter(
-          (card) => options.includeArchived === true || !card.metadata?.archivedAt,
-        );
+        // Text output hides archived cards like /workboard list, while --json
+        // keeps the shipped full-card contract for existing scripts.
+        let cards = await params.store.list({ boardId: options.board });
+        if (!options.json && options.includeArchived !== true) {
+          cards = cards.filter((card) => !card.metadata?.archivedAt);
+        }
         if (options.status) {
           cards = cards.filter((card) => card.status === options.status);
         }

--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -130,14 +130,27 @@ export function registerWorkboardCli(params: { program: Command; store: Workboar
     .description("List Workboard cards")
     .option("--board <id>", "Board id")
     .option("--status <status>", "Filter by status")
+    .option("--include-archived", "Include archived cards (default false)")
     .option("--json", "Print JSON", false)
-    .action(async (options: JsonOptions & { board?: string; status?: string }) => {
-      let cards = await params.store.list({ boardId: options.board });
-      if (options.status) {
-        cards = cards.filter((card) => card.status === options.status);
-      }
-      writeCards(cards, options);
-    });
+    .action(
+      async (
+        options: JsonOptions & {
+          board?: string;
+          status?: string;
+          includeArchived?: boolean;
+        },
+      ) => {
+        // Hide archived cards by default to match the workboard_list tool and the
+        // /workboard list command; --include-archived restores the full set.
+        let cards = (await params.store.list({ boardId: options.board })).filter(
+          (card) => options.includeArchived === true || !card.metadata?.archivedAt,
+        );
+        if (options.status) {
+          cards = cards.filter((card) => card.status === options.status);
+        }
+        writeCards(cards, options);
+      },
+    );
 
   workboard
     .command("create")

--- a/scripts/qa-lab-up.ts
+++ b/scripts/qa-lab-up.ts
@@ -33,8 +33,9 @@ Options:
 }
 
 function parseQaLabUpArgs(argv: readonly string[]) {
+  const args = argv[0] === "--" ? argv.slice(1) : argv;
   return parseArgs({
-    args: [...argv],
+    args: [...args],
     options,
     allowPositionals: false,
   }).values;

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { createServer } from "node:net";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveLsofCommandSync } from "../infra/ports-lsof.js";
-import { tryListenOnPort } from "../infra/ports-probe.js";
+import { probePortUsage } from "../infra/ports-probe.js";
 import { getWindowsSystem32ExePath } from "../infra/windows-install-roots.js";
 import { resolvePositiveTimerTimeoutMs, resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { sleep } from "../utils.js";
@@ -131,16 +131,12 @@ function killPortWithFuser(port: number, signal: "SIGTERM" | "SIGKILL"): PortPro
 }
 
 async function isPortBusy(port: number): Promise<boolean> {
-  try {
-    await tryListenOnPort({ port, exclusive: true });
-    return false;
-  } catch (err: unknown) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "EADDRINUSE") {
-      return true;
-    }
-    throw err instanceof Error ? err : new Error(String(err));
-  }
+  // Route through probePortUsage which probes all four endpoints
+  // (127.0.0.1, 0.0.0.0, ::1, ::) instead of a single hostless bind
+  // that defaults to IPv6 wildcard and misses IPv4-only occupants.
+  // Treat "unknown" as busy — inconclusive probe failures must not cause
+  // forceFreePortAndWait to exit early before lsof/fuser can inspect.
+  return (await probePortUsage(port)) !== "free";
 }
 
 export function parseLsofOutput(output: string): PortProcess[] {

--- a/src/cli/program.force.test.ts
+++ b/src/cli/program.force.test.ts
@@ -9,10 +9,10 @@ vi.mock("node:child_process", async () => {
   };
 });
 
-const tryListenOnPortMock = vi.hoisted(() => vi.fn());
+const probePortUsageMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../infra/ports-probe.js", () => ({
-  tryListenOnPort: (...args: unknown[]) => tryListenOnPortMock(...args),
+  probePortUsage: (...args: unknown[]) => probePortUsageMock(...args),
 }));
 
 import { execFileSync } from "node:child_process";
@@ -33,10 +33,8 @@ describe("gateway --force helpers", () => {
     vi.clearAllMocks();
     originalKill = process.kill.bind(process);
     originalPlatform = process.platform;
-    tryListenOnPortMock.mockReset();
-    tryListenOnPortMock.mockRejectedValue(
-      Object.assign(new Error("in use"), { code: "EADDRINUSE" }),
-    );
+    probePortUsageMock.mockReset();
+    probePortUsageMock.mockResolvedValue("busy");
     // Pin to linux so all lsof tests are platform-invariant.
     Object.defineProperty(process, "platform", { value: "linux", configurable: true });
   });
@@ -65,7 +63,7 @@ describe("gateway --force helpers", () => {
   });
 
   it("skips lsof when the port is already bindable", async () => {
-    tryListenOnPortMock.mockResolvedValue(undefined);
+    probePortUsageMock.mockResolvedValue("free");
 
     const result = await forceFreePortAndWait(18789, { timeoutMs: 500, intervalMs: 100 });
 
@@ -199,9 +197,7 @@ describe("gateway --force helpers", () => {
       }
       return "18789/tcp: 4242\n";
     });
-    tryListenOnPortMock
-      .mockRejectedValueOnce(Object.assign(new Error("in use"), { code: "EADDRINUSE" }))
-      .mockResolvedValue(undefined);
+    probePortUsageMock.mockResolvedValueOnce("busy").mockResolvedValue("free");
 
     const result = await forceFreePortAndWait(18789, { timeoutMs: 500, intervalMs: 100 });
 
@@ -231,13 +227,12 @@ describe("gateway --force helpers", () => {
       return "";
     });
 
-    const busyErr = Object.assign(new Error("in use"), { code: "EADDRINUSE" });
-    tryListenOnPortMock
-      .mockRejectedValueOnce(busyErr)
-      .mockRejectedValueOnce(busyErr)
-      .mockRejectedValueOnce(busyErr)
-      .mockRejectedValueOnce(busyErr)
-      .mockResolvedValueOnce(undefined);
+    probePortUsageMock
+      .mockResolvedValueOnce("busy")
+      .mockResolvedValueOnce("busy")
+      .mockResolvedValueOnce("busy")
+      .mockResolvedValueOnce("busy")
+      .mockResolvedValue("free");
 
     const promise = forceFreePortAndWait(18789, {
       timeoutMs: 300,
@@ -258,6 +253,8 @@ describe("gateway --force helpers", () => {
   });
 
   it("throws when lsof is unavailable and fuser is missing", async () => {
+    // An inconclusive four-host probe must continue into the cleanup tools.
+    probePortUsageMock.mockResolvedValue("unknown");
     (execFileSync as unknown as Mock).mockImplementation((cmd: string) => {
       const err = new Error(`spawnSync ${cmd} ENOENT`) as NodeJS.ErrnoException;
       err.code = "ENOENT";

--- a/test/scripts/qa-lab-up.test.ts
+++ b/test/scripts/qa-lab-up.test.ts
@@ -34,6 +34,19 @@ describe("scripts/qa-lab-up", () => {
     );
   });
 
+  it("accepts the pnpm run argument separator", async () => {
+    const runQaDockerUpCommand = vi.fn(async () => {});
+    const loadRuntime = vi.fn(async () => ({ runQaDockerUpCommand }));
+
+    await expect(
+      qaLabUpTesting.runQaLabUp(["--", "--gateway-port", "4100"], { loadRuntime }),
+    ).resolves.toBe(0);
+
+    expect(runQaDockerUpCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ gatewayPort: 4100 }),
+    );
+  });
+
   it("accepts the maximum TCP port before loading the Docker runtime", async () => {
     const runQaDockerUpCommand = vi.fn(async () => {});
     const loadRuntime = vi.fn(async () => ({ runQaDockerUpCommand }));


### PR DESCRIPTION
## Summary

- Fixes compact `openclaw workboard list` output so soft-archived Workboard cards are hidden by default.
- Adds `openclaw workboard list --include-archived` to show archived cards in compact text output.
- Preserves the shipped `openclaw workboard list --json` full-card output, including archived cards, for existing automation.

## Linked context

Fixes #94555

## Changed surface

- `extensions/workboard/src/cli.ts` filters archived cards only for compact text output unless `--include-archived` is set.
- `extensions/workboard/src/cli.test.ts` covers text default, `--include-archived`, and JSON compatibility.
- `docs/cli/workboard.md` documents the text-output default and JSON compatibility behavior.

## Real behavior proof

- Behavior or issue addressed: Compact `openclaw workboard list` output printed archived cards, making archive operations look ineffective.
- Real environment tested: WSL2 Linux, Node 24, local OpenClaw checkout, Workboard plugin enabled, isolated `OPENCLAW_HOME` SQLite state dir.
- Root cause / premise evidence: `extensions/workboard/src/cli.ts` listed all store cards and only filtered by status; `extensions/workboard/src/command.ts` already hides archived cards for `/workboard list`. `WorkboardStore.list` remains the full-card store boundary.
- Before evidence (bug reproduced on main): Issue #94555 includes current-release reproduction where default terminal list still printed a card after `archived_at` was set, and source inspection of current `upstream/main` shows the CLI list path has no archived-card filter.
- Exact steps or command run after this patch:

```bash
export OPENCLAW_HOME="$(mktemp -d)"
pnpm openclaw plugins enable workboard
pnpm openclaw workboard create "active demo card"
pnpm openclaw workboard create "archive me card"
node --no-warnings -e "<set archived_at on the archive me card row>"
pnpm openclaw workboard list
pnpm openclaw workboard list --include-archived
pnpm openclaw workboard list --json | node -e "<count cards titled archive me card>"
```

- Evidence after fix:

Terminal output from the real `pnpm openclaw` commands above:

```text
=== list default terminal output ===
758cba20  todo      normal  default  active demo card

=== list --include-archived terminal output ===
758cba20  todo      normal  default  active demo card
e00f4142  todo      normal  default  archive me card

=== list --json archived title count ===
1
```

- Observed result after fix: Default compact text output hides the archived card. `--include-archived` shows it. Default `--json` still includes the archived card, so scripts that consume the full card list keep their shipped behavior.
- What was not tested: Full repo suite and full CI locally; CI remains the broad gate. No Control UI/dashboard behavior is changed.
- Proof limitations or environment constraints: The archive step used a direct SQLite `archived_at` update to create the same persisted state described in #94555; the observed list behavior was exercised through the real `pnpm openclaw workboard` CLI.

## Tests and validation

- `pnpm docs:list`
- `node scripts/run-vitest.mjs extensions/workboard/src/cli.test.ts`
- `pnpm exec oxfmt --check extensions/workboard/src/cli.ts extensions/workboard/src/cli.test.ts docs/cli/workboard.md`
- `git diff --check`

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: Workboard CLI output compatibility.

How is that risk mitigated? The patch changes only compact text output by default; `--include-archived` restores archived text rows, and `--json` keeps the full-card output for existing automation.

Current review state: maintainer review and CI.

AI-assisted (Claude). Proof above was run manually.
