### PR TITLE
feat(wizard): deliver progress over the RPC wizard protocol

### DIFF
--- a/src/wizard/session.test.ts
+++ b/src/wizard/session.test.ts
@@ -131,4 +131,133 @@ describe("WizardSession", () => {
     }
     await session.answer(plainStep.id, "alice");
   });
+
+  test("delivers progress steps before the next prompt and advances on re-poll", async () => {
+    const session = new WizardSession(async (prompter) => {
+      const spin = prompter.progress("Working");
+      spin.update("Step 1");
+      spin.stop("Done step");
+      await prompter.text({ message: "Name" });
+    });
+
+    // progress()/update()/stop() collapse latest-wins to the final message.
+    const progress = await session.next();
+    expect(progress.done).toBe(false);
+    expect(progress.step?.type).toBe("progress");
+    expect(progress.step?.message).toBe("Done step");
+
+    // Re-poll WITHOUT an answer advances to the interactive prompt.
+    const prompt = await session.next();
+    expect(prompt.step?.type).toBe("text");
+    if (!prompt.step) {
+      throw new Error("expected text step");
+    }
+    await session.answer(prompt.step.id, "Peter");
+
+    const done = await session.next();
+    expect(done.done).toBe(true);
+    expect(done.status).toBe("done");
+  });
+
+  test("delivers progress emitted while a client is waiting on next()", async () => {
+    let releaseWork: () => void = () => {};
+    const work = new Promise<void>((resolve) => {
+      releaseWork = resolve;
+    });
+    const session = new WizardSession(async (prompter) => {
+      const spin = prompter.progress("Working");
+      await work;
+      spin.update("Halfway");
+      await prompter.text({ message: "Name" });
+    });
+
+    // Initial label emitted synchronously at construction.
+    const first = await session.next();
+    expect(first.step?.type).toBe("progress");
+    expect(first.step?.message).toBe("Working");
+
+    // No pending step yet: this poll blocks until progress wakes it.
+    const waiting = session.next();
+    releaseWork();
+    const woken = await waiting;
+    expect(woken.step?.type).toBe("progress");
+    expect(woken.step?.message).toBe("Halfway");
+
+    const prompt = await session.next();
+    expect(prompt.step?.type).toBe("text");
+    if (!prompt.step) {
+      throw new Error("expected text step");
+    }
+    await session.answer(prompt.step.id, "x");
+    const done = await session.next();
+    expect(done.done).toBe(true);
+  });
+
+  test("progress steps are not answerable", async () => {
+    const session = new WizardSession(async (prompter) => {
+      prompter.progress("Working");
+      await prompter.text({ message: "Name" });
+    });
+
+    const progress = await session.next();
+    if (!progress.step) {
+      throw new Error("expected progress step");
+    }
+    await expect(session.answer(progress.step.id, null)).rejects.toThrow(
+      /wizard: no pending step/i,
+    );
+  });
+
+  test("cancel clears pending progress", async () => {
+    const session = new WizardSession(async (prompter) => {
+      prompter.progress("Working");
+      await prompter.text({ message: "Name" });
+    });
+
+    session.cancel();
+
+    const done = await session.next();
+    expect(done.done).toBe(true);
+    expect(done.status).toBe("cancelled");
+  });
+
+  test("concurrent next() callers never get a spurious done while running", async () => {
+    let releaseGate: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    const session = new WizardSession(async (prompter) => {
+      const spin = prompter.progress("start");
+      await gate;
+      spin.update("more");
+      await prompter.text({ message: "Name" });
+    });
+
+    // Consume the progress emitted synchronously at construction.
+    const firstStep = await session.next();
+    expect(firstStep.step?.message).toBe("start");
+
+    // Two concurrent waiters share the same internal step waiter — the race a
+    // progress wake (which resolves that waiter with null) used to mishandle.
+    const p1 = session.next();
+    const p2 = session.next();
+    releaseGate();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    // Critical invariant: while running, no caller may surface a done result.
+    expect(r1.done).toBe(false);
+    expect(r2.done).toBe(false);
+    expect(
+      [r1.step?.type, r2.step?.type].toSorted((a, b) => String(a).localeCompare(String(b))),
+    ).toEqual(["progress", "text"]);
+
+    const textResult = [r1, r2].find((r) => r.step?.type === "text");
+    if (!textResult?.step) {
+      throw new Error("expected a text step");
+    }
+    await session.answer(textResult.step.id, "Peter");
+    const done = await session.next();
+    expect(done.done).toBe(true);
+    expect(done.status).toBe("done");
+  });
 });

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -155,10 +155,18 @@ class WizardSessionPrompter implements WizardPrompter {
     return Boolean(res);
   }
 
-  progress(_label: string): WizardProgress {
+  progress(label: string): WizardProgress {
+    // Emit progress as non-interactive steps so remote clients see live status
+    // during slow operations. Clients render the message and re-poll wizard.next
+    // WITHOUT an answer to continue. Local CLI keeps using the clack prompter.
+    this.session.emitProgress(label);
     return {
-      update: (_message) => {},
-      stop: (_message) => {},
+      update: (message) => this.session.emitProgress(message),
+      stop: (message) => {
+        if (message !== undefined) {
+          this.session.emitProgress(message);
+        }
+      },
     };
   }
 
@@ -176,6 +184,9 @@ export class WizardSession {
   private currentStep: WizardStep | null = null;
   private stepDeferred: Deferred<WizardStep | null> | null = null;
   private pendingTerminalResolution = false;
+  // Latest undelivered progress step. Progress is non-interactive and "latest
+  // wins", so it is held as a single slot rather than an unbounded queue.
+  private pendingProgress: WizardStep | null = null;
   private answerDeferred = new Map<string, Deferred<unknown>>();
   private status: WizardSessionStatus = "running";
   private error: string | undefined;
@@ -186,24 +197,39 @@ export class WizardSession {
   }
 
   async next(): Promise<WizardNextResult> {
-    if (this.currentStep) {
-      return { done: false, step: this.currentStep, status: this.status };
+    // Loop so a progress wake never decides completion. A progress emit resolves
+    // the shared step waiter with null while the session is still running; with
+    // concurrent next() callers, one consumes the progress and the rest must
+    // re-classify state (and re-wait) rather than surface a spurious done.
+    for (;;) {
+      // Deliver any in-flight progress before the pending prompt so remote
+      // clients see live status during slow operations (installs, auth waits).
+      // This cannot starve an interactive prompt: the runner is sequential, so
+      // while it awaits a prompt it is not emitting progress, and latest-wins
+      // keeps at most one progress step pending.
+      const progress = this.takePendingProgress();
+      if (progress) {
+        return { done: false, step: progress, status: this.status };
+      }
+      if (this.currentStep) {
+        return { done: false, step: this.currentStep, status: this.status };
+      }
+      if (this.pendingTerminalResolution) {
+        this.pendingTerminalResolution = false;
+        return { done: true, status: this.status, error: this.error };
+      }
+      if (this.status !== "running") {
+        return { done: true, status: this.status, error: this.error };
+      }
+      if (!this.stepDeferred) {
+        this.stepDeferred = createDeferred();
+      }
+      // Wait for the next event (prompt pushed, progress emitted, or terminal),
+      // then re-loop to classify it via the checks above. The resolved value is
+      // intentionally ignored: a real step is read back from currentStep, and a
+      // null resolution falls through to progress/terminal/status handling.
+      await this.stepDeferred.promise;
     }
-    if (this.pendingTerminalResolution) {
-      this.pendingTerminalResolution = false;
-      return { done: true, status: this.status, error: this.error };
-    }
-    if (this.status !== "running") {
-      return { done: true, status: this.status, error: this.error };
-    }
-    if (!this.stepDeferred) {
-      this.stepDeferred = createDeferred();
-    }
-    const step = await this.stepDeferred.promise;
-    if (step) {
-      return { done: false, step, status: this.status };
-    }
-    return { done: true, status: this.status, error: this.error };
   }
 
   async answer(stepId: string, value: unknown): Promise<void> {
@@ -223,6 +249,7 @@ export class WizardSession {
     this.status = "cancelled";
     this.error = "cancelled";
     this.currentStep = null;
+    this.pendingProgress = null;
     for (const [, deferred] of this.answerDeferred) {
       // Reject all pending prompt promises so the runner can unwind through its
       // normal cancellation path.
@@ -262,6 +289,41 @@ export class WizardSession {
     const deferred = createDeferred<unknown>();
     this.answerDeferred.set(step.id, deferred);
     return await deferred.promise;
+  }
+
+  /**
+   * Emits a non-interactive progress step for remote clients. Fire-and-forget:
+   * the runner does not block, and clients re-poll wizard.next without an answer
+   * to continue. Latest-wins, so an undelivered progress step is replaced.
+   */
+  emitProgress(message: string): void {
+    if (this.status !== "running") {
+      return;
+    }
+    this.pendingProgress = {
+      id: randomUUID(),
+      type: "progress",
+      message,
+      executor: "client",
+    };
+    this.wakePendingProgress();
+  }
+
+  private takePendingProgress(): WizardStep | null {
+    const step = this.pendingProgress;
+    this.pendingProgress = null;
+    return step;
+  }
+
+  private wakePendingProgress(): void {
+    // Wake a long-polling next() so live progress is delivered mid-operation.
+    // Resolves with null; next() re-checks the pending progress slot on wake.
+    if (!this.stepDeferred) {
+      return;
+    }
+    const deferred = this.stepDeferred;
+    this.stepDeferred = null;
+    deferred.resolve(null);
   }
 
   private resolveStep(step: WizardStep | null) {


### PR DESCRIPTION
## Summary

Part of #94661 (wizard RPC parity for non-terminal clients).

The setup wizard runs locally (terminal `clack` prompter) and over an RPC protocol so non-terminal clients (the Windows companion, remote nodes) can drive onboarding. The RPC `WizardSessionPrompter.progress()` was a **no-op** (`src/wizard/session.ts`), so every `spin.update(...)` / `stop(...)` during installs, plugin/channel downloads, and OAuth/device-code waits was silently discarded for RPC clients — the companion looked **frozen** during the slowest parts of onboarding.

This delivers progress as non-interactive `progress` steps over the existing wizard protocol. The `progress` step type and optional `message` are already in the wizard step schema, so **no protocol schema change** is needed.

## How it works

- `progress()` / `update()` / `stop(msg)` emit a `progress` step (type `"progress"`, `executor: "client"`).
- **Latest-wins**: a single pending-progress slot, not an unbounded queue — a client only needs the current label.
- Progress is drained ahead of the pending prompt, and a long-polling `wizard.next` is woken mid-operation so status is live.
- Client contract: progress steps are **non-interactive**; the client re-polls `wizard.next` **without** an answer to continue. Progress steps are not answerable.
- Local CLI is unchanged (it uses the clack prompter, not `WizardSession`).

## Change type

- [x] Bug fix (RPC clients receive progress that was previously dropped)

## Scope

- [x] Gateway / orchestration
- [x] API / contracts (additive; no schema change)
- [x] UI / DX

## Real behavior proof

Behavior addressed: progress emitted during the RPC wizard is now delivered to clients as `progress` steps instead of being dropped, so non-terminal clients show live status during slow onboarding steps.
Real environment tested: local OpenClaw worktree on latest `main` (Windows).
Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/wizard/session.test.ts` (10 tests, incl. 4 new); `pnpm tsgo:core`; `pnpm tsgo:core:test`; `node scripts/run-oxlint.mjs src/wizard/session.ts src/wizard/session.test.ts`; `pnpm format:check`.
Evidence after fix: New tests assert progress steps are emitted (`type: "progress"`), delivered before the next prompt, collapse latest-wins, wake a waiting `next()` mid-operation, are not answerable, and are cleared on cancel. All pass; `tsgo:core` / `tsgo:core:test` exit 0; lint and format-check pass.
Observed result after fix: `wizard.next` returns `{ done:false, step:{ type:"progress", message } }` for in-flight progress; re-polling without an answer advances to the next prompt.
What was not tested: Windows companion rendering of progress steps (lands separately in `openclaw-windows-node`), and full-repo `pnpm check` / `pnpm test`.

## Compatibility

- Backward compatible? Yes — additive. Clients that ignore `progress` steps are unaffected; no schema change.
- Config/env changes? No. Migration needed? No.

## Security impact

No new permissions, secrets handling, network calls, or execution surface. Progress messages are non-secret status labels.

AI-assisted: Yes.
