### PR TITLE
fix: tighten apple app-specific password redaction to avoid false positives on kebab-case identifiers (#94254)

### DIFF
--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -1094,7 +1094,8 @@ describe("redactSecrets", () => {
     expect(serialized).not.toContain("eyJheaderabcd.eyJpayloadabcd.signatureabcd123456");
     expect(serialized).toContain("main-test-case-name");
     expect(serialized).toContain("standalone app password");
-    expect(serialized).toContain("qrst-uvwx-yzab-cdef");
+    expect(serialized).not.toContain("abcd-efgh-ijkl-mnop");
+    expect(serialized).not.toContain("qrst-uvwx-yzab-cdef");
   });
 
   it("masks app-specific password shapes with Apple/iCloud context in generic fields", () => {

--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -1092,9 +1092,40 @@ describe("redactSecrets", () => {
     expect(serialized).not.toContain("ya29.fake-access-token");
     expect(serialized).not.toContain("1//0fake-refresh-token");
     expect(serialized).not.toContain("eyJheaderabcd.eyJpayloadabcd.signatureabcd123456");
+    expect(serialized).toContain("main-test-case-name");
+    expect(serialized).toContain("standalone app password");
+    expect(serialized).toContain("qrst-uvwx-yzab-cdef");
+  });
+
+  it("masks app-specific password shapes with Apple/iCloud context in generic fields", () => {
+    const output = redactSecrets({
+      data: {
+        text: "iCloud rejected abcd-efgh-ijkl-mnop",
+        errorMessage: "apple app-specific-password qrst-uvwx-yzab-cdef rejected",
+        detail: "benign kube-node-pool-spec identifier preserved",
+      },
+    });
+    const serialized = JSON.stringify(output);
+    expect(serialized).toContain("iCloud rejected");
     expect(serialized).not.toContain("abcd-efgh-ijkl-mnop");
     expect(serialized).not.toContain("qrst-uvwx-yzab-cdef");
-    expect(serialized).toContain("main-test-case-name");
+    expect(serialized).toContain("kube-node-pool-spec");
+  });
+
+  it("masks app-specific password shapes in dedicated apple field keys", () => {
+    expect(redactSensitiveFieldValue("app-specific-password", "abcd-efgh-ijkl-mnop")).toContain(
+      "…",
+    );
+    expect(redactSensitiveFieldValue("icloud", "abcd-efgh-ijkl-mnop")).toContain("…");
+  });
+
+  it("preserves kebab-case identifiers in generic fields without Apple context", () => {
+    expect(redactSensitiveFieldValue("text", "open the help-desk-team-page link")).toBe(
+      "open the help-desk-team-page link",
+    );
+    expect(redactSensitiveFieldValue("error", "module load-some-bare-init crashed")).toBe(
+      "module load-some-bare-init crashed",
+    );
   });
 
   it("preserves benign bare access and refresh fields", () => {

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -93,6 +93,9 @@ const STRUCTURED_SECRET_FIELD_RE = new RegExp(
 );
 const STRUCTURED_APP_PASSWORD_FIELD_RE =
   /^(?:apple|icloud|app[-_]?specific[-_]?password|appSpecificPassword|application[-_]?password|text|content|message|error|errorMessage|detail|details|reason)$/i;
+/** Apple-specific field names that always provide Apple/iCloud context for app password redaction. */
+const APP_SPECIFIC_ONLY_FIELD_RE =
+  /^(?:apple|icloud|app[-_]?specific[-_]?password|appSpecificPassword|application[-_]?password)$/i;
 const APP_SPECIFIC_PASSWORD_RE = /\b([a-z]{4}-[a-z]{4}-[a-z]{4}-[a-z]{4})\b/g;
 const BENIGN_APP_PASSWORD_WORDS = new Set([
   "case",
@@ -939,7 +942,14 @@ function looksLikeAppSpecificPassword(candidate: string): boolean {
   return candidate.split("-").every((part) => !BENIGN_APP_PASSWORD_WORDS.has(part.toLowerCase()));
 }
 
-function redactAppSpecificPasswords(text: string): string {
+const APP_SPECIFIC_PASSWORD_CONTEXT_RE = /\b(?:apple|icloud|app[-_\s]?specific[-_\s]?password)\b/i;
+
+function redactAppSpecificPasswords(text: string, fieldKey?: string): string {
+  if (!fieldKey || !APP_SPECIFIC_ONLY_FIELD_RE.test(fieldKey)) {
+    if (!APP_SPECIFIC_PASSWORD_CONTEXT_RE.test(text)) {
+      return text;
+    }
+  }
   return replacePatternBounded(text, APP_SPECIFIC_PASSWORD_RE, (match: string, token: string) =>
     looksLikeAppSpecificPassword(token)
       ? redactMatch(match, [token], APP_SPECIFIC_PASSWORD_RE)
@@ -1041,7 +1051,7 @@ function redactSensitiveFieldValueWithOptions(
   });
   const shouldRedactAppPassword = redacted !== value || STRUCTURED_APP_PASSWORD_FIELD_RE.test(key);
   if (shouldRedactAppPassword) {
-    const appRedacted = redactAppSpecificPasswords(redacted);
+    const appRedacted = redactAppSpecificPasswords(redacted, key);
     if (appRedacted !== value) {
       return appRedacted;
     }

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -942,7 +942,8 @@ function looksLikeAppSpecificPassword(candidate: string): boolean {
   return candidate.split("-").every((part) => !BENIGN_APP_PASSWORD_WORDS.has(part.toLowerCase()));
 }
 
-const APP_SPECIFIC_PASSWORD_CONTEXT_RE = /\b(?:apple|icloud|app[-_\s]?specific[-_\s]?password)\b/i;
+const APP_SPECIFIC_PASSWORD_CONTEXT_RE =
+  /\b(?:apple|icloud|app[-_\s]?(?:specific[-_\s]?)?password)\b/i;
 
 function redactAppSpecificPasswords(text: string, fieldKey?: string): string {
   if (!fieldKey || !APP_SPECIFIC_ONLY_FIELD_RE.test(fieldKey)) {


### PR DESCRIPTION
## Real behavior proof

**Behavior or issue addressed:** `redact.ts` was masking any `aaaa-bbbb-cccc-dddd` pattern in generic content fields (text, content, message, error, errorMessage, detail, details, reason) as an Apple app-specific password, corrupting legitimate kebab-case identifiers like `kube-node-pool-spec`. The fix adds an Apple/iCloud/app-password context gate so generic fields only run the app-password check when Apple/iCloud/app-password context is present in the value.

**Real environment tested:** macOS 14.6.1, Node 22, openclaw main @ 967fb8d9

**Exact steps or command run after this patch:**
```bash
node --import tsx -e "
import { redactSecrets, redactSensitiveFieldValue } from './src/logging/redact.ts';

// 1. Without Apple context - preserved
console.log('1:', JSON.stringify(redactSensitiveFieldValue('text', 'open the help-desk-team-page link')));
// 2. With iCloud context - masked
console.log('2:', JSON.stringify(redactSensitiveFieldValue('error', 'iCloud rejected abcd-efgh-ijkl-mnop')));
// 3. Apple-specific field - masked
console.log('3:', JSON.stringify(redactSensitiveFieldValue('app-specific-password', 'abcd-efgh-ijkl-mnop')));
// 4. With plain 'app password' context - masked (P1 fix)
console.log('4:', JSON.stringify(redactSensitiveFieldValue('text', 'standalone app password qrst-uvwx-yzab-cdef')));
// 5. With plain 'app password' in errorMessage - masked (P1 fix)
console.log('5:', JSON.stringify(redactSensitiveFieldValue('errorMessage', 'failed with app password qrst-uvwx-yzab-cdef')));
// 6. Nested mixed context
console.log('6:', JSON.stringify(redactSecrets({data: {text: 'iCloud rejected abcd-efgh-ijkl-mnop', errorMessage: 'apple app-specific-password qrst-uvwx-yzab-cdef rejected', detail: 'benign kube-node-pool-spec identifier preserved'}})));
// 7. Nested app password context (P1 fix)
console.log('7:', JSON.stringify(redactSecrets({data: {text: 'standalone app password abcd-efgh-ijkl-mnop', errorMessage: 'failed with app password qrst-uvwx-yzab-cdef'}})));
"
```

**Evidence after fix:** Terminal output from the above command:

```
1: "open the help-desk-team-page link"
2: "iCloud rejected abcd-e…mnop"
3: "abcd-e…mnop"
4: "standalone app password qrst-u…cdef"
5: "failed with app password qrst-u…cdef"
6: {"data":{"text":"iCloud rejected abcd-e…mnop","errorMessage":"apple app-specific-password qrst-u…cdef rejected","detail":"benign kube-node-pool-spec identifier preserved"}}
7: {"data":{"text":"standalone app password abcd-e…mnop","errorMessage":"failed with app password qrst-u…cdef"}}
```

**Observed result after fix:**
- Generic fields without Apple/iCloud/app-password context: kebab-case identifiers are preserved (test 1)
- Generic fields with Apple/iCloud context: Apple passwords are still masked (test 2)
- Apple-specific field keys (app-specific-password, icloud): always masked (test 3)
- Generic fields with plain `app password` context: Apple passwords are still masked (tests 4, 5, 7) - P1 fix
- Nested structured payloads: context-gated masking works correctly per field (test 6)
- All 111 existing unit tests pass

**What was not tested:** Integration with Telegram/transcript pipeline. The change only affects redact.ts; transcript persistence and other redaction paths are unchanged.

## Out-of-scope follow-ups
- P2: per-token context window for same-field mixed content (e.g. `iCloud rejected abcd-efgh-ijkl-mnop; rerun kube-node-pool-spec` could still corrupt the unrelated identifier)