### PR TITLE
fix(ssh): bind ensurePortAvailable to IPv4 loopback

### DIFF
--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -119,7 +119,7 @@ export async function startSshPortForward(opts: {
 
   let localPort = opts.localPortPreferred;
   try {
-    await ensurePortAvailable(localPort);
+    await ensurePortAvailable(localPort, "127.0.0.1");
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {
       localPort = await pickEphemeralPort();


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- `startSshPortForward` in `src/infra/ssh-tunnel.ts` calls `ensurePortAvailable(localPort)` without a host argument.
- This causes the port probe to bind to IPv6 wildcard `::`, missing IPv4-only listeners on dual-stack hosts.
- The preflight reports a busy port as free, leading to tunnel failures.

Why does this matter now?

- Issue #94596: Same root cause as #94379, but on the SSH-tunnel surface. On dual-stack hosts, the host-less probe misses IPv4-only occupants.

What is the intended outcome?

- Pass `"127.0.0.1"` as the host argument to `ensurePortAvailable`, matching the pattern used in the Chrome CDP fix (#94394).

What is intentionally out of scope?

- Changes to other surfaces (Chrome CDP was already fixed in #94394).

What does success look like?

- SSH tunnel port selection correctly detects IPv4-only listeners.

What should reviewers focus on?

- `src/infra/ssh-tunnel.ts:122` — the single-line fix

## Linked context

Which issue does this close?

- Closes #94596

Which issues, PRs, or discussions are related?

- Related #94379: Chrome CDP ensurePortAvailable fix
- Related #94394: Fix for #94379

## Real behavior proof

**Behavior or issue addressed:** startSshPortForward misses IPv4-only port occupants on dual-stack hosts

**Real environment tested:** Local OpenClaw checkout, macOS Darwin, Node 22, local git clone

**Exact steps or command run after this patch:**
1. Build OpenClaw: `pnpm build`
2. Run existing unit tests for ports: `pnpm vitest run src/infra/ports.test.ts`
3. Verify the fix pattern matches the existing test in `ports.test.ts:88`

**Evidence after fix:**
![Screenshot of test run](https://github.com/user-attachments/assets/d7e10ac4-56d1-4723-b586-9e1184b3e63a)

**Observed result after fix:** All 14 port tests pass, including the test that verifies `ensurePortAvailable(port, "127.0.0.1")` correctly detects occupied IPv4 loopback.

**What was not tested:** Live SSH tunnel on dual-stack host (requires actual SSH setup)

**Code comparison:**
```typescript
// Before (buggy): binds to IPv6 wildcard ::, misses IPv4-only listeners
await ensurePortAvailable(localPort);

// After (fixed): explicitly binds to IPv4 loopback
await ensurePortAvailable(localPort, "127.0.0.1");
```
