### PR TITLE
fix(ssh-tunnel): pass 127.0.0.1 host to ensurePortAvailable in startSshPortForward

### DIFF
--- a/src/infra/ssh-tunnel.test.ts
+++ b/src/infra/ssh-tunnel.test.ts
@@ -1,6 +1,12 @@
-// Covers SSH target parsing.
-import { describe, expect, it } from "vitest";
+// Covers SSH target parsing and tunnel setup.
+import { describe, expect, it, vi } from "vitest";
 import { parseSshTarget } from "./ssh-tunnel.js";
+
+const ensurePortAvailableMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./ports.js", () => ({
+  ensurePortAvailable: (...args: unknown[]) => ensurePortAvailableMock(...args),
+}));
 
 describe("parseSshTarget", () => {
   it("parses user@host:port targets", () => {
@@ -28,5 +34,25 @@ describe("parseSshTarget", () => {
     expect(parseSshTarget("-V")).toBeNull();
     expect(parseSshTarget("me@-badhost")).toBeNull();
     expect(parseSshTarget("-oProxyCommand=echo")).toBeNull();
+  });
+});
+
+describe("startSshPortForward", () => {
+  it("passes 127.0.0.1 as the host to ensurePortAvailable", async () => {
+    // Throw a non-EADDRINUSE error so the function short-circuits before spawning SSH.
+    ensurePortAvailableMock.mockRejectedValue(new Error("port check failed"));
+
+    const { startSshPortForward } = await import("./ssh-tunnel.js");
+
+    await expect(
+      startSshPortForward({
+        target: "test@localhost:22",
+        localPortPreferred: 12345,
+        remotePort: 8080,
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow("port check failed");
+
+    expect(ensurePortAvailableMock).toHaveBeenCalledWith(12345, "127.0.0.1");
   });
 });

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -119,7 +119,7 @@ export async function startSshPortForward(opts: {
 
   let localPort = opts.localPortPreferred;
   try {
-    await ensurePortAvailable(localPort);
+    await ensurePortAvailable(localPort, "127.0.0.1");
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {
       localPort = await pickEphemeralPort();


### PR DESCRIPTION
## Summary

The `ensurePortAvailable` call in `startSshPortForward` was missing the `host` parameter, causing the port probe to bind the IPv6 wildcard (`::`) and miss IPv4-only occupants on dual-stack hosts. This is the same address-family flaw fixed in #94394 for the Chrome CDP path.

Pass `"127.0.0.1"` to match every other network probe in this module (`pickEphemeralPort`, `canConnectLocal`, and the SSH `-L` forward itself).

Fixes #94596

## Real behavior proof (required for external PRs)

**Behavior addressed**: On dual-stack hosts, `ensurePortAvailable` in `startSshPortForward` probes without a host argument (wildcard `::` bind), missing IPv4-only port occupants and falsely reporting busy ports as free.

**Real setup tested**:
- **Runtime**: Node v24.16.0, Linux x86_64

**Exact steps or command run after fix**:

```bash
pnpm test src/infra/ssh-tunnel.test.ts
pnpm test src/infra/ports.test.ts
```

**After-fix evidence**:

```
 Test Files  1 passed (1)  (ssh-tunnel)
      Tests  4 passed (4)  (includes new test for 127.0.0.1 host param)

 Test Files  1 passed (1)  (ports regression)
      Tests  14 passed (14)
```

**Observed result after the fix**: `ensurePortAvailable` is called with `(localPort, "127.0.0.1")` in `startSshPortForward`, consistent with all other network probes in the module.

**What was not tested**: Live dual-stack host scenario (requires dual-stack environment with IPv4-only port occupant). Static analysis and unit test coverage confirm the fix addresses the root cause.

## Tests and validation

- **New test**: `startSshPortForward` passes `127.0.0.1` as the host to `ensurePortAvailable` — mocks `ensurePortAvailable` and asserts arguments
- **Existing tests**: 3 `parseSshTarget` tests + 14 `ports` tests continue to pass
- **Change scope**: 1 production line changed, 1 test added

## Risk checklist

Did user-visible behavior change? (`No`) — port detection becomes more accurate, no API change

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?
- The SSH tunnel port selection preflight now scopes to `127.0.0.1` (matching the forward itself). This is lower risk than the current wildcard bind.

How is that risk mitigated?
- The module already uses `127.0.0.1` for `pickEphemeralPort`, `canConnectLocal`, and the SSH `-L` forward argument. This change aligns the preflight with the actual forward binding.

## Current review state

What is the next action?
- Maintainer review
