### PR TITLE
Simplify docs homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,196 +1,79 @@
 ---
-summary: "OpenClaw is a multi-channel gateway for AI agents that runs on any OS."
+summary: "OpenClaw is a self-hosted gateway that lets AI agents work across your chat apps, web UI, and paired devices."
 read_when:
   - Introducing OpenClaw to newcomers
 title: "OpenClaw"
 ---
 
-# OpenClaw 🦞
+# OpenClaw
 
-<p align="center">
-    <img
-        src="/assets/openclaw-logo-text-dark.png"
-        alt="OpenClaw"
-        width="500"
-        class="dark:hidden"
-    />
-    <img
-        src="/assets/openclaw-logo-text.png"
-        alt="OpenClaw"
-        width="500"
-        class="hidden dark:block"
-    />
-</p>
+<div class="home-hero">
+  <div class="home-hero-copy">
+    <p class="home-eyebrow">Self-hosted AI gateway</p>
+    <img class="home-logo" src="/assets/openclaw-logo-text.png" alt="OpenClaw" />
+    <p class="home-lede">
+      Run one Gateway on your own machine and reach your coding agents from Discord, iMessage, Matrix,
+      Microsoft Teams, Signal, Slack, Telegram, WhatsApp, Zalo, the browser Control UI, and mobile nodes.
+    </p>
+    <div class="home-actions">
+      <a class="home-button home-button-primary" href="/start/getting-started">Get started</a>
+      <a class="home-button" href="/web/control-ui">Open the web UI</a>
+      <a class="home-button" href="/channels">Choose a channel</a>
+    </div>
+  </div>
+  <div class="home-flow" aria-label="OpenClaw architecture">
+    <div>Chat apps</div>
+    <span></span>
+    <div>OpenClaw Gateway</div>
+    <span></span>
+    <div>Agents and tools</div>
+  </div>
+</div>
 
-> _"EXFOLIATE! EXFOLIATE!"_ — A space lobster, probably
-
-<p align="center">
-  <strong>Any OS gateway for AI agents across Discord, Google Chat, iMessage, Matrix, Microsoft Teams, Signal, Slack, Telegram, WhatsApp, Zalo, and more.</strong><br />
-  Send a message, get an agent response from your pocket. Run one Gateway across built-in channels, bundled channel plugins, WebChat, and mobile nodes.
-</p>
+## Start with the fastest path
 
 <Columns>
-  <Card title="Get Started" href="/start/getting-started" icon="rocket">
-    Install OpenClaw and bring up the Gateway in minutes.
+  <Card title="Install OpenClaw" href="/start/getting-started" icon="rocket">
+    Install the CLI, run onboarding, and send your first message.
   </Card>
-  <Card title="Run Onboarding" href="/start/wizard" icon="sparkles">
-    Guided setup with `openclaw onboard` and pairing flows.
+  <Card title="Use the Control UI" href="/web/control-ui" icon="layout-dashboard">
+    Chat, inspect sessions, manage nodes, and adjust Gateway settings from a browser.
   </Card>
-  <Card title="Open the Control UI" href="/web/control-ui" icon="layout-dashboard">
-    Launch the browser dashboard for chat, config, and sessions.
+  <Card title="Connect Telegram" href="/channels/telegram" icon="message-square">
+    Use a quick channel setup when you want phone-to-agent messaging first.
   </Card>
 </Columns>
 
-## What is OpenClaw?
-
-OpenClaw is a **self-hosted gateway** that connects your favorite chat apps and channel surfaces — built-in channels plus bundled or external channel plugins such as Discord, Google Chat, iMessage, Matrix, Microsoft Teams, Signal, Slack, Telegram, WhatsApp, Zalo, and more — to AI coding agents. You run a single Gateway process on your own machine (or a server), and it becomes the bridge between your messaging apps and an always-available AI assistant.
-
-**Who is it for?** Developers and power users who want a personal AI assistant they can message from anywhere — without giving up control of their data or relying on a hosted service.
-
-**What makes it different?**
-
-- **Self-hosted**: runs on your hardware, your rules
-- **Multi-channel**: one Gateway serves built-in channels plus bundled or external channel plugins simultaneously
-- **Agent-native**: built for coding agents with tool use, sessions, memory, and multi-agent routing
-- **Open source**: MIT licensed, community-driven
-
-**What do you need?** Node 24 (recommended), or Node 22 LTS (`22.19+`) for compatibility, an API key from your chosen provider, and 5 minutes. For best quality and security, use the strongest latest-generation model available.
-
-## How it works
-
-```mermaid
-flowchart LR
-  A["Chat apps + plugins"] --> B["Gateway"]
-  B --> C["OpenClaw agent"]
-  B --> D["CLI"]
-  B --> E["Web Control UI"]
-  B --> F["macOS app"]
-  B --> G["iOS and Android nodes"]
-```
-
-The Gateway is the single source of truth for sessions, routing, and channel connections.
-
-## Key capabilities
+## What OpenClaw owns
 
 <Columns>
-  <Card title="Multi-channel gateway" icon="network" href="/channels">
-    Discord, iMessage, Signal, Slack, Telegram, WhatsApp, WebChat, and more with a single Gateway process.
+  <Card title="Gateway routing" icon="network" href="/gateway">
+    One local service routes messages across channels, agents, sessions, and devices.
   </Card>
-  <Card title="Plugin channels" icon="plug" href="/tools/plugin">
-    Bundled plugins add Matrix, Nostr, Twitch, Zalo, and more in normal current releases.
+  <Card title="Agent runtime" icon="bot" href="/agent-runtime-architecture">
+    Built-in and external agents can use tools, memory, media, approvals, and subagents.
   </Card>
-  <Card title="Multi-agent routing" icon="route" href="/concepts/multi-agent">
-    Isolated sessions per agent, workspace, or sender.
+  <Card title="Channel plugins" icon="plug" href="/tools/plugin">
+    Bundled and external plugins extend chat surfaces without moving product policy into core.
   </Card>
-  <Card title="Media support" icon="image" href="/nodes/images">
-    Send and receive images, audio, and documents.
-  </Card>
-  <Card title="Web Control UI" icon="monitor" href="/web/control-ui">
-    Browser dashboard for chat, config, sessions, and nodes.
-  </Card>
-  <Card title="Mobile nodes" icon="smartphone" href="/nodes">
-    Pair iOS and Android nodes for Canvas, camera, and voice-enabled workflows.
+  <Card title="Paired nodes" icon="smartphone" href="/nodes">
+    iOS, Android, macOS, and headless nodes add cameras, canvas, voice, and device actions.
   </Card>
 </Columns>
 
-## Quick start
-
-<Steps>
-  <Step title="Install OpenClaw">
-    ```bash
-    npm install -g openclaw@latest
-    ```
-  </Step>
-  <Step title="Onboard and install the service">
-    ```bash
-    openclaw onboard --install-daemon
-    ```
-  </Step>
-  <Step title="Chat">
-    Open the Control UI in your browser and send a message:
-
-    ```bash
-    openclaw dashboard
-    ```
-
-    Or connect a channel ([Telegram](/channels/telegram) is fastest) and chat from your phone.
-
-  </Step>
-</Steps>
-
-Need the full install and dev setup? See [Getting Started](/start/getting-started).
-
-## Dashboard
-
-Open the browser Control UI after the Gateway starts.
-
-- Local default: [http://127.0.0.1:18789/](http://127.0.0.1:18789/)
-- Remote access: [Web surfaces](/web) and [Tailscale](/gateway/tailscale)
-
-<p align="center">
-  <img src="/whatsapp-openclaw.jpg" alt="OpenClaw" width="420" />
-</p>
-
-## Configuration (optional)
-
-Config lives at `~/.openclaw/openclaw.json`.
-
-- If you **do nothing**, OpenClaw uses the bundled OpenClaw agent runtime with per-sender sessions.
-- If you want to lock it down, start with `channels.whatsapp.allowFrom` and (for groups) mention rules.
-
-Example:
-
-```json5
-{
-  channels: {
-    whatsapp: {
-      allowFrom: ["+15555550123"],
-      groups: { "*": { requireMention: true } },
-    },
-  },
-  messages: { groupChat: { mentionPatterns: ["@openclaw"] } },
-}
-```
-
-## Start here
+## Recommended next steps
 
 <Columns>
   <Card title="Docs hubs" href="/start/hubs" icon="book-open">
-    All docs and guides, organized by use case.
+    Browse the full documentation map by task area.
   </Card>
   <Card title="Configuration" href="/gateway/configuration" icon="settings">
-    Core Gateway settings, tokens, and provider config.
-  </Card>
-  <Card title="Remote access" href="/gateway/remote" icon="globe">
-    SSH and tailnet access patterns.
-  </Card>
-  <Card title="Channels" href="/channels/telegram" icon="message-square">
-    Channel-specific setup for Feishu, Microsoft Teams, WhatsApp, Telegram, Discord, and more.
-  </Card>
-  <Card title="Nodes" href="/nodes" icon="smartphone">
-    iOS and Android nodes with pairing, Canvas, camera, and device actions.
-  </Card>
-  <Card title="Help" href="/help" icon="life-buoy">
-    Common fixes and troubleshooting entry point.
-  </Card>
-</Columns>
-
-## Learn more
-
-<Columns>
-  <Card title="Full feature list" href="/concepts/features" icon="list">
-    Complete channel, routing, and media capabilities.
-  </Card>
-  <Card title="Multi-agent routing" href="/concepts/multi-agent" icon="route">
-    Workspace isolation and per-agent sessions.
+    Learn the main config file, credentials, provider settings, and safe defaults.
   </Card>
   <Card title="Security" href="/gateway/security" icon="shield">
-    Tokens, allowlists, and safety controls.
+    Review tokens, allowlists, network exposure, and production safety checks.
   </Card>
   <Card title="Troubleshooting" href="/gateway/troubleshooting" icon="wrench">
-    Gateway diagnostics and common errors.
-  </Card>
-  <Card title="About and credits" href="/reference/credits" icon="info">
-    Project origins, contributors, and license.
+    Diagnose common Gateway, channel, provider, and setup failures.
   </Card>
 </Columns>


### PR DESCRIPTION
## Summary
- Simplify the docs homepage source content so it behaves like a focused product entry page instead of a long article.
- Keep the homepage source aligned with the emergency publish-repo homepage shell PR: openclaw/docs#56.
- Move detailed setup/configuration paths behind focused cards instead of rendering long config and dashboard sections on the homepage.

## Verification
- `pnpm docs:list`
- `git diff --check -- docs/index.md`
- Publish repo proof with this content synced locally:
  - `DOCS_SITE_ARTIFACT_MODE=shell node scripts/docs-site/build.mjs`
  - `DOCS_SITE_ARTIFACT_MODE=shell node scripts/docs-site/smoke.mjs`
  - `node scripts/docs-site/visual-smoke.mjs`

## Real behavior proof
Behavior addressed: The docs homepage was visually cluttered because it rendered like a long article with generated navigation chrome and content that pushed the actual entry points down the page.

Real environment tested: Local `openclaw/docs` publish checkout using the generated docs shell served over an HTTP server from `dist/docs-site`, with Playwright Chromium mobile viewport `390x844`.

Exact steps or command run after this patch: Synced this `docs/index.md` content into the publish checkout, then ran `DOCS_SITE_ARTIFACT_MODE=shell node scripts/docs-site/build.mjs`, `DOCS_SITE_ARTIFACT_MODE=shell node scripts/docs-site/smoke.mjs`, `node scripts/docs-site/visual-smoke.mjs`, and a Playwright HTTP screenshot/geometry probe against `/`.

Evidence after fix: Build output: `built 23020 pages in dist\docs-site (shell)`. Smoke output: `docs site smoke ok: shell, routing, skin, and hidden fixture checks passed (shell)`. Visual output: `docs visual smoke ok: screenshots in .cache\docs-visual`. Playwright mobile geometry output for `/`: `{"bodyClass":"docs-home-page","width":390,"viewport":390,"hasSidebar":false,"hasToc":false,"hasLauncher":false}`.

Observed result after fix: The generated homepage uses `body.docs-home-page`, has no sidebar, has no table of contents, and the mobile homepage does not render the Molty launcher over the hero. The first screen shows the OpenClaw product entry, primary CTAs, and the simplified architecture flow.

What was not tested: I could not verify the live `https://docs.openclaw.ai/` deployment because this GitHub account does not have permission to merge or push to `openclaw/openclaw` or `openclaw/docs`; live deployment still requires maintainer merge of this PR and openclaw/docs#56.

## Notes
Direct push to `openclaw/openclaw` was rejected for account `qq110571515`, so this PR carries the source-of-truth docs change needed to make the publish fix durable.