### PR TITLE
fix(ci): stabilize update run gates

### DIFF
--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -806,7 +806,9 @@ describe("update.run post-core plugin finalize", () => {
     detectRespawnSupervisorMock.mockReturnValueOnce("launchd");
     mockGlobalInstallSurface();
 
-    await captureUpdateRunPayload();
+    await withProcessEnv({ OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway" }, () =>
+      captureUpdateRunPayload(),
+    );
 
     expect(runGatewayUpdateMock).not.toHaveBeenCalled();
     expect(runPostCoreFinalizeAfterGatewayUpdateMock).not.toHaveBeenCalled();

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -296,7 +296,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       } else {
         const preUpdateConfig =
           installSurface.kind === "git"
-            ? await readPreUpdateConfigForPostCoreFinalize().catch((err) => {
+            ? await readPreUpdateConfigForPostCoreFinalize().catch((err: unknown) => {
                 context?.logGateway?.warn(
                   `update.run could not capture pre-update config ${formatControlPlaneActor(actor)} error=${formatUpdateRunErrorMessage(err)}`,
                 );


### PR DESCRIPTION
## Summary

- satisfy the catch-callback lint rule on the new pre-update config read
- make the managed-service handoff test declare its launchd identity instead of inheriting the host environment

This repairs the two mainline failures reproduced by the exact-head CI runs for #94421, #94428, and #94394.

## Verification

- `pnpm exec oxfmt --check src/gateway/server-methods/update.ts src/gateway/server-methods/update.test.ts`
- `pnpm exec oxlint src/gateway/server-methods/update.ts src/gateway/server-methods/update.test.ts`
- `pnpm test src/gateway/server-methods/update.test.ts` — 58 passed
- same test with `OPENCLAW_LAUNCHD_LABEL` and `OPENCLAW_SYSTEMD_UNIT` removed — 58 passed
- fresh Codex autoreview — no actionable findings
