### PR TITLE
fix(infra): bind ensurePortAvailable to 127.0.0.1 in startSshPortForward

### DIFF
--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -119,7 +119,7 @@ export async function startSshPortForward(opts: {
 
   let localPort = opts.localPortPreferred;
   try {
-    await ensurePortAvailable(localPort);
+    await ensurePortAvailable(localPort, "127.0.0.1");
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {
       localPort = await pickEphemeralPort();


### PR DESCRIPTION
## Summary

What problem does this PR solve?
- In `#94394`, the caller-scoped `ensurePortAvailable(port, host?)` was introduced to fix the Chrome CDP missing IPv4 occupant flaw. However, `startSshPortForward` in `src/infra/ssh-tunnel.ts` was missed and was still calling it host-less: `await ensurePortAvailable(localPort);`.
- On dual-stack hosts, this host-less probe binds to the IPv6 wildcard `::` and misses IPv4-only occupants, causing `EADDRINUSE` crashes when the SSH tunnel attempts to start.

Why does this matter now?
- Failing to detect a blocked port causes the SSH tunnel to crash entirely rather than falling back to an ephemeral port.

What is the intended outcome?
- By passing `"127.0.0.1"`, the probe correctly detects busy IPv4 ports and gracefully falls back to an ephemeral port instead of crashing.

What is intentionally out of scope?
- N/A

What does success look like?
- `ensurePortAvailable` correctly throwing when a local IPv4 process is occupying the requested SSH tunnel port.

What should reviewers focus on?
- `src/infra/ssh-tunnel.ts` passing `"127.0.0.1"` to `ensurePortAvailable`.

## Linked context

Which issue does this close?

Closes #94596

Which issues, PRs, or discussions are related?

Related #94394

Was this requested by a maintainer or owner?
No

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Fixing `EADDRINUSE` crashes during SSH tunnel initialization by properly detecting IPv4-bound occupants.
- Real environment tested: Local dual-stack host.
- Exact steps or command run after this patch: 
  1. Bound an IPv4-only process to a local port: `python3 -m http.server 8080 --bind 127.0.0.1`
  2. Triggered the port availability probe against the blocked port via SSH tunnel startup.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): 
Before:
<img width="605" height="64" alt="Screenshot 2026-06-18 at 9 06 04 PM" src="https://github.com/user-attachments/assets/3e10dc0b-29de-483a-b3c2-faa126823add" />
After:
<img width="469" height="52" alt="Screenshot 2026-06-18 at 9 05 39 PM" src="https://github.com/user-attachments/assets/dbc1b4ec-dba3-4cd5-8eea-2ff5a0702542" />

- Observed result after fix: The probe correctly detects the busy IPv4 port and gracefully falls back to an ephemeral port.
- What was not tested: IPv6-only environments.
- Proof limitations or environment constraints: None
- Before evidence (optional but encouraged): The host-less probe binds to `::`, misses the IPv4 occupant, and incorrectly reports the port as free, leading to an `EADDRINUSE` crash.

## Tests and validation

Which commands did you run?
Ran a local HTTP server on `127.0.0.1` to purposefully block the port and manually verified the SSH tunnel startup behavior.

What regression coverage was added or updated?
No new tests were added as the core logic (`ensurePortAvailable`) is already tested; this is an integration wiring fix.

What failed before this fix, if known?
The SSH tunnel initialization crashed with `EADDRINUSE`.

If no test was added, why not?
The fix is a one-line argument addition keeping the file internally consistent with existing `canConnectLocal` and `pickEphemeralPort` calls. Manual verification was sufficient.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
No

Did config, environment, or migration behavior change? (`Yes/No`)
No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
Yes (Network port binding fallback behavior is improved)

What is the highest-risk area?
The highest risk is that environments strictly operating on IPv6-only might fail to bind `"127.0.0.1"`, though the SSH tunnel module assumes `127.0.0.1` extensively elsewhere.

How is that risk mitigated?
By matching the exact interface that the SSH tunnel caller already strictly uses (`127.0.0.1`) across the rest of the file.

## Current review state

What is the next action?
Maintainer review and merge.

What is still waiting on author, maintainer, CI, or external proof?
Waiting for CI and maintainer review.

Which bot or reviewer comments were addressed?
N/A