### PR TITLE
fix(workboard): filter archived cards from CLI list output

### DIFF
--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -130,14 +130,26 @@ export function registerWorkboardCli(params: { program: Command; store: Workboar
     .description("List Workboard cards")
     .option("--board <id>", "Board id")
     .option("--status <status>", "Filter by status")
+    .option("--include-archived", "Include soft-archived cards", false)
     .option("--json", "Print JSON", false)
-    .action(async (options: JsonOptions & { board?: string; status?: string }) => {
-      let cards = await params.store.list({ boardId: options.board });
-      if (options.status) {
-        cards = cards.filter((card) => card.status === options.status);
-      }
-      writeCards(cards, options);
-    });
+    .action(
+      async (
+        options: JsonOptions & {
+          board?: string;
+          status?: string;
+          includeArchived?: boolean;
+        },
+      ) => {
+        let cards = await params.store.list({ boardId: options.board });
+        if (!options.includeArchived) {
+          cards = cards.filter((card) => !card.metadata?.archivedAt);
+        }
+        if (options.status) {
+          cards = cards.filter((card) => card.status === options.status);
+        }
+        writeCards(cards, options);
+      },
+    );
 
   workboard
     .command("create")


### PR DESCRIPTION
## Summary

Default the `workboard list` CLI to hide soft-archived cards,
matching the `workboard_list` API tool behavior.  Add
`--include-archived` flag to restore the old unfiltered view.

## Problem

The `openclaw workboard list` CLI showed all cards including
soft-archived ones, while the `workboard_list` MCP tool / API hid
archived cards by default (when `includeArchived` is unset).
This caused users to think archive operations failed.

## Root Cause

In `extensions/workboard/src/cli.ts`, the `list` command handler
called `store.list()` without filtering on `card.metadata?.archivedAt`.
The API tool path already had this filter in `gateway.ts`.

## Changes

- `extensions/workboard/src/cli.ts` — add `--include-archived` flag
  and default to hiding cards with `archivedAt` set

## Related

Closes #94555

🤖 Generated with [Claude Code](https://claude.com/claude-code)