### PR TITLE
fix(codex): pass budget-scaled maxRenderedContextChars to legacy mirrored-history projection

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -908,6 +908,12 @@ export async function runCodexAppServerAttempt(
       assembledMessages: historyMessages,
       originalHistoryMessages: historyMessages,
       prompt: params.prompt,
+      maxRenderedContextChars: resolveCodexContextEngineProjectionMaxChars({
+        contextTokenBudget: params.contextTokenBudget,
+        reserveTokens: resolveCodexContextEngineProjectionReserveTokens({
+          config: params.config,
+        }),
+      }),
     });
     promptText = projection.promptText;
     prePromptMessageCount = projection.prePromptMessageCount;
@@ -1088,6 +1094,12 @@ export async function runCodexAppServerAttempt(
       assembledMessages: newerVisibleMessages,
       originalHistoryMessages: historyMessages,
       prompt: params.prompt,
+      maxRenderedContextChars: resolveCodexContextEngineProjectionMaxChars({
+        contextTokenBudget: params.contextTokenBudget,
+        reserveTokens: resolveCodexContextEngineProjectionReserveTokens({
+          config: params.config,
+        }),
+      }),
     });
     promptText = projection.promptText;
     prePromptMessageCount = projection.prePromptMessageCount;


### PR DESCRIPTION
## Summary

The legacy mirrored-history fallback in `extensions/codex/src/app-server/run-attempt.ts` calls `projectContextEngineAssemblyForCodex` without passing `maxRenderedContextChars`. When omitted, the function defaults to `DEFAULT_RENDERED_CONTEXT_CHARS = 24_000` (~6,000 tokens of rendered history), even when the model has a much larger context budget (e.g., 272,000 tokens).

This PR passes the budget-scaled `maxRenderedContextChars` to both legacy projection call sites, matching the active-context-engine branch behavior added in PR #80761.

Fixes #84084

## Real behavior proof (required for external PRs)

**Behavior addressed**: Legacy mirrored-history projection caps rendered context at 24,000 characters regardless of the model's actual context budget.

**Real setup tested**:
- **Runtime**: Node v22, OpenClaw main @ beea31a6b5

**Exact steps or command run after fix**:

```bash
cd $WORKTREE_DIR
node scripts/run-vitest.mjs extensions/codex/src/app-server/context-engine-projection.test.ts
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.context-engine.test.ts
```

**After-fix evidence**:

```
Test Files  3 passed (3)
     Tests  141 passed | 1 skipped (1 pre-existing timeout)
```

**Diff**:

```diff
--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -908,6 +908,12 @@
       assembledMessages: historyMessages,
       originalHistoryMessages: historyMessages,
       prompt: params.prompt,
+      maxRenderedContextChars: resolveCodexContextEngineProjectionMaxChars({
+        contextTokenBudget: params.contextTokenBudget,
+        reserveTokens: resolveCodexContextEngineProjectionReserveTokens({
+          config: params.config,
+        }),
+      }),
     });

@@ -1088,6 +1094,12 @@
       assembledMessages: newerVisibleMessages,
       originalHistoryMessages: historyMessages,
       prompt: params.prompt,
+      maxRenderedContextChars: resolveCodexContextEngineProjectionMaxChars({
+        contextTokenBudget: params.contextTokenBudget,
+        reserveTokens: resolveCodexContextEngineProjectionReserveTokens({
+          config: params.config,
+        }),
+      }),
     });
```

**Observed result after the fix**: All existing tests pass. `contextTokenBudget` is already in scope at both call sites. When `contextTokenBudget` is undefined, `resolveCodexContextEngineProjectionMaxChars` falls back to `DEFAULT_RENDERED_CONTEXT_CHARS` — no behavior change for that case.

**What was not tested**: Live high-window Codex session with thread rebuilds. The fix is source-proven and the helpers are already tested.

## Tests and validation

| Suite | Result |
|-------|--------|
| context-engine-projection.test.ts | 13/13 ✅ |
| run-attempt.test.ts | 104/105 ✅ (1 pre-existing timeout) |
| run-attempt.context-engine.test.ts | 24/24 ✅ |

## Risk checklist

Did user-visible behavior change? (`Yes` — legacy fallback now uses budget-appropriate cap instead of 24k hard default)

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?
- When `contextTokenBudget` is undefined, `resolveCodexContextEngineProjectionMaxChars` returns `DEFAULT_RENDERED_CONTEXT_CHARS` — same as before.

How is that risk mitigated?
- The helper function already handles undefined/missing budget correctly. Both `params.contextTokenBudget` and `params.config` are already in scope and used by other paths.

## Current review state

What is the next action?
- Maintainer review
