### PR TITLE
fix(build): allow tsdown heap override

### DIFF
--- a/scripts/tsdown-build.mjs
+++ b/scripts/tsdown-build.mjs
@@ -25,6 +25,7 @@ const DEFAULT_CAPTURE_BYTES = 8 * 1024 * 1024;
 const DEFAULT_HEARTBEAT_MS = 30_000;
 const DEFAULT_TSDOWN_MAX_OLD_SPACE_MB = 12288;
 const DEFAULT_WINDOWS_TSDOWN_MAX_OLD_SPACE_MB = 8192;
+const TSDOWN_MAX_OLD_SPACE_MB_ENV = "OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB";
 const MIN_TSDOWN_MAX_OLD_SPACE_MB = 2048;
 const TSDOWN_CGROUP_MEMORY_HEADROOM_MB = 768;
 const CGROUP_MEMORY_LIMIT_PATHS = [
@@ -403,6 +404,14 @@ function resolveTsdownMaxOldSpaceMb(params = {}) {
     (params.platform ?? process.platform) === "win32"
       ? DEFAULT_WINDOWS_TSDOWN_MAX_OLD_SPACE_MB
       : DEFAULT_TSDOWN_MAX_OLD_SPACE_MB;
+  const envOverride = parsePositiveIntegerEnv(
+    (params.env ?? process.env)[TSDOWN_MAX_OLD_SPACE_MB_ENV],
+    TSDOWN_MAX_OLD_SPACE_MB_ENV,
+  );
+  if (envOverride !== null) {
+    return envOverride;
+  }
+
   const limitBytes = readCgroupMemoryLimitBytes(params) ?? readProcMemTotalBytes(params);
   if (limitBytes === null) {
     return defaultMaxOldSpaceMb;

--- a/scripts/tsdown-build.mjs
+++ b/scripts/tsdown-build.mjs
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { BUNDLED_PLUGIN_PATH_PREFIX } from "./lib/bundled-plugin-paths.mjs";
+import { parsePositiveInt } from "./lib/numeric-options.mjs";
 import { TSDOWN_PACKAGE_OUTPUT_ROOTS } from "./lib/tsdown-output-roots.mjs";
 import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 import { resolvePnpmRunner } from "./pnpm-runner.mjs";
@@ -307,15 +308,7 @@ function parsePositiveIntegerEnv(value, name) {
   if (typeof value !== "string" || value.trim() === "") {
     return null;
   }
-  const text = value.trim();
-  if (!/^\d+$/u.test(text)) {
-    throw new Error(`${name} must be a positive integer`);
-  }
-  const parsed = Number(text);
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new Error(`${name} must be a positive safe integer`);
-  }
-  return parsed;
+  return parsePositiveInt(value, name);
 }
 
 function parseNonNegativeIntegerEnv(value, name) {

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -260,6 +260,17 @@ describe("resolveTsdownBuildInvocation", () => {
     expect(result.options.env.NODE_OPTIONS).toBe("--max-old-space-size=3072");
   });
 
+  it("keeps memory detection when OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB is blank", () => {
+    const result = resolveTsdownBuildInvocation({
+      nodeExecPath: "/usr/bin/node",
+      npmExecPath: "/tmp/pnpm.cjs",
+      env: { OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB: "  " },
+      cgroupMemoryLimitBytes: 7 * 1024 * 1024 * 1024,
+    });
+
+    expect(result.options.env.NODE_OPTIONS).toBe("--max-old-space-size=6400");
+  });
+
   it("uses OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB to normalize inherited NODE_OPTIONS", () => {
     const result = resolveTsdownBuildInvocation({
       platform: "win32",

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -276,7 +276,7 @@ describe("resolveTsdownBuildInvocation", () => {
   });
 
   it("rejects malformed OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB values", () => {
-    for (const value of ["0", "-1", "1.5", "1e3", "4096mb"]) {
+    for (const value of ["0", "-1", "1.5", "1e3", "4096mb", "9007199254740992"]) {
       expect(() =>
         resolveTsdownBuildInvocation({
           nodeExecPath: "/usr/bin/node",

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -54,7 +54,9 @@ function isProcessAlive(pid: number): boolean {
 }
 
 async function sleep(ms: number): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, ms));
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
@@ -245,6 +247,45 @@ describe("resolveTsdownBuildInvocation", () => {
     });
 
     expect(result.options.env.NODE_OPTIONS).toBe("--trace-warnings --max-old-space-size=6400");
+  });
+
+  it("honors OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB over platform and memory defaults", () => {
+    const result = resolveTsdownBuildInvocation({
+      nodeExecPath: "/usr/bin/node",
+      npmExecPath: "/tmp/pnpm.cjs",
+      env: { OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB: "3072" },
+      cgroupMemoryLimitBytes: 7 * 1024 * 1024 * 1024,
+    });
+
+    expect(result.options.env.NODE_OPTIONS).toBe("--max-old-space-size=3072");
+  });
+
+  it("uses OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB to normalize inherited NODE_OPTIONS", () => {
+    const result = resolveTsdownBuildInvocation({
+      platform: "win32",
+      nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",
+      npmExecPath: "C:\\repo\\pnpm.cjs",
+      env: {
+        NODE_OPTIONS: "--trace-warnings --max-old-space-size=12288",
+        OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB: "4096",
+      },
+      ...NO_MEMORY_LIMIT,
+    });
+
+    expect(result.options.env.NODE_OPTIONS).toBe("--trace-warnings --max-old-space-size=4096");
+  });
+
+  it("rejects malformed OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB values", () => {
+    for (const value of ["0", "-1", "1.5", "1e3", "4096mb"]) {
+      expect(() =>
+        resolveTsdownBuildInvocation({
+          nodeExecPath: "/usr/bin/node",
+          npmExecPath: "/tmp/pnpm.cjs",
+          env: { OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB: value },
+          ...NO_MEMORY_LIMIT,
+        }),
+      ).toThrow("OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB must be");
+    }
   });
 
   it("falls back to proc meminfo when the cgroup memory limit is unbounded", () => {
@@ -727,7 +768,7 @@ describe("runTsdownBuildInvocation", () => {
       const rootDir = createTempDir("openclaw-tsdown-timeout-");
       const childPidPath = path.join(rootDir, "child.pid");
       const timeoutMs = 1_000;
-      let childPid = 0;
+      let childPid: number | undefined;
       const childScript = "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);";
       const parentScript = [
         "const { spawn } = require('node:child_process');",
@@ -769,7 +810,7 @@ describe("runTsdownBuildInvocation", () => {
         expect(result.timedOut).toBe(true);
         await waitForDead(childPid, 2_000);
       } finally {
-        if (childPid && isProcessAlive(childPid)) {
+        if (childPid !== undefined && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");
         }
       }


### PR DESCRIPTION
## Summary
- Add `OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB` so constrained build hosts can set the tsdown Node heap cap explicitly.
- Keep existing cgroup/proc memory detection as the fallback when the override is unset.
- Reject malformed override values with the same strict positive-integer parser used by the other tsdown build environment settings.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec oxfmt --check --threads=1 scripts/tsdown-build.mjs test/scripts/tsdown-build.test.ts`
- `pnpm exec oxlint scripts/tsdown-build.mjs test/scripts/tsdown-build.test.ts`
- `node scripts/test-projects.mjs test/scripts/tsdown-build.test.ts`
- `pnpm tsgo:core:test`
- `pnpm tsgo:core`
- `git diff --check`

## Real behavior proof
Behavior addressed: tsdown builds now allow an explicit max-old-space-size override for hosts where automatic memory detection is too high or too low.

Real environment tested: local macOS development worktree on Node `/opt/homebrew/Cellar/node/25.6.1/bin/node`, using the real `scripts/tsdown-build.mjs` module after this patch.

Exact steps or command run after this patch: `OPENCLAW_BUILD_ALL_NO_PNPM=1 OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB=3072 node --input-type=module - <<'EOF' ... resolveTsdownBuildInvocation(...) ... EOF`

Evidence after fix:
```json
{
  "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node",
  "firstArgs": [
    "node_modules/tsdown/dist/run.mjs",
    "--config-loader"
  ],
  "nodeOptions": "--max-old-space-size=3072"
}
```

Observed result after fix: the generated tsdown invocation inherited `OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB=3072` and produced `NODE_OPTIONS=--max-old-space-size=3072`, even with a larger synthetic cgroup memory limit available.

What was not tested: a full production tsdown build inside an actual low-memory container or VPS; the patch was verified at the invocation resolver, targeted test-project, lint, and typecheck layers.
