### PR TITLE
fix(agents): block cyclic sessions_send routes

### DIFF
--- a/packages/gateway-protocol/src/schema/primitives.ts
+++ b/packages/gateway-protocol/src/schema/primitives.ts
@@ -41,6 +41,7 @@ export const InputProvenanceSchema = Type.Object(
     sourceSessionKey: Type.Optional(Type.String()),
     sourceChannel: Type.Optional(Type.String()),
     sourceTool: Type.Optional(Type.String()),
+    visitedAgentIds: Type.Optional(Type.Array(Type.String())),
   },
   { additionalProperties: false },
 );

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -25,6 +25,7 @@ import {
 import { resolveMergedSafeBinProfileFixtures } from "../infra/exec-safe-bin-runtime-policy.js";
 import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
+import type { InputProvenance } from "../sessions/input-provenance.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import type { SkillSnapshot } from "../skills/types.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
@@ -436,6 +437,8 @@ export function createOpenClawCodingTools(options?: {
   messageThreadId?: string | number;
   sandbox?: SandboxContext | null;
   sessionKey?: string;
+  /** Provenance for the current model-visible user turn; tool calls can extend it across handoffs. */
+  inputProvenance?: InputProvenance;
   /**
    * The actual live run session key. When the tool set is constructed with a
    * sandbox/policy session key, this allows `session_status({sessionKey:"current"})`
@@ -1042,6 +1045,7 @@ export function createOpenClawCodingTools(options?: {
           sandboxBrowserBridgeUrl: sandbox?.browser?.bridgeUrl,
           allowHostBrowserControl: sandbox ? sandbox.browserAllowHostControl : true,
           agentSessionKey: options?.sessionKey,
+          inputProvenance: options?.inputProvenance,
           runId: options?.runId,
           runSessionKey: options?.runSessionKey,
           agentChannel: resolveGatewayMessageChannel(options?.messageProvider),

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1281,6 +1281,7 @@ export async function runEmbeddedAttempt(
             senderUsername: params.senderUsername,
             senderE164: params.senderE164,
             senderIsOwner: params.senderIsOwner,
+            inputProvenance: params.inputProvenance,
             allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
             sessionKey: sandboxSessionKey,
             // When sandboxSessionKey differs from the real run session key (e.g. Telegram

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -34,6 +34,7 @@ vi.mock("../config/config.js", () => ({
 
 import "./test-helpers/fast-openclaw-tools-sessions.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
+import type { InputProvenance } from "../sessions/input-provenance.js";
 import {
   testing as embeddedRunsTesting,
   setActiveEmbeddedRun,
@@ -136,6 +137,7 @@ function installMessagingTestRegistry() {
 function createOpenClawTools(options?: {
   agentSessionKey?: string;
   agentChannel?: string;
+  inputProvenance?: InputProvenance;
   sandboxed?: boolean;
   config?: OpenClawConfig;
 }) {
@@ -158,6 +160,7 @@ function createOpenClawTools(options?: {
     createSessionsSendTool({
       agentSessionKey: options?.agentSessionKey,
       agentChannel: options?.agentChannel as never,
+      inputProvenance: options?.inputProvenance,
       sandboxed: options?.sandboxed,
       config,
       callGateway: gatewayCall,
@@ -190,6 +193,7 @@ type AgentCallParams = {
     sourceSessionKey?: string;
     sourceChannel?: string;
     sourceTool?: string;
+    visitedAgentIds?: string[];
   };
 };
 
@@ -390,6 +394,77 @@ describe("sessions tools", () => {
     expect(agentCall).toBeDefined();
     expect(agentParams(agentCall ?? {}).message).toContain("Visible answer");
     expect(agentParams(agentCall ?? {}).message).not.toContain("internal plan");
+  });
+
+  it("sessions_send carries visited agent provenance to the target run", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-chain", status: "accepted" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:beta:main",
+      agentChannel: "discord",
+      inputProvenance: {
+        kind: "inter_session",
+        sourceTool: "sessions_send",
+        visitedAgentIds: ["alpha"],
+      },
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-chain", {
+      sessionKey: "agent:gamma:main",
+      message: "continue the handoff",
+      timeoutSeconds: 0,
+    });
+
+    expect(sessionsSendDetails(result.details).status).toBe("accepted");
+    const agentCall = callGatewayMock.mock.calls
+      .map((call) => call[0] as GatewayCall)
+      .find((call) => call.method === "agent");
+    expect(agentCall).toBeDefined();
+    expect(agentParams(agentCall ?? {}).inputProvenance?.visitedAgentIds).toEqual([
+      "alpha",
+      "beta",
+      "gamma",
+    ]);
+  });
+
+  it("sessions_send blocks delivery back to an agent already in the visited chain", async () => {
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:gamma:main",
+      agentChannel: "discord",
+      inputProvenance: {
+        kind: "inter_session",
+        sourceTool: "sessions_send",
+        visitedAgentIds: ["alpha", "beta"],
+      },
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-cycle", {
+      sessionKey: "agent:alpha:main",
+      message: "loop back",
+      timeoutSeconds: 0,
+    });
+
+    const details = sessionsSendDetails(result.details);
+    expect(details.status).toBe("error");
+    expect(details.error).toContain("cyclic agent-to-agent route");
+    expect(details.error).toContain("alpha -> beta -> gamma -> alpha");
+    expect(
+      callGatewayMock.mock.calls
+        .map((call) => call[0] as GatewayCall)
+        .some((call) => call.method === "agent"),
+    ).toBe(false);
   });
 
   it("sessions_send prepares sanitized aliases without exposing alias keys", () => {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -12,6 +12,7 @@ import { callGateway } from "../gateway/call.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
 import { getActiveRuntimeWebToolsMetadata } from "../secrets/runtime-web-tools-state.js";
+import type { InputProvenance } from "../sessions/input-provenance.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import { resolveTranscriptsConfig } from "../transcripts/config.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
@@ -94,6 +95,7 @@ export function createOpenClawTools(
      */
     runSessionKey?: string;
     agentChannel?: GatewayMessageChannel;
+    inputProvenance?: InputProvenance;
     runId?: string;
     agentAccountId?: string;
     /** Delivery target for topic/thread routing. */
@@ -508,6 +510,7 @@ export function createOpenClawTools(
           createSessionsSendTool({
             agentSessionKey: options?.agentSessionKey,
             agentChannel: options?.agentChannel,
+            inputProvenance: options?.inputProvenance,
             sandboxed: options?.sandboxed,
             config: resolvedConfig,
             callGateway: openClawToolsDeps.callGateway,

--- a/src/agents/tools/agent-step.test.ts
+++ b/src/agents/tools/agent-step.test.ts
@@ -58,7 +58,7 @@ describe("runAgentStep", () => {
           deliver?: boolean;
           sourceReplyDeliveryMode?: string;
           lane?: string;
-          inputProvenance?: { kind?: string; sourceTool?: string };
+          inputProvenance?: { kind?: string; sourceTool?: string; visitedAgentIds?: string[] };
         }
       | undefined;
     expect(params?.message).toContain("[Inter-session message");
@@ -68,6 +68,7 @@ describe("runAgentStep", () => {
     expect(params?.lane).toBe("nested:agent:main:subagent:child");
     expect(params?.inputProvenance?.kind).toBe("inter_session");
     expect(params?.inputProvenance?.sourceTool).toBe("sessions_send");
+    expect(params?.inputProvenance?.visitedAgentIds).toEqual(["main"]);
     expect(params?.message).toContain("isUser=false");
     expect(params?.message).toContain("hello");
     expect(bundleMcpRuntimeMocks.retireSessionMcpRuntimeForSessionKey).toHaveBeenCalledWith({
@@ -120,16 +121,26 @@ describe("runAgentStep", () => {
       transcriptMessage: "",
       extraSystemPrompt: "announce only",
       timeoutMs: 10_000,
+      sourceSessionKey: "agent:alpha:main",
+      visitedAgentIds: ["root", "alpha"],
     });
 
     expect(gatewayCalls).toStrictEqual([]);
     expect(agentCommandFromIngress).toHaveBeenCalledTimes(1);
     const ingressCalls = agentCommandFromIngress.mock.calls as unknown as Array<
-      [{ message?: string; sourceReplyDeliveryMode?: string; transcriptMessage?: string }]
+      [
+        {
+          message?: string;
+          sourceReplyDeliveryMode?: string;
+          transcriptMessage?: string;
+          inputProvenance?: { visitedAgentIds?: string[] };
+        },
+      ]
     >;
     const ingress = ingressCalls[0]?.[0];
     expect(ingress?.message).toContain("internal announce step");
     expect(ingress?.sourceReplyDeliveryMode).toBe("message_tool_only");
     expect(ingress?.transcriptMessage).toBe("");
+    expect(ingress?.inputProvenance?.visitedAgentIds).toEqual(["root", "alpha", "main"]);
   });
 });

--- a/src/agents/tools/agent-step.ts
+++ b/src/agents/tools/agent-step.ts
@@ -5,7 +5,11 @@
  */
 import crypto from "node:crypto";
 import { callGateway } from "../../gateway/call.js";
-import { annotateInterSessionPromptText } from "../../sessions/input-provenance.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import {
+  annotateInterSessionPromptText,
+  extendInputProvenanceVisitedAgentIds,
+} from "../../sessions/input-provenance.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import { retireSessionMcpRuntimeForSessionKey } from "../agent-bundle-mcp-tools.js";
 import { resolveNestedAgentLaneForSession } from "../lanes.js";
@@ -46,6 +50,10 @@ function extractAgentCommandReply(result: unknown): string | undefined {
   return texts.length > 0 ? texts.join("\n\n") : undefined;
 }
 
+function resolveExplicitAgentIdFromSessionKey(sessionKey: string | undefined): string | undefined {
+  return sessionKey?.trim() ? resolveAgentIdFromSessionKey(sessionKey) : undefined;
+}
+
 /** Sends one annotated message to a target session and returns the resulting assistant text. */
 export async function runAgentStep(params: {
   sessionKey: string;
@@ -58,13 +66,24 @@ export async function runAgentStep(params: {
   sourceSessionKey?: string;
   sourceChannel?: string;
   sourceTool?: string;
+  visitedAgentIds?: readonly string[];
 }): Promise<string | undefined> {
   const stepIdem = crypto.randomUUID();
+  const visitedAgentIds = extendInputProvenanceVisitedAgentIds(
+    params.visitedAgentIds
+      ? { kind: "inter_session", visitedAgentIds: [...params.visitedAgentIds] }
+      : undefined,
+    [
+      resolveExplicitAgentIdFromSessionKey(params.sourceSessionKey),
+      resolveAgentIdFromSessionKey(params.sessionKey),
+    ],
+  );
   const inputProvenance = {
     kind: "inter_session" as const,
     sourceSessionKey: params.sourceSessionKey,
     sourceChannel: params.sourceChannel,
     sourceTool: params.sourceTool ?? "sessions_send",
+    visitedAgentIds,
   };
   // Mark inter-session prompts so downstream transcripts can distinguish tool-routed text.
   const message = annotateInterSessionPromptText(params.message, inputProvenance);

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -243,6 +243,34 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
   });
 
+  it("preserves visited agent provenance on internal reply and announce steps", async () => {
+    vi.mocked(runAgentStep)
+      .mockResolvedValueOnce("reply from requester")
+      .mockResolvedValueOnce("ANNOUNCE_SKIP");
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:gamma:discord:channel:target-room",
+      displayKey: "agent:gamma:discord:channel:target-room",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 1,
+      requesterSessionKey: "agent:beta:discord:channel:requester-room",
+      requesterChannel: "discord",
+      visitedAgentIds: ["alpha", "beta", "gamma"],
+      roundOneReply: "Substantive channel reply",
+    });
+
+    expect(runAgentStep).toHaveBeenCalledTimes(2);
+    const replyInput = vi.mocked(runAgentStep).mock.calls[0]?.[0] as
+      | { visitedAgentIds?: string[] }
+      | undefined;
+    const announceInput = vi.mocked(runAgentStep).mock.calls[1]?.[0] as
+      | { visitedAgentIds?: string[] }
+      | undefined;
+    expect(replyInput?.visitedAgentIds).toEqual(["alpha", "beta", "gamma"]);
+    expect(announceInput?.visitedAgentIds).toEqual(["alpha", "beta", "gamma"]);
+  });
+
   it.each([
     {
       source: "deliveryContext.accountId",

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -80,6 +80,7 @@ export async function runSessionsSendA2AFlow(params: {
   maxPingPongTurns: number;
   requesterSessionKey?: string;
   requesterChannel?: GatewayMessageChannel;
+  visitedAgentIds?: readonly string[];
   baseline?: AssistantReplySnapshot;
   roundOneReply?: string;
   waitRunId?: string;
@@ -172,6 +173,7 @@ export async function runSessionsSendA2AFlow(params: {
           sourceChannel:
             nextSessionKey === params.requesterSessionKey ? params.requesterChannel : targetChannel,
           sourceTool: "sessions_send",
+          visitedAgentIds: params.visitedAgentIds,
         });
         if (!replyText || isReplySkip(replyText) || isNonDeliverableSessionsReply(replyText)) {
           break;
@@ -203,6 +205,7 @@ export async function runSessionsSendA2AFlow(params: {
       sourceSessionKey: params.requesterSessionKey,
       sourceChannel: params.requesterChannel,
       sourceTool: "sessions_send",
+      visitedAgentIds: params.visitedAgentIds,
     });
     if (
       announceTarget &&

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -20,7 +20,13 @@ import {
   resolveAgentIdFromSessionKey,
   toAgentStoreSessionKey,
 } from "../../routing/session-key.js";
-import { annotateInterSessionPromptText } from "../../sessions/input-provenance.js";
+import {
+  annotateInterSessionPromptText,
+  extendInputProvenanceVisitedAgentIds,
+  hasInputProvenanceVisitedAgent,
+  normalizeInputProvenance,
+  type InputProvenance,
+} from "../../sessions/input-provenance.js";
 import { isCronRunSessionKey, parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
@@ -239,6 +245,17 @@ function shouldFallbackCronRunScopedActiveDelivery(
   );
 }
 
+function formatAgentCycleError(params: {
+  targetAgentId: string;
+  requesterAgentId: string;
+  visitedAgentIds: readonly string[];
+}): string {
+  const chain = [...params.visitedAgentIds, params.requesterAgentId, params.targetAgentId]
+    .filter(Boolean)
+    .join(" -> ");
+  return `sessions_send blocked a cyclic agent-to-agent route: agent "${params.targetAgentId}" already participated in this message chain (${chain}).`;
+}
+
 async function startAgentRun(params: {
   callGateway: GatewayCaller;
   runId: string;
@@ -343,6 +360,7 @@ async function startAgentRun(params: {
 export function createSessionsSendTool(opts?: {
   agentSessionKey?: string;
   agentChannel?: GatewayMessageChannel;
+  inputProvenance?: InputProvenance;
   sandboxed?: boolean;
   config?: OpenClawConfig;
   callGateway?: GatewayCaller;
@@ -536,6 +554,23 @@ export function createSessionsSendTool(opts?: {
           sessionKey: unresolvedDisplayKey,
         });
       }
+      const normalizedInputProvenance = normalizeInputProvenance(opts?.inputProvenance);
+      const currentInputProvenance =
+        normalizedInputProvenance?.kind === "inter_session" ? normalizedInputProvenance : undefined;
+      const requesterAgentId = resolveAgentIdFromSessionKey(effectiveRequesterKey);
+      const targetAgentId = resolveAgentIdFromSessionKey(resolvedKey);
+      if (hasInputProvenanceVisitedAgent(currentInputProvenance, targetAgentId)) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: formatAgentCycleError({
+            targetAgentId,
+            requesterAgentId,
+            visitedAgentIds: currentInputProvenance?.visitedAgentIds ?? [],
+          }),
+          sessionKey: unresolvedDisplayKey,
+        });
+      }
 
       const ensuredSession = await ensureConfiguredAgentMainSession({
         cfg,
@@ -582,11 +617,16 @@ export function createSessionsSendTool(opts?: {
         requesterChannel: opts?.agentChannel,
         targetSessionKey: displayKey,
       });
+      const visitedAgentIds = extendInputProvenanceVisitedAgentIds(currentInputProvenance, [
+        requesterAgentId,
+        targetAgentId,
+      ]);
       const inputProvenance = {
         kind: "inter_session" as const,
         sourceSessionKey: opts?.agentSessionKey,
         sourceChannel: opts?.agentChannel,
         sourceTool: "sessions_send",
+        visitedAgentIds,
       };
       const sendParams = {
         message: annotateInterSessionPromptText(message, inputProvenance),
@@ -661,6 +701,7 @@ export function createSessionsSendTool(opts?: {
           maxPingPongTurns,
           requesterSessionKey,
           requesterChannel,
+          visitedAgentIds,
           baseline: baselineReply,
           roundOneReply,
           waitRunId,

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -178,11 +178,15 @@ describe("sessions_send gateway loopback", () => {
     expectSessionsSendDetails(result, { reply: "pong", sessionKey: "main" });
 
     const firstCall = spy.mock.calls.at(0)?.[0] as
-      | { lane?: string; inputProvenance?: { kind?: string; sourceTool?: string } }
+      | {
+          lane?: string;
+          inputProvenance?: { kind?: string; sourceTool?: string; visitedAgentIds?: string[] };
+        }
       | undefined;
     expect(firstCall?.lane).toMatch(/^nested(?::|$)/);
     expect(firstCall?.inputProvenance?.kind).toBe("inter_session");
     expect(firstCall?.inputProvenance?.sourceTool).toBe("sessions_send");
+    expect(firstCall?.inputProvenance?.visitedAgentIds).toEqual(["main"]);
   });
 
   it(

--- a/src/sessions/input-provenance.test.ts
+++ b/src/sessions/input-provenance.test.ts
@@ -2,7 +2,10 @@
 import { describe, expect, it } from "vitest";
 import {
   annotateInterSessionPromptText,
+  extendInputProvenanceVisitedAgentIds,
+  hasInputProvenanceVisitedAgent,
   isAgentMediatedCompletionSourceTool,
+  normalizeInputProvenance,
   shouldPreserveUserFacingSessionStateForInputProvenance,
   stripInterSessionPromptPrefixForDisplay,
 } from "./input-provenance.js";
@@ -78,6 +81,32 @@ describe("stripInterSessionPromptPrefixForDisplay", () => {
     });
 
     expect(stripInterSessionPromptPrefixForDisplay(marked)).toBe("forwarded report");
+  });
+});
+
+describe("normalizeInputProvenance", () => {
+  it("normalizes visited agent chains for inter-session loop detection", () => {
+    const provenance = normalizeInputProvenance({
+      kind: "inter_session",
+      sourceTool: "sessions_send",
+      visitedAgentIds: ["Alpha", "beta", "alpha", "", "__"],
+    });
+
+    expect(provenance?.visitedAgentIds).toEqual(["alpha", "beta"]);
+    expect(hasInputProvenanceVisitedAgent(provenance, "ALPHA")).toBe(true);
+    expect(hasInputProvenanceVisitedAgent(provenance, "gamma")).toBe(false);
+  });
+
+  it("extends visited agent chains without duplicating existing agents", () => {
+    const visitedAgentIds = extendInputProvenanceVisitedAgentIds(
+      {
+        kind: "inter_session",
+        visitedAgentIds: ["alpha", "beta"],
+      },
+      ["Beta", "Gamma"],
+    );
+
+    expect(visitedAgentIds).toEqual(["alpha", "beta", "gamma"]);
   });
 });
 

--- a/src/sessions/input-provenance.ts
+++ b/src/sessions/input-provenance.ts
@@ -1,6 +1,7 @@
 // Input provenance helpers normalize source metadata for session messages.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { AgentMessage } from "../../packages/agent-core/src/types.js";
+import { isValidAgentId, normalizeAgentId } from "../routing/session-key.js";
 
 // Input provenance marks whether a user-role message actually came from an
 // external user, another session, or an internal system/tool handoff.
@@ -18,6 +19,7 @@ export type InputProvenance = {
   sourceSessionKey?: string;
   sourceChannel?: string;
   sourceTool?: string;
+  visitedAgentIds?: string[];
 };
 
 export const INTER_SESSION_PROMPT_PREFIX_BASE = "[Inter-session message]";
@@ -36,6 +38,32 @@ function isInputProvenanceKind(value: unknown): value is InputProvenanceKind {
   );
 }
 
+function normalizeInputProvenanceAgentId(value: unknown): string | undefined {
+  const raw = normalizeOptionalString(value);
+  if (!raw) {
+    return undefined;
+  }
+  const agentId = normalizeAgentId(raw);
+  return isValidAgentId(agentId) ? agentId : undefined;
+}
+
+function normalizeInputProvenanceVisitedAgentIds(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const agentIds: string[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    const agentId = normalizeInputProvenanceAgentId(item);
+    if (!agentId || seen.has(agentId)) {
+      continue;
+    }
+    seen.add(agentId);
+    agentIds.push(agentId);
+  }
+  return agentIds.length > 0 ? agentIds : undefined;
+}
+
 export function normalizeInputProvenance(value: unknown): InputProvenance | undefined {
   if (!value || typeof value !== "object") {
     return undefined;
@@ -50,7 +78,35 @@ export function normalizeInputProvenance(value: unknown): InputProvenance | unde
     sourceSessionKey: normalizeOptionalString(record.sourceSessionKey),
     sourceChannel: normalizeOptionalString(record.sourceChannel),
     sourceTool: normalizeOptionalString(record.sourceTool),
+    visitedAgentIds: normalizeInputProvenanceVisitedAgentIds(record.visitedAgentIds),
   };
+}
+
+export function extendInputProvenanceVisitedAgentIds(
+  inputProvenance: InputProvenance | undefined,
+  agentIds: readonly (string | undefined | null)[],
+): string[] | undefined {
+  const next = [...(inputProvenance?.visitedAgentIds ?? [])];
+  const seen = new Set(next);
+  for (const item of agentIds) {
+    const agentId = normalizeInputProvenanceAgentId(item);
+    if (!agentId || seen.has(agentId)) {
+      continue;
+    }
+    seen.add(agentId);
+    next.push(agentId);
+  }
+  return next.length > 0 ? next : undefined;
+}
+
+export function hasInputProvenanceVisitedAgent(
+  inputProvenance: InputProvenance | undefined,
+  agentId: string | undefined | null,
+): boolean {
+  const normalizedAgentId = normalizeInputProvenanceAgentId(agentId);
+  return Boolean(
+    normalizedAgentId && inputProvenance?.visitedAgentIds?.includes(normalizedAgentId),
+  );
 }
 
 // Only attach provenance to user messages that do not already carry it. Existing


### PR DESCRIPTION
## Summary

Fixes #37842.

This adds graph-aware `sessions_send` loop protection by carrying a normalized `visitedAgentIds` chain in `InputProvenance` and blocking a send before delivery when the target agent already appears in the chain.

The change updates the gateway protocol schema, runtime provenance normalizer, OpenClaw tool construction path, the `sessions_send` tool, and internal A2A `runAgentStep` handoffs so the chain survives agent-to-agent turns instead of resetting per pair.

## Real behavior proof

Behavior addressed: `sessions_send` triangular/polygonal agent routes such as A -> B -> C -> A are now blocked before starting the target agent run when the target agent already participated in the provenance chain.

Real environment tested: Local OpenClaw source checkout on branch `openmeta/37842-sessions-send-cycle-guard`; gateway loopback and agent tool tests ran through the repo test wrappers in this Codex worktree.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/sessions/input-provenance.test.ts src/agents/tools/agent-step.test.ts src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/openclaw-tools.sessions.test.ts src/gateway/server.sessions-send.test.ts`; `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false`; `node_modules/.bin/oxfmt --check packages/gateway-protocol/src/schema/primitives.ts src/sessions/input-provenance.ts src/sessions/input-provenance.test.ts src/agents/openclaw-tools.ts src/agents/agent-tools.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/tools/sessions-send-tool.ts src/agents/tools/agent-step.ts src/agents/tools/agent-step.test.ts src/agents/tools/sessions-send-tool.a2a.ts src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/openclaw-tools.sessions.test.ts src/gateway/server.sessions-send.test.ts`; `node scripts/run-oxlint.mjs packages/gateway-protocol/src/schema/primitives.ts src/sessions/input-provenance.ts src/sessions/input-provenance.test.ts src/agents/openclaw-tools.ts src/agents/agent-tools.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/tools/sessions-send-tool.ts src/agents/tools/agent-step.ts src/agents/tools/agent-step.test.ts src/agents/tools/sessions-send-tool.a2a.ts src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/openclaw-tools.sessions.test.ts src/gateway/server.sessions-send.test.ts`; `git diff --check`.

Evidence after fix: `src/agents/openclaw-tools.sessions.test.ts` now proves a chain `alpha -> beta -> gamma` blocks a send back to `alpha` and does not call the gateway `agent` method; `src/gateway/server.sessions-send.test.ts` proves `visitedAgentIds` crosses the gateway agent boundary; `src/agents/tools/agent-step.test.ts` and `src/agents/tools/sessions-send-tool.a2a.test.ts` prove internal reply/announce handoffs preserve the chain.

Observed result after fix: Focused Vitest run passed 3 shards with 5 files and 87 tests total; core tsgo, oxfmt check, oxlint, and `git diff --check` all exited 0.

What was not tested: I did not run a live 17-agent overnight deployment or the full `pnpm check` suite; the proof is focused local source/gateway behavior for the reported sessions_send loop boundary.

## Verification

- `node scripts/run-vitest.mjs src/sessions/input-provenance.test.ts src/agents/tools/agent-step.test.ts src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/openclaw-tools.sessions.test.ts src/gateway/server.sessions-send.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false`
- `node_modules/.bin/oxfmt --check packages/gateway-protocol/src/schema/primitives.ts src/sessions/input-provenance.ts src/sessions/input-provenance.test.ts src/agents/openclaw-tools.ts src/agents/agent-tools.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/tools/sessions-send-tool.ts src/agents/tools/agent-step.ts src/agents/tools/agent-step.test.ts src/agents/tools/sessions-send-tool.a2a.ts src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/openclaw-tools.sessions.test.ts src/gateway/server.sessions-send.test.ts`
- `node scripts/run-oxlint.mjs packages/gateway-protocol/src/schema/primitives.ts src/sessions/input-provenance.ts src/sessions/input-provenance.test.ts src/agents/openclaw-tools.ts src/agents/agent-tools.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/tools/sessions-send-tool.ts src/agents/tools/agent-step.ts src/agents/tools/agent-step.test.ts src/agents/tools/sessions-send-tool.a2a.ts src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/openclaw-tools.sessions.test.ts src/gateway/server.sessions-send.test.ts`
- `git diff --check`

Note: the first normal `scripts/committer` attempt was interrupted after its pre-commit path spent over 10 minutes inside `pnpm install`; the final commit used the repo script's `--fast` path after the checks above had already passed.
