### PR TITLE
fix(ssh-tunnel): pin ensurePortAvailable to IPv4 loopback

### DIFF
--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -119,7 +119,7 @@ export async function startSshPortForward(opts: {
 
   let localPort = opts.localPortPreferred;
   try {
-    await ensurePortAvailable(localPort);
+    await ensurePortAvailable(localPort, "127.0.0.1");
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {
       localPort = await pickEphemeralPort();


### PR DESCRIPTION
## Summary

Pass `"127.0.0.1"` to `ensurePortAvailable` in `startSshPortForward`
to match the actual SSH forward binding address family.

## Problem

The host-less `ensurePortAvailable(localPort)` probes the IPv6
wildcard on dual-stack hosts, missing IPv4-only occupants and
reporting a busy port as free.  Same root cause as #94379/#94394.

## Root Cause

`startSshPortForward` calls `ensurePortAvailable(localPort)` without
an explicit host.  Every other probe in the module pins to IPv4:
`pickEphemeralPort("127.0.0.1")`, `canConnectLocal("127.0.0.1")`,
and the forward itself binds `127.0.0.1`.

## Changes

- `src/infra/ssh-tunnel.ts` — add `"127.0.0.1"` as the second argument
  to `ensurePortAvailable`, matching #94394's fix pattern

## Related

Closes #94596

🤖 Generated with [Claude Code](https://claude.com/claude-code)