### PR TITLE
Preserve aborted sessions across restart opt-in

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -187,6 +187,7 @@ async function writeTerminalTranscriptSessionStore(params: {
   sessionKey: string;
   sessionId: string;
   status?: SessionEntry["status"];
+  abortedLastRun?: boolean;
   omitStatus?: boolean;
   updatedAt: number;
   endedAt: number;
@@ -209,6 +210,7 @@ async function writeTerminalTranscriptSessionStore(params: {
       startedAt: params.endedAt - 10_000,
       endedAt: params.endedAt,
       runtimeMs: 9_000,
+      ...(params.abortedLastRun ? { abortedLastRun: true } : {}),
       ...(status ? { status } : {}),
     },
   });
@@ -1970,6 +1972,45 @@ describe("initSessionState reset policy", () => {
       expect(entry?.status).toBe(scenario.status ?? "done");
       expect(entry?.endedAt).toBe(terminalEndedAt);
     }
+  });
+
+  it("reuses an aborted main session when restart continuation is enabled", async () => {
+    vi.setSystemTime(new Date(2026, 0, 18, 5, 30, 0));
+    const root = await makeCaseDir("openclaw-restart-continuation-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:main";
+    const existingSessionId = "restart-continuation-old";
+    const now = Date.now();
+    const terminalUpdatedAt = now - 10_000;
+    const terminalEndedAt = now - 11_000;
+    await writeTerminalTranscriptSessionStore({
+      storePath,
+      sessionKey,
+      sessionId: existingSessionId,
+      abortedLastRun: true,
+      updatedAt: terminalUpdatedAt,
+      endedAt: terminalEndedAt,
+      transcriptMtimeMs: now,
+    });
+
+    const cfg = {
+      session: { store: storePath, restartContinuation: true },
+    } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: { Body: "hello after restart", SessionKey: sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe(existingSessionId);
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      SessionEntry
+    >;
+    expect(persisted[sessionKey]?.sessionId).toBe(existingSessionId);
+    expect(persisted[sessionKey]?.abortedLastRun).toBe(true);
+    expect(persisted[sessionKey]?.endedAt).toBe(terminalEndedAt);
   });
 
   it("keeps the existing stale session for /reset soft", async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -480,8 +480,15 @@ export async function initSessionState(params: {
       mainKey,
       storePath,
     }));
+  const restartContinuationAllowed =
+    sessionCfg?.restartContinuation === true &&
+    entry?.abortedLastRun === true &&
+    canReuseExistingEntry &&
+    (entryFreshness?.fresh ?? false) &&
+    terminalMainTranscriptNewerThanRegistry;
   const freshEntry =
     (isSystemEvent && canReuseExistingEntry) ||
+    restartContinuationAllowed ||
     (((entryFreshness?.fresh ?? false) || (softResetAllowed && canReuseExistingEntry)) &&
       !terminalMainTranscriptNewerThanRegistry);
   // Capture the current session entry before any reset so its transcript can be

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1636,6 +1636,8 @@ export const FIELD_HELP: Record<string, string> = {
     'Controls typing behavior timing: "never", "instant", "thinking", or "message" based emission points. Keep conservative modes in high-volume channels to avoid unnecessary typing noise.',
   "session.mainKey":
     'Overrides the canonical main session key used for continuity when dmScope or routing logic points to "main". Use a stable value only if you intentionally need custom session anchoring.',
+  "session.restartContinuation":
+    "When enabled, a fresh main session that was marked aborted on the previous run can keep its existing session id across a Gateway restart even if the terminal transcript file is newer than the registry entry. Default: false.",
   "session.sendPolicy":
     "Controls cross-session send permissions using allow/deny rules evaluated against channel, chatType, and key prefixes. Use this to fence where session tools can deliver messages in complex environments.",
   "session.sendPolicy.default":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -824,6 +824,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "session.typingIntervalSeconds": "Session Typing Interval (seconds)",
   "session.typingMode": "Session Typing Mode",
   "session.mainKey": "Session Main Key",
+  "session.restartContinuation": "Session Restart Continuation",
   "session.sendPolicy": "Session Send Policy",
   "session.sendPolicy.default": "Session Send Policy Default Action",
   "session.sendPolicy.rules": "Session Send Policy Rules",

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -225,6 +225,8 @@ export type SessionConfig = {
   typingIntervalSeconds?: number;
   typingMode?: TypingMode;
   mainKey?: string;
+  /** Continue an aborted fresh main session across Gateway restarts. Default: false. */
+  restartContinuation?: boolean;
   sendPolicy?: SessionSendPolicyConfig;
   /** Session transcript write-lock acquisition policy. */
   writeLock?: SessionWriteLockConfig;

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -56,6 +56,7 @@ export const SessionSchema = z
     typingIntervalSeconds: z.number().int().positive().optional(),
     typingMode: TypingModeSchema.optional(),
     mainKey: z.string().optional(),
+    restartContinuation: z.boolean().optional(),
     sendPolicy: SessionSendPolicySchema.optional(),
     writeLock: z
       .object({


### PR DESCRIPTION
﻿Summary
- Add an opt-in `session.restartContinuation` config flag for Gateway restart recovery.
- Reuse a fresh aborted main session when the terminal transcript is newer than the registry entry, preserving the existing session id instead of minting a new one.
- Add config schema, label, and help metadata for the new flag.

Fixes #94458

Verification
- `node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts`
- `node scripts/run-vitest.mjs src/config/schema.help.quality.test.ts src/config/schema.base.generated.test.ts`
