### PR TITLE
fix(workboard): filter archived cards in CLI list by default

### DIFF
--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -130,14 +130,22 @@ export function registerWorkboardCli(params: { program: Command; store: Workboar
     .description("List Workboard cards")
     .option("--board <id>", "Board id")
     .option("--status <status>", "Filter by status")
+    .option("--include-archived", "Include archived cards (default: false)", false)
     .option("--json", "Print JSON", false)
-    .action(async (options: JsonOptions & { board?: string; status?: string }) => {
-      let cards = await params.store.list({ boardId: options.board });
-      if (options.status) {
-        cards = cards.filter((card) => card.status === options.status);
-      }
-      writeCards(cards, options);
-    });
+    .action(
+      async (
+        options: JsonOptions & { board?: string; status?: string; includeArchived?: boolean },
+      ) => {
+        let cards = await params.store.list({ boardId: options.board });
+        if (!options.includeArchived) {
+          cards = cards.filter((card) => !card.metadata?.archivedAt);
+        }
+        if (options.status) {
+          cards = cards.filter((card) => card.status === options.status);
+        }
+        writeCards(cards, options);
+      },
+    );
 
   workboard
     .command("create")


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- `openclaw workboard list` CLI command was showing archived cards while the `workboard_list` API tool filters them by default (when `includeArchived` is unset). This causes CLI/API inconsistency.

Why does this matter now?

- Issue #94555: Users who archive cards via the workboard tool still see them in CLI output, leading them to think archive did not work.

What is the intended outcome?

- CLI `list` command defaults to hiding archived cards, matching API behavior. Added `--include-archived` flag to allow viewing archived cards.

What is intentionally out of scope?

- Changes to other CLI commands or API behavior.

What does success look like?

- `openclaw workboard list` hides archived cards by default
- `openclaw workboard list --include-archived` shows all cards including archived

What should reviewers focus on?

- `extensions/workboard/src/cli.ts` — the list command handler

## Linked context

Which issue does this close?

- Closes #94555

## Real behavior proof

- **Behavior or issue addressed:** CLI list shows archived cards
- **Real environment tested:** Local OpenClaw with workboard plugin
- **Exact steps or command run after this patch:**
  1. Create a card: `openclaw workboard create "test"`
  2. Archive it via DB: `sqlite3 ... "UPDATE workboard_cards SET archived_at = $(date +%s)000 WHERE id='...'"`  
  3. Run `openclaw workboard list` → archived card is now hidden
- **Evidence after fix:** Code filters `!card.metadata?.archivedAt` by default
- **Observed result after fix:** CLI matches API default behavior
- **What was not tested:** Live production session
- **Proof limitations:** Local DB update simulation
