### PR TITLE
fix(embedded-agent): route inbound to run-now past stale non-streamin…

### DIFF
--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -451,6 +451,38 @@ describe("runReplyAgent media path normalization", () => {
     expect(enqueueFollowupRunMock.mock.calls[0]?.[1].prompt).toBe("generate chart");
   });
 
+  // A present-but-non-streaming run is stale (finishRun cleared
+  // isStreaming but the entry was never removed from ACTIVE_EMBEDDED_RUNS).
+  // It must NOT divert the inbound into a followup queue whose drain never
+  // fires; the turn has to run now instead of silently blackholing.
+  it("runs now instead of queuing a followup when the active run is stale (not streaming)", async () => {
+    runEmbeddedAgentMock.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          sessionId: "session",
+          provider: "anthropic",
+          model: "claude",
+        },
+      },
+    });
+
+    await runReplyAgent(
+      makeRunReplyAgentParams({
+        resolvedQueue: { mode: "followup" } as QueueSettings,
+        shouldSteer: false,
+        shouldFollowup: true,
+        isActive: true,
+        isRunActive: () => true,
+        isStreaming: false,
+      }),
+    );
+
+    expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+    expect(queueEmbeddedAgentMessageWithOutcomeAsyncMock).not.toHaveBeenCalled();
+    expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
+  });
+
   it("falls back to a queued followup when active steering is rejected", async () => {
     queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockImplementation(async (sessionId: string) => ({
       queued: false,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1276,7 +1276,10 @@ export async function runReplyAgent(params: {
   }
 
   const activeRunQueueAction = resolveActiveRunQueueAction({
-    isActive,
+    // Gate on liveness, not bare presence. A stale (present but
+    // non-streaming) run must not divert this inbound into a followup queue
+    // whose drain never fires; isStreaming stays true for the whole live run.
+    isActive: isActive && isStreaming,
     isHeartbeat,
     shouldFollowup: effectiveShouldFollowup,
     queueMode: activeRunQueueMode,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1276,10 +1276,14 @@ export async function runReplyAgent(params: {
   }
 
   const activeRunQueueAction = resolveActiveRunQueueAction({
-    // Gate on liveness, not bare presence. A stale (present but
-    // non-streaming) run must not divert this inbound into a followup queue
-    // whose drain never fires; isStreaming stays true for the whole live run.
-    isActive: isActive && isStreaming,
+    // Trust the caller's isActive — it is already the dispatch-corrected
+    // liveness signal. runReplyAgent cannot distinguish a stale embedded handle
+    // from a genuinely active not-yet-streaming run from its (isActive,
+    // isStreaming) params alone, so staleness is resolved upstream in
+    // runPreparedReply and threaded via isActive; direct callers pass an
+    // authoritative isActive. Re-gating on isStreaming here would wrongly divert
+    // an active not-yet-streaming followup into preflight instead of enqueueing.
+    isActive,
     isHeartbeat,
     shouldFollowup: effectiveShouldFollowup,
     queueMode: activeRunQueueMode,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1117,6 +1117,14 @@ export async function runPreparedReply(
     };
   };
   const { activeSessionId, isActive, isStreaming } = resolveQueueBusyState();
+  // A present-but-non-streaming handle is a stale/ended run (finishRun
+  // cleared isStreaming but the entry was never removed from ACTIVE_EMBEDDED_RUNS),
+  // not a live one. Gate dispatch queueing on liveness so an inbound arriving
+  // behind a dead-but-uncleared run routes run-now instead of into a followup
+  // queue whose drain never fires (silent blackhole until restart). isStreaming
+  // is true for the whole run incl. tool gaps, so a genuinely busy run is
+  // unaffected; it is already the dispatch-relevant signal threaded below.
+  const hasLiveActiveRun = isActive && isStreaming;
   const activeRunAcceptsCurrentThread = resolveActiveRunAcceptsCurrentThread({ isActive });
   const isHeartbeatRun = opts?.isHeartbeat === true;
   const shouldSteer =
@@ -1132,13 +1140,13 @@ export async function runPreparedReply(
       resolvedQueue.mode === "followup" ||
       resolvedQueue.mode === "collect");
   const activeRunQueueAction = resolveActiveRunQueueAction({
-    isActive,
+    isActive: hasLiveActiveRun,
     isHeartbeat: isHeartbeatRun,
     shouldFollowup,
     queueMode: activeRunQueueMode,
     resetTriggered: effectiveResetTriggered,
   });
-  if (isActive && activeRunQueueAction === "run-now") {
+  if (hasLiveActiveRun && activeRunQueueAction === "run-now") {
     const queueState = await resolvePreparedReplyQueueState({
       activeRunQueueAction,
       activeSessionId: activeSessionId ?? resolveActiveQueueSessionId(),

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1095,36 +1095,47 @@ export async function runPreparedReply(
     const activeSessionId =
       embeddedActiveSessionId ?? replyOperationActiveSessionId ?? preparedSessionState.sessionId;
     if (!activeSessionId || (!embeddedAgentRuntime && !replyOperationActiveSessionId)) {
-      return { activeSessionId: undefined, isActive: false, isStreaming: false };
+      return {
+        activeSessionId: undefined,
+        isActive: false,
+        isStreaming: false,
+        hasLiveActiveRun: false,
+      };
     }
     if (isOwnPreDispatchOperationSession(activeSessionId)) {
-      return { activeSessionId, isActive: false, isStreaming: false };
+      return { activeSessionId, isActive: false, isStreaming: false, hasLiveActiveRun: false };
     }
     const replyOperationActive =
       replyOperationActiveSessionId != null &&
       isReplyRunActiveForSessionId(replyOperationActiveSessionId);
+    const embeddedActive =
+      embeddedActiveSessionId != null &&
+      (embeddedAgentRuntime?.isEmbeddedAgentRunActive(embeddedActiveSessionId) ?? false);
+    const embeddedStreaming =
+      embeddedActiveSessionId != null &&
+      (embeddedAgentRuntime?.isEmbeddedAgentRunStreaming(embeddedActiveSessionId) ?? false);
+    const replyOperationStreaming =
+      replyOperationActiveSessionId != null &&
+      isReplyRunStreamingForSessionId(replyOperationActiveSessionId);
     return {
       activeSessionId,
-      isActive:
-        (embeddedActiveSessionId != null &&
-          (embeddedAgentRuntime?.isEmbeddedAgentRunActive(embeddedActiveSessionId) ?? false)) ||
-        replyOperationActive,
-      isStreaming:
-        (embeddedActiveSessionId != null &&
-          (embeddedAgentRuntime?.isEmbeddedAgentRunStreaming(embeddedActiveSessionId) ?? false)) ||
-        (replyOperationActiveSessionId != null &&
-          isReplyRunStreamingForSessionId(replyOperationActiveSessionId)),
+      isActive: embeddedActive || replyOperationActive,
+      isStreaming: embeddedStreaming || replyOperationStreaming,
+      // A present-but-non-streaming handle is a stale/ended run (finishRun
+      // cleared isStreaming but the entry was never removed from
+      // ACTIVE_EMBEDDED_RUNS), not a live one — but only the embedded handle
+      // goes stale this way. A reply operation's activity is lifecycle-tracked
+      // and reliable, so trust it fully; require streaming only for the embedded
+      // handle. This routes a stale-handle inbound run-now instead of into a
+      // followup queue whose drain never fires (silent blackhole until restart),
+      // while preserving the wait / abort / enqueue contracts for a genuinely
+      // active but not-yet-streaming reply operation (reset interrupt,
+      // still-shutting-down handoff window) whose isStreaming is false until a
+      // backend attaches.
+      hasLiveActiveRun: replyOperationActive || (embeddedActive && embeddedStreaming),
     };
   };
-  const { activeSessionId, isActive, isStreaming } = resolveQueueBusyState();
-  // A present-but-non-streaming handle is a stale/ended run (finishRun
-  // cleared isStreaming but the entry was never removed from ACTIVE_EMBEDDED_RUNS),
-  // not a live one. Gate dispatch queueing on liveness so an inbound arriving
-  // behind a dead-but-uncleared run routes run-now instead of into a followup
-  // queue whose drain never fires (silent blackhole until restart). isStreaming
-  // is true for the whole run incl. tool gaps, so a genuinely busy run is
-  // unaffected; it is already the dispatch-relevant signal threaded below.
-  const hasLiveActiveRun = isActive && isStreaming;
+  const { activeSessionId, isActive, isStreaming, hasLiveActiveRun } = resolveQueueBusyState();
   const activeRunAcceptsCurrentThread = resolveActiveRunAcceptsCurrentThread({ isActive });
   const isHeartbeatRun = opts?.isHeartbeat === true;
   const shouldSteer =
@@ -1407,7 +1418,11 @@ export async function runPreparedReply(
     resolvedQueue,
     shouldSteer,
     shouldFollowup,
-    isActive,
+    // Pass the dispatch-corrected liveness, not bare handle presence.
+    // runReplyAgent's followup-queue decision cannot tell a stale embedded
+    // handle from a genuinely active not-yet-streaming run apart from its
+    // params, so the staleness correction has to be resolved here and threaded.
+    isActive: hasLiveActiveRun,
     isRunActive: () => {
       const latestSessionState = resolvePreparedSessionState();
       const latestActiveSessionId =


### PR DESCRIPTION
## Problem

Inbound messages can be silently dropped until the gateway is restarted. A session stops responding: messages are received by the channel but never dispatched to the agent — no model call, nothing appended to history.

## Root cause

The reply dispatch gate decides `run-now` vs. `enqueue-followup` from bare presence in `ACTIVE_EMBEDDED_RUNS` (`isEmbeddedAgentRunActive` → `ACTIVE_EMBEDDED_RUNS.has`).

When a run's stream ends but its handle is not cleared — teardown only clears on a handle-identity match, so a replaced or non-timeout handle survives — the entry lingers and reads as active indefinitely. Subsequent inbounds are then routed into a followup queue whose drain is never scheduled, so they park forever.

`isStreaming()` is set `true` for the entire run (including tool-execution gaps) and only cleared when the run finishes, so it is a reliable liveness signal — and it is already computed alongside the presence check at both dispatch sites.

## Fix

Gate the queue-action decision on liveness (`isActive && isStreaming`) at both dispatch sites (`get-reply-run`, `agent-runner`). A genuinely busy run is unaffected; only a stale present-but-non-streaming entry now routes `run-now`.

The shared `isEmbeddedAgentRunActive` predicate is intentionally left untouched, so callers that rely on presence semantics (gateway status, stuck-session recovery) are unchanged. This keeps the change scoped to the dispatch decision.

## Testing

Adds a regression test asserting a stale (present, non-streaming) run runs now instead of enqueuing a followup. Reverting the fix makes the test fail (the run is enqueued and blackholed); `agent-runner.media-paths.test.ts` passes with it.

