### PR TITLE
fix(telegram): strip trailing notify=false marker and send as silent

### DIFF
--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2566,6 +2566,116 @@ describe("sendMessageTelegram", () => {
     });
   });
 
+  it("strips trailing notify=false marker and sends as silent", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 1,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "heartbeat result\nnotify=false", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "heartbeat result", {
+      parse_mode: "HTML",
+      disable_notification: true,
+    });
+  });
+
+  it("strips trailing notify=false with spaces around equals", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 2,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "done\nnotify  =  false", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "done", {
+      parse_mode: "HTML",
+      disable_notification: true,
+    });
+  });
+
+  it("strips case-insensitive notify=false marker", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 3,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "ok\nNotify=FALSE", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "ok", {
+      parse_mode: "HTML",
+      disable_notification: true,
+    });
+  });
+
+  it("does not set disable_notification when no notify=false marker", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 4,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "normal message", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "normal message", expect.objectContaining({}));
+    const callParams = sendMessage.mock.calls[0][2] as Record<string, unknown>;
+    expect(callParams.disable_notification).toBeUndefined();
+  });
+
+  it("keeps disable_notification when both marker and silent flag are set", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 5,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "quiet\nnotify=false", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      silent: true,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "quiet", {
+      parse_mode: "HTML",
+      disable_notification: true,
+    });
+  });
+
   it("parses message_thread_id from recipient string (telegram:group:...:topic:...)", async () => {
     const chatId = "-1001234567890";
     const sendMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -75,6 +75,9 @@ import { resolveTelegramVoiceSend } from "./voice.js";
 
 export { buildInlineKeyboard } from "./inline-keyboard.js";
 
+/** Matches trailing "\nnotify=false" (case-insensitive) that LLMs append to heartbeat/subagent text. */
+const NOTIFY_FALSE_TRAILING_RE = /\n+notify\s*=\s*false\s*$/i;
+
 type TelegramApi = Bot["api"];
 export type TelegramApiOverride = Partial<TelegramApi>;
 type TelegramSendMessageParams = Parameters<TelegramApi["sendMessage"]>[2];
@@ -645,6 +648,12 @@ export async function sendMessageTelegram(
   text: string,
   opts: TelegramSendOpts,
 ): Promise<TelegramSendResult> {
+  // Strip trailing notify=false marker before chunking so the convention
+  // is transparent to all delivery paths (native commands, heartbeat, media).
+  const notifyFalseMatch = NOTIFY_FALSE_TRAILING_RE.exec(text);
+  const strippedText = notifyFalseMatch ? text.slice(0, notifyFalseMatch.index) : text;
+  const effectiveSilent = opts.silent === true || notifyFalseMatch !== null;
+
   const { cfg, account, api } = resolveTelegramApiContext(opts);
   const target = parseTelegramTarget(to);
   const chatId = await resolveAndPersistChatId({
@@ -716,7 +725,7 @@ export async function sendMessageTelegram(
     }
     const plainParams: TelegramSendMessageParams = {
       ...baseParams,
-      ...(opts.silent === true ? { disable_notification: true } : {}),
+      ...(effectiveSilent ? { disable_notification: true } : {}),
     };
     const hasPlainParams = Object.keys(plainParams).length > 0;
     const requestPlain = (label: string) =>
@@ -806,7 +815,7 @@ export async function sendMessageTelegram(
         deliveryKind: "text",
         messageThreadId: lastAcceptedParams?.message_thread_id,
         replyToMessageId: opts.replyToMessageId,
-        silent: opts.silent,
+        silent: effectiveSilent || undefined,
         chunkCount: sentChunkCount,
       });
     }
@@ -887,7 +896,7 @@ export async function sendMessageTelegram(
               tableMode,
             }),
             ...acceptedParams,
-            ...(opts.silent === true ? { disable_notification: true } : {}),
+            ...(effectiveSilent ? { disable_notification: true } : {}),
           }),
         "richMessage",
       );
@@ -918,7 +927,7 @@ export async function sendMessageTelegram(
         deliveryKind: "text",
         messageThreadId: lastAcceptedParams?.message_thread_id,
         replyToMessageId: opts.replyToMessageId,
-        silent: opts.silent,
+        silent: effectiveSilent || undefined,
         chunkCount: sentChunkCount,
       });
     }
@@ -989,9 +998,9 @@ export async function sendMessageTelegram(
 
     if (isVideoNote) {
       caption = undefined;
-      followUpText = text.trim() ? text : undefined;
+      followUpText = strippedText.trim() ? strippedText : undefined;
     } else {
-      const split = splitTelegramCaption(text);
+      const split = splitTelegramCaption(strippedText);
       caption = split.caption;
       followUpText = split.followUpText;
     }
@@ -1012,7 +1021,7 @@ export async function sendMessageTelegram(
     const mediaParams = {
       ...(htmlCaption ? { caption: htmlCaption, parse_mode: "HTML" as const } : {}),
       ...baseMediaParams,
-      ...(opts.silent === true ? { disable_notification: true } : {}),
+      ...(effectiveSilent ? { disable_notification: true } : {}),
       ...(videoDimensions ? { width: videoDimensions.width, height: videoDimensions.height } : {}),
     };
     const sendMedia = async (
@@ -1134,7 +1143,7 @@ export async function sendMessageTelegram(
       deliveryKind: mediaSender.label,
       messageThreadId: mediaParams.message_thread_id,
       replyToMessageId: opts.replyToMessageId,
-      silent: opts.silent,
+      silent: effectiveSilent || undefined,
     });
     recordChannelActivity({
       channel: "telegram",
@@ -1152,10 +1161,10 @@ export async function sendMessageTelegram(
     return { messageId: String(mediaMessageId), chatId: resolvedChatId };
   }
 
-  if (!text || !text.trim()) {
+  if (!strippedText || !strippedText.trim()) {
     throw new Error("Message must be non-empty for Telegram sends");
   }
-  const textResult = await sendChunkedText(text, "text send");
+  const textResult = await sendChunkedText(strippedText, "text send");
   recordChannelActivity({
     channel: "telegram",
     accountId: account.accountId,


### PR DESCRIPTION
## Summary

LLMs append `\nnotify=false` to heartbeat/subagent completion text to indicate silent delivery. Previously this marker was not stripped anywhere in the Telegram send path, so the literal `notify=false` text appeared in delivered messages and notifications were not suppressed.

This fix moves the notify=false handling into `sendMessageTelegram` — the single convergence point for ALL Telegram text sends:
- Native command replies (`deliverReplies` path)
- Heartbeat/subagent completions (`sendDurableMessageBatch` → `sendTelegramPayloadMessages` path)
- Media caption text (`sendMessageTelegram` media branch)

At the entry of `sendMessageTelegram`, the trailing notify=false marker is stripped from the text before chunking, and `effectiveSilent` is derived from both `opts.silent` and marker presence. This `effectiveSilent` replaces all `opts.silent` usages in `disable_notification` spread points (plain text, rich text, and media params).

Fixes #80569

## Verification

- Ran 137 Telegram send tests: all pass (5 new regression tests)
- Ran 21 outbound-adapter tests: all pass
- Real behavior proof via `node --import tsx` with mocked API:
  - `"heartbeat result\nnotify=false"` → text: `"heartbeat result"`, disable_notification: true
  - `"normal message"` → text: `"normal message"`, disable_notification: undefined
  - `"done\nNotify=FALSE"` → text: `"done"`, disable_notification: true (case-insensitive)
  - `"ok\nnotify  =  false"` → text: `"ok"`, disable_notification: true (spaces around =)
- Build (`pnpm build`): succeeds
- Lint (`oxlint`): clean