### PR TITLE
fix(line): retry transient push failures with idempotent retry keys (#86012)

### DIFF
--- a/extensions/line/src/monitor.lifecycle.test.ts
+++ b/extensions/line/src/monitor.lifecycle.test.ts
@@ -17,6 +17,7 @@ const {
   registerWebhookTargetWithPluginRouteMock,
   runDetachedWebhookWorkMock,
   unregisterHttpMock,
+  logLineChannelQuotaMock,
 } = vi.hoisted(() => ({
   createLineBotMock: vi.fn(() => ({
     account: { accountId: "default" },
@@ -29,6 +30,7 @@ const {
   registerWebhookTargetWithPluginRouteMock: vi.fn(),
   runDetachedWebhookWorkMock: vi.fn(),
   unregisterHttpMock: vi.fn(),
+  logLineChannelQuotaMock: vi.fn(),
 }));
 
 let monitorLineProvider: typeof import("./monitor.js").monitorLineProvider;
@@ -136,6 +138,7 @@ vi.mock("./send.js", () => ({
   createLocationMessage: vi.fn(),
   createQuickReplyItems: vi.fn(),
   getUserDisplayName: vi.fn(),
+  logLineChannelQuota: logLineChannelQuotaMock,
   pushMessagesLine: vi.fn(),
   replyMessageLine: vi.fn(),
   showLoadingAnimation: vi.fn(),
@@ -179,6 +182,7 @@ describe("monitorLineProvider lifecycle", () => {
       .mockReset()
       .mockImplementation(() => innerLineWebhookHandlerMock);
     unregisterHttpMock.mockReset();
+    logLineChannelQuotaMock.mockClear();
     registerWebhookTargetWithPluginRouteMock.mockReset().mockImplementation((params) => {
       const withLeadingSlash = params.target.path.startsWith("/")
         ? params.target.path
@@ -260,6 +264,10 @@ describe("monitorLineProvider lifecycle", () => {
     expect(registration.route.pluginId).toBe("line");
     expect(registration.route).not.toHaveProperty("path");
     expect(registration.route).not.toHaveProperty("replaceExisting");
+    expect(logLineChannelQuotaMock).toHaveBeenCalledExactlyOnceWith({
+      cfg: {} as OpenClawConfig,
+      accountId: "work",
+    });
     await monitor.stop();
   });
 
@@ -315,6 +323,22 @@ describe("monitorLineProvider lifecycle", () => {
     const registration = requireWebhookRegistration();
     expect(registration.target.accountId).toBe("work");
     expect(registration.route.accountId).toBe("work");
+    expect(logLineChannelQuotaMock).toHaveBeenCalledExactlyOnceWith({
+      cfg: {
+        channels: {
+          line: {
+            defaultAccount: "work",
+            accounts: {
+              work: {
+                channelAccessToken: "work-token",
+                channelSecret: "work-secret",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "work",
+    });
 
     await monitor.stop();
   });

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -34,6 +34,7 @@ import {
   createLocationMessage,
   createQuickReplyItems,
   getUserDisplayName,
+  logLineChannelQuota,
   pushMessagesLine,
   replyMessageLine,
   showLoadingAnimation,
@@ -409,6 +410,10 @@ export async function monitorLineProvider(
   });
 
   logVerbose(`line: registered webhook handler at ${normalizedPath}`);
+
+  // One-time quota visibility at startup (non-blocking): logs plan tier and
+  // monthly push usage so exhausted quotas surface in logs before push fails.
+  void logLineChannelQuota({ cfg: config, accountId: resolvedAccountId });
 
   let stopped = false;
   let stopPromise: Promise<void> | undefined;

--- a/extensions/line/src/send-retry.test.ts
+++ b/extensions/line/src/send-retry.test.ts
@@ -1,0 +1,443 @@
+import { HTTPFetchError } from "@line/bot-sdk";
+// Line tests cover send retry and quota visibility behavior.
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  pushMessageMock,
+  lineFetchMock,
+  getMessageQuotaMock,
+  getMessageQuotaConsumptionMock,
+  MessagingApiClientMock,
+  requireRuntimeConfigMock,
+  resolveLineAccountMock,
+  resolveLineChannelAccessTokenMock,
+  recordChannelActivityMock,
+  logVerboseMock,
+  warnMock,
+  resolvePinnedHostnameWithPolicyMock,
+} = vi.hoisted(() => {
+  const pushMessageMockLocal = vi.fn();
+  const lineFetchMockLocal = vi.fn();
+  const getMessageQuotaMockLocal = vi.fn();
+  const getMessageQuotaConsumptionMockLocal = vi.fn();
+  const MessagingApiClientMockLocal = vi.fn(function () {
+    return {
+      pushMessage: pushMessageMockLocal,
+      replyMessage: vi.fn(),
+      showLoadingAnimation: vi.fn(),
+      getProfile: vi.fn(),
+      getMessageQuota: getMessageQuotaMockLocal,
+      getMessageQuotaConsumption: getMessageQuotaConsumptionMockLocal,
+    };
+  });
+  const requireRuntimeConfigMockLocal = vi.fn((cfg: unknown) => cfg ?? {});
+  const resolveLineAccountMockLocal = vi.fn(() => ({ accountId: "default" }));
+  const resolveLineChannelAccessTokenMockLocal = vi.fn(() => "line-token");
+  const recordChannelActivityMockLocal = vi.fn();
+  const logVerboseMockLocal = vi.fn();
+  const warnMockLocal = vi.fn();
+  const resolvePinnedHostnameWithPolicyMockLocal = vi.fn();
+  return {
+    pushMessageMock: pushMessageMockLocal,
+    lineFetchMock: lineFetchMockLocal,
+    getMessageQuotaMock: getMessageQuotaMockLocal,
+    getMessageQuotaConsumptionMock: getMessageQuotaConsumptionMockLocal,
+    MessagingApiClientMock: MessagingApiClientMockLocal,
+    requireRuntimeConfigMock: requireRuntimeConfigMockLocal,
+    resolveLineAccountMock: resolveLineAccountMockLocal,
+    resolveLineChannelAccessTokenMock: resolveLineChannelAccessTokenMockLocal,
+    recordChannelActivityMock: recordChannelActivityMockLocal,
+    logVerboseMock: logVerboseMockLocal,
+    warnMock: warnMockLocal,
+    resolvePinnedHostnameWithPolicyMock: resolvePinnedHostnameWithPolicyMockLocal,
+  };
+});
+
+vi.mock("@line/bot-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@line/bot-sdk")>();
+  return {
+    ...actual,
+    messagingApi: { ...actual.messagingApi, MessagingApiClient: MessagingApiClientMock },
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/plugin-config-runtime", () => ({
+  requireRuntimeConfig: requireRuntimeConfigMock,
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveLineAccount: resolveLineAccountMock,
+}));
+
+vi.mock("./channel-access-token.js", () => ({
+  resolveLineChannelAccessToken: resolveLineChannelAccessTokenMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-activity-runtime", () => ({
+  recordChannelActivity: recordChannelActivityMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
+    "openclaw/plugin-sdk/runtime-env",
+  );
+  return {
+    ...actual,
+    logVerbose: logVerboseMock,
+    warn: warnMock,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  resolvePinnedHostnameWithPolicy: resolvePinnedHostnameWithPolicyMock,
+}));
+
+let sendModule: typeof import("./send.js");
+
+const LINE_TEST_CFG = {
+  channels: {
+    line: {
+      accounts: {
+        default: {},
+      },
+    },
+  },
+};
+
+describe("LINE send retry and quota visibility", () => {
+  beforeAll(async () => {
+    sendModule = await import("./send.js");
+  });
+
+  afterAll(() => {
+    vi.doUnmock("@line/bot-sdk");
+    vi.doUnmock("openclaw/plugin-sdk/plugin-config-runtime");
+    vi.doUnmock("./accounts.js");
+    vi.doUnmock("./channel-access-token.js");
+    vi.doUnmock("openclaw/plugin-sdk/channel-activity-runtime");
+    vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+    vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    pushMessageMock.mockReset();
+    lineFetchMock.mockReset();
+    getMessageQuotaMock.mockReset();
+    getMessageQuotaConsumptionMock.mockReset();
+    MessagingApiClientMock.mockReset();
+    requireRuntimeConfigMock.mockClear();
+    resolveLineAccountMock.mockReset();
+    resolveLineChannelAccessTokenMock.mockReset();
+    recordChannelActivityMock.mockReset();
+    logVerboseMock.mockReset();
+    warnMock.mockReset();
+    resolvePinnedHostnameWithPolicyMock.mockReset();
+
+    MessagingApiClientMock.mockImplementation(function () {
+      return {
+        pushMessage: pushMessageMock,
+        replyMessage: vi.fn(),
+        showLoadingAnimation: vi.fn(),
+        getProfile: vi.fn(),
+        getMessageQuota: getMessageQuotaMock,
+        getMessageQuotaConsumption: getMessageQuotaConsumptionMock,
+      };
+    });
+    requireRuntimeConfigMock.mockImplementation((cfg: unknown) => cfg ?? LINE_TEST_CFG);
+    resolveLineAccountMock.mockReturnValue({ accountId: "default" });
+    resolveLineChannelAccessTokenMock.mockReturnValue("line-token");
+    resolvePinnedHostnameWithPolicyMock.mockResolvedValue({
+      hostname: "example.com",
+      addresses: ["93.184.216.34"],
+    });
+    pushMessageMock.mockResolvedValue({ sentMessages: [{ id: "push" }] });
+    lineFetchMock.mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
+      const requestUrl = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+      if (typeof init?.body !== "string") {
+        throw new Error("LINE test fetch requires a JSON string request body");
+      }
+      const payload = JSON.parse(init.body);
+      const provider = requestUrl.endsWith("/push") ? pushMessageMock : null;
+      if (!provider) {
+        throw new Error("LINE retry tests only exercise the push endpoint");
+      }
+      const body = await provider(payload);
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", lineFetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  const RETRY_KEY_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+  function fetchRetryKeys(): Array<string | undefined> {
+    return lineFetchMock.mock.calls.map(
+      ([, init]) => (init?.headers as Record<string, string> | undefined)?.["X-Line-Retry-Key"],
+    );
+  }
+
+  function createLineHttpError(status: number, statusText: string, body: string): HTTPFetchError {
+    return new HTTPFetchError(`${status} - ${statusText}`, {
+      status,
+      statusText,
+      headers: new Headers(),
+      body,
+    });
+  }
+
+  it("does not misclassify network SyntaxErrors as provider acceptance", async () => {
+    vi.useFakeTimers();
+    const failure = new SyntaxError("upstream network decoder failed");
+    lineFetchMock.mockRejectedValue(failure);
+
+    const send = sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG });
+    const settled = send.then(
+      (value) => value,
+      (err) => err,
+    );
+    await vi.advanceTimersByTimeAsync(60_000);
+    await expect(settled).resolves.toBe(failure);
+    expect(isChannelPartialDeliveryError(failure)).toBe(false);
+  });
+
+  it("retries transient push failures and reuses one retry key", async () => {
+    vi.useFakeTimers();
+    lineFetchMock.mockRejectedValueOnce(
+      createLineHttpError(503, "Service Unavailable", "upstream restarting"),
+    );
+
+    const send = sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG });
+    await vi.advanceTimersByTimeAsync(60_000);
+    await expect(send).resolves.toMatchObject({ chatId: "U123" });
+
+    expect(lineFetchMock).toHaveBeenCalledTimes(2);
+    const [firstKey, secondKey] = fetchRetryKeys();
+    expect(firstKey).toMatch(RETRY_KEY_PATTERN);
+    expect(secondKey).toBe(firstKey);
+  });
+
+  it("retries rate-limit 429 responses", async () => {
+    vi.useFakeTimers();
+    lineFetchMock.mockRejectedValueOnce(
+      createLineHttpError(429, "Too Many Requests", "rate limit exceeded"),
+    );
+
+    const send = sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG });
+    await vi.advanceTimersByTimeAsync(60_000);
+    await expect(send).resolves.toMatchObject({ chatId: "U123" });
+
+    expect(lineFetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries 429 responses with a monthly-limit body", async () => {
+    // LINE can return "You have reached your monthly limit." 429s while quota
+    // remains (temporary reservation exhaustion), so the body is not a reliable
+    // permanent marker; the push retry key keeps retries idempotent.
+    vi.useFakeTimers();
+    lineFetchMock.mockRejectedValueOnce(
+      createLineHttpError(429, "Too Many Requests", "You have reached your monthly limit."),
+    );
+
+    const send = sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG });
+    await vi.advanceTimersByTimeAsync(60_000);
+    await expect(send).resolves.toMatchObject({ chatId: "U123" });
+
+    expect(lineFetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a definitive 4xx rejection", async () => {
+    const error = createLineHttpError(400, "Bad Request", "invalid payload");
+    lineFetchMock.mockRejectedValueOnce(error);
+
+    await expect(sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG })).rejects.toBe(
+      error,
+    );
+    expect(lineFetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("does not wrap reply sends in retry or a retry key", async () => {
+    // Reply tokens are single-use; only the upstream auto-reply fallback may push.
+    const error = createLineHttpError(503, "Service Unavailable", "upstream restarting");
+    lineFetchMock.mockRejectedValueOnce(error);
+
+    await expect(
+      sendModule.sendMessageLine("U123", "Hello", {
+        cfg: LINE_TEST_CFG,
+        replyToken: "reply-token",
+      }),
+    ).rejects.toBe(error);
+    expect(lineFetchMock).toHaveBeenCalledOnce();
+    expect(fetchRetryKeys()).toEqual([undefined]);
+  });
+
+  it("uses a fresh retry key per logical push", async () => {
+    await sendModule.pushMessagesLine("U123", [{ type: "text", text: "one" }], {
+      cfg: LINE_TEST_CFG,
+    });
+    await sendModule.pushMessagesLine("U123", [{ type: "text", text: "two" }], {
+      cfg: LINE_TEST_CFG,
+    });
+
+    const [firstKey, secondKey] = fetchRetryKeys();
+    expect(firstKey).toMatch(RETRY_KEY_PATTERN);
+    expect(secondKey).toMatch(RETRY_KEY_PATTERN);
+    expect(secondKey).not.toBe(firstKey);
+  });
+
+  it("treats a 409 retry-key conflict as the already-delivered push", async () => {
+    // LINE echoes the original acceptance receipt when a retry key was already
+    // accepted; the send must resolve so the spool never replays a duplicate.
+    vi.useFakeTimers();
+    lineFetchMock.mockRejectedValueOnce(
+      createLineHttpError(503, "Service Unavailable", "upstream restarting"),
+    );
+    lineFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          message: "The retry key is already accepted",
+          sentMessages: [{ id: "already-delivered" }],
+        }),
+        { status: 409, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const send = sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG });
+    await vi.advanceTimersByTimeAsync(60_000);
+    await expect(send).resolves.toMatchObject({
+      messageId: "already-delivered",
+      chatId: "U123",
+    });
+
+    expect(lineFetchMock).toHaveBeenCalledTimes(2);
+    const [firstKey, secondKey] = fetchRetryKeys();
+    expect(secondKey).toBe(firstKey);
+  });
+
+  it.each([
+    { label: "an unparseable body", body: "not a json receipt" },
+    {
+      label: "a body without a receipt",
+      body: JSON.stringify({ message: "The retry key is already accepted" }),
+    },
+  ])("treats a 409 conflict with $label as a delivered partial delivery", async ({ body }) => {
+    vi.useFakeTimers();
+    lineFetchMock.mockRejectedValueOnce(
+      createLineHttpError(503, "Service Unavailable", "upstream restarting"),
+    );
+    lineFetchMock.mockResolvedValueOnce(
+      new Response(body, { status: 409, headers: { "content-type": "application/json" } }),
+    );
+
+    const send = sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG }).then(
+      (value) => value,
+      (err) => err,
+    );
+    await vi.advanceTimersByTimeAsync(60_000);
+    const error = await send;
+    expect(isChannelPartialDeliveryError(error)).toBe(true);
+    expect(lineFetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps reply 409 conflicts as plain HTTP errors", async () => {
+    // Only push carries a retry key, so a reply 409 is not an accepted receipt
+    // and must surface as a normal provider rejection.
+    lineFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "conflict" }), {
+        status: 409,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(
+      sendModule.sendMessageLine("U123", "Hello", {
+        cfg: LINE_TEST_CFG,
+        replyToken: "reply-token",
+      }),
+    ).rejects.toBeInstanceOf(HTTPFetchError);
+    expect(lineFetchMock).toHaveBeenCalledOnce();
+    expect(fetchRetryKeys()).toEqual([undefined]);
+  });
+
+  it("gives up after the configured retry budget for persistent failures", async () => {
+    vi.useFakeTimers();
+    const error = createLineHttpError(503, "Service Unavailable", "upstream restarting");
+    lineFetchMock.mockRejectedValue(error);
+
+    const send = sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG }).then(
+      (value) => value,
+      (err) => err,
+    );
+    await vi.advanceTimersByTimeAsync(60_000);
+    const rejected = await send;
+    expect(rejected).toBe(error);
+    expect(lineFetchMock).toHaveBeenCalledTimes(5);
+    expect(new Set(fetchRetryKeys()).size).toBe(1);
+  });
+
+  it("logs limited quota consumption at startup", async () => {
+    getMessageQuotaMock.mockResolvedValue({ type: "limited", value: 10_000 });
+    getMessageQuotaConsumptionMock.mockResolvedValue({ totalUsage: 2500 });
+
+    await sendModule.logLineChannelQuota({ cfg: LINE_TEST_CFG });
+
+    expect(logVerboseMock).toHaveBeenCalledWith(
+      "line: quota type=limited, 2500/10000 used (7500 remaining, 25%)",
+    );
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      label: "missing limit value",
+      quota: { type: "limited", value: undefined },
+      usage: 2500,
+      expected: "line: quota type=limited, 2500/0 used (-2500 remaining, 0%)",
+    },
+    {
+      label: "usage beyond the limit",
+      quota: { type: "limited", value: 100 },
+      usage: 250,
+      expected: "line: quota type=limited, 250/100 used (-150 remaining, 250%)",
+    },
+  ])(
+    "warns about exhausted quota for $label without NaN percentages",
+    async ({ quota, usage, expected }) => {
+      getMessageQuotaMock.mockResolvedValue(quota);
+      getMessageQuotaConsumptionMock.mockResolvedValue({ totalUsage: usage });
+
+      await sendModule.logLineChannelQuota({ cfg: LINE_TEST_CFG });
+
+      expect(warnMock).toHaveBeenCalledWith(expected);
+      expect(logVerboseMock).not.toHaveBeenCalledWith(expected);
+    },
+  );
+
+  it("logs unlimited quota plans at startup", async () => {
+    getMessageQuotaMock.mockResolvedValue({ type: "none" });
+
+    await sendModule.logLineChannelQuota({ cfg: LINE_TEST_CFG });
+
+    expect(logVerboseMock).toHaveBeenCalledWith(
+      "line: quota type=none (unlimited plan, no monthly cap)",
+    );
+  });
+
+  it("keeps quota probe failures non-fatal", async () => {
+    getMessageQuotaMock.mockRejectedValue(new Error("quota unavailable"));
+
+    await expect(sendModule.logLineChannelQuota({ cfg: LINE_TEST_CFG })).resolves.toBeUndefined();
+
+    expect(logVerboseMock).toHaveBeenCalledWith(
+      "line: failed to query quota info (non-fatal): Error: quota unavailable",
+    );
+  });
+});

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -729,16 +729,6 @@ describe("LINE send helpers", () => {
     });
   });
 
-  it("does not misclassify network SyntaxErrors as provider acceptance", async () => {
-    const failure = new SyntaxError("upstream network decoder failed");
-    lineFetchMock.mockRejectedValueOnce(failure);
-
-    await expect(sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG })).rejects.toBe(
-      failure,
-    );
-    expect(isChannelPartialDeliveryError(failure)).toBe(false);
-  });
-
   it.each([
     {
       label: "push",

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -1,12 +1,17 @@
 // Line plugin module implements send behavior.
+import { randomUUID } from "node:crypto";
 import { HTTPFetchError, messagingApi } from "@line/bot-sdk";
 import lineBotSdkPackage from "@line/bot-sdk/package.json" with { type: "json" };
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
-import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
-import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { createChannelApiRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
+import { logVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithRuntimeDispatcherOrMockedGlobal } from "openclaw/plugin-sdk/runtime-fetch";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveLineAccount } from "./accounts.js";
@@ -34,6 +39,19 @@ const userProfileCache = new Map<
 const PROFILE_CACHE_TTL_MS = 5 * 60 * 1000;
 const PROFILE_CACHE_MAX_ENTRIES = 1000;
 const LINE_FLEX_ALT_TEXT_LIMIT = 1500;
+
+// LINE recommends exponential backoff for transient push failures (5xx,
+// rate-limit 429) while treating other 4xx as permanent. The X-Line-Retry-Key
+// header (valid 24h) makes every retry attempt for one logical push idempotent
+// server-side; pushLineMessages generates one key per call so retries never
+// duplicate a send that LINE already accepted. strictShouldRetry keeps the
+// generic channel regex fallback from retrying permanent LINE errors.
+const linePushRetryRunner = createChannelApiRetryRunner({
+  retry: { attempts: 5, minDelayMs: 1000, maxDelayMs: 8000, jitter: 0.3 },
+  shouldRetry: isRetryableLineError,
+  strictShouldRetry: true,
+  verbose: true,
+});
 
 function cacheUserProfile(
   userId: string,
@@ -93,6 +111,32 @@ function resolveLineProviderMessageIds(
     );
   }
   return { messageId, messageIds };
+}
+
+async function readLineConflictReceipt(
+  response: Response,
+): Promise<messagingApi.PushMessageResponse> {
+  try {
+    const text = await response.text();
+    const body = text ? (JSON.parse(text) as unknown) : null;
+    const sentMessages =
+      body && typeof body === "object"
+        ? (body as { sentMessages?: unknown }).sentMessages
+        : undefined;
+    if (Array.isArray(sentMessages)) {
+      // The 409 body is the original acceptance receipt; let the caller's
+      // normal receipt resolution validate its shape.
+      return { sentMessages: sentMessages as messagingApi.SentMessage[] };
+    }
+  } catch {
+    // fall through to the partial-delivery guard below
+  }
+  // LINE accepted this retry key before; treat it as delivered even when the
+  // echoed receipt is unreadable, so the spool never replays a duplicate.
+  throw createChannelPartialDeliveryError(
+    new Error("LINE retry key was already accepted but its receipt is unreadable"),
+    { messageIds: [], visibleReplySent: true },
+  );
 }
 
 function normalizeTarget(to: string): string {
@@ -171,6 +215,7 @@ async function sendLineProviderMessages(
   operation: "push" | "reply",
   token: string,
   request: messagingApi.PushMessageRequest | messagingApi.ReplyMessageRequest,
+  retryKey?: string,
 ): Promise<messagingApi.PushMessageResponse | messagingApi.ReplyMessageResponse> {
   const response = await fetchWithRuntimeDispatcherOrMockedGlobal(
     `https://api.line.me/v2/bot/message/${operation}`,
@@ -180,12 +225,20 @@ async function sendLineProviderMessages(
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
         "User-Agent": `@line/bot-sdk/${lineBotSdkPackage.version}`,
+        ...(retryKey ? { "X-Line-Retry-Key": retryKey } : {}),
       },
       body: JSON.stringify(request),
     },
   );
 
   if (!response.ok) {
+    if (response.status === 409 && operation === "push") {
+      // LINE echoes the original response body when a retry key was already
+      // accepted, proving that push was delivered on an earlier attempt (e.g.
+      // its response was lost). Treat it as a successful delivery instead of a
+      // failure so the caller never replays a duplicate send.
+      return readLineConflictReceipt(response);
+    }
     throw new HTTPFetchError(`${response.status} - ${response.statusText}`, {
       status: response.status,
       statusText: response.statusText,
@@ -271,6 +324,27 @@ function logLineHttpError(err: unknown, context: string): void {
   }
 }
 
+function isRetryableLineError(error: unknown): boolean {
+  if (isChannelPartialDeliveryError(error)) {
+    // LINE accepted this request before the receipt became unreadable;
+    // retrying would duplicate the send.
+    return false;
+  }
+  if (!error || typeof error !== "object") {
+    return true;
+  }
+  const { status } = error as { status?: number };
+  if (typeof status === "number" && status >= 400 && status < 500) {
+    // LINE's 429 can mean temporary reservation exhaustion even while quota
+    // remains ("You have reached your monthly limit."), so retry all 429s;
+    // retries stay idempotent via the push retry key. Other 4xx (including
+    // expired reply tokens) are definitive rejections.
+    return status === 429;
+  }
+  // 5xx and network/timeout failures are transient candidates.
+  return true;
+}
+
 function recordLineOutboundActivity(
   accountId: string,
   delivery: { messageIds: string[]; receipt?: LineSendResult["receipt"] },
@@ -320,17 +394,18 @@ async function pushLineMessages(
 
   const { account, token, chatId } = createLinePushContext(to, opts);
   const normalizedMessages = messages.map(normalizeLineMessageActions);
-  const pushRequest = sendLineProviderMessages("push", token, {
-    to: chatId,
-    messages: normalizedMessages,
-  });
+  // One retry key per logical push keeps every retry attempt idempotent, so a
+  // send LINE accepted before a transient failure is never duplicated.
+  const retryKey = randomUUID();
+  const pushRequest = () =>
+    sendLineProviderMessages("push", token, { to: chatId, messages: normalizedMessages }, retryKey);
 
-  const response = behavior.errorContext
-    ? await pushRequest.catch((err: unknown) => {
-        logLineHttpError(err, behavior.errorContext!);
-        throw err;
-      })
-    : await pushRequest;
+  const response = await linePushRetryRunner(pushRequest, "line:push").catch((err: unknown) => {
+    if (behavior.errorContext) {
+      logLineHttpError(err, behavior.errorContext);
+    }
+    throw err;
+  });
   const { messageId, messageIds } = resolveLineProviderMessageIds(response, "push");
   const result: LineSendResult = {
     messageId,
@@ -441,6 +516,7 @@ export async function sendMessageLine(
   }
 
   return pushLineMessages(chatId, messages, opts, {
+    errorContext: "push message",
     verboseMessage: (resolvedChatId) => `line: pushed message to ${resolvedChatId}`,
   });
 }
@@ -624,4 +700,34 @@ export async function getUserProfile(
 export async function getUserDisplayName(userId: string, opts: LineClientOpts): Promise<string> {
   const profile = await getUserProfile(userId, opts);
   return profile?.displayName ?? userId;
+}
+
+export async function logLineChannelQuota(opts: LineClientOpts): Promise<void> {
+  try {
+    const { client } = createLineMessagingClient(opts);
+    const [quotaResponse, consumptionResponse] = await Promise.all([
+      client.getMessageQuota(),
+      client.getMessageQuotaConsumption(),
+    ]);
+
+    if (quotaResponse.type === "none") {
+      logVerbose("line: quota type=none (unlimited plan, no monthly cap)");
+    } else {
+      const used = consumptionResponse.totalUsage;
+      const limit = quotaResponse.value ?? 0;
+      const remaining = limit - used;
+      const pct = limit > 0 ? Math.round((used / limit) * 100) : 0;
+      const message = `line: quota type=limited, ${used}/${limit} used (${remaining} remaining, ${pct}%)`;
+      if (remaining <= 0) {
+        // Exhausted quota blocks every push until the monthly reset; surface it
+        // above verbose level so operators see it without enabling verbose logs.
+        warn(message);
+      } else {
+        logVerbose(message);
+      }
+    }
+  } catch (err) {
+    // Startup visibility only: quota probes must never block or fail the channel.
+    logVerbose(`line: failed to query quota info (non-fatal): ${String(err)}`);
+  }
 }


### PR DESCRIPTION
Closes openclaw/openclaw#86012

## What Problem This Solves

Silent message loss in the LINE channel: `pushMessageLine`/`pushMessagesLine` made a single attempt with no retry, so transient failures (5xx, rate-limit 429, network) silently dropped messages the user believed were delivered. And when a push's response was lost after LINE had already accepted it, a redelivery would send the message twice.

## Why This Change Was Made

LINE documents a retry protocol (https://developers.line.biz/en/docs/messaging-api/retrying-api-request/): retry transient failures with exponential backoff, send the `X-Line-Retry-Key` header so retries are idempotent server-side, treat 409 as "retry key already accepted" (the original receipt is echoed in the body), and treat other 4xx as permanent. The prior code did none of this. This PR implements the documented protocol via the shared SDK `createChannelApiRetryRunner` seam (same runner family as Telegram), and adds a startup quota probe so operators see push-quota exhaustion (which surfaces as 429s) without enabling verbose logging.

## User Impact

- Push messages hitting transient LINE failures are retried up to 5 attempts with exponential backoff (1s → 8s, jittered) under one idempotency key per logical push: no more silent drops, and no duplicate sends when LINE accepted a prior attempt (409 handled as already-delivered, including unreadable-receipt cases, which surface as partial delivery so the webhook spool never replays).
- Reply sends are untouched: single-use reply tokens are never retried or keyed (contractually required).
- At startup the gateway logs the LINE push quota (`used/limit used (remaining, %)`); exhausted quota logs at warn level.

## Evidence

Behavior tests, 74 passing across the touched suites:

- `extensions/line/src/send-retry.test.ts` (17 tests): 503 retried with the same retry key across attempts; 429 retried with and without the monthly-limit body (LINE FAQ: that 429 can be transient while quota remains); definitive 4xx not retried; 409 with an echoed receipt resolves as delivered with the original messageId; 409 with an unreadable receipt rejects as a channel partial-delivery error (auto-reply marks delivery, spool does not replay); reply sends never wrapped in retry or a retry key; reply 409 stays a plain HTTP error; retry budget exhausted after 5 attempts under one key; network SyntaxError not misclassified as provider acceptance; quota logs for unlimited/limited/exhausted plans and non-fatal probe failures.
- `extensions/line/src/send.test.ts` (44 tests) and `extensions/line/src/monitor.lifecycle.test.ts` (13 tests, including exactly-once startup quota call per account).

Local validation:

```
node scripts/run-vitest.mjs extensions/line/src/send-retry.test.ts extensions/line/src/send.test.ts extensions/line/src/monitor.lifecycle.test.ts
# 74 passed
node_modules/.bin/oxlint extensions/line/src/send.ts extensions/line/src/send-retry.test.ts extensions/line/src/monitor.ts extensions/line/src/monitor.lifecycle.test.ts
# 0 warnings / 0 errors
pnpm tsgo:extensions && pnpm tsgo:extensions:test
# exit 0
```

Not tested: live LINE API roundtrip (requires production channel credentials).
