### PR TITLE
fix(codex): release timed-out app-server lanes

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1501,6 +1501,7 @@ export async function runCodexAppServerAttempt(
     interruptTimeoutMs: CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS,
     onInterruptTurn: (input) => interruptCodexTurnBestEffort(client, input),
     onTimeout: (timeout) => {
+      const firstTimeout = !timedOut;
       timedOut = true;
       turnCompletionIdleTimedOut = true;
       turnWatchTimeoutKind = timeout.kind;
@@ -1510,6 +1511,9 @@ export async function runCodexAppServerAttempt(
       turnWatchTimeoutDetails = timeout.details;
       turnCompletionIdleTimeoutMessage =
         "codex app-server turn idle timed out waiting for turn/completed";
+      if (firstTimeout) {
+        params.onAttemptTimeout?.(new Error(turnCompletionIdleTimeoutMessage));
+      }
     },
     onMarkTimedOut: () => projectorRef.current?.markTimedOut(),
     onAbort: (reason) => runAbortController.abort(reason),
@@ -2582,6 +2586,7 @@ export async function runCodexAppServerAttempt(
   turnWatches.touchActivity("turn:start", { arm: true });
   turnWatches.armAttemptIdleWatch();
   turnWatches.touchActivity("turn:start", { attemptProgress: true });
+  params.onAttemptTimeoutArmed?.();
   for (const notification of pendingNotifications.splice(0)) {
     await enqueueNotification(notification);
   }
@@ -2643,6 +2648,7 @@ export async function runCodexAppServerAttempt(
       });
       return;
     }
+    params.onAttemptAbort?.();
     interruptCodexTurnBestEffort(client, {
       threadId: thread.threadId,
       turnId: activeTurnId,

--- a/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts
@@ -1,5 +1,5 @@
 // Coverage for replay-safe Codex app-server recovery retries.
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
@@ -242,6 +242,61 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
     });
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(mockedMarkAuthProfileFailure).not.toHaveBeenCalled();
+  });
+
+  it("releases the same-session lane when a Codex app-server timeout ignores cancellation", async () => {
+    vi.useFakeTimers();
+    let settleIgnoredAttempt: ((value: EmbeddedRunAttemptResult) => void) | undefined;
+    let resolveFirstAttemptStarted: (() => void) | undefined;
+    const firstAttemptStarted = new Promise<void>((resolve) => {
+      resolveFirstAttemptStarted = resolve;
+    });
+    try {
+      mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
+        const { onAttemptTimeoutArmed, onAttemptTimeout } = attemptParams as {
+          onAttemptTimeoutArmed?: () => void;
+          onAttemptTimeout?: (reason: Error) => void;
+        };
+        onAttemptTimeoutArmed?.();
+        resolveFirstAttemptStarted?.();
+        onAttemptTimeout?.(
+          new Error("codex app-server turn idle timed out waiting for turn/completed"),
+        );
+        return await new Promise((resolve) => {
+          settleIgnoredAttempt = resolve;
+        });
+      });
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(successAttempt());
+
+      const firstRun = runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        provider: "codex",
+        model: "gpt-5.5",
+        runId: "run-codex-timeout-lane-release-first",
+        timeoutMs: 48 * 60 * 60 * 1000,
+      });
+      void firstRun.catch(() => {});
+
+      await vi.advanceTimersByTimeAsync(0);
+      await firstAttemptStarted;
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+
+      const secondRun = runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        provider: "codex",
+        model: "gpt-5.5",
+        runId: "run-codex-timeout-lane-release-second",
+      });
+
+      await vi.advanceTimersByTimeAsync(30_001);
+
+      await expect(firstRun).rejects.toMatchObject({ name: "CommandLaneTaskTimeoutError" });
+      await expect(secondRun).resolves.toMatchObject({ meta: { aborted: false } });
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    } finally {
+      settleIgnoredAttempt?.(successAttempt());
+      vi.useRealTimers();
+    }
   });
 
   it("surfaces non-stdio turn/completed idle timeouts instead of throwing", async () => {

--- a/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts
@@ -288,7 +288,9 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
         runId: "run-codex-timeout-lane-release-second",
       });
 
-      await vi.advanceTimersByTimeAsync(30_001);
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(2);
 
       await expect(firstRun).rejects.toMatchObject({ name: "CommandLaneTaskTimeoutError" });
       await expect(secondRun).resolves.toMatchObject({ meta: { aborted: false } });

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1884,7 +1884,7 @@ async function runEmbeddedAgentInternal(
               once: true,
             });
           };
-          // Timeout recovery can continue after an attempt returns, but a native
+          // Timeout recovery can continue after an attempt returns, but a
           // transport that ignores its timeout releases the lane after one grace.
           let timeoutReleaseTimer: ReturnType<typeof setTimeout> | undefined;
           const clearAttemptTimeoutRelease = () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2006,16 +2006,12 @@ async function runEmbeddedAgentInternal(
             runId: params.runId,
             lifecycleGeneration,
             abortSignal: attemptAbortController.signal,
-            onAttemptTimeoutArmed: pluginHarnessOwnsTransport
-              ? undefined
-              : startLaneProgressHeartbeat,
-            onAttemptTimeout: pluginHarnessOwnsTransport ? undefined : armAttemptTimeoutRelease,
-            onAttemptAbort: pluginHarnessOwnsTransport
-              ? undefined
-              : () => {
-                  stopLaneProgressHeartbeat();
-                  laneTaskAbortController.abort();
-                },
+            onAttemptTimeoutArmed: startLaneProgressHeartbeat,
+            onAttemptTimeout: armAttemptTimeoutRelease,
+            onAttemptAbort: () => {
+              stopLaneProgressHeartbeat();
+              laneTaskAbortController.abort();
+            },
             replyOperation: params.replyOperation,
             shouldEmitToolResult: params.shouldEmitToolResult,
             shouldEmitToolOutput: params.shouldEmitToolOutput,


### PR DESCRIPTION
## Summary

Fixes #84569 by releasing the OpenClaw command lane when a Codex app-server attempt hits its own timeout/abort path but the app-server side does not settle promptly.

- Wire the runner's bounded lane-release hooks into plugin-owned harness attempts, not only the native OpenClaw harness.
- Have the Codex app-server harness signal when its turn watchdog is armed, when the watchdog timeout fires, and when explicit non-timeout abort cleanup begins.
- Add regression coverage where a Codex attempt reports a turn/completed idle timeout and then ignores cancellation forever; a second inbound for the same session still runs after the bounded grace.

## Root Cause

Confirmed: the stuck lane is a root OpenClaw/Codex harness ownership bug, not a WhatsApp delivery-only bug. Current main can time out and retire/interrupt a Codex app-server turn, but the outer runner did not give plugin-owned attempts the same lane-release contract added for native runs in PR #94082. If the app-server cleanup never settled, the command lane stayed owned and later same-session work queued indefinitely.

PR #84578 remains a separate WhatsApp final-error delivery mitigation. It does not release a stuck Codex/plugin-owned lane.

Codex contract checked directly in sibling ../codex before patching: app-server v2 exposes turn/start and turn/interrupt requests plus turn/started and turn/completed notifications; turns are terminal only once they report completed/interrupted/failed rather than inProgress.

## Real behavior proof

Behavior addressed: A Codex app-server attempt can time out while waiting for turn/completed, ignore cleanup/cancellation, and leave later same-session inbounds queued forever.

Real environment tested: macOS Darwin 25.5.0 arm64, Node.js v26.3.0, pnpm v11.2.2, local OpenClaw source checkout at fdd9c314b802327c2ccbf11afc23c12f757ec25b.

Exact steps or command run after this patch:

```sh
pnpm test src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts -- --reporter=verbose
pnpm test src/agents/embedded-agent-runner/run.compaction-loop-guard.test.ts extensions/codex/src/app-server/run-attempt.turn-watches.test.ts -- --reporter=verbose
pnpm format:check src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts extensions/codex/src/app-server/run-attempt.ts
pnpm lint src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts extensions/codex/src/app-server/run-attempt.ts
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Evidence after fix:

```text
run.codex-app-server-recovery.test.ts: 1 file passed, 11 tests passed
run.compaction-loop-guard.test.ts: 1 file passed, 10 tests passed
run-attempt.turn-watches.test.ts: 1 file passed, 63 tests passed
format: all matched files use the correct format
lint: core, extensions, and scripts shards finished successfully
git diff --check: clean
autoreview: clean, no accepted/actionable findings
```

Observed result after fix: the new regression rejects the first ignored Codex timeout with CommandLaneTaskTimeoutError after the bounded grace, then the second run for the same session completes successfully, proving the lane drains.

What was not tested: live WhatsApp transport or a live external Codex app-server process wedge. The focused regression exercises the OpenClaw runner/queue contract and Codex plugin timeout hook path that caused the permanent same-session queue ownership.
