### PR TITLE
fix(infra): pin ensurePortAvailable to 127.0.0.1 in startSshPortForward

### DIFF
--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -119,7 +119,7 @@ export async function startSshPortForward(opts: {
 
   let localPort = opts.localPortPreferred;
   try {
-    await ensurePortAvailable(localPort);
+    await ensurePortAvailable(localPort, "127.0.0.1");
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {
       localPort = await pickEphemeralPort();


### PR DESCRIPTION
Fixes #94596

## Summary

- Problem: `startSshPortForward` in `ssh-tunnel.ts` calls `ensurePortAvailable(localPort)` without a host argument. On dual-stack hosts the host-less probe binds the IPv6 wildcard `::` and misses an IPv4-only occupant, reporting a busy port as free.
- Why now: This is the exact same flaw as #94379 (fixed in #94394 for Chrome CDP), but on the SSH-tunnel surface. #94394 fixed the caller-scoped `ensurePortAvailable(port, host?)` API but missed this call site.
- What changed: Pass `"127.0.0.1"` to `ensurePortAvailable` in `startSshPortForward`, matching every other probe in the module.
- What did NOT change: No changes to `ensurePortAvailable` itself, `pickEphemeralPort`, `canConnectLocal`, or the SSH forward args. This is a one-line caller-side fix.
- Outcome: The SSH-tunnel port probe now correctly detects IPv4-only occupants on dual-stack hosts, consistent with the rest of the module.
- Reviewer focus: The single-line change in `src/infra/ssh-tunnel.ts` line 122.

## Verification

```bash
# Verify the fix pins to 127.0.0.1
node --input-type=module -e "
import { readFileSync } from 'node:fs';
const src = readFileSync('src/infra/ssh-tunnel.ts', 'utf8');
const lines = src.split('\n');
const idx = lines.findIndex(l => l.includes('ensurePortAvailable(localPort'));
const line = lines[idx].trim();
console.log('Fixed line:', line);
console.log('Has 127.0.0.1:', line.includes('127.0.0.1'));
console.log('Still host-less:', line === 'await ensurePortAvailable(localPort);');
"

# Verify consistency with other probes
node --input-type=module -e "
import { readFileSync } from 'node:fs';
const src = readFileSync('src/infra/ssh-tunnel.ts', 'utf8');
const checks = {
  'pickEphemeralPort uses 127.0.0.1': src.includes('listen(0, \"127.0.0.1\")'),
  'canConnectLocal uses 127.0.0.1': src.includes('connect({ host: \"127.0.0.1\"') || src.includes('host: \"127.0.0.1\"'),
  'forward uses 127.0.0.1': src.includes('127.0.0.1:\${opts.remotePort}'),
  'ensurePortAvailable uses 127.0.0.1': src.includes('ensurePortAvailable(localPort, \"127.0.0.1\")'),
};
for (const [k, v] of Object.entries(checks)) console.log(k + ':', v);
"
```

## Real behavior proof

**Behavior addressed:** SSH tunnel port preflight on dual-stack hosts now correctly detects IPv4-only occupants, preventing false-free reports.

**Environment tested:** Windows 11 (x64, dual-stack), Node.js v24.16.0.

**Steps run after the patch:**

```bash
# Bind an IPv4-only server, then test old vs new probe behavior
node -e "
import { createServer } from 'node:net';
const server = createServer();
const port = 19876;
await new Promise((resolve, reject) => {
  server.listen(port, '127.0.0.1', () => { console.log('[setup] IPv4-only server on 127.0.0.1:' + port); resolve(); });
  server.on('error', reject);
});
function tryListenOnPort({ port, host }) {
  return new Promise((resolve, reject) => {
    const s = createServer();
    const opts = host ? { port, host } : { port };
    s.listen(opts, () => { const addr = s.address(); s.close(() => resolve(addr)); });
    s.on('error', reject);
  });
}
console.log('\n=== host-less probe (old code) ===');
try { await tryListenOnPort({ port }); console.log('FREE (bug - misses IPv4-only occupant)'); }
catch (err) { console.log('BUSY (' + err.code + ')'); }
console.log('\n=== scoped probe 127.0.0.1 (new code) ===');
try { await tryListenOnPort({ port, host: '127.0.0.1' }); console.log('FREE (unexpected)'); }
catch (err) { console.log('BUSY (' + err.code + ') - fix works!'); }
console.log('\n=== IPv6 probe ===');
try { await tryListenOnPort({ port, host: '::1' }); console.log('FREE on IPv6 (expected - why old code misses)'); }
catch (err) { console.log('BUSY on IPv6 (' + err.code + ')'); }
server.close();
"
```

**Evidence after fix (console output):**

<img width="954" height="394" alt="image" src="https://github.com/user-attachments/assets/b62f66de-660c-4739-bd7e-2bd7c6279df7" />

```text
[setup] IPv4-only server on 127.0.0.1:19876

=== host-less probe (old code) ===
FREE (bug - misses IPv4-only occupant)

=== scoped probe 127.0.0.1 (new code) ===
BUSY (EADDRINUSE) - fix works!

=== IPv6 probe ===
FREE on IPv6 (expected - why old code misses)
```

**Observed result:** The host-less probe (old code) reports the port as FREE despite an IPv4-only listener — the exact bug. The scoped probe with `127.0.0.1` (new code) correctly detects `EADDRINUSE`. The IPv6 probe confirms the root cause: IPv6 wildcard bind does not conflict with IPv4-only listeners on dual-stack hosts.

**Not tested:** Live SSH tunnel (requires a real SSH server). The fix is a one-line argument addition following the exact pattern from #94394.
