### PR TITLE
Fix embedded-run recovery after refreshed session activity

### DIFF
--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -648,6 +648,76 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("aborts stale embedded runs when queued work refreshes session activity", () => {
+    const recoverStuckSession = vi.fn();
+    const stuckSessionWarnMs = 120_000;
+    const stuckSessionAbortMs = 360_000;
+
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+    vi.advanceTimersByTime(507_000);
+    logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+    vi.advanceTimersByTime(122_000);
+
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs,
+          stuckSessionAbortMs,
+        },
+      },
+      { recoverStuckSession },
+    );
+
+    vi.advanceTimersByTime(30_000);
+
+    expectRecoveryCall(
+      recoverStuckSession,
+      { sessionId: "s1", sessionKey: "main", queueDepth: 1, allowActiveAbort: true },
+      ["ageMs", "stateGeneration"],
+    );
+  });
+
+  it("does not abort embedded runs with recent progress just because session activity is old", () => {
+    const recoverStuckSession = vi.fn();
+    const stuckSessionWarnMs = 30_000;
+    const stuckSessionAbortMs = 60_000;
+
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+    vi.advanceTimersByTime(120_000);
+    markDiagnosticRunProgressForTest({
+      sessionId: "s1",
+      sessionKey: "main",
+      reason: "embedded_run:progress",
+    });
+
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs,
+          stuckSessionAbortMs,
+        },
+      },
+      { recoverStuckSession },
+    );
+
+    vi.advanceTimersByTime(30_000);
+
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+    expectRecordFields(
+      getDiagnosticSessionActivitySnapshot({ sessionId: "s1", sessionKey: "main" }),
+      {
+        activeWorkKind: "embedded_run",
+        hasActiveEmbeddedRun: true,
+        lastProgressAgeMs: 30_000,
+        lastProgressReason: "embedded_run:progress",
+      },
+    );
+  });
+
   it("recovers stale native tool calls through the active-run abort path", async () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
@@ -1819,14 +1889,14 @@ describe("stuck session diagnostics threshold", () => {
       logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
-
-      vi.advanceTimersByTime(stuckSessionAbortMs - 1);
       markDiagnosticRunProgressForTest({
         sessionId: "s1",
         sessionKey: "main",
         reason: terminalReason,
       });
-      vi.advanceTimersByTime(1);
+      vi.advanceTimersByTime(stuckSessionAbortMs - stuckSessionWarnMs - 1);
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+      vi.advanceTimersByTime(stuckSessionWarnMs + 1);
     } finally {
       unsubscribe();
     }
@@ -1842,13 +1912,13 @@ describe("stuck session diagnostics threshold", () => {
       classification: "stalled_agent_run",
       reason: "queued_behind_terminal_active_work",
       activeWorkKind: "embedded_run",
-      queueDepth: 1,
+      queueDepth: 2,
       terminalProgressStale: true,
       lastProgressReason: terminalReason,
     });
     expectRecoveryCall(
       recoverStuckSession,
-      { sessionId: "s1", sessionKey: "main", queueDepth: 1, allowActiveAbort: true },
+      { sessionId: "s1", sessionKey: "main", queueDepth: 2, allowActiveAbort: true },
       ["ageMs", "stateGeneration"],
     );
   });

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -500,14 +500,16 @@ function resolveStalledEmbeddedRunAbortMs(stuckSessionWarnMs: number): number {
 
 function isStalledEmbeddedRunRecoveryEligible(params: {
   classification: SessionAttentionClassification | undefined;
-  ageMs: number;
+  activity?: DiagnosticSessionActivitySnapshot;
   stuckSessionAbortMs: number;
 }): boolean {
+  const lastProgressAgeMs = params.activity?.lastProgressAgeMs;
   return (
     params.classification?.eventType === "session.stalled" &&
     params.classification.classification === "stalled_agent_run" &&
     params.classification.activeWorkKind === "embedded_run" &&
-    params.ageMs >= params.stuckSessionAbortMs
+    typeof lastProgressAgeMs === "number" &&
+    lastProgressAgeMs >= params.stuckSessionAbortMs
   );
 }
 
@@ -551,7 +553,6 @@ function isStalledModelCallRecoveryEligible(params: {
 function isActiveAbortRecoveryEligible(params: {
   classification: SessionAttentionClassification | undefined;
   activity?: DiagnosticSessionActivitySnapshot;
-  ageMs: number;
   stuckSessionAbortMs: number;
 }): boolean {
   return (
@@ -1021,7 +1022,6 @@ export function logSessionAttention(
     isActiveAbortRecoveryEligible({
       classification,
       activity,
-      ageMs: params.ageMs,
       stuckSessionAbortMs,
     });
   // The warning backoff throttles repeated log lines/events only. It must never
@@ -1325,7 +1325,6 @@ export function startDiagnosticHeartbeat(
           isActiveAbortRecoveryEligible({
             classification,
             activity,
-            ageMs: attentionAgeMs,
             stuckSessionAbortMs,
           })
         ) {


### PR DESCRIPTION
## Summary
- use active run progress age, rather than session activity age, when deciding whether an embedded run is stale enough for active-abort recovery
- keep embedded-run recovery aligned with the existing tool/model active-work recovery predicates
- add regression coverage for refreshed queued session activity and recent embedded-run progress

## Real behavior proof

**Behavior or issue addressed**: Embedded-run active-abort recovery should still run when queued session activity refreshes the session activity clock, as long as the active embedded run itself has not reported progress past the abort threshold.

**Real environment tested**: Local OpenClaw source checkout running the real diagnostic heartbeat modules with Node/tsx. The proof used a throwaway in-memory diagnostic session only; no channel/account configuration or private runtime state was used.

**Exact steps or command run after this patch**: Ran a Node command that enabled diagnostics, marked a throwaway session as `processing`, marked an embedded run active, started the real diagnostic heartbeat with low diagnostic thresholds, refreshed queued session activity shortly before the heartbeat tick, and recorded the `recoverStuckSession` callback request.

Command shape:

```sh
node --import tsx --input-type=module <<'JS'
// imports the real diagnostic modules, starts the real heartbeat,
// refreshes queued activity, waits for one heartbeat tick,
// and prints the redacted recovery callback result
JS
```

**Evidence after fix**: Redacted terminal output from that command:

```json
{
  "recovered": true,
  "recovery": {
    "allowActiveAbort": true,
    "queueDepth": 1,
    "sessionActivityAgeBelowAbort": true,
    "session": "<redacted>"
  },
  "activity": {
    "activeWorkKind": "embedded_run",
    "hasActiveEmbeddedRun": true,
    "lastProgressAgeMsAtLeastAbort": true
  }
}
```

**Observed result after fix**: The real heartbeat path requested active-abort recovery even though refreshed queued activity kept session activity age below the abort threshold, because embedded-run progress age was past the abort threshold.

**What was not tested**: No external messaging channel, account, Docker image, or production/live gateway was exercised for this PR proof. Those are outside the scope of this upstream diagnostic predicate change.

## Tests
- `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts`
