### PR TITLE
feat(slack): log INFO receipt for inbound app_mention events

### DIFF
--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -5,10 +5,31 @@ import {
   type SlackSystemEventTestOverrides,
 } from "./system-event-test-harness.js";
 
-const { messageQueueMock, messageAllowMock } = vi.hoisted(() => ({
+const { messageQueueMock, messageAllowMock, inboundInfoSpy } = vi.hoisted(() => ({
   messageQueueMock: vi.fn(),
   messageAllowMock: vi.fn(),
+  inboundInfoSpy: vi.fn(),
 }));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  const makeLogger = () => {
+    const logger = {
+      subsystem: "test",
+      isEnabled: () => true,
+      trace: () => {},
+      debug: () => {},
+      info: inboundInfoSpy,
+      warn: () => {},
+      error: () => {},
+      fatal: () => {},
+      raw: () => {},
+      child: () => logger,
+    };
+    return logger;
+  };
+  return { ...actual, createSubsystemLogger: () => makeLogger() };
+});
 
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
   enqueueSystemEvent: (...args: unknown[]) => messageQueueMock(...args),
@@ -21,6 +42,13 @@ vi.mock("openclaw/plugin-sdk/conversation-runtime", () => ({
 }));
 
 let registerSlackMessageEvents: typeof import("./messages.js").registerSlackMessageEvents;
+let formatSlackInboundLogLine: typeof import("./messages.js").formatSlackInboundLogLine;
+
+function inboundLogLines(): string[] {
+  return inboundInfoSpy.mock.calls
+    .map((call) => call[0])
+    .filter((line): line is string => typeof line === "string" && line.startsWith("Inbound "));
+}
 
 type MessageHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
 type RegisteredEventName = "message" | "app_mention";
@@ -57,11 +85,12 @@ function resetMessageMocks(): void {
 }
 
 beforeAll(async () => {
-  ({ registerSlackMessageEvents } = await import("./messages.js"));
+  ({ registerSlackMessageEvents, formatSlackInboundLogLine } = await import("./messages.js"));
 });
 
 beforeEach(() => {
   resetMessageMocks();
+  inboundInfoSpy.mockClear();
 });
 
 function makeChangedEvent(overrides?: { channel?: string; user?: string }) {
@@ -387,6 +416,8 @@ describe("registerSlackMessageEvents", () => {
     });
 
     expect(handleSlackMessage).not.toHaveBeenCalled();
+    // Dropped DM app_mention (already handled via message.im) must not log a receipt.
+    expect(inboundLogLines()).toEqual([]);
   });
 
   it("routes app_mention events from channels to the message handler", async () => {
@@ -397,5 +428,23 @@ describe("registerSlackMessageEvents", () => {
     });
 
     expect(handleSlackMessage).toHaveBeenCalledTimes(1);
+    expect(inboundLogLines()).toEqual([
+      "Inbound app_mention slack:T_TEST:channel:C123:user:U1 -> bot:U_BOT (channel, 14 chars)",
+    ]);
+  });
+
+  it("formats the inbound receipt line with channel, sender, body length, and bot identity", () => {
+    expect(
+      formatSlackInboundLogLine({
+        workspaceId: "T123",
+        channelId: "C456",
+        channelType: "channel",
+        userId: "U789",
+        botUserId: "U_BOT",
+        bodyChars: 42,
+      }),
+    ).toBe(
+      "Inbound app_mention slack:T123:channel:C456:user:U789 -> bot:U_BOT (channel, 42 chars)",
+    );
   });
 });

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -1,7 +1,12 @@
 // Slack plugin module implements messages behavior.
 import type { SlackEventMiddlewareArgs } from "@slack/bolt";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
+import {
+  createSubsystemLogger,
+  danger,
+  logVerbose,
+  shouldLogVerbose,
+} from "openclaw/plugin-sdk/runtime-env";
 import {
   asOptionalRecord as asRecord,
   normalizeOptionalString as asString,
@@ -14,6 +19,22 @@ import type { SlackMessageHandler } from "../message-handler.js";
 import type { SlackMessageChangedEvent } from "../types.js";
 import { resolveSlackMessageSubtypeHandler } from "./message-subtype-handlers.js";
 import { authorizeAndResolveSlackSystemEventContext } from "./system-event-context.js";
+
+// Mirrors the Telegram `[telegram]` inbound logger so cross-channel journal-grep
+// workflows are uniform; the `gateway/channels/slack` subsystem renders as `[slack]`.
+const slackInboundLog = createSubsystemLogger("gateway/channels/slack").child("inbound");
+
+export function formatSlackInboundLogLine(params: {
+  workspaceId: string;
+  channelId: string;
+  channelType: string;
+  userId: string;
+  botUserId: string;
+  bodyChars: number;
+}): string {
+  const from = `slack:${params.workspaceId}:channel:${params.channelId}:user:${params.userId}`;
+  return `Inbound app_mention ${from} -> bot:${params.botUserId} (${params.channelType}, ${params.bodyChars} chars)`;
+}
 
 type SlackAssistantMessageRecord = {
   bot_id?: unknown;
@@ -216,6 +237,21 @@ export function registerSlackMessageEvents(params: {
       if (channelType === "im" || channelType === "mpim") {
         return;
       }
+
+      // Emit a per-inbound receipt before dispatch so a silently-dropped mention
+      // (e.g. router consumes it without a tool call) still leaves journal evidence,
+      // matching the Telegram inbound log. Runs after the DM drop above, so duplicate
+      // DM app_mention events (already handled via message.im) produce no line.
+      slackInboundLog.info(
+        formatSlackInboundLogLine({
+          workspaceId: ctx.teamId,
+          channelId: mention.channel,
+          channelType: channelType ?? "channel",
+          userId: mention.user ?? "unknown",
+          botUserId: ctx.botUserId,
+          bodyChars: (mention.text ?? "").length,
+        }),
+      );
 
       await handleSlackMessage(mention as unknown as SlackMessageEvent, {
         source: "app_mention",

--- a/extensions/slack/src/monitor/events/system-event-test-harness.ts
+++ b/extensions/slack/src/monitor/events/system-event-test-harness.ts
@@ -29,6 +29,7 @@ export function createSlackSystemEventTestHarness(overrides?: SlackSystemEventTe
     runtime: { error: () => {} },
     botUserId: "U_BOT",
     botId: "B_BOT",
+    teamId: "T_TEST",
     dmEnabled: true,
     dmPolicy: overrides?.dmPolicy ?? "open",
     defaultRequireMention: true,


### PR DESCRIPTION
## Summary

- Fixes the Slack/Telegram asymmetry where the Slack provider emits **no** per-inbound log for `app_mention` events, so a mention consumed by the router without a tool call leaves zero journal evidence.
- The Slack provider now emits one `[slack]` INFO receipt **before** dispatch for accepted channel `app_mention` events, mirroring the existing Telegram inbound log.
- DM `app_mention` duplicates (already handled via `message.im`) and mismatched-workspace events stay silent, so no new log volume is added there.

## Linked context

Closes #94691

## Real behavior proof

- Behavior or issue addressed: Slack `app_mention` events produced no INFO line, unlike Telegram inbound, so silent router drops left nothing in the journal between socket-connect and now (issue #94691).
- Real environment tested: Local OpenClaw checkout. No live Slack workspace credentials were available, so the operator-visible line was rendered through the real `createSubsystemLogger` console pipeline (the same code path the gateway uses), not a stub or snapshot.
- Root cause / premise evidence: On `main`, `extensions/slack/src/monitor/events/messages.ts` routes accepted `app_mention` events straight into `handleSlackMessage` with no log, while Telegram logs before dispatch at `extensions/telegram/src/bot-message.ts:185`. The `gateway/channels/slack` subsystem renders as `[slack]` via `formatSubsystemForConsole` in `src/logging/subsystem.ts`.
- Before evidence (bug reproduced on main): `git show HEAD~1:extensions/slack/src/monitor/events/messages.ts` shows the `app_mention` handler (around line 205) containing only the DM-skip guard and `handleSlackMessage`; grepping that handler for `Inbound` returns nothing.
- Exact steps or command run after this patch: emitted the new receipt through the production logger via `node_modules/.bin/tsx`, calling `createSubsystemLogger("gateway/channels/slack").child("inbound").info(formatSlackInboundLogLine(...))` with `OPENCLAW_TEST_CONSOLE=1 OPENCLAW_LOG_LEVEL=info`.
- Evidence after fix: live console output from the production logging pipeline:
```
[slack] Inbound app_mention slack:T0WORKSPACE:channel:C0CHANNEL:user:U0SENDER -> bot:U0BOT (channel, 42 chars)
```
- Observed result after fix: exactly one INFO `[slack]` line carrying channel, sender, body length, and bot identity, matching the Telegram `[telegram]` convention so existing journal-grep workflows stay uniform.
- What was not tested: end-to-end receipt from a live Slack socket-mode workspace dispatching a real `app_mention` over the wire.
- Proof limitations or environment constraints: no live Slack workspace was available; the rendered line uses the real subsystem logger but synthetic workspace/channel/user ids.

## Tests and validation

- `git diff --check`
- `node scripts/run-vitest.mjs run extensions/slack/src/monitor/events/messages.test.ts` (14 passing; adds channel-mention-logs and dropped-DM-no-log coverage plus a formatter assertion)
- `node scripts/run-vitest.mjs run extensions/slack/src/monitor/message-handler.app-mention-race.test.ts` (9 passing; unchanged sibling path)
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json` and the extension test tsconfig: both exit 0

## Risk checklist

Did user-visible behavior change? `No` (operator-facing log only; no message routing change)

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: log volume on busy channel bots.

How is that risk mitigated? One INFO line per accepted channel `app_mention`, matching Telegram's existing per-inbound INFO line; DM duplicates and mismatched-workspace events emit nothing.

Current review state: maintainer review and CI.

AI-assisted. Proof above was run manually.
