### PR TITLE
fix(telegram): skip IP-rotation fallback for local socket allocation failures

### DIFF
--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -1371,6 +1371,18 @@ describe("shouldRetryTelegramTransportFallback", () => {
     expectNoLoggerMessageContaining(loggerWarn, "local socket allocation failure");
   });
 
+  it("still retries for ECONNREFUSED embedded only in the message (preserves existing IP-rotation behavior)", () => {
+    // A message-only `ECONNREFUSED` envelope previously fell through to the
+    // code-less `fetch failed` branch and triggered IP rotation. The message
+    // errno parser must not extract `ECONNREFUSED` from the message (it is not
+    // a local-socket-failure code), otherwise `ctx.codes.size > 0` would block
+    // the fallback for a remote-reachability problem that IP rotation can fix.
+    const err = new TypeError("fetch failed: connect ECONNREFUSED 149.154.167.220:443");
+
+    expect(shouldRetryTelegramTransportFallback(err)).toBe(true);
+    expectNoLoggerMessageContaining(loggerWarn, "local socket allocation failure");
+  });
+
   it("still retries for code-less fetch failed errors with no errno token", () => {
     expect(shouldRetryTelegramTransportFallback(new TypeError("fetch failed"))).toBe(true);
     expectNoLoggerMessageContaining(loggerWarn, "local socket allocation failure");

--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -1365,6 +1365,17 @@ describe("shouldRetryTelegramTransportFallback", () => {
     expectLoggerMessageContaining(loggerWarn, "local socket allocation failure");
   });
 
+  it("does not trigger IP-rotation fallback for EAFNOSUPPORT embedded only in the message", () => {
+    // EAFNOSUPPORT is also a local address-family failure — the kernel cannot
+    // assign a source address for the requested family. Like EADDRNOTAVAIL,
+    // rotating to an alternative Telegram IP cannot fix it.
+    const err = new TypeError("fetch failed: connect EAFNOSUPPORT 149.154.167.220:443 - Local (:::0)");
+
+    expect(shouldRetryTelegramTransportFallback(err)).toBe(false);
+    expectNoLoggerMessageContaining(loggerWarn, "fetch fallback: DNS-resolved IP unreachable");
+    expectLoggerMessageContaining(loggerWarn, "local socket allocation failure");
+  });
+
   it("still retries for remote-reachability errnos that IP rotation can fix", () => {
     const err = buildFetchFallbackError("EHOSTUNREACH");
     expect(shouldRetryTelegramTransportFallback(err)).toBe(true);

--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -113,6 +113,7 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
 let resolveTelegramFetch: typeof import("./fetch.js").resolveTelegramFetch;
 let resolveTelegramApiBase: typeof import("./fetch.js").resolveTelegramApiBase;
 let resolveTelegramTransport: typeof import("./fetch.js").resolveTelegramTransport;
+let shouldRetryTelegramTransportFallback: typeof import("./fetch.js").shouldRetryTelegramTransportFallback;
 const tempDirs: string[] = [];
 
 type TelegramDispatcherPolicy = NonNullable<
@@ -125,8 +126,12 @@ type ExplicitProxyTelegramDispatcherPolicy = Extract<
 >;
 
 beforeAll(async () => {
-  ({ resolveTelegramApiBase, resolveTelegramFetch, resolveTelegramTransport } =
-    await import("./fetch.js"));
+  ({
+    resolveTelegramApiBase,
+    resolveTelegramFetch,
+    resolveTelegramTransport,
+    shouldRetryTelegramTransportFallback,
+  } = await import("./fetch.js"));
 });
 
 beforeEach(() => {
@@ -1326,5 +1331,48 @@ describe("resolveTelegramFetch", () => {
 
       await expect(transport.close()).resolves.toBeUndefined();
     });
+  });
+});
+
+describe("shouldRetryTelegramTransportFallback", () => {
+  beforeEach(() => {
+    loggerDebug.mockReset();
+    loggerWarn.mockReset();
+  });
+
+  it("does not trigger IP-rotation fallback for EADDRNOTAVAIL exposed via cause.code", () => {
+    // Well-behaved undici: errno propagates onto the cause as `.code`.
+    const err = Object.assign(new TypeError("fetch failed"), {
+      cause: Object.assign(new Error("connect EADDRNOTAVAIL 149.154.167.220:443 - Local (0.0.0.0:0)"), {
+        code: "EADDRNOTAVAIL",
+      }),
+    });
+
+    expect(shouldRetryTelegramTransportFallback(err)).toBe(false);
+    expectNoLoggerMessageContaining(loggerWarn, "fetch fallback: DNS-resolved IP unreachable");
+    expectLoggerMessageContaining(loggerWarn, "local socket allocation failure");
+  });
+
+  it("does not trigger IP-rotation fallback for EADDRNOTAVAIL embedded only in the message", () => {
+    // Regression for the reported incident: undici wraps the connect failure as
+    // `fetch failed` without propagating `.code`, so the errno lives only in the
+    // message text. Previously this fell through to the code-less `fetch failed`
+    // branch and rotated to the pinned Telegram IP uselessly.
+    const err = new TypeError("fetch failed: connect EADDRNOTAVAIL 149.154.167.220:443 - Local (0.0.0.0:0)");
+
+    expect(shouldRetryTelegramTransportFallback(err)).toBe(false);
+    expectNoLoggerMessageContaining(loggerWarn, "fetch fallback: DNS-resolved IP unreachable");
+    expectLoggerMessageContaining(loggerWarn, "local socket allocation failure");
+  });
+
+  it("still retries for remote-reachability errnos that IP rotation can fix", () => {
+    const err = buildFetchFallbackError("EHOSTUNREACH");
+    expect(shouldRetryTelegramTransportFallback(err)).toBe(true);
+    expectNoLoggerMessageContaining(loggerWarn, "local socket allocation failure");
+  });
+
+  it("still retries for code-less fetch failed errors with no errno token", () => {
+    expect(shouldRetryTelegramTransportFallback(new TypeError("fetch failed"))).toBe(true);
+    expectNoLoggerMessageContaining(loggerWarn, "local socket allocation failure");
   });
 });

--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -1365,15 +1365,36 @@ describe("shouldRetryTelegramTransportFallback", () => {
     expectLoggerMessageContaining(loggerWarn, "local socket allocation failure");
   });
 
-  it("does not trigger IP-rotation fallback for EAFNOSUPPORT embedded only in the message", () => {
-    // EAFNOSUPPORT is also a local address-family failure — the kernel cannot
-    // assign a source address for the requested family. Like EADDRNOTAVAIL,
-    // rotating to an alternative Telegram IP cannot fix it.
+  it("still retries for EAFNOSUPPORT via the sticky IPv4 fallback dispatcher (message-only)", () => {
+    // EAFNOSUPPORT signals a family-mismatch failure (e.g. IPv6 address-family
+    // not supported). The Telegram transport fallback chain first promotes to a
+    // forced-IPv4 dispatcher (dnsResultOrder=ipv4first, autoSelectFamily=false,
+    // forceIpv4=true), so EAFNOSUPPORT on the IPv6 path is recoverable via IPv4.
+    // EAFNOSUPPORT is NOT in the local-socket-failure set because blocking it
+    // from fallback would preempt the IPv4 recovery path, making a recoverable
+    // family-mismatch error unrecoverable. Since EAFNOSUPPORT is not matched
+    // by the message errno parser, this code-less `fetch failed` envelope falls
+    // through to the `hasFetchFailedEnvelope && ctx.codes.size === 0` branch,
+    // which correctly triggers IP-rotation fallback.
     const err = new TypeError("fetch failed: connect EAFNOSUPPORT 149.154.167.220:443 - Local (:::0)");
 
-    expect(shouldRetryTelegramTransportFallback(err)).toBe(false);
-    expectNoLoggerMessageContaining(loggerWarn, "fetch fallback: DNS-resolved IP unreachable");
-    expectLoggerMessageContaining(loggerWarn, "local socket allocation failure");
+    expect(shouldRetryTelegramTransportFallback(err)).toBe(true);
+    expectNoLoggerMessageContaining(loggerWarn, "local socket allocation failure");
+  });
+
+  it("still retries for EAFNOSUPPORT exposed via cause.code (IPv4 dispatcher can recover)", () => {
+    // When EAFNOSUPPORT propagates via `.code` on the cause chain, it is now
+    // in FALLBACK_RETRY_ERROR_CODES, so `hasKnownNetworkCode` returns true and
+    // the transport fallback chain runs — giving the sticky IPv4 dispatcher a
+    // chance to recover the family-mismatch connection.
+    const err = Object.assign(new TypeError("fetch failed"), {
+      cause: Object.assign(new Error("connect EAFNOSUPPORT 149.154.167.220:443 - Local (:::0)"), {
+        code: "EAFNOSUPPORT",
+      }),
+    });
+
+    expect(shouldRetryTelegramTransportFallback(err)).toBe(true);
+    expectNoLoggerMessageContaining(loggerWarn, "local socket allocation failure");
   });
 
   it("still retries for remote-reachability errnos that IP rotation can fix", () => {

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -126,6 +126,19 @@ const FALLBACK_RETRY_ERROR_CODES = [
   "UND_ERR_SOCKET",
 ] as const;
 
+// Errnos that signal a *local* socket/source-address allocation failure rather
+// than a remote-reachability problem. Rotating to an alternative Telegram API
+// IP cannot fix these (the kernel cannot assign a source address/port for any
+// destination), so falling back through the pinned-IP dispatcher is dead code
+// that only produces misleading "Telegram is down" log noise during an incident.
+const LOCAL_SOCKET_FAILURE_ERROR_CODES = ["EADDRNOTAVAIL"] as const;
+
+// Errno tokens may appear only inside the error `message` when undici wraps a
+// connect failure as `fetch failed` without propagating `.code` onto the cause
+// chain. Match the well-known tokens so detection is not dependent on undici's
+// cause propagation.
+const ERROR_CODE_MESSAGE_PATTERN = /\b(EADDRNOTAVAIL|ETIMEDOUT|ENETDOWN|ENETUNREACH|EHOSTUNREACH|ECONNREFUSED|EAFNOSUPPORT|UND_ERR_CONNECT_TIMEOUT|UND_ERR_SOCKET)\b/i;
+
 type TelegramTransportFallbackContext = {
   message: string;
   codes: Set<string>;
@@ -431,6 +444,13 @@ function collectErrorCodes(err: unknown): Set<string> {
       if (typeof code === "string" && code.trim()) {
         codes.add(code.trim().toUpperCase());
       }
+      const message = (current as { message?: unknown }).message;
+      if (typeof message === "string") {
+        const matched = message.match(ERROR_CODE_MESSAGE_PATTERN);
+        if (matched && matched[1]) {
+          codes.add(matched[1].toUpperCase());
+        }
+      }
       const cause = (current as { cause?: unknown }).cause;
       if (cause && !seen.has(cause)) {
         queue.push(cause);
@@ -473,6 +493,22 @@ function shouldUseTelegramTransportFallback(err: unknown): boolean {
         : "",
     codes: collectErrorCodes(err),
   };
+  // A local socket/source-address allocation failure (e.g. EADDRNOTAVAIL when
+  // the kernel cannot assign a source address/port) is not a remote
+  // reachability problem. Retrying against an alternative Telegram API IP will
+  // hit the same errno on every attempt, so skip the pinned-IP fallback and
+  // surface the real cause instead of misattributing it to Telegram downtime.
+  const hasLocalSocketFailureCode = LOCAL_SOCKET_FAILURE_ERROR_CODES.some((code) =>
+    ctx.codes.has(code),
+  );
+  if (hasLocalSocketFailureCode) {
+    log.warn(
+      `fetch fallback skipped: local socket allocation failure (codes=${formatErrorCodes(
+        err,
+      )}); remote IP rotation cannot help — check ephemeral ports / network extensions`,
+    );
+    return false;
+  }
   const hasFetchFailedEnvelope = ctx.message.includes("fetch failed");
   const hasKnownNetworkCode = FALLBACK_RETRY_ERROR_CODES.some((code) => ctx.codes.has(code));
   return hasKnownNetworkCode || (hasFetchFailedEnvelope && ctx.codes.size === 0);

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -135,9 +135,13 @@ const LOCAL_SOCKET_FAILURE_ERROR_CODES = ["EADDRNOTAVAIL"] as const;
 
 // Errno tokens may appear only inside the error `message` when undici wraps a
 // connect failure as `fetch failed` without propagating `.code` onto the cause
-// chain. Match the well-known tokens so detection is not dependent on undici's
-// cause propagation.
-const ERROR_CODE_MESSAGE_PATTERN = /\b(EADDRNOTAVAIL|ETIMEDOUT|ENETDOWN|ENETUNREACH|EHOSTUNREACH|ECONNREFUSED|EAFNOSUPPORT|UND_ERR_CONNECT_TIMEOUT|UND_ERR_SOCKET)\b/i;
+// chain. Only match the local-socket-failure errno here (not the fallback-retry
+// codes), so that a message-only `ECONNREFUSED` or `EHOSTUNREACH` envelope still
+// falls through to the code-less `fetch failed` branch and keeps the existing
+// IP-rotation behavior. The fallback-retry codes already match via `.code` on
+// the cause chain; matching them from message text too would change the
+// classification for envelopes where undici omits `.code`.
+const LOCAL_SOCKET_FAILURE_MESSAGE_PATTERN = /\b(EADDRNOTAVAIL|EAFNOSUPPORT)\b/i;
 
 type TelegramTransportFallbackContext = {
   message: string;
@@ -446,7 +450,7 @@ function collectErrorCodes(err: unknown): Set<string> {
       }
       const message = (current as { message?: unknown }).message;
       if (typeof message === "string") {
-        const matched = message.match(ERROR_CODE_MESSAGE_PATTERN);
+        const matched = message.match(LOCAL_SOCKET_FAILURE_MESSAGE_PATTERN);
         if (matched && matched[1]) {
           codes.add(matched[1].toUpperCase());
         }

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -117,11 +117,19 @@ type LookupFunction = (
   callback: LookupCallback,
 ) => void;
 
+// Error codes that should trigger the Telegram transport fallback chain.
+// When these errors appear in the cause chain's `.code`, the sticky IPv4
+// dispatcher or IP-rotation loop may recover the connection.
 const FALLBACK_RETRY_ERROR_CODES = [
   "ETIMEDOUT",
   "ENETDOWN",
   "ENETUNREACH",
   "EHOSTUNREACH",
+  // EAFNOSUPPORT signals an address-family mismatch (e.g. IPv6 family not
+  // supported on this host). The sticky IPv4 dispatcher (forceIpv4=true,
+  // dnsResultOrder=ipv4first) can recover from this by forcing IPv4, so
+  // EAFNOSUPPORT should trigger fallback rather than fail-fast.
+  "EAFNOSUPPORT",
   "UND_ERR_CONNECT_TIMEOUT",
   "UND_ERR_SOCKET",
 ] as const;
@@ -131,7 +139,14 @@ const FALLBACK_RETRY_ERROR_CODES = [
 // IP cannot fix these (the kernel cannot assign a source address/port for any
 // destination), so falling back through the pinned-IP dispatcher is dead code
 // that only produces misleading "Telegram is down" log noise during an incident.
-const LOCAL_SOCKET_FAILURE_ERROR_CODES = ["EADDRNOTAVAIL", "EAFNOSUPPORT"] as const;
+//
+// EAFNOSUPPORT is intentionally NOT in this set: the Telegram transport fallback
+// chain first promotes to a forced-IPv4 dispatcher (dnsResultOrder=ipv4first,
+// autoSelectFamily=false, forceIpv4=true), so a mixed-family autoselection
+// failure producing EAFNOSUPPORT on the IPv6 path can recover through the IPv4
+// dispatcher. Blocking EAFNOSUPPORT from fallback would preempt that IPv4
+// recovery path, making a recoverable family-mismatch error unrecoverable.
+const LOCAL_SOCKET_FAILURE_ERROR_CODES = ["EADDRNOTAVAIL"] as const;
 
 // Errno tokens may appear only inside the error `message` when undici wraps a
 // connect failure as `fetch failed` without propagating `.code` onto the cause
@@ -141,7 +156,10 @@ const LOCAL_SOCKET_FAILURE_ERROR_CODES = ["EADDRNOTAVAIL", "EAFNOSUPPORT"] as co
 // IP-rotation behavior. The fallback-retry codes already match via `.code` on
 // the cause chain; matching them from message text too would change the
 // classification for envelopes where undici omits `.code`.
-const LOCAL_SOCKET_FAILURE_MESSAGE_PATTERN = /\b(EADDRNOTAVAIL|EAFNOSUPPORT)\b/i;
+// EAFNOSUPPORT is intentionally excluded from this pattern for the same reason
+// it is excluded from LOCAL_SOCKET_FAILURE_ERROR_CODES: the sticky IPv4
+// dispatcher can recover from family-mismatch failures.
+const LOCAL_SOCKET_FAILURE_MESSAGE_PATTERN = /\b(EADDRNOTAVAIL)\b/i;
 
 type TelegramTransportFallbackContext = {
   message: string;
@@ -502,6 +520,9 @@ function shouldUseTelegramTransportFallback(err: unknown): boolean {
   // reachability problem. Retrying against an alternative Telegram API IP will
   // hit the same errno on every attempt, so skip the pinned-IP fallback and
   // surface the real cause instead of misattributing it to Telegram downtime.
+  // Note: EAFNOSUPPORT is intentionally NOT in the fail-fast set because the
+  // sticky IPv4 dispatcher can recover from family-mismatch failures; see
+  // LOCAL_SOCKET_FAILURE_ERROR_CODES for details.
   const hasLocalSocketFailureCode = LOCAL_SOCKET_FAILURE_ERROR_CODES.some((code) =>
     ctx.codes.has(code),
   );

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -131,7 +131,7 @@ const FALLBACK_RETRY_ERROR_CODES = [
 // IP cannot fix these (the kernel cannot assign a source address/port for any
 // destination), so falling back through the pinned-IP dispatcher is dead code
 // that only produces misleading "Telegram is down" log noise during an incident.
-const LOCAL_SOCKET_FAILURE_ERROR_CODES = ["EADDRNOTAVAIL"] as const;
+const LOCAL_SOCKET_FAILURE_ERROR_CODES = ["EADDRNOTAVAIL", "EAFNOSUPPORT"] as const;
 
 // Errno tokens may appear only inside the error `message` when undici wraps a
 // connect failure as `fetch failed` without propagating `.code` onto the cause


### PR DESCRIPTION
### Summary

When a Telegram `fetch` call fails with a local socket allocation error (EADDRNOTAVAIL or EAFNOSUPPORT), the kernel cannot assign a source address/port for the requested family. However, **EAFNOSUPPORT is recoverable** via the sticky IPv4 dispatcher (forceIpv4=true, dnsResultOrder=ipv4first, autoSelectFamily=false), while **EADDRNOTAVAIL is not recoverable** by any IP rotation (the kernel has no source address for any destination).

Per the ClawSweeper P1 review finding, the original patch incorrectly classified EAFNOSUPPORT as fail-fast alongside EADDRNOTAVAIL. This would preempt the IPv4 recovery path for mixed-family autoselection failures, making a recoverable family-mismatch error unrecoverable.

### Changes

1. `extensions/telegram/src/fetch.ts`:
   - **EADDRNOTAVAIL** remains in `LOCAL_SOCKET_FAILURE_ERROR_CODES` — fail-fast, bypassing IP-rotation fallback. The kernel cannot assign a source address/port for any destination, so rotating IPs cannot help.
   - **EAFNOSUPPORT** removed from `LOCAL_SOCKET_FAILURE_ERROR_CODES` and `LOCAL_SOCKET_FAILURE_MESSAGE_PATTERN`, and **added to `FALLBACK_RETRY_ERROR_CODES`**. The sticky IPv4 dispatcher can recover from address-family mismatch by forcing IPv4.
   - Detailed comments added explaining why EAFNOSUPPORT is excluded from fail-fast and included in retry codes.
   - `LOCAL_SOCKET_FAILURE_MESSAGE_PATTERN` narrowed from `/\b(EADDRNOTAVAIL|EAFNOSUPPORT)\b/i` to `/\b(EADDRNOTAVAIL)\b/i` — EAFNOSUPPORT in message text no longer extracted to codes (message-only EAFNOSUPPORT envelope falls through to code-less `fetch failed` branch, which correctly triggers IP-rotation fallback).

2. `extensions/telegram/src/fetch.test.ts`:
   - EAFNOSUPPORT message-only test changed: now asserts `fallback=true` (code-less `fetch failed` branch triggers IP rotation).
   - Added new test: EAFNOSUPPORT via `.code` on cause → `fallback=true` (`FALLBACK_RETRY_ERROR_CODES` match triggers fallback, IPv4 dispatcher can recover).

### What changed

- **`extensions/telegram/src/fetch.ts`** — `LOCAL_SOCKET_FAILURE_ERROR_CODES` narrowed to `["EADDRNOTAVAIL"]` only; `EAFNOSUPPORT` moved to `FALLBACK_RETRY_ERROR_CODES`; `LOCAL_SOCKET_FAILURE_MESSAGE_PATTERN` narrowed to `/\b(EADDRNOTAVAIL)\b/i`; comments updated.
- **`extensions/telegram/src/fetch.test.ts`** — EAFNOSUPPORT message-only test now asserts fallback=true; added EAFNOSUPPORT `.code` test asserting fallback=true.

### What did NOT change (scope boundary)

- EADDRNOTAVAIL fail-fast classification — unchanged. Rotating IPs cannot help when the kernel has no source address.
- The IP-rotation fallback mechanism itself — unchanged. Only the classification of which errors should trigger it changed.
- The Telegram bot handler or media download logic — unchanged.
- Remote network error retry behavior — ETIMEDOUT, EHOSTUNREACH, ENETUNREACH, and undici `fetch failed` envelopes still trigger IP-rotation fallback.

### Linked context

Closes #94620

### Real behavior proof

- **Behavior addressed**: EADDRNOTAVAIL local socket failures fail-fast (bypassing IP-rotation fallback). EAFNOSUPPORT address-family mismatch errors now trigger the sticky IPv4 dispatcher fallback (recoverable). Remote network errors still trigger fallback.
- **Environment tested**: Node v24.13.1 on Linux x86_64; vitest run extensions/telegram/src/fetch.test.ts — 49 passed.
- **Steps run after the patch**: `node_modules/.bin/vitest run extensions/telegram/src/fetch.test.ts`
- **Evidence after fix**: All 49 tests pass, including:
  - EADDRNOTAVAIL `.code` → false (fail-fast, diagnostic warn)
  - EADDRNOTAVAIL message-only → false (fail-fast, diagnostic warn)
  - EAFNOSUPPORT message-only → true (triggers IP-rotation fallback via code-less `fetch failed` branch)
  - EAFNOSUPPORT `.code` → true (triggers fallback via `FALLBACK_RETRY_ERROR_CODES` match, IPv4 dispatcher can recover)
  - ECONNREFUSED message-only → true (unchanged)
  - EHOSTUNREACH `.code` → true (unchanged)
  - code-less `fetch failed` → true (unchanged)

```
 ❯ |extension-telegram| ../../extensions/telegram/src/fetch.test.ts (49 tests) 701ms
 Test Files  1 passed (1)
      Tests  49 passed (49)
   Duration  1.79s
```

- **Observed result after the fix**: EADDRNOTAVAIL correctly fail-fast, EAFNOSUPPORT correctly triggers fallback via both `.code` and message-only paths. All other classifications unchanged.
- **What was not tested**: A live Telegram API fetch with an actual EADDRNOTAVAIL/EAFNOSUPPORT kernel error during a real bot session. Only the classifier and test paths were verified.

### Tests and validation

- `node_modules/.bin/vitest run extensions/telegram/src/fetch.test.ts` — 49 passed

### Risk checklist

- Did user-visible behavior change? **Yes** — EADDRNOTAVAIL errors no longer trigger IP-rotation retry (same as previous patch). EAFNOSUPPORT errors now **do** trigger IP-rotation retry (changed from previous patch where they were fail-fast).
- Did config, environment, or migration behavior change? **No**
- Did security, auth, secrets, network, or tool execution behavior change? **No**
- Highest-risk area: None — EAFNOSUPPORT is correctly routed to IPv4 recovery path. EADDRNOTAVAIL remains fail-fast as intended by the original issue.
- Risk mitigation: Dual-path errno detection (`.code` + message text) for EADDRNOTAVAIL. EAFNOSUPPORT has two recovery paths: `.code` → `FALLBACK_RETRY_ERROR_CODES` match, message-only → code-less `fetch failed` branch. Diagnostic warn log for EADDRNOTAVAIL preserves operator observability.
