### PR TITLE
fix(channels): keep inbound system event labels body-free

### DIFF
--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -768,11 +768,12 @@ describe("msteams monitor handler authz", () => {
 
     expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).not.toHaveBeenCalled();
     const systemEventCall = enqueueSystemEvent.mock.calls.find(
-      ([text]) => typeof text === "string" && text.includes("please run the deployment"),
+      ([text]) => typeof text === "string" && text.includes("Teams message in channel"),
     );
     if (!systemEventCall) {
       throw new Error("expected skipped Teams message system event");
     }
+    expect(systemEventCall[0]).not.toContain("please run the deployment");
     expect(systemEventCall[1]).toMatchObject({});
   });
 
@@ -810,11 +811,15 @@ describe("msteams monitor handler authz", () => {
 
     expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).toHaveBeenCalled();
     const systemEventCall = enqueueSystemEvent.mock.calls.find(
-      ([text]) => typeof text === "string" && text.includes("please check the build"),
+      ([text]) => typeof text === "string" && text.includes("Teams message in channel"),
     );
     if (!systemEventCall) {
       throw new Error("expected active Teams message system event");
     }
+    expect(systemEventCall[0]).not.toContain("please check the build");
+    const dispatched = firstSettledDispatch();
+    const ctxPayload = recordFromMockCall(dispatched.ctxPayload);
+    expect(ctxPayload.BodyForAgent).toBe("please check the build");
   });
 
   it("authorizes text control commands from static access groups", async () => {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -502,13 +502,13 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       replyToId: activity.replyToId,
     });
 
-    const preview = rawBody.replace(/\s+/g, " ").slice(0, 160);
     const inboundLabel = isDirectMessage
       ? `Teams DM from ${senderName}`
       : `Teams message in ${conversationType} from ${senderName}`;
+    const logPreview = rawBody.replace(/\s+/g, " ").slice(0, 160);
 
     const enqueuePrimaryMessageSystemEvent = () =>
-      core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
+      core.system.enqueueSystemEvent(inboundLabel, {
         sessionKey: route.sessionKey,
         contextKey: `msteams:message:${conversationId}:${activity.id ?? "unknown"}`,
       });
@@ -829,7 +829,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       },
     });
 
-    logVerboseMessage(`msteams inbound: from=${ctxPayload.From} preview="${preview}"`);
+    logVerboseMessage(`msteams inbound: from=${ctxPayload.From} preview="${logPreview}"`);
 
     const sharePointSiteId = msteamsCfg?.sharePointSiteId;
     const { dispatcher, replyOptions, markDispatchIdle } = createMSTeamsReplyDispatcher({

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -158,14 +158,16 @@ describe("slack prepareSlackMessage inbound contract", () => {
     });
   }
 
-  it("queues inbound message system events as untrusted", async () => {
+  it("queues inbound message system events without duplicating body text", async () => {
     const prepared = await prepareWithDefaultCtx(createSlackMessage({}));
 
     assertPrepared(prepared);
-    expect(enqueueSystemEventMock).toHaveBeenCalledWith("Slack DM from Alice: hi", {
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith("Slack DM from Alice", {
       sessionKey: prepared.ctxPayload.SessionKey,
       contextKey: "slack:message:D123:1.000",
     });
+    expect(enqueueSystemEventMock.mock.calls[0]?.[0]).not.toContain("hi");
+    expect(prepared.ctxPayload.RawBody).toContain("hi");
   });
 
   it("prepares wildcard open-policy account DMs", async () => {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -1121,17 +1121,17 @@ export async function prepareSlackMessage(params: {
 
   const roomLabel = channelName ? `#${channelName}` : `#${message.channel}`;
   const senderName = await resolveSenderName();
-  const preview = rawBody.replace(/\s+/g, " ").slice(0, 160);
   const inboundLabel = isDirectMessage
     ? `Slack DM from ${senderName}`
     : `Slack message in ${roomLabel} from ${senderName}`;
+  const preview = rawBody.replace(/\s+/g, " ").slice(0, 160);
   const slackFrom = isDirectMessage
     ? `slack:${message.user}`
     : isRoom
       ? `slack:channel:${message.channel}`
       : `slack:group:${message.channel}`;
 
-  enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
+  enqueueSystemEvent(inboundLabel, {
     sessionKey,
     contextKey: `slack:message:${message.channel}:${message.ts ?? "unknown"}`,
   });


### PR DESCRIPTION
Fixes #94549

## Summary

- Stop Slack and Microsoft Teams primary inbound system events from appending the raw message body preview to the event label.
- Keep the actual inbound message body in the normal channel payload/context fields used by the agent.
- Update Slack and Teams regression coverage, while preserving the existing Mattermost no-enqueue coverage.

## Verification

- `node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/msteams/src/monitor-handler/message-handler.authz.test.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts`
- `git diff --check -- extensions/slack/src/monitor/message-handler/prepare.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/msteams/src/monitor-handler/message-handler.ts extensions/msteams/src/monitor-handler/message-handler.authz.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`

## Real behavior proof

Behavior addressed: Slack and Microsoft Teams arrival-only system event labels no longer duplicate user message text as a 160-character preview.

Real environment tested: Local OpenClaw source checkout with the Slack, Microsoft Teams, and Mattermost channel monitor test harnesses.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/msteams/src/monitor-handler/message-handler.authz.test.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts`.

Evidence after fix: The focused Vitest run passed all three shards: Mattermost 10 tests, Microsoft Teams 18 tests, and Slack 85 tests. `git diff --check` passed for the touched files, and the Codex autoreview reported no accepted/actionable findings.

Observed result after fix: Slack and Microsoft Teams system event calls use only the arrival label, while the user message body remains available in the normal inbound payload (`RawBody` for Slack and `BodyForAgent` for Teams).

What was not tested: Live Slack or Microsoft Teams transport traffic was not exercised; this patch is covered by the channel monitor handler tests requested by the issue.
