### PR TITLE
investigate(memory-core): root-cause for #84882 dreaming silent daily-file deletion

### DIFF
--- a/extensions/memory-core/src/dreaming-integrity-guard.test.ts
+++ b/extensions/memory-core/src/dreaming-integrity-guard.test.ts
@@ -1,0 +1,68 @@
+// Memory Core tests cover dreaming memory-file integrity diagnostics.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { diffMissingMemoryFiles, snapshotMemoryDirFiles } from "./dreaming-integrity-guard.js";
+import { createMemoryCoreTestHarness } from "./test-helpers.js";
+
+const { createTempWorkspace } = createMemoryCoreTestHarness();
+
+describe("dreaming memory-file integrity guard", () => {
+  it("reports ok with an empty snapshot when memory/ does not exist yet", async () => {
+    const workspaceDir = await createTempWorkspace("integrity-missing-dir-");
+    const snapshot = await snapshotMemoryDirFiles(workspaceDir);
+    expect(snapshot).toEqual({ ok: true, files: new Map() });
+  });
+
+  it("snapshots top-level .md files under memory/ and ignores other entries", async () => {
+    const workspaceDir = await createTempWorkspace("integrity-snapshot-");
+    const memoryDir = path.join(workspaceDir, "memory");
+    await fs.mkdir(path.join(memoryDir, "dreaming"), { recursive: true });
+    await fs.writeFile(path.join(memoryDir, "2026-05-15.md"), "hello", "utf-8");
+    await fs.writeFile(path.join(memoryDir, "notes.txt"), "ignored", "utf-8");
+    await fs.writeFile(path.join(memoryDir, "dreaming", "nested.md"), "ignored", "utf-8");
+
+    const snapshot = await snapshotMemoryDirFiles(workspaceDir);
+    expect(snapshot.ok).toBe(true);
+    if (!snapshot.ok) {
+      throw new Error("expected ok snapshot");
+    }
+    expect([...snapshot.files.keys()]).toEqual(["2026-05-15.md"]);
+    expect(snapshot.files.get("2026-05-15.md")?.sizeBytes).toBe(5);
+  });
+
+  it("detects files present before but missing after", async () => {
+    const workspaceDir = await createTempWorkspace("integrity-diff-");
+    const memoryDir = path.join(workspaceDir, "memory");
+    await fs.mkdir(memoryDir, { recursive: true });
+    await fs.writeFile(path.join(memoryDir, "2026-05-15.md"), "old", "utf-8");
+    await fs.writeFile(path.join(memoryDir, "2026-05-16.md"), "kept", "utf-8");
+
+    const before = await snapshotMemoryDirFiles(workspaceDir);
+    await fs.rm(path.join(memoryDir, "2026-05-15.md"));
+    const after = await snapshotMemoryDirFiles(workspaceDir);
+
+    const missing = diffMissingMemoryFiles(before, after);
+    expect(missing).toHaveLength(1);
+    expect(missing[0]?.name).toBe("2026-05-15.md");
+  });
+
+  it("reports no missing files when nothing changed", async () => {
+    const workspaceDir = await createTempWorkspace("integrity-stable-");
+    const memoryDir = path.join(workspaceDir, "memory");
+    await fs.mkdir(memoryDir, { recursive: true });
+    await fs.writeFile(path.join(memoryDir, "2026-05-15.md"), "stable", "utf-8");
+
+    const before = await snapshotMemoryDirFiles(workspaceDir);
+    const after = await snapshotMemoryDirFiles(workspaceDir);
+
+    expect(diffMissingMemoryFiles(before, after)).toEqual([]);
+  });
+
+  it("never reports missing files when either snapshot failed", async () => {
+    const failed = { ok: false as const, reason: "boom" };
+    const okEmpty = { ok: true as const, files: new Map() };
+    expect(diffMissingMemoryFiles(failed, okEmpty)).toEqual([]);
+    expect(diffMissingMemoryFiles(okEmpty, failed)).toEqual([]);
+  });
+});

--- a/extensions/memory-core/src/dreaming-integrity-guard.ts
+++ b/extensions/memory-core/src/dreaming-integrity-guard.ts
@@ -22,7 +22,7 @@ export async function snapshotMemoryDirFiles(
   workspaceDir: string,
 ): Promise<MemoryDirSnapshotResult> {
   const memoryDir = path.join(workspaceDir, "memory");
-  let entries: Dirent<string>[];
+  let entries: Dirent[];
   try {
     entries = await fs.readdir(memoryDir, { withFileTypes: true, encoding: "utf-8" });
   } catch (err) {

--- a/extensions/memory-core/src/dreaming-integrity-guard.ts
+++ b/extensions/memory-core/src/dreaming-integrity-guard.ts
@@ -1,0 +1,71 @@
+// Memory Core plugin module implements dreaming memory-file integrity diagnostics.
+//
+// Diagnostic-only: detects when top-level memory/*.md files disappear during a
+// single dreaming run, to help pin down the unresolved deletion mechanism from
+// issue #84882. Never throws — a failure to snapshot must not affect dreaming.
+import type { Dirent } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type MemoryDirFileMeta = {
+  sizeBytes: number;
+  mtimeMs: number;
+};
+
+export type MemoryDirSnapshotResult =
+  | { ok: true; files: Map<string, MemoryDirFileMeta> }
+  | { ok: false; reason: string };
+
+export type MissingMemoryFile = MemoryDirFileMeta & { name: string };
+
+export async function snapshotMemoryDirFiles(
+  workspaceDir: string,
+): Promise<MemoryDirSnapshotResult> {
+  const memoryDir = path.join(workspaceDir, "memory");
+  let entries: Dirent<string>[];
+  try {
+    entries = await fs.readdir(memoryDir, { withFileTypes: true, encoding: "utf-8" });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return { ok: true, files: new Map() };
+    }
+    return { ok: false, reason: formatSnapshotError(err) };
+  }
+
+  const files = new Map<string, MemoryDirFileMeta>();
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".md")) {
+      continue;
+    }
+    try {
+      const stat = await fs.stat(path.join(memoryDir, entry.name));
+      files.set(entry.name, { sizeBytes: stat.size, mtimeMs: stat.mtimeMs });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+        return { ok: false, reason: formatSnapshotError(err) };
+      }
+      // File raced out between readdir and stat; treat as absent rather than failing.
+    }
+  }
+  return { ok: true, files };
+}
+
+export function diffMissingMemoryFiles(
+  before: MemoryDirSnapshotResult,
+  after: MemoryDirSnapshotResult,
+): MissingMemoryFile[] {
+  if (!before.ok || !after.ok) {
+    return [];
+  }
+  const missing: MissingMemoryFile[] = [];
+  for (const [name, meta] of before.files) {
+    if (!after.files.has(name)) {
+      missing.push({ name, ...meta });
+    }
+  }
+  return missing;
+}
+
+function formatSnapshotError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -563,15 +563,20 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
       repairShortTermPromotionArtifacts,
       rankShortTermPromotionCandidates,
     },
+    { snapshotMemoryDirFiles, diffMissingMemoryFiles },
   ] = await Promise.all([
     import("./dreaming-markdown.js"),
     import("./dreaming-narrative.js"),
     import("./dreaming-phases.js"),
     import("./short-term-promotion.js"),
+    import("./dreaming-integrity-guard.js"),
   ]);
   for (const workspaceDir of workspaces) {
     try {
       const sweepNowMs = Date.now();
+      // Diagnostic for #84882 (daily memory files silently disappearing): snapshot
+      // before this run touches anything so we can tell if files vanished during it.
+      const integrityBeforeSnapshot = await snapshotMemoryDirFiles(workspaceDir);
       await runDreamingSweepPhases({
         workspaceDir,
         pluginConfig,
@@ -687,6 +692,25 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
             model: params.config.execution?.model,
             logger: params.logger,
           });
+        }
+      }
+      const integrityAfterSnapshot = await snapshotMemoryDirFiles(workspaceDir);
+      if (!integrityAfterSnapshot.ok) {
+        params.logger.warn(
+          `memory-core: dreaming integrity check could not verify memory/ after this run [workspace=${workspaceDir}]: ${integrityAfterSnapshot.reason}`,
+        );
+      } else {
+        const missing = diffMissingMemoryFiles(integrityBeforeSnapshot, integrityAfterSnapshot);
+        if (missing.length > 0) {
+          const missingSummary = missing
+            .map(
+              (file) =>
+                `${file.name} (${file.sizeBytes}B, mtime=${new Date(file.mtimeMs).toISOString()})`,
+            )
+            .join(", ");
+          params.logger.error(
+            `memory-core: dreaming integrity check found ${missing.length} memory file(s) disappeared during this run [workspace=${workspaceDir}]: ${missingSummary}`,
+          );
         }
       }
     } catch (err) {


### PR DESCRIPTION
Related: #84882

## What Problem This Solves

`memory-core` Dreaming silently deletes daily memory files (`memory/YYYY-MM-DD.md`) — 46+ files vanished in one incident, then a second incident (May 30) wiped 171 -> 7 files. #94537 already landed atomic-write hardening for the *single current-day write path*, but that PR explicitly does not identify the deletion mechanism, and its fix shape (single-file crash-truncation) doesn't match the reported symptom (many distinct historical dates vanishing in one run).

This PR is a root-cause hunt that did not find the mechanism yet, plus diagnostic instrumentation to catch it red-handed on the next reproduction.

## Why This Change Was Made

What I checked and ruled out:

- `repairShortTermPromotionArtifacts` (the exact log line implicated: "normalized recall artifacts before dreaming") only mutates the recall store (JSON/SQLite via plugin state), never touches `memory/*.md`.
- `scrubDreamingNarrativeArtifacts` only renames `*.jsonl` session transcripts, gated by filename suffix — cannot touch `.md` files.
- `applyShortTermPromotions` only writes `MEMORY.md` (long-term), never deletes daily files.
- `writeDailyDreamingPhaseBlock` (the function #94537 hardened) only ever touches *today's* single file per call — cannot explain ~46 distinct historical dates disappearing in one run.
- Traced the anomalous `memory/2026-05-29-1740.md`-style files from the issue thread to `src/hooks/bundled/session-memory/handler.ts` (the `/new`/`/reset` session-memory hook) — confirmed intentional behavior, not data loss, but it does pollute `memory/` with non-`YYYY-MM-DD.md`-shaped files.
- Read the full `@openclaw/fs-safe` write path used by that hook (`root.write` -> pinned write helper -> Python `os.unlink(basename, dir_fd=...)`) end to end per this repo's dependency-contract-proof rule. Every mutation is single-basename-scoped via dir_fd; no directory-wide glob/cleanup logic anywhere in the chain.

None of the above can produce the reported symptom. Root cause remains unknown.

What this PR adds (diagnostic only): `extensions/memory-core/src/dreaming-integrity-guard.ts` snapshots top-level `memory/*.md` filenames + size + mtime before and after each per-workspace dreaming pass (`dreaming.ts`). If any file present in the "before" snapshot is absent in the "after" snapshot, it logs `logger.error` with the full list (name, size, mtime), so the *next* occurrence leaves a log trail pointing at which dreaming run it happened in, rather than relying on the reporter's own external backup/cron diffing.

- Never throws: snapshot failures (including "directory does not exist") are treated as non-fatal and just skip the check for that run.
- Never mutates anything — read-only `fs.readdir`/`fs.stat`.
- Does not change dreaming behavior or output in the non-buggy case.

## User Impact

No user-visible behavior change. This is read-only diagnostic instrumentation; dreaming runs produce identical output. The only observable difference is an additional `logger.error` entry in the rare case where a top-level `memory/*.md` file disappears between dreaming snapshots — which is exactly the bug this is trying to catch.

## Evidence

```
node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-integrity-guard.test.ts extensions/memory-core/src/dreaming.test.ts
# 2 files, 56 tests passed

pnpm tsgo:extensions:test
# clean
```

New tests cover: missing `memory/` dir (ok, empty snapshot), filtering to top-level `.md` only, detecting a removed file between snapshots, no false positives when nothing changed, and no false positives when either snapshot failed.

Real environment tested: macOS arm64 (M4), Darwin 25.5.0, Node v25.9.0, branch `investigate/84882-dreaming-file-deletion`, commit `494317b886` (rebased onto `upstream/main`).

## Status

Still draft / WIP. This does not fix #84882 — it's instrumentation to catch the actual mechanism red-handed on the next reproduction. Will convert from draft once either (a) the integrity log fires and points at a real culprit, or (b) enough reproductions accumulate to rule this approach out.
