### PR TITLE
fix(telegram): clear split reasoning previews

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3435,6 +3435,36 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(updates.join("\n")).not.toContain("CheckingReading");
   });
 
+  it("clears the prior reasoning preview before splitting into a new reasoning message", async () => {
+    const answerDraftStream = createDraftStream(2001);
+    const reasoningDraftStream = createTestDraftStream({
+      messageId: 3001,
+      clearMessageIdOnForceNew: true,
+    });
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReasoningStream?.({ text: "<think>First thought</think>" });
+      await replyOptions?.onReasoningEnd?.();
+      await replyOptions?.onReasoningStream?.({ text: "<think>Second thought</think>" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({ context: createReasoningStreamContext() });
+
+    expect(reasoningDraftStream.update).toHaveBeenCalledWith("Thinking\n\n_First thought_");
+    expect(reasoningDraftStream.update).toHaveBeenCalledWith("Thinking\n\n_Second thought_");
+    expect(reasoningDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+    expect(reasoningDraftStream.clear).toHaveBeenCalledTimes(2);
+    expect(reasoningDraftStream.clear.mock.invocationCallOrder[0]).toBeLessThan(
+      reasoningDraftStream.forceNewMessage.mock.invocationCallOrder[0],
+    );
+    expect(reasoningDraftStream.clear.mock.invocationCallOrder[0]).toBeLessThan(
+      reasoningDraftStream.update.mock.invocationCallOrder[1],
+    );
+  });
+
   it("streams reasoning from configured defaults", async () => {
     const { answerDraftStream, reasoningDraftStream } = setupDraftStreams({
       answerMessageId: 2001,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1203,6 +1203,18 @@ export const dispatchTelegramMessage = async ({
     lane.stream?.forceNewMessage();
     resetDraftLaneState(lane);
   };
+  const clearReasoningLaneForNewMessage = async () => {
+    if (
+      !reasoningLane.hasStreamedMessage &&
+      typeof reasoningLane.stream?.messageId() !== "number"
+    ) {
+      resetDraftLaneState(reasoningLane);
+      return;
+    }
+    await reasoningLane.stream?.clear();
+    reasoningLane.stream?.forceNewMessage();
+    resetDraftLaneState(reasoningLane);
+  };
   const rotateAnswerLaneForNewMessage = async () => {
     if (materializeAnswerLaneBeforeRotation) {
       await materializeAnswerLaneBeforeRotation();
@@ -2358,8 +2370,7 @@ export const dispatchTelegramMessage = async ({
                     ? (payload) =>
                         enqueueDraftLaneEvent(async () => {
                           if (splitReasoningOnNextStream) {
-                            reasoningLane.stream?.forceNewMessage();
-                            resetDraftLaneState(reasoningLane);
+                            await clearReasoningLaneForNewMessage();
                             splitReasoningOnNextStream = false;
                           }
                           await ingestDraftLaneSegments(payload, true);


### PR DESCRIPTION
## Summary

- Fixes Telegram `/reasoning stream` preview cleanup when a reasoning segment ends and a later reasoning segment starts.
- Clears the existing reasoning draft preview before `forceNewMessage()` resets the stream state, preserving the old preview id long enough for Telegram cleanup.
- Keeps the repair local to the Telegram reasoning draft lifecycle; answer/tool progress draft behavior is intentionally unchanged.
- Adds a focused regression that models the real id-dropping behavior of `forceNewMessage()` and proves cleanup happens before the next reasoning preview update.

## Linked context

Closes #80862

Related #80862

Was this requested by a maintainer or owner?

No direct maintainer request; ClawSweeper marked the issue source-reproducible and queueable.

## Real behavior proof (required for external PRs)

- Behavior addressed: Telegram reasoning previews could be orphaned when `/reasoning stream` split into a later reasoning message because `forceNewMessage()` reset the draft stream before the old preview id was cleaned up.
- Real environment tested: macOS local checkout, Node/Vitest Telegram extension test lane.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/draft-stream.test.ts`
- Evidence after fix: `Test Files 2 passed (2); Tests 176 passed (176); [test] passed 1 Vitest shard`
- Observed result after fix: The new regression verifies the prior reasoning preview is cleared before `forceNewMessage()` and before the second reasoning preview update.
- What was not tested: Live Telegram DM proof with real `/reasoning stream`; no Telegram credentials were used locally.
- Proof limitations or environment constraints: The fix is covered by source-level Telegram dispatcher tests, but live transport proof should still be collected by a maintainer or credentialed environment before landing if required.
- Before evidence (optional but encouraged): Issue #80862 reports repeated `sendMessage` reasoning previews with no matching `editMessageText` or `deleteMessage`; source showed `forceNewMessage()` dropped the old stream message id before cleanup.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/draft-stream.test.ts`
- `git diff --check -- extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `node scripts/run-oxlint.mjs extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review the staged/working-tree changes for issue #80862 only..."`

Regression coverage added:

- Added a dispatcher test for `onReasoningStream -> onReasoningEnd -> onReasoningStream` that uses a draft stream whose `forceNewMessage()` clears the message id, matching the real draft stream behavior.

What failed before this fix, if known?

- The second reasoning stream could call `forceNewMessage()` before cleanup, causing the previous Telegram reasoning preview message id to be lost and leaving the old preview in chat.

If no test was added, why not?

- Not applicable; focused regression coverage was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Telegram reasoning preview messages should no longer remain stale when reasoning is split into a later preview message.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Telegram draft preview lifecycle ordering for reasoning-only stream splits.

How is that risk mitigated?

The change is scoped to the reasoning lane's split path and uses existing draft-stream `clear()` cleanup before starting the next preview message. Existing dispatcher and draft-stream focused tests pass, and autoreview reported no accepted/actionable findings.

## Current review state

What is the next action?

Open PR from `codex/fix-80862-telegram-reasoning-preview` and request maintainer review; collect live Telegram proof if reviewers require transport-level validation.

What is still waiting on author, maintainer, CI, or external proof?

CI and optional live Telegram DM proof are still pending after PR creation.

Which bot or reviewer comments were addressed?

Addressed the ClawSweeper issue analysis that identified `onReasoningEnd -> forceNewMessage()` orphaning the reasoning preview cleanup.
