### PR TITLE
test(scripts): fix test-projects baseline for temp-dir helper importers

### DIFF
--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -858,7 +858,11 @@ describe("test-projects args", () => {
       {
         config: "test/vitest/vitest.unit-fast.config.ts",
         forwardedArgs: [],
-        includePatterns: ["src/install-sh-version.test.ts", "test/scripts/android-version.test.ts"],
+        includePatterns: [
+          "src/install-sh-version.test.ts",
+          "src/proxy-capture/store.sqlite.test.ts",
+          "test/scripts/android-version.test.ts",
+        ],
         watchMode: false,
       },
       {
@@ -884,6 +888,12 @@ describe("test-projects args", () => {
           "test/test-env.test.ts",
           "test/vitest-scoped-config.test.ts",
         ],
+        watchMode: false,
+      },
+      {
+        config: "test/vitest/vitest.commands.config.ts",
+        forwardedArgs: [],
+        includePatterns: ["src/commands/status.scan.shared.test.ts"],
         watchMode: false,
       },
       {


### PR DESCRIPTION
## Summary

`src/scripts/test-projects.test.ts` ("routes top-level test helpers to importing repo tests") is failing on `main`: changing `test/helpers/temp-dir.ts` now routes two tests that the hardcoded expected baseline did not list.

Both files directly import the helper:

- `src/proxy-capture/store.sqlite.test.ts` → `import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js"` → routes to `vitest.unit-fast.config.ts`
- `src/commands/status.scan.shared.test.ts` → same import → routes to `vitest.commands.config.ts`

So `buildVitestRunPlans(["test/helpers/temp-dir.ts"])` correctly includes them; the test's expected snapshot was just stale. This updates the baseline to match the (correct) discovery output — no routing-logic change.

The expected values were captured directly from `buildVitestRunPlans` output, not hand-written.

## Why this is not a silencing change

The actual routing is correct: both test files genuinely import `test/helpers/temp-dir.ts` and match their respective config globs (`unit-fast` default for `src/**.test.ts`, `commands` for `src/commands/**`). The expected list simply hadn't been updated when those importers were added.

## Verification

- `node scripts/run-vitest.mjs src/scripts/test-projects.test.ts` → 82 passed (was 1 failed before this change)
- Reproduced the failure first on a clean `origin/main` checkout to confirm it is a `main` breakage, not PR-specific
- `oxlint --tsconfig config/tsconfig/oxlint.core.json src/scripts/test-projects.test.ts` → clean
- `oxfmt --check` → clean
- `git diff --check` → clean
