### PR TITLE
fix(gateway): type update catch callback

### DIFF
--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -296,7 +296,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       } else {
         const preUpdateConfig =
           installSurface.kind === "git"
-            ? await readPreUpdateConfigForPostCoreFinalize().catch((err) => {
+            ? await readPreUpdateConfigForPostCoreFinalize().catch((err: unknown) => {
                 context?.logGateway?.warn(
                   `update.run could not capture pre-update config ${formatControlPlaneActor(actor)} error=${formatUpdateRunErrorMessage(err)}`,
                 );


### PR DESCRIPTION
Summary:
- Type the update pre-finalize catch callback as unknown to satisfy the current lint rule.
- Keep the change scoped to the unrelated check-lint failure seen on main/PR CI.

Verification:
- pnpm lint --threads=8
- git diff --check
- pnpm openclaw --version

## Real behavior proof
Behavior addressed: The current lint gate rejects src/gateway/server-methods/update.ts because the catch callback variable is not typed as unknown.
Real environment tested: Local Ubuntu/WSL source checkout at 8f295f183da plus this one-line patch, with repo dependencies installed through pnpm.
Exact steps or command run after this patch: pnpm lint --threads=8; git diff --check; pnpm openclaw --version.
Evidence after fix: Terminal output from a real OpenClaw CLI command after the patch: Command pnpm openclaw --version printed OpenClaw 2026.6.8 (5479d39), then node scripts/run-node.mjs --version rebuilt stale dist assets and completed runtime-postbuild plugin SDK, bundled plugin metadata, official channel catalog, runtime overlay, static extension assets, stable root runtime imports, stable root runtime aliases, legacy root runtime compat aliases, and legacy CLI exit compat chunks.
Observed result after fix: pnpm lint --threads=8 completed with Found 0 warnings and 0 errors across the core, extensions, and scripts oxlint shards; git diff --check produced no output; the patched checkout still starts the OpenClaw CLI and reports OpenClaw 2026.6.8 (5479d39).
What was not tested: No gateway update operation was executed because this patch only changes a TypeScript catch callback annotation for lint compliance.
