### PR TITLE
ci: gate PR edit automation by changed field

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -19,6 +19,14 @@ permissions: {}
 
 jobs:
   auto-response:
+    if: >-
+      ${{
+        github.event_name != 'pull_request_target' ||
+        github.event.action != 'edited' ||
+        github.event.changes.title ||
+        github.event.changes.body ||
+        github.event.changes.base
+      }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -26,10 +26,18 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       ${{
-        github.event_name == 'issue_comment' ||
-        !(
-          endsWith(github.actor, '[bot]') &&
-          (github.event.action == 'labeled' || github.event.action == 'unlabeled')
+        (
+          github.event_name == 'issue_comment' ||
+          !(
+            endsWith(github.actor, '[bot]') &&
+            (github.event.action == 'labeled' || github.event.action == 'unlabeled')
+          )
+        ) &&
+        (
+          github.event_name != 'pull_request_target' ||
+          github.event.action != 'edited' ||
+          github.event.changes.body ||
+          github.event.changes.base
         )
       }}
     env:

--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -36,6 +36,7 @@ jobs:
         (
           github.event_name != 'pull_request_target' ||
           github.event.action != 'edited' ||
+          github.event.changes.title ||
           github.event.changes.body ||
           github.event.changes.base
         )

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -27,6 +27,15 @@ permissions: {}
 
 jobs:
   label:
+    if: >-
+      ${{
+        github.event_name == 'pull_request_target' &&
+        (
+          github.event.action != 'edited' ||
+          github.event.changes.title ||
+          github.event.changes.base
+        )
+      }}
     permissions:
       contents: read
       pull-requests: write
@@ -45,11 +54,13 @@ jobs:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
       - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
+        if: ${{ github.event.action != 'edited' || github.event.changes.base }}
         with:
           configuration-path: .github/labeler.yml
           repo-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
           sync-labels: true
       - name: Apply PR size label
+        if: ${{ github.event.action != 'edited' || github.event.changes.base }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
@@ -139,6 +150,7 @@ jobs:
               labels: [targetSizeLabel],
             });
       - name: Apply maintainer or trusted-contributor label
+        if: ${{ github.event.action != 'edited' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
@@ -210,6 +222,7 @@ jobs:
             //   });
             // }
       - name: Apply beta-blocker title label
+        if: ${{ github.event.action != 'edited' || github.event.changes.title }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
@@ -263,6 +276,7 @@ jobs:
               });
             }
       - name: Apply too-many-prs label
+        if: ${{ github.event.action != 'edited' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}

--- a/.github/workflows/real-behavior-proof.yml
+++ b/.github/workflows/real-behavior-proof.yml
@@ -16,6 +16,13 @@ permissions: {}
 jobs:
   real-behavior-proof:
     name: Real behavior proof
+    if: >-
+      ${{
+        github.event_name != 'pull_request_target' ||
+        github.event.action != 'edited' ||
+        github.event.changes.body ||
+        github.event.changes.base
+      }}
     permissions:
       contents: read
       issues: read

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -407,7 +407,11 @@ const PRECISE_SOURCE_TEST_TARGETS = new Map([
 ]);
 const TOOLING_SOURCE_TEST_TARGETS = new Map([
   [".crabbox.yaml", ["test/scripts/package-acceptance-workflow.test.ts"]],
+  [".github/workflows/auto-response.yml", ["test/scripts/ci-workflow-guards.test.ts"]],
   [".github/workflows/ci.yml", ["test/scripts/ci-workflow-guards.test.ts"]],
+  [".github/workflows/clawsweeper-dispatch.yml", ["test/scripts/ci-workflow-guards.test.ts"]],
+  [".github/workflows/labeler.yml", ["test/scripts/ci-workflow-guards.test.ts"]],
+  [".github/workflows/real-behavior-proof.yml", ["test/scripts/ci-workflow-guards.test.ts"]],
   [
     ".github/workflows/security-sensitive-guard.yml",
     ["test/scripts/security-sensitive-guard-workflow.test.ts"],

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -19,6 +19,10 @@ function readCriticalQualityWorkflow() {
   return readFileSync(".github/workflows/codeql-critical-quality.yml", "utf8");
 }
 
+function readWorkflow(path: string) {
+  return parse(readFileSync(path, "utf8"));
+}
+
 function findYamlFiles(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const path = `${directory}/${entry.name}`;
@@ -50,6 +54,46 @@ function findUnpinnedExternalActions(): string[] {
 }
 
 describe("ci workflow guards", () => {
+  it("routes PR edited metadata only to interested automation", () => {
+    const autoResponse = readWorkflow(".github/workflows/auto-response.yml");
+    const clawsweeperDispatch = readWorkflow(".github/workflows/clawsweeper-dispatch.yml");
+    const labeler = readWorkflow(".github/workflows/labeler.yml");
+    const realBehaviorProof = readWorkflow(".github/workflows/real-behavior-proof.yml");
+
+    expect(autoResponse.on.pull_request_target.types).toContain("edited");
+    expect(autoResponse.jobs["auto-response"].if).toContain("github.event.changes.title");
+    expect(autoResponse.jobs["auto-response"].if).toContain("github.event.changes.body");
+    expect(autoResponse.jobs["auto-response"].if).toContain("github.event.changes.base");
+
+    expect(clawsweeperDispatch.on.pull_request_target.types).toContain("edited");
+    expect(clawsweeperDispatch.jobs.dispatch.if).toContain("github.event.changes.body");
+    expect(clawsweeperDispatch.jobs.dispatch.if).toContain("github.event.changes.base");
+    expect(clawsweeperDispatch.jobs.dispatch.if).not.toContain("github.event.changes.title");
+
+    expect(realBehaviorProof.on.pull_request_target.types).toContain("edited");
+    expect(realBehaviorProof.jobs["real-behavior-proof"].if).toContain("github.event.changes.body");
+    expect(realBehaviorProof.jobs["real-behavior-proof"].if).toContain("github.event.changes.base");
+    expect(realBehaviorProof.jobs["real-behavior-proof"].if).not.toContain(
+      "github.event.changes.title",
+    );
+
+    expect(labeler.on.pull_request_target.types).toContain("edited");
+    expect(labeler.jobs.label.if).toContain("github.event.changes.title");
+    expect(labeler.jobs.label.if).toContain("github.event.changes.base");
+    expect(labeler.jobs.label.if).not.toContain("github.event.changes.body");
+
+    const labelerSteps = labeler.jobs.label.steps;
+    expect(labelerSteps.find((step) => step.uses?.startsWith("actions/labeler@"))?.if).toBe(
+      "${{ github.event.action != 'edited' || github.event.changes.base }}",
+    );
+    expect(labelerSteps.find((step) => step.name === "Apply PR size label")?.if).toBe(
+      "${{ github.event.action != 'edited' || github.event.changes.base }}",
+    );
+    expect(labelerSteps.find((step) => step.name === "Apply beta-blocker title label")?.if).toBe(
+      "${{ github.event.action != 'edited' || github.event.changes.title }}",
+    );
+  });
+
   it("makes the hosted release-gate fallback explicit and exact-SHA only", () => {
     const workflow = readCiWorkflow();
     const releaseGate = workflow.on.workflow_dispatch.inputs.release_gate;

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -66,9 +66,9 @@ describe("ci workflow guards", () => {
     expect(autoResponse.jobs["auto-response"].if).toContain("github.event.changes.base");
 
     expect(clawsweeperDispatch.on.pull_request_target.types).toContain("edited");
+    expect(clawsweeperDispatch.jobs.dispatch.if).toContain("github.event.changes.title");
     expect(clawsweeperDispatch.jobs.dispatch.if).toContain("github.event.changes.body");
     expect(clawsweeperDispatch.jobs.dispatch.if).toContain("github.event.changes.base");
-    expect(clawsweeperDispatch.jobs.dispatch.if).not.toContain("github.event.changes.title");
 
     expect(realBehaviorProof.on.pull_request_target.types).toContain("edited");
     expect(realBehaviorProof.jobs["real-behavior-proof"].if).toContain("github.event.changes.body");

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1071,6 +1071,20 @@ describe("scripts/test-projects changed-target routing", () => {
     });
   });
 
+  it("keeps PR automation workflow edits on workflow guard tests", () => {
+    for (const workflowPath of [
+      ".github/workflows/auto-response.yml",
+      ".github/workflows/clawsweeper-dispatch.yml",
+      ".github/workflows/labeler.yml",
+      ".github/workflows/real-behavior-proof.yml",
+    ]) {
+      expect(resolveChangedTestTargetPlan([workflowPath])).toEqual({
+        mode: "targets",
+        targets: ["test/scripts/ci-workflow-guards.test.ts"],
+      });
+    }
+  });
+
   it("keeps security-sensitive guard workflow edits on guard workflow tests", () => {
     expect(
       resolveChangedTestTargetPlan([".github/workflows/security-sensitive-guard.yml"]),


### PR DESCRIPTION
## Summary
- gate PR `edited` automation on the fields each workflow actually consumes
- keep ClawSweeper dispatch active for title/body/base edits because it serializes PR title into its activity payload
- skip expensive PR automation for metadata-only edits while preserving title/body/base behavior
- add workflow guard coverage and changed-test routing for the edited-field matrix

## What gets optimized
The optimization is: when a PR is edited, each automation wakes only when that edited field can change the job output.

- `Auto response` (`auto-response`): wakes for title, body, or base edits.
- `ClawSweeper Dispatch` (`dispatch`): wakes for title, body, or base edits.
- `Labeler` (`label`): wakes for title or base edits.
- `Real behavior proof` (`Real behavior proof`): wakes for body or base edits.

Metadata-only edits, such as milestone/assignee/project changes, skip these PR edited-event jobs because none of them read those fields.

## Verification
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts test/scripts/test-projects.test.ts`
- `node scripts/check-workflows.mjs .github/workflows/auto-response.yml .github/workflows/clawsweeper-dispatch.yml .github/workflows/labeler.yml .github/workflows/real-behavior-proof.yml`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts test/scripts/test-projects.test.ts"`

## Real behavior proof
Behavior addressed: PR `pull_request_target` `edited` automation now wakes only for fields each workflow reads.

Real environment tested: local OpenClaw checkout on branch `optimize-pr-edit-automation` at commit `b480e41f2f3`, plus GitHub PR observer/check-rollup inspection for PR #94682.

Exact steps or command run after this patch:
```sh
node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts test/scripts/test-projects.test.ts
node scripts/check-workflows.mjs .github/workflows/auto-response.yml .github/workflows/clawsweeper-dispatch.yml .github/workflows/labeler.yml .github/workflows/real-behavior-proof.yml
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts test/scripts/test-projects.test.ts"
```

Evidence after fix:
```text
Test Files  2 passed (2)
Tests  189 passed (189)
zizmor...................................................................Passed
No direct inputs interpolation found in composite run blocks.
autoreview clean: no accepted/actionable findings reported
```

PR observer outcome matrix from the proposed branch workflow guards:

| PR event | auto-response | dispatch | label | Real behavior proof |
|---|---:|---:|---:|---:|
| opened | success | success | success | success |
| title edit | success | success | success | skipped |
| body edit | success | success | skipped | success |
| base edit | success | success | success | success |
| metadata edit | skipped | skipped | skipped | skipped |

Observed result after fix: skipped outcomes are intentional. Title edits do not affect real-behavior proof content, body edits do not affect labels, and metadata edits do not affect any of these automation outputs. Base edits wake all four jobs because base can affect routing, labels, proof context, and dispatch context.

Labeler edited-step outcomes:

| PR edit | `actions/labeler` | `Apply PR size label` | `Apply maintainer or trusted-contributor label` | `Apply beta-blocker title label` | `Apply too-many-prs label` |
|---|---:|---:|---:|---:|---:|
| title edit | skipped | skipped | skipped | success | skipped |
| base edit | success | success | skipped | skipped | skipped |
| body edit | skipped | skipped | skipped | skipped | skipped |
| metadata edit | skipped | skipped | skipped | skipped | skipped |

Live PR observer/check-rollup note: current PR head previously showed `Auto response`, `ClawSweeper Dispatch`, `Labeler`, and `Real behavior proof` succeeding on PR #94682. GitHub evaluates `pull_request_target` workflow definitions from the target branch, so live PR runs cannot authoritatively execute this branch's new guards before merge. The matrix above is accepted synthetic/static proof for this workflow-only guard change.

Persistent data-model note: no persistent data model, vector store, embedding metadata, migration, or runtime state changed. The only `metadata`/`embedding` text in this PR is test coverage text and existing changed-test routing names.

What was not tested: a full live GitHub `pull_request_target` edited-event matrix using this branch as the target branch. That can only run after this workflow change lands on a target branch.
