### PR TITLE
fix(infra): pass 127.0.0.1 to ensurePortAvailable in SSH tunnel start

### DIFF
--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -119,7 +119,7 @@ export async function startSshPortForward(opts: {
 
   let localPort = opts.localPortPreferred;
   try {
-    await ensurePortAvailable(localPort);
+    await ensurePortAvailable(localPort, "127.0.0.1");
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {
       localPort = await pickEphemeralPort();


### PR DESCRIPTION
## Summary

Pass `"127.0.0.1"` to `ensurePortAvailable` in `startSshPortForward` so the port availability probe binds the same IPv4 loopback interface the SSH forward itself uses. Without this, the host-less probe binds the IPv6 wildcard `::` and can miss IPv4-only occupants on dual-stack hosts, reporting a busy port as free.

This is the same address-family flaw fixed in #94379 / #94394 for the Chrome CDP caller, now applied to the SSH tunnel surface.

Fixes #94596

## Real behavior proof

**Behavior addressed**: On dual-stack hosts, `ensurePortAvailable(localPort)` (host-less) probes on the IPv6 wildcard `::` and misses an IPv4-only occupant on the same port. The SSH forward itself uses `127.0.0.1` (line 135), `pickEphemeralPort` uses `127.0.0.1` (line 68), and `canConnectLocal` uses `127.0.0.1` (line 83) — only the preflight probe was host-less.

**Real setup tested**:
- **Runtime**: Node 24.13.1, Linux 4.19.112-2.el8.x86_64

**Exact steps or command run after fix**:

```bash
pnpm test -- src/infra/ssh-tunnel.test.ts
pnpm test -- src/infra/ports-probe.test.ts
pnpm test -- src/infra/
```

**After-fix evidence**:

```
 ✓ |unit-fast| src/infra/ssh-tunnel.test.ts (3/3 passed)
 ✓ |unit-fast| src/infra/ports-probe.test.ts (2/2 passed)
 ✓ |unit-fast| src/infra/ (116/117 test files passed — 1 pre-existing failure in errors.test.ts)
```

**Observed result after the fix**: All ssh-tunnel and ports tests pass. The `ensurePortAvailable` call now consistently probes the same `127.0.0.1` interface as every other network operation in this module.

**What was not tested**: Actual dual-stack host behavior (requires dual-stack environment). The fix follows the exact same pattern verified in #94394.

## Tests and validation

- `src/infra/ssh-tunnel.test.ts`: 3/3 ✅
- `src/infra/ports-probe.test.ts`: 2/2 ✅
- Full infra test suite: 1599/1602 passed (3 pre-existing failures in `errors.test.ts`, confirmed on clean `upstream/main`)

## Risk checklist

Did user-visible behavior change? **No** — the SSH tunnel continues to work the same way, just with a more accurate port availability check.

Did config, environment, or migration behavior change? **No**

Did security, auth, secrets, network, or tool execution behavior change? **No** — only the port probe interface is scoped, matching the caller's actual usage.

What is the highest-risk area? **None** — this is a one-line change matching an already-reviewed pattern (#94394).

How is that risk mitigated? The fix is trivially correct: every other network call in this module already uses `127.0.0.1`.

## Current review state

What is the next action? Maintainer review.
