### PR TITLE
feat: add issue fix agent workflow

### DIFF
--- a/scripts/issue-fix-agent
+++ b/scripts/issue-fix-agent
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec node --import tsx "$script_dir/issue-fix-agent-main.ts" "$@"

--- a/scripts/issue-fix-agent-lib/candidates.ts
+++ b/scripts/issue-fix-agent-lib/candidates.ts
@@ -1,0 +1,97 @@
+import type { IssueCandidate, QualifiedCandidate, SkippedCandidate } from "./types.js";
+
+const highRiskLabels = new Set([
+  "security",
+  "auth",
+  "migration",
+  "release",
+  "installer",
+  "feature",
+  "enhancement",
+]);
+
+const maintainerAuthors = new Set([
+  "vincentkoc",
+  "Takhoffman",
+  "gumadeiras",
+  "obviyus",
+  "shakkernerd",
+  "mbelinky",
+  "joshavant",
+  "ngutman",
+  "vignesh07",
+  "huntharo",
+]);
+
+export type CandidateClassification =
+  | { kind: "qualified"; candidate: QualifiedCandidate }
+  | { kind: "skipped"; candidate: SkippedCandidate; reason: string };
+
+function hasConcreteSymptom(issue: IssueCandidate): boolean {
+  const haystack = `${issue.title}\n${issue.body}`.toLowerCase();
+  return /\b(repro|steps|stack|trace|throws|error|crash|fails?|typeerror|exception|regression|expected|actual)\b/u.test(
+    haystack,
+  );
+}
+
+function pathHintScore(issue: IssueCandidate): number {
+  return /\b(?:src|scripts|test|packages|extensions|docs)\/[^\s)]+/u.test(issue.body) ? 2 : 0;
+}
+
+function skipped(issue: IssueCandidate, reason: string): CandidateClassification {
+  return { kind: "skipped", candidate: { ...issue, reason }, reason };
+}
+
+export function classifyIssueCandidate(issue: IssueCandidate): CandidateClassification {
+  if (issue.isPullRequest) {
+    return skipped(issue, "item is a pull request");
+  }
+  const risky = issue.labels.find((label) => highRiskLabels.has(label));
+  if (risky) {
+    return skipped(issue, `high-risk label: ${risky}`);
+  }
+  if (maintainerAuthors.has(issue.author) && !issue.labels.includes("clawsweeper:queueable-fix")) {
+    return skipped(issue, "maintainer-owned queue item without queueable-fix signal");
+  }
+  if (!hasConcreteSymptom(issue)) {
+    return skipped(issue, "missing concrete symptom");
+  }
+
+  const evidence = ["concrete symptom"];
+  let score = 1 + pathHintScore(issue);
+  if (/\b(stack|trace|typeerror|exception)\b/iu.test(issue.body)) {
+    score += 3;
+    evidence.push("error evidence");
+  }
+  if (issue.labels.includes("clawsweeper:source-repro")) {
+    score += 2;
+    evidence.push("source repro label");
+  }
+  if (issue.labels.includes("clawsweeper:queueable-fix")) {
+    score += 2;
+    evidence.push("queueable fix label");
+  }
+  return { kind: "qualified", candidate: { ...issue, evidence, score } };
+}
+
+export function sortQualifiedCandidates(
+  candidates: readonly QualifiedCandidate[],
+): QualifiedCandidate[] {
+  return [...candidates].sort((left, right) => right.score - left.score || left.number - right.number);
+}
+
+export function formatScanResult(params: {
+  qualified: readonly QualifiedCandidate[];
+  skipped: readonly SkippedCandidate[];
+}): string {
+  const lines = ["Qualified candidates:"];
+  for (const candidate of sortQualifiedCandidates(params.qualified)) {
+    lines.push(`#${candidate.number} ${candidate.title} score=${candidate.score} ${candidate.url}`);
+    lines.push(`  evidence: ${candidate.evidence.join(", ")}`);
+  }
+  lines.push("Skipped candidates:");
+  for (const candidate of params.skipped) {
+    lines.push(`skipped #${candidate.number}: ${candidate.reason}`);
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/scripts/issue-fix-agent-lib/checks.ts
+++ b/scripts/issue-fix-agent-lib/checks.ts
@@ -1,0 +1,77 @@
+export type CheckSnapshot = {
+  readonly conclusion: string | null;
+  readonly detailsUrl: string | null;
+  readonly name: string;
+  readonly status: string;
+};
+
+type RawCheckSnapshot = {
+  readonly conclusion?: string | null;
+  readonly detailsUrl?: string | null;
+  readonly details_url?: string | null;
+  readonly name?: string;
+  readonly status?: string;
+};
+
+type CheckClassification =
+  | {
+      readonly failed: CheckSnapshot[];
+      readonly kind: "failed";
+      readonly pending: CheckSnapshot[];
+    }
+  | {
+      readonly failed: CheckSnapshot[];
+      readonly kind: "land_ready";
+      readonly pending: CheckSnapshot[];
+    }
+  | {
+      readonly failed: CheckSnapshot[];
+      readonly kind: "pending";
+      readonly pending: CheckSnapshot[];
+    };
+
+const routineCheckNames = new Set(["Auto response", "Labeler", "docs agents", "performance/stale"]);
+
+function isRelevantCheck(snapshot: CheckSnapshot): boolean {
+  return !routineCheckNames.has(snapshot.name);
+}
+
+function normalizeCheckName(raw: RawCheckSnapshot): string | null {
+  const name = raw.name?.trim();
+  return name ? name : null;
+}
+
+export function normalizePrCheckRollup(raw: readonly RawCheckSnapshot[]): CheckSnapshot[] {
+  return raw.flatMap((entry) => {
+    const name = normalizeCheckName(entry);
+    if (!name) {
+      return [];
+    }
+    return [
+      {
+        conclusion: entry.conclusion ?? null,
+        detailsUrl: entry.detailsUrl ?? entry.details_url ?? null,
+        name,
+        status: entry.status ?? "UNKNOWN",
+      },
+    ];
+  });
+}
+
+export function classifyCheckSnapshots(snapshots: readonly CheckSnapshot[]): CheckClassification {
+  const relevant = snapshots.filter(isRelevantCheck);
+  const failed = relevant.filter((snapshot) => {
+    if (snapshot.status !== "COMPLETED") {
+      return false;
+    }
+    return snapshot.conclusion !== "SUCCESS" && snapshot.conclusion !== "SKIPPED";
+  });
+  const pending = relevant.filter((snapshot) => snapshot.status !== "COMPLETED");
+  if (failed.length > 0) {
+    return { failed, kind: "failed", pending };
+  }
+  if (pending.length > 0) {
+    return { failed, kind: "pending", pending };
+  }
+  return { failed, kind: "land_ready", pending };
+}

--- a/scripts/issue-fix-agent-lib/checks.ts
+++ b/scripts/issue-fix-agent-lib/checks.ts
@@ -7,10 +7,14 @@ export type CheckSnapshot = {
 
 type RawCheckSnapshot = {
   readonly conclusion?: string | null;
+  readonly context?: string;
   readonly detailsUrl?: string | null;
   readonly details_url?: string | null;
   readonly name?: string;
+  readonly state?: string;
   readonly status?: string;
+  readonly targetUrl?: string | null;
+  readonly target_url?: string | null;
 };
 
 type CheckClassification =
@@ -37,8 +41,26 @@ function isRelevantCheck(snapshot: CheckSnapshot): boolean {
 }
 
 function normalizeCheckName(raw: RawCheckSnapshot): string | null {
-  const name = raw.name?.trim();
+  const name = raw.name?.trim() || raw.context?.trim();
   return name ? name : null;
+}
+
+function normalizeStatusContext(raw: RawCheckSnapshot): Pick<CheckSnapshot, "conclusion" | "status"> {
+  switch (raw.state) {
+    case "ERROR":
+    case "FAILURE":
+      return { conclusion: raw.state, status: "COMPLETED" };
+    case "SUCCESS":
+      return { conclusion: "SUCCESS", status: "COMPLETED" };
+    case "EXPECTED":
+    case "PENDING":
+      return { conclusion: null, status: raw.state };
+    default:
+      return {
+        conclusion: raw.conclusion ?? null,
+        status: raw.status ?? "UNKNOWN",
+      };
+  }
 }
 
 export function normalizePrCheckRollup(raw: readonly RawCheckSnapshot[]): CheckSnapshot[] {
@@ -47,12 +69,13 @@ export function normalizePrCheckRollup(raw: readonly RawCheckSnapshot[]): CheckS
     if (!name) {
       return [];
     }
+    const status = normalizeStatusContext(entry);
     return [
       {
-        conclusion: entry.conclusion ?? null,
-        detailsUrl: entry.detailsUrl ?? entry.details_url ?? null,
+        conclusion: status.conclusion,
+        detailsUrl: entry.detailsUrl ?? entry.details_url ?? entry.targetUrl ?? entry.target_url ?? null,
         name,
-        status: entry.status ?? "UNKNOWN",
+        status: status.status,
       },
     ];
   });

--- a/scripts/issue-fix-agent-lib/checks.ts
+++ b/scripts/issue-fix-agent-lib/checks.ts
@@ -83,6 +83,9 @@ export function normalizePrCheckRollup(raw: readonly RawCheckSnapshot[]): CheckS
 
 export function classifyCheckSnapshots(snapshots: readonly CheckSnapshot[]): CheckClassification {
   const relevant = snapshots.filter(isRelevantCheck);
+  if (relevant.length === 0) {
+    return { failed: [], kind: "pending", pending: [] };
+  }
   const failed = relevant.filter((snapshot) => {
     if (snapshot.status !== "COMPLETED") {
       return false;

--- a/scripts/issue-fix-agent-lib/command-runner.ts
+++ b/scripts/issue-fix-agent-lib/command-runner.ts
@@ -1,0 +1,42 @@
+import { spawn } from "node:child_process";
+
+export type CommandResult = {
+  readonly code: number;
+  readonly stdout: string;
+  readonly stderr: string;
+};
+
+export type CommandRunner = (
+  command: string,
+  args: readonly string[],
+  options?: { cwd?: string; timeoutMs?: number },
+) => Promise<CommandResult>;
+
+export const runCommand: CommandRunner = async (command, args, options = {}) =>
+  await new Promise<CommandResult>((resolve, reject) => {
+    const child = spawn(command, [...args], {
+      cwd: options.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const chunks: Buffer[] = [];
+    const errorChunks: Buffer[] = [];
+    const timeout = options.timeoutMs
+      ? setTimeout(() => {
+          child.kill("SIGTERM");
+          reject(new Error(`command timed out: ${command} ${args.join(" ")}`));
+        }, options.timeoutMs)
+      : undefined;
+    child.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => errorChunks.push(chunk));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      resolve({
+        code: code ?? 1,
+        stderr: Buffer.concat(errorChunks).toString("utf8"),
+        stdout: Buffer.concat(chunks).toString("utf8"),
+      });
+    });
+  });

--- a/scripts/issue-fix-agent-lib/github.ts
+++ b/scripts/issue-fix-agent-lib/github.ts
@@ -50,11 +50,8 @@ function normalizeIssue(raw: GitcrawlIssue): IssueCandidate | null {
   };
 }
 
-export async function fetchOpenIssueCandidates(params: {
-  limit: number;
-  runCommand: CommandRunner;
-}): Promise<IssueCandidate[]> {
-  const result = await params.runCommand("gitcrawl", [
+function gitcrawlIssueSearchArgs(limit: number): string[] {
+  return [
     "search",
     "issues",
     "repo:openclaw/openclaw state:open is:issue",
@@ -65,10 +62,39 @@ export async function fetchOpenIssueCandidates(params: {
     "--json",
     "number,title,url,body,labels,author,updatedAt",
     "--limit",
-    String(params.limit),
-  ]);
+    String(limit),
+  ];
+}
+
+function ghIssueListArgs(limit: number): string[] {
+  return [
+    "issue",
+    "list",
+    "--repo",
+    "openclaw/openclaw",
+    "--state",
+    "open",
+    "--search",
+    "is:issue",
+    "--json",
+    "number,title,url,body,labels,author,updatedAt",
+    "--limit",
+    String(limit),
+  ];
+}
+
+export async function fetchOpenIssueCandidates(params: {
+  limit: number;
+  runCommand: CommandRunner;
+}): Promise<IssueCandidate[]> {
+  let result = await params.runCommand("gitcrawl", gitcrawlIssueSearchArgs(params.limit)).catch(
+    async () => await params.runCommand("gh", ghIssueListArgs(params.limit)),
+  );
   if (result.code !== 0) {
-    throw new Error(`gitcrawl issue search failed: ${result.stderr || result.stdout}`);
+    result = await params.runCommand("gh", ghIssueListArgs(params.limit));
+  }
+  if (result.code !== 0) {
+    throw new Error(`issue search failed: ${result.stderr || result.stdout}`);
   }
   return parseJsonArray(result.stdout)
     .map((entry) => normalizeIssue(entry as GitcrawlIssue))

--- a/scripts/issue-fix-agent-lib/github.ts
+++ b/scripts/issue-fix-agent-lib/github.ts
@@ -70,3 +70,25 @@ export async function fetchOpenIssueCandidates(params: {
     .map((entry) => normalizeIssue(entry as GitcrawlIssue))
     .filter((entry): entry is IssueCandidate => entry !== null);
 }
+
+export async function fetchPrCheckRollup(params: {
+  prNumber: number;
+  runCommand: CommandRunner;
+}): Promise<unknown[]> {
+  const result = await params.runCommand("gh", [
+    "pr",
+    "view",
+    String(params.prNumber),
+    "--repo",
+    "openclaw/openclaw",
+    "--json",
+    "statusCheckRollup",
+    "--jq",
+    ".statusCheckRollup",
+  ]);
+  if (result.code !== 0) {
+    throw new Error(`gh pr view failed: ${result.stderr || result.stdout}`);
+  }
+  const parsed = JSON.parse(result.stdout) as unknown;
+  return Array.isArray(parsed) ? parsed : [];
+}

--- a/scripts/issue-fix-agent-lib/github.ts
+++ b/scripts/issue-fix-agent-lib/github.ts
@@ -12,12 +12,16 @@ type GitcrawlIssue = {
   pullRequest?: unknown;
 };
 
-function parseJsonLines(stdout: string): unknown[] {
-  return stdout
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => JSON.parse(line) as unknown);
+function parseJsonArray(stdout: string): unknown[] {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    return [];
+  }
+  const parsed = JSON.parse(trimmed) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error("gitcrawl issue search returned non-array JSON");
+  }
+  return parsed;
 }
 
 function normalizeLabels(labels: GitcrawlIssue["labels"]): string[] {
@@ -66,7 +70,7 @@ export async function fetchOpenIssueCandidates(params: {
   if (result.code !== 0) {
     throw new Error(`gitcrawl issue search failed: ${result.stderr || result.stdout}`);
   }
-  return parseJsonLines(result.stdout)
+  return parseJsonArray(result.stdout)
     .map((entry) => normalizeIssue(entry as GitcrawlIssue))
     .filter((entry): entry is IssueCandidate => entry !== null);
 }

--- a/scripts/issue-fix-agent-lib/github.ts
+++ b/scripts/issue-fix-agent-lib/github.ts
@@ -57,7 +57,7 @@ export async function fetchOpenIssueCandidates(params: {
   const result = await params.runCommand("gitcrawl", [
     "search",
     "issues",
-    "repo:openclaw/openclaw state:open",
+    "repo:openclaw/openclaw state:open is:issue",
     "-R",
     "openclaw/openclaw",
     "--state",

--- a/scripts/issue-fix-agent-lib/github.ts
+++ b/scripts/issue-fix-agent-lib/github.ts
@@ -1,0 +1,72 @@
+import type { CommandRunner } from "./command-runner.js";
+import type { IssueCandidate } from "./types.js";
+
+type GitcrawlIssue = {
+  number?: number;
+  title?: string;
+  url?: string;
+  body?: string;
+  labels?: readonly (string | { name?: string })[];
+  author?: { login?: string } | string;
+  updatedAt?: string;
+  pullRequest?: unknown;
+};
+
+function parseJsonLines(stdout: string): unknown[] {
+  return stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+function normalizeLabels(labels: GitcrawlIssue["labels"]): string[] {
+  return (labels ?? []).flatMap((label) =>
+    typeof label === "string" ? [label] : label.name ? [label.name] : [],
+  );
+}
+
+function normalizeAuthor(author: GitcrawlIssue["author"]): string {
+  return typeof author === "string" ? author : (author?.login ?? "unknown");
+}
+
+function normalizeIssue(raw: GitcrawlIssue): IssueCandidate | null {
+  if (!raw.number || !raw.title || !raw.url) {
+    return null;
+  }
+  return {
+    author: normalizeAuthor(raw.author),
+    body: raw.body ?? "",
+    isPullRequest: raw.pullRequest !== undefined,
+    labels: normalizeLabels(raw.labels),
+    number: raw.number,
+    title: raw.title,
+    updatedAt: raw.updatedAt ?? "",
+    url: raw.url,
+  };
+}
+
+export async function fetchOpenIssueCandidates(params: {
+  limit: number;
+  runCommand: CommandRunner;
+}): Promise<IssueCandidate[]> {
+  const result = await params.runCommand("gitcrawl", [
+    "search",
+    "issues",
+    "repo:openclaw/openclaw state:open",
+    "-R",
+    "openclaw/openclaw",
+    "--state",
+    "open",
+    "--json",
+    "number,title,url,body,labels,author,updatedAt",
+    "--limit",
+    String(params.limit),
+  ]);
+  if (result.code !== 0) {
+    throw new Error(`gitcrawl issue search failed: ${result.stderr || result.stdout}`);
+  }
+  return parseJsonLines(result.stdout)
+    .map((entry) => normalizeIssue(entry as GitcrawlIssue))
+    .filter((entry): entry is IssueCandidate => entry !== null);
+}

--- a/scripts/issue-fix-agent-lib/pr.ts
+++ b/scripts/issue-fix-agent-lib/pr.ts
@@ -1,0 +1,46 @@
+export function renderIssueFixAgentPrTitle(params: {
+  issueNumber: number;
+  scope?: string | null;
+}): string {
+  return params.scope
+    ? `fix(${params.scope}): address issue #${params.issueNumber}`
+    : `fix: address issue #${params.issueNumber}`;
+}
+
+export function renderIssueFixAgentPrBody(params: {
+  issueNumber: number;
+  issueUrl: string;
+  runId: string;
+  touchedFiles: readonly string[];
+  verification: readonly string[];
+  proofGaps?: readonly string[];
+}): string {
+  const touched = params.touchedFiles.length > 0 ? params.touchedFiles : ["No files recorded yet"];
+  const verification =
+    params.verification.length > 0 ? params.verification : ["Verification has not run yet"];
+  const proofGaps = params.proofGaps?.length
+    ? params.proofGaps
+    : ["Final maintainer review and merge decision"];
+  return [
+    "## Summary",
+    "",
+    `- Addresses issue #${params.issueNumber}.`,
+    "- Created by the local issue-fix agent as a draft PR.",
+    "",
+    "## Touched Surface",
+    "",
+    ...touched.map((file) => `- \`${file}\``),
+    "",
+    "## Verification",
+    "",
+    ...verification.map((command) => `- \`${command}\``),
+    "",
+    "## Known Proof Gaps",
+    "",
+    ...proofGaps.map((gap) => `- ${gap}`),
+    "",
+    `Automation run: \`${params.runId}\``,
+    `Closes: ${params.issueUrl}`,
+    "",
+  ].join("\n");
+}

--- a/scripts/issue-fix-agent-lib/state.sqlite.ts
+++ b/scripts/issue-fix-agent-lib/state.sqlite.ts
@@ -1,0 +1,260 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync, SQLInputValue } from "node:sqlite";
+import type { CompiledQuery, Insertable, Selectable, Updateable } from "kysely";
+import { getNodeSqliteKysely } from "../../src/infra/kysely-sync.js";
+import { requireNodeSqlite } from "../../src/infra/node-sqlite.js";
+import type { IssueFixAgentRun, IssueFixAgentState } from "./types.js";
+
+type CompilableQuery<Row = unknown> = {
+  compile(): CompiledQuery<Row>;
+};
+
+type RunsTable = {
+  run_id: string;
+  issue_number: number;
+  issue_title: string;
+  issue_url: string;
+  source: string;
+  state: IssueFixAgentState;
+  created_at: string;
+  updated_at: string;
+  branch_name: string | null;
+  worktree_path: string | null;
+  commit_sha: string | null;
+  pr_number: number | null;
+  pr_url: string | null;
+  terminal_reason: string | null;
+};
+
+type EventsTable = {
+  id: number;
+  run_id: string;
+  kind: string;
+  payload_json: string;
+  created_at: string;
+};
+
+type ChecksTable = {
+  id: number;
+  run_id: string;
+  pr_number: number;
+  head_sha: string;
+  name: string;
+  status: string;
+  conclusion: string | null;
+  details_url: string | null;
+  created_at: string;
+};
+
+type IssueFixAgentDb = {
+  issue_fix_agent_runs: RunsTable;
+  issue_fix_agent_events: EventsTable;
+  issue_fix_agent_checks: ChecksTable;
+};
+
+export type IssueFixAgentStateStore = {
+  readonly db: DatabaseSync;
+  close(): void;
+};
+
+const stateOrder: IssueFixAgentState[] = [
+  "discovered",
+  "qualified",
+  "claimed_local",
+  "branch_created",
+  "patching",
+  "verifying",
+  "committed",
+  "pr_opened",
+  "monitoring",
+  "land_ready",
+  "blocked",
+];
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function randomRunId(): string {
+  return `ifr_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function rowToRun(row: Selectable<RunsTable>): IssueFixAgentRun {
+  return {
+    branchName: row.branch_name,
+    commitSha: row.commit_sha,
+    createdAt: row.created_at,
+    issueNumber: row.issue_number,
+    issueTitle: row.issue_title,
+    issueUrl: row.issue_url,
+    prNumber: row.pr_number,
+    prUrl: row.pr_url,
+    runId: row.run_id,
+    source: row.source,
+    state: row.state,
+    terminalReason: row.terminal_reason,
+    updatedAt: row.updated_at,
+    worktreePath: row.worktree_path,
+  };
+}
+
+function executeIssueFixWrite(db: DatabaseSync, query: CompilableQuery): void {
+  const compiled = query.compile();
+  db.prepare(compiled.sql).run(...(compiled.parameters as SQLInputValue[]));
+}
+
+function executeIssueFixRows<Row>(db: DatabaseSync, query: CompilableQuery<Row>): Row[] {
+  const compiled = query.compile();
+  return db.prepare(compiled.sql).all(...(compiled.parameters as SQLInputValue[])) as Row[];
+}
+
+function executeIssueFixTakeFirst<Row>(
+  db: DatabaseSync,
+  query: CompilableQuery<Row>,
+): Row | undefined {
+  return executeIssueFixRows(db, query)[0];
+}
+
+export function openIssueFixAgentState(dbPath: string): IssueFixAgentStateStore {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const sqlite = requireNodeSqlite();
+  const db = new sqlite.DatabaseSync(dbPath);
+  db.exec(`
+    create table if not exists issue_fix_agent_runs (
+      run_id text primary key,
+      issue_number integer not null,
+      issue_title text not null,
+      issue_url text not null,
+      source text not null,
+      state text not null,
+      created_at text not null,
+      updated_at text not null,
+      branch_name text,
+      worktree_path text,
+      commit_sha text,
+      pr_number integer,
+      pr_url text,
+      terminal_reason text
+    );
+    create table if not exists issue_fix_agent_events (
+      id integer primary key autoincrement,
+      run_id text not null,
+      kind text not null,
+      payload_json text not null,
+      created_at text not null
+    );
+    create table if not exists issue_fix_agent_checks (
+      id integer primary key autoincrement,
+      run_id text not null,
+      pr_number integer not null,
+      head_sha text not null,
+      name text not null,
+      status text not null,
+      conclusion text,
+      details_url text,
+      created_at text not null
+    );
+  `);
+  return { db, close: () => db.close() };
+}
+
+export function createIssueFixAgentRun(
+  store: IssueFixAgentStateStore,
+  input: { issueNumber: number; issueTitle: string; issueUrl: string; source: string },
+): IssueFixAgentRun {
+  const now = nowIso();
+  const row: Insertable<RunsTable> = {
+    branch_name: null,
+    commit_sha: null,
+    created_at: now,
+    issue_number: input.issueNumber,
+    issue_title: input.issueTitle,
+    issue_url: input.issueUrl,
+    pr_number: null,
+    pr_url: null,
+    run_id: randomRunId(),
+    source: input.source,
+    state: "discovered",
+    terminal_reason: null,
+    updated_at: now,
+    worktree_path: null,
+  };
+  const kysely = getNodeSqliteKysely<IssueFixAgentDb>(store.db);
+  executeIssueFixWrite(store.db, kysely.insertInto("issue_fix_agent_runs").values(row));
+  return rowToRun(row as Selectable<RunsTable>);
+}
+
+export function getIssueFixAgentRun(
+  store: IssueFixAgentStateStore,
+  runId: string,
+): IssueFixAgentRun | null {
+  const kysely = getNodeSqliteKysely<IssueFixAgentDb>(store.db);
+  const row = executeIssueFixTakeFirst(
+    store.db,
+    kysely.selectFrom("issue_fix_agent_runs").selectAll().where("run_id", "=", runId),
+  );
+  return row ? rowToRun(row) : null;
+}
+
+export function transitionIssueFixAgentRun(
+  store: IssueFixAgentStateStore,
+  runId: string,
+  nextState: IssueFixAgentState,
+  params: { reason: string },
+): void {
+  const current = getIssueFixAgentRun(store, runId);
+  if (!current) {
+    throw new Error(`unknown issue-fix-agent run: ${runId}`);
+  }
+  const currentIndex = stateOrder.indexOf(current.state);
+  const nextIndex = stateOrder.indexOf(nextState);
+  if (nextIndex < currentIndex && current.state !== "blocked") {
+    throw new Error(`invalid issue-fix-agent transition ${current.state} -> ${nextState}`);
+  }
+  const patch: Updateable<RunsTable> = {
+    state: nextState,
+    terminal_reason: nextState === "blocked" ? params.reason : current.terminalReason,
+    updated_at: nowIso(),
+  };
+  const kysely = getNodeSqliteKysely<IssueFixAgentDb>(store.db);
+  executeIssueFixWrite(
+    store.db,
+    kysely.updateTable("issue_fix_agent_runs").set(patch).where("run_id", "=", runId),
+  );
+  appendIssueFixAgentEvent(store, runId, "transition", { nextState, reason: params.reason });
+}
+
+export function getLatestOpenIssueFixAgentRun(
+  store: IssueFixAgentStateStore,
+): IssueFixAgentRun | null {
+  const kysely = getNodeSqliteKysely<IssueFixAgentDb>(store.db);
+  const row = executeIssueFixTakeFirst(
+    store.db,
+    kysely
+      .selectFrom("issue_fix_agent_runs")
+      .selectAll()
+      .where("state", "not in", ["land_ready", "blocked"])
+      .orderBy("created_at", "desc")
+      .limit(1),
+  );
+  return row ? rowToRun(row) : null;
+}
+
+export function appendIssueFixAgentEvent(
+  store: IssueFixAgentStateStore,
+  runId: string,
+  kind: string,
+  payload: unknown,
+): void {
+  const kysely = getNodeSqliteKysely<IssueFixAgentDb>(store.db);
+  executeIssueFixWrite(
+    store.db,
+    kysely.insertInto("issue_fix_agent_events").values({
+      created_at: nowIso(),
+      kind,
+      payload_json: JSON.stringify(payload),
+      run_id: runId,
+    }),
+  );
+}

--- a/scripts/issue-fix-agent-lib/types.ts
+++ b/scripts/issue-fix-agent-lib/types.ts
@@ -54,3 +54,20 @@ export type QualifiedCandidate = IssueCandidate & {
 export type SkippedCandidate = IssueCandidate & {
   readonly reason: string;
 };
+
+export type IssueFixAgentRun = {
+  readonly runId: string;
+  readonly issueNumber: number;
+  readonly issueTitle: string;
+  readonly issueUrl: string;
+  readonly source: string;
+  readonly state: IssueFixAgentState;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly branchName: string | null;
+  readonly worktreePath: string | null;
+  readonly commitSha: string | null;
+  readonly prNumber: number | null;
+  readonly prUrl: string | null;
+  readonly terminalReason: string | null;
+};

--- a/scripts/issue-fix-agent-lib/types.ts
+++ b/scripts/issue-fix-agent-lib/types.ts
@@ -1,0 +1,56 @@
+export type IssueFixAgentCommand = "scan" | "run" | "resume" | "status" | "monitor" | "gc";
+
+export type IssueFixAgentArgs =
+  | {
+      command: "scan" | "run" | "resume" | "status";
+      execute: boolean;
+      pushPr: boolean;
+      yes: boolean;
+    }
+  | {
+      command: "monitor";
+      execute: boolean;
+      prNumber: number;
+      pushPr: boolean;
+      yes: boolean;
+    }
+  | {
+      command: "gc";
+      dryRun: boolean;
+      execute: boolean;
+      pushPr: boolean;
+      yes: boolean;
+    };
+
+export type IssueFixAgentState =
+  | "discovered"
+  | "qualified"
+  | "claimed_local"
+  | "branch_created"
+  | "patching"
+  | "verifying"
+  | "committed"
+  | "pr_opened"
+  | "monitoring"
+  | "land_ready"
+  | "blocked";
+
+export type IssueCandidate = {
+  readonly number: number;
+  readonly title: string;
+  readonly url: string;
+  readonly body: string;
+  readonly labels: readonly string[];
+  readonly author: string;
+  readonly updatedAt: string;
+  readonly isPullRequest: boolean;
+};
+
+export type QualifiedCandidate = IssueCandidate & {
+  readonly score: number;
+  readonly evidence: readonly string[];
+};
+
+export type SkippedCandidate = IssueCandidate & {
+  readonly reason: string;
+};

--- a/scripts/issue-fix-agent-lib/workflow.ts
+++ b/scripts/issue-fix-agent-lib/workflow.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
 import { classifyIssueCandidate, formatScanResult, sortQualifiedCandidates } from "./candidates.js";
+import { classifyCheckSnapshots, normalizePrCheckRollup } from "./checks.js";
 import { runCommand as defaultRunCommand, type CommandRunner } from "./command-runner.js";
-import { fetchOpenIssueCandidates } from "./github.js";
+import { fetchOpenIssueCandidates, fetchPrCheckRollup } from "./github.js";
 import {
   createIssueFixAgentRun,
   getLatestOpenIssueFixAgentRun,
@@ -57,6 +58,21 @@ export async function runIssueFixAgentCommand(params: WorkflowParams): Promise<v
       );
     } finally {
       store.close();
+    }
+    return;
+  }
+  if (params.args.command === "monitor") {
+    const rawChecks = await fetchPrCheckRollup({
+      prNumber: params.args.prNumber,
+      runCommand: run,
+    });
+    const result = classifyCheckSnapshots(normalizePrCheckRollup(rawChecks));
+    out(`PR #${params.args.prNumber} checks: ${result.kind}`);
+    for (const failed of result.failed) {
+      out(`failed: ${failed.name} ${failed.detailsUrl ?? ""}`.trim());
+    }
+    for (const pending of result.pending) {
+      out(`pending: ${pending.name} ${pending.detailsUrl ?? ""}`.trim());
     }
     return;
   }

--- a/scripts/issue-fix-agent-lib/workflow.ts
+++ b/scripts/issue-fix-agent-lib/workflow.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { classifyIssueCandidate, formatScanResult, sortQualifiedCandidates } from "./candidates.js";
 import { classifyCheckSnapshots, normalizePrCheckRollup } from "./checks.js";
@@ -48,7 +49,12 @@ export async function runIssueFixAgentCommand(params: WorkflowParams): Promise<v
     return;
   }
   if (params.args.command === "status") {
-    const store = openIssueFixAgentState(params.statePath ?? defaultStatePath());
+    const statePath = params.statePath ?? defaultStatePath();
+    if (!fs.existsSync(statePath)) {
+      out("No active issue-fix-agent run.");
+      return;
+    }
+    const store = openIssueFixAgentState(statePath);
     try {
       const active = getLatestOpenIssueFixAgentRun(store);
       out(

--- a/scripts/issue-fix-agent-lib/workflow.ts
+++ b/scripts/issue-fix-agent-lib/workflow.ts
@@ -87,7 +87,7 @@ export async function runIssueFixAgentCommand(params: WorkflowParams): Promise<v
       transitionIssueFixAgentRun(store, created.runId, "claimed_local", {
         reason: "execute enabled",
       });
-      out("Execution stopped before branch creation in this first implementation slice.");
+      out("Execution stopped before push/PR. Branch and patch automation are not enabled yet.");
     } finally {
       store.close();
     }

--- a/scripts/issue-fix-agent-lib/workflow.ts
+++ b/scripts/issue-fix-agent-lib/workflow.ts
@@ -1,0 +1,97 @@
+import path from "node:path";
+import { classifyIssueCandidate, formatScanResult, sortQualifiedCandidates } from "./candidates.js";
+import { runCommand as defaultRunCommand, type CommandRunner } from "./command-runner.js";
+import { fetchOpenIssueCandidates } from "./github.js";
+import {
+  createIssueFixAgentRun,
+  getLatestOpenIssueFixAgentRun,
+  openIssueFixAgentState,
+  transitionIssueFixAgentRun,
+} from "./state.sqlite.js";
+import type { IssueFixAgentArgs, QualifiedCandidate, SkippedCandidate } from "./types.js";
+
+type WorkflowParams = {
+  readonly args: IssueFixAgentArgs;
+  readonly out?: (line: string) => void;
+  readonly runCommand?: CommandRunner;
+  readonly statePath?: string;
+};
+
+function defaultStatePath(): string {
+  return path.join(process.cwd(), ".openclaw", "issue-fix-agent.sqlite");
+}
+
+async function scan(runCommand: CommandRunner): Promise<{
+  qualified: QualifiedCandidate[];
+  skipped: SkippedCandidate[];
+}> {
+  const candidates = await fetchOpenIssueCandidates({ limit: 10, runCommand });
+  const qualified: QualifiedCandidate[] = [];
+  const skipped: SkippedCandidate[] = [];
+  for (const candidate of candidates) {
+    const result = classifyIssueCandidate(candidate);
+    if (result.kind === "qualified") {
+      qualified.push(result.candidate);
+    } else {
+      skipped.push(result.candidate);
+    }
+  }
+  return { qualified: sortQualifiedCandidates(qualified), skipped };
+}
+
+export async function runIssueFixAgentCommand(params: WorkflowParams): Promise<void> {
+  const out = params.out ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const run = params.runCommand ?? defaultRunCommand;
+  if (params.args.command === "scan") {
+    out(formatScanResult(await scan(run)));
+    return;
+  }
+  if (params.args.command === "status") {
+    const store = openIssueFixAgentState(params.statePath ?? defaultStatePath());
+    try {
+      const active = getLatestOpenIssueFixAgentRun(store);
+      out(
+        active
+          ? `Active run ${active.runId}: #${active.issueNumber} ${active.state}`
+          : "No active issue-fix-agent run.",
+      );
+    } finally {
+      store.close();
+    }
+    return;
+  }
+  if (params.args.command === "run") {
+    const result = await scan(run);
+    const candidate = result.qualified[0];
+    if (!candidate) {
+      out(formatScanResult(result));
+      out("No qualified issue-fix-agent candidates.");
+      return;
+    }
+    const store = openIssueFixAgentState(params.statePath ?? defaultStatePath());
+    try {
+      const created = createIssueFixAgentRun(store, {
+        issueNumber: candidate.number,
+        issueTitle: candidate.title,
+        issueUrl: candidate.url,
+        source: "gitcrawl search",
+      });
+      transitionIssueFixAgentRun(store, created.runId, "qualified", {
+        reason: `score=${candidate.score}; evidence=${candidate.evidence.join(", ")}`,
+      });
+      out(`Qualified #${candidate.number}: ${candidate.title}`);
+      if (!params.args.execute) {
+        out("Dry run stopped at qualified. Re-run with --execute to create a branch.");
+        return;
+      }
+      transitionIssueFixAgentRun(store, created.runId, "claimed_local", {
+        reason: "execute enabled",
+      });
+      out("Execution stopped before branch creation in this first implementation slice.");
+    } finally {
+      store.close();
+    }
+    return;
+  }
+  out(`${params.args.command} is not implemented yet.`);
+}

--- a/scripts/issue-fix-agent-lib/workflow.ts
+++ b/scripts/issue-fix-agent-lib/workflow.ts
@@ -19,8 +19,8 @@ type WorkflowParams = {
   readonly statePath?: string;
 };
 
-function defaultStatePath(): string {
-  return path.join(process.cwd(), ".openclaw", "issue-fix-agent.sqlite");
+export function defaultIssueFixAgentStatePath(): string {
+  return path.join(process.cwd(), ".artifacts", "issue-fix-agent.sqlite");
 }
 
 async function scan(runCommand: CommandRunner): Promise<{
@@ -49,7 +49,7 @@ export async function runIssueFixAgentCommand(params: WorkflowParams): Promise<v
     return;
   }
   if (params.args.command === "status") {
-    const statePath = params.statePath ?? defaultStatePath();
+    const statePath = params.statePath ?? defaultIssueFixAgentStatePath();
     if (!fs.existsSync(statePath)) {
       out("No active issue-fix-agent run.");
       return;
@@ -90,7 +90,7 @@ export async function runIssueFixAgentCommand(params: WorkflowParams): Promise<v
       out("No qualified issue-fix-agent candidates.");
       return;
     }
-    const store = openIssueFixAgentState(params.statePath ?? defaultStatePath());
+    const store = openIssueFixAgentState(params.statePath ?? defaultIssueFixAgentStatePath());
     try {
       const created = createIssueFixAgentRun(store, {
         issueNumber: candidate.number,

--- a/scripts/issue-fix-agent-main.ts
+++ b/scripts/issue-fix-agent-main.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+import type { IssueFixAgentArgs } from "./issue-fix-agent-lib/types.js";
+
+function parsePositiveInteger(raw: string | undefined, label: string): number {
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+export function renderIssueFixAgentUsage(): string {
+  return [
+    "Usage:",
+    "  scripts/issue-fix-agent scan",
+    "  scripts/issue-fix-agent run [--execute] [--push-pr] [--yes]",
+    "  scripts/issue-fix-agent resume [--execute] [--push-pr] [--yes]",
+    "  scripts/issue-fix-agent status",
+    "  scripts/issue-fix-agent monitor <pr-number>",
+    "  scripts/issue-fix-agent gc --dry-run",
+  ].join("\n");
+}
+
+export function parseIssueFixAgentArgs(argv: readonly string[]): IssueFixAgentArgs {
+  const [command, maybeValue, ...rest] = argv;
+  const flags = new Set(argv.filter((arg) => arg.startsWith("--")));
+  const execute = flags.has("--execute");
+  const pushPr = flags.has("--push-pr");
+  const yes = flags.has("--yes");
+  if (pushPr && !execute) {
+    throw new Error("--push-pr requires --execute");
+  }
+  if (yes && (!execute || !pushPr)) {
+    throw new Error("--yes requires --execute --push-pr");
+  }
+  switch (command) {
+    case "scan":
+    case "run":
+    case "resume":
+    case "status":
+      return { command, execute, pushPr, yes };
+    case "monitor":
+      return {
+        command,
+        execute,
+        prNumber: parsePositiveInteger(maybeValue, "pr-number"),
+        pushPr,
+        yes,
+      };
+    case "gc":
+      if (!flags.has("--dry-run") || rest.length > 0) {
+        throw new Error("gc requires --dry-run");
+      }
+      return { command, dryRun: true, execute, pushPr, yes };
+    default:
+      throw new Error(renderIssueFixAgentUsage());
+  }
+}
+
+async function main() {
+  const args = parseIssueFixAgentArgs(process.argv.slice(2));
+  process.stdout.write(`${JSON.stringify(args)}\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err: unknown) => {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/issue-fix-agent-main.ts
+++ b/scripts/issue-fix-agent-main.ts
@@ -60,7 +60,8 @@ export function parseIssueFixAgentArgs(argv: readonly string[]): IssueFixAgentAr
 
 async function main() {
   const args = parseIssueFixAgentArgs(process.argv.slice(2));
-  process.stdout.write(`${JSON.stringify(args)}\n`);
+  const { runIssueFixAgentCommand } = await import("./issue-fix-agent-lib/workflow.js");
+  await runIssueFixAgentCommand({ args });
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/test/scripts/issue-fix-agent.test.ts
+++ b/test/scripts/issue-fix-agent.test.ts
@@ -12,6 +12,10 @@ import {
   formatScanResult,
   sortQualifiedCandidates,
 } from "../../scripts/issue-fix-agent-lib/candidates.ts";
+import {
+  classifyCheckSnapshots,
+  normalizePrCheckRollup,
+} from "../../scripts/issue-fix-agent-lib/checks.ts";
 import type { CommandRunner } from "../../scripts/issue-fix-agent-lib/command-runner.ts";
 import { fetchOpenIssueCandidates } from "../../scripts/issue-fix-agent-lib/github.ts";
 import {
@@ -275,6 +279,45 @@ describe("issue-fix-agent workflow", () => {
 
     expect(output.join("\n")).toContain("Execution stopped before push/PR");
   });
+
+  it("monitor prints failed relevant checks", async () => {
+    const calls: string[][] = [];
+    const output: string[] = [];
+    await runIssueFixAgentCommand({
+      args: { command: "monitor", execute: false, prNumber: 123, pushPr: false, yes: false },
+      out: (line) => output.push(line),
+      runCommand: async (command, args) => {
+        calls.push([command, ...args]);
+        return {
+          code: 0,
+          stderr: "",
+          stdout: JSON.stringify([
+            {
+              conclusion: "FAILURE",
+              detailsUrl: "https://example.test/check",
+              name: "Test",
+              status: "COMPLETED",
+            },
+          ]),
+        };
+      },
+    });
+
+    expect(calls[0]).toEqual([
+      "gh",
+      "pr",
+      "view",
+      "123",
+      "--repo",
+      "openclaw/openclaw",
+      "--json",
+      "statusCheckRollup",
+      "--jq",
+      ".statusCheckRollup",
+    ]);
+    expect(output.join("\n")).toContain("PR #123 checks: failed");
+    expect(output.join("\n")).toContain("failed: Test https://example.test/check");
+  });
 });
 
 describe("issue-fix-agent pr rendering", () => {
@@ -292,5 +335,59 @@ describe("issue-fix-agent pr rendering", () => {
     expect(body).toContain("Closes: https://github.com/openclaw/openclaw/issues/12345");
     expect(body).toContain("Automation run: `ifr_1`");
     expect(body).toContain("node scripts/run-vitest.mjs src/commands/status.test.ts");
+  });
+});
+
+describe("issue-fix-agent checks", () => {
+  it("classifies all successful relevant checks as land ready", () => {
+    const snapshots = normalizePrCheckRollup([
+      {
+        conclusion: "SUCCESS",
+        detailsUrl: "https://example.test/check",
+        name: "Test",
+        status: "COMPLETED",
+      },
+    ]);
+
+    expect(classifyCheckSnapshots(snapshots)).toStrictEqual({
+      failed: [],
+      kind: "land_ready",
+      pending: [],
+    });
+  });
+
+  it("reports failed relevant checks", () => {
+    const snapshots = normalizePrCheckRollup([
+      {
+        conclusion: "FAILURE",
+        detailsUrl: "https://example.test/check",
+        name: "Test",
+        status: "COMPLETED",
+      },
+    ]);
+
+    expect(classifyCheckSnapshots(snapshots)).toMatchObject({
+      failed: [{ name: "Test" }],
+      kind: "failed",
+    });
+  });
+
+  it("ignores routine checks", () => {
+    const snapshots = normalizePrCheckRollup([
+      {
+        conclusion: "FAILURE",
+        detailsUrl: "https://example.test/labeler",
+        name: "Labeler",
+        status: "COMPLETED",
+      },
+      {
+        conclusion: "SUCCESS",
+        detailsUrl: "https://example.test/test",
+        name: "Test",
+        status: "COMPLETED",
+      },
+    ]);
+
+    expect(classifyCheckSnapshots(snapshots).kind).toBe("land_ready");
   });
 });

--- a/test/scripts/issue-fix-agent.test.ts
+++ b/test/scripts/issue-fix-agent.test.ts
@@ -22,6 +22,7 @@ import {
   transitionIssueFixAgentRun,
 } from "../../scripts/issue-fix-agent-lib/state.sqlite.ts";
 import type { IssueCandidate } from "../../scripts/issue-fix-agent-lib/types.ts";
+import { runIssueFixAgentCommand } from "../../scripts/issue-fix-agent-lib/workflow.ts";
 
 function issue(overrides: Partial<IssueCandidate> = {}): IssueCandidate {
   return {
@@ -195,5 +196,64 @@ describe("issue-fix-agent github reads", () => {
       "--limit",
       "5",
     ]);
+  });
+});
+
+describe("issue-fix-agent workflow", () => {
+  function gitcrawlIssueStdout() {
+    return `${JSON.stringify({
+      author: { login: "external-user" },
+      body: "Repro: TypeError in src/commands/status.ts",
+      labels: ["bug"],
+      number: 12345,
+      title: "status crashes",
+      updatedAt: "2026-06-01T00:00:00Z",
+      url: "https://github.com/openclaw/openclaw/issues/12345",
+    })}\n`;
+  }
+
+  it("scan prints qualified candidates and performs no writes", async () => {
+    const calls: string[][] = [];
+    const output: string[] = [];
+    await runIssueFixAgentCommand({
+      args: { command: "scan", execute: false, pushPr: false, yes: false },
+      out: (line) => output.push(line),
+      runCommand: async (command, args) => {
+        calls.push([command, ...args]);
+        return { code: 0, stderr: "", stdout: gitcrawlIssueStdout() };
+      },
+    });
+    expect(output.join("\n")).toContain("#12345 status crashes");
+    expect(calls.every((call) => call[0] === "gitcrawl")).toBe(true);
+  });
+
+  it("run dry-runs through qualified and records a resumable state", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "issue-fix-run-"));
+    const output: string[] = [];
+    await runIssueFixAgentCommand({
+      args: { command: "run", execute: false, pushPr: false, yes: false },
+      out: (line) => output.push(line),
+      runCommand: async () => ({ code: 0, stderr: "", stdout: gitcrawlIssueStdout() }),
+      statePath: path.join(root, "state.sqlite"),
+    });
+
+    expect(output.join("\n")).toContain("Dry run stopped at qualified");
+    const store = openIssueFixAgentState(path.join(root, "state.sqlite"));
+    expect(getLatestOpenIssueFixAgentRun(store)).toMatchObject({
+      issueNumber: 12345,
+      state: "qualified",
+    });
+    store.close();
+  });
+
+  it("status reports when there is no active run", async () => {
+    const output: string[] = [];
+    await runIssueFixAgentCommand({
+      args: { command: "status", execute: false, pushPr: false, yes: false },
+      out: (line) => output.push(line),
+      runCommand: async () => ({ code: 0, stderr: "", stdout: "" }),
+      statePath: path.join(fs.mkdtempSync(path.join(os.tmpdir(), "issue-fix-status-")), "state.sqlite"),
+    });
+    expect(output.join("\n")).toContain("No active issue-fix-agent run.");
   });
 });

--- a/test/scripts/issue-fix-agent.test.ts
+++ b/test/scripts/issue-fix-agent.test.ts
@@ -1,0 +1,38 @@
+// Issue Fix Agent tests cover local maintainer automation behavior.
+import { describe, expect, it } from "vitest";
+import {
+  parseIssueFixAgentArgs,
+  renderIssueFixAgentUsage,
+} from "../../scripts/issue-fix-agent-main.ts";
+
+describe("issue-fix-agent args", () => {
+  it("parses scan without write flags", () => {
+    expect(parseIssueFixAgentArgs(["scan"])).toStrictEqual({
+      command: "scan",
+      execute: false,
+      pushPr: false,
+      yes: false,
+    });
+  });
+
+  it("requires --execute before --push-pr", () => {
+    expect(() => parseIssueFixAgentArgs(["run", "--push-pr"])).toThrow(
+      "--push-pr requires --execute",
+    );
+  });
+
+  it("parses monitor with a PR number", () => {
+    expect(parseIssueFixAgentArgs(["monitor", "12345"])).toStrictEqual({
+      command: "monitor",
+      execute: false,
+      prNumber: 12345,
+      pushPr: false,
+      yes: false,
+    });
+  });
+
+  it("renders usage with every first-version command", () => {
+    expect(renderIssueFixAgentUsage()).toContain("scripts/issue-fix-agent scan");
+    expect(renderIssueFixAgentUsage()).toContain("scripts/issue-fix-agent gc --dry-run");
+  });
+});

--- a/test/scripts/issue-fix-agent.test.ts
+++ b/test/scripts/issue-fix-agent.test.ts
@@ -171,15 +171,17 @@ describe("issue-fix-agent github reads", () => {
       return {
         code: 0,
         stderr: "",
-        stdout: `${JSON.stringify({
-          author: { login: "external-user" },
-          body: "Repro: TypeError in src/commands/status.ts",
-          labels: ["bug"],
-          number: 12345,
-          title: "status crashes",
-          updatedAt: "2026-06-01T00:00:00Z",
-          url: "https://github.com/openclaw/openclaw/issues/12345",
-        })}\n`,
+        stdout: JSON.stringify([
+          {
+            author: { login: "external-user" },
+            body: "Repro: TypeError in src/commands/status.ts",
+            labels: ["bug"],
+            number: 12345,
+            title: "status crashes",
+            updatedAt: "2026-06-01T00:00:00Z",
+            url: "https://github.com/openclaw/openclaw/issues/12345",
+          },
+        ]),
       };
     };
 
@@ -209,15 +211,17 @@ describe("issue-fix-agent github reads", () => {
 
 describe("issue-fix-agent workflow", () => {
   function gitcrawlIssueStdout() {
-    return `${JSON.stringify({
-      author: { login: "external-user" },
-      body: "Repro: TypeError in src/commands/status.ts",
-      labels: ["bug"],
-      number: 12345,
-      title: "status crashes",
-      updatedAt: "2026-06-01T00:00:00Z",
-      url: "https://github.com/openclaw/openclaw/issues/12345",
-    })}\n`;
+    return JSON.stringify([
+      {
+        author: { login: "external-user" },
+        body: "Repro: TypeError in src/commands/status.ts",
+        labels: ["bug"],
+        number: 12345,
+        title: "status crashes",
+        updatedAt: "2026-06-01T00:00:00Z",
+        url: "https://github.com/openclaw/openclaw/issues/12345",
+      },
+    ]);
   }
 
   it("scan prints qualified candidates and performs no writes", async () => {

--- a/test/scripts/issue-fix-agent.test.ts
+++ b/test/scripts/issue-fix-agent.test.ts
@@ -405,4 +405,26 @@ describe("issue-fix-agent checks", () => {
 
     expect(classifyCheckSnapshots(snapshots).kind).toBe("land_ready");
   });
+
+  it("does not mark empty relevant checks as land ready", () => {
+    expect(classifyCheckSnapshots([])).toStrictEqual({
+      failed: [],
+      kind: "pending",
+      pending: [],
+    });
+    const routineOnly = normalizePrCheckRollup([
+      {
+        conclusion: "SUCCESS",
+        detailsUrl: "https://example.test/labeler",
+        name: "Labeler",
+        status: "COMPLETED",
+      },
+    ]);
+
+    expect(classifyCheckSnapshots(routineOnly)).toStrictEqual({
+      failed: [],
+      kind: "pending",
+      pending: [],
+    });
+  });
 });

--- a/test/scripts/issue-fix-agent.test.ts
+++ b/test/scripts/issue-fix-agent.test.ts
@@ -372,6 +372,21 @@ describe("issue-fix-agent checks", () => {
     });
   });
 
+  it("reports failed commit status contexts", () => {
+    const snapshots = normalizePrCheckRollup([
+      {
+        context: "ci/external",
+        state: "FAILURE",
+        targetUrl: "https://example.test/status",
+      },
+    ]);
+
+    expect(classifyCheckSnapshots(snapshots)).toMatchObject({
+      failed: [{ detailsUrl: "https://example.test/status", name: "ci/external" }],
+      kind: "failed",
+    });
+  });
+
   it("ignores routine checks", () => {
     const snapshots = normalizePrCheckRollup([
       {

--- a/test/scripts/issue-fix-agent.test.ts
+++ b/test/scripts/issue-fix-agent.test.ts
@@ -15,6 +15,10 @@ import {
 import type { CommandRunner } from "../../scripts/issue-fix-agent-lib/command-runner.ts";
 import { fetchOpenIssueCandidates } from "../../scripts/issue-fix-agent-lib/github.ts";
 import {
+  renderIssueFixAgentPrBody,
+  renderIssueFixAgentPrTitle,
+} from "../../scripts/issue-fix-agent-lib/pr.ts";
+import {
   appendIssueFixAgentEvent,
   createIssueFixAgentRun,
   getLatestOpenIssueFixAgentRun,
@@ -255,5 +259,38 @@ describe("issue-fix-agent workflow", () => {
       statePath: path.join(fs.mkdtempSync(path.join(os.tmpdir(), "issue-fix-status-")), "state.sqlite"),
     });
     expect(output.join("\n")).toContain("No active issue-fix-agent run.");
+  });
+
+  it("execute mode stops before push and PR creation", async () => {
+    const output: string[] = [];
+    await runIssueFixAgentCommand({
+      args: { command: "run", execute: true, pushPr: false, yes: false },
+      out: (line) => output.push(line),
+      runCommand: async () => ({ code: 0, stderr: "", stdout: gitcrawlIssueStdout() }),
+      statePath: path.join(
+        fs.mkdtempSync(path.join(os.tmpdir(), "issue-fix-execute-")),
+        "state.sqlite",
+      ),
+    });
+
+    expect(output.join("\n")).toContain("Execution stopped before push/PR");
+  });
+});
+
+describe("issue-fix-agent pr rendering", () => {
+  it("renders a draft PR title and body with verification evidence", () => {
+    expect(renderIssueFixAgentPrTitle({ issueNumber: 12345, scope: "status" })).toBe(
+      "fix(status): address issue #12345",
+    );
+    const body = renderIssueFixAgentPrBody({
+      issueNumber: 12345,
+      issueUrl: "https://github.com/openclaw/openclaw/issues/12345",
+      runId: "ifr_1",
+      touchedFiles: ["src/commands/status.ts", "src/commands/status.test.ts"],
+      verification: ["node scripts/run-vitest.mjs src/commands/status.test.ts"],
+    });
+    expect(body).toContain("Closes: https://github.com/openclaw/openclaw/issues/12345");
+    expect(body).toContain("Automation run: `ifr_1`");
+    expect(body).toContain("node scripts/run-vitest.mjs src/commands/status.test.ts");
   });
 });

--- a/test/scripts/issue-fix-agent.test.ts
+++ b/test/scripts/issue-fix-agent.test.ts
@@ -1,4 +1,7 @@
 // Issue Fix Agent tests cover local maintainer automation behavior.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   parseIssueFixAgentArgs,
@@ -9,6 +12,13 @@ import {
   formatScanResult,
   sortQualifiedCandidates,
 } from "../../scripts/issue-fix-agent-lib/candidates.ts";
+import {
+  appendIssueFixAgentEvent,
+  createIssueFixAgentRun,
+  getLatestOpenIssueFixAgentRun,
+  openIssueFixAgentState,
+  transitionIssueFixAgentRun,
+} from "../../scripts/issue-fix-agent-lib/state.sqlite.ts";
 import type { IssueCandidate } from "../../scripts/issue-fix-agent-lib/types.ts";
 
 function issue(overrides: Partial<IssueCandidate> = {}): IssueCandidate {
@@ -97,5 +107,47 @@ describe("issue-fix-agent candidates", () => {
     });
     expect(output).toContain("#12345 status crashes with TypeError score=5");
     expect(output).toContain("skipped #99: high-risk label: security");
+  });
+});
+
+describe("issue-fix-agent sqlite state", () => {
+  it("creates a run and resumes the latest non-terminal run", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "issue-fix-agent-state-"));
+    const store = openIssueFixAgentState(path.join(root, "issue-fix-agent.sqlite"));
+    const run = createIssueFixAgentRun(store, {
+      issueNumber: 12345,
+      issueTitle: "status crashes",
+      issueUrl: "https://github.com/openclaw/openclaw/issues/12345",
+      source: "test",
+    });
+    transitionIssueFixAgentRun(store, run.runId, "qualified", {
+      reason: "candidate passed gates",
+    });
+    appendIssueFixAgentEvent(store, run.runId, "note", { message: "verified source repro" });
+
+    expect(getLatestOpenIssueFixAgentRun(store)).toMatchObject({
+      issueNumber: 12345,
+      state: "qualified",
+    });
+    store.close();
+  });
+
+  it("rejects invalid backward transitions", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "issue-fix-agent-transition-"));
+    const store = openIssueFixAgentState(path.join(root, "issue-fix-agent.sqlite"));
+    const run = createIssueFixAgentRun(store, {
+      issueNumber: 12345,
+      issueTitle: "status crashes",
+      issueUrl: "https://github.com/openclaw/openclaw/issues/12345",
+      source: "test",
+    });
+    transitionIssueFixAgentRun(store, run.runId, "qualified", {
+      reason: "candidate passed gates",
+    });
+
+    expect(() =>
+      transitionIssueFixAgentRun(store, run.runId, "discovered", { reason: "backward" }),
+    ).toThrow("invalid issue-fix-agent transition");
+    store.close();
   });
 });

--- a/test/scripts/issue-fix-agent.test.ts
+++ b/test/scripts/issue-fix-agent.test.ts
@@ -196,7 +196,7 @@ describe("issue-fix-agent github reads", () => {
       "gitcrawl",
       "search",
       "issues",
-      "repo:openclaw/openclaw state:open",
+      "repo:openclaw/openclaw state:open is:issue",
       "-R",
       "openclaw/openclaw",
       "--state",

--- a/test/scripts/issue-fix-agent.test.ts
+++ b/test/scripts/issue-fix-agent.test.ts
@@ -256,13 +256,18 @@ describe("issue-fix-agent workflow", () => {
 
   it("status reports when there is no active run", async () => {
     const output: string[] = [];
+    const statePath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), "issue-fix-status-")),
+      "state.sqlite",
+    );
     await runIssueFixAgentCommand({
       args: { command: "status", execute: false, pushPr: false, yes: false },
       out: (line) => output.push(line),
       runCommand: async () => ({ code: 0, stderr: "", stdout: "" }),
-      statePath: path.join(fs.mkdtempSync(path.join(os.tmpdir(), "issue-fix-status-")), "state.sqlite"),
+      statePath,
     });
     expect(output.join("\n")).toContain("No active issue-fix-agent run.");
+    expect(fs.existsSync(statePath)).toBe(false);
   });
 
   it("execute mode stops before push and PR creation", async () => {

--- a/test/scripts/issue-fix-agent.test.ts
+++ b/test/scripts/issue-fix-agent.test.ts
@@ -12,6 +12,8 @@ import {
   formatScanResult,
   sortQualifiedCandidates,
 } from "../../scripts/issue-fix-agent-lib/candidates.ts";
+import type { CommandRunner } from "../../scripts/issue-fix-agent-lib/command-runner.ts";
+import { fetchOpenIssueCandidates } from "../../scripts/issue-fix-agent-lib/github.ts";
 import {
   appendIssueFixAgentEvent,
   createIssueFixAgentRun,
@@ -149,5 +151,49 @@ describe("issue-fix-agent sqlite state", () => {
       transitionIssueFixAgentRun(store, run.runId, "discovered", { reason: "backward" }),
     ).toThrow("invalid issue-fix-agent transition");
     store.close();
+  });
+});
+
+describe("issue-fix-agent github reads", () => {
+  it("reads open issues through gitcrawl and normalizes candidates", async () => {
+    const calls: string[][] = [];
+    const runCommand: CommandRunner = async (command, args) => {
+      calls.push([command, ...args]);
+      return {
+        code: 0,
+        stderr: "",
+        stdout: `${JSON.stringify({
+          author: { login: "external-user" },
+          body: "Repro: TypeError in src/commands/status.ts",
+          labels: ["bug"],
+          number: 12345,
+          title: "status crashes",
+          updatedAt: "2026-06-01T00:00:00Z",
+          url: "https://github.com/openclaw/openclaw/issues/12345",
+        })}\n`,
+      };
+    };
+
+    await expect(fetchOpenIssueCandidates({ limit: 5, runCommand })).resolves.toMatchObject([
+      {
+        author: "external-user",
+        isPullRequest: false,
+        number: 12345,
+      },
+    ]);
+    expect(calls[0]).toEqual([
+      "gitcrawl",
+      "search",
+      "issues",
+      "repo:openclaw/openclaw state:open",
+      "-R",
+      "openclaw/openclaw",
+      "--state",
+      "open",
+      "--json",
+      "number,title,url,body,labels,author,updatedAt",
+      "--limit",
+      "5",
+    ]);
   });
 });

--- a/test/scripts/issue-fix-agent.test.ts
+++ b/test/scripts/issue-fix-agent.test.ts
@@ -4,6 +4,26 @@ import {
   parseIssueFixAgentArgs,
   renderIssueFixAgentUsage,
 } from "../../scripts/issue-fix-agent-main.ts";
+import {
+  classifyIssueCandidate,
+  formatScanResult,
+  sortQualifiedCandidates,
+} from "../../scripts/issue-fix-agent-lib/candidates.ts";
+import type { IssueCandidate } from "../../scripts/issue-fix-agent-lib/types.ts";
+
+function issue(overrides: Partial<IssueCandidate> = {}): IssueCandidate {
+  return {
+    author: "external-user",
+    body: "Repro: running openclaw status throws TypeError at src/commands/status.ts:12",
+    isPullRequest: false,
+    labels: ["bug"],
+    number: 12345,
+    title: "status crashes with TypeError",
+    updatedAt: "2026-06-01T00:00:00Z",
+    url: "https://github.com/openclaw/openclaw/issues/12345",
+    ...overrides,
+  };
+}
 
 describe("issue-fix-agent args", () => {
   it("parses scan without write flags", () => {
@@ -34,5 +54,48 @@ describe("issue-fix-agent args", () => {
   it("renders usage with every first-version command", () => {
     expect(renderIssueFixAgentUsage()).toContain("scripts/issue-fix-agent scan");
     expect(renderIssueFixAgentUsage()).toContain("scripts/issue-fix-agent gc --dry-run");
+  });
+});
+
+describe("issue-fix-agent candidates", () => {
+  it("qualifies concrete narrow bug reports", () => {
+    const result = classifyIssueCandidate(issue());
+    expect(result.kind).toBe("qualified");
+    if (result.kind === "qualified") {
+      expect(result.candidate.score).toBeGreaterThan(0);
+      expect(result.candidate.evidence).toContain("concrete symptom");
+    }
+  });
+
+  it("skips pull requests and high-risk labels", () => {
+    expect(classifyIssueCandidate(issue({ isPullRequest: true }))).toMatchObject({
+      kind: "skipped",
+      reason: "item is a pull request",
+    });
+    expect(classifyIssueCandidate(issue({ labels: ["security"] }))).toMatchObject({
+      kind: "skipped",
+      reason: "high-risk label: security",
+    });
+  });
+
+  it("sorts qualified candidates by score then issue number", () => {
+    const first = classifyIssueCandidate(
+      issue({ labels: ["bug", "clawsweeper:source-repro"], number: 2 }),
+    );
+    const second = classifyIssueCandidate(issue({ number: 1 }));
+    if (first.kind !== "qualified" || second.kind !== "qualified") {
+      throw new Error("expected qualified candidates");
+    }
+    expect(sortQualifiedCandidates([second.candidate, first.candidate]).map((entry) => entry.number))
+      .toEqual([2, 1]);
+  });
+
+  it("formats scan output with qualified and skipped rows", () => {
+    const output = formatScanResult({
+      qualified: [{ ...issue(), score: 5, evidence: ["concrete symptom"] }],
+      skipped: [{ ...issue({ number: 99 }), reason: "high-risk label: security" }],
+    });
+    expect(output).toContain("#12345 status crashes with TypeError score=5");
+    expect(output).toContain("skipped #99: high-risk label: security");
   });
 });

--- a/test/scripts/issue-fix-agent.test.ts
+++ b/test/scripts/issue-fix-agent.test.ts
@@ -30,7 +30,10 @@ import {
   transitionIssueFixAgentRun,
 } from "../../scripts/issue-fix-agent-lib/state.sqlite.ts";
 import type { IssueCandidate } from "../../scripts/issue-fix-agent-lib/types.ts";
-import { runIssueFixAgentCommand } from "../../scripts/issue-fix-agent-lib/workflow.ts";
+import {
+  defaultIssueFixAgentStatePath,
+  runIssueFixAgentCommand,
+} from "../../scripts/issue-fix-agent-lib/workflow.ts";
 
 function issue(overrides: Partial<IssueCandidate> = {}): IssueCandidate {
   return {
@@ -207,6 +210,54 @@ describe("issue-fix-agent github reads", () => {
       "5",
     ]);
   });
+
+  it("falls back to gh issue list when gitcrawl is unavailable", async () => {
+    const calls: string[][] = [];
+    const runCommand: CommandRunner = async (command, args) => {
+      calls.push([command, ...args]);
+      if (command === "gitcrawl") {
+        throw new Error("spawn gitcrawl ENOENT");
+      }
+      return {
+        code: 0,
+        stderr: "",
+        stdout: JSON.stringify([
+          {
+            author: { login: "external-user" },
+            body: "Repro: TypeError in src/commands/status.ts",
+            labels: [{ name: "bug" }],
+            number: 12345,
+            title: "status crashes",
+            updatedAt: "2026-06-01T00:00:00Z",
+            url: "https://github.com/openclaw/openclaw/issues/12345",
+          },
+        ]),
+      };
+    };
+
+    await expect(fetchOpenIssueCandidates({ limit: 5, runCommand })).resolves.toMatchObject([
+      {
+        author: "external-user",
+        isPullRequest: false,
+        number: 12345,
+      },
+    ]);
+    expect(calls[1]).toEqual([
+      "gh",
+      "issue",
+      "list",
+      "--repo",
+      "openclaw/openclaw",
+      "--state",
+      "open",
+      "--search",
+      "is:issue",
+      "--json",
+      "number,title,url,body,labels,author,updatedAt",
+      "--limit",
+      "5",
+    ]);
+  });
 });
 
 describe("issue-fix-agent workflow", () => {
@@ -256,6 +307,12 @@ describe("issue-fix-agent workflow", () => {
       state: "qualified",
     });
     store.close();
+  });
+
+  it("uses an ignored artifact path for default run state", () => {
+    expect(defaultIssueFixAgentStatePath()).toBe(
+      path.join(process.cwd(), ".artifacts", "issue-fix-agent.sqlite"),
+    );
   });
 
   it("status reports when there is no active run", async () => {


### PR DESCRIPTION
## Summary

- Add a local `scripts/issue-fix-agent` workflow for scanning open OpenClaw issues, qualifying low-risk fix candidates, and tracking runs.
- Persist issue-fix agent state in SQLite under an ignored artifact path instead of adding JSON sidecars or runtime cache files.
- Add PR body rendering and check-rollup classification helpers for future issue-fix PR monitoring.
- Cover candidate classification, GitHub/gitcrawl fallback behavior, SQLite state transitions, command parsing, workflow dry-runs, and check classification with focused Vitest coverage.

## Verification

- `node scripts/run-vitest.mjs test/scripts/issue-fix-agent.test.ts`
- `git diff --check origin/main...HEAD`

## Real behavior proof

Behavior addressed: Adds maintainer-side issue handling automation primitives for identifying queueable OpenClaw issues, persisting run state, rendering draft issue-fix PR details, and monitoring relevant PR checks.

Real environment tested: Local OpenClaw worktree, rebased onto `origin/main` at `bad21faf62002c9fbdbe4e923de13fc6e5f19b0a`, then pushed to `wuqxuan/openclaw` branch `agent/issue-fix-agent`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs test/scripts/issue-fix-agent.test.ts`; `git diff --check origin/main...HEAD`.

Evidence after fix: Both commands exited successfully. The pushed head is `c2dac5a347d71079f36a0a6961689af004567049`.

Observed result after fix: The issue-fix agent tests pass, including scan qualification, dry-run state persistence, fallback from `gitcrawl` to `gh`, PR body rendering, and relevant check classification. The whitespace diff check is clean.

What was not tested: Live `gitcrawl`/`gh` issue search against GitHub, live PR creation from the new script, and broad `pnpm check:changed`/Crabbox proof were not run in this local publish pass.
