### PR TITLE
Avoid copying process.env in ingress queue state DB opens

### DIFF
--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -9,7 +9,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import { createChannelIngressQueue } from "./ingress-queue.js";
+import { createChannelIngressQueue, createStateDirEnv } from "./ingress-queue.js";
 
 type ChannelIngressTestDatabase = Pick<OpenClawStateKyselyDatabase, "channel_ingress_events">;
 
@@ -26,6 +26,23 @@ async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T
 describe("channel ingress queue", () => {
   afterEach(() => {
     closeOpenClawStateDatabaseForTest();
+  });
+
+  it("overrides the state dir without copying the full process env", () => {
+    const baseEnv: NodeJS.ProcessEnv = {
+      HOME: "/home/openclaw",
+      PATH: "/usr/local/bin:/usr/bin",
+    };
+    for (let index = 0; index < 10_000; index += 1) {
+      baseEnv[`KUBERNETES_SERVICE_${index}`] = "tcp://10.0.0.1:443";
+    }
+
+    const env = createStateDirEnv("/tmp/openclaw-state", baseEnv);
+
+    expect(env.OPENCLAW_STATE_DIR).toBe("/tmp/openclaw-state");
+    expect(env.HOME).toBe("/home/openclaw");
+    expect(Object.getPrototypeOf(env)).toBe(baseEnv);
+    expect(Object.keys(env)).toEqual(["OPENCLAW_STATE_DIR"]);
   });
 
   it("deduplicates pending and completed ingress events", async () => {

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -186,9 +186,19 @@ function normalizePart(value: string | undefined, fallback: string): string {
   return normalized ? normalized : fallback;
 }
 
+// Keep inherited lookups for HOME/etc. without enumerating large Kubernetes service envs.
+export function createStateDirEnv(
+  stateDir: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  return Object.assign(Object.create(baseEnv) as NodeJS.ProcessEnv, {
+    OPENCLAW_STATE_DIR: stateDir,
+  });
+}
+
 function openStateDatabase(stateDir?: string) {
   return openOpenClawStateDatabase({
-    env: stateDir ? { ...process.env, OPENCLAW_STATE_DIR: stateDir } : process.env,
+    env: stateDir ? createStateDirEnv(stateDir) : process.env,
   });
 }
 


### PR DESCRIPTION
## Summary

Fixes #94571.

This changes the channel ingress queue state DB opener so a queue-specific `stateDir` no longer copies the full `process.env` on every queue operation.

Before:

```ts
{ ...process.env, OPENCLAW_STATE_DIR: stateDir }
```

After:

```ts
Object.assign(Object.create(process.env), { OPENCLAW_STATE_DIR: stateDir })
```

The overlay keeps inherited lookups such as `HOME` / `OPENCLAW_HOME`, while only `OPENCLAW_STATE_DIR` is an own enumerable key.

## Why

Telegram isolated polling ingress drains its durable local spool every ~500ms. Each drain calls channel ingress queue operations such as `recoverStaleClaims`, `listClaims`, and `listPending`. Those operations open the OpenClaw state DB through `src/channels/message/ingress-queue.ts`.

In Kubernetes pods with service links enabled, `process.env` can contain thousands of service variables. Repeatedly spreading `process.env` in this hot path can dominate the drain loop and saturate CPU/event loop responsiveness.

Observed on OpenClaw 2026.6.6 in Kubernetes:

- `Object.keys(process.env).length`: 9274
- `{ ...process.env }` once: 917ms to 1192ms
- queue wrapper `listPending()` once: ~982ms
- queue wrapper `listClaims()` once: ~816ms
- queue wrapper `recoverStaleClaims()` once: ~869ms

Control checks showed SQLite itself was not the bottleneck:

- direct `SELECT count(*)` x10000: ~118ms
- direct OpenClaw state DB + Kysely query: ~0-2ms

## Real behavior proof

- **Behavior or issue addressed**: Telegram isolated polling ingress repeatedly opens the channel ingress queue state DB with a queue-specific `stateDir`. The old path copied every `process.env` key on each queue operation, which becomes a runtime hot path in Kubernetes pods with thousands of service env vars.
- **Real environment tested**: Real Kubernetes OpenClaw runtime pod running OpenClaw 2026.6.6 with Telegram isolated ingress enabled and Kubernetes service env links present. The pod had 9274 environment keys.
- **Exact steps or command run after this patch**: Applied the same prototype env-overlay change used by this PR to the running runtime experiment, then ran node-based queue diagnostics inside the pod against the OpenClaw state DB and Telegram ingress queue operations.
- **Evidence after fix**: Copied live output from the real runtime experiment and the follow-up node behavior check:

```text
before fix: env keys = 9274
before fix: { ...process.env } once = 917ms to 1192ms
before fix: ingress queue listPending() once = ~982ms
before fix: ingress queue listClaims() once = ~816ms
before fix: ingress queue recoverStaleClaims() once = ~869ms
control: direct sqlite SELECT count(*) x10000 = ~118ms
control: direct OpenClaw state DB + Kysely query = ~0-2ms
after fix: prototype env overlay own keys = 1 (OPENCLAW_STATE_DIR)
after fix: inherited HOME lookup preserved through the overlay
after fix: queue wrapper calls returned to normal SQLite-level timings after warmup instead of spending ~0.8-1.2s copying env per queue operation
local exact-helper check: {"spreadOwnKeys":10002,"overlayOwnKeys":1,"overlayHome":"/home/openclaw","spreadMs":3,"overlayMs":0}
```

- **Observed result after fix**: The expensive work moved from enumerating thousands of env keys per DB open to a one-key prototype overlay. In the real runtime experiment this removed the observed ~0.8-1.2s queue-operation delay caused by env copying while preserving inherited env lookups needed by state DB resolution.
- **What was not tested**: Full local workspace Vitest was not completed in the sparse checkout because it triggered dependency installation for 155 workspace projects and the registry install was interrupted. The focused regression test is included for CI on the full repository checkout.

## Reproduction

A lightweight reproduction is to run ingress queue operations with a large env and an explicit queue `stateDir`:

```js
for (let i = 0; i < 10000; i++) {
  process.env[`KUBERNETES_SERVICE_${i}`] = "tcp://10.0.0.1:443";
}
```

Then call the queue with a custom state dir:

```ts
const queue = createChannelIngressQueue({
  channelId: "telegram",
  accountId: "default",
  stateDir,
});

await queue.recoverStaleClaims({ staleMs: 0 });
await queue.listClaims();
await queue.listPending({ limit: 1000, orderBy: "id" });
```

The old implementation enumerates/copies every env key before each DB open; the new implementation does not.

## Tests

- Added a focused regression test that constructs a 10k-key env object and verifies the state-dir env overlay has only `OPENCLAW_STATE_DIR` as its own key while preserving inherited `HOME` lookup.
- Ran `git diff --check` locally.
- Ran a small Node behavior check showing the overlay has one own key and still resolves inherited `HOME`.

I did not complete the local Vitest run because this sparse checkout triggered full workspace dependency installation for 155 workspace projects and the registry install was interrupted. CI should run the normal project test suite on the full repository checkout.
