### PR TITLE
docs(release): backfill complete contribution records

### DIFF
--- a/.agents/skills/openclaw-changelog-update/SKILL.md
+++ b/.agents/skills/openclaw-changelog-update/SKILL.md
@@ -12,10 +12,10 @@ content, ordering, grouping, and attribution discipline.
 
 ## Goal
 
-Rewrite the target `CHANGELOG.md` version section from history, not from stale
-draft notes. Produce grouped user-facing release notes sorted by user interest
-while preserving every relevant issue/PR ref and every human `Thanks @...`
-attribution.
+Rebuild the target `CHANGELOG.md` version section from a complete, generated
+history manifest, not stale draft notes. Produce grouped user-facing release
+notes sorted by user interest while preserving every relevant issue/PR ref and
+every human `Thanks @...` attribution.
 
 ## Inputs
 
@@ -34,8 +34,37 @@ attribution.
    - `git log --first-parent --date=iso-strict --pretty=format:'%h%x09%ad%x09%s' <base-tag>..<target-ref>`
    - `git log --first-parent --grep='(#' --date=short --pretty=format:'%h%x09%ad%x09%s' <base-tag>..<target-ref>`
    - also inspect `--since='24 hours ago'` when main moved during the release.
-3. Read linked PRs/issues or diffs for ambiguous commits. Direct commits matter;
-   infer notes from subject, body, touched files, tests, and nearby commits.
+3. Generate the complete contribution record and editorial manifest before
+   writing grouped prose:
+
+   ```bash
+   node .agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs \
+     --base <base-tag> \
+     --target <target-ref> \
+     --version <YYYY.M.PATCH> \
+     --manifest /tmp/openclaw-release-<YYYY.M.PATCH>.json \
+     --write-ledger
+   ```
+
+   - the manifest is the required input to the rewrite, not an after-the-fact
+     audit; it contains every referenced PR, eligible contributor credit,
+     inline issue context, every direct commit, and an editorial-eligibility
+     classification for PRs and direct commits
+   - for a historical backfill, add `--seed-ref <pre-backfill-ref>` once so
+     contribution records from the prior changelog are retained even when an
+     older merged commit omitted its PR number; the verifier excludes records
+     for work reverted after the base tag, including beta work reverted before
+     the stable release
+   - source PR discovery combines merged GitHub commit associations with merged
+     PR references explicitly present in active commit subjects/bodies so
+     cherry-picks and squash commits remain accounted for. Resolve every
+     association page and exclude PRs merged after the target release commit
+   - read the manifest before editing `### Highlights`, `### Changes`, or
+     `### Fixes`; do not carry old grouped prose forward without re-auditing it
+   - inspect linked PRs/issues or diffs for ambiguous commits. Direct commits
+     are editorial input, not public ledger rows; infer material user outcomes
+     from subject, body, touched files, tests, and nearby commits
+
 4. Rewrite one stable-base section only:
    - use `## YYYY.M.PATCH`
    - do not create beta-specific headings
@@ -44,10 +73,21 @@ attribution.
      section instead of deleting them
 5. Section shape:
    - `### Highlights`: 5-8 bullets, broad user wins first
+     - include only a clear user-visible capability or workflow unlock, a
+       material reliability/safety fix, a broad cross-surface improvement, or
+       a release-defining integration/compatibility milestone
+     - every highlight must say what changed for a user in one sentence; use
+       one user story per bullet and group its supporting PRs
+     - exclude tests, CI, refactors, docs, catalog churn, and implementation
+       detail unless the outcome is a material install/update, data-safety, or
+       widely visible user improvement
    - `### Changes`: new capabilities and behavior changes
    - `### Fixes`: user-facing fixes first, grouped by impact and surface
    - group related changes/fixes by surface and user impact; avoid one bullet
      per tiny commit when several commits tell one user-facing story
+   - `### Complete contribution record`: generated PR-first record after the
+     grouped prose; it is the exhaustive accounting surface, not a second
+     release summary
 6. Preserve attribution:
    - keep `#issue`, `(#PR)`, `Fixes #...`, and `Thanks @...`
    - every human-authored merged PR represented by a user-facing entry needs
@@ -62,17 +102,35 @@ attribution.
    - multiple `Thanks @...` handles in one bullet are expected; do not drop or
      collapse contributor credit just because the note is grouped
    - if one grouped bullet covers both direct commits and PRs, keep all PR refs
-     and thanks, plus any issue refs from the direct commits
-   - before finalizing, audit the final release-note body:
-     - extract all `#NNN` refs from the notes
-     - resolve which refs are PRs and collect human PR authors
-     - resolve issue refs used as bug/report refs and collect human reporters
-     - scan represented commits for `Co-authored-by`
-     - compare those handles to the final `Thanks @...` set
-     - fix every missing human credit or explicitly record why it is omitted
+     and thanks, plus any issue refs and human credit from the direct work
+   - issues remain normal inline `#NNN` references. Do not add a separate
+     linked-issues inventory. The generated PR record keeps source issues
+     inline as `Related #NNN` on the PR that shipped them
+   - when backfilling an older linked-issues inventory, preserve reporter
+     credit inline for every GitHub-confirmed closing PR relationship. Do not
+     infer a PR relationship from a generic cross-reference event, invent an
+     unrelated PR link for a standalone report, or recreate the retired
+     inventory
+   - the complete contribution record lists every merged source PR exactly once
+     as `**PR #NNN**`; source PRs include GitHub commit associations and merged
+     PR references explicitly present in active commit subjects/bodies. It
+     preserves author/co-author credit and any issue references in the original
+     title
+   - direct commits remain in the manifest with GitHub-resolved author,
+     co-author, issue, and editorial-eligibility data. They inform grouped
+     prose but are never rendered as a public `#### Direct commits` dump. Add
+     direct-commit credit to a grouped bullet only when it shares an explicit
+     closing issue reference or at least two distinctive subject terms
+   - the verifier rejects `docs`, `test`, `refactor`, `ci`, `build`, `chore`,
+     and `style` PRs in Highlights, Changes, or Fixes. Keep those internal
+     contributions in the complete PR record, but do not give them editorial
+     release-note space
+   - classify internal-only work from conventional prefixes and clear title
+     signals such as `QA`, `test`, `docs`, `refactor`, `lint`, or `CI`; an
+     untyped title is not automatically editorial
    - do not add GHSA references, advisory IDs, or security advisory slugs to
      changelog entries or GitHub release-note text unless explicitly requested
-   - never thank bots, `@openclaw`, `@clawsweeper`, or `@steipete`
+   - never thank bots, `@claude`, `@openclaw`, `@clawsweeper`, or `@steipete`
    - do not use GitHub's release contributor count as the source of truth; the
      changelog must carry the complete human credit set itself
 7. Sorting preference:
@@ -91,36 +149,50 @@ attribution.
    - if any compatibility `removeAfter` is on/before release date, resolve it
      or explicitly record the blocker before shipping
 10. Validate and ship:
-   - generate and verify the complete contribution ledger before committing:
-     ```bash
-     node .agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs \
-       --base <base-tag> \
-       --target <target-ref> \
-       --version <YYYY.M.PATCH> \
-       --write-ledger
-     ```
-   - the command fails when any `#NNN` reference in release history or the
-     rendered release section is absent from the ledger, when reverted work is
-     presented as shipped, or when an eligible PR author, issue reporter, or
-     known co-author is missing from that entry's `Thanks @...` credit
-   - after the GitHub release or prerelease is published, verify every matching
-     release page against the same source section:
-     ```bash
-     node .agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs \
-       --base <base-tag> \
-       --target <target-ref> \
-       --version <YYYY.M.PATCH> \
-       --release-tag v<YYYY.M.PATCH> \
-       --check-github
-     ```
-   - add one `--release-tag` for every beta and stable page in the train; a
-     `### Release verification` tail is permitted, but any other body drift
-     fails the check; the GitHub body must begin with the complete
-     `## YYYY.M.PATCH` changelog section, including its heading
-   - `git diff --check`
-   - for docs/changelog-only changes, no broad tests are required
-   - commit with `scripts/committer "docs(changelog): refresh YYYY.M.PATCH notes" CHANGELOG.md`
-   - push, pull/rebase if needed, then branch/rebase release from latest `main`
+
+- after the manifest-driven rewrite, regenerate and verify the complete
+  contribution record before committing:
+  ```bash
+  node .agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs \
+    --base <base-tag> \
+    --target <target-ref> \
+    --version <YYYY.M.PATCH> \
+    --manifest /tmp/openclaw-release-<YYYY.M.PATCH>.json \
+    --write-ledger
+  ```
+- the command fails when any `#NNN` reference in release history or the
+  rendered release section cannot resolve, when reverted work is presented
+  as shipped, when a source PR is absent from the contribution record, when
+  direct commits are rendered as a public record dump, when non-editorial
+  PRs appear in grouped prose, or when an eligible PR author or known
+  co-author is missing from that PR's `Thanks @...` credit
+- when grouped prose names a PR, that same bullet must retain every
+  contributor and linked-reporter credit from its generated PR record
+- unqualified `#NNN` references resolve against `openclaw/openclaw`;
+  cross-repository references such as `openclaw/imsg#141` remain literal
+  text and must not be rewritten as local issue links
+- after the GitHub release or prerelease is published, verify every matching
+  release page against the same source section:
+  ```bash
+  node .agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs \
+    --base <base-tag> \
+    --target <target-ref> \
+    --version <YYYY.M.PATCH> \
+    --release-tag v<YYYY.M.PATCH> \
+    --check-github
+  ```
+- add one `--release-tag` for every beta and stable page in the train; a
+  `### Release verification` tail is permitted, but any other body drift
+  fails the check; the GitHub body must begin with the complete
+  `## YYYY.M.PATCH` changelog section, including its heading
+- GitHub release bodies are limited to 125,000 characters. If the complete
+  source section plus an existing verification tail exceeds that limit, keep
+  the source section intact and omit the tail; never truncate the
+  contribution record
+- `git diff --check`
+- for docs/changelog-only changes, no broad tests are required
+- commit with `scripts/committer "docs(changelog): refresh YYYY.M.PATCH notes" CHANGELOG.md`
+- push, pull/rebase if needed, then branch/rebase release from latest `main`
 
 ## Quota / API Outage Rule
 

--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -4,39 +4,107 @@ import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 
 const repo = "openclaw/openclaw";
-const excludedHandles = new Set(["openclaw", "clawsweeper", "codex", "steipete"]);
+const excludedHandles = new Set(["openclaw", "clawsweeper", "claude", "codex", "steipete"]);
+const nonEditorialTypes = new Set([
+  "build",
+  "chore",
+  "ci",
+  "docs",
+  "qa",
+  "refactor",
+  "style",
+  "test",
+]);
+const nonEditorialTitlePattern =
+  /(?:^|[\s:([{\-])(docs?|documentation|tests?|testing|qa|quality assurance|refactor(?:ing)?|ci|continuous integration|build|chore|style|lint|format)(?:$|[\s:)\]}\-])/i;
+const editorialTitlePattern =
+  /^\s*(?:\[[^\]]+\]\s*)?(?:#\d+:\s*)?(?:add|allow|block|enable|expose|fail|fix|harden|honor|improve|keep|migrate|move|persist|preserve|prevent|propagate|rate[- ]?limit|restore|revert|ship|support|treat|validate)\b|^\s*#\d+:/i;
+const genericDirectCommitTerms = new Set([
+  "add",
+  "allow",
+  "avoid",
+  "build",
+  "change",
+  "fix",
+  "improve",
+  "keep",
+  "make",
+  "missing",
+  "move",
+  "omit",
+  "omitted",
+  "prevent",
+  "repair",
+  "required",
+  "restore",
+  "update",
+]);
 
 function fail(message) {
   throw new Error(message);
+}
+
+function printUsage() {
+  console.log(`Usage:
+  node .agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs \\
+    --base <tag-or-sha> --target <tag-or-sha> --version <version> [options]
+
+Required:
+  --base <ref>          Release range start.
+  --target <ref>        Release range end.
+  --version <version>   CHANGELOG.md version heading to verify.
+
+Options:
+  --manifest <path>     Read or write the complete contribution record ledger.
+  --seed-ref <ref>      Use an existing release section as editorial input.
+  --write-ledger        Write the verified ledger back into CHANGELOG.md.
+  --release-tag <tag>   GitHub release tag to compare; repeatable with --check-github.
+  --check-github        Require each supplied GitHub release body to match.
+  --json                Emit machine-readable verification output.
+  --help                Show this help text.`);
 }
 
 function parseArgs(argv) {
   const options = {
     releaseTags: [],
     checkGithub: false,
+    help: false,
     json: false,
+    manifestPath: undefined,
+    seedRef: undefined,
     writeLedger: false,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
+    if (arg === "--help") {
+      options.help = true;
+      continue;
+    }
     if (arg === "--check-github" || arg === "--json" || arg === "--write-ledger") {
       options[
-        arg === "--check-github"
-          ? "checkGithub"
-          : arg === "--write-ledger"
-            ? "writeLedger"
-            : "json"
+        arg === "--check-github" ? "checkGithub" : arg === "--write-ledger" ? "writeLedger" : "json"
       ] = true;
       continue;
     }
-    if (arg === "--base" || arg === "--target" || arg === "--version" || arg === "--release-tag") {
+    if (
+      arg === "--base" ||
+      arg === "--target" ||
+      arg === "--version" ||
+      arg === "--release-tag" ||
+      arg === "--manifest" ||
+      arg === "--seed-ref"
+    ) {
       const value = argv[index + 1];
       if (!value || value.startsWith("--")) {
         fail(`missing value for ${arg}`);
       }
       if (arg === "--release-tag") {
         options.releaseTags.push(value);
+      } else if (arg === "--manifest") {
+        options.manifestPath = value;
+      } else if (arg === "--seed-ref") {
+        options.seedRef = value;
       } else {
         options[arg.slice(2)] = value;
       }
@@ -46,12 +114,16 @@ function parseArgs(argv) {
     fail(`unknown argument: ${arg}`);
   }
 
-  for (const name of ["base", "target", "version"]) {
-    if (!options[name]) {
-      fail(`--${name} is required`);
+  if (!options.help) {
+    for (const name of ["base", "target", "version"]) {
+      if (!options[name]) {
+        fail(`--${name} is required`);
+      }
     }
+  } else if (options.checkGithub || options.releaseTags.length > 0) {
+    fail("--help cannot be combined with verification options");
   }
-  if (options.checkGithub && options.releaseTags.length === 0) {
+  if (!options.help && options.checkGithub && options.releaseTags.length === 0) {
     fail("--check-github requires at least one --release-tag");
   }
   return options;
@@ -61,6 +133,7 @@ function run(command, args) {
   return execFileSync(command, args, {
     encoding: "utf8",
     env: { ...process.env, NO_COLOR: "1" },
+    maxBuffer: 16 * 1024 * 1024,
     stdio: ["ignore", "pipe", "pipe"],
   });
 }
@@ -85,7 +158,32 @@ function escapeRegExp(value) {
 }
 
 function isEligibleHandle(handle) {
-  return Boolean(handle) && !handle.endsWith("[bot]") && !excludedHandles.has(handle.toLowerCase());
+  return (
+    typeof handle === "string" &&
+    handle.toLowerCase() !== "undefined" &&
+    !handle.endsWith("[bot]") &&
+    !excludedHandles.has(handle.toLowerCase())
+  );
+}
+
+function githubHandleFromNoreply(email) {
+  return email.match(/^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/i)?.[1];
+}
+
+function editorialClassification(subject) {
+  const type = subject.match(/^\s*([a-z]+)(?:\([^)]*\))?!?:/i)?.[1]?.toLowerCase();
+  return {
+    editorialEligible:
+      (Boolean(type) || editorialTitlePattern.test(subject)) &&
+      !nonEditorialTypes.has(type) &&
+      !nonEditorialTitlePattern.test(subject),
+    type: type ?? "other",
+  };
+}
+
+function mergedByTarget(mergedAt, targetTimestamp) {
+  const mergedTimestamp = Date.parse(mergedAt);
+  return Number.isFinite(mergedTimestamp) && mergedTimestamp <= targetTimestamp;
 }
 
 function sectionFor(changelog, version) {
@@ -108,7 +206,166 @@ function sectionFor(changelog, version) {
 }
 
 function referencesIn(text) {
-  return [...text.matchAll(/#(\d+)/g)].map((match) => Number(match[1]));
+  const references = [];
+  for (const match of text.matchAll(
+    /(?<![A-Za-z0-9_.-])(?:(?<owner>[A-Za-z0-9_.-]+)\/(?<name>[A-Za-z0-9_.-]+))?#(?<number>\d+)/g,
+  )) {
+    const qualifiedRepository = match.groups?.owner
+      ? `${match.groups.owner}/${match.groups.name}`.toLowerCase()
+      : undefined;
+    if (!qualifiedRepository || qualifiedRepository === repo) {
+      references.push(Number(match.groups?.number));
+    }
+  }
+  return references;
+}
+
+function closingReferencesIn(text) {
+  const references = [];
+  for (const match of text.matchAll(
+    /\b(?:fix(?:es|ed)?|closes?|closed|resolves?|resolved)\s+(?:(?:openclaw\/openclaw)?#\d+)(?:\s*(?:,|and)\s*(?:(?:openclaw\/openclaw)?#\d+))*/gi,
+  )) {
+    appendReferences(references, referencesIn(match[0]));
+  }
+  return references;
+}
+
+function standardRevertedHash(message) {
+  return message
+    .trim()
+    .split(/\n\s*\n/)
+    .map((paragraph) => paragraph.trim())
+    .map((paragraph) => paragraph.match(/^This reverts commit ([0-9a-f]{7,40})\.$/i)?.[1])
+    .find(Boolean);
+}
+
+function handlesIn(text) {
+  const thanksStart = text.lastIndexOf(" Thanks ");
+  if (thanksStart < 0) {
+    return [];
+  }
+  const content = text.slice(0, thanksStart);
+  return [...text.slice(thanksStart).matchAll(/@([A-Za-z0-9-]+)/g)]
+    .map((match) => match[1])
+    .filter(
+      (handle) =>
+        isEligibleHandle(handle) &&
+        !new RegExp(`(?<![A-Za-z0-9-])@${escapeRegExp(handle)}\\b`, "i").test(content),
+    );
+}
+
+function relatedReferencesIn(line) {
+  const related = line.match(/\bRelated ((?:#\d+)(?:, #\d+)*)\./);
+  return related ? referencesIn(related[1]) : [];
+}
+
+function addContributionRecordEntry(entries, key, entry) {
+  const existing = entries.get(key);
+  if (!existing) {
+    entries.set(key, {
+      ...entry,
+      references: [...entry.references],
+      thanks: [...entry.thanks],
+    });
+    return;
+  }
+  appendReferences(existing.references, entry.references);
+  addHandles(existing.thanks, entry.thanks);
+}
+
+function contributionRecordFor(section) {
+  const result = { legacyIssues: new Map(), pullRequests: new Map() };
+  const recordStart = section.source.search(/\n### Complete contribution (?:ledger|record)\r?$/m);
+  if (recordStart < 0) {
+    return result;
+  }
+  const record = section.source.slice(recordStart);
+  let subsection = "";
+  for (const line of record.split("\n")) {
+    if (line === "#### Pull requests") {
+      subsection = "pull-requests";
+      continue;
+    }
+    if (line === "#### Linked issues") {
+      subsection = "linked-issues";
+      continue;
+    }
+    if (line.startsWith("#### ")) {
+      subsection = "";
+      continue;
+    }
+    if (subsection === "pull-requests") {
+      const explicitRecord = line.match(/^- \*\*PR #(\d+)\*\*/);
+      const legacyRecord = line.match(/\(#(\d+)\)\.(?: Thanks.*)?$/);
+      const number = explicitRecord?.[1] ?? legacyRecord?.[1];
+      if (number) {
+        const value = Number(number);
+        addContributionRecordEntry(result.pullRequests, value, {
+          references: relatedReferencesIn(line),
+          thanks: handlesIn(line),
+        });
+      }
+      continue;
+    }
+    if (subsection === "linked-issues") {
+      const number = referencesIn(line)[0];
+      if (number) {
+        addContributionRecordEntry(result.legacyIssues, number, {
+          references: [],
+          thanks: handlesIn(line),
+        });
+      }
+    }
+  }
+  return result;
+}
+
+function mergeContributionRecords(...records) {
+  const merged = { legacyIssues: new Map(), pullRequests: new Map() };
+  for (const record of records) {
+    for (const [number, entry] of record.pullRequests) {
+      addContributionRecordEntry(merged.pullRequests, number, entry);
+    }
+    for (const [number, entry] of record.legacyIssues) {
+      addContributionRecordEntry(merged.legacyIssues, number, entry);
+    }
+  }
+  return merged;
+}
+
+function withoutRevertedContributionRecords(record, revertedReferences) {
+  if (revertedReferences.size === 0) {
+    return record;
+  }
+  const filtered = { legacyIssues: new Map(), pullRequests: new Map() };
+  for (const [number, entry] of record.pullRequests) {
+    if (revertedReferences.has(number)) {
+      continue;
+    }
+    addContributionRecordEntry(filtered.pullRequests, number, {
+      ...entry,
+      references: entry.references.filter((reference) => !revertedReferences.has(reference)),
+    });
+  }
+  for (const [number, entry] of record.legacyIssues) {
+    if (!revertedReferences.has(number)) {
+      addContributionRecordEntry(filtered.legacyIssues, number, entry);
+    }
+  }
+  return filtered;
+}
+
+function contributionRecordReferences(record) {
+  return [...record.pullRequests.keys()];
+}
+
+function contributionRecordMetadataReferences(record) {
+  const references = contributionRecordReferences(record);
+  for (const entry of record.pullRequests.values()) {
+    appendReferences(references, entry.references);
+  }
+  appendReferences(references, record.legacyIssues.keys());
+  return references;
 }
 
 function appendReferences(references, additions) {
@@ -123,11 +380,15 @@ function appendReferences(references, additions) {
 
 function sourceCommits(base, target) {
   const mergeBase = git(["merge-base", base, target]);
+  const targetTimestamp = Date.parse(git(["show", "-s", "--format=%cI", `${target}^{commit}`]));
+  if (!Number.isFinite(targetTimestamp)) {
+    fail(`could not resolve timestamp for release target ${target}`);
+  }
   const output = git([
     "log",
     "--first-parent",
     "--reverse",
-    "--format=%H%x1f%s%x1f%B%x1e",
+    "--format=%H%x1f%s%x1f%an%x1f%ae%x1f%B%x1e",
     `${mergeBase}..${target}`,
   ]);
   const commits = new Map();
@@ -136,18 +397,28 @@ function sourceCommits(base, target) {
     if (!record) {
       continue;
     }
-    const [rawHash, subject, ...bodyParts] = record.split("\x1f");
+    const [rawHash, subject, authorName, authorEmail, ...bodyParts] = record.split("\x1f");
     const hash = rawHash.trim();
     const body = bodyParts.join("\x1f");
-    const revertedHash = body.match(/This reverts commit ([0-9a-f]{7,40})\./i)?.[1];
-    const isRevert = subject.startsWith('Revert "') || Boolean(revertedHash);
-    commits.set(hash, { body, hash, isRevert, revertedHash, subject });
+    const revertedHash = standardRevertedHash(body);
+    const isRevert = Boolean(revertedHash) || subject.startsWith('Revert "');
+    commits.set(hash, {
+      authorEmail,
+      authorName,
+      body,
+      hash,
+      isRevert,
+      revertedHash,
+      subject,
+    });
   }
   for (const commit of commits.values()) {
     if (!commit.revertedHash) {
       continue;
     }
-    const targetHash = [...commits.keys()].find((candidate) => candidate.startsWith(commit.revertedHash));
+    const targetHash = [...commits.keys()].find((candidate) =>
+      candidate.startsWith(commit.revertedHash),
+    );
     if (targetHash) {
       const reverts = revertsByTarget.get(targetHash) ?? [];
       reverts.push(commit.hash);
@@ -164,41 +435,343 @@ function sourceCommits(base, target) {
     active.set(hash, value);
     return value;
   }
+  const revertedCommitStates = new Map();
+  function revertedCommitState(ref, seen = new Set()) {
+    let hash;
+    try {
+      hash = git(["rev-parse", `${ref}^{commit}`]);
+    } catch {
+      return undefined;
+    }
+    const cached = revertedCommitStates.get(hash);
+    if (cached) {
+      return cached;
+    }
+    if (seen.has(hash)) {
+      fail(`cyclic revert history at ${hash}`);
+    }
+    seen.add(hash);
+    const output = git(["show", "-s", "--format=%s%x1f%B", hash]);
+    const [subject, ...bodyParts] = output.split("\x1f");
+    const body = bodyParts.join("\x1f");
+    const message = `${subject}\n${body}`;
+    const revertedHash = standardRevertedHash(body);
+    const targetState = revertedHash ? revertedCommitState(revertedHash, seen) : undefined;
+    const state = targetState
+      ? { ...targetState, depth: targetState.depth + 1 }
+      : { depth: 0, hash, references: referencesIn(message) };
+    revertedCommitStates.set(hash, state);
+    return state;
+  }
 
   const references = [];
   const revertedReferences = new Set();
+  const revertedCommitHashes = new Set();
   const coauthorsByReference = new Map();
+  const activeCommits = [];
   for (const commit of commits.values()) {
+    if (commit.isRevert && isActive(commit.hash)) {
+      const coauthorEmails = [...commit.body.matchAll(/^Co-authored-by:\s*.+?<([^>\s]+)>$/gim)].map(
+        (match) => match[1],
+      );
+      activeCommits.push({
+        authorEmail: commit.authorEmail,
+        authorHandle: githubHandleFromNoreply(commit.authorEmail),
+        authorName: commit.authorName,
+        body: commit.body,
+        closingReferences: [],
+        coauthors: coauthorEmails.map(githubHandleFromNoreply).filter(isEligibleHandle),
+        coauthorEmails,
+        hash: commit.hash,
+        isRevert: true,
+        pullRequests: [],
+        references: [],
+        subject: commit.subject,
+      });
+      continue;
+    }
     if (commit.isRevert) {
       continue;
     }
     const uniqueReferences = [...new Set(referencesIn(`${commit.subject}\n${commit.body}`))];
     if (!isActive(commit.hash)) {
+      revertedCommitHashes.add(commit.hash);
       for (const number of uniqueReferences) {
         revertedReferences.add(number);
       }
       continue;
     }
-    appendReferences(references, uniqueReferences);
-    const coauthors = [...commit.body.matchAll(/<(?:(?:\d+)\+)?([^@<>\s]+)@users\.noreply\.github\.com>/gi)]
-      .map((match) => match[1])
-      .filter(isEligibleHandle);
-    for (const number of uniqueReferences) {
-      if (coauthors.length > 0) {
-        const handles = coauthorsByReference.get(number) ?? new Set();
-        for (const handle of coauthors) {
-          handles.add(handle);
-        }
-        coauthorsByReference.set(number, handles);
-      }
+    const coauthorEmails = [...commit.body.matchAll(/^Co-authored-by:\s*.+?<([^>\s]+)>$/gim)].map(
+      (match) => match[1],
+    );
+    const coauthors = coauthorEmails.map(githubHandleFromNoreply).filter(isEligibleHandle);
+    activeCommits.push({
+      authorEmail: commit.authorEmail,
+      authorHandle: githubHandleFromNoreply(commit.authorEmail),
+      authorName: commit.authorName,
+      body: commit.body,
+      closingReferences: closingReferencesIn(`${commit.subject}\n${commit.body}`),
+      coauthors,
+      coauthorEmails,
+      hash: commit.hash,
+      isRevert: false,
+      pullRequests: [],
+      references: uniqueReferences,
+      subject: commit.subject,
+    });
+  }
+  for (const commit of commits.values()) {
+    if (!commit.isRevert || !commit.revertedHash || !isActive(commit.hash)) {
+      continue;
+    }
+    const targetInRange = [...commits.keys()].some((candidate) =>
+      candidate.startsWith(commit.revertedHash),
+    );
+    if (targetInRange) {
+      continue;
+    }
+    const revertedState = revertedCommitState(commit.revertedHash);
+    if (!revertedState) {
+      continue;
+    }
+    if (revertedState.depth % 2 !== 0) {
+      continue;
+    }
+    revertedCommitHashes.add(revertedState.hash);
+    for (const number of revertedState.references) {
+      revertedReferences.add(number);
     }
   }
+  const activePullRequests = resolveAssociatedPullRequests(
+    activeCommits.map((commit) => commit.hash),
+    targetTimestamp,
+  );
+  const resolvedCoauthors = resolveCommitCoauthors(activeCommits);
+  const pullRequests = new Set();
+  const nonRevertPullRequests = new Set();
+  for (const commit of activeCommits) {
+    const associatedPullRequests = activePullRequests.get(commit.hash) ?? [];
+    commit.pullRequests = associatedPullRequests;
+    addHandles(commit.coauthors, resolvedCoauthors.get(commit.hash) ?? []);
+    appendReferences(commit.references, associatedPullRequests);
+    for (const number of associatedPullRequests) {
+      pullRequests.add(number);
+      if (!commit.isRevert) {
+        nonRevertPullRequests.add(number);
+      }
+    }
+    appendReferences(references, commit.references);
+    if (commit.coauthors.length === 0) {
+      continue;
+    }
+    for (const number of commit.references) {
+      const handles = coauthorsByReference.get(number) ?? new Set();
+      for (const handle of commit.coauthors) {
+        handles.add(handle);
+      }
+      coauthorsByReference.set(number, handles);
+    }
+  }
+  const revertedPullRequests = new Set();
+  for (const pullRequests of resolveAssociatedPullRequests(
+    [...revertedCommitHashes],
+    targetTimestamp,
+  ).values()) {
+    for (const number of pullRequests) {
+      revertedPullRequests.add(number);
+    }
+  }
+  // A later active implementation supersedes an earlier reverted fix, including
+  // direct commits that cite the same issue without having a recoverable PR.
+  for (const commit of activeCommits) {
+    if (commit.isRevert) {
+      continue;
+    }
+    for (const number of commit.references) {
+      revertedReferences.delete(number);
+    }
+  }
+  // A PR can span several commits. A reverted commit does not erase the PR while
+  // another non-revert commit from it remains active in this release range.
+  for (const number of revertedPullRequests) {
+    if (!nonRevertPullRequests.has(number)) {
+      pullRequests.delete(number);
+      revertedReferences.add(number);
+    }
+  }
+  for (const number of pullRequests) {
+    revertedReferences.delete(number);
+  }
 
-  return { mergeBase, references, revertedReferences, coauthorsByReference };
+  return {
+    activeCommits,
+    coauthorsByReference,
+    mergeBase,
+    pullRequests,
+    references,
+    revertedReferences,
+    targetTimestamp,
+  };
 }
 
 function graphql(query) {
-  return githubApi(["graphql", "-f", `query=${query}`]).data;
+  let lastError;
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      return githubApi(["graphql", "-f", `query=${query}`]).data;
+    } catch (error) {
+      lastError = error;
+      const message = [error?.message, error?.stdout, error?.stderr].filter(Boolean).join("\n");
+      // Historical ranges batch hundreds of objects; only retry transient transport failures.
+      if (
+        !/(?:operation timed out|ECONNRESET|ETIMEDOUT|EAI_AGAIN|TLS handshake timeout|stream error: .*CANCEL|unexpected end of JSON input|upstream connect error|connection termination|error connecting to api\.github\.com|Unexpected token '<')/i.test(
+          message,
+        )
+      ) {
+        throw error;
+      }
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500 * 2 ** attempt);
+    }
+  }
+  throw lastError;
+}
+
+function resolveAssociatedPullRequests(commitHashes, targetTimestamp) {
+  const pullRequestsByCommit = new Map();
+  const pending = [];
+  function appendPullRequests(commitHash, connection) {
+    const pullRequests = pullRequestsByCommit.get(commitHash) ?? [];
+    const seen = new Set(pullRequests);
+    for (const pullRequest of connection?.nodes ?? []) {
+      if (
+        pullRequest.mergedAt &&
+        mergedByTarget(pullRequest.mergedAt, targetTimestamp) &&
+        !seen.has(pullRequest.number)
+      ) {
+        pullRequests.push(pullRequest.number);
+        seen.add(pullRequest.number);
+      }
+    }
+    pullRequestsByCommit.set(commitHash, pullRequests);
+    if (connection?.pageInfo?.hasNextPage) {
+      pending.push({ commitHash, cursor: connection.pageInfo.endCursor });
+    }
+  }
+  for (let index = 0; index < commitHashes.length; index += 40) {
+    const chunk = commitHashes.slice(index, index + 40);
+    const fields = chunk
+      .map(
+        (hash, offset) =>
+          `c${index + offset}: repository(owner: "openclaw", name: "openclaw") {
+            object(expression: ${JSON.stringify(hash)}) {
+              ... on Commit {
+                associatedPullRequests(first: 100) {
+                  nodes {
+                    number
+                    mergedAt
+                  }
+                  pageInfo { hasNextPage endCursor }
+                }
+              }
+            }
+          }`,
+      )
+      .join("\n");
+    const data = graphql(`query { ${fields} }`);
+    for (let offset = 0; offset < chunk.length; offset += 1) {
+      appendPullRequests(chunk[offset], data[`c${index + offset}`]?.object?.associatedPullRequests);
+    }
+  }
+  while (pending.length > 0) {
+    const chunk = pending.splice(0, 20);
+    const fields = chunk
+      .map(
+        (item, offset) =>
+          `c${offset}: repository(owner: "openclaw", name: "openclaw") {
+            object(expression: ${JSON.stringify(item.commitHash)}) {
+              ... on Commit {
+                associatedPullRequests(first: 100, after: ${JSON.stringify(item.cursor)}) {
+                  nodes {
+                    number
+                    mergedAt
+                  }
+                  pageInfo { hasNextPage endCursor }
+                }
+              }
+            }
+          }`,
+      )
+      .join("\n");
+    const data = graphql(`query { ${fields} }`);
+    for (let offset = 0; offset < chunk.length; offset += 1) {
+      appendPullRequests(
+        chunk[offset].commitHash,
+        data[`c${offset}`]?.object?.associatedPullRequests,
+      );
+    }
+  }
+  return pullRequestsByCommit;
+}
+
+function issueConnectionName(node) {
+  if (node.__typename === "Issue") {
+    return "closedByPullRequestsReferences";
+  }
+  if (node.__typename === "PullRequest") {
+    return "closingIssuesReferences";
+  }
+  return undefined;
+}
+
+function resolveIssueRelationshipPages(nodes) {
+  const pending = [];
+  for (const [number, node] of nodes) {
+    const connectionName = issueConnectionName(node);
+    const pageInfo = connectionName ? node[connectionName]?.pageInfo : undefined;
+    if (pageInfo?.hasNextPage) {
+      pending.push({ connectionName, cursor: pageInfo.endCursor, number, type: node.__typename });
+    }
+  }
+  while (pending.length > 0) {
+    const chunk = pending.splice(0, 20);
+    const fields = chunk
+      .map((item, offset) => {
+        const connection = `${item.connectionName}(first: 100, after: ${JSON.stringify(item.cursor)}) {
+          nodes { number }
+          pageInfo { hasNextPage endCursor }
+        }`;
+        return `n${offset}: repository(owner: "openclaw", name: "openclaw") {
+          issueOrPullRequest(number: ${item.number}) {
+            ... on ${item.type} {
+              ${connection}
+            }
+          }
+        }`;
+      })
+      .join("\n");
+    const data = graphql(`query { ${fields} }`);
+    for (let offset = 0; offset < chunk.length; offset += 1) {
+      const item = chunk[offset];
+      const node = nodes.get(item.number);
+      const connection = data[`n${offset}`]?.issueOrPullRequest?.[item.connectionName];
+      if (!node || !connection) {
+        continue;
+      }
+      node[item.connectionName] = {
+        nodes: [...(node[item.connectionName]?.nodes ?? []), ...connection.nodes],
+        pageInfo: connection.pageInfo,
+      };
+      if (connection.pageInfo.hasNextPage) {
+        pending.push({
+          connectionName: item.connectionName,
+          cursor: connection.pageInfo.endCursor,
+          number: item.number,
+          type: item.type,
+        });
+      }
+    }
+  }
+  return nodes;
 }
 
 function resolveReferences(numbers) {
@@ -210,8 +783,25 @@ function resolveReferences(numbers) {
         (number) => `n${number}: repository(owner: "openclaw", name: "openclaw") {
           issueOrPullRequest(number: ${number}) {
             __typename
-            ... on Issue { number title author { __typename login } }
-            ... on PullRequest { number title author { __typename login } }
+            ... on Issue {
+              number
+              title
+              author { __typename login }
+              closedByPullRequestsReferences(first: 100) {
+                nodes { number }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+            ... on PullRequest {
+              number
+              title
+              mergedAt
+              author { __typename login }
+              closingIssuesReferences(first: 100) {
+                nodes { number }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
           }
         }`,
       )
@@ -224,10 +814,10 @@ function resolveReferences(numbers) {
       }
     }
   }
-  return nodes;
+  return resolveIssueRelationshipPages(nodes);
 }
 
-function resolveCoauthors(handles) {
+function resolveGitHubHandles(handles) {
   const resolved = new Map();
   const uniqueHandles = [...new Set(handles)];
   for (let index = 0; index < uniqueHandles.length; index += 80) {
@@ -249,6 +839,95 @@ function resolveCoauthors(handles) {
   return resolved;
 }
 
+function resolveDirectCommitAuthors(commits) {
+  const resolved = new Map();
+  const commitsWithoutGitHubHandle = commits.filter((commit) => !commit.author?.handle);
+  for (let index = 0; index < commitsWithoutGitHubHandle.length; index += 40) {
+    const chunk = commitsWithoutGitHubHandle.slice(index, index + 40);
+    const fields = chunk
+      .map(
+        (commit, offset) =>
+          `c${index + offset}: repository(owner: "openclaw", name: "openclaw") {
+            object(expression: ${JSON.stringify(commit.hash)}) {
+              ... on Commit {
+                author {
+                  user {
+                    login
+                  }
+                }
+              }
+            }
+          }`,
+      )
+      .join("\n");
+    const data = graphql(`query { ${fields} }`);
+    for (let offset = 0; offset < chunk.length; offset += 1) {
+      const author = data[`c${index + offset}`]?.object?.author?.user;
+      if (author?.login && isEligibleHandle(author.login)) {
+        resolved.set(chunk[offset].hash, author.login);
+      }
+    }
+  }
+  return resolved;
+}
+
+function resolveCommitCoauthors(commits) {
+  const resolved = new Map();
+  const commitsWithCoauthors = commits.filter((commit) => commit.coauthorEmails.length > 0);
+  for (let index = 0; index < commitsWithCoauthors.length; index += 40) {
+    const chunk = commitsWithCoauthors.slice(index, index + 40);
+    const fields = chunk
+      .map(
+        (commit, offset) =>
+          `c${index + offset}: repository(owner: "openclaw", name: "openclaw") {
+            object(expression: ${JSON.stringify(commit.hash)}) {
+              ... on Commit {
+                authors(first: 20) {
+                  nodes {
+                    email
+                    user { login }
+                  }
+                }
+              }
+            }
+          }`,
+      )
+      .join("\n");
+    const data = graphql(`query { ${fields} }`);
+    for (let offset = 0; offset < chunk.length; offset += 1) {
+      const coauthorEmails = new Set(
+        chunk[offset].coauthorEmails.map((email) => email.toLowerCase()),
+      );
+      const handles =
+        data[`c${index + offset}`]?.object?.authors?.nodes
+          .filter((author) => coauthorEmails.has(author.email?.toLowerCase()))
+          .map((author) => author.user?.login)
+          .filter(isEligibleHandle) ?? [];
+      resolved.set(chunk[offset].hash, handles);
+    }
+  }
+  return resolved;
+}
+
+function withDirectCommitAuthors(commits, resolvedAuthors) {
+  return commits.map((commit) => {
+    const authorHandle = resolvedAuthors.get(commit.hash) ?? commit.author?.handle;
+    const contributors = [];
+    if (authorHandle) {
+      contributors.push(authorHandle);
+    }
+    addHandles(contributors, commit.contributors);
+    return {
+      ...commit,
+      author: {
+        handle: authorHandle,
+        name: commit.author?.name ?? commit.authorName,
+      },
+      contributors,
+    };
+  });
+}
+
 function thanksFor(node, coauthorHandles) {
   const handles = [];
   if (node.author?.__typename === "User" && isEligibleHandle(node.author.login)) {
@@ -262,56 +941,319 @@ function thanksFor(node, coauthorHandles) {
   return handles;
 }
 
-function ledgerFor(base, target, references, nodes, coauthorsByReference, resolvedCoauthors) {
-  const missing = references.filter((number) => !nodes.has(number));
-  if (missing.length > 0) {
-    fail(`GitHub could not resolve source references: ${missing.map((number) => `#${number}`).join(", ")}`);
+function addHandles(handles, additions) {
+  for (const handle of additions) {
+    if (!isEligibleHandle(handle)) {
+      continue;
+    }
+    if (!handles.some((candidate) => candidate.toLowerCase() === handle.toLowerCase())) {
+      handles.push(handle);
+    }
   }
+  return handles;
+}
 
+function titleReferences(entries) {
+  return [...new Set(entries.flatMap((entry) => referencesIn(entry.title)))];
+}
+
+function releaseTitle(title) {
+  return title;
+}
+
+function withSentenceEnding(value) {
+  return /[.!?]$/.test(value) ? value : `${value}.`;
+}
+
+function formatThanks(handles) {
+  const mentions = handles.map((handle) => `@${handle}`);
+  if (mentions.length <= 1) {
+    return mentions[0] ?? "";
+  }
+  if (mentions.length === 2) {
+    return mentions.join(" and ");
+  }
+  return `${mentions.slice(0, -1).join(", ")}, and ${mentions.at(-1)}`;
+}
+
+function directCommitTitleTokens(subject) {
+  const title = subject.replace(/^\s*[a-z]+(?:\([^)]*\))?!?:\s*/i, "");
+  return [...new Set(title.toLowerCase().match(/[a-z0-9][a-z0-9-]{3,}/g) ?? [])].filter(
+    (token) => !genericDirectCommitTerms.has(token),
+  );
+}
+
+function lineHasTerm(line, term) {
+  return new RegExp(`\\b${escapeRegExp(term)}\\b`, "i").test(line);
+}
+
+function directCommitMatchesLine(commit, line) {
+  if (!line.startsWith("- ")) {
+    return false;
+  }
+  if (commit.closingReferences.some((number) => referencesIn(line).includes(number))) {
+    return true;
+  }
+  const matchingTerms = directCommitTitleTokens(commit.subject).filter((token) =>
+    lineHasTerm(line, token),
+  );
+  return matchingTerms.length >= 2;
+}
+
+function directCommitCreditsForLine(line, directCommits) {
+  const contributors = [];
+  for (const commit of directCommits) {
+    if (
+      !editorialClassification(commit.subject).editorialEligible ||
+      !directCommitMatchesLine(commit, line)
+    ) {
+      continue;
+    }
+    addHandles(contributors, commit.contributors);
+  }
+  return contributors;
+}
+
+function completeEditorialCredits(prose, pullRequests, directCommits) {
+  const pullRequestsByNumber = new Map(
+    pullRequests.map((pullRequest) => [pullRequest.number, pullRequest]),
+  );
+  return prose
+    .split("\n")
+    .map((line) => {
+      if (!line.startsWith("- ")) {
+        return line;
+      }
+      const contributors = [];
+      for (const number of referencesIn(line)) {
+        addHandles(contributors, pullRequestsByNumber.get(number)?.thanks ?? []);
+      }
+      addHandles(contributors, directCommitCreditsForLine(line, directCommits));
+      if (contributors.length === 0) {
+        return line;
+      }
+      const existingContributors = handlesIn(line);
+      addHandles(existingContributors, contributors);
+      const thanksStart = line.lastIndexOf(" Thanks ");
+      const rawContent = thanksStart >= 0 ? line.slice(0, thanksStart) : line;
+      const content =
+        referencesIn(rawContent).length === 0
+          ? withSentenceEnding(rawContent)
+          : rawContent.replace(/[.!?]$/, "");
+      return `${content} Thanks ${formatThanks(existingContributors)}.`;
+    })
+    .join("\n");
+}
+
+function issueEntries(numbers, nodes, priorIssues = new Map()) {
+  return [...new Set(numbers)]
+    .map((number) => {
+      const node = nodes.get(number);
+      if (node?.__typename !== "Issue") {
+        return undefined;
+      }
+      const thanks = thanksFor(node, []);
+      addHandles(thanks, priorIssues.get(number)?.thanks ?? []);
+      return {
+        number,
+        thanks,
+        title: node.title.replace(/\s+/g, " ").trim(),
+      };
+    })
+    .filter(Boolean);
+}
+
+function legacyIssuesByPullRequest(priorRecord, nodes) {
+  const result = new Map();
+  for (const number of priorRecord.legacyIssues.keys()) {
+    const issue = nodes.get(number);
+    if (issue?.__typename !== "Issue") {
+      continue;
+    }
+    const pullRequests =
+      issue.closedByPullRequestsReferences?.nodes.map((pullRequest) => pullRequest.number) ?? [];
+    for (const pullRequest of new Set(pullRequests)) {
+      const issues = result.get(pullRequest) ?? [];
+      issues.push(number);
+      result.set(pullRequest, issues);
+    }
+  }
+  return result;
+}
+
+function contributionRelationships(source, nodes, resolvedContributors) {
+  const issuesByPullRequest = new Map();
+  const directCommits = [];
+  for (const commit of source.activeCommits) {
+    const pullRequests = commit.pullRequests;
+    const issues = issueEntries(commit.closingReferences, nodes);
+    if (pullRequests.length === 0) {
+      const authorHandle = commit.authorHandle
+        ? resolvedContributors.get(commit.authorHandle.toLowerCase())
+        : undefined;
+      const contributors = [];
+      if (authorHandle) {
+        contributors.push(authorHandle);
+      }
+      addHandles(
+        contributors,
+        commit.coauthors
+          .map((handle) => resolvedContributors.get(handle.toLowerCase()))
+          .filter(Boolean),
+      );
+      directCommits.push({
+        ...commit,
+        author: { handle: authorHandle, name: commit.authorName },
+        contributors,
+        issues,
+      });
+      continue;
+    }
+    if (issues.length === 0) {
+      continue;
+    }
+    for (const number of pullRequests) {
+      const existing = issuesByPullRequest.get(number) ?? [];
+      issuesByPullRequest.set(number, [...existing, ...issues]);
+    }
+  }
+  return { directCommits, issuesByPullRequest };
+}
+
+function mergeIssues(...groups) {
+  const entries = new Map();
+  for (const group of groups) {
+    for (const issue of group) {
+      const existing = entries.get(issue.number);
+      if (existing) {
+        addHandles(existing.thanks, issue.thanks);
+      } else {
+        entries.set(issue.number, { ...issue, thanks: [...issue.thanks] });
+      }
+    }
+  }
+  return [...entries.values()];
+}
+
+function ledgerFor(
+  base,
+  target,
+  references,
+  nodes,
+  coauthorsByReference,
+  resolvedHandles,
+  relationships,
+  priorRecord,
+  sourcePullRequests,
+  sourceReferences,
+  noteReferences,
+  legacyIssuePullRequests,
+  revertedReferences,
+  targetTimestamp,
+) {
   const entries = references.map((number) => {
     const node = nodes.get(number);
     const rawCoauthors = coauthorsByReference.get(number) ?? new Set();
     const coauthors = [...rawCoauthors]
-      .map((handle) => resolvedCoauthors.get(handle.toLowerCase()))
+      .map((handle) => resolvedHandles.get(handle.toLowerCase()))
       .filter(Boolean);
     return {
       number,
-      title: node.title.replace(/#(\d+)/g, "issue $1").replace(/\s+/g, " ").trim(),
+      title: releaseTitle(node.title.replace(/\s+/g, " ").trim()),
       type: node.__typename,
+      mergedAt: node.mergedAt,
+      closingIssuesReferences: node.closingIssuesReferences,
       thanks: thanksFor(node, coauthors),
     };
   });
 
-  const pullRequests = entries.filter((entry) => entry.type === "PullRequest");
+  const recordedPullRequests = new Set([
+    ...sourcePullRequests,
+    ...sourceReferences,
+    ...noteReferences,
+    ...legacyIssuePullRequests,
+    ...priorRecord.pullRequests.keys(),
+  ]);
+  const pullRequests = entries.filter(
+    (entry) =>
+      entry.type === "PullRequest" &&
+      entry.mergedAt &&
+      mergedByTarget(entry.mergedAt, targetTimestamp) &&
+      recordedPullRequests.has(entry.number) &&
+      !revertedReferences.has(entry.number),
+  );
   const issues = entries.filter((entry) => entry.type === "Issue");
-  const renderEntry = (entry, issue = false) => {
-    const attribution = entry.thanks.length > 0 ? ` Thanks ${entry.thanks.map((handle) => `@${handle}`).join(" and ")}.` : "";
-    return `- ${issue ? "Reported: " : ""}${entry.title} (#${entry.number}).${attribution}`;
+  const legacyIssues = legacyIssuesByPullRequest(priorRecord, nodes);
+  const records = pullRequests.map((entry) => {
+    const titleIssues = issueEntries(referencesIn(entry.title), nodes);
+    const closingIssues = issueEntries(
+      entry.closingIssuesReferences?.nodes.map((issue) => issue.number) ?? [],
+      nodes,
+    );
+    const linkedIssues = mergeIssues(
+      titleIssues,
+      closingIssues,
+      relationships.issuesByPullRequest.get(entry.number) ?? [],
+      issueEntries(legacyIssues.get(entry.number) ?? [], nodes, priorRecord.legacyIssues),
+    );
+    const titleIssueNumbers = new Set(titleIssues.map((issue) => issue.number));
+    const relatedIssues = linkedIssues.filter((issue) => !titleIssueNumbers.has(issue.number));
+    const thanks = [...entry.thanks];
+    for (const issue of linkedIssues) {
+      addHandles(thanks, issue.thanks);
+    }
+    return {
+      ...entry,
+      ...editorialClassification(entry.title),
+      linkedIssues,
+      relatedIssues,
+      thanks,
+    };
+  });
+  const renderEntry = (entry) => {
+    const attribution =
+      entry.thanks.length > 0
+        ? ` Thanks ${entry.thanks.map((handle) => `@${handle}`).join(" and ")}.`
+        : "";
+    const relatedIssues =
+      entry.relatedIssues.length > 0
+        ? ` Related ${entry.relatedIssues.map((issue) => `#${issue.number}`).join(", ")}.`
+        : "";
+    return `- **PR #${entry.number}** ${withSentenceEnding(entry.title)}${relatedIssues}${attribution}`;
   };
   const ledger = [
-    "### Complete contribution ledger",
+    "### Complete contribution record",
     "",
-    `This audited record covers the complete ${base}..${target} history: ${pullRequests.length} PRs and ${issues.length} linked issues. The grouped notes above prioritize user impact; this ledger preserves every contribution reference and eligible human credit.`,
+    `This audited record covers the complete ${base}..${target} history: ${records.length} merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.`,
     "",
     "#### Pull requests",
     "",
-    ...pullRequests.map((entry) => renderEntry(entry)),
-    "",
-    "#### Linked issues",
-    "",
-    ...issues.map((entry) => renderEntry(entry, true)),
+    ...records.map((entry) => renderEntry(entry)),
   ].join("\n");
-  return { entries, issues, ledger, pullRequests };
+  return {
+    entries,
+    issues,
+    ledger,
+    pullRequests: records,
+    titleReferences: titleReferences(records),
+  };
 }
 
-function replaceLedger(changelog, section, ledger) {
-  const beforeLedger = section.source.replace(/\n+### Complete contribution ledger[\s\S]*$/m, "").trimEnd();
+function replaceLedger(changelog, section, ledger, pullRequests, directCommits) {
+  const beforeLedger = completeEditorialCredits(
+    section.source.replace(/\n+### Complete contribution (?:ledger|record)[\s\S]*$/m, "").trimEnd(),
+    pullRequests,
+    directCommits,
+  );
   const replacement = `${beforeLedger}\n\n${ledger}\n`;
   return `${changelog.slice(0, section.start)}${replacement}${changelog.slice(section.end)}`;
 }
 
-function ledgerChecks(section, entries) {
+function ledgerChecks(section, pullRequests, nodes, directCommits) {
   const errors = [];
+  if (/@undefined\b/i.test(section.source)) {
+    errors.push("release section contains invalid @undefined contributor credit");
+  }
   if (!section.source.includes("### Highlights")) {
     errors.push("missing ### Highlights");
   }
@@ -321,25 +1263,29 @@ function ledgerChecks(section, entries) {
   if (!section.source.includes("### Fixes")) {
     errors.push("missing ### Fixes");
   }
-  const ledgerStart = section.source.indexOf("### Complete contribution ledger");
+  const ledgerStart = section.source.indexOf("### Complete contribution record");
   if (ledgerStart < 0) {
-    errors.push("missing ### Complete contribution ledger");
+    errors.push("missing ### Complete contribution record");
     return errors;
   }
   const ledger = section.source.slice(ledgerStart);
-  const entryNumbers = new Set(entries.map((entry) => entry.number));
+  if (ledger.includes("#### Linked issues")) {
+    errors.push("complete contribution record must not have a linked-issues inventory");
+  }
+  if (ledger.includes("#### Direct commits")) {
+    errors.push("complete contribution record must not list direct commits");
+  }
   for (const number of new Set(referencesIn(section.source))) {
-    if (!entryNumbers.has(number)) {
-      errors.push(`missing ledger entry for #${number}`);
+    if (!nodes.has(number)) {
+      errors.push(`unresolved release-note reference #${number}`);
     }
   }
-  for (const entry of entries) {
-    const prefix = entry.type === "Issue" ? "- Reported: " : "- ";
+  for (const entry of pullRequests) {
     const line = ledger
       .split("\n")
-      .find((candidate) => candidate.startsWith(prefix) && candidate.includes(`(#${entry.number})`));
+      .find((candidate) => candidate.startsWith(`- **PR #${entry.number}**`));
     if (!line) {
-      errors.push(`missing ledger entry for #${entry.number}`);
+      errors.push(`missing contribution record for PR #${entry.number}`);
       continue;
     }
     for (const handle of entry.thanks) {
@@ -348,7 +1294,105 @@ function ledgerChecks(section, entries) {
       }
     }
   }
+  const editorialProse = section.source.slice(0, ledgerStart);
+  for (const entry of pullRequests) {
+    if (
+      !entry.editorialEligible &&
+      new RegExp(`(?<![A-Za-z0-9_./-])#${entry.number}\\b`).test(editorialProse)
+    ) {
+      errors.push(
+        `editorial release prose references non-editorial ${entry.type} PR #${entry.number} (${entry.type})`,
+      );
+    }
+  }
+  const editorialLines = editorialProse.split("\n");
+  for (const entry of pullRequests) {
+    for (const line of editorialLines) {
+      if (
+        !new RegExp(`(?<![A-Za-z0-9_./-])#${entry.number}\\b`).test(line) ||
+        !line.startsWith("- ")
+      ) {
+        continue;
+      }
+      for (const handle of entry.thanks) {
+        if (!line.toLowerCase().includes(`@${handle.toLowerCase()}`)) {
+          errors.push(`missing editorial Thanks @${handle} for PR #${entry.number}`);
+        }
+      }
+    }
+  }
+  for (const line of editorialLines) {
+    if (!line.startsWith("- ")) {
+      continue;
+    }
+    for (const handle of directCommitCreditsForLine(line, directCommits)) {
+      if (!line.toLowerCase().includes(`@${handle.toLowerCase()}`)) {
+        errors.push(`missing editorial Thanks @${handle} for directly landed work`);
+      }
+    }
+  }
+  const lines = section.source.split("\n");
+  for (const number of new Set(referencesIn(section.source))) {
+    const node = nodes.get(number);
+    if (node?.__typename !== "Issue") {
+      continue;
+    }
+    for (const handle of thanksFor(node, [])) {
+      const credited = lines.some(
+        (line) =>
+          line.includes(`#${number}`) && line.toLowerCase().includes(`@${handle.toLowerCase()}`),
+      );
+      if (!credited) {
+        errors.push(`missing Thanks @${handle} for issue #${number}`);
+      }
+    }
+  }
   return errors;
+}
+
+function manifestFor(options, source, ledger, directCommitRecords) {
+  const directCommits = directCommitRecords.map((commit) => ({
+    ...editorialClassification(commit.subject),
+    commit: commit.hash.slice(0, 12),
+    subject: commit.subject,
+    references: commit.references,
+    author: commit.author,
+    contributors: commit.contributors,
+    issues: commit.issues.map((issue) => ({
+      number: issue.number,
+      title: issue.title,
+      reporter: issue.thanks,
+    })),
+  }));
+  const unlinkedCommits = directCommits.filter((commit) => commit.references.length === 0);
+  return {
+    schemaVersion: 2,
+    base: options.base,
+    target: options.target,
+    mergeBase: source.mergeBase,
+    version: options.version,
+    source: {
+      references: ledger.entries.length,
+      pullRequests: ledger.pullRequests.length,
+      issues: ledger.issues.length,
+      directCommits: directCommits.length,
+      unlinkedCommits: unlinkedCommits.length,
+    },
+    pullRequests: ledger.pullRequests.map((entry) => ({
+      number: entry.number,
+      title: entry.title,
+      type: entry.type,
+      editorialEligible: entry.editorialEligible,
+      thanks: entry.thanks,
+      linkedIssues: entry.linkedIssues.map((issue) => ({
+        number: issue.number,
+        title: issue.title,
+        reporter: issue.thanks,
+      })),
+    })),
+    directCommits,
+    unlinkedCommits,
+  };
 }
 
 function releaseChecks(section, releaseTags) {
@@ -359,7 +1403,8 @@ function releaseChecks(section, releaseTags) {
     const suffix = release.body.slice(expected.length).trimStart();
     const matches =
       release.body === expected ||
-      (release.body.startsWith(expected) && (suffix === "" || suffix.startsWith("### Release verification")));
+      (release.body.startsWith(expected) &&
+        (suffix === "" || suffix.startsWith("### Release verification")));
     checks.push({
       tag,
       releaseId: release.id,
@@ -372,46 +1417,161 @@ function releaseChecks(section, releaseTags) {
 
 function main() {
   const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printUsage();
+    return;
+  }
   let changelog = readFileSync("CHANGELOG.md", "utf8");
   let section = sectionFor(changelog, options.version);
   const source = sourceCommits(options.base, options.target);
-  const preexistingNotes = section.source.replace(/\n+### Complete contribution ledger[\s\S]*$/m, "");
+  const preexistingNotes = section.source.replace(
+    /\n+### Complete contribution (?:ledger|record)[\s\S]*$/m,
+    "",
+  );
   const noteReferences = referencesIn(preexistingNotes);
-  const revertedNoteReferences = noteReferences.filter((number) => source.revertedReferences.has(number));
+  const revertedNoteReferences = noteReferences.filter((number) =>
+    source.revertedReferences.has(number),
+  );
   if (revertedNoteReferences.length > 0) {
     fail(
-      `release notes reference reverted work: ${[
-        ...new Set(revertedNoteReferences),
-      ]
+      `release notes reference reverted work: ${[...new Set(revertedNoteReferences)]
         .map((number) => `#${number}`)
         .join(", ")}`,
     );
   }
   const references = [...source.references];
   appendReferences(references, noteReferences);
-  const nodes = resolveReferences(references);
-  const coauthorHandles = [...source.coauthorsByReference.values()].flatMap((handles) => [...handles]);
-  const resolvedCoauthors = resolveCoauthors(coauthorHandles);
+  let nodes = resolveReferences(references);
+  const renderedRecord = contributionRecordFor(section);
+  const renderedRecordReferences = contributionRecordMetadataReferences(renderedRecord);
+  const revertedRenderedReferences = renderedRecordReferences.filter((number) =>
+    source.revertedReferences.has(number),
+  );
+  if (!options.writeLedger && revertedRenderedReferences.length > 0) {
+    fail(
+      `contribution record references reverted work: ${[...new Set(revertedRenderedReferences)]
+        .map((number) => `#${number}`)
+        .join(", ")}`,
+    );
+  }
+  let priorRecord = withoutRevertedContributionRecords(renderedRecord, source.revertedReferences);
+  if (options.seedRef) {
+    const seedChangelog = git(["show", `${options.seedRef}:CHANGELOG.md`]);
+    const seedSection = sectionFor(seedChangelog, options.version);
+    priorRecord = mergeContributionRecords(priorRecord, contributionRecordFor(seedSection));
+  }
+  priorRecord = withoutRevertedContributionRecords(priorRecord, source.revertedReferences);
+  const recordedReferences = contributionRecordMetadataReferences(priorRecord);
+  const revertedRecordedReferences = recordedReferences.filter((number) =>
+    source.revertedReferences.has(number),
+  );
+  if (revertedRecordedReferences.length > 0) {
+    fail(
+      `contribution record references reverted work: ${[...new Set(revertedRecordedReferences)]
+        .map((number) => `#${number}`)
+        .join(", ")}`,
+    );
+  }
+  appendReferences(references, recordedReferences);
+  nodes = resolveReferences(references);
+  const legacyIssuePullRequests = [...legacyIssuesByPullRequest(priorRecord, nodes).keys()];
+  appendReferences(references, legacyIssuePullRequests);
+  nodes = resolveReferences(references);
+  const unresolvedSourceReferences = references.filter((number) => !nodes.has(number));
+  if (unresolvedSourceReferences.length > 0) {
+    fail(
+      `GitHub could not resolve source references: ${unresolvedSourceReferences
+        .map((number) => `#${number}`)
+        .join(", ")}`,
+    );
+  }
+  const provisionalEntries = references
+    .map((number) => nodes.get(number))
+    .filter((node) => node?.__typename === "PullRequest");
+  const titleReferenceNumbers = titleReferences(provisionalEntries);
+  const closingIssueNumbers = provisionalEntries.flatMap(
+    (entry) => entry.closingIssuesReferences?.nodes.map((issue) => issue.number) ?? [],
+  );
+  const resolvedReferences = [...references];
+  appendReferences(resolvedReferences, titleReferenceNumbers);
+  appendReferences(resolvedReferences, closingIssueNumbers);
+  nodes = resolveReferences(resolvedReferences);
+  const invalidRecordedPullRequests = [...priorRecord.pullRequests.keys()].filter((number) => {
+    const node = nodes.get(number);
+    return (
+      node?.__typename !== "PullRequest" ||
+      !node.mergedAt ||
+      !mergedByTarget(node.mergedAt, source.targetTimestamp)
+    );
+  });
+  if (!options.writeLedger && invalidRecordedPullRequests.length > 0) {
+    fail(
+      `contribution record contains unresolved or unmerged PRs: ${invalidRecordedPullRequests
+        .map((number) => `#${number}`)
+        .join(", ")}`,
+    );
+  }
+  const unresolvedTitleReferences = titleReferenceNumbers.filter((number) => !nodes.has(number));
+  if (unresolvedTitleReferences.length > 0) {
+    fail(
+      `GitHub could not resolve PR-title references: ${unresolvedTitleReferences
+        .map((number) => `#${number}`)
+        .join(", ")}`,
+    );
+  }
+  const contributorHandles = [
+    ...source.activeCommits.flatMap((commit) => commit.coauthors),
+    ...source.activeCommits.map((commit) => commit.authorHandle).filter(Boolean),
+  ];
+  const resolvedHandles = resolveGitHubHandles(contributorHandles);
+  const relationships = contributionRelationships(source, nodes, resolvedHandles);
+  const unlinkedCommits = source.activeCommits.filter((commit) => commit.references.length === 0);
+  const resolvedCommitAuthors = resolveDirectCommitAuthors(relationships.directCommits);
+  relationships.directCommits = withDirectCommitAuthors(
+    relationships.directCommits,
+    resolvedCommitAuthors,
+  );
   const ledger = ledgerFor(
     options.base,
     options.target,
     references,
     nodes,
     source.coauthorsByReference,
-    resolvedCoauthors,
+    resolvedHandles,
+    relationships,
+    priorRecord,
+    source.pullRequests,
+    source.references,
+    noteReferences,
+    legacyIssuePullRequests,
+    source.revertedReferences,
+    source.targetTimestamp,
   );
+  const manifest = manifestFor(options, source, ledger, relationships.directCommits);
+
+  if (options.manifestPath) {
+    writeFileSync(options.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  }
 
   if (options.writeLedger) {
-    changelog = replaceLedger(changelog, section, ledger.ledger);
+    changelog = replaceLedger(
+      changelog,
+      section,
+      ledger.ledger,
+      ledger.pullRequests,
+      relationships.directCommits,
+    );
     writeFileSync("CHANGELOG.md", changelog);
     section = sectionFor(changelog, options.version);
   }
 
-  const errors = ledgerChecks(section, ledger.entries);
+  const errors = ledgerChecks(section, ledger.pullRequests, nodes, relationships.directCommits);
   const github = options.checkGithub ? releaseChecks(section, options.releaseTags) : [];
   for (const check of github) {
     if (!check.matches) {
-      errors.push(`GitHub release ${check.tag} does not match the ${options.version} CHANGELOG section`);
+      errors.push(
+        `GitHub release ${check.tag} does not match the ${options.version} CHANGELOG section`,
+      );
     }
   }
 
@@ -424,6 +1584,8 @@ function main() {
       references: references.length,
       pullRequests: ledger.pullRequests.length,
       issues: ledger.issues.length,
+      directCommits: manifest.directCommits.length,
+      unlinkedCommits: manifest.unlinkedCommits.length,
     },
     github,
     errors,

--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -249,12 +249,20 @@ Stable publication is not complete until `main` carries the actual shipped relea
   section from history, not existing notes. Use the last reachable stable or
   beta release tag as the base, then inspect every commit through the target
   release SHA.
+- Generate `$openclaw-changelog-update`'s full contribution manifest before
+  the editorial rewrite. It is the required source for `### Highlights`,
+  `### Changes`, and `### Fixes`; do not preserve old grouped prose without
+  comparing it to the manifest's PRs, contributors, direct commits, and
+  unlinked commits.
 - The changelog rewrite is not optional for beta reruns: any `beta.N` after a
   rebase or backport must refresh the same stable-base `## YYYY.M.PATCH` section
   before the new version/tag commit.
 - Include both merged PR commits and direct commits on `main`. Direct commits
   matter: infer notes from their subject, body, touched files, linked issues,
   tests, and nearby code when no PR body exists.
+- Keep direct commits in the generated manifest and use them to shape grouped
+  user outcomes, but never dump them into `CHANGELOG.md` or GitHub release
+  bodies. The public complete record is PR-first and exhaustive for PRs.
 - Prefer PR bodies, issue links, review proof, and commit bodies over commit
   subjects alone. If a commit fixed an issue directly, the commit body should
   name the user-visible behavior, affected surface, issue ref, and credited
@@ -270,11 +278,31 @@ Stable publication is not complete until `main` carries the actual shipped relea
   `#issue`, `(#PR)`, `Fixes #...`, and every human `Thanks @...` handle.
   Multiple thanks in one bullet are expected when multiple contributor PRs are
   grouped.
+- Highlights earn their place only when they are a visible capability/workflow
+  unlock, a material reliability or safety repair, a broad user-facing
+  improvement, or a release-defining integration/compatibility change. Keep
+  five to eight user-outcome bullets; omit tests, CI, refactors, docs, and
+  implementation trivia unless their outcome materially affects users.
+- Do not give `docs`, `test`, `refactor`, `ci`, `build`, `chore`, or `style`
+  PRs/direct commits their own Highlights, Changes, or Fixes entry. They remain
+  accounted for in the PR record or manifest, but are not product release
+  content. Treat explicit internal title signals such as `QA`, `lint`, or
+  `testing` the same way even when the PR has no conventional prefix.
+- Use the generated `### Complete contribution record` as PR-first accounting:
+  every merged source PR appears once with author/co-author credit, including
+  PRs identified only by an explicit active-commit `#NNN` reference after a
+  cherry-pick or squash. Keep issues inline as `#NNN` in titles and grouped
+  prose; do not create a linked-issues inventory or a direct-commit listing.
+  When grouped prose names a PR, keep every contributor and linked-reporter
+  credit from that PR's record on the same bullet.
 - Changelog entries should be user-facing, not internal release-process notes.
 - GitHub release and prerelease bodies must use the full matching
   `CHANGELOG.md` version section, not highlights or an excerpt. When creating
   or editing a release, extract from `## YYYY.M.PATCH` through the line before the
   next level-2 heading and use that complete block as the release notes.
+- GitHub limits release bodies to 125,000 characters. If a historical
+  `### Release verification` tail would exceed that cap, omit the tail and keep
+  the complete changelog section; do not truncate the contribution record.
 - Before publishing or closing a release, run
   `$openclaw-changelog-update`'s `verify-release-notes.mjs` with every stable
   and beta release tag in the train. Do not publish or leave a page live when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,1524 +6,1476 @@ Docs: https://docs.openclaw.ai
 
 ### Highlights
 
-- Telegram and WhatsApp channel delivery are richer and less brittle: Telegram can send structured rich text with tables, lists, expandable blockquotes, preserved intentional line breaks, prompt-preserving CLI backend delivery, retired native draft migration, and safer rich-media boundaries, while WhatsApp now honors configured ACP bindings. (#92679, #93164, #84082, #89421, #92513) Thanks @obviyus, @jzakirov, @spacegeologist, and @TurboTheTurtle.
-- Agent and Gateway recovery is sharper across account-scoped DM sends, generated media completions, auto-reply message-tool final replies, reset archive fallback reads, restart shutdown aborts, yielded subagent pauses, trusted subagent thinking override fallback, yielded cron media, heartbeat dedupe, session identity prompts, and unknown OpenAI agent selector rejection. (#92788, #91246, #92879, #91357, #92631, #92412, #92146, #91287, #92468, #92510) Thanks @yetval, @TurboTheTurtle, @masatohoshino, @CadanHu, @ooiuuii, @openperf, @IWhatsskill, @ZengWen-DT, and @zhangguiping-xydt.
-- Provider/model handling expands and tightens with GLM-5.2, Claude Haiku 4.5 catalog rows, OpenRouter and Google Vertex provider-prefix normalization, managed SecretRef auth, OAuth image-default routing through Codex, bounded model browse discovery, LM Studio binary thinking-off delivery, storeless OpenAI Responses replay gating, invalid OpenAI reasoning-signature and genericized Anthropic thinking-signature recovery, Claude 4.5 Copilot tool-streaming safety, and OpenAI/Anthropic-family payload quarantine for unreadable or post-hook tool schemas. (#92796, #90116, #92627, #91218, #90686, #92824, #92247, #92002, #90706, #92941, #92201, #92916, #75393, #92908, #92921, #92928) Thanks @arkyu2077, @liuhao1024, @bymle, @rohitjavvadi, @nxmxbbd, @bek91, @samson910022, @mmyzwl, @CarlCapital, @snowzlm, @Kailigithub, and @vincentkoc.
-- `/usage` and reply payload hooks now have a native full footer renderer, default template, fixed-decimal formatting, credential-aware limits, better partial-count handling, and warnings for broken templates instead of silent bad output. (#92657, #89835, #89629) Thanks @Marvinthebored.
-- UI and mobile flows are steadier: workspace files can collapse and start collapsed, WebChat backscroll survives streaming, the sidebar session picker remains interactive above the desktop workbench, reset soft args survive UI dispatch, stale dashboard session parent lineage is preserved, and iOS reconnects stale foreground gateways. (#92779, #92622, #92705, #91353, #90658, #92552) Thanks @shakkernerd, @TurboTheTurtle, @NianJiuZst, @zhouhe-xydt, @luoyanglang, and @Solvely-Colin.
-- Memory, state, and diagnostics recover cleaner: oversized OpenAI embedding batches split before 431s, QMD memory search stays available in transient mode, SQLite avoids WAL on NFS state volumes, stuck-session recovery scheduling no longer resets warning backoff, full memory reindexes preserve rollback/cache recovery, raw Memory Wiki source pages stop looking malformed, and Infinity chunk limits stay genuinely unbounded. (#92650, #92618, #92639, #91247, #92752, #92881, #59137, #92876, #69700, #92735) Thanks @mushuiyu886, @TurboTheTurtle, @849261680, @gnanam1990, @TSHOGX, @arlen8411, and @yhterrance.
+- **Richer channel delivery:** Telegram and WhatsApp are less brittle: Telegram renders structured text with tables, lists, expandable blockquotes, preserved intentional line breaks, and CLI-backed replies, while WhatsApp now honors configured ACP bindings. (#92679, #93164, #84082, #89421, #92513) Thanks @obviyus, @vincentkoc, @jzakirov, @spacegeologist, @TurboTheTurtle, @mcaxtr, @myrzka, and @dmorn.
+- **More reliable agent runs:** account-scoped DM sends, generated media completions, auto-reply message-tool final replies, reset archive fallback reads, restart shutdown aborts, yielded subagent pauses, and session identity prompts all stay on the correct recovery path. (#92788, #91246, #92879, #91357, #92631, #92468) Thanks @yetval, @TurboTheTurtle, @masatohoshino, @CadanHu, @vincentkoc, @ooiuuii, @openperf, @zhangguiping-xydt, @QQSHI13, @kumaxs, and @aleps001.
+- **Safer model routing:** new GLM-5.2 and Claude Haiku 4.5 catalog support arrives with normalized provider IDs, managed SecretRef auth, bounded model browsing, and safer OpenAI/Anthropic tool-schema recovery. (#92796, #90116, #92627, #90686, #92247, #92941) Thanks @arkyu2077, @liuhao1024, @lijenhsin, @rohitjavvadi, @samson910022, @maaron34, @syfvb, and @samson1357924.
+- **Useful usage footers:** `/usage` and reply payload hooks now have a native full footer renderer, default template, fixed-decimal formatting, credential-aware limits, better partial-count handling, and warnings for broken templates instead of silent bad output. (#92657, #89835, #89629) Thanks @Marvinthebored.
+- **Predictable web search defaults:** key-free providers such as Parallel Free, DuckDuckGo, Ollama, and Codex Hosted Search remain explicit opt-ins rather than surprising automatic fallbacks. (#93616) Thanks @davemorin and @vincentkoc.
+- **Calmer UI and mobile sessions:** workspace files start collapsed, WebChat backscroll survives streaming, the desktop session picker remains interactive, reset arguments survive dispatch, and iOS reconnects stale foreground Gateways. (#92779, #92622, #92705, #91353, #92552) Thanks @shakkernerd, @TurboTheTurtle, @NianJiuZst, @zhouhe-xydt, @Solvely-Colin, @MaBeitian, @vincentkoc, @Chang2020618, and @DrtyMorty.
+- **Resilient memory and state:** oversized OpenAI embedding batches split before 431s, QMD search stays available in transient mode, SQLite avoids WAL on NFS volumes, and full reindexes preserve rollback/cache recovery. (#92650, #92618, #92639, #91247, #92881) Thanks @mushuiyu886, @BrettHamlin, @zhbcher, @TurboTheTurtle, @Takhoffman, @849261680, @TSHOGX, @vincentkoc, and @AFabyTWE.
 
 ### Changes
 
-- Providers/models: add GLM-5.2 support and Claude Haiku 4.5 catalog entries while keeping provider-qualified model IDs normalized across OpenRouter and Google Vertex paths. (#92796, #90116, #92627, #91218) Thanks @arkyu2077, @liuhao1024, and @bymle.
+- Providers/models: add GLM-5.2 support and Claude Haiku 4.5 catalog entries while keeping provider-qualified model IDs normalized across OpenRouter and Google Vertex paths. (#92796, #90116, #92627, #91218) Thanks @arkyu2077, @liuhao1024, @bymle, @maaron34, @lijenhsin, @davemorin, and @vincentkoc.
 - Web search: keep key-free providers such as Parallel Free, DuckDuckGo, Ollama, and Codex Hosted Search as explicit opt-ins instead of selecting them automatically when no API-backed provider is configured. (#93616) Thanks @davemorin and @vincentkoc.
-- Channel plugins: ship Telegram rich-message delivery and WhatsApp ACP binding support, including preserved intentional line breaks, rich prompt handoff to CLI backends, and transport fixtures for richer drafts. (#92679, #93164, #92513) Thanks @obviyus and @TurboTheTurtle.
-- Agent commands: support `/btw` in CLI-backed sessions and keep CLI usage-error exits classified as usage failures instead of successful runs. (#92669, #92162) Thanks @joshavant and @Pandah97.
+- Channel plugins: ship Telegram rich-message delivery and WhatsApp ACP binding support, including preserved intentional line breaks, rich prompt handoff to CLI backends, and transport fixtures for richer drafts. (#92679, #93164, #92513) Thanks @obviyus, @TurboTheTurtle, @vincentkoc, @mcaxtr, and @dmorn.
+- Agent commands: support `/btw` in CLI-backed sessions and keep CLI usage-error exits classified as usage failures instead of successful runs. (#92669, #92162) Thanks @joshavant, @Pandah97, @marcospaulo, @davemorin, and @vincentkoc.
 - Usage hooks: add built-in full footer rendering, default footer templates, per-turn usage state, credential-aware limits, and fixed-decimal formatting for usage-bar templates. (#92657, #89835, #89629) Thanks @Marvinthebored.
-- Docs and operator guidance: document node config examples, clarify before-install hook scope, correct agent default concurrency comments, refresh ZAI provider docs, and update channel/group docs for current Telegram and WhatsApp behavior. (#92677, #92766, #92695) Thanks @liuhao1024, @sallyom, and @ArielSmoliar.
 
 ### Fixes
 
-- Channels and delivery: preserve account-scoped DM channel send policy, intentional rich-message line breaks in Telegram and status output, rich Telegram final replies, rich Telegram tables and lists, Telegram thread-create CLI remapping, Feishu dynamic-agent routes after persisted binding reuse, Slack outbound `message_sent` hooks, contributed message-tool schema optionality, same-channel generated media completions, and channel chunking around surrogate pairs and Infinity limits. (#92788, #93164, #92679, #89421, #89943, #42837, #92814, #91137, #91246, #92735) Thanks @yetval, @obviyus, @spacegeologist, @rishitamrakar, @liuhao1024, @lundog, @TurboTheTurtle, and @yhterrance.
+- Channels and delivery: preserve account-scoped DM channel send policy, intentional rich-message line breaks in Telegram and status output, rich Telegram final replies, rich Telegram tables and lists, Telegram thread-create CLI remapping, Feishu dynamic-agent routes after persisted binding reuse, Slack outbound `message_sent` hooks, contributed message-tool schema optionality, same-channel generated media completions, and channel chunking around surrogate pairs and Infinity limits. (#92788, #93164, #92679, #89421, #89943, #42837, #92814, #91137, #91246, #92735) Thanks @yetval, @obviyus, @spacegeologist, @rishitamrakar, @liuhao1024, @lundog, @TurboTheTurtle, @yhterrance, @vincentkoc, @myrzka, @cwlong163-afk, @kumaxs, @shakkernerd, and @RewardsPal.
 - Gemini CLI: use the selected OpenClaw OAuth/API-key auth profile in an isolated Gemini CLI runtime home, preventing ambient Google machine credentials from overriding the chosen profile. (#88748) Thanks @jason-allen-oneal and @shakkernerd.
 - Feishu: fetch quoted/replied message content before the empty-message guard so a mention-only reply that quotes a message with meaningful content is no longer dropped. (#90192) Thanks @bladin.
 - Discord: give generated auto-thread titles a 60-second timeout and 4,096-token reasoning-model output budget, clamped to the selected model output cap. (#64734) Thanks @hanamizuki.
-- Agent, cron, and Gateway runtime: mark active main sessions before restart shutdown aborts, pause yielded subagent runs whose terminal also signals abort, clamp trusted subagent thinking overrides through provider/model fallback, preserve yielded media completions, deliver channel message-tool final replies through auto-reply while hiding internal delivery hints, restore reset archive fallback reads when active async transcripts are missing, de-duplicate main-session heartbeat events, expose session identity in runtime prompts, reject unknown OpenAI agent selectors, keep generated media completions, slash-command block replies, and trajectory export commands in WebChat, and require admin privileges for HTTP session/model override surfaces. (#91357, #92631, #92412, #92146, #92879, #91287, #92468, #92510, #91246, #92651, #92646) Thanks @ooiuuii, @openperf, @IWhatsskill, @masatohoshino, @CadanHu, @ZengWen-DT, @zhangguiping-xydt, and @TurboTheTurtle.
-- Providers and model replay: preserve storeless OpenAI Responses replay compatibility, recover invalid OpenAI reasoning signatures and genericized Anthropic thinking-signature replay errors, route OAuth image defaults through Codex for eligible OpenAI profiles, avoid eager tool streaming for Claude 4.5 in Copilot, quarantine unreadable and post-hook OpenAI/Anthropic-family tool schemas without broadening allowed tool choices, deliver explicit thinking-off requests to LM Studio binary-thinking models, honor profile auth for SecretRef model entries, bound model browsing, strip provider prefixes where runtimes need bare IDs, and surface nested embedding fetch failures. (#90706, #92941, #92201, #92916, #92824, #75393, #92908, #92921, #92928, #92002, #90686, #92247, #92627, #91218, #92628) Thanks @snowzlm, @mmyzwl, @CarlCapital, @bek91, @Kailigithub, @vincentkoc, @rohitjavvadi, @samson910022, @nxmxbbd, @liuhao1024, @bymle, and @mushuiyu886.
-- Memory, state, diagnostics, and config: split header-too-large embedding batches, keep QMD memory search enabled in transient mode, avoid SQLite WAL on NFS volumes, preserve recovery scheduling outside stuck-session warning backoff, preserve full-reindex rollback/cache recovery, treat raw Memory Wiki source pages as source evidence, and keep shell environment fallbacks contained in config write tests. (#92650, #92618, #92639, #91247, #92752, #92881, #59137, #92876, #69700) Thanks @mushuiyu886, @TurboTheTurtle, @849261680, @gnanam1990, @TSHOGX, and @arlen8411.
-- UI/mobile/TUI: preserve dashboard session parent lineage, WebChat backscroll, reset soft command args, sidebar session picker interactivity, collapsed workspace files, resolved `/model` confirmation refs, stale foreground iOS Gateway reconnects, and paused setup-parent stdin after inherited-stdio child exit. (#90658, #92622, #91353, #92705, #92779, #92773, #92552, #93159) Thanks @luoyanglang, @TurboTheTurtle, @zhouhe-xydt, @NianJiuZst, @shakkernerd, @NarahariRaghava, @Solvely-Colin, and @fuller-stack-dev.
-- Plugins and updates: repair missing required platform packages during managed plugin installs and updates, including omitted Codex platform binaries.
-- Dependencies: update Hono to 4.12.25 so published OpenClaw and ACPX packages use the patched runtime.
-- Release and test reliability: extend slow Gateway/full-suite watchdogs, split local full-suite shards when throttled, stabilize plugin auth marker fixtures, avoid brittle provider-ref error text, fold Telegram RTT sampling into live QA evidence, simplify QA scorecard mappings around canonical coverage IDs, keep QA Lab bootstrap selection assertions aligned with flow-only scenarios, skip QA coverage artifact consumers when runtime parity producer status is not green, keep Feishu lifecycle release checks pointed at the active fixture config, isolate trajectory-export live seed turns from Codex-native shell approvals, preserve release-check child refs while pinning expected SHAs, widen live OpenAI TTS budgets for slower provider responses, and avoid false downgrade prompts for unresolved latest-tag updates. (#92652, #92550, #92558, #92911) Thanks @RomneyDa and @Andy312432.
+- Agent, cron, and Gateway runtime: mark active main sessions before restart shutdown aborts, pause yielded subagent runs whose terminal also signals abort, clamp trusted subagent thinking overrides through provider/model fallback, preserve yielded media completions, deliver channel message-tool final replies through auto-reply while hiding internal delivery hints, restore reset archive fallback reads when active async transcripts are missing, de-duplicate main-session heartbeat events, expose session identity in runtime prompts, reject unknown OpenAI agent selectors, keep generated media completions, slash-command block replies, and trajectory export commands in WebChat, and require admin privileges for HTTP session/model override surfaces. (#91357, #92631, #92412, #92146, #92879, #91287, #92468, #92510, #91246, #92651, #92646) Thanks @ooiuuii, @openperf, @IWhatsskill, @masatohoshino, @CadanHu, @ZengWen-DT, @zhangguiping-xydt, @TurboTheTurtle, @oiGaDio, @aleps001, @vincentkoc, @GSL-R, @QQSHI13, @ryanhelms, @kumaxs, @steipete-oai, @hxy91819, @davemorin, and @nailujac.
+- Providers and model replay: preserve storeless OpenAI Responses replay compatibility, recover invalid OpenAI reasoning signatures and genericized Anthropic thinking-signature replay errors, route OAuth image defaults through Codex for eligible OpenAI profiles, avoid eager tool streaming for Claude 4.5 in Copilot, quarantine unreadable and post-hook OpenAI/Anthropic-family tool schemas without broadening allowed tool choices, deliver explicit thinking-off requests to LM Studio binary-thinking models, honor profile auth for SecretRef model entries, bound model browsing, strip provider prefixes where runtimes need bare IDs, and surface nested embedding fetch failures. (#90706, #92941, #92201, #92916, #92824, #75393, #92908, #92921, #92928, #92002, #90686, #92247, #92627, #91218, #92628) Thanks @snowzlm, @mmyzwl, @CarlCapital, @bek91, @Kailigithub, @vincentkoc, @rohitjavvadi, @samson910022, @nxmxbbd, @liuhao1024, @bymle, @mushuiyu886, @finchinslc, @syfvb, @lijenhsin, @crsnpalmer-art, @samson1357924, @shakkernerd, and @mlaihk.
+- Memory, state, diagnostics, and config: split header-too-large embedding batches, keep QMD memory search enabled in transient mode, avoid SQLite WAL on NFS volumes, preserve recovery scheduling outside stuck-session warning backoff, preserve full-reindex rollback/cache recovery, and treat raw Memory Wiki source pages as source evidence. (#92650, #92618, #92639, #91247, #92752, #92881, #59137, #92876) Thanks @mushuiyu886, @TurboTheTurtle, @849261680, @gnanam1990, @TSHOGX, @vincentkoc, @arlen8411, @BrettHamlin, @zhbcher, @Takhoffman, @AFabyTWE, @davemorin, and @zhuyankarl.
+- UI/mobile/TUI: preserve dashboard session parent lineage, WebChat backscroll, reset soft command args, sidebar session picker interactivity, collapsed workspace files, resolved `/model` confirmation refs, stale foreground iOS Gateway reconnects, and paused setup-parent stdin after inherited-stdio child exit. (#90658, #92622, #91353, #92705, #92779, #92773, #92552, #93159) Thanks @luoyanglang, @TurboTheTurtle, @zhouhe-xydt, @NianJiuZst, @shakkernerd, @NarahariRaghava, @Solvely-Colin, @fuller-stack-dev, @lily-oc, @MaBeitian, @vincentkoc, @obviyus, @DrtyMorty, and @Chang2020618.
+- Plugins and updates: repair missing required platform packages during managed plugin installs and updates, including omitted Codex platform binaries. Thanks @vincentkoc.
+- Dependencies: update Hono to 4.12.25 so published OpenClaw and ACPX packages use the patched runtime. Thanks @vincentkoc.
+- Updates: avoid a false downgrade prompt when the latest tag cannot resolve. (#92911) Thanks @Andy312432 and @vincentkoc.
 
-### Complete contribution ledger
+### Complete contribution record
 
-This audited record covers the complete v2026.6.6..v2026.6.8 history: 167 PRs and 67 linked issues. The grouped notes above prioritize user impact; this ledger preserves every contribution reference and eligible human credit.
+This audited record covers the complete v2026.6.6..v2026.6.8 history: 192 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
 
 #### Pull requests
 
-- fix(cron): report SQLite storage path in cron.status instead of legacy jobs.json (#92144). Thanks @liuhao1024.
-- fix(channel): harden local setup trust (#92175). Thanks @hxy91819.
-- fix: handle explicit silent assistant replies (#92073). Thanks @sallyom.
-- fix(docker): bundle QA Lab runtime in the image (#92087). Thanks @jesse-merhi.
-- fix(anthropic-vertex): stop re-marking cache_control on transport-budgeted payloads (#92387). Thanks @openperf and @Takhoffman.
-- Fix doctor preview channel SecretRef resolution (#92229). Thanks @joshavant.
-- Fix disabled heartbeat one-shot cron retries (#92225). Thanks @joshavant.
-- Fix configured DeepSeek model transport inheritance (#92265). Thanks @joshavant.
-- Fail closed for CLI-backed /btw fallback (#92226). Thanks @joshavant.
-- Fix suppressed heartbeat commitment delivery (#92231). Thanks @joshavant.
-- fix(agents): classify structured unsupported model errors (#92280). Thanks @joshavant.
-- Fix OTLP log trace correlation (#92276). Thanks @joshavant.
-- fix(update): hand off Linux service auto-updates (#92282). Thanks @joshavant.
-- fix: resolve managed SecretRef provider auth (#92235). Thanks @joshavant.
-- Fix provider static model fallback resolution (#92293). Thanks @joshavant.
-- fix(agent): continue after source message tool replies (#92343). Thanks @joshavant.
-- fix(codex): preserve memory prompt registration (#92350). Thanks @rubencu.
-- fix: clarify gateway SecretRef auth diagnostics (#92290). Thanks @joshavant.
-- fix: repair rejected Anthropic thinking replay (#92286). Thanks @joshavant.
-- Fix Telegram spooled buffered replay (#92281). Thanks @joshavant.
-- fix(outbound): honor top-level image param as send media source (issue 92407) (#92416). Thanks @xydigit-sj.
-- fix(sandbox): render CLI skill prompts from materialized paths (#92508). Thanks @brokemac79.
-- chore: fix esbuild production audit failure (#92540). Thanks @RomneyDa.
-- Add QA evidence artifact output (#91484). Thanks @RomneyDa.
-- Add QA scorecard taxonomy validation (#91500). Thanks @RomneyDa.
-- feat(moonshot): add Kimi K2.7 Code support (#92554).
-- fix(moonshot): backfill reasoning_content on assistant tool-call replay messages (#92396). Thanks @xialonglee.
-- Fix lifecycle timeout cleanup after leader exit (#92566). Thanks @RomneyDa.
-- Expose paged channel action results (#88993). Thanks @fuller-stack-dev.
-- fix(fireworks): resolve catalog model params from plugin.json via core (#90326). Thanks @obuchowski.
-- fix(doctor): warn for untrusted external Discord plugin (#86629). Thanks @brokemac79.
-- fix(providers): skip unreadable Mistral tool schemas (#90242). Thanks @vincentkoc.
-- fix(reply): mirror same-channel Slack final replies (#92498). Thanks @TurboTheTurtle.
-- fix(channels): default boundary logger for swallowed progress-draft start errors (#92083). Thanks @hansraj316.
-- fix(channels): make timer-fired progress-draft start errors observable (#92031). Thanks @hansraj316.
-- fix(agents): isolate invalid plugin model catalogs [AI-assisted] (#92564). Thanks @tangtaizong666.
-- docs: UX-013 — design system documentation (#89827). Thanks @BunsDev.
-- feat(ui): hide empty workboard columns (#89615). Thanks @BunsDev.
-- fix(a11y): B-1+B-2+B-3 — contrast, focus states, minimum font sizes (#89822). Thanks @BunsDev.
-- fix issue 92218: memory_search tool disabled with QMD backend (#92618). Thanks @mushuiyu886.
-- docs(gateway): add uptime monitoring guidance to health check docs (fixes issue 55768) (#92608). Thanks @liuhao1024.
-- fix(docs): pin Windows Hub download links to v2026.6.5 (#92605). Thanks @lzyyzznl.
-- issue 92589: fix(internal-runtime-context): wrap prompt-preface runtime context body in delimiters (#92593). Thanks @zhangqueping.
-- Run Vitest and Playwright scenarios from qa suite (#92606). Thanks @RomneyDa.
-- feat(hooks): per-turn usageState on reply_payload_sending (#89629). Thanks @Marvinthebored.
-- feat(usage): native templated /usage full footer renderer (#89835). Thanks @Marvinthebored.
-- fix(models): bound /models and models list catalog loading (#92247). Thanks @samson910022.
-- fix(gateway): honor profile auth for SecretRef model entries (#90686). Thanks @rohitjavvadi.
-- fix: require admin for HTTP session kills (#92651). Thanks @steipete-oai.
-- test(models): stabilize plugin auth marker fixtures (#92652).
-- fix(slack): warn when channels map is keyed by name instead of channel ID (#89438). Thanks @Alix-007.
-- fix(agents): pause yielded subagent runs whose terminal also signals abort (#92631). Thanks @openperf.
-- fix(ui): preserve WebChat backscroll during streaming (#92622). Thanks @TurboTheTurtle.
-- fix(openrouter): strip openrouter/ prefix from model ID in normalizeResolvedModel hook (fixes issue 92611) (#92627). Thanks @liuhao1024.
-- fix(cron): preserve yielded media completions (#92146). Thanks @IWhatsskill.
-- fix: add Claude Haiku 4.5 static catalog entries (#90116). Thanks @arkyu2077.
-- fix(channels): keep contributed message-tool schema properties optional (#91137). Thanks @lundog.
-- fix(copilot): disable eager tool streaming for Claude 4.5 (#75393). Thanks @Kailigithub.
-- fix issue 73713: surface nested embedding fetch failures (#92628). Thanks @mushuiyu886.
-- fix(slack): emit message_sent hook on outbound delivery (mirror Telegram) (#89943). Thanks @rishitamrakar.
-- fix(docs): finalize i18n postprocess before skip (#92668). Thanks @hxy91819.
-- fix: split image setup and request timeout semantics (#92673). Thanks @hxy91819.
-- fix(memory): keep memory_search in transient qmd mode (#92639). Thanks @TurboTheTurtle and @Takhoffman.
-- fix(ui): restore sidebar session picker interactivity above desktop workbench (#92705). Thanks @NianJiuZst.
-- feat: support /btw in CLI-backed sessions (#92669). Thanks @joshavant.
-- fix(gateway): mark active main sessions before restart shutdown aborts (#91357). Thanks @ooiuuii.
-- fix(ios): force stale foreground gateway reconnects (#92552). Thanks @Solvely-Colin.
-- fix(diagnostics): keep recovery scheduling out of the stuck-session warning backoff (#92752). Thanks @gnanam1990 and @Takhoffman.
-- clarify before_install hook scope (#92766). Thanks @sallyom.
-- Honor WhatsApp configured ACP bindings (#92513). Thanks @TurboTheTurtle and @mcaxtr.
-- feat(providers): add GLM-5.2 support (#92796).
-- fix(heartbeat): route outbound mirror to isolated session key (#92807). Thanks @agent-merkava.
-- fix(memory): explain skipped short-term recall hits (#92745). Thanks @mushuiyu886.
-- fix(gateway): forward image-only input on /v1/responses (parity with chat completions) (#92488). Thanks @s554097550.
-- fix(status): avoid cumulative usage for context percent (#92604). Thanks @ashishpatel26.
-- fix(nodes): surface pending reapproval diagnostics (#92547). Thanks @fuller-stack-dev.
-- fix(doctor): avoid false-positive legacy cron store warning when store was already migrated (fixes issue 92683) (#92690). Thanks @liuhao1024.
-- fix(telegram): skip IPv4 fallback when user explicitly configures non-ipv4first dnsResultOrder (fixes issue 41671) (#92806). Thanks @liuhao1024 and @vincentkoc.
-- fix(macos): defer isOverflowing mutation to break SwiftUI render loop (fixes issue 43480) (#92778). Thanks @liuhao1024 and @vincentkoc.
-- fix(gateway): use resolveNonNegativeNumber for totalTokens to display 0 instead of ? (fixes issue 43009) (#92795). Thanks @liuhao1024 and @vincentkoc.
-- fix(gateway): preserve active runs during plugin finalization (#92746). Thanks @scotthuang and @vincentkoc.
-- UI: localize Logs tab labels (#92820). Thanks @rubensfox20.
-- UI: localize logs hardcoded labels (#61080). Thanks @rubensfox20.
-- fix(telegram): preserve command callbacks while prefixing generic callback data (#92825). Thanks @hnshah.
-- fix(telegram): add 'callback_data:' prefix to inline button callbacks (#54962). Thanks @hnshah.
-- fix(copilot): drop thinking blocks from replay (#87060). Thanks @giodl73-repo.
-- fix(github-copilot): strip thinking blocks from latest assistant turn (issue 81520) (#81534). Thanks @SymbolStar.
-- feat(browser): extend --labels overlay to full-page and element captures (#92834). Thanks @hxy91819.
-- fix issue 92039: [Bug]: WhatsApp login reports success before auth is durably persisted, so Docker rebuilds/upgrades can force relink (#92095). Thanks @zhangguiping-xydt.
-- fix(stale): exempt ClawSweeper actionable labels from stale lifecycle (fixes issue 89564) (#92801). Thanks @liuhao1024.
-- fix(status): render sub-1000 token counts as plain integers (#89736). Thanks @jbetala7 and @vincentkoc.
-- fix(agents): catch malformed image blocks in sanitizeContentBlocksImages (#92792). Thanks @LowCode191 and @vincentkoc.
-- ci: gate stable releases on Windows companion assets (#92555). Thanks @fuller-stack-dev.
-- fix(agents): add usage guidance to sessions_spawn tool description (fixes issue 91814) (#91824). Thanks @zenglingbiao.
-- fix(qqbot): surface failed media sends (#92823). Thanks @zhangguiping-xydt.
-- Fix diagnostics OTEL runtime install trust (#92045). Thanks @efpiva.
-- fix(update): continue after package doctor warnings (#91586). Thanks @fuller-stack-dev.
-- fix(feishu): target typing reaction on inbound (#67783). Thanks @huiwen01.
-- fix(feishu): preserve root_id thread routing without thread_id forcing (#73958). Thanks @huiwen01.
-- fix(lobster): surface workflow path errors (#68106). Thanks @vvitovec.
-- fix(openai): preserve opaque reasoning transcript fields (#90682). Thanks @toruvieI.
-- fix(anthropic): strip thinking blocks from history when thinking is disabled (fixes issue 92360) (#92373). Thanks @liuhao1024.
-- fix(anthropic): merge consecutive assistant turns in turn validation (#87346). Thanks @Jefsky.
-- fix(anthropic): quarantine invalid direct tool schemas (#92896).
-- fix(anthropic): quarantine invalid projected tools (#89418). Thanks @vincentkoc.
-- fix(agents): guard Anthropic tool descriptors (#89221). Thanks @vincentkoc.
-- fix(agents): guard Anthropic tool schema conversion (#90228). Thanks @vincentkoc.
-- fix(agents): skip unreadable Anthropic tool schemas (#89622). Thanks @vincentkoc.
-- fix(llm): guard Anthropic provider tool descriptors (#89229). Thanks @vincentkoc.
-- fix(providers): skip unreadable Anthropic tool schemas (#90278). Thanks @vincentkoc.
-- fix(active-memory): preserve verbose recall summaries (#90739). Thanks @brokemac79.
-- Simplify QA scorecard mapping shape (#92558). Thanks @RomneyDa.
-- fix(memory-wiki): stop flagging raw source pages as malformed (#92876). Thanks @vincentkoc.
-- fix(providers): quarantine unreadable Anthropic payload tools (#92908).
-- fix(memory): preserve reindex rollback recovery (#92881). Thanks @TSHOGX and @vincentkoc.
-- fix(openai): quarantine unreadable tool schemas (#92921).
-- fix(openai): quarantine unreadable projected tools (#89413). Thanks @vincentkoc.
-- fix(agents): materialize OpenAI tool schemas (#89013). Thanks @vincentkoc.
-- fix(agents): guard OpenAI transport tool descriptors (#89016). Thanks @vincentkoc.
-- fix(agents): guard OpenAI tool schema conversion (#89378). Thanks @vincentkoc.
-- fix(agents): harden OpenAI strict schema inspection (#89543). Thanks @vincentkoc.
-- fix(agents): guard OpenAI strict tool diagnostics (#90200). Thanks @vincentkoc.
-- fix(providers): skip unreadable OpenAI completion tool schemas (#90283). Thanks @vincentkoc.
-- fix(providers): skip unreadable OpenAI responses tool schemas (#90286). Thanks @vincentkoc.
-- fix(openai): skip unreadable responses tool schemas (#90397). Thanks @vincentkoc.
-- Fold Telegram RTT sampling into live QA evidence (#92550). Thanks @RomneyDa.
-- fix(media): route OAuth image defaults through Codex (#92824). Thanks @bek91.
-- fix(cli): avoid false downgrade prompt for latest tag (#92911). Thanks @Andy312432 and @vincentkoc.
-- fix(openai): guard post-hook tool payloads (#92928).
-- fix(openai): guard responses tool payload names (#89703). Thanks @vincentkoc.
-- fix(sessions): fall back to reset archive for missing async transcripts (#92879). Thanks @masatohoshino and @CadanHu and @vincentkoc.
-- fix(feishu): re-resolve route when dynamic agent binding already exists in runtime config (fixes issue 42837) (#92814). Thanks @liuhao1024 and @vincentkoc.
-- fix(openai): omit gpt-5.5 tool reasoning effort (#90574). Thanks @BSG2000.
-- fix(openai): recover invalid reasoning signatures (#92941).
-- fix(lmstudio): deliver thinking "off" to binary-thinking models (#92002). Thanks @nxmxbbd.
-- issue 92201: Embedded runner: freshly streamed thinking signatures intermittently invalid on replay (Anthropic); recovery wrapper never fires because error text is genericized (#92916). Thanks @mmyzwl.
-- fix(agents): do not misclassify client-disconnect abort as run timeout (#90936). Thanks @openperf.
-- fix(agents): make wrapToolWithBeforeToolCallHook idempotent to prevent double hook execution (fixes issue 92973) (#93009). Thanks @zenglingbiao.
-- fix(cron): require explicit message target proof (#92318). Thanks @hxy91819.
-- fix(gateway): repair usage cost aggregation across agents (#93022). Thanks @luke-skywalker-open-claw and @stablegenius49.
-- fix(tui): keep parent stdin paused after exit (#93159). Thanks @fuller-stack-dev.
-- Keep key-free web search providers opt-in (#93616). Thanks @davemorin and @vincentkoc.
-- feat(telegram): send rich message text (#92679). Thanks @obviyus.
-- fix(telegram): preserve rich markdown line breaks (#93164). Thanks @vincentkoc.
-- fix(telegram): allow expandable blockquotes (#84082). Thanks @jzakirov.
-- fix(telegram): expose thread create CLI remap (#89421). Thanks @spacegeologist.
-- fix(sessions): derive channel from account-scoped DM session keys in send-policy (#92788). Thanks @yetval.
-- Fix webchat media completion handoff (#91246). Thanks @TurboTheTurtle.
-- fix(cron): de-duplicate main-session systemEvent in heartbeat model input (#91287). Thanks @ZengWen-DT.
-- fix issue 92453: add session identity to runtime prompt (#92468). Thanks @zhangguiping-xydt.
-- fix(gateway): reject unknown OpenAI agent selectors (#92510). Thanks @zhangguiping-xydt.
-- fix(google): strip provider prefix from Vertex model path (#91218). Thanks @bymle.
-- fix(OpenAI Responses): disable item id replay for storeless providers (#90706). Thanks @snowzlm.
-- feat(usage): ship built-in /usage full footer (#92657). Thanks @Marvinthebored.
-- fix: start workspace files collapsed (#92779). Thanks @shakkernerd.
-- fix(ui): preserve /reset soft args in Control UI dispatch (#91353). Thanks @zhouhe-xydt.
-- fix(ui): preserve dashboard session parent lineage when session list is stale (#90658). Thanks @luoyanglang.
-- fix issue 92465: split OpenAI 431 embedding batches (#92650). Thanks @mushuiyu886.
-- fix(state): avoid sqlite wal on nfs state volumes (#91247). Thanks @849261680.
-- fix(memory): preserve retry state and embedding cache across reindex rollback (#59137). Thanks @TSHOGX.
-- fix(markdown-core): treat Infinity chunk limit as unbounded, not 1 (#92735). Thanks @yhterrance.
-- issue 92069: fix(cli): usage errors exit 0 (#92162). Thanks @Pandah97.
-- docs(nodes): add openclaw.json config example to Nodes overview (#92677). Thanks @liuhao1024.
-- docs(config): correct maxConcurrent default in agent-defaults type comments (AI-assisted) (#92695). Thanks @ArielSmoliar.
-- fix(discord): raise thread title timeout and tokens to fit reasoning models (#64734). Thanks @hanamizuki.
-- fix: require admin for HTTP model overrides (#92646). Thanks @steipete-oai.
-- fix(tui): show resolved canonical model ref in /model confirmation (#92773). Thanks @NarahariRaghava.
-
-#### Linked issues
-
-- Reported: [Bug]: openclaw cron status reports legacy storePath (#91766). Thanks @AaronFaby.
-- Reported: [Bug]: Node.js auto-installer fails silently with ioctl errors then falsely reports success before crashing (#73837). Thanks @ItsMeForLua.
-- Reported: [Bug]: Missing SQLite perf and query-plan harness (#91616). Thanks @galiniliev.
-- Reported: [Feature]: Error: Gateway service install not supported on openbsd (#25621). Thanks @kucharskim.
-- Reported: [Bug]: cron edit --cron silently strips schedule.tz and staggerMs (direct path replaces schedule without merging) (#92291). Thanks @dcapclaw.
-- Reported: message tool: `image` param silently dropped on send — delivers text without attachment but returns ok:true (#92407). Thanks @ichirokyoto.
-- Reported: Kimi K2.6 reasoning_content 400 regression in long conversations after LCM compaction (follow-up issue 70392) (#71491). Thanks @RoseKongPS.
-- Reported: [Bug]: Moonshot/Kimi duplicate tool-call IDs in replay, exposed by WhatsApp group chats (#51593). Thanks @Faaab84 and @Pluviobyte.
-- Reported: Discord channel stays disabled with no warning unless `plugins.entries.discord.enabled` is set (#83212). Thanks @cdeyoung67.
-- Reported: [Bug]: Slack channel/thread sessions never persist assistant replies to the session transcript → total context loss when the CLI session binding is invalidated (#92489). Thanks @TalkingHeadsJed and @TurboTheTurtle.
-- Reported: ModelRegistry: a single invalid plugin catalog aborts the entire custom-models load, leaving zero models and an unlogged error (#92553). Thanks @fxstein.
-- Reported: Health check bloat: uptime monitors must use /health, not /v1/chat/completions (#55768). Thanks @faahim.
-- Reported: [Bug]: Windows Hub download link is not working (#92470). Thanks @arjkul.
-- Reported: Feishu channel leaks system runtime context (relevant-memories, sender metadata) into user-visible reply (#92589). Thanks @jovi2014-cyber.
-- Reported: [Performance] /models command slow in v2026.6.1 — catalog loading regression (#91809). Thanks @syfvb.
-- Reported: models.list marks auth-profile-backed SecretRef providers unavailable (#90685). Thanks @rohitjavvadi.
-- Reported: Name-keyed entries in channels.slack.channels silently dropped under groupPolicy: "allowlist" (#81665). Thanks @cjalden.
-- Reported: [Bug]: sessions_yield in a depth-1 subagent settles its background task as "cancelled" (operator-reserved status) and delivers a false "Background task cancelled" notice to the requester session (#92448). Thanks @aleps001.
-- Reported: [Bug]: OpenRouter: Anthropic models send wrong model ID to API (includes openrouter/ prefix) (#92611). Thanks @lijenhsin.
-- Reported: anthropic (api_key) provider: Claude Haiku 4.5 missing from static model catalog → "Unknown model" (model_not_found) (#90088). Thanks @maaron34.
-- Reported: github-copilot: tools[].eager_input_streaming still rejected on v2026.4.29 (re: issue 72183) (#75348). Thanks @finchinslc and @Kailigithub.
-- Reported: openclaw infer embedding create fails with TypeError: fetch failed on Node 24 despite valid Voyage credential; underlying cause is swallowed (#73713). Thanks @crsnpalmer-art.
-- Reported: Gateway runs well-formed-but-unknown agent slug under agents.defaults instead of 4xx (no roster validation in resolveAgentIdForRequest; x-openclaw-agent-id header never roster-validated) (#92504). Thanks @ryanhelms.
-- Reported: [Bug]: Delivery retry loop corrupts active sessions (R-004) — retry selector bypasses delivery.mode=none (#91420). Thanks @CarotaWealth.
-- Reported: Agent runtime header lacks session identity, causing misleading self-references (#92453). Thanks @QQSHI13.
-- Reported: fix(slack): emit message_sent hook on outbound delivery (mirror Telegram) (#89942). Thanks @rishitamrakar.
-- Reported: bug(cli): usage errors exit 0 (#92069). Thanks @marcospaulo.
-- Reported: void requireRef silences dead-import lint via side-effect expression (#83878). Thanks @davinci282828.
-- Reported: formatDiskSpaceBytes emits "1024 MiB" instead of "1.0 GiB" at the GiB boundary (#90245). Thanks @jbetala7.
-- Reported: `setFeishuClientRuntimeForTest` resets the SDK without clearing the client cache (#83911). Thanks @davinci282828.
-- Reported: [Bug]: Cron job with sessionTarget: "main" triggers both systemEvent and reminder despite delivery.mode: "none" (#44922). Thanks @GSL-R.
-- Reported: music_generate background task completion delivery consistently fails (completion wake + fallback both fail) (#91003). Thanks @kumaxs.
-- Reported: [Bug]: In the Control UI, `/reset soft` is truncated to `/reset` when executed, and the args are lost (#91316). Thanks @MaBeitian.
-- Reported: Bug: dashboard child sessions record assistant replies but do not display them (#90623). Thanks @lily-oc.
-- Reported: openclaw message thread create for Telegram: thread-create → topic-create remap not happening; gateway rejects with Unsupported Telegram action (#81581). Thanks @myrzka.
-- Reported: [Bug]: GatewayRequestError: Error: file is not a database: code=ERR_SQLITE_ERROR (#90491). Thanks @AFabyTWE.
-- Reported: Signal image captions truncated to first character (Infinity chunk limit normalizes to 1) (#92734). Thanks @yhterrance.
-- Reported: Docs feedback: /nodes (#92662). Thanks @Casper-Mars.
-- Reported: Bulk memory import can hit OpenAI 431; chunked indexing avoids it (#92465). Thanks @BrettHamlin.
-- Reported: Docker image ships an extraneous stale openclaw in /app/node_modules (extensions pin the published release) (#92551). Thanks @fxstein.
-- Reported: Telegram callback queries time out when agent turn is queued behind sequentialize (#42156). Thanks @Diaspar4u.
-- Reported: doctor + cron status still report the retired cron/jobs.json store after the SQLite migration (2026.6.5) (#92683). Thanks @motteman.
-- Reported: [Bug]: Telegram media download fails on IPv4-broken / IPv6-working hosts because runtime IPv4 fallback overrides config (#41671). Thanks @leandroirani933-ctrl and @vincentkoc.
-- Reported: macOS app pinwheels due to SwiftUI infinite render loop in VoiceWakeOverlay (#43480). Thanks @gdiab and @vincentkoc.
-- Reported: TUI displays Context Tokens as ?/200k instead of actual value (#43009). Thanks @ltxy12138-ai and @vincentkoc.
-- Reported: [Bug]: Telegram inline button callback_query not routed to agent — hallucination instead of tool call (#54909). Thanks @timt80 and @hnshah.
-- Reported: Status/session context window can over-report the selected model's actual window (#39857). Thanks @xdanger.
-- Reported: [Bug]: Reasoning model thinking blocks (<thinking> tags) in conversation history cause HTTP 400 on GitHub Copilot provider (#81520). Thanks @warcold.
-- Reported: fix(memory): EPERM on Windows persists after 64187 retry — needs copyFile/unlink fallback (was in closed PR 71611) (#78640). Thanks @MilleniumGenAI.
-- Reported: [Bug]: WhatsApp block streaming can suppress complete final replies after partial stream delivery (#81078). Thanks @Jackten.
-- Reported: Bug: Twilio voice-call can get stuck in hold music after failed/no-stream call (#81122). Thanks @donkeykong91.
-- Reported: [Bug]: Stale workflow does not exempt ClawSweeper queueable issues (#89564). Thanks @brokemac79.
-- Reported: [Bug]: `openclaw status` renders sub-1000 token counts as misleading fractional k (999 → "1.0k") (#89735). Thanks @jbetala7 and @vincentkoc.
-- Reported: [Feature]: sessions_spawn tool description lacks usage guidance, causing agents to not use sub-agents when appropriate (#91814). Thanks @cattails-lgao.
-- Reported: [Bug]: Lobster tool falls back to pipeline parsing for relative workflow file paths (#68101). Thanks @MPC7500 and @vvitovec.
-- Reported: openai-chatgpt-responses native replay sends encrypted reasoning and breaks next turn with invalid_encrypted_content (#90093). Thanks @richardmqq.
-- Reported: [Bug]: Persistent sessions corrupted by stale thinking blocks — provider rejects all subsequent turns (#92360). Thanks @notnaji.
-- Reported: Bug: Subagent announce-delivery echo messages inherit wrong provider/model metadata, causing persistent "thinking blocks cannot be modified" errors after gateway restart (#87329). Thanks @travellingsoldier85.
-- Reported: Codex-authenticated installs can auto-select direct OpenAI for image media understanding without OPENAI_API_KEY (#87168). Thanks @bek91.
-- Reported: [Bug]: Feishu dynamicAgentCreation feature not working (#42837). Thanks @cwlong163-afk and @vincentkoc.
-- Reported: BUG: sessions_spawn silently half-fails when thinking level is unsupported — fan-out spawns produce non-deterministic survivors, no signal to orchestrator (fix: symmetrize CLI-launch fallback with embedded path) (#92412). Thanks @oiGaDio.
-- Reported: Config hot-reload permanently disabled when inotify watches exhausted (no polling fallback) (#92851). Thanks @danbao.
-- Reported: Gateway becomes slow or times out under multi-session / multi-agent load (#92057). Thanks @xiaopings.
-- Reported: fix(memory-wiki): guard against missing agentIds (#92207). Thanks @qq230849622-a11y.
-- Reported: Embedded runner: freshly streamed thinking signatures intermittently invalid on replay (Anthropic); recovery wrapper never fires because error text is genericized (#92201). Thanks @CarlCapital.
-- Reported: before_tool_call hook fires twice: tools double-wrapped after normalizeToolParameters strips the wrap marker (#92973). Thanks @dertbv.
-- Reported: memory-wiki lint: sources/ directory requires frontmatter on raw imported files (#69700). Thanks @arlen8411.
-
+- **PR #92144** fix(cron): report SQLite storage path in cron.status instead of legacy jobs.json. Related #91766. Thanks @liuhao1024 and @AaronFaby.
+- **PR #92175** fix(channel): harden local setup trust. Thanks @hxy91819.
+- **PR #91528** fix #73837: stop after failed Node package installs. Thanks @mushuiyu886 and @ItsMeForLua.
+- **PR #91561** fix(wizard): report keyless web_search providers as ready, not missing a key. Thanks @NormallyGaussian.
+- **PR #92073** fix: handle explicit silent assistant replies. Related #92038. Thanks @sallyom and @vultusv.
+- **PR #91311** Allow Skill Workshop apply through trusted skill symlinks. Thanks @abnershang.
+- **PR #88245** refactor(whatsapp): introduce inbound message contexts. Thanks @mcaxtr.
+- **PR #92212** refactor: move workspace skill writes to lifecycle. Thanks @shakkernerd.
+- **PR #92248** Remove ClawHub owner preflight. Thanks @Patrick-Erichsen.
+- **PR #91617** test(sqlite): add state perf query plan harness. Related #91616. Thanks @galiniliev.
+- **PR #91626** fix(daemon): keep status readable on unsupported services. Related #25621. Thanks @mushuiyu886 and @kucharskim.
+- **PR #92295** fix(cron): preserve tz and staggerMs when --cron replaces expression. Related #92291. Thanks @liuhao1024 and @dcapclaw.
+- **PR #92087** fix(docker): bundle QA Lab runtime in the image. Thanks @jesse-merhi.
+- **PR #92004** fix(telegram): classify streaming preview edit failures instead of killing the draft. Thanks @obviyus.
+- **PR #91997** fix(telegram): survive getUpdates conflicts in isolated polling ingress. Thanks @obviyus.
+- **PR #92387** fix(anthropic-vertex): stop re-marking cache_control on transport-budgeted payloads. Related #91982. Thanks @openperf and @Takhoffman and @danieljimz.
+- **PR #92229** Fix doctor preview channel SecretRef resolution. Related #91939. Thanks @joshavant and @Niriakot.
+- **PR #92225** Fix disabled heartbeat one-shot cron retries. Related #91775. Thanks @joshavant and @A1fred-AI.
+- **PR #92265** Fix configured DeepSeek model transport inheritance. Related #92148. Thanks @joshavant and @marcoraepple-sys.
+- **PR #92226** Fail closed for CLI-backed /btw fallback. Related #92168. Thanks @joshavant and @wangwllu.
+- **PR #92231** Fix suppressed heartbeat commitment delivery. Related #91948. Thanks @joshavant and @bizzle12368239.
+- **PR #92280** fix(agents): classify structured unsupported model errors. Related #92118. Thanks @joshavant and @pikaqqqqqq.
+- **PR #92276** Fix OTLP log trace correlation. Related #91865. Thanks @joshavant and @sinzin91.
+- **PR #92282** fix(update): hand off Linux service auto-updates. Related #91823. Thanks @joshavant and @hanyizuo.
+- **PR #92235** fix: resolve managed SecretRef provider auth. Related #92097. Thanks @joshavant and @LINSUISHENG034.
+- **PR #92293** Fix provider static model fallback resolution. Related #92009. Thanks @joshavant and @mattsfraser.
+- **PR #92343** fix(agent): continue after source message tool replies. Related #92169. Thanks @joshavant and @elyalvarado.
+- **PR #92350** fix(codex): preserve memory prompt registration. Thanks @rubencu and @sallyom.
+- **PR #92290** fix: clarify gateway SecretRef auth diagnostics. Related #91815. Thanks @joshavant and @mattsfraser.
+- **PR #92286** fix: repair rejected Anthropic thinking replay. Related #91983. Thanks @joshavant and @reginaldomarcilon.
+- **PR #92281** Fix Telegram spooled buffered replay. Related #92129. Thanks @joshavant and @riseandshinefutures.
+- **PR #47493** fix(doctor): show per-step progress spinners during update. Thanks @amersheeny.
+- **PR #92416** fix(outbound): honor top-level image param as send media source (#92407). Thanks @xydigit-sj and @ichirokyoto.
+- **PR #92508** fix(sandbox): render CLI skill prompts from materialized paths. Thanks @brokemac79.
+- **PR #92540** chore: fix esbuild production audit failure. Thanks @RomneyDa.
+- **PR #91484** Add QA evidence artifact output. Thanks @RomneyDa.
+- **PR #91500** Add QA scorecard taxonomy validation. Thanks @RomneyDa.
+- **PR #84082** fix(telegram): allow expandable blockquotes. Thanks @jzakirov.
+- **PR #92554** feat(moonshot): add Kimi K2.7 Code support.
+- **PR #92396** fix(moonshot): backfill reasoning_content on assistant tool-call replay messages. Related #71491. Thanks @xialonglee and @RoseKongPS.
+- **PR #92566** Fix lifecycle timeout cleanup after leader exit. Thanks @RomneyDa.
+- **PR #92311** ci: split plugin ClawHub publishing paths. Thanks @Patrick-Erichsen.
+- **PR #92216** fix(gateway): mirror hidden commentary-phase assistant events. Thanks @ragesaq.
+- **PR #87596** fix(moonshot): rewrite duplicate native Kimi tool_call ids on replay. Related #51593. Thanks @Pluviobyte and @Faaab84.
+- **PR #88993** Expose paged channel action results. Thanks @fuller-stack-dev.
+- **PR #90326** fix(fireworks): resolve catalog model params from plugin.json via core. Thanks @obuchowski.
+- **PR #86629** fix(doctor): warn for untrusted external Discord plugin. Related #83212. Thanks @brokemac79 and @ooiuuii and @cdeyoung67.
+- **PR #90242** fix(providers): skip unreadable Mistral tool schemas. Thanks @vincentkoc.
+- **PR #92498** fix(reply): mirror same-channel Slack final replies. Related #92489. Thanks @TurboTheTurtle and @TalkingHeadsJed.
+- **PR #92083** fix(channels): default boundary logger for swallowed progress-draft start errors. Thanks @hansraj316.
+- **PR #92564** fix(agents): isolate invalid plugin model catalogs [AI-assisted]. Related #92553. Thanks @tangtaizong666 and @fxstein.
+- **PR #89827** docs: UX-013 — design system documentation. Thanks @BunsDev.
+- **PR #89615** feat(ui): hide empty workboard columns. Thanks @BunsDev.
+- **PR #89822** fix(a11y): B-1+B-2+B-3 — contrast, focus states, minimum font sizes. Thanks @BunsDev.
+- **PR #92618** fix #92218: memory_search tool disabled with QMD backend. Thanks @mushuiyu886 and @zhbcher.
+- **PR #92608** docs(gateway): add uptime monitoring guidance to health check docs (fixes #55768). Thanks @liuhao1024 and @faahim.
+- **PR #92605** fix(docs): pin Windows Hub download links to v2026.6.5. Related #92470. Thanks @lzyyzznl and @arjkul.
+- **PR #92593** #92589: fix(internal-runtime-context): wrap prompt-preface runtime context body in delimiters. Thanks @zhangqueping and @jovi2014-cyber.
+- **PR #92606** Run Vitest and Playwright scenarios from qa suite. Thanks @RomneyDa.
+- **PR #89629** feat(hooks): per-turn usageState on reply_payload_sending. Thanks @Marvinthebored.
+- **PR #89835** feat(usage): native templated /usage full footer renderer. Thanks @Marvinthebored.
+- **PR #92247** fix(models): bound /models and models list catalog loading. Related #91809. Thanks @samson910022 and @samson1357924 and @syfvb.
+- **PR #92646** fix: require admin for HTTP model overrides. Thanks @steipete-oai.
+- **PR #90686** fix(gateway): honor profile auth for SecretRef model entries. Related #90685. Thanks @rohitjavvadi.
+- **PR #92651** fix: require admin for HTTP session kills. Thanks @steipete-oai.
+- **PR #92652** test(models): stabilize plugin auth marker fixtures.
+- **PR #89438** fix(slack): warn when channels map is keyed by name instead of channel ID. Related #81665. Thanks @Alix-007 and @cjalden.
+- **PR #92631** fix(agents): pause yielded subagent runs whose terminal also signals abort. Related #92448. Thanks @openperf and @vincentkoc and @aleps001.
+- **PR #92622** fix(ui): preserve WebChat backscroll during streaming. Related #92386. Thanks @TurboTheTurtle and @vincentkoc and @DrtyMorty.
+- **PR #92627** fix(openrouter): strip openrouter/ prefix from model ID in normalizeResolvedModel hook (fixes #92611). Thanks @liuhao1024 and @lijenhsin.
+- **PR #92146** fix(cron): preserve yielded media completions. Related #92120. Thanks @IWhatsskill and @nailujac.
+- **PR #90116** fix: add Claude Haiku 4.5 static catalog entries. Related #90088. Thanks @arkyu2077 and @maaron34.
+- **PR #91137** fix(channels): keep contributed message-tool schema properties optional. Related #67852. Thanks @lundog and @RewardsPal.
+- **PR #75393** fix(copilot): disable eager tool streaming for Claude 4.5. Related #75348. Thanks @Kailigithub and @finchinslc.
+- **PR #92628** fix #73713: surface nested embedding fetch failures. Thanks @mushuiyu886 and @crsnpalmer-art.
+- **PR #92510** fix(gateway): reject unknown OpenAI agent selectors. Related #92504. Thanks @zhangguiping-xydt and @ryanhelms.
+- **PR #91453** fix #91420: [Bug]: Delivery retry loop corrupts active sessions (R-004) — retry selector bypasses delivery.mode=none. Thanks @zhangguiping-xydt and @CarotaWealth.
+- **PR #92468** fix #92453: add session identity to runtime prompt. Thanks @zhangguiping-xydt and @QQSHI13.
+- **PR #89943** fix(slack): emit message_sent hook on outbound delivery (mirror Telegram). Related #89942. Thanks @rishitamrakar.
+- **PR #92668** fix(docs): finalize i18n postprocess before skip. Thanks @hxy91819.
+- **PR #92673** fix: split image setup and request timeout semantics. Thanks @hxy91819.
+- **PR #92162** #92069: fix(cli): usage errors exit 0. Thanks @Pandah97 and @marcospaulo.
+- **PR #91185** fix(browser): remove dead requireRef import and void expression in register.navigation.ts. Related #83878. Thanks @whiteyzy and @davinci282828.
+- **PR #90706** fix(OpenAI Responses): disable item id replay for storeless providers. Related #89728. Thanks @snowzlm.
+- **PR #90247** fix(disk-space): promote 1024 MiB to 1.0 GiB in disk warnings. Related #90245. Thanks @jbetala7.
+- **PR #92657** feat(usage): ship built-in /usage full footer. Thanks @Marvinthebored.
+- **PR #90464** perf(terminal): reuse ANSI scanner during truncation. Thanks @yyzquwu.
+- **PR #91281** fix(feishu): clear client cache when SDK is replaced via setFeishuClientRuntimeForTest. Related #83911. Thanks @whiteyzy and @davinci282828.
+- **PR #92639** fix(memory): keep memory_search in transient qmd mode. Related #92464. Thanks @TurboTheTurtle and @Takhoffman and @BrettHamlin.
+- **PR #91287** fix(cron): de-duplicate main-session systemEvent in heartbeat model input. Related #44922. Thanks @ZengWen-DT and @GSL-R.
+- **PR #91246** Fix webchat media completion handoff. Related #91003. Thanks @TurboTheTurtle and @kumaxs.
+- **PR #91353** fix(ui): preserve /reset soft args in Control UI dispatch. Related #91316. Thanks @zhouhe-xydt and @MaBeitian.
+- **PR #92679** feat(telegram): send rich message text. Thanks @obviyus.
+- **PR #92705** fix(ui): restore sidebar session picker interactivity above desktop workbench. Related #92707. Thanks @NianJiuZst and @vincentkoc.
+- **PR #91218** fix(google): strip provider prefix from Vertex model path. Thanks @bymle.
+- **PR #92669** feat: support /btw in CLI-backed sessions. Thanks @joshavant.
+- **PR #91357** fix(gateway): mark active main sessions before restart shutdown aborts. Related #91355. Thanks @ooiuuii.
+- **PR #91066** fix(parallel): send openclaw-parallel User-Agent on free Search MCP requests. Thanks @NormallyGaussian.
+- **PR #90658** fix(ui): preserve dashboard session parent lineage when session list is stale. Related #90623. Thanks @luoyanglang and @lily-oc.
+- **PR #92552** fix(ios): force stale foreground gateway reconnects. Thanks @Solvely-Colin.
+- **PR #89421** fix(telegram): expose thread create CLI remap. Related #81581. Thanks @spacegeologist and @myrzka.
+- **PR #92779** fix: start workspace files collapsed. Related #90359. Thanks @shakkernerd and @Chang2020618.
+- **PR #91247** fix(state): avoid sqlite wal on nfs state volumes. Related #90491. Thanks @849261680 and @AFabyTWE.
+- **PR #92773** fix(tui): show resolved canonical model ref in /model confirmation. Thanks @NarahariRaghava.
+- **PR #92752** fix(diagnostics): keep recovery scheduling out of the stuck-session warning backoff. Related #92742. Thanks @gnanam1990 and @Takhoffman and @zhuyankarl.
+- **PR #92735** fix(markdown-core): treat Infinity chunk limit as unbounded, not 1. Related #92734. Thanks @yhterrance.
+- **PR #92695** docs(config): correct maxConcurrent default in agent-defaults type comments (AI-assisted). Thanks @ArielSmoliar.
+- **PR #92766** clarify before_install hook scope. Related #91593. Thanks @sallyom and @Trump-last.
+- **PR #92677** docs(nodes): add openclaw.json config example to Nodes overview. Related #92662. Thanks @liuhao1024 and @Casper-Mars.
+- **PR #92513** Honor WhatsApp configured ACP bindings. Related #92449. Thanks @TurboTheTurtle and @mcaxtr and @dmorn.
+- **PR #92650** fix #92465: split OpenAI 431 embedding batches. Thanks @mushuiyu886 and @BrettHamlin.
+- **PR #92796** feat(providers): add GLM-5.2 support.
+- **PR #92788** fix(sessions): derive channel from account-scoped DM session keys in send-policy. Thanks @yetval.
+- **PR #92590** Docker image ships an extraneous stale openclaw in /app/node_modules (extensions pin the published release). Related #92551. Thanks @lzyyzznl and @fxstein.
+- **PR #92393** chore(deps): bump the swift-deps group across 1 directory with 3 updates.
+- **PR #92476** fix(agents): preserve compatible CLI session runtime pins. Thanks @yu-xin-c.
+- **PR #92483** fix(matrix): validate CLI numeric option ranges. Related #92482. Thanks @rohitjavvadi.
+- **PR #92490** fix(canvas): validate CLI numeric options. Related #92487. Thanks @rohitjavvadi.
+- **PR #92802** fix(ui): reflow composer beside workspace rail. Thanks @Solvely-Colin and @shakkernerd.
+- **PR #91059** fix(configure): mask gateway token input in CLI wizard prompt. Thanks @anurag-bg-neu.
+- **PR #91143** fix(ports): only classify SSH -L/-R tunnels on the queried port as ssh. Related #91142. Thanks @jbetala7.
+- **PR #91110** fix(tavily): keep web_search contract executable. Related #91096. Thanks @extrasmall0 and @xucongyuan98-sys.
+- **PR #91181** fix(daemon): strip schtasks backslash prefix when matching gateway task name. Related #90494. Thanks @425072024 and @Darnellicious.
+- **PR #91187** fix(cron): isolate auth profile failure policy so cron runs don't pollute shared cooldowns. Related #90991. Thanks @openperf and @cx306806112.
+- **PR #92807** fix(heartbeat): route outbound mirror to isolated session key. Thanks @agent-merkava.
+- **PR #92745** fix(memory): explain skipped short-term recall hits. Related #92706. Thanks @mushuiyu886 and @armarinho.
+- **PR #92488** fix(gateway): forward image-only input on /v1/responses (parity with chat completions). Thanks @s554097550 and @cursoragent.
+- **PR #92604** fix(status): avoid cumulative usage for context percent. Related #83526. Thanks @ashishpatel26 and @darconadalabarga.
+- **PR #92810** fix: reject unvalidated voice media streams. Thanks @steipete-oai.
+- **PR #92800** fix(telegram): answer callback queries before sequentialize delays them. Related #42156. Thanks @liuhao1024 and @Diaspar4u.
+- **PR #92547** fix(nodes): surface pending reapproval diagnostics. Thanks @fuller-stack-dev.
+- **PR #92690** fix(doctor): avoid false-positive legacy cron store warning when store was already migrated (fixes #92683). Thanks @liuhao1024 and @motteman.
+- **PR #92806** fix(telegram): skip IPv4 fallback when user explicitly configures non-ipv4first dnsResultOrder (fixes #41671). Thanks @liuhao1024 and @vincentkoc and @leandroirani933-ctrl.
+- **PR #92778** fix(macos): defer isOverflowing mutation to break SwiftUI render loop (fixes #43480). Thanks @liuhao1024 and @vincentkoc and @gdiab.
+- **PR #92795** fix(gateway): use resolveNonNegativeNumber for totalTokens to display 0 instead of ? (fixes #43009). Thanks @liuhao1024 and @vincentkoc and @ltxy12138-ai.
+- **PR #92746** fix(gateway): preserve active runs during plugin finalization. Thanks @scotthuang and @vincentkoc.
+- **PR #92820** UI: localize Logs tab labels. Thanks @rubensfox20.
+- **PR #92825** fix(telegram): preserve command callbacks while prefixing generic callback data. Related #54909. Thanks @hnshah and @timt80.
+- **PR #90889** fix: cap session context overrides by model window. Related #39857. Thanks @xdanger.
+- **PR #92830** fix(copilot): strip replayed thinking blocks. Related #81520. Thanks @giodl73-repo and @warcold.
+- **PR #92834** feat(browser): extend --labels overlay to full-page and element captures. Thanks @hxy91819 and @FMLS and @cursoragent.
+- **PR #92836** fix(discord): raise thread title timeout and tokens to fit reasoning models. Thanks @hanamizuki.
+- **PR #92095** fix #92039: [Bug]: WhatsApp login reports success before auth is durably persisted, so Docker rebuilds/upgrades can force relink. Thanks @zhangguiping-xydt and @dinorastoder.
+- **PR #92801** fix(stale): exempt ClawSweeper actionable labels from stale lifecycle (fixes #89564). Thanks @liuhao1024 and @brokemac79.
+- **PR #89736** fix(status): render sub-1000 token counts as plain integers. Related #89735. Thanks @jbetala7 and @vincentkoc.
+- **PR #92792** fix(agents): catch malformed image blocks in sanitizeContentBlocksImages. Thanks @LowCode191 and @vincentkoc.
+- **PR #92555** ci: gate stable releases on Windows companion assets. Thanks @fuller-stack-dev.
+- **PR #91824** fix(agents): add usage guidance to sessions_spawn tool description (fixes #91814). Thanks @zenglingbiao and @vincentkoc and @cattails-lgao.
+- **PR #92840** fix(feishu): await HTTP server shutdown during monitor cleanup. Related #48183. Thanks @alex-xuweilong and @ai-nurmamat.
+- **PR #91632** feat: add tool search directory mode. Thanks @fuller-stack-dev.
+- **PR #92823** fix(qqbot): surface failed media sends. Thanks @zhangguiping-xydt and @vincentkoc.
+- **PR #92849** fix(tailscale): preserve parse errors for malformed JSON. Thanks @franciscomaestre.
+- **PR #92045** Fix diagnostics OTEL runtime install trust. Thanks @efpiva.
+- **PR #92853** fix(acp): accept MCP date protocolVersion in ACP server. Related #56102. Thanks @bugkill3r and @moliveto.
+- **PR #92854** fix(hooks): reject slug-generator error payloads. Thanks @Cypherm.
+- **PR #92855** fix(ui): repair iOS Safari chat viewport handling. Thanks @macdao.
+- **PR #91586** fix(update): continue after package doctor warnings. Thanks @fuller-stack-dev.
+- **PR #92862** fix(feishu): target typing reaction on inbound message. Thanks @huiwen01.
+- **PR #92861** fix(lobster): surface workflow path errors. Related #68101. Thanks @vvitovec and @MPC7500.
+- **PR #69975** fix(cli): clarify --tz help text for offset-less --at values. Related #59456. Thanks @rrrrrredy.
+- **PR #90682** fix(openai): preserve opaque reasoning transcript fields. Related #90093. Thanks @toruvieI and @richardmqq.
+- **PR #92373** fix(anthropic): strip thinking blocks from history when thinking is disabled (fixes #92360). Thanks @liuhao1024 and @notnaji.
+- **PR #87346** fix(anthropic): merge consecutive assistant turns in turn validation. Related #87329. Thanks @Jefsky and @travellingsoldier85.
+- **PR #92896** fix(anthropic): quarantine invalid direct tool schemas. Thanks @vincentkoc.
+- **PR #90739** fix(active-memory): preserve verbose recall summaries. Related #90454. Thanks @brokemac79 and @nocode-ananas.
+- **PR #92558** Simplify QA scorecard mapping shape. Thanks @RomneyDa.
+- **PR #92876** fix(memory-wiki): stop flagging raw source pages as malformed. Thanks @vincentkoc.
+- **PR #92908** fix(providers): quarantine unreadable Anthropic payload tools. Thanks @vincentkoc.
+- **PR #92881** fix(memory): preserve reindex rollback recovery. Thanks @TSHOGX and @vincentkoc.
+- **PR #92921** fix(openai): quarantine unreadable tool schemas. Thanks @vincentkoc.
+- **PR #92550** Fold Telegram RTT sampling into live QA evidence. Thanks @RomneyDa.
+- **PR #92824** fix(media): route OAuth image defaults through Codex. Related #87168. Thanks @bek91.
+- **PR #92928** fix(openai): guard post-hook tool payloads. Thanks @vincentkoc.
+- **PR #92814** fix(feishu): re-resolve route when dynamic agent binding already exists in runtime config (fixes #42837). Thanks @liuhao1024 and @vincentkoc and @cwlong163-afk.
+- **PR #89055** fix: restart gateway after isolated cron setup timeout. Thanks @ghitafilali.
+- **PR #90574** fix(openai): omit gpt-5.5 tool reasoning effort. Thanks @BSG2000.
+- **PR #92941** fix(openai): recover invalid reasoning signatures.
+- **PR #92914** fix(agents): clamp unsupported thinking for subagent spawns instead of hard-failing. Related #92412. Thanks @openperf and @oiGaDio.
+- **PR #92573** fix: preserve config-selected subagent model overrides. Related #92486. Thanks @arkyu2077 and @PatrickTrent.
+- **PR #92852** fix(gateway): fall back to polling when config watcher exhausts inotify retries. Related #92851. Thanks @danbao.
+- **PR #92362** fix(gateway): build row metadata context for single session lists. Thanks @anyech.
+- **PR #92897** fix(memory-wiki): tolerate public artifacts without agent ids. Related #92207. Thanks @yu-xin-c and @qq230849622-a11y.
+- **PR #92002** fix(lmstudio): deliver thinking "off" to binary-thinking models. Related #91913. Thanks @nxmxbbd and @mlaihk.
+- **PR #92738** Forward suppressed-source progress for message-tool channel replies. Thanks @ragesaq.
+- **PR #92916** #92201: Embedded runner: freshly streamed thinking signatures intermittently invalid on replay (Anthropic); recovery wrapper never fires because error text is genericized. Thanks @mmyzwl and @CarlCapital.
+- **PR #90936** fix(agents): do not misclassify client-disconnect abort as run timeout. Related #90764. Thanks @openperf and @reginaldomarcilon.
+- **PR #93009** fix(agents): make wrapToolWithBeforeToolCallHook idempotent to prevent double hook execution (fixes #92973). Thanks @zenglingbiao and @dertbv.
+- **PR #92318** fix(cron): require explicit message target proof. Thanks @hxy91819.
+- **PR #93022** fix(gateway): repair usage cost aggregation across agents. Thanks @luke-skywalker-open-claw and @stablegenius49.
+- **PR #93159** fix(tui): keep parent stdin paused after exit. Thanks @fuller-stack-dev.
+- **PR #93616** Keep key-free web search providers opt-in. Thanks @davemorin and @vincentkoc.
+- **PR #93164** fix(telegram): preserve rich markdown line breaks. Thanks @vincentkoc.
 ## 2026.6.7
 
 ### Highlights
 
-- Telegram, outbound delivery, and channel recovery are sturdier: polling conflicts surface and restart safely, draft preview failures retry instead of ending a stream, delivered Slack replies remain in transcripts, and top-level image sends keep their intended media source. (#92281, #92498, #92083, #92407) Thanks @joshavant, @TurboTheTurtle, @hansraj316, and @xydigit-sj.
-- Provider and agent recovery covers SecretRef-backed profiles, configured DeepSeek transports, static model fallback, rejected Anthropic thinking replay, Codex prompt memory registration, and Kimi K2.7 Code support. (#92265, #92235, #92293, #92286, #92350, #92554) Thanks @joshavant, @rubencu, and @xialonglee.
-- Cron, update, installer, and doctor paths now report SQLite-backed cron state, preserve disabled heartbeat retries, hand off Linux service auto-updates, and make external plugin/channel diagnosis clearer. (#92144, #92225, #92282, #86629) Thanks @liuhao1024, @joshavant, and @brokemac79.
+- **Durable channel replies:** Telegram polling and preview failures recover instead of ending a stream, Slack keeps delivered replies in the transcript, and top-level image sends retain their intended media source. (#92281, #92498, #92416) Thanks @joshavant, @TurboTheTurtle, @xydigit-sj, @ichirokyoto, @TalkingHeadsJed, and @riseandshinefutures.
+- **More dependable provider sessions:** SecretRef-backed profiles, configured DeepSeek transports, static model fallback, Anthropic thinking replay, and Codex prompt memory all recover cleanly instead of leaving a turn unusable. (#92265, #92235, #92293, #92286, #92350) Thanks @joshavant, @rubencu, @sallyom, @marcoraepple-sys, @LINSUISHENG034, @mattsfraser, and @reginaldomarcilon.
+- **Kimi K2.7 Code support:** the provider catalog now includes the new Kimi coding model, with replay handling that preserves its reasoning content across tool turns. (#92554, #92396) Thanks @xialonglee and @RoseKongPS.
+- **Safer operations:** SQLite-backed cron status, disabled heartbeat retries, Linux service updates, and external-plugin diagnosis now expose clearer, actionable state to operators. (#92144, #92225, #92282, #86629) Thanks @liuhao1024, @joshavant, @brokemac79, @AaronFaby, @cdeyoung67, @ooiuuii, @shakkernerd, @A1fred-AI, and @hanyizuo.
+- **Guarded skill installs:** Skill Workshop support-file targets now go through trusted lifecycle writes instead of unbounded filesystem updates, while ClawHub package checks stay on the current release path. (#91311) Thanks @abnershang.
 
 ### Changes
 
-- Skills and plugin workflows now permit trusted Skill Workshop support-file targets only through guarded lifecycle writes, and package publishing uses the current ClawHub plugin checks.
+- Skills and plugin workflows now permit trusted Skill Workshop support-file targets only through guarded lifecycle writes, and package publishing uses the current ClawHub plugin checks. (#91311) Thanks @abnershang and @vincentkoc.
 - Providers: add Kimi K2.7 Code support. (#92554)
-- QA: add evidence artifacts and scorecard taxonomy validation for release proof. (#91484, #91500) Thanks @RomneyDa.
 
 ### Fixes
 
-- Channels and delivery: recover Telegram preview and polling failures, retain Slack final replies in transcripts, preserve top-level outbound image parameters, and make channel-action result pages available to callers. (#92281, #92498, #92407, #88993) Thanks @joshavant, @TurboTheTurtle, @xydigit-sj, and @fuller-stack-dev.
-- Agent/provider reliability: preserve configured model transport/auth resolution, fail closed for unsupported CLI-backed `/btw` fallback, continue after source message-tool replies, repair Anthropic thinking replay, and keep Codex memory prompts registered. (#92265, #92226, #92343, #92286, #92350) Thanks @joshavant and @rubencu.
-- Operations: make cron and daemon status resilient, preserve disabled heartbeat one-shot retries, hand off Linux service auto-updates, and keep lifecycle timeout cleanup alive after leader exit. (#92144, #92225, #92282, #92566) Thanks @liuhao1024, @joshavant, and @RomneyDa.
+- Channels and delivery: recover Telegram preview and polling failures, retain Slack final replies in transcripts, preserve top-level outbound image parameters, and make channel-action result pages available to callers. (#92281, #92498, #92407, #88993) Thanks @joshavant, @TurboTheTurtle, @xydigit-sj, @fuller-stack-dev, @TalkingHeadsJed, and @riseandshinefutures.
+- Agent/provider reliability: preserve configured model transport/auth resolution, fail closed for unsupported CLI-backed `/btw` fallback, continue after source message-tool replies, repair Anthropic thinking replay, and keep Codex memory prompts registered. (#92265, #92226, #92343, #92286, #92350) Thanks @joshavant, @rubencu, @sallyom, @marcoraepple-sys, @wangwllu, @elyalvarado, and @reginaldomarcilon.
+- Operations: make cron and daemon status resilient, preserve disabled heartbeat one-shot retries, hand off Linux service auto-updates, and keep lifecycle timeout cleanup alive after leader exit. (#92144, #92225, #92282, #92566) Thanks @liuhao1024, @joshavant, @RomneyDa, @AaronFaby, @A1fred-AI, and @hanyizuo.
 
-### Complete contribution ledger
+### Complete contribution record
 
-This audited record covers the complete v2026.6.6..v2026.6.7-beta.1 history: 44 PRs and 14 linked issues. The grouped notes above prioritize user impact; this ledger preserves every contribution reference and eligible human credit.
+This audited record covers the complete v2026.6.6..v2026.6.7-beta.1 history: 59 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
 
 #### Pull requests
 
-- fix(cron): report SQLite storage path in cron.status instead of legacy jobs.json (#92144). Thanks @liuhao1024.
-- fix(channel): harden local setup trust (#92175). Thanks @hxy91819.
-- fix: handle explicit silent assistant replies (#92073). Thanks @sallyom.
-- fix(docker): bundle QA Lab runtime in the image (#92087). Thanks @jesse-merhi.
-- fix(anthropic-vertex): stop re-marking cache_control on transport-budgeted payloads (#92387). Thanks @openperf and @Takhoffman.
-- Fix doctor preview channel SecretRef resolution (#92229). Thanks @joshavant.
-- Fix disabled heartbeat one-shot cron retries (#92225). Thanks @joshavant.
-- Fix configured DeepSeek model transport inheritance (#92265). Thanks @joshavant.
-- Fail closed for CLI-backed /btw fallback (#92226). Thanks @joshavant.
-- Fix suppressed heartbeat commitment delivery (#92231). Thanks @joshavant.
-- fix(agents): classify structured unsupported model errors (#92280). Thanks @joshavant.
-- Fix OTLP log trace correlation (#92276). Thanks @joshavant.
-- fix(update): hand off Linux service auto-updates (#92282). Thanks @joshavant.
-- fix: resolve managed SecretRef provider auth (#92235). Thanks @joshavant.
-- Fix provider static model fallback resolution (#92293). Thanks @joshavant.
-- fix(agent): continue after source message tool replies (#92343). Thanks @joshavant.
-- fix(codex): preserve memory prompt registration (#92350). Thanks @rubencu.
-- fix: clarify gateway SecretRef auth diagnostics (#92290). Thanks @joshavant.
-- fix: repair rejected Anthropic thinking replay (#92286). Thanks @joshavant.
-- Fix Telegram spooled buffered replay (#92281). Thanks @joshavant.
-- fix(outbound): honor top-level image param as send media source (issue 92407) (#92416). Thanks @xydigit-sj.
-- fix(sandbox): render CLI skill prompts from materialized paths (#92508). Thanks @brokemac79.
-- chore: fix esbuild production audit failure (#92540). Thanks @RomneyDa.
-- Add QA evidence artifact output (#91484). Thanks @RomneyDa.
-- Add QA scorecard taxonomy validation (#91500). Thanks @RomneyDa.
-- feat(moonshot): add Kimi K2.7 Code support (#92554).
-- fix(moonshot): backfill reasoning_content on assistant tool-call replay messages (#92396). Thanks @xialonglee.
-- Fix lifecycle timeout cleanup after leader exit (#92566). Thanks @RomneyDa.
-- Expose paged channel action results (#88993). Thanks @fuller-stack-dev.
-- fix(fireworks): resolve catalog model params from plugin.json via core (#90326). Thanks @obuchowski.
-- fix(doctor): warn for untrusted external Discord plugin (#86629). Thanks @brokemac79.
-- fix(providers): skip unreadable Mistral tool schemas (#90242). Thanks @vincentkoc.
-- fix(reply): mirror same-channel Slack final replies (#92498). Thanks @TurboTheTurtle.
-- fix(channels): default boundary logger for swallowed progress-draft start errors (#92083). Thanks @hansraj316.
-- fix(channels): make timer-fired progress-draft start errors observable (#92031). Thanks @hansraj316.
-- fix(agents): isolate invalid plugin model catalogs [AI-assisted] (#92564). Thanks @tangtaizong666.
-- docs: UX-013 — design system documentation (#89827). Thanks @BunsDev.
-- feat(ui): hide empty workboard columns (#89615). Thanks @BunsDev.
-- fix(a11y): B-1+B-2+B-3 — contrast, focus states, minimum font sizes (#89822). Thanks @BunsDev.
-- fix issue 92218: memory_search tool disabled with QMD backend (#92618). Thanks @mushuiyu886.
-- docs(gateway): add uptime monitoring guidance to health check docs (fixes issue 55768) (#92608). Thanks @liuhao1024.
-- fix(docs): pin Windows Hub download links to v2026.6.5 (#92605). Thanks @lzyyzznl.
-- issue 92589: fix(internal-runtime-context): wrap prompt-preface runtime context body in delimiters (#92593). Thanks @zhangqueping.
-- Run Vitest and Playwright scenarios from qa suite (#92606). Thanks @RomneyDa.
-
-#### Linked issues
-
-- Reported: [Bug]: openclaw cron status reports legacy storePath (#91766). Thanks @AaronFaby.
-- Reported: [Bug]: Node.js auto-installer fails silently with ioctl errors then falsely reports success before crashing (#73837). Thanks @ItsMeForLua.
-- Reported: [Bug]: Missing SQLite perf and query-plan harness (#91616). Thanks @galiniliev.
-- Reported: [Feature]: Error: Gateway service install not supported on openbsd (#25621). Thanks @kucharskim.
-- Reported: [Bug]: cron edit --cron silently strips schedule.tz and staggerMs (direct path replaces schedule without merging) (#92291). Thanks @dcapclaw.
-- Reported: message tool: `image` param silently dropped on send — delivers text without attachment but returns ok:true (#92407). Thanks @ichirokyoto.
-- Reported: Kimi K2.6 reasoning_content 400 regression in long conversations after LCM compaction (follow-up issue 70392) (#71491). Thanks @RoseKongPS.
-- Reported: [Bug]: Moonshot/Kimi duplicate tool-call IDs in replay, exposed by WhatsApp group chats (#51593). Thanks @Faaab84 and @Pluviobyte.
-- Reported: Discord channel stays disabled with no warning unless `plugins.entries.discord.enabled` is set (#83212). Thanks @cdeyoung67.
-- Reported: [Bug]: Slack channel/thread sessions never persist assistant replies to the session transcript → total context loss when the CLI session binding is invalidated (#92489). Thanks @TalkingHeadsJed and @TurboTheTurtle.
-- Reported: ModelRegistry: a single invalid plugin catalog aborts the entire custom-models load, leaving zero models and an unlogged error (#92553). Thanks @fxstein.
-- Reported: Health check bloat: uptime monitors must use /health, not /v1/chat/completions (#55768). Thanks @faahim.
-- Reported: [Bug]: Windows Hub download link is not working (#92470). Thanks @arjkul.
-- Reported: Feishu channel leaks system runtime context (relevant-memories, sender metadata) into user-visible reply (#92589). Thanks @jovi2014-cyber.
-
+- **PR #92144** fix(cron): report SQLite storage path in cron.status instead of legacy jobs.json. Related #91766. Thanks @liuhao1024 and @AaronFaby.
+- **PR #92175** fix(channel): harden local setup trust. Thanks @hxy91819.
+- **PR #91528** fix #73837: stop after failed Node package installs. Thanks @mushuiyu886 and @ItsMeForLua.
+- **PR #91561** fix(wizard): report keyless web_search providers as ready, not missing a key. Thanks @NormallyGaussian.
+- **PR #92073** fix: handle explicit silent assistant replies. Related #92038. Thanks @sallyom and @vultusv.
+- **PR #91311** Allow Skill Workshop apply through trusted skill symlinks. Thanks @abnershang.
+- **PR #88245** refactor(whatsapp): introduce inbound message contexts. Thanks @mcaxtr.
+- **PR #92212** refactor: move workspace skill writes to lifecycle. Thanks @shakkernerd.
+- **PR #92248** Remove ClawHub owner preflight. Thanks @Patrick-Erichsen.
+- **PR #91617** test(sqlite): add state perf query plan harness. Related #91616. Thanks @galiniliev.
+- **PR #91626** fix(daemon): keep status readable on unsupported services. Related #25621. Thanks @mushuiyu886 and @kucharskim.
+- **PR #92295** fix(cron): preserve tz and staggerMs when --cron replaces expression. Related #92291. Thanks @liuhao1024 and @dcapclaw.
+- **PR #92087** fix(docker): bundle QA Lab runtime in the image. Thanks @jesse-merhi.
+- **PR #92004** fix(telegram): classify streaming preview edit failures instead of killing the draft. Thanks @obviyus.
+- **PR #91997** fix(telegram): survive getUpdates conflicts in isolated polling ingress. Thanks @obviyus.
+- **PR #92387** fix(anthropic-vertex): stop re-marking cache_control on transport-budgeted payloads. Related #91982. Thanks @openperf and @Takhoffman and @danieljimz.
+- **PR #92229** Fix doctor preview channel SecretRef resolution. Related #91939. Thanks @joshavant and @Niriakot.
+- **PR #92225** Fix disabled heartbeat one-shot cron retries. Related #91775. Thanks @joshavant and @A1fred-AI.
+- **PR #92265** Fix configured DeepSeek model transport inheritance. Related #92148. Thanks @joshavant and @marcoraepple-sys.
+- **PR #92226** Fail closed for CLI-backed /btw fallback. Related #92168. Thanks @joshavant and @wangwllu.
+- **PR #92231** Fix suppressed heartbeat commitment delivery. Related #91948. Thanks @joshavant and @bizzle12368239.
+- **PR #92280** fix(agents): classify structured unsupported model errors. Related #92118. Thanks @joshavant and @pikaqqqqqq.
+- **PR #92276** Fix OTLP log trace correlation. Related #91865. Thanks @joshavant and @sinzin91.
+- **PR #92282** fix(update): hand off Linux service auto-updates. Related #91823. Thanks @joshavant and @hanyizuo.
+- **PR #92235** fix: resolve managed SecretRef provider auth. Related #92097. Thanks @joshavant and @LINSUISHENG034.
+- **PR #92293** Fix provider static model fallback resolution. Related #92009. Thanks @joshavant and @mattsfraser.
+- **PR #92343** fix(agent): continue after source message tool replies. Related #92169. Thanks @joshavant and @elyalvarado.
+- **PR #92350** fix(codex): preserve memory prompt registration. Thanks @rubencu and @sallyom.
+- **PR #92290** fix: clarify gateway SecretRef auth diagnostics. Related #91815. Thanks @joshavant and @mattsfraser.
+- **PR #92286** fix: repair rejected Anthropic thinking replay. Related #91983. Thanks @joshavant and @reginaldomarcilon.
+- **PR #92281** Fix Telegram spooled buffered replay. Related #92129. Thanks @joshavant and @riseandshinefutures.
+- **PR #47493** fix(doctor): show per-step progress spinners during update. Thanks @amersheeny.
+- **PR #92416** fix(outbound): honor top-level image param as send media source (#92407). Thanks @xydigit-sj and @ichirokyoto.
+- **PR #92508** fix(sandbox): render CLI skill prompts from materialized paths. Thanks @brokemac79.
+- **PR #92540** chore: fix esbuild production audit failure. Thanks @RomneyDa.
+- **PR #91484** Add QA evidence artifact output. Thanks @RomneyDa.
+- **PR #91500** Add QA scorecard taxonomy validation. Thanks @RomneyDa.
+- **PR #84082** fix(telegram): allow expandable blockquotes. Thanks @jzakirov.
+- **PR #92554** feat(moonshot): add Kimi K2.7 Code support.
+- **PR #92396** fix(moonshot): backfill reasoning_content on assistant tool-call replay messages. Related #71491. Thanks @xialonglee and @RoseKongPS.
+- **PR #92566** Fix lifecycle timeout cleanup after leader exit. Thanks @RomneyDa.
+- **PR #92311** ci: split plugin ClawHub publishing paths. Thanks @Patrick-Erichsen.
+- **PR #92216** fix(gateway): mirror hidden commentary-phase assistant events. Thanks @ragesaq.
+- **PR #87596** fix(moonshot): rewrite duplicate native Kimi tool_call ids on replay. Related #51593. Thanks @Pluviobyte and @Faaab84.
+- **PR #88993** Expose paged channel action results. Thanks @fuller-stack-dev.
+- **PR #90326** fix(fireworks): resolve catalog model params from plugin.json via core. Thanks @obuchowski.
+- **PR #86629** fix(doctor): warn for untrusted external Discord plugin. Related #83212. Thanks @brokemac79 and @ooiuuii and @cdeyoung67.
+- **PR #90242** fix(providers): skip unreadable Mistral tool schemas. Thanks @vincentkoc.
+- **PR #92498** fix(reply): mirror same-channel Slack final replies. Related #92489. Thanks @TurboTheTurtle and @TalkingHeadsJed.
+- **PR #92083** fix(channels): default boundary logger for swallowed progress-draft start errors. Thanks @hansraj316.
+- **PR #92564** fix(agents): isolate invalid plugin model catalogs [AI-assisted]. Related #92553. Thanks @tangtaizong666 and @fxstein.
+- **PR #89827** docs: UX-013 — design system documentation. Thanks @BunsDev.
+- **PR #89615** feat(ui): hide empty workboard columns. Thanks @BunsDev.
+- **PR #89822** fix(a11y): B-1+B-2+B-3 — contrast, focus states, minimum font sizes. Thanks @BunsDev.
+- **PR #92618** fix #92218: memory_search tool disabled with QMD backend. Thanks @mushuiyu886 and @zhbcher.
+- **PR #92608** docs(gateway): add uptime monitoring guidance to health check docs (fixes #55768). Thanks @liuhao1024 and @faahim.
+- **PR #92605** fix(docs): pin Windows Hub download links to v2026.6.5. Related #92470. Thanks @lzyyzznl and @arjkul.
+- **PR #92593** #92589: fix(internal-runtime-context): wrap prompt-preface runtime context body in delimiters. Thanks @zhangqueping and @jovi2014-cyber.
+- **PR #92606** Run Vitest and Playwright scenarios from qa suite. Thanks @RomneyDa.
 ## 2026.6.6
 
 ### Highlights
 
-- Security boundaries are substantially tighter across transcripts, sandbox binds, host environment inheritance, MCP stdio, Codex HTTP access, native search policy, elevated sender checks, deleted-agent ACP bypasses, loopback tools, Discord moderation, and Teams group actions; exec approvals now fail closed on timeout. (#91529, #91618, #91615, #91619, #91741, #91745, #91746, #91748, #91749, #91750, #91751, #91752, #91763, #89938) Thanks @joshavant, @pgondhi987, @mmaps, @eleqtrizit, @shakkernerd, and @drobison00.
-- Telegram delivery is safer and more coherent: account-scoped topics route to the right agent, streamed text survives tool calls, `/compact` works on generic ingress, callback handling uses concrete APIs, draft chunking is shared, durable dispatch dedupe moved into the SDK, and unauthorized DM text stays out of cache and prompt context. (#91189, #88682, #89588, #90212, #91876, #91874, #91904, #91478, #91915) Thanks @codysai001, @alexzhu0, @joelnishanth, @snowzlm, @obviyus, and @sallyom.
-- iMessage recovery and delivery now cover always-on inbound restart, durable echo markers, block streaming, idle approval discovery, hardened outbound transport, and actionable inbound startup diagnostics. (#91335, #91449, #88969, #88530, #91783, #91785) Thanks @omarshahine, @jmissig, and @colmbrogan.
-- Browser and MCP connectivity gained existing-session CDP support, discovered WebSocket validation, default-profile `cdpUrl` handling, safer browser-output boundaries, Streamable HTTP loopback transport, corrected OAuth/SSE authorization handling, and broader schema compatibility. (#91422, #89851, #91736, #91747, #91451, #80143) Thanks @pgondhi987, @anagnorisis2peripeteia, @lifuyue, @eleqtrizit, @LiuwqGit, and @HemantSudarshan.
-- Control UI startup and first-reply latency are lower through cached model metadata, removal of the startup catalog wait, lazy slash-command loading, and first-event tracing with slow-reply diagnostics. (#91531, #91538, #91568, #91583, #91598)
-- Provider support expands with OpenRouter OAuth onboarding and Claude Fable 5 adaptive thinking, while Codex sessions keep correct compaction ownership, local models skip guardian review, dynamic tool progress normalizes cleanly, and Gemma 4 reasoning replay is preserved. (#91830, #91882, #91590, #88630, #88768, #91696) Thanks @Patrick-Erichsen, @joshavant, @bdjben, and @Coder-Wangyankun.
+- **Tighter security boundaries:** transcript, sandbox, MCP, browser, channel, and exec-approval paths now fail closed around unsafe access, timed-out approvals, and malformed boundary input. (#91529, #91618, #91741, #91750, #89938) Thanks @joshavant, @pgondhi987, @mmaps, @eleqtrizit, @drobison00, @vincentkoc, and @devinkuhn.
+- **Reliable Telegram delivery:** account-scoped topics route to the correct agent, streamed text survives tool calls, callbacks and draft chunks stay coherent, and unauthorized DM text does not enter cache or prompt context. (#91189, #88682, #90212, #91478, #91915) Thanks @codysai001, @alexzhu0, @snowzlm, @obviyus, @sallyom, @AbdelftahZowail, @producedbysavant, @shakkernerd, @vincentkoc, and @BSG2000.
+- **iMessage stays connected:** always-on inbound recovery, durable echo markers, block streaming, idle approval discovery, and outbound transport now survive restarts and idle periods. (#91335, #91449, #88969, #91783) Thanks @omarshahine, @jmissig, @dwonshin, @colmbrogan, @vincentkoc, and @TurboTheTurtle.
+- **Better browser and MCP connectivity:** existing browser sessions, CDP/WebSocket discovery, default-profile URLs, OAuth/SSE transport, and tool schemas now connect through clearer, safer paths. (#91422, #89851, #91736, #91451) Thanks @pgondhi987, @anagnorisis2peripeteia, @eleqtrizit, @LiuwqGit, @lifuyue, @marcusbsorensen, @cursoragent, @vincentkoc, @849261680, and @mgrandau.
+- **Faster first replies:** Control UI startup no longer waits on broad model loading, while cached metadata, lazy slash-command work, and first-event tracing make slow initial responses visible. (#91531, #91538, #91568, #91583) Thanks @vincentkoc and @BSG2000.
+- **Broader provider support:** OpenRouter OAuth and Claude Fable 5 land alongside correct Codex compaction ownership, local-model execution, normalized tool progress, and Gemma 4 reasoning replay. (#91830, #91882, #91590, #88630, #91696) Thanks @Patrick-Erichsen, @joshavant, @bdjben, @Coder-Wangyankun, @vincentkoc, @bfox55, @shakkernerd, and @NOVA-Openclaw.
 
 ### Changes
 
-- CLI progress: emit Claude CLI commentary progress events and bridge inter-tool commentary into channel progress without exposing internal protocol scaffolding. (#89834, #90883) Thanks @anagnorisis2peripeteia.
-- Observability: allow trusted diagnostics channels to capture tool input/output content, add first-assistant-event traces, and warn on slow initial replies. (#91256, #91568, #91583) Thanks @amknight.
-- Plugins/ClawHub: dogfood reusable package publishing, let dry runs skip publish approval, allow declared installed trusted hooks, report managed plugin version drift, and warn instead of failing on retired Skill Workshop configuration. (#91574, #91591, #90004, #90927, #90838) Thanks @Patrick-Erichsen, @brokemac79, and @lonexreb.
-- Memory/providers: move the local llama.cpp runtime into its provider plugin, batch embeddings across files, persist the agent model catalog cache, and keep QMD JSON search one-shot while filtering stale REM recall previews. (#91324, #89138, #90457, #91837, #91851) Thanks @osolmaz, @mushuiyu886, @ai-hpc, and @TurboTheTurtle.
-- Channels/mobile: add the QQBot group mention toggle, improve iPad and iPhone control surfaces, and expose the active connection host in the TUI footer. (#91423, #91557, #89909) Thanks @cxyhhhhh, @Solvely-Colin, and @baskduf.
-- Performance: prewarm TUI runtime plugins, deduplicate plugin auto-enable fanout, trim dense text-delta snapshots, and reuse prepared startup model metadata. (#90782, #89978, #91580, #91531) Thanks @RomneyDa and @ai-hpc.
+- CLI progress: emit Claude CLI commentary progress events and bridge inter-tool commentary into channel progress without exposing internal protocol scaffolding. (#89834, #90883) Thanks @anagnorisis2peripeteia, @AbdelftahZowail, @kentuscn, and @vincentkoc.
+- Observability: allow trusted diagnostics channels to capture tool input/output content, add first-assistant-event traces, and warn on slow initial replies. (#91256, #91568, #91583) Thanks @amknight, @mjunaidca, and @vincentkoc.
+- Plugins/ClawHub: dogfood reusable package publishing, let dry runs skip publish approval, allow declared installed trusted hooks, report managed plugin version drift, and warn instead of failing on retired Skill Workshop configuration. (#91574, #91591, #90004, #90927, #90838) Thanks @Patrick-Erichsen, @brokemac79, @lonexreb, @rogerallen1, @vincentkoc, and @ryanhelms.
+- Memory/providers: move the local llama.cpp runtime into its provider plugin, batch embeddings across files, persist the agent model catalog cache, and keep QMD JSON search one-shot while filtering stale REM recall previews. (#91324, #89138, #90457, #91837, #91851) Thanks @osolmaz, @mushuiyu886, @ai-hpc, @TurboTheTurtle, @jalehman, @hartmark, @vincentkoc, @rudi193-cmd, @Peilsender, and @xpysgdhr.
+- Channels/mobile: add the QQBot group mention toggle, improve iPad and iPhone control surfaces, and expose the active connection host in the TUI footer. (#91423, #91557, #89909) Thanks @cxyhhhhh, @Solvely-Colin, @baskduf, @joshavant, @sliverp, and @deuxksy.
+- Performance: prewarm TUI runtime plugins, deduplicate plugin auto-enable fanout, trim dense text-delta snapshots, and reuse prepared startup model metadata. (#90782, #89978, #91580, #91531) Thanks @RomneyDa, @ai-hpc, @vincentkoc, and @JakeBiggs.
 
 ### Fixes
 
-- Agent/session recovery: drop stale approval follow-ups after session rebind, remove drained reply-queue items by identity, recover stale main and visible replies, preserve Codex context-engine compaction ownership, lower the default compaction timeout to 180 seconds while respecting explicit configuration, and keep provider-failure terminal lifecycle state correct. (#85679, #91450, #91566, #91840, #91590, #91361, #91895) Thanks @openperf, @yetval, @joshavant, @wangmiao0668000666, and @TurboTheTurtle.
-- User-visible content boundaries: suppress Codex/Harmony protocol artifacts, neutralize browser and LanceDB memory media directives, redact transcript images, and preserve native `/compact` replies through source suppression. (#89151, #91422, #91425, #91529, #90212) Thanks @joelnishanth, @pgondhi987, @joshavant, and @snowzlm.
-- Channel delivery: keep WhatsApp captured replies attached to the successor controller after restart, retry Feishu rate limits, preserve Mattermost thread replies, canonicalize LINE webhook paths, restore Discord reply hydration and runtime timeout exports, and show OpenAI Realtime WebRTC assistant transcripts. (#85823, #89659, #91684, #91649, #90263, #91686, #90426) Thanks @itsuzef, @ladygege, @jacobtomlinson, @fuller-stack-dev, and @shushushv.
+- Agent/session recovery: drop stale approval follow-ups after session rebind, remove drained reply-queue items by identity, recover stale main and visible replies, preserve Codex context-engine compaction ownership, lower the default compaction timeout to 180 seconds while respecting explicit configuration, and keep provider-failure terminal lifecycle state correct. (#85679, #91450, #91566, #91840, #91590, #91361, #91895) Thanks @openperf, @yetval, @joshavant, @wangmiao0668000666, @TurboTheTurtle, @two3pro, @velvet-shark, @sallyom, @849261680, @vincentkoc, @Tony-ooo, @Jerry-Xin, @olveww-dot, and @nikhilmaddirala.
+- User-visible content boundaries: suppress Codex/Harmony protocol artifacts, neutralize browser and LanceDB memory media directives, redact transcript images, and preserve native `/compact` replies through source suppression. (#89151, #91422, #91425, #91529, #90212) Thanks @joelnishanth, @pgondhi987, @joshavant, @snowzlm, @reslp, @vincentkoc, and @devinkuhn.
+- Channel delivery: keep WhatsApp captured replies attached to the successor controller after restart, retry Feishu rate limits, preserve Mattermost thread replies, canonicalize LINE webhook paths, restore Discord reply hydration and runtime timeout exports, and show OpenAI Realtime WebRTC assistant transcripts. (#85823, #89659, #91684, #91649, #90263, #91686, #90426) Thanks @itsuzef, @ladygege, @jacobtomlinson, @fuller-stack-dev, @shushushv, @mcaxtr, @AxelHu, @vincentkoc, @marshallm-create, @sliverp, and @dahifi.
 - Cron: cancel active task runs cleanly, preserve terminal timeout/cancel state, and recover no-deliver tool warnings instead of silently losing the outcome. (#90666, #90678) Thanks @ai-hpc.
-- Gateway/config/auth: share the approval runtime socket token, replace arrays explicitly in `config.patch`, skip the deleted-agent guard only for valid ACP harness sessions, surface headless LaunchAgent state, verify SQLite auth migration before cleanup, and arm QMD startup maintenance. (#87105, #91551, #91219, #91614, #91740, #91978) Thanks @fuller-stack-dev and @scotthuang.
-- Providers/Codex: clarify quota errors, restore the Codex synthetic usage line, canonicalize Codex protocol assets, require API-key auth for realtime voice, normalize ACP model refs, preserve Gemma 4 `reasoning_content`, and avoid guardian review for local models. (#91390, #91709, #91507, #91567, #88630, #91696) Thanks @hxy91819, @brokemac79, @RomneyDa, @joshavant, and @Coder-Wangyankun.
-- Updates/builds: recover package Gateway restarts after refresh failure, expose plugin convergence repair, fall back to Corepack in PATH-less pnpm environments, seed the correct Docker store packages, and keep ClawHub dry-run and publish paths reusable. (#91581, #91599, #91547, #91591) Thanks @fuller-stack-dev, @sallyom, and @Patrick-Erichsen.
-- UI: require explicit user intent before opening chat sessions and drain restored chat queues after session switches. (#91480) Thanks @TurboTheTurtle.
+- Gateway/config/auth: share the approval runtime socket token, replace arrays explicitly in `config.patch`, skip the deleted-agent guard only for valid ACP harness sessions, surface headless LaunchAgent state, verify SQLite auth migration before cleanup, and arm QMD startup maintenance. (#87105, #91551, #91219, #91614, #91740, #91978) Thanks @fuller-stack-dev, @scotthuang, @joshavant, @velvet-shark, @vincentkoc, and @dahifi.
+- Providers/Codex: clarify quota errors, restore the Codex synthetic usage line, canonicalize Codex protocol assets, require API-key auth for realtime voice, normalize ACP model refs, preserve Gemma 4 `reasoning_content`, and avoid guardian review for local models. (#91390, #91709, #91507, #91567, #88630, #91696) Thanks @hxy91819, @brokemac79, @RomneyDa, @joshavant, @Coder-Wangyankun, @vincentkoc, @bfox55, @shakkernerd, and @sergiopesch.
+- Updates/builds: recover package Gateway restarts after refresh failure, expose plugin convergence repair, fall back to Corepack in PATH-less pnpm environments, seed the correct Docker store packages, and keep ClawHub dry-run and publish paths reusable. (#91581, #91599, #91547, #91591) Thanks @fuller-stack-dev, @sallyom, @Patrick-Erichsen, @vincentkoc, and @laurenceputra.
+- UI: require explicit user intent before opening chat sessions and drain restored chat queues after session switches. (#91480) Thanks @TurboTheTurtle, @Takhoffman, and @zdwalter.
 - Android: avoid the `dataSync` foreground-service type for persistent nodes. (#80082) Thanks @davelutztx.
-- Native hooks: bound relay lifetimes so abandoned native hook connections cannot linger indefinitely. (#91550) Thanks @joshavant.
+- Native hooks: bound relay lifetimes so abandoned native hook connections cannot linger indefinitely. (#91550) Thanks @joshavant and @clem-git.
 
-### Complete contribution ledger
+### Complete contribution record
 
-This audited record covers the complete v2026.6.5..v2026.6.6 history: 186 PRs and 45 linked issues. The grouped notes above prioritize user impact; this ledger preserves every contribution reference and eligible human credit.
+This audited record covers the complete v2026.6.5..v2026.6.6 history: 198 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
 
 #### Pull requests
 
-- fix(imessage): always-on inbound recovery and dedupe (#91335). Thanks @omarshahine.
-- fix: clarify provider quota errors (#91390). Thanks @hxy91819.
-- docs: preserve channel brand terms in Chinese i18n (#91419). Thanks @hxy91819.
-- docs: preserve LINE across localized docs glossaries (#91442). Thanks @hxy91819.
-- fix(browser): neutralize media directives in browser output [AI] (#91422). Thanks @pgondhi987.
-- feat(cli): emit commentary progress events from Claude CLI parser (#89834). Thanks @anagnorisis2peripeteia.
-- fix(context): report compactable transcript counts (#91158). Thanks @Pluviobyte.
-- fix(imessage): honor block streaming config (#91449). Thanks @jmissig and @omarshahine.
-- build(deps): bump github.com/steipete/peekaboo from 3.3.0 to 3.4.0 in /apps/macos in the swift-deps group (#91364).
-- build(deps): bump actions/github-script from 8 to 9 (#91368).
-- chore: add taxonomy file (#91512). Thanks @kevinslin.
-- build(deps): bump actions/cache from 4 to 5 (#91369).
-- build(deps): bump the actions group with 2 updates (#91367).
-- build(deps): bump the android-deps group in /apps/android with 3 updates (#91365).
-- chore: bump Codex app-server to 0.137.0 (#91496). Thanks @RomneyDa.
-- perf(control-ui): reuse startup model metadata (#91531). Thanks @vincentkoc.
-- feat: canonicalize Codex protocol JSON asset ordering (#91507). Thanks @RomneyDa.
-- fix: bound native hook relay lifetime (#91550). Thanks @joshavant.
-- Fix transcript image redaction (#91529). Thanks @joshavant.
-- Fix config.patch explicit array replacement (#91551). Thanks @joshavant.
-- fix(whatsapp): route captured replies through successor controller after restart (#85823). Thanks @itsuzef and @mcaxtr.
-- perf(control-ui): warn on slow first replies (#91583). Thanks @vincentkoc.
-- fix(feishu): retry on send rate-limit errors (230020/230006) (#89659). Thanks @ladygege.
-- fix(feishu): propagate rate-limit errors from typing indicator to circuit breaker (#28157). Thanks @guoqunabc.
-- Fix Docker store seed target packages (#91547). Thanks @sallyom.
-- fix: make docs i18n frontmatter translation resilient (#91578). Thanks @hxy91819.
-- fix(openai): require api-key auth for realtime voice (#91567). Thanks @joshavant.
-- fix: let ClawHub dry runs skip publish approval (#91591). Thanks @Patrick-Erichsen.
-- fix(memory-lancedb): guard memory recall output [AI] (#91425). Thanks @pgondhi987.
-- fix(imessage): persist echo markers before send (#88969). Thanks @colmbrogan.
-- Fix stale main session startup recovery (#91566). Thanks @joshavant.
-- docs: include plugin prerelease in release validation approval (#91637).
-- fix(line): canonicalize trailing-slash webhook paths (#91649).
-- feat(qqbot): add /bot-group-allways command to toggle mention requirement (#91423). Thanks @cxyhhhhh.
-- fix(docs): continue partial i18n batches after file errors (#91642). Thanks @hxy91819.
-- chore(plugin-sdk): refresh API baseline hash (#91661).
-- docs: fix release CI Android dispatch guidance (#91665).
-- fix issue 88009: [Feature]: batched memory embedding should batch over files (#89138). Thanks @mushuiyu886 and @jalehman.
-- fix(plugin-sdk): align Discord component edit facade types (#91679). Thanks @vincentkoc.
-- fix(discord): restore runtime timeout compatibility exports (#91686). Thanks @vincentkoc.
-- fix: expand unsafe host env denylist (#91618). Thanks @pgondhi987.
-- fix: block rustup toolchain env overrides [AI] (#91615). Thanks @pgondhi987.
-- fix: block git protocol env controls [AI] (#91619). Thanks @pgondhi987.
-- perf(tui): prewarm runtime plugins before first send (#90782). Thanks @RomneyDa.
-- fix(config): warn for retired skill-workshop plugin entry instead of failing validation (issue 90244) (#90838). Thanks @lonexreb.
-- docs: clarify Matrix plugin upgrade repair (#91753). Thanks @RomneyDa.
-- docs: align Feishu DM policy defaults (#91755). Thanks @RomneyDa.
-- fix(discord): require sender for moderation actions [AI] (#91745). Thanks @eleqtrizit.
-- docs: clarify trusted-proxy Control UI scope behavior (#85950). Thanks @nielskaspers.
-- fix(msteams): require admin for group actions (#91746). Thanks @eleqtrizit.
-- feat(diagnostics-otel): capture tool input/output content via trusted channel (#91256). Thanks @amknight.
-- fix(gateway): restrict non-owner loopback tools (#91749). Thanks @eleqtrizit.
-- fix(elevated): reject group ids as senders (#91748). Thanks @eleqtrizit.
-- fix(codex): guard sandbox http requests (#91752). Thanks @eleqtrizit.
-- fix(mcp): harden stdio env filtering (#91751). Thanks @eleqtrizit.
-- Clarify env-var executable behavior reports in SECURITY.md (#91765). Thanks @jacobtomlinson.
-- fix(ui): require user intent for chat sessions (#91480). Thanks @TurboTheTurtle and @Takhoffman.
-- fix(mcp): lowercase SSE event-source header keys to prevent duplicate Authorization (401) (#91773). Thanks @Takhoffman.
-- Validate sandbox bind parent paths [AI] (#91741). Thanks @mmaps.
-- fix(imessage): skip idle approval discovery scans (#88530). Thanks @colmbrogan and @omarshahine.
-- fix(ui): drain restored chat queue after session switch (#91780). Thanks @tmimmanuel.
-- fix(search): enforce native web search tool policy (#91750). Thanks @eleqtrizit.
-- fix(config): clarify retired skill workshop plugin warning (#91757). Thanks @RomneyDa.
-- fix(doctor): keep TTS legacy migration on supported paths (#91787).
-- fix(imessage): harden outbound send transport (#91783). Thanks @omarshahine.
-- fix(imessage): surface inbound startup diagnostics (#91785). Thanks @omarshahine.
-- Fix context-engine compaction ownership for Codex sessions (#91590). Thanks @joshavant.
-- Improve iPad and iPhone control surfaces (#91557). Thanks @Solvely-Colin and @joshavant.
-- chore(deps): bump useblacksmith/setup-docker-builder from 1.8.0 to 1.9.0 in the actions group (#91666).
-- docs: link ClawHub plugin validation fixes guide (#91819). Thanks @Patrick-Erichsen.
-- fix(codex): avoid guardian review for local models (#88630). Thanks @vincentkoc.
-- fix(memory-core): keep QMD JSON search one-shot (#91837). Thanks @TurboTheTurtle.
-- Fix stale visible reply recovery (#91840). Thanks @joshavant.
-- block unauthorized Telegram DM text from prompt context (#91478). Thanks @sallyom.
-- fix(compaction): lower default timeout from 900s to 180s, preserve explicit config (#91361). Thanks @wangmiao0668000666 and @velvet-shark.
-- fix(sandbox): use materialized skill paths in startup prompts (#91791). Thanks @brokemac79.
-- Support existing-session browser CDP endpoints (#91736). Thanks @lifuyue.
-- fix(browser): validate discovered CDP websocket URLs (#91747). Thanks @eleqtrizit.
-- feat(anthropic): support Claude Fable 5 adaptive thinking (#91882).
-- fix(mcp): repair OAuth redirect, errors, and unicode schema patterns (#91451). Thanks @LiuwqGit.
-- fix(talk): show OpenAI Realtime WebRTC assistant transcripts (#90426). Thanks @shushushv.
-- fix(agents): preserve reasoning_content replay for Gemma 4 openai-completions models (#91696). Thanks @Coder-Wangyankun.
-- Fail closed on exec approval timeout (#89938). Thanks @drobison00.
-- fix(webchat): finalize provider failure lifecycle (#91895). Thanks @TurboTheTurtle.
-- fix(browser): honor cdpUrl for user default profile (#80143). Thanks @HemantSudarshan.
-- fix(cron): reject cron expressions that have no reachable run time (#91688). Thanks @yetval.
-- fix(cron): use final-call usage for session token totals (#91737). Thanks @MonkeyLeeT.
-- Redact tool output secrets (#85196). Thanks @amknight.
-- fix(security): block build tool env overrides (#92007). Thanks @eleqtrizit.
-- fix: preserve non-oneOf protocol schema array order (#91891). Thanks @RomneyDa.
-- fix(macos): hide unsupported Voice Wake controls (#91754). Thanks @RomneyDa.
-- test(ci): restore upgrade survivor session fixture (#92049). Thanks @vincentkoc.
-- fix(fal): parse raw completed queue results (#92051). Thanks @harjothkhara.
-- fix(agents): prefer explicit sessions_send keys (#92047). Thanks @vincentkoc.
-- fix(agents): prefer sessionKey in sessions_send (#74009).
-- fix(memory-core): check SQLite plugin state for dreaming ingestion audit after JSON migration (fixes issue 92017) (#92020). Thanks @zenglingbiao.
-- fix(mcp): always log channel-bridge notification failures (#92032). Thanks @hansraj316.
-- fix(gateway): log swallowed background-task finalization errors (#92033). Thanks @hansraj316.
-- fix(sessions): derive channel from direct-chat session keys in send-policy (#92022). Thanks @hansraj316.
-- fix(xai): clarify x_search query guidance (#91163). Thanks @rubencu.
-- fix(memory): write dream fallback without subagent runtime (#90121). Thanks @a-m-a-r-a.
-- fix(ui): show prompt progress while sending (#91215). Thanks @zhangguiping-xydt.
-- fix(tools): surface unsupported-signal in anyOf availability (#92029). Thanks @hansraj316.
-- perf(agents): memoize XML attribute regex in DSML stream parser (#92034). Thanks @hansraj316.
-- perf(agents): sanitize compaction messages once for token estimation (#92026). Thanks @hansraj316.
-- fix(opencode-go): add qwen plus tiered pricing (#91351). Thanks @849261680.
-- fix(gateway): recover config hot-reload after watcher errors (#92027). Thanks @hansraj316.
-- feat(cron): add readable ISO time fields to `cron runs` JSON output (#91471). Thanks @FMLS.
-- :bug: fix(agents): classify harness provider mismatch as format error (issue 91710) (#91711). Thanks @a-tokyo.
-- fix(models): keep bundled provider catalog when configured base URL is blank (issue 91270) (#91292). Thanks @yetval.
-- :bug: fix(openai): remove chatgpt-responses transport override from gpt-5.3-codex catalog entry (#91720). Thanks @a-tokyo.
-- fix(control-ui): make Control UI bootstrap config endpoint base-path-relative (issue 66946) (#91305). Thanks @Alix-007.
-- fix(exec): honor state dir approvals (#92056). Thanks @vincentkoc.
-- fix(memory): self-heal missing index identity by initializing provider during sync (#91897). Thanks @xydt-tanshanshan.
-- fix(diagnostics): release wedged session lane when stuck-session recovery aborts a run with queued session work (#91802). Thanks @openperf.
-- fix(cron): structural top-of-hour match in stagger heuristic (#92030). Thanks @hansraj316.
-- fix(media): resolve state-relative inbound attachments (#92055). Thanks @sercada.
-- fix(agent): dampen Discord stale thread replies (#91962).
-- fix(agents): honor configured CLI resume timeouts (#90912). Thanks @ai-hpc.
-- fix(web_fetch): sanitize URL whitespace from LLM tool call arguments (fixes issue 91651) (#91950). Thanks @zenglingbiao.
-- fix(discord): scope command-deploy cache by application id (#77367). Thanks @lonexreb.
-- fix(sessions): preserve user /model override across daily/idle session rollover (issue 90119) (#90128). Thanks @Marvinthebored.
-- fix(clickclack): allow explicit enable through plugin allowlist (#92084).
-- feat(auto-reply): durable inter-tool commentary via verbose standalone progress (supersedes issue 89850/issue 89890) (#91976). Thanks @anagnorisis2peripeteia.
-- issue 92109: [Bug]: EmbeddedAttemptSessionTakeoverError caused by Btrfs ctimeNs instability (#92123). Thanks @lzyyzznl.
-- fix(feishu): reply inside P2P direct-message threads (#92136). Thanks @LiaoyuanNing and @vincentkoc.
-- fix(agents): stabilize a2a prompt cache context (#90173). Thanks @Sunjae-k.
-- fix(cli-runner): scope claude-cli queue to live-session owner identity (issue 91946) (#91974). Thanks @wangwllu.
-- fix(thinking): apply Claude profile to anthropic-messages catalog rows (#92053). Thanks @wangwllu.
-- Google: show detailed Gemini CLI OAuth extraction failures (#41991). Thanks @bgmbgm94.
-- fix(qqbot): flush tool output before silent non-streaming final (#92074). Thanks @sliverp.
-- fix(models): clarify provider model registration hint (#89508). Thanks @sweetcornna.
-- fix(agents): keep migrated session entry ids unique on v1 upgrade (#89085). Thanks @yetval.
-- fix(discord): clean migrated thread binding state (#89552). Thanks @SYU8384.
-- fix(cron): reject durations that overflow to a non-finite value (#89448). Thanks @Alix-007.
-- fix(doctor): warn on unsupported hook entry loaders (#89319). Thanks @leno23.
-- fix(config): stop config.patch replacePaths index suffix from widening array consent (#91966). Thanks @yetval.
-- fix(plugins): rescan storm in "/models" call (regression shipped since v2026.5.18) (#92127). Thanks @obuchowski.
-- fix(ollama): use provider thinking default in SDK session factory (#91657). Thanks @openperf.
-- fix(memory): abort orphaned embedding work when memory_search times out (#91742). Thanks @dreamhunter2333.
-- fix(memory-core): retry narrative message reads (#89091). Thanks @bennewell35.
-- fix(cli): validate gateway-rpc --timeout (#54646). Thanks @ruanrrn and @comeran.
-- fix(CLI): validate gateway-facing timeout input (#40953). Thanks @comeran and @ruanrrn.
-- Keep gateway CLI timeout client-side after accepted runs (#60661). Thanks @judicialcoder and @ruanrrn and @comeran.
-- fix(agents): retry same model across short rate-limit windows (#91911). Thanks @lanzhi-lee.
-- fix: require ACP metadata for deleted-agent bypass (#91763). Thanks @shakkernerd.
-- fix(telegram): route account-scoped topic agents (#91189). Thanks @codysai001.
-- Preserve Telegram streamed text blocks between tool calls (#88682). Thanks @alexzhu0.
-- fix(telegram): restore /compact on generic message ingress (#89588). Thanks @joelnishanth.
-- fix(agents): deliver native /compact replies through source suppression (#90212). Thanks @snowzlm.
-- Fix Telegram callback API handling (#91876). Thanks @obviyus.
-- Share channel draft chunking resolver (#91874). Thanks @obviyus.
-- fix(telegram): use SDK dispatch dedupe (#91904). Thanks @obviyus.
-- fix(telegram): audit follow-ups — block-mode chunk config, dedupe bucket cleanup, grammy contract trust (#91915). Thanks @obviyus.
-- fix(gateway): support Streamable HTTP MCP transport on loopback server (#89851). Thanks @anagnorisis2peripeteia.
-- perf(control-ui): avoid startup catalog wait (#91538). Thanks @vincentkoc.
-- perf(control-ui): trace first assistant event (#91568). Thanks @vincentkoc.
-- perf(control-ui): lazy load slash commands (#91598). Thanks @vincentkoc.
-- feat: add OpenRouter OAuth to onboarding (#91830). Thanks @Patrick-Erichsen.
-- fix(codex): normalize dynamic tool progress results (#88768). Thanks @bdjben.
-- fix(cli): bridge inter-tool commentary events to channel progress (#90883). Thanks @anagnorisis2peripeteia.
-- feat: dogfood reusable ClawHub package publish (#91574). Thanks @Patrick-Erichsen.
-- [plugin sdk] Allow declared installed trusted hooks (#90004). Thanks @brokemac79.
-- fix(doctor): report managed plugin version drift (#90927). Thanks @brokemac79.
-- fix(memory): move local llama.cpp runtime to provider plugin (#91324). Thanks @osolmaz.
-- fix(models): persist agent catalog cache (#90457). Thanks @ai-hpc.
-- fix(memory-core): filter stale recall entries in REM harness preview (#91851). Thanks @vincentkoc.
-- fix(tui): show connection host in footer (#89909). Thanks @baskduf.
-- perf(config): dedupe plugin auto-enable fanout work (#89978). Thanks @ai-hpc.
-- fix(agents): trim dense text delta snapshots (#91580). Thanks @vincentkoc.
-- fix(agents): drop stale exec approval followups after session rebind (#85679). Thanks @openperf.
-- fix(reply-queue): remove the drained item by reference instead of front index (#91450). Thanks @yetval.
-- fix(delivery): suppress Codex/Harmony internal protocol artifacts from user-facing channels (#89151). Thanks @joelnishanth.
-- fix(mattermost): keep default replies in existing threads (#91684). Thanks @jacobtomlinson.
-- fix(discord): hydrate reply context metadata (#90263). Thanks @fuller-stack-dev.
-- fix(cron): cancel active cron task runs (#90666). Thanks @ai-hpc.
-- fix(cron): recover no-deliver tool warnings (#90678). Thanks @ai-hpc.
-- fix(gateway): share approval runtime socket token (#87105). Thanks @fuller-stack-dev.
-- fix(gateway): skip deleted-agent guard for ACP harness session keys (#91219). Thanks @scotthuang.
-- fix(gateway): surface headless LaunchAgent state (#91614). Thanks @fuller-stack-dev.
-- fix(auth): verify SQLite auth migration before cleanup (#91740). Thanks @fuller-stack-dev.
-- fix(gateway): arm qmd startup maintenance (#91978). Thanks @vincentkoc.
-- fix(status): restore Codex synthetic usage line (#91709). Thanks @brokemac79.
-- fix(update): recover package gateway restart after refresh failure (#91581). Thanks @fuller-stack-dev.
-- fix(update): expose plugin convergence repair (#91599). Thanks @fuller-stack-dev.
-- fix(android): avoid dataSync FGS for persistent node (#80082). Thanks @davelutztx.
-
-#### Linked issues
-
-- Reported: iMessage bridge recovery can dispatch stale inbound backlog as fresh requests (#89237). Thanks @dwonshin and @omarshahine.
-- Reported: Telegram streaming: intermediate text blocks between tool calls are silently lost (overwritten by final block) (#87326). Thanks @AbdelftahZowail.
-- Reported: Bug: Text before tool calls is lost in Feishu streaming card reply mode (#84486). Thanks @kentuscn.
-- Reported: Bug: memory_search hybrid mode not returning FTS matches (#48300). Thanks @sabo961.
-- Reported: Memory index meta never written when gateway auto-sync finds identity missing with existing chunks (#90338). Thanks @junxuku-byte.
-- Reported: openai-completions adapter silently passes empty content[] with stopReason=stop (#91394). Thanks @EXIIEX.
-- Reported: memory(qmd): collections never rebind when a collection's root path changes (#91251). Thanks @sasan1200.
-- Reported: [Bug]: refactor(cron): reduce excessive `as unknown as` type assertions in store loading (#91314). Thanks @SpecialLeon.
-- Reported: [Bug] Exec approval follow-up can leak into a new session after /new because it rebinds by sessionKey instead of original sessionId (#59349). Thanks @two3pro.
-- Reported: [Bug]: Internal messages surface in Telegram chat (#88128). Thanks @reslp.
-- Reported: [Bug]: /status Context does not distinguish prompt usage from compactable transcript content (#91150). Thanks @samiralibabic and @Pluviobyte.
-- Reported: Mission Control: docs links navigate to 127.0.0.1:4317 instead of docs.openclaw.ai (#89465). Thanks @phoebepageoc-cloud.
-- Reported: [Bug]: dir_list is exposed without usable node context and is mistaken for local directory listing. (#91482). Thanks @wilfried-codex.
-- Reported: [Bug]: Doctor does not report official managed plugin version drift after core upgrade (#90891). Thanks @brokemac79.
-- Reported: [Bug]: Telegram channel drops / compact slash command - never appears in commands.log (#89525). Thanks @bomberluke37-prog.
-- Reported: Dashboard "Open config" fails on Windows: Start-Process -LiteralPath is invalid in all PowerShell versions (#90157). Thanks @jackmtl71.
-- Reported: Feishu plugin lacks retry logic for API rate limit errors (#70879). Thanks @AxelHu.
-- Reported: WebRTC Talk: TypeError 'this.peer is null' when calling addTrack on null RTCPeerConnection (#89434). Thanks @losts1.
-- Reported: [Bug]: Local model provider calls thread block gateway event loop on Windows beta; trivial infer run takes ~4 minutes (#86599). Thanks @JakeBiggs.
-- Reported: [Feature]: batched memory embedding should batch over files (#88009). Thanks @hartmark and @mushuiyu886 and @jalehman.
-- Reported: [Bug]: Codex/OpenAI usage line disappears from status after 2026.6.5-beta.6 (#91694). Thanks @brokemac79.
-- Reported: [Bug]: Workshop files missing from OpenClaw 2026.6.1 npm package (#90244). Thanks @rogerallen1.
-- Reported: diagnostics.otel.captureContent.\* is non-functional — runtime broadcast emits sanitized paramsSummary only (#77391). Thanks @mjunaidca.
-- Reported: dmPolicy allowFrom not enforced for Telegram text messages — unauthorized users reach agents (#91209). Thanks @producedbysavant.
-- Reported: MCP remote OAuth: two bugs block streamable-http servers (regex `\:` under /u; OAuth errors surfaced as [object Response]) (#91433). Thanks @marcusbsorensen.
-- Reported: [Bug]: In-turn reasoning dropped on multi-turn tool replay for non-400 openai models (gemma4/vLLM) — silent agentic-quality regression (#91645). Thanks @bfox55.
-- Reported: cron wake action does not support agentId — always routes to default agent (#46886). Thanks @aidyfeng.
-- Reported: [Bug]: hooks.mappings[].agentId and sessionKey silently ignored for action="wake" (#64556). Thanks @jaserNo1.
-- Reported: [Bug]: `chmodSync` in `openOpenClawStateDatabase` crashes gateway on filesystems without POSIX permission support (#91919). Thanks @david-garcia-garcia.
-- Reported: [Bug]: sessions_send unexpectedly injects label, causing mutual-exclusion error with sessionKey (#64699). Thanks @sunxq1017-hash.
-- Reported: [Bug]: memory status reports "ingestion state absent" after dreaming JSON→SQLite migration (#92017). Thanks @JUMPUNDER.
-- Reported: [Bug]: v2026.6.1 regression: openai/gpt-5.3-codex silently falls back to Sonnet — Codex harness rejects "openai" provider due to stale npm plugin (#91710). Thanks @a-tokyo.
-- Reported: [Bug]: Gemini can't resolve on embedded runtime (#91270). Thanks @resYuto.
-- Reported: [Bug]: **Control UI路径重复导致404错误，聊天功能无法使用** (#66946). Thanks @yndwx01.
-- Reported: bug(memory): gateway cannot self-heal a missing index identity when chunks are already indexed (#91167). Thanks @kiagentkronos-cell.
-- Reported: bug(tools): web_fetch fails with 'Invalid URL' when LLM generates a space in the protocol scheme (#91651). Thanks @akang1798.
-- Reported: [Bug]: Slash commands not registered for non-default Discord accounts in multi-bot setup (#77359). Thanks @igmarketing.
-- Reported: [Bug]: User /model override silently dropped on daily/idle session rollover (survives /new but not the 4AM reset) (#90119). Thanks @Marvinthebored.
-- Reported: [Bug]: EmbeddedAttemptSessionTakeoverError caused by Btrfs ctimeNs instability (#92109). Thanks @recruits.
-- Reported: [Bug]: gateway opens an empty memory database when main.sqlite is absent during the index swap, leaving memory_search paused with "index metadata is missing" until restart (#91216). Thanks @chrisreddington.
-- Reported: [Bug] Claude CLI backend serializes all fresh sessions sharing one workspace via resolveCliRunQueueKey (#91946). Thanks @wangwllu.
-- Reported: Native Anthropic adapter silently drops `thinking` to `off` for custom provider ids (resolveThinkingProfile only matches exact `anthropic`/`claude-cli`) (#91975). Thanks @wangwllu.
-- Reported: Security: Unauthorized OAuth credential extraction from Gemini CLI installation (#54289). Thanks @jinduwang1001-max.
-- Reported: parseDurationMs rejects zero and negative values but allows arbitrarily large floats (#83906). Thanks @davinci282828.
-- Reported: memory_search tool-level timeout orphans background embedding work (#91718). Thanks @NOVA-Openclaw.
-
+- **PR #91335** fix(imessage): always-on inbound recovery and dedupe. Related #89237. Thanks @omarshahine and @vincentkoc and @dwonshin.
+- **PR #91189** fix(telegram): route account-scoped topic agents. Thanks @codysai001.
+- **PR #88682** Preserve Telegram streamed text blocks between tool calls. Related #87326. Thanks @alexzhu0 and @AbdelftahZowail.
+- **PR #91390** fix: clarify provider quota errors. Thanks @hxy91819.
+- **PR #90883** fix(cli): bridge inter-tool commentary events to channel progress. Thanks @anagnorisis2peripeteia.
+- **PR #91419** docs: preserve channel brand terms in Chinese i18n. Thanks @hxy91819.
+- **PR #87105** fix(gateway): share approval runtime socket token. Thanks @fuller-stack-dev.
+- **PR #80082** fix(android): avoid dataSync FGS for persistent node. Thanks @davelutztx.
+- **PR #91442** docs: preserve LINE across localized docs glossaries. Thanks @hxy91819.
+- **PR #88768** fix(codex): normalize dynamic tool progress results. Thanks @bdjben.
+- **PR #91422** fix(browser): neutralize media directives in browser output [AI]. Thanks @pgondhi987.
+- **PR #89834** feat(cli): emit commentary progress events from Claude CLI parser. Related #87326. Thanks @anagnorisis2peripeteia and @AbdelftahZowail.
+- **PR #85679** fix(agents): drop stale exec approval followups after session rebind. Related #59349. Thanks @openperf and @two3pro.
+- **PR #91450** fix(reply-queue): remove the drained item by reference instead of front index. Thanks @yetval.
+- **PR #89151** fix(delivery): suppress Codex/Harmony internal protocol artifacts from user-facing channels. Related #88128. Thanks @joelnishanth and @reslp.
+- **PR #90678** fix(cron): recover no-deliver tool warnings. Thanks @ai-hpc.
+- **PR #91449** fix(imessage): honor block streaming config. Thanks @jmissig and @omarshahine.
+- **PR #91508** Revert "docs: add maturity scorecard mirror". Thanks @kevinslin.
+- **PR #91364** build(deps): bump github.com/steipete/peekaboo from 3.3.0 to 3.4.0 in /apps/macos in the swift-deps group.
+- **PR #91368** build(deps): bump actions/github-script from 8 to 9.
+- **PR #91512** chore: add taxonomy file. Thanks @kevinslin.
+- **PR #91369** build(deps): bump actions/cache from 4 to 5.
+- **PR #91367** build(deps): bump the actions group with 2 updates.
+- **PR #91365** build(deps): bump the android-deps group in /apps/android with 3 updates.
+- **PR #91496** chore: bump Codex app-server to 0.137.0. Thanks @RomneyDa.
+- **PR #90666** fix(cron): cancel active cron task runs. Thanks @ai-hpc.
+- **PR #90927** fix(doctor): report managed plugin version drift. Related #90891. Thanks @brokemac79.
+- **PR #91531** perf(control-ui): reuse startup model metadata. Thanks @vincentkoc.
+- **PR #91538** perf(control-ui): avoid startup catalog wait. Thanks @vincentkoc.
+- **PR #91507** feat: canonicalize Codex protocol JSON asset ordering. Thanks @RomneyDa.
+- **PR #91550** fix: bound native hook relay lifetime. Related #90993. Thanks @joshavant and @clem-git.
+- **PR #89588** fix(telegram): restore /compact on generic message ingress. Related #89525. Thanks @joelnishanth and @cursoragent and @bomberluke37-prog.
+- **PR #91529** Fix transcript image redaction. Related #90760. Thanks @joshavant and @devinkuhn.
+- **PR #91551** Fix config.patch explicit array replacement. Thanks @joshavant.
+- **PR #91568** perf(control-ui): trace first assistant event. Thanks @vincentkoc.
+- **PR #85823** fix(whatsapp): route captured replies through successor controller after restart. Thanks @itsuzef and @mcaxtr.
+- **PR #91574** feat: dogfood reusable ClawHub package publish. Thanks @Patrick-Erichsen.
+- **PR #91583** perf(control-ui): warn on slow first replies. Thanks @vincentkoc.
+- **PR #89659** fix(feishu): retry on send rate-limit errors (230020/230006). Related #70879. Thanks @ladygege and @marshallm-create and @sliverp and @AxelHu.
+- **PR #91547** Fix Docker store seed target packages. Related #91035. Thanks @sallyom and @laurenceputra.
+- **PR #91578** fix: make docs i18n frontmatter translation resilient. Thanks @hxy91819.
+- **PR #91567** fix(openai): require api-key auth for realtime voice. Related #90456. Thanks @joshavant and @sergiopesch.
+- **PR #91591** fix: let ClawHub dry runs skip publish approval. Thanks @Patrick-Erichsen.
+- **PR #91598** perf(control-ui): lazy load slash commands. Thanks @vincentkoc.
+- **PR #91580** fix(agents): trim dense text delta snapshots. Related #86599. Thanks @vincentkoc and @JakeBiggs.
+- **PR #91425** fix(memory-lancedb): guard memory recall output [AI]. Thanks @pgondhi987.
+- **PR #88969** fix(imessage): persist echo markers before send. Thanks @colmbrogan.
+- **PR #91566** Fix stale main session startup recovery. Related #90525. Thanks @joshavant and @Tony-ooo.
+- **PR #91324** fix(memory): move local llama.cpp runtime to provider plugin. Related #88705. Thanks @osolmaz and @Peilsender.
+- **PR #91637** docs: include plugin prerelease in release validation approval.
+- **PR #91649** fix(line): canonicalize trailing-slash webhook paths.
+- **PR #91423** feat(qqbot): add /bot-group-allways command to toggle mention requirement. Thanks @cxyhhhhh and @sliverp.
+- **PR #91642** fix(docs): continue partial i18n batches after file errors. Thanks @hxy91819.
+- **PR #91661** chore(plugin-sdk): refresh API baseline hash.
+- **PR #91665** docs: fix release CI Android dispatch guidance.
+- **PR #89138** fix #88009: [Feature]: batched memory embedding should batch over files. Thanks @mushuiyu886 and @jalehman and @hartmark.
+- **PR #91679** fix(plugin-sdk): align Discord component edit facade types. Thanks @vincentkoc.
+- **PR #91686** fix(discord): restore runtime timeout compatibility exports. Thanks @vincentkoc.
+- **PR #90212** fix(agents): deliver native /compact replies through source suppression. Thanks @snowzlm.
+- **PR #91618** fix: expand unsafe host env denylist. Thanks @pgondhi987.
+- **PR #91615** fix: block rustup toolchain env overrides [AI]. Thanks @pgondhi987.
+- **PR #89851** fix(gateway): support Streamable HTTP MCP transport on loopback server. Thanks @anagnorisis2peripeteia.
+- **PR #91619** fix: block git protocol env controls [AI]. Thanks @pgondhi987.
+- **PR #91684** fix(mattermost): keep default replies in existing threads. Thanks @jacobtomlinson.
+- **PR #90457** fix(models): persist agent catalog cache. Thanks @ai-hpc.
+- **PR #91709** fix(status): restore Codex synthetic usage line. Related #91694. Thanks @brokemac79.
+- **PR #89909** fix(tui): show connection host in footer. Related #56276. Thanks @baskduf and @deuxksy.
+- **PR #89978** perf(config): dedupe plugin auto-enable fanout work. Thanks @ai-hpc.
+- **PR #91219** fix(gateway): skip deleted-agent guard for ACP harness session keys. Thanks @scotthuang.
+- **PR #90782** perf(tui): prewarm runtime plugins before first send. Thanks @RomneyDa.
+- **PR #90838** fix(config): warn for retired skill-workshop plugin entry instead of failing validation (#90244). Thanks @lonexreb and @rogerallen1.
+- **PR #91753** docs: clarify Matrix plugin upgrade repair. Thanks @RomneyDa.
+- **PR #91755** docs: align Feishu DM policy defaults. Thanks @RomneyDa.
+- **PR #91745** fix(discord): require sender for moderation actions [AI]. Thanks @eleqtrizit.
+- **PR #85950** docs: clarify trusted-proxy Control UI scope behavior. Related #80063. Thanks @nielskaspers and @longstoryscott.
+- **PR #91746** fix(msteams): require admin for group actions. Thanks @eleqtrizit.
+- **PR #91256** feat(diagnostics-otel): capture tool input/output content via trusted channel. Thanks @amknight.
+- **PR #91749** fix(gateway): restrict non-owner loopback tools. Thanks @eleqtrizit.
+- **PR #91748** fix(elevated): reject group ids as senders. Thanks @eleqtrizit.
+- **PR #91752** fix(codex): guard sandbox http requests. Thanks @eleqtrizit.
+- **PR #91763** fix: require ACP metadata for deleted-agent bypass. Thanks @shakkernerd.
+- **PR #91751** fix(mcp): harden stdio env filtering. Thanks @eleqtrizit.
+- **PR #91765** Clarify env-var executable behavior reports in SECURITY.md. Thanks @jacobtomlinson.
+- **PR #91480** fix(ui): require user intent for chat sessions. Related #89760. Thanks @TurboTheTurtle and @Takhoffman and @zdwalter.
+- **PR #91777** docs: remove superpowers spec draft. Thanks @Patrick-Erichsen.
+- **PR #91773** fix(mcp): lowercase SSE event-source header keys to prevent duplicate Authorization (401). Thanks @Takhoffman.
+- **PR #91741** Validate sandbox bind parent paths [AI]. Thanks @mmaps.
+- **PR #88530** fix(imessage): skip idle approval discovery scans. Thanks @colmbrogan and @omarshahine.
+- **PR #91780** fix(ui): drain restored chat queue after session switch. Thanks @tmimmanuel.
+- **PR #91750** fix(search): enforce native web search tool policy. Thanks @eleqtrizit.
+- **PR #91757** fix(config): clarify retired skill workshop plugin warning. Thanks @RomneyDa.
+- **PR #91787** fix(doctor): keep TTS legacy migration on supported paths.
+- **PR #91783** fix(imessage): harden outbound send transport. Related #84329. Thanks @omarshahine and @TurboTheTurtle.
+- **PR #91785** fix(imessage): surface inbound startup diagnostics. Thanks @omarshahine.
+- **PR #91590** Fix context-engine compaction ownership for Codex sessions. Thanks @joshavant.
+- **PR #91557** Improve iPad and iPhone control surfaces. Thanks @Solvely-Colin and @joshavant.
+- **PR #91666** chore(deps): bump useblacksmith/setup-docker-builder from 1.8.0 to 1.9.0 in the actions group.
+- **PR #91819** docs: link ClawHub plugin validation fixes guide. Thanks @Patrick-Erichsen.
+- **PR #88630** fix(codex): avoid guardian review for local models. Thanks @vincentkoc.
+- **PR #91830** feat: add OpenRouter OAuth to onboarding. Thanks @Patrick-Erichsen.
+- **PR #91842** fix(plugin-sdk): refresh API baseline hash.
+- **PR #91614** fix(gateway): surface headless LaunchAgent state. Thanks @fuller-stack-dev.
+- **PR #91851** fix(memory-core): filter stale recall entries in REM harness preview. Thanks @vincentkoc.
+- **PR #91859** fix(ci): disable memory slot in release smoke config. Thanks @vincentkoc.
+- **PR #90004** [plugin sdk] Allow declared installed trusted hooks. Related #87735. Thanks @brokemac79 and @ryanhelms.
+- **PR #91837** fix(memory-core): keep QMD JSON search one-shot. Related #91821. Thanks @TurboTheTurtle and @xpysgdhr.
+- **PR #91871** Remove bundled channel contract fallbacks. Thanks @obviyus.
+- **PR #91879** fix(ci): include ACPX in shared live-test image.
+- **PR #91840** Fix stale visible reply recovery. Related #90535. Thanks @joshavant and @Jerry-Xin.
+- **PR #91876** Fix Telegram callback API handling. Thanks @obviyus.
+- **PR #91874** Share channel draft chunking resolver. Thanks @obviyus.
+- **PR #91599** fix(update): expose plugin convergence repair. Thanks @fuller-stack-dev.
+- **PR #91581** fix(update): recover package gateway restart after refresh failure. Thanks @fuller-stack-dev.
+- **PR #91904** fix(telegram): use SDK dispatch dedupe. Thanks @obviyus.
+- **PR #90263** fix(discord): hydrate reply context metadata. Thanks @fuller-stack-dev.
+- **PR #91478** block unauthorized Telegram DM text from prompt context. Related #91209. Thanks @sallyom and @producedbysavant.
+- **PR #91915** fix(telegram): audit follow-ups — block-mode chunk config, dedupe bucket cleanup, grammy contract trust. Thanks @obviyus.
+- **PR #91361** fix(compaction): lower default timeout from 900s to 180s, preserve explicit config. Related #91358. Thanks @wangmiao0668000666 and @velvet-shark and @olveww-dot.
+- **PR #91791** fix(sandbox): use materialized skill paths in startup prompts. Related #91761. Thanks @brokemac79 and @vincentkoc and @gbb-netizen.
+- **PR #91736** Support existing-session browser CDP endpoints. Related #56118. Thanks @lifuyue and @mgrandau.
+- **PR #91747** fix(browser): validate discovered CDP websocket URLs. Thanks @eleqtrizit.
+- **PR #91882** feat(anthropic): support Claude Fable 5 adaptive thinking. Related #91805. Thanks @NOVA-Openclaw.
+- **PR #91884** fix(memory): keep ignored-name QMD roots watchable. Thanks @vincentkoc.
+- **PR #91740** fix(auth): verify SQLite auth migration before cleanup. Thanks @fuller-stack-dev and @velvet-shark.
+- **PR #91451** fix(mcp): repair OAuth redirect, errors, and unicode schema patterns. Related #91433. Thanks @LiuwqGit and @cursoragent and @vincentkoc and @marcusbsorensen.
+- **PR #91978** fix(gateway): arm qmd startup maintenance. Thanks @vincentkoc.
+- **PR #90426** fix(talk): show OpenAI Realtime WebRTC assistant transcripts. Thanks @shushushv and @vincentkoc.
+- **PR #91696** fix(agents): preserve reasoning_content replay for Gemma 4 openai-completions models. Related #91645. Thanks @Coder-Wangyankun and @bfox55.
+- **PR #89938** Fail closed on exec approval timeout. Thanks @drobison00.
+- **PR #91895** fix(webchat): finalize provider failure lifecycle. Related #91730. Thanks @TurboTheTurtle and @sallyom and @nikhilmaddirala.
+- **PR #80143** fix(browser): honor cdpUrl for user default profile. Related #48042. Thanks @HemantSudarshan and @Max-Resilient.
+- **PR #91688** fix(cron): reject cron expressions that have no reachable run time. Thanks @yetval and @vincentkoc.
+- **PR #91737** fix(cron): use final-call usage for session token totals. Related #91716. Thanks @MonkeyLeeT and @vincentkoc and @yetval.
+- **PR #89605** fix(process): return timeout code for killed commands. Thanks @ai-hpc.
+- **PR #80013** perf(usage-cost-cache): throttle full-cache rewrites during refresh. Thanks @zeroaltitude.
+- **PR #76731** Fix mobile Control UI chat layout. Thanks @Solvely-Colin.
+- **PR #83738** fix(cron): capture originating session/agent on the cron wake tool call. Thanks @anagnorisis2peripeteia.
+- **PR #85196** Redact tool output secrets. Thanks @amknight.
+- **PR #92007** fix(security): block build tool env overrides. Thanks @eleqtrizit.
+- **PR #91891** fix: preserve non-oneOf protocol schema array order. Thanks @RomneyDa.
+- **PR #91754** fix(macos): hide unsupported Voice Wake controls. Related #89575. Thanks @RomneyDa and @cwhyhy.
+- **PR #92049** test(ci): restore upgrade survivor session fixture. Thanks @vincentkoc.
+- **PR #89670** fix: keep skill toggles keyed by skill identity. Related #89661. Thanks @s-moffett.
+- **PR #91934** fix(state): tolerate chmod failures when opening the state database. Related #91919. Thanks @truffle-dev and @david-garcia-garcia.
+- **PR #92051** fix(fal): parse raw completed queue results. Related #91989. Thanks @harjothkhara and @oswaldyeo.
+- **PR #92047** fix(agents): prefer explicit sessions_send keys. Related #64699. Thanks @vincentkoc and @sunxq1017-hash.
+- **PR #92020** fix(memory-core): check SQLite plugin state for dreaming ingestion audit after JSON migration (fixes #92017). Thanks @zenglingbiao and @JUMPUNDER.
+- **PR #92032** fix(mcp): always log channel-bridge notification failures. Thanks @hansraj316.
+- **PR #92033** fix(gateway): log swallowed background-task finalization errors. Thanks @hansraj316.
+- **PR #92022** fix(sessions): derive channel from direct-chat session keys in send-policy. Thanks @hansraj316.
+- **PR #91163** fix(xai): clarify x_search query guidance. Thanks @rubencu.
+- **PR #90121** fix(memory): write dream fallback without subagent runtime. Thanks @a-m-a-r-a.
+- **PR #91215** fix(ui): show prompt progress while sending. Related #91199. Thanks @zhangguiping-xydt and @vincentkoc and @Monniasza.
+- **PR #92029** fix(tools): surface unsupported-signal in anyOf availability. Thanks @hansraj316.
+- **PR #92034** perf(agents): memoize XML attribute regex in DSML stream parser. Thanks @hansraj316.
+- **PR #92026** perf(agents): sanitize compaction messages once for token estimation. Thanks @hansraj316.
+- **PR #91351** fix(opencode-go): add qwen plus tiered pricing. Related #91238. Thanks @849261680 and @vincentkoc and @samson910022.
+- **PR #92027** fix(gateway): recover config hot-reload after watcher errors. Thanks @hansraj316.
+- **PR #91471** feat(cron): add readable ISO time fields to `cron runs` JSON output. Thanks @FMLS and @cursoragent.
+- **PR #91711** :bug: fix(agents): classify harness provider mismatch as format error (#91710). Thanks @a-tokyo.
+- **PR #91292** fix(models): keep bundled provider catalog when configured base URL is blank (#91270). Thanks @yetval and @vincentkoc and @resYuto.
+- **PR #91720** :bug: fix(openai): remove chatgpt-responses transport override from gpt-5.3-codex catalog entry. Related #91710. Thanks @a-tokyo.
+- **PR #91305** fix(control-ui): make Control UI bootstrap config endpoint base-path-relative (#66946). Thanks @Alix-007 and @vincentkoc and @yndwx01.
+- **PR #92056** fix(exec): honor state dir approvals. Thanks @vincentkoc.
+- **PR #91897** fix(memory): self-heal missing index identity by initializing provider during sync. Thanks @xydt-tanshanshan and @vincentkoc.
+- **PR #91802** fix(diagnostics): release wedged session lane when stuck-session recovery aborts a run with queued session work. Related #91700. Thanks @openperf and @infocus13.
+- **PR #92030** fix(cron): structural top-of-hour match in stagger heuristic. Thanks @hansraj316 and @vincentkoc.
+- **PR #92055** fix(media): resolve state-relative inbound attachments. Thanks @sercada and @vincentkoc.
+- **PR #91962** fix(agent): dampen Discord stale thread replies. Thanks @RomneyDa.
+- **PR #90912** fix(agents): honor configured CLI resume timeouts. Thanks @ai-hpc and @vincentkoc.
+- **PR #91296** fix: hand off supervised git updates. Thanks @abnershang.
+- **PR #91950** fix(web_fetch): sanitize URL whitespace from LLM tool call arguments (fixes #91651). Thanks @zenglingbiao and @vincentkoc and @akang1798.
+- **PR #77367** fix(discord): scope command-deploy cache by application id. Related #77359. Thanks @lonexreb and @sallyom and @igmarketing.
+- **PR #91976** feat(auto-reply): durable inter-tool commentary via verbose standalone progress (supersedes #89850/#89890). Thanks @anagnorisis2peripeteia.
+- **PR #90128** fix(sessions): preserve user /model override across daily/idle session rollover (#90119). Thanks @Marvinthebored.
+- **PR #92084** fix(clickclack): allow explicit enable through plugin allowlist.
+- **PR #92092** fix(auto-reply): stop dropping claude-cli narration when commentary lane is off. Thanks @ragesaq.
+- **PR #92123** #92109: [Bug]: EmbeddedAttemptSessionTakeoverError caused by Btrfs ctimeNs instability. Thanks @lzyyzznl and @vincentkoc and @recruits.
+- **PR #92136** fix(feishu): reply inside P2P direct-message threads. Thanks @LiaoyuanNing and @vincentkoc.
+- **PR #92121** fix(memory): preserve live SQLite index during swaps. Related #91216. Thanks @xydt-tanshanshan and @chrisreddington.
+- **PR #90173** fix(agents): stabilize a2a prompt cache context. Thanks @Sunjae-k and @sunjae-1.
+- **PR #91974** fix(cli-runner): scope claude-cli queue to live-session owner identity (#91946). Thanks @wangwllu.
+- **PR #92053** fix(thinking): apply Claude profile to anthropic-messages catalog rows. Related #91975. Thanks @wangwllu.
+- **PR #41991** Google: show detailed Gemini CLI OAuth extraction failures. Thanks @bgmbgm94.
+- **PR #92074** fix(qqbot): flush tool output before silent non-streaming final. Thanks @sliverp.
+- **PR #89508** fix(models): clarify provider model registration hint. Related #89192. Thanks @sweetcornna and @aaajiao.
+- **PR #89085** fix(agents): keep migrated session entry ids unique on v1 upgrade. Thanks @yetval.
+- **PR #89552** fix(discord): clean migrated thread binding state. Thanks @SYU8384.
+- **PR #89448** fix(cron): reject durations that overflow to a non-finite value. Related #83906. Thanks @Alix-007 and @davinci282828.
+- **PR #89319** fix(doctor): warn on unsupported hook entry loaders. Related #89309. Thanks @leno23 and @vincentkoc and @CameronWeller.
+- **PR #91966** fix(config): stop config.patch replacePaths index suffix from widening array consent. Thanks @yetval and @vincentkoc.
+- **PR #92127** fix(plugins): rescan storm in "/models" call (regression shipped since v2026.5.18). Thanks @obuchowski.
+- **PR #91657** fix(ollama): use provider thinking default in SDK session factory. Related #91428. Thanks @openperf and @vincentkoc and @anijatsu.
+- **PR #91742** fix(memory): abort orphaned embedding work when memory_search times out. Related #91718. Thanks @dreamhunter2333 and @vincentkoc and @NOVA-Openclaw.
+- **PR #89091** fix(memory-core): retry narrative message reads. Thanks @bennewell35.
+- **PR #92150** fix(release): gate beta publish on plugin verification. Thanks @vincentkoc.
+- **PR #92158** fix(cli): validate gateway RPC timeout inputs. Thanks @ruanrrn and @comeran.
+- **PR #91911** fix(agents): retry same model across short rate-limit windows. Thanks @lanzhi-lee.
 ## 2026.6.5
 
 ### Highlights
 
-- QQBot now strips model reasoning/thinking scaffolding before native delivery, preventing raw `<thinking>` content from leaking into channel replies. (#89913, #90132) Thanks @openperf.
-- MCP tool results now coerce `resource_link`, `resource`, `audio`, malformed image, and future non-text/image blocks at the materialize boundary, preventing Anthropic 400s and poisoned session history after a tool returns richer MCP content. (#90710, #90728) Thanks @RanSHammer and @849261680.
-- Anthropic extended-thinking sessions recover after prompt-cache expiry or Gateway restart because stream start events wait for `message_start`, letting pre-generation signature errors trigger the existing recovery retry. (#90667, #90697) Thanks @openperf.
-- Parallel is now a bundled `web_search` provider with `PARALLEL_API_KEY` discovery, guarded endpoint handling, cache-safe session ids, onboarding picker support, and docs. (#85158) Thanks @NormallyGaussian.
-- Google Vertex ADC users get static catalog rows and runtime model resolution again, while single-provider cooldown recovery and memory adapter status checks are more reliable. (#90506, #90609, #90717, #90816) Thanks @849261680.
-- Matrix can preflight voice notes before mention gating, preserve thread reads/replies through Matrix relations pagination, and carry QA coverage for voice and thread flows. (#78016, #90415)
-- Auth and plugin install state is more durable: auth profiles now live in SQLite, official npm plugin install records keep their trusted pins, and prerelease fallback integrity checks avoid carrying stale integrity forward. (#89102, #88585)
-- macOS node mode no longer silently self-reconnects away from a healthy direct Gateway session, reducing unexpected companion app session churn. (#90668, #90815) Thanks @vrurg.
-- Upgrade and service paths are safer: cron legacy JSON stores migrate during doctor preflight, service env placeholders no longer mask state-dir secrets, WhatsApp startup waits are bounded, and disabled WhatsApp accounts tear down on config reload. (#90072, #90208, #90277, #90488, #90486, #87951, #87965) Thanks @MonkeyLeeT, @sallyom, @mcaxtr, and @MukundaKatta.
+- **Safer channel output:** QQBot strips model reasoning and thinking scaffolding before native delivery, so users see the final answer rather than raw internal markup. (#89913, #90132) Thanks @openperf, @dygg2001, @Takhoffman, and @vincentkoc.
+- **MCP results no longer poison sessions:** `resource_link`, audio, malformed images, and future non-text blocks are normalized before provider conversion, avoiding Anthropic 400s and broken follow-up history. (#90710, #90728) Thanks @RanSHammer, @849261680, and @Takhoffman.
+- **Anthropic extended thinking recovers after restarts:** prompt-cache expiry and early-signature failures wait for a real message start, so they reach the existing retry path rather than ending a turn. (#90667, #90697) Thanks @openperf, @MIHHHMIH, @Takhoffman, @vincentkoc, @itsuzef, and @mcaxtr.
+- **Parallel web search is bundled:** API-key discovery, guarded endpoint handling, cache-safe session IDs, onboarding, and documentation make it a first-class search provider. (#85158) Thanks @NormallyGaussian.
+- **Better Matrix and Vertex reliability:** Matrix voice notes and threaded conversations retain their context, while Google Vertex ADC models regain static catalog and runtime resolution. (#78016, #90415, #90506, #90609) Thanks @849261680, @frankdierolf, and @paulogogs.
+- **Safer upgrades and restarts:** cron JSON stores migrate before runtime, service env placeholders stop masking secrets, and macOS avoids unnecessary direct-Gateway reconnect churn. (#90072, #90208, #90668, #90815) Thanks @MonkeyLeeT, @sallyom, @vrurg, @wlassalle724, @jalehman, @Takhoffman, @zhangguiping-xydt, @joshavant, and @vincentkoc.
 
 ### Changes
 
-- Search/providers: add the Parallel bundled web-search plugin, live provider tests, registration contracts, onboarding/docs wiring, and guarded `api.parallel.ai/v1/search` support. (#85158) Thanks @NormallyGaussian.
-- Matrix/channels: add voice-message preflight and thread-aware read/reply behavior, including Matrix QA scenario wiring and docs for voice-message behavior. (#78016, #90415)
-- Skills/ClawHub: install ClawHub skills backed by GitHub repositories through the resolved install API, download the pinned GitHub commit, keep install-policy checks, and report install telemetry after success. (#90478) Thanks @Patrick-Erichsen.
+- Search/providers: add the Parallel bundled web-search plugin, registration contracts, onboarding integration, and guarded `api.parallel.ai/v1/search` support. (#85158) Thanks @NormallyGaussian and @vincentkoc.
+- Matrix/channels: add voice-message preflight and thread-aware read/reply behavior. (#78016, #90415) Thanks @frankdierolf.
+- Skills/ClawHub: install ClawHub skills backed by GitHub repositories through the resolved install API, download the pinned GitHub commit, keep install-policy checks, and report install telemetry after success. (#90478) Thanks @Patrick-Erichsen, @vincentkoc, @itsuzef, and @mcaxtr.
 - Google Chat/channels: add native approval card actions and click handling so Google Chat approvals use platform-native cards instead of generic message flow.
-- Mobile: Android provider/model screens now surface expiring, unavailable, unresolved, and attention states more clearly, while iOS settings and Talk tabs keep diagnostics, gateway rows, attachment labels, and unavailable Talk controls reachable.
-- Memory: QMD search can use the new rerank toggle, and memory adapter status uses the resolved default model identity when checking plain status. (#61834)
-- Docs/tooling: add Parallel search docs, refresh weather-skill guidance toward `web_fetch`, clarify legacy `openai-codex` auth, document release/test helper scripts, and tighten changed-test routing docs for CI/debugging work. (#90028, #90250) Thanks @fuller-stack-dev.
-- Release/process: switch release trains to `YYYY.M.PATCH` monthly patch numbering, keep pre-transition tags compatible, and pin the June 2026 floor at `2026.6.5` after the published beta.
-- Platform maintenance: refresh Android, Swift/macOS, Docker, CodeQL, Buildx, Docker build/push, and Codex Action dependencies for this release train. (#74980, #81757, #86481, #86483, #90601)
-- QQBot: add `/bot-group-allways on|off` slash command (with named-account and default-account support) to toggle whether group messages require an `@mention` before the bot replies, and clear the runtime config snapshot after the write so the new account-level `defaultRequireMention` takes effect immediately without restart. (#91423) Thanks @cxyhhhhh.
+- Mobile: Android provider/model screens now surface expiring, unavailable, unresolved, and attention states more clearly, while iOS settings and Talk tabs keep diagnostics, gateway rows, attachment labels, and unavailable Talk controls reachable. Thanks @joshavant and @shakkernerd.
+- Memory: QMD search can use the new rerank toggle, and memory adapter status uses the resolved default model identity when checking plain status. (#61834) Thanks @kouka-t0yohei and @vincentkoc.
+- QQBot: add `/bot-group-allways on|off` slash command (with named-account and default-account support) to toggle whether group messages require an `@mention` before the bot replies, and clear the runtime config snapshot after the write so the new account-level `defaultRequireMention` takes effect immediately without restart. (#91423) Thanks @cxyhhhhh, @joshavant, @vincentkoc, @itsuzef, @mcaxtr, and @jacobtomlinson.
 
 ### Fixes
 
-- Agents: `sessions_send` now honors an explicit `sessionKey` when stale label metadata is also present, and denied session-id sends no longer echo the resolved canonical session key. Fixes #64699; refs #74009 and #41199. Thanks @Mintalix, @RevisitMoon, and @Mocha-s.
-- Channel content boundaries: QQBot now strips reasoning/thinking tags before sending, preserving final answers while hiding internal model narration from users. (#89913, #90132) Thanks @openperf.
-- Agents/MCP/providers: coerce non-text/image MCP tool-result blocks before they reach provider converters, preserving valid images and turning richer MCP content into text instead of malformed image blocks. (#90710, #90728) Thanks @RanSHammer and @849261680.
-- Anthropic/Codex/ACP/agent recovery: defer Anthropic stream start events until `message_start`, strip stale compaction thinking signatures before Anthropic replay, detect unsigned thinking-only stalls, refresh prompt fences after compaction writes, reject empty completion handoffs, preserve parent streaming-off overrides/shared progress commentary, forward heartbeat metadata to context-engine hooks, and cover Codex session/thread migration edge cases. (#90667, #90697, #90163, #90108, #89874, #89505, #90632, #89302, #90729, #90317, #90319) Thanks @openperf, @100yenadmin, and @ooiuuii.
-- Provider/model resolution: preserve Google Vertex ADC auth markers in generated catalogs, re-probe a single-provider primary after cooldown, share Codex model visibility, fail closed for unknown model auth, preserve Codex alias availability, keep unresolved profile refs unknown, and avoid resolving auth while listing models. (#90506, #90609, #90717, #90702) Thanks @849261680.
-- Gateway/macOS/mobile: avoid duplicate Gateway probe warnings by identity, rate-limit node pairing requests while preserving paired-node reconnects, keep macOS node mode on a healthy direct Gateway session, keep iOS diagnostics and gateway rows reachable, and avoid Linux ARM Gradle resource tasks during Android builds. (#85791, #90147, #90668, #90815) Thanks @giodl73-repo and @vrurg.
-- TUI/chat/Workboard/auto-reply: optimistic user messages stay stable across stale history reloads, runId reassignment, and abort windows instead of disappearing, jumping, or lingering as ghost rows; Workboard stale lifecycle bulk updates no longer overwrite newer status/provenance; message-tool sends now count as delivery. (#86205, #89600, #88592, #90123) Thanks @RomneyDa.
-- Cron/update/service env: doctor config preflight now migrates legacy cron JSON stores into SQLite before runtime reads, service env planning skips unresolved placeholders that would mask state-dir `.env` values, and session transcript rewrites keep registry markers/discriminants consistent. (#90072, #90208, #90277, #90488) Thanks @MonkeyLeeT and @sallyom.
-- Security/config/tooling: guard MCP HTTP redirects, protect global agent config defaults, and keep release/test/tooling proof failures bounded and explicit. (#89732, #90145)
-- Channels: WhatsApp restarts when per-account config changes, bounds background startup waits, closes failed sockets, and preserves reconnect behavior; Mattermost slash commands keep their state on `globalThis`; Feishu streaming cards preserve full merged content; voice-call tracks Twilio streams after connect; ClickClack reply tools respect `toolsAllow`. (#87951, #87965, #90486, #68113, #90534, #90181, #90607, #89500) Thanks @MukundaKatta, @mcaxtr, @infoanton, @mushuiyu886, and @sahibzada-allahyar.
-- Feishu: retry transient send rate-limit errors (HTTP 429, per-chat code 230020, tenant-level code 11232) with linear backoff, including SDK responses that fulfill with rate-limit bodies instead of throwing, and route streaming-card sends through the retry wrapper. (#89659) Thanks @ladygege.
-- Release/CI/E2E: main CI guard drift, PR merge diff scoping, live Docker credential staging, base-image qualification, installer Docker classification, Playwright dependency install recovery, API-key auth for Codex live Docker lanes, Parallels option terminators, and JSON-mode progress handling are tighter so release proof fails cleaner. (#90532, #90287, #90058) Thanks @RomneyDa, @hxy91819, and @mrunalp.
-- Release/CI/E2E: Docker E2E and live Docker harness runs now apply default memory, CPU, and process ceilings while preserving explicit per-lane overrides.
-- Release/CI/E2E: plugin lifecycle matrix resource sampling now fails phases that exceed RSS, wall-clock, or CPU ceilings instead of only logging the measurements.
-- Release/CI/E2E: Codex npm plugin live assertions now cap transcript discovery and diagnostic log reads so failure proof stays bounded.
-- Memory: keep doctor REM harness previews aligned with live REM by dropping short-term recall snippets whose source files disappeared before rendering preview output. Thanks @samzong and @frankekn.
-- Tests/state isolation: QA Lab valid-tool-call metrics now require runtime tool-call evidence when runtime parity data is available instead of counting tool-backed scenario pass status alone.
-- Tests/state isolation: QA Lab runtime parity now fails planned-only tool-call rows without matching tool results instead of treating matching mock plans as real tool evidence.
-- Tests/state isolation: provider, media, auth, cron, task, session, sandbox, Gateway, and Codex timeout fixtures now scope more home/state/env data per test, reducing cross-test leakage and making release validation failures less noisy. (#90027, #89974)
+- Agents: `sessions_send` now honors an explicit `sessionKey` when stale label metadata is also present, and denied session-id sends no longer echo the resolved canonical session key. Fixes #64699; refs #74009 and #41199 Thanks @Mintalix, @RevisitMoon, @Mocha-s, @chouxiaozi1989, @sunxq1017-hash, @vincentkoc, and @joshavant.
+- Channel content boundaries: QQBot now strips reasoning/thinking tags before sending, preserving final answers while hiding internal model narration from users. (#89913, #90132) Thanks @openperf, @Takhoffman, @dygg2001, and @vincentkoc.
+- Agents/MCP/providers: coerce non-text/image MCP tool-result blocks before they reach provider converters, preserving valid images and turning richer MCP content into text instead of malformed image blocks. (#90710, #90728) Thanks @RanSHammer, @849261680, @Takhoffman, @vincentkoc, and @LiuwqGit.
+- Anthropic/Codex/ACP/agent recovery: defer Anthropic stream start events until `message_start`, strip stale compaction thinking signatures before Anthropic replay, detect unsigned thinking-only stalls, refresh prompt fences after compaction writes, reject empty completion handoffs, preserve parent streaming-off overrides/shared progress commentary, forward heartbeat metadata to context-engine hooks, and cover Codex session/thread migration edge cases. (#90667, #90697, #90163, #90108, #89874, #89505, #90632, #89302, #90729, #90317, #90319) Thanks @openperf, @100yenadmin, @ooiuuii, @johnib, @Takhoffman, @MIHHHMIH, @dexiosmb, @zenglingbiao, @jalehman, @huangxun375-stack, @holgergruenhagen, @vincentkoc, @joshavant, and @ArthurusDent.
+- Provider/model resolution: preserve Google Vertex ADC auth markers in generated catalogs, re-probe a single-provider primary after cooldown, share Codex model visibility, fail closed for unknown model auth, preserve Codex alias availability, keep unresolved profile refs unknown, and avoid resolving auth while listing models. (#90506, #90609, #90717, #90702) Thanks @849261680, @paulogogs, @brtkwr, and @vincentkoc.
+- Gateway/macOS/mobile: avoid duplicate Gateway probe warnings by identity, rate-limit node pairing requests while preserving paired-node reconnects, keep macOS node mode on a healthy direct Gateway session, keep iOS diagnostics and gateway rows reachable, and avoid Linux ARM Gradle resource tasks during Android builds. (#85791, #90147, #90668, #90815) Thanks @giodl73-repo, @vrurg, @pgondhi987, @Takhoffman, @zhangguiping-xydt, @vincentkoc, @joshavant, and @shakkernerd.
+- TUI/chat/Workboard/auto-reply: optimistic user messages stay stable across stale history reloads, runId reassignment, and abort windows instead of disappearing, jumping, or lingering as ghost rows; Workboard stale lifecycle bulk updates no longer overwrite newer status/provenance; message-tool sends now count as delivery. (#86205, #89600, #88592, #90123) Thanks @RomneyDa, @BunsDev, @kzclaw, @mcaxtr, @vincentkoc, @joshavant, and @LiuwqGit.
+- Cron/update/service env: doctor config preflight now migrates legacy cron JSON stores into SQLite before runtime reads, service env planning skips unresolved placeholders that would mask state-dir `.env` values, and session transcript rewrites keep registry markers/discriminants consistent. (#90072, #90208, #90277, #90488) Thanks @MonkeyLeeT, @sallyom, @Kvikkulf, @jalehman, @wlassalle724, @shakkernerd, and @vincentkoc.
+- Security/config/tooling: guard MCP HTTP redirects, protect global agent config defaults, and keep malformed operational limits bounded and explicit. (#89732, #90145) Thanks @pgondhi987, @vincentkoc, and @joshavant.
+- Channels: WhatsApp restarts when per-account config changes, bounds background startup waits, closes failed sockets, and preserves reconnect behavior; Mattermost slash commands keep their state on `globalThis`; Feishu streaming cards preserve full merged content; voice-call tracks Twilio streams after connect; ClickClack reply tools respect `toolsAllow`. (#87951, #87965, #90486, #68113, #90534, #90181, #90607, #89500) Thanks @MukundaKatta, @mcaxtr, @infoanton, @mushuiyu886, @sahibzada-allahyar, @borntobefree2-cmyk, @Takhoffman, @mmaps, @MMMMSSSS8899, @ly85206559, @sliverp, @vincentkoc, @joshavant, @LiuwqGit, @itsuzef, @wjm7220, and @donkeykong91.
+- Feishu: retry transient send rate-limit errors (HTTP 429, per-chat code 230020, tenant-level code 11232) with linear backoff, including SDK responses that fulfill with rate-limit bodies instead of throwing, and route streaming-card sends through the retry wrapper. (#89659) Thanks @ladygege, @AxelHu, @marshallm-create, @sliverp, @joshavant, @vincentkoc, @itsuzef, and @mcaxtr.
+- Memory: keep doctor REM harness previews aligned with live REM by dropping short-term recall snippets whose source files disappeared before rendering preview output. Thanks @samzong, @frankekn, and @vincentkoc.
 
-### Complete contribution ledger
+### Complete contribution record
 
-This audited record covers the complete v2026.6.2-beta.1..v2026.6.5 history: 94 PRs and 47 linked issues. The grouped notes above prioritize user impact; this ledger preserves every contribution reference and eligible human credit.
+This audited record covers the complete v2026.6.2-beta.1..v2026.6.5 history: 142 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
 
 #### Pull requests
 
-- refactor(auth): store auth profiles in SQLite (#89102).
-- docs: clarify legacy openai-codex auth (#90028). Thanks @jalehman.
-- Fix Workboard status persistence (#89600). Thanks @BunsDev.
-- Pin official npm plugin install records (#88585). Thanks @zhuisDEV.
-- fix(auto-reply): count message tool sends as delivery (#90123). Thanks @mcaxtr.
-- fix(whatsapp): restart channel when a per-account config field changes so disabled accounts are torn down (#87965). Thanks @MukundaKatta and @mcaxtr.
-- fix: protect global agent config defaults [AI] (#90145). Thanks @pgondhi987.
-- Rate limit node pairing requests [AI] (#90147). Thanks @pgondhi987.
-- fix: guard MCP HTTP redirects [AI] (#89732). Thanks @pgondhi987.
-- fix(feishu): preserve streaming card content (#90181). Thanks @mushuiyu886.
-- fix(docker): qualify base image refs for podman short-name mode (#90058). Thanks @mrunalp.
-- fix(acp): re-add opt-in parent commentary progress (#89505). Thanks @100yenadmin.
-- fix(ci): scope PR merge diff checks to first parent (#90287). Thanks @hxy91819.
-- fix(agents): strip stale compaction thinking signatures before Anthropic replay (#90163). Thanks @openperf.
-- fix(whastapp): bound connection startup waits (#90486). Thanks @mcaxtr.
-- fix service env placeholder collection (#90488). Thanks @sallyom.
-- feat: install GitHub-backed ClawHub skills (#90478). Thanks @Patrick-Erichsen.
-- Fix main CI guard drift (#90532). Thanks @RomneyDa.
-- fix(mattermost): anchor slash state on globalThis (issue 68113) (#90534). Thanks @Takhoffman.
-- Add Codex multi-agent config migration coverage (#90317). Thanks @ooiuuii.
-- Add Codex session route migration coverage (#90319). Thanks @ooiuuii.
-- fix(qqbot): sanitize outbound text to strip reasoning/thinking content (#90132). Thanks @openperf and @Takhoffman.
-- fix(agents): detect unsigned thinking-only stall when reasoning payload inflates payloadCount (#89874). Thanks @openperf and @Takhoffman.
-- Propagate ClickClack tool policy through reply dispatch (#89500). Thanks @mmaps.
-- feat(matrix): handle voice preflight and threads (#90415).
-- fix(cron): auto-migrate legacy cron store (#90208). Thanks @MonkeyLeeT and @jalehman.
-- fix(gateway): dedupe probe warnings by gateway identity (#85791). Thanks @giodl73-repo.
-- fix(context-engine): forward isHeartbeat to afterTurn (fixes issue 89302) (#90632). Thanks @zenglingbiao and @jalehman.
-- docs: prefer web_fetch in weather skill (#90250). Thanks @fuller-stack-dev.
-- feat(parallel): add Parallel as a bundled web_search provider (#85158). Thanks @NormallyGaussian.
-- fix(tui): stabilize optimistic user messages across history reloads, runId reassignment, and abort (#86205). Thanks @RomneyDa.
-- chore(deps): bump the swift-deps group across 1 directory with 3 updates (#86483).
-- chore(deps): bump the actions group across 1 directory with 4 updates (#90601).
-- chore(deps): bump github.com/apple/swift-testing from 6.3.1 to 6.3.2 in /apps/swabble in the swift-deps group across 1 directory (#81757).
-- chore(deps): bump the android-deps group across 1 directory with 9 updates (#86481).
-- build(deps): bump docker/login-action from 3.6.0 to 4.1.0 (#74980).
-- fix(agents): re-probe single-provider primary during cooldown (#90717). Thanks @849261680.
-- fix(google): preserve Vertex ADC catalog auth (#90609). Thanks @849261680.
-- test(codex): pin completion-idle timeout thread reset (#90027). Thanks @harjothkhara.
-- fix(voice-call): track Twilio streams after connect (#90607). Thanks @sahibzada-allahyar and @Takhoffman.
-- fix(agents): coerce non-text/image MCP tool-result blocks to text (fixes issue 90710) (#90728). Thanks @849261680 and @Takhoffman.
-- fix(llm): defer Anthropic stream start event until after message_start (#90697). Thanks @openperf and @Takhoffman.
-- fix(memory): resolve adapter default model in plain status identity check (#90816). Thanks @849261680 and @Takhoffman.
-- fix issue 90668: [Bug]: macOS node mode can silently self-reconnect in a healthy direct gateway session (#90815). Thanks @Takhoffman.
-- Fix OpenAI audio auth to use API keys (#90793). Thanks @Glucksberg.
-- fix(codex): preserve completed replies after client close (#90790). Thanks @brokemac79 and @jalehman.
-- fix(imessage): frame rpc stdout on LF only (#90845). Thanks @omarshahine.
-- fix(uninstall): refuse to remove current working directory during cleanup (#90813). Thanks @xydigit-sj.
-- fix(talk): resolve realtime provider secret refs (#90914). Thanks @ngutman.
-- [codex] Add iOS Apple Review demo mode (#90919). Thanks @ngutman.
-- docs: improve plugin inventory layout (#90922). Thanks @joshp123.
-- fix(agents): stabilize user-turn serialization across turns to preserve prompt cache (#90811). Thanks @Marvinthebored and @jalehman.
-- fix(imessage): send TTS audio as voice messages (#90853). Thanks @omarshahine.
-- feat(parallel): add free Parallel Search MCP as the zero-config default web_search provider (#90849). Thanks @NormallyGaussian.
-- fix: store memory-core dreams state in sqlite (#91056).
-- fix(test): type overflow resolver mock (#91098). Thanks @RomneyDa.
-- refactor(matrix): store crypto sidecars in sqlite (#91100).
-- perf(qqbot): narrow tool discovery cold load (#90780). Thanks @RomneyDa.
-- refactor(memory-wiki): store import runs in sqlite (#91108).
-- fix: strip Google provider prefix from Gemini paths (#91125).
-- fix(outbound): keep Discord runtime adapters resolvable (#91119). Thanks @TurboTheTurtle and @thewilloftheshadow.
-- fix(qqbot): migrate group tool policy config (#91128).
-- fix(agents): dispatch subagent spawn in process (#90612). Thanks @lanzhi-lee.
-- fix(outbound): materialize buffer-only message.send attachments (#90794). Thanks @LiuwqGit.
-- fix(infra/agents): session-routing guard for coalesced gateway restart continuations (issue 86742) (#87323). Thanks @openperf.
-- fix(gateway/restart): write sentinel with continuationMessage on coalesced restart (#74443). Thanks @hclsys.
-- fix(gateway): report unqueued restart continuations (#83370). Thanks @stainlu.
-- feat(ios): clarify talk realtime fallback (#91201). Thanks @ngutman.
-- fix(agents): prevent ReDoS in background-session name derivation (#91233). Thanks @Takhoffman.
-- fix(imessage): self-explaining private-API failures and dedicated send timeout (#91041). Thanks @omarshahine.
-- feat(android): add theme mode selection (#90752). Thanks @Tosko4 and @joshavant.
-- fix: gate owner-only HTTP tools (#90261). Thanks @pgondhi987 and @joshavant.
-- fix(codex): quarantine unreadable dynamic tools (#90022). Thanks @vincentkoc.
-- fix(outbound): preserve retries for budget-deferred deliveries (#91241). Thanks @849261680 and @Takhoffman.
-- fix(agents): do not refresh lastUsedAt on MCP lease release (#91124). Thanks @openperf and @Takhoffman.
-- fix(imessage): gate split-send coalescing on imsg metadata (#90858). Thanks @omarshahine.
-- Gateway: avoid duplicate block stream replies (#137). Thanks @jverdi.
-- fix: complete gateway server refactoring and fix Swift compiler crash (#141).
-- fix(imessage): coalesce split-sends without delaying normal DMs (#90795). Thanks @omarshahine.
-- fix(codex): preserve native subagent completion results (#91235). Thanks @849261680 and @Takhoffman.
-- fix(cron): preserve isolated agent turn payload message (#91230). Thanks @849261680 and @Takhoffman.
-- feat(whatsapp): expand live QA coverage (#90480). Thanks @mcaxtr.
-- fix(gateway): preserve stale channel restart diagnostics (#90937). Thanks @snowzlm and @Takhoffman.
-- fix(anthropic): drop reasoning_content replay signatures (#91231). Thanks @849261680 and @Takhoffman.
-- fix issue 90452: Regression: Heartbeat exec completion still shows generic fallback text instead of actual output (#90897). Thanks @mushuiyu886 and @Takhoffman.
-- refactor: move session metadata to SQLite (#91322).
-- Fix transcript image redaction (#91529). Thanks @joshavant.
-- Fix config.patch explicit array replacement (#91551). Thanks @joshavant.
-- fix(whatsapp): route captured replies through successor controller after restart (#85823). Thanks @itsuzef and @mcaxtr.
-- fix(feishu): retry on send rate-limit errors (230020/230006) (#89659). Thanks @ladygege.
-- fix(feishu): propagate rate-limit errors from typing indicator to circuit breaker (#28157). Thanks @guoqunabc.
-- Fix Docker store seed target packages (#91547). Thanks @sallyom.
-- feat(qqbot): add /bot-group-allways command to toggle mention requirement (#91423). Thanks @cxyhhhhh.
-- fix(agents): prefer sessionKey in sessions_send (#74009).
-
-#### Linked issues
-
-- Reported: bug(workboard): Control UI card settings don't persist + drag to running fails (#88592). Thanks @kzclaw.
-- Reported: [Bug]: Compaction re-injection produces stale thinking signatures → Anthropic API rejection (#90108). Thanks @dexiosmb.
-- Reported: [Feature]: expose QMD no-rerank for memory.qmd query mode (#61834). Thanks @kouka-t0yohei.
-- Reported: [Bug]: Mattermost slash commands return 503 "not yet initialized" in v2026.4.15 (#68113). Thanks @infoanton and @Takhoffman.
-- Reported: [Bug]: [Bug]: ContextEngine afterTurn declares isHeartbeat but does not forward it (#89302). Thanks @huangxun375-stack and @zenglingbiao and @jalehman.
-- Reported: [Bug]: blockedUntil for subscription_limit set far in the future never re-probes when no fallback is configured (#90702). Thanks @brtkwr.
-- Reported: EmbeddedAttemptSessionTakeoverError: auto-compaction at reason=threshold trips fence on rewritten session jsonl (#90729). Thanks @johnib.
-- Reported: Codex app-server turn idle timeout is surfaced as user interruption (#89974). Thanks @FelixStarlite.
-- Reported: convertContentBlocks coerces MCP resource_link/resource/audio blocks into malformed image blocks -> Anthropic 400 -> poisoned session history (#90710). Thanks @RanSHammer and @849261680 and @Takhoffman.
-- Reported: [Bug]: macOS node mode can silently self-reconnect in a healthy direct gateway session (#90668). Thanks @vrurg and @Takhoffman.
-- Reported: [Bug]: lifecycle:end event payload missing aborted and stopReason on pi-embedded path (#66534). Thanks @xiaohuaxi.
-- Reported: Active-memory embedded memory_search intermittently loses embedding provider and falls back to FTS-only (#89691). Thanks @joeykrug.
-- Reported: [Bug]: Agent-specific MiniMax auth resolves from main agent auth-profiles.json (#64274). Thanks @blaspat.
-- Reported: Bug: cron server_error retry classifier matches any bare 5xx-looking number (#90947). Thanks @Nas01010101.
-- Reported: Bug: /export-session crashes with ENOENT — export-html template assets shipped under wrong dist path (#90843). Thanks @Tank-x3.
-- Reported: Gateway startup does not load the plugin owning a configured memory embedding provider (memorySearch.provider) (#89651). Thanks @joeykrug.
-- Reported: [Bug]: Vertex AI eu multi-region unreachable — host prefix is hardcoded (#89891). Thanks @Wimcomander.
-- Reported: Gemini web_search provider returns malformed JSON response on plain searches (#88528). Thanks @TarsTriggerBot.
-- Reported: Gateway writes streamed usage.cost.total for OpenRouter calls — up to 4× under actual billed amount on tier-priced models (#68066). Thanks @chrispatil.
-- Reported: Microsoft Foundry DeepSeek V4 alias providers still inject `thinking` after issue 87737 fix (#90520). Thanks @wlassalle724.
-- Reported: [Bug]: Foundry Entra ID onboarding fails to save with "Unrecognized key: thinkingLevelMap" (#91011). Thanks @chrisreddington.
-- Reported: [Bug]: requiresReasoningContentOnAssistantMessages missing from ModelCompatSchema — can't replicate native DeepSeek behavior on custom providers (#89660). Thanks @kyKKK.
-- Reported: [Bug]: [REGRESSION] Tool calls with arguments arrive as empty objects when using LM Studio (openai-responses API). (#90585). Thanks @ceo-nada.
-- Reported: Bug: loopDetection cannot block message tool loops — volatile messageId in result defeats all critical-level detection paths (#89090). Thanks @wujiaming88.
-- Reported: [Bug]: detectCompat in openai-completions.ts misses Xiaomi endpoints for requiresReasoningContentOnAssistantMessages — diverges from openai-completions-compat.ts (#91106). Thanks @KrasimirKralev.
-- Reported: [Bug]: microsoft-foundry reasoning models return 400 invalid_encrypted_content when continuing a thread (#91033). Thanks @chrisreddington.
-- Reported: Codex migration (2026.6.1) drops the gpt-5.5 model when a canonical `openai` provider exists for embeddings — agents go silent (#90047). Thanks @holgergruenhagen.
-- Reported: [Bug]: message.send can fail for buffer-only attachments without an explicit media path or URL (#90768). Thanks @Timofa.
-- Reported: [Bug]: vision-skip guard bypassed when agents.defaults.imageModel is set, even with vision-capable primary model (#91084). Thanks @AxelHu.
-- Reported: [Bug]: memory pressure WARN is non-actionable — no units, no breakdown, no operator guidance, no self-heal, and log level disagrees with payload (#90783). Thanks @xdengli.
-- Reported: [Bug]: Regression 2026.6.1: orphan tool.call fail-closed handling silently discards the composed assistant reply ("Embedded agent failed before reply") (#91067). Thanks @Francois3d.
-- Reported: [Bug]: gateway restart continuationMessage can be accepted but not queued after coalesced restart (#86742). Thanks @songshikang0111.
-- Reported: Reply-context body truncation: cover ReplyChain and fallback ReplyToBody JSON paths (#91042). Thanks @wangwllu.
-- Reported: [Bug]: Non-workspace skills are inaccessible to the agent when sandbox is in workspaceAccess: "rw" mode (#90410). Thanks @gbb-netizen.
-- Reported: macOS Swift Compiler Crash in OnboardingView+Wizard.swift (#139). Thanks @daveonkels.
-- Reported: Remove client-side iMessage split-send coalescing once imsg coalesces upstream (#91243). Thanks @omarshahine.
-- Reported: Regression: Heartbeat exec completion still shows generic fallback text instead of actual output (#90452). Thanks @bizzle12368239 and @Takhoffman.
-- Reported: Feishu plugin lacks retry logic for API rate limit errors (#70879). Thanks @AxelHu.
-- Reported: [Bug]: 5.28 regression — reasoning/thinking content leaks into QQBot replies (regression of issue 6470) (#89913). Thanks @dygg2001.
-- Reported: [Bug]: Extended thinking sessions permanently broken after gateway restart / cache miss — no recovery for research agents (#90667). Thanks @MIHHHMIH.
-- Reported: [Bug]: [Bug]: google-vertex models fail with model_not_found at runtime on 2026.5.28 and 2026.6.1 — direct Vertex API calls succeed with same credentials (#90506). Thanks @paulogogs.
-- Reported: [Feature]: Voice messages to agent don't work on Matrix (#78016). Thanks @frankdierolf.
-- Reported: Cron state silently wiped during SQLite migration on upgrade to 2026.6.1 (#90072). Thanks @wlassalle724.
-- Reported: gateway install --force drops MINIMAX_API_KEY from service-env despite managed keys list (#90277). Thanks @Kvikkulf.
-- Reported: Dynamic reload doesn't disable a running WhatsApp account when its enabled flag flips to false (#87951). Thanks @borntobefree2-cmyk.
-- Reported: [Bug]: sessions_send unexpectedly injects label, causing mutual-exclusion error with sessionKey (#64699). Thanks @sunxq1017-hash.
-- Reported: Agent-to-Agent Communication Tools Have Parameter Conflicts (#41199). Thanks @chouxiaozi1989.
-
+- **PR #89102** refactor(auth): store auth profiles in SQLite.
+- **PR #90028** docs: clarify legacy openai-codex auth. Thanks @jalehman.
+- **PR #89600** Fix Workboard status persistence. Related #88592. Thanks @BunsDev and @kzclaw.
+- **PR #90067** fix(workboard): isolate stale lifecycle bulk patches. Thanks @BunsDev.
+- **PR #88585** Pin official npm plugin install records. Thanks @zhuisDEV.
+- **PR #90053** fix: hide Skill Workshop revision handoff from chat. Thanks @shakkernerd.
+- **PR #90123** fix(auto-reply): count message tool sends as delivery. Thanks @mcaxtr.
+- **PR #87965** fix(whatsapp): restart channel when a per-account config field changes so disabled accounts are torn down. Related #87951. Thanks @MukundaKatta and @mcaxtr and @borntobefree2-cmyk.
+- **PR #90145** fix: protect global agent config defaults [AI]. Thanks @pgondhi987.
+- **PR #90147** Rate limit node pairing requests [AI]. Thanks @pgondhi987.
+- **PR #89732** fix: guard MCP HTTP redirects [AI]. Thanks @pgondhi987.
+- **PR #90181** fix(feishu): preserve streaming card content. Related #90164. Thanks @mushuiyu886 and @sliverp and @wjm7220.
+- **PR #90058** fix(docker): qualify base image refs for podman short-name mode. Thanks @mrunalp and @sallyom.
+- **PR #89488** fix: stabilize Anthropic cache marker through tool loops. Thanks @Marvinthebored.
+- **PR #89505** fix(acp): re-add opt-in parent commentary progress. Related #89501. Thanks @100yenadmin.
+- **PR #90341** fix(acp): default parent commentary in progress mode. Thanks @obviyus.
+- **PR #90351** fix(message-tool): stabilize send idempotency keys. Thanks @jesse-merhi.
+- **PR #90375** refactor: remove Feishu runtime dedupe JSON fallback.
+- **PR #90385** refactor: move MS Teams state migration to doctor.
+- **PR #90287** fix(ci): scope PR merge diff checks to first parent. Thanks @hxy91819.
+- **PR #90436** Add NVIDIA Nemotron 3 Ultra default. Thanks @jacobtomlinson.
+- **PR #90205** fix: tolerate missing streamed response content type. Thanks @jalehman.
+- **PR #90163** fix(agents): strip stale compaction thinking signatures before Anthropic replay. Related #90108. Thanks @openperf and @dexiosmb.
+- **PR #90486** fix(whastapp): bound connection startup waits. Thanks @mcaxtr and @MMMMSSSS8899.
+- **PR #90488** fix service env placeholder collection. Thanks @sallyom.
+- **PR #90478** feat: install GitHub-backed ClawHub skills. Thanks @Patrick-Erichsen.
+- **PR #90304** feat(memory): support qmd query rerank toggle. Related #61834. Thanks @osolmaz and @kouka-t0yohei.
+- **PR #90532** Fix main CI guard drift. Thanks @RomneyDa.
+- **PR #90534** fix(mattermost): anchor slash state on globalThis (#68113). Thanks @Takhoffman and @ly85206559 and @infoanton.
+- **PR #89502** feat(googlechat): add native approval cards. Thanks @kevinslin.
+- **PR #90317** Add Codex multi-agent config migration coverage. Thanks @ooiuuii.
+- **PR #90319** Add Codex session route migration coverage. Thanks @ooiuuii.
+- **PR #90132** fix(qqbot): sanitize outbound text to strip reasoning/thinking content. Related #89913. Thanks @openperf and @Takhoffman and @dygg2001.
+- **PR #89874** fix(agents): detect unsigned thinking-only stall when reasoning payload inflates payloadCount. Related #89787. Thanks @openperf and @Takhoffman and @ArthurusDent.
+- **PR #90594** fix(android): align provider readiness with available models. Thanks @Tosko4.
+- **PR #90576** fix(sessions): reconcile stale terminal main transcripts. Related #60542. Thanks @ferminquant and @kAIborg24.
+- **PR #90405** Fix ClickClack toolsAllow reply dispatch. Thanks @mmaps.
+- **PR #90415** feat(matrix): handle voice preflight and threads. Related #78016. Thanks @frankdierolf.
+- **PR #90208** fix(cron): auto-migrate legacy cron store. Related #90072. Thanks @MonkeyLeeT and @jalehman and @wlassalle724.
+- **PR #85791** fix(gateway): dedupe probe warnings by gateway identity. Thanks @giodl73-repo.
+- **PR #90632** fix(context-engine): forward isHeartbeat to afterTurn (fixes #89302). Thanks @zenglingbiao and @jalehman and @huangxun375-stack.
+- **PR #90250** docs: prefer web_fetch in weather skill. Thanks @fuller-stack-dev.
+- **PR #85158** feat(parallel): add Parallel as a bundled web_search provider. Thanks @NormallyGaussian.
+- **PR #86205** fix(tui): stabilize optimistic user messages across history reloads, runId reassignment, and abort. Thanks @RomneyDa.
+- **PR #86483** chore(deps): bump the swift-deps group across 1 directory with 3 updates.
+- **PR #90601** chore(deps): bump the actions group across 1 directory with 4 updates.
+- **PR #81757** chore(deps): bump github.com/apple/swift-testing from 6.3.1 to 6.3.2 in /apps/swabble in the swift-deps group across 1 directory.
+- **PR #86481** chore(deps): bump the android-deps group across 1 directory with 9 updates.
+- **PR #74980** build(deps): bump docker/login-action from 3.6.0 to 4.1.0.
+- **PR #90717** fix(agents): re-probe single-provider primary during cooldown. Related #90702. Thanks @849261680 and @brtkwr.
+- **PR #90609** fix(google): preserve Vertex ADC catalog auth. Related #90506. Thanks @849261680 and @paulogogs.
+- **PR #90775** fix: refresh prompt fence after compaction writes. Related #90729. Thanks @jalehman and @johnib.
+- **PR #90027** test(codex): pin completion-idle timeout thread reset. Thanks @harjothkhara.
+- **PR #89566** fix(telegram): suppress post-final tool error noise. Thanks @keshavbotagent.
+- **PR #90607** fix(voice-call): track Twilio streams after connect. Related #81122. Thanks @sahibzada-allahyar and @Takhoffman and @donkeykong91.
+- **PR #90728** fix(agents): coerce non-text/image MCP tool-result blocks to text (fixes #90710). Thanks @849261680 and @Takhoffman and @RanSHammer.
+- **PR #90697** fix(llm): defer Anthropic stream start event until after message_start. Related #90667. Thanks @openperf and @Takhoffman and @MIHHHMIH.
+- **PR #90816** fix(memory): resolve adapter default model in plain status identity check. Related #90413. Thanks @849261680 and @Takhoffman and @colinmac-boop.
+- **PR #90815** fix #90668: [Bug]: macOS node mode can silently self-reconnect in a healthy direct gateway session. Thanks @Takhoffman and @zhangguiping-xydt and @vrurg.
+- **PR #90793** Fix OpenAI audio auth to use API keys. Thanks @Glucksberg and @sallyom.
+- **PR #90790** fix(codex): preserve completed replies after client close. Related #90771. Thanks @brokemac79 and @jalehman.
+- **PR #90820** fix(codex): report completion timeout diagnostics. Thanks @kevinslin.
+- **PR #90845** fix(imessage): frame rpc stdout on LF only. Related #89830. Thanks @omarshahine and @mmartoccia.
+- **PR #90813** fix(uninstall): refuse to remove current working directory during cleanup. Related #90806. Thanks @xydigit-sj and @sallyom and @brandondube.
+- **PR #90336** fix(memory): fail fast when embeddings provider is unavailable. Related #89691. Thanks @osolmaz and @joeykrug.
+- **PR #90914** fix(talk): resolve realtime provider secret refs. Thanks @ngutman.
+- **PR #88771** fix(agents): stream phased text deltas incrementally. Thanks @vincentkoc.
+- **PR #87856** fix(agents): count streamed model deltas incrementally. Thanks @vincentkoc.
+- **PR #88882** test(gateway): add small model live profile. Thanks @vincentkoc.
+- **PR #90919** [codex] Add iOS Apple Review demo mode. Thanks @ngutman.
+- **PR #90954** fix(cron): require HTTP context for server_error retry classification. Related #90947. Thanks @Nas01010101.
+- **PR #90854** fix(build): copy export-html assets to dist/export-html matching runtime path (fixes #90843). Thanks @zenglingbiao and @Tank-x3.
+- **PR #90922** docs: improve plugin inventory layout. Thanks @joshp123.
+- **PR #89652** fix(plugins): load owning plugin for configured memory embedding provider at startup. Related #89651. Thanks @joeykrug.
+- **PR #90811** fix(agents): stabilize user-turn serialization across turns to preserve prompt cache. Related #90810. Thanks @Marvinthebored and @jalehman.
+- **PR #90853** fix(imessage): send TTS audio as voice messages. Thanks @omarshahine.
+- **PR #90995** fix(release): use monthly patch versions. Thanks @vincentkoc.
+- **PR #91030** fix: store device-pair notify state in sqlite.
+- **PR #91034** fix: store acpx process state in sqlite.
+- **PR #90849** feat(parallel): add free Parallel Search MCP as the zero-config default web_search provider. Thanks @NormallyGaussian.
+- **PR #91056** fix: store memory-core dreams state in sqlite.
+- **PR #89918** fix(vertex): route eu/us multi-region to .rep.googleapis.com host. Related #89891. Thanks @alkor2000 and @Wimcomander.
+- **PR #91058** fix(gemini): accept empty grounding metadata. Related #88528. Thanks @TarsTriggerBot.
+- **PR #91072** refactor(memory-wiki): store source sync state in sqlite.
+- **PR #91073** fix(openrouter): reconcile streamed generation cost. Related #68066. Thanks @chrispatil.
+- **PR #91032** docs(imessage): require DisableLibraryValidation on modern macOS; document macOS 26 injection gates. Thanks @omarshahine.
+- **PR #87933** fix(agents): suppress DeepSeek thinking for Foundry aliases. Related #90520. Thanks @MukundaKatta and @wlassalle724.
+- **PR #91037** fix(config): allow thinkingLevelMap in persisted model schema. Related #91011. Thanks @wsyjh8 and @chrisreddington.
+- **PR #89832** fix(config): allow requiresReasoningContentOnAssistantMessages in ModelCompatSchema. Related #89660. Thanks @KrasimirKralev and @kyKKK.
+- **PR #91088** refactor(matrix): store sync cache in sqlite.
+- **PR #90138** fix(minimax): exempt M3 from thinking-disabled wrapper. Thanks @IamVNIE.
+- **PR #91053** refactor: store Zalo hosted media in plugin state.
+- **PR #91098** fix(test): type overflow resolver mock. Thanks @RomneyDa.
+- **PR #81277** fix(google): handle compressed Vertex ADC token refresh responses. Thanks @liaoandi.
+- **PR #91100** refactor(matrix): store crypto sidecars in sqlite.
+- **PR #90260** fix(agents): decode xai and venice tool-call arguments exactly once. Thanks @yetval.
+- **PR #90593** fix: preserve LM Studio Responses tool arguments. Related #90585. Thanks @849261680 and @ceo-nada.
+- **PR #89109** fix(agents): block message-tool spam loops defeated by volatile message ids. Related #89090. Thanks @openperf and @wujiaming88.
+- **PR #90429** Fix LM Studio wizard prompter binding. Thanks @christineyan4.
+- **PR #90780** perf(qqbot): narrow tool discovery cold load. Thanks @RomneyDa.
+- **PR #90504** fix(codex): preserve post-tool reasoning liveness. Thanks @fuller-stack-dev.
+- **PR #91113** fix: align Xiaomi completions replay compat. Related #91106. Thanks @KrasimirKralev.
+- **PR #91108** refactor(memory-wiki): store import runs in sqlite.
+- **PR #91118** fix: preserve Foundry Responses reasoning replay ids. Related #91033. Thanks @chrisreddington.
+- **PR #91125** fix: strip Google provider prefix from Gemini paths. Related #71932. Thanks @soumoucookie.
+- **PR #90056** fix(doctor): merge disjoint openai-codex model entries into canonical openai provider. Related #90047. Thanks @openperf and @holgergruenhagen.
+- **PR #91127** refactor: store sandbox registry in sqlite.
+- **PR #91131** fix: migrate legacy agent registry schema via doctor.
+- **PR #91119** fix(outbound): keep Discord runtime adapters resolvable. Related #90162. Thanks @TurboTheTurtle and @thewilloftheshadow and @hoyanhan.
+- **PR #91128** fix(qqbot): migrate group tool policy config.
+- **PR #91133** refactor(plugin-sdk): persist dedupe state in sqlite.
+- **PR #90612** fix(agents): dispatch subagent spawn in process. Thanks @lanzhi-lee.
+- **PR #87323** fix(infra/agents): session-routing guard for coalesced gateway restart continuations (#86742). Thanks @openperf and @songshikang0111.
+- **PR #91101** fix(inbound-meta): apply head+tail body truncation to ReplyChain and ReplyToBody JSON paths (fixes #91042). Thanks @zenglingbiao and @wangwllu.
+- **PR #91201** feat(ios): clarify talk realtime fallback. Thanks @ngutman.
+- **PR #91233** fix(agents): prevent ReDoS in background-session name derivation. Thanks @Takhoffman and @yetval.
+- **PR #90798** fix(agents): materialize sandbox skills for rw sandboxes. Related #90410. Thanks @brokemac79 and @gbb-netizen.
+- **PR #91248** fix: preserve live Ollama catalog metadata. Related #90315. Thanks @civiltox.
+- **PR #91041** fix(imessage): self-explaining private-API failures and dedicated send timeout. Thanks @omarshahine.
+- **PR #90029** feat: add live provider model catalog helper. Thanks @fuller-stack-dev.
+- **PR #90752** feat(android): add theme mode selection. Thanks @Tosko4 and @joshavant.
+- **PR #90261** fix: gate owner-only HTTP tools. Thanks @pgondhi987 and @joshavant.
+- **PR #90022** fix(codex): quarantine unreadable dynamic tools. Thanks @vincentkoc.
+- **PR #88822** fix(agents): compact lean local tool catalogs. Thanks @vincentkoc.
+- **PR #89350** fix(agents): guard prompt cache tool names. Thanks @vincentkoc.
+- **PR #91241** fix(outbound): preserve retries for budget-deferred deliveries. Thanks @849261680 and @Takhoffman.
+- **PR #91124** fix(agents): do not refresh lastUsedAt on MCP lease release. Related #91075. Thanks @openperf and @Takhoffman and @Atlas-crete.
+- **PR #90858** fix(imessage): gate split-send coalescing on imsg metadata. Thanks @omarshahine.
+- **PR #91235** fix(codex): preserve native subagent completion results. Related #91120. Thanks @849261680 and @Takhoffman and @jinon86.
+- **PR #91230** fix(cron): preserve isolated agent turn payload message. Related #91228. Thanks @849261680 and @Takhoffman and @AgentXaGent.
+- **PR #90480** feat(whatsapp): expand live QA coverage. Thanks @mcaxtr.
+- **PR #89712** feat(cron): support command jobs. Thanks @mbelinky.
+- **PR #90937** fix(gateway): preserve stale channel restart diagnostics. Related #90901. Thanks @snowzlm and @Takhoffman and @Tony-ooo.
+- **PR #91231** fix(anthropic): drop reasoning_content replay signatures. Related #91205. Thanks @849261680 and @Takhoffman and @bobgitmcgrath.
+- **PR #90897** fix #90452: Regression: Heartbeat exec completion still shows generic fallback text instead of actual output. Thanks @mushuiyu886 and @Takhoffman and @bizzle12368239.
+- **PR #91322** refactor: move session metadata to SQLite.
+- **PR #91529** Fix transcript image redaction. Related #90760. Thanks @joshavant and @devinkuhn.
+- **PR #91551** Fix config.patch explicit array replacement. Thanks @joshavant.
+- **PR #85823** fix(whatsapp): route captured replies through successor controller after restart. Thanks @itsuzef and @mcaxtr.
+- **PR #89659** fix(feishu): retry on send rate-limit errors (230020/230006). Related #70879. Thanks @ladygege and @marshallm-create and @sliverp and @AxelHu.
+- **PR #91547** Fix Docker store seed target packages. Related #91035. Thanks @sallyom and @laurenceputra.
+- **PR #91423** feat(qqbot): add /bot-group-allways command to toggle mention requirement. Thanks @cxyhhhhh.
 ## 2026.6.2
 
 ### Highlights
 
-- Plugin and skill installs now use an operator install policy instead of the old dangerous-code scanner path, with clearer doctor, CLI, ClawHub, and troubleshooting surfaces for package, archive, source, upload, and marketplace installs. (#89516) Thanks @joshavant.
-- Telegram, Feishu, Discord, WhatsApp, and outbound delivery paths got safer around duplicate transcript mirrors, Telegram admin writeback, streamed-final previews, approval allowlists, setup runtime state, poll modifiers, Discord voice errors, and internal progress traces. (#88973, #89626, #89812, #89035, #89814, #89813, #89601) Thanks @pgondhi987, @Petru2224, @zhangguiping-xydt, @codezz, and @takhoffman.
-- Chat, Control UI, Skill Workshop, Workboard, Android companion shell, and WebChat flows now preserve visible streaming text, reconcile completed sends, expose ACK timing, add Workboard keyboard movement, harden dialog accessibility, lazy-load usage views, keep current chat toggles working, and improve Android companion-first shell navigation. (#89801, #89777, #89802) Thanks @vincentkoc.
-- Security, policy, and config recovery now reject corrupt shell snapshots, unsupported policy keys, unsafe exec approval precheck environments, malformed script limits, and suspicious gateway startup configs while adding data-handling conformance checks. (#89701, #87074, #81488, #87056, #89480) Thanks @RomneyDa, @giodl73-repo, and @mmaps.
-- Gateway, agent, Codex, provider, model, and memory paths now recover session write-lock release failures, abandoned Codex app-server startups, stream-to-parent ACP spawns, custom-provider runtime fanout, bundled provider aliases, prompt-cache boundaries, Gemini stop sequences, Kimi cache markers, and watcher pressure warnings. (#89811, #89244) Thanks @RomneyDa and @takhoffman.
-- Release, CI, Docker, Crabbox/Testbox, package, and E2E validation lanes now bound more network calls, malformed numeric limits, process groups, cleanup leaks, package hydration paths, Windows installer publishing, release asset verification, and log drains so failures produce bounded proof instead of hanging.
+- **Governed plugin and skill installs:** the old dangerous-code scanner gives way to an operator install policy with clearer doctor, CLI, ClawHub, package, archive, source, upload, and marketplace recovery paths. (#89516) Thanks @joshavant and @vincentkoc.
+- **Safer channel delivery:** Telegram, Feishu, Discord, WhatsApp, and outbound sends now handle transcript mirroring, streamed finals, admin writeback, approval allowlists, poll modifiers, and setup state without corrupting delivery. (#88973, #89626, #89812, #89035, #89814, #89813, #89601) Thanks @pgondhi987, @Petru2224, @zhangguiping-xydt, @ppmuzyk, @codezz, @takhoffman, @vincentkoc, @harjothkhara, @obviyus, @glenn-agent, @kesslerio, and @leiJack-lo.
+- **Steadier chat and operator UI:** visible stream text, completed sends, Workboard keyboard navigation, dialog accessibility, lazy usage views, and Android companion flows retain their state through normal interaction. (#89801, #89777) Thanks @vincentkoc.
+- **Stricter safety checks:** config, policy, shell snapshots, exec prechecks, script limits, and Gateway startup reject malformed or unsafe input before it becomes runtime state. (#89701, #87074, #81488, #87056, #89480) Thanks @RomneyDa, @giodl73-repo, @mmaps, @drobison00, @vincentkoc, and @q1387154-spec.
+- **More reliable Gateway and model sessions:** session locks, abandoned Codex startup, ACP handoffs, custom-provider fanout, provider aliases, prompt caching, and memory checks recover without leaving a run wedged. (#89811, #89244) Thanks @RomneyDa, @takhoffman, @spencer2211, and @vincentkoc.
 
 ### Changes
 
-- Plugins/security: replace dangerous-code scanner enforcement with operator install policy, install-policy context, doctor checks, install/update CLI wiring, ClawHub metadata paths, and package/archive/source/upload lifecycle coverage. (#89516) Thanks @joshavant.
+- Plugins/security: replace dangerous-code scanner enforcement with operator install policy, install-policy context, doctor checks, install/update CLI wiring, ClawHub metadata paths, and package/archive/source/upload lifecycle coverage. (#89516) Thanks @joshavant and @vincentkoc.
 - Policy: add data-handling conformance checks and reject unsupported policy keys. (#87056, #87074) Thanks @giodl73-repo.
 - Telegram/channels: show commentary and reasoning in progress drafts, share progress draft compositors across channel plugins, and keep Telegram polling stop/reset boundaries cheaper and more reliable.
-- UI/mobile: add Workboard keyboard movement controls, tighten Workboard card operations, improve Android companion-first shell UX, and document chat ACK timing metadata. (#89802) Thanks @vincentkoc.
-- Release metadata: align the root package, publishable plugin manifests, generated shrinkwraps, appcast, iOS, Android, macOS, Matrix plugin changelog, and docs/generated baselines with the 2026.6.2 beta train.
-- Release/packaging: promote Windows node installer publishing, require verified Windows release asset links, and document GitHub release-note edits.
-- Docs: refresh Windows Hub setup guidance and document Gateway, CLI, and plugin SDK helper contracts.
+- UI/mobile: add Workboard keyboard movement controls, tighten Workboard card operations, and improve Android companion-first shell UX. Thanks @vincentkoc.
 
 ### Fixes
 
-- Channels/outbound: keep channel sends durable when transcript mirroring fails, stop schema-padded poll modifiers from blocking normal sends, preserve WebChat `sessions_send` handoffs, preserve Discord channel-label suppression while hiding internal agent failure traces, match Discord libopus error shapes, and sanitize Discord tool progress scaffolding. (#89626, #89812, #89601) Thanks @Petru2224, @codezz, and @takhoffman.
-- Telegram/Feishu: require admin rights for Telegram target writeback, keep Telegram DM exec approval allowlists working with `ask:off`, prevent Telegram preview duplication across streaming modes, isolate verbose status after streamed finals, cancel clean restart stop timers, slow polling restart storms, and wire Feishu setup runtime setters. (#88973, #89035, #89813, #89814) Thanks @pgondhi987, @zhangguiping-xydt, and @takhoffman.
+- Channels/outbound: keep channel sends durable when transcript mirroring fails, stop schema-padded poll modifiers from blocking normal sends, preserve WebChat `sessions_send` handoffs, preserve Discord channel-label suppression while hiding internal agent failure traces, match Discord libopus error shapes, and sanitize Discord tool progress scaffolding. (#89626, #89812, #89601) Thanks @Petru2224, @codezz, @takhoffman, @harjothkhara, and @vincentkoc.
+- Telegram/Feishu: require admin rights for Telegram target writeback, keep Telegram DM exec approval allowlists working with `ask:off`, prevent Telegram preview duplication across streaming modes, isolate verbose status after streamed finals, cancel clean restart stop timers, slow polling restart storms, and wire Feishu setup runtime setters. (#88973, #89035, #89813, #89814) Thanks @pgondhi987, @zhangguiping-xydt, @ppmuzyk, @takhoffman, @vincentkoc, @obviyus, @kesslerio, @glenn-agent, and @leiJack-lo.
 - Feishu: preserve full streaming card content by sending the merged text on each update instead of only the latest delta, so card readers see complete output when intermediate frames are missed. (#90181) Thanks @mushuiyu886.
-- Chat/UI/Gateway: preserve visible chat stream text, clear stale stream buffers before terminal commits, reconcile completed sends, scroll pending sends into view, harden Workboard dialog accessibility, stabilize WebChat prompt-cache affinity, overlap chat catalog startup, render chat history incrementally, lazy-load usage dashboard, and report gateway health auth diagnostics. (#89337) Thanks @RomneyDa.
-- Agents/Codex/providers/models: release session write locks when prompt-release fence reads fail, retire abandoned Codex app-server startups, keep stream-to-parent ACP spawns registered, close Codex startup clients on timeout, recover bundled provider aliases, avoid custom-provider runtime fanout, preserve provider prompt-cache boundaries, forward Gemini stop sequences, and strip Kimi-incompatible Anthropic cache markers. (#89811) Thanks @takhoffman.
-- Memory/build/update: warn after startup watcher pressure checks, externalize optional Baileys image backends, restore and pin Canvas A2UI compatibility assets, keep plugin repair fetch failures nonblocking, restore Skill Workshop view switching, and keep the current chat toggle active after awaited session switches. (#89244) Thanks @RomneyDa.
-- Plugins/auth: keep Hermes migration reports pointed at SQLite auth-profile stores and keep plugin auth-profile reuse tests on the current store path.
+- Chat/UI/Gateway: preserve visible chat stream text, clear stale stream buffers before terminal commits, reconcile completed sends, scroll pending sends into view, harden Workboard dialog accessibility, stabilize WebChat prompt-cache affinity, overlap chat catalog startup, render chat history incrementally, lazy-load usage dashboard, and report gateway health auth diagnostics. (#89337) Thanks @RomneyDa and @vincentkoc.
+- Agents/Codex/providers/models: release session write locks when prompt-release fence reads fail, retire abandoned Codex app-server startups, keep stream-to-parent ACP spawns registered, close Codex startup clients on timeout, recover bundled provider aliases, avoid custom-provider runtime fanout, preserve provider prompt-cache boundaries, forward Gemini stop sequences, and strip Kimi-incompatible Anthropic cache markers. (#89811) Thanks @takhoffman, @spencer2211, and @vincentkoc.
+- Memory/build/update: warn after startup watcher pressure checks, externalize optional Baileys image backends, restore and pin Canvas A2UI compatibility assets, keep plugin repair fetch failures nonblocking, restore Skill Workshop view switching, and keep the current chat toggle active after awaited session switches. (#89244) Thanks @RomneyDa and @vincentkoc.
+- Plugins/auth: keep Hermes migration reports pointed at SQLite auth-profile stores.
 - Plugins/CLI: avoid importing the runtime plugin loader only to clear in-process caches after short-lived plugin install, enable, disable, update, and uninstall commands refresh registry metadata.
-- Security/config/tooling: reject corrupt shell snapshots, suspicious gateway startup configs, malformed release/test/tooling/Docker/perf numeric limits, oversized audit responses, unsafe exec precheck env, and invalid pending-agent SQLite scaffold denials. (#89701, #89705, #89480, #81488) Thanks @RomneyDa and @mmaps.
-- Release/CI/E2E: restore package changelog extraction after the post-2026.6.1 version bump, keep hydrated pnpm modules under `node_modules` for ARM/Linux package lifecycle scripts, keep OpenAI live-cache prerequisites advisory while Anthropic prerequisites stay blocking, retry Windows Parallels background log appends on transient file-lock errors, bound candidate GitHub and cross-OS Discord fetches, harden ARM smoke/browser checks, show Docker build heartbeats, reset Crabbox pnpm hydrate state, and isolate Testbox/Docker/release journey artifacts.
-- Release/CI/E2E: keep Crabbox hydrate pnpm stores on the persistent cache volume while still resetting volatile modules, reducing cold installs and runner memory churn.
-- Release/CI/E2E: fail secret-provider proof startup immediately when the gateway exits by signal instead of waiting for the readiness timeout.
-- Release/CI/E2E: report plugin gateway gauntlet command-log write failures as failed rows instead of crashing the harness from child-process callbacks.
-- Release/CI/E2E: abort stalled Kitchen Sink RPC readiness probes as soon as the gateway exits so proof failures return promptly.
-- Release/CI/E2E: keep Parallels JSON-mode progress on stderr so macOS, Linux, Windows, and aggregate update smoke summaries stay parseable on stdout.
-- Release/CI/E2E: fail Crabbox sparse-sync runs clearly when their temporary full checkout disappears while the child process is running, instead of pretending the child's deleted cwd can be repaired.
-- Release/CI/E2E: fail PTY-backed E2E commands when transcript logs cannot be written instead of letting missing proof capture crash around a live child process.
-- Release/CI/E2E: fail mock OpenAI request-log write errors with clear HTTP responses instead of leaving provider proof clients waiting on a broken socket.
-- Release/CI/E2E: fail Parallels host-command log write errors through the command result path instead of leaving streaming smoke phases unresolved.
+- Security/config/tooling: reject corrupt shell snapshots, suspicious gateway startup configs, malformed numeric limits, oversized audit responses, unsafe exec precheck env, and invalid pending-agent SQLite scaffold denials. (#89701, #89705, #89480, #81488) Thanks @RomneyDa, @mmaps, @drobison00, @vincentkoc, and @q1387154-spec.
 
-### Complete contribution ledger
+### Complete contribution record
 
-This audited record covers the complete v2026.6.1..v2026.6.2-beta.1 history: 24 PRs and 12 linked issues. The grouped notes above prioritize user impact; this ledger preserves every contribution reference and eligible human credit.
+This audited record covers the complete v2026.6.1..v2026.6.2-beta.1 history: 57 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
 
 #### Pull requests
 
-- fix: recover suspicious gateway startup configs (#89480).
-- Policy: add data handling conformance checks (#87056). Thanks @giodl73-repo.
-- Harden node exec approval precheck env [AI] (#81488). Thanks @mmaps and @drobison00.
-- fix(policy): reject unsupported policy keys (#87074). Thanks @giodl73-repo.
-- fix(outbound): stop schema-padded poll modifiers from blocking send (#89601). Thanks @codezz and @Takhoffman.
-- fix(exec): reject corrupt shell snapshots (#89701). Thanks @RomneyDa.
-- fix: allowlist pending agent sqlite scaffold (#89705). Thanks @RomneyDa.
-- fix: report gateway health auth diagnostics (#89337). Thanks @RomneyDa.
-- perf(ui): label delayed chat sends in telemetry (#89777). Thanks @vincentkoc.
-- perf(ui): surface chat ACK server timing (#89801). Thanks @vincentkoc.
-- docs(web): document chat ACK timing metadata (#89802). Thanks @vincentkoc.
-- fix(agents): release session write lock if fence read throws on prompt release (#89811). Thanks @Takhoffman.
-- fix(telegram): isolate verbose status after streamed finals (#89813). Thanks @Takhoffman.
-- fix(feishu): wire setup runtime setter (#89814). Thanks @Takhoffman.
-- fix issue 88773: [Bug]: Telegram DM exec requires approval despite allowlist + ask:off — works in webchat, not in Telegram (#89035). Thanks @zhangguiping-xydt.
-- fix(outbound): keep channel send durable when transcript mirror fails (issue 89626) (#89812). Thanks @Takhoffman.
-- fix(telegram): require admin for target writeback [AI] (#88973). Thanks @pgondhi987.
-- test(channels): fix guardrail regex lint (#89960). Thanks @RomneyDa.
-- Add operator install policy and remove dangerous-code install scanners (#89516). Thanks @joshavant.
-- docs: document auth profile failure policy contract (#89613).
-- fix(codex): accept first-party OpenAI plugin marketplaces (bundled and primary-runtime) (#82219). Thanks @yaanfpv.
-- fix(update): surface plugin channel fallbacks (#81422). Thanks @BKF-Gitty.
-- fix(memory): warn after startup watcher pressure check (#89244). Thanks @RomneyDa.
-- fix(feishu): preserve streaming card content (#90181). Thanks @mushuiyu886.
-
-#### Linked issues
-
-- Reported: Bug: 5.28 transport refactor regressed prompt caching for Anthropic and OpenAI-compatible providers (#89386). Thanks @Enominera.
-- Reported: Kimi Code returns empty content when Anthropic cache_control markers are sent (#76612). Thanks @vliuyt.
-- Reported: webchat creates new agent run per message, destroying prompt cache (93% → 29% hit rate) (#89139). Thanks @Enominera.
-- Reported: [Bug]: sessions_send inter-session messages render as 'user' in WebChat — should show as agent-forwarded (#89161). Thanks @Xj49688-lgtm.
-- Reported: [Bug]: [BUG] UI shows agent "running" after conversation ends — requires manual page refresh every time (#87699). Thanks @csck-luoy.
-- Reported: [Bug]: Control UI webchat duplicates every assistant reply on 2026.4.21 — regression from issue 5964/issue 39469 (#71992). Thanks @rzhnrhjr6j-cloud.
-- Reported: [Bug]: 2026.4.14 Windows chat UI regression: input text swallowed, streamed replies often invisible until refresh, typing indicator flashes then blanks (#67035). Thanks @q7793527.
-- Reported: [Bug]: Telegram DM exec requires approval despite allowlist + ask:off — works in webchat, not in Telegram (#88773). Thanks @ppmuzyk.
-- Reported: [Bug]: Telegram `streaming.mode: "partial"` and `"block"` duplicate the full preview when reply >4096 chars (#87624). Thanks @tuckyapps.
-- Reported: Sub-agent completion events delivered 3x — duplicate messages on auto-announce retry (#89626). Thanks @Petru2224 and @Takhoffman.
-- Reported: lossless-claw compaction breaks tool_calls/tool message chain → 499 error on model switch (#88561). Thanks @Finn-jiejie.
-- Reported: Browser existing-session Chrome MCP tabs fail with 300ms attach timeout despite doctor passing (#88213). Thanks @lamkan0210.
-
+- **PR #88922** fix(google): forward stop sequences to Gemini generationConfig. Thanks @coder999999999.
+- **PR #89460** fix(models): preserve provider prompt cache boundaries. Related #89386. Thanks @Enominera.
+- **PR #89478** fix: restore Skill Workshop view switcher. Thanks @shakkernerd.
+- **PR #76741** fix(kimi): strip anthropic cache markers. Related #76612. Thanks @BryanTegomoh and @vliuyt.
+- **PR #89480** fix: recover suspicious gateway startup configs. Related #89331. Thanks @q1387154-spec.
+- **PR #87056** Policy: add data handling conformance checks. Thanks @giodl73-repo.
+- **PR #81488** Harden node exec approval precheck env [AI]. Thanks @mmaps and @drobison00.
+- **PR #89356** Add accessible Workboard movement controls. Thanks @BunsDev.
+- **PR #87074** fix(policy): reject unsupported policy keys. Thanks @giodl73-repo.
+- **PR #89601** fix(outbound): stop schema-padded poll modifiers from blocking send. Thanks @codezz and @Takhoffman.
+- **PR #88963** perf(telegram): avoid broad reset-boundary scan. Thanks @MonkeyLeeT.
+- **PR #89125** Suppress internal agent failure traces before channel delivery. Thanks @fuller-stack-dev.
+- **PR #89701** fix(exec): reject corrupt shell snapshots. Thanks @RomneyDa.
+- **PR #89705** fix: allowlist pending agent sqlite scaffold. Thanks @RomneyDa.
+- **PR #89704** Share channel progress draft compositor. Thanks @obviyus.
+- **PR #89708** perf(control-ui): coalesce chat metadata startup. Thanks @vincentkoc.
+- **PR #89337** fix: report gateway health auth diagnostics. Related #89711. Thanks @RomneyDa.
+- **PR #88685** Render dashboard chat history incrementally. Related #87345. Thanks @alexzhu0 and @2xmncvcx92-dotcom.
+- **PR #89740** fix(gateway): stabilize webchat prompt cache affinity. Related #89139. Thanks @vincentkoc and @Enominera.
+- **PR #89191** fix(webchat): show sessions_send handoffs as forwarded. Related #89161. Thanks @849261680 and @Xj49688-lgtm.
+- **PR #89723** fix(auto-reply): surface fatal channel errors. Thanks @fuller-stack-dev.
+- **PR #89727** fix #87699: [Bug]: [BUG] UI shows agent "running" after conversation ends — requires manual page refresh every time. Thanks @zhangguiping-xydt and @csck-luoy.
+- **PR #88786** fix #71992: [Bug]: Control UI webchat duplicates every assistant reply on 2026.4.21 — regression from #5964/#39469. Thanks @zhangguiping-xydt and @rzhnrhjr6j-cloud and @astoreyai and @kAIborg24.
+- **PR #89530** fix(ui): preserve visible chat stream text. Related #67035. Thanks @osolmaz and @q7793527.
+- **PR #87072** feat(telegram): opt-in interleaved progress lane. Thanks @anagnorisis2peripeteia.
+- **PR #89771** perf(ui): start chat refresh before bootstrap. Thanks @vincentkoc.
+- **PR #89777** perf(ui): label delayed chat sends in telemetry. Thanks @vincentkoc.
+- **PR #89786** perf(gateway): overlap chat catalog startup. Thanks @vincentkoc.
+- **PR #89793** test(ui): cover control chat send timing phases. Thanks @vincentkoc.
+- **PR #89801** perf(ui): surface chat ACK server timing. Thanks @vincentkoc.
+- **PR #89355** Harden Workboard modal and drawer accessibility. Thanks @BunsDev.
+- **PR #89802** docs(web): document chat ACK timing metadata. Thanks @vincentkoc.
+- **PR #89391** fix(android): improve companion-first shell UX. Thanks @Tosko4.
+- **PR #89811** fix(agents): release session write lock if fence read throws on prompt release. Thanks @Takhoffman and @spencer2211.
+- **PR #89808** perf(ui): trace chat send server milestones. Thanks @vincentkoc.
+- **PR #89813** fix(telegram): isolate verbose status after streamed finals. Related #89540. Thanks @Takhoffman and @kesslerio.
+- **PR #89814** fix(feishu): wire setup runtime setter. Related #88024. Thanks @Takhoffman and @glenn-agent and @leiJack-lo.
+- **PR #85961** fix #85807: retain Telegram preview after generation race. Thanks @zhangguiping-xydt and @samson1357924.
+- **PR #89035** fix #88773: [Bug]: Telegram DM exec requires approval despite allowlist + ask:off — works in webchat, not in Telegram. Thanks @zhangguiping-xydt and @obviyus and @ppmuzyk.
+- **PR #88634** fix(telegram): prevent preview duplication in partial and block streaming modes. Related #87624. Thanks @jmao0001 and @tuckyapps.
+- **PR #89812** fix(outbound): keep channel send durable when transcript mirror fails (#89626). Thanks @Takhoffman and @harjothkhara and @Petru2224.
+- **PR #88973** fix(telegram): require admin for target writeback [AI]. Thanks @pgondhi987 and @vincentkoc.
+- **PR #89449** refactor(gateway): share duplicated test helpers. Thanks @vincentkoc.
+- **PR #88832** fix(telegram): slow polling restart storms. Thanks @TurboTheTurtle.
+- **PR #89960** test(channels): fix guardrail regex lint. Thanks @RomneyDa.
+- **PR #89244** fix(memory): warn after startup watcher pressure check. Thanks @RomneyDa.
+- **PR #89516** Add operator install policy and remove dangerous-code install scanners. Thanks @joshavant.
+- **PR #90024** chore(release): update appcast for 2026.6.1.
+- **PR #89613** docs: document auth profile failure policy contract.
+- **PR #89548** fix(agents): classify read-only shell commands as non-mutating. Thanks @Glucksberg.
+- **PR #89939** fix: keep stream-to-parent spawns registered. Thanks @scotthuang.
+- **PR #88964** fix(agents): repair context-engine tool-result pairing. Related #88561. Thanks @MonkeyLeeT and @Finn-jiejie.
+- **PR #82219** fix(codex): accept first-party OpenAI plugin marketplaces (bundled and primary-runtime). Related #82216. Thanks @yaanfpv.
+- **PR #89998** revert(codex): revert first-party marketplace allowlist. Thanks @kevinslin.
+- **PR #89176** fix(browser): honor tab timeout for Chrome MCP. Related #88213. Thanks @MonkeyLeeT and @lamkan0210.
+- **PR #90043** fix: restore Skill Workshop current chat toggle. Thanks @shakkernerd.
+- **PR #81422** fix(update): surface plugin channel fallbacks. Thanks @BKF-Gitty.
 ## 2026.6.1
 
 ### Highlights
 
-- Agents and CLI-backed runtimes recover more cleanly from interrupted tool calls, stale session bindings, compaction handoffs, auth-profile failover, reasoning-tag cleanup, and media delivery retries. (#85798, #87484, #88129, #88136, #88141, #88162, #88182, #88924, #89220) Thanks @RomneyDa, @neeravmakwana, and @omarshahine.
-- Channels and mobile delivery are steadier across Telegram, WhatsApp, iMessage, Slack, Discord, Microsoft Teams, Google Chat, Google Meet, QQBot, and iOS realtime Talk. (#88096, #88105, #88183, #88749, #88866, #88948, #88984, #89015, #88231) Thanks @omarshahine, @Jensenwgd, and @sliverp.
-- Provider and plugin requests now bound more timers, retries, OAuth/device-code lifetimes, media downloads, local service probes, generated-content polling, provider-catalog failures, reasoning output, and model catalog paths before they can hang a run. (#88480, #88512, #88767, #88781, #88851, #88860, #89343, #89379, #89400) Thanks @vincentkoc, @charles-openclaw, @zz327455573, @849261680, and @XuZehan-iCenter.
-- Skills, Skill Workshop, and plugin loading now handle proposal review, stale disabled snapshots, support-file approvals, locale/routing fixes, and loader failures more clearly, so channel turns avoid disabled SecretRefs and operators get better recovery guidance. (#79072, #79173, #88734) Thanks @zeus1959 and @shakkernerd.
-- Workboard, SecretRef plugin manifests, hosted iOS push relay, typed presentation command actions, and external Copilot/Tokenjuice packaging add broader orchestration, integration, SDK, and plugin delivery surfaces. (#82326, #87469, #87796, #88107, #88117, #88721, #89336) Thanks @RomneyDa.
-- Chat and Control UI startup paths keep sends alive through history loading, stream deltas incrementally, skip markdown work while streaming, keep drafts local while typing, clear the composer after sends, trace first-output latency, cache transcript renders, prioritize first connect, and expose calmer composer controls and notification settings. (#74715, #88772, #88825, #88952, #88960, #88998, #89030, #89106) Thanks @VladyslavLevchuk, @vincentkoc, and @sallyom.
-- iMessage monitor state, inbound queues, Discord thread bindings, plugin install ledgers, session metadata, gateway runtime state, plugin metadata, memory watchers, and store writes moved toward SQLite-backed or cached state so restarts and hot paths do less repeated work. (#88794, #88797, #88866, #89075, #89185, #89188, #85351) Thanks @RomneyDa and @NianJiuZst.
-- Release, CI, Docker, E2E, plugin install, update, doctor, diagnostics, and security lanes now cap more logs, response bodies, readiness probes, artifact checks, status polling, child workflow waits, docker package cleanup, quiet test stalls, downgrade repair, and health probes so failures report bounded proof instead of stalling. (#84988, #87914, #87952, #88966, #89169, #89701, #89731) Thanks @LibraHo, @Niriakot, @MukundaKatta, and @RomneyDa.
+- **Resilient agent and Codex runs:** interrupted tool calls, stale session bindings, compaction handoffs, auth-profile failover, reasoning-tag cleanup, yielded subagents, and generated-media delivery all recover without leaving work stranded. (#85798, #87484, #88182, #89220) Thanks @RomneyDa, @neeravmakwana, @joshavant, @omarshahine, @vincentkoc, @bgmbgm94, and @ksiyuna-claw.
+- **Reliable channel and mobile delivery:** WhatsApp, iMessage, Discord state, QQBot, and iOS Talk now preserve replies, typing, session state, QR-login recovery, and realtime connections across normal restart and transport failure paths. (#88183, #88866, #88948, #89015, #88231) Thanks @mcaxtr, @omarshahine, @sliverp, @Jensenwgd, @ngutman, @vincentkoc, and @alfredjbclaw.
+- **Faster Control UI chat:** startup, local drafts, incremental stream rendering, transcript caching, first connect, and post-send cleanup no longer compete with the active conversation. (#88952, #88960, #88998, #89030, #89106) Thanks @vincentkoc and @sallyom.
+- **Governed skills and plugins:** Skill Workshop proposals, disabled-skill snapshots, support-file approvals, plugin contracts, and external package boundaries are clearer and safer for operators. (#79173, #82326, #89336) Thanks @zeus1959, @sallyom, @RomneyDa, @maverikva, @vincentkoc, and @shakkernerd.
+- **Richer operator coordination:** Workboard goals, task-backed runs, and SQLite-backed plugin state make multi-agent work and installed-plugin discovery survive reloads cleanly. (#87469, #88794) Thanks @vincentkoc.
+- **More dependable providers:** Google defaults, provider IDs, model catalogs, OAuth/device-code flows, media timers, and reasoning output now stay valid across hosted and local runtimes. (#88512, #88781, #89343, #89379, #89400) Thanks @1052326311, @charles-openclaw, @zz327455573, @849261680, @xzh-xydt, @azgardtek, @google, @mrbrl, @nyuDSA, @vincentkoc, and @cjalden.
 
 ### Changes
 
-- Docs: add a dedicated Skill Workshop guide covering governed skill creation, reviewable proposals, CLI, Gateway, agent tool behavior, approval policy, support files, and recovery; refresh ClawHub cards; and add ClawHub CLI, iMessage SSH-wrapper TCC, Android helper, diff-language, and host-local media-send guidance. (#79658, #88734, #88758, #88865, #89297) Thanks @simplyclever914, @shakkernerd, @vyctorbrzezowski, @TurboTheTurtle, @RomneyDa, and @Wang-Yeah623.
-- Skills: let the `skill_workshop` agent tool apply, reject, and quarantine explicit proposals through the guarded review flow. Thanks @shakkernerd.
-- Skills: let proposals carry approved support files under standard skill folders, with scanner, hash, and rollback safeguards. Thanks @shakkernerd.
+- Skills: let the `skill_workshop` agent tool apply, reject, and quarantine explicit proposals through the guarded review flow. Thanks @shakkernerd and @vincentkoc.
+- Skills: let proposals carry approved support files under standard skill folders, with scanner, hash, and rollback safeguards. Thanks @shakkernerd and @vincentkoc.
 - Skills: let pending proposals be revised in place with versioned, dated proposal frontmatter before approval. Thanks @shakkernerd.
-- Skills: add Skill Workshop with pending proposals, CLI/Gateway review actions, rollback metadata, and the `skill_workshop` agent tool. Thanks @shakkernerd.
-- Skill Workshop: add the Control UI navigation, styled dashboard, proposal today view, revision dialog, file preview modal, searchable preview files, reusable session handoff, and localized strings.
+- Skills: add Skill Workshop with pending proposals, CLI/Gateway review actions, rollback metadata, and the `skill_workshop` agent tool. Thanks @shakkernerd and @vincentkoc.
+- Skill Workshop: add the Control UI navigation, styled dashboard, proposal today view, revision dialog, file preview modal, searchable preview files, reusable session handoff, and localized strings. Thanks @vincentkoc and @shakkernerd.
 - Plugins: externalize Tokenjuice as the official `@openclaw/tokenjuice` plugin with npm and ClawHub publish metadata.
 - Plugins: externalize the GitHub Copilot agent runtime as the official `@openclaw/copilot` plugin with npm and ClawHub publish metadata.
-- iOS: add hosted push relay defaults, realtime Talk playback, and a guarded WebSocket ping path for more reliable mobile sessions. (#88096, #88105, #88231)
+- iOS: add hosted push relay defaults, realtime Talk playback, and a guarded WebSocket ping path for more reliable mobile sessions. (#88096, #88105, #88231) Thanks @ngutman.
 - iOS: support native iPad display layouts.
 - Android: add installed-app inspection commands, notification picker helpers, and updated-system-app classification.
 - Workboard: add orchestration primitives and agent coordination tools for multi-agent planning and run tracking. (#87469)
 - Workboard: wire task-backed board runs and show task comments in the edit modal.
 - Code mode: add internal namespaces for scoped agent/global sessions and exact namespace tool dispatch. (#88043)
-- Code mode: add MCP API files and docs for code-mode integrations.
 - Gateway: support Tailscale Serve service names for local service routing.
-- Control UI: add a Dreaming-tab agent selector and propagate the selected agent through Dreaming status, diary, and diary actions. (#78748) Thanks @stevenepalmer.
+- Control UI: add a Dreaming-tab agent selector and propagate the selected agent through Dreaming status, diary, and diary actions. (#78748) Thanks @stevenepalmer, @vincentkoc, and @ttomiczek.
 - Control UI: add calmer chat composer controls, local draft typing state, and first-output latency instrumentation for active chat entry. (#88772, #88998) Thanks @vincentkoc.
-- Plugins: add a SecretRef provider integration manifest contract and extract shared LLM core packages for provider/plugin reuse. (#82326, #88117)
-- Plugin SDK: add typed presentation command actions and the bounded `resolve_exec_env` hook for plugin-provided exec environment contributions. (#88721)
-- Plugins: persist the plugin install index in SQLite so installed package lookup survives reloads with less filesystem scanning. (#88794)
+- Plugins: add a SecretRef provider integration manifest contract. (#82326) Thanks @sallyom.
+- Plugin SDK: add typed presentation command actions and the bounded `resolve_exec_env` hook for plugin-provided exec environment contributions. (#88721) Thanks @vincentkoc.
+- Plugins: persist the plugin install index in SQLite so installed package lookup survives reloads with less filesystem scanning. (#88794) Thanks @vincentkoc.
 - Providers: add MiniMax M3 model support. (#88860)
 - Tools/media: allow validated host-local text document media sends while keeping unsafe plain-text media sends blocked. (#79658) Thanks @simplyclever914.
-- Doctor: add disk space health checks and stabilize post-upgrade JSON probes.
-- Channels: store inbound queues in SQLite and migrate iMessage monitor state to SQLite-backed tracking. (#88797)
-- Skills: add the core skills index and centralize skills runtime loading, status, filtering, and prompt formatting.
+- Doctor: add disk space health checks and stabilize post-upgrade JSON probes. Thanks @vincentkoc.
+- Channels: store inbound queues in SQLite and migrate iMessage monitor state to SQLite-backed tracking. (#88797) Thanks @vincentkoc.
+- Skills: add the core skills index and centralize skills runtime loading, status, filtering, and prompt formatting. Thanks @shakkernerd.
 
 ### Fixes
 
-- Release/CI/E2E: fail early when Crabbox sparse-sync full checkouts do not have enough local disk, with guidance for moving the sync root.
 - Build: render independent CLI startup metadata help snapshots concurrently to cut cold build-all metadata time.
-- Plugins: stop timed-out package-boundary prep steps by process group so descendant TypeScript/helper processes do not survive local check cleanup.
-- Control UI: serve static assets asynchronously after safe-open checks so large UI files do not block Gateway request handling.
-- Scripts/UI: forward direct wrapper SIGHUP shutdown to child processes so terminal hangups do not leave wrapped dev commands running.
-- Gateway: return the post-expiration pending-work revision from node drains so reconnecting nodes do not observe stale queue revisions after expired items are pruned.
-- Release/CI/E2E: keep temporary full-sync checkouts alive while slow Crabbox leases boot, so sparse worktree runs do not lose their sync source before file-list generation.
-- Release/CI/E2E: normalize inherited Linux `C.UTF-8` locale settings before raw AWS macOS Crabbox bootstrap commands, avoiding macOS locale warnings during package-manager hydration.
-- Release/CI/E2E: keep gateway watch regression checks from copying large static plugin assets inside the measured idle window.
-- Update: keep core updates nonblocking when missing external plugin repair downloads or soft plugin repair warnings would otherwise stall, pin post-core plugin compatibility to the downgraded core version, and still block installed active plugin payload smoke failures. (#84431, #87914, #87952) Thanks @TurboTheTurtle, @Niriakot, and @MukundaKatta.
-- Agents/providers: keep streaming tool-call argument parsing record-shaped when providers emit valid non-object JSON such as `null` or arrays.
-- Release/CI/E2E: reset incremental log readers when watched log files rotate without shrinking, so same-size replacements do not hide new readiness or RPC lines.
-- Talk: preserve explicit `null` payloads on controller-created turn and output-audio lifecycle events.
+- Plugins: stop timed-out package-boundary prep steps by process group so descendant TypeScript/helper processes do not survive local check cleanup. Thanks @vincentkoc.
+- Control UI: serve static assets asynchronously after safe-open checks so large UI files do not block Gateway request handling. Thanks @vincentkoc.
+- Scripts/UI: forward direct wrapper SIGHUP shutdown to child processes so terminal hangups do not leave wrapped dev commands running. Thanks @vincentkoc.
+- Gateway: return the post-expiration pending-work revision from node drains so reconnecting nodes do not observe stale queue revisions after expired items are pruned. Thanks @vincentkoc.
+- Update: keep core updates nonblocking when missing external plugin repair downloads or soft plugin repair warnings would otherwise stall, pin post-core plugin compatibility to the downgraded core version, and still block installed active plugin payload smoke failures. (#84431, #87914, #87952) Thanks @TurboTheTurtle, @Niriakot, @MukundaKatta, @giodl73-repo, @vincentkoc, and @davinci282828.
+- Agents/providers: keep streaming tool-call argument parsing record-shaped when providers emit valid non-object JSON such as `null` or arrays. Thanks @vincentkoc.
+- Talk: preserve explicit `null` payloads on controller-created turn and output-audio lifecycle events. Thanks @vincentkoc.
 - Agents/TUI: keep local custom provider runs from loading plugin runtime and auth alias metadata when plugins are disabled.
 - Agents/TUI: restore in-flight TUI run switch-back behavior, keep no-policy native hook fallback available, guard vanished workspaces, and keep lightweight isolated subagents lightweight.
 - Agents/media: keep async image, music, and video generation starts from ending the Codex turn, avoid duplicate generated-media fallbacks, and let mixed requests continue with summaries or other work while media renders in the background. (#89220) Thanks @omarshahine.
-- Agents/Codex: keep public OpenAI API-key profiles from being treated as native Codex app-server auth while preserving persisted Codex OAuth sessions.
-- Agents/Codex: stream Codex app-server final-answer partials to live reply previews, preserve ACP metadata in SQLite, prefer real tool results over synthetic repair output, prevent aborted app-server turn handles from lingering, migrate legacy OpenAI Codex `lastGood` auth state, and preserve workspace/session metadata through ACP runtime refactors. (#88405, #88724, #88730) Thanks @vincentkoc.
-- Control UI: keep collapsed tool cards labeled with the tool name and action instead of generic output text. Thanks @shakkernerd.
-- Agents/Codex: surface Skill Workshop guidance in Codex app-server prompts when `skill_workshop` is available. Thanks @shakkernerd.
-- Skill Workshop: restore and localize the Control UI board/today view switcher so review workflows keep their intended layout toggle across locales. Thanks @shakkernerd.
-- Agents/auth: write auth profiles atomically, dispatch auth failures by type, add force re-login and exhausted-failover recovery, clear legacy auto fallback pins, preserve workspaces during state-only uninstall, and compact before oversized turns so recovery paths avoid partial state. (#85798, #87484, #89181) Thanks @RomneyDa and @neeravmakwana.
-- Skills: skip disabled skill env overrides from stale persisted snapshots so disabled skill `apiKey` SecretRefs cannot abort embedded or channel turns. (#79072, #79173) Thanks @zeus1959.
-- Skill Workshop: render the Control UI tab from filtered navigation state and keep filtered fallback routing stable.
-- CLI: avoid live catalog validation during `openclaw agents add`, so adding a secondary agent no longer depends on provider catalog availability. (#76284, #88314) Thanks @zhangguiping-xydt.
-- CLI: harden CLI and plugin edge cases, and keep `plugins list --json` on the snapshot-only path so plugin sweeps avoid loading the full runtime status graph. (#88896)
-- CLI/desktop: bridge WSL clipboard operations through the shell, recognize manual-update launchd jobs, and keep machine-readable startup output parseable during progress setup. (#88764, #88689) Thanks @alexzhu0.
-- Plugins: make PixVerse external-plugin ClawHub metadata explicit and keep it out of bundled dist builds.
-- Plugins: clarify plugin loader failure guidance and treat soft plugin repair warnings as nonfatal so missing or incompatible plugin packages point operators at the right repair path without blocking unrelated work. (#84431) Thanks @TurboTheTurtle.
-- Plugins: preserve npm plugin roots after blocked installs, skip plugin-local `openclaw` peer symlinks during rollback snapshots, relink those peers after restore, isolate cached tool runtime siblings, isolate provider catalog projections and web-provider factory failures, and keep private LLM-core declarations bundled so one bad plugin does not poison sibling runtime paths. (#77237, #88767, #88807, #89336) Thanks @vincentkoc and @RomneyDa.
-- Cron: keep SQLite cron migrations compatible with legacy run-log tables, archived job stores, diagnostic cron names, single-job run-history names, startup cron retries, and legacy one-shot delete-after-run behavior. (#88285, #88294, #89075) Thanks @kip-claw.
-- Cron: keep update delivery validation scoped, harden restart state, and retire MCP runtimes on isolated cron cleanup.
-- Auto-reply: guard dispatcher failure-count probes so missing optional counters do not break SDK-typed recovery paths. (#89318) Thanks @Alix-007 and @takhoffman.
-- Memory: serialize QMD update/embed writes per store, reduce Linux watcher fan-out, avoid noisy gateway watcher warnings, retry transient FileProvider-backed reads, preserve phase signals on read errors, harden envelope metadata sanitization, reattach Linux native watchers when directories are recreated, and rewrite generated transcript paths on rollover so memory/search state survives concurrent gateway and CLI activity. (#66339, #85931, #89185, #89188, #89246, #85351) Thanks @openperf, @amittell, @RomneyDa, and @NianJiuZst.
-- Memory: keep vector-disabled FTS indexes from resolving embedding providers during sync and search.
-- Providers: bound generated media downloads from OpenAI, Runway, xAI, MiniMax, BytePlus, DashScope-compatible, FAL, OpenRouter, Google, Vydra, and Comfy providers.
-- Providers: resolve Google defaults to `google-generative-ai`, register Vertex static catalog rows and `gemini-3.1-flash-lite`, align Foundry reasoning metadata, skip DeepSeek V4 thinking params on Foundry fallback, use MiniMax account OAuth endpoints, preserve Copilot Claude 1M capabilities, suppress disabled Ollama reasoning output, forward Gemini stop sequences, switch direct Gemini reasoning to native mode, strip provider self-prefixes and Kimi-incompatible Anthropic cache markers, keep OpenAI stop-finished tool calls, and avoid replay ids when the Responses store is disabled. (#88480, #88512, #88781, #89343, #89379, #89400, #76612) Thanks @coder999999999, @BryanTegomoh, @vliuyt, @charles-openclaw, @zz327455573, @849261680, and @XuZehan-iCenter.
+- Agents/Codex: keep public OpenAI API-key profiles from being treated as native Codex app-server auth while preserving persisted Codex OAuth sessions. Thanks @vincentkoc.
+- Agents/Codex: stream Codex app-server final-answer partials to live reply previews, preserve ACP metadata in SQLite, prefer real tool results over synthetic repair output, prevent aborted app-server turn handles from lingering, migrate legacy OpenAI Codex `lastGood` auth state, and preserve workspace/session metadata through ACP runtime refactors. (#88405, #88724, #88730) Thanks @vincentkoc and @crash2kx.
+- Control UI: keep collapsed tool cards labeled with the tool name and action instead of generic output text. Thanks @shakkernerd and @vincentkoc.
+- Agents/Codex: surface Skill Workshop guidance in Codex app-server prompts when `skill_workshop` is available. Thanks @shakkernerd and @vincentkoc.
+- Skill Workshop: restore and localize the Control UI board/today view switcher so review workflows keep their intended layout toggle across locales. Thanks @shakkernerd and @vincentkoc.
+- Agents/auth: write auth profiles atomically, dispatch auth failures by type, add force re-login and exhausted-failover recovery, clear legacy auto fallback pins, preserve workspaces during state-only uninstall, and compact before oversized turns so recovery paths avoid partial state. (#85798, #87484, #89181) Thanks @RomneyDa, @neeravmakwana, @vincentkoc, and @bgmbgm94.
+- Skills: skip disabled skill env overrides from stale persisted snapshots so disabled skill `apiKey` SecretRefs cannot abort embedded or channel turns. (#79072, #79173) Thanks @zeus1959, @maverikva, and @shakkernerd.
+- Skill Workshop: render the Control UI tab from filtered navigation state and keep filtered fallback routing stable. Thanks @vincentkoc and @shakkernerd.
+- CLI: avoid live catalog validation during `openclaw agents add`, so adding a secondary agent no longer depends on provider catalog availability. (#76284, #88314) Thanks @zhangguiping-xydt and @RicardoUKMX.
+- CLI: harden CLI and plugin edge cases, and keep `plugins list --json` on the snapshot-only path so plugin sweeps avoid loading the full runtime status graph. (#88896) Thanks @vincentkoc.
+- CLI/desktop: bridge WSL clipboard operations through the shell, recognize manual-update launchd jobs, and keep machine-readable startup output parseable during progress setup. (#88764, #88689) Thanks @alexzhu0, @TurboTheTurtle, @toruvieI, and @deonkretch.
+- Plugins: make PixVerse external-plugin ClawHub metadata explicit and keep it out of bundled dist builds. Thanks @vincentkoc.
+- Plugins: clarify plugin loader failure guidance and treat soft plugin repair warnings as nonfatal so missing or incompatible plugin packages point operators at the right repair path without blocking unrelated work. (#84431) Thanks @TurboTheTurtle and @davinci282828.
+- Plugins: preserve npm plugin roots after blocked installs, skip plugin-local `openclaw` peer symlinks during rollback snapshots, relink those peers after restore, isolate cached tool runtime siblings, isolate provider catalog projections and web-provider factory failures, and keep private LLM-core declarations bundled so one bad plugin does not poison sibling runtime paths. (#77237, #88767, #88807, #89336) Thanks @vincentkoc, @RomneyDa, and @zhuisDEV.
+- Cron: keep SQLite cron migrations compatible with legacy run-log tables, archived job stores, diagnostic cron names, single-job run-history names, startup cron retries, and legacy one-shot delete-after-run behavior. (#88285, #88294, #89075) Thanks @kip-claw, @Takhoffman, @bennewell35, and @highfly-hi.
+- Cron: keep update delivery validation scoped, harden restart state, and retire MCP runtimes on isolated cron cleanup. Thanks @vincentkoc.
+- Auto-reply: guard dispatcher failure-count probes so missing optional counters do not break SDK-typed recovery paths. (#89318) Thanks @Alix-007, @takhoffman, and @Bigzhangbig.
+- Memory: serialize QMD update/embed writes per store, reduce Linux watcher fan-out, avoid noisy gateway watcher warnings, retry transient FileProvider-backed reads, preserve phase signals on read errors, harden envelope metadata sanitization, reattach Linux native watchers when directories are recreated, and rewrite generated transcript paths on rollover so memory/search state survives concurrent gateway and CLI activity. (#66339, #85931, #89185, #89188, #89246, #85351) Thanks @openperf, @amittell, @RomneyDa, @NianJiuZst, @SakenW, @vincentkoc, @chrisabad, and @richardmqq.
+- Memory: keep vector-disabled FTS indexes from resolving embedding providers during sync and search. Thanks @vincentkoc.
+- Providers: bound generated media downloads from OpenAI, Runway, xAI, MiniMax, BytePlus, DashScope-compatible, FAL, OpenRouter, Google, Vydra, and Comfy providers. Thanks @vincentkoc.
+- Providers: resolve Google defaults to `google-generative-ai`, register Vertex static catalog rows and `gemini-3.1-flash-lite`, align Foundry reasoning metadata, skip DeepSeek V4 thinking params on Foundry fallback, use MiniMax account OAuth endpoints, preserve Copilot Claude 1M capabilities, suppress disabled Ollama reasoning output, forward Gemini stop sequences, switch direct Gemini reasoning to native mode, strip provider self-prefixes and Kimi-incompatible Anthropic cache markers, keep OpenAI stop-finished tool calls, and avoid replay ids when the Responses store is disabled. (#88480, #88512, #88781, #89343, #89379, #89400, #76612) Thanks @coder999999999, @BryanTegomoh, @vliuyt, @charles-openclaw, @zz327455573, @849261680, @XuZehan-iCenter, @azgardtek, @1052326311, @google, @mrbrl, @xzh-xydt, @nyuDSA, @vincentkoc, and @cjalden.
 - Providers: cap GitHub Copilot OAuth request timeouts before creating abort signals.
 - Cron: retry recurring jobs after transient model rate limits before waiting for the next scheduled slot.
-- Agents/Codex: keep live session locks during cleanup, recover interrupted CLI tool transcripts, preserve Codex auth and compaction session identity, clear orphan tool state, cap app-server idle timers, and keep media completion delivery retryable. (#88129, #88136, #88141, #88162, #88182)
-- Chat/UI: show Gateway chat failures as visible assistant messages in the Control UI instead of only setting an invisible error state.
-- Channels: cap Telegram, Discord, WhatsApp, Signal, Feishu, Google Chat, Microsoft Teams, QQBot, Nostr, Zalo, Zalouser, and Nextcloud-style request/retry timers; preserve SMS approval reply routes; keep iMessage typing active during tool work; allow RFC2544 benchmark ranges for QQBot token fetches; and retry WhatsApp QR login 408 timeouts. (#88183, #88948, #88984, #89015) Thanks @omarshahine, @Jensenwgd, and @sliverp.
-- Security/config parsing: reject unsafe OAuth/token lifetimes, retry-after delays, inbound timestamps, response body sizes, command timeout config, sandbox observer token TTLs, corrupt shell snapshots, untrusted workspace setup-only channel loads, remote media reference overreads, trajectory export leaks, hooks-token auth reuse, and gateway WebSocket calls after close. (#86953, #87376, #88974, #89354, #89701) Thanks @hxy91819, @coygeek, @pgondhi987, and @RomneyDa.
+- Agents/Codex: keep live session locks during cleanup, recover interrupted CLI tool transcripts, preserve Codex auth and compaction session identity, clear orphan tool state, cap app-server idle timers, and keep media completion delivery retryable. (#88129, #88136, #88141, #88162, #88182) Thanks @joshavant, @vincentkoc, @ssdatye, and @ksiyuna-claw.
+- Chat/UI: show Gateway chat failures as visible assistant messages in the Control UI instead of only setting an invisible error state. Thanks @vincentkoc.
+- Channels: cap Telegram, Discord, WhatsApp, Signal, Feishu, Google Chat, Microsoft Teams, QQBot, Nostr, Zalo, Zalouser, and Nextcloud-style request/retry timers; preserve SMS approval reply routes; keep iMessage typing active during tool work; allow RFC2544 benchmark ranges for QQBot token fetches; and retry WhatsApp QR login 408 timeouts. (#88183, #88948, #88984, #89015) Thanks @omarshahine, @Jensenwgd, @sliverp, @mcaxtr, @vincentkoc, and @alfredjbclaw.
+- Security/config parsing: reject unsafe OAuth/token lifetimes, retry-after delays, inbound timestamps, response body sizes, command timeout config, sandbox observer token TTLs, corrupt shell snapshots, untrusted workspace setup-only channel loads, remote media reference overreads, trajectory export leaks, hooks-token auth reuse, and gateway WebSocket calls after close. (#86953, #87376, #88974, #89354, #89701) Thanks @hxy91819, @coygeek, @pgondhi987, @RomneyDa, @SebTardif, and @vincentkoc.
 - Providers/media: cap local service, model, usage, queue, generated media, TTS, music, workflow polling, and provider OAuth request timers across hosted and local providers.
-- Release/CI/E2E: bound release candidate reads, beta smoke REST calls, plugin npm verification commands, changelog restore, cross-OS process groups, kitchen-sink and bundled plugin readiness probes, secret-provider probes, Telegram credential timeouts, Control UI i18n and CLI startup metadata generation, Vitest routing, dependency guard admin approvals, child workflow failure detection, quiet Node test shard stalls, dist cache restores, Docker base-image/package cleanup, and mainline test flakes. (#84988, #88127, #88137, #88155, #88160, #88966, #89169) Thanks @LibraHo and @RomneyDa.
-- Release/CI/E2E: keep Kitchen Sink live plugin MCP probes resolving source-checkout workspace packages and align the live gauntlet with current Kitchen Sink diagnostics.
 - Backup: accept root-relative hardlink targets during backup verification. (#89328) Thanks @abnershang.
-- Release/CI/E2E: run the secret-provider integration proof through the repo pnpm runner so native macOS and Windows validation use the hydrated package-manager shim.
-- Release/CI/E2E: run the Telegram desktop proof gateway through the repo pnpm runner so native macOS proof uses the hydrated package-manager shim.
-- Docs/CI: run Mintlify anchor checks through the repo pnpm runner so docs link validation works when pnpm is only available through the hydrated package-manager shim.
 - Agents: keep configured fallback model metadata typed so provider params, context-token caps, and media input limits do not break changed-gate typechecks.
-- Agents: accept hidden `sessions_send` body aliases before validation while keeping the model-facing `message` schema canonical. (#88229) Thanks @zhangguiping-xydt.
-- Chat/UI: preserve startup chat sends during history loading, unblock the initial Control UI chat send, stream chat deltas incrementally, skip markdown parsing while streaming, keep drafts local while typing, guard composer rerenders, cache chat transcript renders, record pending-send paint timing, show the Communication Notifications tab, honor Chromium executable overrides, and detect system Chromium for E2E. (#74715, #88952, #88960, #88998) Thanks @VladyslavLevchuk and @vincentkoc.
+- Agents: accept hidden `sessions_send` body aliases before validation while keeping the model-facing `message` schema canonical. (#88229) Thanks @zhangguiping-xydt and @jsonmez.
+- Chat/UI: preserve startup chat sends during history loading, unblock the initial Control UI chat send, stream chat deltas incrementally, skip markdown parsing while streaming, keep drafts local while typing, guard composer rerenders, cache chat transcript renders, record pending-send paint timing, show the Communication Notifications tab, and honor Chromium executable overrides. (#74715, #88952, #88960, #88998) Thanks @VladyslavLevchuk and @vincentkoc.
 - Channels: stop schema-padded poll modifiers from turning normal `send` actions into invalid poll sends. (#89601) Thanks @codezz and @takhoffman.
-- Channels: preserve long Feishu streaming replies, recover failed progress draft starts, send visible fallbacks when accepted Feishu turns produce no final reply, preserve external `sessions_send` routes, persist Discord thread bindings in SQLite, tolerate iMessage self-chat timestamp skew, preserve colon-prefixed slash commands in mention parsing, decode Nostr `npub` allowlists correctly, and suppress raw provider errors during channel delivery. (#87896, #88749, #88803, #88866) Thanks @MonkeyLeeT.
-- Config/status/doctor: skip unresolved shell references in state-dir dotenv files, resolve gateway auth secrets during deep status audits, surface disabled Codex plugin routes in doctor lint, respect explicit PI runtime policy, report runtime tool-schema and gateway health credential errors, clear recovered embedded-run activity, migrate voice-call call logs through doctor, and keep post-upgrade JSON stable. (#88731, #88761, #88820, #88288, #89731) Thanks @brokemac79, @openperf, and @RomneyDa.
-- Gateway/session state: list commands from the Gateway plugin registry, harden MCP loopback tool schemas, hide phantom agent-store rows from `sessions.list`, make task persistence failures explicit, support Tailscale Serve service names, guard Browser/Chrome pending attach aborts, and carry session UUIDs on interactive dispatch events. (#88305) Thanks @rohitjavvadi.
-- Gateway/plugins: narrow plugin lookup memoization to the stable plugin/runtime inputs, avoiding repeated lookup work without mixing disabled or filtered plugin state.
-- OpenAI/TTS: handle speed directives for OpenAI TTS voices. (#74089)
-- CI/Crabbox: keep default runner capacity on the Azure credit-backed on-demand D4 lane with the Azure SSH port and a Git-independent full check job, so broad validation avoids low-priority spot quota stalls, hydrate port mismatches, non-Git hydrated workspaces, and stale AWS region hints.
-- CI/Crabbox: route Crabbox wrapper and Testbox workflow edits to their regression tests so changed-test gates do not silently run zero specs.
-- CI/workflows: route workflow sanity helper edits to their guard tests and cover composite-action input interpolation checks.
-- CI/tooling: route CI scope, dependency, changelog, and docs helper edits to their owner tests instead of silently skipping changed-test coverage.
-- CI/tooling: route package, release, and install helper edits to their owner tests so changed-test gates cover publish and installer script changes.
-- CI/tooling: route shared script library edits through their owner tests so lock, process, safety, and scan helpers do not skip changed-test coverage.
-- CI/tooling: skip expensive import-graph scans once a changed diff already requires broad fallback, keeping local changed-test planning fast while still collecting explicit owner tests.
-- CI/tooling: route script edits through conventional owner tests when matching `test/scripts` or `src/scripts` coverage already exists.
-- CI/tooling: honor option terminators in the memory FD repro script so follow-on arguments are not reparsed.
-- Release/CI/E2E: assert plugin lifecycle runtime inspect output instead of only capturing it.
-- Release/CI/E2E: make gateway-network prove the advertised health RPC and retry early WebSocket closes without burning full open timeouts.
-- Release/CI/E2E: honor option terminators across release, Parallels smoke, plugin gauntlet, and extension-memory scripts.
-- Release/CI/E2E: fail plugin gateway gauntlet QA chunks when the requested suite summary is missing or invalid.
+- Channels: preserve long Feishu streaming replies, recover failed progress draft starts, send visible fallbacks when accepted Feishu turns produce no final reply, preserve external `sessions_send` routes, persist Discord thread bindings in SQLite, tolerate iMessage self-chat timestamp skew, preserve colon-prefixed slash commands in mention parsing, decode Nostr `npub` allowlists correctly, and suppress raw provider errors during channel delivery. (#87896, #88749, #88803, #88866) Thanks @MonkeyLeeT, @ArthurNie, @vincentkoc, @SebTardif, and @Lvan185.
+- Config/status/doctor: skip unresolved shell references in state-dir dotenv files, resolve gateway auth secrets during deep status audits, respect explicit PI runtime policy, report runtime tool-schema and gateway health credential errors, clear recovered embedded-run activity, and keep post-upgrade JSON stable. (#88820, #88288, #89731) Thanks @openperf, @RomneyDa, @Alix-007, @vincentkoc, @Iman-Sharif, and @mathias15010.
+- Gateway/session state: list commands from the Gateway plugin registry, harden MCP loopback tool schemas, hide phantom agent-store rows from `sessions.list`, make task persistence failures explicit, support Tailscale Serve service names, guard Browser/Chrome pending attach aborts, and carry session UUIDs on interactive dispatch events. (#88305) Thanks @rohitjavvadi and @vincentkoc.
+- Gateway/plugins: narrow plugin lookup memoization to the stable plugin/runtime inputs, avoiding repeated lookup work without mixing disabled or filtered plugin state. Thanks @vincentkoc.
+- OpenAI/TTS: handle speed directives for OpenAI TTS voices. (#74089) Thanks @stainlu, @useramuser, and @vincentkoc.
 - Performance: prebuild QA runtime probes with generated plugin assets but without CLI startup metadata.
-- Performance: skip declaration bundling for runtime-only CLI startup and gateway watch build profiles.
-- Performance: reuse prepared provider handles, strict tool schemas, gateway runtime metadata, session maintenance config, plugin metadata, bundled skill allowlists, package-local plugin artifacts, single-entry store writes, and validated/serialized session prompt blobs.
+- Performance: skip declaration bundling for runtime-only CLI startup and gateway watch build profiles. Thanks @vincentkoc.
+- Performance: reuse prepared provider handles, strict tool schemas, gateway runtime metadata, session maintenance config, plugin metadata, bundled skill allowlists, package-local plugin artifacts, single-entry store writes, and validated/serialized session prompt blobs. Thanks @vincentkoc and @shakkernerd.
 
-### Complete contribution ledger
+### Complete contribution record
 
-This audited record covers the complete v2026.5.31-beta.4..v2026.6.1 history: 104 PRs and 27 linked issues. The grouped notes above prioritize user impact; this ledger preserves every contribution reference and eligible human credit.
+This audited record covers the complete v2026.5.31-beta.4..v2026.6.1 history: 115 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
 
 #### Pull requests
 
-- perf(ui): keep chat draft local while typing (#88998). Thanks @vincentkoc.
-- fix(plugins): block untrusted workspace setup-only channel loads (#86953). Thanks @hxy91819.
-- perf(control-ui): prioritize first connect startup (#89030). Thanks @vincentkoc.
-- fix(ui): clear chat composer after send (#89106). Thanks @sallyom.
-- fix: bound remote media reference reads [AI] (#88974). Thanks @pgondhi987.
-- fix: allow admins to approve dependency guard (#88966). Thanks @RomneyDa.
-- fix(ci): restore dist cache before artifact builds (#89169). Thanks @RomneyDa.
-- fix(agents): actionable copy for exhausted auth-profile failover (#85798). Thanks @RomneyDa.
-- Keep JSON CLI output clean during startup (#88689). Thanks @alexzhu0.
-- fix(memory): retry transient FileProvider-backed reads (#85351). Thanks @NianJiuZst.
-- fix(memory-core): reduce Linux watcher fan-out (#89188). Thanks @RomneyDa.
-- docs: refresh ClawHub showcase cards (#88734). Thanks @vyctorbrzezowski.
-- test: reset gateway timers at test boundaries (#89212). Thanks @RomneyDa.
-- fix(agents): dispatch auth failures by type (#89181). Thanks @RomneyDa.
-- fix(memory): warn on gateway watcher FD risk (#89185). Thanks @RomneyDa.
-- Revert "fix(memory): warn on gateway watcher FD risk" (#89246). Thanks @RomneyDa.
-- Keep iMessage typing active during tool work (#88948). Thanks @omarshahine.
-- fix(agents): avoid duplicate generated media fallback (#89220). Thanks @omarshahine.
-- docs: add ClawHub CLI page (#89297). Thanks @Wang-Yeah623 and @Takhoffman.
-- fix(auto-reply): guard missing dispatcher getFailedCounts without weakening the SDK type (#89318). Thanks @Takhoffman.
-- Fix backup verifier for root-relative hardlink targets (#89328). Thanks @abnershang.
-- fix(openai): honor OPENAI_BASE_URL when no provider config sets a baseUrl (#74427). Thanks @sunapi386.
-- fix(anthropic): honor ANTHROPIC_BASE_URL when no baseUrl is configured (#74432). Thanks @sunapi386.
-- fix(cache): honour explicit cacheRetention for OpenRouter→Anthropic models (#79370). Thanks @mene-crab.
-- fix(github-copilot): expose thinking profile via bundled provider-policy-api (#79894). Thanks @jakepresent.
-- fix(configure): allow pruning stale provider models (#80366). Thanks @jbetala7.
-- fix: remove isOpenAIProvider gate from applyPatchEnabled (#88359). Thanks @bottenbenny.
-- Fix private llm-core leaks in plugin SDK declarations (#89336). Thanks @RomneyDa.
-- fix(qqbot): allow RFC2544 benchmark range for token fetch (issue 88984) (#89015). Thanks @sliverp.
-- fix(agents): don't fail CLI turn when the native harness owns compaction (#87785). Thanks @solomonneas.
-- fix(memory-core): keep startup cron retries quiet (#89075). Thanks @Takhoffman.
-- fix: redact trajectory exports consistently (#89354). Thanks @pgondhi987.
-- fix(logging): requeue stuck session lane after abort (#89293). Thanks @Pluviobyte.
-- fix(infra): prefer npm-shrinkwrap.json over packageManager field for npm detection (#88283). Thanks @Alix-007.
-- Treat soft plugin repair warnings as nonfatal (#84431). Thanks @TurboTheTurtle.
-- fix(update): pin post-core plugin compatibility to the downgraded core version (issue 87914) (#87952). Thanks @MukundaKatta.
-- trace: Correlate channel message diagnostics into one trace (#88821). Thanks @bek91.
-- fix(google): add missing gemini-3.1-flash-lite to google-vertex catalog (#89400). Thanks @xzh-xydt.
-- fix(providers): use native reasoning mode for Gemini instead of tagged (#89379). Thanks @849261680.
-- fix(llm): prevent reasoning_content leak when reasoning is disabled (#89343). Thanks @zz327455573.
-- fix(exec): reject corrupt shell snapshots (#89701). Thanks @RomneyDa.
-- fix(outbound): stop schema-padded poll modifiers from blocking send (#89601). Thanks @codezz and @Takhoffman.
-- fix: backport gateway health credential handling (#89731). Thanks @RomneyDa.
-- fix(agents): clear legacy auto fallback pins (#87484). Thanks @neeravmakwana.
-- fix: keep live OpenClaw session locks during cleanup (#88129).
-- fix(agents): centralize terminal run outcome precedence (#88136).
-- fix: route generated media completions through requester agent (#88141).
-- fix(agents): extend terminal outcome projections (#88162).
-- Fix subagent DM completion delivery after yield (#88182). Thanks @joshavant.
-- fix(agents): strip streamed reasoning tags (#88924).
-- feat(ios): default to hosted push relay (#88096). Thanks @ngutman.
-- feat(ios): add talk tab realtime playback (#88105). Thanks @ngutman.
-- fix(whatsapp): retry QR login 408 timeouts (#88183). Thanks @mcaxtr.
-- fix(channels): recover failed progress draft starts (#88749).
-- Persist Discord thread bindings in SQLite (#88866).
-- fix(ios): guard websocket ping continuation (#88231). Thanks @ngutman.
-- fix: resolve google provider default API to google-generative-ai (#88512). Thanks @1052326311.
-- fix(plugin-sdk): isolate provider catalog projection failures (#88767). Thanks @vincentkoc.
-- fix(models): strip remaining provider self prefixes (#88781). Thanks @charles-openclaw.
-- Persist OpenRouter model cache in SQLite (#88851).
-- feat(minimax): add MiniMax M3 support (#88860).
-- fix: skip disabled skill snapshot env overrides (#79173). Thanks @zeus1959.
-- Add plugin manifest contract for SecretRef provider integrations (#82326). Thanks @sallyom.
-- feat: add core session goals (#87469).
-- feat(ci): autoscrub dependency lockfile-only PR changes (#87796). Thanks @RomneyDa.
-- feat: only include the current changelog section in tarball (#88107). Thanks @RomneyDa.
-- refactor: extract LLM core packages (#88117).
-- feat(plugin-sdk): add typed presentation command actions (#88721).
-- fix(ui): show Communication Notifications tab (#74715). Thanks @VladyslavLevchuk.
-- feat: calm composer controls (#88772).
-- perf: streamline chat startup metadata (#88825).
-- perf(ui): cache chat transcript renders (#88952). Thanks @vincentkoc.
-- perf(ui): record pending send paint timing (#88960). Thanks @vincentkoc.
-- Persist plugin install index in SQLite (#88794).
-- Migrate iMessage monitor state to SQLite (#88797).
-- Refresh Node Docker base image digests (#84988). Thanks @LibraHo.
-- Allow validated TXT/JSON/YAML media sends (#79658). Thanks @simplyclever914.
-- docs(imessage): document SSH wrapper TCC send failure (#88758). Thanks @TurboTheTurtle.
-- docs: clarify diffs language pack additions (#88865). Thanks @RomneyDa.
-- feat: add internal code mode namespaces (#88043).
-- fix(ui): add agent selector to dreaming tab (#78748). Thanks @stevenepalmer.
-- fix: persist ACP metadata in SQLite (#88724).
-- fix(codex): stream final answer partials (#88730).
-- fix issue 76284: [Bug]: openclaw agents add blocked — cannot add Jon/Atlas as separate agents (#88314). Thanks @zhangguiping-xydt.
-- fix: harden CLI and plugin edge cases (#88896).
-- fix(update): recognize manual-update launchd jobs (#88764). Thanks @TurboTheTurtle.
-- Preserve managed npm plugin root when install validation blocks update (#77237). Thanks @zhuisDEV.
-- fix(plugins): isolate web provider factory failures (#88807). Thanks @vincentkoc.
-- Move cron persistence to SQLite (#88285).
-- fix(cron): include job name when reading single-job run history (#88294). Thanks @kip-claw.
-- fix(memory): serialize qmd update writes across processes to stop SQLITE_BUSY (#85931). Thanks @openperf.
-- perf(test): fix explicit-file Vitest wrapper hangs (#88127). Thanks @RomneyDa.
-- fix ci mainline checks (#88137). Thanks @RomneyDa.
-- test(infra): avoid max fake-timer jumps (#88155). Thanks @RomneyDa.
-- test(unit-fast): isolate fake-timer files (#88160). Thanks @RomneyDa.
-- fix(agents): normalize sessions_send message aliases (#88229). Thanks @zhangguiping-xydt.
-- fix(feishu): fallback when accepted turns send no visible reply (#87896). Thanks @ArthurNie.
-- fix(reply): preserve sessions_send external routes (#88803). Thanks @MonkeyLeeT.
-- refactor: migrate voice-call call logs through doctor (#88731).
-- [codex] Surface disabled Codex plugin routes in doctor lint (#88761). Thanks @brokemac79.
-- fix(diagnostics): clear embedded-run activity when recovery declares lane idle (#88820). Thanks @openperf.
-- fix(config): skip state-dir dotenv values that are unresolved shell references (#88288). Thanks @Alix-007.
-- fix(browser): isolate Chrome MCP pending attach aborts (#88305). Thanks @rohitjavvadi.
-- fix(openai/tts): handle [[tts:speed]] directive in OpenAI speech provider (issue 12163) (#74089). Thanks @stainlu.
-
-#### Linked issues
-
-- Reported: Sanitise outbound message.send tool arguments to prevent runtime scaffolding leak (FM-3) and chat_id routing bleed (FM-2) on weaker models (#89100). Thanks @bobgitmcgrath.
-- Reported: External CLI harnesses blocked by stale auth-profiles gate (#85105). Thanks @saphoroth.
-- Reported: configure wizard: models block is append-only — stale/delisted model entries never pruned (#80347). Thanks @wherewolf87.
-- Reported: Bug: apply_patch unavailable on non-OpenAI providers due to hardcoded isOpenAIProvider gate (#88357). Thanks @bottenbenny.
-- Reported: [Bug]: `apply_patch` is treated as an unknown/plugin-only tool in agent policy pipeline, so agent-routed runs cannot execute it (#45269). Thanks @Alfred-claw28.
-- Reported: [Bug] QQ bot token fetch still blocked by SSRF — RFC2544 benchmark range not allowed (#88984). Thanks @Jensenwgd.
-- Reported: Codex app-server thread lifecycle latency is hidden between attempt-dispatch and session.started (#84640). Thanks @crash2kx.
-- Reported: macOS LaunchAgent gateway restart/stop can leave gateway unloaded when invoked in-band (#89174). Thanks @bek91.
-- Reported: [Bug][Codex Runtime]: Discord progress reasoning stream overwrites prior reasoning chunks (#83983). Thanks @xueqingli1.
-- Reported: Stuck-session recovery discards queued user messages after aborting ghost run (#89208). Thanks @ketos-jona.
-- Reported: [Bug]: 2026.5.27 npm install calls itself pnpm (#87732). Thanks @jasonftl.
-- Reported: Bug: resuming a session with a corrupted header line silently wipes the entire transcript (data loss) (#89037). Thanks @yetval.
-- Reported: [Bug]: QQBot credential backups bypass gateway state isolation (#84313). Thanks @coygeek.
-- Reported: diagnostics-prometheus can spam log.record errors after rollback when plugin version remains newer than OpenClaw core (#87914). Thanks @Niriakot.
-- Reported: google-vertex: gemini-3.1-flash-lite missing from pi-ai model catalog, causes silent failure with no fallback (#89390). Thanks @nyuDSA.
-- Reported: [Bug]: Context-engine overflow retry can bind a fresh Codex thread without projected context (#88355). Thanks @100yenadmin.
-- Reported: Gemini text-tag reasoning conflicts with native thinking — produces unclosed <think>, empty post-tool turn, payloads=0 (#69220). Thanks @mrbrl.
-- Reported: v2026.5.18 doctor/status can leave openai-codex OAuth sidecar auth partially repaired while runtime still fails (#84252). Thanks @TurboTheTurtle.
-- Reported: Bug: before_agent_finalize hook never fires for OpenClaw agents (main, coder, etc.) (#87585). Thanks @lileilei-camera.
-- Reported: [Feature]: Add `supportsPromptCacheKey` to Mistral transport compat patch (#83709). Thanks @Net-Sentinel.
-- Reported: [Bug]: Reusing hooks.token as gateway password collapses hook auth into full operator auth (#87376). Thanks @coygeek.
-- Reported: Kimi Code returns empty content when Anthropic cache_control markers are sent (#76612). Thanks @vliuyt.
-- Reported: Google Gemini chat model routes to openai-responses transport (401), native @google/genai transport never selected (#88480). Thanks @azgardtek.
-- Reported: [Bug] skills.entries.gh-issues.apiKey SecretRef unresolved in WhatsApp lane sessions (env:default:GITHUB_PAT) (#79072). Thanks @maverikva.
-- Reported: [Bug]: Telegram partial streaming receives no assistant deltas for openai-codex; newline chunking only sends final blocks (#88405). Thanks @crash2kx.
-- Reported: [Bug]: openclaw agents add blocked — cannot add Jon/Atlas as separate agents (#76284). Thanks @RicardoUKMX.
-- Reported: memory search can hit QMD SQLite lock contention during normal runtime (#66339). Thanks @SakenW.
-
+- **PR #88995** perf(ui): guard chat composer controls. Thanks @vincentkoc.
+- **PR #88998** perf(ui): keep chat draft local while typing. Thanks @vincentkoc.
+- **PR #89012** perf(ui): trace chat first output latency. Thanks @vincentkoc.
+- **PR #89019** perf(ui): speed up first global chat sends. Thanks @vincentkoc.
+- **PR #86953** fix(plugins): block untrusted workspace setup-only channel loads. Thanks @hxy91819 and @SebTardif.
+- **PR #89030** perf(control-ui): prioritize first connect startup. Thanks @vincentkoc.
+- **PR #89058** perf(control-ui): hydrate chat startup state. Thanks @vincentkoc.
+- **PR #89106** fix(ui): clear chat composer after send. Related #89108. Thanks @sallyom.
+- **PR #88974** fix: bound remote media reference reads [AI]. Thanks @pgondhi987.
+- **PR #88966** fix: allow admins to approve dependency guard. Thanks @RomneyDa.
+- **PR #89169** fix(ci): restore dist cache before artifact builds. Thanks @RomneyDa.
+- **PR #85798** fix(agents): actionable copy for exhausted auth-profile failover. Thanks @RomneyDa.
+- **PR #88689** Keep JSON CLI output clean during startup. Related #88602. Thanks @alexzhu0 and @toruvieI.
+- **PR #85351** fix(memory): retry transient FileProvider-backed reads. Related #85252. Thanks @NianJiuZst and @richardmqq.
+- **PR #89188** fix(memory-core): reduce Linux watcher fan-out. Related #89182. Thanks @RomneyDa.
+- **PR #88734** docs: refresh ClawHub showcase cards. Thanks @vyctorbrzezowski.
+- **PR #89212** test: reset gateway timers at test boundaries. Thanks @RomneyDa.
+- **PR #89181** fix(agents): dispatch auth failures by type. Thanks @RomneyDa.
+- **PR #89180** enhance(slack): route plugin approvals through native UI. Thanks @kevinslin.
+- **PR #89185** fix(memory): warn on gateway watcher FD risk. Related #71335. Thanks @RomneyDa and @chrisabad.
+- **PR #89135** fix(ui): render skill workshop tab. Thanks @Solvely-Colin.
+- **PR #89246** Revert "fix(memory): warn on gateway watcher FD risk". Thanks @RomneyDa.
+- **PR #88948** Keep iMessage typing active during tool work. Related #75847. Thanks @omarshahine and @alfredjbclaw.
+- **PR #89220** fix(agents): avoid duplicate generated media fallback. Thanks @omarshahine.
+- **PR #88946** Fix live model inference edge cases. Related #44870, #63685, #74305, #83192, #83810, #84109, #84688, #84697, #84804, #85806, #85918, #86808, #87381, #87740, #87768, #88039, #88439, #88456, #88833, #88918, #89008, #89241, #89242. Thanks @86jkuncle and @behroozbc and @SimSef and @tassiocamara and @chac4l and @alfredpennyworthtc-netizen and @shichuzhu and @mz1009-web and @devinallen-07 and @garyd9 and @silvesterxm and @jsompis and @xiaoxuesheng123467 and @TitanBob2026 and @guzzijones and @fenglanhua and @Nassiel and @ge0el and @pigfoot and @yetval and @joshgaskin and @shadow-enthusiast.
+- **PR #89305** fix(agents): bypass stale auth for plugin harnesses. Related #85105. Thanks @saphoroth.
+- **PR #89297** docs: add ClawHub CLI page. Thanks @Wang-Yeah623 and @Takhoffman.
+- **PR #89318** fix(auto-reply): guard missing dispatcher getFailedCounts without weakening the SDK type. Related #89116. Thanks @Takhoffman and @Alix-007 and @Bigzhangbig.
+- **PR #89321** fix: honor channel model overrides in agent ingress. Related #60078. Thanks @davidbordenwi.
+- **PR #89328** Fix backup verifier for root-relative hardlink targets. Thanks @abnershang.
+- **PR #87907** fix(memory): validate memory index identity. Related #83333. Thanks @osolmaz and @jacka-L.
+- **PR #89347** fix: repair model provider edge cases. Related #80347, #88357, #45269. Thanks @wherewolf87 and @bottenbenny and @Alfred-claw28.
+- **PR #89336** Fix private llm-core leaks in plugin SDK declarations. Thanks @RomneyDa.
+- **PR #89015** fix(qqbot): allow RFC2544 benchmark range for token fetch (#88984). Thanks @sliverp and @Jensenwgd.
+- **PR #89046** feat(android): add installed apps node command. Thanks @Tosko4.
+- **PR #88315** feat(agents): generalized native compaction ownership for CLI backends. Thanks @anagnorisis2peripeteia.
+- **PR #89075** fix(memory-core): keep startup cron retries quiet. Related #75889. Thanks @Takhoffman and @bennewell35 and @highfly-hi.
+- **PR #89049** fix(idle-timeout): honor provider timeout for no-timeout runs. Thanks @lanzhi-lee.
+- **PR #89047** fix: hide sessions_spawn timeout overrides. Thanks @lanzhi-lee.
+- **PR #89036** fix(cron): reject blank delivery targets. Thanks @lanzhi-lee.
+- **PR #89354** fix: redact trajectory exports consistently. Thanks @pgondhi987.
+- **PR #88101** fix(codex): trace app-server thread lifecycle timing. Related #84640. Thanks @ai-hpc and @crash2kx.
+- **PR #89243** fix: guard in-band macOS LaunchAgent stop. Related #89174. Thanks @bek91.
+- **PR #87339** fix(discord): accumulate reasoning progress deltas. Related #83983. Thanks @giodl73-repo and @xueqingli1.
+- **PR #89298** fix(diagnostics): re-queue pending messages after stuck-session recovery aborts ghost run. Related #89208. Thanks @LiLan0125 and @ketos-jona.
+- **PR #88821** trace: Correlate channel message diagnostics into one trace. Related #88811. Thanks @bek91.
+- **PR #89411** fix: detect shrinkwrapped npm installs. Related #87732. Thanks @jasonftl.
+- **PR #87749** fix(messages): preserve inbound audio for message-tool TTS. Related #87708. Thanks @ai-hpc and @nikodim-ai.
+- **PR #84431** Treat soft plugin repair warnings as nonfatal. Related #83889. Thanks @TurboTheTurtle and @davinci282828.
+- **PR #78005** feat(status): detect externalized plugin version drift in --deep. Thanks @hussein1362.
+- **PR #89050** fix(sessions): preserve corrupt-header transcripts. Related #89037. Thanks @charles-openclaw and @yetval.
+- **PR #84314** fix: QQBot credential backups bypass gateway state isolation. Related #84313. Thanks @coygeek.
+- **PR #89281** fix: repeat doctor state migration repairs. Thanks @RomneyDa.
+- **PR #87952** fix(update): pin post-core plugin compatibility to the downgraded core version (#87914). Thanks @MukundaKatta and @giodl73-repo and @Niriakot.
+- **PR #89417** refactor: tighten agent harness surfaces.
+- **PR #89400** fix(google): add missing gemini-3.1-flash-lite to google-vertex catalog. Related #89390. Thanks @xzh-xydt and @nyuDSA.
+- **PR #88699** fix(codex): clear stale context-engine projection after overflow retry. Related #88355. Thanks @SebTardif and @100yenadmin.
+- **PR #89379** fix(providers): use native reasoning mode for Gemini instead of tagged. Related #69220. Thanks @849261680 and @mrbrl.
+- **PR #84266** Surface unresolved OAuth sidecar auth failures. Related #84252. Thanks @TurboTheTurtle.
+- **PR #88879** feat(plugin-sdk): add resolve_exec_env hook. Thanks @lanzhi-lee.
+- **PR #89432** fix(qqbot): migrate state stores to sqlite kv.
+- **PR #89436** fix(llm): gate OpenAI-compatible reasoning output. Thanks @zz327455573.
+- **PR #87703** fix(agents): run before_agent_finalize for embedded agents. Related #87585. Thanks @ai-hpc and @lileilei-camera.
+- **PR #89440** fix(llm): keep OpenAI-compatible reasoning streams active. Related #84384. Thanks @teknolojay.
+- **PR #88976** fix(mistral): enable prompt cache key compat. Related #83709. Thanks @Alix-007 and @Net-Sentinel.
+- **PR #87379** fix: audit and repair hooks token reuse with Gateway auth. Related #87376. Thanks @coygeek.
+- **PR #89701** fix(exec): reject corrupt shell snapshots. Thanks @RomneyDa.
+- **PR #89601** fix(outbound): stop schema-padded poll modifiers from blocking send. Thanks @codezz and @Takhoffman.
+- **PR #89731** fix: backport gateway health credential handling. Thanks @RomneyDa.
+- **PR #87484** fix(agents): clear legacy auto fallback pins. Related #87467. Thanks @neeravmakwana and @bgmbgm94.
+- **PR #88182** Fix subagent DM completion delivery after yield. Related #88042. Thanks @joshavant and @ksiyuna-claw.
+- **PR #88183** fix(whatsapp): retry QR login 408 timeouts. Thanks @mcaxtr.
+- **PR #88866** Persist Discord thread bindings in SQLite.
+- **PR #88231** fix(ios): guard websocket ping continuation. Thanks @ngutman.
+- **PR #88952** perf(ui): cache chat transcript renders. Thanks @vincentkoc.
+- **PR #88960** perf(ui): record pending send paint timing. Thanks @vincentkoc.
+- **PR #79173** fix: skip disabled skill snapshot env overrides. Related #79072. Thanks @zeus1959 and @maverikva.
+- **PR #82326** Add plugin manifest contract for SecretRef provider integrations. Thanks @sallyom.
+- **PR #87469** feat: add core session goals.
+- **PR #88794** Persist plugin install index in SQLite.
+- **PR #88512** fix: resolve google provider default API to google-generative-ai. Related #88480. Thanks @1052326311 and @azgardtek.
+- **PR #88781** fix(models): strip remaining provider self prefixes. Related #88770. Thanks @charles-openclaw and @cjalden.
+- **PR #88096** feat(ios): default to hosted push relay. Thanks @ngutman.
+- **PR #88105** feat(ios): add talk tab realtime playback. Thanks @ngutman.
+- **PR #88043** feat: add internal code mode namespaces.
+- **PR #78748** fix(ui): add agent selector to dreaming tab. Related #63558. Thanks @stevenepalmer and @ttomiczek.
+- **PR #88772** feat: calm composer controls.
+- **PR #88721** feat(plugin-sdk): add typed presentation command actions.
+- **PR #88860** feat(minimax): add MiniMax M3 support.
+- **PR #79658** Allow validated TXT/JSON/YAML media sends. Thanks @simplyclever914.
+- **PR #88797** Migrate iMessage monitor state to SQLite.
+- **PR #88724** fix: persist ACP metadata in SQLite.
+- **PR #88730** fix(codex): stream final answer partials. Related #88405. Thanks @crash2kx.
+- **PR #88314** fix #76284: [Bug]: openclaw agents add blocked — cannot add Jon/Atlas as separate agents. Thanks @zhangguiping-xydt and @RicardoUKMX.
+- **PR #88896** fix: harden CLI and plugin edge cases.
+- **PR #88764** fix(update): recognize manual-update launchd jobs. Related #88736. Thanks @TurboTheTurtle and @deonkretch.
+- **PR #77237** Preserve managed npm plugin root when install validation blocks update. Thanks @zhuisDEV.
+- **PR #88767** fix(plugin-sdk): isolate provider catalog projection failures. Thanks @vincentkoc.
+- **PR #88807** fix(plugins): isolate web provider factory failures. Thanks @vincentkoc.
+- **PR #88285** Move cron persistence to SQLite.
+- **PR #88294** fix(cron): include job name when reading single-job run history. Thanks @kip-claw.
+- **PR #85931** fix(memory): serialize qmd update writes across processes to stop SQLITE_BUSY. Related #66339. Thanks @openperf and @SakenW.
+- **PR #88129** fix: keep live OpenClaw session locks during cleanup.
+- **PR #88136** fix(agents): centralize terminal run outcome precedence. Related #87444. Thanks @ssdatye.
+- **PR #88141** fix: route generated media completions through requester agent.
+- **PR #88162** fix(agents): extend terminal outcome projections.
+- **PR #88229** fix(agents): normalize sessions_send message aliases. Related #88146. Thanks @zhangguiping-xydt and @jsonmez.
+- **PR #74715** fix(ui): show Communication Notifications tab. Thanks @VladyslavLevchuk.
+- **PR #87896** fix(feishu): fallback when accepted turns send no visible reply. Thanks @ArthurNie.
+- **PR #88749** fix(channels): recover failed progress draft starts. Related #83115. Thanks @SebTardif.
+- **PR #88803** fix(reply): preserve sessions_send external routes. Related #88044. Thanks @MonkeyLeeT and @Lvan185.
+- **PR #88820** fix(diagnostics): clear embedded-run activity when recovery declares lane idle. Related #88660. Thanks @openperf and @Iman-Sharif.
+- **PR #88288** fix(config): skip state-dir dotenv values that are unresolved shell references. Related #88274. Thanks @Alix-007 and @mathias15010.
+- **PR #88305** fix(browser): isolate Chrome MCP pending attach aborts. Related #88304. Thanks @rohitjavvadi.
+- **PR #74089** fix(openai/tts): handle [[tts:speed]] directive in OpenAI speech provider (#12163). Thanks @stainlu and @useramuser.
 ## 2026.5.31
 
 ### Highlights
 
-- Chat and Control UI responsiveness improved across streamed markdown, transcript rendering, draft persistence, pending-send painting, scrolling, and first-message handling. (#88952, #88960, #88998) Thanks @vincentkoc.
-- Agent, Codex, and auth recovery is more resilient around stale bootstrap history, legacy Codex auth state, reasoning-tag cleanup, shell snapshot validation, and automatic fallback recovery. (#87484, #88924) Thanks @RomneyDa.
-- Cron, channels, and session delivery now preserve external routes, include job names in single-job history, and keep replies and state transitions clearer across restarts. (#88294, #88803) Thanks @kip-claw and @MonkeyLeeT.
+- **Faster Control UI chat:** transcript rendering, draft persistence, pending-send paint, scrolling, and first-message work no longer block one another while a conversation is active. (#88952, #88960, #88998) Thanks @vincentkoc.
+- **More reliable agent recovery:** fallback auth state, legacy Codex app-server auth, stale bootstrap history, and streamed reasoning cleanup recover cleanly instead of carrying stale turn state forward. (#87484, #88924) Thanks @neeravmakwana, @vincentkoc, @bgmbgm94, and @kdonthar.
+- **Clearer cron and channel history:** external `sessions_send` routes, single-job history, and channel reply state retain the right destination and job context through restarts. (#88294, #88803) Thanks @kip-claw, @MonkeyLeeT, @vincentkoc, and @Lvan185.
+- **Better operator coordination:** core session goals and durable plugin-install state make long-running work easier to inspect and resume after reloads. (#87469, #88794) Thanks @vincentkoc.
+- **Safer mobile reconnects:** iOS realtime sessions retain their WebSocket continuation instead of failing a healthy Talk connection, with hosted push/realtime paths kept aligned. (#88231) Thanks @ngutman and @vincentkoc.
 
 ### Changes
 
 - Workboard task details, Android notification app selection, and Dreaming candidate scoring gained broader operator controls.
-- Control UI now streams stable Markdown blocks and records more chat responsiveness signals to guide first-reply performance work.
-- Release and E2E infrastructure adds tighter package, installer, Docker, Parallels, Telegram, and plugin-lifecycle proof boundaries.
+- Control UI now streams stable Markdown blocks and records more chat responsiveness signals to guide first-reply performance work. Thanks @vincentkoc.
 
 ### Fixes
 
 - Chat/UI: keep first Control UI sends responsive, retain pending sends while history catches up, cache transcript renders, and avoid draft persistence or navigation churn from blocking the active conversation. (#88952, #88960, #88998) Thanks @vincentkoc.
-- Agents/Codex/auth: repair automatic fallback state, accept supported legacy Codex app-server auth, remove stale bootstrap history, strip streamed reasoning tags, and validate shell snapshots against trusted environment data. (#87484, #88924) Thanks @RomneyDa.
-- Cron/channels: preserve external `sessions_send` routes, include the job name in single-job history, keep Mattermost attachments on the upload path, and bound Telegram/installer/Parallels proof cleanup. (#88294, #88803) Thanks @kip-claw and @MonkeyLeeT.
+- Agents/Codex/auth: repair automatic fallback state, accept supported legacy Codex app-server auth, remove stale bootstrap history, strip streamed reasoning tags, and validate shell snapshots against trusted environment data. (#87484, #88924) Thanks @RomneyDa, @neeravmakwana, @vincentkoc, @bgmbgm94, and @kdonthar.
+- Cron/channels: preserve external `sessions_send` routes, include the job name in single-job history, keep Mattermost attachments on the upload path, and bound Telegram/installer/Parallels proof cleanup. (#88294, #88803) Thanks @kip-claw, @MonkeyLeeT, @vincentkoc, and @Lvan185.
 
-### Complete contribution ledger
+### Complete contribution record
 
-This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 167 PRs and 135 linked issues. The grouped notes above prioritize user impact; this ledger preserves every contribution reference and eligible human credit.
+This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 402 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
 
 #### Pull requests
 
-- feat: add core session goals (#87469).
-- fix: keep live OpenClaw session locks during cleanup (#88129).
-- Fix heartbeat default run timeout (#88133).
-- fix ci mainline checks (#88137). Thanks @RomneyDa.
-- Add plugin manifest contract for SecretRef provider integrations (#82326). Thanks @sallyom and @joshavant.
-- fix: route generated media completions through requester agent (#88141).
-- refactor: share native approval route gates (#87770). Thanks @kevinslin.
-- test(infra): avoid max fake-timer jumps (#88155). Thanks @RomneyDa.
-- test(unit-fast): isolate fake-timer files (#88160). Thanks @RomneyDa.
-- fix(gateway): resolve message actions against runtime config (#84535). Thanks @funmerlin and @joshavant.
-- feat: only include the current changelog section in tarball (#88107). Thanks @RomneyDa.
-- fix(agents): classify embedded provider business denials for fallback (#84814). Thanks @Takhoffman.
-- fix(agents): extend terminal outcome projections (#88162).
-- Fix subagent DM completion delivery after yield (#88182). Thanks @joshavant.
-- Fix Codex raw image generation media projection (#88191). Thanks @joshavant.
-- Fix restart sentinel internal continuations (#88161). Thanks @joshavant.
-- ci: extend platform checkout fetch timeout (#88199). Thanks @RomneyDa.
-- feat(ci): autoscrub dependency lockfile-only PR changes (#87796). Thanks @RomneyDa.
-- perf(test): fix explicit-file Vitest wrapper hangs (#88127). Thanks @RomneyDa.
-- fix(whatsapp): retry QR login 408 timeouts (#88183). Thanks @mcaxtr.
-- fix(ios): guard websocket ping continuation (#88231). Thanks @ngutman.
-- refactor: extract LLM core packages (#88117).
-- refactor(agents): type media completion delivery misses (#88250).
-- feat: add hosted model providers (#88247).
-- refactor: extract markdown core package (#88265).
-- refactor: move terminal core into package (#88279).
-- fix(agents): harden autoreview Windows harness (#88284). Thanks @vincentkoc.
-- Persist subagent registry in SQLite (#88260).
-- refactor: extract media understanding common package (#88297).
-- fix(test): include workflow lint target in routing expectation (#88310). Thanks @vincentkoc.
-- fix(ui): stop pulsing completed stream segments (#88225). Thanks @scotthuang.
-- feat(ios): refresh app store metadata (#88235). Thanks @ngutman.
-- Add per-agent SQLite cache store (#88349).
-- [Fix] Deliver restart recovery replies (#86089). Thanks @samzong.
-- refactor(matrix): move ephemeral state to plugin sqlite (#88387).
-- test(tasks): cover task domain view mappers (#86755). Thanks @leno23.
-- Expose resolved subagent model metadata (#80037). Thanks @guanbear.
-- feat: expand workboard orchestration metadata (#88408).
-- feat(gateway): forward OpenAI stop sequences through chat completions (#87920). Thanks @Lellansin.
-- fix(export-html): guard msg.content and result.content filter/iteration paths against non-array values (#88271). Thanks @Alix-007.
-- ci: keep harness changes on fast checks (#88429).
-- Move cron persistence to SQLite (#88285).
-- fix(build): avoid stale agent-core dts warnings (#87915). Thanks @keshavbotagent.
-- Refactor subagent thread binding into core (#88416).
-- refactor: extract web content core package (#88346).
-- fix(responses): drop orphaned assistant msg\_\* id when reasoning is dropped (issue 88019) (#88067). Thanks @BSG2000.
-- Fix /acp spawn cwd inheritance for target agent workspaces (#82415). Thanks @summerview1997.
-- fix(slack): preserve thread context for Agents & Assistants DM root messages (#63840). Thanks @zozo123.
-- fix: scrub serialized tool-call text from replies (#86924). Thanks @fuller-stack-dev.
-- feat: add internal code mode namespaces (#88043).
-- fix(ui): add agent selector to dreaming tab (#78748). Thanks @stevenepalmer.
-- Refactor cron migrations under doctor (#88455).
-- fix(ci): ignore fenced headings in proof parser (#87390). Thanks @MonkeyLeeT.
-- fix(agents): bound plugin system context (#87341). Thanks @MonkeyLeeT.
-- Refactor browser screenshot vision through shared media understanding (#84247). Thanks @scotthuang.
-- refactor: unify OpenAI provider identity (#88451).
-- fix issue 79380: [Bug]: Gateway CPU spin / crash loop on Raspberry Pi 4 (ARM64) — regression from 4.23 to 4.25+ (#79418). Thanks @zhangguiping-xydt.
-- fix: clarify generated media reply prompts (#88458).
-- Fix iMessage startup watch replay (#88406). Thanks @obviyus.
-- docs: remove divider comments (#88115).
-- fix(webchat): preserve refresh-visible history and composer state (#83992). Thanks @spacegeologist.
-- fix(auto-reply): redact secrets in config show output (#88496). Thanks @jason-allen-oneal.
-- feat: improve MCP operator controls (#88536).
-- fix(openai): preserve custom provider id through memory embedding adapter (#81170). Thanks @adone0.
-- memory-lancedb: add configurable timeout/retry for embedding calls (#56532). Thanks @amittell.
-- fix(infra): guard against overwriting corrupt target session store during migration (#88018). Thanks @Feelw00.
-- fix(cron): accept sub-second --at datetimes resolved in a timezone (#88185). Thanks @coder999999999.
-- feat: add scoped mention pattern policy (#70864). Thanks @patrick-slimelab.
-- feat: add mention pattern policies (#87200). Thanks @deepshekhardas.
-- fix(agents): route per-turn media task hints below the cache boundary (#87998). Thanks @nxmxbbd.
-- test(plugins): cover Link agent wallet bundle shape (#75181). Thanks @stainlu.
-- chore(lint): enable object-shorthand (#81808). Thanks @tanshanshan.
-- refactor: extract media and ACP core packages (#88534).
-- [AI-assisted] fix(plugins): scope startup metadata manifest reads (#84628). Thanks @IWhatsskill.
-- Refactor cron SQLite runtime paths (#88582).
-- fix(memory): retry transient embedding transport failures (#44167). Thanks @MrGeDiao.
-- fix(gateway): guide dashboard auth after service repair (#88466). Thanks @sallyom.
-- fix(ui): keep transient chat errors out of page headers (#88463). Thanks @sallyom.
-- refactor: make OpenAI Codex legacy doctor-only (#88605).
-- fix(browser): document stable tab references (#88393). Thanks @FMLS and @hxy91819.
-- fix(agents): classify expired thinking signatures (#88340). Thanks @Takhoffman.
-- fix(devices): refresh paired device last-seen metadata (#81189). Thanks @vyctorbrzezowski.
-- fix: queue subagent completion handoffs (#88613).
-- refactor: move plugin state stores to SQLite (#88609).
-- fix(config): add dropReasoningFromHistory config for openai-completions providers (issue 88068) (#88071). Thanks @chengzhichao-xydt.
-- fix(tasks): reclaim ACP zombie runs blocking gateway restart (#88281). Thanks @openperf.
-- [codex] fix Codex continuity projection regressions (#88407). Thanks @NianJiuZst.
-- fix(tui): skip history reload when final event has displayable output (#88004). Thanks @SebTardif.
-- fix(webchat): suppress stale active session row racing a completed turn (issue 87875) (#87962). Thanks @MukundaKatta.
-- fix(tui): use middle truncation for paths and commands in tool display (#88050). Thanks @SebTardif.
-- fix(tui): preserve pending local runs during session sync (#87959). Thanks @nao860226-rgb.
-- feat(codex): add portable Codex command pickers (#82224). Thanks @yaanfpv.
-- fix(agents): normalize prefixed Anthropic fallback model ids (issue 88560) (#88587). Thanks @TurboTheTurtle.
-- refactor: expand acp core package (#88618).
-- feat: add MCP code-mode namespace (#88636).
-- fix(gateway): reject pre-reset run lifecycle events from clobbering the rotated session row (#88583). Thanks @openperf.
-- fix(messages): use best-effort for implicit tool-only source replies (#84232). Thanks @tianxiaochannel-oss88.
-- fix(agents): preserve runtime tools in lean mode (#88381). Thanks @vincentkoc.
-- fix(telegram): preserve /usage footer for tool-only replies (#87425). Thanks @giodl73-repo.
-- refactor: clean up ACP package metadata and helpers (#88659).
-- fix(sms): cover native proof follow-ups (#88601). Thanks @clawSean.
-- fix(agents): report stale session locks without cleanup (#88658).
-- Fix Google Chat message tool thread replies (#80996). Thanks @franco-viotti.
-- fix: route iMessage DM media through attachment handoff (#87904). Thanks @HOYALIM and @omarshahine.
-- feat(github-copilot): add Claude Opus 4.8 to default model catalog (#88547). Thanks @saju01.
-- fix(slack): keep one draft message in progress mode (#85612). Thanks @mycarrysun.
-- fix(ollama): yield during dense stream processing (#87818). Thanks @vincentkoc.
-- refactor: move delivery queues to SQLite (#88665).
-- feat: add typed MCP code-mode API (#88678).
-- fix(agents): avoid full stream replay on text deltas (#88252). Thanks @vincentkoc.
-- refactor: clean up ACP translator and manager tests (#88677).
-- fix: persist ACP metadata in SQLite (#88724).
-- feat(plugin-sdk): add typed presentation command actions (#88721).
-- Allow validated TXT/JSON/YAML media sends (#79658). Thanks @simplyclever914.
-- Refresh Node Docker base image digests (#84988). Thanks @LibraHo.
-- fix(memory): serialize qmd update writes across processes to stop SQLITE_BUSY (#85931). Thanks @openperf.
-- fix(codex): stream final answer partials (#88730).
-- fix issue 76284: [Bug]: openclaw agents add blocked — cannot add Jon/Atlas as separate agents (#88314). Thanks @zhangguiping-xydt.
-- refactor: extract ACP turn runner (#88739).
-- refactor: extract ACP close session flow (#88744).
-- refactor: migrate voice-call call logs through doctor (#88731).
-- refactor: extract ACP runtime option commands (#88747).
-- fix(ui): show Communication Notifications tab (#74715). Thanks @VladyslavLevchuk.
-- fix(channels): recover failed progress draft starts (#88749).
-- fix: skip disabled skill snapshot env overrides (#79173). Thanks @zeus1959.
-- refactor: split ACP manager session flows (#88752).
-- fix(openai/tts): handle [[tts:speed]] directive in OpenAI speech provider (issue 12163) (#74089). Thanks @stainlu.
-- fix(feishu): fallback when accepted turns send no visible reply (#87896). Thanks @ArthurNie.
-- [codex] Surface disabled Codex plugin routes in doctor lint (#88761). Thanks @brokemac79 and @jalehman.
-- feat(doctor): add disk space health check for state directory (#59196). Thanks @alkor2000.
-- fix(daemon): preserve container service env across regen (#82828). Thanks @wAngByg.
-- fix(models): strip remaining provider self prefixes (#88781). Thanks @charles-openclaw.
-- fix(update): recognize manual-update launchd jobs (#88764). Thanks @TurboTheTurtle.
-- fix: resolve google provider default API to google-generative-ai (#88512). Thanks @1052326311 and @Xin.
-- feat: calm composer controls (#88772).
-- fix(agents): cap bootstrap snapshot cache (#88149). Thanks @yozakura-ava.
-- Migrate iMessage monitor state to SQLite (#88797).
-- fix(cron): retire MCP runtimes on isolated cron timeout and dispose (#87981). Thanks @Jerry-Xin.
-- Persist plugin install index in SQLite (#88794).
-- Preserve managed npm plugin root when install validation blocks update (#77237). Thanks @zhuisDEV.
-- fix(config): skip state-dir dotenv values that are unresolved shell references (#88288). Thanks @Alix-007.
-- fix(plugins): isolate web provider factory failures (#88807). Thanks @vincentkoc.
-- Persist OpenRouter model cache in SQLite (#88851).
-- perf: streamline chat startup metadata (#88825).
-- fix: allow missing native hook relay without policy (#88620). Thanks @woodym-dotcom.
-- test(agents): include Ollama in small live model matrix (#87838). Thanks @vincentkoc.
-- feat(minimax): add MiniMax M3 support (#88860).
-- fix(browser): isolate Chrome MCP pending attach aborts (#88305). Thanks @rohitjavvadi.
-- fix(microsoft-foundry): satisfy extension lint (#88855). Thanks @RomneyDa.
-- test: consolidate plugin registration contracts (#88824). Thanks @RomneyDa.
-- test(ui): remove stylesheet grep tests (#88847). Thanks @RomneyDa.
-- test(agents): use neutral tool schema fixtures (#88848). Thanks @vincentkoc.
-- Persist Discord thread bindings in SQLite (#88866).
-- docs: clarify diffs language pack additions (#88865). Thanks @RomneyDa.
-- docs: continue inline comment pass (#88849).
-- fix(plugins): fail closed on trusted policy errors (#88394). Thanks @vincentkoc.
-- docs(imessage): document SSH wrapper TCC send failure (#88758). Thanks @TurboTheTurtle.
-- fix(reply): preserve sessions_send external routes (#88803). Thanks @MonkeyLeeT.
-- fix(cron): include job name when reading single-job run history (#88294). Thanks @kip-claw.
-- fix: harden CLI and plugin edge cases (#88896).
-- fix(plugin-sdk): isolate provider catalog projection failures (#88767). Thanks @vincentkoc.
-- fix(agents): clear legacy auto fallback pins (#87484). Thanks @neeravmakwana.
-- fix(diagnostics): clear embedded-run activity when recovery declares lane idle (#88820). Thanks @openperf.
-- fix(agents): strip streamed reasoning tags (#88924).
-- perf(ui): cache chat transcript renders (#88952). Thanks @vincentkoc.
-- perf(ui): record pending send paint timing (#88960). Thanks @vincentkoc.
-- perf(ui): keep chat draft local while typing (#88998). Thanks @vincentkoc.
-
-#### Linked issues
-
-- Reported: Session lock auto-cleanup on staleness detection (#87779). Thanks @todd-chisel.
-- Reported: Heartbeat scheduler silently stops dispatching polls after session compaction/recreation (#87438). Thanks @ovrsr.
-- Reported: Event-loop starvation during context compaction causes fetch timeouts (16.9s timer delay) (#86358). Thanks @Mithril1991.
-- Reported: [Bug]: Codex OAuth compaction falls back to direct OpenAI API and fails without OPENAI_API_KEY (#86820). Thanks @kopl-blip.
-- Reported: [Feature]: Add Xiaomi MiMo Token Plan provider support / fix Token Plan connection (#86169). Thanks @openclaws420.
-- Reported: Bug: WebSocket close before connection established causes uncaughtException crash — not covered by isBenignUncaughtExceptionError (#88257). Thanks @survivor998 and @akrimm702.
-- Reported: Gateway buffers tool-kind text instead of delivering immediately (streaming.mode partial ignored) (#66509). Thanks @gabrielduartesignart.
-- Reported: Bug: independent scripts in ~/.openclaw/extensions/ crash Gateway (missing openclaw.plugin.json) (#88198). Thanks @mmhzlrj.
-- Reported: [Feature]: Add collapsible toggle for recent sessions section in sidebar (#85510). Thanks @NianJiuZst.
-- Reported: [Bug]: /new /reset (#49517). Thanks @KaysonYeh and @KhanCold.
-- Reported: [Bug]: No progress feedback during npm install in non-interactive (piped) mode (#82305). Thanks @SebTardif.
-- Reported: Bug: Telegram multi-image messages - first image transcribed but excluded from media header, others in media header but not transcribed (#47587). Thanks @yzjJosh.
-- Reported: Bug: update.run SIGUSR1 restart can be ignored, then future gateway.restart coalesces as already in-flight (#79577). Thanks @richardmqq and @wAngByg.
-- Reported: update.run can report success after package swap even when gateway restart is ignored (#78110). Thanks @davelutztx and @wAngByg.
-- Reported: Gateway restart timeout can interrupt active agent work without marking sessions for continuation (#82433). Thanks @chac4l and @wAngByg.
-- Reported: [Bug]: agents.defaults.models aliases silently re-resolve target refs to openai/<alias-key> on 5.x (#88218). Thanks @herculeanfit1.
-- Reported: [Feature]: Show node name in exec tool call transparency message (#77719). Thanks @civiltox.
-- Reported: skill-creator: make .skill package file order deterministic (#37748). Thanks @shuofengzhang.
-- Reported: Bug: dist/export-html/template.js content.filter crash — missing Array.isArray guard in dist bundle (#88255). Thanks @survivor998.
-- Reported: [Bug]: WebChat model picker displays default model after switching sessions, even though model override is persisted (#86597). Thanks @xuli500177.
-- Reported: subagent-registry: cleanupBrowserSessionsForLifecycleEnd wrapper invoked twice for same runId in embedded mode (#68668). Thanks @Feelw00.
-- Reported: [Feature]: Add human-readable live progress logs for heavy operators (#83441). Thanks @ndj888.
-- Reported: mcp/channel-bridge: pendingClaudePermissions / pendingApprovals leak — no TTL, no close-clear, no cap (#71646). Thanks @Feelw00.
-- Reported: [Bug]: Azure Responses session replay keeps msg id without required reasoning after fallback (#88019). Thanks @BSG2000.
-- Reported: Approval-gate denials routed via followup-channel produce phantom 'missing tool result' synthetic placeholders (#88167). Thanks @jhartman00.
-- Reported: TUI can show error status without surfacing the run error (#85782). Thanks @shakkernerd.
-- Reported: [Feature]: Dashboard sidebar "Recent" sessions should filter by currently selected agent (#88214). Thanks @wujitianya.
-- Reported: [Slack] Subagent results lose thread_ts in DM assistant threads — cross-thread contamination with concurrent requests (#63659). Thanks @dev-ithitchhiker.
-- Reported: Control UI: Dreaming tab has no agent selector — cannot switch between agent contexts (#63558). Thanks @ttomiczek and @stevenepalmer.
-- Reported: Cron announce delivery strips plugin-canonical provider prefix after target resolution (#87905). Thanks @xmoxmo and @TurboTheTurtle.
-- Reported: [Bug]: valid tool call XML in LLM reasoning block is sometimes executed by gateway (#85161). Thanks @syncword.
-- Reported: [Bug]: browser.upload cannot access files from managed inbound media (WebChat attachments) (#83544). Thanks @scorpiord.
-- Reported: [UX] WebChat: add a full-message reader for truncated or long messages (#84651). Thanks @100yenadmin.
-- Reported: Bug: chat.history truncates long assistant messages at 12k chars even when they fit the history budget (#53242). Thanks @navendugoyal19.
-- Reported: [Bug]: Gateway CPU spin / crash loop on Raspberry Pi 4 (ARM64) — regression from 4.23 to 4.25+ (#79380). Thanks @jorgemarmor.
-- Reported: [Feature Request] Allow cron jobs to set session key matching inbound DM reply routing (#80212). Thanks @SergeyKerj.
-- Reported: /skill <name> fails to invoke available skill commands in live chat (#88056). Thanks @shakkernerd.
-- Reported: Telegram edit action: support editMessageCaption and editMessageReplyMarkup for media messages (#86161). Thanks @crowneglobal and @TurboTheTurtle.
-- Reported: [Bug]: WebChat refresh can lose visible conversation history when transcript tail is mostly internal tool traffic (#83344). Thanks @zachisfine.
-- Reported: [Bug]: memory_search tool fails with "fetch failed" despite embedding provider configured (#47884). Thanks @AllenSupermanxiaodingdang.
-- Reported: memory_search can stall a live session when the memory manager/tool-result path does not fail open (#49524). Thanks @liaosvcaf.
-- Reported: [Bug]: Talk mode can speak a different answer than the Control UI when agent reply uses message_tool_only / delivery-mirror (#85275). Thanks @BsnizND and @TurboTheTurtle.
-- Reported: Runtime sites bypass `prependSystemPromptAdditionAfterCacheBoundary`, destabilising Anthropic + OpenAI prompt caching (#85203). Thanks @AV500group.
-- Reported: [Bug]: [Windows] exec() and read() commands corrupted with </arg_value>> suffix (#48780). Thanks @koden588-blip.
-- Reported: Control UI: tool call result payload missing from expanded block (#70746). Thanks @tarvis0523.
-- Reported: [Bug]: diagnostic stuck-session recovery emits a phantom `session.recovery.requested` event when generation bumps mid-flight (#88010). Thanks @Feelw00.
-- Reported: [Bug]: Codex bundled plugins like chrome and computer-use cannot be enabled from openclaw.json (#82216). Thanks @yaanfpv.
-- Reported: [Bug]: Codex plugin binding slient replies when attaching an existing Codex CLI session on a paired node (#87721). Thanks @wingleungron.
-- Reported: claude-cli auth-epoch flips on token rotation, forcing session resets mid-conversation (#74312). Thanks @aderius.
-- Reported: [Bug] Auth router ignores provider entry's apiKey field, resolves via auth.order by canonical provider ID — wrong key for split provider entries (#67423). Thanks @presidenzo and @kinjitakabe.
-- Reported: Plugin discovery loads all dist/extensions/ manifests at boot regardless of tools.allow (~500 MB structural heap) (#70533). Thanks @jpippo364 and @IWhatsskill.
-- Reported: mediaUnderstandingProviders audio path hard-requires API key, breaking no-auth/local STT providers (#74644). Thanks @mozi1924.
-- Reported: Bug: Fallback models echo BOOT.md instructions instead of executing them (#53732). Thanks @alvaro630.
-- Reported: Bug: memory search live embedding fails ~20–40% with `fetch failed | other side closed` (provider-agnostic; upstream healthy) (#71784). Thanks @kevinheinrichs and @MrGeDiao.
-- Reported: memory reindex aborts on transient embedding transport errors instead of retrying or splitting the batch (#44166). Thanks @MrGeDiao.
-- Reported: [Bug]: auth.cooldowns config change forces full gateway restart, drops in-flight CLI runs (#88443). Thanks @MrMaturin.
-- Reported: paired_devices.createdAt / lastSeenAt are null — cannot identify stale paired clients (#81169). Thanks @deminson.
-- Reported: Shell builtins (e.g. cd) always trigger approval gate even when allowlist is configured (#46056). Thanks @aukei.
-- Reported: [Bug]: No config key to override dropReasoningFromHistory for openai-completions providers (#88068). Thanks @syncword.
-- Reported: [Bug]: slug-generator HTTP 400 misclassified as profile-wide billing failure (5h cooldown), kills all agents on profile (#71709). Thanks @nikolaykazakovvs-ux.
-- Reported: ACP zombie runs block gateway restart/update after 27 days (#88205). Thanks @subaochen.
-- Reported: [TUI] Final assistant message disappears on completion — loadHistory() clearAll() races server persistence (not a repaint bug; issue 86871 / issue 87423 does not fix it) (#87922). Thanks @darconadalabarga.
-- Reported: Bug: TUI truncates paths/commands, leaking ellipsis into model context (#87936). Thanks @Joel-Claw.
-- Reported: [Bug]: Auth profile cooldown triggers chain exhaustion without actual Google API errors in v2026.5.26 (#87462). Thanks @fenglanhua.
-- Reported: Session file lock leak when user manually aborts agent (non-timeout abort never releases lock) (#88600). Thanks @williammu.
-- Reported: Synthetic 'missing tool result' entries injected for parallel tool calls on Anthropic Claude, despite real results being produced (#88168). Thanks @jhartman00 and @TurboTheTurtle.
-- Reported: Session JSONL lock can remain held after synthetic tool-result flush (#88647). Thanks @TurboTheTurtle.
-- Reported: sessions_spawn(runtime="subagent") ignores inherited/per-agent subagent thinking defaults and initializes children at low (#55790). Thanks @vrurg.
-- Reported: [Bug] Control UI shows wrong thinkingDefault for agents using non-default model (#81760). Thanks @caiming0331.
-- Reported: [Bug]: DeepSeek v4-pro: 400 "reasoning_content must be passed back" with thinking=disabled (#74374). Thanks @simmssun-hashh.
-- Reported: [Bug]: sessions.reset can be overwritten by stale lifecycle events from the old run (#88538). Thanks @tianxiaochannel-oss88.
-- Reported: models auth login overwrites and truncates main openclaw.json; auth-profiles.json silently wipes existing profiles (#88565). Thanks @corleonexie-maker.
-- Reported: Slack message_tool_only source replies fail because durable send requires reconcileUnknownSend (#84078). Thanks @tianxiaochannel-oss88.
-- Reported: [Bug]: Discord mentionAliases is not applied to session reply / final assistant text, only to message tool calls (#88360). Thanks @hughbeyond.
-- Reported: [Bug]: Codex transient/fresh no-context-engine starts drop prior session context after issue 88262 (#88352). Thanks @100yenadmin.
-- Reported: [Bug]: Codex resumes ignore OpenClaw-visible messages written after native binding (#88354). Thanks @100yenadmin.
-- Reported: [Bug]: Discord DM pairing identity mismatch breaks PluralKit users; extractDiscordSessionKind regex missing "direct" peer kind (#86332). Thanks @Sanjays2402.
-- Reported: Session transcript `file_lock_stale` persists on 2026.5.19 with no remaining lockfile or file holder (#87217). Thanks @ruben2000de.
-- Reported: Dreaming narrative sessions become orphaned — visible in sidebar but undeletable via session management (#88322). Thanks @TheDenStudios.
-- Reported: [Bug]: renderTable misaligns borders when a wide CJK/emoji grapheme lands in a narrow (width-1) column (#88556). Thanks @jbetala7.
-- Reported: Gateway leaks undici sockets on every streamed Anthropic API call (buildManagedResponse missing finalize on GC) (#67461). Thanks @jakedwyer.
-- Reported: fix(doctor): auto-repair stale session snapshot paths on --fix instead of reporting-only (#85689). Thanks @ggzeng.
-- Reported: Group chat messages don't update in real-time on iOS — requires exit and re-entry (#80231). Thanks @jm7v7fgpdy-sketch.
-- Reported: [Bug]: Codex model catalog cold-start miss for gpt-5.3-codex after gateway restart (#88510). Thanks @wlassalle724.
-- Reported: memoryFlush has no escalation when assistant process dies mid-flush — session permanently over threshold, every subsequent message wedges (#85645). Thanks @rhclaw.
-- Reported: node-extra-ca-certs: CA bundle auto-injection only triggers for nvm, misses fnm/volta/asdf and 5 other version managers (#59494). Thanks @alkor2000.
-- Reported: Telegram isolated polling spool drain: ENOENT race in recoverStaleTelegramSpooledUpdateClaims (#87847). Thanks @ppanphper.
-- Reported: [Bug]: Local model provider calls thread block gateway event loop on Windows beta; trivial infer run takes ~4 minutes (#86599). Thanks @JakeBiggs.
-- Reported: subagent_ended hook does not fire for runs created via api.runtime.subagent.run() (#59164). Thanks @Amyssjj.
-- Reported: [Bug] TypeError at prompt assembly stage when lossless-claw is enabled (reading 'length' on undefined) (#75541). Thanks @tyyim.
-- Reported: Bug: Anthropic API-key auth shows 'invalid bearer token' in status --usage, but the key works for inference (#85124). Thanks @rqlangley.
-- Reported: [Bug]: heartbeat isolatedSession rotates sessionId but reuses old transcript file (#65564). Thanks @akessel56.
-- Reported: [Bug]: Feishu channel: message tool triggers "missing tool result in session history" in v2026.5.16+ (#84134). Thanks @avatasia.
-- Reported: Bug: `openclaw gateway restart` and `openclaw status` do not detect system-level systemd service (#87577). Thanks @fisherman86-ai.
-- Reported: memory search can hit QMD SQLite lock contention during normal runtime (#66339). Thanks @SakenW.
-- Reported: TUI status line shows wrong session displayName after Telegram interaction (#55354). Thanks @toruvieI.
-- Reported: Bug: DiscordEntityCache REST entity Map grows unbounded across bot lifetime (#77975). Thanks @fede-kamel.
-- Reported: [Bug]: readPhaseSignalStore silently loses all phase signal data on non-ENOENT I/O errors (#77881). Thanks @SimbaKingjoe.
-- Reported: [Bug]: openclaw agents add blocked — cannot add Jon/Atlas as separate agents (#76284). Thanks @RicardoUKMX.
-- Reported: [Bug]: Feishu embedded agent returns HTTP 401 "Invalid token" to user instead of retrying with refreshed token (#56197). Thanks @lokamir.
-- Reported: Bug: skills refresh-state workspaceVersions map retains entries after watcher teardown (#77997). Thanks @fede-kamel.
-- Reported: Bug: pre-auth bootstrap-token verify allows mutex-stall DoS without rate limit (#77978). Thanks @fede-kamel.
-- Reported: Feishu DM messages visible in Feishu history but missing from OpenClaw session (#87234). Thanks @ArthurNie.
-- Reported: [Bug]: Uninstall deletes workspace inside .openclaw even when "delete workspace" is unchecked (#75052). Thanks @XueJourney.
-- Reported: [Feature]: Support Tailscale Serve `--service` for ControlUI exposure (#88629). Thanks @resYuto.
-- Reported: [Bug]: an interrupted auth.json write (full disk / quota / power loss) corrupts the credential store and silently locks out all providers (#88028). Thanks @Feelw00.
-- Reported: Feature Request: Add speed parameter support for OpenAI TTS (#12163). Thanks @useramuser.
-- Reported: [Bug]: image_generate in isolated cron session closes turn before receiving callback — cron never completes (#88001). Thanks @nailujac.
-- Reported: bug(workboard): Control UI card settings don't persist + drag to running fails (#88592). Thanks @kzclaw.
-- Reported: session file changed while embedded prompt lock was released (#88703). Thanks @neo-hu.
-- Reported: Session key reflects origin channel, but agents may misinterpret it as current channel (#84544). Thanks @lykeion-dev.
-- Reported: [Bug] Logger \_meta.hostname always "unknown" on macOS — os.hostname() returns empty string at module-load time (#87258). Thanks @mmhzlrj.
-- Reported: [Bug]: OpenClaw 2026.5.7 subagent regression (#81214). Thanks @GreyWolfRon.
-- Reported: [BUG] (feishu) Streaming cards silently truncate long plain-text replies due to Feishu card markdown content limits (#88631). Thanks @Leorand-dev.
-- Reported: Google Gemini chat model routes to openai-responses transport (401), native @google/genai transport never selected (#88480). Thanks @azgardtek and @Xin.
-- Reported: Delivery layer: posts raw errorMessage verbatim when assistant message has stopReason=error (#69737). Thanks @alexisperumal.
-- Reported: TypeError: Cannot read properties of undefined (reading "replace") during embedded agent run (v2026.4.1) (#60113). Thanks @wujiaming88 and @Pluviobyte.
-- Reported: Dream diary fallback exposes raw memory staging fragments (#88391). Thanks @Carme99.
-- Reported: sessions.list returns phantom store-key entry with null updatedAt and no sessionId (#57376). Thanks @smarchetti.
-- Reported: [Bug]: Isolated cron runs can wedge gateway (#87821). Thanks @zachisfine.
-- Reported: [Bug]: doctor emits repeated tool-policy removal audit lines at normal console level (#87798). Thanks @oalansilva and @giodl73-repo.
-- Reported: Bug: structured tool_calls with finish_reason stop are dropped as non_deliverable_terminal_turn (#88791). Thanks @kiagentkronos-cell.
-- Reported: pi-trajectory-flush timeout aborts entire agent run — should degrade gracefully (#88520). Thanks @novac42code and @TurboTheTurtle.
-- Reported: [Bug]: v2026.05.28 breaks Google Vertex Express API Key (#88816). Thanks @randompup.
-- Reported: Bug: gateway service env renders Supermemory API key as literal env reference (#88274). Thanks @mathias15010.
-- Reported: [Bug]: status --deep falsely reports gateway.auth.mode="none" when token auth is configured via secret reference (#87815). Thanks @kAIborg24.
-- Reported: ensureAgentWorkspace re-seeds over wiped workspace without confirmation (#88333). Thanks @HT-Moh and @TurboTheTurtle.
-- Reported: Stop openai.com Codex runtime creep: respect explicit PI config (#88706). Thanks @toruvieI.
-- Reported: [Bug]: PreToolUse hook relay outage blocks trusted callback commands before ingress execution (#87543). Thanks @jsompis and @woodym-dotcom.
-- Reported: tools.config.schema.lookup on unknown path surfaces a JS TypeError to channels instead of a clean tool-result (#88813). Thanks @cjalden.
-- Reported: [Bug]: Discord reply metadata is not exposed to before_dispatch hooks (#88521). Thanks @hoyanhan.
-- Reported: Control UI: browser (F5) full-page reload re-fetches all API data — slow and state-less (#85939). Thanks @34262315716.
-- Reported: [Feature]: Emit runtime warning when Control UI config will silently reject non-secure connections (#71669). Thanks @profbernardoj.
-- Reported: Device identity generation should not depend on browser Secure Context — breaks HTTP reverse-proxy deployments (#53274). Thanks @misselvexu.
-- Reported: [Bug]: OpenClaw Mattermost message tool reports ok while filePath/attachments are not uploaded (#87930). Thanks @NewCoffee7477.
-
+- **PR #87469** feat: add core session goals.
+- **PR #88129** fix: keep live OpenClaw session locks during cleanup.
+- **PR #88133** Fix heartbeat default run timeout. Related #87438. Thanks @ovrsr.
+- **PR #88132** fix: move compaction planning off the event loop. Related #86358. Thanks @Mithril1991.
+- **PR #88137** fix ci mainline checks. Thanks @RomneyDa.
+- **PR #88140** perf: centralize skills indexing and visibility. Thanks @shakkernerd.
+- **PR #82326** Add plugin manifest contract for SecretRef provider integrations. Thanks @sallyom and @joshavant.
+- **PR #88141** fix: route generated media completions through requester agent.
+- **PR #87770** refactor: share native approval route gates. Thanks @kevinslin.
+- **PR #88156** Refactor SQLite state base and plugin migration.
+- **PR #87781** fix(codex): prevent false completion stalls during native streams. Thanks @keshavbotagent.
+- **PR #88136** fix(agents): centralize terminal run outcome precedence. Related #87444. Thanks @ssdatye.
+- **PR #88155** test(infra): avoid max fake-timer jumps. Thanks @RomneyDa.
+- **PR #88160** test(unit-fast): isolate fake-timer files. Thanks @RomneyDa.
+- **PR #84535** fix(gateway): resolve message actions against runtime config. Related #84530. Thanks @funmerlin and @joshavant.
+- **PR #88107** feat: only include the current changelog section in tarball. Thanks @RomneyDa.
+- **PR #88130** fix(agents): preserve Codex auth for compaction fallback. Related #86820. Thanks @kopl-blip.
+- **PR #84814** fix(agents): classify embedded provider business denials for fallback. Related #48680. Thanks @Takhoffman and @yu-xin-c and @lovensky1992-wk.
+- **PR #88178** feat(workboard): add orchestration primitives.
+- **PR #88162** fix(agents): extend terminal outcome projections.
+- **PR #88182** Fix subagent DM completion delivery after yield. Related #88042. Thanks @joshavant and @ksiyuna-claw.
+- **PR #88191** Fix Codex raw image generation media projection. Related #87948. Thanks @joshavant and @mazetsoligarh-cell.
+- **PR #88134** fix(imessage): preserve SMS approval reply routes. Thanks @kevinslin.
+- **PR #88161** Fix restart sentinel internal continuations. Related #87792. Thanks @joshavant and @chrispydizzle.
+- **PR #88199** ci: extend platform checkout fetch timeout. Thanks @RomneyDa.
+- **PR #87796** feat(ci): autoscrub dependency lockfile-only PR changes. Thanks @RomneyDa.
+- **PR #88200** Refactor task state onto shared SQLite.
+- **PR #88083** fix(agent): preserve media task success on delivery miss. Thanks @obviyus.
+- **PR #88127** perf(test): fix explicit-file Vitest wrapper hangs. Thanks @RomneyDa.
+- **PR #88183** fix(whatsapp): retry QR login 408 timeouts. Thanks @mcaxtr.
+- **PR #84234** fix(cli-runner): write-side flush gate + orphan-tool-use invalidator. Thanks @adele-with-a-b.
+- **PR #88231** fix(ios): guard websocket ping continuation. Thanks @ngutman.
+- **PR #88117** refactor: extract LLM core packages.
+- **PR #88248** fix: show chat errors as visible messages.
+- **PR #88250** refactor(agents): type media completion delivery misses.
+- **PR #88207** Fix Codex native thread overflow rotation. Thanks @fuller-stack-dev.
+- **PR #88109** refactor: extract media generation core package.
+- **PR #88247** feat: add hosted model providers.
+- **PR #88259** feat(workboard): add board ops recovery metadata.
+- **PR #87788** fix(codex): move skills list and memory pointer to collaboration instructions. Thanks @lastguru-net.
+- **PR #88262** fix(codex): stop injecting mirrored history into prompts.
+- **PR #88177** fix(codex): prevent post-tool edit stream timeouts. Thanks @keshavbotagent.
+- **PR #88265** refactor: extract markdown core package.
+- **PR #88279** refactor: move terminal core into package.
+- **PR #86179** feat:Add Xiaomi Token Plan provider support. Related #86169. Thanks @NianJiuZst and @openclaws420.
+- **PR #88211** fix(plugins): resolve ${ENV_VAR} references in plugin config before handoff. Related #88195. Thanks @Marvinthebored and @Peetiegonzalez.
+- **PR #88284** fix(agents): harden autoreview Windows harness. Thanks @vincentkoc.
+- **PR #88260** Persist subagent registry in SQLite.
+- **PR #88217** refactor: unify OpenAI provider identity.
+- **PR #88297** refactor: extract media understanding common package.
+- **PR #88299** fix(gateway): recover channels after reload stop timeout. Thanks @obviyus.
+- **PR #88326** perf(cli): reduce room-event Claude cache churn. Thanks @obviyus.
+- **PR #88310** fix(test): include workflow lint target in routing expectation. Thanks @vincentkoc.
+- **PR #88225** fix(ui): stop pulsing completed stream segments. Thanks @scotthuang.
+- **PR #88298** fix: classify ws pre-handshake close as benign. Related #88257. Thanks @akrimm702 and @survivor998.
+- **PR #88338** feat(workboard): persist orchestration metadata in sqlite.
+- **PR #88266** refactor: extract model catalog core package.
+- **PR #88235** feat(ios): refresh app store metadata. Thanks @ngutman.
+- **PR #85258** fix(qqbot): deliver partial tool progress. Related #66509. Thanks @samzong and @vincentkoc and @gabrielduartesignart.
+- **PR #88349** Add per-agent SQLite cache store.
+- **PR #88135** fix(codex): refresh stale managed runtime plugin. Related #87650. Thanks @brokemac79 and @thoth-ctl.
+- **PR #68844** fix(outbound): pack newline-mode paragraphs up to limit. Thanks @kesslerio.
+- **PR #88236** fix(plugins): ignore helper files in extension roots. Related #88198. Thanks @mushuiyu886 and @mmhzlrj.
+- **PR #86089** [Fix] Deliver restart recovery replies. Related #69249. Thanks @samzong and @slideshow-dingo.
+- **PR #88375** refactor: route model catalog imports to core package.
+- **PR #85511** feat(ui): add collapsible toggle for recent sessions in sidebar. Related #85510. Thanks @NianJiuZst.
+- **PR #80560** fix(tui): distinguish /new and /reset command descriptions. Related #49517. Thanks @KhanCold and @KaysonYeh.
+- **PR #88229** fix(agents): normalize sessions_send message aliases. Related #88146. Thanks @zhangguiping-xydt and @jsonmez.
+- **PR #88387** refactor(matrix): move ephemeral state to plugin sqlite.
+- **PR #86755** test(tasks): cover task domain view mappers. Thanks @leno23.
+- **PR #76355** fix(install): show progress during npm install in non-interactive mode. Related #82305. Thanks @SebTardif.
+- **PR #77279** fix(media): dedupe identical path/url in inbound media-note formatter (#47587). Thanks @MoerAI and @yzjJosh.
+- **PR #82824** fix(gateway): explain ignored config-triggered restart when restart command is disabled. Thanks @wAngByg.
+- **PR #85979** fix(discord): omit undefined component registry fields [AI]. Thanks @funmerlin.
+- **PR #76091** Fix Discord reply typing lifecycle. Thanks @zhuisDEV.
+- **PR #88232** fix(models): prefer exact configured provider refs before aliases. Related #88218. Thanks @stevenepalmer and @herculeanfit1.
+- **PR #88276** fix(feishu): stream plain replies as cards. Thanks @qiangu.
+- **PR #80037** Expose resolved subagent model metadata. Thanks @guanbear.
+- **PR #78288** Agents/exec: show target node name in exec tool transparency messages. Related #77719. Thanks @JiataiWang and @civiltox.
+- **PR #88408** feat: expand workboard orchestration metadata.
+- **PR #87920** feat(gateway): forward OpenAI stop sequences through chat completions. Thanks @Lellansin.
+- **PR #87886** fix(skill-creator): sort files for deterministic .skill package order. Related #37748. Thanks @coder999999999 and @shuofengzhang.
+- **PR #88399** Improve MCP operability.
+- **PR #88398** refactor: move model catalog refs into core package.
+- **PR #88328** feat: add Skill Workshop and skill research. Thanks @shakkernerd.
+- **PR #88271** fix(export-html): guard msg.content and result.content filter/iteration paths against non-array values. Related #88255. Thanks @Alix-007 and @survivor998.
+- **PR #88429** ci: keep harness changes on fast checks.
+- **PR #88430** fix(scripts): quiet minimal runtime asset copies. Thanks @vincentkoc.
+- **PR #88321** fix(codex): keep app-server continuation turns alive. Related #88196, #88331. Thanks @abnershang and @aounakram.
+- **PR #88435** refactor: move model catalog normalization into core package.
+- **PR #88226** fix(llm): repair \u escapes that lack four hex digits in streaming JSON. Thanks @coder999999999.
+- **PR #88380** fix(ui): keep chat model selected after session switch. Related #86597. Thanks @brokemac79 and @xuli500177.
+- **PR #88285** Move cron persistence to SQLite.
+- **PR #87915** fix(build): avoid stale agent-core dts warnings. Thanks @keshavbotagent.
+- **PR #68669** fix(agents): dedupe subagent browser session cleanup wrapper with dispatch flag. Related #68668. Thanks @Feelw00.
+- **PR #88411** refactor(msteams): persist conversation and poll stores in sqlite.
+- **PR #88303** Skip browser cleanup when browser is disabled. Thanks @poison.
+- **PR #88416** Refactor subagent thread binding into core.
+- **PR #83956** feat(cli): add sessions tail progress view. Related #83441. Thanks @spacegeologist and @ndj888.
+- **PR #71648** fix(mcp): bound pendingClaudePermissions / pendingApprovals via TTL sweeper + close clear. Related #71646. Thanks @Feelw00.
+- **PR #88346** refactor: extract web content core package.
+- **PR #71280** test(gateway): avoid brittle shutdown timer assertion. Thanks @hansolo949.
+- **PR #80686** fix(agents): extend session-write-lock payload-less orphan grace from 5s to 30s. Thanks @wAngByg.
+- **PR #88067** fix(responses): drop orphaned assistant msg_* id when reasoning is dropped (#88019). Thanks @BSG2000.
+- **PR #88417** [codex] Route denied exec approval followups to sessions. Related #88167. Thanks @brokemac79 and @jhartman00.
+- **PR #85996** fix #85782: surface terminal TUI lifecycle errors. Thanks @zhangguiping-xydt and @vincentkoc and @shakkernerd.
+- **PR #88445** refactor: source model catalog types from core.
+- **PR #88444** Classify release dependency ownership metadata.
+- **PR #82415** Fix /acp spawn cwd inheritance for target agent workspaces. Thanks @summerview1997.
+- **PR #88448** refactor: simplify sqlite cron persistence.
+- **PR #88268** fix #88214: [Feature]: Dashboard sidebar Recent sessions should filter by currently selected agent. Thanks @zhangguiping-xydt and @wujitianya.
+- **PR #86642** feat: pass structured provider error signals to hooks. Thanks @fuller-stack-dev.
+- **PR #63840** fix(slack): preserve thread context for Agents & Assistants DM root messages. Related #63659. Thanks @zozo123 and @dev-ithitchhiker.
+- **PR #86924** fix: scrub serialized tool-call text from replies. Thanks @fuller-stack-dev.
+- **PR #87093** fix: promote serialized tool calls via repair package. Thanks @fuller-stack-dev.
+- **PR #88452** chore(release): update appcast for 2026.5.28.
+- **PR #88043** feat: add internal code mode namespaces.
+- **PR #78748** fix(ui): add agent selector to dreaming tab. Related #63558. Thanks @stevenepalmer and @ttomiczek.
+- **PR #88455** Refactor cron migrations under doctor.
+- **PR #87929** fix(cron): preserve plugin delivery targets. Related #87905. Thanks @TurboTheTurtle and @xmoxmo.
+- **PR #87390** fix(ci): ignore fenced headings in proof parser. Thanks @MonkeyLeeT.
+- **PR #85248** fix(gateway): strip spurious tool call blocks when provider signals stop. Related #85161. Thanks @Jerry-Xin and @syncword.
+- **PR #83660** fix(browser): allow upload from inbound media directory. Related #83544. Thanks @spacegeologist and @scorpiord.
+- **PR #88467** feat: improve MCP operator workflows.
+- **PR #84247** Refactor browser screenshot vision through shared media understanding. Thanks @scotthuang.
+- **PR #88464** Move Workboard to relational SQLite.
+- **PR #88451** refactor: unify OpenAI provider identity.
+- **PR #88459** refactor: extract normalization core package.
+- **PR #84670** [codex] fix webchat full-message reader for truncated history. Related #84651. Thanks @NianJiuZst and @100yenadmin.
+- **PR #88462** fix(heartbeat): advance stale scheduler deferrals. Related #79380. Thanks @jorgemarmor.
+- **PR #88461** refactor(cron): split service timer helpers.
+- **PR #88427** fix(auth): bound inherited oauth expiry.
+- **PR #88458** fix: clarify generated media reply prompts.
+- **PR #88421** [codex] Fix Telegram DM topic session routing. Related #80212. Thanks @brokemac79 and @SergeyKerj.
+- **PR #88113** fix(commands): make /skill load workspace skills. Related #88056. Thanks @MonkeyLeeT and @shakkernerd.
+- **PR #85904** fix(slack): keep DM thread turns out of active steering. Thanks @guanbear.
+- **PR #88395** build(OpenClawKit): make ElevenLabsKit (talk/TTS) an optional package trait. Thanks @mochiexists and @atlascodesai.
+- **PR #88469** refactor(telegram): persist plugin state in sqlite.
+- **PR #88406** Fix iMessage startup watch replay. Thanks @obviyus.
+- **PR #87179** fix(discord): deliver same-session channel replies. Related #87157. Thanks @stevenepalmer and @neo-jacked-in.
+- **PR #88115** docs: remove divider comments.
+- **PR #88319** fix(agents): skip below-target CLI compaction failures. Thanks @frankekn.
+- **PR #88552** Remove channel test isolation hack.
+- **PR #86176** Fix Telegram media message edits. Related #86161. Thanks @TurboTheTurtle and @crowneglobal.
+- **PR #88476** feat: add Twilio SMS channel.
+- **PR #83992** fix(webchat): preserve refresh-visible history and composer state. Related #83344. Thanks @spacegeologist and @zachisfine.
+- **PR #88496** fix(auto-reply): redact secrets in config show output. Related #65623. Thanks @jason-allen-oneal and @coygeek.
+- **PR #88536** feat: improve MCP operator controls.
+- **PR #84290** Doctor: expose UI freshness health findings. Thanks @giodl73-repo.
+- **PR #88539** refactor(telegram): keep topic thread mapping plugin-local.
+- **PR #80391** fix(scripts): timeout crabbox wrapper sanity checks. Thanks @ejames-dev.
+- **PR #85990** Prefer Talk source-reply final text. Related #85275. Thanks @TurboTheTurtle and @BsnizND.
+- **PR #65914** fix(memory): respect qmd status timeout and skip checkpoint exports. Thanks @shawnduggan.
+- **PR #88555** feat(workboard): add worker dispatch CLI.
+- **PR #88018** fix(infra): guard against overwriting corrupt target session store during migration. Related #88017. Thanks @Feelw00.
+- **PR #88185** fix(cron): accept sub-second --at datetimes resolved in a timezone. Thanks @coder999999999.
+- **PR #88378** fix(xiaomi): support MiMo voicedesign TTS. Thanks @GimingRao.
+- **PR #70864** feat: add scoped mention pattern policy. Thanks @patrick-slimelab.
+- **PR #87998** fix(agents): route per-turn media task hints below the cache boundary. Related #85203. Thanks @nxmxbbd and @AV500group.
+- **PR #75181** test(plugins): cover Link agent wallet bundle shape. Thanks @stainlu.
+- **PR #88347** fix(agents): strip malformed arg-value suffixes. Related #48780. Thanks @vincentkoc and @koden588-blip.
+- **PR #88578** docs: document scoped mention patterns.
+- **PR #81808** chore(lint): enable object-shorthand. Thanks @tanshanshan.
+- **PR #70789** fix(ui): fix tool result pairing for sequential same-name tool calls. Related #70746. Thanks @chinar-amrutkar and @tarvis0523.
+- **PR #88011** fix(logging): align diagnostic recovery in-flight dedup keys. Related #88010. Thanks @Feelw00.
+- **PR #88574** Fix silent internal aborts after tool-use turns. Thanks @obviyus.
+- **PR #82219** fix(codex): accept first-party OpenAI plugin marketplaces (bundled and primary-runtime). Related #82216. Thanks @yaanfpv.
+- **PR #83719** feat(dreaming): add report-only shadow trial runner. Thanks @iFiras-Max1.
+- **PR #87772** fix(reply): deliver plugin binding replies. Related #87721. Thanks @MonkeyLeeT and @wingleungron.
+- **PR #74493** fix(cli): identity-only auth-epoch hashing for token credentials (#74312). Thanks @stainlu and @aderius.
+- **PR #88534** refactor: extract media and ACP core packages.
+- **PR #79447** fix(model-auth): resolve per-entry apiKey profile ID references. Related #67423. Thanks @kinjitakabe and @presidenzo.
+- **PR #88577** fix(sms): diagnose Twilio webhook setup.
+- **PR #84628** [AI-assisted] fix(plugins): scope startup metadata manifest reads. Related #70533. Thanks @IWhatsskill and @jpippo364.
+- **PR #88582** Refactor cron SQLite runtime paths.
+- **PR #88595** perf: speed up chat hydration and add 3D workboard.
+- **PR #75005** fix(media): allow explicit synthetic auth for media providers. Related #74644. Thanks @sqsge and @mozi1924.
+- **PR #75128** fix(boot): wrap BOOT.md in internal-runtime-context, strip from message-tool args (#53732). Thanks @stainlu and @alvaro630.
+- **PR #88599** fix(memory): retry transient embedding failures. Related #44166, #71784. Thanks @MrGeDiao and @kevinheinrichs.
+- **PR #88466** fix(gateway): guide dashboard auth after service repair. Related #88290. Thanks @sallyom and @drarturryzhov-boop.
+- **PR #88463** fix(ui): keep transient chat errors out of page headers. Thanks @sallyom.
+- **PR #88474** [AI-assisted] fix(gateway): avoid restarts for auth cooldown reloads. Related #88443. Thanks @IWhatsskill and @MrMaturin.
+- **PR #88603** fix(media): use typed auth for no-auth media providers. Related #74644. Thanks @mozi1924.
+- **PR #88605** refactor: make OpenAI Codex legacy doctor-only.
+- **PR #88440** Retry stale CLI sessions inside runner lifecycle. Related #77089. Thanks @brokemac79 and @clawdbotv2.
+- **PR #88393** fix(browser): document stable tab references. Thanks @FMLS and @hxy91819.
+- **PR #88340** fix(agents): classify expired thinking signatures. Related #88020. Thanks @Takhoffman and @BryanTegomoh and @bryanbaer.
+- **PR #88607** fix(devices): refresh paired device last-seen metadata. Related #81169. Thanks @vyctorbrzezowski and @deminson.
+- **PR #88613** fix: queue subagent completion handoffs.
+- **PR #88609** refactor: move plugin state stores to SQLite.
+- **PR #79363** fix(exec): allow known safe shell builtins in allowlist mode. Related #46056. Thanks @kinjitakabe and @aukei.
+- **PR #88617** fix(agents): preserve reasoning replay from model metadata. Related #88068. Thanks @syncword.
+- **PR #77953** fix(auto-reply): honor per-model thinking params. Thanks @tynamite.
+- **PR #88626** refactor(openai): confine legacy codex repair to doctor.
+- **PR #87887** fix(hooks): isolate slug-generator failures from shared auth profile (#71709). Thanks @openperf and @nikolaykazakovvs-ux.
+- **PR #88281** fix(tasks): reclaim ACP zombie runs blocking gateway restart. Related #88205. Thanks @openperf and @subaochen.
+- **PR #88619** refactor: unify subagent handoffs into agent steering queue.
+- **PR #88004** fix(tui): skip history reload when final event has displayable output. Related #87922. Thanks @SebTardif and @darconadalabarga.
+- **PR #87962** fix(webchat): suppress stale active session row racing a completed turn (#87875). Thanks @MukundaKatta and @TunMax.
+- **PR #88050** fix(tui): use middle truncation for paths and commands in tool display. Related #87936. Thanks @SebTardif and @Joel-Claw.
+- **PR #86463** fix(auto-reply): warn on substantive private message-tool finals. Thanks @yaoyi1222.
+- **PR #88554** docs: clarify Android token comments.
+- **PR #87959** fix(tui): preserve pending local runs during session sync. Thanks @nao860226-rgb and @vincentkoc.
+- **PR #82224** feat(codex): add portable Codex command pickers. Thanks @yaanfpv.
+- **PR #88637** chore: bump OpenClaw version to 2026.5.31.
+- **PR #88587** fix(agents): normalize prefixed Anthropic fallback model ids (#88560). Thanks @TurboTheTurtle and @cjalden.
+- **PR #88351** fix(doctor): diagnose malformed provider catalogs. Thanks @vincentkoc.
+- **PR #88618** refactor: expand acp core package.
+- **PR #87538** fix(agents): model-scope cooldown for transport timeout (#87462). Thanks @openperf and @fenglanhua.
+- **PR #88623** fix(agents): release session lock on manual abort. Related #88600. Thanks @williammu.
+- **PR #88588** fix(agents): avoid synthetic tool results during parallel races (#88168). Thanks @TurboTheTurtle and @jhartman00.
+- **PR #88636** feat: add MCP code-mode namespace.
+- **PR #88558** fix(gateway): enforce OpenAI tool_choice required/function contracts. Thanks @Lellansin.
+- **PR #88628** fix: scope plugin tools and async media starts.
+- **PR #84007** fix(agents): inherit subagent thinking defaults. Related #55790. Thanks @stevenepalmer and @vrurg.
+- **PR #81795** Fix Control UI agent thinking defaults. Related #81760. Thanks @jbetala7 and @caiming0331.
+- **PR #74418** fix(agents): recognize params.thinking=false and "disabled"/"none" as thinking=off. Related #74374. Thanks @yelog and @simmssun-hashh.
+- **PR #88583** fix(gateway): reject pre-reset run lifecycle events from clobbering the rotated session row. Related #88538. Thanks @openperf and @tianxiaochannel-oss88.
+- **PR #88612** fix(models): keep auth login out of main config. Related #88565. Thanks @corleonexie-maker.
+- **PR #88655** fix(gateway): reject stale lifecycle session updates. Related #88538. Thanks @tianxiaochannel-oss88.
+- **PR #88658** fix(agents): report stale session locks without cleanup.
+- **PR #88661** ci: stabilize Testbox changed checks.
+- **PR #88641** feat: add exec shell snapshot cache.
+- **PR #84232** fix(messages): use best-effort for implicit tool-only source replies. Related #84078. Thanks @tianxiaochannel-oss88.
+- **PR #88381** fix(agents): preserve runtime tools in lean mode. Thanks @vincentkoc.
+- **PR #88527** fix(discord): ping mention-bearing final replies under live preview (#88360). Thanks @openperf and @hughbeyond.
+- **PR #88659** refactor: clean up ACP package metadata and helpers.
+- **PR #88652** fix(codex): restore bounded recovery continuity. Related #88352, #88354. Thanks @100yenadmin.
+- **PR #82739** fix(macos): prevent duplicate menu bar icons. Thanks @afalk42.
+- **PR #87975** fix(slack): avoid forced threads for replyToMode off. Thanks @lawrencetran.
+- **PR #86397** fix(discord): PluralKit DM pairing identity + `direct` peer regex (#86332). Thanks @Sanjays2402.
+- **PR #88601** fix(sms): cover native proof follow-ups. Thanks @clawSean.
+- **PR #88670** fix(agents): retry transient stale session locks.
+- **PR #80996** Fix Google Chat message tool thread replies. Related #80995. Thanks @franco-viotti.
+- **PR #88549** fix(memory-core): reclaim orphaned dreaming sessions with surviving transcripts. Related #88322. Thanks @Alix-007 and @TheDenStudios.
+- **PR #88557** fix(terminal): clamp wide graphemes in narrow table cells. Related #88556. Thanks @jbetala7.
+- **PR #87904** fix: route iMessage DM media through attachment handoff. Related #87597. Thanks @HOYALIM and @omarshahine and @TurboTheTurtle.
+- **PR #88547** feat(github-copilot): add Claude Opus 4.8 to default model catalog. Thanks @saju01.
+- **PR #88428** fix(discord): route thread bindings to plugin owners. Related #64199. Thanks @SYU8384 and @hoh-dev-bot.
+- **PR #85612** fix(slack): keep one draft message in progress mode. Thanks @mycarrysun.
+- **PR #88500** fix: release abandoned provider streams. Related #67461. Thanks @samzong and @jakedwyer.
+- **PR #85691** fix(doctor): auto-repair stale session snapshot paths on --fix. Related #85689. Thanks @ggzeng.
+- **PR #86737** fix(ios): subscribe to per-session transcripts so group chats update in real time (#80231). Thanks @yetval and @jm7v7fgpdy-sketch.
+- **PR #88642** fix(whatsapp): suppress spurious typing indicator on silent tool-only runs. Related #450. Thanks @Bluetegu and @thesash.
+- **PR #88635** fix(secrets): treat Codex app-server marker as non-secret. Thanks @vortexopenclaw.
+- **PR #88525** feat(deepseek): show provider balance in usage status. Thanks @litang9.
+- **PR #88563** fix(agents): resolve exact static-catalog models for plugin-harness cold start (#88510). Thanks @yetval and @wlassalle724.
+- **PR #87818** fix(ollama): yield during dense stream processing. Thanks @vincentkoc and @udaymanish6.
+- **PR #88665** refactor: move delivery queues to SQLite.
+- **PR #88676** fix(auto-reply): add memory flush failure tracking with retry exhaustion. Thanks @Jerry-Xin.
+- **PR #88672** fix(plugins): reuse current metadata snapshot in provider hot paths. Thanks @masatohoshino.
+- **PR #88678** feat: add typed MCP code-mode API.
+- **PR #77882** fix(feishu): gate bitable tools by tools config. Thanks @glfruit.
+- **PR #59172** fix(cli): extend holiday tagline dates through 2030. Thanks @alkor2000.
+- **PR #88252** fix(agents): avoid full stream replay on text deltas. Thanks @vincentkoc.
+- **PR #59500** fix: extend CA bundle auto-injection to all 8 Node version managers. Related #59494. Thanks @alkor2000.
+- **PR #87855** fix(telegram): handle ENOENT race in spool drain recovery rename. Related #87847. Thanks @SebTardif and @ppanphper.
+- **PR #88677** refactor: clean up ACP translator and manager tests.
+- **PR #88715** perf(plugins): avoid duplicate provider hook load probes.
+- **PR #88675** refactor: move plugin state slices to sqlite.
+- **PR #88153** fix(agents): count stream deltas incrementally. Thanks @vincentkoc.
+- **PR #87698** fix(gateway): emit subagent_ended hook for api.runtime.subagent.run() (#59164). Thanks @sweetcornna and @Amyssjj.
+- **PR #81692** fix(doctor): detect stale gateway service version metadata. Thanks @wAngByg.
+- **PR #87549** fix(agents): validate context engine assemble result shape. Related #75541. Thanks @Pluviobyte and @tyyim.
+- **PR #88720** refactor: extract ACP translator session updates.
+- **PR #85666** fix #85124: skip Anthropic API keys for usage status. Thanks @zhangguiping-xydt and @rqlangley.
+- **PR #88722** refactor: make Telegram message cache SQLite-only.
+- **PR #88724** fix: persist ACP metadata in SQLite.
+- **PR #86917** fix(session-store): rewrite generated transcript paths on rollover. Thanks @Sunjae-k and @sunjae-1.
+- **PR #84419** fix(session): prefer real tool result over synthetic error in transcript repair. Thanks @Jerry-Xin.
+- **PR #88725** refactor: extract ACP manager runtime handle cache.
+- **PR #88721** feat(plugin-sdk): add typed presentation command actions.
+- **PR #79658** Allow validated TXT/JSON/YAML media sends. Thanks @simplyclever914.
+- **PR #87618** fix(daemon): detect system-scope systemd gateway units on Linux (#87577). Thanks @yetval and @fisherman86-ai.
+- **PR #84988** Refresh Node Docker base image digests. Related #84981. Thanks @LibraHo.
+- **PR #85931** fix(memory): serialize qmd update writes across processes to stop SQLITE_BUSY. Related #66339. Thanks @openperf and @SakenW.
+- **PR #78793** fix(approvals): interpolate request id into "Reply with:" line. Thanks @itsuzef.
+- **PR #88730** fix(codex): stream final answer partials. Related #88405. Thanks @crash2kx.
+- **PR #80801** fix(auth): force re-login flag, remediation hint, and session-scoped fallback skip cache. Thanks @MertBasar0.
+- **PR #88729** refactor: extract ACP runtime handle ensure flow.
+- **PR #79040** fix(gateway): guard buildGroupDisplayName behind group/channel chatType. Related #55354. Thanks @sebuh-infsol and @toruvieI.
+- **PR #77952** fix(discord): bound REST entity cache to prevent unbounded Map growth. Related #77975. Thanks @fede-kamel.
+- **PR #88733** refactor: extract ACP runtime resume state.
+- **PR #77924** fix(memory-core): preserve phase signals on read errors. Related #77881. Thanks @bennewell35 and @SimbaKingjoe.
+- **PR #88314** fix #76284: [Bug]: openclaw agents add blocked — cannot add Jon/Atlas as separate agents. Thanks @zhangguiping-xydt and @RicardoUKMX.
+- **PR #77394** fix(agents): sanitize raw HTTP 401 provider errors in user-visible replies (#56197). Thanks @jeffrey701 and @lokamir.
+- **PR #88739** refactor: extract ACP turn runner.
+- **PR #77998** fix(skills): clear workspaceVersions entry when skills watcher is disabled. Related #77997. Thanks @fede-kamel.
+- **PR #77527** fix(gateway): rate-limit pre-auth bootstrap-token verify to prevent mutex DoS. Related #77978. Thanks @fede-kamel.
+- **PR #88744** refactor: extract ACP close session flow.
+- **PR #88731** refactor: migrate voice-call call logs through doctor.
+- **PR #87522** fix: force preflight compaction before oversized agent turns. Related #87234. Thanks @ArthurNie.
+- **PR #75061** fix: preserve workspaces during state-only uninstall. Related #75052. Thanks @Jason-Bai and @XueJourney.
+- **PR #79465** Fix ACP command bypass for channel text commands. Thanks @RoeeJ.
+- **PR #88747** refactor: extract ACP runtime option commands.
+- **PR #74715** fix(ui): show Communication Notifications tab. Thanks @VladyslavLevchuk.
+- **PR #88691** feat(gateway): support Tailscale Serve service names. Related #88629. Thanks @charles-openclaw and @resYuto.
+- **PR #88749** fix(channels): recover failed progress draft starts. Related #83115. Thanks @SebTardif.
+- **PR #88029** fix(agents): atomic auth.json write to prevent credential lockout on crash. Related #88028. Thanks @Feelw00.
+- **PR #85277** fix(openai): avoid stale Responses message id replay. Thanks @latensified.
+- **PR #79173** fix: skip disabled skill snapshot env overrides. Related #79072. Thanks @zeus1959 and @maverikva.
+- **PR #88752** refactor: split ACP manager session flows.
+- **PR #79149** fix(ci): guard workflow template injection. Related #68428. Thanks @WT-WSL and @visionik.
+- **PR #74089** fix(openai/tts): handle [[tts:speed]] directive in OpenAI speech provider (#12163). Thanks @stainlu and @useramuser.
+- **PR #88763** feat: add code-mode MCP API files.
+- **PR #87896** fix(feishu): fallback when accepted turns send no visible reply. Thanks @ArthurNie.
+- **PR #88761** [codex] Surface disabled Codex plugin routes in doctor lint. Related #88751. Thanks @brokemac79 and @jalehman.
+- **PR #88759** fix: repair providerless Codex session overrides. Thanks @earlvanze.
+- **PR #88740** fix(hooks): pass media metadata to internal message_received hook. Thanks @SebTardif.
+- **PR #88695** fix(agents): wait for cron media completions. Related #88001. Thanks @nailujac.
+- **PR #88762** fix(ui): show Workboard comments in edit modal. Thanks @MonkeyLeeT.
+- **PR #88765** fix(agents): publish owned announcement session writes. Related #88703. Thanks @TurboTheTurtle and @neo-hu.
+- **PR #59196** feat(doctor): add disk space health check for state directory. Thanks @alkor2000.
+- **PR #79260** feat(doctor): add --post-upgrade --json mode for plugin-compat findings. Thanks @arniesaha.
+- **PR #88486** fix(diagnostics): carry session UUID on interactive dispatch events. Thanks @arniesaha.
+- **PR #84904** fix: avoid replaying Responses item ids when store is disabled. Thanks @zhanghang02.
+- **PR #82828** fix(daemon): preserve container service env across regen. Thanks @wAngByg.
+- **PR #88755** fix(agents): expose session status route context. Related #84544. Thanks @nxmxbbd and @lykeion-dev.
+- **PR #88781** fix(models): strip remaining provider self prefixes. Related #88770. Thanks @charles-openclaw and @cjalden.
+- **PR #88131** fix(logging): refresh file log hostname per write. Related #87258. Thanks @lonexreb and @mmhzlrj.
+- **PR #88667** fix #81214: [Bug]: OpenClaw 2026.5.7 subagent regression. Thanks @zhangguiping-xydt and @GreyWolfRon.
+- **PR #88764** fix(update): recognize manual-update launchd jobs. Related #88736. Thanks @TurboTheTurtle and @deonkretch.
+- **PR #88727** fix(feishu): preserve long streaming replies. Related #88631. Thanks @MonkeyLeeT and @Leorand-dev.
+- **PR #88512** fix: resolve google provider default API to google-generative-ai. Related #88480. Thanks @1052326311 and @Xin and @azgardtek.
+- **PR #88756** feat: add Skill Workshop Control UI. Thanks @shakkernerd.
+- **PR #88610** fix: suppress raw provider errors in channel delivery. Related #69737. Thanks @jason-allen-oneal and @alexisperumal.
+- **PR #88808** perf: hydrate chat history session metadata.
+- **PR #88735** fix(agents): harden runtime tool schema quarantine. Thanks @vincentkoc.
+- **PR #88221** fix(nostr): decode npub allowFrom entries to hex correctly. Thanks @DocNR and @hypoxicdrive.
+- **PR #88772** feat: calm composer controls.
+- **PR #88388** fix(agents): guard transport payload sanitizer against non-string input. Related #60113. Thanks @Pluviobyte and @cursoragent and @wujiaming88.
+- **PR #88149** fix(agents): cap bootstrap snapshot cache. Thanks @yozakura-ava.
+- **PR #88545** fix(memory-core): stop dream diary fallback from leaking raw staging fragments. Related #88391. Thanks @Alix-007 and @Carme99.
+- **PR #88289** fix(microsoft-foundry): skip DeepSeek V4 thinking params on Foundry fallback. Thanks @silvesterxm.
+- **PR #88209** fix(subagents): roll formatTokenShort over to "m" at 1000k. Thanks @coder999999999.
+- **PR #88008** fix(tasks): persist task store before in-memory mutation to prevent sqlite divergence. Related #88007. Thanks @Feelw00.
+- **PR #88306** fix(gateway): hide phantom agent store rows from sessions.list. Related #57376. Thanks @Alix-007 and @smarchetti.
+- **PR #88760** fix(doctor): report runtime tool schema errors. Thanks @vincentkoc.
+- **PR #88495** fix(imessage): tolerate sub-second self-chat reflection skew. Thanks @colmbrogan.
+- **PR #88797** Migrate iMessage monitor state to SQLite.
+- **PR #87981** fix(cron): retire MCP runtimes on isolated cron timeout and dispose. Related #87821. Thanks @Jerry-Xin and @zachisfine.
+- **PR #88410** fix(gateway): harden MCP loopback tool schemas. Thanks @vincentkoc.
+- **PR #88100** fix(doctor): quiet tool policy removal audits. Related #87798. Thanks @giodl73-repo and @oalansilva.
+- **PR #88804** fix(agents): preserve stop-finished OpenAI tool calls. Related #88791. Thanks @MonkeyLeeT and @kiagentkronos-cell.
+- **PR #88802** test(agents): cover nonfatal trajectory flush timeout. Related #88520. Thanks @TurboTheTurtle and @novac42code.
+- **PR #88819** fix(workboard): wire task-backed board runs. Thanks @vincentkoc.
+- **PR #88608** fix(minimax): use account OAuth device endpoints. Thanks @MatthewSchleder.
+- **PR #88794** Persist plugin install index in SQLite.
+- **PR #88827** Add Vertex API key model config regression coverage. Related #88816. Thanks @TurboTheTurtle and @randompup.
+- **PR #77237** Preserve managed npm plugin root when install validation blocks update. Thanks @zhuisDEV.
+- **PR #88288** fix(config): skip state-dir dotenv values that are unresolved shell references. Related #88274. Thanks @Alix-007 and @mathias15010.
+- **PR #87848** fix(status): resolve gateway auth secrets for deep audit. Related #87815. Thanks @ai-hpc and @kAIborg24.
+- **PR #88807** fix(plugins): isolate web provider factory failures. Thanks @vincentkoc.
+- **PR #88518** fix(plugins): isolate cached tool runtime siblings. Thanks @vincentkoc.
+- **PR #88851** Persist OpenRouter model cache in SQLite.
+- **PR #88485** fix(agents): guard vanished workspaces. Related #88333. Thanks @TurboTheTurtle and @HT-Moh.
+- **PR #88825** perf: streamline chat startup metadata.
+- **PR #88723** fix(doctor): respect explicit PI runtime policy. Related #88706. Thanks @toruvieI.
+- **PR #88365** fix(infra): bridge WSL clipboard through shell. Related #88080. Thanks @vincentkoc and @YaneCheung.
+- **PR #88785** fix: restore backgrounded in-flight runs on TUI switch-back via gateway snapshot. Thanks @williamliu-ai.
+- **PR #87992** feat(ios): support native iPad display. Thanks @EmpX2025.
+- **PR #88846** fix: preserve no-policy native hook fallback. Thanks @woodym-dotcom.
+- **PR #81264** fix(installer): align Node version floor with package engine. Thanks @kiranmagic7.
+- **PR #87838** test(agents): include Ollama in small live model matrix. Thanks @vincentkoc.
+- **PR #88860** feat(minimax): add MiniMax M3 support.
+- **PR #88305** fix(browser): isolate Chrome MCP pending attach aborts. Related #88304. Thanks @rohitjavvadi.
+- **PR #88814** fix(ci): repair current main checks. Thanks @vincentkoc.
+- **PR #88855** fix(microsoft-foundry): satisfy extension lint. Thanks @RomneyDa.
+- **PR #88824** test: consolidate plugin registration contracts. Thanks @RomneyDa.
+- **PR #88847** test(ui): remove stylesheet grep tests. Thanks @RomneyDa.
+- **PR #88704** fix(memory): rehydrate daily list promotions. Related #87854. Thanks @MonkeyLeeT and @KingYiKa.
+- **PR #88848** test(agents): use neutral tool schema fixtures. Thanks @vincentkoc.
+- **PR #88817** fix(agents): return schema lookup misses in-band. Related #88813. Thanks @ksj3421 and @cjalden.
+- **PR #88866** Persist Discord thread bindings in SQLite.
+- **PR #88801** fix(hooks): expose inbound reply metadata before dispatch. Related #88521. Thanks @TurboTheTurtle and @hoyanhan.
+- **PR #88865** docs: clarify diffs language pack additions. Thanks @RomneyDa.
+- **PR #88849** docs: continue inline comment pass.
+- **PR #87077** fix(ui): bypass service worker for top-level navigations. Thanks @nayrosk.
+- **PR #88394** fix(plugins): fail closed on trusted policy errors. Thanks @vincentkoc.
+- **PR #88758** docs(imessage): document SSH wrapper TCC send failure. Related #79289. Thanks @TurboTheTurtle.
+- **PR #88859** fix(mattermost): route send attachments through upload. Related #87930. Thanks @vincentkoc and @NewCoffee7477.
+- **PR #88830** feat(dreaming): score candidates with shadow trial results. Thanks @iFiras-Max1.
+- **PR #88803** fix(reply): preserve sessions_send external routes. Related #88044. Thanks @MonkeyLeeT and @Lvan185.
+- **PR #88294** fix(cron): include job name when reading single-job run history. Thanks @kip-claw.
+- **PR #88896** fix: harden CLI and plugin edge cases.
+- **PR #88767** fix(plugin-sdk): isolate provider catalog projection failures. Thanks @vincentkoc.
+- **PR #88892** feat(ui): improve Workboard task details. Thanks @vincentkoc.
+- **PR #88806** fix(memory-lancedb): reject envelope metadata sludge (incl. marker-free shapes). Thanks @amittell.
+- **PR #88921** fix(ui): keep first control chat sends responsive. Thanks @vincentkoc.
+- **PR #87484** fix(agents): clear legacy auto fallback pins. Related #87467. Thanks @neeravmakwana and @bgmbgm94.
+- **PR #88904** fix(android): add notification app picker. Thanks @Tosko4.
+- **PR #88820** fix(diagnostics): clear embedded-run activity when recovery declares lane idle. Related #88660. Thanks @openperf and @Iman-Sharif.
+- **PR #88897** refactor(copilot): compact sessions through SDK state.
+- **PR #88924** fix(agents): strip streamed reasoning tags. Related #88741. Thanks @kdonthar.
+- **PR #88937** fix(ui): render pending sends in chat thread. Thanks @vincentkoc.
+- **PR #88949** fix(ui): scroll pending sends into view. Thanks @vincentkoc.
+- **PR #88952** perf(ui): cache chat transcript renders. Thanks @vincentkoc.
+- **PR #88960** perf(ui): record pending send paint timing. Thanks @vincentkoc.
+- **PR #88972** perf(ui): debounce chat draft persistence. Thanks @vincentkoc.
+- **PR #88978** perf(ui): skip closed slash menu rerenders. Thanks @vincentkoc.
+- **PR #88982** fix(test): wait for telegram timer flushes. Thanks @vincentkoc.
+- **PR #88989** perf(ui): guard chat transcript rerenders. Thanks @vincentkoc.
 ## 2026.5.28
 
 ### Highlights


### PR DESCRIPTION
## Summary

- Backfill seven release changelog sections and their GitHub release bodies with complete PR-first contribution records.
- Make release generation use direct commits, explicit cherry-pick PR references, grouped prose, and legacy issue closers as audited inputs.
- Add guards for reverts, target-date bounds, association pagination, attribution, and exact release-body parity.

## Linked context

Maintainer-requested release-note backfill.

## Tests and validation

- Regenerated and verified all seven release ranges.
- Exact GitHub readback across 22 stable/beta release pages.
- oxfmt, changelog attribution check, diff check, and autoreview clean.

## Risk checklist

- User-visible behavior change: Yes, release documentation only.
- Config or migration behavior change: No.
- Security, auth, secrets, network, or tool execution behavior change: No.
- Highest risk: historical attribution or record completeness.
- Mitigation: source-ledger verification, GitHub relationship checks, and byte-for-byte release-body readback.

## Current review state

Ready to land with rebase merge; no squash requested.