### PR TITLE
fix #94053: keep heartbeat plain-text replies private in message-tool mode

### DIFF
--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -310,6 +310,27 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     });
   });
 
+  it("keeps plain text replies private when heartbeat response tool is not invoked in message-tool mode", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath, visibleReplies: "message_tool" });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      replySpy.mockResolvedValue({ text: "Nothing to report HEARTBEAT_OK" });
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).not.toHaveBeenCalled();
+    });
+  });
+
   it("rewrites foreground generic runner failure payloads before heartbeat delivery", async () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -32,6 +32,7 @@ import {
   resolveHeartbeatToolResponseFromReplyResult,
   type HeartbeatToolResponse,
 } from "../auto-reply/heartbeat-tool-response.js";
+import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   isHeartbeatContentEffectivelyEmpty,
@@ -1829,6 +1830,9 @@ export async function runHeartbeatOnce(opts: {
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const heartbeatToolResponse = resolveHeartbeatToolResponseFromReplyResult(replyResult);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
+    const replyPayloadDeliverableDespiteSuppression =
+      replyPayload != null &&
+      getReplyPayloadMetadata(replyPayload)?.deliverDespiteSourceReplySuppression === true;
     if (
       !heartbeatToolResponse &&
       (!replyPayload || !hasOutboundReplyContent(replyPayload)) &&
@@ -1934,8 +1938,14 @@ export async function runHeartbeatOnce(opts: {
       normalized.text = replacement.text;
       normalized.shouldSkip = false;
     }
+    const suppressMainBecauseToolNotUsed =
+      usesHeartbeatResponseTool &&
+      !heartbeatToolResponse &&
+      !replyPayloadDeliverableDespiteSuppression;
     const shouldSkipMain =
-      normalized.shouldSkip && !normalized.hasMedia && !hasRelayableExecCompletion;
+      (normalized.shouldSkip || suppressMainBecauseToolNotUsed) &&
+      !normalized.hasMedia &&
+      !hasRelayableExecCompletion;
     if (shouldSkipMain && reasoningPayloads.length === 0) {
       await restoreHeartbeatUpdatedAt({
         storePath,


### PR DESCRIPTION
Superseded by #94111, which addresses the same issue with a similar fix. Closing this duplicate.