### PR TITLE
fix(mcp): serialize OAuth refresh tokens

### DIFF
--- a/src/agents/mcp-oauth.test.ts
+++ b/src/agents/mcp-oauth.test.ts
@@ -236,14 +236,16 @@ describe("MCP OAuth provider", () => {
           expect(fetchFn).toHaveBeenCalledOnce();
         });
 
-        expect(provider.saveClientInformation).toBeDefined();
-        await provider.saveClientInformation?.({ client_id: "client-after-refresh-started" });
+        const pendingClientInformationSave = provider.saveClientInformation?.({
+          client_id: "client-after-refresh-started",
+        });
         expect(resolveRefresh).toBeDefined();
         resolveRefresh?.();
         await expect(pendingRefresh.then((response) => response.json())).resolves.toMatchObject({
           access_token: "new-access",
           refresh_token: "new-refresh",
         });
+        await pendingClientInformationSave;
 
         expect(await provider.clientInformation()).toMatchObject({
           client_id: "client-after-refresh-started",
@@ -255,6 +257,117 @@ describe("MCP OAuth provider", () => {
       },
       {
         prefix: "openclaw-mcp-oauth-refresh-store-merge-",
+        skipSessionCleanup: true,
+        env: {
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+      },
+    );
+  });
+
+  it("does not persist invalid 200 refresh token responses before SDK validation", async () => {
+    await withTempHome(
+      async () => {
+        const provider = createMcpOAuthClientProvider({
+          serverName: "Remote Docs",
+          serverUrl: "https://mcp.example.com/mcp",
+        });
+        await provider.saveTokens({
+          access_token: "old-access",
+          refresh_token: "old-refresh",
+          token_type: "Bearer",
+        });
+
+        const fetchFn = vi.fn(async () => {
+          return new Response(
+            JSON.stringify({
+              refresh_token: "new-refresh",
+              token_type: "Bearer",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        });
+
+        await expect(
+          provider.wrapFetchForTokenRefresh(fetchFn)(new URL("https://auth.example.com/token"), {
+            method: "POST",
+            body: new URLSearchParams({
+              grant_type: "refresh_token",
+              refresh_token: "old-refresh",
+            }),
+          }),
+        ).rejects.toThrow();
+
+        await expect(provider.tokens()).resolves.toMatchObject({
+          access_token: "old-access",
+          refresh_token: "old-refresh",
+        });
+      },
+      {
+        prefix: "openclaw-mcp-oauth-invalid-refresh-response-",
+        skipSessionCleanup: true,
+        env: {
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+      },
+    );
+  });
+
+  it("merges the SDK follow-up refresh save with concurrent OAuth metadata writes", async () => {
+    await withTempHome(
+      async () => {
+        const provider = createMcpOAuthClientProvider({
+          serverName: "Remote Docs",
+          serverUrl: "https://mcp.example.com/mcp",
+        });
+        await provider.saveTokens({
+          access_token: "old-access",
+          refresh_token: "old-refresh",
+          token_type: "Bearer",
+        });
+
+        const fetchFn = vi.fn(async () => {
+          return new Response(
+            JSON.stringify({
+              access_token: "new-access",
+              refresh_token: "new-refresh",
+              token_type: "Bearer",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        });
+
+        const response = await provider.wrapFetchForTokenRefresh(fetchFn)(
+          new URL("https://auth.example.com/token"),
+          {
+            method: "POST",
+            body: new URLSearchParams({
+              grant_type: "refresh_token",
+              refresh_token: "old-refresh",
+            }),
+          },
+        );
+
+        await Promise.all([
+          provider.saveClientInformation?.({ client_id: "client-after-refresh" }),
+          response
+            .clone()
+            .json()
+            .then((tokens) => provider.saveTokens(tokens)),
+        ]);
+
+        expect(await provider.clientInformation()).toMatchObject({
+          client_id: "client-after-refresh",
+        });
+        await expect(provider.tokens()).resolves.toMatchObject({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+        });
+      },
+      {
+        prefix: "openclaw-mcp-oauth-sdk-follow-up-save-",
         skipSessionCleanup: true,
         env: {
           OPENCLAW_CONFIG_PATH: undefined,

--- a/src/agents/mcp-oauth.test.ts
+++ b/src/agents/mcp-oauth.test.ts
@@ -578,6 +578,73 @@ describe("MCP OAuth provider", () => {
     );
   });
 
+  it("preserves concurrent token writes while persisting localhost redirect fallback", async () => {
+    await withTempHome(
+      async () => {
+        authMock.mockReset();
+        authMock
+          .mockRejectedValueOnce(new Error("invalid_client_metadata: redirect_uri rejected"))
+          .mockResolvedValueOnce("AUTHORIZED");
+
+        let releaseRedirectWrite: (() => void) | undefined;
+        const redirectWritePaused = new Promise<void>((resolve) => {
+          const originalWriteFile = fs.writeFile.bind(fs);
+          vi.spyOn(fs, "writeFile").mockImplementation(async (file, data, options) => {
+            if (
+              typeof data === "string" &&
+              data.includes('"redirectUrl": "http://localhost:8989/oauth/callback"') &&
+              !data.includes('"access_token": "rotated-access"')
+            ) {
+              resolve();
+              await new Promise<void>((release) => {
+                releaseRedirectWrite = release;
+              });
+            }
+            return await originalWriteFile(file, data, options);
+          });
+        });
+
+        try {
+          const login = runMcpOAuthLogin({
+            serverName: "Calendly",
+            serverUrl: "https://mcp.calendly.com/",
+          });
+          await redirectWritePaused;
+
+          const provider = createMcpOAuthClientProvider({
+            serverName: "Calendly",
+            serverUrl: "https://mcp.calendly.com/",
+          });
+          const saveTokens = provider.saveTokens({
+            access_token: "rotated-access",
+            refresh_token: "rotated-refresh",
+            token_type: "Bearer",
+          });
+
+          releaseRedirectWrite?.();
+          await Promise.all([login, saveTokens]);
+
+          await expect(provider.tokens()).resolves.toMatchObject({
+            access_token: "rotated-access",
+            refresh_token: "rotated-refresh",
+          });
+          expect(provider.redirectUrl).toBe("http://localhost:8989/oauth/callback");
+        } finally {
+          vi.restoreAllMocks();
+          releaseRedirectWrite?.();
+        }
+      },
+      {
+        prefix: "openclaw-mcp-oauth-localhost-token-race-",
+        skipSessionCleanup: true,
+        env: {
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+      },
+    );
+  });
+
   it("does not start hidden authorization flows without an authorization callback", async () => {
     // Normal agent/tool execution must not open browser auth flows implicitly;
     // operators use the explicit mcp login command instead.

--- a/src/agents/mcp-oauth.test.ts
+++ b/src/agents/mcp-oauth.test.ts
@@ -194,6 +194,152 @@ describe("MCP OAuth provider", () => {
     );
   });
 
+  it("preserves OAuth metadata saved while a refresh is in flight", async () => {
+    await withTempHome(
+      async () => {
+        const provider = createMcpOAuthClientProvider({
+          serverName: "Remote Docs",
+          serverUrl: "https://mcp.example.com/mcp",
+        });
+        await provider.saveTokens({
+          access_token: "old-access",
+          refresh_token: "old-refresh",
+          token_type: "Bearer",
+        });
+
+        let resolveRefresh: (() => void) | undefined;
+        const fetchFn = vi.fn(async () => {
+          await new Promise<void>((resolve) => {
+            resolveRefresh = resolve;
+          });
+          return new Response(
+            JSON.stringify({
+              access_token: "new-access",
+              refresh_token: "new-refresh",
+              token_type: "Bearer",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        });
+
+        const pendingRefresh = provider.wrapFetchForTokenRefresh(fetchFn)(
+          new URL("https://auth.example.com/token"),
+          {
+            method: "POST",
+            body: new URLSearchParams({
+              grant_type: "refresh_token",
+              refresh_token: "old-refresh",
+            }),
+          },
+        );
+        await vi.waitFor(() => {
+          expect(fetchFn).toHaveBeenCalledOnce();
+        });
+
+        expect(provider.saveClientInformation).toBeDefined();
+        await provider.saveClientInformation?.({ client_id: "client-after-refresh-started" });
+        expect(resolveRefresh).toBeDefined();
+        resolveRefresh?.();
+        await expect(pendingRefresh.then((response) => response.json())).resolves.toMatchObject({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+        });
+
+        expect(await provider.clientInformation()).toMatchObject({
+          client_id: "client-after-refresh-started",
+        });
+        await expect(provider.tokens()).resolves.toMatchObject({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+        });
+      },
+      {
+        prefix: "openclaw-mcp-oauth-refresh-store-merge-",
+        skipSessionCleanup: true,
+        env: {
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+      },
+    );
+  });
+
+  it("releases the refresh lock when the token endpoint exceeds the refresh deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      await withTempHome(
+        async () => {
+          const provider = createMcpOAuthClientProvider({
+            serverName: "Remote Docs",
+            serverUrl: "https://mcp.example.com/mcp",
+          });
+          await provider.saveTokens({
+            access_token: "old-access",
+            refresh_token: "old-refresh",
+            token_type: "Bearer",
+          });
+
+          const fetchFn = vi
+            .fn()
+            .mockImplementationOnce(
+              () =>
+                new Promise<Response>(() => {
+                  // Simulates a provider that never completes the refresh request.
+                }),
+            )
+            .mockResolvedValueOnce(
+              new Response(
+                JSON.stringify({
+                  access_token: "new-access",
+                  refresh_token: "new-refresh",
+                  token_type: "Bearer",
+                }),
+                { status: 200, headers: { "content-type": "application/json" } },
+              ),
+            );
+          const wrappedFetch = provider.wrapFetchForTokenRefresh(fetchFn);
+          const refreshInit = () => ({
+            method: "POST",
+            body: new URLSearchParams({
+              grant_type: "refresh_token",
+              refresh_token: "old-refresh",
+            }),
+          });
+
+          const stalledRefresh = wrappedFetch(
+            new URL("https://auth.example.com/token"),
+            refreshInit(),
+          );
+          await vi.waitFor(() => {
+            expect(fetchFn).toHaveBeenCalledOnce();
+          });
+          await vi.advanceTimersByTimeAsync(90_000);
+          await expect(stalledRefresh).rejects.toThrow(/timed out refreshing/i);
+
+          const recoveredRefresh = await wrappedFetch(
+            new URL("https://auth.example.com/token"),
+            refreshInit(),
+          );
+          await expect(recoveredRefresh.json()).resolves.toMatchObject({
+            access_token: "new-access",
+            refresh_token: "new-refresh",
+          });
+          expect(fetchFn).toHaveBeenCalledTimes(2);
+        },
+        {
+          prefix: "openclaw-mcp-oauth-refresh-deadline-",
+          skipSessionCleanup: true,
+          env: {
+            OPENCLAW_CONFIG_PATH: undefined,
+            OPENCLAW_STATE_DIR: undefined,
+          },
+        },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps the legacy loopback redirect as the default for upgrade compatibility", () => {
     const provider = createMcpOAuthClientProvider({
       serverName: "Calendly",

--- a/src/agents/mcp-oauth.test.ts
+++ b/src/agents/mcp-oauth.test.ts
@@ -377,7 +377,7 @@ describe("MCP OAuth provider", () => {
     );
   });
 
-  it("releases the refresh lock when the token endpoint exceeds the refresh deadline", async () => {
+  it("keeps refresh followers waiting until a stalled token request releases the lock", async () => {
     vi.useFakeTimers();
     try {
       await withTempHome(
@@ -426,14 +426,17 @@ describe("MCP OAuth provider", () => {
           await vi.waitFor(() => {
             expect(fetchFn).toHaveBeenCalledOnce();
           });
-          await vi.advanceTimersByTimeAsync(90_000);
-          await expect(stalledRefresh).rejects.toThrow(/timed out refreshing/i);
-
-          const recoveredRefresh = await wrappedFetch(
+          const waitingRefresh = wrappedFetch(
             new URL("https://auth.example.com/token"),
             refreshInit(),
           );
-          await expect(recoveredRefresh.json()).resolves.toMatchObject({
+          await vi.advanceTimersByTimeAsync(90_000);
+          await expect(stalledRefresh).rejects.toThrow(/timed out refreshing/i);
+          await vi.waitFor(() => {
+            expect(fetchFn).toHaveBeenCalledTimes(2);
+          });
+
+          await expect(waitingRefresh.then((response) => response.json())).resolves.toMatchObject({
             access_token: "new-access",
             refresh_token: "new-refresh",
           });

--- a/src/agents/mcp-oauth.test.ts
+++ b/src/agents/mcp-oauth.test.ts
@@ -77,6 +77,123 @@ describe("MCP OAuth provider", () => {
     );
   });
 
+  it("returns stored rotated tokens instead of replaying a stale refresh token", async () => {
+    await withTempHome(
+      async () => {
+        const provider = createMcpOAuthClientProvider({
+          serverName: "Remote Docs",
+          serverUrl: "https://mcp.example.com/mcp",
+        });
+        await provider.saveTokens({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          token_type: "Bearer",
+        });
+
+        const fetchFn = vi.fn(async () => {
+          return new Response(
+            JSON.stringify({
+              access_token: "replayed-access",
+              refresh_token: "replayed-refresh",
+              token_type: "Bearer",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        });
+
+        const response = await provider.wrapFetchForTokenRefresh(fetchFn)(
+          new URL("https://auth.example.com/token"),
+          {
+            method: "POST",
+            body: new URLSearchParams({
+              grant_type: "refresh_token",
+              refresh_token: "old-refresh",
+            }),
+          },
+        );
+
+        await expect(response.json()).resolves.toMatchObject({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+        });
+        expect(fetchFn).not.toHaveBeenCalled();
+      },
+      {
+        prefix: "openclaw-mcp-oauth-stale-refresh-",
+        skipSessionCleanup: true,
+        env: {
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+      },
+    );
+  });
+
+  it("serializes concurrent refreshes so rotating refresh tokens are not replayed", async () => {
+    await withTempHome(
+      async () => {
+        const provider = createMcpOAuthClientProvider({
+          serverName: "Remote Docs",
+          serverUrl: "https://mcp.example.com/mcp",
+        });
+        await provider.saveTokens({
+          access_token: "old-access",
+          refresh_token: "old-refresh",
+          token_type: "Bearer",
+        });
+
+        const fetchFn = vi.fn(async () => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 25);
+          });
+          return new Response(
+            JSON.stringify({
+              access_token: "new-access",
+              refresh_token: "new-refresh",
+              token_type: "Bearer",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        });
+        const wrappedFetch = provider.wrapFetchForTokenRefresh(fetchFn);
+        const refreshInit = () => ({
+          method: "POST",
+          body: new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: "old-refresh",
+          }),
+        });
+
+        const [first, second] = await Promise.all([
+          wrappedFetch(new URL("https://auth.example.com/token"), refreshInit()),
+          wrappedFetch(new URL("https://auth.example.com/token"), refreshInit()),
+        ]);
+
+        await expect(first.json()).resolves.toMatchObject({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+        });
+        await expect(second.json()).resolves.toMatchObject({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+        });
+        expect(fetchFn).toHaveBeenCalledOnce();
+        await expect(provider.tokens()).resolves.toMatchObject({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+        });
+      },
+      {
+        prefix: "openclaw-mcp-oauth-concurrent-refresh-",
+        skipSessionCleanup: true,
+        env: {
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+      },
+    );
+  });
+
   it("keeps the legacy loopback redirect as the default for upgrade compatibility", () => {
     const provider = createMcpOAuthClientProvider({
       serverName: "Calendly",

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -49,10 +49,10 @@ export type McpOAuthCredentialsStatus = {
 
 const LEGACY_DEFAULT_REDIRECT_URL = "http://127.0.0.1:8989/oauth/callback";
 const LOCALHOST_REDIRECT_URL = "http://localhost:8989/oauth/callback";
-const REFRESH_LOCK_TIMEOUT_MS = 60_000;
-const REFRESH_LOCK_STALE_MS = 120_000;
-const REFRESH_LOCK_POLL_MS = 100;
 const REFRESH_REQUEST_TIMEOUT_MS = 90_000;
+const REFRESH_LOCK_TIMEOUT_MS = REFRESH_REQUEST_TIMEOUT_MS + 30_000;
+const REFRESH_LOCK_STALE_MS = REFRESH_LOCK_TIMEOUT_MS + 30_000;
+const REFRESH_LOCK_POLL_MS = 100;
 
 function isMcpOAuthRedirectRegistrationError(error: unknown): boolean {
   return /invalid_client_metadata|redirect_uri/i.test(String(error));

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -465,8 +465,10 @@ export async function runMcpOAuthLogin(params: {
           redirectUrl: LOCALHOST_REDIRECT_URL,
         },
       });
-      const retryStore = await readStore(filePath);
-      await writeStore(filePath, { ...retryStore, redirectUrl: LOCALHOST_REDIRECT_URL });
+      await updateStore(filePath, (latestStore) => ({
+        ...latestStore,
+        redirectUrl: LOCALHOST_REDIRECT_URL,
+      }));
       return result;
     }
     throw error;

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -51,6 +51,7 @@ const LOCALHOST_REDIRECT_URL = "http://localhost:8989/oauth/callback";
 const REFRESH_LOCK_TIMEOUT_MS = 60_000;
 const REFRESH_LOCK_STALE_MS = 120_000;
 const REFRESH_LOCK_POLL_MS = 100;
+const REFRESH_REQUEST_TIMEOUT_MS = 90_000;
 
 function isMcpOAuthRedirectRegistrationError(error: unknown): boolean {
   return /invalid_client_metadata|redirect_uri/i.test(String(error));
@@ -176,6 +177,44 @@ async function parseRefreshResponseTokens(
 ): Promise<OAuthTokens> {
   const payload = (await response.clone().json()) as OAuthTokens;
   return { refresh_token: refreshToken, ...payload };
+}
+
+async function fetchRefreshTokenWithDeadline(
+  fetchFn: FetchLike,
+  input: Parameters<FetchLike>[0],
+  init: Parameters<FetchLike>[1] | undefined,
+): Promise<Response> {
+  const controller = new AbortController();
+  const callerSignal = init?.signal;
+  if (callerSignal?.aborted) {
+    controller.abort(callerSignal.reason);
+    throw new Error("MCP OAuth token refresh was aborted.");
+  }
+
+  const abortFromCaller = () => {
+    controller.abort(callerSignal?.reason);
+  };
+  callerSignal?.addEventListener("abort", abortFromCaller, { once: true });
+
+  let timeout: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      controller.abort();
+      reject(new Error("Timed out refreshing MCP OAuth tokens."));
+    }, REFRESH_REQUEST_TIMEOUT_MS);
+  });
+
+  try {
+    return await Promise.race([
+      fetchFn(input, { ...init, signal: controller.signal }),
+      timeoutPromise,
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    callerSignal?.removeEventListener("abort", abortFromCaller);
+  }
 }
 
 function resolveOAuthRedirectUrl(config: McpOAuthConfig, store: McpOAuthStore = {}): string {
@@ -316,7 +355,7 @@ export function createMcpOAuthClientProvider(params: {
             return responseFromTokens(currentTokens);
           }
 
-          const response = await (fetchFn ?? fetch)(input, init);
+          const response = await fetchRefreshTokenWithDeadline(fetchFn ?? fetch, input, init);
           if (!response.ok) {
             return response;
           }
@@ -325,7 +364,8 @@ export function createMcpOAuthClientProvider(params: {
           // Persisting the clone before releasing the lock lets concurrent callers
           // observe the rotated refresh token instead of replaying the stale one.
           const tokens = await parseRefreshResponseTokens(response, refreshToken);
-          await writeStore(filePath, { ...store, tokens });
+          const latestStore = await readStore(filePath);
+          await writeStore(filePath, { ...latestStore, tokens });
           return response;
         } finally {
           await lock.release();

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -16,6 +16,7 @@ import type {
   OAuthClientMetadata,
   OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { OAuthTokensSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveStateDir } from "../config/paths.js";
@@ -92,6 +93,18 @@ async function writeStore(filePath: string, store: McpOAuthStore): Promise<void>
   await fsPromises.chmod(tempPath, 0o600).catch(() => {});
   await fsPromises.rename(tempPath, filePath);
   await fsPromises.chmod(filePath, 0o600).catch(() => {});
+}
+
+async function updateStore(
+  filePath: string,
+  update: (store: McpOAuthStore) => McpOAuthStore,
+): Promise<void> {
+  const lock = await acquireStoreLock(filePath);
+  try {
+    await writeStore(filePath, update(await readStore(filePath)));
+  } finally {
+    await lock.release();
+  }
 }
 
 async function sleep(ms: number): Promise<void> {
@@ -175,8 +188,10 @@ async function parseRefreshResponseTokens(
   response: Response,
   refreshToken: string,
 ): Promise<OAuthTokens> {
-  const payload = (await response.clone().json()) as OAuthTokens;
-  return { refresh_token: refreshToken, ...payload };
+  return OAuthTokensSchema.parse({
+    refresh_token: refreshToken,
+    ...(await response.clone().json()),
+  });
 }
 
 async function fetchRefreshTokenWithDeadline(
@@ -275,35 +290,33 @@ export function createMcpOAuthClientProvider(params: {
     },
     async state() {
       assertAuthorizationRedirectAllowed();
-      const store = await readStore(filePath);
       const state = randomUUID();
-      await writeStore(filePath, { ...store, state });
+      await updateStore(filePath, (store) => ({ ...store, state }));
       return state;
     },
     async clientInformation() {
       return (await readStore(filePath)).clientInformation;
     },
     async saveClientInformation(clientInformation) {
-      const store = await readStore(filePath);
-      await writeStore(filePath, { ...store, clientInformation });
+      await updateStore(filePath, (store) => ({ ...store, clientInformation }));
     },
     async tokens() {
       return (await readStore(filePath)).tokens;
     },
     async saveTokens(tokens) {
-      const store = await readStore(filePath);
-      await writeStore(filePath, { ...store, tokens });
+      await updateStore(filePath, (store) => ({ ...store, tokens }));
     },
     async redirectToAuthorization(authorizationUrl) {
       assertAuthorizationRedirectAllowed();
-      const store = await readStore(filePath);
-      await writeStore(filePath, { ...store, lastAuthorizationUrl: authorizationUrl.toString() });
+      await updateStore(filePath, (store) => ({
+        ...store,
+        lastAuthorizationUrl: authorizationUrl.toString(),
+      }));
       await params.onAuthorizationUrl?.(authorizationUrl);
     },
     async saveCodeVerifier(codeVerifier) {
       assertAuthorizationRedirectAllowed();
-      const store = await readStore(filePath);
-      await writeStore(filePath, { ...store, codeVerifier });
+      await updateStore(filePath, (store) => ({ ...store, codeVerifier }));
     },
     async codeVerifier() {
       const codeVerifier = (await readStore(filePath)).codeVerifier;
@@ -313,25 +326,25 @@ export function createMcpOAuthClientProvider(params: {
       return codeVerifier;
     },
     async invalidateCredentials(scope) {
-      const store = await readStore(filePath);
-      const next: McpOAuthStore = { ...store };
-      if (scope === "all" || scope === "client") {
-        delete next.clientInformation;
-      }
-      if (scope === "all" || scope === "tokens") {
-        delete next.tokens;
-      }
-      if (scope === "all" || scope === "verifier") {
-        delete next.codeVerifier;
-      }
-      if (scope === "all" || scope === "discovery") {
-        delete next.discoveryState;
-      }
-      await writeStore(filePath, next);
+      await updateStore(filePath, (store) => {
+        const next: McpOAuthStore = { ...store };
+        if (scope === "all" || scope === "client") {
+          delete next.clientInformation;
+        }
+        if (scope === "all" || scope === "tokens") {
+          delete next.tokens;
+        }
+        if (scope === "all" || scope === "verifier") {
+          delete next.codeVerifier;
+        }
+        if (scope === "all" || scope === "discovery") {
+          delete next.discoveryState;
+        }
+        return next;
+      });
     },
     async saveDiscoveryState(discoveryState) {
-      const store = await readStore(filePath);
-      await writeStore(filePath, { ...store, discoveryState });
+      await updateStore(filePath, (store) => ({ ...store, discoveryState }));
     },
     async discoveryState() {
       return (await readStore(filePath)).discoveryState;

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -48,6 +48,9 @@ export type McpOAuthCredentialsStatus = {
 
 const LEGACY_DEFAULT_REDIRECT_URL = "http://127.0.0.1:8989/oauth/callback";
 const LOCALHOST_REDIRECT_URL = "http://localhost:8989/oauth/callback";
+const REFRESH_LOCK_TIMEOUT_MS = 60_000;
+const REFRESH_LOCK_STALE_MS = 120_000;
+const REFRESH_LOCK_POLL_MS = 100;
 
 function isMcpOAuthRedirectRegistrationError(error: unknown): boolean {
   return /invalid_client_metadata|redirect_uri/i.test(String(error));
@@ -77,11 +80,102 @@ function readStoreSync(filePath: string): McpOAuthStore {
 
 async function writeStore(filePath: string, store: McpOAuthStore): Promise<void> {
   await fsPromises.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
-  await fsPromises.writeFile(filePath, JSON.stringify(store, null, 2), {
+  const tempPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  await fsPromises.writeFile(tempPath, JSON.stringify(store, null, 2), {
     encoding: "utf-8",
     mode: 0o600,
   });
+  await fsPromises.chmod(tempPath, 0o600).catch(() => {});
+  await fsPromises.rename(tempPath, filePath);
   await fsPromises.chmod(filePath, 0o600).catch(() => {});
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+type StoreLock = {
+  release: () => Promise<void>;
+};
+
+async function acquireStoreLock(filePath: string): Promise<StoreLock> {
+  await fsPromises.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const lockPath = `${filePath}.lock`;
+  const lockId = randomUUID();
+  const started = Date.now();
+  while (true) {
+    try {
+      const handle = await fsPromises.open(lockPath, "wx", 0o600);
+      try {
+        await handle.writeFile(
+          JSON.stringify({
+            id: lockId,
+            pid: process.pid,
+            createdAt: new Date().toISOString(),
+          }),
+          "utf-8",
+        );
+      } finally {
+        await handle.close();
+      }
+      return {
+        release: async () => {
+          const current = await readStore(lockPath);
+          if ((current as { id?: string }).id === lockId) {
+            await fsPromises.rm(lockPath, { force: true }).catch(() => {});
+          }
+        },
+      };
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") {
+        throw error;
+      }
+      const stat = await fsPromises.stat(lockPath).catch(() => null);
+      if (stat && Date.now() - stat.mtimeMs > REFRESH_LOCK_STALE_MS) {
+        await fsPromises.rm(lockPath, { force: true }).catch(() => {});
+        continue;
+      }
+      if (Date.now() - started > REFRESH_LOCK_TIMEOUT_MS) {
+        throw new Error(
+          `Timed out waiting for MCP OAuth token refresh lock for ${path.basename(filePath)}.`,
+          { cause: error },
+        );
+      }
+      await sleep(REFRESH_LOCK_POLL_MS);
+    }
+  }
+}
+
+function refreshTokenFromRequestBody(body: BodyInit | null | undefined): string | null {
+  if (body instanceof URLSearchParams) {
+    return body.get("grant_type") === "refresh_token" ? body.get("refresh_token") : null;
+  }
+  if (typeof body === "string") {
+    const params = new URLSearchParams(body);
+    return params.get("grant_type") === "refresh_token" ? params.get("refresh_token") : null;
+  }
+  return null;
+}
+
+function responseFromTokens(tokens: OAuthTokens): Response {
+  return new Response(JSON.stringify(tokens), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function parseRefreshResponseTokens(
+  response: Response,
+  refreshToken: string,
+): Promise<OAuthTokens> {
+  const payload = (await response.clone().json()) as OAuthTokens;
+  return { refresh_token: refreshToken, ...payload };
 }
 
 function resolveOAuthRedirectUrl(config: McpOAuthConfig, store: McpOAuthStore = {}): string {
@@ -109,6 +203,10 @@ function buildOAuthClientMetadata(
   };
 }
 
+type OAuthClientProviderWithRefreshSerialization = OAuthClientProvider & {
+  wrapFetchForTokenRefresh(fetchFn?: FetchLike): FetchLike;
+};
+
 /** Creates the MCP SDK OAuth provider backed by OpenClaw's private store. */
 export function createMcpOAuthClientProvider(params: {
   serverName: string;
@@ -116,7 +214,7 @@ export function createMcpOAuthClientProvider(params: {
   config?: McpOAuthConfig;
   onAuthorizationUrl?: (url: URL) => void | Promise<void>;
   allowAuthorizationRedirect?: boolean;
-}): OAuthClientProvider {
+}): OAuthClientProviderWithRefreshSerialization {
   const config = params.config ?? {};
   const filePath = oauthStorePath(params.serverName, params.serverUrl);
   const allowAuthorizationRedirect =
@@ -199,6 +297,41 @@ export function createMcpOAuthClientProvider(params: {
     async discoveryState() {
       return (await readStore(filePath)).discoveryState;
     },
+    wrapFetchForTokenRefresh(fetchFn) {
+      return async (input, init) => {
+        const refreshToken = refreshTokenFromRequestBody(init?.body);
+        if (!refreshToken) {
+          return await (fetchFn ?? fetch)(input, init);
+        }
+
+        const lock = await acquireStoreLock(filePath);
+        try {
+          const store = await readStore(filePath);
+          const currentTokens = store.tokens;
+          if (
+            currentTokens?.refresh_token &&
+            currentTokens.refresh_token !== refreshToken &&
+            currentTokens.access_token
+          ) {
+            return responseFromTokens(currentTokens);
+          }
+
+          const response = await (fetchFn ?? fetch)(input, init);
+          if (!response.ok) {
+            return response;
+          }
+
+          // The MCP SDK refresh path parses the same response and calls saveTokens().
+          // Persisting the clone before releasing the lock lets concurrent callers
+          // observe the rotated refresh token instead of replaying the stale one.
+          const tokens = await parseRefreshResponseTokens(response, refreshToken);
+          await writeStore(filePath, { ...store, tokens });
+          return response;
+        } finally {
+          await lock.release();
+        }
+      };
+    },
   };
 }
 
@@ -233,18 +366,16 @@ async function runMcpOAuthLoginAttempt(params: {
   fetchFn?: FetchLike;
   onAuthorizationUrl?: (url: URL) => void | Promise<void>;
 }): Promise<"authorized" | "redirect"> {
-  const result = await auth(
-    createMcpOAuthClientProvider({
-      ...params,
-      allowAuthorizationRedirect: true,
-    }),
-    {
-      serverUrl: params.serverUrl,
-      authorizationCode: normalizeOptionalString(params.authorizationCode),
-      scope: normalizeOptionalString(params.config?.scope),
-      fetchFn: params.fetchFn,
-    },
-  );
+  const provider = createMcpOAuthClientProvider({
+    ...params,
+    allowAuthorizationRedirect: true,
+  });
+  const result = await auth(provider, {
+    serverUrl: params.serverUrl,
+    authorizationCode: normalizeOptionalString(params.authorizationCode),
+    scope: normalizeOptionalString(params.config?.scope),
+    fetchFn: provider.wrapFetchForTokenRefresh(params.fetchFn),
+  });
   return result === "AUTHORIZED" ? "authorized" : "redirect";
 }
 

--- a/src/agents/mcp-transport.test.ts
+++ b/src/agents/mcp-transport.test.ts
@@ -1,4 +1,5 @@
 // Covers MCP HTTP transport redirects, SSRF guardrails, and auth/TLS handoff.
+import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveMcpTransport } from "./mcp-transport.js";
 
@@ -6,6 +7,14 @@ type StreamableTransportOptions = {
   requestInit?: RequestInit;
   fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
   authProvider?: unknown;
+};
+
+type OAuthTestProvider = {
+  saveTokens(tokens: {
+    access_token: string;
+    refresh_token: string;
+    token_type: string;
+  }): Promise<void>;
 };
 
 const {
@@ -331,6 +340,66 @@ describe("resolveMcpTransport", () => {
 
     expect(new Headers(runtimeFetchCall(0)?.[1]?.headers).get("x-tenant")).toBe("docs");
     expect(new Headers(runtimeFetchCall(1)?.[1]?.headers).get("x-tenant")).toBeNull();
+  });
+
+  it("reuses rotated OAuth refresh tokens through streamable HTTP transports", async () => {
+    await withTempHome(
+      async () => {
+        runtimeFetchMock.mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: "new-access",
+              refresh_token: "new-refresh",
+              token_type: "Bearer",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+
+        resolveMcpTransport("probe", {
+          url: "https://mcp.example.com/mcp",
+          transport: "streamable-http",
+          auth: "oauth",
+        });
+
+        const options = latestStreamableTransportOptions();
+        const provider = options.authProvider as OAuthTestProvider;
+        const fetch = latestStreamableFetch();
+        await provider.saveTokens({
+          access_token: "old-access",
+          refresh_token: "old-refresh",
+          token_type: "Bearer",
+        });
+        const refreshInit = () => ({
+          method: "POST",
+          body: new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: "old-refresh",
+          }),
+        });
+
+        const first = await fetch("https://auth.example.com/token", refreshInit());
+        const second = await fetch("https://auth.example.com/token", refreshInit());
+
+        await expect(first.json()).resolves.toMatchObject({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+        });
+        await expect(second.json()).resolves.toMatchObject({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+        });
+        expect(runtimeFetchMock).toHaveBeenCalledOnce();
+      },
+      {
+        prefix: "openclaw-mcp-transport-oauth-refresh-",
+        skipSessionCleanup: true,
+        env: {
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+      },
+    );
   });
 
   it("merges SSE event-source headers case-insensitively so auth is not duplicated", async () => {

--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -136,11 +136,15 @@ export function resolveMcpTransport(
           resourceUrl: resolved.url,
         })
       : baseFetch;
+  const transportFetch =
+    resolved.auth === "oauth" && authProvider
+      ? authProvider.wrapFetchForTokenRefresh(httpFetch)
+      : httpFetch;
   if (resolved.transportType === "streamable-http") {
     return {
       transport: new StreamableHTTPClientTransport(new URL(resolved.url), {
         requestInit: resolved.auth === "oauth" || !headers ? undefined : { headers },
-        fetch: httpFetch,
+        fetch: transportFetch,
         authProvider,
       }),
       description: resolved.description,
@@ -155,9 +159,12 @@ export function resolveMcpTransport(
   return {
     transport: new SSEClientTransport(new URL(resolved.url), {
       requestInit: resolved.auth === "oauth" || !hasHeaders ? undefined : { headers: sseHeaders },
-      fetch: httpFetch,
+      fetch: transportFetch,
       eventSourceInit: {
-        fetch: buildSseEventSourceFetch(resolved.auth === "oauth" ? {} : sseHeaders, httpFetch),
+        fetch: buildSseEventSourceFetch(
+          resolved.auth === "oauth" ? {} : sseHeaders,
+          transportFetch,
+        ),
       },
       authProvider,
     }),


### PR DESCRIPTION
## Summary
- Serialize MCP OAuth refresh-token requests per server so concurrent callers do not replay stale rotating refresh tokens.
- Persist successful refresh responses before releasing the lock, while preserving existing localhost redirect fallback behavior on current main.
- Serialize the localhost redirect fallback store write as well, so it cannot clobber a concurrent token rotation.
- Wire the serialized fetch wrapper through streamable HTTP and SSE MCP transports.

Supersedes #93909 with a narrow current-main PR. This branch intentionally excludes the prior release, dependency, generated-output, UI, localization, and provider churn.

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/mcp-oauth.test.ts src/agents/mcp-transport.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/mcp-oauth.ts src/agents/mcp-oauth.test.ts src/agents/mcp-transport.ts src/agents/mcp-transport.test.ts`
- `node scripts/run-oxlint.mjs src/agents/mcp-oauth.ts src/agents/mcp-oauth.test.ts src/agents/mcp-transport.ts src/agents/mcp-transport.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `git diff --check`

## ClawSweeper Correction
2026-06-26 correction commit: `476d66f582 fix(mcp): lock OAuth redirect fallback writes`.

ClawSweeper identified one remaining raw read/write path in the localhost redirect fallback. That path now uses `updateStore(filePath, ...)`, so the redirect-url migration write is serialized with token refresh writes and merges into the latest store snapshot instead of writing a stale pre-token-rotation snapshot.

New regression added: `preserves concurrent token writes while persisting localhost redirect fallback` in `src/agents/mcp-oauth.test.ts`. It pauses the redirect fallback write, performs a concurrent `saveTokens(...)` rotation, releases the fallback write, and asserts the final provider store keeps the rotated `access_token` / `refresh_token` while also persisting `http://localhost:8989/oauth/callback`.

## Real Behavior Proof
Behavior addressed: concurrent MCP OAuth refresh attempts with rotating refresh tokens now serialize and reuse the latest stored token response instead of sending stale refresh tokens again.

Real environment tested: local OpenClaw source worktree on current upstream main, using the actual `src/agents/mcp-oauth.ts` provider and a local HTTP token endpoint. The published `@modelcontextprotocol/sdk` auth/transport source was inspected before implementation.

Exact steps or command run after this patch: ran a `pnpm exec tsx` smoke that created a temp HOME/OpenClaw state dir, started a local HTTP token endpoint, saved old OAuth tokens through `createMcpOAuthClientProvider`, then issued two concurrent `refresh_token` POSTs through `provider.wrapFetchForTokenRefresh(fetch)`.

Evidence after fix:
```json
{
  "tokenEndpointCalls": 1,
  "first": {
    "access_token": "new-access",
    "refresh_token": "new-refresh",
    "token_type": "Bearer"
  },
  "second": {
    "refresh_token": "new-refresh",
    "access_token": "new-access",
    "token_type": "Bearer"
  },
  "stored": {
    "refresh_token": "new-refresh",
    "access_token": "new-access",
    "token_type": "Bearer"
  }
}
```

Observed result after fix: the local token endpoint received one request, both concurrent callers received the rotated refresh token, and the OpenClaw credential store ended with the rotated token.

What was not tested: live third-party OAuth provider with real rotating refresh tokens.

<!-- proof-refresh: 2026-06-26T15:20Z -->
