### PR TITLE
fix(macos): open NSOpenPanel for embedded Control UI file inputs (#94468)

### DIFF
--- a/apps/macos/Sources/OpenClaw/CanvasWindowController+UIDelegate.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController+UIDelegate.swift
@@ -1,0 +1,32 @@
+import AppKit
+import WebKit
+
+extension CanvasWindowController {
+    // MARK: - WKUIDelegate
+
+    /// Bridges `<input type="file">` clicks in canvas HTML to a native `NSOpenPanel`.
+    /// Without a `WKUIDelegate`, WebKit silently drops the request and file-picker
+    /// buttons in canvas pages do nothing.
+    @MainActor
+    func webView(
+        _ webView: WKWebView,
+        runOpenPanelWith parameters: WKOpenPanelParameters,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor @Sendable ([URL]?) -> Void)
+    {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = parameters.allowsDirectories
+        panel.allowsMultipleSelection = parameters.allowsMultipleSelection
+        panel.resolvesAliases = true
+        if let window = self.window {
+            panel.beginSheetModal(for: window) { response in
+                completionHandler(response == .OK ? panel.urls : nil)
+            }
+            return
+        }
+        panel.begin { response in
+            completionHandler(response == .OK ? panel.urls : nil)
+        }
+    }
+}

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
@@ -5,7 +5,7 @@ import OpenClawKit
 import WebKit
 
 @MainActor
-final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NSWindowDelegate {
+final class CanvasWindowController: NSWindowController, WKNavigationDelegate, WKUIDelegate, NSWindowDelegate {
     let sessionKey: String
     private let root: URL
     private let sessionDir: URL
@@ -159,6 +159,7 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NS
         }
 
         self.webView.navigationDelegate = self
+        self.webView.uiDelegate = self
         self.window?.delegate = self
         self.container.onClose = { [weak self] in
             self?.hideCanvas()

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -19,7 +19,7 @@ private final class DashboardWindowDragRegionView: NSView {
 }
 
 @MainActor
-final class DashboardWindowController: NSWindowController, WKNavigationDelegate, NSWindowDelegate {
+final class DashboardWindowController: NSWindowController, WKNavigationDelegate, WKUIDelegate, NSWindowDelegate {
     private let webView: WKWebView
     private var currentURL: URL
     private var auth: DashboardWindowAuth
@@ -44,7 +44,35 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         super.init(window: window)
 
         self.webView.navigationDelegate = self
+        self.webView.uiDelegate = self
         self.window?.delegate = self
+    }
+
+    // MARK: - WKUIDelegate
+
+    /// Bridges `<input type="file">` clicks in the embedded Control UI to a native
+    /// `NSOpenPanel`; without a `WKUIDelegate`, WebKit silently drops the request
+    /// and "Choose image" / file-picker buttons do nothing.
+    func webView(
+        _ webView: WKWebView,
+        runOpenPanelWith parameters: WKOpenPanelParameters,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor @Sendable ([URL]?) -> Void)
+    {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = parameters.allowsDirectories
+        panel.allowsMultipleSelection = parameters.allowsMultipleSelection
+        panel.resolvesAliases = true
+        if let window = self.window {
+            panel.beginSheetModal(for: window) { response in
+                completionHandler(response == .OK ? panel.urls : nil)
+            }
+            return
+        }
+        panel.begin { response in
+            completionHandler(response == .OK ? panel.urls : nil)
+        }
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
## Summary

- Wire `WKUIDelegate` on the macOS embedded Control UI `WKWebView` so `<input type="file">` clicks (Personal Settings **Choose image**) open a native `NSOpenPanel` instead of doing nothing.
- Apply the same delegate wiring to `CanvasWindowController` so canvas HTML pages with file inputs behave consistently.

## Motivation

Closes #94468.

`DashboardWindowController` hosts Control UI in a `WKWebView` that only set `navigationDelegate`, not `uiDelegate`. WebKit routes file-input clicks through `WKUIDelegate.webView(_:runOpenPanelWith:initiatedByFrame:completionHandler:)`; without a UI delegate, the request is dropped and **Choose image** never opens a panel — matching the investigation on the issue.

## Verification

- `swift test --disable-keychain --filter DashboardWindowSmokeTests` — 4 passed
- `SKIP_PNPM_INSTALL=1 ALLOW_ADHOC_SIGNING=1 bash scripts/package-mac-app.sh`
- `pnpm format:swift` — 0 files require formatting
- Manual macOS app verification (see Real behavior proof)

Environment: macOS 26.x, Xcode 26.x / Swift 6.x, launchd gateway on `127.0.0.1:18789`, branch `fix/macos-file-picker` @ `4f477c4ed0`.

## Real behavior proof

- Behavior or issue addressed: macOS embedded Control UI **Choose image** (`<input type="file">`) did not open the native file picker because the hosting `WKWebView` had no `WKUIDelegate`.
- Real environment tested: macOS 26.x, OpenClaw `dist/OpenClaw.app` built from `fix/macos-file-picker` at commit `27f06198e3`, launchd-managed local Gateway on `127.0.0.1:18789`.
- Exact steps or command run after this patch:
  1. `SKIP_PNPM_INSTALL=1 ALLOW_ADHOC_SIGNING=1 bash scripts/package-mac-app.sh`
  2. `pnpm openclaw gateway install && pnpm openclaw gateway start`
  3. `open dist/OpenClaw.app` → open Dashboard
  4. Quick Settings → Personal → click **Choose image**
  5. Select a local PNG/JPEG in the native Open panel
  6. **Settings → Developer → Debug → Canvas → Eval**, run:
     ```javascript
     (() => {
       document.body.innerHTML =
         '<p style="color:white;font:14px system-ui">Canvas file test</p>' +
         '<input type="file" id="f" accept="image/*">';
       document.getElementById('f').click();
       return 'injected';
     })()
     ```
- Evidence after fix: ![after-fix-nsopenpanel](https://github.com/user-attachments/assets/39aed6fc-422d-4146-970d-3073e86f2b1c) ![canvas-file-picker](https://github.com/user-attachments/assets/6ac1159b-b15d-435a-8a31-6ee237382427)
- Observed result after fix: Clicking **Choose image** opens the native macOS Open panel as a sheet over the Control UI; after selecting an image the avatar preview updates in Personal settings; injecting the file input in the Canvas `WKWebView` and triggering it, the native macOS Open panel (`NSOpenPanel`) appears as expected.
- What was not tested: Multi-file selection.

## Risk checklist

- User-visible behavior change: Yes (file picker now works)
- Config/environment change: No
- Security/auth/network/tool execution: No
- Highest-risk area: `WKUIDelegate` / `NSOpenPanel` sheet presentation on Dashboard and Canvas windows
- Mitigation: Manual verification on Dashboard avatar path; existing Dashboard smoke tests still pass