### PR TITLE
fix(android): make offline chat actionable

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 85,
+      "line": 96,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Copied gateway diagnostics",
       "surface": "android",
@@ -3459,7 +3459,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 435,
+      "line": 440,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Overview",
       "surface": "android",
@@ -3467,7 +3467,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 480,
+      "line": 485,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No recent sessions",
       "surface": "android",
@@ -3475,7 +3475,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 482,
+      "line": 487,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start Chat",
       "surface": "android",
@@ -3483,7 +3483,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 542,
+      "line": 547,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -3491,7 +3491,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 550,
+      "line": 555,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search",
       "surface": "android",
@@ -3499,7 +3499,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 602,
+      "line": 607,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "ACTIVE AGENT",
       "surface": "android",
@@ -3507,7 +3507,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 611,
+      "line": 616,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View",
       "surface": "android",
@@ -3515,7 +3515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 614,
+      "line": 619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pendingRunCount active",
       "surface": "android",
@@ -3523,7 +3523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 614,
+      "line": 619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Idle",
       "surface": "android",
@@ -3531,7 +3531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 614,
+      "line": 619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Runs",
       "surface": "android",
@@ -3539,7 +3539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 615,
+      "line": 620,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$sessionCount recent",
       "surface": "android",
@@ -3547,7 +3547,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 615,
+      "line": 620,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Sessions",
       "surface": "android",
@@ -3555,7 +3555,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 616,
+      "line": 621,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Cron",
       "surface": "android",
@@ -3563,7 +3563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 619,
+      "line": 624,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -3571,7 +3571,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 623,
+      "line": 628,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Reconnect gateway",
       "surface": "android",
@@ -3579,7 +3579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 768,
+      "line": 773,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${card.title}",
       "surface": "android",
@@ -3587,7 +3587,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 836,
+      "line": 841,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk",
       "surface": "android",
@@ -3595,7 +3595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 837,
+      "line": 842,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open Talk",
       "surface": "android",
@@ -3603,7 +3603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 839,
+      "line": 844,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk settings",
       "surface": "android",
@@ -3611,7 +3611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 847,
+      "line": 852,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent Sessions",
       "surface": "android",
@@ -3619,7 +3619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 857,
+      "line": 862,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View all",
       "surface": "android",
@@ -3627,7 +3627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 975,
+      "line": 980,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$onlineNodes/$nodeCount",
       "surface": "android",
@@ -3635,7 +3635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 975,
+      "line": 980,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "None",
       "surface": "android",
@@ -3643,7 +3643,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1007,
+      "line": 1012,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent conversations",
       "surface": "android",
@@ -3651,7 +3651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1058,
+      "line": 1063,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · $pendingRunCount active ${pluralize(\"run\", pendingRunCount)}",
       "surface": "android",
@@ -3659,7 +3659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1179,
+      "line": 1184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -3667,7 +3667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1318,
+      "line": 1323,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open session",
       "surface": "android",
@@ -3675,7 +3675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1430,
+      "line": 1437,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Back to home",
       "surface": "android",
@@ -3683,7 +3683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1433,
+      "line": 1440,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Settings",
       "surface": "android",
@@ -3691,7 +3691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1436,
+      "line": 1443,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search settings",
       "surface": "android",
@@ -3699,7 +3699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1454,
+      "line": 1461,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$readyProviderCount ready",
       "surface": "android",
@@ -3707,7 +3707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1454,
+      "line": 1461,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review readiness",
       "surface": "android",
@@ -3715,7 +3715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1464,
+      "line": 1471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker muted",
       "surface": "android",
@@ -3723,7 +3723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1464,
+      "line": 1471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker on",
       "surface": "android",
@@ -3731,7 +3731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1466,
+      "line": 1473,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -3739,7 +3739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1466,
+      "line": 1473,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Smart delivery",
       "surface": "android",
@@ -3747,7 +3747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1467,
+      "line": 1474,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Camera enabled",
       "surface": "android",
@@ -3755,7 +3755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1467,
+      "line": 1474,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Locked",
       "surface": "android",
@@ -3763,7 +3763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1499,
+      "line": 1506,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "surface": "android",
@@ -3771,7 +3771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1502,
+      "line": 1509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems operational",
       "surface": "android",
@@ -3779,7 +3779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1502,
+      "line": 1509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -3787,7 +3787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1534,
+      "line": 1541,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No provider usage",
       "surface": "android",
@@ -3795,7 +3795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1535,
+      "line": 1542,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 provider",
       "surface": "android",
@@ -3803,7 +3803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1536,
+      "line": 1543,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count providers",
       "surface": "android",
@@ -3811,7 +3811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1542,
+      "line": 1549,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$ready/${skills.size} ready",
       "surface": "android",
@@ -3819,7 +3819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1542,
+      "line": 1549,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No skills",
       "surface": "android",
@@ -3827,7 +3827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1718,
+      "line": 1725,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw mobile",
       "surface": "android",
@@ -3835,7 +3835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1722,
+      "line": 1729,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open profile",
       "surface": "android",
@@ -3843,7 +3843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1784,
+      "line": 1791,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${row.title}",
       "surface": "android",
@@ -3851,7 +3851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1803,
+      "line": 1810,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Main session",
       "surface": "android",
@@ -4539,7 +4539,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 184,
+      "line": 203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -4547,7 +4547,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 278,
+      "line": 309,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -4555,7 +4555,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 329,
+      "line": 360,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -4563,7 +4563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 350,
+      "line": 381,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -4571,7 +4571,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 353,
+      "line": 384,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -4579,7 +4579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 476,
+      "line": 508,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -4587,15 +4587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 496,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Gateway offline",
-      "surface": "android",
-      "id": "native.android.79e0bed1eb1bd6aa"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 496,
+      "line": 534,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -4603,7 +4595,23 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 656,
+      "line": 565,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Fix connection",
+      "surface": "android",
+      "id": "native.android.6bbe3c5b5193d985"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 566,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Copy diagnostics",
+      "surface": "android",
+      "id": "native.android.579c05816c7dfa79"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 711,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -4611,7 +4619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 661,
+      "line": 716,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -4619,7 +4627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 671,
+      "line": 726,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -4627,7 +4635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 672,
+      "line": 727,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -4635,7 +4643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 753,
+      "line": 820,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -4643,7 +4651,15 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 835,
+      "line": 837,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Gateway offline",
+      "surface": "android",
+      "id": "native.android.8e3e367df24cae4b"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 927,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -4651,7 +4667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 850,
+      "line": 942,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -4659,7 +4675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 865,
+      "line": 957,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -4667,7 +4683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 903,
+      "line": 995,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -4675,7 +4691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 915,
+      "line": 1007,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -4683,7 +4699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 924,
+      "line": 1016,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -4691,7 +4707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 980,
+      "line": 1072,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -4699,7 +4715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1015,
+      "line": 1111,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt
@@ -26,6 +26,39 @@ internal fun gatewayStatusHasDiagnostics(statusText: String): Boolean {
   return lower != "offline" && !lower.contains("connecting")
 }
 
+/** Resolves the best non-secret endpoint label available to diagnostics surfaces. */
+internal fun gatewayDiagnosticsEndpoint(
+  remoteAddress: String?,
+  manualHost: String,
+  manualPort: Int,
+  manualTls: Boolean,
+): String {
+  remoteAddress?.trim()?.takeIf { it.isNotEmpty() }?.let { return it }
+  return composeGatewayManualUrl(manualHost, manualPort.toString(), manualTls)?.let { parseGatewayEndpoint(it)?.displayUrl } ?: "Not set"
+}
+
+/** Summarizes why chat is blocked without dumping raw gateway logs into the UI. */
+internal fun gatewayOfflineDiagnosis(
+  statusText: String,
+  gatewayAddress: String,
+): String {
+  val status = gatewayStatusForDisplay(statusText)
+  val lower = status.lowercase()
+  val endpoint = gatewayAddress.trim()
+  return when {
+    endpoint.isBlank() || endpoint.equals("not set", ignoreCase = true) -> "Endpoint not configured"
+    lower.contains("pair") || lower.contains("approve") -> "Pairing needs approval"
+    lower.contains("auth") || lower.contains("token") || lower.contains("password") -> "Authentication needs attention"
+    lower.contains("certificate") || lower.contains("tls") || lower.contains("fingerprint") -> "TLS trust needs review"
+    lower.contains("node") && (lower.contains("not registered") || lower.contains("not paired")) -> "Node is not registered"
+    lower.contains("provider") && (lower.contains("offline") || lower.contains("unavailable") || lower.contains("not ready")) -> "Provider is offline"
+    lower.contains("timeout") || lower.contains("refused") || lower.contains("unreachable") || lower.contains("failed") || lower.contains("error") -> "Gateway is unreachable"
+    lower.contains("connecting") || lower.contains("reconnecting") -> "Connection is still retrying"
+    lower == "offline" || lower.contains("not connected") -> "Gateway is unreachable"
+    else -> status
+  }
+}
+
 /** Detects pairing/approval status text so UI can offer pairing-specific actions. */
 internal fun gatewayStatusLooksLikePairing(statusText: String): Boolean {
   val lower = gatewayStatusForDisplay(statusText).lowercase()
@@ -68,6 +101,7 @@ internal fun buildGatewayDiagnosticsReport(
     - device: $device
     - android: $androidVersion (SDK ${Build.VERSION.SDK_INT})
     - gateway address: $endpoint
+    - diagnosis: ${gatewayOfflineDiagnosis(statusText = status, gatewayAddress = endpoint)}
     - status/error: $status
     """.trimIndent()
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt
@@ -37,28 +37,6 @@ internal fun gatewayDiagnosticsEndpoint(
   return composeGatewayManualUrl(manualHost, manualPort.toString(), manualTls)?.let { parseGatewayEndpoint(it)?.displayUrl } ?: "Not set"
 }
 
-/** Summarizes why chat is blocked without dumping raw gateway logs into the UI. */
-internal fun gatewayOfflineDiagnosis(
-  statusText: String,
-  gatewayAddress: String,
-): String {
-  val status = gatewayStatusForDisplay(statusText)
-  val lower = status.lowercase()
-  val endpoint = gatewayAddress.trim()
-  return when {
-    endpoint.isBlank() || endpoint.equals("not set", ignoreCase = true) -> "Endpoint not configured"
-    lower.contains("pair") || lower.contains("approve") -> "Pairing needs approval"
-    lower.contains("auth") || lower.contains("token") || lower.contains("password") -> "Authentication needs attention"
-    lower.contains("certificate") || lower.contains("tls") || lower.contains("fingerprint") -> "TLS trust needs review"
-    lower.contains("node") && (lower.contains("not registered") || lower.contains("not paired")) -> "Node is not registered"
-    lower.contains("provider") && (lower.contains("offline") || lower.contains("unavailable") || lower.contains("not ready")) -> "Provider is offline"
-    lower.contains("timeout") || lower.contains("refused") || lower.contains("unreachable") || lower.contains("failed") || lower.contains("error") -> "Gateway is unreachable"
-    lower.contains("connecting") || lower.contains("reconnecting") -> "Connection is still retrying"
-    lower == "offline" || lower.contains("not connected") -> "Gateway is unreachable"
-    else -> status
-  }
-}
-
 /** Detects pairing/approval status text so UI can offer pairing-specific actions. */
 internal fun gatewayStatusLooksLikePairing(statusText: String): Boolean {
   val lower = gatewayStatusForDisplay(statusText).lowercase()
@@ -101,7 +79,6 @@ internal fun buildGatewayDiagnosticsReport(
     - device: $device
     - android: $androidVersion (SDK ${Build.VERSION.SDK_INT})
     - gateway address: $endpoint
-    - diagnosis: ${gatewayOfflineDiagnosis(statusText = status, gatewayAddress = endpoint)}
     - status/error: $status
     """.trimIndent()
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -222,6 +222,11 @@ fun ShellScreen(
               viewModel = viewModel,
               onVoice = { activeTab = Tab.Voice },
               onOpenSessions = { activeTab = Tab.Sessions },
+              onOpenGatewaySettings = {
+                settingsRoute = SettingsRoute.Gateway
+                returnToOverviewFromSettings = false
+                activeTab = Tab.Settings
+              },
             )
           Tab.Voice ->
             VoiceShellScreen(
@@ -1328,6 +1333,7 @@ private fun ChatShellScreen(
   viewModel: MainViewModel,
   onVoice: () -> Unit,
   onOpenSessions: () -> Unit,
+  onOpenGatewaySettings: () -> Unit,
 ) {
   ClawScaffold(
     contentPadding = PaddingValues(start = 0.dp, top = 8.dp, end = 0.dp, bottom = 0.dp),
@@ -1337,6 +1343,7 @@ private fun ChatShellScreen(
       viewModel = viewModel,
       onVoice = onVoice,
       onOpenSessions = onOpenSessions,
+      onOpenGatewaySettings = onOpenGatewaySettings,
     )
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -7,12 +7,17 @@ import ai.openclaw.app.chat.ChatMessageContent
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.OutgoingAttachment
+import ai.openclaw.app.ui.copyGatewayDiagnosticsReport
 import ai.openclaw.app.ui.design.ClawListItem
 import ai.openclaw.app.ui.design.ClawLoadingState
 import ai.openclaw.app.ui.design.ClawPanel
+import ai.openclaw.app.ui.design.ClawPrimaryButton
+import ai.openclaw.app.ui.design.ClawSecondaryButton
 import ai.openclaw.app.ui.design.ClawStatus
 import ai.openclaw.app.ui.design.ClawStatusPill
 import ai.openclaw.app.ui.design.ClawTheme
+import ai.openclaw.app.ui.gatewayDiagnosticsEndpoint
+import ai.openclaw.app.ui.gatewayOfflineDiagnosis
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
@@ -43,6 +48,8 @@ import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Refresh
@@ -85,12 +92,14 @@ fun ChatScreen(
   viewModel: MainViewModel,
   onVoice: () -> Unit,
   onOpenSessions: () -> Unit,
+  onOpenGatewaySettings: () -> Unit,
 ) {
   val messages by viewModel.chatMessages.collectAsState()
   val historyLoading by viewModel.chatHistoryLoading.collectAsState()
   val errorText by viewModel.chatError.collectAsState()
   val pendingRunCount by viewModel.pendingRunCount.collectAsState()
   val healthOk by viewModel.chatHealthOk.collectAsState()
+  val gatewayConnected by viewModel.isConnected.collectAsState()
   val sessionKey by viewModel.chatSessionKey.collectAsState()
   val mainSessionKey by viewModel.mainSessionKey.collectAsState()
   val thinkingLevel by viewModel.chatThinkingLevel.collectAsState()
@@ -99,7 +108,15 @@ fun ChatScreen(
   val sessions by viewModel.chatSessions.collectAsState()
   val chatDraft by viewModel.chatDraft.collectAsState()
   val pendingAssistantAutoSend by viewModel.pendingAssistantAutoSend.collectAsState()
+  val statusText by viewModel.statusText.collectAsState()
+  val remoteAddress by viewModel.remoteAddress.collectAsState()
+  val manualHost by viewModel.manualHost.collectAsState()
+  val manualPort by viewModel.manualPort.collectAsState()
+  val manualTls by viewModel.manualTls.collectAsState()
   val contextUsage = resolveChatContextUsage(sessionKey = sessionKey, mainSessionKey = mainSessionKey, sessions = sessions)
+  val gatewayAddress = gatewayDiagnosticsEndpoint(remoteAddress = remoteAddress, manualHost = manualHost, manualPort = manualPort, manualTls = manualTls)
+  val offlineDiagnosis = gatewayOfflineDiagnosis(statusText = statusText, gatewayAddress = gatewayAddress)
+  val gatewayOffline = !gatewayConnected
   val context = LocalContext.current
   val resolver = context.contentResolver
   val scope = rememberCoroutineScope()
@@ -181,7 +198,7 @@ fun ChatScreen(
     )
 
     errorText?.takeIf { it.isNotBlank() }?.let { error ->
-      ChatNotice(title = "Chat needs attention", body = userFacingChatError(error))
+      ChatNotice(title = "Chat needs attention", body = userFacingChatError(error = error, gatewayConnected = gatewayConnected))
     }
 
     ChatMessageList(
@@ -191,6 +208,17 @@ fun ChatScreen(
       pendingToolCalls = pendingToolCalls,
       streamingAssistantText = streamingAssistantText,
       healthOk = healthOk,
+      gatewayOffline = gatewayOffline,
+      offlineDiagnosis = offlineDiagnosis,
+      onFixConnection = onOpenGatewaySettings,
+      onCopyDiagnostics = {
+        copyGatewayDiagnosticsReport(
+          context = context,
+          screen = "chat",
+          gatewayAddress = gatewayAddress,
+          statusText = statusText,
+        )
+      },
       onStarterPrompt = { prompt -> input = prompt },
       modifier = Modifier.weight(1f),
     )
@@ -202,11 +230,22 @@ fun ChatScreen(
       thinkingLevel = thinkingLevel,
       contextUsage = contextUsage,
       healthOk = healthOk,
+      gatewayOffline = gatewayOffline,
+      offlineDiagnosis = offlineDiagnosis,
       pendingRunCount = pendingRunCount,
       onThinkingLevelChange = viewModel::setChatThinkingLevel,
       onPickImages = { pickImages.launch("image/*") },
       onRemoveAttachment = { id -> attachments.removeAll { it.id == id } },
       onVoice = onVoice,
+      onFixConnection = onOpenGatewaySettings,
+      onCopyDiagnostics = {
+        copyGatewayDiagnosticsReport(
+          context = context,
+          screen = "chat composer",
+          gatewayAddress = gatewayAddress,
+          statusText = statusText,
+        )
+      },
       onAbort = viewModel::abortChat,
       onSend = {
         val message = input.trim()
@@ -421,6 +460,10 @@ private fun ChatMessageList(
   pendingToolCalls: List<ChatPendingToolCall>,
   streamingAssistantText: String?,
   healthOk: Boolean,
+  gatewayOffline: Boolean,
+  offlineDiagnosis: String,
+  onFixConnection: () -> Unit,
+  onCopyDiagnostics: () -> Unit,
   onStarterPrompt: (String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -475,7 +518,15 @@ private fun ChatMessageList(
       if (historyLoading) {
         ClawLoadingState(title = "Loading session", modifier = Modifier.align(Alignment.Center))
       } else {
-        EmptyChatHint(healthOk = healthOk, onStarterPrompt = onStarterPrompt, modifier = Modifier.align(Alignment.Center))
+        EmptyChatHint(
+          healthOk = healthOk,
+          gatewayOffline = gatewayOffline,
+          offlineDiagnosis = offlineDiagnosis,
+          onFixConnection = onFixConnection,
+          onCopyDiagnostics = onCopyDiagnostics,
+          onStarterPrompt = onStarterPrompt,
+          modifier = Modifier.align(Alignment.Center),
+        )
       }
     }
   }
@@ -484,6 +535,10 @@ private fun ChatMessageList(
 @Composable
 private fun EmptyChatHint(
   healthOk: Boolean,
+  gatewayOffline: Boolean,
+  offlineDiagnosis: String,
+  onFixConnection: () -> Unit,
+  onCopyDiagnostics: () -> Unit,
   onStarterPrompt: (String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -498,8 +553,10 @@ private fun EmptyChatHint(
         text =
           if (healthOk) {
             "Start with a prompt, or use voice."
+          } else if (gatewayOffline) {
+            "Cannot send yet: $offlineDiagnosis."
           } else {
-            "Reconnect from Settings to send messages."
+            "Chat is checking Gateway health."
           },
         style = ClawTheme.type.body,
         color = ClawTheme.colors.textMuted,
@@ -508,7 +565,24 @@ private fun EmptyChatHint(
     }
     if (healthOk) {
       StarterPromptList(onStarterPrompt = onStarterPrompt)
+    } else if (gatewayOffline) {
+      ChatOfflineActions(onFixConnection = onFixConnection, onCopyDiagnostics = onCopyDiagnostics)
     }
+  }
+}
+
+@Composable
+private fun ChatOfflineActions(
+  onFixConnection: () -> Unit,
+  onCopyDiagnostics: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    modifier = modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    ClawPrimaryButton(text = "Fix connection", icon = Icons.Default.Cloud, onClick = onFixConnection, modifier = Modifier.weight(1f))
+    ClawSecondaryButton(text = "Copy diagnostics", icon = Icons.Default.ContentCopy, onClick = onCopyDiagnostics, modifier = Modifier.weight(1f))
   }
 }
 
@@ -708,11 +782,15 @@ private fun ChatComposer(
   thinkingLevel: String,
   contextUsage: ChatContextUsage,
   healthOk: Boolean,
+  gatewayOffline: Boolean,
+  offlineDiagnosis: String,
   pendingRunCount: Int,
   onThinkingLevelChange: (String) -> Unit,
   onPickImages: () -> Unit,
   onRemoveAttachment: (String) -> Unit,
   onVoice: () -> Unit,
+  onFixConnection: () -> Unit,
+  onCopyDiagnostics: () -> Unit,
   onAbort: () -> Unit,
   onSend: () -> Unit,
 ) {
@@ -735,6 +813,14 @@ private fun ChatComposer(
       )
     }
 
+    if (!healthOk && gatewayOffline) {
+      ChatOfflineNotice(
+        diagnosis = offlineDiagnosis,
+        onFixConnection = onFixConnection,
+        onCopyDiagnostics = onCopyDiagnostics,
+      )
+    }
+
     if (pendingRunCount > 0) {
       Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
         Surface(
@@ -754,6 +840,26 @@ private fun ChatComposer(
           }
         }
       }
+    }
+  }
+}
+
+@Composable
+private fun ChatOfflineNotice(
+  diagnosis: String,
+  onFixConnection: () -> Unit,
+  onCopyDiagnostics: () -> Unit,
+) {
+  ClawPanel(contentPadding = PaddingValues(horizontal = 10.dp, vertical = 9.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+      Text(
+        text = "Gateway offline · $diagnosis",
+        style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp),
+        color = ClawTheme.colors.warning,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+      )
+      ChatOfflineActions(onFixConnection = onFixConnection, onCopyDiagnostics = onCopyDiagnostics)
     }
   }
 }
@@ -982,10 +1088,14 @@ private fun SendButton(
   }
 }
 
-private fun userFacingChatError(error: String): String {
+internal fun userFacingChatError(
+  error: String,
+  gatewayConnected: Boolean,
+): String {
   val lower = error.lowercase(Locale.US)
   return when {
-    lower.contains("not connected") -> "Gateway is offline. Open Settings to reconnect."
+    lower.contains("not connected") && gatewayConnected -> "Chat is still checking Gateway health."
+    lower.contains("not connected") -> "Gateway is offline. Fix the connection below or copy diagnostics."
     lower.contains("unauthorized") || lower.contains("auth") -> "Gateway authentication needs attention."
     else -> error
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -17,7 +17,7 @@ import ai.openclaw.app.ui.design.ClawStatus
 import ai.openclaw.app.ui.design.ClawStatusPill
 import ai.openclaw.app.ui.design.ClawTheme
 import ai.openclaw.app.ui.gatewayDiagnosticsEndpoint
-import ai.openclaw.app.ui.gatewayOfflineDiagnosis
+import ai.openclaw.app.ui.gatewayStatusForDisplay
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
@@ -100,6 +100,7 @@ fun ChatScreen(
   val pendingRunCount by viewModel.pendingRunCount.collectAsState()
   val healthOk by viewModel.chatHealthOk.collectAsState()
   val gatewayConnected by viewModel.isConnected.collectAsState()
+  val gatewayConnectionProblem by viewModel.gatewayConnectionProblem.collectAsState()
   val sessionKey by viewModel.chatSessionKey.collectAsState()
   val mainSessionKey by viewModel.mainSessionKey.collectAsState()
   val thinkingLevel by viewModel.chatThinkingLevel.collectAsState()
@@ -115,7 +116,8 @@ fun ChatScreen(
   val manualTls by viewModel.manualTls.collectAsState()
   val contextUsage = resolveChatContextUsage(sessionKey = sessionKey, mainSessionKey = mainSessionKey, sessions = sessions)
   val gatewayAddress = gatewayDiagnosticsEndpoint(remoteAddress = remoteAddress, manualHost = manualHost, manualPort = manualPort, manualTls = manualTls)
-  val offlineDiagnosis = gatewayOfflineDiagnosis(statusText = statusText, gatewayAddress = gatewayAddress)
+  val gatewayProblemMessage = gatewayConnectionProblem?.message?.takeIf { it.isNotBlank() }
+  val offlineStatus = gatewayStatusForDisplay(gatewayProblemMessage ?: statusText)
   val gatewayOffline = !gatewayConnected
   val context = LocalContext.current
   val resolver = context.contentResolver
@@ -209,16 +211,6 @@ fun ChatScreen(
       streamingAssistantText = streamingAssistantText,
       healthOk = healthOk,
       gatewayOffline = gatewayOffline,
-      offlineDiagnosis = offlineDiagnosis,
-      onFixConnection = onOpenGatewaySettings,
-      onCopyDiagnostics = {
-        copyGatewayDiagnosticsReport(
-          context = context,
-          screen = "chat",
-          gatewayAddress = gatewayAddress,
-          statusText = statusText,
-        )
-      },
       onStarterPrompt = { prompt -> input = prompt },
       modifier = Modifier.weight(1f),
     )
@@ -231,7 +223,7 @@ fun ChatScreen(
       contextUsage = contextUsage,
       healthOk = healthOk,
       gatewayOffline = gatewayOffline,
-      offlineDiagnosis = offlineDiagnosis,
+      offlineStatus = offlineStatus,
       pendingRunCount = pendingRunCount,
       onThinkingLevelChange = viewModel::setChatThinkingLevel,
       onPickImages = { pickImages.launch("image/*") },
@@ -243,7 +235,7 @@ fun ChatScreen(
           context = context,
           screen = "chat composer",
           gatewayAddress = gatewayAddress,
-          statusText = statusText,
+          statusText = offlineStatus,
         )
       },
       onAbort = viewModel::abortChat,
@@ -461,9 +453,6 @@ private fun ChatMessageList(
   streamingAssistantText: String?,
   healthOk: Boolean,
   gatewayOffline: Boolean,
-  offlineDiagnosis: String,
-  onFixConnection: () -> Unit,
-  onCopyDiagnostics: () -> Unit,
   onStarterPrompt: (String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -521,9 +510,6 @@ private fun ChatMessageList(
         EmptyChatHint(
           healthOk = healthOk,
           gatewayOffline = gatewayOffline,
-          offlineDiagnosis = offlineDiagnosis,
-          onFixConnection = onFixConnection,
-          onCopyDiagnostics = onCopyDiagnostics,
           onStarterPrompt = onStarterPrompt,
           modifier = Modifier.align(Alignment.Center),
         )
@@ -536,9 +522,6 @@ private fun ChatMessageList(
 private fun EmptyChatHint(
   healthOk: Boolean,
   gatewayOffline: Boolean,
-  offlineDiagnosis: String,
-  onFixConnection: () -> Unit,
-  onCopyDiagnostics: () -> Unit,
   onStarterPrompt: (String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -554,7 +537,7 @@ private fun EmptyChatHint(
           if (healthOk) {
             "Start with a prompt, or use voice."
           } else if (gatewayOffline) {
-            "Cannot send yet: $offlineDiagnosis."
+            "Use the recovery options below to reconnect."
           } else {
             "Chat is checking Gateway health."
           },
@@ -565,8 +548,6 @@ private fun EmptyChatHint(
     }
     if (healthOk) {
       StarterPromptList(onStarterPrompt = onStarterPrompt)
-    } else if (gatewayOffline) {
-      ChatOfflineActions(onFixConnection = onFixConnection, onCopyDiagnostics = onCopyDiagnostics)
     }
   }
 }
@@ -783,7 +764,7 @@ private fun ChatComposer(
   contextUsage: ChatContextUsage,
   healthOk: Boolean,
   gatewayOffline: Boolean,
-  offlineDiagnosis: String,
+  offlineStatus: String,
   pendingRunCount: Int,
   onThinkingLevelChange: (String) -> Unit,
   onPickImages: () -> Unit,
@@ -815,7 +796,7 @@ private fun ChatComposer(
 
     if (!healthOk && gatewayOffline) {
       ChatOfflineNotice(
-        diagnosis = offlineDiagnosis,
+        status = offlineStatus,
         onFixConnection = onFixConnection,
         onCopyDiagnostics = onCopyDiagnostics,
       )
@@ -846,16 +827,21 @@ private fun ChatComposer(
 
 @Composable
 private fun ChatOfflineNotice(
-  diagnosis: String,
+  status: String,
   onFixConnection: () -> Unit,
   onCopyDiagnostics: () -> Unit,
 ) {
   ClawPanel(contentPadding = PaddingValues(horizontal = 10.dp, vertical = 9.dp)) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
       Text(
-        text = "Gateway offline · $diagnosis",
+        text = "Gateway offline",
         style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp),
         color = ClawTheme.colors.warning,
+      )
+      Text(
+        text = status,
+        style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp),
+        color = ClawTheme.colors.textMuted,
         maxLines = 2,
         overflow = TextOverflow.Ellipsis,
       )

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayDiagnosticsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayDiagnosticsTest.kt
@@ -1,0 +1,70 @@
+package ai.openclaw.app.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GatewayDiagnosticsTest {
+  @Test
+  fun endpointPrefersLiveRemoteAddress() {
+    assertEquals(
+      "wss://gateway.example.test",
+      gatewayDiagnosticsEndpoint(
+        remoteAddress = " wss://gateway.example.test ",
+        manualHost = "10.0.2.2",
+        manualPort = 18789,
+        manualTls = false,
+      ),
+    )
+  }
+
+  @Test
+  fun endpointFallsBackToManualConfig() {
+    assertEquals(
+      "http://10.0.2.2:18789",
+      gatewayDiagnosticsEndpoint(
+        remoteAddress = null,
+        manualHost = "10.0.2.2",
+        manualPort = 18789,
+        manualTls = false,
+      ),
+    )
+  }
+
+  @Test
+  fun endpointReportsMissingConfig() {
+    assertEquals(
+      "Not set",
+      gatewayDiagnosticsEndpoint(
+        remoteAddress = null,
+        manualHost = "",
+        manualPort = 18789,
+        manualTls = false,
+      ),
+    )
+  }
+
+  @Test
+  fun offlineDiagnosisClassifiesCommonConnectionFailures() {
+    assertEquals("Endpoint not configured", gatewayOfflineDiagnosis(statusText = "Offline", gatewayAddress = "Not set"))
+    assertEquals("Pairing needs approval", gatewayOfflineDiagnosis(statusText = "Pairing request pending approval", gatewayAddress = "ws://10.0.2.2:18789"))
+    assertEquals("Authentication needs attention", gatewayOfflineDiagnosis(statusText = "Auth token rejected", gatewayAddress = "ws://10.0.2.2:18789"))
+    assertEquals("TLS trust needs review", gatewayOfflineDiagnosis(statusText = "TLS fingerprint changed", gatewayAddress = "wss://gateway.example.test"))
+    assertEquals("Gateway is unreachable", gatewayOfflineDiagnosis(statusText = "connection refused", gatewayAddress = "ws://10.0.2.2:18789"))
+  }
+
+  @Test
+  fun diagnosticsReportIncludesDiagnosisAndSupportContext() {
+    val report =
+      buildGatewayDiagnosticsReport(
+        screen = "chat composer",
+        gatewayAddress = "http://10.0.2.2:18789",
+        statusText = "connection refused",
+      )
+
+    assertTrue(report.contains("- screen: chat composer"))
+    assertTrue(report.contains("- gateway address: http://10.0.2.2:18789"))
+    assertTrue(report.contains("- diagnosis: Gateway is unreachable"))
+    assertTrue(report.contains("- status/error: connection refused"))
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayDiagnosticsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayDiagnosticsTest.kt
@@ -45,16 +45,7 @@ class GatewayDiagnosticsTest {
   }
 
   @Test
-  fun offlineDiagnosisClassifiesCommonConnectionFailures() {
-    assertEquals("Endpoint not configured", gatewayOfflineDiagnosis(statusText = "Offline", gatewayAddress = "Not set"))
-    assertEquals("Pairing needs approval", gatewayOfflineDiagnosis(statusText = "Pairing request pending approval", gatewayAddress = "ws://10.0.2.2:18789"))
-    assertEquals("Authentication needs attention", gatewayOfflineDiagnosis(statusText = "Auth token rejected", gatewayAddress = "ws://10.0.2.2:18789"))
-    assertEquals("TLS trust needs review", gatewayOfflineDiagnosis(statusText = "TLS fingerprint changed", gatewayAddress = "wss://gateway.example.test"))
-    assertEquals("Gateway is unreachable", gatewayOfflineDiagnosis(statusText = "connection refused", gatewayAddress = "ws://10.0.2.2:18789"))
-  }
-
-  @Test
-  fun diagnosticsReportIncludesDiagnosisAndSupportContext() {
+  fun diagnosticsReportIncludesSupportContext() {
     val report =
       buildGatewayDiagnosticsReport(
         screen = "chat composer",
@@ -64,7 +55,6 @@ class GatewayDiagnosticsTest {
 
     assertTrue(report.contains("- screen: chat composer"))
     assertTrue(report.contains("- gateway address: http://10.0.2.2:18789"))
-    assertTrue(report.contains("- diagnosis: Gateway is unreachable"))
     assertTrue(report.contains("- status/error: connection refused"))
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatErrorTextTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatErrorTextTest.kt
@@ -1,0 +1,22 @@
+package ai.openclaw.app.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatErrorTextTest {
+  @Test
+  fun notConnectedErrorPointsToFixActionsOnlyWhenGatewayIsOffline() {
+    assertEquals(
+      "Gateway is offline. Fix the connection below or copy diagnostics.",
+      userFacingChatError(error = "not connected", gatewayConnected = false),
+    )
+  }
+
+  @Test
+  fun notConnectedErrorDoesNotClaimGatewayOfflineDuringConnectedHealthBootstrap() {
+    assertEquals(
+      "Chat is still checking Gateway health.",
+      userFacingChatError(error = "not connected", gatewayConnected = true),
+    )
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Android Chat disabled its composer while the Gateway was offline, but the screen offered no direct recovery action. Users had to leave Chat and discover Gateway Settings themselves.

## Why This Change Was Made

This adds one shared offline recovery panel below the conversation. `Fix connection` opens the existing Gateway Settings surface, and `Copy diagnostics` copies the current structured Gateway problem/status. The implementation consumes `GatewayConnectionProblem` directly instead of reclassifying freeform status text, so Android has one owner for connection diagnosis and one recovery path for empty and existing conversations.

## User Impact

Disconnected Chat is no longer a dead end. Users can open the canonical connection settings or copy concise diagnostics from the blocked composer state. Connected Gateway/chat-health bootstrap behavior is unchanged.

## Evidence

Prepared against current `main` at `71ccc9a487d8778ab015ced2789350e7dc2015fa`.

| Before | After |
| --- | --- |
| Offline Chat only reported the block. ![Before: offline Chat without recovery actions](https://github.com/user-attachments/assets/11b1bf52-fdc6-4697-8b37-c48641e01caa) | One recovery panel provides `Fix connection` and `Copy diagnostics`. ![After: actionable offline Chat](https://github.com/user-attachments/assets/863490b2-e732-4123-9755-e4ef92592c76) |

Emulator interaction proof: tapping `Fix connection` opened Gateway Settings.

Commands run:

```text
ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.GatewayDiagnosticsTest --tests ai.openclaw.app.ui.chat.ChatErrorTextTest :app:ktlintCheck :app:assemblePlayDebug
node --import tsx scripts/native-app-i18n.ts check
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode uncommitted
```

Results: focused Android tests, formatting, Play debug assembly, native i18n inventory, diff validation, and fresh autoreview passed. Exact-head GitHub CI passed 48/48 jobs: https://github.com/openclaw/openclaw/actions/runs/28575663612.

Known proof boundary: emulator proof covers the recovery panel and settings navigation. Clipboard contents are covered by focused unit tests rather than shell readback.
