### PR TITLE
fix(doctor): warn on empty core tool allowlists

### DIFF
--- a/.agents/skills/openclaw-debugging/SKILL.md
+++ b/.agents/skills/openclaw-debugging/SKILL.md
@@ -65,6 +65,13 @@ openclaw logs --follow
 - **Tool surface:** inspect final model-visible tool names, not only the tool
   registry or config. Code mode means exactly `exec` and `wait` only after it
   actually activates.
+- **Doctor tool-policy diagnostics:** treat the core tool catalog as a config
+  vocabulary, not proof that a tool is callable in every run. For
+  `No callable tools remain`, prove the active policy intersection (`profile`,
+  `allow`, `alsoAllow`, provider/agent policy) separately from runtime-conditional
+  registration such as browser, media, web, update_plan, embedded, or sandbox
+  gates. Doctor lint should warn on confirmed empty policy intersections and stay
+  conservative around plugin/glob/dynamic tool availability.
 - **Provider payload:** log fields, model id, service tier, reasoning, input
   size, metadata keys, prompt-cache key presence, and tool names before SDK
   call.

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -192,6 +192,50 @@ describe("runDoctorLintCli", () => {
     }
   });
 
+  it("reports empty tool policy intersections through doctor lint JSON", async () => {
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {
+        tools: {
+          profile: "coding",
+          allow: ["group:messaging"],
+        },
+      } as unknown as OpenClawConfig,
+      path: "/tmp/openclaw.json",
+    });
+
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const exitCode = await runDoctorLintCli(runtime, {
+        json: true,
+        onlyIds: ["core/doctor/tool-policy-empty-allowlist"],
+      });
+
+      expect(exitCode).toBe(1);
+      const payload = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
+      expect(payload).toMatchObject({
+        ok: false,
+        checksRun: 1,
+        findings: [
+          {
+            checkId: "core/doctor/tool-policy-empty-allowlist",
+            severity: "warning",
+            path: "tools.allow",
+          },
+        ],
+      });
+      expect(payload.findings[0].message).toContain(
+        'tools.allow selects known core tool(s) "message"',
+      );
+      expect(payload.findings[0].message).toContain('tools.profile "coding"');
+      expect(payload.findings[0].message).toContain("No callable tools remain");
+      expect(payload.findings[0].fixHint).toContain("does not auto-fix");
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+
   it("rejects invalid severity thresholds", async () => {
     await expect(runDoctorLintCli(runtime, { severityMin: "warnng" })).rejects.toThrow(
       "Invalid --severity-min value",

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
+  collectEmptyCoreToolAllowlistWarnings,
   collectDoctorPreviewNotes,
   collectChannelBoundMessageToolPolicyWarnings,
   collectDoctorPreviewWarnings,
@@ -823,6 +824,413 @@ describe("doctor preview warnings", () => {
     expect(warning).toContain("tools.exec is configured");
     expect(warning).toContain('tools.alsoAllow: ["exec", "process"]');
     expect(warning).not.toContain("doctor --fix");
+  });
+
+  it("warns when tools.profile and tools.allow leave no known core tools", async () => {
+    const warnings = await collectDoctorPreviewWarnings({
+      cfg: {
+        tools: {
+          profile: "coding",
+          allow: ["group:messaging"],
+        },
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    const warning = expectSingleWarningContaining(
+      warnings,
+      'tools.allow selects known core tool(s) "message"',
+    );
+    expect(warning).toContain('tools.profile "coding"');
+    expect(warning).toContain("No callable tools remain");
+    expect(warning).not.toContain("doctor --fix");
+  });
+
+  it("does not warn for glob allowlists that may also match plugin tools", () => {
+    expect(
+      collectEmptyCoreToolAllowlistWarnings({
+        tools: {
+          profile: "coding",
+          allow: ["mess*"],
+        },
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("warns when an agent allowlist is emptied by inherited policy", () => {
+    const warnings = collectEmptyCoreToolAllowlistWarnings({
+      tools: {
+        profile: "coding",
+      },
+      agents: {
+        list: [
+          {
+            id: "chat",
+            tools: {
+              allow: ["group:messaging"],
+            },
+          },
+        ],
+      },
+    });
+
+    const warning = expectSingleWarningContaining(
+      warnings,
+      'agents.list[0].tools.allow selects known core tool(s) "message"',
+    );
+    expect(warning).toContain('tools.profile "coding"');
+  });
+
+  it("does not warn when alsoAllow preserves an explicitly allowed core tool", () => {
+    expect(
+      collectEmptyCoreToolAllowlistWarnings({
+        tools: {
+          profile: "coding",
+          allow: ["group:messaging"],
+          alsoAllow: ["message"],
+        },
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("does not warn when alsoAllow keeps another core tool callable", () => {
+    expect(
+      collectEmptyCoreToolAllowlistWarnings({
+        tools: {
+          profile: "coding",
+          allow: ["group:messaging"],
+          alsoAllow: ["read"],
+        },
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("does not warn when allow selects a default-enabled built-in web tool", () => {
+    expect(
+      collectEmptyCoreToolAllowlistWarnings({
+        tools: {
+          profile: "coding",
+          allow: ["web_fetch"],
+        },
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("does not warn when allow selects an explicitly enabled update_plan tool", () => {
+    expect(
+      collectEmptyCoreToolAllowlistWarnings({
+        tools: {
+          profile: "coding",
+          allow: ["update_plan"],
+          experimental: {
+            planTool: true,
+          },
+        },
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("warns when alsoAllow only preserves a runtime-conditional core tool", () => {
+    const warnings = collectEmptyCoreToolAllowlistWarnings({
+      tools: {
+        profile: "coding",
+        allow: ["group:messaging"],
+        alsoAllow: ["browser"],
+      },
+    });
+
+    const warning = expectSingleWarningContaining(
+      warnings,
+      'tools.allow selects known core tool(s) "message"',
+    );
+    expect(warning).toContain('tools.profile "coding"');
+  });
+
+  it("does not warn when allow selects a runtime-conditional core tool", () => {
+    expect(
+      collectEmptyCoreToolAllowlistWarnings({
+        tools: {
+          profile: "coding",
+          allow: ["image"],
+        },
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("does not warn when allow selects an embedded-conditional control tool", () => {
+    expect(
+      collectEmptyCoreToolAllowlistWarnings({
+        tools: {
+          profile: "full",
+          allow: ["gateway"],
+        },
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("warns when profile filters an explicitly allowed session tool", () => {
+    const warnings = collectEmptyCoreToolAllowlistWarnings({
+      tools: {
+        profile: "minimal",
+        allow: ["sessions_send"],
+      },
+    });
+
+    const warning = expectSingleWarningContaining(
+      warnings,
+      'tools.allow selects known core tool(s) "sessions_send"',
+    );
+    expect(warning).toContain('tools.profile "minimal"');
+  });
+
+  it("warns when alsoAllow only preserves an optional core tool", () => {
+    const warnings = collectEmptyCoreToolAllowlistWarnings({
+      tools: {
+        profile: "minimal",
+        allow: ["message"],
+        alsoAllow: ["update_plan"],
+      },
+    });
+
+    const warning = expectSingleWarningContaining(
+      warnings,
+      'tools.allow selects known core tool(s) "message"',
+    );
+    expect(warning).toContain('tools.profile "minimal"');
+  });
+
+  it("does not warn when alsoAllow may keep plugin tools callable", () => {
+    expect(
+      collectEmptyCoreToolAllowlistWarnings({
+        tools: {
+          profile: "coding",
+          allow: ["group:messaging"],
+          alsoAllow: ["plugin_doctor"],
+        },
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("does not warn when a mixed plugin allowlist could still leave plugin tools callable", () => {
+    expect(
+      collectEmptyCoreToolAllowlistWarnings({
+        tools: {
+          profile: "coding",
+          allow: ["group:messaging", "plugin_doctor"],
+        },
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("warns when provider profile filters a global core allowlist to empty", () => {
+    const warnings = collectEmptyCoreToolAllowlistWarnings({
+      tools: {
+        allow: ["message"],
+        byProvider: {
+          openai: {
+            profile: "coding",
+          },
+        },
+      },
+    });
+
+    const warning = expectSingleWarningContaining(
+      warnings,
+      'tools.allow selects known core tool(s) "message"',
+    );
+    expect(warning).toContain('tools.byProvider.openai.profile "coding"');
+  });
+
+  it("deduplicates the same allowlist emptied by profile and provider filters", () => {
+    const warnings = collectEmptyCoreToolAllowlistWarnings({
+      tools: {
+        profile: "coding",
+        allow: ["group:messaging"],
+        byProvider: {
+          openai: {
+            profile: "coding",
+          },
+        },
+      },
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('tools.allow selects known core tool(s) "message"');
+  });
+
+  it("does not warn for provider policies unused by the active model", () => {
+    expect(
+      collectEmptyCoreToolAllowlistWarnings({
+        tools: {
+          allow: ["message"],
+          byProvider: {
+            openai: {
+              profile: "coding",
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-sonnet-4.6",
+            },
+          },
+        },
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("does not use the fallback default provider when explicit agents use another provider", () => {
+    expect(
+      collectEmptyCoreToolAllowlistWarnings({
+        tools: {
+          allow: ["message"],
+          byProvider: {
+            openai: {
+              profile: "coding",
+            },
+          },
+        },
+        agents: {
+          list: [
+            {
+              id: "chat",
+              model: {
+                primary: "anthropic/claude-sonnet-4.6",
+              },
+            },
+          ],
+        },
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("warns when an agent without tools inherits an empty provider-filtered allowlist", () => {
+    const warnings = collectEmptyCoreToolAllowlistWarnings({
+      tools: {
+        allow: ["message"],
+        byProvider: {
+          openai: {
+            profile: "coding",
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "chat",
+            model: {
+              primary: "openai/gpt-5.5",
+            },
+          },
+        ],
+      },
+    });
+
+    const warning = expectSingleWarningContaining(
+      warnings,
+      'tools.allow selects known core tool(s) "message"',
+    );
+    expect(warning).toContain('tools.byProvider.openai.profile "coding"');
+  });
+
+  it("warns when a global provider policy filters an agent allowlist to empty", () => {
+    const warnings = collectEmptyCoreToolAllowlistWarnings({
+      tools: {
+        byProvider: {
+          openai: {
+            profile: "coding",
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "chat",
+            model: {
+              primary: "openai/gpt-5.5",
+            },
+            tools: {
+              allow: ["message"],
+            },
+          },
+        ],
+      },
+    });
+
+    const warning = expectSingleWarningContaining(
+      warnings,
+      'agents.list[0].tools.allow selects known core tool(s) "message"',
+    );
+    expect(warning).toContain('tools.byProvider.openai.profile "coding"');
+  });
+
+  it("warns when an agent provider policy filters an inherited global allowlist to empty", () => {
+    const warnings = collectEmptyCoreToolAllowlistWarnings({
+      tools: {
+        allow: ["message"],
+      },
+      agents: {
+        list: [
+          {
+            id: "chat",
+            model: {
+              primary: "openai/gpt-5.5",
+            },
+            tools: {
+              byProvider: {
+                openai: {
+                  profile: "coding",
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const warning = expectSingleWarningContaining(
+      warnings,
+      'tools.allow selects known core tool(s) "message"',
+    );
+    expect(warning).toContain('agents.list[0].tools.byProvider.openai.profile "coding"');
+  });
+
+  it("warns when merged provider policies empty a global allowlist", () => {
+    const warnings = collectEmptyCoreToolAllowlistWarnings({
+      tools: {
+        allow: ["read", "message"],
+        byProvider: {
+          openai: {
+            profile: "coding",
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "chat",
+            model: {
+              primary: "openai/gpt-5.5",
+            },
+            tools: {
+              byProvider: {
+                openai: {
+                  allow: ["message"],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expectWarningsContaining(warnings, [
+      'tools.allow selects known core tool(s) "read", "message"',
+      'agents.list[0].tools.byProvider.openai.allow selects known core tool(s) "message"',
+    ]);
+    const warning = warnings.join("\n");
+    expect(warning).toContain('tools.byProvider.openai.profile "coding"');
   });
 
   it("does not suggest alsoAllow when configured section warnings already have allow", () => {

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -6,11 +6,16 @@ import { resolveAgentConfig } from "../../../agents/agent-scope-config.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../../agents/defaults.js";
 import { parseModelRef } from "../../../agents/model-selection-normalize.js";
 import { pickSandboxToolPolicy } from "../../../agents/sandbox-tool-policy.js";
+import { isKnownCoreToolId } from "../../../agents/tool-catalog.js";
 import {
   isToolAllowedByPolicies,
   isToolAllowedByPolicyName,
 } from "../../../agents/tool-policy-match.js";
-import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "../../../agents/tool-policy.js";
+import {
+  expandToolGroups,
+  mergeAlsoAllowPolicy,
+  resolveToolProfilePolicy,
+} from "../../../agents/tool-policy.js";
 import { resolveAgentModelPrimaryValue } from "../../../config/model-input.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { AgentToolsConfig, ToolsConfig } from "../../../config/types.tools.js";
@@ -96,6 +101,13 @@ type ToolPolicyConfig = {
   alsoAllow?: string[];
   deny?: string[];
   profile?: string;
+  byProvider?: Record<string, ToolPolicyConfig>;
+};
+
+export type EmptyCoreToolAllowlistIssue = {
+  pathLabel: string;
+  coreTools: string[];
+  profileLabels: string[];
 };
 
 function normalizeProviderPolicyKey(value: string): string {
@@ -118,10 +130,18 @@ function resolveProviderToolPolicy(params: {
   modelProvider: string;
   modelId: string;
 }): ToolPolicyConfig | undefined {
+  return resolveProviderToolPolicyEntry(params)?.policy;
+}
+
+function resolveProviderToolPolicyEntry(params: {
+  byProvider?: Record<string, ToolPolicyConfig>;
+  modelProvider: string;
+  modelId: string;
+}): { key: string; policy: ToolPolicyConfig } | undefined {
   if (!params.byProvider) {
     return undefined;
   }
-  const lookup = new Map<string, { canonical: boolean; value: ToolPolicyConfig }>();
+  const lookup = new Map<string, { canonical: boolean; key: string; policy: ToolPolicyConfig }>();
   for (const [key, value] of Object.entries(params.byProvider)) {
     const normalized = normalizeProviderPolicyKey(key);
     if (!normalized) {
@@ -130,14 +150,14 @@ function resolveProviderToolPolicy(params: {
     const canonical = isCanonicalProviderPolicyKey(key);
     const existing = lookup.get(normalized);
     if (!existing || (canonical && !existing.canonical)) {
-      lookup.set(normalized, { canonical, value });
+      lookup.set(normalized, { canonical, key, policy: value });
     }
   }
 
   const provider = normalizeProviderPolicyKey(params.modelProvider);
   const modelId = normalizeLowercaseStringOrEmpty(params.modelId);
   const fullModelId = modelId ? `${provider}/${modelId}` : undefined;
-  return (fullModelId ? lookup.get(fullModelId)?.value : undefined) ?? lookup.get(provider)?.value;
+  return (fullModelId ? lookup.get(fullModelId) : undefined) ?? lookup.get(provider);
 }
 
 function resolveMessageToolAvailability(params: {
@@ -332,6 +352,337 @@ function formatChannelList(channels: string[]): string {
     .slice(0, 2)
     .map((channel) => `"${channel}"`)
     .join(", ")}, and ${channels.length - 2} more`;
+}
+
+const DOCTOR_CONFIRMED_RUNTIME_CORE_TOOL_IDS = new Set([
+  "agents_list",
+  "apply_patch",
+  "create_goal",
+  "edit",
+  "exec",
+  "get_goal",
+  "message",
+  "process",
+  "read",
+  "session_status",
+  "sessions_history",
+  "sessions_list",
+  "sessions_yield",
+  "subagents",
+  "tts",
+  "update_goal",
+  "write",
+]);
+
+function isDoctorConfirmedRuntimeCoreToolId(tool: string): boolean {
+  // The catalog also names plugin/runtime-conditional tools such as browser,
+  // code_execution, x_search, and memory_*; they cannot prove a linted config
+  // has a callable tool without constructing the real runtime.
+  return DOCTOR_CONFIRMED_RUNTIME_CORE_TOOL_IDS.has(tool);
+}
+
+function listExplicitKnownCoreAllowTools(allow?: string[]): string[] | undefined {
+  if (!Array.isArray(allow) || allow.length === 0) {
+    return undefined;
+  }
+  const expanded = expandToolGroups(allow);
+  if (expanded.includes("*")) {
+    return undefined;
+  }
+  const coreTools = new Set<string>();
+  for (const entry of expanded) {
+    if (isKnownCoreToolId(entry)) {
+      coreTools.add(entry);
+      continue;
+    }
+    // Plugin tools share the same model-facing namespace, so static doctor
+    // must not claim this allowlist is empty.
+    return undefined;
+  }
+  return [...coreTools];
+}
+
+function mayAllowNonCoreTools(list?: string[]): boolean {
+  if (!Array.isArray(list) || list.length === 0) {
+    return false;
+  }
+  const expanded = expandToolGroups(list);
+  return expanded.some((entry) => entry === "*" || !isKnownCoreToolId(entry));
+}
+
+function profilePolicyFor(
+  profile: string | undefined,
+  alsoAllow: string[] | undefined,
+): ReturnType<typeof mergeAlsoAllowPolicy> {
+  return mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), alsoAllow);
+}
+
+function collectEmptyCoreToolAllowlistScopeIssues(params: {
+  pathLabel: string;
+  allow?: string[];
+  profileLabels?: string[];
+  policies: Array<ReturnType<typeof pickSandboxToolPolicy> | undefined>;
+}): EmptyCoreToolAllowlistIssue[] {
+  const explicitCoreAllowTools = listExplicitKnownCoreAllowTools(params.allow);
+  if (!explicitCoreAllowTools) {
+    return [];
+  }
+  const survivingTools = explicitCoreAllowTools.filter((tool) =>
+    isToolAllowedByPolicies(tool, params.policies),
+  );
+  if (survivingTools.length > 0) {
+    return [];
+  }
+  const survivingKnownCoreTools = [...DOCTOR_CONFIRMED_RUNTIME_CORE_TOOL_IDS].filter((tool) =>
+    isToolAllowedByPolicies(tool, params.policies),
+  );
+  if (survivingKnownCoreTools.length > 0) {
+    return [];
+  }
+  return [
+    {
+      pathLabel: params.pathLabel,
+      coreTools: explicitCoreAllowTools,
+      profileLabels: params.profileLabels ?? [],
+    },
+  ];
+}
+
+export function formatEmptyCoreToolAllowlistWarning(issue: EmptyCoreToolAllowlistIssue): string {
+  const profileText =
+    issue.profileLabels.length > 0 ? ` with ${issue.profileLabels.join(" and ")}` : "";
+  return `- ${issue.pathLabel}.allow selects known core tool(s) ${issue.coreTools
+    .map((tool) => `"${tool}"`)
+    .join(
+      ", ",
+    )}, but the active tool policy${profileText} filters all of them out. Agent turns can fail before the model request with "No callable tools remain". Choose the intended access shape explicitly, such as switching the profile, adding required tools to alsoAllow, or removing the conflicting allowlist; doctor does not auto-fix this because each option changes tool access.`;
+}
+
+function resolveActiveProviderPolicy(params: {
+  tools: ToolPolicyConfig | undefined;
+  modelProvider: string;
+  modelId: string;
+}): { pathLabel: string; policy: ToolPolicyConfig } | undefined {
+  const entry = resolveProviderToolPolicyEntry({
+    byProvider: params.tools?.byProvider,
+    modelProvider: params.modelProvider,
+    modelId: params.modelId,
+  });
+  if (!entry) {
+    return undefined;
+  }
+  return { pathLabel: `byProvider.${entry.key}`, policy: entry.policy };
+}
+
+function addIssue(
+  issues: EmptyCoreToolAllowlistIssue[],
+  seen: Set<string>,
+  params: Parameters<typeof collectEmptyCoreToolAllowlistScopeIssues>[0],
+): void {
+  for (const issue of collectEmptyCoreToolAllowlistScopeIssues(params)) {
+    const key = `${issue.pathLabel}\0${issue.coreTools.join(",")}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    issues.push(issue);
+  }
+}
+
+function appendEffectivePolicyAllowlistIssue(params: {
+  issues: EmptyCoreToolAllowlistIssue[];
+  seen: Set<string>;
+  pathLabel: string;
+  allow?: string[];
+  toolProfile?: string;
+  toolProfileLabel?: string;
+  toolAlsoAllow?: string[];
+  basePolicies: Array<ReturnType<typeof pickSandboxToolPolicy> | undefined>;
+  globalProvider?: { pathLabel: string; policy: ToolPolicyConfig };
+  agentProvider?: { pathLabel: string; policy: ToolPolicyConfig };
+  agentProviderOwnerPath?: string;
+}): void {
+  const providerProfile =
+    params.agentProvider?.policy.profile ?? params.globalProvider?.policy.profile;
+  const providerAlsoAllow =
+    params.agentProvider?.policy.alsoAllow ?? params.globalProvider?.policy.alsoAllow;
+  if (mayAllowNonCoreTools(params.toolAlsoAllow) || mayAllowNonCoreTools(providerAlsoAllow)) {
+    return;
+  }
+  const providerProfileLabel = params.agentProvider?.policy.profile
+    ? `${params.agentProviderOwnerPath}.${params.agentProvider.pathLabel}.profile "${params.agentProvider.policy.profile}"`
+    : params.globalProvider?.policy.profile
+      ? `tools.${params.globalProvider.pathLabel}.profile "${params.globalProvider.policy.profile}"`
+      : undefined;
+  addIssue(params.issues, params.seen, {
+    pathLabel: params.pathLabel,
+    allow: params.allow,
+    profileLabels: [
+      ...(params.toolProfileLabel ? [params.toolProfileLabel] : []),
+      ...(providerProfileLabel ? [providerProfileLabel] : []),
+    ],
+    policies: [
+      profilePolicyFor(params.toolProfile, params.toolAlsoAllow),
+      profilePolicyFor(providerProfile, providerAlsoAllow),
+      ...params.basePolicies,
+      pickSandboxToolPolicy(params.globalProvider?.policy),
+      pickSandboxToolPolicy(params.agentProvider?.policy),
+    ],
+  });
+}
+
+function formatAgentProfileLabel(params: {
+  agentIndex: number;
+  agentProfile?: string;
+  globalProfile?: string;
+}): string | undefined {
+  if (params.agentProfile) {
+    return `agents.list[${params.agentIndex}].tools.profile "${params.agentProfile}"`;
+  }
+  if (params.globalProfile) {
+    return `tools.profile "${params.globalProfile}"`;
+  }
+  return undefined;
+}
+
+/** Detect explicit core allowlists that become empty after profile/policy filters. */
+export function collectEmptyCoreToolAllowlistIssues(
+  cfg: OpenClawConfig,
+): EmptyCoreToolAllowlistIssue[] {
+  const issues: EmptyCoreToolAllowlistIssue[] = [];
+  const seen = new Set<string>();
+  const agentRecords = listAgentRecords(cfg);
+  const defaultModelRef = resolvePrimaryModelRef(cfg);
+  const globalProfile = cfg.tools?.profile;
+  const globalPolicy = pickSandboxToolPolicy(cfg.tools);
+  appendEffectivePolicyAllowlistIssue({
+    issues,
+    seen,
+    pathLabel: "tools",
+    allow: cfg.tools?.allow,
+    toolProfile: globalProfile,
+    toolProfileLabel: globalProfile ? `tools.profile "${globalProfile}"` : undefined,
+    toolAlsoAllow: cfg.tools?.alsoAllow,
+    basePolicies: [globalPolicy],
+  });
+  if (agentRecords.length === 0) {
+    const defaultGlobalProviderPolicy = resolveActiveProviderPolicy({
+      tools: cfg.tools,
+      modelProvider: defaultModelRef.provider,
+      modelId: defaultModelRef.model,
+    });
+    appendEffectivePolicyAllowlistIssue({
+      issues,
+      seen,
+      pathLabel: "tools",
+      allow: cfg.tools?.allow,
+      toolProfile: globalProfile,
+      toolProfileLabel: globalProfile ? `tools.profile "${globalProfile}"` : undefined,
+      toolAlsoAllow: cfg.tools?.alsoAllow,
+      basePolicies: [globalPolicy],
+      globalProvider: defaultGlobalProviderPolicy,
+    });
+    appendEffectivePolicyAllowlistIssue({
+      issues,
+      seen,
+      pathLabel: defaultGlobalProviderPolicy
+        ? `tools.${defaultGlobalProviderPolicy.pathLabel}`
+        : "tools.byProvider",
+      allow: defaultGlobalProviderPolicy?.policy.allow,
+      toolProfile: globalProfile,
+      toolProfileLabel: globalProfile ? `tools.profile "${globalProfile}"` : undefined,
+      toolAlsoAllow: cfg.tools?.alsoAllow,
+      basePolicies: [globalPolicy],
+      globalProvider: defaultGlobalProviderPolicy,
+    });
+  }
+  for (const [index, agent] of agentRecords.entries()) {
+    const agentTools = hasRecord(agent.tools) ? (agent.tools as AgentToolsConfig) : undefined;
+    const agentConfig =
+      typeof agent.id === "string" ? resolveAgentConfig(cfg, agent.id) : undefined;
+    const agentModelRef = resolvePrimaryModelRef(cfg, agentConfig?.model);
+    const agentProfile = agentTools?.profile ?? globalProfile;
+    const agentProfileLabel = formatAgentProfileLabel({
+      agentIndex: index,
+      agentProfile: agentTools?.profile,
+      globalProfile,
+    });
+    const agentAlsoAllow = agentTools?.alsoAllow ?? cfg.tools?.alsoAllow;
+    const agentPolicy = pickSandboxToolPolicy(agentTools);
+    const basePolicies = [globalPolicy, agentPolicy];
+    const agentGlobalProviderPolicy = resolveActiveProviderPolicy({
+      tools: cfg.tools,
+      modelProvider: agentModelRef.provider,
+      modelId: agentModelRef.model,
+    });
+    const agentProviderPolicy = resolveActiveProviderPolicy({
+      tools: agentTools,
+      modelProvider: agentModelRef.provider,
+      modelId: agentModelRef.model,
+    });
+    appendEffectivePolicyAllowlistIssue({
+      issues,
+      seen,
+      pathLabel: "tools",
+      allow: cfg.tools?.allow,
+      toolProfile: agentProfile,
+      toolProfileLabel: agentProfileLabel,
+      toolAlsoAllow: agentAlsoAllow,
+      basePolicies,
+      globalProvider: agentGlobalProviderPolicy,
+      agentProvider: agentProviderPolicy,
+      agentProviderOwnerPath: `agents.list[${index}].tools`,
+    });
+    appendEffectivePolicyAllowlistIssue({
+      issues,
+      seen,
+      pathLabel: `agents.list[${index}].tools`,
+      allow: agentTools?.allow,
+      toolProfile: agentProfile,
+      toolProfileLabel: agentProfileLabel,
+      toolAlsoAllow: agentAlsoAllow,
+      basePolicies,
+      globalProvider: agentGlobalProviderPolicy,
+      agentProvider: agentProviderPolicy,
+      agentProviderOwnerPath: `agents.list[${index}].tools`,
+    });
+    appendEffectivePolicyAllowlistIssue({
+      issues,
+      seen,
+      pathLabel: agentGlobalProviderPolicy
+        ? `tools.${agentGlobalProviderPolicy.pathLabel}`
+        : "tools.byProvider",
+      allow: agentGlobalProviderPolicy?.policy.allow,
+      toolProfile: agentProfile,
+      toolProfileLabel: agentProfileLabel,
+      toolAlsoAllow: agentAlsoAllow,
+      basePolicies,
+      globalProvider: agentGlobalProviderPolicy,
+      agentProvider: agentProviderPolicy,
+      agentProviderOwnerPath: `agents.list[${index}].tools`,
+    });
+    appendEffectivePolicyAllowlistIssue({
+      issues,
+      seen,
+      pathLabel: agentProviderPolicy
+        ? `agents.list[${index}].tools.${agentProviderPolicy.pathLabel}`
+        : `agents.list[${index}].tools.byProvider`,
+      allow: agentProviderPolicy?.policy.allow,
+      toolProfile: agentProfile,
+      toolProfileLabel: agentProfileLabel,
+      toolAlsoAllow: agentAlsoAllow,
+      basePolicies,
+      globalProvider: agentGlobalProviderPolicy,
+      agentProvider: agentProviderPolicy,
+      agentProviderOwnerPath: `agents.list[${index}].tools`,
+    });
+  }
+  return issues;
+}
+
+/** Warn when explicit core allowlists become empty after profile/policy filters. */
+export function collectEmptyCoreToolAllowlistWarnings(cfg: OpenClawConfig): string[] {
+  return collectEmptyCoreToolAllowlistIssues(cfg).map(formatEmptyCoreToolAllowlistWarning);
 }
 
 /** Warn when routed channel agents lack the message tool required for channel actions. */
@@ -791,6 +1142,7 @@ export async function collectDoctorPreviewNotes(params: {
   const hasPluginConfig = hasPlugins(params.cfg);
 
   warnings.push(...collectVisibleReplyToolPolicyWarnings(params.cfg));
+  warnings.push(...collectEmptyCoreToolAllowlistWarnings(params.cfg));
   warnings.push(...collectChannelBoundMessageToolPolicyWarnings(params.cfg));
   warnings.push(...collectProfileConfiguredToolSectionWarnings(params.cfg));
   const { collectBlockedLegacyOpenAICodexProviderWarnings } =

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -330,6 +330,34 @@ describe("registerCoreHealthChecks", () => {
     );
   });
 
+  it("reports empty core tool allowlist policy through doctor lint", async () => {
+    const check = getCheck(
+      createCoreHealthChecks(createDeps()),
+      "core/doctor/tool-policy-empty-allowlist",
+    );
+
+    const findings = await check.detect({
+      mode: "lint",
+      runtime,
+      cfg: {
+        tools: {
+          profile: "coding",
+          allow: ["group:messaging"],
+        },
+      },
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/tool-policy-empty-allowlist",
+        severity: "warning",
+        path: "tools.allow",
+        message: expect.stringContaining('tools.allow selects known core tool(s) "message"'),
+        fixHint: expect.stringContaining("does not auto-fix"),
+      }),
+    ]);
+  });
+
   it("reports disabled Codex plugin routes as core health findings", async () => {
     const check = getCheck(
       createCoreHealthChecks(createDeps()),

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -23,6 +23,10 @@ import {
   uiProtocolFreshnessIssueToRepairEffects,
 } from "../commands/doctor-ui.js";
 import { collectDisabledCodexPluginRouteIssues } from "../commands/doctor/shared/codex-route-warnings.js";
+import {
+  collectEmptyCoreToolAllowlistIssues,
+  formatEmptyCoreToolAllowlistWarning,
+} from "../commands/doctor/shared/preview-warnings.js";
 import type { ConfigValidationIssue, OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
 import { hasAmbiguousGatewayAuthModeConfig } from "../gateway/auth-mode-policy.js";
@@ -571,6 +575,25 @@ function createSecurityCheck(deps: CoreHealthCheckDeps): HealthCheck {
   };
 }
 
+const toolPolicyEmptyAllowlistCheck: HealthCheck = {
+  id: "core/doctor/tool-policy-empty-allowlist",
+  kind: "core",
+  description: "Tool allowlists leave at least one known core tool available after profiles.",
+  source: "doctor",
+  async detect(ctx) {
+    return collectEmptyCoreToolAllowlistIssues(ctx.cfg).map(
+      (issue): HealthFinding => ({
+        checkId: "core/doctor/tool-policy-empty-allowlist",
+        severity: "warning",
+        message: normalizeDoctorNoteLine(formatEmptyCoreToolAllowlistWarning(issue)),
+        path: `${issue.pathLabel}.allow`,
+        fixHint:
+          "Review the tool policy and choose the intended access shape; doctor does not auto-fix this because switching profile, alsoAllow, or allow changes tool access.",
+      }),
+    );
+  },
+};
+
 const openAIOAuthTlsCheck: HealthCheck = {
   id: "core/doctor/oauth-tls",
   kind: "core",
@@ -955,6 +978,7 @@ function createConvertedWorkflowChecks(deps: CoreHealthCheckDeps): readonly Heal
     uiProtocolFreshnessCheck,
     gatewayPlatformNotesCheck,
     createSecurityCheck(deps),
+    toolPolicyEmptyAllowlistCheck,
     browserCheck,
     openAIOAuthTlsCheck,
     hooksModelCheck,

--- a/src/flows/doctor-health-conversion-plan.ts
+++ b/src/flows/doctor-health-conversion-plan.ts
@@ -189,6 +189,12 @@ export const doctorHealthConversionRules = [
     rule: "Detect explicit live tool-result cap overrides that are stale or ineffective; preserve deep-mode effective cap output as finding metadata.",
   },
   {
+    contributionId: "doctor:tool-policy-empty-allowlist",
+    conversion: "detect-only",
+    target: ["core/doctor/tool-policy-empty-allowlist"],
+    rule: "Warn when configured core tool allowlists become empty after profile and policy filters; do not repair automatically because each valid fix changes tool access.",
+  },
+  {
     contributionId: "doctor:provider-catalog-projection",
     conversion: "detect-only",
     target: ["core/doctor/provider-catalog-projection"],

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -6,6 +6,66 @@ import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 
 describe("cli json stdout contract", () => {
+  it("reports empty tool policy intersections from `doctor --lint --json`", async () => {
+    await withTempHome(
+      async (tempHome) => {
+        const configPath = path.join(tempHome, ".openclaw", "openclaw.json");
+        await fs.mkdir(path.dirname(configPath), { recursive: true });
+        await fs.writeFile(
+          configPath,
+          JSON.stringify({
+            tools: {
+              profile: "coding",
+              allow: ["group:messaging"],
+            },
+          }),
+          "utf8",
+        );
+
+        const env = {
+          ...process.env,
+          HOME: tempHome,
+          USERPROFILE: tempHome,
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_TEST_FAST: "1",
+        };
+        delete env.OPENCLAW_HOME;
+        delete env.OPENCLAW_STATE_DIR;
+        delete env.VITEST;
+
+        const entry = path.resolve(process.cwd(), "src/entry.ts");
+        const result = spawnSync(
+          process.execPath,
+          [
+            "--import",
+            "tsx",
+            entry,
+            "doctor",
+            "--lint",
+            "--json",
+            "--only",
+            "core/doctor/tool-policy-empty-allowlist",
+          ],
+          { cwd: process.cwd(), env, encoding: "utf8" },
+        );
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).not.toContain("No callable tools remain");
+        const parsed = JSON.parse(result.stdout) as {
+          findings?: Array<{ checkId?: string; message?: string; path?: string }>;
+        };
+        expect(parsed.findings).toEqual([
+          expect.objectContaining({
+            checkId: "core/doctor/tool-policy-empty-allowlist",
+            path: "tools.allow",
+            message: expect.stringContaining('tools.allow selects known core tool(s) "message"'),
+          }),
+        ]);
+      },
+      { prefix: "openclaw-doctor-lint-json-e2e-" },
+    );
+  });
+
   it("keeps `update status --json` stdout parseable even with legacy doctor preflight inputs", async () => {
     await withTempHome(
       async (tempHome) => {


### PR DESCRIPTION
## Summary

- Add a read-only doctor preview/lint diagnostic for explicit core tool allowlists that become empty after active tool profile, provider, and agent policy filtering.
- Surface the diagnostic through `doctor --lint` as `core/doctor/tool-policy-empty-allowlist`, including JSON output and health conversion metadata.
- Document the debugging lesson in the OpenClaw debugging skill: the core tool catalog is config vocabulary, not proof that a tool is callable in every runtime mode.

## Background

We investigated a production-style incident where an OpenClaw channel appeared broken, but the root cause was configuration: `tools.profile: "coding"` combined with `tools.allow: ["group:messaging"]`. That expands to the `message` core tool, then the `coding` profile filters it out, leaving no callable tools. Runtime then fails before the model request with `No callable tools remain`, which looks like a channel/provider failure to ordinary users.

The existing doctor flow did not flag this configuration, so the failure was difficult to diagnose from operator-facing tooling.

## Solution

- Detect explicit core-tool allowlists whose selected core tools are all filtered by the active policy intersection.
- Keep the diagnostic conservative around plugin tools, globs, and dynamic runtime registration so doctor lint does not claim more than static config can prove.
- Do not auto-fix: switching profile, adding `alsoAllow`, or removing `allow` all change tool-access semantics and should remain an operator choice.

## Verification

- `git diff --check`
- `/data/code/openclaw/openclaw/node_modules/.bin/oxfmt --write --threads=1 src/commands/doctor/shared/preview-warnings.ts src/commands/doctor/shared/preview-warnings.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-core-checks.test.ts src/flows/doctor-health-conversion-plan.ts src/commands/doctor-lint.test.ts test/cli-json-stdout.e2e.test.ts`
- `node scripts/run-vitest.mjs src/commands/doctor/shared/preview-warnings.test.ts src/flows/doctor-core-checks.test.ts src/commands/doctor-lint.test.ts test/cli-json-stdout.e2e.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local --base upstream/main --parallel-tests "node scripts/run-vitest.mjs src/commands/doctor/shared/preview-warnings.test.ts src/flows/doctor-core-checks.test.ts src/commands/doctor-lint.test.ts test/cli-json-stdout.e2e.test.ts"`

Autoreview result: `autoreview clean: no accepted/actionable findings reported`.
