### PR TITLE
fix(codex): keep runtime context out of turn input

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -17,7 +17,12 @@ import {
 import { resolveAgentWorkspaceDir } from "openclaw/plugin-sdk/agent-runtime";
 import { buildMemorySystemPromptAddition } from "openclaw/plugin-sdk/core";
 import { MESSAGE_TOOL_DELIVERY_HINTS } from "openclaw/plugin-sdk/message-tool-delivery-hints";
-import type { CodexDynamicToolFunctionSpec, CodexDynamicToolSpec, JsonValue } from "./protocol.js";
+import type {
+  CodexAdditionalContextEntry,
+  CodexDynamicToolFunctionSpec,
+  CodexDynamicToolSpec,
+  JsonValue,
+} from "./protocol.js";
 import { flattenCodexDynamicToolFunctions } from "./protocol.js";
 import { isJsonObject } from "./protocol.js";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
@@ -42,6 +47,8 @@ const CODEX_WORKSPACE_DEVELOPER_CONTEXT_BASENAMES = new Set([
 ]);
 const CODEX_HEARTBEAT_CONTEXT_BASENAME = "heartbeat.md";
 const CODEX_MEMORY_CONTEXT_BASENAME = "memory.md";
+const CODEX_OPENCLAW_RUNTIME_CONTEXT_KEY = "openclaw_runtime_context";
+const CODEX_OPENCLAW_DELIVERY_METADATA_CONTEXT_KEY = "openclaw_delivery_metadata";
 const CODEX_MEMORY_TOOL_NAMES = new Set(["memory_search", "memory_get"]);
 const CODEX_BOOTSTRAP_CONTEXT_ORDER = new Map<string, number>([
   ["soul.md", 10],
@@ -75,6 +82,11 @@ type CodexWorkspaceBootstrapContext = CodexBootstrapContext & {
   turnScopedDeveloperInstructions?: string;
   memoryCollaborationInstructions?: string;
   heartbeatCollaborationInstructions?: string;
+};
+type CodexOpenClawAdditionalContext = Record<string, CodexAdditionalContextEntry>;
+export type CodexOpenClawTurnPromptSubmission = {
+  promptText: string;
+  additionalContext?: CodexOpenClawAdditionalContext;
 };
 
 /** Reads mirrored Codex session history for harness hooks. */
@@ -559,31 +571,50 @@ export function renderCodexSkillsCollaborationInstructions(params: {
 }
 
 /**
- * Prepends OpenClaw context while preserving leading delivery metadata as
- * routing guidance instead of user request text.
+ * Sends OpenClaw runtime context through Codex's transient additionalContext
+ * lane so native user history only stores the real turn text.
  */
-export function prependCodexOpenClawPromptContext(
+export function buildCodexOpenClawTurnPromptSubmission(
   prompt: string,
   context: string | undefined,
   options: { preservePromptWithoutContext?: boolean } = {},
-): string {
+): CodexOpenClawTurnPromptSubmission {
   const { deliveryHint, prompt: promptWithoutDeliveryHint } = splitLeadingCodexDeliveryHint(prompt);
   if (!context?.trim() && (!deliveryHint || options.preservePromptWithoutContext)) {
-    return prompt;
+    return { promptText: prompt };
   }
-  const promptSection = promptWithoutDeliveryHint.startsWith(
-    "OpenClaw assembled context for this turn:",
-  )
-    ? promptWithoutDeliveryHint
-    : ["Current user request:", promptWithoutDeliveryHint].join("\n");
-  const deliverySection = deliveryHint
-    ? [
+  const additionalContext = buildCodexOpenClawAdditionalContext({
+    promptContext: context,
+    deliveryHint,
+  });
+  return {
+    promptText: promptWithoutDeliveryHint,
+    ...(additionalContext ? { additionalContext } : {}),
+  };
+}
+
+function buildCodexOpenClawAdditionalContext(params: {
+  promptContext?: string;
+  deliveryHint?: string;
+}): CodexOpenClawAdditionalContext | undefined {
+  const additionalContext: CodexOpenClawAdditionalContext = {};
+  if (params.promptContext?.trim()) {
+    additionalContext[CODEX_OPENCLAW_RUNTIME_CONTEXT_KEY] = {
+      kind: "untrusted",
+      value: params.promptContext.trim(),
+    };
+  }
+  if (params.deliveryHint?.trim()) {
+    additionalContext[CODEX_OPENCLAW_DELIVERY_METADATA_CONTEXT_KEY] = {
+      kind: "untrusted",
+      value: [
         "OpenClaw delivery metadata:",
         "This delivery metadata is runtime routing guidance, not the user's request.",
-        deliveryHint,
-      ].join("\n")
-    : undefined;
-  return [context?.trim(), deliverySection, promptSection].filter(Boolean).join("\n\n");
+        params.deliveryHint,
+      ].join("\n"),
+    };
+  }
+  return Object.keys(additionalContext).length > 0 ? additionalContext : undefined;
 }
 
 function splitLeadingCodexDeliveryHint(prompt: string): {

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -179,9 +179,17 @@ export type CodexTurnInterruptParams = JsonObject & {
   turnId: string;
 };
 
+export type CodexAdditionalContextKind = "untrusted" | "application";
+
+export type CodexAdditionalContextEntry = JsonObject & {
+  value: string;
+  kind: CodexAdditionalContextKind;
+};
+
 export type CodexTurnStartParams = JsonObject & {
   threadId: string;
   input?: CodexUserInput[];
+  additionalContext?: Record<string, CodexAdditionalContextEntry> | null;
   cwd?: string;
   model?: string;
   approvalPolicy?: string | JsonObject;

--- a/extensions/codex/src/app-server/provider-capabilities.test.ts
+++ b/extensions/codex/src/app-server/provider-capabilities.test.ts
@@ -77,6 +77,7 @@ describe("resolveCodexProviderWebSearchSupport", () => {
     const { clientFactory, request } = createClientFactory(false);
 
     await expect(resolveSupport(clientFactory, " OpenAI ")).resolves.toBe("supported");
+    expect(clientFactory).not.toHaveBeenCalled();
     expect(request).not.toHaveBeenCalled();
   });
 
@@ -85,6 +86,7 @@ describe("resolveCodexProviderWebSearchSupport", () => {
 
     await expect(resolveSupport(clientFactory, "amazon-bedrock")).resolves.toBe("unsupported");
     await expect(resolveSupport(clientFactory, "custom-provider")).resolves.toBe("unsupported");
+    expect(clientFactory).not.toHaveBeenCalled();
     expect(request).not.toHaveBeenCalled();
   });
 });

--- a/extensions/codex/src/app-server/provider-capabilities.ts
+++ b/extensions/codex/src/app-server/provider-capabilities.ts
@@ -53,6 +53,13 @@ export async function resolveCodexProviderWebSearchSupport(params: {
   modelProviderOverride: string | undefined;
   signal: AbortSignal;
 }): Promise<CodexNativeWebSearchSupport> {
+  const modelProviderOverride = params.modelProviderOverride?.trim().toLowerCase();
+  if (modelProviderOverride === "openai") {
+    return "supported";
+  }
+  if (modelProviderOverride) {
+    return "unsupported";
+  }
   let client: CodexAppServerClient | undefined;
   try {
     client = await params.clientFactory(

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -22,10 +22,10 @@ import { CODEX_GPT5_BEHAVIOR_CONTRACT } from "../../prompt-overlay.js";
 import { defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
 import {
   buildCodexOpenClawPromptContext,
+  buildCodexOpenClawTurnPromptSubmission,
   buildCodexSystemPromptReport,
   buildCodexWorkspaceBootstrapContext,
   getCodexWorkspaceMemoryToolNames,
-  prependCodexOpenClawPromptContext,
 } from "./attempt-context.js";
 import { resolveCodexAppServerEnvApiKeyCacheKey } from "./auth-bridge.js";
 import { CodexAppServerRpcError } from "./client.js";
@@ -120,6 +120,15 @@ function expectResumeRequest(
   for (const [key, value] of Object.entries(params)) {
     expect(requestParams?.[key]).toEqual(value);
   }
+}
+
+type TestCodexAdditionalContext = Record<string, { kind?: string; value?: string }>;
+
+function readTestAdditionalContextValue(
+  context: TestCodexAdditionalContext | undefined,
+  key: string,
+): string {
+  return context?.[key]?.value ?? "";
 }
 
 const DISABLED_CODEX_WEB_SEARCH_THREAD_CONFIG_FINGERPRINT = JSON.stringify({
@@ -273,7 +282,7 @@ async function buildCodexTurnContextForTest(
     params,
     workspacePromptContext: workspaceBootstrapContext.promptContext,
   });
-  const codexTurnPromptText = prependCodexOpenClawPromptContext(
+  const codexTurnSubmission = buildCodexOpenClawTurnPromptSubmission(
     params.prompt,
     openClawPromptContext,
   );
@@ -281,7 +290,8 @@ async function buildCodexTurnContextForTest(
     threadId: "thread-1",
     cwd: workspaceDir,
     appServer: resolveCodexAppServerRuntimeOptions({}),
-    promptText: codexTurnPromptText,
+    promptText: codexTurnSubmission.promptText,
+    additionalContext: codexTurnSubmission.additionalContext,
     turnScopedDeveloperInstructions: workspaceBootstrapContext.turnScopedDeveloperInstructions,
     memoryCollaborationInstructions: workspaceBootstrapContext.memoryCollaborationInstructions,
     heartbeatCollaborationInstructions:
@@ -300,6 +310,7 @@ async function buildCodexTurnContextForTest(
     tools: dynamicTools,
   });
   return {
+    additionalContext: turnStartParams.additionalContext,
     collaborationInstructions,
     inputText,
     systemPromptReport,
@@ -1344,15 +1355,23 @@ describe("runCodexAppServerAttempt", () => {
 
       const turnStart = harness.requests.find((request) => request.method === "turn/start");
       const turnStartParams = turnStart?.params as {
+        additionalContext?: TestCodexAdditionalContext;
         input?: Array<{ text?: string }>;
       };
       const inputText = turnStartParams.input?.[0]?.text ?? "";
-      expect(inputText).toContain("OpenClaw delivery metadata:");
-      expect(inputText).toContain(
+      const deliveryContext = readTestAdditionalContextValue(
+        turnStartParams.additionalContext,
+        "openclaw_delivery_metadata",
+      );
+      expect(inputText).toBe("hello");
+      expect(deliveryContext).toContain("OpenClaw delivery metadata:");
+      expect(deliveryContext).toContain(
         "This delivery metadata is runtime routing guidance, not the user's request.",
       );
-      expect(inputText).toContain(deliveryHint);
-      expect(inputText).toContain("Current user request:\nhello");
+      expect(deliveryContext).toContain(deliveryHint);
+      expect(inputText).not.toContain(deliveryHint);
+      expect(inputText).not.toContain("OpenClaw delivery metadata:");
+      expect(inputText).not.toContain("Current user request:");
       expect(inputText).not.toContain("Current user request:\nDelivery:");
     }
   });
@@ -2707,7 +2726,7 @@ describe("runCodexAppServerAttempt", () => {
     );
   });
 
-  it("injects bounded MEMORY.md when memory tools are unavailable", async () => {
+  it("passes bounded MEMORY.md as Codex additional context when memory tools are unavailable", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const memorySummary = "Memory summary goes here.";
@@ -2725,12 +2744,22 @@ describe("runCodexAppServerAttempt", () => {
 
     const turnStart = harness.requests.find((request) => request.method === "turn/start");
     const turnStartParams = turnStart?.params as {
+      additionalContext?: TestCodexAdditionalContext;
       input?: Array<{ text?: string }>;
     };
     const inputText = turnStartParams.input?.[0]?.text ?? "";
+    const runtimeContext = readTestAdditionalContextValue(
+      turnStartParams.additionalContext,
+      "openclaw_runtime_context",
+    );
     expect(inputText).not.toContain("OpenClaw Workspace Memory");
     expect(inputText).not.toContain("memory_search");
-    expect(inputText).toContain(memorySummary);
+    expect(inputText).not.toContain(memorySummary);
+    expect(inputText).toBe("hello");
+    expect(runtimeContext).toContain("OpenClaw runtime context for this turn:");
+    expect(runtimeContext).toContain("OpenClaw Workspace Context");
+    expect(runtimeContext).toContain(memorySummary);
+    expect(turnStartParams.additionalContext?.openclaw_runtime_context?.kind).toBe("untrusted");
 
     const fileStats = new Map(
       result.systemPromptReport?.injectedWorkspaceFiles.map((file) => [file.name, file]) ?? [],
@@ -2853,11 +2882,16 @@ describe("runCodexAppServerAttempt", () => {
       createRuntimeDynamicTool("memory_get"),
     ]);
 
-    const { collaborationInstructions, inputText, systemPromptReport } =
+    const { additionalContext, collaborationInstructions, inputText, systemPromptReport } =
       await buildCodexTurnContextForTest(params, workspaceDir);
+    const runtimeContext = readTestAdditionalContextValue(
+      additionalContext,
+      "openclaw_runtime_context",
+    );
     expect(inputText).not.toContain("OpenClaw Workspace Memory");
     expect(inputText).not.toContain(memorySummary);
-    expect(inputText).toContain(hookContext);
+    expect(inputText).not.toContain(hookContext);
+    expect(runtimeContext).toContain(hookContext);
     expect(collaborationInstructions).toContain("OpenClaw Workspace Memory");
     expect(collaborationInstructions).not.toContain(memorySummary);
 
@@ -2908,11 +2942,16 @@ describe("runCodexAppServerAttempt", () => {
     params.runtimePlan = createCodexRuntimePlanFixture();
     setAgentWorkspaceForTest(params, workspaceDir);
 
-    const { collaborationInstructions, inputText, systemPromptReport } =
+    const { additionalContext, collaborationInstructions, inputText, systemPromptReport } =
       await buildCodexTurnContextForTest(params, workspaceDir);
+    const runtimeContext = readTestAdditionalContextValue(
+      additionalContext,
+      "openclaw_runtime_context",
+    );
     expect(inputText).not.toContain("OpenClaw Workspace Memory");
     expect(inputText).not.toContain(rootMemory);
-    expect(inputText).toContain(nestedMemory);
+    expect(inputText).not.toContain(nestedMemory);
+    expect(runtimeContext).toContain(nestedMemory);
     expect(collaborationInstructions).toContain("OpenClaw Workspace Memory");
     expect(collaborationInstructions).not.toContain(rootMemory);
     expect(collaborationInstructions).not.toContain(nestedMemory);
@@ -2950,12 +2989,17 @@ describe("runCodexAppServerAttempt", () => {
     params.runtimePlan = createCodexRuntimePlanFixture();
     setAgentWorkspaceForTest(params, path.join(tempDir, "memory-workspace"));
 
-    const { collaborationInstructions, inputText, systemPromptReport } =
+    const { additionalContext, collaborationInstructions, inputText, systemPromptReport } =
       await buildCodexTurnContextForTest(params, workspaceDir);
+    const runtimeContext = readTestAdditionalContextValue(
+      additionalContext,
+      "openclaw_runtime_context",
+    );
     expect(collaborationInstructions).not.toContain("## Memory Recall");
     expect(collaborationInstructions).not.toContain("OpenClaw Workspace Memory");
     expect(inputText).not.toContain("OpenClaw Workspace Memory");
-    expect(inputText).toContain(memorySummary);
+    expect(inputText).not.toContain(memorySummary);
+    expect(runtimeContext).toContain(memorySummary);
 
     const fileStats = new Map(
       systemPromptReport.injectedWorkspaceFiles.map((file) => [file.name, file]),

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -59,10 +59,10 @@ import {
 } from "./attempt-client-cleanup.js";
 import {
   buildCodexOpenClawPromptContext,
+  buildCodexOpenClawTurnPromptSubmission,
   buildCodexSystemPromptReport,
   buildCodexWorkspaceBootstrapContext,
   getCodexWorkspaceMemoryToolNames,
-  prependCodexOpenClawPromptContext,
   readContextEngineThreadBootstrapProjection,
   readMirroredSessionHistoryMessages,
   renderCodexSkillsCollaborationInstructions,
@@ -1015,12 +1015,14 @@ export async function runCodexAppServerAttempt(
       ctx: hookContext,
     });
   let promptBuild = await buildPromptFromCurrentInputs();
-  const decorateCodexTurnPromptText = (prompt: string) =>
-    prependCodexOpenClawPromptContext(prompt, openClawPromptContext, {
+  const buildCodexTurnPromptSubmission = (prompt: string) =>
+    buildCodexOpenClawTurnPromptSubmission(prompt, openClawPromptContext, {
       preservePromptWithoutContext:
         params.bootstrapContextMode === "lightweight" && params.bootstrapContextRunKind === "cron",
     });
-  let codexTurnPromptText = decorateCodexTurnPromptText(promptBuild.prompt);
+  let codexTurnPromptSubmission = buildCodexTurnPromptSubmission(promptBuild.prompt);
+  let codexTurnPromptText = codexTurnPromptSubmission.promptText;
+  let codexTurnAdditionalContext = codexTurnPromptSubmission.additionalContext;
   const buildCodexTurnCollaborationDeveloperInstructions = () =>
     buildTurnCollaborationMode(params, {
       turnScopedDeveloperInstructions: workspaceBootstrapContext.turnScopedDeveloperInstructions,
@@ -1036,7 +1038,9 @@ export async function runCodexAppServerAttempt(
     );
   const rebuildCodexPromptBuildFromCurrentProjection = async () => {
     promptBuild = await buildPromptFromCurrentInputs();
-    codexTurnPromptText = decorateCodexTurnPromptText(promptBuild.prompt);
+    codexTurnPromptSubmission = buildCodexTurnPromptSubmission(promptBuild.prompt);
+    codexTurnPromptText = codexTurnPromptSubmission.promptText;
+    codexTurnAdditionalContext = codexTurnPromptSubmission.additionalContext;
   };
   const rebuildCodexTurnPromptTextFromCurrentProjection = async () => {
     const nextPromptBuild = await buildPromptFromCurrentInputs();
@@ -1046,7 +1050,9 @@ export async function runCodexAppServerAttempt(
       ...promptBuild,
       prompt: nextPromptBuild.prompt,
     };
-    codexTurnPromptText = decorateCodexTurnPromptText(nextPromptBuild.prompt);
+    codexTurnPromptSubmission = buildCodexTurnPromptSubmission(nextPromptBuild.prompt);
+    codexTurnPromptText = codexTurnPromptSubmission.promptText;
+    codexTurnAdditionalContext = codexTurnPromptSubmission.additionalContext;
   };
   const selectNewerVisibleHistoryAfterBinding = (binding: CodexAppServerThreadBinding) => {
     const bindingUpdatedAt = Date.parse(binding.updatedAt);
@@ -2202,6 +2208,7 @@ export async function runCodexAppServerAttempt(
       cwd: codexExecutionCwd,
       appServer: pluginAppServer,
       promptText: codexTurnPromptText,
+      additionalContext: codexTurnAdditionalContext,
       sandboxPolicy: codexSandboxPolicy,
       environmentSelection: codexEnvironmentSelection,
       model: thread.model,

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -549,6 +549,29 @@ describe("Codex app-server native code mode config", () => {
     expect(request.personality).toBe("none");
   });
 
+  it("keeps Codex additional context separate from turn text input", () => {
+    const request = buildTurnStartParams(createAttemptParams({ provider: "openai" }), {
+      threadId: "thread-1",
+      cwd: "/repo",
+      appServer: createAppServerOptions() as never,
+      promptText: "hello",
+      additionalContext: {
+        openclaw_runtime_context: {
+          kind: "untrusted",
+          value: "OpenClaw runtime context for this turn:\nreference",
+        },
+      },
+    });
+
+    expect(request.input).toEqual([{ type: "text", text: "hello", text_elements: [] }]);
+    expect(request.additionalContext).toEqual({
+      openclaw_runtime_context: {
+        kind: "untrusted",
+        value: "OpenClaw runtime context for this turn:\nreference",
+      },
+    });
+  });
+
   it("allows thread config to opt into Codex code-mode-only", () => {
     const request = buildThreadStartParams(createAttemptParams({ provider: "openai" }), {
       cwd: "/repo",

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -1398,6 +1398,7 @@ export function buildTurnStartParams(
     cwd: string;
     appServer: CodexAppServerRuntimeOptions;
     promptText?: string;
+    additionalContext?: CodexTurnStartParams["additionalContext"];
     sandboxPolicy?: CodexSandboxPolicy;
     environmentSelection?: CodexTurnEnvironmentParams[];
     model?: string | null;
@@ -1420,6 +1421,7 @@ export function buildTurnStartParams(
   return {
     threadId: options.threadId,
     input: buildUserInput(params, options.promptText),
+    ...(options.additionalContext ? { additionalContext: options.additionalContext } : {}),
     cwd: options.cwd,
     approvalPolicy: options.appServer.approvalPolicy,
     approvalsReviewer: options.appServer.approvalsReviewer,

--- a/extensions/codex/test-api.ts
+++ b/extensions/codex/test-api.ts
@@ -13,7 +13,11 @@ import {
 import type { CodexPluginConfig } from "./src/app-server/config.js";
 import { filterCodexDynamicTools } from "./src/app-server/dynamic-tool-profile.js";
 import { createCodexDynamicToolBridge } from "./src/app-server/dynamic-tools.js";
-import type { CodexDynamicToolSpec, JsonObject } from "./src/app-server/protocol.js";
+import type {
+  CodexDynamicToolSpec,
+  CodexTurnStartParams,
+  JsonObject,
+} from "./src/app-server/protocol.js";
 import {
   buildDeveloperInstructions,
   buildThreadResumeParams,
@@ -48,6 +52,7 @@ export function buildCodexHarnessPromptSnapshot(params: {
   appServer: CodexAppServerRuntimeOptions;
   config?: JsonObject;
   promptText?: string;
+  additionalContext?: CodexTurnStartParams["additionalContext"];
   developerInstructionAdditions?: string;
   turnScopedDeveloperInstructions?: string;
   heartbeatCollaborationInstructions?: string;
@@ -78,6 +83,7 @@ export function buildCodexHarnessPromptSnapshot(params: {
       cwd: params.cwd,
       appServer: params.appServer,
       promptText: params.promptText,
+      additionalContext: params.additionalContext,
       turnScopedDeveloperInstructions: params.turnScopedDeveloperInstructions,
       heartbeatCollaborationInstructions: params.heartbeatCollaborationInstructions,
     }),

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/README.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/README.md
@@ -8,9 +8,9 @@ These fixtures capture the default OpenAI/Codex happy path for prompt review:
 - Codex harness default coverage for tool-only visible source replies.
 - Telegram direct chat, Discord group chat, and a heartbeat turn with `heartbeat_respond` available through searchable dynamic tools.
 
-The Markdown files show selected app-server thread/turn params plus a reconstructed model-bound prompt layer stack: Codex `gpt-5.5` model instructions from a pinned Codex model catalog fixture, Codex permission developer instructions for the happy-path yolo profile, OpenClaw developer instructions, turn input with simulated OpenClaw workspace bootstrap runtime context, heartbeat collaboration-mode guidance when applicable, and references to the complete dynamic tool catalog.
+The Markdown files show selected app-server thread/turn params plus a reconstructed model-bound prompt layer stack: Codex `gpt-5.5` model instructions from a pinned Codex model catalog fixture, Codex permission developer instructions for the happy-path yolo profile, OpenClaw developer instructions, transient Codex additional context with simulated OpenClaw workspace bootstrap runtime context, real turn input text, heartbeat collaboration-mode guidance when applicable, and references to the complete dynamic tool catalog.
 
-The workspace bootstrap simulation includes dummy workspace contents so prompt reviewers can see how OpenClaw routes stable profile files into Codex developer instructions, keeps `MEMORY.md` in turn input, and points heartbeat turns at `HEARTBEAT.md` without inlining it. `AGENTS.md` is intentionally not repeated here because Codex loads it natively.
+The workspace bootstrap simulation includes dummy workspace contents so prompt reviewers can see how OpenClaw routes stable profile files into Codex developer instructions, keeps `MEMORY.md` in transient Codex additional context, and points heartbeat turns at `HEARTBEAT.md` without inlining it. `AGENTS.md` is intentionally not repeated here because Codex loads it natively.
 
 The tool catalog is pinned to the canonical happy-path OpenClaw tools so optional locally installed plugin tools do not create fixture churn.
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -7,7 +7,7 @@
 - Default happy path: the same Codex agent is mentioned in a Discord group/channel while Telegram can remain the user's primary direct interface.
 - Group-visible output must be explicit through the message tool; the model is also told to mostly lurk unless directly addressed or clearly useful.
 - This captures the OpenClaw-owned Codex app-server inputs and reconstructs the stable Codex model/permission layers from committed Codex prompt fixtures.
-- This also simulates Codex workspace bootstrap routing: `TOOLS.md` as inherited developer instructions, `SOUL.md`, `IDENTITY.md`, and `USER.md` as turn-scoped collaboration instructions, `MEMORY.md` in turn input, and `HEARTBEAT.md` as a heartbeat-only file pointer.
+- This also simulates Codex workspace bootstrap routing: `TOOLS.md` as inherited developer instructions, `SOUL.md`, `IDENTITY.md`, and `USER.md` as turn-scoped collaboration instructions, `MEMORY.md` in transient Codex additional context, and `HEARTBEAT.md` as a heartbeat-only file pointer.
 
 ## Scenario Metadata
 
@@ -138,6 +138,12 @@
 
 ```json
 {
+  "additionalContext": {
+    "openclaw_runtime_context": {
+      "kind": "untrusted",
+      "value": "OpenClaw runtime context for this turn:\nTreat this OpenClaw-provided context as supporting project/user reference for the current request.\n\n## OpenClaw Workspace Context\n\nOpenClaw loaded these user-editable workspace files for the current turn. Codex loads AGENTS.md natively. TOOLS.md is provided as inherited Codex developer instructions. SOUL.md, IDENTITY.md, and USER.md are provided as turn-scoped collaboration instructions so native Codex subagents do not inherit them. HEARTBEAT.md is handled by heartbeat collaboration-mode guidance. Those files are not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\n\n## /tmp/openclaw-happy-path/workspace/MEMORY.md\n\n<MEMORY.md contents will be here>"
+    }
+  },
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
   "collaborationMode": {
@@ -168,7 +174,7 @@
 
 ## Reconstructed Model-Bound Prompt Layers
 
-This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, Codex thread config instructions when present, OpenClaw developer instructions, turn-scoped collaboration-mode instructions when OpenClaw provides them, turn input with OpenClaw runtime context, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as native workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and built-in collaboration-mode instructions inside the Codex runtime.
+This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, Codex thread config instructions when present, OpenClaw developer instructions, turn-scoped collaboration-mode instructions when OpenClaw provides them, transient Codex additional context for OpenClaw runtime references, the real turn input text, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as native workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and built-in collaboration-mode instructions inside the Codex runtime.
 
 ### Layer Metadata
 
@@ -201,7 +207,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "developerInstructionsFrom": "extensions/codex app-server thread/start developerInstructions",
     "dynamicToolsFrom": "codex-dynamic-tools.discord-group.json",
     "userInputFrom": "extensions/codex app-server turn/start input",
-    "workspaceBootstrapContextFrom": "extensions/codex app-server turn/start input OpenClaw runtime context"
+    "workspaceBootstrapContextFrom": "extensions/codex app-server turn/start additionalContext.openclaw_runtime_context"
   }
 }
 ```
@@ -210,6 +216,10 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
 
 ```json
 {
+  "codexAdditionalContext": {
+    "chars": 773,
+    "roughTokens": 194
+  },
   "codexCollaborationModeDeveloperInstructions": {
     "chars": 1433,
     "roughTokens": 359
@@ -235,16 +245,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 747
   },
   "totalTextOnly": {
-    "chars": 27700,
-    "roughTokens": 6925
+    "chars": 27716,
+    "roughTokens": 6929
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78344,
-    "roughTokens": 19586
+    "chars": 78360,
+    "roughTokens": 19590
   },
   "userInputText": {
-    "chars": 1629,
-    "roughTokens": 408
+    "chars": 870,
+    "roughTokens": 218
   }
 }
 ```
@@ -495,9 +505,10 @@ OpenClaw loaded these workspace instruction files from the active agent workspac
 <USER.md contents will be here>
 ```
 
-### User: Turn Input Text
+### User: Codex Additional Context
 
-````text
+```text
+openclaw_runtime_context (untrusted):
 OpenClaw runtime context for this turn:
 Treat this OpenClaw-provided context as supporting project/user reference for the current request.
 
@@ -512,8 +523,11 @@ The following project context files have been loaded:
 ## /tmp/openclaw-happy-path/workspace/MEMORY.md
 
 <MEMORY.md contents will be here>
+```
 
-Current user request:
+### User: Turn Input Text
+
+````text
 Conversation info (untrusted metadata):
 ```json
 {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -7,7 +7,7 @@
 - Default happy path: OpenAI model through the Codex harness/runtime, Telegram direct conversation, and message-tool-only visible replies.
 - A quiet turn is represented by not calling `message(action=send)`; the normal final assistant text is private to OpenClaw/Codex.
 - This captures the OpenClaw-owned Codex app-server inputs and reconstructs the stable Codex model/permission layers from committed Codex prompt fixtures.
-- This also simulates Codex workspace bootstrap routing: `TOOLS.md` as inherited developer instructions, `SOUL.md`, `IDENTITY.md`, and `USER.md` as turn-scoped collaboration instructions, `MEMORY.md` in turn input, and `HEARTBEAT.md` as a heartbeat-only file pointer.
+- This also simulates Codex workspace bootstrap routing: `TOOLS.md` as inherited developer instructions, `SOUL.md`, `IDENTITY.md`, and `USER.md` as turn-scoped collaboration instructions, `MEMORY.md` in transient Codex additional context, and `HEARTBEAT.md` as a heartbeat-only file pointer.
 
 ## Scenario Metadata
 
@@ -138,6 +138,12 @@
 
 ```json
 {
+  "additionalContext": {
+    "openclaw_runtime_context": {
+      "kind": "untrusted",
+      "value": "OpenClaw runtime context for this turn:\nTreat this OpenClaw-provided context as supporting project/user reference for the current request.\n\n## OpenClaw Workspace Context\n\nOpenClaw loaded these user-editable workspace files for the current turn. Codex loads AGENTS.md natively. TOOLS.md is provided as inherited Codex developer instructions. SOUL.md, IDENTITY.md, and USER.md are provided as turn-scoped collaboration instructions so native Codex subagents do not inherit them. HEARTBEAT.md is handled by heartbeat collaboration-mode guidance. Those files are not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\n\n## /tmp/openclaw-happy-path/workspace/MEMORY.md\n\n<MEMORY.md contents will be here>"
+    }
+  },
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
   "collaborationMode": {
@@ -168,7 +174,7 @@
 
 ## Reconstructed Model-Bound Prompt Layers
 
-This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, Codex thread config instructions when present, OpenClaw developer instructions, turn-scoped collaboration-mode instructions when OpenClaw provides them, turn input with OpenClaw runtime context, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as native workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and built-in collaboration-mode instructions inside the Codex runtime.
+This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, Codex thread config instructions when present, OpenClaw developer instructions, turn-scoped collaboration-mode instructions when OpenClaw provides them, transient Codex additional context for OpenClaw runtime references, the real turn input text, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as native workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and built-in collaboration-mode instructions inside the Codex runtime.
 
 ### Layer Metadata
 
@@ -201,7 +207,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "developerInstructionsFrom": "extensions/codex app-server thread/start developerInstructions",
     "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
     "userInputFrom": "extensions/codex app-server turn/start input",
-    "workspaceBootstrapContextFrom": "extensions/codex app-server turn/start input OpenClaw runtime context"
+    "workspaceBootstrapContextFrom": "extensions/codex app-server turn/start additionalContext.openclaw_runtime_context"
   }
 }
 ```
@@ -210,6 +216,10 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
 
 ```json
 {
+  "codexAdditionalContext": {
+    "chars": 773,
+    "roughTokens": 194
+  },
   "codexCollaborationModeDeveloperInstructions": {
     "chars": 1433,
     "roughTokens": 359
@@ -235,16 +245,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 491
   },
   "totalTextOnly": {
-    "chars": 26176,
-    "roughTokens": 6544
+    "chars": 26192,
+    "roughTokens": 6548
   },
   "totalWithDynamicToolsJson": {
-    "chars": 76489,
-    "roughTokens": 19123
+    "chars": 76505,
+    "roughTokens": 19127
   },
   "userInputText": {
-    "chars": 1129,
-    "roughTokens": 283
+    "chars": 370,
+    "roughTokens": 93
   }
 }
 ```
@@ -493,9 +503,10 @@ OpenClaw loaded these workspace instruction files from the active agent workspac
 <USER.md contents will be here>
 ```
 
-### User: Turn Input Text
+### User: Codex Additional Context
 
-````text
+```text
+openclaw_runtime_context (untrusted):
 OpenClaw runtime context for this turn:
 Treat this OpenClaw-provided context as supporting project/user reference for the current request.
 
@@ -510,8 +521,11 @@ The following project context files have been loaded:
 ## /tmp/openclaw-happy-path/workspace/MEMORY.md
 
 <MEMORY.md contents will be here>
+```
 
-Current user request:
+### User: Turn Input Text
+
+````text
 Conversation info (untrusted metadata):
 ```json
 {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -7,7 +7,7 @@
 - Heartbeat happy path: Codex receives the structured `heartbeat_respond` dynamic tool in the searchable catalog instead of the initial tool context.
 - The heartbeat tool still carries the notify/no-notify decision, outcome, summary, and optional notification text instead of relying only on final-text parsing.
 - This captures the OpenClaw-owned Codex app-server inputs and reconstructs the stable Codex model/permission layers from committed Codex prompt fixtures.
-- This also simulates Codex workspace bootstrap routing: `TOOLS.md` as inherited developer instructions, `SOUL.md`, `IDENTITY.md`, and `USER.md` as turn-scoped collaboration instructions, `MEMORY.md` in turn input, and `HEARTBEAT.md` as a heartbeat-only file pointer.
+- This also simulates Codex workspace bootstrap routing: `TOOLS.md` as inherited developer instructions, `SOUL.md`, `IDENTITY.md`, and `USER.md` as turn-scoped collaboration instructions, `MEMORY.md` in transient Codex additional context, and `HEARTBEAT.md` as a heartbeat-only file pointer.
 
 ## Scenario Metadata
 
@@ -139,6 +139,12 @@
 
 ```json
 {
+  "additionalContext": {
+    "openclaw_runtime_context": {
+      "kind": "untrusted",
+      "value": "OpenClaw runtime context for this turn:\nTreat this OpenClaw-provided context as supporting project/user reference for the current request.\n\n## OpenClaw Workspace Context\n\nOpenClaw loaded these user-editable workspace files for the current turn. Codex loads AGENTS.md natively. TOOLS.md is provided as inherited Codex developer instructions. SOUL.md, IDENTITY.md, and USER.md are provided as turn-scoped collaboration instructions so native Codex subagents do not inherit them. HEARTBEAT.md is handled by heartbeat collaboration-mode guidance. Those files are not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\n\n## /tmp/openclaw-happy-path/workspace/MEMORY.md\n\n<MEMORY.md contents will be here>"
+    }
+  },
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
   "collaborationMode": {
@@ -169,7 +175,7 @@
 
 ## Reconstructed Model-Bound Prompt Layers
 
-This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, Codex thread config instructions when present, OpenClaw developer instructions, turn-scoped collaboration-mode instructions when OpenClaw provides them, turn input with OpenClaw runtime context, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as native workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and built-in collaboration-mode instructions inside the Codex runtime.
+This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, Codex thread config instructions when present, OpenClaw developer instructions, turn-scoped collaboration-mode instructions when OpenClaw provides them, transient Codex additional context for OpenClaw runtime references, the real turn input text, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as native workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and built-in collaboration-mode instructions inside the Codex runtime.
 
 ### Layer Metadata
 
@@ -202,7 +208,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "developerInstructionsFrom": "extensions/codex app-server thread/start developerInstructions",
     "dynamicToolsFrom": "codex-dynamic-tools.heartbeat-turn.json",
     "userInputFrom": "extensions/codex app-server turn/start input",
-    "workspaceBootstrapContextFrom": "extensions/codex app-server turn/start input OpenClaw runtime context"
+    "workspaceBootstrapContextFrom": "extensions/codex app-server turn/start additionalContext.openclaw_runtime_context"
   }
 }
 ```
@@ -211,6 +217,10 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
 
 ```json
 {
+  "codexAdditionalContext": {
+    "chars": 773,
+    "roughTokens": 194
+  },
   "codexCollaborationModeDeveloperInstructions": {
     "chars": 2119,
     "roughTokens": 530
@@ -236,16 +246,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 496
   },
   "totalTextOnly": {
-    "chars": 27119,
-    "roughTokens": 6780
+    "chars": 27135,
+    "roughTokens": 6784
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78722,
-    "roughTokens": 19681
+    "chars": 78738,
+    "roughTokens": 19685
   },
   "userInputText": {
-    "chars": 1367,
-    "roughTokens": 342
+    "chars": 608,
+    "roughTokens": 152
   }
 }
 ```
@@ -503,9 +513,10 @@ HEARTBEAT.md exists in the active agent workspace. Read it before proceeding wit
 - /tmp/openclaw-happy-path/workspace/HEARTBEAT.md
 ```
 
-### User: Turn Input Text
+### User: Codex Additional Context
 
-````text
+```text
+openclaw_runtime_context (untrusted):
 OpenClaw runtime context for this turn:
 Treat this OpenClaw-provided context as supporting project/user reference for the current request.
 
@@ -520,8 +531,11 @@ The following project context files have been loaded:
 ## /tmp/openclaw-happy-path/workspace/MEMORY.md
 
 <MEMORY.md contents will be here>
+```
 
-Current user request:
+### User: Turn Input Text
+
+````text
 Conversation info (untrusted metadata):
 ```json
 {

--- a/test/helpers/agents/happy-path-prompt-snapshots.ts
+++ b/test/helpers/agents/happy-path-prompt-snapshots.ts
@@ -100,6 +100,7 @@ type CodexPromptSnapshotApi = {
     appServer: unknown;
     config?: Record<string, unknown>;
     promptText?: string;
+    additionalContext?: Record<string, { kind: "untrusted" | "application"; value: string }>;
     developerInstructionAdditions?: string;
     turnScopedDeveloperInstructions?: string;
     heartbeatCollaborationInstructions?: string;
@@ -665,12 +666,16 @@ function renderModelBoundPromptLayers(params: {
       ? params.codexSnapshot.turnStartParams.collaborationMode.settings.developer_instructions
       : "";
   const turnInputText = readCodexTurnInputText(params.codexSnapshot.turnStartParams);
+  const additionalContextText = readCodexAdditionalContextText(
+    params.codexSnapshot.turnStartParams,
+  );
   const textOnlyTotal = [
     codexModelInstructions,
     CODEX_YOLO_PERMISSION_INSTRUCTIONS,
     codexConfigInstructions,
     openClawDeveloperInstructions,
     codexCollaborationModeInstructions,
+    additionalContextText,
     turnInputText,
   ]
     .filter(Boolean)
@@ -680,7 +685,7 @@ function renderModelBoundPromptLayers(params: {
   return [
     "## Reconstructed Model-Bound Prompt Layers",
     "",
-    "This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, Codex thread config instructions when present, OpenClaw developer instructions, turn-scoped collaboration-mode instructions when OpenClaw provides them, turn input with OpenClaw runtime context, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as native workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and built-in collaboration-mode instructions inside the Codex runtime.",
+    "This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, Codex thread config instructions when present, OpenClaw developer instructions, turn-scoped collaboration-mode instructions when OpenClaw provides them, transient Codex additional context for OpenClaw runtime references, the real turn input text, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as native workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and built-in collaboration-mode instructions inside the Codex runtime.",
     "",
     "### Layer Metadata",
     "",
@@ -699,7 +704,7 @@ function renderModelBoundPromptLayers(params: {
         openClawRuntime: {
           configInstructionsFrom: "extensions/codex app-server thread/start config.instructions",
           workspaceBootstrapContextFrom:
-            "extensions/codex app-server turn/start input OpenClaw runtime context",
+            "extensions/codex app-server turn/start additionalContext.openclaw_runtime_context",
           developerInstructionsFrom:
             "extensions/codex app-server thread/start developerInstructions",
           collaborationModeDeveloperInstructionsFrom:
@@ -724,6 +729,7 @@ function renderModelBoundPromptLayers(params: {
         codexWorkspaceBootstrapConfigInstructions: textStats(codexConfigInstructions),
         openClawDeveloperInstructions: textStats(openClawDeveloperInstructions),
         codexCollaborationModeDeveloperInstructions: textStats(codexCollaborationModeInstructions),
+        codexAdditionalContext: textStats(additionalContextText),
         userInputText: textStats(turnInputText),
         dynamicToolsJson: textStats(params.dynamicToolsJson),
         totalTextOnly: textStats(textOnlyTotal),
@@ -753,6 +759,10 @@ function renderModelBoundPromptLayers(params: {
       ? markdownFence("text", codexCollaborationModeInstructions)
       : "This turn asks Codex app-server to resolve its built-in Default collaboration-mode instructions at runtime.",
     "",
+    "### User: Codex Additional Context",
+    "",
+    markdownFence("text", additionalContextText),
+    "",
     "### User: Turn Input Text",
     "",
     markdownFence("text", turnInputText),
@@ -778,6 +788,32 @@ function readCodexTurnInputText(turnStartParams: { input?: unknown }): string {
   return firstText?.text ?? "";
 }
 
+function readCodexAdditionalContextText(turnStartParams: { additionalContext?: unknown }): string {
+  const additionalContext = turnStartParams.additionalContext;
+  if (
+    !additionalContext ||
+    typeof additionalContext !== "object" ||
+    Array.isArray(additionalContext)
+  ) {
+    return "";
+  }
+  return Object.entries(additionalContext)
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        return undefined;
+      }
+      const value = (entry as { value?: unknown }).value;
+      const kind = (entry as { kind?: unknown }).kind;
+      if (typeof value !== "string" || typeof kind !== "string") {
+        return undefined;
+      }
+      return `${key} (${kind}):\n${value}`;
+    })
+    .filter((section): section is string => Boolean(section))
+    .join("\n\n");
+}
+
 function buildCodexOpenClawRuntimeContext(): string {
   return [
     "OpenClaw runtime context for this turn:",
@@ -789,8 +825,16 @@ function buildCodexOpenClawRuntimeContext(): string {
   ].join("\n");
 }
 
-function prependCodexOpenClawRuntimeContext(prompt: string): string {
-  return [buildCodexOpenClawRuntimeContext(), "", "Current user request:", prompt].join("\n");
+function buildCodexOpenClawRuntimeAdditionalContext(): Record<
+  string,
+  { kind: "untrusted"; value: string }
+> {
+  return {
+    openclaw_runtime_context: {
+      kind: "untrusted",
+      value: buildCodexOpenClawRuntimeContext(),
+    },
+  };
 }
 
 function renderScenarioSnapshot(
@@ -802,7 +846,6 @@ function renderScenarioSnapshot(
     sessionKey: scenario.ctx.SessionKey ?? `agent:main:${scenario.id}`,
   });
   const appServer = codexApi.resolveCodexPromptSnapshotAppServerOptions();
-  const codexTurnPromptText = prependCodexOpenClawRuntimeContext(scenario.prompt);
   const codexSnapshot = codexApi.buildCodexHarnessPromptSnapshot({
     attempt,
     cwd: WORKSPACE_DIR,
@@ -810,7 +853,8 @@ function renderScenarioSnapshot(
     dynamicTools: scenario.dynamicTools,
     appServer,
     config: CODEX_PROMPT_SNAPSHOT_THREAD_CONFIG,
-    promptText: codexTurnPromptText,
+    promptText: scenario.prompt,
+    additionalContext: buildCodexOpenClawRuntimeAdditionalContext(),
     developerInstructionAdditions: CODEX_WORKSPACE_THREAD_DEVELOPER_INSTRUCTIONS,
     turnScopedDeveloperInstructions: CODEX_WORKSPACE_TURN_SCOPED_DEVELOPER_INSTRUCTIONS,
     heartbeatCollaborationInstructions:
@@ -830,7 +874,7 @@ function renderScenarioSnapshot(
     "",
     ...scenario.notes.map((note) => `- ${note}`),
     "- This captures the OpenClaw-owned Codex app-server inputs and reconstructs the stable Codex model/permission layers from committed Codex prompt fixtures.",
-    "- This also simulates Codex workspace bootstrap routing: `TOOLS.md` as inherited developer instructions, `SOUL.md`, `IDENTITY.md`, and `USER.md` as turn-scoped collaboration instructions, `MEMORY.md` in turn input, and `HEARTBEAT.md` as a heartbeat-only file pointer.",
+    "- This also simulates Codex workspace bootstrap routing: `TOOLS.md` as inherited developer instructions, `SOUL.md`, `IDENTITY.md`, and `USER.md` as turn-scoped collaboration instructions, `MEMORY.md` in transient Codex additional context, and `HEARTBEAT.md` as a heartbeat-only file pointer.",
     "",
     "## Scenario Metadata",
     "",
@@ -898,9 +942,9 @@ function renderReadme(scenarios: PromptScenario[]): string {
     "- Codex harness default coverage for tool-only visible source replies.",
     "- Telegram direct chat, Discord group chat, and a heartbeat turn with `heartbeat_respond` available through searchable dynamic tools.",
     "",
-    "The Markdown files show selected app-server thread/turn params plus a reconstructed model-bound prompt layer stack: Codex `gpt-5.5` model instructions from a pinned Codex model catalog fixture, Codex permission developer instructions for the happy-path yolo profile, OpenClaw developer instructions, turn input with simulated OpenClaw workspace bootstrap runtime context, heartbeat collaboration-mode guidance when applicable, and references to the complete dynamic tool catalog.",
+    "The Markdown files show selected app-server thread/turn params plus a reconstructed model-bound prompt layer stack: Codex `gpt-5.5` model instructions from a pinned Codex model catalog fixture, Codex permission developer instructions for the happy-path yolo profile, OpenClaw developer instructions, transient Codex additional context with simulated OpenClaw workspace bootstrap runtime context, real turn input text, heartbeat collaboration-mode guidance when applicable, and references to the complete dynamic tool catalog.",
     "",
-    "The workspace bootstrap simulation includes dummy workspace contents so prompt reviewers can see how OpenClaw routes stable profile files into Codex developer instructions, keeps `MEMORY.md` in turn input, and points heartbeat turns at `HEARTBEAT.md` without inlining it. `AGENTS.md` is intentionally not repeated here because Codex loads it natively.",
+    "The workspace bootstrap simulation includes dummy workspace contents so prompt reviewers can see how OpenClaw routes stable profile files into Codex developer instructions, keeps `MEMORY.md` in transient Codex additional context, and points heartbeat turns at `HEARTBEAT.md` without inlining it. `AGENTS.md` is intentionally not repeated here because Codex loads it natively.",
     "",
     "The tool catalog is pinned to the canonical happy-path OpenClaw tools so optional locally installed plugin tools do not create fixture churn.",
     "",

--- a/test/scripts/prompt-snapshots.test.ts
+++ b/test/scripts/prompt-snapshots.test.ts
@@ -159,14 +159,30 @@ describe("happy path prompt snapshots", () => {
     );
     expect(telegram).toContain("### User: Codex Config Instructions");
     expect(telegram).toContain("### User: Turn Input Text");
-    expect(telegram).toContain("OpenClaw runtime context for this turn:");
+    expect(telegram).toContain("### User: Codex Additional Context");
+    const additionalContext = renderedPromptSection(
+      telegram,
+      "### User: Codex Additional Context",
+      "### User: Turn Input Text",
+    );
+    const turnInputText = renderedPromptSection(
+      telegram,
+      "### User: Turn Input Text",
+      "### Tools: Dynamic Tool Catalog",
+    );
+    expect(turnInputText).not.toContain("OpenClaw runtime context for this turn:");
+    expect(additionalContext).toContain("OpenClaw runtime context for this turn:");
     expect(telegram).toContain("<SOUL.md contents will be here>");
     expect(telegram).toContain("<IDENTITY.md contents will be here>");
     expect(telegram).toContain("<TOOLS.md contents will be here>");
     expect(telegram).toContain("<USER.md contents will be here>");
-    expect(telegram).toContain("<MEMORY.md contents will be here>");
-    expect(telegram).not.toContain("<HEARTBEAT.md contents will be here>");
-    expect(telegram).toContain("Codex loads AGENTS.md natively");
+    expect(additionalContext).toContain("<MEMORY.md contents will be here>");
+    expect(additionalContext).not.toContain("<SOUL.md contents will be here>");
+    expect(additionalContext).not.toContain("<IDENTITY.md contents will be here>");
+    expect(additionalContext).not.toContain("<TOOLS.md contents will be here>");
+    expect(additionalContext).not.toContain("<USER.md contents will be here>");
+    expect(additionalContext).not.toContain("<HEARTBEAT.md contents will be here>");
+    expect(additionalContext).toContain("Codex loads AGENTS.md natively");
     expect(telegram).toContain("### Tools: Dynamic Tool Catalog");
   });
 


### PR DESCRIPTION
## Summary

Closes #84662.

- Route OpenClaw per-turn runtime context through Codex `turn/start.additionalContext` instead of prepending it to the visible user input text.
- Keep delivery metadata out of the user request by sending it as `openclaw_delivery_metadata` additional context.
- Extend Codex app-server protocol typings, turn/start construction, run-attempt prompt assembly, prompt snapshots, and tests to assert the separation.
- Short-circuit provider-qualified Codex model override web-search capability probing before leasing an app-server client, preserving managed `web_search` for local/provider-specific overrides.

## Root Cause

OpenClaw previously prepended workspace/runtime context and some delivery metadata into the same text field passed as Codex `turn/start.input`. Codex persists native user history for the real turn input, so every turn could make OpenClaw runtime context look like user-authored history and grow future model input.

## Codex Source Checked

Sibling Codex checkout inspected at `../codex` commit `5b22a8e`.

- `codex-rs/app-server-protocol/src/protocol/v2/turn.rs:44-84` defines `AdditionalContextKind`, `AdditionalContextEntry`, and experimental `TurnStartParams.additional_context`.
- `codex-rs/app-server/src/request_processors/turn_processor.rs:28-42` maps v2 additional context into core entries, and `:445-477` passes it on `Op::UserInput`.
- `codex-rs/protocol/src/protocol.rs:526-535` shows core `Op::UserInput` carries `additional_context` separately from `items`.
- `codex-rs/core/src/session/handlers.rs:245-255` and `codex-rs/core/src/session/mod.rs:3409-3427` merge additional context into response items before appending the real `TurnInput::UserInput`.
- `codex-rs/core/src/state/additional_context.rs:20-35` maps `Untrusted` entries to `AdditionalContextUserFragment`, and `codex-rs/context-fragments/src/additional_context.rs:21-24` confirms that fragment is user-role context rather than developer authority.
- `codex-rs/app-server/tests/suite/v2/turn_start.rs:318-358` already exercises additional context flowing to model input.

## Real behavior proof

Behavior addressed:
OpenClaw Codex turns now keep runtime context and delivery routing metadata out of the native turn input text while still providing them to Codex as transient untrusted additional context for the current turn.

Real environment tested:
Local OpenClaw checkout on this branch after `pnpm build`, invoking the actual `extensions/codex/src/app-server` implementation with `node --import tsx` outside Vitest/mocks.

Exact steps or command run after this patch:

```sh
node --import tsx - <<'TS'
import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "openclaw/plugin-sdk/message-tool-delivery-hints";
import { buildCodexOpenClawTurnPromptSubmission } from "./extensions/codex/src/app-server/attempt-context.ts";
import { resolveCodexAppServerRuntimeOptions } from "./extensions/codex/src/app-server/config.ts";
import { buildTurnStartParams } from "./extensions/codex/src/app-server/thread-lifecycle.ts";

const runtimeContext = [
  "OpenClaw runtime context for this turn:",
  "## OpenClaw Workspace Context",
  "## /tmp/openclaw-smoke/MEMORY.md",
  "remembered harness preference",
].join("\n");
const prompt = `${MESSAGE_TOOL_ONLY_DELIVERY_HINT}\n\nFix issue #84662 without hiding the user's request.`;
const submission = buildCodexOpenClawTurnPromptSubmission(prompt, runtimeContext);
const turnStart = buildTurnStartParams(
  {
    prompt,
    provider: "codex",
    modelId: "gpt-5.4-codex",
    model: { provider: "codex", input: ["text"] },
    thinkLevel: "medium",
    authProfileStore: { version: 1, profiles: {} },
    config: {},
  } as never,
  {
    threadId: "thread-smoke",
    cwd: process.cwd(),
    appServer: resolveCodexAppServerRuntimeOptions({ env: {}, openClawSandboxActive: false }),
    promptText: submission.promptText,
    additionalContext: submission.additionalContext,
  },
);
const inputText = turnStart.input?.[0]?.text ?? "";
const additionalContext = turnStart.additionalContext ?? {};
const runtime = additionalContext.openclaw_runtime_context;
const delivery = additionalContext.openclaw_delivery_metadata;
console.log(JSON.stringify({
  inputText,
  inputContainsRuntimeContext: inputText.includes("OpenClaw runtime context for this turn:"),
  inputContainsDeliveryHint: inputText.includes("Delivery:"),
  additionalContextKeys: Object.keys(additionalContext).sort(),
  runtimeKind: runtime?.kind,
  runtimeContainsMemoryReference: runtime?.value.includes("MEMORY.md") ?? false,
  deliveryKind: delivery?.kind,
  deliveryContainsHint: delivery?.value.includes("Final assistant text is not automatically delivered") ?? false,
}, null, 2));
TS
```

Evidence after fix:

```json
{
  "inputText": "Fix issue #84662 without hiding the user's request.",
  "inputContainsRuntimeContext": false,
  "inputContainsDeliveryHint": false,
  "additionalContextKeys": [
    "openclaw_delivery_metadata",
    "openclaw_runtime_context"
  ],
  "runtimeKind": "untrusted",
  "runtimeContainsMemoryReference": true,
  "deliveryKind": "untrusted",
  "deliveryContainsHint": true
}
```

Observed result after fix:
The real turn input contains only the user's request. The OpenClaw runtime context and delivery hint are present under untrusted `additionalContext` keys, matching the Codex app-server path that does not store them as native user input text.

What was not tested:
I did not run a fresh `$autoreview` because this Codex session exposed no callable `$autoreview` tool (`tool_search` for `$autoreview` returned 0 tools). I also did not drive a full live Codex app-server process against the Responses API; the live smoke above exercises the actual OpenClaw app-server request construction code locally.

## Validation

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts extensions/codex/src/app-server/compact.test.ts extensions/codex/src/app-server/provider-capabilities.test.ts test/scripts/prompt-snapshots.test.ts`
- `node --import tsx scripts/generate-prompt-snapshots.ts --check`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false`
- `node_modules/.bin/oxfmt --check --threads=1 ...changed TS files...`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json ...changed extension TS files...`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json test/helpers/agents/happy-path-prompt-snapshots.ts test/scripts/prompt-snapshots.test.ts`
- `git diff --check`
- `pnpm build`
