### PR TITLE
fix(embedded-agent): recover thinking-signature rejection delivered a…

### DIFF
--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -610,6 +610,74 @@ describe("wrapAnthropicStreamWithRecovery", () => {
     });
   });
 
+  it("recovers a thinking-signature rejection delivered as a terminal result message", async () => {
+    // Regression: the provider 400 arrives as a resolved result message
+    // (stopReason "error" + errorMessage), not an error event or a thrown
+    // rejection, and no content streams first. The wrapper must still retry once
+    // without thinking blocks and notify so the session is repaired, rather than
+    // returning the error and wedging on every replay (replay_invalid).
+    let callCount = 0;
+    const recovered = vi.fn();
+    const errorResult = createTestAssistantMessage({
+      content: [{ type: "text", text: "" }],
+      stopReason: "error",
+      errorMessage:
+        '{"type":"error","error":{"type":"invalid_request_error",' +
+        '"message":"messages.11.content.12: Invalid `signature` in `thinking` block"}}',
+    });
+    const finalMessage = createTestAssistantMessage({
+      content: [{ type: "text", text: "recovered" }],
+      stopReason: "stop",
+    });
+    const originalMessages = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "", thinkingSignature: "" },
+          { type: "text", text: "visible answer" },
+        ],
+      },
+    ]);
+    const contexts: Array<{ messages?: AgentMessage[] }> = [];
+    const wrapped = wrapAnthropicStreamWithRecovery(
+      ((_model, context) => {
+        callCount += 1;
+        contexts.push(context as { messages?: AgentMessage[] });
+        const stream = createAssistantMessageEventStream();
+        if (callCount === 1) {
+          // Resolve the final result with an error message and stream no chunks,
+          // i.e. the provider 400 surfaces only via result(), not as an event.
+          queueMicrotask(() => stream.end(errorResult));
+        } else {
+          queueMicrotask(() => {
+            stream.push({ type: "done", reason: "stop", message: finalMessage });
+            stream.end();
+          });
+        }
+        return stream;
+      }) as Parameters<typeof wrapAnthropicStreamWithRecovery>[0],
+      { id: "test-session", onRecoveredAnthropicThinking: recovered },
+    );
+
+    const response = (await wrapped(
+      {} as never,
+      { messages: originalMessages } as never,
+      {} as never,
+    )) as { result: () => Promise<unknown> } & AsyncIterable<unknown>;
+    for await (const event of response) {
+      void event;
+    }
+
+    await expect(response.result()).resolves.toEqual(finalMessage);
+    expect(callCount).toBe(2);
+    expect(recovered).toHaveBeenCalledTimes(1);
+    const retryMessage = contexts[1]?.messages?.[0];
+    if (!retryMessage || retryMessage.role !== "assistant") {
+      throw new Error("Expected Anthropic recovery retry to start with an assistant message");
+    }
+    expect(retryMessage.content).toEqual([{ type: "text", text: "visible answer" }]);
+  });
+
   it("does not notify recovery when the stripped-thinking retry also fails", async () => {
     const recovered = vi.fn();
     let callCount = 0;

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -678,6 +678,27 @@ async function pumpStreamWithRecovery(
       outer.push(chunk as Parameters<typeof outer.push>[0]);
     }
     const result = await (resolved as { result?: () => Promise<AssistantMessage> }).result?.();
+    // A provider signature rejection can surface as a *terminal result
+    // message* (stopReason "error" + errorMessage) — not an in-stream error
+    // event or a thrown rejection — when the stream resolves the 400 instead of
+    // throwing. The latest-turn exemption in stripInvalidThinkingSignatures
+    // intentionally lets a corrupted latest thinking block flow through to this
+    // recovery path, so if recovery does not fire here the session 400s on every
+    // replay (replay_invalid) and wedges until a manual restart. Recover this
+    // carrier once, the same as the error-event branch above. Guarded by
+    // !yieldedOutput because a signature 400 is rejected before any content
+    // streams, so this only fires for a turn that produced no visible output.
+    if (
+      !yieldedOutput &&
+      result?.stopReason === "error" &&
+      shouldRecoverAnthropicThinkingError(result, sessionMeta)
+    ) {
+      sessionMeta.recoveredAnthropicThinking = true;
+      log.warn(
+        `[session-recovery] Anthropic thinking error in terminal result; retrying once without thinking blocks: sessionId=${sessionMeta.id}`,
+      );
+      return retryStreamWithoutThinking(outer, retry, notify);
+    }
     return result as AssistantMessage;
   } catch (error: unknown) {
     if (!shouldRecoverAnthropicThinkingError(error, sessionMeta)) {


### PR DESCRIPTION
## Problem

A session can wedge and stop responding after an Anthropic invalid-thinking-signature error: every subsequent turn 400s on replay (`replay_invalid`) and never recovers until the gateway is manually restarted. The failing turn produces no visible output — the model call is rejected before anything streams.

## Root cause

`wrapAnthropicStreamWithRecovery` already recovers an invalid-thinking-signature 400 when it arrives as an in-stream **error event** or as a **thrown rejection** — it retries once without thinking blocks and repairs the session.

But the same 400 can surface a third way: as a **terminal result message**. The stream resolves normally and `result()` returns an `AssistantMessage` with `stopReason: "error"` and an `errorMessage` carrying the `invalid_request_error` (_"Invalid signature in thinking block"_). No error event is emitted and nothing is thrown, so neither existing recovery branch fires and the wrapper returns the error result unchanged.

Because the latest-turn exemption in `stripInvalidThinkingSignatures` intentionally lets a corrupted *latest* thinking block flow through to this recovery path, a session that hits this carrier 400s on every replay and stays wedged.

## Fix

Handle the terminal-result carrier in `pumpStreamWithRecovery`, the same way as the existing error-event branch: after `result()` resolves, if the turn produced no output and the result is a recoverable Anthropic thinking error, mark `recoveredAnthropicThinking`, log a `[session-recovery]` warning, and retry once without thinking blocks (`retryStreamWithoutThinking`).

- Guarded by `!yieldedOutput`: a signature 400 is rejected before any content streams, so the branch only fires for a turn that produced no visible output — a turn that already streamed content is untouched.
- Gated by the existing `shouldRecoverAnthropicThinkingError(result, sessionMeta)` predicate, so only invalid-thinking-signature errors trigger recovery; any other terminal error is returned unchanged.
- Scoped to `thinking.ts`; no change to the streaming/error-event paths or to `stripInvalidThinkingSignatures`.

This is a narrow recovery-carrier follow-up within the open Anthropic invalid-thinking-signature cluster (canonical: #92201). It closes the terminal-result gap left by the error-event / raw-error recovery in #92916 and the durable transcript repair in #92286; it is not the create-side / replay-policy fix tracked by the canonical issue.

## Testing

Adds a regression test in `thinking.test.ts`: *"recovers a thinking-signature rejection delivered as a terminal result message"*. The provider 400 is delivered only via `result()` (`stopReason: "error"` + `errorMessage`) with no chunks streamed first. It asserts the wrapper retries once (`callCount === 2`), notifies recovery exactly once (`onRecoveredAnthropicThinking`), starts the retry context with the thinking block stripped (keeps the visible text), and resolves to the recovered final message. Reverting the fix makes the test fail — the error result is returned and the session wedges.

## Real behavior proof

- **Behavior or issue addressed:** An Anthropic invalid-thinking-signature error delivered as a *terminal result* (`stopReason: error`, no streamed content) previously left the session wedged — every replay re-hit `replay_invalid` and the turn produced no output until a manual gateway restart. After the fix, the recovery path strips the rejected thinking blocks and retries the turn once, and the session continues on its own.
- **Real environment tested:** Live OpenClaw gateway on macOS (Apple Silicon, Node 24.14.1), provider Anthropic, model `claude-opus-4-8`, WhatsApp channel, `sessionKey=agent:main:main`. The running build is VE-816, an independent implementation of the same terminal-result-carrier recovery this PR adds (detect the recoverable thinking-signature error on a no-output terminal result → strip thinking blocks → retry once). It is a separate build, so the recovery log wording differs — see "What was not tested".
- **Exact steps or command run after this patch:** Normal production traffic continued to encounter the provider `Invalid `signature` in `thinking` block` rejection on real inbound turns; inspected the gateway's structured runtime logs with `openclaw logs` (file `/tmp/openclaw/openclaw-2026-06-19.log`) and cross-checked the self-hosted Langfuse trace store.
- **Evidence after fix:** Redacted runtime logs captured via `openclaw logs` (phone numbers and message bodies removed; `request_id` is already runtime-hashed):
  ```
  2026-06-19T16:29:27.892Z embedded_run_agent_end runId=17b3656e… isError=true model=claude-opus-4-8 provider=anthropic providerRuntimeFailureKind=replay_invalid rawErrorPreview={"type":"error","error":{"type":"invalid_request_error","message":"messages.15.content.0: Invalid `signature` in `thinking` block"},"request_id":"sha256:2b0afdf2fea9"}
  2026-06-19T16:29:27.999Z [session-recovery] stripped thinking blocks after provider rejected replay: repaired=22 sessionKey=agent:main:main
  2026-06-19T16:29:28.024Z [session-recovery] repaired rejected thinking replay; retrying turn attempt=1/1 sessionKey=agent:main:main
  ```
  Three independent organic occurrences on 2026-06-19 (16:29Z repaired=22, 18:00Z repaired=32, 23:41Z repaired=69), each immediately followed by a successful reply on the same turn. Corroborated in Langfuse: the failing GENERATION carried `stopReason: error` with the `invalid_request_error`, and a clean retry GENERATION ran ~3.4s later in the same trace.
- **Observed result after fix:** The wedge cleared automatically — after the strip-and-retry the model call succeeded and the session continued normally for ~3.5 hours with no manual restart. Contrast the same setup on the days before this recovery was deployed (2026-06-17 and 2026-06-18): the identical signature error recurred in 4× retry storms at a fixed message position (17, 24, and 12 rejected generations across three sessions) with zero `[session-recovery]` lines, and each wedged turn ended with empty assistant output.
- **What was not tested:** The literal head build of this PR branch was not the running binary — the captured behavior comes from VE-816, an independent implementation of the same terminal-result recovery path (its log strings read `stripped thinking blocks` / `repaired rejected thinking replay` rather than this branch's phrasing). No synthetic or forced reproduction was used; every capture is an organic production occurrence.
