### PR TITLE
fix(slack): stop leaking bot token into /api/auth.test request body

### DIFF
--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -1,0 +1,31 @@
+// Slack tests cover auth.test token handling during provider boot.
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getSlackClient,
+  resetSlackTestState,
+  startSlackMonitor,
+  stopSlackMonitor,
+} from "../monitor.test-helpers.js";
+
+const { monitorSlackProvider } = await import("./provider.js");
+
+beforeEach(() => {
+  resetSlackTestState();
+});
+
+describe("auth.test boot call", () => {
+  it("does not pass the bot token in the call arguments", async () => {
+    const monitor = startSlackMonitor(monitorSlackProvider);
+    await stopSlackMonitor(monitor);
+
+    const client = getSlackClient();
+    expect(client.auth.test).toHaveBeenCalledTimes(1);
+    // The SDK serializes every property from the call argument into the POST
+    // body.  Passing { token } would leak the bot token into the request
+    // payload alongside the Authorization header.
+    const firstArg = client.auth.test.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    if (firstArg != null) {
+      expect(firstArg).not.toHaveProperty("token");
+    }
+  });
+});

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -300,7 +300,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   let authTestFailed = false;
   let authTestError: string | undefined;
   try {
-    const auth = await app.client.auth.test({ token: botToken });
+    const auth = await app.client.auth.test();
     botUserId = auth.user_id ?? "";
     botId = (auth as { bot_id?: string }).bot_id ?? "";
     teamId = auth.team_id ?? "";


### PR DESCRIPTION
The bot token is already passed as an `Authorization` header,
so we don't need to send it in the request body when calling `/api/auth.test`.

See [Slack API documentation](https://api.slack.com/methods/auth.test).

Also, showing with `curl` that the bot token is not needed in the request body when passed as an `Authorization` header when calling `/api/auth.test`:
```
curl -X POST https://slack.com:443/api/auth.test -H "Authorization: Bearer xoxb-..."
{"ok":true,"url":"https://xcoulonworkspace.slack.com/","team":"xcoulon",...}
```

## Real Behavior Proof

Behavior addressed: Slack provider startup no longer passes the bot token in the `/api/auth.test` request body. The bot token remains supplied through the Slack SDK Authorization header, and Slack Socket Mode startup still works with a real app token.

Real environment tested: PR head `12624110135f29bb87b42a975ec092fc1f2df655` in an isolated local worktree, using a fresh real Slack workspace/app with real `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` values kept only in local environment variables.

Exact steps or command run after this patch: `pnpm install`; `pnpm build`; `pnpm test extensions/slack/src/monitor/provider.auth-test-token.test.ts -- --reporter=verbose`; live Slack API probe calling `https://slack.com/api/auth.test` with only `Authorization: Bearer ...`; live Slack Bolt proof using the plugin's Slack SDK version where `app.client.auth.test()` was called with no argument and Socket Mode was started/stopped; live OpenClaw Slack provider proof importing `extensions/slack/src/monitor/provider.ts` and running `monitorSlackProvider` with the real Slack bot/app tokens until connection.

Evidence after fix: The targeted Vitest regression passed 1 file / 1 test (`does not pass the bot token in the call arguments`). The live Slack API probe returned `ok: true` with no token in the request body. The live Slack Bolt proof verified `calledWithTokenArgument: false` and successfully started/stopped Socket Mode. The live OpenClaw provider proof observed `slack socket mode connected` and exited cleanly after abort.

Observed result after fix: Slack accepts `auth.test` with the bot token only in the Authorization header, matching this PR's runtime behavior. OpenClaw's Slack provider can still authenticate and connect to Slack Socket Mode from this PR head.

What was not tested: A full Mantis Slack desktop run did not complete successfully because the latest failure was infrastructure/hydration related (`hydrate-mode=prehydrated requires node_modules in the remote workspace`) before exercising this PR's Slack behavior. A full local gateway CLI startup from the source checkout also hit an unrelated bundled-plugin source-loader issue before Slack startup; the changed provider path itself was tested live.

## Maintainer proof

Validated by @sallyom on PR head `12624110135f29bb87b42a975ec092fc1f2df655` with a fresh Slack workspace/app using real `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` values kept in local environment only.

- `pnpm test extensions/slack/src/monitor/provider.auth-test-token.test.ts -- --reporter=verbose` passed: 1 file, 1 test (`does not pass the bot token in the call arguments`).
- Live Slack API contract proof passed: `auth.test` returned `ok: true` when called with the bot token only in the `Authorization: Bearer ...` header.
- Live Slack Bolt proof passed using the same Slack SDK dependency version as the plugin: `app.client.auth.test()` succeeded with no `token` argument, and Socket Mode started/stopped successfully with the app token.
- Live OpenClaw Slack provider proof passed: imported `extensions/slack/src/monitor/provider.ts` from this PR head, ran `monitorSlackProvider` with the real Slack bot/app tokens, observed `slack socket mode connected`, then aborted and exited cleanly.

Mantis Slack desktop proof was attempted separately, but the latest failure was infrastructure/hydration related (`hydrate-mode=prehydrated requires node_modules in the remote workspace`) before exercising this PR's Slack behavior.

AI-assisted: Claude Code
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
