### PR TITLE
fix(sessions): preserve MediaType index alignment in persisted transcript (#94255)

### DIFF
--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -139,12 +139,13 @@ function normalizeMediaEntryForTranscript(media: PersistedUserTurnMediaInput):
   };
 }
 
+// FIX #94255: Preserve index alignment across parallel Media* arrays by not
+// filtering falsy values. The writer (alignedStrings) pads holes with "" to
+// keep indexes stable; filtering those pads breaks the parallel-array contract.
 function normalizeOptionalTextArray(
   values: readonly (string | null | undefined)[] | null | undefined,
-): string[] {
-  return (
-    values?.map(normalizeOptionalText).filter((value): value is string => Boolean(value)) ?? []
-  );
+): (string | undefined)[] {
+  return values?.map(normalizeOptionalText) ?? [];
 }
 
 const URL_LIKE_MEDIA_PATH_PATTERN = /^[a-z][a-z0-9+.-]*:/i;


### PR DESCRIPTION
## Summary

Fixes index misalignment in persisted transcript's parallel Media* arrays. The reader (`normalizeOptionalTextArray`) was compacting holes with `.filter(Boolean)` while the writer (`alignedStrings`) intentionally pads holes with `""` — breaking the parallel-array contract on multi-attachment turns where an earlier attachment lacks a type/url.

Fixes #94255

## Real behavior proof (required for external PRs)

**Behavior addressed**: Attachment content-types (and URLs) are assigned to the wrong attachment when an earlier attachment lacks a type/url in inbound media turns.

**Real setup tested**:
- **Runtime**: Node.js v24.13.1, Linux 4.19.112

**Exact steps or command run after fix**:

Input `{ MediaPaths: ["/media/a.bin","/media/b.png"], MediaTypes: ["","image/png"] }`:

Before fix:
```
OUT /media/a.bin => image/png      <-- WRONG (belongs to b.png)
OUT /media/b.png => image/png
```

After fix:
```
OUT /media/a.bin => undefined      <-- correct: no type borrowed from the next attachment
OUT /media/b.png => image/png
```

**What was not tested**: Full E2E inbound media pipeline (unit-level verification of the array alignment contract).

## Tests and validation

- TypeScript type check passes (return type `(string | undefined)[]` compatible with all callers)
- All 3 call sites of `normalizeOptionalTextArray` are within `buildPersistedUserTurnMediaInputsFromFields` and already handle `undefined` via `??`

## Risk checklist

Did user-visible behavior change? (`Yes`)
- Persisted transcript metadata is now correct for multi-attachment turns

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?
- The function's return type changed; any external caller expecting `string[]` may need a type guard

How is that risk mitigated?
- Only 3 callers, all within the same function in the same file, all already handling `undefined`
- `alignedStrings` writer remains unchanged

## Current review state

What is the next action?
- Maintainer review
