### PR TITLE
feat(config): allow modelIdNormalization in models.providers config

### DIFF
--- a/src/agents/model-ref-shared.test.ts
+++ b/src/agents/model-ref-shared.test.ts
@@ -5,6 +5,7 @@ import {
   setCurrentPluginMetadataSnapshot,
 } from "../plugins/current-plugin-metadata-snapshot.js";
 import {
+  collectConfigProviderModelIdNormalizationPolicies,
   normalizeConfiguredProviderCatalogModelId,
   normalizeStaticProviderModelId,
 } from "./model-ref-shared.js";
@@ -147,6 +148,111 @@ describe("normalizeStaticProviderModelId", () => {
 
     expect(normalizeStaticProviderModelId("custom", "latest")).toBe("custom/modern-model");
   });
+
+  it("applies config-defined provider prefixWhenBare policy", () => {
+    // #94557: config-defined modelIdNormalization should add a provider prefix
+    // to bare model ids, same as manifest-defined rules.
+    const configProviderPolicies = new Map([["openai", { prefixWhenBare: "openai" }]]);
+    expect(normalizeStaticProviderModelId("openai", "gpt-5.5", { configProviderPolicies })).toBe(
+      "openai/gpt-5.5",
+    );
+  });
+
+  it("preserves already-prefixed model ids with config-defined policies", () => {
+    // #94557: config prefixWhenBare must not double-prefix (same guard as #77167, #84887).
+    const configProviderPolicies = new Map([["openai", { prefixWhenBare: "openai" }]]);
+    expect(
+      normalizeStaticProviderModelId("openai", "openai/gpt-5.5", { configProviderPolicies }),
+    ).toBe("openai/gpt-5.5");
+  });
+
+  it("merges config-defined policies with manifest policies (manifest wins)", () => {
+    // #94557: config-defined policies supplement manifest rules but do not
+    // override them for the same provider.
+    const manifestPlugins = [
+      {
+        modelIdNormalization: {
+          providers: {
+            openai: {
+              prefixWhenBare: "openai-compat",
+            },
+          },
+        },
+      },
+    ];
+    const configProviderPolicies = new Map([["openai", { prefixWhenBare: "openai" }]]);
+    expect(
+      normalizeStaticProviderModelId("openai", "gpt-5.5", {
+        manifestPlugins,
+        configProviderPolicies,
+      }),
+    ).toBe("openai-compat/gpt-5.5");
+  });
+
+  it("applies config-defined policies for a provider not in manifest", () => {
+    // #94557: config-defined policies work even when no manifest policy exists
+    // for that provider.
+    const manifestPlugins = [
+      {
+        modelIdNormalization: {
+          providers: {
+            nvidia: {
+              prefixWhenBare: "nvidia",
+            },
+          },
+        },
+      },
+    ];
+    const configProviderPolicies = new Map([["openai", { prefixWhenBare: "openai" }]]);
+    expect(
+      normalizeStaticProviderModelId("openai", "gpt-5.5", {
+        manifestPlugins,
+        configProviderPolicies,
+      }),
+    ).toBe("openai/gpt-5.5");
+    // Manifest rule for nvidia is unchanged
+    expect(
+      normalizeStaticProviderModelId("nvidia", "nemotron-3", {
+        manifestPlugins,
+        configProviderPolicies,
+      }),
+    ).toBe("nvidia/nemotron-3");
+  });
+});
+
+describe("collectConfigProviderModelIdNormalizationPolicies", () => {
+  it("returns empty map for undefined providers", () => {
+    const result = collectConfigProviderModelIdNormalizationPolicies(undefined);
+    expect(result.size).toBe(0);
+  });
+
+  it("extracts modelIdNormalization from configured providers", () => {
+    const providers = {
+      openai: {
+        baseUrl: "https://api.openai.com/v1",
+        api: "openai-completions",
+        modelIdNormalization: {
+          prefixWhenBare: "openai",
+        },
+        models: [{ id: "gpt-5.5" }],
+      },
+    };
+    const result = collectConfigProviderModelIdNormalizationPolicies(providers);
+    expect(result.size).toBe(1);
+    expect(result.get("openai")).toEqual({ prefixWhenBare: "openai" });
+  });
+
+  it("skips providers without modelIdNormalization", () => {
+    const providers = {
+      openai: {
+        baseUrl: "https://api.openai.com/v1",
+        api: "openai-completions",
+        models: [{ id: "gpt-5.5" }],
+      },
+    };
+    const result = collectConfigProviderModelIdNormalizationPolicies(providers);
+    expect(result.size).toBe(0);
+  });
 });
 
 describe("normalizeConfiguredProviderCatalogModelId", () => {
@@ -184,5 +290,13 @@ describe("normalizeConfiguredProviderCatalogModelId", () => {
     expect(
       normalizeConfiguredProviderCatalogModelId("kilocode", "kilocode/google/gemini-3-pro-preview"),
     ).toBe("kilocode/google/gemini-3.1-pro-preview");
+  });
+
+  it("applies config-defined provider policies to configured catalog ids", () => {
+    // #94557: configProviderPolicies apply to normalized configured catalog ids.
+    const configProviderPolicies = new Map([["openai", { prefixWhenBare: "openai" }]]);
+    expect(
+      normalizeConfiguredProviderCatalogModelId("openai", "gpt-5.5", { configProviderPolicies }),
+    ).toBe("openai/gpt-5.5");
   });
 });

--- a/src/agents/model-ref-shared.ts
+++ b/src/agents/model-ref-shared.ts
@@ -19,12 +19,7 @@ type StaticModelRef = {
   model: string;
 };
 
-export type ProviderModelIdNormalizationOptions = {
-  allowManifestNormalization?: boolean;
-  manifestPlugins?: readonly ManifestModelIdNormalizationRecord[];
-};
-
-type ManifestModelIdNormalizationProvider = {
+export type ManifestModelIdNormalizationProvider = {
   aliases?: Record<string, string>;
   stripPrefixes?: string[];
   prefixWhenBare?: string;
@@ -32,6 +27,13 @@ type ManifestModelIdNormalizationProvider = {
     modelPrefix: string;
     prefix: string;
   }[];
+};
+
+export type ProviderModelIdNormalizationOptions = {
+  allowManifestNormalization?: boolean;
+  manifestPlugins?: readonly ManifestModelIdNormalizationRecord[];
+  /** Per-provider model-id normalization policies from config (models.providers.<id>.modelIdNormalization). */
+  configProviderPolicies?: ReadonlyMap<string, ManifestModelIdNormalizationProvider>;
 };
 
 type ManifestModelIdNormalizationRecord = {
@@ -57,7 +59,50 @@ export function modelKey(provider: string, model: string): string {
     : `${providerId}/${modelId}`;
 }
 
-/** Normalize a static provider model ID with built-in and optional manifest policy. */
+type MergeConfigProviderPoliciesOptions = {
+  manifestPolicies?: Map<string, ManifestModelIdNormalizationProvider>;
+  configProviderPolicies?: ReadonlyMap<string, ManifestModelIdNormalizationProvider>;
+};
+
+/** Merge config-defined provider policies into the manifest policy map.
+ *  Manifest rules take precedence on the same provider key. */
+function mergeConfigProviderPolicies(
+  options: MergeConfigProviderPoliciesOptions,
+): Map<string, ManifestModelIdNormalizationProvider> {
+  if (!options.configProviderPolicies || options.configProviderPolicies.size === 0) {
+    return options.manifestPolicies ?? new Map();
+  }
+  const merged = new Map(options.manifestPolicies ?? []);
+  for (const [providerKey, policy] of options.configProviderPolicies) {
+    if (!merged.has(providerKey)) {
+      merged.set(providerKey, policy);
+    }
+  }
+  return merged;
+}
+
+type CollectMergedPoliciesOptions = {
+  allowManifestNormalization?: boolean;
+  manifestPlugins?: readonly ManifestModelIdNormalizationRecord[];
+  configProviderPolicies?: ReadonlyMap<string, ManifestModelIdNormalizationProvider>;
+};
+
+function collectMergedPolicies(
+  options: CollectMergedPoliciesOptions,
+): Map<string, ManifestModelIdNormalizationProvider> | undefined {
+  const manifest = options.manifestPlugins
+    ? collectManifestModelIdNormalizationPolicies(options.manifestPlugins)
+    : undefined;
+  if (!manifest && (!options.configProviderPolicies || options.configProviderPolicies.size === 0)) {
+    return undefined;
+  }
+  return mergeConfigProviderPolicies({
+    manifestPolicies: manifest,
+    configProviderPolicies: options.configProviderPolicies,
+  });
+}
+
+/** Normalize a static provider model ID with built-in, manifest, and config-defined policy. */
 export function normalizeStaticProviderModelId(
   provider: string,
   model: string,
@@ -67,16 +112,16 @@ export function normalizeStaticProviderModelId(
   if (options.allowManifestNormalization === false) {
     return normalizeBuiltInProviderModelId(normalizedProvider, model);
   }
-  if (options.manifestPlugins) {
-    return normalizeStaticProviderModelIdWithPolicies(
-      normalizedProvider,
-      model,
-      collectManifestModelIdNormalizationPolicies(options.manifestPlugins),
-    );
+
+  const mergedPolicies = collectMergedPolicies(options);
+  if (mergedPolicies) {
+    return normalizeStaticProviderModelIdWithPolicies(normalizedProvider, model, mergedPolicies);
   }
+
   const manifestModelId =
     normalizeProviderModelIdWithManifest({
       provider: normalizedProvider,
+      providerPolicies: options.configProviderPolicies,
       context: {
         provider: normalizedProvider,
         modelId: model,
@@ -94,13 +139,12 @@ export function normalizeConfiguredProviderCatalogModelId(
   if (options.allowManifestNormalization === false) {
     return normalizeConfiguredProviderCatalogModelIdShared(provider, model, new Map());
   }
-  if (options.manifestPlugins) {
-    return normalizeConfiguredProviderCatalogModelIdShared(
-      provider,
-      model,
-      collectManifestModelIdNormalizationPolicies(options.manifestPlugins),
-    );
+
+  const mergedPolicies = collectMergedPolicies(options);
+  if (mergedPolicies) {
+    return normalizeConfiguredProviderCatalogModelIdShared(provider, model, mergedPolicies);
   }
+
   return normalizeConfiguredProviderCatalogModelRef(
     normalizeStaticProviderModelId(provider, model, options),
   );
@@ -149,4 +193,23 @@ export function formatLiteralProviderPrefixedModelRef(provider: string, modelRef
     return trimmedRef;
   }
   return normalizedRef.startsWith(`${providerId}/`) ? `${providerId}/${trimmedRef}` : trimmedRef;
+}
+
+/** Extract model-id normalization policies from config-defined model providers. */
+export function collectConfigProviderModelIdNormalizationPolicies(
+  providers?: Record<string, unknown>,
+): Map<string, ManifestModelIdNormalizationProvider> {
+  const policies = new Map<string, ManifestModelIdNormalizationProvider>();
+  if (!providers) return policies;
+  for (const [providerKey, providerConfig] of Object.entries(providers)) {
+    if (!providerConfig || typeof providerConfig !== "object") continue;
+    const cfg = providerConfig as Record<string, unknown>;
+    const norm = cfg.modelIdNormalization;
+    if (!norm || typeof norm !== "object") continue;
+    policies.set(
+      normalizeLowercaseStringOrEmpty(providerKey),
+      norm as ManifestModelIdNormalizationProvider,
+    );
+  }
+  return policies;
 }

--- a/src/agents/model-selection-normalize.ts
+++ b/src/agents/model-selection-normalize.ts
@@ -10,7 +10,11 @@ import {
 import { stripSelfProviderModelPrefix } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
-import { modelKey as sharedModelKey, normalizeStaticProviderModelId } from "./model-ref-shared.js";
+import {
+  modelKey as sharedModelKey,
+  normalizeStaticProviderModelId,
+  type ManifestModelIdNormalizationProvider,
+} from "./model-ref-shared.js";
 import { normalizeProviderModelIdWithRuntime } from "./provider-model-normalization.runtime.js";
 
 // Shared provider/model normalization facade for agent model selection. It
@@ -22,6 +26,8 @@ export type ModelRef = {
 
 export type ModelManifestNormalizationContext = {
   manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
+  /** Per-provider model-id normalization policies from config (models.providers.<id>.modelIdNormalization). */
+  configProviderPolicies?: ReadonlyMap<string, ManifestModelIdNormalizationProvider>;
 };
 
 /** Build the canonical provider/model key for model selection. */
@@ -79,6 +85,7 @@ function normalizeProviderModelId(
   const staticModelId = normalizeStaticProviderModelId(provider, providerModel, {
     allowManifestNormalization: options?.allowManifestNormalization,
     manifestPlugins: options?.manifestPlugins,
+    configProviderPolicies: options?.configProviderPolicies,
   });
   if (options?.allowPluginNormalization === false) {
     return staticModelId;

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -20,6 +20,7 @@ import { splitTrailingAuthProfile } from "./model-ref-profile.js";
 import {
   normalizeConfiguredProviderCatalogModelId,
   normalizeStaticProviderModelId,
+  collectConfigProviderModelIdNormalizationPolicies,
 } from "./model-ref-shared.js";
 import {
   type ModelManifestNormalizationContext,
@@ -212,6 +213,7 @@ export function inferUniqueProviderFromConfiguredModels(
         allowManifestNormalization: params.allowManifestNormalization,
         allowPluginNormalization: false,
         manifestPlugins: params.manifestPlugins,
+        configProviderPolicies: params.configProviderPolicies,
       });
       if (!parsed) {
         continue;
@@ -239,6 +241,7 @@ export function inferUniqueProviderFromConfiguredModels(
         const normalizedModelId = normalizeConfiguredProviderCatalogModelId(providerId, modelId, {
           allowManifestNormalization: params.allowManifestNormalization,
           manifestPlugins: params.manifestPlugins,
+          configProviderPolicies: params.configProviderPolicies,
         });
         if (
           modelId === model ||
@@ -372,6 +375,7 @@ export function resolveConfiguredOpenRouterCompatAlias(
       allowManifestNormalization: params.allowManifestNormalization,
       allowPluginNormalization: params.allowPluginNormalization,
       manifestPlugins: params.manifestPlugins,
+      configProviderPolicies: params.configProviderPolicies,
     });
   }
   if (normalized !== OPENROUTER_COMPAT_FREE_ALIAS || !params.cfg) {
@@ -410,6 +414,7 @@ function parseModelRefWithCompatAlias(
       allowManifestNormalization: params.allowManifestNormalization,
       allowPluginNormalization: params.allowPluginNormalization,
       manifestPlugins: params.manifestPlugins,
+      configProviderPolicies: params.configProviderPolicies,
     })
   );
 }
@@ -459,10 +464,12 @@ function normalizeExactConfiguredProviderRef(
       normalizeStaticProviderModelId(provider, modelRaw.trim(), {
         allowManifestNormalization: params.allowManifestNormalization,
         manifestPlugins: params.manifestPlugins,
+        configProviderPolicies: params.configProviderPolicies,
       }),
       {
         allowManifestNormalization: params.allowManifestNormalization,
         manifestPlugins: params.manifestPlugins,
+        configProviderPolicies: params.configProviderPolicies,
       },
     ),
   };
@@ -735,6 +742,7 @@ export function resolveModelRefFromString(
     allowManifestNormalization: params.allowManifestNormalization,
     allowPluginNormalization: params.allowPluginNormalization,
     manifestPlugins: params.manifestPlugins,
+    configProviderPolicies: params.configProviderPolicies,
   });
   if (!parsed) {
     return null;
@@ -752,6 +760,9 @@ export function resolveConfiguredModelRef(
     allowPluginNormalization?: boolean;
   } & ModelManifestNormalizationContext,
 ): ModelRef {
+  const configProviderPolicies = collectConfigProviderModelIdNormalizationPolicies(
+    params.cfg?.models?.providers as Record<string, unknown> | undefined,
+  );
   const rawModel = resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model) ?? "";
   if (rawModel) {
     const trimmed = rawModel.trim();
@@ -775,6 +786,7 @@ export function resolveConfiguredModelRef(
         allowManifestNormalization: params.allowManifestNormalization,
         allowPluginNormalization: params.allowPluginNormalization,
         manifestPlugins: manifestPluginContext.get(),
+        configProviderPolicies,
       });
       if (aliasRef) {
         return aliasRef;
@@ -789,6 +801,7 @@ export function resolveConfiguredModelRef(
       return normalizeExactConfiguredProviderRef(exactConfiguredPrimary, {
         allowManifestNormalization: params.allowManifestNormalization,
         manifestPlugins: manifestPluginContext.get(),
+        configProviderPolicies,
       });
     }
     const aliasCandidate = profileStripped ? undefined : exactAliasCandidate;
@@ -838,6 +851,7 @@ export function resolveConfiguredModelRef(
         manifestPlugins: needsOpenRouterCompatManifestPlugins
           ? manifestPluginContext.get()
           : manifestPlugins,
+        configProviderPolicies,
       });
       if (openrouterCompatRef) {
         return openrouterCompatRef;
@@ -848,6 +862,7 @@ export function resolveConfiguredModelRef(
         model: trimmed,
         allowManifestNormalization: false,
         manifestPlugins,
+        configProviderPolicies,
       });
       let inferredProviderManifestPlugins = manifestPlugins;
       if (
@@ -863,6 +878,7 @@ export function resolveConfiguredModelRef(
             model: trimmed,
             allowManifestNormalization: params.allowManifestNormalization,
             manifestPlugins: inferredProviderManifestPlugins,
+            configProviderPolicies,
           }) ?? inferredProvider;
       }
       if (inferredProvider) {
@@ -872,6 +888,7 @@ export function resolveConfiguredModelRef(
             : false,
           allowPluginNormalization: params.allowPluginNormalization,
           manifestPlugins: inferredProviderManifestPlugins,
+          configProviderPolicies,
         });
       }
 
@@ -890,6 +907,7 @@ export function resolveConfiguredModelRef(
       allowManifestNormalization: params.allowManifestNormalization,
       allowPluginNormalization: params.allowPluginNormalization,
       manifestPlugins: manifestPluginContext.get(),
+      configProviderPolicies,
     });
     if (resolved) {
       return resolved.ref;
@@ -1278,6 +1296,7 @@ export function buildConfiguredModelCatalog(params: {
   cfg: OpenClawConfig;
   workspaceDir?: string;
   manifestPlugins?: ModelManifestPlugins;
+  configProviderPolicies?: ModelManifestNormalizationContext["configProviderPolicies"];
 }): ModelCatalogEntry[] {
   const providers = params.cfg.models?.providers;
   if (!providers || typeof providers !== "object") {
@@ -1285,6 +1304,7 @@ export function buildConfiguredModelCatalog(params: {
   }
 
   const manifestPlugins = resolveConfiguredModelManifestPlugins(params);
+  const configProviderPolicies = params.configProviderPolicies;
   const catalog: ModelCatalogEntry[] = [];
   for (const [providerRaw, provider] of Object.entries(providers)) {
     const providerId = normalizeProviderId(providerRaw);
@@ -1294,7 +1314,10 @@ export function buildConfiguredModelCatalog(params: {
     for (const model of provider.models) {
       const rawId = normalizeOptionalString(model?.id) ?? "";
       const id = rawId
-        ? normalizeConfiguredProviderCatalogModelId(providerId, rawId, { manifestPlugins })
+        ? normalizeConfiguredProviderCatalogModelId(providerId, rawId, {
+            manifestPlugins,
+            configProviderPolicies,
+          })
         : "";
       if (!id) {
         continue;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -512,6 +512,21 @@ const ModelProviderSchema = z
     headers: z.record(z.string(), SecretInputSchema.register(sensitive)).optional(),
     authHeader: z.boolean().optional(),
     request: ConfiguredModelProviderRequestSchema,
+    modelIdNormalization: z
+      .object({
+        aliases: z.record(z.string(), z.string()).optional(),
+        stripPrefixes: z.array(z.string()).optional(),
+        prefixWhenBare: z.string().optional(),
+        prefixWhenBareAfterAliasStartsWith: z
+          .array(
+            z.object({
+              modelPrefix: z.string(),
+              prefix: z.string(),
+            }),
+          )
+          .optional(),
+      })
+      .optional(),
     models: z.array(ModelDefinitionSchema).optional(),
   })
   .strict();

--- a/src/plugins/manifest-model-id-normalization.ts
+++ b/src/plugins/manifest-model-id-normalization.ts
@@ -78,21 +78,35 @@ function loadManifestModelIdNormalizationPolicies(
   return policies;
 }
 
-/** Normalizes a provider model id using plugin manifest-declared model-id policies. */
+/** Normalizes a provider model id using plugin manifest-declared model-id policies.
+ *  Config-defined provider policies (providerPolicies) supplement manifest rules;
+ *  manifest policies take precedence on the same provider key. */
 export function normalizeProviderModelIdWithManifest(params: {
   provider: string;
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   plugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
+  providerPolicies?: ReadonlyMap<string, PluginManifestModelIdNormalizationProvider>;
   context: {
     provider: string;
     modelId: string;
   };
 }): string | undefined {
+  const manifestPolicies = loadManifestModelIdNormalizationPolicies(params);
+
+  const policies = new Map(manifestPolicies);
+  if (params.providerPolicies && params.providerPolicies.size > 0) {
+    for (const [key, policy] of params.providerPolicies) {
+      if (!policies.has(key)) {
+        policies.set(key, policy);
+      }
+    }
+  }
+
   return normalizeProviderModelIdWithPolicies({
     provider: params.provider,
-    policies: loadManifestModelIdNormalizationPolicies(params),
+    policies,
     context: {
       modelId: params.context.modelId,
     },


### PR DESCRIPTION
## Summary

Allow operators to set `modelIdNormalization` (including `prefixWhenBare`) in `models.providers.<provider>` config so native model providers can be routed through Cloudflare AI Gateway's REST and Unified API endpoints, which require provider-prefixed model ids (`author/model`). Previously, `modelIdNormalization` was manifest-only and could not be set from `openclaw.json`, blocking native providers from using the recommended REST API.

- Adds optional `modelIdNormalization` field to `ModelProviderSchema` in `zod-schema.core.ts`
- Merges config-defined normalization policies alongside manifest policies in `normalizeStaticProviderModelId` and `normalizeConfiguredProviderCatalogModelId`
- Adds `configProviderPolicies` option to normalization context and threads through model-selection call chain
- Adds `collectConfigProviderModelIdNormalizationPolicies` helper
- Config policies are merged with manifest policies; manifest rules take precedence on the same provider key
- Already-prefixed model ids are preserved (no double-prefixing, maintaining fix from #77167 / #84887)

Fixes #94557

## Real behavior proof

**Behavior addressed**: A native model provider (e.g., openai) pointing at Cloudflare AI Gateway REST API receives bare model ids (e.g., `gpt-5.5`) instead of the required `author/model` form (e.g., `openai/gpt-5.5`), causing 404/400 errors.

**Real setup tested**: Node 24.16.0, Linux x86_64, pnpm + vitest.

**Exact steps or command run after fix**:

```bash
pnpm exec vitest run src/agents/model-ref-shared.test.ts
```

**After-fix evidence**:

```
Test Files  1 passed (1)
     Tests  20 passed (20)
  Duration  5.08s
```

**Observed result after the fix**: All 20 tests pass (13 existing + 7 new), including:
- Config-defined `prefixWhenBare` applies correctly
- Already-prefixed model ids are preserved (no double-prefix)
- Manifest policies take precedence over config policies for the same provider
- Config policies work for providers not in manifest
- Empty/missing `modelIdNormalization` is handled safely

**What was not tested**: End-to-end integration with Cloudflare AI Gateway; live API roundtrip verification.

## Tests and validation

- Typecheck: clean (no new errors; 2 pre-existing unrelated errors in config/io.ts)
- Unit tests: 20/20 passed (model-ref-shared.test.ts)
- No regression in existing normalization behavior

## Risk checklist

Did user-visible behavior change? `Yes` — operators can now set `modelIdNormalization` in provider config.

Did config, environment, or migration behavior change? `Yes` — a new optional config key is accepted under `models.providers.<provider>`.

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area?
- The `modelIdNormalization` config key is new and optional; it defaults to no behavior change

How is that risk mitigated?
- The field is optional, defaults to undefined, and is only applied when explicitly configured
- Manifest policies take precedence on the same provider, preserving existing plugin behavior
- Double-prefix guard (hasProviderPrefix) is unchanged

## Current review state

What is the next action?
- Maintainer review
