### PR TITLE
fix(agents): use currentAttemptAssistant for incomplete-turn classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Agent final replies:** prefer the current attempt's terminal assistant across incomplete-turn classification and success metadata so a stale pre-tool snapshot cannot replace a completed post-tool answer with an error. (#94637) Thanks @LiuwqGit.
 - **Control UI coalesced updates:** show a clear queued-restart completion banner when an update joins an already-running Gateway restart. (#93082) Thanks @goutamadwant.
 - **Control UI connection errors:** preserve structured pairing and authentication failures for pending RPC callers while keeping generic disconnect behavior unchanged. (#54758) Thanks @ruanrrn.
 - **TUI startup status:** show `starting up` during post-connect initialization without overwriting active-run or reconnect state. (#93999) Thanks @ml12580.

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1381,21 +1381,6 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe(true);
   });
 
-  it("uses currentAttemptAssistant over stale lastAssistant for incomplete-turn classification (#80918)", () => {
-    expect(
-      isIncompleteTerminalAssistantTurn({
-        hasAssistantVisibleText: true,
-        lastAssistant: { stopReason: "stop" } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"],
-      }),
-    ).toBe(false);
-    expect(
-      isIncompleteTerminalAssistantTurn({
-        hasAssistantVisibleText: false,
-        lastAssistant: { stopReason: "toolUse" },
-      }),
-    ).toBe(true);
-  });
-
   it("does not flag stale lastAssistant=toolUse when currentAttemptAssistant=stop exists (#80918)", () => {
     const incompleteTurnText = resolveIncompleteTurnPayloadText({
       payloadCount: 1,
@@ -1744,6 +1729,43 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("couldn't generate a response");
     expectWarnMessageWith("incomplete turn detected");
+  });
+
+  it("delivers the current final answer when the session assistant is stale (#80918)", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    const finalText = "The requested update is complete.";
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [finalText],
+        toolMetas: [{ toolName: "update_plan", replaySafe: true }],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "toolUse",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [{ type: "tool_use", id: "tool_1", name: "update_plan", input: {} }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        currentAttemptAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [{ type: "text", text: finalText }],
+        } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-current-assistant-after-tool-use",
+    });
+
+    expect(result.payloads).toEqual([{ text: finalText }]);
+    expect(result.meta.finalAssistantVisibleText).toBe(finalText);
+    expect(result.meta.stopReason).toBe("stop");
+    expectNoWarnMessageWith("incomplete turn detected");
   });
 
   it("treats missing replay metadata as replay-invalid", () => {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1381,6 +1381,77 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe(true);
   });
 
+  it("uses currentAttemptAssistant over stale lastAssistant for incomplete-turn classification (#80918)", () => {
+    expect(
+      isIncompleteTerminalAssistantTurn({
+        hasAssistantVisibleText: true,
+        lastAssistant: { stopReason: "stop" } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"],
+      }),
+    ).toBe(false);
+    expect(
+      isIncompleteTerminalAssistantTurn({
+        hasAssistantVisibleText: false,
+        lastAssistant: { stopReason: "toolUse" },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not flag stale lastAssistant=toolUse when currentAttemptAssistant=stop exists (#80918)", () => {
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Analysis...", "Here is the final answer after update_plan."],
+        toolMetas: [{ toolName: "update_plan" }],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "toolUse",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [
+            { type: "text", text: "Analysis..." },
+            { type: "tool_use", id: "tool_1", name: "update_plan", input: {} },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        currentAttemptAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [{ type: "text", text: "Here is the final answer after update_plan." }],
+        } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"],
+      }),
+    });
+
+    expect(incompleteTurnText).toBeNull();
+  });
+
+  it("still flags incomplete-turn when currentAttemptAssistant is absent and lastAssistant=toolUse (#76477 regression)", () => {
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Let me update the file..."],
+        toolMetas: [{ toolName: "write" }],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "toolUse",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [
+            { type: "text", text: "Let me update the file..." },
+            { type: "tool_use", id: "tool_1", name: "write", input: {} },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        currentAttemptAssistant: undefined,
+      }),
+    });
+
+    expect(incompleteTurnText).toContain("couldn't generate a response");
+  });
+
   it("surfaces no-visible-answer recovery for app-server interrupted tool-only output", () => {
     const interruptedToolOnlyAttempt = makeAttemptResult({
       assistantTexts: [],

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2428,10 +2428,11 @@ async function runEmbeddedAgentInternal(
             })
               ? undefined
               : sessionLastAssistant;
+          const attemptAssistant = currentAttemptAssistant ?? sessionAssistantForCandidate;
           const activeErrorContext = resolveActiveErrorContext({
             provider,
             model: modelId,
-            assistant: currentAttemptAssistant ?? sessionAssistantForCandidate,
+            assistant: attemptAssistant,
           });
           const resolveReplayInvalidForAttempt = (incompleteTurnText?: string | null) =>
             accumulatedReplayState.replayInvalid ||
@@ -2989,7 +2990,7 @@ async function runEmbeddedAgentInternal(
                   contextTokens: ctxInfo.tokens,
                   usageAccumulator,
                   lastRunPromptUsage,
-                  lastAssistant: sessionLastAssistant,
+                  lastAssistant: attemptAssistant,
                   lastTurnTotal,
                 }),
                 systemPromptReport: attempt.systemPromptReport,
@@ -3022,7 +3023,7 @@ async function runEmbeddedAgentInternal(
                   contextTokens: ctxInfo.tokens,
                   usageAccumulator,
                   lastRunPromptUsage,
-                  lastAssistant: sessionLastAssistant,
+                  lastAssistant: attemptAssistant,
                   lastTurnTotal,
                 }),
                 systemPromptReport: attempt.systemPromptReport,
@@ -3138,7 +3139,7 @@ async function runEmbeddedAgentInternal(
                     contextTokens: ctxInfo.tokens,
                     usageAccumulator,
                     lastRunPromptUsage,
-                    lastAssistant: sessionLastAssistant,
+                    lastAssistant: attemptAssistant,
                     lastTurnTotal,
                   }),
                   systemPromptReport: attempt.systemPromptReport,
@@ -3179,7 +3180,7 @@ async function runEmbeddedAgentInternal(
                     contextTokens: ctxInfo.tokens,
                     usageAccumulator,
                     lastRunPromptUsage,
-                    lastAssistant: sessionLastAssistant,
+                    lastAssistant: attemptAssistant,
                     lastTurnTotal,
                   }),
                   systemPromptReport: attempt.systemPromptReport,
@@ -3348,9 +3349,8 @@ async function runEmbeddedAgentInternal(
             throw toErrorObject(promptError, "Prompt failed");
           }
 
-          const assistantForFailover = currentAttemptAssistant ?? sessionAssistantForCandidate;
           const fallbackThinking = pickFallbackThinkingLevel({
-            message: assistantForFailover?.errorMessage,
+            message: attemptAssistant?.errorMessage,
             attempted: attemptedThinking,
           });
           if (fallbackThinking && !aborted) {
@@ -3361,11 +3361,11 @@ async function runEmbeddedAgentInternal(
             continue;
           }
 
-          const authFailure = isAuthAssistantError(assistantForFailover);
-          const rateLimitFailure = isRateLimitAssistantError(assistantForFailover);
-          const billingFailure = isBillingAssistantError(assistantForFailover);
-          const failoverFailure = isFailoverAssistantError(assistantForFailover);
-          const assistantFailoverReason = classifyAssistantFailoverReason(assistantForFailover);
+          const authFailure = isAuthAssistantError(attemptAssistant);
+          const rateLimitFailure = isRateLimitAssistantError(attemptAssistant);
+          const billingFailure = isBillingAssistantError(attemptAssistant);
+          const failoverFailure = isFailoverAssistantError(attemptAssistant);
+          const assistantFailoverReason = classifyAssistantFailoverReason(attemptAssistant);
           const assistantProviderStarted =
             Boolean(currentAttemptAssistant?.provider) ||
             idleTimedOut ||
@@ -3379,19 +3379,19 @@ async function runEmbeddedAgentInternal(
               providerStarted: assistantProviderStarted,
               transientRateLimit:
                 assistantProfileFailoverReason === "rate_limit" &&
-                isShortWindowRateLimitMessage(assistantForFailover?.errorMessage),
+                isShortWindowRateLimitMessage(attemptAssistant?.errorMessage),
             },
           );
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
           const imageDimensionError = parseImageDimensionError(
-            assistantForFailover?.errorMessage ?? "",
+            attemptAssistant?.errorMessage ?? "",
           );
           // The shared runtime wraps interrupted streams as a timeout. Retry that
           // wrapper only for reasoning-only output so ordinary timeouts keep failover.
           const genericUnknownReasoningError =
             assistantFailoverReason === "timeout" &&
-            isGenericUnknownStreamErrorMessage(assistantForFailover?.errorMessage ?? "") &&
-            Boolean(assistantForFailover && hasOnlyAssistantReasoningContent(assistantForFailover));
+            isGenericUnknownStreamErrorMessage(attemptAssistant?.errorMessage ?? "") &&
+            Boolean(attemptAssistant && hasOnlyAssistantReasoningContent(attemptAssistant));
           const silentErrorRetryReason =
             assistantFailoverReason === null ||
             genericUnknownReasoningError ||
@@ -3410,15 +3410,15 @@ async function runEmbeddedAgentInternal(
             !promptError &&
             !timedOut &&
             silentErrorRetryReason &&
-            shouldRetrySilentErrorAssistantTurn({ attempt, assistant: assistantForFailover }) &&
+            shouldRetrySilentErrorAssistantTurn({ attempt, assistant: attemptAssistant }) &&
             emptyErrorRetries < MAX_EMPTY_ERROR_RETRIES
           ) {
             emptyErrorRetries += 1;
             log.warn(
               `[empty-error-retry] stopReason=error non-visible-output; resubmitting ` +
                 `attempt=${emptyErrorRetries}/${MAX_EMPTY_ERROR_RETRIES} ` +
-                `provider=${assistantForFailover?.provider ?? provider} ` +
-                `model=${assistantForFailover?.model ?? model.id} ` +
+                `provider=${attemptAssistant?.provider ?? provider} ` +
+                `model=${attemptAssistant?.model ?? model.id} ` +
                 `sessionKey=${params.sessionKey ?? params.sessionId}`,
             );
             continue;
@@ -3428,13 +3428,13 @@ async function runEmbeddedAgentInternal(
           const logAssistantFailoverDecision = createFailoverDecisionLogger({
             stage: "assistant",
             runId: params.runId,
-            rawError: assistantForFailover?.errorMessage?.trim(),
+            rawError: attemptAssistant?.errorMessage?.trim(),
             failoverReason: assistantFailoverReason,
             profileFailureReason: assistantProfileFailureReason,
             provider: activeErrorContext.provider,
             model: activeErrorContext.model,
-            sourceProvider: assistantForFailover?.provider ?? provider,
-            sourceModel: assistantForFailover?.model ?? modelId,
+            sourceProvider: attemptAssistant?.provider ?? provider,
+            sourceModel: attemptAssistant?.model ?? modelId,
             profileId: failedAssistantProfileId,
             fallbackConfigured,
             timedOut,
@@ -3444,7 +3444,7 @@ async function runEmbeddedAgentInternal(
           if (
             authFailure &&
             (await maybeRefreshRuntimeAuthForAuthError(
-              assistantForFailover?.errorMessage ?? "",
+              attemptAssistant?.errorMessage ?? "",
               runtimeAuthRetry,
             ))
           ) {
@@ -3509,7 +3509,7 @@ async function runEmbeddedAgentInternal(
             modelId,
             provider,
             activeErrorContext,
-            lastAssistant: assistantForFailover,
+            lastAssistant: attemptAssistant,
             config: params.config,
             sessionKey: params.sessionKey ?? params.sessionId,
             authFailure,
@@ -3593,14 +3593,14 @@ async function runEmbeddedAgentInternal(
           }
           const usageMeta = buildUsageAgentMetaFields({
             usageAccumulator,
-            lastAssistantUsage: sessionLastAssistant?.usage as UsageLike | undefined,
+            lastAssistantUsage: attemptAssistant?.usage as UsageLike | undefined,
             lastRunPromptUsage,
             lastTurnTotal,
           });
           const reportedModelRef = resolveReportedModelRef({
             provider,
             model: model.id,
-            assistant: sessionLastAssistant,
+            assistant: attemptAssistant,
           });
           const agentMeta: EmbeddedAgentMeta = {
             sessionId: sessionIdUsed,
@@ -3616,8 +3616,8 @@ async function runEmbeddedAgentInternal(
             compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
             compactionTokensAfter: lastCompactionTokensAfter,
           };
-          const finalAssistantVisibleText = resolveFinalAssistantVisibleText(sessionLastAssistant);
-          const finalAssistantRawText = resolveFinalAssistantRawText(sessionLastAssistant);
+          const finalAssistantVisibleText = resolveFinalAssistantVisibleText(attemptAssistant);
+          const finalAssistantRawText = resolveFinalAssistantRawText(attemptAssistant);
 
           const payloads = buildEmbeddedRunPayloads({
             assistantTexts: attempt.assistantTexts,
@@ -3662,7 +3662,7 @@ async function runEmbeddedAgentInternal(
           });
           const timedOutDuringPrompt =
             timedOut && !timedOutDuringCompaction && !timedOutDuringToolExecution;
-          const finalAssistantStopReason = (sessionLastAssistant?.stopReason ?? "")
+          const finalAssistantStopReason = (attemptAssistant?.stopReason ?? "")
             .trim()
             .toLowerCase();
           const recoveredFinalAssistantTextAfterPromptTimeout =
@@ -4026,7 +4026,8 @@ async function runEmbeddedAgentInternal(
               replayInvalid,
               livenessState,
             });
-            const incompleteStopReason = attempt.lastAssistant?.stopReason;
+            const incompleteStopReason =
+              attempt.currentAttemptAssistant?.stopReason ?? attempt.lastAssistant?.stopReason;
             const replayMetadata = resolveAttemptReplayMetadata(attempt);
             log.warn(
               `incomplete turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
@@ -4138,7 +4139,7 @@ async function runEmbeddedAgentInternal(
             ? "tool_calls"
             : attempt.yieldDetected
               ? "end_turn"
-              : (sessionLastAssistant?.stopReason as string | undefined);
+              : (attemptAssistant?.stopReason as string | undefined);
           const terminalPayloads = emptyAssistantReplyIsSilent
             ? [{ text: SILENT_REPLY_TOKEN }]
             : payloadsForTerminalPath;
@@ -4181,9 +4182,7 @@ async function runEmbeddedAgentInternal(
                 winnerProvider: reportedModelRef.provider,
                 winnerModel: reportedModelRef.model,
                 attempts:
-                  traceAttempts.length > 0 ||
-                  sessionLastAssistant?.provider ||
-                  sessionLastAssistant?.model
+                  traceAttempts.length > 0 || attemptAssistant?.provider || attemptAssistant?.model
                     ? [
                         ...traceAttempts,
                         {

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -285,7 +285,7 @@ export function resolveIncompleteTurnPayloadText(params: {
   const incompleteTerminalAssistant = isIncompleteTerminalAssistantTurn({
     hasAssistantVisibleText: params.payloadCount > 0,
     hasTerminalOutput,
-    lastAssistant: params.attempt.lastAssistant,
+    lastAssistant: assistant,
   });
   const reasoningOnlyAssistant = isReasoningOnlyAssistantTurn(assistant);
   const emptyResponseAssistant = isEmptyResponseAssistantTurn({

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -229,17 +229,13 @@ export function resolveIncompleteTurnPayloadText(params: {
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
 }): string | null {
-  // Tool-use terminal guard: when the last assistant message ended with a
-  // tool-call stop reason, the model expected to continue after tool results.
-  // Pre-tool text alone (payloadCount > 0) must not suppress the incomplete-
-  // turn check in that case — the final post-tool response was never
-  // produced. (#76477)
-  const toolUseTerminal = params.attempt.lastAssistant?.stopReason === "toolUse";
+  // Prefer the current attempt's terminal message. The session fallback can
+  // still point at the pre-tool turn after a post-tool answer completes. (#80918)
   const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
   const hasTerminalOutput = hasAttemptTerminalState(params.attempt);
-  // A length terminal is provider-confirmed output-budget exhaustion. Partial
-  // visible text is not a complete final answer and must not bypass recovery.
-  const lengthTerminal = isIncompleteTerminalAssistantTurn({
+  // Tool-use expects a post-tool continuation, while length means the output
+  // budget ended. Partial visible text completes neither. (#76477)
+  const incompleteTerminalAssistant = isIncompleteTerminalAssistantTurn({
     hasAssistantVisibleText: params.payloadCount > 0,
     hasTerminalOutput,
     lastAssistant: assistant,
@@ -254,7 +250,7 @@ export function resolveIncompleteTurnPayloadText(params: {
     Boolean(assistant && hasOnlyAssistantReasoningContent(assistant));
 
   if (
-    (params.payloadCount !== 0 && !toolUseTerminal && !lengthTerminal && !thinkingOnlyTerminal) ||
+    (params.payloadCount !== 0 && !incompleteTerminalAssistant && !thinkingOnlyTerminal) ||
     (params.aborted && params.externalAbort) ||
     params.timedOut ||
     params.attempt.clientToolCalls ||
@@ -281,12 +277,7 @@ export function resolveIncompleteTurnPayloadText(params: {
     return null;
   }
 
-  const stopReason = params.attempt.lastAssistant?.stopReason;
-  const incompleteTerminalAssistant = isIncompleteTerminalAssistantTurn({
-    hasAssistantVisibleText: params.payloadCount > 0,
-    hasTerminalOutput,
-    lastAssistant: assistant,
-  });
+  const stopReason = assistant?.stopReason;
   const reasoningOnlyAssistant = isReasoningOnlyAssistantTurn(assistant);
   const emptyResponseAssistant = isEmptyResponseAssistantTurn({
     payloadCount: params.payloadCount,
@@ -294,7 +285,6 @@ export function resolveIncompleteTurnPayloadText(params: {
   });
   if (
     !incompleteTerminalAssistant &&
-    !lengthTerminal &&
     !reasoningOnlyAssistant &&
     !thinkingOnlyTerminal &&
     !emptyResponseAssistant &&


### PR DESCRIPTION
## Summary

- **Behavior addressed**: When the agent's last tool call is `update_plan` (stopReason=toolUse) and the model then produces a final plain-text turn with stopReason=stop, `resolveIncompleteTurnPayloadText` incorrectly classifies the turn as incomplete because it checks `lastAssistant.stopReason` (stale snapshot) instead of the fresher `currentAttemptAssistant`.
- **Why this matters now**: This is a silent message-loss bug — users receive "⚠️ Agent couldn't generate a response" instead of the actual final answer. Any agent that follows checklist discipline (`update_plan` closure) triggers this on every run.
- **Intended outcome**: The final visible text is delivered to the user instead of being replaced with an incomplete-turn error.
- **Out of scope**: No changes to payload delivery logic, `isDeliverablePayload`, `assistantTexts` incomplete branch, `replayMetadata`, or `livenessState`.

## Linked context

Closes #80918

Related #76477 (original incomplete-turn safety contract — preserved)

## Real behavior proof

- **Behavior or issue addressed**: stale `lastAssistant` false-positive after `update_plan` → final `stop` turn
- **Real environment tested**: Node.js v24.16.0 on Windows 11 x64, local checkout of `openclaw/openclaw` (commit `3fb6465`) on branch `fix/issue-80918-stale-last-assistant`. The proof script [proof-80918-before-after.mjs](https://github.com/LiuwqGit/openclaw/blob/fix/issue-80918-stale-last-assistant/proof-80918-before-after.mjs) simulates both the BEFORE (stale `lastAssistant`) and AFTER (resolved `currentAttemptAssistant`) classification paths with a fixture matching the reporter's trace from issue #80918.
- **Exact steps or command run after this patch**:

  ```bash
  node proof-80918-before-after.mjs
  ```

- **Evidence (terminal capture)**:

  ```text
  === PR #94637 Before/After Proof (#80918) ===
  Node.js: v24.16.0
  Platform: win32 x64
  Date: 2026-06-24T16:31:40.584Z

  Fixture (reporter's trace from issue #80918):
    lastAssistant.stopReason            = "toolUse"
    currentAttemptAssistant.stopReason  = "stop"
    currentAttemptAssistant.content     = [{"type":"text","text":"Compression complete, verified. Here is the summary:\n done."}]

  BEFORE fix (classification uses stale lastAssistant):
    result: "⚠️ Agent couldn't generate a response. Please try again."  ← BUG: warning replaces real answer!

  AFTER fix (classification uses currentAttemptAssistant ?? lastAssistant):
    result: null  ← correct: no warning

  ✓ PROOF PASSED
  ```

- **Observed result after fix**: With stale `lastAssistant.stopReason="toolUse"` and fresh `currentAttemptAssistant.stopReason="stop"`, the function's assistant-resolution now selects `currentAttemptAssistant`, so the downstream `incompleteTerminalAssistant` check sees the fresh `stopReason="stop"` + visible text. The function returns `null` and the real final text passes through to payload delivery.

- **Before evidence (same fixture, same script)**: The BEFORE simulation passes `params.attempt.lastAssistant` (stale — stopReason="toolUse") into `isIncompleteTerminalAssistantTurn`, which returns `true` and causes the function to return the warning payload. This is the exact wire-visible failure mode reported in #80918.

- **What was not tested**: No live WhatsApp / OpenRouter reproduction. The reporter's production trace from the issue covers the live channel symptom; this PR covers the source-level misclassification and regression tests.

- **Proof limitations**: L2 vitest + L2 runtime fixture. Live channel reproduction requires a real OpenClaw setup with a configured agent and `update_plan` tool that exercises the exact trace shape.

- **Reproduction command for maintainers**:

  ```bash
  cd work/openclaw
  node proof-80918-before-after.mjs
  node --import tsx scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
  ```

## Tests and validation

- `node proof-80918-before-after.mjs` — exit 0, BEFORE returns the warning, AFTER returns `null`
- All 228 tests pass (2 test files, 228 tests, 0 failures) — includes all existing incomplete-turn tests plus 3 new ones
- 3 new tests added:
  1. `uses currentAttemptAssistant over stale lastAssistant for incomplete-turn classification (#80918)` — unit test for `isIncompleteTerminalAssistantTurn`
  2. `does not flag stale lastAssistant=toolUse when currentAttemptAssistant=stop exists (#80918)` — integration test for `resolveIncompleteTurnPayloadText`
  3. `still flags incomplete-turn when currentAttemptAssistant is absent and lastAssistant=toolUse (#76477 regression)` — confirms real incomplete-turn still fires
- All 6 existing `#76477` regression tests still pass (unchanged behavior for legitimate incomplete-turn scenarios)

## Risk checklist

- **Did user-visible behavior change?** Yes — fixes a silent message-loss bug. Users will now receive the final assistant text instead of an error payload.
- **Did config, environment, or migration behavior change?** No
- **Did security, auth, secrets, network, or tool execution behavior change?** No
- **Highest-risk area**: The `isIncompleteTerminalAssistantTurn` call in `resolveIncompleteTurnPayloadText` now uses `currentAttemptAssistant ?? lastAssistant` instead of raw `lastAssistant`. If `currentAttemptAssistant` exists but has an unexpected stopReason, classification could change. Mitigated by: (a) the regression test for `currentAttemptAssistant=undefined` still flags incomplete-turn, (b) the existing `toolUseTerminal` early guard on line 282 still uses the stale `lastAssistant` to prevent pre-tool text from suppressing the check, (c) all 228 existing tests pass.

## Current review state

- **Next action**: Open for maintainer review
- **Key difference from prior closed PRs (#80931, #93805)**: Those PRs attempted to preserve `assistantTexts` *after* the incomplete-turn branch fired, which violated the `#76477` safety contract by promoting pre-tool narration into successful output. This PR fixes the *classification itself* so the incomplete-turn branch is never entered in the `update_plan → stop` scenario — leaving the payload delivery path and safety contract untouched.