### PR TITLE
fix(xai): allow private self-hosted Responses endpoints

### DIFF
--- a/src/agents/tools/web-search-provider-common.test.ts
+++ b/src/agents/tools/web-search-provider-common.test.ts
@@ -1,5 +1,20 @@
 // Shared web_search provider tests cover module-local cache isolation.
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { withSelfHostedWebToolsEndpointMock, withTrustedWebToolsEndpointMock } = vi.hoisted(() => ({
+  withSelfHostedWebToolsEndpointMock: vi.fn(),
+  withTrustedWebToolsEndpointMock: vi.fn(),
+}));
+
+vi.mock("./web-guarded-fetch.js", () => ({
+  withSelfHostedWebToolsEndpoint: withSelfHostedWebToolsEndpointMock,
+  withTrustedWebToolsEndpoint: withTrustedWebToolsEndpointMock,
+}));
+
+beforeEach(() => {
+  withSelfHostedWebToolsEndpointMock.mockReset();
+  withTrustedWebToolsEndpointMock.mockReset();
+});
 
 describe("web_search shared cache", () => {
   it("keeps cache entries module-local instead of exposing them on a global symbol", async () => {
@@ -16,5 +31,70 @@ describe("web_search shared cache", () => {
     expect(
       (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.web-search.cache")],
     ).toBeUndefined();
+  });
+
+  it("posts trusted JSON web tools through the self-hosted guard for private HTTP endpoints", async () => {
+    vi.resetModules();
+    withSelfHostedWebToolsEndpointMock.mockImplementation(async (_params, run) => {
+      return await run({
+        response: new Response(JSON.stringify({ ok: true }), { status: 200 }),
+        finalUrl: "http://web-tools.internal:4000/v1/responses",
+      });
+    });
+
+    const module = await import("./web-search-provider-common.js");
+    const parsed = await module.postTrustedWebToolsJson(
+      {
+        url: "http://web-tools.internal:4000/v1/responses",
+        timeoutSeconds: 30,
+        apiKey: "egsk_proxy_key", // pragma: allowlist secret
+        body: { model: "grok-4-1-fast", input: "search", tools: [{ type: "x_search" }] },
+        errorLabel: "xAI",
+      },
+      async (response) => ({ status: response.status }),
+    );
+
+    expect(parsed).toEqual({ status: 200 });
+    expect(withSelfHostedWebToolsEndpointMock).toHaveBeenCalledOnce();
+    expect(withTrustedWebToolsEndpointMock).not.toHaveBeenCalled();
+    const [params] = withSelfHostedWebToolsEndpointMock.mock.calls[0] as [
+      {
+        url?: string;
+        timeoutSeconds?: number;
+        init?: { method?: string; headers?: Record<string, string>; body?: string };
+      },
+      unknown,
+    ];
+    expect(params.url).toBe("http://web-tools.internal:4000/v1/responses");
+    expect(params.timeoutSeconds).toBe(30);
+    expect(params.init?.method).toBe("POST");
+    expect(params.init?.headers?.Authorization).toBe("Bearer egsk_proxy_key");
+    expect(JSON.parse(params.init?.body ?? "{}")).toMatchObject({ tools: [{ type: "x_search" }] });
+  });
+
+  it("keeps HTTPS JSON web tools on the trusted guard", async () => {
+    vi.resetModules();
+    withTrustedWebToolsEndpointMock.mockImplementation(async (_params, run) => {
+      return await run({
+        response: new Response(JSON.stringify({ ok: true }), { status: 200 }),
+        finalUrl: "https://api.example.test/v1/responses",
+      });
+    });
+
+    const module = await import("./web-search-provider-common.js");
+    const parsed = await module.postTrustedWebToolsJson(
+      {
+        url: "https://api.example.test/v1/responses",
+        timeoutSeconds: 30,
+        apiKey: "egsk_proxy_key", // pragma: allowlist secret
+        body: { model: "grok-4-1-fast", input: "search", tools: [{ type: "x_search" }] },
+        errorLabel: "xAI",
+      },
+      async (response) => ({ status: response.status }),
+    );
+
+    expect(parsed).toEqual({ status: 200 });
+    expect(withTrustedWebToolsEndpointMock).toHaveBeenCalledOnce();
+    expect(withSelfHostedWebToolsEndpointMock).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/tools/web-search-provider-common.ts
+++ b/src/agents/tools/web-search-provider-common.ts
@@ -6,6 +6,7 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
+import { assertHttpUrlTargetsPrivateNetwork } from "../../plugin-sdk/ssrf-policy.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import {
@@ -39,6 +40,27 @@ async function loadSelfHostedWebToolsEndpoint(): Promise<
   WebGuardedFetchModule["withSelfHostedWebToolsEndpoint"]
 > {
   return (await webGuardedFetchLoader.load()).withSelfHostedWebToolsEndpoint;
+}
+
+async function loadJsonWebToolsEndpoint(
+  url: string,
+): Promise<
+  | WebGuardedFetchModule["withTrustedWebToolsEndpoint"]
+  | WebGuardedFetchModule["withSelfHostedWebToolsEndpoint"]
+> {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "http:") {
+      await assertHttpUrlTargetsPrivateNetwork(parsed.toString(), {
+        dangerouslyAllowPrivateNetwork: true,
+      });
+      return await loadSelfHostedWebToolsEndpoint();
+    }
+  } catch {
+    // Preserve the existing trusted-path behavior for invalid and public HTTP URLs.
+  }
+
+  return await loadTrustedWebToolsEndpoint();
 }
 
 export type SearchConfigRecord = (NonNullable<OpenClawConfig["tools"]>["web"] extends infer Web
@@ -142,8 +164,8 @@ export async function postTrustedWebToolsJson<T>(
   },
   parseResponse: (response: Response) => Promise<T>,
 ): Promise<T> {
-  const withTrustedWebToolsEndpoint = await loadTrustedWebToolsEndpoint();
-  return withTrustedWebToolsEndpoint(
+  const withJsonWebToolsEndpoint = await loadJsonWebToolsEndpoint(params.url);
+  return withJsonWebToolsEndpoint(
     {
       url: params.url,
       timeoutSeconds: params.timeoutSeconds,


### PR DESCRIPTION
## Summary
- route JSON web-tool posts for private HTTP endpoints through the self-hosted web-tools guard
- keep HTTPS endpoints on the existing trusted guard
- add regression coverage for internal HTTP and HTTPS paths

## Test
- PNPM_HOME=/tmp/pnpm-home XDG_CACHE_HOME=/tmp/pnpm-cache pnpm vitest run src/agents/tools/web-search-provider-common.test.ts