### PR TITLE
test(sqlite): use shared temp directory helper

### DIFF
--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -1,14 +1,19 @@
 // Status scan shared tests cover gateway probe snapshots, Tailscale URLs, and shared scan helpers.
-import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import {
   buildTailscaleHttpsUrl,
   resolveGatewayProbeSnapshot,
   resolveSharedMemoryStatusSnapshot,
 } from "./status.scan.shared.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  cleanupTempDirs(tempDirs);
+});
 
 const mocks = vi.hoisted(() => ({
   buildGatewayConnectionDetailsWithResolvers: vi.fn(),
@@ -574,7 +579,7 @@ describe("resolveSharedMemoryStatusSnapshot", () => {
   });
 
   it("recognizes shipped memory tables before the manager migrates them", async () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-status-memory-"));
+    const tempDir = makeTempDir(tempDirs, "openclaw-status-memory-");
     const databasePath = path.join(tempDir, "openclaw-agent.sqlite");
     const db = new DatabaseSync(databasePath);
     db.exec(`
@@ -616,25 +621,21 @@ describe("resolveSharedMemoryStatusSnapshot", () => {
     };
     const getMemorySearchManager = vi.fn(async () => ({ manager }));
 
-    try {
-      const result = await resolveSharedMemoryStatusSnapshot({
-        cfg: {},
-        agentStatus: { defaultId: "main" },
-        memoryPlugin: { enabled: true, slot: "memory-core" },
-        resolveMemoryConfig: vi.fn(() => ({ store: { databasePath } })),
-        getMemorySearchManager,
-        requireDefaultDatabasePath: () => databasePath,
-      });
+    const result = await resolveSharedMemoryStatusSnapshot({
+      cfg: {},
+      agentStatus: { defaultId: "main" },
+      memoryPlugin: { enabled: true, slot: "memory-core" },
+      resolveMemoryConfig: vi.fn(() => ({ store: { databasePath } })),
+      getMemorySearchManager,
+      requireDefaultDatabasePath: () => databasePath,
+    });
 
-      expect(getMemorySearchManager).toHaveBeenCalledOnce();
-      expect(result?.files).toBe(1);
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(getMemorySearchManager).toHaveBeenCalledOnce();
+    expect(result?.files).toBe(1);
   });
 
   it("does not initialize memory status for an agent database owned by another feature", async () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-status-memory-"));
+    const tempDir = makeTempDir(tempDirs, "openclaw-status-memory-");
     const databasePath = path.join(tempDir, "openclaw-agent.sqlite");
     const db = new DatabaseSync(databasePath);
     db.exec(`
@@ -649,20 +650,16 @@ describe("resolveSharedMemoryStatusSnapshot", () => {
     db.close();
     const getMemorySearchManager = vi.fn(async () => ({ manager: null }));
 
-    try {
-      const result = await resolveSharedMemoryStatusSnapshot({
-        cfg: {},
-        agentStatus: { defaultId: "main" },
-        memoryPlugin: { enabled: true, slot: "memory-core" },
-        resolveMemoryConfig: vi.fn(() => ({ store: { databasePath } })),
-        getMemorySearchManager,
-        requireDefaultDatabasePath: () => databasePath,
-      });
+    const result = await resolveSharedMemoryStatusSnapshot({
+      cfg: {},
+      agentStatus: { defaultId: "main" },
+      memoryPlugin: { enabled: true, slot: "memory-core" },
+      resolveMemoryConfig: vi.fn(() => ({ store: { databasePath } })),
+      getMemorySearchManager,
+      requireDefaultDatabasePath: () => databasePath,
+    });
 
-      expect(result).toBeNull();
-      expect(getMemorySearchManager).not.toHaveBeenCalled();
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(result).toBeNull();
+    expect(getMemorySearchManager).not.toHaveBeenCalled();
   });
 });

--- a/src/proxy-capture/store.sqlite.test.ts
+++ b/src/proxy-capture/store.sqlite.test.ts
@@ -1,8 +1,8 @@
 // Proxy capture SQLite store tests cover persisted capture reads and writes.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
@@ -19,23 +19,16 @@ afterEach(() => {
   closeDebugProxyCaptureStore();
   closeOpenClawStateDatabaseForTest();
   vi.restoreAllMocks();
-  while (cleanupDirs.length > 0) {
-    const dir = cleanupDirs.pop();
-    if (dir) {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
-  }
+  cleanupTempDirs(cleanupDirs);
 });
 
 function makeStore() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-proxy-capture-"));
-  cleanupDirs.push(root);
+  const root = makeTempDir(cleanupDirs, "openclaw-proxy-capture-");
   return new DebugProxyCaptureStore({ env: { OPENCLAW_STATE_DIR: root } });
 }
 
 function makeStateEnv(prefix: string): NodeJS.ProcessEnv {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  cleanupDirs.push(root);
+  const root = makeTempDir(cleanupDirs, prefix);
   return { OPENCLAW_STATE_DIR: root };
 }
 
@@ -80,8 +73,7 @@ describe("DebugProxyCaptureStore", () => {
   });
 
   it("preserves the shipped path-based Plugin SDK overloads", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-proxy-capture-legacy-sdk-"));
-    cleanupDirs.push(root);
+    const root = makeTempDir(cleanupDirs, "openclaw-proxy-capture-legacy-sdk-");
     const dbPath = path.join(root, "capture.sqlite");
     const blobDir = path.join(root, "blobs");
     const lease = acquireDebugProxyCaptureStore(dbPath, blobDir);


### PR DESCRIPTION
## Summary
- replace raw test temp-directory creation with `test/helpers/temp-dir.ts`
- centralize cleanup for the affected status and proxy SQLite tests
- clear the `check-guards` temp-directory warnings

## Validation
- `node scripts/report-test-temp-creations.mjs --base origin/main --head HEAD --fail-on-findings`
- `pnpm test:serial src/commands/status.scan.shared.test.ts src/proxy-capture/store.sqlite.test.ts` (Testbox, 25 tests)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof
- test-only cleanup; no runtime behavior changed
- Testbox warning reporter returned no findings and both affected SQLite test suites passed