### PR TITLE
fix(infra): probe 127.0.0.1 in startSshPortForward port preflight

### DIFF
--- a/src/infra/ssh-tunnel.test.ts
+++ b/src/infra/ssh-tunnel.test.ts
@@ -1,6 +1,13 @@
-// Covers SSH target parsing.
-import { describe, expect, it } from "vitest";
-import { parseSshTarget } from "./ssh-tunnel.js";
+// Covers SSH target parsing and SSH tunnel port allocation.
+import { describe, expect, it, vi } from "vitest";
+
+const ensurePortAvailableMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./ports.js", () => ({
+  ensurePortAvailable: (...args: unknown[]) => ensurePortAvailableMock(...args),
+}));
+
+import { parseSshTarget, startSshPortForward } from "./ssh-tunnel.js";
 
 describe("parseSshTarget", () => {
   it("parses user@host:port targets", () => {
@@ -28,5 +35,31 @@ describe("parseSshTarget", () => {
     expect(parseSshTarget("-V")).toBeNull();
     expect(parseSshTarget("me@-badhost")).toBeNull();
     expect(parseSshTarget("-oProxyCommand=echo")).toBeNull();
+  });
+});
+
+describe("startSshPortForward port probe", () => {
+  it("probes the IPv4 loopback owned by the forward, not the wildcard bind", async () => {
+    // The SSH forward binds 127.0.0.1 (-L localPort:127.0.0.1:remotePort), so the
+    // preflight must scope the probe to that interface. A host-less probe would bind
+    // the IPv6 wildcard `::` and miss an IPv4-only occupant (#94596).
+    const probeError = new Error("probe interrupted");
+    ensurePortAvailableMock.mockImplementation(async () => {
+      throw probeError;
+    });
+
+    // A non-EADDRINUSE error surfaces before ssh is spawned, so this never reaches
+    // the child process.
+    await expect(
+      startSshPortForward({
+        target: "user@example.com:22",
+        localPortPreferred: 54321,
+        remotePort: 22,
+        timeoutMs: 1000,
+      }),
+    ).rejects.toBe(probeError);
+
+    expect(ensurePortAvailableMock).toHaveBeenCalledWith(54321, "127.0.0.1");
+    expect(ensurePortAvailableMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -119,7 +119,10 @@ export async function startSshPortForward(opts: {
 
   let localPort = opts.localPortPreferred;
   try {
-    await ensurePortAvailable(localPort);
+    // The forward binds 127.0.0.1 (see `-L` below), so probe the IPv4 loopback
+    // explicitly instead of the wildcard `::`. A host-less probe on a dual-stack
+    // host can miss an IPv4-only occupant and report a busy port as free.
+    await ensurePortAvailable(localPort, "127.0.0.1");
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {
       localPort = await pickEphemeralPort();


### PR DESCRIPTION
## Summary
- `startSshPortForward` in `src/infra/ssh-tunnel.ts` still called `ensurePortAvailable(localPort)` host-less after #94394, so on a dual-stack host the preflight probe bound the IPv6 wildcard `::` and could miss an IPv4-only occupant — re-introducing the #94379 flaw on the SSH-tunnel surface.
- The forward itself binds `127.0.0.1` (`-L localPort:127.0.0.1:remotePort`), so the probe is now scoped to the interface the forward actually owns: `ensurePortAvailable(localPort, "127.0.0.1")`.
- This matches the pattern #94394 applied to the Chrome CDP caller and is internally consistent with the rest of the module (`pickEphemeralPort`, `canConnectLocal`, and the `-L` forward all pin `127.0.0.1`).

## Change Type
- [x] Bug fix / [ ] Feature / [ ] Refactor / [ ] Docs / [ ] Security / [ ] Chore

## Scope
- [ ] Gateway / [ ] Skills / [ ] Auth / [ ] Memory / [ ] Integrations / [x] API / [ ] UI/UX / [ ] CI

## Root Cause
- Root cause: `ensurePortAvailable` gained a caller-scoped `host` parameter in #94394, but the SSH-tunnel caller was not updated, so its preflight still probed the wildcard bind instead of the IPv4 loopback the forward owns.
- Missing detection/guardrail: the SSH-tunnel module was internally inconsistent — every other probe in it pinned `127.0.0.1`, but the preflight did not.

## Real behavior proof
**Behavior addressed:** The SSH-tunnel port preflight now probes the IPv4 loopback (`127.0.0.1`) that the forward binds, instead of the host-less wildcard, so an IPv4-only occupant is detected on dual-stack hosts where the wildcard bind does not cover IPv4.

**Environment tested:** Node 24.13.1 on Linux (dual-stack kernel, `net.ipv6.bindv6only=0`), tsx loader, calling the actual patched production helper from source.

**Steps run after the patch:** Called the real production helper `ensurePortAvailable` from `src/infra/ports.ts` via `node --import tsx`, binding a real IPv4-loopback occupant with `node:net` and confirming the scoped probe surfaces `PortInUseError`. The new `startSshPortForward port probe` unit test asserts the SSH-tunnel caller now passes `127.0.0.1`.

```bash
node --import tsx --no-warnings -e "
import { ensurePortAvailable } from './src/infra/ports.ts';
import net from 'node:net';
const server = net.createServer();
const port = await new Promise((resolve) => {
  server.listen(0, '127.0.0.1', () => resolve(server.address().port));
});
const probe = async (host) => {
  try { await ensurePortAvailable(port, host); return 'FREE'; }
  catch (err) { return err && err.name === 'PortInUseError' ? 'BUSY (PortInUseError)' : 'ERR'; }
};
const scoped = await probe('127.0.0.1');
const hostless = await new Promise((res) => {
  try { ensurePortAvailable(port).then(() => res('FREE')).catch((e) => res(e && e.name === 'PortInUseError' ? 'BUSY (PortInUseError)' : 'ERR')); }
  catch (e) { res('ERR'); }
});
await new Promise((r) => server.close(r));
console.log(JSON.stringify({ occupant: '127.0.0.1:' + port, scopedProbe127001: scoped, hostlessProbe: hostless }, null, 2));
"
```

**Evidence after fix:**

```text
{
  "occupant": "127.0.0.1:39929",
  "scopedProbe127001": "BUSY (PortInUseError)",
  "hostlessProbe": "BUSY (PortInUseError)"
}
```

```text
$ node_modules/.bin/vitest run src/infra/ssh-tunnel.test.ts src/infra/ports.test.ts
 Test Files  2 passed (2)
      Tests  18 passed (18)
```

The new `startSshPortForward port probe` test asserts the call is `ensurePortAvailable(54321, "127.0.0.1")` — confirming the SSH-tunnel caller now passes the IPv4 loopback host.

**Observed result after the fix:** The host-scoped production probe detects the IPv4-loopback occupant and raises `PortInUseError`, the SSH-tunnel caller passes `127.0.0.1` to the probe, and all 18 targeted tests pass.

**What was not tested:** The platform-specific false-free itself — this Linux kernel has `net.ipv6.bindv6only=0`, so the host-less `::` wildcard probe *also* sees the IPv4 occupant and reports BUSY (the miss only occurs on `bindv6only=1` systems such as some macOS/Windows configs). I could not reproduce the false-free locally, so the before/after divergence on a real dual-stack `bindv6only=1` host was not captured; the fix is verified by call-site contract test + scoped-probe production-function behavior, matching the #94394 pattern.

## Regression Test Plan
- `src/infra/ssh-tunnel.test.ts`: new `startSshPortForward port probe` case mocks `ensurePortAvailable` and asserts the call is `(localPort, "127.0.0.1")`, surfacing a non-`EADDRINUSE` error before ssh spawns so no real child process is needed.
- This is the smallest reliable guardrail: it pins the call-site contract without depending on a real ssh binary or a dual-stack listener.

## User-visible / Behavior Changes
On dual-stack hosts, an SSH tunnel's preferred local port is now correctly rejected when an IPv4-only process already holds it, instead of being reported as free and then failing later at the `ssh -L` bind.

## Security Impact
- New permissions? No
- Secrets handling changed? No
- New network calls? No

Closes #94596
