### PR TITLE
fix: #80507 show dry-run output for message send/poll

### DIFF
--- a/src/commands/message-format.ts
+++ b/src/commands/message-format.ts
@@ -247,7 +247,7 @@ export function formatMessageCliText(result: MessageActionRunResult): string[] {
   const width = getTerminalTableWidth();
   const opts: FormatOpts = { width };
 
-  if (result.handledBy === "dry-run") {
+  if (result.dryRun) {
     return [muted(`[dry-run] would run ${result.action} via ${result.channel}`)];
   }
 


### PR DESCRIPTION
## Summary

When `openclaw message send --dry-run` is used, the pretty-text CLI output incorrectly prints `✅ Sent via <channel>. Message ID: unknown` — the same success message as a real send. The formatter checks `result.handledBy === "dry-run"`, but the send/poll execution path (`executeSendAction`) always returns `handledBy: "core"` with a separate `dryRun: true` flag, so the dry-run branch is dead code.

The fix changes the condition from `result.handledBy === "dry-run"` to `result.dryRun`. All four variants of `MessageActionRunResult` (`send`, `broadcast`, `poll`, `action`) include the required `dryRun: boolean` field, making this a type-safe single-line fix.

Fixes #80507

## Real behavior proof

**Behavior addressed**: Fix `openclaw message send --dry-run` (and the equivalent poll path) so the pretty-text CLI output shows a muted `[dry-run] would run send via <channel>` line instead of incorrectly printing `✅ Sent via <channel>. Message ID: unknown`.

**Real environment tested**: Linux 6.8.0-124-generic x64 / OpenClaw 2026.6.8 (built from source at a8d60d352e) / Node.js v25.9.0

**Exact steps or command run after this patch**:

```bash
# 1. Run message send with --dry-run (pretty-text output)
node openclaw.mjs message send --channel slack --target "channel:test123" --message "qa probe" --dry-run

# 2. Verify the JSON output confirms dryRun was honored
node openclaw.mjs message send --channel slack --target "channel:test123" --message "qa probe" --dry-run --json
```

**After-fix evidence**:

```
$ node openclaw.mjs message send --channel slack --target "channel:test123" --message "qa probe" --dry-run
[dry-run] would run send via slack

$ node openclaw.mjs message send --channel slack --target "channel:test123" --message "qa probe" --dry-run --json
{
  "action": "send",
  "channel": "slack",
  "dryRun": true,
  "handledBy": "core",
  "payload": {
    "channel": "slack",
    "to": "test123",
    "via": "direct",
    "mediaUrl": null,
    "dryRun": true
  }
}
```

**Observed result after the fix**: The pretty-text output now correctly prints `[dry-run] would run send via slack` (muted style) instead of the old buggy `✅ Sent via Slack. Message ID: unknown`. The `--json` output confirms `dryRun: true` and `handledBy: "core"` — proving the fix correctly checks `result.dryRun` rather than the never-set `result.handledBy === "dry-run"`.

**What was not tested**: The broadcast dry-run path (kind: "broadcast" with `handledBy: "dry-run"`) was not explicitly tested, but the type-safe change preserves existing behavior for broadcast since `dryRun` is also present on that variant.

## Tests and validation

### Type safety

The `MessageActionRunResult` union type guarantees correctness:

```typescript
// All four variants have dryRun: boolean (required, not optional):
type MessageActionRunResult =
  | { kind: "send";    handledBy: "plugin" | "core" | "internal-source"; dryRun: boolean; ... }
  | { kind: "broadcast"; handledBy: "core" | "dry-run";                   dryRun: boolean; ... }
  | { kind: "poll";    handledBy: "plugin" | "core";                      dryRun: boolean; ... }
  | { kind: "action";  handledBy: "plugin" | "dry-run";                  dryRun: boolean; ... }
```

- `kind: "send"` → `handledBy` is never `"dry-run"` (was dead code)
- `kind: "poll"` → `handledBy` is never `"dry-run"` (was dead code)
- `kind: "broadcast"` and `kind: "action"` → `handledBy` CAN be `"dry-run"`, but `dryRun` is also present and truthy — behavior preserved

The fix moves from checking a value that can never be `"dry-run"` on the send/poll path (`handledBy`) to checking the field that correctly indicates dry-run state (`dryRun`).

### Build verification

```bash
$ pnpm build cliStartup
[build-all] phase timings: total 18.3s; slowest write-cli-startup-metadata 12.4s; tsdown 4.83s
Build succeeded with no errors.
```

## Risk checklist

- [x] This change is backwards compatible
- [x] This change has been tested with existing configurations
- [ ] I have updated relevant documentation (N/A — no behavior contract change)
- [ ] Breaking changes (if any) are documented in Summary (N/A)

## Current review state

- [x] Self-review completed
- [ ] At least one maintainer review
- [ ] All CI checks passed