### PR TITLE
fix(sessions): preserve trajectory on reset for outbound forensics (fixes #90707)

### DIFF
--- a/src/config/sessions/artifacts.test.ts
+++ b/src/config/sessions/artifacts.test.ts
@@ -89,6 +89,16 @@ describe("session artifact helpers", () => {
       ),
     ).toBe(false);
     expect(isUsageCountedSessionTranscriptFileName("abc.trajectory.jsonl")).toBe(false);
+    expect(
+      isUsageCountedSessionTranscriptFileName(
+        "abc.trajectory.jsonl.reset.2026-01-01T00-00-00.000Z",
+      ),
+    ).toBe(false);
+    expect(
+      isUsageCountedSessionTranscriptFileName(
+        "abc.trajectory-path.json.reset.2026-01-01T00-00-00.000Z",
+      ),
+    ).toBe(false);
   });
 
   it("parses usage-counted session ids from file names", () => {
@@ -108,6 +118,9 @@ describe("session artifact helpers", () => {
       ),
     ).toBeNull();
     expect(parseUsageCountedSessionIdFromFileName("abc.trajectory.jsonl")).toBeNull();
+    expect(
+      parseUsageCountedSessionIdFromFileName("abc.trajectory.jsonl.reset.2026-01-01T00-00-00.000Z"),
+    ).toBeNull();
   });
 
   it("parses exact compaction checkpoint transcript file names", () => {

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -126,6 +126,12 @@ export function isArchivedTrajectorySessionArtifactName(fileName: string): boole
   return liveName !== null && isTrajectorySessionArtifactName(liveName);
 }
 
+/** Returns true for archived trajectory runtime artifacts (not pointers). */
+export function isArchivedTrajectoryRuntimeArtifactName(fileName: string): boolean {
+  const liveName = stripSessionArchiveSuffix(fileName);
+  return liveName !== null && isTrajectoryRuntimeArtifactName(liveName);
+}
+
 /** Returns true for primary session transcript files that represent live session history. */
 export function isPrimarySessionTranscriptFileName(fileName: string): boolean {
   if (fileName === "sessions.json") {

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -98,6 +98,34 @@ export function isTrajectorySessionArtifactName(fileName: string): boolean {
   return isTrajectoryRuntimeArtifactName(fileName) || isTrajectoryPointerArtifactName(fileName);
 }
 
+// Strip a `.<reason>.<ts>` archive suffix and return the live name it was
+// rotated from, or null when the name is not an archive. Lets archive-aware
+// classifiers reason about the underlying artifact (e.g. a trajectory runtime
+// file) instead of the timestamped wrapper.
+function stripSessionArchiveSuffix(fileName: string): string | null {
+  for (const reason of ["reset", "deleted", "bak"] as const) {
+    const marker = `.${reason}.`;
+    const index = fileName.lastIndexOf(marker);
+    if (index <= 0) {
+      continue;
+    }
+    if (ARCHIVE_TIMESTAMP_RE.test(fileName.slice(index + marker.length))) {
+      return fileName.slice(0, index);
+    }
+  }
+  return null;
+}
+
+// Reset preserves the trajectory sibling as `<sid>.trajectory.jsonl.reset.<ts>`
+// (#90707). That name carries a generic `.reset.<ts>` suffix, so without this
+// guard the usage/transcript classifiers below would treat it as a transcript
+// archive and parse a synthetic `<sid>.trajectory` session id — feeding tool
+// call args/results into transcript usage accounting and memory/search hits.
+export function isArchivedTrajectorySessionArtifactName(fileName: string): boolean {
+  const liveName = stripSessionArchiveSuffix(fileName);
+  return liveName !== null && isTrajectorySessionArtifactName(liveName);
+}
+
 /** Returns true for primary session transcript files that represent live session history. */
 export function isPrimarySessionTranscriptFileName(fileName: string): boolean {
   if (fileName === "sessions.json") {
@@ -120,6 +148,9 @@ export function isUsageCountedSessionTranscriptFileName(fileName: string): boole
   if (isPrimarySessionTranscriptFileName(fileName)) {
     return true;
   }
+  if (isArchivedTrajectorySessionArtifactName(fileName)) {
+    return false;
+  }
   return hasArchiveSuffix(fileName, "reset") || hasArchiveSuffix(fileName, "deleted");
 }
 
@@ -127,6 +158,9 @@ export function isUsageCountedSessionTranscriptFileName(fileName: string): boole
 export function parseUsageCountedSessionIdFromFileName(fileName: string): string | null {
   if (isPrimarySessionTranscriptFileName(fileName)) {
     return fileName.slice(0, -".jsonl".length);
+  }
+  if (isArchivedTrajectorySessionArtifactName(fileName)) {
+    return null;
   }
   for (const reason of ["reset", "deleted"] as const) {
     const marker = `.jsonl.${reason}.`;

--- a/src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
+++ b/src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
@@ -2,6 +2,7 @@
 // rule shares one directory listing per cleanup call. Store maintenance runs
 // this on each save, so per-rule listings would multiply READDIR load.
 import fsPromises from "node:fs/promises";
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -100,5 +101,40 @@ describe("cleanupArchivedSessionTranscripts", () => {
 
     expect(result).toEqual({ removed: 0, scanned: 0 });
     expect(readdirSpy).not.toHaveBeenCalled();
+  });
+
+  it("prunes reset trajectory archives under OPENCLAW_TRAJECTORY_DIR (#90707)", async () => {
+    const trajectoryDir = path.join(dir, "trajectory-override");
+    fs.mkdirSync(trajectoryDir, { recursive: true });
+    const previous = process.env.OPENCLAW_TRAJECTORY_DIR;
+    try {
+      process.env.OPENCLAW_TRAJECTORY_DIR = trajectoryDir;
+      await fsPromises.writeFile(
+        path.join(trajectoryDir, `session.jsonl.reset.${OLD_STAMP}`),
+        "",
+      );
+      await fsPromises.writeFile(
+        path.join(trajectoryDir, `session.jsonl.reset.${FRESH_STAMP}`),
+        "",
+      );
+
+      const result = await cleanupArchivedSessionTranscripts({
+        directories: [dir],
+        rules: [{ reason: "reset", olderThanMs: 30 * DAY_MS }],
+        nowMs: NOW_MS,
+      });
+
+      expect(result.scanned).toBe(2);
+      expect(result.removed).toBe(1);
+      const remaining = await fsPromises.readdir(trajectoryDir);
+      expect(remaining).toEqual([`session.jsonl.reset.${FRESH_STAMP}`]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_TRAJECTORY_DIR;
+      } else {
+        process.env.OPENCLAW_TRAJECTORY_DIR = previous;
+      }
+      fs.rmSync(trajectoryDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
+++ b/src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
@@ -185,4 +185,39 @@ describe("cleanupArchivedSessionTranscripts", () => {
       fs.rmSync(trajectoryDir, { recursive: true, force: true });
     }
   });
+
+  it("preserves transcript cleanup when OPENCLAW_TRAJECTORY_DIR overlaps a requested directory (#94593)", async () => {
+    const previous = process.env.OPENCLAW_TRAJECTORY_DIR;
+    const runtimeHeader = JSON.stringify({
+      traceSchema: "openclaw-trajectory",
+      schemaVersion: 1,
+      source: "runtime",
+      sessionId: "session",
+    });
+    try {
+      process.env.OPENCLAW_TRAJECTORY_DIR = dir;
+      const transcriptArchive = `session.jsonl.reset.${OLD_STAMP}`;
+      const trajectoryArchive = `session.trajectory.jsonl.reset.${OLD_STAMP}`;
+      const unrelated = `backup.jsonl.deleted.${OLD_STAMP}`;
+      await fsPromises.writeFile(path.join(dir, transcriptArchive), "transcript\n");
+      await fsPromises.writeFile(path.join(dir, trajectoryArchive), `${runtimeHeader}\n`);
+      await fsPromises.writeFile(path.join(dir, unrelated), "not a trajectory\n");
+
+      const result = await cleanupArchivedSessionTranscripts({
+        directories: [dir],
+        rules: [{ reason: "reset", olderThanMs: 30 * DAY_MS }],
+        nowMs: NOW_MS,
+      });
+
+      expect(result.removed).toBe(2);
+      expect(result.scanned).toBe(2);
+      expect(await remaining()).toEqual([unrelated]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_TRAJECTORY_DIR;
+      } else {
+        process.env.OPENCLAW_TRAJECTORY_DIR = previous;
+      }
+    }
+  });
 });

--- a/src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
+++ b/src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
@@ -194,13 +194,21 @@ describe("cleanupArchivedSessionTranscripts", () => {
       source: "runtime",
       sessionId: "session",
     });
+    const pointerHeader = JSON.stringify({
+      traceSchema: "openclaw-trajectory-pointer",
+      schemaVersion: 1,
+      sessionId: "session",
+      runtimeFile: "/some/session.trajectory.jsonl",
+    });
     try {
       process.env.OPENCLAW_TRAJECTORY_DIR = dir;
       const transcriptArchive = `session.jsonl.reset.${OLD_STAMP}`;
-      const trajectoryArchive = `session.trajectory.jsonl.reset.${OLD_STAMP}`;
+      const trajectoryRuntimeArchive = `session.trajectory.jsonl.reset.${OLD_STAMP}`;
+      const trajectoryPointerArchive = `session.trajectory-path.json.reset.${OLD_STAMP}`;
       const unrelated = `backup.jsonl.deleted.${OLD_STAMP}`;
       await fsPromises.writeFile(path.join(dir, transcriptArchive), "transcript\n");
-      await fsPromises.writeFile(path.join(dir, trajectoryArchive), `${runtimeHeader}\n`);
+      await fsPromises.writeFile(path.join(dir, trajectoryRuntimeArchive), `${runtimeHeader}\n`);
+      await fsPromises.writeFile(path.join(dir, trajectoryPointerArchive), `${pointerHeader}\n`);
       await fsPromises.writeFile(path.join(dir, unrelated), "not a trajectory\n");
 
       const result = await cleanupArchivedSessionTranscripts({
@@ -209,8 +217,8 @@ describe("cleanupArchivedSessionTranscripts", () => {
         nowMs: NOW_MS,
       });
 
-      expect(result.removed).toBe(2);
-      expect(result.scanned).toBe(2);
+      expect(result.removed).toBe(3);
+      expect(result.scanned).toBe(3);
       expect(await remaining()).toEqual([unrelated]);
     } finally {
       if (previous === undefined) {

--- a/src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
+++ b/src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
@@ -1,8 +1,8 @@
+import fs from "node:fs";
 // Gateway tests cover archived-transcript retention cleanup: every retention
 // rule shares one directory listing per cleanup call. Store maintenance runs
 // this on each save, so per-rule listings would multiply READDIR load.
 import fsPromises from "node:fs/promises";
-import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -107,15 +107,21 @@ describe("cleanupArchivedSessionTranscripts", () => {
     const trajectoryDir = path.join(dir, "trajectory-override");
     fs.mkdirSync(trajectoryDir, { recursive: true });
     const previous = process.env.OPENCLAW_TRAJECTORY_DIR;
+    const runtimeHeader = JSON.stringify({
+      traceSchema: "openclaw-trajectory",
+      schemaVersion: 1,
+      source: "runtime",
+      sessionId: "session",
+    });
     try {
       process.env.OPENCLAW_TRAJECTORY_DIR = trajectoryDir;
       await fsPromises.writeFile(
-        path.join(trajectoryDir, `session.jsonl.reset.${OLD_STAMP}`),
-        "",
+        path.join(trajectoryDir, `session.trajectory.jsonl.reset.${OLD_STAMP}`),
+        `${runtimeHeader}\n`,
       );
       await fsPromises.writeFile(
-        path.join(trajectoryDir, `session.jsonl.reset.${FRESH_STAMP}`),
-        "",
+        path.join(trajectoryDir, `session.trajectory.jsonl.reset.${FRESH_STAMP}`),
+        `${runtimeHeader}\n`,
       );
 
       const result = await cleanupArchivedSessionTranscripts({
@@ -126,8 +132,50 @@ describe("cleanupArchivedSessionTranscripts", () => {
 
       expect(result.scanned).toBe(2);
       expect(result.removed).toBe(1);
-      const remaining = await fsPromises.readdir(trajectoryDir);
-      expect(remaining).toEqual([`session.jsonl.reset.${FRESH_STAMP}`]);
+      const trajectoryRemaining = await fsPromises.readdir(trajectoryDir);
+      expect(trajectoryRemaining).toEqual([`session.trajectory.jsonl.reset.${FRESH_STAMP}`]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_TRAJECTORY_DIR;
+      } else {
+        process.env.OPENCLAW_TRAJECTORY_DIR = previous;
+      }
+      fs.rmSync(trajectoryDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves unrelated archive-looking files in OPENCLAW_TRAJECTORY_DIR (#94593)", async () => {
+    const trajectoryDir = path.join(dir, "trajectory-override");
+    fs.mkdirSync(trajectoryDir, { recursive: true });
+    const previous = process.env.OPENCLAW_TRAJECTORY_DIR;
+    const runtimeHeader = JSON.stringify({
+      traceSchema: "openclaw-trajectory",
+      schemaVersion: 1,
+      source: "runtime",
+      sessionId: "session",
+    });
+    try {
+      process.env.OPENCLAW_TRAJECTORY_DIR = trajectoryDir;
+      const owned = `session.trajectory.jsonl.reset.${OLD_STAMP}`;
+      const unrelated = `backup.jsonl.reset.${OLD_STAMP}`;
+      const unrelatedDeleted = `backup.jsonl.deleted.${OLD_STAMP}`;
+      await fsPromises.writeFile(path.join(trajectoryDir, owned), `${runtimeHeader}\n`);
+      await fsPromises.writeFile(path.join(trajectoryDir, unrelated), "not a trajectory\n");
+      await fsPromises.writeFile(path.join(trajectoryDir, unrelatedDeleted), "not a trajectory\n");
+
+      const result = await cleanupArchivedSessionTranscripts({
+        directories: [dir],
+        rules: [
+          { reason: "reset", olderThanMs: 30 * DAY_MS },
+          { reason: "deleted", olderThanMs: 30 * DAY_MS },
+        ],
+        nowMs: NOW_MS,
+      });
+
+      expect(result.removed).toBe(1);
+      expect(result.scanned).toBe(3);
+      const trajectoryRemaining = (await fsPromises.readdir(trajectoryDir)).toSorted();
+      expect(trajectoryRemaining).toEqual([unrelatedDeleted, unrelated]);
     } finally {
       if (previous === undefined) {
         delete process.env.OPENCLAW_TRAJECTORY_DIR;

--- a/src/gateway/session-transcript-files.fs.archive-events.test.ts
+++ b/src/gateway/session-transcript-files.fs.archive-events.test.ts
@@ -13,6 +13,18 @@ import {
   archiveSessionTranscriptsDetailed,
 } from "./session-transcript-files.fs.js";
 
+function writeTrajectoryPointer(pointerFile: string, sessionId: string, runtimeFile: string): void {
+  fs.writeFileSync(
+    pointerFile,
+    `${JSON.stringify({
+      traceSchema: "openclaw-trajectory-pointer",
+      schemaVersion: 1,
+      sessionId,
+      runtimeFile,
+    })}\n`,
+  );
+}
+
 const subscriptions: Array<() => void> = [];
 
 afterEach(() => {
@@ -143,7 +155,7 @@ describe("archiveSessionTranscriptsDetailed failure surface", () => {
       const pointerFile = path.join(tmpDir, `${sessionId}.trajectory-path.json`);
       fs.writeFileSync(sessionFile, '{"type":"session-meta","agentId":"main"}\n');
       fs.writeFileSync(trajectoryFile, '{"traceSchema":"openclaw-trajectory"}\n');
-      fs.writeFileSync(pointerFile, `{"runtimeFile":${JSON.stringify(trajectoryFile)}}\n`);
+      writeTrajectoryPointer(pointerFile, sessionId, trajectoryFile);
 
       const archived = archiveSessionTranscriptsDetailed({
         sessionId,
@@ -175,7 +187,7 @@ describe("archiveSessionTranscriptsDetailed failure surface", () => {
       const pointerFile = path.join(tmpDir, `${sessionId}.trajectory-path.json`);
       fs.writeFileSync(sessionFile, '{"type":"session-meta","agentId":"main"}\n');
       fs.writeFileSync(trajectoryFile, '{"traceSchema":"openclaw-trajectory"}\n');
-      fs.writeFileSync(pointerFile, `{"runtimeFile":${JSON.stringify(trajectoryFile)}}\n`);
+      writeTrajectoryPointer(pointerFile, sessionId, trajectoryFile);
 
       const archived = archiveSessionTranscriptsDetailed({
         sessionId,
@@ -193,6 +205,44 @@ describe("archiveSessionTranscriptsDetailed failure surface", () => {
       const remaining = fs.readdirSync(tmpDir);
       expect(remaining.some((name) => name.includes(".trajectory.jsonl.reset."))).toBe(false);
     } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("archives pointer-resolved runtime files from OPENCLAW_TRAJECTORY_DIR on reset", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-archive-trajectory-override-"));
+    const previousTrajectoryDir = process.env.OPENCLAW_TRAJECTORY_DIR;
+    try {
+      const sessionId = "66666666-6666-4666-8666-666666666666";
+      const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+      const trajectoryDir = path.join(tmpDir, "traces");
+      const overrideRuntime = path.join(trajectoryDir, `${sessionId}.jsonl`);
+      const pointerFile = path.join(tmpDir, `${sessionId}.trajectory-path.json`);
+      fs.mkdirSync(trajectoryDir, { recursive: true });
+      process.env.OPENCLAW_TRAJECTORY_DIR = trajectoryDir;
+      fs.writeFileSync(sessionFile, '{"type":"session-meta","agentId":"main"}\n');
+      fs.writeFileSync(overrideRuntime, '{"traceSchema":"openclaw-trajectory"}\n');
+      writeTrajectoryPointer(pointerFile, sessionId, overrideRuntime);
+
+      const archived = archiveSessionTranscriptsDetailed({
+        sessionId,
+        storePath: path.join(tmpDir, "store.json"),
+        sessionFile,
+        agentId: "main",
+        reason: "reset",
+      });
+
+      expect(archived).toHaveLength(1);
+      expect(fs.existsSync(overrideRuntime)).toBe(false);
+      expect(fs.existsSync(pointerFile)).toBe(false);
+      const remaining = fs.readdirSync(trajectoryDir);
+      expect(remaining.some((name) => name.includes(".jsonl.reset."))).toBe(true);
+    } finally {
+      if (previousTrajectoryDir === undefined) {
+        delete process.env.OPENCLAW_TRAJECTORY_DIR;
+      } else {
+        process.env.OPENCLAW_TRAJECTORY_DIR = previousTrajectoryDir;
+      }
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });

--- a/src/gateway/session-transcript-files.fs.archive-events.test.ts
+++ b/src/gateway/session-transcript-files.fs.archive-events.test.ts
@@ -159,8 +159,8 @@ describe("archiveSessionTranscriptsDetailed failure surface", () => {
       expect(fs.existsSync(trajectoryFile)).toBe(false);
       expect(fs.existsSync(pointerFile)).toBe(false);
       const remaining = fs.readdirSync(tmpDir);
-      expect(remaining.some((name) => /\.trajectory\.jsonl\.reset\.\d/.test(name))).toBe(true);
-      expect(remaining.some((name) => /\.trajectory-path\.json\.reset\.\d/.test(name))).toBe(true);
+      expect(remaining.some((name) => name.includes(".trajectory.jsonl.reset."))).toBe(true);
+      expect(remaining.some((name) => name.includes(".trajectory-path.json.reset."))).toBe(true);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -191,7 +191,7 @@ describe("archiveSessionTranscriptsDetailed failure surface", () => {
       expect(fs.existsSync(trajectoryFile)).toBe(true);
       expect(fs.existsSync(pointerFile)).toBe(true);
       const remaining = fs.readdirSync(tmpDir);
-      expect(remaining.some((name) => /\.trajectory\.jsonl\.reset\./.test(name))).toBe(false);
+      expect(remaining.some((name) => name.includes(".trajectory.jsonl.reset."))).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/src/gateway/session-transcript-files.fs.archive-events.test.ts
+++ b/src/gateway/session-transcript-files.fs.archive-events.test.ts
@@ -25,6 +25,22 @@ function writeTrajectoryPointer(pointerFile: string, sessionId: string, runtimeF
   );
 }
 
+function writeTrajectoryRuntime(filePath: string, sessionId: string): void {
+  fs.writeFileSync(
+    filePath,
+    `${JSON.stringify({
+      traceSchema: "openclaw-trajectory",
+      schemaVersion: 1,
+      source: "runtime",
+      sessionId,
+    })}\n`,
+  );
+}
+
+function writeSessionMeta(filePath: string, agentId: string): void {
+  fs.writeFileSync(filePath, `${JSON.stringify({ type: "session-meta", agentId })}\n`);
+}
+
 const subscriptions: Array<() => void> = [];
 
 afterEach(() => {
@@ -153,8 +169,8 @@ describe("archiveSessionTranscriptsDetailed failure surface", () => {
       const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
       const trajectoryFile = path.join(tmpDir, `${sessionId}.trajectory.jsonl`);
       const pointerFile = path.join(tmpDir, `${sessionId}.trajectory-path.json`);
-      fs.writeFileSync(sessionFile, '{"type":"session-meta","agentId":"main"}\n');
-      fs.writeFileSync(trajectoryFile, '{"traceSchema":"openclaw-trajectory"}\n');
+      writeSessionMeta(sessionFile, "main");
+      writeTrajectoryRuntime(trajectoryFile, sessionId);
       writeTrajectoryPointer(pointerFile, sessionId, trajectoryFile);
 
       const archived = archiveSessionTranscriptsDetailed({
@@ -165,9 +181,10 @@ describe("archiveSessionTranscriptsDetailed failure surface", () => {
         reason: "reset",
       });
 
-      expect(archived).toHaveLength(1);
+      // Transcript + runtime + pointer = 3 archived entries.
       // The live trajectory artifacts are renamed, not deleted, so post-reset
       // forensics can still read the assistant's tool calls/results (#90707).
+      expect(archived).toHaveLength(3);
       expect(fs.existsSync(trajectoryFile)).toBe(false);
       expect(fs.existsSync(pointerFile)).toBe(false);
       const remaining = fs.readdirSync(tmpDir);
@@ -185,8 +202,8 @@ describe("archiveSessionTranscriptsDetailed failure surface", () => {
       const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
       const trajectoryFile = path.join(tmpDir, `${sessionId}.trajectory.jsonl`);
       const pointerFile = path.join(tmpDir, `${sessionId}.trajectory-path.json`);
-      fs.writeFileSync(sessionFile, '{"type":"session-meta","agentId":"main"}\n');
-      fs.writeFileSync(trajectoryFile, '{"traceSchema":"openclaw-trajectory"}\n');
+      writeSessionMeta(sessionFile, "main");
+      writeTrajectoryRuntime(trajectoryFile, sessionId);
       writeTrajectoryPointer(pointerFile, sessionId, trajectoryFile);
 
       const archived = archiveSessionTranscriptsDetailed({
@@ -220,8 +237,8 @@ describe("archiveSessionTranscriptsDetailed failure surface", () => {
       const pointerFile = path.join(tmpDir, `${sessionId}.trajectory-path.json`);
       fs.mkdirSync(trajectoryDir, { recursive: true });
       process.env.OPENCLAW_TRAJECTORY_DIR = trajectoryDir;
-      fs.writeFileSync(sessionFile, '{"type":"session-meta","agentId":"main"}\n');
-      fs.writeFileSync(overrideRuntime, '{"traceSchema":"openclaw-trajectory"}\n');
+      writeSessionMeta(sessionFile, "main");
+      writeTrajectoryRuntime(overrideRuntime, sessionId);
       writeTrajectoryPointer(pointerFile, sessionId, overrideRuntime);
 
       const archived = archiveSessionTranscriptsDetailed({
@@ -232,7 +249,8 @@ describe("archiveSessionTranscriptsDetailed failure surface", () => {
         reason: "reset",
       });
 
-      expect(archived).toHaveLength(1);
+      // Transcript + override runtime + pointer = 3 archived entries.
+      expect(archived).toHaveLength(3);
       expect(fs.existsSync(overrideRuntime)).toBe(false);
       expect(fs.existsSync(pointerFile)).toBe(false);
       const remaining = fs.readdirSync(trajectoryDir);
@@ -290,6 +308,103 @@ describe("archiveSessionTranscriptsDetailed failure surface", () => {
       } catch {
         // Already restored.
       }
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not archive a pointer-resolved runtime file with a non-trajectory basename", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-archive-trajectory-basename-"));
+    try {
+      const sessionId = "77777777-7777-4777-8777-777777777777";
+      const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+      const trajectoryFile = path.join(tmpDir, `${sessionId}.trajectory.jsonl`);
+      const pointerFile = path.join(tmpDir, `${sessionId}.trajectory-path.json`);
+      const unrelatedFile = path.join(tmpDir, "unrelated-data.jsonl");
+      writeSessionMeta(sessionFile, "main");
+      writeTrajectoryRuntime(trajectoryFile, sessionId);
+      writeTrajectoryRuntime(unrelatedFile, sessionId);
+      writeTrajectoryPointer(pointerFile, sessionId, unrelatedFile);
+
+      const archived = archiveSessionTranscriptsDetailed({
+        sessionId,
+        storePath: path.join(tmpDir, "store.json"),
+        sessionFile,
+        agentId: "main",
+        reason: "reset",
+      });
+
+      // Transcript + default runtime + pointer. The pointer-resolved file is
+      // skipped because its basename does not match.
+      expect(archived).toHaveLength(3);
+      expect(fs.existsSync(unrelatedFile)).toBe(true);
+      expect(fs.existsSync(trajectoryFile)).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not archive a pointer-resolved runtime file lacking a session event header", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-archive-trajectory-header-"));
+    try {
+      const sessionId = "88888888-8888-4888-8888-888888888888";
+      const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+      const trajectoryFile = path.join(tmpDir, `${sessionId}.trajectory.jsonl`);
+      const pointerFile = path.join(tmpDir, `${sessionId}.trajectory-path.json`);
+      const altDir = path.join(tmpDir, "alt");
+      fs.mkdirSync(altDir, { recursive: true });
+      const fakeRuntime = path.join(altDir, `${sessionId}.jsonl`);
+      fs.writeFileSync(fakeRuntime, '{"traceSchema":"openclaw-trajectory","source":"runtime"}\n');
+      writeSessionMeta(sessionFile, "main");
+      writeTrajectoryRuntime(trajectoryFile, sessionId);
+      writeTrajectoryPointer(pointerFile, sessionId, fakeRuntime);
+
+      const archived = archiveSessionTranscriptsDetailed({
+        sessionId,
+        storePath: path.join(tmpDir, "store.json"),
+        sessionFile,
+        agentId: "main",
+        reason: "reset",
+      });
+
+      // Transcript + default runtime + pointer. The pointer-resolved file
+      // passes the basename check but fails the session-event gate.
+      expect(archived).toHaveLength(3);
+      expect(fs.existsSync(fakeRuntime)).toBe(true);
+      expect(fs.existsSync(trajectoryFile)).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("archives a pointer-resolved runtime file that passes ownership checks", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-archive-trajectory-valid-"));
+    try {
+      const sessionId = "99999999-9999-4999-8999-999999999999";
+      const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+      const trajectoryFile = path.join(tmpDir, `${sessionId}.trajectory.jsonl`);
+      const pointerFile = path.join(tmpDir, `${sessionId}.trajectory-path.json`);
+      const altDir = path.join(tmpDir, "alt");
+      fs.mkdirSync(altDir, { recursive: true });
+      const altRuntime = path.join(altDir, `${sessionId}.jsonl`);
+      writeSessionMeta(sessionFile, "main");
+      writeTrajectoryRuntime(trajectoryFile, sessionId);
+      writeTrajectoryRuntime(altRuntime, sessionId);
+      writeTrajectoryPointer(pointerFile, sessionId, altRuntime);
+
+      const archived = archiveSessionTranscriptsDetailed({
+        sessionId,
+        storePath: path.join(tmpDir, "store.json"),
+        sessionFile,
+        agentId: "main",
+        reason: "reset",
+      });
+
+      // Transcript + default runtime + pointer-resolved runtime + pointer = 4
+      expect(archived).toHaveLength(4);
+      expect(fs.existsSync(altRuntime)).toBe(false);
+      expect(fs.existsSync(trajectoryFile)).toBe(false);
+      expect(fs.existsSync(pointerFile)).toBe(false);
+    } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });

--- a/src/gateway/session-transcript-files.fs.archive-events.test.ts
+++ b/src/gateway/session-transcript-files.fs.archive-events.test.ts
@@ -134,6 +134,69 @@ describe("archiveSessionTranscriptsDetailed failure surface", () => {
     }
   });
 
+  it("preserves the sibling trajectory and pointer on reset", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-archive-trajectory-reset-"));
+    try {
+      const sessionId = "44444444-4444-4444-8444-444444444444";
+      const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+      const trajectoryFile = path.join(tmpDir, `${sessionId}.trajectory.jsonl`);
+      const pointerFile = path.join(tmpDir, `${sessionId}.trajectory-path.json`);
+      fs.writeFileSync(sessionFile, '{"type":"session-meta","agentId":"main"}\n');
+      fs.writeFileSync(trajectoryFile, '{"traceSchema":"openclaw-trajectory"}\n');
+      fs.writeFileSync(pointerFile, `{"runtimeFile":${JSON.stringify(trajectoryFile)}}\n`);
+
+      const archived = archiveSessionTranscriptsDetailed({
+        sessionId,
+        storePath: path.join(tmpDir, "store.json"),
+        sessionFile,
+        agentId: "main",
+        reason: "reset",
+      });
+
+      expect(archived).toHaveLength(1);
+      // The live trajectory artifacts are renamed, not deleted, so post-reset
+      // forensics can still read the assistant's tool calls/results (#90707).
+      expect(fs.existsSync(trajectoryFile)).toBe(false);
+      expect(fs.existsSync(pointerFile)).toBe(false);
+      const remaining = fs.readdirSync(tmpDir);
+      expect(remaining.some((name) => /\.trajectory\.jsonl\.reset\.\d/.test(name))).toBe(true);
+      expect(remaining.some((name) => /\.trajectory-path\.json\.reset\.\d/.test(name))).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not archive trajectory siblings for a deleted session", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-archive-trajectory-deleted-"));
+    try {
+      const sessionId = "55555555-5555-4555-8555-555555555555";
+      const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+      const trajectoryFile = path.join(tmpDir, `${sessionId}.trajectory.jsonl`);
+      const pointerFile = path.join(tmpDir, `${sessionId}.trajectory-path.json`);
+      fs.writeFileSync(sessionFile, '{"type":"session-meta","agentId":"main"}\n');
+      fs.writeFileSync(trajectoryFile, '{"traceSchema":"openclaw-trajectory"}\n');
+      fs.writeFileSync(pointerFile, `{"runtimeFile":${JSON.stringify(trajectoryFile)}}\n`);
+
+      const archived = archiveSessionTranscriptsDetailed({
+        sessionId,
+        storePath: path.join(tmpDir, "store.json"),
+        sessionFile,
+        agentId: "main",
+        reason: "deleted",
+      });
+
+      expect(archived).toHaveLength(1);
+      // A deleted/pruned session still owns the trajectory removal path, so the
+      // archive step must leave the live siblings untouched.
+      expect(fs.existsSync(trajectoryFile)).toBe(true);
+      expect(fs.existsSync(pointerFile)).toBe(true);
+      const remaining = fs.readdirSync(tmpDir);
+      expect(remaining.some((name) => /\.trajectory\.jsonl\.reset\./.test(name))).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("surfaces real chmod archive failures through onArchiveError", () => {
     if (process.platform === "win32" || process.getuid?.() === 0) {
       return;

--- a/src/gateway/session-transcript-files.fs.archive-events.test.ts
+++ b/src/gateway/session-transcript-files.fs.archive-events.test.ts
@@ -250,11 +250,57 @@ describe("archiveSessionTranscriptsDetailed failure surface", () => {
       });
 
       // Transcript + override runtime + pointer = 3 archived entries.
+      // The override runtime is archived with an unambiguous trajectory name so
+      // it is never discovered as a transcript archive (#94593).
       expect(archived).toHaveLength(3);
       expect(fs.existsSync(overrideRuntime)).toBe(false);
       expect(fs.existsSync(pointerFile)).toBe(false);
       const remaining = fs.readdirSync(trajectoryDir);
-      expect(remaining.some((name) => name.includes(".jsonl.reset."))).toBe(true);
+      expect(remaining.some((name) => name.includes(".trajectory.jsonl.reset."))).toBe(true);
+      expect(remaining.some((name) => /^[0-9a-f-]+\.jsonl\.reset\./.test(name))).toBe(false);
+    } finally {
+      if (previousTrajectoryDir === undefined) {
+        delete process.env.OPENCLAW_TRAJECTORY_DIR;
+      } else {
+        process.env.OPENCLAW_TRAJECTORY_DIR = previousTrajectoryDir;
+      }
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("archives both override and env-free sibling runtimes when the env changed after creation (#94593)", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-archive-trajectory-env-change-"));
+    const previousTrajectoryDir = process.env.OPENCLAW_TRAJECTORY_DIR;
+    try {
+      const sessionId = "77777777-7777-4777-8777-777777777777";
+      const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+      const trajectoryDir = path.join(tmpDir, "traces");
+      const overrideRuntime = path.join(trajectoryDir, `${sessionId}.jsonl`);
+      const siblingRuntime = path.join(tmpDir, `${sessionId}.trajectory.jsonl`);
+      const pointerFile = path.join(tmpDir, `${sessionId}.trajectory-path.json`);
+      fs.mkdirSync(trajectoryDir, { recursive: true });
+      // Session was created before OPENCLAW_TRAJECTORY_DIR existed, so the live
+      // runtime is the env-free sibling. Later the operator enabled the override
+      // dir, and the pointer was updated to point there.
+      process.env.OPENCLAW_TRAJECTORY_DIR = trajectoryDir;
+      writeSessionMeta(sessionFile, "main");
+      writeTrajectoryRuntime(siblingRuntime, sessionId);
+      writeTrajectoryRuntime(overrideRuntime, sessionId);
+      writeTrajectoryPointer(pointerFile, sessionId, overrideRuntime);
+
+      const archived = archiveSessionTranscriptsDetailed({
+        sessionId,
+        storePath: path.join(tmpDir, "store.json"),
+        sessionFile,
+        agentId: "main",
+        reason: "reset",
+      });
+
+      // Transcript + override runtime + env-free sibling runtime + pointer = 4.
+      expect(archived).toHaveLength(4);
+      expect(fs.existsSync(overrideRuntime)).toBe(false);
+      expect(fs.existsSync(siblingRuntime)).toBe(false);
+      expect(fs.existsSync(pointerFile)).toBe(false);
     } finally {
       if (previousTrajectoryDir === undefined) {
         delete process.env.OPENCLAW_TRAJECTORY_DIR;

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -16,11 +16,12 @@ import {
   resolveSessionTranscriptPath,
   resolveSessionTranscriptPathInDir,
 } from "../config/sessions/paths.js";
-import { resolveRequiredHomeDir } from "../infra/home-dir.js";
+import { resolveHomeRelativePath, resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import {
   resolveTrajectoryFilePath,
   resolveTrajectoryPointerFilePath,
+  safeTrajectorySessionFileName,
 } from "../trajectory/paths.js";
 
 type ArchiveFileReason = SessionArchiveReason;
@@ -377,6 +378,49 @@ export function archiveFileOnDisk(filePath: string, reason: ArchiveFileReason): 
   return archived;
 }
 
+// Validate that a pointer-resolved runtime file path is actually a trajectory
+// runtime file for the given session. The pointer JSON shape/session checks in
+// readArchiveTrajectoryPointerRuntimeFile confirm the pointer is well-formed, but
+// the runtimeFile field can name any writable path. This gate requires the
+// resolved basename to match the expected session-scoped trajectory name and the
+// first line to carry a matching session event before the file is trusted.
+function isValidPointerResolvedTrajectoryRuntime(
+  filePath: string,
+  sessionId: string,
+): boolean {
+  const expectedName = `${safeTrajectorySessionFileName(sessionId)}.jsonl`;
+  if (path.basename(path.resolve(filePath)) !== expectedName) {
+    return false;
+  }
+  try {
+    const fd = fs.openSync(filePath, "r");
+    const buffer = Buffer.alloc(64 * 1024);
+    const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
+    fs.closeSync(fd);
+    if (bytesRead <= 0) {
+      return false;
+    }
+    const firstLine = buffer
+      .subarray(0, bytesRead)
+      .toString("utf8")
+      .split(/\r?\n/u)
+      .find((line) => line.trim());
+    if (!firstLine) {
+      return false;
+    }
+    const parsed: unknown = JSON.parse(firstLine.trim());
+    return (
+      isRecord(parsed) &&
+      parsed.traceSchema === "openclaw-trajectory" &&
+      parsed.schemaVersion === 1 &&
+      parsed.source === "runtime" &&
+      parsed.sessionId === sessionId
+    );
+  } catch {
+    return false;
+  }
+}
+
 // Rename the trajectory runtime file and its pointer sidecar next to a reset
 // transcript into `.reset.<ts>` archives. A reset preserves the transcript as
 // `.jsonl.reset.<ts>`, but the sibling trajectory (assistant tool calls/results)
@@ -414,20 +458,37 @@ function readArchiveTrajectoryPointerRuntimeFile(
   }
 }
 
-function archiveResetTrajectorySiblings(transcriptPath: string, sessionId: string): void {
+function archiveResetTrajectorySiblings(
+  transcriptPath: string,
+  sessionId: string,
+): ArchivedSessionTranscript[] {
   const ts = formatSessionArchiveTimestamp();
   const pointerPath = resolveTrajectoryPointerFilePath(transcriptPath);
-  const runtimeTargets = new Set<string>([
-    resolveTrajectoryFilePath({ env: process.env, sessionFile: transcriptPath, sessionId }),
-  ]);
+  const defaultRuntimePath = resolveTrajectoryFilePath({
+    env: process.env,
+    sessionFile: transcriptPath,
+    sessionId,
+  });
+  const runtimeTargets = new Set<string>([defaultRuntimePath]);
   const pointerRuntime = readArchiveTrajectoryPointerRuntimeFile(pointerPath, sessionId);
-  if (pointerRuntime) {
-    runtimeTargets.add(pointerRuntime);
+  if (
+    pointerRuntime &&
+    canonicalizePathForComparison(pointerRuntime) !==
+      canonicalizePathForComparison(defaultRuntimePath)
+  ) {
+    // The pointer can name any writable path; only trust it when the resolved
+    // file looks like a session-owned trajectory runtime.
+    if (isValidPointerResolvedTrajectoryRuntime(pointerRuntime, sessionId)) {
+      runtimeTargets.add(pointerRuntime);
+    }
   }
+  const archived: ArchivedSessionTranscript[] = [];
   const renameArchive = (filePath: string) => {
     try {
       if (fs.existsSync(filePath)) {
-        fs.renameSync(filePath, `${filePath}.reset.${ts}`);
+        const archivedPath = `${filePath}.reset.${ts}`;
+        fs.renameSync(filePath, archivedPath);
+        archived.push({ sourcePath: filePath, archivedPath });
       }
     } catch {
       // Ignore: the transcript reset is the source of truth; a trajectory
@@ -438,6 +499,7 @@ function archiveResetTrajectorySiblings(transcriptPath: string, sessionId: strin
     renameArchive(runtimePath);
   }
   renameArchive(pointerPath);
+  return archived;
 }
 
 export function archiveSessionTranscripts(opts: {
@@ -500,7 +562,7 @@ export function archiveSessionTranscriptsDetailed(opts: {
       // Only a reset preserves the transcript; a deleted/pruned session still
       // hands its trajectory to the existing removal path, so keep that as-is.
       if (opts.reason === "reset") {
-        archiveResetTrajectorySiblings(candidatePath, opts.sessionId);
+        archived.push(...archiveResetTrajectorySiblings(candidatePath, opts.sessionId));
       }
     } catch (err) {
       opts.onArchiveError?.(err, candidatePath);
@@ -568,7 +630,17 @@ export async function cleanupArchivedSessionTranscripts(opts: {
     return { removed: 0, scanned: 0 };
   }
   const now = opts.nowMs ?? Date.now();
-  const directories = uniqueStrings(opts.directories.map((dir) => path.resolve(dir)));
+  // Reset-archived trajectory runtime files may live in the
+  // OPENCLAW_TRAJECTORY_DIR override directory, which is not part of the
+  // session store directory tree. Include it so
+  // `.trajectory.jsonl.reset.<ts>` archives are pruned by the existing reset
+  // retention rule (#90707).
+  const trajectoryDirOverride = process.env.OPENCLAW_TRAJECTORY_DIR?.trim();
+  const dirs = opts.directories.map((dir) => path.resolve(dir));
+  if (trajectoryDirOverride) {
+    dirs.push(path.resolve(resolveHomeRelativePath(trajectoryDirOverride)));
+  }
+  const directories = uniqueStrings(dirs);
   let removed = 0;
   let scanned = 0;
 

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -17,6 +17,10 @@ import {
 } from "../config/sessions/paths.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import {
+  resolveTrajectoryFilePath,
+  resolveTrajectoryPointerFilePath,
+} from "../trajectory/paths.js";
 
 type ArchiveFileReason = SessionArchiveReason;
 type ResetArchiveCandidate = { archivePath: string; name: string; timestamp: number };
@@ -372,6 +376,33 @@ export function archiveFileOnDisk(filePath: string, reason: ArchiveFileReason): 
   return archived;
 }
 
+// Rename the trajectory runtime file and its pointer sidecar next to a reset
+// transcript into `.reset.<ts>` archives. A reset preserves the transcript as
+// `.jsonl.reset.<ts>`, but the sibling trajectory (assistant tool calls/results)
+// is otherwise lost — overwritten when the session file path is reused, or left
+// dangling and reclaimed as an orphan — which makes post-incident forensics on
+// outbound actions impossible (#90707). The shared `.reset.<ts>` suffix is what
+// the retention sweep keys on, so these archives ride the existing
+// reset-archive cleanup instead of growing unbounded. Best-effort: a missing or
+// locked sibling must not fail the transcript reset that already succeeded.
+function archiveResetTrajectorySiblings(transcriptPath: string, sessionId: string): void {
+  const ts = formatSessionArchiveTimestamp();
+  const siblings = [
+    resolveTrajectoryFilePath({ env: {}, sessionFile: transcriptPath, sessionId }),
+    resolveTrajectoryPointerFilePath(transcriptPath),
+  ];
+  for (const sibling of siblings) {
+    try {
+      if (fs.existsSync(sibling)) {
+        fs.renameSync(sibling, `${sibling}.reset.${ts}`);
+      }
+    } catch {
+      // Ignore: the transcript reset is the source of truth; a trajectory
+      // sibling that cannot be archived just falls back to prior behavior.
+    }
+  }
+}
+
 export function archiveSessionTranscripts(opts: {
   sessionId: string;
   storePath: string | undefined;
@@ -427,10 +458,13 @@ export function archiveSessionTranscriptsDetailed(opts: {
       continue;
     }
     try {
-      archived.push({
-        sourcePath: candidatePath,
-        archivedPath: archiveFileOnDisk(candidatePath, opts.reason),
-      });
+      const archivedPath = archiveFileOnDisk(candidatePath, opts.reason);
+      archived.push({ sourcePath: candidatePath, archivedPath });
+      // Only a reset preserves the transcript; a deleted/pruned session still
+      // hands its trajectory to the existing removal path, so keep that as-is.
+      if (opts.reason === "reset") {
+        archiveResetTrajectorySiblings(candidatePath, opts.sessionId);
+      }
     } catch (err) {
       opts.onArchiveError?.(err, candidatePath);
     }

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import {
   formatSessionArchiveTimestamp,
@@ -385,22 +386,58 @@ export function archiveFileOnDisk(filePath: string, reason: ArchiveFileReason): 
 // the retention sweep keys on, so these archives ride the existing
 // reset-archive cleanup instead of growing unbounded. Best-effort: a missing or
 // locked sibling must not fail the transcript reset that already succeeded.
+function readArchiveTrajectoryPointerRuntimeFile(
+  pointerPath: string,
+  sessionId: string,
+): string | null {
+  try {
+    const lst = fs.lstatSync(pointerPath);
+    if (!lst.isFile() || lst.isSymbolicLink()) {
+      return null;
+    }
+    const parsed: unknown = JSON.parse(fs.readFileSync(pointerPath, "utf8"));
+    if (!isRecord(parsed)) {
+      return null;
+    }
+    if (
+      parsed.traceSchema !== "openclaw-trajectory-pointer" ||
+      parsed.schemaVersion !== 1 ||
+      parsed.sessionId !== sessionId ||
+      typeof parsed.runtimeFile !== "string" ||
+      !parsed.runtimeFile.trim()
+    ) {
+      return null;
+    }
+    return path.resolve(parsed.runtimeFile);
+  } catch {
+    return null;
+  }
+}
+
 function archiveResetTrajectorySiblings(transcriptPath: string, sessionId: string): void {
   const ts = formatSessionArchiveTimestamp();
-  const siblings = [
-    resolveTrajectoryFilePath({ env: {}, sessionFile: transcriptPath, sessionId }),
-    resolveTrajectoryPointerFilePath(transcriptPath),
-  ];
-  for (const sibling of siblings) {
+  const pointerPath = resolveTrajectoryPointerFilePath(transcriptPath);
+  const runtimeTargets = new Set<string>([
+    resolveTrajectoryFilePath({ env: process.env, sessionFile: transcriptPath, sessionId }),
+  ]);
+  const pointerRuntime = readArchiveTrajectoryPointerRuntimeFile(pointerPath, sessionId);
+  if (pointerRuntime) {
+    runtimeTargets.add(pointerRuntime);
+  }
+  const renameArchive = (filePath: string) => {
     try {
-      if (fs.existsSync(sibling)) {
-        fs.renameSync(sibling, `${sibling}.reset.${ts}`);
+      if (fs.existsSync(filePath)) {
+        fs.renameSync(filePath, `${filePath}.reset.${ts}`);
       }
     } catch {
       // Ignore: the transcript reset is the source of truth; a trajectory
       // sibling that cannot be archived just falls back to prior behavior.
     }
+  };
+  for (const runtimePath of runtimeTargets) {
+    renameArchive(runtimePath);
   }
+  renameArchive(pointerPath);
 }
 
 export function archiveSessionTranscripts(opts: {

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -384,21 +384,22 @@ export function archiveFileOnDisk(filePath: string, reason: ArchiveFileReason): 
 // the runtimeFile field can name any writable path. This gate requires the
 // resolved basename to match the expected session-scoped trajectory name and the
 // first line to carry a matching session event before the file is trusted.
-function isValidPointerResolvedTrajectoryRuntime(
-  filePath: string,
-  sessionId: string,
-): boolean {
+function isValidPointerResolvedTrajectoryRuntime(filePath: string, sessionId: string): boolean {
   const expectedName = `${safeTrajectorySessionFileName(sessionId)}.jsonl`;
   if (path.basename(path.resolve(filePath)) !== expectedName) {
     return false;
   }
+  return isTrajectoryRuntimeFileHeader(filePath, sessionId);
+}
+
+function readTrajectoryRuntimeHeader(filePath: string): unknown {
   try {
     const fd = fs.openSync(filePath, "r");
     const buffer = Buffer.alloc(64 * 1024);
     const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
     fs.closeSync(fd);
     if (bytesRead <= 0) {
-      return false;
+      return undefined;
     }
     const firstLine = buffer
       .subarray(0, bytesRead)
@@ -406,19 +407,30 @@ function isValidPointerResolvedTrajectoryRuntime(
       .split(/\r?\n/u)
       .find((line) => line.trim());
     if (!firstLine) {
-      return false;
+      return undefined;
     }
-    const parsed: unknown = JSON.parse(firstLine.trim());
-    return (
-      isRecord(parsed) &&
-      parsed.traceSchema === "openclaw-trajectory" &&
-      parsed.schemaVersion === 1 &&
-      parsed.source === "runtime" &&
-      parsed.sessionId === sessionId
-    );
+    return JSON.parse(firstLine.trim());
   } catch {
+    return undefined;
+  }
+}
+
+function isTrajectoryRuntimeFileHeader(filePath: string, sessionId?: string): boolean {
+  const parsed = readTrajectoryRuntimeHeader(filePath);
+  if (!isRecord(parsed)) {
     return false;
   }
+  if (
+    parsed.traceSchema !== "openclaw-trajectory" ||
+    parsed.schemaVersion !== 1 ||
+    parsed.source !== "runtime"
+  ) {
+    return false;
+  }
+  if (sessionId !== undefined && parsed.sessionId !== sessionId) {
+    return false;
+  }
+  return true;
 }
 
 // Rename the trajectory runtime file and its pointer sidecar next to a reset
@@ -469,7 +481,19 @@ function archiveResetTrajectorySiblings(
     sessionFile: transcriptPath,
     sessionId,
   });
-  const runtimeTargets = new Set<string>([defaultRuntimePath]);
+  // Also archive the env-free sibling path. If OPENCLAW_TRAJECTORY_DIR was
+  // enabled after the session was created, the live runtime may still live next
+  // to the transcript while the pointer names the override dir (#94593).
+  const envFreeSiblingRuntimePath = resolveTrajectoryFilePath({
+    env: {},
+    sessionFile: transcriptPath,
+    sessionId,
+  });
+  const trajectoryDirOverride = process.env.OPENCLAW_TRAJECTORY_DIR?.trim();
+  const overrideDirResolved = trajectoryDirOverride
+    ? path.resolve(resolveHomeRelativePath(trajectoryDirOverride))
+    : undefined;
+  const runtimeTargets = new Set<string>([defaultRuntimePath, envFreeSiblingRuntimePath]);
   const pointerRuntime = readArchiveTrajectoryPointerRuntimeFile(pointerPath, sessionId);
   if (
     pointerRuntime &&
@@ -483,10 +507,19 @@ function archiveResetTrajectorySiblings(
     }
   }
   const archived: ArchivedSessionTranscript[] = [];
-  const renameArchive = (filePath: string) => {
+  const renameArchive = (filePath: string, archivedName?: string) => {
     try {
       if (fs.existsSync(filePath)) {
-        const archivedPath = `${filePath}.reset.${ts}`;
+        let archivedPath: string;
+        if (archivedName) {
+          // Override runtimes live as <sessionId>.jsonl inside OPENCLAW_TRAJECTORY_DIR.
+          // If that directory overlaps with the sessions directory, a plain
+          // .jsonl.reset.<ts> name would be discovered as a transcript archive.
+          // Archive with an unambiguous trajectory name instead (#94593).
+          archivedPath = path.join(path.dirname(filePath), archivedName);
+        } else {
+          archivedPath = `${filePath}.reset.${ts}`;
+        }
         fs.renameSync(filePath, archivedPath);
         archived.push({ sourcePath: filePath, archivedPath });
       }
@@ -495,8 +528,17 @@ function archiveResetTrajectorySiblings(
       // sibling that cannot be archived just falls back to prior behavior.
     }
   };
+  const safeSessionName = safeTrajectorySessionFileName(sessionId);
   for (const runtimePath of runtimeTargets) {
-    renameArchive(runtimePath);
+    const runtimeDir = path.dirname(path.resolve(runtimePath));
+    const isOverrideRuntime =
+      overrideDirResolved !== undefined &&
+      canonicalizePathForComparison(runtimeDir) ===
+        canonicalizePathForComparison(overrideDirResolved);
+    renameArchive(
+      runtimePath,
+      isOverrideRuntime ? `${safeSessionName}.trajectory.jsonl.reset.${ts}` : undefined,
+    );
   }
   renameArchive(pointerPath);
   return archived;
@@ -636,15 +678,21 @@ export async function cleanupArchivedSessionTranscripts(opts: {
   // `.trajectory.jsonl.reset.<ts>` archives are pruned by the existing reset
   // retention rule (#90707).
   const trajectoryDirOverride = process.env.OPENCLAW_TRAJECTORY_DIR?.trim();
+  const overrideDirResolved = trajectoryDirOverride
+    ? path.resolve(resolveHomeRelativePath(trajectoryDirOverride))
+    : undefined;
   const dirs = opts.directories.map((dir) => path.resolve(dir));
-  if (trajectoryDirOverride) {
-    dirs.push(path.resolve(resolveHomeRelativePath(trajectoryDirOverride)));
+  if (overrideDirResolved) {
+    dirs.push(overrideDirResolved);
   }
   const directories = uniqueStrings(dirs);
   let removed = 0;
   let scanned = 0;
 
   for (const dir of directories) {
+    const isOverrideDir =
+      overrideDirResolved !== undefined &&
+      canonicalizePathForComparison(dir) === canonicalizePathForComparison(overrideDirResolved);
     const entries = await fs.promises.readdir(dir).catch(() => []);
     for (const entry of entries) {
       for (const rule of rules) {
@@ -657,6 +705,12 @@ export async function cleanupArchivedSessionTranscripts(opts: {
           const fullPath = path.join(dir, entry);
           const stat = await fs.promises.stat(fullPath).catch(() => null);
           if (stat?.isFile()) {
+            // The override directory is operator-configured and may contain
+            // unrelated archive-looking files. Only remove files that carry an
+            // OpenClaw trajectory runtime header (#94593).
+            if (isOverrideDir && !isTrajectoryRuntimeFileHeader(fullPath)) {
+              continue;
+            }
             await fs.promises.rm(fullPath).catch(() => undefined);
             removed += 1;
           }

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -7,7 +7,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import {
   formatSessionArchiveTimestamp,
-  isArchivedTrajectorySessionArtifactName,
+  isArchivedTrajectoryRuntimeArtifactName,
   parseSessionArchiveTimestamp,
   type SessionArchiveReason,
 } from "../config/sessions/artifacts.js";
@@ -697,12 +697,14 @@ export async function cleanupArchivedSessionTranscripts(opts: {
       canonicalizePathForComparison(dir) === canonicalizePathForComparison(overrideDirResolved);
     const isOriginalDir = originalDirs.has(dir);
     // The override directory is operator-configured and may contain unrelated
-    // archive-looking files. Only remove files that carry an OpenClaw trajectory
-    // runtime header when scanning the override-only directory. If the override
-    // directory is also an explicitly requested cleanup directory, normal
-    // transcript archive cleanup must continue to work there (#94593).
+    // archive-looking files. Only remove trajectory runtime files that carry an
+    // OpenClaw trajectory runtime header when scanning the override-only
+    // directory; pointer archives are owned session artifacts and should follow
+    // normal retention rules. If the override directory is also an explicitly
+    // requested cleanup directory, normal transcript archive cleanup must
+    // continue to work there (#94593).
     const requireTrajectoryHeader = (entry: string) =>
-      isOverrideDir && (!isOriginalDir || isArchivedTrajectorySessionArtifactName(entry));
+      isOverrideDir && (!isOriginalDir || isArchivedTrajectoryRuntimeArtifactName(entry));
     const entries = await fs.promises.readdir(dir).catch(() => []);
     for (const entry of entries) {
       for (const rule of rules) {

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -7,6 +7,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import {
   formatSessionArchiveTimestamp,
+  isArchivedTrajectorySessionArtifactName,
   parseSessionArchiveTimestamp,
   type SessionArchiveReason,
 } from "../config/sessions/artifacts.js";
@@ -681,6 +682,7 @@ export async function cleanupArchivedSessionTranscripts(opts: {
   const overrideDirResolved = trajectoryDirOverride
     ? path.resolve(resolveHomeRelativePath(trajectoryDirOverride))
     : undefined;
+  const originalDirs = new Set(opts.directories.map((dir) => path.resolve(dir)));
   const dirs = opts.directories.map((dir) => path.resolve(dir));
   if (overrideDirResolved) {
     dirs.push(overrideDirResolved);
@@ -693,6 +695,14 @@ export async function cleanupArchivedSessionTranscripts(opts: {
     const isOverrideDir =
       overrideDirResolved !== undefined &&
       canonicalizePathForComparison(dir) === canonicalizePathForComparison(overrideDirResolved);
+    const isOriginalDir = originalDirs.has(dir);
+    // The override directory is operator-configured and may contain unrelated
+    // archive-looking files. Only remove files that carry an OpenClaw trajectory
+    // runtime header when scanning the override-only directory. If the override
+    // directory is also an explicitly requested cleanup directory, normal
+    // transcript archive cleanup must continue to work there (#94593).
+    const requireTrajectoryHeader = (entry: string) =>
+      isOverrideDir && (!isOriginalDir || isArchivedTrajectorySessionArtifactName(entry));
     const entries = await fs.promises.readdir(dir).catch(() => []);
     for (const entry of entries) {
       for (const rule of rules) {
@@ -705,10 +715,7 @@ export async function cleanupArchivedSessionTranscripts(opts: {
           const fullPath = path.join(dir, entry);
           const stat = await fs.promises.stat(fullPath).catch(() => null);
           if (stat?.isFile()) {
-            // The override directory is operator-configured and may contain
-            // unrelated archive-looking files. Only remove files that carry an
-            // OpenClaw trajectory runtime header (#94593).
-            if (isOverrideDir && !isTrajectoryRuntimeFileHeader(fullPath)) {
+            if (requireTrajectoryHeader(entry) && !isTrajectoryRuntimeFileHeader(fullPath)) {
               continue;
             }
             await fs.promises.rm(fullPath).catch(() => undefined);


### PR DESCRIPTION
## What Problem This Solves

Closes #90707.

On `/new` and `/reset`, OpenClaw archives the session transcript as `<sid>.jsonl.reset.<ts>` but the sibling **trajectory** file `<sid>.trajectory.jsonl` (the assistant's tool calls and tool results) and its `<sid>.trajectory-path.json` pointer are lost — overwritten when the session file path is reused, or left at their live names and then reclaimed by the lifecycle cleanup for the now-unreferenced old session id. For sessions that issued outbound communications, this makes post-incident forensics impossible.

## Why This Change Was Made

The fix mirrors the transcript-archive behavior for the trajectory in the shared reset path `archiveSessionTranscriptsDetailed` (used by both reset entry points). Recent review also identified two P1 gaps:

1. **Env-free sibling preservation:** Sessions created before `OPENCLAW_TRAJECTORY_DIR` was enabled keep their live runtime next to the transcript, even when the pointer later names an override directory. Reset now archives both the current-env target and the env-free sibling.
2. **Constrained override cleanup:** The override directory is operator-configured, so the retention sweep now only removes files that carry a valid OpenClaw trajectory runtime header; unrelated archive-looking files are preserved.
3. **Unambiguous override archive names:** Override runtimes live as `<sessionId>.jsonl` inside `OPENCLAW_TRAJECTORY_DIR`. If that directory overlaps with the sessions directory, a plain `.jsonl.reset.<ts>` archive would be discovered as a transcript archive. Override runtimes are now archived as `<sessionId>.trajectory.jsonl.reset.<ts>` so they are excluded by the existing trajectory classifiers.

### Retention and upgrade compatibility

- **No new retention code.** Reset-archived trajectories use the existing `.reset.<ts>` suffix and are pruned by the existing `resetArchiveRetentionMs` rule, so archive volume remains bounded.
- **Sensitive-data boundary.** Reset archives intentionally retain tool-call arguments and tool results for the configured retention window; this is the forensic purpose of the fix and matches the retention policy already applied to transcripts.
- **Backward compatible.** No existing file formats, database schemas, or session store layouts are changed. Existing sessions are unaffected until their next reset, at which point their trajectory is preserved instead of lost.
- **Operator-configured dir is read, not owned.** Adding `OPENCLAW_TRAJECTORY_DIR` to the cleanup scan only removes header-proven OpenClaw trajectory archives; it does not create new files or alter the directory's ownership semantics.

## User Impact

Reset-time session archives now retain the exact tool calls and tool results that preceded outbound actions, enabling post-incident forensics. Normal reset/delete behavior is otherwise unchanged, and no unbounded archive growth is introduced because the existing `.reset.<ts>` retention sweep prunes old trajectory archives.

## Real behavior proof

**Environment:** Linux, Node 22, local `.mts` proof script driving the real `archiveSessionTranscriptsDetailed` and `removeSessionTrajectoryArtifacts` production functions against real on-disk session directories.

**Fix (16 passed, 0 failed):**

```
[case 1] reset archives env-free sibling trajectory
  ok: transcript archived
  ok: sibling runtime no longer live
  ok: pointer no longer live
  ok: reset archive exists
  ok: lifecycle cleanup removed nothing
  ok: reset archive still exists after cleanup

[case 2] reset archives both override runtime and env-free sibling
  ok: archived 4 entries (transcript + 2 runtimes + pointer)
  ok: override runtime archived
  ok: sibling runtime archived
  ok: override reset archive has trajectory name
  ok: override reset archive is not plain .jsonl.reset
  ok: sibling reset archive exists

[case 3] override-dir cleanup preserves unrelated archive-looking files
  ok: removed exactly the owned archive
  ok: scanned both candidates
  ok: unrelated file preserved
  ok: owned archive removed

=== Proof Summary ===
ALL PROOF ASSERTIONS: 16 passed, 0 failed
```

**Negative control (origin/main, same script):**

```
[case 1] reset archives env-free sibling trajectory
  ok: transcript archived
  FAIL: sibling runtime no longer live
  FAIL: pointer no longer live
  FAIL: reset archive exists
  FAIL: lifecycle cleanup removed nothing
  FAIL: reset archive still exists after cleanup

[case 2] reset archives both override runtime and env-free sibling
  FAIL: archived 4 entries (transcript + 2 runtimes + pointer)
  FAIL: override runtime archived
  FAIL: sibling runtime archived
  FAIL: override reset archive has trajectory name
  ok: override reset archive is not plain .jsonl.reset
  FAIL: sibling reset archive exists

[case 3] override-dir cleanup preserves unrelated archive-looking files
  FAIL: removed exactly the owned archive
  FAIL: scanned both candidates
  ok: unrelated file preserved
  FAIL: owned archive removed

=== Proof Summary ===
ALL PROOF ASSERTIONS: 3 passed, 13 failed
EXIT=1
```

## Evidence

### Vitest (real filesystem)

```
 Test Files  8 passed (gateway) | 1 passed (runtime-config)
      Tests  72 passed (gateway) | 9 passed (runtime-config)
```

### Review findings addressed

| Finding | Fix |
|---------|-----|
| [P1] Env-free trajectory sibling lost on reset | `archiveResetTrajectorySiblings` now seeds `runtimeTargets` with both the current-env path and the env-free sibling path (`resolveTrajectoryFilePath({ env: {} })`) |
| [P1] Override cleanup can delete unrelated files | `cleanupArchivedSessionTranscripts` only removes files in `OPENCLAW_TRAJECTORY_DIR` whose first line validates as an OpenClaw trajectory runtime header |
| [P2] Override trajectory archives can be mistaken for transcript archives | Override runtimes are archived as `<sessionId>.trajectory.jsonl.reset.<ts>`, so existing trajectory classifiers exclude them from transcript scans |

### Regression tests added

- `archive-events.test.ts`: env-change scenario — both override runtime and env-free sibling are archived on reset.
- `archive-cleanup.test.ts`: unrelated archive-looking files in a shared override directory are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
