### PR TITLE
fix(infra): pin ensurePortAvailable to 127.0.0.1 in startSshPortForward (fixes #94596)

### DIFF
--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -119,7 +119,7 @@ export async function startSshPortForward(opts: {
 
   let localPort = opts.localPortPreferred;
   try {
-    await ensurePortAvailable(localPort);
+    await ensurePortAvailable(localPort, "127.0.0.1");
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {
       localPort = await pickEphemeralPort();


### PR DESCRIPTION
### Summary

- **Problem**: `startSshPortForward` in `src/infra/ssh-tunnel.ts` calls `ensurePortAvailable(localPort)` without a host, like the earlier Chrome CDP caller did before #94394. On dual-stack hosts the host-less probe binds the IPv6 wildcard `::` and misses an IPv4-only occupant, reporting a busy port as free.
- **Root Cause**: The SSH tunnel path pins its forward to `127.0.0.1` (via `-L ${localPort}:127.0.0.1:${remotePort}`) and every other probe in the module uses IPv4 loopback (`pickEphemeralPort`, `canConnectLocal`), but the `ensurePortAvailable` call was left host-less when the host parameter was added in #94394.
- **Fix**: Pass `"127.0.0.1"` as the host argument, matching the caller's actual bind interface.
- **What changed**:
  - `src/infra/ssh-tunnel.ts` — add `"127.0.0.1"` host parameter to `ensurePortAvailable(localPort)` call
- **What did NOT change (scope boundary)**:
  - The Chrome CDP caller was already fixed in #94394
  - The `EADDRINUSE` fallback to `pickEphemeralPort()` is unchanged
  - No other `ensurePortAvailable` call sites were affected

### Reproduction

1. On a dual-stack Linux host, occupy port N with an IPv4-only listener
2. Configure an SSH tunnel with `localPortPreferred: N`
3. **Before this PR**: `ensurePortAvailable(N)` binds `::` (IPv6), sees port N as free, proceeds to `ssh -L N:127.0.0.1:...` which fails with `EADDRINUSE`
4. **After this PR**: `ensurePortAvailable(N, "127.0.0.1")` correctly detects the IPv4 occupant and falls back to `pickEphemeralPort()`

### Real behavior proof

**Behavior or issue addressed (94596)**: On dual-stack hosts the SSH tunnel port preflight uses a host-less probe that misses IPv4-only occupants, identical to the root cause fixed for the Chrome CDP path in #94394. The one-line fix aligns the SSH tunnel caller with every other IPv4-scoped probe in the same module.

**Real environment tested**: Linux, Node 22 — the project's CI shard runner against the SSH tunnel and ports test suites

**Exact steps or command run after this patch**: `npx vitest run src/infra/ssh-tunnel.test.ts src/infra/ports.test.ts`

**Evidence before fix**:
```text
src/infra/ssh-tunnel.ts line 122:
  await ensurePortAvailable(localPort);
The host parameter added in #94394 is missing — the probe binds :: and
misses IPv4-only occupants on dual-stack hosts.
```

**Evidence after fix**:
```text
$ npx vitest run src/infra/ssh-tunnel.test.ts src/infra/ports.test.ts

 Test Files  2 passed (2)
      Tests  16 passed (16)

All SSH tunnel and port inspection scenarios pass — the preflight probe
now uses 127.0.0.1 consistently with every other IPv4-scoped call in the
module (pickEphemeralPort, canConnectLocal, and the SSH -L forward itself).
```

**Observed result after fix**: The `ensurePortAvailable` call in `startSshPortForward` now pins to `127.0.0.1`, matching the exact same IPv4 scope as the SSH `-L` forward it guards. If an IPv4-only occupant holds the port, the probe correctly reports it as busy and the caller falls back to `pickEphemeralPort()`.

**What was not tested**: Live dual-stack host with an actual IPv4-only port occupant was not driven — this requires a dual-stack Linux environment. The probe behavior is verified through the existing ports test infrastructure which covers the IPv4 loopback binding path.

**Repro confirmation**: The fix mirrors the exact pattern applied to the Chrome CDP caller in #94394 — same root cause, same one-line fix. The SSH tunnel test suite and ports test suite pass without regression.

### Risk / Mitigation

- **Risk**: None. This is a scoped alignment fix matching the existing IPv4 convention in the same module.
  **Mitigation**: Every other probe in `ssh-tunnel.ts` already uses `127.0.0.1`. The `EADDRINUSE` fallback to `pickEphemeralPort()` remains in place.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] infra

### Regression Test Plan

- `npx vitest run src/infra/ssh-tunnel.test.ts`
- `npx vitest run src/infra/ports.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #94596
