### PR TITLE
Standardize QA coverage IDs on dotted names

### DIFF
--- a/.agents/skills/claw-score/SKILL.md
+++ b/.agents/skills/claw-score/SKILL.md
@@ -30,6 +30,9 @@ out of this repo. If a score needs private evidence, use the redacted
   completeness-instruction paths.
 - Feature `coverageIds` are ANDed proof targets, not aliases. A feature may
   list multiple IDs when each ID proves part of one capability.
+- Coverage IDs use dotted `namespace.behavior` form, with lowercase
+  alphanumeric/dash segments. Profile, surface, and category IDs may remain
+  dashed or dotted.
 - Keep categories and feature names unique, product-shaped, and broader than raw
   coverage IDs. Do not promote generic IDs into standalone feature names.
 - Avoid duplicate coverage-ID bundles under different feature names in one

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -59,6 +59,9 @@ selected-category counts and missing coverage IDs; the individual evidence
 entries remain the source of truth for the tests, coverage roles, and results.
 Taxonomy feature coverage IDs are exact proof targets, not aliases. Primary
 scenario coverage fulfills matching IDs; secondary coverage stays advisory.
+Coverage IDs use dotted `namespace.behavior` form with lowercase
+alphanumeric/dash segments; profile, surface, and category IDs may still use
+the existing dashed or dotted taxonomy IDs.
 Slim evidence omits per-entry `execution` and sets `evidenceMode: "slim"`;
 `smoke-ci` defaults to slim, and `--evidence-mode full` restores full entries:
 

--- a/extensions/qa-lab/src/coverage-report.test.ts
+++ b/extensions/qa-lab/src/coverage-report.test.ts
@@ -14,6 +14,7 @@ const TEST_EXECUTABLE_COVERAGE_ID = "channels.dm";
 const TEST_BROWSER_CATEGORY_ID = "browser-control-ui-and-webchat.browser-ui";
 const TEST_BROWSER_COVERAGE_ID = "ui.control";
 const TEST_WEBCHAT_COVERAGE_ID = "ui.webchat";
+const DOTTED_COVERAGE_ID_PATTERN = /^[a-z0-9][a-z0-9-]*(?:\.[a-z0-9][a-z0-9-]*)+$/;
 
 function testMaturityTaxonomy(params?: {
   categoryId?: string;
@@ -138,6 +139,11 @@ describe("qa coverage report", () => {
     expect(inventory.scorecardTaxonomy.evidenceRefCount).toBeGreaterThan(0);
     expect(inventory.scorecardTaxonomy.scenarioCoverageIdCount).toBeGreaterThan(0);
     expect(inventory.scorecardTaxonomy.unknownCoverageIdCount).toBe(0);
+    expect(
+      inventory.scorecardTaxonomy.categories
+        .flatMap((category) => category.coverageIds)
+        .every((coverageId) => DOTTED_COVERAGE_ID_PATTERN.test(coverageId)),
+    ).toBe(true);
     expect(inventory.scorecardTaxonomy.validationIssues.length).toBeGreaterThan(0);
     expect(
       inventory.scorecardTaxonomy.validationIssues.some((issue) =>

--- a/extensions/qa-lab/src/evidence-gallery.test.ts
+++ b/extensions/qa-lab/src/evidence-gallery.test.ts
@@ -198,7 +198,7 @@ describe("evidence gallery", () => {
           surface: "web-ui",
         },
         {
-          coverageIds: ["cli-entrypoint"],
+          coverageIds: ["cli.entrypoint"],
           runner: {
             availability: "local",
             command: "pnpm openclaw qa suite --scenario ux-matrix-evidence-dashboard",
@@ -274,7 +274,7 @@ describe("evidence gallery", () => {
             title: "UX Matrix: cli / error-state",
             source: { path: "scripts/ux-matrix/dashboard.ts" },
           },
-          coverage: [{ id: "status-snapshots", role: "primary" }],
+          coverage: [{ id: "cli.status-snapshots", role: "primary" }],
           execution: {
             runner: "ux-matrix-dashboard",
             environment: {
@@ -359,7 +359,7 @@ describe("evidence gallery", () => {
       {
         artifactKinds: [],
         artifactPaths: [],
-        coverageIds: ["cli-entrypoint"],
+        coverageIds: ["cli.entrypoint"],
         runner: {
           availability: "local",
           command: "pnpm openclaw qa suite --scenario ux-matrix-evidence-dashboard",

--- a/extensions/qa-lab/src/evidence-summary.test.ts
+++ b/extensions/qa-lab/src/evidence-summary.test.ts
@@ -346,7 +346,7 @@ describe("evidence summary", () => {
           id: "control-ui.browser-run",
           title: "Control UI browser workflow",
           sourcePath: "ui/control-ui.e2e.test.ts",
-          primaryCoverageIds: ["control-ui.browser"],
+          primaryCoverageIds: ["ui.control"],
           docsRefs: ["docs/concepts/qa-e2e-automation.md"],
           codeRefs: ["ui/"],
         },
@@ -374,7 +374,7 @@ describe("evidence summary", () => {
       },
       coverage: [
         {
-          id: "control-ui.browser",
+          id: "ui.control",
           role: "primary",
         },
       ],

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -77,12 +77,15 @@ describe("qa scenario catalog", () => {
         .map((scenario) => scenario.id),
     ).toStrictEqual([]);
     expect(
-      pack.scenarios
-        .flatMap((scenario) => [
-          ...(scenario.coverage?.primary ?? []),
-          ...(scenario.coverage?.secondary ?? []),
-        ])
-        .every((coverageId) => dottedCoverageIdPattern.test(coverageId)),
+      pack.scenarios.every(
+        (scenario) =>
+          (scenario.coverage?.primary ?? []).every((coverageId) =>
+            dottedCoverageIdPattern.test(coverageId),
+          ) &&
+          (scenario.coverage?.secondary ?? []).every((coverageId) =>
+            dottedCoverageIdPattern.test(coverageId),
+          ),
+      ),
     ).toBe(true);
     expect(readQaScenarioById("memory-recall").coverage?.primary).toContain("memory.recall");
   });

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -25,6 +25,8 @@ function listScenarioMarkdownPaths(dir = "qa/scenarios"): string[] {
 }
 
 describe("qa scenario catalog", () => {
+  const dottedCoverageIdPattern = /^[a-z0-9][a-z0-9-]*(?:\.[a-z0-9][a-z0-9-]*)+$/;
+
   it("keeps repo-backed scenarios YAML-only", () => {
     expect(listScenarioMarkdownPaths()).toStrictEqual([]);
   });
@@ -74,6 +76,14 @@ describe("qa scenario catalog", () => {
         .filter((scenario) => !(scenario.coverage?.primary.length ?? 0))
         .map((scenario) => scenario.id),
     ).toStrictEqual([]);
+    expect(
+      pack.scenarios
+        .flatMap((scenario) => [
+          ...(scenario.coverage?.primary ?? []),
+          ...(scenario.coverage?.secondary ?? []),
+        ])
+        .every((coverageId) => dottedCoverageIdPattern.test(coverageId)),
+    ).toBe(true);
     expect(readQaScenarioById("memory-recall").coverage?.primary).toContain("memory.recall");
   });
 

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -87,8 +87,8 @@ const qaScenarioExecutionSchema = z.union([
 const qaCoverageIdSchema = z
   .string()
   .trim()
-  .regex(/^[a-z0-9]+(?:[.-][a-z0-9]+)*$/, {
-    message: "coverage ids must use lowercase dotted or dashed tokens",
+  .regex(/^[a-z0-9][a-z0-9-]*(?:\.[a-z0-9][a-z0-9-]*)+$/, {
+    message: "coverage ids must use lowercase dotted tokens",
   });
 
 const qaCoverageIdListSchema = z.array(qaCoverageIdSchema).min(1);

--- a/extensions/qa-lab/src/scorecard-taxonomy.ts
+++ b/extensions/qa-lab/src/scorecard-taxonomy.ts
@@ -11,7 +11,14 @@ const qaScorecardIdSchema = z
   .string()
   .trim()
   .regex(/^[a-z0-9]+(?:[.-][a-z0-9]+)*$/, {
-    message: "scorecard and coverage ids must use lowercase dotted or dashed tokens",
+    message: "scorecard ids must use lowercase dotted or dashed tokens",
+  });
+
+const qaCoverageIdSchema = z
+  .string()
+  .trim()
+  .regex(/^[a-z0-9][a-z0-9-]*(?:\.[a-z0-9][a-z0-9-]*)+$/, {
+    message: "coverage ids must use lowercase dotted tokens",
   });
 
 function isRepoRootRelativeRef(value: string) {
@@ -31,7 +38,7 @@ const qaScorecardProfileSchema = z.object({
 
 const qaMaturityFeatureSchema = z.object({
   name: z.string().trim().min(1),
-  coverageIds: z.array(qaScorecardIdSchema).default([]),
+  coverageIds: z.array(qaCoverageIdSchema).default([]),
   description: z.string().trim().min(1).optional(),
 });
 

--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -726,9 +726,9 @@ describe("qa test file scenario runner", () => {
         "tools.evidence",
         "workspace.artifacts",
         "ui.control",
-        "control-ui",
-        "cli-entrypoint",
-        "status-snapshots",
+        "gateway.control-ui-hosting",
+        "cli.entrypoint",
+        "cli.status-snapshots",
       ]),
     );
     const artifactKinds = evidence.entries.flatMap(

--- a/extensions/qa-lab/web/src/ui-render.test.ts
+++ b/extensions/qa-lab/web/src/ui-render.test.ts
@@ -213,7 +213,7 @@ describe("QA Lab UI evidence render", () => {
                 {
                   artifactKinds: [],
                   artifactPaths: [],
-                  coverageIds: ["cli-entrypoint"],
+                  coverageIds: ["cli.entrypoint"],
                   runner: {
                     availability: "local",
                     command: "pnpm openclaw qa suite --scenario ux-matrix-evidence-dashboard",
@@ -247,7 +247,7 @@ describe("QA Lab UI evidence render", () => {
     expect(html).toContain('data-evidence-entry-id="ux-matrix.web-ui.first-run"');
     expect(html).toContain("evidence-matrix-cell-proof-gap");
     expect(html).toContain("not executed in this run");
-    expect(html).toContain("Coverage: cli-entrypoint");
+    expect(html).toContain("Coverage: cli.entrypoint");
     expect(html).toContain("Runner: cli-status");
     expect(html).toContain("Open media artifact");
     expect(html).toContain("Open video artifact");

--- a/qa/scenarios/channels/thread-follow-up.yaml
+++ b/qa/scenarios/channels/thread-follow-up.yaml
@@ -6,7 +6,7 @@ scenario:
   coverage:
     primary:
       - channels.threads
-      - thread-parent-child-placement
+      - channels.thread-parent-child-placement
     secondary:
       - channels.qa-channel
   objective: Verify the agent can keep follow-up work inside a thread and not leak context into the root channel.

--- a/qa/scenarios/index.yaml
+++ b/qa/scenarios/index.yaml
@@ -17,7 +17,8 @@ title: OpenClaw QA Scenario Pack
 #
 # - add `coverage.primary` IDs to each scenario's `scenario` block
 # - add `coverage.secondary` only when a scenario intentionally protects another behavior
-# - keep IDs behavior-shaped, broad enough to reuse, lowercase, and dotted or dashed
+# - keep IDs behavior-shaped, broad enough to reuse, lowercase, and dotted
+#   as `namespace.behavior`, with dashes allowed inside each segment
 # - use the exact values listed under feature `coverageIds` in `taxonomy.yaml`
 # - taxonomy feature coverage IDs are exact proof targets, not aliases
 # - scenario primary can list multiple IDs only when this scenario is primary

--- a/qa/scenarios/media/image-generation-roundtrip.yaml
+++ b/qa/scenarios/media/image-generation-roundtrip.yaml
@@ -6,7 +6,7 @@ scenario:
   coverage:
     primary:
       - media.image-generation
-      - generated-image-persistence-and-delivery
+      - media.image-generation-delivery
     secondary:
       - channels.qa-channel
   objective: Verify a generated image is saved as media, reattached on the next turn, and described correctly through the vision path.

--- a/qa/scenarios/plugins/plugin-lifecycle-probe.yaml
+++ b/qa/scenarios/plugins/plugin-lifecycle-probe.yaml
@@ -7,8 +7,8 @@ scenario:
     primary:
       - plugins.lifecycle
     secondary:
-      - plugin-validation-and-repair
-      - plugin-setup
+      - cli.plugin-validation-repair
+      - plugins.setup-flows
   objective: Exercise strict plugin load/uninstall proof parsing through QA Lab evidence.
   successCriteria:
     - Enabled loaded plugin inspect JSON is accepted as proof.

--- a/qa/scenarios/runtime/anthropic-thinking-error-recovery-replay-safe-read.yaml
+++ b/qa/scenarios/runtime/anthropic-thinking-error-recovery-replay-safe-read.yaml
@@ -5,7 +5,7 @@ scenario:
   surface: runtime
   coverage:
     primary:
-      - signed-redacted-thinking-replay
+      - anthropic.signed-redacted-thinking-replay
     secondary:
       - runtime.retry-policy
   gatewayConfigPatch:

--- a/qa/scenarios/runtime/docker-prometheus-smoke.yaml
+++ b/qa/scenarios/runtime/docker-prometheus-smoke.yaml
@@ -6,7 +6,7 @@ scenario:
   coverage:
     primary:
       - telemetry.prometheus
-      - gateway-authenticated-get-api-diagnostics-prometheus
+      - telemetry.prometheus-authenticated-gateway-export
     secondary:
       - harness.qa-lab
       - docker.e2e

--- a/qa/scenarios/runtime/gateway-smoke.yaml
+++ b/qa/scenarios/runtime/gateway-smoke.yaml
@@ -5,10 +5,10 @@ scenario:
   surface: runtime
   coverage:
     primary:
-      - websocket-transport
+      - gateway.websocket-transport
     secondary:
-      - health-apis
-      - hello-ok-snapshot
+      - gateway.health-apis
+      - gateway.hello-ok-snapshot
   objective: Exercise gateway health and WebSocket smoke assertions through QA Lab evidence.
   successCriteria:
     - Gateway health probe succeeds against a reachable local endpoint.

--- a/qa/scenarios/runtime/package-openclaw-for-docker.yaml
+++ b/qa/scenarios/runtime/package-openclaw-for-docker.yaml
@@ -5,9 +5,9 @@ scenario:
   surface: docker-podman-hosting
   coverage:
     primary:
-      - docker-e2e-package-artifact-generation
+      - docker.package-artifact-generation
     secondary:
-      - package-manager-installs
+      - cli.package-manager-installs
       - runtime.package-update
   objective: Exercise bounded OpenClaw package artifact generation through QA Lab evidence.
   successCriteria:

--- a/qa/scenarios/runtime/qa-otel-smoke.yaml
+++ b/qa/scenarios/runtime/qa-otel-smoke.yaml
@@ -8,7 +8,7 @@ scenario:
       - telemetry.otel
     secondary:
       - harness.qa-lab
-      - plugin-sdk-diagnostic-runtime-exports
+      - telemetry.plugin-sdk-runtime-exports
   objective: Exercise bounded local OTLP capture and OpenTelemetry smoke assertions through QA Lab evidence.
   successCriteria:
     - Package-manager forwarded QA OTEL smoke arguments parse correctly.

--- a/qa/scenarios/scheduling/cron-one-minute-ping.yaml
+++ b/qa/scenarios/scheduling/cron-one-minute-ping.yaml
@@ -6,8 +6,8 @@ scenario:
   coverage:
     primary:
       - scheduling.cron
-      - cron-rpcs
-      - chat-announce-delivery
+      - scheduling.cron-rpcs
+      - scheduling.chat-announce-delivery
     secondary:
       - channels.qa-channel
   objective: Verify the agent can schedule a cron reminder one minute in the future and receive the follow-up in the QA channel.

--- a/qa/scenarios/ui/control-ui-qa-channel-image-roundtrip.yaml
+++ b/qa/scenarios/ui/control-ui-qa-channel-image-roundtrip.yaml
@@ -6,7 +6,7 @@ scenario:
   coverage:
     primary:
       - ui.control
-      - dashboard-open-auth-bootstrap
+      - ui.dashboard-auth-bootstrap
     secondary:
       - media.image-understanding
       - channels.qa-channel

--- a/qa/scenarios/ui/ux-matrix-evidence-dashboard.yaml
+++ b/qa/scenarios/ui/ux-matrix-evidence-dashboard.yaml
@@ -9,9 +9,9 @@ scenario:
       - qa.artifact-safety
     secondary:
       - ui.control
-      - control-ui
-      - cli-entrypoint
-      - status-snapshots
+      - gateway.control-ui-hosting
+      - cli.entrypoint
+      - cli.status-snapshots
       - tools.evidence
       - workspace.artifacts
   objective: Produce UX Matrix evidence artifacts through the QA Lab script producer contract.

--- a/scripts/qa/ux-matrix-evidence-producer.ts
+++ b/scripts/qa/ux-matrix-evidence-producer.ts
@@ -516,7 +516,7 @@ export async function runUxMatrixEvidenceProducer(options: ProducerOptions) {
             ]
           : []),
       ],
-      coverageIds: ["ui.control", "control-ui"],
+      coverageIds: ["ui.control", "gateway.control-ui-hosting"],
       failureReason: matrixScreenshotResult.failureReason,
       stage: "screenshot-artifact",
       status: matrixScreenshotResult.status,
@@ -526,7 +526,7 @@ export async function runUxMatrixEvidenceProducer(options: ProducerOptions) {
     },
     {
       artifacts: [{ kind: "log", path: relativeToArtifactBase(options.artifactBase, cliLogPath) }],
-      coverageIds: ["cli-entrypoint", "status-snapshots"],
+      coverageIds: ["cli.entrypoint", "cli.status-snapshots"],
       failureReason: cliResult.failureReason,
       stage: "entrypoint-help",
       status: cliResult.status,

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -76,22 +76,22 @@ surfaces:
         id: approvals-and-remote-execution
         features:
           - name: Exec approvals
-            coverageIds: [exec-approvals]
+            coverageIds: [gateway.exec-approvals]
             description: Exec approval request, lookup, wait, resolve, and policy snapshot APIs.
           - name: Plugin approvals
-            coverageIds: [plugin-approvals]
+            coverageIds: [gateway.plugin-approvals]
             description: Plugin approval request, wait, and resolution flows.
           - name: Node exec approvals
-            coverageIds: [node-exec-approvals]
+            coverageIds: [gateway.node-exec-approvals]
             description: Node-local exec approval policy relay through Gateway RPC.
           - name: Approved node execution
-            coverageIds: [approved-node-execution]
+            coverageIds: [gateway.approved-node-execution]
             description: Canonical `systemRunPlan` binding for node-host execution.
           - name: Approval mutation safety
-            coverageIds: [approval-mutation-safety]
+            coverageIds: [gateway.approval-mutation-safety]
             description: Rejection of mutated `command`, `cwd`, `agentId`, or `sessionKey` after approval preparation.
           - name: Delivery fallback behavior
-            coverageIds: [delivery-fallback-behavior]
+            coverageIds: [gateway.delivery-fallback-behavior]
             description: Agent delivery fallback between strict deliverable routes and session-only execution.
         docs:
           - docs/gateway/protocol.md
@@ -105,16 +105,16 @@ surfaces:
         id: http-apis
         features:
           - name: OpenAI-compatible APIs
-            coverageIds: [openai-compatible-apis]
+            coverageIds: [gateway.openai-compatible-apis]
             description: OpenAI-compatible HTTP APIs (`/v1/models`, `/v1/chat/completions`, `/v1/responses`, `/v1/embeddings`).
           - name: Tool invocation API
-            coverageIds: [tool-invocation-api]
+            coverageIds: [gateway.tool-invocation-api]
             description: HTTP tools invoke path.
           - name: Admin API access
-            coverageIds: [admin-api-access]
+            coverageIds: [gateway.admin-api-access]
             description: Optional admin HTTP RPC plugin route.
           - name: Hook ingress
-            coverageIds: [hook-ingress]
+            coverageIds: [gateway.hook-ingress]
             description: Hook hosting and HTTP ingress routes.
         docs:
           - docs/gateway/index.md
@@ -135,16 +135,16 @@ surfaces:
         id: hosted-web-surface
         features:
           - name: Control UI
-            coverageIds: [control-ui]
+            coverageIds: [gateway.control-ui-hosting]
             description: Control UI hosting on the Gateway server.
           - name: WebChat hosting
-            coverageIds: [webchat-hosting]
+            coverageIds: [gateway.webchat-hosting]
             description: WebChat hosting.
           - name: Plugin web routes
-            coverageIds: [plugin-web-routes]
+            coverageIds: [gateway.plugin-web-routes]
             description: Canvas and other plugin HTTP surfaces served by the Gateway.
           - name: Canvas and A2UI routes
-            coverageIds: [canvas-and-a2ui-routes]
+            coverageIds: [gateway.canvas-and-a2ui-routes]
             description: Canvas documents, A2UI transport, and browser-hosted plugin routes under the Gateway HTTP server.
         docs:
           - docs/gateway/index.md
@@ -164,64 +164,64 @@ surfaces:
         id: gateway-rpc-apis-and-events
         features:
           - name: Health APIs
-            coverageIds: [health-apis]
+            coverageIds: [gateway.health-apis]
             description: '`health` and `status` RPCs.'
           - name: Identity and presence APIs
-            coverageIds: [identity-and-presence-apis]
+            coverageIds: [gateway.identity-and-presence-apis]
             description: '`gateway.identity.get`, `system-presence`, `system-event`, and heartbeat RPCs.'
           - name: Model APIs
-            coverageIds: [model-apis]
+            coverageIds: [gateway.model-apis]
             description: '`models.list` RPCs.'
           - name: Usage and memory APIs
-            coverageIds: [usage-and-memory-apis]
+            coverageIds: [gateway.usage-and-memory-apis]
             description: Usage summaries and memory readiness RPCs.
           - name: Session APIs
             coverageIds: [agents.subagents, gateway.sessions-list, tools.session-status]
             description: '`sessions.*` RPCs.'
           - name: Chat APIs
-            coverageIds: [chat-apis]
+            coverageIds: [gateway.chat-apis]
             description: '`chat.*` and `agent.wait` RPCs.'
           - name: Channel APIs
-            coverageIds: [channel-apis]
+            coverageIds: [gateway.channel-apis]
             description: '`channels.status` and `channels.logout` RPCs.'
           - name: Web login and wake APIs
-            coverageIds: [web-login-and-wake-apis]
+            coverageIds: [gateway.web-login-and-wake-apis]
             description: '`web.login.*`, `push.test`, and `voicewake.*` RPCs.'
           - name: Config and secrets APIs
-            coverageIds: [config-and-secrets-apis]
+            coverageIds: [gateway.config-and-secrets-apis]
             description: '`config.*` and `secrets.*` RPCs.'
           - name: Update and setup APIs
-            coverageIds: [update-and-setup-apis]
+            coverageIds: [gateway.update-and-setup-apis]
             description: '`update.*` and `wizard.*` RPCs.'
           - name: Agent and artifact APIs
-            coverageIds: [agent-and-artifact-apis]
+            coverageIds: [gateway.agent-and-artifact-apis]
             description: '`agents.*`, agent files, environments, and artifact RPCs.'
           - name: Task and automation APIs
-            coverageIds: [task-and-automation-apis]
+            coverageIds: [gateway.task-and-automation-apis]
             description: '`wake`, `cron.*`, and `tasks.*` RPCs.'
           - name: Tool and skill APIs
-            coverageIds: [tool-and-skill-apis]
+            coverageIds: [gateway.tool-and-skill-apis]
             description: '`commands.list`, `tools.*`, and `skills.*` RPCs.'
           - name: Request and event envelopes
-            coverageIds: [request-and-event-envelopes]
+            coverageIds: [gateway.request-and-event-envelopes]
             description: Request, response, and event frame shapes.
           - name: Idempotent side effects
-            coverageIds: [idempotent-side-effects]
+            coverageIds: [gateway.idempotent-side-effects]
             description: Idempotency requirements for side-effecting methods.
           - name: Method discovery
-            coverageIds: [method-discovery]
+            coverageIds: [gateway.method-discovery]
             description: Method discovery via `hello-ok.features.methods`.
           - name: Event discovery
-            coverageIds: [event-discovery]
+            coverageIds: [gateway.event-discovery]
             description: Event discovery via `hello-ok.features.events`.
           - name: Accepted-then-final results
-            coverageIds: [accepted-then-final-results]
+            coverageIds: [gateway.accepted-then-final-results]
             description: Immediate accepted ack plus later final result.
           - name: Event ordering
-            coverageIds: [event-ordering]
+            coverageIds: [gateway.event-ordering]
             description: Sequence handling and per-client monotonic event ordering.
           - name: State refresh after gaps
-            coverageIds: [state-refresh-after-gaps]
+            coverageIds: [gateway.state-refresh-after-gaps]
             description: No-replay event model and explicit gap recovery via state refresh.
         docs:
           - docs/gateway/protocol.md
@@ -241,34 +241,34 @@ surfaces:
         id: device-auth-and-pairing
         features:
           - name: Shared-secret login
-            coverageIds: [shared-secret-login]
+            coverageIds: [gateway.shared-secret-login]
             description: Shared-secret auth by token or password.
           - name: Trusted proxy auth
-            coverageIds: [trusted-proxy-auth]
+            coverageIds: [security.trusted-proxy-auth]
             description: Trusted-proxy and identity-bearing auth modes.
           - name: Private ingress mode
-            coverageIds: [private-ingress-mode]
+            coverageIds: [gateway.private-ingress-mode]
             description: 'Private-ingress `gateway.auth.mode: "none"` behavior and its limits.'
           - name: Device challenge signing
-            coverageIds: [device-challenge-signing]
+            coverageIds: [gateway.device-challenge-signing]
             description: Device identity signing against the challenge nonce.
           - name: Device tokens
-            coverageIds: [device-tokens]
+            coverageIds: [gateway.device-tokens]
             description: Device token issuance, persistence, reconnect reuse, rotation, and revocation.
           - name: Setup-code bootstrap
-            coverageIds: [setup-code-bootstrap]
+            coverageIds: [gateway.setup-code-bootstrap]
             description: Bootstrap setup-code token flows and bounded operator token handoff.
           - name: Auth mismatch recovery
-            coverageIds: [auth-mismatch-recovery]
+            coverageIds: [gateway.auth-mismatch-recovery]
             description: Recovery semantics for `AUTH_TOKEN_MISMATCH` and `AUTH_SCOPE_MISMATCH`.
           - name: Device auth migration
-            coverageIds: [device-auth-migration]
+            coverageIds: [gateway.device-auth-migration]
             description: Device-auth migration errors and required v2/v3 signature behavior.
           - name: Client pairing
-            coverageIds: [client-pairing]
+            coverageIds: [gateway.client-pairing]
             description: Device pairing requirements for new clients.
           - name: Node pairing
-            coverageIds: [node-pairing]
+            coverageIds: [security.node-pairing]
             description: Node pairing flows, including pending requests, approvals, expiry, and trusted-CIDR or metadata-upgrade auto-approval boundaries.
         docs:
           - docs/gateway/protocol.md
@@ -283,22 +283,22 @@ surfaces:
         id: network-access-and-discovery
         features:
           - name: Loopback and LAN access
-            coverageIds: [loopback-and-lan-access]
+            coverageIds: [gateway.loopback-and-lan-access]
             description: Loopback and LAN-facing Gateway exposure.
           - name: Tailnet access
-            coverageIds: [tailnet-access]
+            coverageIds: [gateway.tailnet-access]
             description: Tailnet-facing Gateway exposure and MagicDNS/Tailscale routing.
           - name: SSH tunnels
-            coverageIds: [ssh-tunnels]
+            coverageIds: [gateway.ssh-tunnels]
             description: SSH tunneling as the fallback remote path.
           - name: Endpoint discovery
-            coverageIds: [endpoint-discovery]
+            coverageIds: [gateway.endpoint-discovery]
             description: Bonjour/DNS-SD discovery, wide-area DNS-SD, and advertised transport hints.
           - name: Saved endpoints
-            coverageIds: [saved-endpoints]
+            coverageIds: [gateway.saved-endpoints]
             description: Saved remote Gateway endpoints and route preference order.
           - name: TLS pinning
-            coverageIds: [tls-pinning]
+            coverageIds: [gateway.tls-pinning]
             description: TLS enablement and optional certificate fingerprint pinning.
         docs:
           - docs/gateway/index.md
@@ -313,28 +313,28 @@ surfaces:
         id: nodes-and-remote-capabilities
         features:
           - name: Node presence
-            coverageIds: [node-presence]
+            coverageIds: [gateway.node-presence]
             description: Node presence in the same WS control plane as operator clients.
           - name: Node capabilities
-            coverageIds: [node-capabilities]
+            coverageIds: [gateway.node-capabilities]
             description: Node capability declaration at connect time.
           - name: Node inventory
-            coverageIds: [node-inventory]
+            coverageIds: [gateway.node-inventory]
             description: '`node.list`, `node.describe`, and naming/state visibility.'
           - name: Node actions
-            coverageIds: [node-actions]
+            coverageIds: [gateway.node-actions]
             description: '`node.invoke` and `node.invoke.result`.'
           - name: Node events
-            coverageIds: [node-events]
+            coverageIds: [gateway.node-events]
             description: '`node.event`, especially `node.presence.alive`.'
           - name: Pending work delivery
-            coverageIds: [pending-work-delivery]
+            coverageIds: [gateway.pending-work-delivery]
             description: Pending work APIs for connected and disconnected nodes.
           - name: Remote device capabilities
-            coverageIds: [remote-device-capabilities]
+            coverageIds: [gateway.remote-device-capabilities]
             description: Relay of remote capability surfaces such as camera, canvas, screen, location, voice, and browser.
           - name: Remote host commands
-            coverageIds: [remote-host-commands]
+            coverageIds: [gateway.remote-host-commands]
             description: Relay of remote host-command capability surfaces.
         docs:
           - docs/gateway/protocol.md
@@ -349,25 +349,25 @@ surfaces:
         id: health-diagnostics-and-repair
         features:
           - name: Health snapshots
-            coverageIds: [health-snapshots]
+            coverageIds: [telemetry.health-snapshots]
             description: '`health` and `status` snapshots.'
           - name: Channel readiness
-            coverageIds: [channel-readiness]
+            coverageIds: [gateway.channel-readiness]
             description: Channel readiness probing through the running Gateway.
           - name: Stability diagnostics
-            coverageIds: [stability-diagnostics]
+            coverageIds: [gateway.stability-diagnostics]
             description: Stability recorder output.
           - name: Payload diagnostics
-            coverageIds: [payload-diagnostics]
+            coverageIds: [gateway.payload-diagnostics]
             description: '`payload.large` diagnostics.'
           - name: Diagnostics exports
-            coverageIds: [diagnostics-exports]
+            coverageIds: [gateway.diagnostics-exports]
             description: Diagnostics export contents, privacy model, and CLI/chat triggers.
           - name: Doctor checks
-            coverageIds: [doctor-checks]
+            coverageIds: [telemetry.doctor-checks]
             description: Doctor checks for UI protocol freshness, service drift, auth/pairing drift, port collisions, sandbox/runtime best practices, and source-install issues.
           - name: Log tailing
-            coverageIds: [log-tailing]
+            coverageIds: [gateway.log-tailing]
             description: Log tailing and operational signal visibility.
         docs:
           - docs/gateway/index.md
@@ -382,25 +382,25 @@ surfaces:
         id: protocol-compatibility
         features:
           - name: Published protocol schema
-            coverageIds: [published-protocol-schema]
+            coverageIds: [gateway.published-protocol-schema]
             description: TypeBox as the protocol source of truth.
           - name: Runtime request validation
-            coverageIds: [runtime-request-validation]
+            coverageIds: [gateway.runtime-request-validation]
             description: Runtime validators for protocol payloads.
           - name: JSON Schema export
-            coverageIds: [json-schema-export]
+            coverageIds: [gateway.json-schema-export]
             description: Generated JSON Schema for protocol payloads.
           - name: Swift client models
-            coverageIds: [swift-client-models]
+            coverageIds: [gateway.swift-client-models]
             description: Swift model generation.
           - name: Version negotiation
-            coverageIds: [version-negotiation]
+            coverageIds: [gateway.version-negotiation]
             description: Current protocol constants and supported protocol range behavior.
           - name: Client transport defaults
-            coverageIds: [client-transport-defaults]
+            coverageIds: [gateway.client-transport-defaults]
             description: Client defaults for request timeouts, reconnect backoff, and tick handling.
           - name: Backward-compatible evolution
-            coverageIds: [backward-compatible-evolution]
+            coverageIds: [gateway.backward-compatible-evolution]
             description: Additive evolution discipline for new methods, events, or payload fields.
         docs:
           - docs/gateway/protocol.md
@@ -416,19 +416,19 @@ surfaces:
         id: roles-and-permissions
         features:
           - name: Role negotiation
-            coverageIds: [role-negotiation]
+            coverageIds: [gateway.role-negotiation]
             description: '`operator` versus `node` role negotiation.'
           - name: Operator permissions
-            coverageIds: [operator-permissions]
+            coverageIds: [gateway.operator-permissions]
             description: Core operator scopes such as `operator.read`, `operator.write`, `operator.admin`, `operator.approvals`, `operator.pairing`, and `operator.talk.secrets`.
           - name: Approval-gated actions
-            coverageIds: [approval-gated-actions]
+            coverageIds: [gateway.approval-gated-actions]
             description: Extra approval-time scope requirements for pairing and dangerous node commands.
           - name: Untrusted node declarations
-            coverageIds: [untrusted-node-declarations]
+            coverageIds: [gateway.untrusted-node-declarations]
             description: Node-declared `caps`, `commands`, and `permissions` as claims rather than trusted truth.
           - name: Event scoping
-            coverageIds: [event-scoping]
+            coverageIds: [gateway.event-scoping]
             description: Broadcast event scoping, including fail-closed behavior for unknown event families.
         docs:
           - docs/gateway/protocol.md
@@ -442,25 +442,25 @@ surfaces:
         id: gateway-lifecycle
         features:
           - name: Foreground startup
-            coverageIds: [foreground-startup]
+            coverageIds: [gateway.foreground-startup]
             description: Local foreground startup via `openclaw gateway`.
           - name: Service installation
-            coverageIds: [service-installation]
+            coverageIds: [gateway.service-installation]
             description: Supervised lifecycle installation on macOS, Linux user/systemd, and native Windows task scheduling.
           - name: Restart and stop
             coverageIds: [config.restart-apply, plugins.capabilities, runtime.gateway-restart]
             description: Correct `restart` and `stop` behavior for supervised installs.
           - name: Service status
-            coverageIds: [service-status]
+            coverageIds: [gateway.service-status]
             description: Status behavior for supervised installs.
           - name: Bind and port settings
-            coverageIds: [bind-and-port-settings]
+            coverageIds: [gateway.bind-and-port-settings]
             description: Bind and port precedence across CLI flags, env vars, config, and persisted supervisor metadata.
           - name: Config reload
             coverageIds: [config.hot-apply, plugins.hot-reload, plugins.lifecycle, plugins.skills]
             description: 'Config reload modes: `off`, `hot`, `restart`, and `hybrid`.'
           - name: Multi-gateway isolation
-            coverageIds: [multi-gateway-isolation]
+            coverageIds: [gateway.multi-gateway-isolation]
             description: Multiple-gateway isolation on one host, including config/state/workspace separation.
         docs:
           - docs/gateway/index.md
@@ -474,22 +474,22 @@ surfaces:
         id: security-controls
         features:
           - name: Non-loopback auth
-            coverageIds: [non-loopback-auth]
+            coverageIds: [gateway.non-loopback-auth]
             description: Auth-required non-loopback exposure.
           - name: Trusted proxy exceptions
-            coverageIds: [trusted-proxy-exceptions]
+            coverageIds: [gateway.trusted-proxy-exceptions]
             description: Trusted-proxy and control-plane device-auth exceptions.
           - name: Gateway and node trust boundaries
-            coverageIds: [gateway-and-node-trust-boundaries]
+            coverageIds: [gateway.gateway-and-node-trust-boundaries]
             description: Gateway/node trust-domain definition.
           - name: Trusted CIDR auto-approval
-            coverageIds: [trusted-cidr-auto-approval]
+            coverageIds: [gateway.trusted-cidr-auto-approval]
             description: Trusted-CIDR limits for node auto-approval.
           - name: Fail-closed protocol handling
-            coverageIds: [fail-closed-protocol-handling]
+            coverageIds: [gateway.fail-closed-protocol-handling]
             description: Fail-fast/fail-closed behavior for protocol violations and unknown event families.
           - name: Remote execution safeguards
-            coverageIds: [remote-execution-safeguards]
+            coverageIds: [gateway.remote-execution-safeguards]
             description: Security posture around remote node execution and browser-control relay.
         docs:
           - docs/gateway/security/index.md
@@ -504,28 +504,28 @@ surfaces:
         id: websocket-connection
         features:
           - name: WebSocket transport
-            coverageIds: [websocket-transport]
+            coverageIds: [gateway.websocket-transport]
             description: WebSocket transport with JSON text frames.
           - name: Connect challenge
-            coverageIds: [connect-challenge]
+            coverageIds: [gateway.connect-challenge]
             description: Mandatory pre-connect `connect.challenge`.
           - name: Connect request
-            coverageIds: [connect-request]
+            coverageIds: [gateway.connect-request]
             description: Mandatory first-frame `connect` request.
           - name: Protocol version negotiation
-            coverageIds: [protocol-version-negotiation]
+            coverageIds: [gateway.protocol-version-negotiation]
             description: Protocol range negotiation (`minProtocol`/`maxProtocol`).
           - name: hello-ok snapshot
-            coverageIds: [hello-ok-snapshot]
+            coverageIds: [gateway.hello-ok-snapshot]
             description: 'Required `hello-ok` payload structure: server identity, negotiated auth, feature discovery, snapshot, and policy limits.'
           - name: Startup retry
-            coverageIds: [startup-retry]
+            coverageIds: [gateway.startup-retry]
             description: Retryable startup-sidecar `UNAVAILABLE` behavior during Gateway startup.
           - name: Session limits
-            coverageIds: [session-limits]
+            coverageIds: [gateway.session-limits]
             description: Post-handshake policy advertisement (`maxPayload`, `maxBufferedBytes`, `tickIntervalMs`).
           - name: Plugin surface URLs
-            coverageIds: [plugin-surface-urls]
+            coverageIds: [gateway.plugin-surface-urls]
             description: Optional `pluginSurfaceUrls` issuance and refresh.
         docs:
           - docs/gateway/protocol.md
@@ -553,22 +553,22 @@ surfaces:
         id: cli-setup
         features:
           - name: Installer scripts
-            coverageIds: [installer-scripts]
+            coverageIds: [cli.installer-scripts]
             description: Hosted installer scripts set up Node, install OpenClaw, and optionally start onboarding.
           - name: Local prefix install
-            coverageIds: [local-prefix-install]
+            coverageIds: [cli.local-prefix-install]
             description: The local-prefix installer keeps Node and OpenClaw under a dedicated OpenClaw directory instead of relying on a system-wide runtime.
           - name: Package-manager installs
-            coverageIds: [package-manager-installs]
+            coverageIds: [cli.package-manager-installs]
             description: npm, pnpm, and bun global installs are supported when the operator manages Node directly, including PATH wiring expectations.
           - name: Supported Node runtime
-            coverageIds: [supported-node-runtime]
+            coverageIds: [cli.supported-node-runtime]
             description: OpenClaw documents the supported Node versions and recommended runtime before normal CLI workflows continue.
           - name: Source checkout install
-            coverageIds: [source-checkout-install]
+            coverageIds: [cli.source-checkout-install]
             description: Operators can run OpenClaw from a source checkout for development or recovery workflows, and update flows distinguish this path from package installs.
           - name: CLI entrypoint
-            coverageIds: [cli-entrypoint]
+            coverageIds: [cli.entrypoint]
             description: The packaged openclaw launcher, openclaw --help, openclaw --version, runtime preflight, and basic recovery expectations are documented.
         docs:
           - docs/install/index.md
@@ -586,19 +586,19 @@ surfaces:
         id: onboarding-and-auth-setup
         features:
           - name: Guided onboarding
-            coverageIds: [guided-onboarding]
+            coverageIds: [cli.guided-onboarding]
             description: openclaw onboard walks through workspace, gateway, model auth, channels, skills, and health setup.
           - name: Targeted reconfiguration
-            coverageIds: [targeted-reconfiguration]
+            coverageIds: [cli.targeted-reconfiguration]
             description: openclaw configure lets operators revisit only the sections they want to change after the initial setup.
           - name: Auth choices
-            coverageIds: [auth-choices]
+            coverageIds: [cli.auth-choices]
             description: Onboarding and configure support API-key, OAuth, and other provider-specific auth choices.
           - name: Gateway auth storage
-            coverageIds: [gateway-auth-storage]
+            coverageIds: [cli.gateway-auth-storage]
             description: Gateway token and password setup are documented, including SecretRef-managed storage behavior.
           - name: Remote onboarding
-            coverageIds: [remote-onboarding]
+            coverageIds: [cli.remote-onboarding]
             description: Remote-gateway onboarding documents what is configured locally versus what must already exist on the remote host.
         docs:
           - docs/cli/onboard.md
@@ -613,19 +613,19 @@ surfaces:
         id: plugin-and-channel-setup
         features:
           - name: Channel picker
-            coverageIds: [channel-picker]
+            coverageIds: [cli.channel-picker]
             description: Onboarding can guide the operator through choosing which channels to configure.
           - name: Plugin install sources
-            coverageIds: [plugin-install-sources]
+            coverageIds: [cli.plugin-install-sources]
             description: Plugin setup supports bundled, npm, ClawHub, marketplace, git, and local install sources.
           - name: Channel account setup
-            coverageIds: [channel-account-setup]
+            coverageIds: [cli.channel-account-setup]
             description: Channel commands support interactive and flag-driven account configuration for supported chat transports.
           - name: Post-setup probes
-            coverageIds: [post-setup-probes]
+            coverageIds: [cli.post-setup-probes]
             description: Operators can probe channel status and capabilities after setup to verify that the configured account works.
           - name: Remote gateway caveat
-            coverageIds: [remote-gateway-caveat]
+            coverageIds: [cli.remote-gateway-caveat]
             description: Remote onboarding documents that plugin installation does not happen locally when the gateway runs elsewhere.
         docs:
           - docs/cli/onboard.md
@@ -640,19 +640,19 @@ surfaces:
         id: gateway-service-management
         features:
           - name: Foreground gateway runs
-            coverageIds: [foreground-gateway-runs]
+            coverageIds: [cli.foreground-gateway-runs]
             description: Operators can run the gateway directly from the CLI for local development or ad hoc recovery.
           - name: Service install and control
-            coverageIds: [service-install-and-control]
+            coverageIds: [cli.service-install-and-control]
             description: The CLI documents install, status, start, stop, restart, and run flows for managed gateway services.
           - name: Service auth wiring
             coverageIds: [agents.create, channels.discord-config, config.crestodian-setup]
             description: Gateway service installation documents how auth tokens and other sensitive values are handled.
           - name: Drift and reinstall recovery
-            coverageIds: [drift-and-reinstall-recovery]
+            coverageIds: [cli.drift-and-reinstall-recovery]
             description: Operators are given explicit guidance for repairing or reinstalling a broken managed gateway service.
           - name: Service health checks
-            coverageIds: [service-health-checks]
+            coverageIds: [cli.service-health-checks]
             description: Gateway service flows point operators at runtime health and troubleshooting checks after install or restart.
         docs:
           - docs/cli/gateway.md
@@ -667,19 +667,19 @@ surfaces:
         id: cli-observability
         features:
           - name: Status snapshots
-            coverageIds: [status-snapshots]
+            coverageIds: [cli.status-snapshots]
             description: openclaw status and related flags summarize runtime state, config health, and update context.
           - name: Health snapshots
-            coverageIds: [health-snapshots]
+            coverageIds: [telemetry.health-snapshots]
             description: openclaw health gives a fast gateway health read and supports verbose or JSON output.
           - name: Remote log tailing
-            coverageIds: [remote-log-tailing]
+            coverageIds: [cli.remote-log-tailing]
             description: openclaw logs tails gateway logs over RPC, including follow mode and JSON output.
           - name: Diagnostics export
-            coverageIds: [diagnostics-export]
+            coverageIds: [cli.diagnostics-export]
             description: Gateway diagnostics bundles can be exported locally for bug reports and support workflows.
           - name: Support-safe redaction
-            coverageIds: [support-safe-redaction]
+            coverageIds: [cli.support-safe-redaction]
             description: Diagnostics and status paths document privacy and redaction expectations before sharing results.
         docs:
           - docs/cli/status.md
@@ -695,34 +695,34 @@ surfaces:
         id: doctor
         features:
           - name: Interactive repair
-            coverageIds: [interactive-repair]
+            coverageIds: [cli.interactive-repair]
             description: openclaw doctor supports inspect, repair, non-interactive, and forceful repair postures.
           - name: Config migration
-            coverageIds: [config-migration]
+            coverageIds: [cli.config-migration]
             description: Doctor rewrites legacy or damaged config and state into supported current formats.
           - name: Auth and SecretRef checks
-            coverageIds: [auth-and-secretref-checks]
+            coverageIds: [cli.auth-and-secretref-checks]
             description: Doctor audits auth shape, token generation, and supported SecretRef-backed config paths.
           - name: Plugin validation and repair
-            coverageIds: [plugin-validation-and-repair]
+            coverageIds: [cli.plugin-validation-repair]
             description: Doctor surfaces plugin-config issues and extension schema drift that block normal runtime operation.
           - name: Lint and JSON findings
-            coverageIds: [lint-and-json-findings]
+            coverageIds: [cli.lint-and-json-findings]
             description: openclaw doctor --lint --json provides stable machine-readable findings for automation.
           - name: Extra gateway discovery
-            coverageIds: [extra-gateway-discovery]
+            coverageIds: [cli.extra-gateway-discovery]
             description: Doctor can scan for unexpected gateway services and conflicting installs.
           - name: Supervisor drift repair
-            coverageIds: [supervisor-drift-repair]
+            coverageIds: [cli.supervisor-drift-repair]
             description: Doctor checks managed service definitions and can repair launchd, systemd, or Scheduled Task drift.
           - name: Port and startup diagnosis
-            coverageIds: [port-and-startup-diagnosis]
+            coverageIds: [cli.port-and-startup-diagnosis]
             description: Doctor points operators at port conflicts, restart failures, and recent gateway errors.
           - name: Runtime path checks
-            coverageIds: [runtime-path-checks]
+            coverageIds: [cli.runtime-path-checks]
             description: Doctor checks runtime-path best practices and common path misconfigurations.
           - name: Restart guidance
-            coverageIds: [restart-guidance]
+            coverageIds: [cli.restart-guidance]
             description: Doctor explains when a health issue needs a restart or a deeper service repair path.
         docs:
           - docs/cli/doctor.md
@@ -740,19 +740,19 @@ surfaces:
         id: updates-and-upgrades
         features:
           - name: Update channels
-            coverageIds: [update-channels]
+            coverageIds: [cli.update-channels]
             description: openclaw update supports stable, beta, and dev channel selection.
           - name: Install-kind switching
-            coverageIds: [install-kind-switching]
+            coverageIds: [cli.install-kind-switching]
             description: Update flows can switch between package installs and git/source installs when supported.
           - name: Managed gateway restart
-            coverageIds: [managed-gateway-restart]
+            coverageIds: [cli.managed-gateway-restart]
             description: Update flows document when the managed gateway is stopped, restarted, or intentionally left alone.
           - name: Update status and RPC
-            coverageIds: [update-status-and-rpc]
+            coverageIds: [cli.update-status-and-rpc]
             description: Operators can inspect update status and related gateway control-plane state.
           - name: Plugin convergence
-            coverageIds: [plugin-convergence]
+            coverageIds: [cli.plugin-convergence]
             description: Core updates document how plugin versions and plugin repair warnings are handled afterward.
         docs:
           - docs/install/updating.md
@@ -806,28 +806,28 @@ surfaces:
         id: authoring-and-packaging-plugins
         features:
           - name: Root SDK entrypoint
-            coverageIds: [root-sdk-entrypoint]
+            coverageIds: [plugins.root-sdk-entrypoint]
             description: Plugin authors use the supported root Plugin SDK entrypoint when the top-level contract is sufficient.
           - name: Focused SDK imports
-            coverageIds: [focused-sdk-imports]
+            coverageIds: [plugins.focused-sdk-imports]
             description: Plugin authors use focused Plugin SDK subpaths instead of relying on one broad catch-all entrypoint.
           - name: Entrypoint discovery
-            coverageIds: [entrypoint-discovery]
+            coverageIds: [plugins.entrypoint-discovery]
             description: Plugin authors discover the supported public entrypoints and their support status from the SDK docs and entrypoint catalog.
           - name: Migration shims
-            coverageIds: [migration-shims]
+            coverageIds: [plugins.migration-shims]
             description: Deprecated or compatibility subpaths continue to resolve during author migrations.
           - name: Plugin manifest
-            coverageIds: [plugin-manifest]
+            coverageIds: [plugins.manifest]
             description: '`openclaw.plugin.json` declares plugin identity, capabilities, and config schema.'
           - name: Package metadata
-            coverageIds: [package-metadata]
+            coverageIds: [plugins.package-metadata]
             description: '`package.json` carries the required `openclaw` metadata for discovery and release flows.'
           - name: Runtime compatibility
-            coverageIds: [runtime-compatibility]
+            coverageIds: [plugins.runtime-compatibility]
             description: Plugin packages declare supported runtime and plugin API compatibility.
           - name: Validation feedback
-            coverageIds: [validation-feedback]
+            coverageIds: [plugins.validation-feedback]
             description: Manifest and package contract validation fails fast on malformed or inconsistent metadata.
         docs:
           - docs/plugins/building-plugins.md
@@ -849,19 +849,19 @@ surfaces:
         id: bundled-plugins
         features:
           - name: Bundled plugin listing
-            coverageIds: [bundled-plugin-listing]
+            coverageIds: [plugins.bundled-plugin-listing]
             description: Operators and maintainers can inspect the bundled plugin set and its published metadata.
           - name: Bundled source overlays
-            coverageIds: [bundled-source-overlays]
+            coverageIds: [plugins.bundled-source-overlays]
             description: Source overlays work for local development and repo-driven testing.
           - name: Packaged bundled plugins
-            coverageIds: [packaged-bundled-plugins]
+            coverageIds: [plugins.packaged-bundled-plugins]
             description: Built distributions discover bundled plugins from packaged roots.
           - name: Generated plugin inventory
-            coverageIds: [generated-plugin-inventory]
+            coverageIds: [plugins.generated-plugin-inventory]
             description: Generated plugin inventory and reference docs describe what ships in core versus what installs separately.
           - name: Bundled channel IDs
-            coverageIds: [bundled-channel-ids]
+            coverageIds: [plugins.bundled-channel-ids]
             description: Bundled channel ids are discovered and normalized from plugin metadata.
         docs:
           - docs/plugins/plugin-inventory.md
@@ -877,22 +877,22 @@ surfaces:
         id: canvas-plugin
         features:
           - name: Hosted Canvas and A2UI surfaces
-            coverageIds: [hosted-canvas-and-a2ui-surfaces]
+            coverageIds: [plugins.hosted-canvas-and-a2ui-surfaces]
             description: Canvas plugin registers authenticated Gateway HTTP and WebSocket routes for hosted Canvas documents and A2UI runtime surfaces.
           - name: Agent canvas tool
-            coverageIds: [agent-canvas-tool]
+            coverageIds: [plugins.agent-canvas-tool]
             description: Canvas plugin registers the agent-facing `canvas` tool for present, hide, navigate, eval, snapshot, and A2UI control.
           - name: Node Canvas commands
-            coverageIds: [node-canvas-commands]
+            coverageIds: [plugins.node-canvas-commands]
             description: Canvas plugin owns node invoke policy for `canvas.present`, `canvas.navigate`, `canvas.eval`, `canvas.snapshot`, and `canvas.a2ui.*` commands.
           - name: Control UI embeds
-            coverageIds: [control-ui-embeds]
+            coverageIds: [plugins.control-ui-embeds]
             description: Assistant output can embed hosted Canvas document URLs in Control UI and WebChat sessions.
           - name: Canvas documents
-            coverageIds: [canvas-documents]
+            coverageIds: [plugins.canvas-documents]
             description: Canvas plugin materializes hosted document files and `/__openclaw__/canvas/documents/...` URLs.
           - name: A2UI transport and snapshots
-            coverageIds: [a2ui-transport-and-snapshots]
+            coverageIds: [plugins.a2ui-transport-and-snapshots]
             description: Canvas plugin groups A2UI push, reset, and JSONL transport with snapshot capture and node-rendered Canvas state.
         docs:
           - docs/plugins/reference/canvas.md
@@ -910,7 +910,7 @@ surfaces:
         id: installing-and-running-plugins
         features:
           - name: Plugin setup
-            coverageIds: [plugin-setup]
+            coverageIds: [plugins.setup-flows]
             description: Operators can run plugin setup flows without fully activating runtime behavior.
           - name: Runtime activation
             coverageIds: [config.hot-apply, gateway.performance, models.live-openai, plugins.before-prompt-build, plugins.before-tool-call, plugins.hot-reload, plugins.kitchen-sink, plugins.lifecycle, plugins.plugin-tools, plugins.runtime, plugins.skills, runtime.gateway-log-sentinel.plugin-hooks]
@@ -922,7 +922,7 @@ surfaces:
             coverageIds: [plugins.contracts.tools, runtime.gateway-log-sentinel.plugin-contracts]
             description: Unsafe or unsupported plugin loads are blocked with diagnosable failures before runtime execution.
           - name: Dependency repair
-            coverageIds: [dependency-repair]
+            coverageIds: [plugins.dependency-repair]
             description: Runtime can detect and repair missing or stale plugin dependencies.
           - name: Install update and uninstall
             coverageIds: [plugins.hot-install, plugins.skills, runtime.gateway-restart, runtime.package-update, runtime.update-run]
@@ -942,19 +942,19 @@ surfaces:
         id: channel-plugins
         features:
           - name: Inbound event handling
-            coverageIds: [inbound-event-handling]
+            coverageIds: [plugins.inbound-event-handling]
             description: Channel plugins register inbound hooks and normalize incoming events.
           - name: Outbound delivery
-            coverageIds: [outbound-delivery]
+            coverageIds: [plugins.outbound-delivery]
             description: Outbound adapters translate model output into channel-specific payloads.
           - name: Ingress authorization
-            coverageIds: [ingress-authorization]
+            coverageIds: [plugins.ingress-authorization]
             description: Channel ingress runtime enforces the shared inbound authorization boundary.
           - name: Destination resolution
-            coverageIds: [destination-resolution]
+            coverageIds: [plugins.destination-resolution]
             description: Target resolution maps users, threads, and conversations into channel destinations.
           - name: Native approval prompts
-            coverageIds: [native-approval-prompts]
+            coverageIds: [plugins.native-approval-prompts]
             description: Native channel actions can route approval prompts and responses through the approval system.
         docs:
           - docs/plugins/sdk-channel-plugins.md
@@ -971,19 +971,19 @@ surfaces:
         id: provider-and-tool-plugins
         features:
           - name: Provider plugins
-            coverageIds: [provider-plugins]
+            coverageIds: [plugins.provider-plugins]
             description: Provider plugins register models and capabilities with the runtime.
           - name: Tool plugins
             coverageIds: [gateway.performance, models.live-openai, plugins.before-prompt-build, plugins.before-tool-call, plugins.kitchen-sink, plugins.lifecycle, plugins.mcp-tools, plugins.plugin-tools, runtime.gateway-log-sentinel.plugin-hooks, tools.invocation]
             description: Tool plugins register discoverable tools and static metadata without ambiguous runtime ownership.
           - name: Model catalogs
-            coverageIds: [model-catalogs]
+            coverageIds: [plugins.model-catalogs]
             description: Provider model catalogs are discoverable and merge cleanly into global listings.
           - name: Provider auth
-            coverageIds: [provider-auth]
+            coverageIds: [plugins.provider-auth]
             description: Provider auth configuration and secret handling are supported.
           - name: Web search and fetch
-            coverageIds: [web-search-and-fetch]
+            coverageIds: [plugins.web-search-and-fetch]
             description: Provider or tool plugins can expose web search and fetch capabilities.
           - name: Mixed plugins
             coverageIds: [config.hot-apply, config.restart-apply, plugins.capabilities, plugins.hot-install, plugins.runtime, plugins.skills, tools.invocation, tools.skill-invocation]
@@ -1003,22 +1003,22 @@ surfaces:
         id: plugin-approvals
         features:
           - name: Approval requests
-            coverageIds: [approval-requests]
+            coverageIds: [plugins.approval-requests]
             description: Plugin-initiated actions can request and resolve approvals through the standard flow.
           - name: Native approval delivery
-            coverageIds: [native-approval-delivery]
+            coverageIds: [plugins.native-approval-delivery]
             description: Privileged plugin actions can route approvals through channel-native prompts and responses.
           - name: Same-chat fallbacks
-            coverageIds: [same-chat-fallbacks]
+            coverageIds: [plugins.same-chat-fallbacks]
             description: Approval delivery can fall back to same-chat authorization notices when native routing is unavailable.
           - name: Exec and plugin separation
-            coverageIds: [exec-and-plugin-separation]
+            coverageIds: [plugins.exec-and-plugin-separation]
             description: Exec approvals remain distinct from plugin approval paths and native permission relays.
           - name: Approval replay protection
-            coverageIds: [approval-replay-protection]
+            coverageIds: [plugins.approval-replay-protection]
             description: Approval decisions remain scoped to the originating request, target, and device or node binding.
           - name: Security helpers
-            coverageIds: [security-helpers]
+            coverageIds: [plugins.security-helpers]
             description: Security helper exports provide approved primitives without widening trust boundaries.
         docs:
           - docs/plugins/plugin-permission-requests.md
@@ -1034,22 +1034,22 @@ surfaces:
         id: publishing-plugins
         features:
           - name: Install sources
-            coverageIds: [install-sources]
+            coverageIds: [plugins.install-sources]
             description: Supported plugin install sources are explicit and validated.
           - name: ClawHub publishing
-            coverageIds: [clawhub-publishing]
+            coverageIds: [plugins.clawhub-publishing]
             description: Plugin metadata and workflows support publishing to ClawHub.
           - name: npm publishing
-            coverageIds: [npm-publishing]
+            coverageIds: [plugins.npm-publishing]
             description: Plugin metadata and workflows support publishing to npm when applicable.
           - name: Compatibility signaling
-            coverageIds: [compatibility-signaling]
+            coverageIds: [plugins.compatibility-signaling]
             description: Compatibility registry data maps plugins to supported runtime versions or channels.
           - name: Update and rollback expectations
-            coverageIds: [update-and-rollback-expectations]
+            coverageIds: [plugins.update-and-rollback-expectations]
             description: Plugin update semantics define what can be upgraded in place and what requires operator intervention.
           - name: Third-party publication rules
-            coverageIds: [third-party-publication-rules]
+            coverageIds: [plugins.third-party-publication-rules]
             description: External package acceptance rules gate third-party plugin packaging and publication.
         docs:
           - docs/cli/plugins.md
@@ -1066,19 +1066,19 @@ surfaces:
         id: testing-plugins
         features:
           - name: Test fixtures
-            coverageIds: [test-fixtures]
+            coverageIds: [plugins.test-fixtures]
             description: Fixtures provide reusable plugin metadata and runtime test inputs.
           - name: Local test environment
-            coverageIds: [local-test-environment]
+            coverageIds: [plugins.local-test-environment]
             description: Plugin authors can set up the local test environment and scoped helper configuration for plugin testing.
           - name: Plugin runtime harness
             coverageIds: [plugins.contracts.tools, runtime.gateway-log-sentinel.plugin-contracts]
             description: Plugin test harnesses cover authoring and runtime integration paths.
           - name: Unit and integration scaffolds
-            coverageIds: [unit-and-integration-scaffolds]
+            coverageIds: [plugins.unit-and-integration-scaffolds]
             description: Scoped test helpers and configuration support unit and integration testing for plugin surfaces.
           - name: Docker lifecycle suites
-            coverageIds: [docker-lifecycle-suites]
+            coverageIds: [plugins.docker-lifecycle-suites]
             description: Docker-based end-to-end scripts validate packaged plugin lifecycle flows.
           - name: Smoke tests
             coverageIds: [gateway.performance, models.live-openai, plugins.kitchen-sink, plugins.lifecycle, plugins.plugin-tools]
@@ -1137,13 +1137,13 @@ surfaces:
             coverageIds: [agents.openclaw-harness, workspace.planning]
             description: Choosing Codex app-server, ACP, and other external runtime harnesses.
           - name: CLI runtime aliases
-            coverageIds: [cli-runtime-aliases]
+            coverageIds: [runtime.cli-runtime-aliases]
             description: Runtime aliases and CLI-based execution paths such as Claude CLI and Gemini CLI.
           - name: Subagent turns
             coverageIds: [agents.subagents, agents.synthesis, channels.qa-channel, gateway.sessions-list, runtime.delivery, tools.sessions-spawn]
             description: Spawning, delivering, and announcing subagent work outside the default embedded path.
           - name: Runtime recovery
-            coverageIds: [runtime-recovery]
+            coverageIds: [runtime.recovery]
             description: Cleanup, timeout, and liveness behavior for external runtimes and subagents.
         docs:
           - docs/concepts/agent-runtimes.md
@@ -1160,19 +1160,19 @@ surfaces:
         id: hosted-provider-execution
         features:
           - name: Hosted provider turns
-            coverageIds: [hosted-provider-turns]
+            coverageIds: [runtime.hosted-provider-turns]
             description: Running agent turns against hosted providers such as OpenAI, Anthropic, and Google.
           - name: Provider-specific model options
-            coverageIds: [provider-specific-model-options]
+            coverageIds: [runtime.provider-specific-model-options]
             description: Provider-specific model parameters and runtime request settings exposed to users or operators.
           - name: Hosted tool use
-            coverageIds: [hosted-tool-use]
+            coverageIds: [runtime.hosted-tool-use]
             description: Tool use behavior when the active runtime is a hosted provider.
           - name: Reasoning and cache controls
-            coverageIds: [reasoning-and-cache-controls]
+            coverageIds: [runtime.reasoning-and-cache-controls]
             description: Provider-specific reasoning, thinking, and cache-related controls during hosted execution.
           - name: Hosted streaming and replies
-            coverageIds: [hosted-streaming-and-replies]
+            coverageIds: [runtime.hosted-streaming-and-replies]
             description: Operator-visible streaming and reply behavior while hosted adapters normalize payload differences.
         docs:
           - docs/providers/openai.md
@@ -1189,19 +1189,19 @@ surfaces:
         id: local-and-self-hosted-providers
         features:
           - name: Local provider profiles
-            coverageIds: [local-provider-profiles]
+            coverageIds: [runtime.local-provider-profiles]
             description: Local model profile configuration for Ollama and OpenAI-compatible local servers.
           - name: Tool-capability flags
-            coverageIds: [tool-capability-flags]
+            coverageIds: [runtime.tool-capability-flags]
             description: Local provider capability flags and behavior for tool use.
           - name: Timeouts and context windows
-            coverageIds: [timeouts-and-context-windows]
+            coverageIds: [runtime.timeouts-and-context-windows]
             description: Local provider timeout and context-window configuration.
           - name: Local smoke checks
-            coverageIds: [local-smoke-checks]
+            coverageIds: [runtime.local-smoke-checks]
             description: Local image and model smoke checks visible to operators.
           - name: Local failure handling
-            coverageIds: [local-failure-handling]
+            coverageIds: [runtime.local-failure-handling]
             description: Operator-facing failure handling for local and self-hosted providers.
         docs:
           - docs/providers/ollama.md
@@ -1226,7 +1226,7 @@ surfaces:
             coverageIds: [models.switching, models.thinking, runtime.reasoning-visibility, runtime.session-continuity]
             description: Resolving thinking and context settings as part of model selection.
           - name: Invalid route recovery
-            coverageIds: [invalid-route-recovery]
+            coverageIds: [runtime.invalid-route-recovery]
             description: Preserving or clearing invalid route state when selections drift or fail.
         docs:
           - docs/concepts/models.md
@@ -1252,25 +1252,25 @@ surfaces:
             coverageIds: [gateway.performance, models.live-openai, plugins.kitchen-sink, plugins.lifecycle, plugins.plugin-tools]
             description: Doctor, status, and related credential health checks and repair signals.
           - name: Auth failover
-            coverageIds: [auth-failover]
+            coverageIds: [runtime.auth-failover]
             description: Same-provider and cross-profile auth fallback behavior.
           - name: Provider fallback recovery
             coverageIds: [memory.failure-handling, runtime.fallbacks]
             description: Provider and auth-profile fallback behavior when execution fails.
           - name: Rate-limit and capacity recovery
-            coverageIds: [rate-limit-and-capacity-recovery]
+            coverageIds: [runtime.rate-limit-and-capacity-recovery]
             description: Recovery paths for quota, capacity, and rate-limit failures.
           - name: Missing-key and OAuth guidance
-            coverageIds: [missing-key-and-oauth-guidance]
+            coverageIds: [runtime.missing-key-and-oauth-guidance]
             description: Operator guidance for missing keys, expired OAuth state, and related auth failures.
           - name: Restart and stale-route recovery
-            coverageIds: [restart-and-stale-route-recovery]
+            coverageIds: [runtime.restart-and-stale-route-recovery]
             description: Recovery from stale route state, restart requirements, and related provider drift.
           - name: Structured provider diagnostics
-            coverageIds: [structured-provider-diagnostics]
+            coverageIds: [runtime.structured-provider-diagnostics]
             description: Structured provider errors and diagnostics delivered into logs or agent replies.
           - name: Subagent credential propagation
-            coverageIds: [subagent-credential-propagation]
+            coverageIds: [runtime.subagent-credential-propagation]
             description: Propagating provider credentials into subagent and delegated runtime flows.
         docs:
           - docs/concepts/models.md
@@ -1332,19 +1332,19 @@ surfaces:
             coverageIds: [qa.artifact-safety, runtime.inventory, runtime.tool-policy, security.redaction]
             description: Which tools are available during a turn after policy resolution and provider-based suppression.
           - name: Sandboxed exec behavior
-            coverageIds: [sandboxed-exec-behavior]
+            coverageIds: [runtime.sandboxed-exec-behavior]
             description: Exec behavior, sandbox roots, and workspace constraints visible to operators.
           - name: Approval flow
             coverageIds: [personal.approval-denial, runtime.approvals, tools.followthrough]
             description: Operator approval gates for tool execution.
           - name: Elevated execution
-            coverageIds: [elevated-execution]
+            coverageIds: [runtime.elevated-execution]
             description: Elevated host execution rules and related controls.
           - name: Tool safety controls
             coverageIds: [personal.tool-safety, tools.safety]
             description: Before-tool-call hooks and related guardrails that shape operator-visible tool behavior.
           - name: Delegated tool access
-            coverageIds: [delegated-tool-access]
+            coverageIds: [runtime.delegated-tool-access]
             description: Inherited or narrowed tool policy for subagents and delegated execution.
         docs:
           - docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -1374,10 +1374,10 @@ surfaces:
         id: cli-session-and-transcript-management
         features:
           - name: CLI Session
-            coverageIds: [cli-session]
+            coverageIds: [session.cli-session]
             description: Covers CLI Session across `openclaw sessions`, `openclaw transcripts`, cleanup, show/list/path behavior, TUI session history actions, and Gateway-backed session management commands.
           - name: Transcript Management
-            coverageIds: [transcript-management]
+            coverageIds: [session.transcript-management]
             description: Covers Transcript Management across `openclaw sessions`, `openclaw transcripts`, cleanup, show/list/path behavior, TUI session history actions, and Gateway-backed session management commands.
         docs:
           - docs/concepts/session.md
@@ -1397,7 +1397,7 @@ surfaces:
             coverageIds: [runtime.compaction, runtime.empty-response-recovery, runtime.reasoning-only-recovery, runtime.retry-policy]
             description: Covers Compaction across manual and automatic compaction, preemptive overflow checks, context-window estimation, session pruning, tool-result trimming, compaction providers, retry/timeout behavior, and compacted transcript checkpoints.
           - name: Pruning
-            coverageIds: [pruning]
+            coverageIds: [session.pruning]
             description: Covers Pruning across manual and automatic compaction, preemptive overflow checks, context-window estimation, session pruning, tool-result trimming, compaction providers, retry/timeout behavior, and compacted transcript checkpoints.
           - name: Token Pressure
             coverageIds: [runtime.codex-app-server, runtime.first-hour-20, runtime.gateway-log-sentinel.codex-progress, runtime.long-context, runtime.soak-100]
@@ -1458,10 +1458,10 @@ surfaces:
         id: diagnostics-maintenance-and-recovery
         features:
           - name: Session diagnostic reports
-            coverageIds: [session-diagnostic-reports]
+            coverageIds: [session.diagnostic-reports]
             description: Covers stuck-session diagnostics, diagnostic bundles, stability snapshots, and operator visibility into transcript and session health.
           - name: Session maintenance warnings
-            coverageIds: [session-maintenance-warnings]
+            coverageIds: [session.maintenance-warnings]
             description: Covers restart maintenance warnings, delivery queues, memory/session cleanup signals, and operator-visible maintenance state.
           - name: Session and transcript recovery
             coverageIds: [config.restart-apply, memory.failure-handling, runtime.delivery, runtime.fallbacks, runtime.gateway-restart, runtime.package-update, runtime.restart-recovery, runtime.update-run]
@@ -1503,7 +1503,7 @@ surfaces:
         id: memory
         features:
           - name: Memory Backend Storage
-            coverageIds: [memory-backend-storage]
+            coverageIds: [session.memory-backend-storage]
             description: Covers Memory Backend Storage across memory backend config, SQLite schema, vector acceleration, embedding provider selection, remote embedding fetch, QMD process/query parsing, session transcript indexing for search, extra paths, and backend security boundaries.
           - name: Embedding Search
             coverageIds: [channels.qa-channel, memory.active-recall, memory.ranking, memory.recall, personal.memory-recall]
@@ -1539,7 +1539,7 @@ surfaces:
         id: session-routing
         features:
           - name: Session Routing
-            coverageIds: [session-routing]
+            coverageIds: [memory.session-routing]
             description: Covers Session Routing across `sessionKey` construction, target resolution, conversation bindings, session labels, per-conversation isolation, thread binding, model selection continuity tied to sessions, and agent/workspace store targeting.
           - name: Conversation routing
             coverageIds: [channels.webchat, runtime.direct-reply-routing, tools.message]
@@ -1559,10 +1559,10 @@ surfaces:
         id: transcript-persistence
         features:
           - name: Transcript Persistence
-            coverageIds: [transcript-persistence]
+            coverageIds: [session.transcript-persistence]
             description: Covers Transcript Persistence across JSONL session files, transcript append and redaction, session write locks, transcript rotation/archive behavior, disk budget cleanup, provider transcript stores, and restart/repair durability.
           - name: Durability
-            coverageIds: [durability]
+            coverageIds: [session.durability]
             description: Covers Durability across JSONL session files, transcript append and redaction, session write locks, transcript rotation/archive behavior, disk budget cleanup, provider transcript stores, and restart/repair durability.
         docs:
           - docs/reference/session-management-compaction.md
@@ -1592,19 +1592,19 @@ surfaces:
         id: channel-actions-commands-and-approvals
         features:
           - name: Channel-native commands
-            coverageIds: [channel-native-commands]
+            coverageIds: [channels.native-commands]
             description: Channel-native commands and command authorization gates
           - name: Native command session target
-            coverageIds: [native-command-session-target]
+            coverageIds: [channels.native-command-session-target]
             description: Native command session target resolution
           - name: Message actions
-            coverageIds: [message-actions]
+            coverageIds: [channels.message-actions]
             description: Message actions, action dispatch, and trusted requester checks
           - name: Message tool API discovery
-            coverageIds: [message-tool-api-discovery]
+            coverageIds: [channels.message-tool-api-discovery]
             description: Message tool API discovery for channel actions
           - name: Channel-native approval prompts
-            coverageIds: [channel-native-approval-prompts]
+            coverageIds: [channels.native-approval-prompts]
             description: Channel-native approval prompts and plugin/exec approval routing
         docs:
           - docs/channels/groups.md
@@ -1622,19 +1622,19 @@ surfaces:
         id: channel-setup
         features:
           - name: Supported channel catalog
-            coverageIds: [supported-channel-catalog]
+            coverageIds: [channels.supported-channel-catalog]
             description: Supported channel catalog and docs index
           - name: Channel status taxonomy in channels list
-            coverageIds: [channel-status-taxonomy-in-channels-list]
+            coverageIds: [channels.status-taxonomy-in-channels-list]
             description: Channel status taxonomy in channels list, channels status, and setup status output
           - name: Setup/onboarding flows
             coverageIds: [agents.create, channels.discord-config, config.crestodian-setup]
             description: Setup/onboarding flows, including first-run channel selection and channel account setup
           - name: Install-on-demand
-            coverageIds: [install-on-demand]
+            coverageIds: [channels.install-on-demand]
             description: Install-on-demand, downloadable, bundled, official external, local, npm, and ClawHub distinctions
           - name: Setup wizard metadata
-            coverageIds: [setup-wizard-metadata]
+            coverageIds: [channels.setup-wizard-metadata]
             description: Setup wizard metadata and setup-safe plugin entrypoints
         docs:
           - docs/channels/index.md
@@ -1660,10 +1660,10 @@ surfaces:
             coverageIds: [channels.dm, channels.qa-channel, channels.threads, memory.thread-isolation, personal.channel-replies]
             description: Native threads, topics, parent-child bindings, and thread spawn behavior
           - name: Broadcast groups
-            coverageIds: [broadcast-groups]
+            coverageIds: [channels.broadcast-groups]
             description: Broadcast groups and multi-agent group routing
           - name: Bot-loop protection
-            coverageIds: [bot-loop-protection]
+            coverageIds: [channels.bot-loop-protection]
             description: Bot-loop protection for room behavior
         docs:
           - docs/channels/groups.md
@@ -1681,19 +1681,19 @@ surfaces:
         id: inbound-access-and-identity-gates
         features:
           - name: DM pairing
-            coverageIds: [dm-pairing]
+            coverageIds: [security.dm-pairing]
             description: DM pairing and allowFrom sender controls
           - name: Group/channel allowlists
-            coverageIds: [group-channel-allowlists]
+            coverageIds: [channels.group-channel-allowlists]
             description: Group/channel allowlists and sender allowlists
           - name: Access group expansion
-            coverageIds: [access-group-expansion]
+            coverageIds: [channels.access-group-expansion]
             description: Access group expansion and sender authorization helpers
           - name: Mention gating
-            coverageIds: [mention-gating]
+            coverageIds: [channels.mention-gating]
             description: Mention gating, implicit mentions, command bypass, and bot-loop-aware admission
           - name: Sanitized inbound identity/route projections
-            coverageIds: [sanitized-inbound-identity-route-projections]
+            coverageIds: [channels.sanitized-inbound-identity-route-projections]
             description: Sanitized inbound identity/route projections for downstream dispatch
         docs:
           - docs/channels/access-groups.md
@@ -1710,16 +1710,16 @@ surfaces:
         id: media-attachments-and-rich-channel-data
         features:
           - name: Inbound media normalization
-            coverageIds: [inbound-media-normalization]
+            coverageIds: [channels.inbound-media-normalization]
             description: Inbound media normalization, attachment persistence, and history media context
           - name: Outbound direct text/media sends
-            coverageIds: [outbound-direct-text-media-sends]
+            coverageIds: [channels.outbound-direct-text-media-sends]
             description: Outbound direct text/media sends and rich payload adapter support
           - name: Provider-specific channelData
-            coverageIds: [provider-specific-channeldata]
+            coverageIds: [channels.provider-specific-channeldata]
             description: Provider-specific channelData, quick replies, locations, polls, reactions, and voice-note handling
           - name: Media roots
-            coverageIds: [media-roots]
+            coverageIds: [channels.media-roots]
             description: Media roots and file-path safety for channel inbound storage
         docs:
           - docs/channels/line.md
@@ -1767,31 +1767,31 @@ surfaces:
             coverageIds: [channels.dm, channels.qa-channel, channels.threads, personal.channel-replies]
             description: Inbound and command conversation resolution across sessions, threads, and provider-owned targets.
           - name: Session key construction
-            coverageIds: [session-key-construction]
+            coverageIds: [memory.session-key-construction]
             description: Session key construction and session metadata recording
           - name: Agent selection precedence
-            coverageIds: [agent-selection-precedence]
+            coverageIds: [channels.agent-selection-precedence]
             description: Agent binding precedence and broadcast group dispatch
           - name: Runtime conversation routing
-            coverageIds: [runtime-conversation-routing]
+            coverageIds: [channels.runtime-conversation-routing]
             description: Runtime conversation bindings and ACP session binding routes
           - name: Thread/parent-child placement
-            coverageIds: [thread-parent-child-placement]
+            coverageIds: [channels.thread-parent-child-placement]
             description: Thread/parent-child placement and provider-owned target normalization
           - name: Plugin registry resolution
             coverageIds: [agents.subagents, channels.direct-visible-replies, channels.dm, channels.group-messages, channels.group-visible-replies, channels.message-actions, channels.qa-channel, channels.threads, media.image-generation, media.image-understanding, memory.recall, personal.channel-replies, personal.memory-recall, personal.reminders, runtime.delivery, scheduling.cron, scheduling.dedup, tools.message, ui.control]
             description: Plugin registry resolution and scoped channel runtime creation
           - name: Channel account startup
-            coverageIds: [channel-account-startup]
+            coverageIds: [channels.account-startup]
             description: Channel account startup, shutdown, logout, abort, and manual-stop state
           - name: Whole-channel lifecycle controls
-            coverageIds: [whole-channel-lifecycle-controls]
+            coverageIds: [channels.whole-channel-lifecycle-controls]
             description: Whole-channel and per-account lifecycle fanout for start, stop, logout, restart, and runtime snapshots.
           - name: Config/secrets reload interactions
-            coverageIds: [config-secrets-reload-interactions]
+            coverageIds: [channels.config-secrets-reload-interactions]
             description: Config/secrets reload interactions with channel plugin reload targets
           - name: Auto-restart
-            coverageIds: [auto-restart]
+            coverageIds: [channels.auto-restart]
             description: Auto-restart, backoff, crash-loop caps, and runtime snapshot reporting
         docs:
           - docs/channels/channel-routing.md
@@ -1814,16 +1814,16 @@ surfaces:
         id: status-health-and-operator-controls
         features:
           - name: channels.status
-            coverageIds: [channels-status]
+            coverageIds: [channels.status]
             description: channels.status, probes, account snapshots, and warnings
           - name: Channel health policy
             coverageIds: [channels.dedup, channels.reconnect, runtime.delivery]
             description: Channel health policy, health monitor restarts, stale socket detection, cooldowns, and restart caps
           - name: Operator CLI controls
-            coverageIds: [operator-cli-controls]
+            coverageIds: [channels.operator-cli-controls]
             description: Operator CLI controls for start, stop, logout, status, restart, and troubleshoot
           - name: Status read-model
-            coverageIds: [status-read-model]
+            coverageIds: [channels.status-read-model]
             description: Status read-model and plugin status snapshots
         docs:
           - docs/gateway/health.md
@@ -1857,7 +1857,7 @@ surfaces:
             coverageIds: [personal.approval-denial, personal.tool-safety, runtime.approvals, tools.followthrough, tools.safety]
             description: Covers Approval Policy across exec approval policy, host-local approval stores, allowlist and ask modes, dangerous tool safeguards, native/chat approval routing, plugin approval routing, approval decisions, approval binding, and operator-facing CLI management.
           - name: Dangerous Tool Safeguards
-            coverageIds: [dangerous-tool-safeguards]
+            coverageIds: [security.dangerous-tool-safeguards]
             description: Covers Dangerous Tool Safeguards across exec approval policy, host-local approval stores, allowlist and ask modes, dangerous tool safeguards, native/chat approval routing, plugin approval routing, approval decisions, approval binding, and operator-facing CLI management.
         docs:
           - docs/tools/exec-approvals.md
@@ -1874,31 +1874,31 @@ surfaces:
         id: gateway-auth-and-remote-access
         features:
           - name: Shared Gateway token/password auth
-            coverageIds: [shared-gateway-token-password-auth]
+            coverageIds: [security.shared-gateway-token-password-auth]
             description: Token and password auth for Gateway HTTP and WebSocket clients, including runtime auth resolution, startup validation, shared-secret comparison, and operator guidance.
           - name: Gateway auth mode
-            coverageIds: [gateway-auth-mode]
+            coverageIds: [security.gateway-auth-mode]
             description: Gateway auth mode selection, including private ingress behavior and operator warnings for unsafe exposure.
           - name: Trusted-proxy identity
-            coverageIds: [trusted-proxy-identity]
+            coverageIds: [security.trusted-proxy-identity]
             description: Trusted-proxy identity, gateway.trustedProxies, trustedProxy.userHeader, requiredHeaders, allowUsers, allowLoopback, reverse-proxy source validation, and scope behavior
           - name: Tailscale Serve/Funnel
-            coverageIds: [tailscale-serve-funnel]
+            coverageIds: [raspberry-pi.tailscale-serve-funnel]
             description: Tailscale Serve/Funnel and reverse-proxy exposure rules, including Tailscale identity headers, tailscale whois, Funnel password requirements, and separation between Control UI/WS identity and HTTP API auth
           - name: Bind and origin restrictions
-            coverageIds: [bind-and-origin-restrictions]
+            coverageIds: [security.bind-and-origin-restrictions]
             description: loopback/LAN/tailnet/custom bind modes, non-loopback exposure checks, browser Origin checks, controlUi.allowedOrigins, Host-header fallback risk, and forwarded-header handling
           - name: WebSocket handshake auth
-            coverageIds: [websocket-handshake-auth]
+            coverageIds: [security.websocket-handshake-auth]
             description: WebSocket handshake auth, including challenge/connect ordering, nonce-bound device auth, shared auth, browser origin checks, pre-auth limits, unauthenticated socket timeout, and stale shared-auth rotation
           - name: Operator-facing docs
-            coverageIds: [operator-facing-docs]
+            coverageIds: [security.operator-facing-docs]
             description: Operator-facing docs and runbooks for security audit, remote access, exposure rollback, Tailscale, trusted proxy, credential rotation, and explicit credential probing
           - name: Browser Control UI
-            coverageIds: [browser-control-ui]
+            coverageIds: [security.browser-control-ui]
             description: Covers Browser Control UI across Control UI/WebChat browser trust, device pairing for browser clients, allowed origins, Tailscale/trusted-proxy behavior for browser sessions, and related browser control ui and remote client trust behavior.
           - name: Remote Client Trust
-            coverageIds: [remote-client-trust]
+            coverageIds: [security.remote-client-trust]
             description: Covers Remote Client Trust across Control UI/WebChat browser trust, device pairing for browser clients, allowed origins, Tailscale/trusted-proxy behavior for browser sessions, and related browser control ui and remote client trust behavior.
         docs:
           - docs/gateway/security/index.md
@@ -1926,13 +1926,13 @@ surfaces:
         id: channel-access-control
         features:
           - name: Channel Identity
-            coverageIds: [channel-identity]
+            coverageIds: [security.channel-identity]
             description: 'Covers Channel Identity across who can talk to OpenClaw through message channels: DM pairing codes, pairing stores, `dmPolicy`, `allowFrom`, and related channel identity, allowlists, and sender pairing behavior.'
           - name: Allowlists
-            coverageIds: [allowlists]
+            coverageIds: [security.allowlists]
             description: 'Covers Allowlists across who can talk to OpenClaw through message channels: DM pairing codes, pairing stores, `dmPolicy`, `allowFrom`, and related channel identity, allowlists, and sender pairing behavior.'
           - name: Sender Pairing
-            coverageIds: [sender-pairing]
+            coverageIds: [security.sender-pairing]
             description: 'Covers Sender Pairing across who can talk to OpenClaw through message channels: DM pairing codes, pairing stores, `dmPolicy`, `allowFrom`, and related channel identity, allowlists, and sender pairing behavior.'
         docs:
           - docs/channels/pairing.md
@@ -1949,37 +1949,37 @@ surfaces:
         id: device-and-node-pairing
         features:
           - name: Setup codes
-            coverageIds: [setup-codes]
+            coverageIds: [security.setup-codes]
             description: Setup codes and QR pairing UX for mobile/node onboarding through the device-pair plugin
           - name: Device identity creation
-            coverageIds: [device-identity-creation]
+            coverageIds: [security.device-identity-creation]
             description: Device identity creation, storage, public-key-derived device IDs, challenge signing, and server verification
           - name: Device-token issuance
-            coverageIds: [device-token-issuance]
+            coverageIds: [security.device-token-issuance]
             description: Device-token issuance, reconnect reuse, token mismatch recovery, token rotation, token revocation, and stale-token cleanup
           - name: Device pairing approvals for operator
-            coverageIds: [device-pairing-approvals-for-operator]
+            coverageIds: [security.device-pairing-approvals-for-operator]
             description: Device pairing approvals for operator and node roles, including pending requests, role/scope upgrades, and repair requests
           - name: Operator scopes that gate pairing
-            coverageIds: [operator-scopes-that-gate-pairing]
+            coverageIds: [security.operator-scopes-that-gate-pairing]
             description: Operator scopes that gate pairing, device token management, node pairing, and higher-risk role/scope approvals
           - name: Local Control UI
-            coverageIds: [local-control-ui]
+            coverageIds: [security.local-control-ui]
             description: Local Control UI, WebChat, trusted-proxy, and backend auto-pairing or device-less exception behavior where it affects operator pairing
           - name: Auth migration
-            coverageIds: [auth-migration]
+            coverageIds: [security.auth-migration]
             description: Auth migration and recovery errors for pre-challenge device signing, token drift, scope mismatch, and mixed gateway auth configuration
           - name: Operator-facing docs
-            coverageIds: [operator-facing-docs]
+            coverageIds: [security.operator-facing-docs]
             description: Operator-facing docs for devices, pairing, WebChat, Control UI, protocol auth, and troubleshooting
           - name: Node Pairing
-            coverageIds: [node-pairing]
+            coverageIds: [security.node-pairing]
             description: Covers Node Pairing across node/device pairing for capability hosts, pending and approved node state, trusted-CIDR auto-approval, node-declared command/capability trust boundaries, and related node pairing, capability trust, and remote exec approvals behavior.
           - name: Capability Trust
-            coverageIds: [capability-trust]
+            coverageIds: [security.capability-trust]
             description: Covers Capability Trust across node/device pairing for capability hosts, pending and approved node state, trusted-CIDR auto-approval, node-declared command/capability trust boundaries, and related node pairing, capability trust, and remote exec approvals behavior.
           - name: Remote Exec Approvals
-            coverageIds: [remote-exec-approvals]
+            coverageIds: [security.remote-exec-approvals]
             description: Covers Remote Exec Approvals across node/device pairing for capability hosts, pending and approved node state, trusted-CIDR auto-approval, node-declared command/capability trust boundaries, and related node pairing, capability trust, and remote exec approvals behavior.
         docs:
           - docs/gateway/protocol.md
@@ -2003,10 +2003,10 @@ surfaces:
         id: plugin-trust
         features:
           - name: Plugin Installation Trust
-            coverageIds: [plugin-installation-trust]
+            coverageIds: [security.plugin-installation-trust]
             description: Covers Plugin Installation Trust across plugin manifest trust, plugin install/update safety scans, plugin allowlists, manifest-owned auth/secret metadata, and related plugin installation trust and security boundaries behavior.
           - name: Security Boundaries
-            coverageIds: [security-boundaries]
+            coverageIds: [security.boundaries]
             description: Covers Security Boundaries across plugin manifest trust, plugin install/update safety scans, plugin allowlists, manifest-owned auth/secret metadata, and related plugin installation trust and security boundaries behavior.
         docs:
           - docs/plugins/manifest.md
@@ -2023,19 +2023,19 @@ surfaces:
         id: credential-and-secret-hygiene
         features:
           - name: Provider Auth Profiles
-            coverageIds: [provider-auth-profiles]
+            coverageIds: [security.provider-auth-profiles]
             description: 'Covers Provider Auth Profiles across provider credentials and auth health as a security/secrets surface: API keys, OAuth profiles, `auth-profiles.json`, auth order, and related provider auth profiles and api key health behavior.'
           - name: API Key Health
-            coverageIds: [api-key-health]
+            coverageIds: [security.api-key-health]
             description: 'Covers API Key Health across provider credentials and auth health as a security/secrets surface: API keys, OAuth profiles, `auth-profiles.json`, auth order, and related provider auth profiles and api key health behavior.'
           - name: Secrets Storage
-            coverageIds: [secrets-storage]
+            coverageIds: [security.secrets-storage]
             description: Covers Secrets Storage across SecretRef contract and providers, runtime secret snapshots, gateway auth SecretRefs, auth-profile and generated model residues, and related secrets storage, redaction, and configuration hygiene behavior.
           - name: Redaction
             coverageIds: [memory.dreaming, memory.promotion, personal.diagnostics, personal.redaction, qa.artifact-safety, runtime.tool-policy, security.redaction]
             description: Covers Redaction across SecretRef contract and providers, runtime secret snapshots, gateway auth SecretRefs, auth-profile and generated model residues, and related secrets storage, redaction, and configuration hygiene behavior.
           - name: Configuration Hygiene
-            coverageIds: [configuration-hygiene]
+            coverageIds: [security.configuration-hygiene]
             description: Covers Configuration Hygiene across SecretRef contract and providers, runtime secret snapshots, gateway auth SecretRefs, auth-profile and generated model residues, and related secrets storage, redaction, and configuration hygiene behavior.
         docs:
           - docs/gateway/authentication.md
@@ -2073,37 +2073,37 @@ surfaces:
         id: health-and-repair
         features:
           - name: Background health-monitor loop
-            coverageIds: [background-health-monitor-loop]
+            coverageIds: [telemetry.background-health-monitor-loop]
             description: Background health-monitor loop for configured channel accounts
           - name: Per-account enable/disable settings
-            coverageIds: [per-account-enable-disable-settings]
+            coverageIds: [telemetry.per-account-enable-disable-settings]
             description: Per-account enable/disable settings behavior, status, and operator-visible verification.
           - name: Startup grace
-            coverageIds: [startup-grace]
+            coverageIds: [telemetry.startup-grace]
             description: Startup grace, connect grace, stale transport activity detection, busy/stuck handling, restart cooldowns, and max restarts per hour
           - name: Restart logging
-            coverageIds: [restart-logging]
+            coverageIds: [telemetry.restart-logging]
             description: Restart logging and runtime snapshot evaluation
           - name: openclaw doctor
             coverageIds: [runtime.codex-plugin.auth, runtime.codex-plugin.lifecycle, runtime.doctor-repair]
             description: openclaw doctor, openclaw doctor --fix, --repair, --yes, --non-interactive, --deep, and --lint
           - name: Structured health checks
-            coverageIds: [structured-health-checks]
+            coverageIds: [telemetry.structured-health-checks]
             description: Structured health checks, findings, repair results, check selection, JSON lint output, severity filtering, and exit behavior
           - name: Core doctor checks
-            coverageIds: [core-doctor-checks]
+            coverageIds: [telemetry.core-doctor-checks]
             description: Core doctor checks for gateway config, services, auth, state integrity, skills, plugins, sandbox, migrations, and provider route health
           - name: Plugin SDK doctor/health contracts
-            coverageIds: [plugin-sdk-doctor-health-contracts]
+            coverageIds: [telemetry.plugin-sdk-doctor-health-contracts]
             description: Plugin SDK doctor/health contracts behavior, status, and operator-visible verification.
           - name: openclaw status
-            coverageIds: [openclaw-status]
+            coverageIds: [windows.openclaw-status]
             description: openclaw status, openclaw status --all, and openclaw status --deep
           - name: openclaw health
-            coverageIds: [openclaw-health]
+            coverageIds: [telemetry.openclaw-health]
             description: openclaw health, openclaw health --verbose, and openclaw health --json
           - name: Gateway RPC health
-            coverageIds: [gateway-rpc-health]
+            coverageIds: [telemetry.gateway-rpc-health]
             description: Gateway RPC health and status
           - name: Cached health snapshots
             coverageIds: [gateway.performance, models.live-openai, plugins.kitchen-sink, plugins.lifecycle, plugins.plugin-tools]
@@ -2132,19 +2132,19 @@ surfaces:
         id: logging
         features:
           - name: Rolling Gateway JSONL file logs
-            coverageIds: [rolling-gateway-jsonl-file-logs]
+            coverageIds: [telemetry.rolling-gateway-jsonl-file-logs]
             description: Rolling Gateway JSONL file logs and console output
           - name: openclaw logs
-            coverageIds: [openclaw-logs]
+            coverageIds: [telemetry.openclaw-logs]
             description: openclaw logs, openclaw logs --follow, JSON/plain/color/timezone modes, and local fallback behavior
           - name: Gateway RPC logs.tail
-            coverageIds: [gateway-rpc-logs-tail]
+            coverageIds: [telemetry.gateway-rpc-logs-tail]
             description: Gateway RPC logs.tail behavior, status, and operator-visible verification.
           - name: Redaction patterns and sinks
-            coverageIds: [redaction-patterns-and-sinks]
+            coverageIds: [telemetry.redaction-patterns-and-sinks]
             description: console, file logs, OTLP log records, transcript text, Control UI tool-call events, support exports, and WS protocol logs
           - name: Trace correlation fields
-            coverageIds: [trace-correlation-fields]
+            coverageIds: [telemetry.trace-correlation-fields]
             description: Trace correlation fields on log records and linked diagnostic events.
         docs:
           - docs/logging.md
@@ -2160,28 +2160,28 @@ surfaces:
         id: diagnostic-collection
         features:
           - name: openclaw gateway diagnostics export
-            coverageIds: [openclaw-gateway-diagnostics-export]
+            coverageIds: [telemetry.openclaw-gateway-diagnostics-export]
             description: openclaw gateway diagnostics export and --json / --output / log-size options
           - name: openclaw gateway stability --bundle
-            coverageIds: [openclaw-gateway-stability-bundle]
+            coverageIds: [telemetry.openclaw-gateway-stability-bundle]
             description: openclaw gateway stability --bundle latest --export
           - name: Chat /diagnostics
-            coverageIds: [chat-diagnostics]
+            coverageIds: [telemetry.chat-diagnostics]
             description: Chat /diagnostics and /codex diagnostics approval flows
           - name: Support zip composition
             coverageIds: [personal.diagnostics, personal.redaction, qa.artifact-safety]
             description: Support zip composition, safe relative paths, sanitized config/status/health/log/stability files, and privacy manifest
           - name: Bounded in-process stability recorder
-            coverageIds: [bounded-in-process-stability-recorder]
+            coverageIds: [telemetry.bounded-in-process-stability-recorder]
             description: Bounded in-process stability recorder and diagnostics.stability RPC
           - name: openclaw gateway stability
-            coverageIds: [openclaw-gateway-stability]
+            coverageIds: [telemetry.openclaw-gateway-stability]
             description: openclaw gateway stability, stability filtering, persisted stability bundles, and export-from-bundle
           - name: Memory pressure events
-            coverageIds: [memory-pressure-events]
+            coverageIds: [telemetry.memory-pressure-events]
             description: Memory pressure events, event-loop liveness warnings, oversized payload events, queue/session summaries, and fatal/shutdown/restart snapshots
           - name: Critical memory pressure snapshot option
-            coverageIds: [critical-memory-pressure-snapshot-option]
+            coverageIds: [telemetry.critical-memory-pressure-snapshot-option]
             description: Critical memory pressure snapshot option with V8/cgroup/session-file evidence
         docs:
           - docs/gateway/diagnostics.md
@@ -2201,43 +2201,43 @@ surfaces:
         id: telemetry-export
         features:
           - name: Diagnostic event types
-            coverageIds: [diagnostic-event-types]
+            coverageIds: [telemetry.diagnostic-event-types]
             description: Diagnostic event types and trusted/internal/public subscription boundaries
           - name: Async dispatch
-            coverageIds: [async-dispatch]
+            coverageIds: [automation.async-dispatch]
             description: Async dispatch, queue saturation summaries, immutable event copies, private data handling, and diagnostics enablement
           - name: W3C trace context creation
-            coverageIds: [w3c-trace-context-creation]
+            coverageIds: [telemetry.w3c-trace-context-creation]
             description: W3C trace context creation, active request scopes, child spans, and trusted traceparent formatting
           - name: Plugin SDK diagnostic runtime exports
-            coverageIds: [plugin-sdk-diagnostic-runtime-exports]
+            coverageIds: [telemetry.plugin-sdk-runtime-exports]
             description: Plugin SDK diagnostic runtime exports and hook context trace fields
           - name: Model-call diagnostic events
-            coverageIds: [model-call-diagnostic-events]
+            coverageIds: [telemetry.model-call-diagnostic-events]
             description: Model-call, tool, exec, webhook, message, Talk, session, harness, and exporter diagnostic events.
           - name: diagnostics-otel plugin install
-            coverageIds: [diagnostics-otel-plugin-install]
+            coverageIds: [telemetry.diagnostics-otel-plugin-install]
             description: diagnostics-otel plugin install, enablement, config, env overrides, sampling, flush interval, and preloaded SDK mode
           - name: OTLP/HTTP traces
             coverageIds: [harness.qa-lab, telemetry.otel]
             description: OTLP/HTTP traces, metrics, and logs
           - name: Trusted trace context
-            coverageIds: [trusted-trace-context]
+            coverageIds: [telemetry.trusted-trace-context]
             description: Trusted trace context, W3C traceparent propagation to model calls, file-log correlation, content-capture controls, and redacted/bounded attributes
           - name: Model and runtime telemetry
             coverageIds: [docker.e2e, harness.qa-lab, harness.tool-trace-visibility, personal.failure-recovery, personal.no-fake-progress, personal.task-followthrough, runtime.qa-bus, telemetry.otel, telemetry.prometheus, tools.evidence, tools.trace]
             description: Model, tool, message, session, queue, Talk, exec, webhook, context assembly, harness, and exporter-health signals
           - name: diagnostics-prometheus plugin install
-            coverageIds: [diagnostics-prometheus-plugin-install]
+            coverageIds: [telemetry.diagnostics-prometheus-plugin-install]
             description: diagnostics-prometheus plugin install and enablement
           - name: Gateway-authenticated GET /api/diagnostics/prometheus
-            coverageIds: [gateway-authenticated-get-api-diagnostics-prometheus]
+            coverageIds: [telemetry.prometheus-authenticated-gateway-export]
             description: Gateway-authenticated GET /api/diagnostics/prometheus behavior, status, and operator-visible verification.
           - name: Prometheus text exposition
             coverageIds: [docker.e2e, harness.qa-lab, telemetry.prometheus]
             description: Prometheus text exposition, counters, gauges, histograms, label policy, series cap, and overflow metric
           - name: Trusted diagnostic event subscription
-            coverageIds: [trusted-diagnostic-event-subscription]
+            coverageIds: [telemetry.trusted-diagnostic-event-subscription]
             description: Trusted diagnostic event subscription and rendering of run, model, tool, message, Talk, queue, session, liveness, payload, memory, and exporter metrics
         docs:
           - docs/plugins/hooks.md
@@ -2263,16 +2263,16 @@ surfaces:
         id: session-diagnostics
         features:
           - name: session.state
-            coverageIds: [session-state]
+            coverageIds: [telemetry.session-state]
             description: session.state, session.stuck, session.long_running, session.stalled, session.recovery.*, and session.turn.created diagnostic events
           - name: Diagnostic session activity snapshots
-            coverageIds: [diagnostic-session-activity-snapshots]
+            coverageIds: [telemetry.diagnostic-session-activity-snapshots]
             description: Diagnostic session activity snapshots for embedded runs, model calls, and tool calls
           - name: Model usage
-            coverageIds: [model-usage]
+            coverageIds: [telemetry.model-usage]
             description: Model usage, token/cost, model-call byte/timing, run attempts, and usage logs
           - name: Export of session signals to stability
-            coverageIds: [export-of-session-signals-to-stability]
+            coverageIds: [telemetry.export-of-session-signals-to-stability]
             description: Export of session signals to stability, OpenTelemetry, and Prometheus
         docs:
           - docs/gateway/opentelemetry.md
@@ -2303,16 +2303,16 @@ surfaces:
         id: cron-jobs
         features:
           - name: Create/edit/remove jobs
-            coverageIds: [create-edit-remove-jobs]
+            coverageIds: [automation.create-edit-remove-jobs]
             description: Covers Create/edit/remove jobs across cron job creation, listing, inspection, editing, and related cron job lifecycle behavior.
           - name: Schedule types
-            coverageIds: [schedule-types]
+            coverageIds: [automation.schedule-types]
             description: Covers Schedule types across cron job creation, listing, inspection, editing, and related cron job lifecycle behavior.
           - name: Timezone and stagger
-            coverageIds: [timezone-and-stagger]
+            coverageIds: [automation.timezone-and-stagger]
             description: Covers Timezone and stagger across cron job creation, listing, inspection, editing, and related cron job lifecycle behavior.
           - name: Cron RPCs
-            coverageIds: [cron-rpcs]
+            coverageIds: [scheduling.cron-rpcs]
             description: Covers Cron RPCs across cron job creation, listing, inspection, editing, and related cron job lifecycle behavior.
           - name: Agent cron tool
             coverageIds: [channels.qa-channel, personal.reminders, scheduling.cron]
@@ -2324,28 +2324,28 @@ surfaces:
             coverageIds: [scheduling.cron, scheduling.dedup]
             description: Covers Isolated cron execution across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
           - name: Model/provider preflight
-            coverageIds: [model-provider-preflight]
+            coverageIds: [automation.model-provider-preflight]
             description: Covers Model/provider preflight across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
           - name: Run history
             coverageIds: [channels.qa-channel, scheduling.cron, scheduling.dedup]
             description: Covers Run history across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
           - name: Timeout and denial diagnostics
-            coverageIds: [timeout-and-denial-diagnostics]
+            coverageIds: [automation.timeout-and-denial-diagnostics]
             description: Covers Timeout and denial diagnostics across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
           - name: Chat announce delivery
-            coverageIds: [chat-announce-delivery]
+            coverageIds: [scheduling.chat-announce-delivery]
             description: Covers Chat announce delivery across cron output delivery modes, channel target resolution, direct delivery retries, transcript mirroring, and related cron delivery and failure alerts behavior.
           - name: Webhook delivery
-            coverageIds: [webhook-delivery]
+            coverageIds: [automation.webhook-delivery]
             description: Covers Webhook delivery across cron output delivery modes, channel target resolution, direct delivery retries, transcript mirroring, and related cron delivery and failure alerts behavior.
           - name: Failure destinations
-            coverageIds: [failure-destinations]
+            coverageIds: [automation.failure-destinations]
             description: Covers Failure destinations across cron output delivery modes, channel target resolution, direct delivery retries, transcript mirroring, and related cron delivery and failure alerts behavior.
           - name: Skipped-run alerts
-            coverageIds: [skipped-run-alerts]
+            coverageIds: [automation.skipped-run-alerts]
             description: Covers Skipped-run alerts across cron output delivery modes, channel target resolution, direct delivery retries, transcript mirroring, and related cron delivery and failure alerts behavior.
           - name: Delivery previews
-            coverageIds: [delivery-previews]
+            coverageIds: [automation.delivery-previews]
             description: Covers Delivery previews across cron output delivery modes, channel target resolution, direct delivery retries, transcript mirroring, and related cron delivery and failure alerts behavior.
         docs:
           - docs/automation/cron-jobs.md
@@ -2378,49 +2378,49 @@ surfaces:
         id: event-ingress
         features:
           - name: Telegram long polling
-            coverageIds: [telegram-long-polling]
+            coverageIds: [automation.telegram-long-polling]
             description: Covers Telegram long polling across channel-level long polling and webhook modes, especially Telegram and Zalo; polling liveness, leases, watchdog thresholds, and related channel polling and webhooks behavior.
           - name: Telegram webhook mode
-            coverageIds: [telegram-webhook-mode]
+            coverageIds: [automation.telegram-webhook-mode]
             description: Covers Telegram webhook mode across channel-level long polling and webhook modes, especially Telegram and Zalo; polling liveness, leases, watchdog thresholds, and related channel polling and webhooks behavior.
           - name: Zalo polling/webhook mode
-            coverageIds: [zalo-polling-webhook-mode]
+            coverageIds: [automation.zalo-polling-webhook-mode]
             description: Covers Zalo polling/webhook mode across channel-level long polling and webhook modes, especially Telegram and Zalo; polling liveness, leases, watchdog thresholds, and related channel polling and webhooks behavior.
           - name: Polling stall diagnostics
-            coverageIds: [polling-stall-diagnostics]
+            coverageIds: [automation.polling-stall-diagnostics]
             description: Covers Polling stall diagnostics across channel-level long polling and webhook modes, especially Telegram and Zalo; polling liveness, leases, watchdog thresholds, and related channel polling and webhooks behavior.
           - name: iMessage watch fallback
-            coverageIds: [imessage-watch-fallback]
+            coverageIds: [automation.imessage-watch-fallback]
             description: Covers iMessage watch fallback across channel-level long polling and webhook modes, especially Telegram and Zalo; polling liveness, leases, watchdog thresholds, and related channel polling and webhooks behavior.
           - name: Gmail setup wizard
-            coverageIds: [gmail-setup-wizard]
+            coverageIds: [automation.gmail-setup-wizard]
             description: Covers Gmail setup wizard across `openclaw webhooks gmail setup`, `hooks.gmail` config, `gog gmail watch start/serve`, watcher startup and renewal, and related gmail pub/sub watchers behavior.
           - name: Watcher start/serve
-            coverageIds: [watcher-start-serve]
+            coverageIds: [automation.watcher-start-serve]
             description: Covers Watcher start/serve across `openclaw webhooks gmail setup`, `hooks.gmail` config, `gog gmail watch start/serve`, watcher startup and renewal, and related gmail pub/sub watchers behavior.
           - name: Tailscale/public routing
-            coverageIds: [tailscale-public-routing]
+            coverageIds: [automation.tailscale-public-routing]
             description: Covers Tailscale/public routing across `openclaw webhooks gmail setup`, `hooks.gmail` config, `gog gmail watch start/serve`, watcher startup and renewal, and related gmail pub/sub watchers behavior.
           - name: Push token validation
-            coverageIds: [push-token-validation]
+            coverageIds: [automation.push-token-validation]
             description: Covers Push token validation across `openclaw webhooks gmail setup`, `hooks.gmail` config, `gog gmail watch start/serve`, watcher startup and renewal, and related gmail pub/sub watchers behavior.
           - name: Gmail event routing
-            coverageIds: [gmail-event-routing]
+            coverageIds: [automation.gmail-event-routing]
             description: Covers Gmail event routing across `openclaw webhooks gmail setup`, `hooks.gmail` config, `gog gmail watch start/serve`, watcher startup and renewal, and related gmail pub/sub watchers behavior.
           - name: POST /hooks/wake
-            coverageIds: [post-hooks-wake]
+            coverageIds: [automation.post-hooks-wake]
             description: Covers POST /hooks/wake across `/hooks/wake`, `/hooks/agent`, mapped hooks under `/hooks/<name>`, token extraction, and related http webhooks behavior.
           - name: POST /hooks/agent
-            coverageIds: [post-hooks-agent]
+            coverageIds: [automation.post-hooks-agent]
             description: Covers POST /hooks/agent across `/hooks/wake`, `/hooks/agent`, mapped hooks under `/hooks/<name>`, token extraction, and related http webhooks behavior.
           - name: Mapped hooks
-            coverageIds: [mapped-hooks]
+            coverageIds: [automation.mapped-hooks]
             description: Covers Mapped hooks across `/hooks/wake`, `/hooks/agent`, mapped hooks under `/hooks/<name>`, token extraction, and related http webhooks behavior.
           - name: Hook auth policy
-            coverageIds: [hook-auth-policy]
+            coverageIds: [automation.hook-auth-policy]
             description: Covers Hook auth policy across `/hooks/wake`, `/hooks/agent`, mapped hooks under `/hooks/<name>`, token extraction, and related http webhooks behavior.
           - name: Async dispatch
-            coverageIds: [async-dispatch]
+            coverageIds: [automation.async-dispatch]
             description: Covers Async dispatch across `/hooks/wake`, `/hooks/agent`, mapped hooks under `/hooks/<name>`, token extraction, and related http webhooks behavior.
         docs:
           - docs/channels/telegram.md
@@ -2454,37 +2454,37 @@ surfaces:
         id: automation-hooks
         features:
           - name: HOOK.md authoring
-            coverageIds: [hook-md-authoring]
+            coverageIds: [automation.hook-md-authoring]
             description: Covers HOOK.md authoring across `HOOK.md` metadata, handler loading, bundled/managed/workspace/plugin hook discovery, eligibility policy, and related internal hooks behavior.
           - name: Hook discovery
-            coverageIds: [hook-discovery]
+            coverageIds: [automation.hook-discovery]
             description: Covers Hook discovery across `HOOK.md` metadata, handler loading, bundled/managed/workspace/plugin hook discovery, eligibility policy, and related internal hooks behavior.
           - name: Hook CLI management
-            coverageIds: [hook-cli-management]
+            coverageIds: [automation.hook-cli-management]
             description: Covers Hook CLI management across `HOOK.md` metadata, handler loading, bundled/managed/workspace/plugin hook discovery, eligibility policy, and related internal hooks behavior.
           - name: Hook packs
-            coverageIds: [hook-packs]
+            coverageIds: [automation.hook-packs]
             description: Covers Hook packs across `HOOK.md` metadata, handler loading, bundled/managed/workspace/plugin hook discovery, eligibility policy, and related internal hooks behavior.
           - name: Lifecycle event dispatch
-            coverageIds: [lifecycle-event-dispatch]
+            coverageIds: [automation.lifecycle-event-dispatch]
             description: Covers Lifecycle event dispatch across `HOOK.md` metadata, handler loading, bundled/managed/workspace/plugin hook discovery, eligibility policy, and related internal hooks behavior.
           - name: api.on registration
-            coverageIds: [api-on-registration]
+            coverageIds: [automation.api-on-registration]
             description: Covers api.on registration across `api.on(...)` typed hooks, priority/timeout behavior, decision hooks such as `before_tool_call`, message and dispatch hooks, and related plugin hooks behavior.
           - name: Tool-call policy hooks
-            coverageIds: [tool-call-policy-hooks]
+            coverageIds: [automation.tool-call-policy-hooks]
             description: Covers Tool-call policy hooks across `api.on(...)` typed hooks, priority/timeout behavior, decision hooks such as `before_tool_call`, message and dispatch hooks, and related plugin hooks behavior.
           - name: Message hooks
-            coverageIds: [message-hooks]
+            coverageIds: [automation.message-hooks]
             description: Covers Message hooks across `api.on(...)` typed hooks, priority/timeout behavior, decision hooks such as `before_tool_call`, message and dispatch hooks, and related plugin hooks behavior.
           - name: Session/lifecycle hooks
-            coverageIds: [session-lifecycle-hooks]
+            coverageIds: [automation.session-lifecycle-hooks]
             description: Covers Session/lifecycle hooks across `api.on(...)` typed hooks, priority/timeout behavior, decision hooks such as `before_tool_call`, message and dispatch hooks, and related plugin hooks behavior.
           - name: Plugin approval requests
-            coverageIds: [plugin-approval-requests]
+            coverageIds: [automation.plugin-approval-requests]
             description: Covers Plugin approval requests across `api.on(...)` typed hooks, priority/timeout behavior, decision hooks such as `before_tool_call`, message and dispatch hooks, and related plugin hooks behavior.
           - name: cron_changed
-            coverageIds: [cron-changed]
+            coverageIds: [automation.cron-changed]
             description: Covers cron_changed across `api.on(...)` typed hooks, priority/timeout behavior, decision hooks such as `before_tool_call`, message and dispatch hooks, and related plugin hooks behavior.
         docs:
           - docs/automation/hooks.md
@@ -2510,34 +2510,34 @@ surfaces:
         id: background-tasks-and-flows
         features:
           - name: Task list/show/cancel
-            coverageIds: [task-list-show-cancel]
+            coverageIds: [automation.task-list-show-cancel]
             description: Covers Task list/show/cancel across task creation, status transitions, runtime types, owner/session access, and related background task ledger behavior.
           - name: Task notifications
-            coverageIds: [task-notifications]
+            coverageIds: [automation.task-notifications]
             description: Covers Task notifications across task creation, status transitions, runtime types, owner/session access, and related background task ledger behavior.
           - name: Task audit and maintenance
-            coverageIds: [task-audit-and-maintenance]
+            coverageIds: [automation.task-audit-and-maintenance]
             description: Covers Task audit and maintenance across task creation, status transitions, runtime types, owner/session access, and related background task ledger behavior.
           - name: Chat task board
-            coverageIds: [chat-task-board]
+            coverageIds: [automation.chat-task-board]
             description: Covers Chat task board across task creation, status transitions, runtime types, owner/session access, and related background task ledger behavior.
           - name: Task pressure status
-            coverageIds: [task-pressure-status]
+            coverageIds: [automation.task-pressure-status]
             description: Covers Task pressure status across task creation, status transitions, runtime types, owner/session access, and related background task ledger behavior.
           - name: Managed flows
-            coverageIds: [managed-flows]
+            coverageIds: [automation.managed-flows]
             description: Covers Managed flows across managed and mirrored flow modes, flow registry persistence, revision tracking, owner-scoped access, and related task flow behavior.
           - name: Mirrored flows
-            coverageIds: [mirrored-flows]
+            coverageIds: [automation.mirrored-flows]
             description: Covers Mirrored flows across managed and mirrored flow modes, flow registry persistence, revision tracking, owner-scoped access, and related task flow behavior.
           - name: openclaw tasks flow
-            coverageIds: [openclaw-tasks-flow]
+            coverageIds: [automation.openclaw-tasks-flow]
             description: Covers openclaw tasks flow across managed and mirrored flow modes, flow registry persistence, revision tracking, owner-scoped access, and related task flow behavior.
           - name: Flow audit and maintenance
-            coverageIds: [flow-audit-and-maintenance]
+            coverageIds: [automation.flow-audit-and-maintenance]
             description: Covers Flow audit and maintenance across managed and mirrored flow modes, flow registry persistence, revision tracking, owner-scoped access, and related task flow behavior.
           - name: Plugin managedFlows
-            coverageIds: [plugin-managedflows]
+            coverageIds: [automation.plugin-managedflows]
             description: Covers Plugin managedFlows across managed and mirrored flow modes, flow registry persistence, revision tracking, owner-scoped access, and related task flow behavior.
         docs:
           - docs/automation/tasks.md
@@ -2562,16 +2562,16 @@ surfaces:
         id: heartbeat
         features:
           - name: Heartbeat scheduling
-            coverageIds: [heartbeat-scheduling]
+            coverageIds: [automation.heartbeat-scheduling]
             description: Covers Heartbeat scheduling across periodic heartbeat runs, active-hours and variable schedule behavior, wake/cooldown handling, heartbeat prompts and due-only task mode, and related heartbeat and commitments behavior.
           - name: Active hours
-            coverageIds: [active-hours]
+            coverageIds: [automation.active-hours]
             description: Covers Active hours across periodic heartbeat runs, active-hours and variable schedule behavior, wake/cooldown handling, heartbeat prompts and due-only task mode, and related heartbeat and commitments behavior.
           - name: Wake and cooldown handling
-            coverageIds: [wake-and-cooldown-handling]
+            coverageIds: [automation.wake-and-cooldown-handling]
             description: Covers Wake and cooldown handling across periodic heartbeat runs, active-hours and variable schedule behavior, wake/cooldown handling, heartbeat prompts and due-only task mode, and related heartbeat and commitments behavior.
           - name: Due-only heartbeat tasks
-            coverageIds: [due-only-heartbeat-tasks]
+            coverageIds: [automation.due-only-heartbeat-tasks]
             description: Covers Due-only heartbeat tasks across periodic heartbeat runs, active-hours and variable schedule behavior, wake/cooldown handling, heartbeat prompts and due-only task mode, and related heartbeat and commitments behavior.
           - name: Commitment check-ins
             coverageIds: [commitments.heartbeat-target-none, commitments.scope, runtime.delivery]
@@ -2593,34 +2593,34 @@ surfaces:
         id: polling-controls
         features:
           - name: openclaw message poll
-            coverageIds: [openclaw-message-poll]
+            coverageIds: [automation.openclaw-message-poll]
             description: Covers openclaw message poll across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
           - name: Telegram polls
-            coverageIds: [telegram-polls]
+            coverageIds: [automation.telegram-polls]
             description: Covers Telegram polls across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
           - name: Teams polls
-            coverageIds: [teams-polls]
+            coverageIds: [automation.teams-polls]
             description: Covers Teams polls across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
           - name: Poll flags
-            coverageIds: [poll-flags]
+            coverageIds: [automation.poll-flags]
             description: Covers Poll flags across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
           - name: Channel capability gates
-            coverageIds: [channel-capability-gates]
+            coverageIds: [automation.channel-capability-gates]
             description: Covers Channel capability gates across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
           - name: process poll
-            coverageIds: [process-poll]
+            coverageIds: [automation.process-poll]
             description: Covers process poll across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
           - name: process log
-            coverageIds: [process-log]
+            coverageIds: [automation.process-log]
             description: Covers process log across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
           - name: Background process status
-            coverageIds: [background-process-status]
+            coverageIds: [automation.background-process-status]
             description: Covers Background process status across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
           - name: No-progress loop detection
-            coverageIds: [no-progress-loop-detection]
+            coverageIds: [automation.no-progress-loop-detection]
             description: Covers No-progress loop detection across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
           - name: Process input controls
-            coverageIds: [process-input-controls]
+            coverageIds: [automation.process-input-controls]
             description: Covers Process input controls across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
         docs:
           - docs/automation/poll.md
@@ -2657,28 +2657,28 @@ surfaces:
         id: media-intake-and-access
         features:
           - name: Local and remote media references
-            coverageIds: [local-and-remote-media-references]
+            coverageIds: [media.local-and-remote-media-references]
             description: 'Covers Local and remote media references across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
           - name: MIME and type detection
-            coverageIds: [mime-and-type-detection]
+            coverageIds: [media.mime-and-type-detection]
             description: 'Covers MIME and type detection across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
           - name: Size caps and bounded reads
-            coverageIds: [size-caps-and-bounded-reads]
+            coverageIds: [media.size-caps-and-bounded-reads]
             description: 'Covers Size caps and bounded reads across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
           - name: Safe remote fetch
-            coverageIds: [safe-remote-fetch]
+            coverageIds: [media.safe-remote-fetch]
             description: 'Covers Safe remote fetch across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
           - name: Local root policy
-            coverageIds: [local-root-policy]
+            coverageIds: [media.local-root-policy]
             description: 'Covers Local root policy across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
           - name: Inbound media store
-            coverageIds: [inbound-media-store]
+            coverageIds: [media.inbound-media-store]
             description: 'Covers Inbound media store across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
           - name: PDF/document extraction dispatch
-            coverageIds: [pdf-document-extraction-dispatch]
+            coverageIds: [media.pdf-document-extraction-dispatch]
             description: 'Covers PDF/document extraction dispatch across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
           - name: QR and media helper classification
-            coverageIds: [qr-and-media-helper-classification]
+            coverageIds: [media.qr-and-media-helper-classification]
             description: 'Covers QR and media helper classification across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
         docs:
           - docs/tools/media-overview.md
@@ -2704,19 +2704,19 @@ surfaces:
         id: channel-media-handling
         features:
           - name: Inbound attachment staging
-            coverageIds: [inbound-attachment-staging]
+            coverageIds: [media.inbound-attachment-staging]
             description: Covers Inbound attachment staging across inbound attachment staging, sandbox rewrites, `MediaPath`/`MediaPaths`/`MediaUrls` templating, media notes, and related channel attachment staging and reply media delivery behavior.
           - name: Sandbox media rewrites
-            coverageIds: [sandbox-media-rewrites]
+            coverageIds: [media.sandbox-media-rewrites]
             description: Covers Sandbox media rewrites across inbound attachment staging, sandbox rewrites, `MediaPath`/`MediaPaths`/`MediaUrls` templating, media notes, and related channel attachment staging and reply media delivery behavior.
           - name: Reply media templating
-            coverageIds: [reply-media-templating]
+            coverageIds: [media.reply-media-templating]
             description: Covers Reply media templating across inbound attachment staging, sandbox rewrites, `MediaPath`/`MediaPaths`/`MediaUrls` templating, media notes, and related channel attachment staging and reply media delivery behavior.
           - name: Message-tool attachment delivery
-            coverageIds: [message-tool-attachment-delivery]
+            coverageIds: [media.message-tool-attachment-delivery]
             description: Covers Message-tool attachment delivery across inbound attachment staging, sandbox rewrites, `MediaPath`/`MediaPaths`/`MediaUrls` templating, media notes, and related channel attachment staging and reply media delivery behavior.
           - name: Duplicate delivery suppression
-            coverageIds: [duplicate-delivery-suppression]
+            coverageIds: [media.duplicate-delivery-suppression]
             description: Covers Duplicate delivery suppression across inbound attachment staging, sandbox rewrites, `MediaPath`/`MediaPaths`/`MediaUrls` templating, media notes, and related channel attachment staging and reply media delivery behavior.
         docs:
           - docs/nodes/images.md
@@ -2737,7 +2737,7 @@ surfaces:
         id: media-configuration
         features:
           - name: Media capability configuration
-            coverageIds: [media-capability-configuration]
+            coverageIds: [media.capability-configuration]
             description: tools.media image/audio/video config, shared and per-capability media model entries, provider/CLI entry resolution, auth-backed capability selection, fallback ordering, scope rules, concurrency, active-model skip behavior, offloaded image routing, image generation tool factory availability, image generation task status/list/duplicate guard, and generated-media delivery into the reply pipeline
         docs:
           - docs/tools/media-overview.md
@@ -2753,10 +2753,10 @@ surfaces:
         id: text-to-speech-delivery
         features:
           - name: TTS
-            coverageIds: [tts]
+            coverageIds: [media.tts]
             description: Covers TTS across `tts` agent/tool and Gateway methods, `messages.tts`, provider registry, directives, and related tts and outbound voice audio delivery behavior.
           - name: Outbound Voice Audio Delivery
-            coverageIds: [outbound-voice-audio-delivery]
+            coverageIds: [media.outbound-voice-audio-delivery]
             description: Covers Outbound Voice Audio Delivery across `tts` agent/tool and Gateway methods, `messages.tts`, provider registry, directives, and related tts and outbound voice audio delivery behavior.
         docs:
           - docs/tools/tts.md
@@ -2773,40 +2773,40 @@ surfaces:
         id: media-understanding
         features:
           - name: Audio attachment selection
-            coverageIds: [audio-attachment-selection]
+            coverageIds: [media.audio-attachment-selection]
             description: Covers Audio attachment selection across batch audio/STT media understanding, local CLI fallbacks, provider transcription, voice-note preflight before mention gates, and related audio transcription and voice note understanding behavior.
           - name: Batch STT provider and CLI fallback
-            coverageIds: [batch-stt-provider-and-cli-fallback]
+            coverageIds: [media.batch-stt-provider-and-cli-fallback]
             description: Covers Batch STT provider and CLI fallback across batch audio/STT media understanding, local CLI fallbacks, provider transcription, voice-note preflight before mention gates, and related audio transcription and voice note understanding behavior.
           - name: Voice-note mention preflight
-            coverageIds: [voice-note-mention-preflight]
+            coverageIds: [media.voice-note-mention-preflight]
             description: Covers Voice-note mention preflight across batch audio/STT media understanding, local CLI fallbacks, provider transcription, voice-note preflight before mention gates, and related audio transcription and voice note understanding behavior.
           - name: Transcript insertion and echo
-            coverageIds: [transcript-insertion-and-echo]
+            coverageIds: [media.transcript-insertion-and-echo]
             description: Covers Transcript insertion and echo across batch audio/STT media understanding, local CLI fallbacks, provider transcription, voice-note preflight before mention gates, and related audio transcription and voice note understanding behavior.
           - name: Audio proxy and limit handling
-            coverageIds: [audio-proxy-and-limit-handling]
+            coverageIds: [media.audio-proxy-and-limit-handling]
             description: Covers Audio proxy and limit handling across batch audio/STT media understanding, local CLI fallbacks, provider transcription, voice-note preflight before mention gates, and related audio transcription and voice note understanding behavior.
           - name: Inbound image summarization
             coverageIds: [channels.qa-channel, media.image-understanding, ui.control]
             description: Covers Inbound image summarization across image summarization before reply routing, active-model vision skip behavior, text-only model offload through `MediaPaths`/`media://inbound`, image-model fallback resolution, and related image understanding and vision routing behavior.
           - name: Active vision model bypass
-            coverageIds: [active-vision-model-bypass]
+            coverageIds: [media.active-vision-model-bypass]
             description: Covers Active vision model bypass across image summarization before reply routing, active-model vision skip behavior, text-only model offload through `MediaPaths`/`media://inbound`, image-model fallback resolution, and related image understanding and vision routing behavior.
           - name: Text-only model media offload
-            coverageIds: [text-only-model-media-offload]
+            coverageIds: [media.text-only-model-media-offload]
             description: Covers Text-only model media offload across image summarization before reply routing, active-model vision skip behavior, text-only model offload through `MediaPaths`/`media://inbound`, image-model fallback resolution, and related image understanding and vision routing behavior.
           - name: Vision provider fallback
-            coverageIds: [vision-provider-fallback]
+            coverageIds: [media.vision-provider-fallback]
             description: Covers Vision provider fallback across image summarization before reply routing, active-model vision skip behavior, text-only model offload through `MediaPaths`/`media://inbound`, image-model fallback resolution, and related image understanding and vision routing behavior.
           - name: Image and PDF input routing
-            coverageIds: [image-and-pdf-input-routing]
+            coverageIds: [media.image-and-pdf-input-routing]
             description: Covers Image and PDF input routing across image summarization before reply routing, active-model vision skip behavior, text-only model offload through `MediaPaths`/`media://inbound`, image-model fallback resolution, and related image understanding and vision routing behavior.
           - name: Video Understanding
-            coverageIds: [video-understanding]
+            coverageIds: [media.video-understanding]
             description: Covers Video Understanding across video summarization before reply routing, provider/CLI video media entries, size and timeout controls, proxy support, video request construction, and direct video analysis paths. It does not score video generation.
           - name: Direct Video Analysis
-            coverageIds: [direct-video-analysis]
+            coverageIds: [media.direct-video-analysis]
             description: Covers Direct Video Analysis across video summarization before reply routing, provider/CLI video media entries, size and timeout controls, proxy support, video request construction, and direct video analysis paths. It does not score video generation.
         docs:
           - docs/nodes/audio.md
@@ -2846,49 +2846,49 @@ surfaces:
             coverageIds: [media.image-generation, tools.native-image-generation]
             description: Covers image generation provider and model routing across `image_generate`, provider registration, provider capability listing, and related image generation tool behavior.
           - name: Reference image editing
-            coverageIds: [reference-image-editing]
+            coverageIds: [media.reference-image-editing]
             description: Covers Reference image editing across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
           - name: Generated image task lifecycle
-            coverageIds: [generated-image-task-lifecycle]
+            coverageIds: [media.generated-image-task-lifecycle]
             description: Covers Generated image task lifecycle across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
           - name: Generated image persistence and delivery
-            coverageIds: [generated-image-persistence-and-delivery]
+            coverageIds: [media.image-generation-delivery]
             description: Covers Generated image persistence and delivery across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
           - name: Music generation tool invocation
-            coverageIds: [music-generation-tool-invocation]
+            coverageIds: [media.music-generation-tool-invocation]
             description: Covers Music generation tool invocation across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation tool and provider routing behavior.
           - name: Music generation provider controls
-            coverageIds: [music-generation-provider-controls]
+            coverageIds: [media.music-generation-provider-controls]
             description: Covers music generation provider and model controls across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation routing behavior.
           - name: Lyrics, instrumental, duration, and format controls
-            coverageIds: [lyrics-instrumental-duration-and-format-controls]
+            coverageIds: [media.lyrics-instrumental-duration-and-format-controls]
             description: Covers Lyrics, instrumental, duration, and format controls across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation tool and provider routing behavior.
           - name: Reference inputs where supported
-            coverageIds: [reference-inputs-where-supported]
+            coverageIds: [media.reference-inputs-where-supported]
             description: Covers Reference inputs where supported across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation tool and provider routing behavior.
           - name: Music task lifecycle and duplicate status
-            coverageIds: [music-task-lifecycle-and-duplicate-status]
+            coverageIds: [media.music-task-lifecycle-and-duplicate-status]
             description: Covers Music task lifecycle and duplicate status across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation tool and provider routing behavior.
           - name: Generated audio persistence and delivery
             coverageIds: [tools.tts]
             description: Covers Generated audio persistence and delivery across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation tool and provider routing behavior.
           - name: Video generation tool invocation
-            coverageIds: [video-generation-tool-invocation]
+            coverageIds: [media.video-generation-tool-invocation]
             description: Covers Video generation tool invocation across `video_generate`, mode resolution, provider capabilities, reference image/video/audio inputs, and related video generation tool and provider routing behavior.
           - name: Mode and provider capability selection
-            coverageIds: [mode-and-provider-capability-selection]
+            coverageIds: [media.mode-and-provider-capability-selection]
             description: Covers Mode and provider capability selection across `video_generate`, mode resolution, provider capabilities, reference image/video/audio inputs, and related video generation tool and provider routing behavior.
           - name: Reference image, video, and audio inputs
-            coverageIds: [reference-image-video-and-audio-inputs]
+            coverageIds: [media.reference-image-video-and-audio-inputs]
             description: Covers Reference image, video, and audio inputs across `video_generate`, mode resolution, provider capabilities, reference image/video/audio inputs, and related video generation tool and provider routing behavior.
           - name: Provider option validation
-            coverageIds: [provider-option-validation]
+            coverageIds: [media.provider-option-validation]
             description: Covers Provider option validation across `video_generate`, mode resolution, provider capabilities, reference image/video/audio inputs, and related video generation tool and provider routing behavior.
           - name: Video task lifecycle and status
-            coverageIds: [video-task-lifecycle-and-status]
+            coverageIds: [media.video-task-lifecycle-and-status]
             description: Covers Video task lifecycle and status across `video_generate`, mode resolution, provider capabilities, reference image/video/audio inputs, and related video generation tool and provider routing behavior.
           - name: Generated video persistence and delivery
-            coverageIds: [generated-video-persistence-and-delivery]
+            coverageIds: [media.generated-video-persistence-and-delivery]
             description: Covers Generated video persistence and delivery across `video_generate`, mode resolution, provider capabilities, reference image/video/audio inputs, and related video generation tool and provider routing behavior.
         docs:
           - docs/tools/image-generation.md
@@ -2937,25 +2937,25 @@ surfaces:
         id: talk-providers
         features:
           - name: OpenAI Realtime voice backend bridge
-            coverageIds: [openai-realtime-voice-backend-bridge]
+            coverageIds: [voice.openai-realtime-voice-backend-bridge]
             description: OpenAI Realtime voice backend bridge and browser WebRTC credential path
           - name: Google Gemini Live backend bridge
-            coverageIds: [google-gemini-live-backend-bridge]
+            coverageIds: [voice.google-gemini-live-backend-bridge]
             description: Google Gemini Live backend bridge and browser token/WebSocket path
           - name: Realtime voice provider SDK contracts
-            coverageIds: [realtime-voice-provider-sdk-contracts]
+            coverageIds: [voice.realtime-voice-provider-sdk-contracts]
             description: Realtime voice provider SDK contracts, activation metadata, provider registry, and resolver
           - name: Provider diagnostics
-            coverageIds: [provider-diagnostics]
+            coverageIds: [models.diagnostics]
             description: Provider diagnostics, reconnect behavior, tool declarations, and bridge session lifecycle
           - name: Talk catalog
-            coverageIds: [talk-catalog]
+            coverageIds: [voice.talk-catalog]
             description: Talk catalog discovery for transport, brain, speech, realtime voice, and transcription providers.
           - name: Talk provider config
-            coverageIds: [talk-provider-config]
+            coverageIds: [voice.talk-provider-config]
             description: Talk provider selection, provider-specific realtime settings, and secret exposure rules.
           - name: Shared native config parsing
-            coverageIds: [shared-native-config-parsing]
+            coverageIds: [voice.shared-native-config-parsing]
             description: Shared native config parsing for macOS, iOS, and Android
         docs:
           - docs/providers/openai.md
@@ -2975,37 +2975,37 @@ surfaces:
         id: realtime-talk-sessions
         features:
           - name: Agent consult handoff
-            coverageIds: [agent-consult-handoff]
+            coverageIds: [voice.agent-consult-handoff]
             description: Consult handoff behavior between active Talk sessions and agent runs.
           - name: Active Talk agent-run status
-            coverageIds: [active-talk-agent-run-status]
+            coverageIds: [voice.active-talk-agent-run-status]
             description: Active Talk agent-run status, cancel, steer, and follow-up controls
           - name: Talkback runtime behavior
-            coverageIds: [talkback-runtime-behavior]
+            coverageIds: [voice.talkback-runtime-behavior]
             description: Talkback runtime behavior and assistant speech coordination
           - name: Forced consult scheduling
-            coverageIds: [forced-consult-scheduling]
+            coverageIds: [voice.forced-consult-scheduling]
             description: Forced consult scheduling and control event propagation
           - name: Browser Talk start/stop UI
-            coverageIds: [browser-talk-start-stop-ui]
+            coverageIds: [voice.browser-talk-start-stop-ui]
             description: Browser Talk start/stop UI and status display
           - name: Browser WebRTC sessions
-            coverageIds: [browser-webrtc-sessions]
+            coverageIds: [voice.browser-webrtc-sessions]
             description: Browser WebRTC sessions for OpenAI Realtime and Google Live providers.
           - name: Browser relay mode
-            coverageIds: [browser-relay-mode]
+            coverageIds: [voice.browser-relay-mode]
             description: Browser relay mode for backend-only realtime providers.
           - name: Browser tool-call forwarding
-            coverageIds: [browser-tool-call-forwarding]
+            coverageIds: [voice.browser-tool-call-forwarding]
             description: Browser tool-call forwarding, transcript events, and audio playback
           - name: Realtime session controls
-            coverageIds: [realtime-session-controls]
+            coverageIds: [voice.realtime-session-controls]
             description: Realtime session create, audio append, turn cancellation, steering, tool-result submission, and close controls.
           - name: Gateway relay sessions
-            coverageIds: [gateway-relay-sessions]
+            coverageIds: [voice.gateway-relay-sessions]
             description: Gateway relay sessions for realtime voice and transcription flows.
           - name: Audio-frame limits
-            coverageIds: [audio-frame-limits]
+            coverageIds: [voice.audio-frame-limits]
             description: Audio-frame limits, session TTL, per-connection/global caps, transcript events, and relay cleanup
         docs:
           - docs/nodes/talk.md
@@ -3027,19 +3027,19 @@ surfaces:
         id: speech-and-transcription
         features:
           - name: Voice directives
-            coverageIds: [voice-directives]
+            coverageIds: [voice.directives]
             description: Voice directives and directive stripping before TTS playback.
           - name: Talk speech playback
-            coverageIds: [talk-speech-playback]
+            coverageIds: [voice.talk-speech-playback]
             description: Gateway talk.speak and fallback TTS behavior.
           - name: Transcription relay sessions
-            coverageIds: [transcription-relay-sessions]
+            coverageIds: [voice.transcription-relay-sessions]
             description: Gateway transcription relay sessions, transcript events, and cleanup behavior.
           - name: Realtime transcription providers
-            coverageIds: [realtime-transcription-providers]
+            coverageIds: [models.realtime-transcription-providers]
             description: Realtime transcription provider selection, diagnostics, and provider-specific bridge behavior.
           - name: Native directive parsing
-            coverageIds: [native-directive-parsing]
+            coverageIds: [voice.native-directive-parsing]
             description: Native directive parsing and Talk speech locale behavior
         docs:
           - docs/nodes/talk.md
@@ -3055,16 +3055,16 @@ surfaces:
         id: native-app-talk
         features:
           - name: macOS native Talk mode
-            coverageIds: [macos-native-talk-mode]
+            coverageIds: [voice.macos-native-talk-mode]
             description: macOS native Talk mode, speech recognition, TTS playback, and push-to-talk handoff
           - name: iOS Talk mode
-            coverageIds: [ios-talk-mode]
+            coverageIds: [voice.ios-talk-mode]
             description: iOS Talk mode, WebRTC sessions, realtime relay sessions, and wake preferences
           - name: Android Talk mode
-            coverageIds: [android-talk-mode]
+            coverageIds: [voice.android-talk-mode]
             description: Android Talk mode, speech-recognizer mode, realtime relay, mic capture, and debug E2E receiver
           - name: Shared Talk config
-            coverageIds: [shared-talk-config]
+            coverageIds: [voice.shared-talk-config]
             description: Shared Talk config and command parsing
         docs:
           - docs/nodes/talk.md
@@ -3079,16 +3079,16 @@ surfaces:
         id: voice-wake-and-routing
         features:
           - name: Wake-word settings
-            coverageIds: [wake-word-settings]
+            coverageIds: [voice.wake-word-settings]
             description: Gateway-owned wake-word settings and routing preferences.
           - name: Wake routing
-            coverageIds: [wake-routing]
+            coverageIds: [voice.wake-routing]
             description: Default, last-focused app, local app, and specific-node routing methods.
           - name: macOS Voice Wake runtime
-            coverageIds: [macos-voice-wake-runtime]
+            coverageIds: [voice.macos-voice-wake-runtime]
             description: macOS Voice Wake runtime, push-to-talk hotkey, overlay adoption, pause/resume behavior, and forwarding
           - name: Mobile wake preferences
-            coverageIds: [mobile-wake-preferences]
+            coverageIds: [voice.mobile-wake-preferences]
             description: iOS and Android wake preferences and command extraction.
         docs:
           - docs/nodes/voicewake.md
@@ -3104,19 +3104,19 @@ surfaces:
         id: talk-observability
         features:
           - name: Talk event logging
-            coverageIds: [talk-event-logging]
+            coverageIds: [voice.talk-event-logging]
             description: Talk event logging and diagnostics event mapping
           - name: Session-log health
-            coverageIds: [session-log-health]
+            coverageIds: [voice.session-log-health]
             description: Session-log health, transcript records, bridge events, and echo/output suppression timing
           - name: Live smoke output
-            coverageIds: [live-smoke-output]
+            coverageIds: [voice.live-smoke-output]
             description: Live smoke output and provider event inspection
           - name: Prometheus diagnostic counters
-            coverageIds: [prometheus-diagnostic-counters]
+            coverageIds: [voice.prometheus-diagnostic-counters]
             description: Prometheus diagnostic counters for Talk events
           - name: Operator visibility into setup
-            coverageIds: [operator-visibility-into-setup]
+            coverageIds: [voice.operator-visibility-into-setup]
             description: Operator visibility into setup, latency, and failure modes
         docs:
           - docs/web/control-ui.md
@@ -3146,19 +3146,19 @@ surfaces:
         id: browser-realtime-talk
         features:
           - name: Browser Talk start/stop
-            coverageIds: [browser-talk-start-stop]
+            coverageIds: [ui.browser-talk-start-stop]
             description: Covers Browser Talk start/stop across browser Talk controls, Talk options, OpenAI browser WebRTC, Google Live/provider WebSocket, and related browser realtime talk behavior.
           - name: Provider session selection
-            coverageIds: [provider-session-selection]
+            coverageIds: [ui.provider-session-selection]
             description: Covers Provider session selection across browser Talk controls, Talk options, OpenAI browser WebRTC, Google Live/provider WebSocket, and related browser realtime talk behavior.
           - name: Gateway relay audio
-            coverageIds: [gateway-relay-audio]
+            coverageIds: [ui.gateway-relay-audio]
             description: Covers Gateway relay audio across browser Talk controls, Talk options, OpenAI browser WebRTC, Google Live/provider WebSocket, and related browser realtime talk behavior.
           - name: Tool-call consults
-            coverageIds: [tool-call-consults]
+            coverageIds: [ui.tool-call-consults]
             description: Covers Tool-call consults across browser Talk controls, Talk options, OpenAI browser WebRTC, Google Live/provider WebSocket, and related browser realtime talk behavior.
           - name: Steer and cancel
-            coverageIds: [steer-and-cancel]
+            coverageIds: [ui.steer-and-cancel]
             description: Covers Steer and cancel across browser Talk controls, Talk options, OpenAI browser WebRTC, Google Live/provider WebSocket, and related browser realtime talk behavior.
         docs:
           - docs/web/control-ui.md
@@ -3179,19 +3179,19 @@ surfaces:
         id: browser-access-and-trust
         features:
           - name: Device pairing
-            coverageIds: [device-pairing]
+            coverageIds: [ui.device-pairing]
             description: Covers Device pairing across Control UI/WebChat Gateway connection setup, browser-origin checks, token/password auth, trusted-proxy and Tailscale Serve auth, and related gateway connection, auth, device pairing, and remote origins behavior.
           - name: Token/password auth
-            coverageIds: [token-password-auth]
+            coverageIds: [ui.token-password-auth]
             description: Covers Token/password auth across Control UI/WebChat Gateway connection setup, browser-origin checks, token/password auth, trusted-proxy and Tailscale Serve auth, and related gateway connection, auth, device pairing, and remote origins behavior.
           - name: Tailscale Serve auth
-            coverageIds: [tailscale-serve-auth]
+            coverageIds: [ui.tailscale-serve-auth]
             description: Covers Tailscale Serve auth across Control UI/WebChat Gateway connection setup, browser-origin checks, token/password auth, trusted-proxy and Tailscale Serve auth, and related gateway connection, auth, device pairing, and remote origins behavior.
           - name: Trusted proxy auth
-            coverageIds: [trusted-proxy-auth]
+            coverageIds: [security.trusted-proxy-auth]
             description: Covers Trusted proxy auth across Control UI/WebChat Gateway connection setup, browser-origin checks, token/password auth, trusted-proxy and Tailscale Serve auth, and related gateway connection, auth, device pairing, and remote origins behavior.
           - name: Allowed origins/gatewayUrl
-            coverageIds: [allowed-origins-gatewayurl]
+            coverageIds: [ui.allowed-origins-gatewayurl]
             description: Covers Allowed origins/gatewayUrl across Control UI/WebChat Gateway connection setup, browser-origin checks, token/password auth, trusted-proxy and Tailscale Serve auth, and related gateway connection, auth, device pairing, and remote origins behavior.
         docs:
           - docs/web/control-ui.md
@@ -3213,19 +3213,19 @@ surfaces:
         id: configuration
         features:
           - name: Config snapshots
-            coverageIds: [config-snapshots]
+            coverageIds: [ui.config-snapshots]
             description: Covers Config snapshots across `config.get`, `config.set`, `config.apply`, `config.patch`, and related config schema editing and safe writes behavior.
           - name: Schema form editing
-            coverageIds: [schema-form-editing]
+            coverageIds: [ui.schema-form-editing]
             description: Covers Schema form editing across `config.get`, `config.set`, `config.apply`, `config.patch`, and related config schema editing and safe writes behavior.
           - name: Raw JSON editing
-            coverageIds: [raw-json-editing]
+            coverageIds: [ui.raw-json-editing]
             description: Covers Raw JSON editing across `config.get`, `config.set`, `config.apply`, `config.patch`, and related config schema editing and safe writes behavior.
           - name: Base-hash guarded writes
-            coverageIds: [base-hash-guarded-writes]
+            coverageIds: [ui.base-hash-guarded-writes]
             description: Covers Base-hash guarded writes across `config.get`, `config.set`, `config.apply`, `config.patch`, and related config schema editing and safe writes behavior.
           - name: Apply and restart
-            coverageIds: [apply-and-restart]
+            coverageIds: [ui.apply-and-restart]
             description: Covers Apply and restart across `config.get`, `config.set`, `config.apply`, `config.patch`, and related config schema editing and safe writes behavior.
         docs:
           - docs/web/control-ui.md
@@ -3248,31 +3248,31 @@ surfaces:
             coverageIds: [channels.qa-channel, media.image-understanding, ui.control]
             description: Covers Gateway-hosted UI across serving the Control UI bundle from the Gateway, root and base-path routing, static asset MIME/cache behavior, public PWA assets, and related control ui shell and routing behavior.
           - name: Dashboard open/auth bootstrap
-            coverageIds: [dashboard-open-auth-bootstrap]
+            coverageIds: [ui.dashboard-auth-bootstrap]
             description: Covers Dashboard open/auth bootstrap across serving the Control UI bundle from the Gateway, root and base-path routing, static asset MIME/cache behavior, public PWA assets, and related control ui shell and routing behavior.
           - name: Base-path routing
-            coverageIds: [base-path-routing]
+            coverageIds: [ui.base-path-routing]
             description: Covers Base-path routing across serving the Control UI bundle from the Gateway, root and base-path routing, static asset MIME/cache behavior, public PWA assets, and related control ui shell and routing behavior.
           - name: Static asset recovery
-            coverageIds: [static-asset-recovery]
+            coverageIds: [ui.static-asset-recovery]
             description: Covers Static asset recovery across serving the Control UI bundle from the Gateway, root and base-path routing, static asset MIME/cache behavior, public PWA assets, and related control ui shell and routing behavior.
           - name: Dev gatewayUrl target
-            coverageIds: [dev-gatewayurl-target]
+            coverageIds: [ui.dev-gatewayurl-target]
             description: Covers Dev gatewayUrl target across serving the Control UI bundle from the Gateway, root and base-path routing, static asset MIME/cache behavior, public PWA assets, and related control ui shell and routing behavior.
           - name: PWA install metadata
-            coverageIds: [pwa-install-metadata]
+            coverageIds: [ui.pwa-install-metadata]
             description: Covers PWA install metadata across browser PWA install metadata, production service-worker registration, push event handling, notification-click behavior, and related pwa install and web push notifications behavior.
           - name: Service worker updates
-            coverageIds: [service-worker-updates]
+            coverageIds: [ui.service-worker-updates]
             description: Covers Service worker updates across browser PWA install metadata, production service-worker registration, push event handling, notification-click behavior, and related pwa install and web push notifications behavior.
           - name: VAPID keys
-            coverageIds: [vapid-keys]
+            coverageIds: [ui.vapid-keys]
             description: Covers VAPID keys across browser PWA install metadata, production service-worker registration, push event handling, notification-click behavior, and related pwa install and web push notifications behavior.
           - name: Subscribe/unsubscribe
-            coverageIds: [subscribe-unsubscribe]
+            coverageIds: [ui.subscribe-unsubscribe]
             description: Covers Subscribe/unsubscribe across browser PWA install metadata, production service-worker registration, push event handling, notification-click behavior, and related pwa install and web push notifications behavior.
           - name: Test notifications
-            coverageIds: [test-notifications]
+            coverageIds: [ui.test-notifications]
             description: Covers Test notifications across browser PWA install metadata, production service-worker registration, push event handling, notification-click behavior, and related pwa install and web push notifications behavior.
         docs:
           - docs/web/control-ui.md
@@ -3299,49 +3299,49 @@ surfaces:
         id: webchat-conversations
         features:
           - name: Send and abort
-            coverageIds: [send-and-abort]
+            coverageIds: [ui.send-and-abort]
             description: 'Covers Send and abort across browser chat composition and display UX after an authenticated Gateway connection exists: composer controls, slash commands, session and agent filtering, model/thinking overrides, and related chat composer and message rendering behavior.'
           - name: Session and agent picker
-            coverageIds: [session-and-agent-picker]
+            coverageIds: [ui.session-and-agent-picker]
             description: 'Covers Session and agent picker across browser chat composition and display UX after an authenticated Gateway connection exists: composer controls, slash commands, session and agent filtering, model/thinking overrides, and related chat composer and message rendering behavior.'
           - name: Model/thinking controls
-            coverageIds: [model-thinking-controls]
+            coverageIds: [ui.model-thinking-controls]
             description: 'Covers Model/thinking controls across browser chat composition and display UX after an authenticated Gateway connection exists: composer controls, slash commands, session and agent filtering, model/thinking overrides, and related chat composer and message rendering behavior.'
           - name: Attachments
-            coverageIds: [attachments]
+            coverageIds: [ui.attachments]
             description: 'Covers Attachments across browser chat composition and display UX after an authenticated Gateway connection exists: composer controls, slash commands, session and agent filtering, model/thinking overrides, and related chat composer and message rendering behavior.'
           - name: Markdown/tool/media rendering
-            coverageIds: [markdown-tool-media-rendering]
+            coverageIds: [ui.markdown-tool-media-rendering]
             description: 'Covers Markdown/tool/media rendering across browser chat composition and display UX after an authenticated Gateway connection exists: composer controls, slash commands, session and agent filtering, model/thinking overrides, and related chat composer and message rendering behavior.'
           - name: chat.history projection
-            coverageIds: [chat-history-projection]
+            coverageIds: [ui.chat-history-projection]
             description: Covers chat.history projection across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
           - name: chat.send lifecycle
             coverageIds: [channels.qa-channel, channels.webchat, media.image-understanding, runtime.direct-reply-routing, tools.message, ui.control]
             description: Covers chat.send lifecycle across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
           - name: Abort/partial retention
-            coverageIds: [abort-partial-retention]
+            coverageIds: [ui.abort-partial-retention]
             description: Covers Abort/partial retention across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
           - name: Injected assistant notes
-            coverageIds: [injected-assistant-notes]
+            coverageIds: [ui.injected-assistant-notes]
             description: Covers Injected assistant notes across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
           - name: Reconnect continuity
-            coverageIds: [reconnect-continuity]
+            coverageIds: [ui.reconnect-continuity]
             description: Covers Reconnect continuity across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
           - name: Hosted embeds
-            coverageIds: [hosted-embeds]
+            coverageIds: [ui.hosted-embeds]
             description: Covers Hosted embeds across `[embed ...]` rendering policy, `gateway.controlUi.embedSandbox`, external embed URL gating, CSP and frame denial, and related hosted media and embed safety behavior.
           - name: External embed gating
-            coverageIds: [external-embed-gating]
+            coverageIds: [ui.external-embed-gating]
             description: Covers External embed gating across `[embed ...]` rendering policy, `gateway.controlUi.embedSandbox`, external embed URL gating, CSP and frame denial, and related hosted media and embed safety behavior.
           - name: Assistant media tickets
-            coverageIds: [assistant-media-tickets]
+            coverageIds: [ui.assistant-media-tickets]
             description: Covers Assistant media tickets across `[embed ...]` rendering policy, `gateway.controlUi.embedSandbox`, external embed URL gating, CSP and frame denial, and related hosted media and embed safety behavior.
           - name: Authenticated avatars
-            coverageIds: [authenticated-avatars]
+            coverageIds: [ui.authenticated-avatars]
             description: Covers Authenticated avatars across `[embed ...]` rendering policy, `gateway.controlUi.embedSandbox`, external embed URL gating, CSP and frame denial, and related hosted media and embed safety behavior.
           - name: CSP image policy
-            coverageIds: [csp-image-policy]
+            coverageIds: [ui.csp-image-policy]
             description: Covers CSP image policy across `[embed ...]` rendering policy, `gateway.controlUi.embedSandbox`, external embed URL gating, CSP and frame denial, and related hosted media and embed safety behavior.
         docs:
           - docs/web/control-ui.md
@@ -3374,34 +3374,34 @@ surfaces:
         id: operator-console
         features:
           - name: Health/status/models
-            coverageIds: [health-status-models]
+            coverageIds: [ui.health-status-models]
             description: Covers Health/status/models across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
           - name: Live log tail
-            coverageIds: [live-log-tail]
+            coverageIds: [ui.live-log-tail]
             description: Covers Live log tail across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
           - name: Update run/status
             coverageIds: [runtime.gateway-restart, runtime.package-update, runtime.update-run]
             description: Covers Update run/status across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
           - name: Activity summaries
-            coverageIds: [activity-summaries]
+            coverageIds: [ui.activity-summaries]
             description: Covers Activity summaries across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
           - name: RPC timing telemetry
-            coverageIds: [rpc-timing-telemetry]
+            coverageIds: [ui.rpc-timing-telemetry]
             description: Covers RPC timing telemetry across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
           - name: Channels/login
-            coverageIds: [channels-login]
+            coverageIds: [ui.channels-login]
             description: 'Covers Channels/login across non-config operator panels in the browser Control UI: channels and login, instances/presence, sessions, cron jobs, skills, nodes, exec approvals, agents, usage, dreams, and the dashboard navigation that surfaces them.'
           - name: Session manager and history
-            coverageIds: [session-manager-and-history]
+            coverageIds: [ui.session-manager-and-history]
             description: Covers browser Control UI session manager, session history, instance presence, approvals, diagnostics, and log tabs.
           - name: Cron
-            coverageIds: [cron]
+            coverageIds: [ui.cron]
             description: 'Covers Cron across non-config operator panels in the browser Control UI: channels and login, instances/presence, sessions, cron jobs, skills, nodes, exec approvals, agents, usage, dreams, and the dashboard navigation that surfaces them.'
           - name: Skills/nodes
-            coverageIds: [skills-nodes]
+            coverageIds: [ui.skills-nodes]
             description: 'Covers Skills/nodes across non-config operator panels in the browser Control UI: channels and login, instances/presence, sessions, cron jobs, skills, nodes, exec approvals, agents, usage, dreams, and the dashboard navigation that surfaces them.'
           - name: Exec approvals/agents
-            coverageIds: [exec-approvals-agents]
+            coverageIds: [ui.exec-approvals-agents]
             description: 'Covers Exec approvals/agents across non-config operator panels in the browser Control UI: channels and login, instances/presence, sessions, cron jobs, skills, nodes, exec approvals, agents, usage, dreams, and the dashboard navigation that surfaces them.'
         docs:
           - docs/web/control-ui.md
@@ -3443,46 +3443,46 @@ surfaces:
         id: runtime-modes
         features:
           - name: Gateway TUI launch
-            coverageIds: [gateway-tui-launch]
+            coverageIds: [tui.gateway-tui-launch]
             description: Covers Gateway TUI launch across `openclaw tui`, `openclaw chat`, `openclaw terminal`, local-vs-Gateway option validation, launch relaunching from setup/hatch paths, initial message and timeout flags, and launch docs.
           - name: Local chat launch
-            coverageIds: [local-chat-launch]
+            coverageIds: [tui.local-chat-launch]
             description: Covers Local chat launch across `openclaw tui`, `openclaw chat`, `openclaw terminal`, local-vs-Gateway option validation, launch relaunching from setup/hatch paths, initial message and timeout flags, and launch docs.
           - name: Terminal alias launch
-            coverageIds: [terminal-alias-launch]
+            coverageIds: [tui.terminal-alias-launch]
             description: Covers Terminal alias launch across `openclaw tui`, `openclaw chat`, `openclaw terminal`, local-vs-Gateway option validation, launch relaunching from setup/hatch paths, initial message and timeout flags, and launch docs.
           - name: Initial message launch
-            coverageIds: [initial-message-launch]
+            coverageIds: [tui.initial-message-launch]
             description: Covers Initial message launch across `openclaw tui`, `openclaw chat`, `openclaw terminal`, local-vs-Gateway option validation, launch relaunching from setup/hatch paths, initial message and timeout flags, and launch docs.
           - name: Launch option validation
-            coverageIds: [launch-option-validation]
+            coverageIds: [tui.launch-option-validation]
             description: Covers Launch option validation across `openclaw tui`, `openclaw chat`, `openclaw terminal`, local-vs-Gateway option validation, launch relaunching from setup/hatch paths, initial message and timeout flags, and launch docs.
           - name: Gateway connection
-            coverageIds: [gateway-connection]
+            coverageIds: [tui.gateway-connection]
             description: Covers Gateway connection across Gateway connection resolution, token/password/SecretRef auth for TUI, `--url` auth requirements, client mode/capability registration, and related gateway transport, auth, and history behavior.
           - name: Gateway authentication
-            coverageIds: [gateway-authentication]
+            coverageIds: [tui.gateway-authentication]
             description: Covers Gateway authentication across Gateway connection resolution, token/password/SecretRef auth for TUI, `--url` auth requirements, client mode/capability registration, and related gateway transport, auth, and history behavior.
           - name: History load on attach
-            coverageIds: [history-load-on-attach]
+            coverageIds: [tui.history-load-on-attach]
             description: Covers History load on attach across Gateway connection resolution, token/password/SecretRef auth for TUI, `--url` auth requirements, client mode/capability registration, and related gateway transport, auth, and history behavior.
           - name: Reconnect visibility
-            coverageIds: [reconnect-visibility]
+            coverageIds: [tui.reconnect-visibility]
             description: Covers Reconnect visibility across Gateway connection resolution, token/password/SecretRef auth for TUI, `--url` auth requirements, client mode/capability registration, and related gateway transport, auth, and history behavior.
           - name: Gateway command RPCs
-            coverageIds: [gateway-command-rpcs]
+            coverageIds: [tui.gateway-command-rpcs]
             description: Covers Gateway command RPCs across Gateway connection resolution, token/password/SecretRef auth for TUI, `--url` auth requirements, client mode/capability registration, and related gateway transport, auth, and history behavior.
           - name: Embedded local chat
-            coverageIds: [embedded-local-chat]
+            coverageIds: [tui.embedded-local-chat]
             description: Covers Embedded local chat across embedded backend lifecycle, local model catalog loading, local `chat.send` event projection, queued local runs, local session history, local `/auth`, local config repair docs, and Gateway-free recovery scenarios.
           - name: Local auth flow
-            coverageIds: [local-auth-flow]
+            coverageIds: [tui.local-auth-flow]
             description: Covers Local auth flow across embedded backend lifecycle, local model catalog loading, local `chat.send` event projection, queued local runs, local session history, local `/auth`, local config repair docs, and Gateway-free recovery scenarios.
           - name: Config repair loop
-            coverageIds: [config-repair-loop]
+            coverageIds: [tui.config-repair-loop]
             description: Covers Config repair loop across embedded backend lifecycle, local model catalog loading, local `chat.send` event projection, queued local runs, local session history, local `/auth`, local config repair docs, and Gateway-free recovery scenarios.
           - name: Gateway-free recovery
-            coverageIds: [gateway-free-recovery]
+            coverageIds: [tui.gateway-free-recovery]
             description: Covers Gateway-free recovery across embedded backend lifecycle, local model catalog loading, local `chat.send` event projection, queued local runs, local session history, local `/auth`, local config repair docs, and Gateway-free recovery scenarios.
         docs:
           - docs/cli/tui.md
@@ -3513,28 +3513,28 @@ surfaces:
         id: input-and-commands
         features:
           - name: Message composition
-            coverageIds: [message-composition]
+            coverageIds: [tui.message-composition]
             description: Covers Message composition across editor, submit handler, input history, slash/local shell routing, busy-submit behavior, paste fallback, backspace dedupe, Ctrl/Esc shortcuts, AltGr handling, and documented keyboard shortcuts.
           - name: Input history
-            coverageIds: [input-history]
+            coverageIds: [tui.input-history]
             description: Covers Input history across editor, submit handler, input history, slash/local shell routing, busy-submit behavior, paste fallback, backspace dedupe, Ctrl/Esc shortcuts, AltGr handling, and documented keyboard shortcuts.
           - name: Keyboard shortcuts
-            coverageIds: [keyboard-shortcuts]
+            coverageIds: [tui.keyboard-shortcuts]
             description: Covers Keyboard shortcuts across editor, submit handler, input history, slash/local shell routing, busy-submit behavior, paste fallback, backspace dedupe, Ctrl/Esc shortcuts, AltGr handling, and documented keyboard shortcuts.
           - name: Paste and busy-submit handling
-            coverageIds: [paste-and-busy-submit-handling]
+            coverageIds: [tui.paste-and-busy-submit-handling]
             description: Covers Paste and busy-submit handling across editor, submit handler, input history, slash/local shell routing, busy-submit behavior, paste fallback, backspace dedupe, Ctrl/Esc shortcuts, AltGr handling, and documented keyboard shortcuts.
           - name: IME and AltGr handling
-            coverageIds: [ime-and-altgr-handling]
+            coverageIds: [tui.ime-and-altgr-handling]
             description: Covers IME and AltGr handling across editor, submit handler, input history, slash/local shell routing, busy-submit behavior, paste fallback, backspace dedupe, Ctrl/Esc shortcuts, AltGr handling, and documented keyboard shortcuts.
           - name: Slash Commands
-            coverageIds: [slash-commands]
+            coverageIds: [slack.slash-commands]
             description: Covers Slash Commands across slash command parsing, command forwarding, local-only commands, model/agent/session selectors, settings overlay, context mode picker, dynamic Gateway command list, session patch commands, and command docs.
           - name: Pickers
-            coverageIds: [pickers]
+            coverageIds: [tui.pickers]
             description: Covers Pickers across slash command parsing, command forwarding, local-only commands, model/agent/session selectors, settings overlay, context mode picker, dynamic Gateway command list, session patch commands, and command docs.
           - name: Settings
-            coverageIds: [settings]
+            coverageIds: [tui.settings]
             description: Covers Settings across slash command parsing, command forwarding, local-only commands, model/agent/session selectors, settings overlay, context mode picker, dynamic Gateway command list, session patch commands, and command docs.
         docs:
           - docs/web/tui.md
@@ -3557,13 +3557,13 @@ surfaces:
         id: session-management
         features:
           - name: Session Lifecycle
-            coverageIds: [session-lifecycle]
+            coverageIds: [tui.session-lifecycle]
             description: Covers Session Lifecycle across session-key resolution, last selected session persistence, session picker policy, history loading, and related session lifecycle, history, and resume behavior.
           - name: History
-            coverageIds: [history]
+            coverageIds: [tui.history]
             description: Covers History across session-key resolution, last selected session persistence, session picker policy, history loading, and related session lifecycle, history, and resume behavior.
           - name: Resume
-            coverageIds: [resume]
+            coverageIds: [tui.resume]
             description: Covers Resume across session-key resolution, last selected session persistence, session picker policy, history loading, and related session lifecycle, history, and resume behavior.
         docs:
           - docs/web/tui.md
@@ -3580,16 +3580,16 @@ surfaces:
         id: local-shell-execution
         features:
           - name: Bang-command routing
-            coverageIds: [bang-command-routing]
+            coverageIds: [tui.bang-command-routing]
             description: Covers Bang-command routing across `!` routing, local exec approval prompt, Yes/No overlay, command execution, output capture and cap, exit/error rendering, environment marker, cwd handling, and docs that distinguish local host execution from Gateway execution.
           - name: Approval prompt
-            coverageIds: [approval-prompt]
+            coverageIds: [tui.approval-prompt]
             description: Covers Approval prompt across `!` routing, local exec approval prompt, Yes/No overlay, command execution, output capture and cap, exit/error rendering, environment marker, cwd handling, and docs that distinguish local host execution from Gateway execution.
           - name: Command output display
-            coverageIds: [command-output-display]
+            coverageIds: [tui.command-output-display]
             description: Covers Command output display across `!` routing, local exec approval prompt, Yes/No overlay, command execution, output capture and cap, exit/error rendering, environment marker, cwd handling, and docs that distinguish local host execution from Gateway execution.
           - name: Execution environment marker
-            coverageIds: [execution-environment-marker]
+            coverageIds: [tui.execution-environment-marker]
             description: Covers Execution environment marker across `!` routing, local exec approval prompt, Yes/No overlay, command execution, output capture and cap, exit/error rendering, environment marker, cwd handling, and docs that distinguish local host execution from Gateway execution.
         docs:
           - docs/web/tui.md
@@ -3609,16 +3609,16 @@ surfaces:
         id: rendering-and-output-safety
         features:
           - name: Streaming Message Rendering
-            coverageIds: [streaming-message-rendering]
+            coverageIds: [tui.streaming-message-rendering]
             description: Covers Streaming Message Rendering across chat log rendering, assistant stream assembly, final/error resolution, thinking visibility, and related streaming message rendering and tool cards behavior.
           - name: Tool Cards
-            coverageIds: [tool-cards]
+            coverageIds: [tui.tool-cards]
             description: Covers Tool Cards across chat log rendering, assistant stream assembly, final/error resolution, thinking visibility, and related streaming message rendering and tool cards behavior.
           - name: Terminal Rendering Primitives
-            coverageIds: [terminal-rendering-primitives]
+            coverageIds: [tui.terminal-rendering-primitives]
             description: 'Covers Terminal Rendering Primitives across shared terminal output helpers used by CLI/TUI surfaces: safe stream writing, text sanitization, ANSI/OSC handling, table wrapping, and related terminal rendering primitives and output safety behavior.'
           - name: Output Safety
-            coverageIds: [output-safety]
+            coverageIds: [tui.output-safety]
             description: 'Covers Output Safety across shared terminal output helpers used by CLI/TUI surfaces: safe stream writing, text sanitization, ANSI/OSC handling, table wrapping, and related terminal rendering primitives and output safety behavior.'
         docs:
           - docs/web/tui.md
@@ -3654,25 +3654,25 @@ surfaces:
         id: publishing
         features:
           - name: ClawHub package publishing owner
-            coverageIds: [clawhub-package-publishing-owner]
+            coverageIds: [clawhub.package-publishing-owner]
             description: ClawHub package publishing owner and scope rules
           - name: OpenClaw-owned package release validation for ClawHub
-            coverageIds: [openclaw-owned-package-release-validation-for-clawhub]
+            coverageIds: [clawhub.openclaw-owned-package-release-validation-for-clawhub]
             description: OpenClaw-owned package release validation for ClawHub and npm
           - name: Version bump gates
-            coverageIds: [version-bump-gates]
+            coverageIds: [clawhub.version-bump-gates]
             description: Version bump gates for changed publishable plugins
           - name: npm trusted publishing provenance
-            coverageIds: [npm-trusted-publishing-provenance]
+            coverageIds: [clawhub.npm-trusted-publishing-provenance]
             description: npm trusted publishing provenance metadata
           - name: External code plugin package contract required
-            coverageIds: [external-code-plugin-package-contract-required]
+            coverageIds: [clawhub.external-code-plugin-package-contract-required]
             description: External code plugin package contract required before publish
           - name: Skill package metadata
-            coverageIds: [skill-package-metadata]
+            coverageIds: [clawhub.skill-package-metadata]
             description: Publish-ready skill metadata, file limits, versions, and tags.
           - name: Skill publishing flow
-            coverageIds: [skill-publishing-flow]
+            coverageIds: [clawhub.skill-publishing-flow]
             description: Owner-scoped ClawHub skill publishing, validation, release, and review.
         docs:
           - docs/clawhub/publishing.md
@@ -3692,19 +3692,19 @@ surfaces:
         id: catalog-discovery
         features:
           - name: Plugin catalog search
-            coverageIds: [openclaw-plugins-search-as-the-clawhub]
+            coverageIds: [clawhub.openclaw-plugins-search-as-the-clawhub]
             description: OpenClaw plugin search resolves ClawHub package lookup results.
           - name: Search result metadata
-            coverageIds: [search-result-metadata]
+            coverageIds: [clawhub.search-result-metadata]
             description: Search results include package identity, channel, version, summary, compatibility, and source metadata.
           - name: Plugin and skill search separation
-            coverageIds: [distinction-between-plugin-search]
+            coverageIds: [clawhub.distinction-between-plugin-search]
             description: Plugin search and skill search stay distinct even when both use ClawHub metadata.
           - name: Catalog lookup failure
-            coverageIds: [catalog-lookup-failure]
+            coverageIds: [clawhub.catalog-lookup-failure]
             description: Catalog lookup failure and empty-result behavior
           - name: Skill catalog search
-            coverageIds: [skill-catalog-search]
+            coverageIds: [clawhub.skill-catalog-search]
             description: Search, list, inspect, and install ClawHub-tracked skills from the CLI.
         docs:
           - docs/tools/plugin.md
@@ -3722,40 +3722,40 @@ surfaces:
         id: compatibility-and-trust
         features:
           - name: openclaw.compat.pluginApi
-            coverageIds: [openclaw-compat-pluginapi]
+            coverageIds: [clawhub.openclaw-compat-pluginapi]
             description: openclaw.compat.pluginApi, build metadata, and host/gateway minimums
           - name: ClawHub package compatibility validation
-            coverageIds: [clawhub-package-compatibility-validation]
+            coverageIds: [clawhub.package-compatibility-validation]
             description: Evidence scope for ClawHub package compatibility validation.
           - name: npm compatibility fallback to the newest
-            coverageIds: [npm-compatibility-fallback-to-the-newest]
+            coverageIds: [clawhub.npm-compatibility-fallback-to-the-newest]
             description: npm compatibility fallback to the newest compatible stable version
           - name: Official external plugin catalog behavior
-            coverageIds: [official-external-plugin-catalog-behavior]
+            coverageIds: [clawhub.official-external-plugin-catalog-behavior]
             description: Official external plugin catalog behavior and bundled-to-external migration
           - name: Compatibility docs
-            coverageIds: [compatibility-docs]
+            coverageIds: [clawhub.compatibility-docs]
             description: Compatibility docs and deprecation registry
           - name: Operator trust model for installing
-            coverageIds: [operator-trust-model-for-installing]
+            coverageIds: [clawhub.operator-trust-model-for-installing]
             description: Operator trust model for installing and enabling external code
           - name: ClawHub archive
-            coverageIds: [clawhub-archive]
+            coverageIds: [clawhub.archive]
             description: ClawHub archive and ClawPack digest verification
           - name: npm integrity drift
-            coverageIds: [npm-integrity-drift]
+            coverageIds: [clawhub.npm-integrity-drift]
             description: npm integrity drift and managed install checks
           - name: Built-in dangerous-code scanner
-            coverageIds: [built-in-dangerous-code-scanner]
+            coverageIds: [clawhub.built-in-dangerous-code-scanner]
             description: Built-in dangerous-code scanner and break-glass override semantics
           - name: ClawHub publishing review/hidden-release behavior as upstream
-            coverageIds: [clawhub-publishing-review-hidden-release-behavior-as-upstream]
+            coverageIds: [clawhub.publishing-review-hidden-release-behavior-as-upstream]
             description: ClawHub publishing review/hidden-release behavior as upstream trust signal
           - name: Skill archive safety
-            coverageIds: [skill-archive-safety]
+            coverageIds: [clawhub.skill-archive-safety]
             description: Uploaded skill archives are gated and reuse extraction protections.
           - name: Skill audit signals
-            coverageIds: [skill-audit-signals]
+            coverageIds: [clawhub.skill-audit-signals]
             description: ClawHub audit status, risk, findings, and trust metadata apply to skill packages.
         docs:
           - docs/tools/plugin.md
@@ -3781,82 +3781,82 @@ surfaces:
         id: plugin-lifecycle-and-health
         features:
           - name: Source prefixes
-            coverageIds: [source-prefixes]
+            coverageIds: [clawhub.source-prefixes]
             description: Source prefixes and shorthand resolution cover ClawHub, npm, local, archive, and marketplace plugin sources.
           - name: Bare package launch behavior
-            coverageIds: [bare-package-behavior-during-the-launch]
+            coverageIds: [clawhub.bare-package-behavior-during-the-launch]
             description: Bare package behavior during the launch cutover
           - name: Explicit pinned versions
-            coverageIds: [explicit-pinned-versions]
+            coverageIds: [clawhub.explicit-pinned-versions]
             description: Explicit pinned versions, prerelease tags, and stable fallback behavior
           - name: Managed install records that preserve source
-            coverageIds: [managed-install-records-that-preserve-source]
+            coverageIds: [clawhub.managed-install-records-that-preserve-source]
             description: Managed install records that preserve source metadata for update/uninstall
           - name: Codex
-            coverageIds: [codex]
+            coverageIds: [clawhub.codex]
             description: Codex, Claude, and Cursor-compatible bundle detection
           - name: Local
-            coverageIds: [local]
+            coverageIds: [clawhub.local]
             description: Local, archive, and marketplace install paths
           - name: Marketplace list
-            coverageIds: [marketplace-list]
+            coverageIds: [clawhub.marketplace-list]
             description: Marketplace list, shortcut, and install flows
           - name: Supported mapped features
-            coverageIds: [supported-mapped-features]
+            coverageIds: [clawhub.supported-mapped-features]
             description: Supported mapped features and detected-but-not-executed capabilities
           - name: Remote marketplace path safety
-            coverageIds: [remote-marketplace-path-safety]
+            coverageIds: [clawhub.remote-marketplace-path-safety]
             description: Remote marketplace path safety and archive download guards
           - name: Update by plugin id
-            coverageIds: [update-by-plugin-id]
+            coverageIds: [clawhub.update-by-plugin-id]
             description: Update by plugin id, npm spec, ClawHub spec, beta channel, and marketplace
           - name: Reinstall vs update semantics
-            coverageIds: [reinstall-vs-update-semantics]
+            coverageIds: [clawhub.reinstall-vs-update-semantics]
             description: Evidence scope for Reinstall vs update semantics.
           - name: Downgrade
-            coverageIds: [downgrade]
+            coverageIds: [clawhub.downgrade]
             description: Downgrade and pinned selectors
           - name: Uninstall config/index/policy/file cleanup
-            coverageIds: [uninstall-config-index-policy-file-cleanup]
+            coverageIds: [clawhub.uninstall-config-index-policy-file-cleanup]
             description: Evidence scope for Uninstall config/index/policy/file cleanup.
           - name: Gateway restart and reload requirements
-            coverageIds: [gateway-restart-reload-requirements-after]
+            coverageIds: [clawhub.gateway-restart-reload-requirements-after]
             description: Gateway restart/reload requirements after install/update/uninstall
           - name: Per-plugin managed npm project
-            coverageIds: [per-plugin-managed-npm-project]
+            coverageIds: [clawhub.per-plugin-managed-npm-project]
             description: Per-plugin managed npm project roots
           - name: npm-pack local release-candidate installs
-            coverageIds: [npm-pack-local-release-candidate-installs]
+            coverageIds: [clawhub.npm-pack-local-release-candidate-installs]
             description: npm-pack local release-candidate installs through npm semantics
           - name: Dependency ownership between plugin packages
-            coverageIds: [dependency-ownership-between-plugin-packages]
+            coverageIds: [clawhub.dependency-ownership-between-plugin-packages]
             description: Dependency ownership between plugin packages and OpenClaw
           - name: Peer dependency relinking
-            coverageIds: [peer-dependency-relinking]
+            coverageIds: [clawhub.peer-dependency-relinking]
             description: Peer dependency relinking for openclaw/plugin-sdk/*
           - name: Legacy dependency root cleanup
-            coverageIds: [legacy-dependency-root-cleanup]
+            coverageIds: [clawhub.legacy-dependency-root-cleanup]
             description: Legacy dependency root cleanup and doctor repair
           - name: Plugin inventory commands
-            coverageIds: [plugins-list]
+            coverageIds: [clawhub.plugins-list]
             description: Plugin list, inspect, runtime inspect, and doctor commands expose operator inventory and diagnostics.
           - name: Local plugin index
-            coverageIds: [local-plugin-index]
+            coverageIds: [clawhub.local-plugin-index]
             description: Local plugin index and persisted cold registry state
           - name: Troubleshooting stale config
-            coverageIds: [troubleshooting-stale-config]
+            coverageIds: [clawhub.troubleshooting-stale-config]
             description: Troubleshooting covers stale config, blocked paths, dependencies, missing plugins, and repair guidance.
           - name: Runtime verification after Gateway
-            coverageIds: [runtime-verification-after-gateway]
+            coverageIds: [clawhub.runtime-verification-after-gateway]
             description: Runtime verification after Gateway restart
           - name: ClawHub skill installs
-            coverageIds: [clawhub-skill-installs]
+            coverageIds: [clawhub.skill-installs]
             description: Install and update ClawHub-tracked workspace or global skills.
           - name: Skill upload install path
-            coverageIds: [skill-upload-install-path]
+            coverageIds: [clawhub.skill-upload-install-path]
             description: Trusted private archive upload and install through skills upload APIs.
           - name: Skill dependency installers
-            coverageIds: [skill-dependency-installers]
+            coverageIds: [clawhub.skill-dependency-installers]
             description: Declared Brew, Node, Go, uv, or download installers for skill packages.
         docs:
           - docs/tools/plugin.md
@@ -3901,16 +3901,16 @@ surfaces:
         id: client-api
         features:
           - name: SDK entrypoints
-            coverageIds: [sdk-entrypoints]
+            coverageIds: [app-sdk.sdk-entrypoints]
             description: Public package imports and helper objects for external apps.
           - name: Namespace layout
-            coverageIds: [namespace-layout]
+            coverageIds: [app-sdk.namespace-layout]
             description: High-level and low-level namespaces such as agents and sessions.
           - name: Package split
-            coverageIds: [package-split]
+            coverageIds: [app-sdk.package-split]
             description: Core SDK, React helpers, and testing package boundaries.
           - name: App/plugin boundary
-            coverageIds: [app-plugin-boundary]
+            coverageIds: [app-sdk.app-plugin-boundary]
             description: Clear distinction between external app integrations and in-process plugin authoring.
         docs:
           - docs/concepts/openclaw-sdk.md
@@ -3927,19 +3927,19 @@ surfaces:
         id: gateway-access
         features:
           - name: Gateway connect
-            coverageIds: [gateway-connect]
+            coverageIds: [app-sdk.gateway-connect]
             description: SDK construction for explicit Gateway connections.
           - name: URL and token config
-            coverageIds: [url-and-token-config]
+            coverageIds: [app-sdk.url-and-token-config]
             description: URL, token, and auth inputs for external clients.
           - name: Auto gateway
-            coverageIds: [auto-gateway]
+            coverageIds: [app-sdk.auto-gateway]
             description: Automatic Gateway discovery behavior for supported environments.
           - name: Custom transport
-            coverageIds: [custom-transport]
+            coverageIds: [app-sdk.custom-transport]
             description: Transport injection for non-default client environments.
           - name: Scopes and redaction
-            coverageIds: [scopes-and-redaction]
+            coverageIds: [app-sdk.scopes-and-redaction]
             description: Token scopes, secret-forwarding defaults, and redaction boundaries.
         docs:
           - docs/concepts/openclaw-sdk.md
@@ -3959,22 +3959,22 @@ surfaces:
         id: agent-conversations
         features:
           - name: Agent handles
-            coverageIds: [agent-handles]
+            coverageIds: [app-sdk.agent-handles]
             description: SDK-side agent object creation and lookup.
           - name: Agent runs
-            coverageIds: [agent-runs]
+            coverageIds: [app-sdk.agent-runs]
             description: Agent execution path with streamed run events.
           - name: Run results
-            coverageIds: [run-results]
+            coverageIds: [app-sdk.run-results]
             description: Run result envelope, wait semantics, timeout handling, and result normalization.
           - name: Session creation
-            coverageIds: [session-creation]
+            coverageIds: [app-sdk.session-creation]
             description: Reusable session handle creation.
           - name: Session send
-            coverageIds: [session-send]
+            coverageIds: [app-sdk.session-send]
             description: Session transcript interaction from external apps.
           - name: Session controls
-            coverageIds: [session-controls]
+            coverageIds: [app-sdk.session-controls]
             description: Patch, abort, and compact operations.
         docs:
           - docs/concepts/openclaw-sdk.md
@@ -3994,19 +3994,19 @@ surfaces:
         id: events-and-approvals
         features:
           - name: Event stream
-            coverageIds: [event-stream]
+            coverageIds: [app-sdk.event-stream]
             description: SDK stream subscription for app-wide and per-run events.
           - name: Event envelope
-            coverageIds: [event-envelope]
+            coverageIds: [app-sdk.event-envelope]
             description: Stable event envelope for external clients.
           - name: Replay cursors
-            coverageIds: [replay-cursors]
+            coverageIds: [app-sdk.replay-cursors]
             description: Replayable event families with stable cursors.
           - name: Approval callbacks
-            coverageIds: [approval-callbacks]
+            coverageIds: [app-sdk.approval-callbacks]
             description: First-class approval handling for external apps.
           - name: Questions
-            coverageIds: [questions]
+            coverageIds: [app-sdk.questions]
             description: Question handling alongside approval flows.
         docs:
           - docs/concepts/openclaw-sdk.md
@@ -4025,19 +4025,19 @@ surfaces:
         id: resource-helpers
         features:
           - name: Models
-            coverageIds: [models]
+            coverageIds: [app-sdk.models]
             description: Typed model discovery helpers.
           - name: ToolSpace
-            coverageIds: [toolspace]
+            coverageIds: [app-sdk.toolspace]
             description: Tool discovery and invocation abstraction for external apps.
           - name: Artifact resources
             coverageIds: [workspace.artifacts, workspace.builds]
             description: SDK helpers for workspace artifact summaries, generated build outputs, retention metadata, and downloads.
           - name: Tasks
-            coverageIds: [tasks]
+            coverageIds: [app-sdk.tasks]
             description: SDK helpers around Gateway task APIs.
           - name: Environments
-            coverageIds: [environments]
+            coverageIds: [app-sdk.environments]
             description: Managed environment provider lifecycle and metadata.
         docs:
           - docs/concepts/openclaw-sdk.md
@@ -4054,19 +4054,19 @@ surfaces:
         id: compatibility
         features:
           - name: Generated client
-            coverageIds: [generated-client]
+            coverageIds: [app-sdk.generated-client]
             description: Client generation from Gateway schemas.
           - name: Ergonomic wrappers
-            coverageIds: [ergonomic-wrappers]
+            coverageIds: [app-sdk.ergonomic-wrappers]
             description: Handwritten wrappers layered on generated transport contracts.
           - name: Unsupported calls
-            coverageIds: [unsupported-calls]
+            coverageIds: [app-sdk.unsupported-calls]
             description: Explicit errors for unsupported environment mutations and future per-run overrides.
           - name: Schema alignment
-            coverageIds: [schema-alignment]
+            coverageIds: [app-sdk.schema-alignment]
             description: SDK behavior stays aligned with Gateway schemas.
           - name: Public package contract
-            coverageIds: [public-package-contract]
+            coverageIds: [app-sdk.public-package-contract]
             description: Package publication and reusable-client expectations tracked explicitly.
         docs:
           - docs/reference/openclaw-sdk-api-design.md
@@ -4099,16 +4099,16 @@ surfaces:
         id: cli-setup
         features:
           - name: Hosted installer
-            coverageIds: [hosted-installer]
+            coverageIds: [macos.hosted-installer]
             description: Hosted installer and local-prefix install paths on macOS
           - name: Node 24 recommendation
-            coverageIds: [node-24-recommendation]
+            coverageIds: [macos.node-24-recommendation]
             description: Node 24 recommendation and Node 22.19+ compatibility floor
           - name: App-triggered CLI install
-            coverageIds: [app-triggered-cli-install]
+            coverageIds: [macos.app-triggered-cli-install]
             description: App-triggered CLI install and runtime discovery
           - name: Shell PATH and version-manager drift
-            coverageIds: [shell-path-and-version-manager-drift]
+            coverageIds: [macos.shell-path-and-version-manager-drift]
             description: Shell PATH, package-manager, and version-manager drift that affect the host Gateway.
         docs:
           - docs/platforms/macos.md
@@ -4124,31 +4124,31 @@ surfaces:
         id: local-gateway-integration
         features:
           - name: App local/remote connection mode
-            coverageIds: [app-local-remote-connection-mode]
+            coverageIds: [macos.app-local-remote-connection-mode]
             description: App local/remote connection mode coordination
           - name: App-managed Gateway LaunchAgent install/restart/uninstall
-            coverageIds: [app-managed-gateway-launchagent-install-restart-uninstall]
+            coverageIds: [macos.app-managed-gateway-launchagent-install-restart-uninstall]
             description: App-managed Gateway LaunchAgent install/restart/uninstall through the CLI
           - name: CLI install detection
-            coverageIds: [cli-install-detection]
+            coverageIds: [macos.cli-install-detection]
             description: CLI install detection and app install prompt
           - name: Attach-to-existing local Gateway compatibility
-            coverageIds: [attach-to-existing-local-gateway-compatibility]
+            coverageIds: [macos.attach-to-existing-local-gateway-compatibility]
             description: Attach-to-existing local Gateway compatibility checks
           - name: Gateway endpoint
-            coverageIds: [gateway-endpoint]
+            coverageIds: [macos.gateway-endpoint]
             description: Gateway endpoint, credential, and control-channel resolution
           - name: gateway.mode=local configuration
-            coverageIds: [gateway-mode-local-configuration]
+            coverageIds: [macos.gateway-mode-local-configuration]
             description: gateway.mode=local configuration and defaulting during service install
           - name: Loopback bind
-            coverageIds: [loopback-bind]
+            coverageIds: [macos.loopback-bind]
             description: Loopback bind, explicit host/bind overrides, auth requirements, and port precedence
           - name: Local app endpoint resolution
-            coverageIds: [local-app-endpoint-resolution]
+            coverageIds: [macos.local-app-endpoint-resolution]
             description: Local app endpoint resolution, local control channel, and attach-to-existing Gateway behavior
           - name: Bonjour discovery
-            coverageIds: [bonjour-discovery]
+            coverageIds: [macos.bonjour-discovery]
             description: Bonjour discovery and local status/probe/health surfaces
         docs:
           - docs/platforms/macos.md
@@ -4168,19 +4168,19 @@ surfaces:
         id: remote-gateway-mode
         features:
           - name: macOS app "Remote over SSH"
-            coverageIds: [macos-app-remote-over-ssh]
+            coverageIds: [macos.app-remote-over-ssh]
             description: macOS app "Remote over SSH" and direct remote Gateway modes
           - name: SSH tunnel setup
-            coverageIds: [ssh-tunnel-setup]
+            coverageIds: [macos.ssh-tunnel-setup]
             description: SSH tunnel setup, stable local forward ownership, and tunnel restart/backoff
           - name: Tailscale MagicDNS
-            coverageIds: [tailscale-magicdns]
+            coverageIds: [macos.tailscale-magicdns]
             description: Tailscale MagicDNS, Serve, and Funnel guidance for remote access
           - name: Remote endpoint token/password/TLS fingerprint
-            coverageIds: [remote-endpoint-token-password-tls-fingerprint]
+            coverageIds: [macos.remote-endpoint-token-password-tls-fingerprint]
             description: Remote endpoint token/password/TLS fingerprint resolution
           - name: Local node host startup
-            coverageIds: [local-node-host-startup]
+            coverageIds: [macos.local-node-host-startup]
             description: Local node host startup and local Gateway suppression while the app is remote
         docs:
           - docs/platforms/mac/remote.md
@@ -4195,34 +4195,34 @@ surfaces:
         id: gateway-service-lifecycle
         features:
           - name: Per-user Gateway LaunchAgent install
-            coverageIds: [per-user-gateway-launchagent-install]
+            coverageIds: [macos.per-user-gateway-launchagent-install]
             description: Per-user Gateway LaunchAgent install, stage, uninstall, start, stop, restart, and status
           - name: launchctl bootstrap
-            coverageIds: [launchctl-bootstrap]
+            coverageIds: [macos.launchctl-bootstrap]
             description: launchctl bootstrap, bootout, enable, disable, kickstart, runtime parsing, installed-but-unloaded repair, and --disable semantics
           - name: LaunchAgent labels
-            coverageIds: [launchagent-labels]
+            coverageIds: [macos.launchagent-labels]
             description: LaunchAgent labels, profile labels, legacy cleanup, service metadata, plist generation, KeepAlive, RunAtLoad, logs, working directory, and temp directory handling
           - name: Gateway token/env handling
-            coverageIds: [gateway-token-env-handling]
+            coverageIds: [macos.gateway-token-env-handling]
             description: Gateway token/env handling, owner-only env files/wrappers, managed service env keys, and config audit/status output
           - name: App-managed LaunchAgent handoff
-            coverageIds: [app-managed-launchagent-handoff]
+            coverageIds: [macos.app-managed-launchagent-handoff]
             description: macOS app integration that manages the Gateway LaunchAgent in local mode and avoids it in remote or attach-only modes.
           - name: openclaw update package/git handoff
-            coverageIds: [openclaw-update-package-git-handoff]
+            coverageIds: [macos.openclaw-update-package-git-handoff]
             description: openclaw update package/git handoff on macOS
           - name: Managed service refresh
-            coverageIds: [managed-service-refresh]
+            coverageIds: [macos.managed-service-refresh]
             description: Managed service refresh and LaunchAgent rebootstrap after updates
           - name: Stale updater launchd job detection
-            coverageIds: [stale-updater-launchd-job-detection]
+            coverageIds: [macos.stale-updater-launchd-job-detection]
             description: Stale updater launchd job detection and cleanup
           - name: openclaw uninstall
-            coverageIds: [openclaw-uninstall]
+            coverageIds: [macos.openclaw-uninstall]
             description: openclaw uninstall, service uninstall, state cleanup, and manual launchd removal
           - name: Stranded service recovery
-            coverageIds: [stranded-service-recovery]
+            coverageIds: [macos.stranded-service-recovery]
             description: Recovery after partially updated or stranded macOS Gateway services.
         docs:
           - docs/platforms/macos.md
@@ -4244,16 +4244,16 @@ surfaces:
         id: diagnostics-and-observability
         features:
           - name: LaunchAgent log paths
-            coverageIds: [launchagent-log-paths]
+            coverageIds: [macos.launchagent-log-paths]
             description: LaunchAgent log paths and app diagnostic log paths
           - name: openclaw gateway status --deep
-            coverageIds: [openclaw-gateway-status-deep]
+            coverageIds: [macos.openclaw-gateway-status-deep]
             description: openclaw gateway status --deep, gateway probe, doctor, health, and logs commands
           - name: Gateway silently stops responding
-            coverageIds: [gateway-silently-stops-responding]
+            coverageIds: [macos.gateway-silently-stops-responding]
             description: Gateway silently stops responding, ENETDOWN sleep/wake failure, port conflicts, invalid config, and memory pressure runbooks
           - name: Stale updater jobs
-            coverageIds: [stale-updater-jobs]
+            coverageIds: [macos.stale-updater-jobs]
             description: Stale updater jobs, service config drift, and LaunchAgent environment diagnostics
         docs:
           - docs/platforms/mac/bundled-gateway.md
@@ -4270,16 +4270,16 @@ surfaces:
         id: permissions-and-native-capabilities
         features:
           - name: macOS TCC permission prompts/status
-            coverageIds: [macos-tcc-permission-prompts-status]
+            coverageIds: [macos.tcc-permission-prompts-status]
             description: macOS TCC permission prompts/status for Accessibility, AppleScript, Screen Recording, Microphone, Speech Recognition, Camera, Location, Notifications, and Voice Wake
           - name: Native node capability exposure
-            coverageIds: [native-node-capability-exposure]
+            coverageIds: [macos.native-node-capability-exposure]
             description: Native node capability exposure for screen/canvas/browser/system operations
           - name: system.run policy
-            coverageIds: [system-run-policy]
+            coverageIds: [macos.system-run-policy]
             description: system.run policy and local/remote node execution expectations
           - name: Permission-driven support
-            coverageIds: [permission-driven-support]
+            coverageIds: [macos.permission-driven-support]
             description: Permission-driven support and operator diagnostics
         docs:
           - docs/platforms/macos.md
@@ -4293,19 +4293,19 @@ surfaces:
         id: profiles-and-isolation
         features:
           - name: Profile-specific LaunchAgent labels
-            coverageIds: [profile-specific-launchagent-labels]
+            coverageIds: [macos.profile-specific-launchagent-labels]
             description: Profile-specific LaunchAgent labels and plist paths
           - name: Profile-specific state/config/workspace roots
-            coverageIds: [profile-specific-state-config-workspace-roots]
+            coverageIds: [macos.profile-specific-state-config-workspace-roots]
             description: Profile-specific state, config, and workspace roots for isolated local Gateways.
           - name: Derived ports
-            coverageIds: [derived-ports]
+            coverageIds: [macos.derived-ports]
             description: Derived ports and multi-Gateway conflict avoidance
           - name: Rescue bot setup
-            coverageIds: [rescue-bot-setup]
+            coverageIds: [macos.rescue-bot-setup]
             description: Rescue bot setup and operator checks
           - name: Extra Gateway process detection
-            coverageIds: [extra-gateway-process-detection]
+            coverageIds: [macos.extra-gateway-process-detection]
             description: Deep status detection for extra Gateway-like services and duplicate local processes.
         docs:
           - docs/gateway/multiple-gateways.md
@@ -4334,16 +4334,16 @@ surfaces:
         id: canvas
         features:
           - name: Canvas panel open/hide/navigate/eval/snapshot
-            coverageIds: [canvas-panel-open-hide-navigate-eval-snapshot]
+            coverageIds: [macos.canvas-panel-open-hide-navigate-eval-snapshot]
             description: Canvas panel open/hide/navigate/eval/snapshot behavior, status, and operator-visible verification.
           - name: Local custom URL scheme
-            coverageIds: [local-custom-url-scheme]
+            coverageIds: [macos.local-custom-url-scheme]
             description: Local custom URL scheme and session-root file serving
           - name: A2UI host auto-navigation
-            coverageIds: [a2ui-host-auto-navigation]
+            coverageIds: [macos.a2ui-host-auto-navigation]
             description: A2UI host auto-navigation, push/reset, and action bridge
           - name: Canvas enable/disable setting
-            coverageIds: [canvas-enable-disable-setting]
+            coverageIds: [macos.canvas-enable-disable-setting]
             description: Canvas enable/disable setting and node command behavior
         docs:
           - docs/platforms/mac/canvas.md
@@ -4358,25 +4358,25 @@ surfaces:
         id: local-setup
         features:
           - name: Local mode Gateway attach/start/stop
-            coverageIds: [local-mode-gateway-attach-start-stop]
+            coverageIds: [macos.local-mode-gateway-attach-start-stop]
             description: Local mode Gateway attach/start/stop behavior, status, and operator-visible verification.
           - name: LaunchAgent install/update/restart/uninstall
-            coverageIds: [launchagent-install-update-restart-uninstall]
+            coverageIds: [macos.launchagent-install-update-restart-uninstall]
             description: LaunchAgent install/update/restart/uninstall through app-managed CLI calls
           - name: Existing-listener detection
-            coverageIds: [existing-listener-detection]
+            coverageIds: [macos.existing-listener-detection]
             description: Existing-listener detection, port guarding, and launchd log path
           - name: Native first-run onboarding flow
-            coverageIds: [native-first-run-onboarding-flow]
+            coverageIds: [macos.native-first-run-onboarding-flow]
             description: Native first-run onboarding flow and completion marker
           - name: CLI discovery
-            coverageIds: [cli-discovery]
+            coverageIds: [macos.cli-discovery]
             description: CLI discovery and "Install CLI" prompt/install path
           - name: Local workspace selection
-            coverageIds: [local-workspace-selection]
+            coverageIds: [macos.local-workspace-selection]
             description: Local workspace selection and Gateway wizard startup
           - name: Onboarding WebChat session separation
-            coverageIds: [onboarding-webchat-session-separation]
+            coverageIds: [macos.onboarding-webchat-session-separation]
             description: Onboarding WebChat session separation behavior, status, and operator-visible verification.
         docs:
           - docs/platforms/mac/bundled-gateway.md
@@ -4394,19 +4394,19 @@ surfaces:
         id: status-and-settings
         features:
           - name: Menu-bar status
-            coverageIds: [menu-bar-status]
+            coverageIds: [macos.menu-bar-status]
             description: Menu-bar status, action menu, status icon state, dock menu, dashboard/chat/canvas/talk shortcuts
           - name: Activity state ingestion
-            coverageIds: [activity-state-ingestion]
+            coverageIds: [macos.activity-state-ingestion]
             description: Activity state ingestion and status row behavior
           - name: Settings navigation
-            coverageIds: [settings-navigation]
+            coverageIds: [macos.settings-navigation]
             description: Settings navigation and tabs
           - name: Health polling
-            coverageIds: [health-polling]
+            coverageIds: [macos.health-polling]
             description: Health polling, channel status, logs, debug actions, config/session/instance visibility
           - name: Channels settings
-            coverageIds: [channels-settings]
+            coverageIds: [macos.channels-settings]
             description: Channels settings and QR/login/probe status surfaced through the app
         docs:
           - docs/platforms/mac/menu-bar.md
@@ -4426,19 +4426,19 @@ surfaces:
         id: native-capabilities
         features:
           - name: Mac node session connection
-            coverageIds: [mac-node-session-connection]
+            coverageIds: [macos.mac-node-session-connection]
             description: Mac node session connection, capability and command advertisement
           - name: system.run
-            coverageIds: [system-run]
+            coverageIds: [macos.system-run]
             description: system.run, system.which, system.notify, exec approvals get/set
           - name: Exec approval policy
-            coverageIds: [exec-approval-policy]
+            coverageIds: [macos.exec-approval-policy]
             description: Exec approval policy, app exec host, local socket, and event emission
           - name: Permission requests
-            coverageIds: [permission-requests]
+            coverageIds: [macos.permission-requests]
             description: Permission requests, status polling, settings UI, and node permission advertisement
           - name: TCC persistence
-            coverageIds: [tcc-persistence]
+            coverageIds: [macos.tcc-persistence]
             description: TCC persistence, signing requirements, and safe app-owned permission guidance
         docs:
           - docs/platforms/macos.md
@@ -4457,13 +4457,13 @@ surfaces:
         id: remote-connections
         features:
           - name: Remote connection mode selection
-            coverageIds: [remote-connection-mode-selection]
+            coverageIds: [macos.remote-connection-mode-selection]
             description: Remote connection mode selection and configuration
           - name: SSH tunnel
-            coverageIds: [ssh-tunnel]
+            coverageIds: [macos.ssh-tunnel]
             description: SSH tunnel and direct ws/wss Gateway transport
           - name: Gateway discovery
-            coverageIds: [gateway-discovery]
+            coverageIds: [gateway.discovery]
             description: Gateway discovery, TLS pin repair, and remote node-service startup
         docs:
           - docs/platforms/mac/remote.md
@@ -4478,13 +4478,13 @@ surfaces:
         id: voice-and-talk
         features:
           - name: Voice Wake runtime
-            coverageIds: [voice-wake-runtime]
+            coverageIds: [macos.voice-wake-runtime]
             description: Voice Wake runtime, trigger detection, permissions, overlay, chimes, and forwarding
           - name: Push-to-talk
-            coverageIds: [push-to-talk]
+            coverageIds: [macos.push-to-talk]
             description: Push-to-talk and Talk Mode capture/listen/think/speak lifecycle
           - name: Talk provider playback plan
-            coverageIds: [talk-provider-playback-plan]
+            coverageIds: [macos.talk-provider-playback-plan]
             description: Talk provider playback plan and Gateway talk status
         docs:
           - docs/platforms/mac/voicewake.md
@@ -4500,13 +4500,13 @@ surfaces:
         id: webchat
         features:
           - name: Native SwiftUI WebChat window
-            coverageIds: [native-swiftui-webchat-window]
+            coverageIds: [macos.native-swiftui-webchat-window]
             description: Native SwiftUI WebChat window and menu panel
           - name: Gateway chat transport
-            coverageIds: [gateway-chat-transport]
+            coverageIds: [gateway.chat-transport]
             description: Gateway chat transport, session/model/thinking controls, event mapping, and health
           - name: Local and remote data-plane reuse
-            coverageIds: [local-and-remote-data-plane-reuse]
+            coverageIds: [macos.local-and-remote-data-plane-reuse]
             description: Local and remote data-plane reuse across native WebChat sessions.
         docs:
           - docs/platforms/mac/webchat.md
@@ -4521,19 +4521,19 @@ surfaces:
         id: remote-webchat
         features:
           - name: macOS WebChat transport
-            coverageIds: [macos-webchat-transport]
+            coverageIds: [macos.webchat-transport]
             description: Covers macOS WebChat transport across native macOS WebChat, Gateway connection reuse, native chat transport mapping, window/panel presentation, and related remote webchat client bridges behavior.
           - name: SSH tunnel data plane
-            coverageIds: [ssh-tunnel-data-plane]
+            coverageIds: [macos.ssh-tunnel-data-plane]
             description: Covers SSH tunnel data plane across native macOS WebChat, Gateway connection reuse, native chat transport mapping, window/panel presentation, and related remote webchat client bridges behavior.
           - name: Direct ws/wss remote mode
-            coverageIds: [direct-ws-wss-remote-mode]
+            coverageIds: [macos.direct-ws-wss-remote-mode]
             description: Covers Direct ws/wss remote mode across native macOS WebChat, Gateway connection reuse, native chat transport mapping, window/panel presentation, and related remote webchat client bridges behavior.
           - name: Session continuity
-            coverageIds: [session-continuity]
+            coverageIds: [memory.session-continuity]
             description: Covers Session continuity across native macOS WebChat, Gateway connection reuse, native chat transport mapping, window/panel presentation, and related remote webchat client bridges behavior.
           - name: Remote troubleshooting
-            coverageIds: [remote-troubleshooting]
+            coverageIds: [macos.remote-troubleshooting]
             description: Covers Remote troubleshooting across native macOS WebChat, Gateway connection reuse, native chat transport mapping, window/panel presentation, and related remote webchat client bridges behavior.
         docs:
           - docs/platforms/mac/webchat.md
@@ -4567,16 +4567,16 @@ surfaces:
         id: host-setup-and-updates
         features:
           - name: Linux CLI install
-            coverageIds: [linux-cli-install]
+            coverageIds: [linux.cli-install]
             description: Linux CLI installation paths and operator verification after install.
           - name: Node runtime prerequisites
-            coverageIds: [node-runtime-prerequisites]
+            coverageIds: [linux.node-runtime-prerequisites]
             description: Node runtime version requirements and host prerequisite checks for Linux Gateway operation.
           - name: Package-manager policy
-            coverageIds: [package-manager-policy]
+            coverageIds: [linux.package-manager-policy]
             description: Supported package-manager and platform policy for Linux install and update paths.
           - name: Update path
-            coverageIds: [update-path]
+            coverageIds: [linux.update-path]
             description: Linux update workflow, package or git handoff, and post-update verification.
         docs:
           - docs/install/index.md
@@ -4594,22 +4594,22 @@ surfaces:
         id: gateway-runtime-and-service-control
         features:
           - name: Foreground Gateway Runtime
-            coverageIds: [foreground-gateway-runtime]
+            coverageIds: [linux.foreground-gateway-runtime]
             description: Covers Foreground Gateway Runtime user-facing controls, state display, navigation, and rendering behavior for Foreground Gateway Runtime and Process Control.
           - name: Process Control
-            coverageIds: [process-control]
+            coverageIds: [linux.process-control]
             description: Covers Process Control user-facing controls, state display, navigation, and rendering behavior for Foreground Gateway Runtime and Process Control.
           - name: Systemd User Service Lifecycle setup
-            coverageIds: [systemd-user-service-lifecycle-setup]
+            coverageIds: [linux.systemd-user-service-lifecycle-setup]
             description: Defines Systemd User Service Lifecycle setup setup, credential, configuration, and operator verification behavior for Systemd User Service Lifecycle.
           - name: Systemd User Service Lifecycle operation
-            coverageIds: [systemd-user-service-lifecycle-operation]
+            coverageIds: [linux.systemd-user-service-lifecycle-operation]
             description: Defines Systemd User Service Lifecycle operation setup, credential, configuration, and operator verification behavior for Systemd User Service Lifecycle.
           - name: Systemd User Service Lifecycle status
-            coverageIds: [systemd-user-service-lifecycle-status]
+            coverageIds: [linux.systemd-user-service-lifecycle-status]
             description: Defines Systemd User Service Lifecycle status setup, credential, configuration, and operator verification behavior for Systemd User Service Lifecycle.
           - name: Systemd User Service Lifecycle recovery
-            coverageIds: [systemd-user-service-lifecycle-recovery]
+            coverageIds: [linux.systemd-user-service-lifecycle-recovery]
             description: Defines Systemd User Service Lifecycle recovery setup, credential, configuration, and operator verification behavior for Systemd User Service Lifecycle.
         docs:
           - docs/gateway/index.md
@@ -4633,22 +4633,22 @@ surfaces:
         id: remote-access-and-security
         features:
           - name: Remote Network Exposure
-            coverageIds: [remote-network-exposure]
+            coverageIds: [linux.remote-network-exposure]
             description: Defines Remote Network Exposure authorization, trust, safety boundaries, and operator controls for Remote Network Exposure, Tls, and Tailscale.
           - name: TLS
-            coverageIds: [tls]
+            coverageIds: [linux.tls]
             description: Defines TLS authorization, trust, safety boundaries, and operator controls for Remote Network Exposure, Tls, and Tailscale.
           - name: Tailscale
-            coverageIds: [tailscale]
+            coverageIds: [linux.tailscale]
             description: Defines Tailscale authorization, trust, safety boundaries, and operator controls for Remote Network Exposure, Tls, and Tailscale.
           - name: Gateway exposure safeguards
-            coverageIds: [gateway-exposure-safeguards]
+            coverageIds: [linux.gateway-exposure-safeguards]
             description: Defines exposure checks, unsafe-network warnings, and operator controls for Linux Gateway security boundaries.
           - name: Gateway authentication modes
-            coverageIds: [gateway-authentication-modes]
+            coverageIds: [linux.gateway-authentication-modes]
             description: Defines token/password auth, shared-secret resolution, and operator verification for Linux Gateway authentication.
           - name: Secret Handling
-            coverageIds: [secret-handling]
+            coverageIds: [linux.secret-handling]
             description: Defines Secret Handling setup, credential, configuration, and operator verification behavior for Security, Auth, and Secret Handling.
         docs:
           - docs/gateway/remote.md
@@ -4673,16 +4673,16 @@ surfaces:
         id: diagnostics-and-repair
         features:
           - name: Gateway diagnostic reports
-            coverageIds: [gateway-diagnostic-reports]
+            coverageIds: [linux.gateway-diagnostic-reports]
             description: Covers Gateway status, diagnostic output, failure handling, and operator repair for diagnostics, logs, doctor, and repair workflows.
           - name: Gateway log tailing
-            coverageIds: [gateway-log-tailing]
+            coverageIds: [linux.gateway-log-tailing]
             description: Covers log viewing, log tailing, local fallback behavior, and operator-visible Gateway log status.
           - name: Doctor checks
-            coverageIds: [doctor-checks]
+            coverageIds: [telemetry.doctor-checks]
             description: Covers `openclaw doctor` checks, Gateway health probes, and operator diagnostics for Linux Gateway deployments.
           - name: Operator repair guidance
-            coverageIds: [operator-repair-guidance]
+            coverageIds: [linux.operator-repair-guidance]
             description: Covers failure handling, repair guidance, and recovery steps for Linux Gateway diagnostics and doctor findings.
         docs:
           - docs/cli/status.md
@@ -4704,13 +4704,13 @@ surfaces:
         id: deployment-targets
         features:
           - name: VPS
-            coverageIds: [vps]
+            coverageIds: [linux.vps]
             description: Defines VPS setup, credential, configuration, and operator verification behavior for Vps, Container, and Cloud Deployment Guidance.
           - name: Container
-            coverageIds: [container]
+            coverageIds: [linux.container]
             description: Defines Container setup, credential, configuration, and operator verification behavior for Vps, Container, and Cloud Deployment Guidance.
           - name: Cloud Deployment Guidance
-            coverageIds: [cloud-deployment-guidance]
+            coverageIds: [linux.cloud-deployment-guidance]
             description: Defines Cloud Deployment Guidance setup, credential, configuration, and operator verification behavior for Vps, Container, and Cloud Deployment Guidance.
         docs:
           - docs/vps.md
@@ -4745,13 +4745,13 @@ surfaces:
         id: app-distribution
         features:
           - name: Native app package
-            coverageIds: [native-app-package]
+            coverageIds: [linux.native-app-package]
             description: Native Linux companion-app package availability and installation path.
           - name: Distro package targets
-            coverageIds: [distro-package-targets]
+            coverageIds: [linux.distro-package-targets]
             description: Distro package targets, desktop files, icons, autostart, and update metadata
           - name: Official release metadata
-            coverageIds: [official-release-metadata]
+            coverageIds: [linux.official-release-metadata]
             description: Official release metadata for downstream consoles
         docs:
           - docs/platforms/linux.md
@@ -4767,16 +4767,16 @@ surfaces:
         id: gateway-connectivity
         features:
           - name: Local Gateway attach and status
-            coverageIds: [local-gateway-attach-and-status]
+            coverageIds: [linux.local-gateway-attach-and-status]
             description: Local Gateway attach, start, and status behavior from a Linux app.
           - name: Gateway pairing and auth
-            coverageIds: [gateway-pairing-and-auth]
+            coverageIds: [linux.gateway-pairing-and-auth]
             description: Gateway auth and device pairing from a native Linux client.
           - name: Remote mode
-            coverageIds: [remote-mode]
+            coverageIds: [linux.remote-mode]
             description: Remote mode through direct URL, SSH tunnel, or Tailscale
           - name: Local and remote resource boundaries
-            coverageIds: [local-and-remote-resource-boundaries]
+            coverageIds: [linux.local-and-remote-resource-boundaries]
             description: Local and remote resource boundaries for a Linux companion client.
         docs:
           - docs/platforms/linux.md
@@ -4794,13 +4794,13 @@ surfaces:
         id: chat-and-sessions
         features:
           - name: Native Linux chat window
-            coverageIds: [native-linux-chat-window]
+            coverageIds: [linux.native-linux-chat-window]
             description: Native Linux chat window behavior, status, and operator-visible verification.
           - name: Transcript
-            coverageIds: [transcript]
+            coverageIds: [linux.transcript]
             description: Transcript, composer, session picker, model picker, send/abort/follow-up controls
           - name: Gateway chat transport
-            coverageIds: [gateway-chat-transport]
+            coverageIds: [gateway.chat-transport]
             description: Gateway WebSocket chat transport from a Linux desktop client.
         docs:
           - docs/platforms/linux.md
@@ -4816,31 +4816,31 @@ surfaces:
         id: desktop-capabilities
         features:
           - name: Linux desktop permissions
-            coverageIds: [linux-desktop-permissions]
+            coverageIds: [linux.desktop-permissions]
             description: Linux desktop permissions for notifications, microphone, screen, camera, accessibility, portals, and desktop-environment APIs
           - name: Secret storage
-            coverageIds: [secret-storage]
+            coverageIds: [linux.secret-storage]
             description: Secret storage for Gateway token, device identity, approval socket token, and app settings
           - name: Sandbox/package posture
-            coverageIds: [sandbox-package-posture]
+            coverageIds: [linux.sandbox-package-posture]
             description: Sandbox/package posture for Flatpak/Snap/AppImage or system packages
           - name: Linux native node identity
-            coverageIds: [linux-native-node-identity]
+            coverageIds: [linux.native-node-identity]
             description: Linux native node identity and capability advertisement
           - name: Host command execution
-            coverageIds: [host-command-execution]
+            coverageIds: [tools.host-command-execution]
             description: Host command execution through system.run and related desktop tools.
           - name: Desktop tools
-            coverageIds: [desktop-tools]
+            coverageIds: [linux.desktop-tools]
             description: Desktop tools such as screen, camera, notifications, Canvas, and local command execution
           - name: Linux native Talk
-            coverageIds: [linux-native-talk]
+            coverageIds: [linux.native-talk]
             description: Linux native Talk, push-to-talk, voice wake, and transcription
           - name: Microphone capture
-            coverageIds: [microphone-capture]
+            coverageIds: [linux.microphone-capture]
             description: Microphone capture, screen/camera capture, desktop context sensing, and local media attachment flows
           - name: Native media permissions
-            coverageIds: [native-media-permissions]
+            coverageIds: [linux.native-media-permissions]
             description: Native media permissions and foreground/background behavior
         docs:
           - docs/platforms/linux.md
@@ -4865,25 +4865,25 @@ surfaces:
         id: status-and-diagnostics
         features:
           - name: Native Linux app readiness
-            coverageIds: [native-linux-app-readiness]
+            coverageIds: [linux.native-linux-app-readiness]
             description: Native Linux app readiness states
           - name: Gateway health/status display
-            coverageIds: [gateway-health-status-display]
+            coverageIds: [linux.gateway-health-status-display]
             description: Gateway health/status display behavior, status, and operator-visible verification.
           - name: Log/transcript opening
-            coverageIds: [log-transcript-opening]
+            coverageIds: [linux.log-transcript-opening]
             description: Log/transcript opening and locality-aware resource handling
           - name: Doctor/repair affordances
-            coverageIds: [doctor-repair-affordances]
+            coverageIds: [linux.doctor-repair-affordances]
             description: Doctor/repair affordances and systemd lifecycle diagnostics
           - name: Linux tray/status item
-            coverageIds: [linux-tray-status-item]
+            coverageIds: [linux.tray-status-item]
             description: Linux tray/status item behavior, status, and operator-visible verification.
           - name: Runtime status row
-            coverageIds: [runtime-status-row]
+            coverageIds: [linux.runtime-status-row]
             description: Runtime status row and native notifications
           - name: Desktop-environment integration
-            coverageIds: [desktop-environment-integration]
+            coverageIds: [linux.desktop-environment-integration]
             description: Desktop-environment integration for GNOME/KDE/Wayland/X11 tray behavior
         docs:
           - docs/platforms/linux.md
@@ -4916,22 +4916,22 @@ surfaces:
         id: wsl-setup
         features:
           - name: WSL2 + Ubuntu installation
-            coverageIds: [wsl2-ubuntu-installation]
+            coverageIds: [wsl2.ubuntu-installation]
             description: WSL2 and Ubuntu installation requirements.
           - name: Node runtime
-            coverageIds: [node-runtime]
+            coverageIds: [wsl2.node-runtime]
             description: Node 24 and Node 22.19+ runtime requirements inside WSL2.
           - name: Linux install flow inside WSL2
-            coverageIds: [linux-install-flow-inside-wsl2]
+            coverageIds: [wsl2.linux-install-flow-inside-wsl2]
             description: Linux install and getting-started flow run inside WSL2.
           - name: WSL2 runtime boundary
-            coverageIds: [wsl2-runtime-boundary]
+            coverageIds: [wsl2.runtime-boundary]
             description: WSL2 runtime boundary and its distinction from native Windows installs.
           - name: WSL2 network-family requirements
-            coverageIds: [wsl2-network-family-requirements]
+            coverageIds: [wsl2.network-family-requirements]
             description: WSL2-specific network-family requirements that affect Gateway startup.
           - name: Source install and build inside WSL2
-            coverageIds: [source-install-and-build-inside-wsl2]
+            coverageIds: [wsl2.source-install-and-build-inside-wsl2]
             description: Source install and build workflow inside the WSL2 distribution.
         docs:
           - docs/platforms/windows.md
@@ -4947,28 +4947,28 @@ surfaces:
         id: cli
         features:
           - name: WSL2 CLI entrypoints
-            coverageIds: [wsl2-cli-entrypoints]
+            coverageIds: [wsl2.cli-entrypoints]
             description: openclaw CLI install, version, onboard, doctor, status, and update commands run inside the WSL2 Linux environment.
           - name: openclaw onboard
-            coverageIds: [openclaw-onboard]
+            coverageIds: [windows.openclaw-onboard]
             description: openclaw onboard and non-interactive onboarding run inside the WSL2 Linux environment.
           - name: openclaw doctor status and logs
-            coverageIds: [openclaw-doctor-status-and-logs]
+            coverageIds: [wsl2.openclaw-doctor-status-and-logs]
             description: openclaw doctor, status, and logs provide WSL2-specific repair and diagnostic feedback.
           - name: openclaw update
-            coverageIds: [openclaw-update]
+            coverageIds: [wsl2.openclaw-update]
             description: openclaw update, channel switching, dry-run/status diagnostics
           - name: npm/pnpm/git package-root
-            coverageIds: [npm-pnpm-git-package-root]
+            coverageIds: [wsl2.npm-pnpm-git-package-root]
             description: npm/pnpm/git package-root and install-mode switching
           - name: Managed systemd Gateway restart
-            coverageIds: [managed-systemd-gateway-restart]
+            coverageIds: [wsl2.managed-systemd-gateway-restart]
             description: Managed systemd Gateway restart and update handoff
           - name: Service metadata refresh
-            coverageIds: [service-metadata-refresh]
+            coverageIds: [wsl2.service-metadata-refresh]
             description: Service metadata refresh after WSL2 Gateway updates.
           - name: Package-manager caveats
-            coverageIds: [package-manager-caveats]
+            coverageIds: [wsl2.package-manager-caveats]
             description: Package-manager caveats seen from WSL2 source and package installs.
         docs:
           - docs/platforms/windows.md
@@ -4993,34 +4993,34 @@ surfaces:
         id: gateway-service-lifecycle
         features:
           - name: Onboarded systemd install
-            coverageIds: [onboarded-systemd-install]
+            coverageIds: [wsl2.onboarded-systemd-install]
             description: openclaw onboard daemon installation inside WSL2.
           - name: Gateway service install
-            coverageIds: [gateway-service-install]
+            coverageIds: [wsl2.gateway-service-install]
             description: openclaw gateway install behavior under WSL2 systemd.
           - name: systemd user unit rendering
-            coverageIds: [systemd-user-unit-rendering]
+            coverageIds: [wsl2.systemd-user-unit-rendering]
             description: systemd user unit rendering and lifecycle metadata.
           - name: WSL-aware systemd unavailable hints
-            coverageIds: [wsl-aware-systemd-unavailable-hints]
+            coverageIds: [wsl2.wsl-aware-systemd-unavailable-hints]
             description: Operator hints when systemd is unavailable in the WSL distribution.
           - name: Doctor service repair
-            coverageIds: [doctor-service-repair]
+            coverageIds: [wsl2.doctor-service-repair]
             description: Doctor repair behavior for WSL2 Gateway services.
           - name: WSL user-service linger
-            coverageIds: [wsl-user-service-linger]
+            coverageIds: [wsl2.wsl-user-service-linger]
             description: WSL user-service linger behavior, status, and operator-visible verification.
           - name: Systemd availability after Windows boot
-            coverageIds: [systemd-availability-after-windows-boot]
+            coverageIds: [wsl2.systemd-availability-after-windows-boot]
             description: Systemd availability after Windows boot and WSL distribution startup.
           - name: Windows startup task for WSL
-            coverageIds: [windows-startup-task-for-wsl]
+            coverageIds: [wsl2.windows-startup-task-for-wsl]
             description: Windows startup task behavior for launching WSL before login.
           - name: Verification before Windows sign-in
-            coverageIds: [verification-before-windows-sign-in]
+            coverageIds: [wsl2.verification-before-windows-sign-in]
             description: Verification before Windows sign-in behavior, status, and operator-visible verification.
           - name: Clear expectations around PC power
-            coverageIds: [clear-expectations-around-pc-power]
+            coverageIds: [wsl2.clear-expectations-around-pc-power]
             description: Clear expectations around PC power, sleep, Windows boot, WSL boot, and Gateway uptime
         docs:
           - docs/platforms/windows.md
@@ -5039,37 +5039,37 @@ surfaces:
         id: gateway-access-and-exposure
         features:
           - name: Gateway token/password auth
-            coverageIds: [gateway-token-password-auth]
+            coverageIds: [wsl2.gateway-token-password-auth]
             description: Gateway token and password auth for clients running through WSL2.
           - name: Provider credentials
-            coverageIds: [provider-credentials]
+            coverageIds: [security.provider-credentials]
             description: Provider credential storage and lookup from inside the WSL2 environment.
           - name: Gateway auth SecretRefs
-            coverageIds: [gateway-auth-secretrefs]
+            coverageIds: [wsl2.gateway-auth-secretrefs]
             description: Gateway auth SecretRef handling for WSL2-hosted Gateway processes.
           - name: Remote URL credential precedence
-            coverageIds: [remote-url-credential-precedence]
+            coverageIds: [wsl2.remote-url-credential-precedence]
             description: Remote URL credential precedence when WSL2 clients connect to local or remote Gateways.
           - name: WSL virtual network
-            coverageIds: [wsl-virtual-network]
+            coverageIds: [wsl2.wsl-virtual-network]
             description: WSL virtual network behavior and host/guest addressing.
           - name: Windows portproxy setup
-            coverageIds: [windows-portproxy-setup]
+            coverageIds: [wsl2.windows-portproxy-setup]
             description: Windows netsh interface portproxy setup for exposing WSL services.
           - name: Windows Firewall rules
-            coverageIds: [windows-firewall-rules]
+            coverageIds: [wsl2.windows-firewall-rules]
             description: Windows Firewall rules for WSL Gateway access.
           - name: Reachable Gateway URLs
-            coverageIds: [reachable-gateway-urls]
+            coverageIds: [wsl2.reachable-gateway-urls]
             description: Gateway URLs that must be reachable from Windows, WSL2, and LAN clients.
           - name: Loopback and LAN exposure
-            coverageIds: [loopback-and-lan-exposure]
+            coverageIds: [wsl2.loopback-and-lan-exposure]
             description: Loopback versus LAN listen behavior for WSL2 Gateway exposure.
           - name: WSL2 IPv4 networking
-            coverageIds: [wsl2-ipv4-networking]
+            coverageIds: [wsl2.ipv4-networking]
             description: WSL2-specific IPv4 network-family behavior.
           - name: Tailscale remote access
-            coverageIds: [tailscale-remote-access]
+            coverageIds: [wsl2.tailscale-remote-access]
             description: Tailscale and remote access behavior where it intersects WSL2 networking.
         docs:
           - docs/gateway/authentication.md
@@ -5093,19 +5093,19 @@ surfaces:
             coverageIds: [runtime.codex-plugin.auth, runtime.codex-plugin.lifecycle, runtime.doctor-repair]
             description: openclaw doctor and repair/migration for WSL2 Gateway
           - name: openclaw status
-            coverageIds: [openclaw-status]
+            coverageIds: [windows.openclaw-status]
             description: openclaw status, status --all, and Gateway service/runtime summary
           - name: openclaw logs
-            coverageIds: [openclaw-logs]
+            coverageIds: [telemetry.openclaw-logs]
             description: openclaw logs and Linux systemd journal fallback
           - name: SecretRef
-            coverageIds: [secretref]
+            coverageIds: [wsl2.secretref]
             description: SecretRef and auth diagnostics visible from status/doctor
           - name: WSL/systemd unavailable hints
-            coverageIds: [wsl-systemd-unavailable-hints]
+            coverageIds: [wsl2.wsl-systemd-unavailable-hints]
             description: WSL/systemd unavailable hints and linger checks
           - name: Operator repair guidance after WSL2 service
-            coverageIds: [operator-repair-guidance-after-wsl2-service]
+            coverageIds: [wsl2.operator-repair-guidance-after-wsl2-service]
             description: Operator repair guidance after WSL2 service, config, or Gateway failures
         docs:
           - docs/platforms/windows.md
@@ -5122,22 +5122,22 @@ surfaces:
         id: browser-and-control-ui
         features:
           - name: WSL2 Gateway with Windows browser
-            coverageIds: [wsl2-gateway-with-windows-browser]
+            coverageIds: [wsl2.gateway-with-windows-browser]
             description: WSL2 Gateway with Windows browser and Windows Chrome
           - name: Windows Control UI URL
-            coverageIds: [windows-control-ui-url]
+            coverageIds: [wsl2.windows-control-ui-url]
             description: Windows Control UI URL and origin guidance
           - name: Raw remote CDP to Windows Chrome
-            coverageIds: [raw-remote-cdp-to-windows-chrome]
+            coverageIds: [wsl2.raw-remote-cdp-to-windows-chrome]
             description: Raw remote CDP access from WSL2 to a Windows Chrome instance.
           - name: Host-local Chrome MCP
-            coverageIds: [host-local-chrome-mcp]
+            coverageIds: [wsl2.host-local-chrome-mcp]
             description: Host-local Chrome MCP and existing-session boundary
           - name: Browser profile cdpUrl
-            coverageIds: [browser-profile-cdpurl]
+            coverageIds: [wsl2.browser-profile-cdpurl]
             description: Browser profile cdpUrl and attachOnly config
           - name: Layered diagnostics
-            coverageIds: [layered-diagnostics]
+            coverageIds: [wsl2.layered-diagnostics]
             description: Layered diagnostics for auth/origin/CDP failures
         docs:
           - docs/tools/browser-wsl2-windows-remote-cdp-troubleshooting.md
@@ -5167,31 +5167,31 @@ surfaces:
         id: cli
         features:
           - name: PowerShell installer
-            coverageIds: [powershell-installer]
+            coverageIds: [windows.powershell-installer]
             description: Native Windows install.ps1 hosted installer path and flags.
           - name: Node and package-manager bootstrap
-            coverageIds: [node-and-package-manager-bootstrap]
+            coverageIds: [windows.node-and-package-manager-bootstrap]
             description: Node, Git, pnpm, npm, and PATH bootstrap for native Windows.
           - name: npm global install
-            coverageIds: [npm-global-install]
+            coverageIds: [windows.npm-global-install]
             description: npm global install, git checkout install, and generated openclaw.cmd.
           - name: Packaged CLI launcher
-            coverageIds: [packaged-cli-launcher]
+            coverageIds: [windows.packaged-cli-launcher]
             description: Packaged openclaw CLI launcher, version, and doctor entrypoints.
           - name: Windows command shims
-            coverageIds: [windows-command-shims]
+            coverageIds: [windows.command-shims]
             description: Windows .cmd launcher, PATHEXT, and package-manager shim compatibility.
           - name: openclaw onboard
-            coverageIds: [openclaw-onboard]
+            coverageIds: [windows.openclaw-onboard]
             description: openclaw onboard and openclaw onboard --non-interactive on native Windows
           - name: Local Gateway config
-            coverageIds: [local-gateway-config]
+            coverageIds: [windows.local-gateway-config]
             description: Local Gateway config, auth choice, gateway token/password SecretRef handling, and local endpoint defaults.
           - name: Daemon install flags
-            coverageIds: [daemon-install-flags]
+            coverageIds: [windows.daemon-install-flags]
             description: Daemon install flags for native Windows onboarding.
           - name: Native-vs-WSL setup boundary
-            coverageIds: [native-vs-wsl-setup-boundary]
+            coverageIds: [windows.native-vs-wsl-setup-boundary]
             description: Setup boundary between native Windows Gateway and the recommended WSL2 path.
         docs:
           - docs/install/index.md
@@ -5214,37 +5214,37 @@ surfaces:
         id: gateway-management
         features:
           - name: openclaw gateway
-            coverageIds: [openclaw-gateway]
+            coverageIds: [windows.openclaw-gateway]
             description: openclaw gateway, openclaw gateway run, openclaw gateway status, and foreground process behavior.
           - name: Foreground runtime health/readiness
-            coverageIds: [foreground-runtime-health-readiness]
+            coverageIds: [windows.foreground-runtime-health-readiness]
             description: Foreground runtime health/readiness and local loopback Gateway targets
           - name: Windows-specific restart/signal
-            coverageIds: [windows-specific-restart-signal]
+            coverageIds: [windows.specific-restart-signal]
             description: Windows-specific restart/signal and process-control behavior
           - name: Unmanaged foreground mode
-            coverageIds: [unmanaged-foreground-mode]
+            coverageIds: [windows.unmanaged-foreground-mode]
             description: Operator expectations when running without a managed Scheduled Task.
           - name: openclaw gateway install
-            coverageIds: [openclaw-gateway-install]
+            coverageIds: [windows.openclaw-gateway-install]
             description: openclaw gateway install, status, start, stop, restart, and managed startup behavior.
           - name: Gateway launcher files
-            coverageIds: [gateway-launcher-files]
+            coverageIds: [windows.gateway-launcher-files]
             description: Generated gateway.cmd and hidden launcher files for managed startup.
           - name: Scheduled Task runtime status
-            coverageIds: [scheduled-task-runtime-status]
+            coverageIds: [windows.scheduled-task-runtime-status]
             description: Scheduled Task runtime status, task-user selection, listener/PID fallback, and task repair.
           - name: Startup-folder fallback
-            coverageIds: [startup-folder-fallback]
+            coverageIds: [windows.startup-folder-fallback]
             description: Startup-folder fallback when Task Scheduler is unavailable.
           - name: openclaw status
-            coverageIds: [openclaw-status]
+            coverageIds: [windows.openclaw-status]
             description: openclaw status, openclaw gateway status, gateway status --deep, and Windows repair guidance.
           - name: Windows service inspection
-            coverageIds: [windows-service-inspection]
+            coverageIds: [windows.service-inspection]
             description: Windows service inspection, Task Scheduler runtime parsing, Startup-folder
           - name: Post-install diagnostics
-            coverageIds: [post-install-diagnostics]
+            coverageIds: [windows.post-install-diagnostics]
             description: Expected diagnostics, status, and repair behavior after native Windows install.
         docs:
           - docs/platforms/windows.md
@@ -5267,16 +5267,16 @@ surfaces:
         id: networking
         features:
           - name: Native Windows host networking
-            coverageIds: [native-windows-host-networking]
+            coverageIds: [windows.native-windows-host-networking]
             description: Native Windows host binding and Gateway exposure behavior.
           - name: netsh interface portproxy
-            coverageIds: [netsh-interface-portproxy]
+            coverageIds: [windows.netsh-interface-portproxy]
             description: netsh interface portproxy, Windows Firewall rules, and WSL IP refresh
           - name: Gateway status and probe output
-            coverageIds: [gateway-status-and-probe-output]
+            coverageIds: [windows.gateway-status-and-probe-output]
             description: Gateway status and probe output that helps operators verify Windows networking.
           - name: Loopback, LAN, and WSL boundary
-            coverageIds: [loopback-lan-and-wsl-boundary]
+            coverageIds: [windows.loopback-lan-and-wsl-boundary]
             description: Boundaries between loopback, LAN, and WSL exposure modes.
         docs:
           - docs/platforms/windows.md
@@ -5293,16 +5293,16 @@ surfaces:
         id: updates
         features:
           - name: openclaw update on native Windows package
-            coverageIds: [openclaw-update-on-native-windows-package]
+            coverageIds: [windows.openclaw-update-on-native-windows-package]
             description: openclaw update on native Windows package installs
           - name: Managed Gateway stop/restart
-            coverageIds: [managed-gateway-stop-restart]
+            coverageIds: [windows.managed-gateway-stop-restart]
             description: Managed Gateway stop/restart and service metadata refresh during update
           - name: Detached update handoff
-            coverageIds: [detached-update-handoff]
+            coverageIds: [windows.detached-update-handoff]
             description: Detached update handoff from a running Gateway.
           - name: Windows package locks
-            coverageIds: [windows-package-locks]
+            coverageIds: [windows.package-locks]
             description: Windows package locks, EBUSY/EPERM behavior, staged swaps, child-window
         docs:
           - docs/install/updating.md
@@ -5331,16 +5331,16 @@ surfaces:
         id: installation-and-updates
         features:
           - name: Official app download
-            coverageIds: [official-app-download]
+            coverageIds: [windows.official-app-download]
             description: Official app download or installer path for the native Windows companion app.
           - name: MSI/MSIX/App Installer/winget-style packaging
-            coverageIds: [msi-msix-app-installer-winget-style-packaging]
+            coverageIds: [windows.msi-msix-app-installer-winget-style-packaging]
             description: MSI/MSIX/App Installer/winget-style packaging, signing, update, rollback, uninstall, and desktop entries
           - name: Windows architecture handling for x64
-            coverageIds: [windows-architecture-handling-for-x64]
+            coverageIds: [windows.architecture-handling-for-x64]
             description: Windows architecture handling for x64 and ARM64
           - name: App release channel
-            coverageIds: [app-release-channel]
+            coverageIds: [windows.app-release-channel]
             description: App release channel, architecture handling, and update availability.
         docs:
           - docs/platforms/windows.md
@@ -5356,13 +5356,13 @@ surfaces:
         id: gateway-connection
         features:
           - name: App-managed local Gateway attach/start
-            coverageIds: [app-managed-local-gateway-attach-start]
+            coverageIds: [windows.app-managed-local-gateway-attach-start]
             description: App-managed local Gateway attach/start and status
           - name: Remote Gateway connection modes
-            coverageIds: [remote-gateway-connection-modes]
+            coverageIds: [windows.remote-gateway-connection-modes]
             description: Remote Gateway connection modes, token/TLS handling, and reconnect
           - name: Device/node pairing
-            coverageIds: [device-node-pairing]
+            coverageIds: [windows.device-node-pairing]
             description: Device/node pairing, pending approval UX, and pairing recovery
         docs:
           - docs/platforms/windows.md
@@ -5380,10 +5380,10 @@ surfaces:
         id: chat-sessions
         features:
           - name: Native Windows chat window
-            coverageIds: [native-windows-chat-window]
+            coverageIds: [windows.native-windows-chat-window]
             description: Native Windows chat window, transcript, composer, session picker, model/thinking controls, abort/follow-up actions, reconnect handling, and tool rendering
           - name: Gateway chat transport
-            coverageIds: [gateway-chat-transport]
+            coverageIds: [gateway.chat-transport]
             description: Gateway chat transport and session control from the native Windows app.
         docs:
           - docs/platforms/windows.md
@@ -5398,19 +5398,19 @@ surfaces:
         id: status-and-repair
         features:
           - name: App health states
-            coverageIds: [app-health-states]
+            coverageIds: [windows.app-health-states]
             description: App health states, Gateway/node readiness, diagnostic panels, log opening, update status, repair actions, and support bundle behavior
           - name: App-specific repair
-            coverageIds: [app-specific-repair]
+            coverageIds: [windows.app-specific-repair]
             description: App-specific repair for pairing, permissions, service lifecycle, stale versions, and protocol mismatch
           - name: Windows system tray app
-            coverageIds: [windows-system-tray-app]
+            coverageIds: [windows.system-tray-app]
             description: Windows system tray app, status icon, status menu, native notifications, and app launch/quit controls
           - name: Status indicators
-            coverageIds: [status-indicators]
+            coverageIds: [windows.status-indicators]
             description: Status indicators for Gateway, node pairing, work activity, and updates
           - name: App-specific notification permission
-            coverageIds: [app-specific-notification-permission]
+            coverageIds: [windows.app-specific-notification-permission]
             description: App-specific notification permission and failure handling
         docs:
           - docs/platforms/windows.md
@@ -5428,34 +5428,34 @@ surfaces:
         id: desktop-tools-and-permissions
         features:
           - name: Windows node identity
-            coverageIds: [windows-node-identity]
+            coverageIds: [windows.node-identity]
             description: Windows node identity and capability advertisement.
           - name: Host command execution
-            coverageIds: [host-command-execution]
+            coverageIds: [tools.host-command-execution]
             description: Host command execution through system.run and related desktop tools.
           - name: Desktop command policy
-            coverageIds: [desktop-command-policy]
+            coverageIds: [windows.desktop-command-policy]
             description: Desktop command allow/deny policy for native Windows tools.
           - name: App approval prompts
-            coverageIds: [app-approval-prompts]
+            coverageIds: [windows.app-approval-prompts]
             description: App UI prompts for approval-sensitive desktop commands.
           - name: Screen and media capture
-            coverageIds: [screen-and-media-capture]
+            coverageIds: [windows.screen-and-media-capture]
             description: Screen snapshot, recording, and native media capture affordances.
           - name: Canvas host behavior
-            coverageIds: [canvas-host-behavior]
+            coverageIds: [windows.canvas-host-behavior]
             description: Canvas and A2UI host behavior in a native Windows companion app.
           - name: Windows shell integrations
-            coverageIds: [windows-shell-integrations]
+            coverageIds: [windows.shell-integrations]
             description: Windows shell and PowerToys-style desktop integrations.
           - name: App secrets
-            coverageIds: [app-secrets]
+            coverageIds: [windows.app-secrets]
             description: App secrets, token persistence, secure local IPC, app signing identity, AppContainer or desktop permission posture
           - name: Windows ACL
-            coverageIds: [windows-acl]
+            coverageIds: [windows.acl]
             description: Windows ACL and filesystem hygiene for app-owned state
           - name: Command approval
-            coverageIds: [command-approval]
+            coverageIds: [windows.command-approval]
             description: Command approval and dangerous capability gating as surfaced to users
         docs:
           - docs/platforms/windows.md
@@ -5490,7 +5490,7 @@ surfaces:
         id: media-capture
         features:
           - name: Camera and media capture
-            coverageIds: [camera-and-media-capture]
+            coverageIds: [android.camera-and-media-capture]
             description: Camera listing, capture, photo, screen, and media capture behavior.
         docs:
           - docs/platforms/android.md
@@ -5505,7 +5505,7 @@ surfaces:
         id: mobile-chat
         features:
           - name: Chat tab
-            coverageIds: [chat-tab]
+            coverageIds: [android.chat-tab]
             description: Chat tab, session list/filtering, composer, image attachments, message parsing/rendering, model/provider status adjacent to chat, and Gateway chat RPC integration
         docs:
           - docs/platforms/android.md
@@ -5519,7 +5519,7 @@ surfaces:
         id: connection-setup
         features:
           - name: Gateway discovery
-            coverageIds: [gateway-discovery]
+            coverageIds: [gateway.discovery]
             description: Gateway discovery, setup-code and manual endpoint parsing, WS/WSS connection setup, TLS trust decisions, device identity, stored device tokens, node/operator auth, and connection error handling
         docs:
           - docs/platforms/android.md
@@ -5535,13 +5535,13 @@ surfaces:
         id: distribution
         features:
           - name: Public Google Play install path
-            coverageIds: [public-google-play-install-path]
+            coverageIds: [android.public-google-play-install-path]
             description: Public Google Play install path and source build/run entrypoints
           - name: Manual install path
-            coverageIds: [manual-install-path]
+            coverageIds: [android.manual-install-path]
             description: Manual install path and Google Play distribution behavior.
           - name: Release smoke and startup performance
-            coverageIds: [release-smoke-and-startup-performance]
+            coverageIds: [android.release-smoke-and-startup-performance]
             description: Release smoke and startup performance checks for Android app distribution.
         docs:
           - docs/platforms/android.md
@@ -5555,7 +5555,7 @@ surfaces:
         id: settings
         features:
           - name: Settings sheet
-            coverageIds: [settings-sheet]
+            coverageIds: [android.settings-sheet]
             description: Settings sheet and settings detail screens, permission request UX, notification forwarding controls, Nodes & Devices status, provider/model diagnostics, secure preferences, and copyable Gateway diagnostic report
         docs:
           - docs/platforms/android.md
@@ -5569,7 +5569,7 @@ surfaces:
         id: voice
         features:
           - name: Voice tab
-            coverageIds: [voice-tab]
+            coverageIds: [android.voice-tab]
             description: Voice tab, manual mic capture, Talk Mode listen/think/speak loop, Gateway Talk config, talk.speak, realtime relay mode, voice capture service type, and voice e2e receiver/script
         docs:
           - docs/platforms/android.md
@@ -5584,10 +5584,10 @@ surfaces:
         id: device-runtime
         features:
           - name: Background reconnect and presence
-            coverageIds: [background-reconnect-and-presence]
+            coverageIds: [android.background-reconnect-and-presence]
             description: Foreground-service presence, reconnect, and node presence behavior.
           - name: Device command availability
-            coverageIds: [device-command-availability]
+            coverageIds: [android.device-command-availability]
             description: Android device command availability and capability advertisement.
         docs:
           - docs/platforms/android.md
@@ -5620,7 +5620,7 @@ surfaces:
         id: media-and-sharing
         features:
           - name: Camera list/snap/clip
-            coverageIds: [camera-list-snap-clip]
+            coverageIds: [ios.camera-list-snap-clip]
             description: Camera list/snap/clip, photo-library latest image payloads, screen recording as media, Share Extension draft/send flow, attachment extraction, gateway relay settings for share, and mobile media payload limits
         docs:
           - docs/platforms/ios.md
@@ -5635,7 +5635,7 @@ surfaces:
         id: canvas-and-screen
         features:
           - name: Canvas present/hide/navigate/eval/snapshot
-            coverageIds: [canvas-present-hide-navigate-eval-snapshot]
+            coverageIds: [ios.canvas-present-hide-navigate-eval-snapshot]
             description: Canvas present/hide/navigate/eval/snapshot, A2UI reset/push/pushJSONL, WKWebView scaffold loading, trusted A2UI action bridge, screen recording, foreground command gates, and Gateway Canvas host URL handling
         docs:
           - docs/platforms/ios.md
@@ -5650,7 +5650,7 @@ surfaces:
         id: chat-and-sessions
         features:
           - name: Chat sessions and operator controls
-            coverageIds: [chat-sessions-and-operator-controls]
+            coverageIds: [ios.chat-sessions-and-operator-controls]
             description: Operator session transport, Chat tab, chat composer/history/streaming/tool display, command-center, permissions, and session controls.
         docs:
           - docs/platforms/ios.md
@@ -5667,25 +5667,25 @@ surfaces:
         id: gateway-setup-and-diagnostics
         features:
           - name: Bonjour/local
-            coverageIds: [bonjour-local]
+            coverageIds: [ios.bonjour-local]
             description: Bonjour/local and wide-area gateway discovery
           - name: Manual host/port
-            coverageIds: [manual-host-port]
+            coverageIds: [ios.manual-host-port]
             description: Manual host/port and QR/setup-code onboarding
           - name: Gateway connect configuration persistence
-            coverageIds: [gateway-connect-configuration-persistence]
+            coverageIds: [ios.gateway-connect-configuration-persistence]
             description: Gateway connect configuration persistence behavior, status, and operator-visible verification.
           - name: TLS fingerprint trust prompt
-            coverageIds: [tls-fingerprint-trust-prompt]
+            coverageIds: [ios.tls-fingerprint-trust-prompt]
             description: TLS fingerprint trust prompt and pinning behavior
           - name: Pairing approval
-            coverageIds: [pairing-approval]
+            coverageIds: [ios.pairing-approval]
             description: Pairing approval, device auth/keychain storage, and node+operator session auth
           - name: Pairing/auth diagnostics for users
-            coverageIds: [pairing-auth-diagnostics-for-users]
+            coverageIds: [ios.pairing-auth-diagnostics-for-users]
             description: Pairing/auth diagnostics for users and operators
           - name: Settings tab
-            coverageIds: [settings-tab]
+            coverageIds: [ios.settings-tab]
             description: Settings tab, Gateway settings, manual networking helpers, QR/setup-code intake, permission toggles and requests, discovery logs, Gateway problem details, diagnostics issue list, notification authorization state, and visible recovery actions
         docs:
           - docs/platforms/ios.md
@@ -5705,7 +5705,7 @@ surfaces:
         id: distribution
         features:
           - name: Internal preview status
-            coverageIds: [internal-preview-status]
+            coverageIds: [ios.internal-preview-status]
             description: Internal preview status, source/Xcode manual deploy, local signing, XcodeGen project generation, Fastlane TestFlight archive/upload, versioning/changelog/metadata, release artifacts, and official-vs-local build flags
         docs:
           - docs/platforms/ios.md
@@ -5719,10 +5719,10 @@ surfaces:
         id: device-commands
         features:
           - name: Location modes
-            coverageIds: [location-modes]
+            coverageIds: [ios.location-modes]
             description: Location modes, current location, significant-location events, motion activity and pedometer, contacts, calendar, reminders, permission request bridges, and personal-context command payloads
           - name: Device command handling
-            coverageIds: [device-command-handling]
+            coverageIds: [ios.device-command-handling]
             description: iOS device command handling, foreground/background gating, command specifications, and capability visibility.
         docs:
           - docs/platforms/ios.md
@@ -5742,7 +5742,7 @@ surfaces:
         id: notifications-and-background
         features:
           - name: APNs registration and relay delivery
-            coverageIds: [apns-registration-and-relay-delivery]
+            coverageIds: [ios.apns-registration-and-relay-delivery]
             description: Direct and relay-backed APNs registration, push relay trust, stored relay handles, background alive windows, and Live Activity updates.
         docs:
           - docs/platforms/ios.md
@@ -5758,7 +5758,7 @@ surfaces:
         id: voice
         features:
           - name: Voice wake
-            coverageIds: [voice-wake]
+            coverageIds: [ios.voice-wake]
             description: Voice wake, trigger-word sync, Talk Mode, push-to-talk commands, realtime Gateway relay, Speech and microphone permissions, audio session coordination, background suspension, and voice settings
         docs:
           - docs/platforms/ios.md
@@ -5787,25 +5787,25 @@ surfaces:
         id: delivery-and-recovery
         features:
           - name: APNs relay/direct registration as it affects
-            coverageIds: [apns-relay-direct-registration-as-it-affects]
+            coverageIds: [watchos.apns-relay-direct-registration-as-it-affects]
             description: APNs relay/direct registration as it affects watch approval wake/recovery
           - name: Silent push
-            coverageIds: [silent-push]
+            coverageIds: [watchos.silent-push]
             description: Silent push, background refresh, and significant-location wake paths
           - name: Pending approval recovery IDs
-            coverageIds: [pending-approval-recovery-ids]
+            coverageIds: [watchos.pending-approval-recovery-ids]
             description: Pending approval recovery IDs, snapshot refresh, and resolved/stale cleanup
           - name: Gateway-side iOS exec approval
-            coverageIds: [gateway-side-ios-exec-approval]
+            coverageIds: [watchos.gateway-side-ios-exec-approval]
             description: Gateway-side iOS exec approval APNs targeting
           - name: iPhone-side WatchConnectivity transport
-            coverageIds: [iphone-side-watchconnectivity-transport]
+            coverageIds: [watchos.iphone-side-watchconnectivity-transport]
             description: iPhone-side WatchConnectivity transport and status snapshot
           - name: Watch-side receiver activation
-            coverageIds: [watch-side-receiver-activation]
+            coverageIds: [watchos.watch-side-receiver-activation]
             description: Watch-side receiver activation and inbound payload handling
           - name: Delivery fallback among reachable messages
-            coverageIds: [delivery-fallback-among-reachable-messages]
+            coverageIds: [watchos.delivery-fallback-among-reachable-messages]
             description: Delivery fallback among reachable messages, queued user info, and application context snapshots
         docs:
           - docs/platforms/ios.md
@@ -5820,13 +5820,13 @@ surfaces:
         id: exec-approvals
         features:
           - name: Watch exec approval prompt
-            coverageIds: [watch-exec-approval-prompt]
+            coverageIds: [watchos.watch-exec-approval-prompt]
             description: Watch exec approval prompt, snapshot, resolve, resolved, and expired payloads
           - name: Watch approval list/detail UI
-            coverageIds: [watch-approval-list-detail-ui]
+            coverageIds: [watchos.watch-approval-list-detail-ui]
             description: Watch approval list/detail UI and decision buttons
           - name: iPhone-side prompt caching
-            coverageIds: [iphone-side-prompt-caching]
+            coverageIds: [watchos.iphone-side-prompt-caching]
             description: iPhone-side prompt caching, watch prompt publishing, snapshot handling, and resolution
         docs:
           - docs/tools/exec-approvals.md
@@ -5840,22 +5840,22 @@ surfaces:
         id: distribution-and-support
         features:
           - name: Watch app
-            coverageIds: [watch-app]
+            coverageIds: [watchos.watch-app]
             description: Watch app and WatchKit extension targets
           - name: Signing/profile variables
-            coverageIds: [signing-profile-variables]
+            coverageIds: [watchos.signing-profile-variables]
             description: Signing/profile variables, bundle identifiers, icon assets, and iOS beta release flow
           - name: Public/support status
-            coverageIds: [public-support-status]
+            coverageIds: [watchos.public-support-status]
             description: Public/support status for the watch companion as distributed through the iOS app
           - name: Changelog
-            coverageIds: [changelog]
+            coverageIds: [watchos.changelog]
             description: Changelog and repo-history evidence for watchOS companion maturity
           - name: Release metadata
-            coverageIds: [release-metadata]
+            coverageIds: [watchos.release-metadata]
             description: Release metadata and app-store/TestFlight preparation evidence
           - name: Historical bug/regression themes relevant to scoring
-            coverageIds: [historical-bug-regression-themes-relevant-to-scoring]
+            coverageIds: [watchos.historical-bug-regression-themes-relevant-to-scoring]
             description: Historical bug/regression themes relevant to scoring current source quality
         docs:
           - docs/platforms/ios.md
@@ -5870,25 +5870,25 @@ surfaces:
         id: notifications-and-replies
         features:
           - name: watch.status
-            coverageIds: [watch-status]
+            coverageIds: [watchos.watch-status]
             description: watch.status and watch.notify command contracts
           - name: Payload normalization
-            coverageIds: [payload-normalization]
+            coverageIds: [watchos.payload-normalization]
             description: Payload normalization for title/body, prompt/session metadata, priority, risk, and action buttons
           - name: Mirrored iOS notification fallback when watch
-            coverageIds: [mirrored-ios-notification-fallback-when-watch]
+            coverageIds: [watchos.mirrored-ios-notification-fallback-when-watch]
             description: Mirrored iOS notification fallback when watch delivery is queued
           - name: Watch action buttons from generic prompt
-            coverageIds: [watch-action-buttons-from-generic-prompt]
+            coverageIds: [watchos.watch-action-buttons-from-generic-prompt]
             description: Watch action buttons from generic prompt notifications
           - name: Watch-to-iPhone reply payloads
-            coverageIds: [watch-to-iphone-reply-payloads]
+            coverageIds: [watchos.watch-to-iphone-reply-payloads]
             description: Watch-to-iPhone reply payloads behavior, status, and operator-visible verification.
           - name: iPhone-side dedupe
-            coverageIds: [iphone-side-dedupe]
+            coverageIds: [watchos.iphone-side-dedupe]
             description: iPhone-side dedupe, offline queueing, and agent request forwarding
           - name: Mirrored iOS notification action
-            coverageIds: [mirrored-ios-notification-action]
+            coverageIds: [watchos.mirrored-ios-notification-action]
             description: Mirrored iOS notification action fallback
         docs:
           - docs/platforms/ios.md
@@ -5903,13 +5903,13 @@ surfaces:
         id: watch-app-ui
         features:
           - name: Watch app entry point
-            coverageIds: [watch-app-entry-point]
+            coverageIds: [watchos.watch-app-entry-point]
             description: Watch app entry point and SwiftUI navigation
           - name: Generic inbox
-            coverageIds: [generic-inbox]
+            coverageIds: [watchos.generic-inbox]
             description: Generic inbox, prompt actions, exec approval loading/list/detail views
           - name: Persistent watch inbox state
-            coverageIds: [persistent-watch-inbox-state]
+            coverageIds: [watchos.persistent-watch-inbox-state]
             description: Persistent watch inbox state and duplicate-delivery suppression
         docs:
           - docs/platforms/ios.md
@@ -5936,40 +5936,40 @@ surfaces:
         id: setup-and-compatibility
         features:
           - name: Hardware and 64-bit OS requirements
-            coverageIds: [hardware-and-64-bit-os-requirements]
+            coverageIds: [raspberry-pi.hardware-and-64-bit-os-requirements]
             description: Defines Hardware and 64-bit OS requirements setup, credential, configuration, and operator verification behavior for ARM Linux Setup and Prerequisites.
           - name: Node runtime setup
-            coverageIds: [node-runtime-setup]
+            coverageIds: [raspberry-pi.node-runtime-setup]
             description: Defines Node runtime setup setup, credential, configuration, and operator verification behavior for ARM Linux Setup and Prerequisites.
           - name: OpenClaw install and onboarding
-            coverageIds: [openclaw-install-and-onboarding]
+            coverageIds: [raspberry-pi.openclaw-install-and-onboarding]
             description: Defines OpenClaw install and onboarding setup, credential, configuration, and operator verification behavior for ARM Linux Setup and Prerequisites.
           - name: First-run verification
-            coverageIds: [first-run-verification]
+            coverageIds: [raspberry-pi.first-run-verification]
             description: Defines First-run verification setup, credential, configuration, and operator verification behavior for ARM Linux Setup and Prerequisites.
           - name: Supported Pi model selection
-            coverageIds: [supported-pi-model-selection]
+            coverageIds: [raspberry-pi.supported-pi-model-selection]
             description: Defines Supported Pi model selection setup, credential, configuration, and operator verification behavior for Hardware Support Boundary.
           - name: 64-bit ARM boundary
-            coverageIds: [64-bit-arm-boundary]
+            coverageIds: [raspberry-pi.64-bit-arm-boundary]
             description: Defines 64-bit ARM boundary setup, credential, configuration, and operator verification behavior for Hardware Support Boundary.
           - name: Unsupported device guidance
-            coverageIds: [unsupported-device-guidance]
+            coverageIds: [raspberry-pi.unsupported-device-guidance]
             description: Defines Unsupported device guidance setup, credential, configuration, and operator verification behavior for Hardware Support Boundary.
           - name: Slow-device caveats
-            coverageIds: [slow-device-caveats]
+            coverageIds: [raspberry-pi.slow-device-caveats]
             description: Defines Slow-device caveats setup, credential, configuration, and operator verification behavior for Hardware Support Boundary.
           - name: npm/pnpm/Bun install modes
-            coverageIds: [npm-pnpm-bun-install-modes]
+            coverageIds: [raspberry-pi.npm-pnpm-bun-install-modes]
             description: Defines npm/pnpm/Bun install modes setup, credential, configuration, and operator verification behavior for Package Manager and ARM Binary Compatibility.
           - name: Installer architecture detection
-            coverageIds: [installer-architecture-detection]
+            coverageIds: [raspberry-pi.installer-architecture-detection]
             description: Defines Installer architecture detection setup, credential, configuration, and operator verification behavior for Package Manager and ARM Binary Compatibility.
           - name: Optional ARM binary checks
-            coverageIds: [optional-arm-binary-checks]
+            coverageIds: [raspberry-pi.optional-arm-binary-checks]
             description: Defines Optional ARM binary checks setup, credential, configuration, and operator verification behavior for Package Manager and ARM Binary Compatibility.
           - name: Fallback/build guidance
-            coverageIds: [fallback-build-guidance]
+            coverageIds: [raspberry-pi.fallback-build-guidance]
             description: Defines Fallback/build guidance setup, credential, configuration, and operator verification behavior for Package Manager and ARM Binary Compatibility.
         docs:
           - docs/install/raspberry-pi.md
@@ -6001,31 +6001,31 @@ surfaces:
         id: remote-access-and-auth
         features:
           - name: Headless API-key auth
-            coverageIds: [headless-api-key-auth]
+            coverageIds: [raspberry-pi.headless-api-key-auth]
             description: Defines Headless API-key auth context assembly, persistence, token-pressure handling, and recovery behavior for Gateway Auth, Device Pairing, and Secrets.
           - name: Gateway shared-secret auth
-            coverageIds: [gateway-shared-secret-auth]
+            coverageIds: [raspberry-pi.gateway-shared-secret-auth]
             description: Defines Gateway shared-secret auth context assembly, persistence, token-pressure handling, and recovery behavior for Gateway Auth, Device Pairing, and Secrets.
           - name: Device pairing approvals
-            coverageIds: [device-pairing-approvals]
+            coverageIds: [raspberry-pi.device-pairing-approvals]
             description: Defines Device pairing approvals context assembly, persistence, token-pressure handling, and recovery behavior for Gateway Auth, Device Pairing, and Secrets.
           - name: SecretRef handling
-            coverageIds: [secretref-handling]
+            coverageIds: [raspberry-pi.secretref-handling]
             description: Defines SecretRef handling context assembly, persistence, token-pressure handling, and recovery behavior for Gateway Auth, Device Pairing, and Secrets.
           - name: Token drift recovery
-            coverageIds: [token-drift-recovery]
+            coverageIds: [raspberry-pi.token-drift-recovery]
             description: Defines Token drift recovery context assembly, persistence, token-pressure handling, and recovery behavior for Gateway Auth, Device Pairing, and Secrets.
           - name: SSH tunnel dashboard access
-            coverageIds: [ssh-tunnel-dashboard-access]
+            coverageIds: [raspberry-pi.ssh-tunnel-dashboard-access]
             description: Defines SSH tunnel dashboard access setup, credential, configuration, and operator verification behavior for Remote Access and Control UI.
           - name: Tailscale Serve/Funnel
-            coverageIds: [tailscale-serve-funnel]
+            coverageIds: [raspberry-pi.tailscale-serve-funnel]
             description: Defines Tailscale Serve/Funnel setup, credential, configuration, and operator verification behavior for Remote Access and Control UI.
           - name: Loopback/non-loopback exposure controls
-            coverageIds: [loopback-non-loopback-exposure-controls]
+            coverageIds: [raspberry-pi.loopback-non-loopback-exposure-controls]
             description: Defines Loopback/non-loopback exposure controls setup, credential, configuration, and operator verification behavior for Remote Access and Control UI.
           - name: Authenticated Control UI access
-            coverageIds: [authenticated-control-ui-access]
+            coverageIds: [raspberry-pi.authenticated-control-ui-access]
             description: Defines Authenticated Control UI access setup, credential, configuration, and operator verification behavior for Remote Access and Control UI.
         docs:
           - docs/install/raspberry-pi.md
@@ -6055,34 +6055,34 @@ surfaces:
         id: gateway-runtime
         features:
           - name: Always-on Gateway process
-            coverageIds: [always-on-gateway-process]
+            coverageIds: [raspberry-pi.always-on-gateway-process]
             description: Defines Always-on Gateway process setup, credential, configuration, and operator verification behavior for Headless Gateway and Model Setup.
           - name: Cloud model configuration
-            coverageIds: [cloud-model-configuration]
+            coverageIds: [raspberry-pi.cloud-model-configuration]
             description: Defines Cloud model configuration setup, credential, configuration, and operator verification behavior for Headless Gateway and Model Setup.
           - name: Channel startup
-            coverageIds: [channel-startup]
+            coverageIds: [raspberry-pi.channel-startup]
             description: Defines Channel startup setup, credential, configuration, and operator verification behavior for Headless Gateway and Model Setup.
           - name: Gateway health/status
-            coverageIds: [gateway-health-status]
+            coverageIds: [raspberry-pi.gateway-health-status]
             description: Defines Gateway health/status setup, credential, configuration, and operator verification behavior for Headless Gateway and Model Setup.
           - name: User service install
-            coverageIds: [user-service-install]
+            coverageIds: [raspberry-pi.user-service-install]
             description: Defines User service install setup, credential, configuration, and operator verification behavior for systemd Service and Boot Persistence.
           - name: linger/boot persistence
-            coverageIds: [linger-boot-persistence]
+            coverageIds: [raspberry-pi.linger-boot-persistence]
             description: Defines linger/boot persistence setup, credential, configuration, and operator verification behavior for systemd Service and Boot Persistence.
           - name: Service drop-ins
-            coverageIds: [service-drop-ins]
+            coverageIds: [raspberry-pi.service-drop-ins]
             description: Defines Service drop-ins setup, credential, configuration, and operator verification behavior for systemd Service and Boot Persistence.
           - name: Restart tuning
-            coverageIds: [restart-tuning]
+            coverageIds: [raspberry-pi.restart-tuning]
             description: Defines Restart tuning setup, credential, configuration, and operator verification behavior for systemd Service and Boot Persistence.
           - name: Status/log inspection
-            coverageIds: [status-log-inspection]
+            coverageIds: [raspberry-pi.status-log-inspection]
             description: Defines Status/log inspection setup, credential, configuration, and operator verification behavior for systemd Service and Boot Persistence.
           - name: Backup/restore
-            coverageIds: [backup-restore]
+            coverageIds: [raspberry-pi.backup-restore]
             description: Defines Backup/restore setup, credential, configuration, and operator verification behavior for systemd Service and Boot Persistence.
         docs:
           - docs/gateway/index.md
@@ -6111,19 +6111,19 @@ surfaces:
         id: performance-and-diagnostics
         features:
           - name: Swap and low-RAM tuning
-            coverageIds: [swap-and-low-ram-tuning]
+            coverageIds: [raspberry-pi.swap-and-low-ram-tuning]
             description: Defines Swap and low-RAM tuning setup, credential, configuration, and operator verification behavior for Resource Tuning and Diagnostics.
           - name: USB SSD guidance
-            coverageIds: [usb-ssd-guidance]
+            coverageIds: [raspberry-pi.usb-ssd-guidance]
             description: Defines USB SSD guidance setup, credential, configuration, and operator verification behavior for Resource Tuning and Diagnostics.
           - name: Compile cache/no-respawn settings
-            coverageIds: [compile-cache-no-respawn-settings]
+            coverageIds: [raspberry-pi.compile-cache-no-respawn-settings]
             description: Defines Compile cache/no-respawn settings setup, credential, configuration, and operator verification behavior for Resource Tuning and Diagnostics.
           - name: OOM/performance troubleshooting
-            coverageIds: [oom-performance-troubleshooting]
+            coverageIds: [raspberry-pi.oom-performance-troubleshooting]
             description: Defines OOM/performance troubleshooting setup, credential, configuration, and operator verification behavior for Resource Tuning and Diagnostics.
           - name: Diagnostics bundles
-            coverageIds: [diagnostics-bundles]
+            coverageIds: [raspberry-pi.diagnostics-bundles]
             description: Defines Diagnostics bundles setup, credential, configuration, and operator verification behavior for Resource Tuning and Diagnostics.
         docs:
           - docs/install/raspberry-pi.md
@@ -6159,22 +6159,22 @@ surfaces:
         id: container-setup
         features:
           - name: Local Image Setup Script
-            coverageIds: [local-image-setup-script]
+            coverageIds: [docker.local-image-setup-script]
             description: Covers Local Image Setup Script across `./scripts/docker/setup.sh` local-image and GHCR-image setup. Docker Compose gateway and sidecar CLI shape. First-run onboarding, token handling, bind/origin defaults, and post-start channel setup commands. Docker-only first-run notes, and related docker install, compose, and first-run setup behavior.
           - name: Docker Compose gateway
-            coverageIds: [docker-compose-gateway]
+            coverageIds: [docker.compose-gateway]
             description: Docker Compose gateway and sidecar CLI shape
           - name: First-run onboarding
-            coverageIds: [first-run-onboarding]
+            coverageIds: [docker.first-run-onboarding]
             description: First-run onboarding, token handling, bind/origin defaults, and post-start channel setup commands
           - name: Docker-only first-run notes
-            coverageIds: [docker-only-first-run-notes]
+            coverageIds: [docker.only-first-run-notes]
             description: Docker-only first-run notes, excluding Podman rootless setup and general Gateway protocol internals
           - name: Podman setup scripts and Quadlet template
-            coverageIds: [podman-setup-scripts-and-quadlet-template]
+            coverageIds: [docker.setup-scripts-and-quadlet-template]
             description: Podman setup docs, scripts/podman/setup.sh, scripts/run-openclaw-podman.sh, and scripts/podman/openclaw.container.in
           - name: Rootless Podman image setup
-            coverageIds: [rootless-podman-image-setup]
+            coverageIds: [docker.rootless-podman-image-setup]
             description: Rootless Podman image setup, launch, setup/onboarding, host CLI routing, Quadlet autostart, and owner/permission checks
         docs:
           - docs/install/docker.md
@@ -6190,37 +6190,37 @@ surfaces:
         id: container-operations
         features:
           - name: Host CLI routing into running Docker/Podman
-            coverageIds: [host-cli-routing-into-running-docker-podman]
+            coverageIds: [docker.host-cli-routing-into-running-docker-podman]
             description: Host CLI routing into running Docker/Podman containers
           - name: Container Targeting
-            coverageIds: [container-targeting]
+            coverageIds: [docker.container-targeting]
             description: Covers Container Targeting across Host CLI routing into running Docker/Podman containers. `--container` and `OPENCLAW_CONTAINER` behavior, env handling, ambiguous runtime detection, loopback proxy guard, and related host cli container targeting and update lifecycle behavior.
           - name: Container update/rebuild/restart guidance for Docker
-            coverageIds: [container-update-rebuild-restart-guidance-for-docker]
+            coverageIds: [docker.container-update-rebuild-restart-guidance-for-docker]
             description: Container update/rebuild/restart guidance for Docker and Podman hosts
           - name: Docker Compose mounts and secrets
-            coverageIds: [docker-compose]
+            coverageIds: [docker.compose]
             description: Docker Compose and Podman config/workspace/auth-profile secret mounts
           - name: Gateway token generation
-            coverageIds: [gateway-token-generation]
+            coverageIds: [docker.gateway-token-generation]
             description: Gateway token generation, reuse, .env persistence, and Control UI allowed origins
           - name: Ownership
-            coverageIds: [ownership]
+            coverageIds: [docker.ownership]
             description: Ownership, permissions, SELinux mount behavior, and state survival across container replacement
           - name: Docker Compose network access
-            coverageIds: [docker-compose-network-access]
+            coverageIds: [docker.compose-network-access]
             description: Docker Compose and Podman port publishing, bind mode, host local provider access, Bonjour, Tailscale, and Control UI origins
           - name: Container health endpoints
-            coverageIds: [container-health-endpoints]
+            coverageIds: [docker.container-health-endpoints]
             description: Container health endpoints, Dockerfile/Compose healthchecks, openclaw health, logs, and metrics/OTel docs
           - name: Provider/VPS Docker hosting docs
-            coverageIds: [provider-vps-docker-hosting-docs]
+            coverageIds: [docker.provider-vps-docker-hosting-docs]
             description: Provider/VPS Docker hosting docs and operational runbooks
           - name: Docker VM persistence/update guidance
-            coverageIds: [docker-vm-persistence-update-guidance]
+            coverageIds: [docker.vm-persistence-update-guidance]
             description: Docker VM persistence/update guidance, Hetzner/Hostinger/DigitalOcean adjacency, Kubernetes/container warnings, and secure exposure
           - name: Operator-facing update
-            coverageIds: [operator-facing-update]
+            coverageIds: [docker.operator-facing-update]
             description: Operator-facing update, backup, persistence, low-memory, and troubleshooting guidance
         docs:
           - docs/install/podman.md
@@ -6243,19 +6243,19 @@ surfaces:
         id: image-release-and-validation
         features:
           - name: Root Dockerfile build stages
-            coverageIds: [root-dockerfile-build-stages]
+            coverageIds: [docker.root-dockerfile-build-stages]
             description: Root Dockerfile build stages, runtime image contents, optional browser and Docker CLI build args
           - name: Docker release workflow
-            coverageIds: [docker-release-workflow]
+            coverageIds: [docker.release-workflow]
             description: Docker release workflow for GHCR publishing, multi-arch tags, manifests, and attestation verification
           - name: Docker E2E package artifact generation
-            coverageIds: [docker-e2e-package-artifact-generation]
+            coverageIds: [docker.package-artifact-generation]
             description: Docker E2E package artifact generation and shared build helpers
           - name: Docker E2E plan/scheduler scripts
             coverageIds: [docker.e2e, harness.qa-lab, telemetry.prometheus]
             description: Docker E2E plan/scheduler scripts, lane metadata, targeted grouping, package artifact generation, and GitHub hydration action
           - name: Release-path install
-            coverageIds: [release-path-install]
+            coverageIds: [docker.release-path-install]
             description: Release-path install, update, upgrade survivor, live-provider, plugin, Open WebUI, and cleanup scenario planning
         docs:
           - docs/install/docker.md
@@ -6272,13 +6272,13 @@ surfaces:
         id: agent-sandbox-and-tooling
         features:
           - name: Docker gateway setup
-            coverageIds: [docker-gateway-setup]
+            coverageIds: [docker.gateway-setup]
             description: Docker gateway setup with OPENCLAW_SANDBOX, Docker CLI build arg, socket mount, sandbox config writes, and rollback behavior
           - name: Docker-backed agent sandbox support
-            coverageIds: [docker-backed-agent-sandbox-support]
+            coverageIds: [docker.backed-agent-sandbox-support]
             description: Docker-backed agent sandbox docs, source behavior, and tests that affect container-hosted Gateway operators.
           - name: Container image dependency baking
-            coverageIds: [container-image-dependency-baking]
+            coverageIds: [docker.container-image-dependency-baking]
             description: Container image dependency baking for skills/plugins/tools
         docs:
           - docs/install/docker.md
@@ -6306,19 +6306,19 @@ surfaces:
         id: deployment-setup
         features:
           - name: Kustomize packaging
-            coverageIds: [kustomize-packaging]
+            coverageIds: [kubernetes.kustomize-packaging]
             description: Kustomize-first deployment posture and Helm non-goal.
           - name: Cluster prerequisites
-            coverageIds: [cluster-prerequisites]
+            coverageIds: [kubernetes.cluster-prerequisites]
             description: Cluster access, kubectl context, and provider-key prerequisites.
           - name: Quick deploy
-            coverageIds: [quick-deploy]
+            coverageIds: [kubernetes.quick-deploy]
             description: One-command cluster deployment path.
           - name: Manifest apply
-            coverageIds: [manifest-apply]
+            coverageIds: [kubernetes.manifest-apply]
             description: Step-by-step secret creation and manifest apply workflow.
           - name: Kind validation
-            coverageIds: [kind-validation]
+            coverageIds: [kubernetes.kind-validation]
             description: Local Kind cluster test workflow.
         docs:
           - docs/install/kubernetes.md
@@ -6337,19 +6337,19 @@ surfaces:
         id: configuration-and-secrets
         features:
           - name: Agent instructions
-            coverageIds: [agent-instructions]
+            coverageIds: [kubernetes.agent-instructions]
             description: ConfigMap-based agent instruction injection.
           - name: Gateway config
-            coverageIds: [gateway-config]
+            coverageIds: [kubernetes.gateway-config]
             description: ConfigMap-based Gateway configuration.
           - name: Provider secrets
-            coverageIds: [provider-secrets]
+            coverageIds: [kubernetes.provider-secrets]
             description: Kubernetes Secret-backed provider-key setup.
           - name: Secret rotation
-            coverageIds: [secret-rotation]
+            coverageIds: [kubernetes.secret-rotation]
             description: Provider-key patching and redeploy expectations.
           - name: Image and namespace
-            coverageIds: [image-and-namespace]
+            coverageIds: [kubernetes.image-and-namespace]
             description: Custom image pinning and namespace override.
         docs:
           - docs/install/kubernetes.md
@@ -6368,19 +6368,19 @@ surfaces:
         id: access-and-exposure
         features:
           - name: Port-forward access
-            coverageIds: [port-forward-access]
+            coverageIds: [kubernetes.port-forward-access]
             description: kubectl port-forward path for local Gateway access.
           - name: Service endpoint
-            coverageIds: [service-endpoint]
+            coverageIds: [kubernetes.service-endpoint]
             description: Kubernetes Service access model for the Gateway.
           - name: Ingress exposure
-            coverageIds: [ingress-exposure]
+            coverageIds: [kubernetes.ingress-exposure]
             description: Ingress and load-balancer exposure beyond port-forward.
           - name: Auth and TLS
-            coverageIds: [auth-and-tls]
+            coverageIds: [kubernetes.auth-and-tls]
             description: Required authentication, TLS, and origin controls for exposed deployments.
           - name: Localhost posture
-            coverageIds: [localhost-posture]
+            coverageIds: [kubernetes.localhost-posture]
             description: Cluster-local runtime assumptions and localhost access boundaries.
         docs:
           - docs/install/kubernetes.md
@@ -6400,19 +6400,19 @@ surfaces:
         id: cluster-lifecycle
         features:
           - name: Resource layout
-            coverageIds: [resource-layout]
+            coverageIds: [kubernetes.resource-layout]
             description: Namespace, Deployment, Service, PVC, ConfigMap, and Secret inventory.
           - name: State persistence
-            coverageIds: [state-persistence]
+            coverageIds: [kubernetes.state-persistence]
             description: PVC-backed state expectations and cleanup implications.
           - name: Redeploy
-            coverageIds: [redeploy]
+            coverageIds: [kubernetes.redeploy]
             description: Re-apply manifests and restart pod workflow.
           - name: Teardown
-            coverageIds: [teardown]
+            coverageIds: [kubernetes.teardown]
             description: Namespace deletion and PVC cleanup path.
           - name: Security context
-            coverageIds: [security-context]
+            coverageIds: [kubernetes.security-context]
             description: Pod security, namespace scope, and runtime isolation notes.
         docs:
           - docs/install/kubernetes.md
@@ -6444,16 +6444,16 @@ surfaces:
         id: install-handoff
         features:
           - name: Nix install overview
-            coverageIds: [nix-install-overview]
+            coverageIds: [nix.install-overview]
             description: Covers Nix install overview across public Nix install page, install index discoverability, docs navigation, and the handoff to the first-party `nix-openclaw` Home Manager module. It excludes the actual external `openclaw/nix-openclaw` repository implementation, and related public nix docs and nix-openclaw handoff behavior.
           - name: nix-openclaw source-of-truth
-            coverageIds: [nix-openclaw-source-of-truth]
+            coverageIds: [nix.openclaw-source-of-truth]
             description: Covers nix-openclaw source-of-truth across public Nix install page, install index discoverability, docs navigation, and the handoff to the first-party `nix-openclaw` Home Manager module. It excludes the actual external `openclaw/nix-openclaw` repository implementation, and related public nix docs and nix-openclaw handoff behavior.
           - name: Install discoverability
-            coverageIds: [install-discoverability]
+            coverageIds: [nix.install-discoverability]
             description: Covers Install discoverability across public Nix install page, install index discoverability, docs navigation, and the handoff to the first-party `nix-openclaw` Home Manager module. It excludes the actual external `openclaw/nix-openclaw` repository implementation, and related public nix docs and nix-openclaw handoff behavior.
           - name: Verification handoff
-            coverageIds: [verification-handoff]
+            coverageIds: [nix.verification-handoff]
             description: Covers Verification handoff across public Nix install page, install index discoverability, docs navigation, and the handoff to the first-party `nix-openclaw` Home Manager module. It excludes the actual external `openclaw/nix-openclaw` repository implementation, and related public nix docs and nix-openclaw handoff behavior.
         docs:
           - docs/install/nix.md
@@ -6470,16 +6470,16 @@ surfaces:
         id: plugin-lifecycle
         features:
           - name: Lifecycle command refusal
-            coverageIds: [lifecycle-command-refusal]
+            coverageIds: [nix.lifecycle-command-refusal]
             description: Covers Lifecycle command refusal across plugin install/update/uninstall/enable/disable behavior in Nix mode, `/nix/store` hardlink handling, manifest registry safety, and user-facing guidance for declarative plugin selection.
           - name: Declarative plugin selection
-            coverageIds: [declarative-plugin-selection]
+            coverageIds: [nix.declarative-plugin-selection]
             description: Covers Declarative plugin selection across plugin install/update/uninstall/enable/disable behavior in Nix mode, `/nix/store` hardlink handling, manifest registry safety, and user-facing guidance for declarative plugin selection.
           - name: Nix-store plugin loading
-            coverageIds: [nix-store-plugin-loading]
+            coverageIds: [nix.store-plugin-loading]
             description: Covers Nix-store plugin loading across plugin install/update/uninstall/enable/disable behavior in Nix mode, `/nix/store` hardlink handling, manifest registry safety, and user-facing guidance for declarative plugin selection.
           - name: Hardlink safety
-            coverageIds: [hardlink-safety]
+            coverageIds: [nix.hardlink-safety]
             description: Covers Hardlink safety across plugin install/update/uninstall/enable/disable behavior in Nix mode, `/nix/store` hardlink handling, manifest registry safety, and user-facing guidance for declarative plugin selection.
         docs:
           - docs/plugins/manage-plugins.md
@@ -6496,25 +6496,25 @@ surfaces:
         id: activation-and-app-ux
         features:
           - name: Environment activation
-            coverageIds: [environment-activation]
+            coverageIds: [nix.environment-activation]
             description: Covers Environment activation across Nix mode activation, environment-variable detection, macOS default detection, and the operator docs that explain how Nix mode is enabled.
           - name: macOS defaults activation
-            coverageIds: [macos-defaults-activation]
+            coverageIds: [nix.macos-defaults-activation]
             description: Covers macOS defaults activation across Nix mode activation, environment-variable detection, macOS default detection, and the operator docs that explain how Nix mode is enabled.
           - name: Runtime Nix-mode detection
-            coverageIds: [runtime-nix-mode-detection]
+            coverageIds: [nix.runtime-nix-mode-detection]
             description: Covers Runtime Nix-mode detection across Nix mode activation, environment-variable detection, macOS default detection, and the operator docs that explain how Nix mode is enabled.
           - name: Stable Nix defaults
-            coverageIds: [stable-nix-defaults]
+            coverageIds: [nix.stable-nix-defaults]
             description: Covers Stable Nix defaults across macOS app's `openclaw.nixMode` default handling, config read-only UX, settings banner, onboarding behavior, and local config write prevention.
           - name: Managed-by-Nix banner
-            coverageIds: [managed-by-nix-banner]
+            coverageIds: [nix.managed-by-nix-banner]
             description: Covers Managed-by-Nix banner across macOS app's `openclaw.nixMode` default handling, config read-only UX, settings banner, onboarding behavior, and local config write prevention.
           - name: Read-only config controls
-            coverageIds: [read-only-config-controls]
+            coverageIds: [nix.read-only-config-controls]
             description: Covers Read-only config controls across macOS app's `openclaw.nixMode` default handling, config read-only UX, settings banner, onboarding behavior, and local config write prevention.
           - name: Onboarding skip
-            coverageIds: [onboarding-skip]
+            coverageIds: [nix.onboarding-skip]
             description: Covers Onboarding skip across macOS app's `openclaw.nixMode` default handling, config read-only UX, settings banner, onboarding behavior, and local config write prevention.
         docs:
           - docs/install/nix.md
@@ -6532,25 +6532,25 @@ surfaces:
         id: config-and-state
         features:
           - name: Immutable config guard
-            coverageIds: [immutable-config-guard]
+            coverageIds: [nix.immutable-config-guard]
             description: Covers Immutable config guard across `OPENCLAW_NIX_MODE_CONFIG_IMMUTABLE` guard, source-edit guidance, config writer integration, and the agent-first Nix source instruction.
           - name: Config writer refusal
-            coverageIds: [config-writer-refusal]
+            coverageIds: [nix.config-writer-refusal]
             description: Covers Config writer refusal across `OPENCLAW_NIX_MODE_CONFIG_IMMUTABLE` guard, source-edit guidance, config writer integration, and the agent-first Nix source instruction.
           - name: Agent-first Nix edits
-            coverageIds: [agent-first-nix-edits]
+            coverageIds: [nix.agent-first-nix-edits]
             description: Covers Agent-first Nix edits across `OPENCLAW_NIX_MODE_CONFIG_IMMUTABLE` guard, source-edit guidance, config writer integration, and the agent-first Nix source instruction.
           - name: Explicit config path
-            coverageIds: [explicit-config-path]
+            coverageIds: [nix.explicit-config-path]
             description: Covers Explicit config path across config/state path environment variables, immutable store expectations, path resolution, state integrity checks around `/nix/store`, and runtime guidance that state should stay writable.
           - name: Writable state directory
-            coverageIds: [writable-state-directory]
+            coverageIds: [nix.writable-state-directory]
             description: Covers Writable state directory across config/state path environment variables, immutable store expectations, path resolution, state integrity checks around `/nix/store`, and runtime guidance that state should stay writable.
           - name: Immutable-store config support
-            coverageIds: [immutable-store-config-support]
+            coverageIds: [nix.immutable-store-config-support]
             description: Covers Immutable-store config support across config/state path environment variables, immutable store expectations, path resolution, state integrity checks around `/nix/store`, and runtime guidance that state should stay writable.
           - name: State integrity checks
-            coverageIds: [state-integrity-checks]
+            coverageIds: [nix.state-integrity-checks]
             description: Covers State integrity checks across config/state path environment variables, immutable store expectations, path resolution, state integrity checks around `/nix/store`, and runtime guidance that state should stay writable.
         docs:
           - docs/install/nix.md
@@ -6570,28 +6570,28 @@ surfaces:
         id: service-runtime-and-guards
         features:
           - name: Nix profile PATH discovery
-            coverageIds: [nix-profile-path-discovery]
+            coverageIds: [nix.profile-path-discovery]
             description: Covers Nix profile PATH discovery across `NIX_PROFILES` handling, `~/.nix-profile/bin` fallback, launchd/systemd service PATH generation, and adjacent safe binary resolution rules.
           - name: Profile precedence
-            coverageIds: [profile-precedence]
+            coverageIds: [nix.profile-precedence]
             description: Covers Profile precedence across `NIX_PROFILES` handling, `~/.nix-profile/bin` fallback, launchd/systemd service PATH generation, and adjacent safe binary resolution rules.
           - name: Service PATH fallback
-            coverageIds: [service-path-fallback]
+            coverageIds: [nix.service-path-fallback]
             description: Covers Service PATH fallback across `NIX_PROFILES` handling, `~/.nix-profile/bin` fallback, launchd/systemd service PATH generation, and adjacent safe binary resolution rules.
           - name: Trusted binary boundaries
-            coverageIds: [trusted-binary-boundaries]
+            coverageIds: [nix.trusted-binary-boundaries]
             description: Covers Trusted binary boundaries across `NIX_PROFILES` handling, `~/.nix-profile/bin` fallback, launchd/systemd service PATH generation, and adjacent safe binary resolution rules.
           - name: Setup write refusal
-            coverageIds: [setup-write-refusal]
+            coverageIds: [nix.setup-write-refusal]
             description: Covers Setup write refusal across `openclaw setup`, `openclaw doctor` repair/token modes, `openclaw update`/startup auto-update behavior, and daemon service install/uninstall behavior under Nix mode.
           - name: Doctor repair refusal
-            coverageIds: [doctor-repair-refusal]
+            coverageIds: [nix.doctor-repair-refusal]
             description: Covers Doctor repair refusal across `openclaw setup`, `openclaw doctor` repair/token modes, `openclaw update`/startup auto-update behavior, and daemon service install/uninstall behavior under Nix mode.
           - name: Update handoff
-            coverageIds: [update-handoff]
+            coverageIds: [nix.update-handoff]
             description: Covers Update handoff across `openclaw setup`, `openclaw doctor` repair/token modes, `openclaw update`/startup auto-update behavior, and daemon service install/uninstall behavior under Nix mode.
           - name: Service lifecycle handoff
-            coverageIds: [service-lifecycle-handoff]
+            coverageIds: [nix.service-lifecycle-handoff]
             description: Covers Service lifecycle handoff across `openclaw setup`, `openclaw doctor` repair/token modes, `openclaw update`/startup auto-update behavior, and daemon service install/uninstall behavior under Nix mode.
         docs:
           - docs/install/nix.md
@@ -6627,34 +6627,34 @@ surfaces:
         id: channel-setup-and-operations
         features:
           - name: Application and bot setup
-            coverageIds: [application-and-bot-setup]
+            coverageIds: [discord.application-and-bot-setup]
             description: Covers Application and bot setup across Discord application/bot creation guidance, bot token and `applicationId` configuration, env and SecretRef token resolution, setup wizard/account inspection, and related bot setup and account configuration behavior.
           - name: Token and application ID configuration
-            coverageIds: [token-and-application-id-configuration]
+            coverageIds: [discord.token-and-application-id-configuration]
             description: Covers Token and application ID configuration across Discord application/bot creation guidance, bot token and `applicationId` configuration, env and SecretRef token resolution, setup wizard/account inspection, and related bot setup and account configuration behavior.
           - name: Setup wizard and account inspection
-            coverageIds: [setup-wizard-and-account-inspection]
+            coverageIds: [discord.setup-wizard-and-account-inspection]
             description: Covers Setup wizard and account inspection across Discord application/bot creation guidance, bot token and `applicationId` configuration, env and SecretRef token resolution, setup wizard/account inspection, and related bot setup and account configuration behavior.
           - name: Status, doctor, and intent checks
-            coverageIds: [status-doctor-and-intent-checks]
+            coverageIds: [discord.status-doctor-and-intent-checks]
             description: Covers Status, doctor, and intent checks across Discord application/bot creation guidance, bot token and `applicationId` configuration, env and SecretRef token resolution, setup wizard/account inspection, and related bot setup and account configuration behavior.
           - name: Multi-account bot configuration
-            coverageIds: [multi-account-bot-configuration]
+            coverageIds: [discord.multi-account-bot-configuration]
             description: Covers Multi-account bot configuration across Discord application/bot creation guidance, bot token and `applicationId` configuration, env and SecretRef token resolution, setup wizard/account inspection, and related bot setup and account configuration behavior.
           - name: Account monitor startup
-            coverageIds: [account-monitor-startup]
+            coverageIds: [discord.account-monitor-startup]
             description: Covers Account monitor startup across Discord gateway monitor startup path, runtime provider lifecycle, WebSocket gateway client, reconnect/heartbeat handling, and related gateway monitor and runtime lifecycle behavior.
           - name: Gateway WebSocket lifecycle
-            coverageIds: [gateway-websocket-lifecycle]
+            coverageIds: [discord.gateway-websocket-lifecycle]
             description: Covers Gateway WebSocket lifecycle across Discord gateway monitor startup path, runtime provider lifecycle, WebSocket gateway client, reconnect/heartbeat handling, and related gateway monitor and runtime lifecycle behavior.
           - name: Reconnect and heartbeat handling
-            coverageIds: [reconnect-and-heartbeat-handling]
+            coverageIds: [discord.reconnect-and-heartbeat-handling]
             description: Covers Reconnect and heartbeat handling across Discord gateway monitor startup path, runtime provider lifecycle, WebSocket gateway client, reconnect/heartbeat handling, and related gateway monitor and runtime lifecycle behavior.
           - name: Rate limits and gateway metadata
-            coverageIds: [rate-limits-and-gateway-metadata]
+            coverageIds: [discord.rate-limits-and-gateway-metadata]
             description: Covers Rate limits and gateway metadata across Discord gateway monitor startup path, runtime provider lifecycle, WebSocket gateway client, reconnect/heartbeat handling, and related gateway monitor and runtime lifecycle behavior.
           - name: Status, probe, and health-monitor recovery
-            coverageIds: [status-probe-and-health-monitor-recovery]
+            coverageIds: [discord.status-probe-and-health-monitor-recovery]
             description: Covers Status, probe, and health-monitor recovery across Discord gateway monitor startup path, runtime provider lifecycle, WebSocket gateway client, reconnect/heartbeat handling, and related gateway monitor and runtime lifecycle behavior.
         docs:
           - docs/channels/discord.md
@@ -6681,22 +6681,22 @@ surfaces:
         id: access-and-identity
         features:
           - name: DM policy modes
-            coverageIds: [dm-policy-modes]
+            coverageIds: [discord.dm-policy-modes]
             description: 'Covers DM policy modes across Discord direct-message `dmPolicy` modes: `pairing`, `allowlist`, `open`, and `disabled`. Canonical and legacy `allowFrom` resolution across top-level Discord config, and related dm pairing and sender authorization behavior.'
           - name: Allowlist inheritance
-            coverageIds: [allowlist-inheritance]
+            coverageIds: [discord.allowlist-inheritance]
             description: 'Covers Allowlist inheritance across Discord direct-message `dmPolicy` modes: `pairing`, `allowlist`, `open`, and `disabled`. Canonical and legacy `allowFrom` resolution across top-level Discord config, and related dm pairing and sender authorization behavior.'
           - name: Pairing-code approval
-            coverageIds: [pairing-code-approval]
+            coverageIds: [security.pairing-code-approval]
             description: 'Covers Pairing-code approval across Discord direct-message `dmPolicy` modes: `pairing`, `allowlist`, `open`, and `disabled`. Canonical and legacy `allowFrom` resolution across top-level Discord config, and related dm pairing and sender authorization behavior.'
           - name: Sender authorization
-            coverageIds: [sender-authorization]
+            coverageIds: [security.sender-authorization]
             description: 'Covers Sender authorization across Discord direct-message `dmPolicy` modes: `pairing`, `allowlist`, `open`, and `disabled`. Canonical and legacy `allowFrom` resolution across top-level Discord config, and related dm pairing and sender authorization behavior.'
           - name: Access-group authorization
-            coverageIds: [access-group-authorization]
+            coverageIds: [discord.access-group-authorization]
             description: 'Covers Access-group authorization across Discord direct-message `dmPolicy` modes: `pairing`, `allowlist`, `open`, and `disabled`. Canonical and legacy `allowFrom` resolution across top-level Discord config, and related dm pairing and sender authorization behavior.'
           - name: Group DM authorization
-            coverageIds: [group-dm-authorization]
+            coverageIds: [discord.group-dm-authorization]
             description: 'Covers Group DM authorization across Discord direct-message `dmPolicy` modes: `pairing`, `allowlist`, `open`, and `disabled`. Canonical and legacy `allowFrom` resolution across top-level Discord config, and related dm pairing and sender authorization behavior.'
         docs:
           - docs/channels/discord.md
@@ -6716,40 +6716,40 @@ surfaces:
         id: conversation-routing-and-delivery
         features:
           - name: Guild and channel admission
-            coverageIds: [guild-and-channel-admission]
+            coverageIds: [discord.guild-and-channel-admission]
             description: Covers Guild and channel admission across Guild allowlist and `groupPolicy` admission for Discord guild channels and threads. `requireMention`, bot-loop prevention, command/mention bypasses, and unmentioned room-event history. Channel, and related guild channel routing and session isolation behavior.
           - name: Mention gating
-            coverageIds: [mention-gating]
+            coverageIds: [channels.mention-gating]
             description: Covers Mention gating across Guild allowlist and `groupPolicy` admission for Discord guild channels and threads. `requireMention`, bot-loop prevention, command/mention bypasses, and unmentioned room-event history. Channel, and related guild channel routing and session isolation behavior.
           - name: Session key isolation
-            coverageIds: [session-key-isolation]
+            coverageIds: [discord.session-key-isolation]
             description: Covers Session key isolation across Guild allowlist and `groupPolicy` admission for Discord guild channels and threads. `requireMention`, bot-loop prevention, command/mention bypasses, and unmentioned room-event history. Channel, and related guild channel routing and session isolation behavior.
           - name: Configured and runtime routing
-            coverageIds: [configured-and-runtime-routing]
+            coverageIds: [discord.configured-and-runtime-routing]
             description: Covers Configured and runtime bindings across Guild allowlist and `groupPolicy` admission for Discord guild channels and threads. `requireMention`, bot-loop prevention, command/mention bypasses, and unmentioned room-event history. Channel, and related guild channel routing and session isolation behavior.
           - name: Inbound context visibility
-            coverageIds: [inbound-context-visibility]
+            coverageIds: [discord.inbound-context-visibility]
             description: Covers Inbound context visibility across Guild allowlist and `groupPolicy` admission for Discord guild channels and threads. `requireMention`, bot-loop prevention, command/mention bypasses, and unmentioned room-event history. Channel, and related guild channel routing and session isolation behavior.
           - name: Forum and media-channel thread posts
-            coverageIds: [forum-and-media-channel-thread-posts]
+            coverageIds: [discord.forum-and-media-channel-thread-posts]
             description: 'Covers Forum and media-channel thread posts across Discord forum/media channel posts created as threads from parent channel targets. CLI and message-tool thread actions: `thread-create`, `thread-list`, and `thread-reply`. Discord target parsing for `channel:<id>`, user targets, and related threads, forums, and delegated-agent bindings behavior.'
           - name: Thread actions
-            coverageIds: [thread-actions]
+            coverageIds: [discord.thread-actions]
             description: 'Covers Thread actions across Discord forum/media channel posts created as threads from parent channel targets. CLI and message-tool thread actions: `thread-create`, `thread-list`, and `thread-reply`. Discord target parsing for `channel:<id>`, user targets, and related threads, forums, and delegated-agent bindings behavior.'
           - name: Target parsing
-            coverageIds: [target-parsing]
+            coverageIds: [discord.target-parsing]
             description: 'Covers Target parsing across Discord forum/media channel posts created as threads from parent channel targets. CLI and message-tool thread actions: `thread-create`, `thread-list`, and `thread-reply`. Discord target parsing for `channel:<id>`, user targets, and related threads, forums, and delegated-agent bindings behavior.'
           - name: Thread context resolution
-            coverageIds: [thread-context-resolution]
+            coverageIds: [discord.thread-context-resolution]
             description: 'Covers Thread context resolution across Discord forum/media channel posts created as threads from parent channel targets. CLI and message-tool thread actions: `thread-create`, `thread-list`, and `thread-reply`. Discord target parsing for `channel:<id>`, user targets, and related threads, forums, and delegated-agent bindings behavior.'
           - name: Thread-bound session routing
-            coverageIds: [thread-bound-session-routing]
+            coverageIds: [discord.thread-bound-session-routing]
             description: 'Covers Thread-bound session routing across Discord forum/media channel posts created as threads from parent channel targets. CLI and message-tool thread actions: `thread-create`, `thread-list`, and `thread-reply`. Discord target parsing for `channel:<id>`, user targets, and related threads, forums, and delegated-agent bindings behavior.'
           - name: ACP agent routing
-            coverageIds: [acp-agent-routing]
+            coverageIds: [discord.acp-agent-routing]
             description: 'Covers ACP bindings across Discord forum/media channel posts created as threads from parent channel targets. CLI and message-tool thread actions: `thread-create`, `thread-list`, and `thread-reply`. Discord target parsing for `channel:<id>`, user targets, and related threads, forums, and delegated-agent bindings behavior.'
           - name: Routing lifecycle
-            coverageIds: [routing-lifecycle]
+            coverageIds: [discord.routing-lifecycle]
             description: 'Covers Binding lifecycle across Discord forum/media channel posts created as threads from parent channel targets. CLI and message-tool thread actions: `thread-create`, `thread-list`, and `thread-reply`. Discord target parsing for `channel:<id>`, user targets, and related threads, forums, and delegated-agent bindings behavior.'
         docs:
           - docs/channels/discord.md
@@ -6777,7 +6777,7 @@ surfaces:
         id: media-and-rich-content
         features:
           - name: Media and Rich Content
-            coverageIds: [media-and-rich-content]
+            coverageIds: [channels.media-rich-content]
             description: Evidence scope for Media and Rich Content.
         docs:
           - docs/channels/discord.md
@@ -6790,19 +6790,19 @@ surfaces:
         id: native-controls-and-approvals
         features:
           - name: Native slash command registration
-            coverageIds: [native-slash-command-registration]
+            coverageIds: [discord.native-slash-command-registration]
             description: Native slash command registration and reconciliation for Discord application commands
           - name: Native slash command execution
-            coverageIds: [native-slash-command-execution]
+            coverageIds: [discord.native-slash-command-execution]
             description: Native slash command execution, autocomplete, authz, and interaction dispatch
           - name: Model Picker Commands
-            coverageIds: [model-picker-commands]
+            coverageIds: [discord.model-picker-commands]
             description: Covers Model Picker Commands across Native slash command registration and reconciliation for Discord application commands. Native slash command execution, autocomplete, authz, and interaction dispatch. `/model` and `/models` picker flows, and related native slash commands, components, and interactive callbacks behavior.
           - name: Components v2 messages
-            coverageIds: [components-v2-messages]
+            coverageIds: [discord.components-v2-messages]
             description: Components v2 messages, buttons, string/user/role/mentionable/channel selects, modal triggers, and modal submits
           - name: Callback TTL
-            coverageIds: [callback-ttl]
+            coverageIds: [discord.callback-ttl]
             description: Callback TTL, reusable versus single-use callbacks, persistent callback registry entries, allowedUsers, guild/DM/group authz, and plugin interactive callback dispatch
         docs:
           - docs/channels/discord.md
@@ -6816,19 +6816,19 @@ surfaces:
         id: realtime-voice-and-calls
         features:
           - name: Voice Channel Lifecycle
-            coverageIds: [voice-channel-lifecycle]
+            coverageIds: [discord.voice-channel-lifecycle]
             description: Covers Voice Channel Lifecycle across Includes Discord voice channel sessions controlled by `/vc join`, `/vc status`, and `/vc leave`; config-driven `autoJoin`; `followUsers`; voice/stage channel allowlists; connect/reconnect and DAVE handling; `stt-tts`, `agent-proxy`, and related realtime voice channels behavior.
           - name: Auto-join and follow-users
-            coverageIds: [auto-join-and-follow-users]
+            coverageIds: [discord.auto-join-and-follow-users]
             description: Covers Auto-join and follow-users across Includes Discord voice channel sessions controlled by `/vc join`, `/vc status`, and `/vc leave`; config-driven `autoJoin`; `followUsers`; voice/stage channel allowlists; connect/reconnect and DAVE handling; `stt-tts`, `agent-proxy`, and related realtime voice channels behavior.
           - name: Realtime voice modes
-            coverageIds: [realtime-voice-modes]
+            coverageIds: [discord.realtime-voice-modes]
             description: Covers Realtime voice modes across Includes Discord voice channel sessions controlled by `/vc join`, `/vc status`, and `/vc leave`; config-driven `autoJoin`; `followUsers`; voice/stage channel allowlists; connect/reconnect and DAVE handling; `stt-tts`, `agent-proxy`, and related realtime voice channels behavior.
           - name: Wake, barge-in, and echo handling
-            coverageIds: [wake-barge-in-and-echo-handling]
+            coverageIds: [discord.wake-barge-in-and-echo-handling]
             description: Covers Wake, barge-in, and echo handling across Includes Discord voice channel sessions controlled by `/vc join`, `/vc status`, and `/vc leave`; config-driven `autoJoin`; `followUsers`; voice/stage channel allowlists; connect/reconnect and DAVE handling; `stt-tts`, `agent-proxy`, and related realtime voice channels behavior.
           - name: Voice codec and DAVE recovery
-            coverageIds: [voice-codec-and-dave-recovery]
+            coverageIds: [discord.voice-codec-and-dave-recovery]
             description: Covers Voice codec and DAVE recovery across Includes Discord voice channel sessions controlled by `/vc join`, `/vc status`, and `/vc leave`; config-driven `autoJoin`; `followUsers`; voice/stage channel allowlists; connect/reconnect and DAVE handling; `stt-tts`, `agent-proxy`, and related realtime voice channels behavior.
         docs:
           - docs/channels/discord.md
@@ -6862,34 +6862,34 @@ surfaces:
         id: channel-setup-and-operations
         features:
           - name: BotFather token creation
-            coverageIds: [botfather-token-creation]
+            coverageIds: [telegram.botfather-token-creation]
             description: BotFather token creation and first gateway start
           - name: TELEGRAM_BOT_TOKEN
-            coverageIds: [telegram-bot-token]
+            coverageIds: [telegram.bot-token]
             description: TELEGRAM_BOT_TOKEN, botToken, tokenFile, and account-scoped token
           - name: Setup wizard credential capture
-            coverageIds: [setup-wizard-credential-capture]
+            coverageIds: [telegram.setup-wizard-credential-capture]
             description: Setup wizard credential capture, allowlist prompts, and DM policy defaults
           - name: Startup getMe
-            coverageIds: [startup-getme]
+            coverageIds: [telegram.startup-getme]
             description: Startup getMe, bot-info cache, account throttling, and multi-account default
           - name: Doctor/status surfacing
-            coverageIds: [doctor-status-surfacing]
+            coverageIds: [telegram.doctor-status-surfacing]
             description: Doctor/status surfacing for invalid tokens, missing defaults, and read-only
           - name: Named account configuration
-            coverageIds: [named-account-configuration]
+            coverageIds: [telegram.named-account-configuration]
             description: Named account configuration, default account selection, account-local group
           - name: CLI/message-tool targets
-            coverageIds: [cli-message-tool-targets]
+            coverageIds: [telegram.cli-message-tool-targets]
             description: numeric chat IDs, usernames, forum-topic
           - name: Directory adapters
-            coverageIds: [directory-adapters]
+            coverageIds: [telegram.directory-adapters]
             description: Directory adapters and configured peers/groups for user-facing target lists
           - name: Channel status
-            coverageIds: [channel-status]
+            coverageIds: [telegram.channel-status]
             description: Channel status, channels status --probe, token source summaries, liveness
           - name: Account-scoped outbound
-            coverageIds: [account-scoped-outbound]
+            coverageIds: [telegram.account-scoped-outbound]
             description: Account-scoped outbound, poll, media, and approval target resolution
         docs:
           - docs/channels/telegram.md
@@ -6906,34 +6906,34 @@ surfaces:
         id: access-and-identity
         features:
           - name: dmPolicy modes
-            coverageIds: [dmpolicy-modes]
+            coverageIds: [telegram.dmpolicy-modes]
             description: pairing, allowlist, open, and disabled
           - name: Pairing-code approval
-            coverageIds: [pairing-code-approval]
+            coverageIds: [security.pairing-code-approval]
             description: Pairing-code approval, first-owner bootstrap, and commands.ownerAllowFrom
           - name: Numeric Telegram user ID normalization with telegram
-            coverageIds: [numeric-telegram-user-id-normalization-with-telegram]
+            coverageIds: [telegram.numeric-telegram-user-id-normalization-with-telegram]
             description: 'and tg: prefixes'
           - name: allowFrom
-            coverageIds: [allowfrom]
+            coverageIds: [telegram.allowfrom]
             description: allowFrom, groupAllowFrom, access groups, and DM-versus-group boundaries
           - name: Unauthorized DM
-            coverageIds: [unauthorized-dm]
+            coverageIds: [telegram.unauthorized-dm]
             description: Unauthorized DM, group, command, callback, and reaction handling
           - name: Group allowlists
-            coverageIds: [group-allowlists]
+            coverageIds: [security.group-allowlists]
             description: Group allowlists, groupPolicy, groupAllowFrom, and mention gating
           - name: Supergroup negative chat IDs
-            coverageIds: [supergroup-negative-chat-ids]
+            coverageIds: [telegram.supergroup-negative-chat-ids]
             description: Supergroup negative chat IDs and group/topic config inheritance
           - name: Forum topic session keys
-            coverageIds: [forum-topic-session-keys]
+            coverageIds: [telegram.forum-topic-session-keys]
             description: Forum topic session keys, message_thread_id, General topic behavior, and topic routing.
           - name: ACP topic routing
-            coverageIds: [acp-topic-routing]
+            coverageIds: [telegram.acp-topic-routing]
             description: ACP topic binding and /acp spawn --thread
           - name: Session key construction
-            coverageIds: [session-key-construction]
+            coverageIds: [memory.session-key-construction]
             description: Session key construction, conversation route matching, and reply target
         docs:
           - docs/channels/telegram.md
@@ -6952,7 +6952,7 @@ surfaces:
         id: conversation-routing-and-delivery
         features:
           - name: Conversation Routing and Delivery
-            coverageIds: [conversation-routing-and-delivery]
+            coverageIds: [channels.conversation-routing-delivery]
             description: Evidence scope for Conversation Routing and Delivery.
         docs:
           - docs/channels/telegram.md
@@ -6967,7 +6967,7 @@ surfaces:
         id: media-and-rich-content
         features:
           - name: Media and Rich Content
-            coverageIds: [media-and-rich-content]
+            coverageIds: [channels.media-rich-content]
             description: Evidence scope for Media and Rich Content.
         docs:
           - docs/channels/telegram.md
@@ -6981,31 +6981,31 @@ surfaces:
         id: native-controls-and-approvals
         features:
           - name: Inline keyboard rendering
-            coverageIds: [inline-keyboard-rendering]
+            coverageIds: [telegram.inline-keyboard-rendering]
             description: Inline keyboard rendering, callback query handling, Mini App URL buttons, and approval callbacks.
           - name: Exec approvals in DMs
-            coverageIds: [exec-approvals-in-dms]
+            coverageIds: [telegram.exec-approvals-in-dms]
             description: Exec approvals in DMs, channels, topics, or both; approver resolution; plugin
           - name: Message actions
-            coverageIds: [message-actions]
+            coverageIds: [channels.message-actions]
             description: send, poll, react, delete, edit, sticker, and sticker search actions.
           - name: Action capability discovery
-            coverageIds: [action-capability-discovery]
+            coverageIds: [telegram.action-capability-discovery]
             description: Action capability discovery, gating config, account-scoped action gates, and requester trust checks.
           - name: Native setMyCommands startup sync
-            coverageIds: [native-setmycommands-startup-sync]
+            coverageIds: [telegram.native-setmycommands-startup-sync]
             description: Native setMyCommands startup sync, custom commands, native aliases, plugin
           - name: Command name/description normalization
-            coverageIds: [command-name-description-normalization]
+            coverageIds: [telegram.command-name-description-normalization]
             description: Command name/description normalization, menu budget trimming, duplicate
           - name: Built-in commands
-            coverageIds: [built-in-commands]
+            coverageIds: [telegram.built-in-commands]
             description: Built-in commands such as /help, /commands, /whoami, /status, and related command UI.
           - name: Command authorization in DMs
-            coverageIds: [command-authorization-in-dms]
+            coverageIds: [telegram.command-authorization-in-dms]
             description: Command authorization in DMs, groups, and commands addressed to other bots
           - name: Model buttons
-            coverageIds: [model-buttons]
+            coverageIds: [telegram.model-buttons]
             description: Model buttons and command UI helpers
         docs:
           - docs/channels/telegram.md
@@ -7036,19 +7036,19 @@ surfaces:
         id: channel-setup-and-operations
         features:
           - name: Official @openclaw/whatsapp plugin metadata
-            coverageIds: [official-openclaw-whatsapp-plugin-metadata]
+            coverageIds: [whatsapp.official-openclaw-whatsapp-plugin-metadata]
             description: Official @openclaw/whatsapp plugin metadata, package entrypoints, and setup discovery.
           - name: openclaw plugin install whatsapp
-            coverageIds: [openclaw-plugin-install-whatsapp]
+            coverageIds: [whatsapp.openclaw-plugin-install-whatsapp]
             description: openclaw plugin install whatsapp and config-first setup guidance
           - name: Channel config schema
-            coverageIds: [channel-config-schema]
+            coverageIds: [whatsapp.channel-config-schema]
             description: Channel config schema, plugin hooks, setup finalization, default account, and secret handling.
           - name: Baileys socket lifecycle
-            coverageIds: [baileys-socket-lifecycle]
+            coverageIds: [whatsapp.baileys-socket-lifecycle]
             description: Baileys socket lifecycle, connection controller state, reconnect decisions, and repair status.
           - name: Operator troubleshooting
-            coverageIds: [operator-troubleshooting]
+            coverageIds: [whatsapp.operator-troubleshooting]
             description: Operator troubleshooting for reconnect loops, stale sockets, Bun/Node runtime
         docs:
           - docs/channels/whatsapp.md
@@ -7067,25 +7067,25 @@ surfaces:
         id: access-and-identity
         features:
           - name: QR login
-            coverageIds: [qr-login]
+            coverageIds: [whatsapp.qr-login]
             description: QR login and agent login QR flows
           - name: Baileys multi-file auth persistence
-            coverageIds: [baileys-multi-file-auth-persistence]
+            coverageIds: [whatsapp.baileys-multi-file-auth-persistence]
             description: Baileys multi-file auth persistence, queued credential writes, backup restore, and login recovery.
           - name: DM pairing challenge
-            coverageIds: [dm-pairing-challenge]
+            coverageIds: [whatsapp.dm-pairing-challenge]
             description: DM pairing challenge and allow-store persistence where it intersects WhatsApp
           - name: Multi-account/default-account resolution
-            coverageIds: [multi-account-default-account-resolution]
+            coverageIds: [whatsapp.multi-account-default-account-resolution]
             description: Multi-account/default-account resolution and Baileys 515/401 recovery
           - name: Direct-message dmPolicy
-            coverageIds: [direct-message-dmpolicy]
+            coverageIds: [whatsapp.direct-message-dmpolicy]
             description: Direct-message dmPolicy, allowFrom, pairing challenge, pairing-store
           - name: Sender identity extraction
-            coverageIds: [sender-identity-extraction]
+            coverageIds: [whatsapp.sender-identity-extraction]
             description: Sender identity extraction, read receipts, self-chat safeguards, and contact matching.
           - name: Privacy controls for plugin hooks
-            coverageIds: [privacy-controls-for-plugin-hooks]
+            coverageIds: [whatsapp.privacy-controls-for-plugin-hooks]
             description: Privacy controls for plugin hooks and untrusted context
         docs:
           - docs/channels/whatsapp.md
@@ -7103,16 +7103,16 @@ surfaces:
         id: conversation-routing-and-delivery
         features:
           - name: Group allowlists
-            coverageIds: [group-allowlists]
+            coverageIds: [security.group-allowlists]
             description: Group allowlists, groupPolicy, exact group JIDs, requireMention, owner
           - name: Group session keys
-            coverageIds: [group-session-keys]
+            coverageIds: [whatsapp.group-session-keys]
             description: Group session keys, broadcast fanout, outbound mentions, and group prompt
           - name: Outbound text sends
-            coverageIds: [outbound-text-sends]
+            coverageIds: [whatsapp.outbound-text-sends]
             description: Outbound text sends, message-tool delivery, explicit DM/group/newsletter
           - name: Provider-accepted receipts
-            coverageIds: [provider-accepted-receipts]
+            coverageIds: [whatsapp.provider-accepted-receipts]
             description: Provider-accepted receipts and durable delivery identifiers
         docs:
           - docs/channels/whatsapp.md
@@ -7128,10 +7128,10 @@ surfaces:
         id: media-and-rich-content
         features:
           - name: Inbound media download
-            coverageIds: [inbound-media-download]
+            coverageIds: [whatsapp.inbound-media-download]
             description: Inbound media download and placeholder construction, quoted media extraction, and file handoff.
           - name: Outbound image
-            coverageIds: [outbound-image]
+            coverageIds: [whatsapp.outbound-image]
             description: Outbound image, audio, video, document, and voice-note payload construction.
         docs:
           - docs/channels/whatsapp.md
@@ -7144,10 +7144,10 @@ surfaces:
         id: native-controls-and-approvals
         features:
           - name: Native exec
-            coverageIds: [native-exec]
+            coverageIds: [whatsapp.native-exec]
             description: Native exec and plugin approval delivery through WhatsApp
           - name: Approver target resolution
-            coverageIds: [approver-target-resolution]
+            coverageIds: [whatsapp.approver-target-resolution]
             description: Approver target resolution, DM/group target eligibility, route suppression, and approval delivery.
         docs:
           - docs/channels/whatsapp.md
@@ -7174,34 +7174,34 @@ surfaces:
         id: channel-setup-and-operations
         features:
           - name: App Install
-            coverageIds: [app-install]
+            coverageIds: [slack.app-install]
             description: Covers App Install across installing `@openclaw/slack`, creating the Slack app, choosing recommended/minimal manifests, bot/app/user/signing-secret credential handling, and related app install, auth, manifest, and scopes behavior.
           - name: Slack app credentials
-            coverageIds: [slack-app-credentials]
+            coverageIds: [slack.app-credentials]
             description: Covers bot/app/user tokens, signing-secret handling, and Slack credential setup for app authentication.
           - name: Manifest
-            coverageIds: [manifest]
+            coverageIds: [slack.manifest]
             description: Covers Manifest across installing `@openclaw/slack`, creating the Slack app, choosing recommended/minimal manifests, bot/app/user/signing-secret credential handling, and related app install, auth, manifest, and scopes behavior.
           - name: Scopes
-            coverageIds: [scopes]
+            coverageIds: [slack.scopes]
             description: Covers Scopes across installing `@openclaw/slack`, creating the Slack app, choosing recommended/minimal manifests, bot/app/user/signing-secret credential handling, and related app install, auth, manifest, and scopes behavior.
           - name: Channel status diagnostics
-            coverageIds: [channel-status-diagnostics]
+            coverageIds: [slack.channel-status-diagnostics]
             description: Covers `openclaw channels status --probe`, account snapshots, token source/status fields, capability and scope diagnostics, and Slack repair guidance.
           - name: Slack account status
-            coverageIds: [slack-account-status]
+            coverageIds: [slack.account-status]
             description: Covers account snapshots, token source/status fields, capability summaries, and Slack status output.
           - name: Operator Repair
-            coverageIds: [operator-repair]
+            coverageIds: [codex.operator-repair]
             description: Covers Operator Repair across `openclaw channels status --probe`, account snapshots, token source/status fields, capability and scope diagnostics, and related diagnostics, status, and operator repair behavior.
           - name: Socket
-            coverageIds: [socket]
+            coverageIds: [slack.socket]
             description: Covers Socket across Socket Mode startup/reconnect/backoff, HTTP Request URL registration and signing-secret verification, transport mode selection, multi-account lifecycle, status/liveness, and runtime startup/skip behavior.
           - name: HTTP transport
-            coverageIds: [http-transport]
+            coverageIds: [slack.http-transport]
             description: Covers HTTP Request URL registration, signing-secret verification, transport mode selection, multi-account lifecycle, status/liveness, and Slack HTTP runtime startup/skip behavior.
           - name: Runtime Lifecycle
-            coverageIds: [runtime-lifecycle]
+            coverageIds: [slack.runtime-lifecycle]
             description: Covers Runtime Lifecycle across Socket Mode startup/reconnect/backoff, HTTP Request URL registration and signing-secret verification, transport mode selection, multi-account lifecycle, status/liveness, and runtime startup/skip behavior.
         docs:
           - docs/channels/slack.md
@@ -7234,7 +7234,7 @@ surfaces:
         id: access-and-identity
         features:
           - name: Access and Identity
-            coverageIds: [access-and-identity]
+            coverageIds: [channels.access-and-identity]
             description: Evidence scope for Access and Identity.
         docs:
           - docs/channels/slack.md
@@ -7248,19 +7248,19 @@ surfaces:
         id: conversation-routing-and-delivery
         features:
           - name: Channel allowlists
-            coverageIds: [channel-allowlists]
+            coverageIds: [slack.channel-allowlists]
             description: Covers channel allowlists, `groupPolicy`, channel/user gates, mention gates, and subteam mention behavior.
           - name: Thread routing
-            coverageIds: [thread-routing]
+            coverageIds: [slack.thread-routing]
             description: Covers Slack thread routing, thread-aware reply targeting, and session binding for channel threads.
           - name: Session Isolation
-            coverageIds: [session-isolation]
+            coverageIds: [slack.session-isolation]
             description: Covers Session Isolation across channel allowlists, `groupPolicy`, channel/user gates, mention and subteam mention behavior, and related channel/thread routing and session isolation behavior.
           - name: DM Pairing
-            coverageIds: [dm-pairing]
+            coverageIds: [security.dm-pairing]
             description: Covers DM Pairing across Slack DM routing, `dmPolicy`, `allowFrom`, pairing approvals, group DMs/MPIMs, account-level allowlist inheritance, command authorization in DMs, and sender identity normalization.
           - name: Sender Authorization
-            coverageIds: [sender-authorization]
+            coverageIds: [security.sender-authorization]
             description: Covers Sender Authorization across Slack DM routing, `dmPolicy`, `allowFrom`, pairing approvals, group DMs/MPIMs, account-level allowlist inheritance, command authorization in DMs, and sender identity normalization.
         docs:
           - docs/channels/slack.md
@@ -7282,7 +7282,7 @@ surfaces:
         id: media-and-rich-content
         features:
           - name: Media and Rich Content
-            coverageIds: [media-and-rich-content]
+            coverageIds: [channels.media-rich-content]
             description: Evidence scope for Media and Rich Content.
         docs:
           - docs/channels/slack.md
@@ -7296,28 +7296,28 @@ surfaces:
         id: native-controls-and-approvals
         features:
           - name: Slash Commands
-            coverageIds: [slash-commands]
+            coverageIds: [slack.slash-commands]
             description: Covers Slash Commands across configured slash command mode, native slash commands, command registration expectations, session keys, and related slash commands and native command routing behavior.
           - name: Native Command Routing
-            coverageIds: [native-command-routing]
+            coverageIds: [slack.native-command-routing]
             description: Covers Native Command Routing across configured slash command mode, native slash commands, command registration expectations, session keys, and related slash commands and native command routing behavior.
           - name: Interactive Replies
-            coverageIds: [interactive-replies]
+            coverageIds: [slack.interactive-replies]
             description: Covers Interactive Replies across App Home publish/open behavior, Slack assistant thread started/context-changed events, block actions, modal submissions, and related interactive replies, app home, and assistant events behavior.
           - name: App Home
-            coverageIds: [app-home]
+            coverageIds: [slack.app-home]
             description: Covers App Home across App Home publish/open behavior, Slack assistant thread started/context-changed events, block actions, modal submissions, and related interactive replies, app home, and assistant events behavior.
           - name: Assistant Events
-            coverageIds: [assistant-events]
+            coverageIds: [slack.assistant-events]
             description: Covers Assistant Events across App Home publish/open behavior, Slack assistant thread started/context-changed events, block actions, modal submissions, and related interactive replies, app home, and assistant events behavior.
           - name: Native Approvals
-            coverageIds: [native-approvals]
+            coverageIds: [security.native-approvals]
             description: Covers Native Approvals across Slack native exec and plugin approvals, Block Kit approval prompts, approval auth, approval routing, and related native approvals, actions, and security-sensitive ops behavior.
           - name: Actions
-            coverageIds: [actions]
+            coverageIds: [slack.actions]
             description: Covers Actions across Slack native exec and plugin approvals, Block Kit approval prompts, approval auth, approval routing, and related native approvals, actions, and security-sensitive ops behavior.
           - name: Security-sensitive Ops
-            coverageIds: [security-sensitive-ops]
+            coverageIds: [slack.security-sensitive-ops]
             description: Covers Security-sensitive Ops across Slack native exec and plugin approvals, Block Kit approval prompts, approval auth, approval routing, and related native approvals, actions, and security-sensitive ops behavior.
         docs:
           - docs/channels/slack.md
@@ -7358,37 +7358,37 @@ surfaces:
         id: channel-setup-and-operations
         features:
           - name: Translate legacy config
-            coverageIds: [translate-legacy-config]
+            coverageIds: [imessage.translate-legacy-config]
             description: Covers Translate legacy config across removal announcement, migration guide, config reference, old `channels.bluebubbles` key translation, group registry footgun, session caveats, attachment/action parity notes, and operator cutover checklist.
           - name: Cut over safely
-            coverageIds: [cut-over-safely]
+            coverageIds: [imessage.cut-over-safely]
             description: Covers Cut over safely across removal announcement, migration guide, config reference, old `channels.bluebubbles` key translation, group registry footgun, session caveats, attachment/action parity notes, and operator cutover checklist.
           - name: Handle migration caveats
-            coverageIds: [handle-migration-caveats]
+            coverageIds: [imessage.handle-migration-caveats]
             description: Covers Handle migration caveats across removal announcement, migration guide, config reference, old `channels.bluebubbles` key translation, group registry footgun, session caveats, attachment/action parity notes, and operator cutover checklist.
           - name: Run local imsg
-            coverageIds: [run-local-imsg]
+            coverageIds: [imessage.run-local-imsg]
             description: Covers Run local imsg across local and remote `imsg rpc`, `cliPath`, `dbPath`, `remoteHost`, and related imsg transport, host requirements, and permissions behavior.
           - name: Run through SSH wrapper
-            coverageIds: [run-through-ssh-wrapper]
+            coverageIds: [imessage.run-through-ssh-wrapper]
             description: Covers Run through SSH wrapper across local and remote `imsg rpc`, `cliPath`, `dbPath`, `remoteHost`, and related imsg transport, host requirements, and permissions behavior.
           - name: Grant macOS permissions
-            coverageIds: [grant-macos-permissions]
+            coverageIds: [imessage.grant-macos-permissions]
             description: Covers Grant macOS permissions across local and remote `imsg rpc`, `cliPath`, `dbPath`, `remoteHost`, and related imsg transport, host requirements, and permissions behavior.
           - name: Probe runtime health
-            coverageIds: [probe-runtime-health]
+            coverageIds: [imessage.probe-runtime-health]
             description: Covers Probe runtime health across local and remote `imsg rpc`, `cliPath`, `dbPath`, `remoteHost`, and related imsg transport, host requirements, and permissions behavior.
           - name: Account setup prompts
-            coverageIds: [account-setup-prompts]
+            coverageIds: [imessage.account-setup-prompts]
             description: Covers setup prompts, policy writes, account merging, default account selection, and account configuration behavior for iMessage/BlueBubbles.
           - name: Account status checks
-            coverageIds: [account-status-checks]
+            coverageIds: [imessage.account-status-checks]
             description: Covers account status output, setup state, account merging, and default account selection for iMessage/BlueBubbles.
           - name: Doctor repair checks
-            coverageIds: [doctor-repair-checks]
+            coverageIds: [imessage.doctor-repair-checks]
             description: Covers doctor checks, setup repair prompts, and policy verification for iMessage/BlueBubbles account configuration.
           - name: Account Config
-            coverageIds: [account-config]
+            coverageIds: [imessage.account-config]
             description: Covers Account Config across setup prompts, policy writes, account merging, default account selection, and related setup, status, doctor, and account config behavior.
         docs:
           - docs/announcements/bluebubbles-imessage.md
@@ -7416,22 +7416,22 @@ surfaces:
         id: access-and-identity
         features:
           - name: Authorize direct senders
-            coverageIds: [authorize-direct-senders]
+            coverageIds: [imessage.authorize-direct-senders]
             description: Covers Authorize direct senders across `dmPolicy`, `allowFrom`, pairing, sender identity normalization, and related dm pairing, access, and session routing behavior.
           - name: Route direct conversations
-            coverageIds: [route-direct-conversations]
+            coverageIds: [imessage.route-direct-conversations]
             description: Covers Route direct conversations across `dmPolicy`, `allowFrom`, pairing, sender identity normalization, and related dm pairing, access, and session routing behavior.
           - name: Bind ACP sessions
-            coverageIds: [bind-acp-sessions]
+            coverageIds: [imessage.bind-acp-sessions]
             description: Covers Bind ACP sessions across `dmPolicy`, `allowFrom`, pairing, sender identity normalization, and related dm pairing, access, and session routing behavior.
           - name: Group Policy
-            coverageIds: [group-policy]
+            coverageIds: [imessage.group-policy]
             description: Covers Group Policy across `groupPolicy`, `groupAllowFrom`, `groups`, wildcard registry entries, `requireMention`, mention patterns, per-group tools, per-group system prompts, group sessions, and warnings for allowlist misconfiguration.
           - name: Mentions
-            coverageIds: [mentions]
+            coverageIds: [imessage.mentions]
             description: Covers Mentions across `groupPolicy`, `groupAllowFrom`, `groups`, wildcard registry entries, `requireMention`, mention patterns, per-group tools, per-group system prompts, group sessions, and warnings for allowlist misconfiguration.
           - name: System Prompts
-            coverageIds: [system-prompts]
+            coverageIds: [imessage.system-prompts]
             description: Covers System Prompts across `groupPolicy`, `groupAllowFrom`, `groups`, wildcard registry entries, `requireMention`, mention patterns, per-group tools, per-group system prompts, group sessions, and warnings for allowlist misconfiguration.
         docs:
           - docs/channels/imessage.md
@@ -7452,16 +7452,16 @@ surfaces:
         id: conversation-routing-and-delivery
         features:
           - name: Watch live messages
-            coverageIds: [watch-live-messages]
+            coverageIds: [imessage.watch-live-messages]
             description: Covers Watch live messages across inbound `watch.subscribe`, notification parsing, echo and self-chat guards, sent-message cache, same-sender DM coalescing, DM history, reaction event routing, catchup cursor/replay, and live cursor advancement.
           - name: Coalesce split-send DMs
-            coverageIds: [coalesce-split-send-dms]
+            coverageIds: [imessage.coalesce-split-send-dms]
             description: Covers Coalesce split-send DMs across inbound `watch.subscribe`, notification parsing, echo and self-chat guards, sent-message cache, same-sender DM coalescing, DM history, reaction event routing, catchup cursor/replay, and live cursor advancement.
           - name: Replay missed messages
-            coverageIds: [replay-missed-messages]
+            coverageIds: [imessage.replay-missed-messages]
             description: Covers Replay missed messages across inbound `watch.subscribe`, notification parsing, echo and self-chat guards, sent-message cache, same-sender DM coalescing, DM history, reaction event routing, catchup cursor/replay, and live cursor advancement.
           - name: Seed conversation history
-            coverageIds: [seed-conversation-history]
+            coverageIds: [imessage.seed-conversation-history]
             description: Covers Seed conversation history across inbound `watch.subscribe`, notification parsing, echo and self-chat guards, sent-message cache, same-sender DM coalescing, DM history, reaction event routing, catchup cursor/replay, and live cursor advancement.
         docs:
           - docs/channels/imessage.md
@@ -7476,25 +7476,25 @@ surfaces:
         id: media-and-rich-content
         features:
           - name: Media
-            coverageIds: [media]
+            coverageIds: [imessage.media]
             description: Covers Media across `includeAttachments`, attachment root allowlists, remote attachment roots, `remoteHost` SCP fetches, HEIC conversion, size caps, outbound media sends, `send-attachment`, text chunking, and media receipts.
           - name: Attachments
-            coverageIds: [attachments]
+            coverageIds: [ui.attachments]
             description: Covers Attachments across `includeAttachments`, attachment root allowlists, remote attachment roots, `remoteHost` SCP fetches, HEIC conversion, size caps, outbound media sends, `send-attachment`, text chunking, and media receipts.
           - name: Remote Fetch
-            coverageIds: [remote-fetch]
+            coverageIds: [imessage.remote-fetch]
             description: Covers Remote Fetch across `includeAttachments`, attachment root allowlists, remote attachment roots, `remoteHost` SCP fetches, HEIC conversion, size caps, outbound media sends, `send-attachment`, text chunking, and media receipts.
           - name: Chunking
-            coverageIds: [chunking]
+            coverageIds: [imessage.chunking]
             description: Covers Chunking across `includeAttachments`, attachment root allowlists, remote attachment roots, `remoteHost` SCP fetches, HEIC conversion, size caps, outbound media sends, `send-attachment`, text chunking, and media receipts.
           - name: Native Actions
-            coverageIds: [native-actions]
+            coverageIds: [imessage.native-actions]
             description: Covers Native Actions across private API probing, action availability, action config gates, tapback mapping, edit/unsend/reply/effects/group management, `send-rich --file`, message-tool visibility/target grammar, and action dispatch errors.
           - name: Private API
-            coverageIds: [private-api]
+            coverageIds: [imessage.private-api]
             description: Covers Private API across private API probing, action availability, action config gates, tapback mapping, edit/unsend/reply/effects/group management, `send-rich --file`, message-tool visibility/target grammar, and action dispatch errors.
           - name: Message Tool
-            coverageIds: [message-tool]
+            coverageIds: [imessage.message-tool]
             description: Covers Message Tool across private API probing, action availability, action config gates, tapback mapping, edit/unsend/reply/effects/group management, `send-rich --file`, message-tool visibility/target grammar, and action dispatch errors.
         docs:
           - docs/channels/imessage.md
@@ -7518,13 +7518,13 @@ surfaces:
         id: native-controls-and-approvals
         features:
           - name: Native Approvals
-            coverageIds: [native-approvals]
+            coverageIds: [security.native-approvals]
             description: Covers Native Approvals across native approval delivery, exec/plugin approval routing, reaction-based approval decisions, `/approve` authorization changes, and related native approvals, reactions, and operator control behavior.
           - name: Reactions
-            coverageIds: [reactions]
+            coverageIds: [imessage.reactions]
             description: Covers Reactions across native approval delivery, exec/plugin approval routing, reaction-based approval decisions, `/approve` authorization changes, and related native approvals, reactions, and operator control behavior.
           - name: Operator Control
-            coverageIds: [operator-control]
+            coverageIds: [imessage.operator-control]
             description: Covers Operator Control across native approval delivery, exec/plugin approval routing, reaction-based approval decisions, `/approve` authorization changes, and related native approvals, reactions, and operator control behavior.
         docs:
           - docs/channels/imessage.md
@@ -7554,25 +7554,25 @@ surfaces:
         id: channel-setup-and-operations
         features:
           - name: QR link setup
-            coverageIds: [qr-link-setup]
+            coverageIds: [signal.qr-link-setup]
             description: Defines QR link setup setup, credential, configuration, and operator verification behavior for Setup, Install, and Account Provisioning.
           - name: SMS registration
-            coverageIds: [sms-registration]
+            coverageIds: [signal.sms-registration]
             description: Defines SMS registration setup, credential, configuration, and operator verification behavior for Setup, Install, and Account Provisioning.
           - name: Installer and binary setup
-            coverageIds: [installer-and-binary-setup]
+            coverageIds: [signal.installer-and-binary-setup]
             description: Defines Installer and binary setup setup, credential, configuration, and operator verification behavior for Setup, Install, and Account Provisioning.
           - name: Container account provisioning
-            coverageIds: [container-account-provisioning]
+            coverageIds: [signal.container-account-provisioning]
             description: Defines Container account provisioning setup, credential, configuration, and operator verification behavior for Setup, Install, and Account Provisioning.
           - name: Status probes
-            coverageIds: [status-probes]
+            coverageIds: [signal.status-probes]
             description: Defines Status probes setup, credential, configuration, and operator verification behavior for Diagnostics, Config Status, and Operator Guardrails.
           - name: Setup diagnostics
-            coverageIds: [setup-diagnostics]
+            coverageIds: [signal.setup-diagnostics]
             description: Defines Setup diagnostics setup, credential, configuration, and operator verification behavior for Diagnostics, Config Status, and Operator Guardrails.
           - name: Account safety guardrails
-            coverageIds: [account-safety-guardrails]
+            coverageIds: [signal.account-safety-guardrails]
             description: Defines Account safety guardrails setup, credential, configuration, and operator verification behavior for Diagnostics, Config Status, and Operator Guardrails.
         docs:
           - docs/channels/signal.md
@@ -7596,22 +7596,22 @@ surfaces:
         id: access-and-identity
         features:
           - name: DM pairing
-            coverageIds: [dm-pairing]
+            coverageIds: [security.dm-pairing]
             description: Defines DM pairing setup, credential, configuration, and operator verification behavior for DM Pairing and Access Control.
           - name: DM allowlists
-            coverageIds: [dm-allowlists]
+            coverageIds: [signal.dm-allowlists]
             description: Defines DM allowlists setup, credential, configuration, and operator verification behavior for DM Pairing and Access Control.
           - name: Sender identity normalization
-            coverageIds: [sender-identity-normalization]
+            coverageIds: [signal.sender-identity-normalization]
             description: Defines Sender identity normalization setup, credential, configuration, and operator verification behavior for DM Pairing and Access Control.
           - name: Group allowlists
-            coverageIds: [group-allowlists]
+            coverageIds: [security.group-allowlists]
             description: Defines Group allowlists authorization, trust, safety boundaries, and operator controls for Group Routing, Mentions, and Pending History.
           - name: Mention gates
-            coverageIds: [mention-gates]
+            coverageIds: [matrix.mention-gates]
             description: Defines Mention gates authorization, trust, safety boundaries, and operator controls for Group Routing, Mentions, and Pending History.
           - name: Pending group history
-            coverageIds: [pending-group-history]
+            coverageIds: [signal.pending-group-history]
             description: Defines Pending group history authorization, trust, safety boundaries, and operator controls for Group Routing, Mentions, and Pending History.
         docs:
           - docs/channels/signal.md
@@ -7633,7 +7633,7 @@ surfaces:
         id: conversation-routing-and-delivery
         features:
           - name: Conversation Routing and Delivery
-            coverageIds: [conversation-routing-and-delivery]
+            coverageIds: [channels.conversation-routing-delivery]
             description: Evidence scope for Conversation Routing and Delivery.
         docs:
           - docs/channels/signal.md
@@ -7646,25 +7646,25 @@ surfaces:
         id: media-and-rich-content
         features:
           - name: Text delivery targets
-            coverageIds: [text-delivery-targets]
+            coverageIds: [signal.text-delivery-targets]
             description: Covers Text delivery targets routing, session binding, history, and conversation context for Outbound Delivery, Media, Receipts, and Typing.
           - name: Media delivery and limits
-            coverageIds: [media-delivery-and-limits]
+            coverageIds: [signal.media-delivery-and-limits]
             description: Covers Media delivery and limits routing, session binding, history, and conversation context for Outbound Delivery, Media, Receipts, and Typing.
           - name: Typing and read receipts
-            coverageIds: [typing-and-read-receipts]
+            coverageIds: [signal.typing-and-read-receipts]
             description: Covers Typing and read receipts routing, session binding, history, and conversation context for Outbound Delivery, Media, Receipts, and Typing.
           - name: Styled/chunked output
-            coverageIds: [styled-chunked-output]
+            coverageIds: [signal.styled-chunked-output]
             description: Covers Styled/chunked output routing, session binding, history, and conversation context for Outbound Delivery, Media, Receipts, and Typing.
           - name: Reaction action discovery
-            coverageIds: [reaction-action-discovery]
+            coverageIds: [signal.reaction-action-discovery]
             description: Covers Reaction action discovery routing, session binding, history, and conversation context for Reactions Message Tool.
           - name: Add/remove reactions
-            coverageIds: [add-remove-reactions]
+            coverageIds: [signal.add-remove-reactions]
             description: Covers Add/remove reactions routing, session binding, history, and conversation context for Reactions Message Tool.
           - name: Group reaction targeting
-            coverageIds: [group-reaction-targeting]
+            coverageIds: [signal.group-reaction-targeting]
             description: Covers Group reaction targeting routing, session binding, history, and conversation context for Reactions Message Tool.
         docs:
           - docs/channels/signal.md
@@ -7687,13 +7687,13 @@ surfaces:
         id: native-controls-and-approvals
         features:
           - name: Native approval routing
-            coverageIds: [native-approval-routing]
+            coverageIds: [signal.native-approval-routing]
             description: Defines Native approval routing authorization, trust, safety boundaries, and operator controls for Approval Routing and Reaction Resolution.
           - name: Reaction approval responses
-            coverageIds: [reaction-approval-responses]
+            coverageIds: [signal.reaction-approval-responses]
             description: Defines Reaction approval responses authorization, trust, safety boundaries, and operator controls for Approval Routing and Reaction Resolution.
           - name: Approver targeting
-            coverageIds: [approver-targeting]
+            coverageIds: [signal.approver-targeting]
             description: Defines Approver targeting authorization, trust, safety boundaries, and operator controls for Approval Routing and Reaction Resolution.
         docs:
           - docs/channels/signal.md
@@ -7726,52 +7726,52 @@ surfaces:
         id: channel-setup-and-operations
         features:
           - name: Google Cloud project setup
-            coverageIds: [google-cloud-project-setup]
+            coverageIds: [google-chat.google-cloud-project-setup]
             description: Covers Google Cloud project setup across Google Chat plugin installation, Google Cloud project and Chat API setup, service account JSON/file/env credential selection, `audienceType`, and related setup auth and workspace app behavior.
           - name: Chat app configuration
-            coverageIds: [chat-app-configuration]
+            coverageIds: [google-chat.chat-app-configuration]
             description: Covers Chat app configuration across Google Chat plugin installation, Google Cloud project and Chat API setup, service account JSON/file/env credential selection, `audienceType`, and related setup auth and workspace app behavior.
           - name: Service account setup
-            coverageIds: [service-account-setup]
+            coverageIds: [google-chat.service-account-setup]
             description: Covers Service account setup across Google Chat plugin installation, Google Cloud project and Chat API setup, service account JSON/file/env credential selection, `audienceType`, and related setup auth and workspace app behavior.
           - name: Webhook audience and path
-            coverageIds: [webhook-audience-and-path]
+            coverageIds: [google-chat.webhook-audience-and-path]
             description: Covers Webhook audience and path across Google Chat plugin installation, Google Cloud project and Chat API setup, service account JSON/file/env credential selection, `audienceType`, and related setup auth and workspace app behavior.
           - name: Workspace visibility and app status
-            coverageIds: [workspace-visibility-and-app-status]
+            coverageIds: [google-chat.workspace-visibility-and-app-status]
             description: Covers Workspace visibility and app status across Google Chat plugin installation, Google Cloud project and Chat API setup, service account JSON/file/env credential selection, `audienceType`, and related setup auth and workspace app behavior.
           - name: Guided channel setup
-            coverageIds: [guided-channel-setup]
+            coverageIds: [google-chat.guided-channel-setup]
             description: Covers Guided channel setup across Google Chat plugin installation, Google Cloud project and Chat API setup, service account JSON/file/env credential selection, `audienceType`, and related setup auth and workspace app behavior.
           - name: Account resolution
-            coverageIds: [account-resolution]
+            coverageIds: [google-chat.account-resolution]
             description: Covers Account resolution across `accounts`, `defaultAccount`, top-level and account credential inheritance, service account SecretRefs, and related multi account secrets status and diagnostics behavior.
           - name: Service account SecretRefs
-            coverageIds: [service-account-secretrefs]
+            coverageIds: [google-chat.service-account-secretrefs]
             description: Covers Service account SecretRefs across `accounts`, `defaultAccount`, top-level and account credential inheritance, service account SecretRefs, and related multi account secrets status and diagnostics behavior.
           - name: Env file and inline credentials
-            coverageIds: [env-file-and-inline-credentials]
+            coverageIds: [google-chat.env-file-and-inline-credentials]
             description: Covers Env file and inline credentials across `accounts`, `defaultAccount`, top-level and account credential inheritance, service account SecretRefs, and related multi account secrets status and diagnostics behavior.
           - name: Channel status and probes
-            coverageIds: [channel-status-and-probes]
+            coverageIds: [google-chat.channel-status-and-probes]
             description: Covers Channel status and probes across `accounts`, `defaultAccount`, top-level and account credential inheritance, service account SecretRefs, and related multi account secrets status and diagnostics behavior.
           - name: Directory and mutable-id diagnostics
-            coverageIds: [directory-and-mutable-id-diagnostics]
+            coverageIds: [google-chat.directory-and-mutable-id-diagnostics]
             description: Covers Directory and mutable-id diagnostics across `accounts`, `defaultAccount`, top-level and account credential inheritance, service account SecretRefs, and related multi account secrets status and diagnostics behavior.
           - name: NPM and ClawHub install
-            coverageIds: [npm-and-clawhub-install]
+            coverageIds: [google-chat.npm-and-clawhub-install]
             description: Covers NPM and ClawHub install across npm/ClawHub plugin metadata, docs navigation, plugin references, official external plugin catalog, and related plugin distribution operator ui and docs behavior.
           - name: Plugin docs and catalog routing
-            coverageIds: [plugin-docs-and-catalog-routing]
+            coverageIds: [google-chat.plugin-docs-and-catalog-routing]
             description: Covers Plugin docs and catalog routing across npm/ClawHub plugin metadata, docs navigation, plugin references, official external plugin catalog, and related plugin distribution operator ui and docs behavior.
           - name: Channel aliases and labels
-            coverageIds: [channel-aliases-and-labels]
+            coverageIds: [google-chat.channel-aliases-and-labels]
             description: Covers Channel aliases and labels across npm/ClawHub plugin metadata, docs navigation, plugin references, official external plugin catalog, and related plugin distribution operator ui and docs behavior.
           - name: Operator status UI
-            coverageIds: [operator-status-ui]
+            coverageIds: [google-chat.operator-status-ui]
             description: Covers Operator status UI across npm/ClawHub plugin metadata, docs navigation, plugin references, official external plugin catalog, and related plugin distribution operator ui and docs behavior.
           - name: Install/update metadata
-            coverageIds: [install-update-metadata]
+            coverageIds: [google-chat.install-update-metadata]
             description: Covers Install/update metadata across npm/ClawHub plugin metadata, docs navigation, plugin references, official external plugin catalog, and related plugin distribution operator ui and docs behavior.
         docs:
           - docs/channels/googlechat.md
@@ -7810,37 +7810,37 @@ surfaces:
         id: access-and-identity
         features:
           - name: DM pairing approval
-            coverageIds: [dm-pairing-approval]
+            coverageIds: [google-chat.dm-pairing-approval]
             description: Covers DM pairing approval across Google Chat DMs, `dm.policy`, `dm.allowFrom`, pairing challenges, and related dm pairing and sender authorization behavior.
           - name: Sender allowlists
-            coverageIds: [sender-allowlists]
+            coverageIds: [google-chat.sender-allowlists]
             description: Covers Sender allowlists across Google Chat DMs, `dm.policy`, `dm.allowFrom`, pairing challenges, and related dm pairing and sender authorization behavior.
           - name: Google Chat identity matching
-            coverageIds: [google-chat-identity-matching]
+            coverageIds: [google-chat.identity-matching]
             description: Covers Google Chat identity matching across Google Chat DMs, `dm.policy`, `dm.allowFrom`, pairing challenges, and related dm pairing and sender authorization behavior.
           - name: Direct session routing
-            coverageIds: [direct-session-routing]
+            coverageIds: [google-chat.direct-session-routing]
             description: Covers Direct session routing across Google Chat DMs, `dm.policy`, `dm.allowFrom`, pairing challenges, and related dm pairing and sender authorization behavior.
           - name: Pairing diagnostics
-            coverageIds: [pairing-diagnostics]
+            coverageIds: [google-chat.pairing-diagnostics]
             description: Covers Pairing diagnostics across Google Chat DMs, `dm.policy`, `dm.allowFrom`, pairing challenges, and related dm pairing and sender authorization behavior.
           - name: Space allowlists
-            coverageIds: [space-allowlists]
+            coverageIds: [google-chat.space-allowlists]
             description: Covers Space allowlists across Google Chat spaces and group messages, `groupPolicy`, `groups`, wildcard groups, and related space routing mentions and session isolation behavior.
           - name: Mention gating
-            coverageIds: [mention-gating]
+            coverageIds: [channels.mention-gating]
             description: Covers Mention gating across Google Chat spaces and group messages, `groupPolicy`, `groups`, wildcard groups, and related space routing mentions and session isolation behavior.
           - name: Sender access groups
-            coverageIds: [sender-access-groups]
+            coverageIds: [google-chat.sender-access-groups]
             description: Covers Sender access groups across Google Chat spaces and group messages, `groupPolicy`, `groups`, wildcard groups, and related space routing mentions and session isolation behavior.
           - name: Group session isolation
-            coverageIds: [group-session-isolation]
+            coverageIds: [google-chat.group-session-isolation]
             description: Covers Group session isolation across Google Chat spaces and group messages, `groupPolicy`, `groups`, wildcard groups, and related space routing mentions and session isolation behavior.
           - name: Bot-loop protection
-            coverageIds: [bot-loop-protection]
+            coverageIds: [channels.bot-loop-protection]
             description: Covers Bot-loop protection across Google Chat spaces and group messages, `groupPolicy`, `groups`, wildcard groups, and related space routing mentions and session isolation behavior.
           - name: Space diagnostics
-            coverageIds: [space-diagnostics]
+            coverageIds: [google-chat.space-diagnostics]
             description: Covers Space diagnostics across Google Chat spaces and group messages, `groupPolicy`, `groups`, wildcard groups, and related space routing mentions and session isolation behavior.
         docs:
           - docs/channels/googlechat.md
@@ -7870,7 +7870,7 @@ surfaces:
         id: conversation-routing-and-delivery
         features:
           - name: Conversation Routing and Delivery
-            coverageIds: [conversation-routing-and-delivery]
+            coverageIds: [channels.conversation-routing-delivery]
             description: Evidence scope for Conversation Routing and Delivery.
         docs:
           - docs/channels/googlechat.md
@@ -7886,7 +7886,7 @@ surfaces:
         id: media-and-rich-content
         features:
           - name: Media and Rich Content
-            coverageIds: [media-and-rich-content]
+            coverageIds: [channels.media-rich-content]
             description: Evidence scope for Media and Rich Content.
         docs:
           - docs/channels/googlechat.md
@@ -7902,52 +7902,52 @@ surfaces:
         id: native-controls-and-approvals
         features:
           - name: Inbound attachments
-            coverageIds: [inbound-attachments]
+            coverageIds: [google-chat.inbound-attachments]
             description: Covers Inbound attachments across inbound Google Chat attachment download, media store handoff, outbound media reply delivery, `upload-file`, and related media attachments and file transfer behavior.
           - name: Outbound media replies
-            coverageIds: [outbound-media-replies]
+            coverageIds: [google-chat.outbound-media-replies]
             description: Covers Outbound media replies across inbound Google Chat attachment download, media store handoff, outbound media reply delivery, `upload-file`, and related media attachments and file transfer behavior.
           - name: Message upload action
-            coverageIds: [message-upload-action]
+            coverageIds: [google-chat.message-upload-action]
             description: Covers Message upload action across inbound Google Chat attachment download, media store handoff, outbound media reply delivery, `upload-file`, and related media attachments and file transfer behavior.
           - name: Media source and size controls
-            coverageIds: [media-source-and-size-controls]
+            coverageIds: [google-chat.media-source-and-size-controls]
             description: Covers Media source and size controls across inbound Google Chat attachment download, media store handoff, outbound media reply delivery, `upload-file`, and related media attachments and file transfer behavior.
           - name: Media receipts and thread placement
-            coverageIds: [media-receipts-and-thread-placement]
+            coverageIds: [google-chat.media-receipts-and-thread-placement]
             description: Covers Media receipts and thread placement across inbound Google Chat attachment download, media store handoff, outbound media reply delivery, `upload-file`, and related media attachments and file transfer behavior.
           - name: Text send action
-            coverageIds: [text-send-action]
+            coverageIds: [google-chat.text-send-action]
             description: Covers Text send action across Google Chat message tool action discovery, `send`, `upload-file`, `react`, and related message actions reactions and approval auth behavior.
           - name: Upload-file action
-            coverageIds: [upload-file-action]
+            coverageIds: [google-chat.upload-file-action]
             description: Covers Upload-file action across Google Chat message tool action discovery, `send`, `upload-file`, `react`, and related message actions reactions and approval auth behavior.
           - name: Reaction actions
-            coverageIds: [reaction-actions]
+            coverageIds: [google-chat.reaction-actions]
             description: Covers Reaction actions across Google Chat message tool action discovery, `send`, `upload-file`, `react`, and related message actions reactions and approval auth behavior.
           - name: Action capability gates
-            coverageIds: [action-capability-gates]
+            coverageIds: [google-chat.action-capability-gates]
             description: Covers Action capability gates across Google Chat message tool action discovery, `send`, `upload-file`, `react`, and related message actions reactions and approval auth behavior.
           - name: Approval sender matching
-            coverageIds: [approval-sender-matching]
+            coverageIds: [google-chat.approval-sender-matching]
             description: Covers Approval sender matching across Google Chat message tool action discovery, `send`, `upload-file`, `react`, and related message actions reactions and approval auth behavior.
           - name: Thread-aware replies
-            coverageIds: [thread-aware-replies]
+            coverageIds: [google-chat.thread-aware-replies]
             description: Covers Thread-aware replies across inbound thread resource propagation, `replyToMode`, Google Chat `messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD`, text chunking, and related threaded replies streaming and typing lifecycle behavior.
           - name: Streaming and chunked replies
-            coverageIds: [streaming-and-chunked-replies]
+            coverageIds: [google-chat.streaming-and-chunked-replies]
             description: Covers Streaming and chunked replies across inbound thread resource propagation, `replyToMode`, Google Chat `messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD`, text chunking, and related threaded replies streaming and typing lifecycle behavior.
           - name: Typing placeholder lifecycle
-            coverageIds: [typing-placeholder-lifecycle]
+            coverageIds: [google-chat.typing-placeholder-lifecycle]
             description: Covers Typing placeholder lifecycle across inbound thread resource propagation, `replyToMode`, Google Chat `messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD`, text chunking, and related threaded replies streaming and typing lifecycle behavior.
           - name: Message-tool current-source replies
-            coverageIds: [message-tool-current-source-replies]
+            coverageIds: [google-chat.message-tool-current-source-replies]
             description: Covers Message-tool current-source replies across inbound thread resource propagation, `replyToMode`, Google Chat `messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD`, text chunking, and related threaded replies streaming and typing lifecycle behavior.
           - name: NO_REPLY cleanup
-            coverageIds: [no-reply-cleanup]
+            coverageIds: [google-chat.no-reply-cleanup]
             description: Covers NO_REPLY cleanup across inbound thread resource propagation, `replyToMode`, Google Chat `messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD`, text chunking, and related threaded replies streaming and typing lifecycle behavior.
           - name: Markdown/text rendering
-            coverageIds: [markdown-text-rendering]
+            coverageIds: [google-chat.markdown-text-rendering]
             description: Covers Markdown/text rendering across inbound thread resource propagation, `replyToMode`, Google Chat `messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD`, text chunking, and related threaded replies streaming and typing lifecycle behavior.
         docs:
           - docs/channels/googlechat.md
@@ -7998,19 +7998,19 @@ surfaces:
         id: channel-setup-and-operations
         features:
           - name: Matrix plugin identity
-            coverageIds: [matrix-plugin-identity]
+            coverageIds: [matrix.plugin-identity]
             description: Matrix plugin identity, install metadata, runtime/setup entries, and account configuration.
           - name: Setup wizard
-            coverageIds: [setup-wizard]
+            coverageIds: [matrix.setup-wizard]
             description: Setup wizard, setup adapter, validation, post-write bootstrap, and account setup.
           - name: Account discovery
-            coverageIds: [account-discovery]
+            coverageIds: [matrix.account-discovery]
             description: Account discovery, default account rules, env-backed accounts, and stored account metadata.
           - name: Matrix doctor warnings
-            coverageIds: [matrix-doctor-warnings]
+            coverageIds: [matrix.doctor-warnings]
             description: Matrix doctor warnings, config normalization, and stale plugin config cleanup.
           - name: Matrix probe/status
-            coverageIds: [matrix-probe-status]
+            coverageIds: [matrix.probe-status]
             description: Matrix probe/status, live directory lookup, CLI diagnostics, and QA runtime status.
         docs:
           - docs/channels/matrix.md
@@ -8026,25 +8026,25 @@ surfaces:
         id: access-and-identity
         features:
           - name: DM policy
-            coverageIds: [dm-policy]
+            coverageIds: [matrix.dm-policy]
             description: DM policy, pairing, allowFrom, groupAllowFrom, room allowlists, and live access checks.
           - name: Direct-room classification
-            coverageIds: [direct-room-classification]
+            coverageIds: [matrix.direct-room-classification]
             description: Direct-room classification and repair-adjacent routing decisions
           - name: Inbound route selection across sender-bound DMs
-            coverageIds: [inbound-route-selection-across-sender-bound-dms]
+            coverageIds: [matrix.inbound-route-selection-across-sender-bound-dms]
             description: Inbound route selection across sender-bound DMs, room bindings, and account-scoped routes.
           - name: Mention gates
-            coverageIds: [mention-gates]
+            coverageIds: [matrix.mention-gates]
             description: Mention gates, slash command access checks, bot-loop suppression, and context admission.
           - name: Matrix thread reply routing
-            coverageIds: [matrix-thread-reply-routing]
+            coverageIds: [matrix.thread-reply-routing]
             description: Matrix thread reply routing, thread root/context extraction, and thread-aware session placement.
           - name: Persisted Matrix thread routing managers
-            coverageIds: [persisted-matrix-thread-routing-managers]
+            coverageIds: [matrix.persisted-matrix-thread-routing-managers]
             description: Persisted Matrix thread binding managers, child session binding, and activity tracking.
           - name: ACP/subagent spawn hooks
-            coverageIds: [acp-subagent-spawn-hooks]
+            coverageIds: [matrix.acp-subagent-spawn-hooks]
             description: ACP/subagent spawn hooks and Matrix delivery targets for child sessions
         docs:
           - docs/channels/matrix.md
@@ -8061,7 +8061,7 @@ surfaces:
         id: conversation-routing-and-delivery
         features:
           - name: Conversation Routing and Delivery
-            coverageIds: [conversation-routing-and-delivery]
+            coverageIds: [channels.conversation-routing-delivery]
             description: Evidence scope for Conversation Routing and Delivery.
         docs:
           - docs/channels/matrix.md
@@ -8074,7 +8074,7 @@ surfaces:
         id: media-and-rich-content
         features:
           - name: Media and Rich Content
-            coverageIds: [media-and-rich-content]
+            coverageIds: [channels.media-rich-content]
             description: Evidence scope for Media and Rich Content.
         docs:
           - docs/channels/matrix.md
@@ -8087,22 +8087,22 @@ surfaces:
         id: native-controls-and-approvals
         features:
           - name: Channel action discovery
-            coverageIds: [channel-action-discovery]
+            coverageIds: [matrix.channel-action-discovery]
             description: Channel action discovery, account-scoped action gates, and tool schemas
           - name: Message send/read/edit/delete
-            coverageIds: [message-send-read-edit-delete]
+            coverageIds: [matrix.message-send-read-edit-delete]
             description: Message send/read/edit/delete, poll voting, reaction add/remove/list, pins, and related room tools.
           - name: Profile media loading
-            coverageIds: [profile-media-loading]
+            coverageIds: [matrix.profile-media-loading]
             description: Profile media loading from URL or local path.
           - name: Outbound Matrix text
-            coverageIds: [outbound-matrix-text]
+            coverageIds: [matrix.outbound-matrix-text]
             description: Outbound Matrix text, media, encrypted media, poll, typing, read receipt, and delivery behavior.
           - name: Message presentation metadata
-            coverageIds: [message-presentation-metadata]
+            coverageIds: [matrix.message-presentation-metadata]
             description: Message presentation metadata, Matrix mention metadata, and chunked delivery behavior.
           - name: Inbound media failure handling
-            coverageIds: [inbound-media-failure-handling]
+            coverageIds: [matrix.inbound-media-failure-handling]
             description: Inbound media download failure handling when it affects outbound replies.
         docs:
           - docs/channels/matrix.md
@@ -8117,13 +8117,13 @@ surfaces:
         id: encryption-and-verification
         features:
           - name: Encryption setup
-            coverageIds: [encryption-setup]
+            coverageIds: [matrix.encryption-setup]
             description: Encryption setup, crypto availability, recovery-key storage, and secret storage.
           - name: Encrypted media upload/download
-            coverageIds: [encrypted-media-upload-download]
+            coverageIds: [matrix.encrypted-media-upload-download]
             description: Encrypted media upload/download and startup verification notices
           - name: Legacy state
-            coverageIds: [legacy-state]
+            coverageIds: [matrix.legacy-state]
             description: Legacy state and crypto migration, migration snapshots, and gateway startup repair.
         docs:
           - docs/channels/matrix.md
@@ -8151,31 +8151,31 @@ surfaces:
         id: channel-setup-and-operations
         features:
           - name: Teams CLI app creation
-            coverageIds: [teams-cli-app-creation]
+            coverageIds: [microsoft-teams.teams-cli-app-creation]
             description: Covers Microsoft Teams channel installation through `teams app create`, bot registration, manifest creation, credential generation, and setup verification.
           - name: Bot registration and manifest upload
-            coverageIds: [bot-registration-and-manifest-upload]
+            coverageIds: [microsoft-teams.bot-registration-and-manifest-upload]
             description: Covers Entra ID application registration, Azure Bot setup, Teams app manifest/RSC permissions, and Teams app package upload.
           - name: Credential configuration
-            coverageIds: [credential-configuration]
+            coverageIds: [microsoft-teams.credential-configuration]
             description: Covers CLIENT_ID, CLIENT_SECRET, TENANT_ID, `MSTEAMS_*` environment variables, and OpenClaw `channels.msteams` credential configuration.
           - name: Teams app install verification
-            coverageIds: [teams-app-install-verification]
+            coverageIds: [microsoft-teams.teams-app-install-verification]
             description: Covers Teams install links, app installation in Teams, and `teams app doctor` verification after setup.
           - name: Setup status
-            coverageIds: [setup-status]
+            coverageIds: [microsoft-teams.setup-status]
             description: Covers Setup status across setup wizard status, credential prompts, env credential detection, setup docs, and related diagnostics and repair behavior.
           - name: Probe and scope reporting
-            coverageIds: [probe-and-scope-reporting]
+            coverageIds: [microsoft-teams.probe-and-scope-reporting]
             description: Covers Probe and scope reporting across setup wizard status, credential prompts, env credential detection, setup docs, and related diagnostics and repair behavior.
           - name: Teams app doctor
-            coverageIds: [teams-app-doctor]
+            coverageIds: [microsoft-teams.teams-app-doctor]
             description: Covers Teams app doctor across setup wizard status, credential prompts, env credential detection, setup docs, and related diagnostics and repair behavior.
           - name: Webhook and health diagnostics
-            coverageIds: [webhook-and-health-diagnostics]
+            coverageIds: [microsoft-teams.webhook-and-health-diagnostics]
             description: Covers Webhook and health diagnostics across setup wizard status, credential prompts, env credential detection, setup docs, and related diagnostics and repair behavior.
           - name: Operator repair paths
-            coverageIds: [operator-repair-paths]
+            coverageIds: [microsoft-teams.operator-repair-paths]
             description: Covers Operator repair paths across setup wizard status, credential prompts, env credential detection, setup docs, and related diagnostics and repair behavior.
         docs:
           - docs/channels/msteams.md
@@ -8206,31 +8206,31 @@ surfaces:
         id: access-and-identity
         features:
           - name: DM pairing
-            coverageIds: [dm-pairing]
+            coverageIds: [security.dm-pairing]
             description: Covers DM pairing across DM pairing, `dmPolicy`, `allowFrom`, AAD ID matching, and related dm pairing and sender access behavior.
           - name: Stable sender identity
-            coverageIds: [stable-sender-identity]
+            coverageIds: [microsoft-teams.stable-sender-identity]
             description: Covers Stable sender identity across DM pairing, `dmPolicy`, `allowFrom`, AAD ID matching, and related dm pairing and sender access behavior.
           - name: Allowlists and access groups
-            coverageIds: [allowlists-and-access-groups]
+            coverageIds: [microsoft-teams.allowlists-and-access-groups]
             description: Covers Allowlists and access groups across DM pairing, `dmPolicy`, `allowFrom`, AAD ID matching, and related dm pairing and sender access behavior.
           - name: Invoke and command authorization
-            coverageIds: [invoke-and-command-authorization]
+            coverageIds: [microsoft-teams.invoke-and-command-authorization]
             description: Covers Invoke and command authorization across DM pairing, `dmPolicy`, `allowFrom`, AAD ID matching, and related dm pairing and sender access behavior.
           - name: Teams-originated config writes
-            coverageIds: [teams-originated-config-writes]
+            coverageIds: [microsoft-teams.teams-originated-config-writes]
             description: Covers Teams-originated config writes across DM pairing, `dmPolicy`, `allowFrom`, AAD ID matching, and related dm pairing and sender access behavior.
           - name: Bot Framework SSO invokes
-            coverageIds: [bot-framework-sso-invokes]
+            coverageIds: [microsoft-teams.bot-framework-sso-invokes]
             description: Covers Bot Framework SSO invoke handling and OAuth token exchange for Microsoft Teams users.
           - name: Delegated token storage
-            coverageIds: [delegated-token-storage]
+            coverageIds: [microsoft-teams.delegated-token-storage]
             description: Covers delegated token storage, token refresh, and recovery for Microsoft Teams user auth.
           - name: Graph directory lookup
-            coverageIds: [graph-directory-lookup]
+            coverageIds: [microsoft-teams.graph-directory-lookup]
             description: Covers Graph app token resolution and directory lookup behavior for Teams routing and user metadata.
           - name: Member profile lookup
-            coverageIds: [member-profile-lookup]
+            coverageIds: [microsoft-teams.member-profile-lookup]
             description: Covers member info lookup and user metadata retrieval for Microsoft Teams conversations.
         docs:
           - docs/channels/msteams.md
@@ -8253,19 +8253,19 @@ surfaces:
         id: conversation-routing-and-delivery
         features:
           - name: Team and channel allowlists
-            coverageIds: [team-and-channel-allowlists]
+            coverageIds: [microsoft-teams.team-and-channel-allowlists]
             description: Covers Teams/channel allowlists, stable conversation IDs, `channels.msteams.teams`, wildcard routing, and team/channel name resolution.
           - name: Deterministic channel replies
-            coverageIds: [deterministic-channel-replies]
+            coverageIds: [microsoft-teams.deterministic-channel-replies]
             description: Covers deterministic reply routing back to the Teams channel where a message arrived and wildcard routing safeguards.
           - name: Mention-gated group access
-            coverageIds: [mention-gated-group-access]
+            coverageIds: [microsoft-teams.mention-gated-group-access]
             description: Covers `groupPolicy`, `groupAllowFrom`, `requireMention`, and mention-gated group or channel replies.
           - name: Session routing
-            coverageIds: [session-routing]
+            coverageIds: [memory.session-routing]
             description: Covers deterministic reply routing, session keys, channel bindings, and conversation isolation for Microsoft Teams rooms and channels.
           - name: Reply and thread context
-            coverageIds: [reply-and-thread-context]
+            coverageIds: [microsoft-teams.reply-and-thread-context]
             description: Covers reply context, quoted source messages, thread-aware routing, and room context for Teams conversations.
         docs:
           - docs/channels/msteams.md
@@ -8288,19 +8288,19 @@ surfaces:
         id: media-and-rich-content
         features:
           - name: Inbound attachments
-            coverageIds: [inbound-attachments]
+            coverageIds: [google-chat.inbound-attachments]
             description: Covers Inbound attachments across inbound attachments, inline images, `msteams://media` placeholders, Graph hosted content, and related media and file sharing behavior.
           - name: Graph-hosted media
-            coverageIds: [graph-hosted-media]
+            coverageIds: [microsoft-teams.graph-hosted-media]
             description: Covers Graph-hosted media across inbound attachments, inline images, `msteams://media` placeholders, Graph hosted content, and related media and file sharing behavior.
           - name: File consent
-            coverageIds: [file-consent]
+            coverageIds: [microsoft-teams.file-consent]
             description: Covers File consent across inbound attachments, inline images, `msteams://media` placeholders, Graph hosted content, and related media and file sharing behavior.
           - name: SharePoint and OneDrive sharing
-            coverageIds: [sharepoint-and-onedrive-sharing]
+            coverageIds: [microsoft-teams.sharepoint-and-onedrive-sharing]
             description: Covers SharePoint and OneDrive sharing across inbound attachments, inline images, `msteams://media` placeholders, Graph hosted content, and related media and file sharing behavior.
           - name: Media fetch safety
-            coverageIds: [media-fetch-safety]
+            coverageIds: [microsoft-teams.media-fetch-safety]
             description: Covers Media fetch safety across inbound attachments, inline images, `msteams://media` placeholders, Graph hosted content, and related media and file sharing behavior.
         docs:
           - docs/channels/msteams.md
@@ -8316,19 +8316,19 @@ surfaces:
         id: native-controls-and-approvals
         features:
           - name: Message action discovery
-            coverageIds: [message-action-discovery]
+            coverageIds: [microsoft-teams.message-action-discovery]
             description: Covers Message action discovery across message-tool discovery, upload-file, poll, read/search, and related actions and approvals behavior.
           - name: Polls and reactions
-            coverageIds: [polls-and-reactions]
+            coverageIds: [microsoft-teams.polls-and-reactions]
             description: Covers Polls and reactions across message-tool discovery, upload-file, poll, read/search, and related actions and approvals behavior.
           - name: Read, edit, delete, and pin
-            coverageIds: [read-edit-delete-and-pin]
+            coverageIds: [microsoft-teams.read-edit-delete-and-pin]
             description: Covers Read, edit, delete, and pin across message-tool discovery, upload-file, poll, read/search, and related actions and approvals behavior.
           - name: Native approval cards
-            coverageIds: [native-approval-cards]
+            coverageIds: [microsoft-teams.native-approval-cards]
             description: Covers Native approval cards across message-tool discovery, upload-file, poll, read/search, and related actions and approvals behavior.
           - name: Feedback and group actions
-            coverageIds: [feedback-and-group-actions]
+            coverageIds: [microsoft-teams.feedback-and-group-actions]
             description: Covers Feedback and group actions across message-tool discovery, upload-file, poll, read/search, and related actions and approvals behavior.
         docs:
           - docs/channels/msteams.md
@@ -8359,7 +8359,7 @@ surfaces:
         id: channel-setup-and-operations
         features:
           - name: Channel Setup and Operations
-            coverageIds: [channel-setup-and-operations]
+            coverageIds: [channels.setup-operations]
             description: Evidence scope for Channel Setup and Operations.
         docs: []
         search_anchors:
@@ -8371,7 +8371,7 @@ surfaces:
         id: access-and-identity
         features:
           - name: Access and Identity
-            coverageIds: [access-and-identity]
+            coverageIds: [channels.access-and-identity]
             description: Evidence scope for Access and Identity.
         docs: []
         search_anchors:
@@ -8383,7 +8383,7 @@ surfaces:
         id: conversation-routing-and-delivery
         features:
           - name: Conversation Routing and Delivery
-            coverageIds: [conversation-routing-and-delivery]
+            coverageIds: [channels.conversation-routing-delivery]
             description: Evidence scope for Conversation Routing and Delivery.
         docs: []
         search_anchors:
@@ -8395,7 +8395,7 @@ surfaces:
         id: media-and-rich-content
         features:
           - name: Media and Rich Content
-            coverageIds: [media-and-rich-content]
+            coverageIds: [channels.media-rich-content]
             description: Evidence scope for Media and Rich Content.
         docs: []
         search_anchors:
@@ -8421,22 +8421,22 @@ surfaces:
         id: channel-setup-and-operations
         features:
           - name: Docs channel index
-            coverageIds: [docs-channel-index]
+            coverageIds: [regional-channels.docs-channel-index]
             description: Docs channel index, plugin reference pages, redirects, and pairing support list for regional channels
           - name: Official external channel catalog entries
-            coverageIds: [official-external-channel-catalog-entries]
+            coverageIds: [regional-channels.official-external-channel-catalog-entries]
             description: Official external channel catalog entries for WeCom, Yuanbao, Weixin, and adjacent external channels
           - name: Core channel-plugin catalog
-            coverageIds: [core-channel-plugin-catalog]
+            coverageIds: [regional-channels.core-channel-plugin-catalog]
             description: Core channel-plugin catalog, alias normalization, install-plan resolution, trusted-source flags, repair hints, and status/list output
           - name: Channel setup wizard
-            coverageIds: [channel-setup-wizard]
+            coverageIds: [regional-channels.channel-setup-wizard]
             description: Channel setup wizard and i18n blurbs for regional channels
           - name: Missing-plugin
-            coverageIds: [missing-plugin]
+            coverageIds: [regional-channels.missing-plugin]
             description: Missing-plugin, stale-plugin, raw package-manager upgrade, and doctor/repair paths
           - name: Cross-channel ingress/access/refactor concerns
-            coverageIds: [cross-channel-ingress-access-refactor-concerns]
+            coverageIds: [regional-channels.cross-channel-ingress-access-refactor-concerns]
             description: Cross-channel ingress/access/refactor concerns for regional plugins
         docs:
           - docs/channels/index.md
@@ -8452,7 +8452,7 @@ surfaces:
         id: access-and-identity
         features:
           - name: Access and Identity
-            coverageIds: [access-and-identity]
+            coverageIds: [channels.access-and-identity]
             description: Evidence scope for Access and Identity.
         docs: []
         search_anchors:
@@ -8464,7 +8464,7 @@ surfaces:
         id: conversation-routing-and-delivery
         features:
           - name: Conversation Routing and Delivery
-            coverageIds: [conversation-routing-and-delivery]
+            coverageIds: [channels.conversation-routing-delivery]
             description: Evidence scope for Conversation Routing and Delivery.
         docs: []
         search_anchors:
@@ -8476,7 +8476,7 @@ surfaces:
         id: media-and-rich-content
         features:
           - name: Media and Rich Content
-            coverageIds: [media-and-rich-content]
+            coverageIds: [channels.media-rich-content]
             description: Evidence scope for Media and Rich Content.
         docs: []
         search_anchors:
@@ -8502,10 +8502,10 @@ surfaces:
         id: channel-setup-and-operations
         features:
           - name: Voice call CLI, RPC, and agent tool
-            coverageIds: [voice-call-cli-rpc-agent-tool]
+            coverageIds: [voice-call.cli-rpc-agent-tool]
             description: CLI, Gateway RPC, and agent tool
           - name: Voice call setup smoke
-            coverageIds: [voice-call-setup-smoke]
+            coverageIds: [voice-call.setup-smoke]
             description: Setup, Configuration, and Smoke
         docs:
           - docs/cli/voicecall.md
@@ -8520,7 +8520,7 @@ surfaces:
         id: access-and-identity
         features:
           - name: Voice call webhook security
-            coverageIds: [voice-call-webhook-security]
+            coverageIds: [voice-call.webhook-security]
             description: Webhook Exposure and Security
         docs:
           - docs/plugins/voice-call.md
@@ -8533,7 +8533,7 @@ surfaces:
         id: conversation-routing-and-delivery
         features:
           - name: Voice call inbound routing
-            coverageIds: [voice-call-inbound-routing]
+            coverageIds: [voice-call.inbound-routing]
             description: Inbound Routing, Sessions, and Lifecycle
         docs:
           - docs/plugins/voice-call.md
@@ -8545,10 +8545,10 @@ surfaces:
         id: media-and-rich-content
         features:
           - name: Voice call provider transports
-            coverageIds: [voice-call-provider-transports]
+            coverageIds: [voice-call.provider-transports]
             description: Provider Transports and Call Control
           - name: Voice call telephony audio
-            coverageIds: [voice-call-telephony-audio]
+            coverageIds: [voice-call.telephony-audio]
             description: Telephony TTS, playback, DTMF, and audio
         docs:
           - docs/plugins/voice-call.md
@@ -8562,10 +8562,10 @@ surfaces:
         id: realtime-voice-and-calls
         features:
           - name: Voice call realtime consult
-            coverageIds: [voice-call-realtime-consult]
+            coverageIds: [voice-call.realtime-consult]
             description: Realtime Voice and Agent Consult
           - name: Voice call streaming transcription
-            coverageIds: [voice-call-streaming-transcription]
+            coverageIds: [voice-call.streaming-transcription]
             description: Streaming Transcription and Auto-response
         docs:
           - docs/plugins/voice-call.md
@@ -8595,19 +8595,19 @@ surfaces:
             coverageIds: [models.openai, tools.web-search]
             description: 'Covers Canonical OpenAI Model Routing across user/operator-facing model route contract: canonical `openai/gpt-*` refs, legacy `openai-codex/*` model refs, model catalog rows, context limits, and related canonical openai model routing and catalog behavior.'
           - name: Catalog
-            coverageIds: [catalog]
+            coverageIds: [codex.catalog]
             description: 'Covers Catalog across user/operator-facing model route contract: canonical `openai/gpt-*` refs, legacy `openai-codex/*` model refs, model catalog rows, context limits, and related canonical openai model routing and catalog behavior.'
           - name: Codex OAuth Profiles
             coverageIds: [auth-profiles.provider-selection, runtime.codex-plugin.auth, runtime.doctor-repair]
             description: Covers Codex OAuth Profiles across `openai-codex` auth profiles, profile ordering, profile metadata repair, token refresh, account-id propagation, usage/cooldown handling, and auth selection for Codex-backed OpenAI agent turns.
           - name: Subscription Usage
-            coverageIds: [subscription-usage]
+            coverageIds: [codex.subscription-usage]
             description: Covers Subscription Usage across `openai-codex` auth profiles, profile ordering, profile metadata repair, token refresh, account-id propagation, usage/cooldown handling, and auth selection for Codex-backed OpenAI agent turns.
           - name: Doctor Diagnostics
             coverageIds: [runtime.codex-plugin.version]
             description: 'Covers Doctor Diagnostics across operator-facing repair and diagnosis for OpenAI/Codex provider path problems: stale route migration, persisted session pins, runtime pins, auth-profile sidecars, profile metadata, status/probe output, and recovery commands.'
           - name: Operator Repair
-            coverageIds: [operator-repair]
+            coverageIds: [codex.operator-repair]
             description: 'Covers Operator Repair across operator-facing repair and diagnosis for OpenAI/Codex provider path problems: stale route migration, persisted session pins, runtime pins, auth-profile sidecars, profile metadata, status/probe output, and recovery commands.'
         docs:
           - docs/providers/openai.md
@@ -8635,7 +8635,7 @@ surfaces:
         id: responses-and-tool-compatibility
         features:
           - name: Codex Responses Transport
-            coverageIds: [codex-responses-transport]
+            coverageIds: [codex.responses-transport]
             description: Covers Codex Responses Transport across low-level provider request/streaming path for `openai-codex-responses` and the shared OpenAI Responses conversion code used by direct OpenAI and Codex-auth compatibility routes.
           - name: Payload Compatibility
             coverageIds: [runtime.prompt-compatibility, tools.fs.read]
@@ -8644,7 +8644,7 @@ surfaces:
             coverageIds: [runtime.codex-native-workspace.read, tools.fs.read]
             description: Covers Tool Context across provider-facing tools, context injection, media inputs, native-vs-client tool ownership, OpenAI Responses compatibility, and how OpenAI/Codex models receive OpenClaw runtime context.
           - name: Capability Compatibility
-            coverageIds: [capability-compatibility]
+            coverageIds: [codex.capability-compatibility]
             description: Covers Capability Compatibility across provider-facing tools, context injection, media inputs, native-vs-client tool ownership, OpenAI Responses compatibility, and how OpenAI/Codex models receive OpenClaw runtime context.
         docs:
           - docs/providers/openai.md
@@ -8687,10 +8687,10 @@ surfaces:
         id: image-and-multimodal-input
         features:
           - name: Image Generation Editing
-            coverageIds: [image-generation-editing]
+            coverageIds: [codex.image-generation-editing]
             description: Covers Image Generation Editing across OpenAI image generation and editing, Codex OAuth image backend, transparent-background routing, Azure/private OpenAI image endpoints, and related image generation editing and multimodal input behavior.
           - name: Multimodal Input
-            coverageIds: [multimodal-input]
+            coverageIds: [codex.multimodal-input]
             description: Covers Multimodal Input across OpenAI image generation and editing, Codex OAuth image backend, transparent-background routing, Azure/private OpenAI image endpoints, and related image generation editing and multimodal input behavior.
         docs:
           - docs/providers/openai.md
@@ -8707,10 +8707,10 @@ surfaces:
         id: voice-and-realtime-audio
         features:
           - name: Realtime Voice Transcription
-            coverageIds: [realtime-voice-transcription]
+            coverageIds: [codex.realtime-voice-transcription]
             description: Covers Realtime Voice Transcription across OpenAI text-to-speech, batch speech-to-text, Realtime transcription, Realtime voice, browser Talk/WebRTC, backend WebSocket bridges, OAuth-backed client secret minting, Azure Realtime deployments, and voice-control behavior.
           - name: Speech
-            coverageIds: [speech]
+            coverageIds: [codex.speech]
             description: Covers Speech across OpenAI text-to-speech, batch speech-to-text, Realtime transcription, Realtime voice, browser Talk/WebRTC, backend WebSocket bridges, OAuth-backed client secret minting, Azure Realtime deployments, and voice-control behavior.
         docs:
           - docs/providers/openai.md
@@ -8741,31 +8741,31 @@ surfaces:
         id: provider-auth-and-recovery
         features:
           - name: API-key onboarding
-            coverageIds: [api-key-onboarding]
+            coverageIds: [gateway.api-key-onboarding]
             description: 'Covers API-key onboarding across Anthropic credential surface before a model request is made: onboarding choices, API-key storage, Claude CLI credential migration, setup-token validation, and related credential setup and health behavior.'
           - name: Claude CLI credential reuse
-            coverageIds: [claude-cli-credential-reuse]
+            coverageIds: [anthropic.claude-cli-credential-reuse]
             description: 'Covers Claude CLI credential reuse across Anthropic credential surface before a model request is made: onboarding choices, API-key storage, Claude CLI credential migration, setup-token validation, and related credential setup and health behavior.'
           - name: Setup-token auth
-            coverageIds: [setup-token-auth]
+            coverageIds: [anthropic.setup-token-auth]
             description: 'Covers Setup-token auth across Anthropic credential surface before a model request is made: onboarding choices, API-key storage, Claude CLI credential migration, setup-token validation, and related credential setup and health behavior.'
           - name: Auth profile health
-            coverageIds: [auth-profile-health]
+            coverageIds: [anthropic.auth-profile-health]
             description: 'Covers Auth profile health across Anthropic credential surface before a model request is made: onboarding choices, API-key storage, Claude CLI credential migration, setup-token validation, and related credential setup and health behavior.'
           - name: Model status
-            coverageIds: [model-status]
+            coverageIds: [anthropic.model-status]
             description: 'Covers Model status across operator diagnostics and recovery for Anthropic provider failures: status output, usage windows, auth profile source reporting, cooldown and disabled profile reporting, and related diagnostics and recovery behavior.'
           - name: Usage windows
-            coverageIds: [usage-windows]
+            coverageIds: [anthropic.usage-windows]
             description: 'Covers Usage windows across operator diagnostics and recovery for Anthropic provider failures: status output, usage windows, auth profile source reporting, cooldown and disabled profile reporting, and related diagnostics and recovery behavior.'
           - name: Cooldown/profile reporting
-            coverageIds: [cooldown-profile-reporting]
+            coverageIds: [anthropic.cooldown-profile-reporting]
             description: 'Covers Cooldown/profile reporting across operator diagnostics and recovery for Anthropic provider failures: status output, usage windows, auth profile source reporting, cooldown and disabled profile reporting, and related diagnostics and recovery behavior.'
           - name: Long-context recovery
-            coverageIds: [long-context-recovery]
+            coverageIds: [anthropic.long-context-recovery]
             description: 'Covers Long-context recovery across operator diagnostics and recovery for Anthropic provider failures: status output, usage windows, auth profile source reporting, cooldown and disabled profile reporting, and related diagnostics and recovery behavior.'
           - name: Fallback guidance
-            coverageIds: [fallback-guidance]
+            coverageIds: [anthropic.fallback-guidance]
             description: 'Covers Fallback guidance across operator diagnostics and recovery for Anthropic provider failures: status output, usage windows, auth profile source reporting, cooldown and disabled profile reporting, and related diagnostics and recovery behavior.'
         docs:
           - docs/providers/anthropic.md
@@ -8789,7 +8789,7 @@ surfaces:
         id: model-and-runtime-selection
         features:
           - name: Bundled Claude catalog
-            coverageIds: [bundled-claude-catalog]
+            coverageIds: [anthropic.bundled-claude-catalog]
             description: 'Covers Bundled Claude catalog across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
           - name: Canonical anthropic refs
             coverageIds: [models.anthropic, models.provider-auth]
@@ -8798,25 +8798,25 @@ surfaces:
             coverageIds: [models.claude-cli, models.provider-capabilities]
             description: 'Covers Claude CLI compatibility across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
           - name: Model picker availability
-            coverageIds: [model-picker-availability]
+            coverageIds: [models.picker-availability]
             description: 'Covers Model picker availability across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
           - name: Capability metadata
-            coverageIds: [capability-metadata]
+            coverageIds: [anthropic.capability-metadata]
             description: 'Covers Capability metadata across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
           - name: Runtime selection
-            coverageIds: [runtime-selection]
+            coverageIds: [anthropic.runtime-selection]
             description: 'Covers Runtime selection across OpenClaw''s host-local Claude CLI path after auth is available: the `claude-cli` backend, its command/args/env defaults, MCP tool bridge, native tool mode, and related claude cli backend behavior.'
           - name: Session continuity
-            coverageIds: [session-continuity]
+            coverageIds: [memory.session-continuity]
             description: 'Covers Session continuity across OpenClaw''s host-local Claude CLI path after auth is available: the `claude-cli` backend, its command/args/env defaults, MCP tool bridge, native tool mode, and related claude cli backend behavior.'
           - name: MCP/tool bridge
-            coverageIds: [mcp-tool-bridge]
+            coverageIds: [anthropic.mcp-tool-bridge]
             description: 'Covers MCP/tool bridge across OpenClaw''s host-local Claude CLI path after auth is available: the `claude-cli` backend, its command/args/env defaults, MCP tool bridge, native tool mode, and related claude cli backend behavior.'
           - name: Permission-mode mapping
-            coverageIds: [permission-mode-mapping]
+            coverageIds: [anthropic.permission-mode-mapping]
             description: 'Covers Permission-mode mapping across OpenClaw''s host-local Claude CLI path after auth is available: the `claude-cli` backend, its command/args/env defaults, MCP tool bridge, native tool mode, and related claude cli backend behavior.'
           - name: Fallback prelude
-            coverageIds: [fallback-prelude]
+            coverageIds: [anthropic.fallback-prelude]
             description: 'Covers Fallback prelude across OpenClaw''s host-local Claude CLI path after auth is available: the `claude-cli` backend, its command/args/env defaults, MCP tool bridge, native tool mode, and related claude cli backend behavior.'
         docs:
           - docs/providers/anthropic.md
@@ -8840,34 +8840,34 @@ surfaces:
         id: request-transport-and-turn-semantics
         features:
           - name: API-key/OAuth transport
-            coverageIds: [api-key-oauth-transport]
+            coverageIds: [anthropic.api-key-oauth-transport]
             description: 'Covers API-key/OAuth transport across direct Anthropic `api: "anthropic-messages"` request and stream behavior: API-key and OAuth transport setup, Anthropic beta headers, model-id normalization for direct hosts, payload construction, and related direct anthropic api behavior.'
           - name: Messages payloads
-            coverageIds: [messages-payloads]
+            coverageIds: [anthropic.messages-payloads]
             description: 'Covers Messages payloads across direct Anthropic `api: "anthropic-messages"` request and stream behavior: API-key and OAuth transport setup, Anthropic beta headers, model-id normalization for direct hosts, payload construction, and related direct anthropic api behavior.'
           - name: Streaming decode
-            coverageIds: [streaming-decode]
+            coverageIds: [anthropic.streaming-decode]
             description: 'Covers Streaming decode across direct Anthropic `api: "anthropic-messages"` request and stream behavior: API-key and OAuth transport setup, Anthropic beta headers, model-id normalization for direct hosts, payload construction, and related direct anthropic api behavior.'
           - name: Usage and stop reasons
-            coverageIds: [usage-and-stop-reasons]
+            coverageIds: [anthropic.usage-and-stop-reasons]
             description: 'Covers Usage and stop reasons across direct Anthropic `api: "anthropic-messages"` request and stream behavior: API-key and OAuth transport setup, Anthropic beta headers, model-id normalization for direct hosts, payload construction, and related direct anthropic api behavior.'
           - name: Abort/error handling
-            coverageIds: [abort-error-handling]
+            coverageIds: [anthropic.abort-error-handling]
             description: 'Covers Abort/error handling across direct Anthropic `api: "anthropic-messages"` request and stream behavior: API-key and OAuth transport setup, Anthropic beta headers, model-id normalization for direct hosts, payload construction, and related direct anthropic api behavior.'
           - name: Tool-use blocks
-            coverageIds: [tool-use-blocks]
+            coverageIds: [anthropic.tool-use-blocks]
             description: 'Covers Tool-use blocks across Anthropic-specific turn semantics inside agent runs: tool declarations, tool-use block conversion, tool-result conversion, tool-call id normalization, and related tools and thinking behavior.'
           - name: Tool-result replay
-            coverageIds: [tool-result-replay]
+            coverageIds: [anthropic.tool-result-replay]
             description: 'Covers Tool-result replay across Anthropic-specific turn semantics inside agent runs: tool declarations, tool-use block conversion, tool-result conversion, tool-call id normalization, and related tools and thinking behavior.'
           - name: Partial JSON recovery
-            coverageIds: [partial-json-recovery]
+            coverageIds: [anthropic.partial-json-recovery]
             description: 'Covers Partial JSON recovery across Anthropic-specific turn semantics inside agent runs: tool declarations, tool-use block conversion, tool-result conversion, tool-call id normalization, and related tools and thinking behavior.'
           - name: Native thinking
-            coverageIds: [native-thinking]
+            coverageIds: [anthropic.native-thinking]
             description: 'Covers Native thinking across Anthropic-specific turn semantics inside agent runs: tool declarations, tool-use block conversion, tool-result conversion, tool-call id normalization, and related tools and thinking behavior.'
           - name: Signed/redacted thinking replay
-            coverageIds: [signed-redacted-thinking-replay]
+            coverageIds: [anthropic.signed-redacted-thinking-replay]
             description: 'Covers Signed/redacted thinking replay across Anthropic-specific turn semantics inside agent runs: tool declarations, tool-use block conversion, tool-result conversion, tool-call id normalization, and related tools and thinking behavior.'
         docs:
           - docs/providers/anthropic.md
@@ -8892,19 +8892,19 @@ surfaces:
         id: prompt-cache-and-context
         features:
           - name: Cache retention
-            coverageIds: [cache-retention]
+            coverageIds: [anthropic.cache-retention]
             description: 'Covers Cache retention across Anthropic-specific request knobs outside the core content stream: prompt cache retention, cache-control markers, system-prompt cache boundary, 1M context sizing, and related prompt cache and context behavior.'
           - name: System-prompt cache boundary
-            coverageIds: [system-prompt-cache-boundary]
+            coverageIds: [anthropic.system-prompt-cache-boundary]
             description: 'Covers System-prompt cache boundary across Anthropic-specific request knobs outside the core content stream: prompt cache retention, cache-control markers, system-prompt cache boundary, 1M context sizing, and related prompt cache and context behavior.'
           - name: 1M context
-            coverageIds: [1m-context]
+            coverageIds: [anthropic.1m-context]
             description: 'Covers 1M context across Anthropic-specific request knobs outside the core content stream: prompt cache retention, cache-control markers, system-prompt cache boundary, 1M context sizing, and related prompt cache and context behavior.'
           - name: Fast mode/service tier
-            coverageIds: [fast-mode-service-tier]
+            coverageIds: [anthropic.fast-mode-service-tier]
             description: 'Covers Fast mode/service tier across Anthropic-specific request knobs outside the core content stream: prompt cache retention, cache-control markers, system-prompt cache boundary, 1M context sizing, and related prompt cache and context behavior.'
           - name: Cache diagnostics
-            coverageIds: [cache-diagnostics]
+            coverageIds: [anthropic.cache-diagnostics]
             description: 'Covers Cache diagnostics across Anthropic-specific request knobs outside the core content stream: prompt cache retention, cache-control markers, system-prompt cache boundary, 1M context sizing, and related prompt cache and context behavior.'
         docs:
           - docs/providers/anthropic.md
@@ -8923,16 +8923,16 @@ surfaces:
         id: media-inputs
         features:
           - name: Image input
-            coverageIds: [image-input]
+            coverageIds: [anthropic.image-input]
             description: 'Covers Image input across Anthropic media understanding as part of the provider path: image input support, PDF native document input metadata, default media model selection, auto-priority, and related media inputs behavior.'
           - name: PDF document input
-            coverageIds: [pdf-document-input]
+            coverageIds: [anthropic.pdf-document-input]
             description: 'Covers PDF document input across Anthropic media understanding as part of the provider path: image input support, PDF native document input metadata, default media model selection, auto-priority, and related media inputs behavior.'
           - name: Media model fallback
-            coverageIds: [media-model-fallback]
+            coverageIds: [anthropic.media-model-fallback]
             description: 'Covers Media model fallback across Anthropic media understanding as part of the provider path: image input support, PDF native document input metadata, default media model selection, auto-priority, and related media inputs behavior.'
           - name: Image tool results
-            coverageIds: [image-tool-results]
+            coverageIds: [anthropic.image-tool-results]
             description: 'Covers Image tool results across Anthropic media understanding as part of the provider path: image input support, PDF native document input metadata, default media model selection, auto-priority, and related media inputs behavior.'
         docs:
           - docs/providers/anthropic.md
@@ -8962,34 +8962,34 @@ surfaces:
         id: provider-setup-and-credentials
         features:
           - name: API key onboarding
-            coverageIds: [api-key-onboarding]
+            coverageIds: [gateway.api-key-onboarding]
             description: Covers API key onboarding across direct `GEMINI_API_KEY` and `GOOGLE_API_KEY` auth, setup provider metadata, setup auth choices, provider config fields, and related provider auth and setup behavior.
           - name: Auth choice metadata
-            coverageIds: [auth-choice-metadata]
+            coverageIds: [google.auth-choice-metadata]
             description: Covers Auth choice metadata across direct `GEMINI_API_KEY` and `GOOGLE_API_KEY` auth, setup provider metadata, setup auth choices, provider config fields, and related provider auth and setup behavior.
           - name: Gemini CLI OAuth setup
-            coverageIds: [gemini-cli-oauth-setup]
+            coverageIds: [google.gemini-cli-oauth-setup]
             description: Covers Gemini CLI OAuth setup across direct `GEMINI_API_KEY` and `GOOGLE_API_KEY` auth, setup provider metadata, setup auth choices, provider config fields, and related provider auth and setup behavior.
           - name: Vertex ADC setup
-            coverageIds: [vertex-adc-setup]
+            coverageIds: [google.vertex-adc-setup]
             description: Covers Vertex ADC setup across direct `GEMINI_API_KEY` and `GOOGLE_API_KEY` auth, setup provider metadata, setup auth choices, provider config fields, and related provider auth and setup behavior.
           - name: Daemon and fallback credentials
-            coverageIds: [daemon-and-fallback-credentials]
+            coverageIds: [google.daemon-and-fallback-credentials]
             description: Covers Daemon and fallback credentials across direct `GEMINI_API_KEY` and `GOOGLE_API_KEY` auth, setup provider metadata, setup auth choices, provider config fields, and related provider auth and setup behavior.
           - name: CLI runtime selection
-            coverageIds: [cli-runtime-selection]
+            coverageIds: [google.cli-runtime-selection]
             description: 'Covers CLI runtime selection across `google-gemini-cli` provider, canonical `google/*` model refs using `agentRuntime.id: "google-gemini-cli"`, legacy `google-gemini-cli/*` refs, Gemini CLI command invocation, and related gemini cli oauth behavior.'
           - name: OAuth login and refresh
-            coverageIds: [oauth-login-and-refresh]
+            coverageIds: [google.oauth-login-and-refresh]
             description: 'Covers OAuth login and refresh across `google-gemini-cli` provider, canonical `google/*` model refs using `agentRuntime.id: "google-gemini-cli"`, legacy `google-gemini-cli/*` refs, Gemini CLI command invocation, and related gemini cli oauth behavior.'
           - name: Canonical Google model refs
-            coverageIds: [canonical-google-model-refs]
+            coverageIds: [google.canonical-google-model-refs]
             description: 'Covers Canonical Google model refs across `google-gemini-cli` provider, canonical `google/*` model refs using `agentRuntime.id: "google-gemini-cli"`, legacy `google-gemini-cli/*` refs, Gemini CLI command invocation, and related gemini cli oauth behavior.'
           - name: CLI usage normalization
-            coverageIds: [cli-usage-normalization]
+            coverageIds: [google.cli-usage-normalization]
             description: 'Covers CLI usage normalization across `google-gemini-cli` provider, canonical `google/*` model refs using `agentRuntime.id: "google-gemini-cli"`, legacy `google-gemini-cli/*` refs, Gemini CLI command invocation, and related gemini cli oauth behavior.'
           - name: OAuth diagnostics
-            coverageIds: [oauth-diagnostics]
+            coverageIds: [google.oauth-diagnostics]
             description: 'Covers OAuth diagnostics across `google-gemini-cli` provider, canonical `google/*` model refs using `agentRuntime.id: "google-gemini-cli"`, legacy `google-gemini-cli/*` refs, Gemini CLI command invocation, and related gemini cli oauth behavior.'
         docs:
           - docs/providers/google.md
@@ -9011,34 +9011,34 @@ surfaces:
         id: model-routing-and-endpoints
         features:
           - name: Catalog rows and aliases
-            coverageIds: [catalog-rows-and-aliases]
+            coverageIds: [google.catalog-rows-and-aliases]
             description: Covers Catalog rows and aliases across model catalog rows, model ID normalization, dynamic model resolution, provider hooks, and related model catalog and routing behavior.
           - name: Dynamic model resolution
-            coverageIds: [dynamic-model-resolution]
+            coverageIds: [google.dynamic-model-resolution]
             description: Covers Dynamic model resolution across model catalog rows, model ID normalization, dynamic model resolution, provider hooks, and related model catalog and routing behavior.
           - name: Provider routing
-            coverageIds: [provider-routing]
+            coverageIds: [google.provider-routing]
             description: Covers Provider routing across model catalog rows, model ID normalization, dynamic model resolution, provider hooks, and related model catalog and routing behavior.
           - name: Google-native config normalization
-            coverageIds: [google-native-config-normalization]
+            coverageIds: [google.native-config-normalization]
             description: Covers Google-native config normalization across model catalog rows, model ID normalization, dynamic model resolution, provider hooks, and related model catalog and routing behavior.
           - name: Model picker availability
-            coverageIds: [model-picker-availability]
+            coverageIds: [models.picker-availability]
             description: Covers Model picker availability across model catalog rows, model ID normalization, dynamic model resolution, provider hooks, and related model catalog and routing behavior.
           - name: Vertex provider selection
-            coverageIds: [vertex-provider-selection]
+            coverageIds: [google.vertex-provider-selection]
             description: Covers Vertex provider selection across `google-vertex`, Vertex ADC/service-account auth, project/location endpoint construction, custom Google-compatible base URL handling, and related vertex ai and custom endpoints behavior.
           - name: ADC/service-account auth
-            coverageIds: [adc-service-account-auth]
+            coverageIds: [google.adc-service-account-auth]
             description: Covers ADC/service-account auth across `google-vertex`, Vertex ADC/service-account auth, project/location endpoint construction, custom Google-compatible base URL handling, and related vertex ai and custom endpoints behavior.
           - name: Project/location endpoints
-            coverageIds: [project-location-endpoints]
+            coverageIds: [google.project-location-endpoints]
             description: Covers Project/location endpoints across `google-vertex`, Vertex ADC/service-account auth, project/location endpoint construction, custom Google-compatible base URL handling, and related vertex ai and custom endpoints behavior.
           - name: Custom base URL policy
-            coverageIds: [custom-base-url-policy]
+            coverageIds: [google.custom-base-url-policy]
             description: Covers Custom base URL policy across `google-vertex`, Vertex ADC/service-account auth, project/location endpoint construction, custom Google-compatible base URL handling, and related vertex ai and custom endpoints behavior.
           - name: Compatibility boundaries
-            coverageIds: [compatibility-boundaries]
+            coverageIds: [google.compatibility-boundaries]
             description: Covers Compatibility boundaries across `google-vertex`, Vertex ADC/service-account auth, project/location endpoint construction, custom Google-compatible base URL handling, and related vertex ai and custom endpoints behavior.
         docs:
           - docs/providers/google.md
@@ -9062,31 +9062,31 @@ surfaces:
         id: direct-gemini-runtime
         features:
           - name: Direct Gemini chat
-            coverageIds: [direct-gemini-chat]
+            coverageIds: [google.direct-gemini-chat]
             description: 'Covers Direct Gemini chat across direct `google-generative-ai` Gemini transport and shared Google message/stream conversion: request URL construction, request config, text/image/audio/video/tool payload conversion, function response handling, and related direct gemini api behavior.'
           - name: Multimodal inputs
-            coverageIds: [multimodal-inputs]
+            coverageIds: [google.multimodal-inputs]
             description: 'Covers Multimodal inputs across direct `google-generative-ai` Gemini transport and shared Google message/stream conversion: request URL construction, request config, text/image/audio/video/tool payload conversion, function response handling, and related direct gemini api behavior.'
           - name: Tool-call streaming
-            coverageIds: [tool-call-streaming]
+            coverageIds: [google.tool-call-streaming]
             description: 'Covers Tool-call streaming across direct `google-generative-ai` Gemini transport and shared Google message/stream conversion: request URL construction, request config, text/image/audio/video/tool payload conversion, function response handling, and related direct gemini api behavior.'
           - name: Usage and stop reasons
-            coverageIds: [usage-and-stop-reasons]
+            coverageIds: [anthropic.usage-and-stop-reasons]
             description: 'Covers Usage and stop reasons across direct `google-generative-ai` Gemini transport and shared Google message/stream conversion: request URL construction, request config, text/image/audio/video/tool payload conversion, function response handling, and related direct gemini api behavior.'
           - name: Direct Gemini transport payloads
-            coverageIds: [direct-gemini-transport-payloads]
+            coverageIds: [google.direct-gemini-transport-payloads]
             description: 'Covers direct `google-generative-ai` Gemini transport and shared Google message/stream conversion: request URL construction, request config, text/image/audio/video/tool payload conversion, function response handling, and related direct Gemini API behavior.'
           - name: Thinking-level mapping
-            coverageIds: [thinking-level-mapping]
+            coverageIds: [google.thinking-level-mapping]
             description: Covers Thinking-level mapping across Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
           - name: Thought-signature replay policy
-            coverageIds: [thought-signature-replay]
+            coverageIds: [google.thought-signature-replay]
             description: Covers Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
           - name: Tool turn ordering
-            coverageIds: [tool-turn-ordering]
+            coverageIds: [google.tool-turn-ordering]
             description: Covers Tool turn ordering across Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
           - name: Incomplete-turn recovery
-            coverageIds: [incomplete-turn-recovery]
+            coverageIds: [google.incomplete-turn-recovery]
             description: Covers Incomplete-turn recovery across Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
         docs:
           - docs/providers/google.md
@@ -9109,34 +9109,34 @@ surfaces:
         id: media-search-and-realtime
         features:
           - name: Bundled plugin distribution
-            coverageIds: [bundled-plugin-distribution]
+            coverageIds: [google.bundled-plugin-distribution]
             description: Covers Bundled plugin distribution across bundled `@openclaw/google-plugin` package, plugin manifest distribution, auto-enable metadata, capability-provider registration, and related google plugin adapters behavior.
           - name: Provider auto-enable metadata
-            coverageIds: [provider-auto-enable-metadata]
+            coverageIds: [google.provider-auto-enable-metadata]
             description: Covers Provider auto-enable metadata across bundled `@openclaw/google-plugin` package, plugin manifest distribution, auto-enable metadata, capability-provider registration, and related google plugin adapters behavior.
           - name: Image and media adapters
-            coverageIds: [image-and-media-adapters]
+            coverageIds: [google.image-and-media-adapters]
             description: Covers Image and media adapters across bundled `@openclaw/google-plugin` package, plugin manifest distribution, auto-enable metadata, capability-provider registration, and related google plugin adapters behavior.
           - name: Speech and realtime adapters
-            coverageIds: [speech-and-realtime-adapters]
+            coverageIds: [google.speech-and-realtime-adapters]
             description: Covers Speech and realtime adapters across bundled `@openclaw/google-plugin` package, plugin manifest distribution, auto-enable metadata, capability-provider registration, and related google plugin adapters behavior.
           - name: Search and generation tools
-            coverageIds: [search-and-generation-tools]
+            coverageIds: [google.search-and-generation-tools]
             description: Covers Search and generation tools across bundled `@openclaw/google-plugin` package, plugin manifest distribution, auto-enable metadata, capability-provider registration, and related google plugin adapters behavior.
           - name: Realtime voice sessions
-            coverageIds: [realtime-voice-sessions]
+            coverageIds: [google.realtime-voice-sessions]
             description: Covers Realtime voice sessions across Gemini Live realtime voice provider behavior, Talk relay integration, constrained browser websocket tokens, audio queueing, and related gemini live talk behavior.
           - name: Constrained browser tokens
-            coverageIds: [constrained-browser-tokens]
+            coverageIds: [google.constrained-browser-tokens]
             description: Covers Constrained browser tokens across Gemini Live realtime voice provider behavior, Talk relay integration, constrained browser websocket tokens, audio queueing, and related gemini live talk behavior.
           - name: Audio and transcript events
-            coverageIds: [audio-and-transcript-events]
+            coverageIds: [google.audio-and-transcript-events]
             description: Covers Audio and transcript events across Gemini Live realtime voice provider behavior, Talk relay integration, constrained browser websocket tokens, audio queueing, and related gemini live talk behavior.
           - name: Live tool calls
-            coverageIds: [live-tool-calls]
+            coverageIds: [google.live-tool-calls]
             description: Covers Live tool calls across Gemini Live realtime voice provider behavior, Talk relay integration, constrained browser websocket tokens, audio queueing, and related gemini live talk behavior.
           - name: Session reconnects
-            coverageIds: [session-reconnects]
+            coverageIds: [google.session-reconnects]
             description: Covers Session reconnects across Gemini Live realtime voice provider behavior, Talk relay integration, constrained browser websocket tokens, audio queueing, and related gemini live talk behavior.
         docs:
           - docs/plugins/reference/google.md
@@ -9158,19 +9158,19 @@ surfaces:
         id: prompt-caching
         features:
           - name: Cache retention config
-            coverageIds: [cache-retention-config]
+            coverageIds: [google.cache-retention-config]
             description: Covers Cache retention config across direct `google-generative-ai` Gemini prompt cache eligibility, `cacheRetention`, managed `cachedContents` create/reuse/refresh, manual `cachedContent` config, and related prompt caching behavior.
           - name: Managed cachedContents
-            coverageIds: [managed-cachedcontents]
+            coverageIds: [google.managed-cachedcontents]
             description: Covers Managed cachedContents across direct `google-generative-ai` Gemini prompt cache eligibility, `cacheRetention`, managed `cachedContents` create/reuse/refresh, manual `cachedContent` config, and related prompt caching behavior.
           - name: Manual cachedContent handles
-            coverageIds: [manual-cachedcontent-handles]
+            coverageIds: [google.manual-cachedcontent-handles]
             description: Covers Manual cachedContent handles across direct `google-generative-ai` Gemini prompt cache eligibility, `cacheRetention`, managed `cachedContents` create/reuse/refresh, manual `cachedContent` config, and related prompt caching behavior.
           - name: Cache usage accounting
-            coverageIds: [cache-usage-accounting]
+            coverageIds: [google.cache-usage-accounting]
             description: Covers Cache usage accounting across direct `google-generative-ai` Gemini prompt cache eligibility, `cacheRetention`, managed `cachedContents` create/reuse/refresh, manual `cachedContent` config, and related prompt caching behavior.
           - name: Cache diagnostics and live proof
-            coverageIds: [cache-diagnostics-and-live-proof]
+            coverageIds: [google.cache-diagnostics-and-live-proof]
             description: Covers Cache diagnostics and live proof across direct `google-generative-ai` Gemini prompt cache eligibility, `cacheRetention`, managed `cachedContents` create/reuse/refresh, manual `cachedContent` config, and related prompt caching behavior.
         docs:
           - docs/reference/prompt-caching.md
@@ -9203,46 +9203,46 @@ surfaces:
         id: provider-setup-and-auth
         features:
           - name: First-run setup
-            coverageIds: [first-run-setup]
+            coverageIds: [openrouter.first-run-setup]
             description: 'Covers First-run setup across user-facing setup and provider registration: the `/providers/openrouter` docs, plugin manifest, provider registration hook, default model registration, and related operator setup and model selection behavior.'
           - name: Default model selection
-            coverageIds: [default-model-selection]
+            coverageIds: [openrouter.default-model-selection]
             description: 'Covers Default model selection across user-facing setup and provider registration: the `/providers/openrouter` docs, plugin manifest, provider registration hook, default model registration, and related operator setup and model selection behavior.'
           - name: Provider plugin registration
-            coverageIds: [provider-plugin-registration]
+            coverageIds: [openrouter.provider-plugin-registration]
             description: 'Covers Provider plugin registration across user-facing setup and provider registration: the `/providers/openrouter` docs, plugin manifest, provider registration hook, default model registration, and related operator setup and model selection behavior.'
           - name: Model-ref examples
-            coverageIds: [model-ref-examples]
+            coverageIds: [openrouter.model-ref-examples]
             description: 'Covers Model-ref examples across user-facing setup and provider registration: the `/providers/openrouter` docs, plugin manifest, provider registration hook, default model registration, and related operator setup and model selection behavior.'
           - name: OPENROUTER_API_KEY
-            coverageIds: [openrouter-api-key]
+            coverageIds: [openrouter.api-key]
             description: Covers OPENROUTER_API_KEY across `OPENROUTER_API_KEY` discovery, onboarding/auth-choice storage, `auth-profiles.json`, status/probe visibility, and related credentials and auth profiles behavior.
           - name: Auth profiles and auth order
-            coverageIds: [auth-profiles-and-auth-order]
+            coverageIds: [openrouter.auth-profiles-and-auth-order]
             description: Covers Auth profiles and auth order across `OPENROUTER_API_KEY` discovery, onboarding/auth-choice storage, `auth-profiles.json`, status/probe visibility, and related credentials and auth profiles behavior.
           - name: Status/probe and removal
-            coverageIds: [status-probe-and-removal]
+            coverageIds: [openrouter.status-probe-and-removal]
             description: Covers Status/probe and removal across `OPENROUTER_API_KEY` discovery, onboarding/auth-choice storage, `auth-profiles.json`, status/probe visibility, and related credentials and auth profiles behavior.
           - name: Provider-entry SecretRef/API-key resolution
-            coverageIds: [provider-entry-secretref-api-key-resolution]
+            coverageIds: [openrouter.provider-entry-secretref-api-key-resolution]
             description: Covers Provider-entry SecretRef/API-key resolution across `OPENROUTER_API_KEY` discovery, onboarding/auth-choice storage, `auth-profiles.json`, status/probe visibility, and related credentials and auth profiles behavior.
           - name: Gateway env inheritance
-            coverageIds: [gateway-env-inheritance]
+            coverageIds: [openrouter.gateway-env-inheritance]
             description: Covers Gateway env inheritance across `OPENROUTER_API_KEY` discovery, onboarding/auth-choice storage, `auth-profiles.json`, status/probe visibility, and related credentials and auth profiles behavior.
           - name: Static catalog rows
-            coverageIds: [static-catalog-rows]
+            coverageIds: [openrouter.static-catalog-rows]
             description: Covers Static catalog rows across static catalog rows, dynamic model capability discovery, model-id normalization, `openrouter/<provider>/<model>` references, and related model catalog and dynamic discovery behavior.
           - name: Dynamic /models discovery
-            coverageIds: [dynamic-models-discovery]
+            coverageIds: [openrouter.dynamic-models-discovery]
             description: Covers Dynamic /models discovery across static catalog rows, dynamic model capability discovery, model-id normalization, `openrouter/<provider>/<model>` references, and related model catalog and dynamic discovery behavior.
           - name: openrouter/auto and nested refs
-            coverageIds: [openrouter-auto-and-nested-refs]
+            coverageIds: [openrouter.auto-and-nested-refs]
             description: Covers openrouter/auto and nested refs across static catalog rows, dynamic model capability discovery, model-id normalization, `openrouter/<provider>/<model>` references, and related model catalog and dynamic discovery behavior.
           - name: Free-model scan/probe
-            coverageIds: [free-model-scan-probe]
+            coverageIds: [openrouter.free-model-scan-probe]
             description: Covers Free-model scan/probe across static catalog rows, dynamic model capability discovery, model-id normalization, `openrouter/<provider>/<model>` references, and related model catalog and dynamic discovery behavior.
           - name: Model list/picker cache
-            coverageIds: [model-list-picker-cache]
+            coverageIds: [openrouter.model-list-picker-cache]
             description: Covers Model list/picker cache across static catalog rows, dynamic model capability discovery, model-id normalization, `openrouter/<provider>/<model>` references, and related model catalog and dynamic discovery behavior.
         docs:
           - docs/providers/openrouter.md
@@ -9273,49 +9273,49 @@ surfaces:
         id: chat-runtime-and-normalization
         features:
           - name: Chat completions route
-            coverageIds: [chat-completions-route]
+            coverageIds: [openrouter.chat-completions-route]
             description: Covers Chat completions route across OpenRouter chat completions transport, `models.providers.openrouter.params.provider` routing, per-model routing overrides, OpenRouter proxy reasoning payloads, and related chat routing and reasoning behavior.
           - name: Provider routing params
-            coverageIds: [provider-routing-params]
+            coverageIds: [openrouter.provider-routing-params]
             description: Covers Provider routing params across OpenRouter chat completions transport, `models.providers.openrouter.params.provider` routing, per-model routing overrides, OpenRouter proxy reasoning payloads, and related chat routing and reasoning behavior.
           - name: Per-model route overrides
-            coverageIds: [per-model-route-overrides]
+            coverageIds: [openrouter.per-model-route-overrides]
             description: Covers Per-model route overrides across OpenRouter chat completions transport, `models.providers.openrouter.params.provider` routing, per-model routing overrides, OpenRouter proxy reasoning payloads, and related chat routing and reasoning behavior.
           - name: Reasoning payload policy
-            coverageIds: [reasoning-payload-policy]
+            coverageIds: [openrouter.reasoning-payload-policy]
             description: Covers Reasoning payload policy across OpenRouter chat completions transport, `models.providers.openrouter.params.provider` routing, per-model routing overrides, OpenRouter proxy reasoning payloads, and related chat routing and reasoning behavior.
           - name: Anthropic/Gemini/DeepSeek variants
-            coverageIds: [anthropic-gemini-deepseek-variants]
+            coverageIds: [openrouter.anthropic-gemini-deepseek-variants]
             description: Covers Anthropic/Gemini/DeepSeek variants across OpenRouter chat completions transport, `models.providers.openrouter.params.provider` routing, per-model routing overrides, OpenRouter proxy reasoning payloads, and related chat routing and reasoning behavior.
           - name: Streamed content parsing
-            coverageIds: [streamed-content-parsing]
+            coverageIds: [openrouter.streamed-content-parsing]
             description: Covers Streamed content parsing across streamed response parsing, visible output extraction from OpenRouter `reasoning_details`, tool-call delta preservation, Mistral strict9 replay policy, and related streaming and tool-call replay behavior.
           - name: reasoning_details visible output
-            coverageIds: [reasoning-details-visible-output]
+            coverageIds: [openrouter.reasoning-details-visible-output]
             description: Covers reasoning_details visible output across streamed response parsing, visible output extraction from OpenRouter `reasoning_details`, tool-call delta preservation, Mistral strict9 replay policy, and related streaming and tool-call replay behavior.
           - name: Tool-call delta preservation
-            coverageIds: [tool-call-delta-preservation]
+            coverageIds: [openrouter.tool-call-delta-preservation]
             description: Covers Tool-call delta preservation across streamed response parsing, visible output extraction from OpenRouter `reasoning_details`, tool-call delta preservation, Mistral strict9 replay policy, and related streaming and tool-call replay behavior.
           - name: Family-specific replay policy
-            coverageIds: [family-specific-replay-policy]
+            coverageIds: [openrouter.family-specific-replay-policy]
             description: Covers Family-specific replay policy across streamed response parsing, visible output extraction from OpenRouter `reasoning_details`, tool-call delta preservation, Mistral strict9 replay policy, and related streaming and tool-call replay behavior.
           - name: Response-model and usage normalization
-            coverageIds: [response-model-and-usage-normalization]
+            coverageIds: [openrouter.response-model-and-usage-normalization]
             description: Covers Response-model and usage normalization across streamed response parsing, visible output extraction from OpenRouter `reasoning_details`, tool-call delta preservation, Mistral strict9 replay policy, and related streaming and tool-call replay behavior.
           - name: Attribution headers
-            coverageIds: [attribution-headers]
+            coverageIds: [openrouter.attribution-headers]
             description: Covers Attribution headers across OpenRouter app attribution, response cache headers, TTL and clear behavior, Anthropic cache-control markers, prompt-cache retention, cache-read/cache-write usage mapping, verified-route gating, and custom proxy exclusions.
           - name: Response-cache headers/TTL/clear
-            coverageIds: [response-cache-headers-ttl-clear]
+            coverageIds: [openrouter.response-cache-headers-ttl-clear]
             description: Covers Response-cache headers/TTL/clear across OpenRouter app attribution, response cache headers, TTL and clear behavior, Anthropic cache-control markers, prompt-cache retention, cache-read/cache-write usage mapping, verified-route gating, and custom proxy exclusions.
           - name: Anthropic cache-control markers
-            coverageIds: [anthropic-cache-control-markers]
+            coverageIds: [openrouter.anthropic-cache-control-markers]
             description: Covers Anthropic cache-control markers across OpenRouter app attribution, response cache headers, TTL and clear behavior, Anthropic cache-control markers, prompt-cache retention, cache-read/cache-write usage mapping, verified-route gating, and custom proxy exclusions.
           - name: Cache usage mapping
-            coverageIds: [cache-usage-mapping]
+            coverageIds: [openrouter.cache-usage-mapping]
             description: Covers Cache usage mapping across OpenRouter app attribution, response cache headers, TTL and clear behavior, Anthropic cache-control markers, prompt-cache retention, cache-read/cache-write usage mapping, verified-route gating, and custom proxy exclusions.
           - name: Custom proxy exclusions
-            coverageIds: [custom-proxy-exclusions]
+            coverageIds: [openrouter.custom-proxy-exclusions]
             description: Covers Custom proxy exclusions across OpenRouter app attribution, response cache headers, TTL and clear behavior, Anthropic cache-control markers, prompt-cache retention, cache-read/cache-write usage mapping, verified-route gating, and custom proxy exclusions.
         docs:
           - docs/providers/openrouter.md
@@ -9343,19 +9343,19 @@ surfaces:
         id: provider-recovery-and-diagnostics
         features:
           - name: Timeout/retry classification
-            coverageIds: [timeout-retry-classification]
+            coverageIds: [openrouter.timeout-retry-classification]
             description: Covers Timeout/retry classification across OpenRouter timeout and retry classification, provider-specific generic errors, auth/billing/key-limit classification, context overflow parsing, and related failover and diagnostics behavior.
           - name: Auth/billing/key-limit classification
-            coverageIds: [auth-billing-key-limit-classification]
+            coverageIds: [openrouter.auth-billing-key-limit-classification]
             description: Covers Auth/billing/key-limit classification across OpenRouter timeout and retry classification, provider-specific generic errors, auth/billing/key-limit classification, context overflow parsing, and related failover and diagnostics behavior.
           - name: Context overflow
-            coverageIds: [context-overflow]
+            coverageIds: [openrouter.context-overflow]
             description: Covers Context overflow across OpenRouter timeout and retry classification, provider-specific generic errors, auth/billing/key-limit classification, context overflow parsing, and related failover and diagnostics behavior.
           - name: Model fallback notices
-            coverageIds: [model-fallback-notices]
+            coverageIds: [openrouter.model-fallback-notices]
             description: Covers Model fallback notices across OpenRouter timeout and retry classification, provider-specific generic errors, auth/billing/key-limit classification, context overflow parsing, and related failover and diagnostics behavior.
           - name: Guarded fetch/pricing warnings
-            coverageIds: [guarded-fetch-pricing-warnings]
+            coverageIds: [openrouter.guarded-fetch-pricing-warnings]
             description: Covers Guarded fetch/pricing warnings across OpenRouter timeout and retry classification, provider-specific generic errors, auth/billing/key-limit classification, context overflow parsing, and related failover and diagnostics behavior.
         docs:
           - docs/concepts/model-failover.md
@@ -9373,25 +9373,25 @@ surfaces:
         id: media-generation-and-speech
         features:
           - name: image_generate OpenRouter route
-            coverageIds: [image-generate-openrouter-route]
+            coverageIds: [openrouter.image-generate-openrouter-route]
             description: Covers image_generate OpenRouter route across OpenRouter image, video, music, TTS, and related image, video, music, and speech behavior.
           - name: video_generate async jobs/polling/download
-            coverageIds: [video-generate-async-jobs-polling-download]
+            coverageIds: [openrouter.video-generate-async-jobs-polling-download]
             description: Covers video_generate async jobs/polling/download across OpenRouter image, video, music, TTS, and related image, video, music, and speech behavior.
           - name: music_generate audio route
-            coverageIds: [music-generate-audio-route]
+            coverageIds: [openrouter.music-generate-audio-route]
             description: Covers music_generate audio route across OpenRouter image, video, music, TTS, and related image, video, music, and speech behavior.
           - name: Text-to-speech
-            coverageIds: [text-to-speech]
+            coverageIds: [openrouter.text-to-speech]
             description: Covers Text-to-speech across OpenRouter image, video, music, TTS, and related image, video, music, and speech behavior.
           - name: Speech-to-text transcription
-            coverageIds: [speech-to-text-transcription]
+            coverageIds: [openrouter.speech-to-text-transcription]
             description: Covers Speech-to-text transcription across OpenRouter image, video, music, TTS, and related image, video, music, and speech behavior.
           - name: Inbound media understanding
-            coverageIds: [inbound-media-understanding]
+            coverageIds: [openrouter.inbound-media-understanding]
             description: Covers Inbound media understanding across OpenRouter image, video, music, TTS, and related image, video, music, and speech behavior.
           - name: Generated artifact delivery
-            coverageIds: [generated-artifact-delivery]
+            coverageIds: [openrouter.generated-artifact-delivery]
             description: Covers Generated artifact delivery across OpenRouter image, video, music, TTS, and related image, video, music, and speech behavior.
         docs:
           - docs/providers/openrouter.md
@@ -9428,40 +9428,40 @@ surfaces:
         id: provider-setup-lifecycle-and-diagnostics
         features:
           - name: Provider Selection
-            coverageIds: [provider-selection]
+            coverageIds: [local-models.provider-selection]
             description: Covers Provider Selection across provider choice, `openclaw onboard`, model-picker contributions, non-interactive setup, and related provider selection and onboarding behavior.
           - name: Onboarding
-            coverageIds: [onboarding]
+            coverageIds: [local-models.onboarding]
             description: Covers Onboarding across provider choice, `openclaw onboard`, model-picker contributions, non-interactive setup, and related provider selection and onboarding behavior.
           - name: localService configuration
-            coverageIds: [localservice-configuration]
+            coverageIds: [local-models.localservice-configuration]
             description: Covers localService configuration across `localService` config contract, process startup, readiness probes, lease/release behavior during provider requests, and related local service lifecycle and readiness behavior.
           - name: Process startup and readiness
-            coverageIds: [process-startup-and-readiness]
+            coverageIds: [local-models.process-startup-and-readiness]
             description: Covers Process startup and readiness across `localService` config contract, process startup, readiness probes, lease/release behavior during provider requests, and related local service lifecycle and readiness behavior.
           - name: Request leases and idle shutdown
-            coverageIds: [request-leases-and-idle-shutdown]
+            coverageIds: [local-models.request-leases-and-idle-shutdown]
             description: Covers Request leases and idle shutdown across `localService` config contract, process startup, readiness probes, lease/release behavior during provider requests, and related local service lifecycle and readiness behavior.
           - name: Health checks and restart
-            coverageIds: [health-checks-and-restart]
+            coverageIds: [local-models.health-checks-and-restart]
             description: Covers Health checks and restart across `localService` config contract, process startup, readiness probes, lease/release behavior during provider requests, and related local service lifecycle and readiness behavior.
           - name: Provider recipes
-            coverageIds: [provider-recipes]
+            coverageIds: [local-models.provider-recipes]
             description: Covers Provider recipes across `localService` config contract, process startup, readiness probes, lease/release behavior during provider requests, and related local service lifecycle and readiness behavior.
           - name: Local provider status
-            coverageIds: [local-provider-status]
+            coverageIds: [local-models.local-provider-status]
             description: Covers Local provider status across user-facing diagnostic commands, provider HTTP error normalization, model-not-found classification, direct local backend probes, and related diagnostics and troubleshooting behavior.
           - name: Backend reachability probes
-            coverageIds: [backend-reachability-probes]
+            coverageIds: [local-models.backend-reachability-probes]
             description: Covers Backend reachability probes across user-facing diagnostic commands, provider HTTP error normalization, model-not-found classification, direct local backend probes, and related diagnostics and troubleshooting behavior.
           - name: Model availability errors
-            coverageIds: [model-availability-errors]
+            coverageIds: [local-models.model-availability-errors]
             description: Covers Model availability errors across user-facing diagnostic commands, provider HTTP error normalization, model-not-found classification, direct local backend probes, and related diagnostics and troubleshooting behavior.
           - name: Memory readiness diagnostics
-            coverageIds: [memory-readiness-diagnostics]
+            coverageIds: [local-models.memory-readiness-diagnostics]
             description: Covers Memory readiness diagnostics across user-facing diagnostic commands, provider HTTP error normalization, model-not-found classification, direct local backend probes, and related diagnostics and troubleshooting behavior.
           - name: Provider troubleshooting docs
-            coverageIds: [provider-troubleshooting-docs]
+            coverageIds: [local-models.provider-troubleshooting-docs]
             description: Covers Provider troubleshooting docs across user-facing diagnostic commands, provider HTTP error normalization, model-not-found classification, direct local backend probes, and related diagnostics and troubleshooting behavior.
         docs:
           - docs/gateway/local-models.md
@@ -9493,34 +9493,34 @@ surfaces:
         id: native-provider-plugins
         features:
           - name: Ollama setup and model pulling
-            coverageIds: [ollama-setup-and-model-pulling]
+            coverageIds: [local-models.ollama-setup-and-model-pulling]
             description: Covers Ollama setup and model pulling across native Ollama chat/model discovery, cloud+local/local-only setup, local auth markers, model pulling, and related ollama native provider behavior.
           - name: Model discovery
-            coverageIds: [model-discovery]
+            coverageIds: [local-models.model-discovery]
             description: Covers Model discovery across native Ollama chat/model discovery, cloud+local/local-only setup, local auth markers, model pulling, and related ollama native provider behavior.
           - name: Streaming and vision
-            coverageIds: [streaming-and-vision]
+            coverageIds: [local-models.streaming-and-vision]
             description: Covers Streaming and vision across native Ollama chat/model discovery, cloud+local/local-only setup, local auth markers, model pulling, and related ollama native provider behavior.
           - name: Ollama embeddings
-            coverageIds: [ollama-embeddings]
+            coverageIds: [local-models.ollama-embeddings]
             description: Covers Ollama embeddings across native Ollama chat/model discovery, cloud+local/local-only setup, local auth markers, model pulling, and related ollama native provider behavior.
           - name: Web-search support
-            coverageIds: [web-search-support]
+            coverageIds: [local-models.web-search-support]
             description: Covers Web-search support across native Ollama chat/model discovery, cloud+local/local-only setup, local auth markers, model pulling, and related ollama native provider behavior.
           - name: LM Studio setup
-            coverageIds: [lm-studio-setup]
+            coverageIds: [local-models.lm-studio-setup]
             description: Covers LM Studio setup across LM Studio provider plugin, `/providers/lmstudio` docs, model discovery from LM Studio APIs, auth behavior for local and authenticated instances, preload/JIT behavior, OpenAI-compatible streaming, and LM Studio memory embeddings.
           - name: Model discovery and auth
-            coverageIds: [model-discovery-and-auth]
+            coverageIds: [local-models.model-discovery-and-auth]
             description: Covers Model discovery and auth across LM Studio provider plugin, `/providers/lmstudio` docs, model discovery from LM Studio APIs, auth behavior for local and authenticated instances, preload/JIT behavior, OpenAI-compatible streaming, and LM Studio memory embeddings.
           - name: Model preload and JIT loading
-            coverageIds: [model-preload-and-jit-loading]
+            coverageIds: [local-models.model-preload-and-jit-loading]
             description: Covers Model preload and JIT loading across LM Studio provider plugin, `/providers/lmstudio` docs, model discovery from LM Studio APIs, auth behavior for local and authenticated instances, preload/JIT behavior, OpenAI-compatible streaming, and LM Studio memory embeddings.
           - name: Streaming compatibility
-            coverageIds: [streaming-compatibility]
+            coverageIds: [local-models.streaming-compatibility]
             description: Covers Streaming compatibility across LM Studio provider plugin, `/providers/lmstudio` docs, model discovery from LM Studio APIs, auth behavior for local and authenticated instances, preload/JIT behavior, OpenAI-compatible streaming, and LM Studio memory embeddings.
           - name: LM Studio embeddings
-            coverageIds: [lm-studio-embeddings]
+            coverageIds: [local-models.lm-studio-embeddings]
             description: Covers LM Studio embeddings across LM Studio provider plugin, `/providers/lmstudio` docs, model discovery from LM Studio APIs, auth behavior for local and authenticated instances, preload/JIT behavior, OpenAI-compatible streaming, and LM Studio memory embeddings.
         docs:
           - docs/providers/ollama.md
@@ -9542,28 +9542,28 @@ surfaces:
         id: openai-compatible-runtime-compatibility
         features:
           - name: Bundled provider setup
-            coverageIds: [bundled-provider-setup]
+            coverageIds: [local-models.bundled-provider-setup]
             description: Covers Bundled provider setup across bundled `vllm` and `sglang` provider plugins, docs, default env/base URL behavior, `/v1/models` discovery, and related vllm and sglang openai-compatible providers behavior.
           - name: Model Discovery Endpoint
-            coverageIds: [model-discovery-endpoint]
+            coverageIds: [local-models.model-discovery-endpoint]
             description: Covers Model Discovery Endpoint across bundled `vllm` and `sglang` provider plugins, docs, default env/base URL behavior, `/v1/models` discovery, and related vllm and sglang openai-compatible providers behavior.
           - name: Non-interactive configuration
-            coverageIds: [non-interactive-configuration]
+            coverageIds: [local-models.non-interactive-configuration]
             description: Covers Non-interactive configuration across bundled `vllm` and `sglang` provider plugins, docs, default env/base URL behavior, `/v1/models` discovery, and related vllm and sglang openai-compatible providers behavior.
           - name: vLLM thinking controls
-            coverageIds: [vllm-thinking-controls]
+            coverageIds: [local-models.vllm-thinking-controls]
             description: Covers vLLM thinking controls across bundled `vllm` and `sglang` provider plugins, docs, default env/base URL behavior, `/v1/models` discovery, and related vllm and sglang openai-compatible providers behavior.
           - name: OpenAI-compatible chat and tool semantics
-            coverageIds: [openai-compatible-chat-and-tool-semantics]
+            coverageIds: [local-models.openai-compatible-chat-and-tool-semantics]
             description: Covers OpenAI-compatible chat and tool semantics across bundled `vllm` and `sglang` provider plugins, docs, default env/base URL behavior, `/v1/models` discovery, and related vllm and sglang openai-compatible providers behavior.
           - name: SGLang compatibility guidance
-            coverageIds: [sglang-compatibility-guidance]
+            coverageIds: [local-models.sglang-compatibility-guidance]
             description: Covers SGLang compatibility guidance across bundled `vllm` and `sglang` provider plugins, docs, default env/base URL behavior, `/v1/models` discovery, and related vllm and sglang openai-compatible providers behavior.
           - name: Request Stream Compatibility
-            coverageIds: [request-stream-compatibility]
+            coverageIds: [local-models.request-stream-compatibility]
             description: Covers Request Stream Compatibility across chat and Responses-style request shaping, streaming normalization, tool-call compatibility, local-model reasoning controls, and related request stream compatibility and tool calling behavior.
           - name: Tool Calling
-            coverageIds: [tool-calling]
+            coverageIds: [local-models.tool-calling]
             description: Covers Tool Calling across chat and Responses-style request shaping, streaming normalization, tool-call compatibility, local-model reasoning controls, and related request stream compatibility and tool calling behavior.
         docs:
           - docs/providers/vllm.md
@@ -9587,19 +9587,19 @@ surfaces:
         id: local-memory-and-embeddings
         features:
           - name: Embedding provider selection
-            coverageIds: [embedding-provider-selection]
+            coverageIds: [local-models.embedding-provider-selection]
             description: Covers Embedding provider selection across local embedding provider registration for Ollama and LM Studio, memory host embedding behavior, memory search readiness, local `memoryFlush` model overrides, and related local embeddings and memory behavior.
           - name: Memory search readiness
-            coverageIds: [memory-search-readiness]
+            coverageIds: [local-models.memory-search-readiness]
             description: Covers Memory search readiness across local embedding provider registration for Ollama and LM Studio, memory host embedding behavior, memory search readiness, local `memoryFlush` model overrides, and related local embeddings and memory behavior.
           - name: memoryFlush model override
-            coverageIds: [memoryflush-model-override]
+            coverageIds: [local-models.memoryflush-model-override]
             description: Covers memoryFlush model override across local embedding provider registration for Ollama and LM Studio, memory host embedding behavior, memory search readiness, local `memoryFlush` model overrides, and related local embeddings and memory behavior.
           - name: Fallback lexical search
-            coverageIds: [fallback-lexical-search]
+            coverageIds: [local-models.fallback-lexical-search]
             description: Covers Fallback lexical search across local embedding provider registration for Ollama and LM Studio, memory host embedding behavior, memory search readiness, local `memoryFlush` model overrides, and related local embeddings and memory behavior.
           - name: Provider mismatch guidance
-            coverageIds: [provider-mismatch-guidance]
+            coverageIds: [local-models.provider-mismatch-guidance]
             description: Covers Provider mismatch guidance across local embedding provider registration for Ollama and LM Studio, memory host embedding behavior, memory search readiness, local `memoryFlush` model overrides, and related local embeddings and memory behavior.
         docs:
           - docs/concepts/memory.md
@@ -9616,10 +9616,10 @@ surfaces:
         id: network-safety-and-prompt-controls
         features:
           - name: Safety Network
-            coverageIds: [safety-network]
+            coverageIds: [local-models.safety-network]
             description: Covers Safety Network across private-network and exact-origin trust for local provider base URLs, SSRF protections for self-hosted setup, special-token sanitization, local-model lean prompt behavior, and related safety network and prompt pressure controls behavior.
           - name: Prompt Pressure Controls
-            coverageIds: [prompt-pressure-controls]
+            coverageIds: [local-models.prompt-pressure-controls]
             description: Covers Prompt Pressure Controls across private-network and exact-origin trust for local provider base URLs, SSRF protections for self-hosted setup, special-token sanitization, local-model lean prompt behavior, and related safety network and prompt pressure controls behavior.
         docs:
           - docs/gateway/security/index.md
@@ -9650,40 +9650,40 @@ surfaces:
         id: hosted-llm-providers
         features:
           - name: Bedrock setup
-            coverageIds: [bedrock-setup]
+            coverageIds: [hosted-providers.bedrock-setup]
             description: Covers Bedrock setup across Amazon Bedrock, Bedrock Mantle, Cloudflare AI Gateway, Vercel AI Gateway, and related cloud and gateway providers behavior.
           - name: Gateway/proxy routing
-            coverageIds: [gateway-proxy-routing]
+            coverageIds: [hosted-providers.gateway-proxy-routing]
             description: Covers Gateway/proxy routing across Amazon Bedrock, Bedrock Mantle, Cloudflare AI Gateway, Vercel AI Gateway, and related cloud and gateway providers behavior.
           - name: Copilot/OpenCode hosted access
-            coverageIds: [copilot-opencode-hosted-access]
+            coverageIds: [hosted-providers.copilot-opencode-hosted-access]
             description: Covers Copilot/OpenCode hosted access across Amazon Bedrock, Bedrock Mantle, Cloudflare AI Gateway, Vercel AI Gateway, and related cloud and gateway providers behavior.
           - name: Proxy capability diagnostics
-            coverageIds: [proxy-capability-diagnostics]
+            coverageIds: [hosted-providers.proxy-capability-diagnostics]
             description: Covers Proxy capability diagnostics across Amazon Bedrock, Bedrock Mantle, Cloudflare AI Gateway, Vercel AI Gateway, and related cloud and gateway providers behavior.
           - name: Hosted text completion
-            coverageIds: [hosted-text-completion]
+            coverageIds: [hosted-providers.hosted-text-completion]
             description: 'Covers Hosted text completion across hosted text providers that mostly use OpenAI-compatible routes or close variants: DeepSeek, Groq, Mistral, Together, and related openai-compatible hosted text providers behavior.'
           - name: Tool-call and streaming compatibility
-            coverageIds: [tool-call-and-streaming-compatibility]
+            coverageIds: [hosted-providers.tool-call-and-streaming-compatibility]
             description: 'Covers Tool-call and streaming compatibility across hosted text providers that mostly use OpenAI-compatible routes or close variants: DeepSeek, Groq, Mistral, Together, and related openai-compatible hosted text providers behavior.'
           - name: Model catalog resolution
-            coverageIds: [model-catalog-resolution]
+            coverageIds: [hosted-providers.model-catalog-resolution]
             description: 'Covers Model catalog resolution across hosted text providers that mostly use OpenAI-compatible routes or close variants: DeepSeek, Groq, Mistral, Together, and related openai-compatible hosted text providers behavior.'
           - name: Provider-specific request shaping
-            coverageIds: [provider-specific-request-shaping]
+            coverageIds: [hosted-providers.provider-specific-request-shaping]
             description: 'Covers Provider-specific request shaping across hosted text providers that mostly use OpenAI-compatible routes or close variants: DeepSeek, Groq, Mistral, Together, and related openai-compatible hosted text providers behavior.'
           - name: Regional provider setup
-            coverageIds: [regional-provider-setup]
+            coverageIds: [hosted-providers.regional-provider-setup]
             description: Covers Regional provider setup across Qwen, Alibaba, Tencent, Qianfan, and related regional hosted llm providers behavior.
           - name: Region and plan routing
-            coverageIds: [region-and-plan-routing]
+            coverageIds: [hosted-providers.region-and-plan-routing]
             description: Covers Region and plan routing across Qwen, Alibaba, Tencent, Qianfan, and related regional hosted llm providers behavior.
           - name: Regional live smoke
-            coverageIds: [regional-live-smoke]
+            coverageIds: [hosted-providers.regional-live-smoke]
             description: Covers Regional live smoke across Qwen, Alibaba, Tencent, Qianfan, and related regional hosted llm providers behavior.
           - name: Account prerequisite diagnostics
-            coverageIds: [account-prerequisite-diagnostics]
+            coverageIds: [hosted-providers.account-prerequisite-diagnostics]
             description: Covers Account prerequisite diagnostics across Qwen, Alibaba, Tencent, Qianfan, and related regional hosted llm providers behavior.
         docs:
           - docs/providers/index.md
@@ -9709,28 +9709,28 @@ surfaces:
         id: hosted-media-providers
         features:
           - name: Image generation providers
-            coverageIds: [image-generation-providers]
+            coverageIds: [hosted-providers.image-generation-providers]
             description: Covers Image generation providers across hosted image, video, and music generation provider paths, including DeepInfra, and related hosted media generation providers behavior.
           - name: Video generation providers
-            coverageIds: [video-generation-providers]
+            coverageIds: [hosted-providers.video-generation-providers]
             description: Covers Video generation providers across hosted image, video, and music generation provider paths, including DeepInfra, and related hosted media generation providers behavior.
           - name: Music generation providers
-            coverageIds: [music-generation-providers]
+            coverageIds: [hosted-providers.music-generation-providers]
             description: Covers Music generation providers across hosted image, video, and music generation provider paths, including DeepInfra, and related hosted media generation providers behavior.
           - name: Media mode coverage
-            coverageIds: [media-mode-coverage]
+            coverageIds: [hosted-providers.media-mode-coverage]
             description: Covers Media mode coverage across hosted image, video, and music generation provider paths, including DeepInfra, and related hosted media generation providers behavior.
           - name: Text-to-speech providers
-            coverageIds: [text-to-speech-providers]
+            coverageIds: [hosted-providers.text-to-speech-providers]
             description: Covers Text-to-speech providers across text-to-speech, speech-to-text, realtime transcription, telephony audio, and related hosted speech, transcription, and audio providers behavior.
           - name: Speech-to-text providers
-            coverageIds: [speech-to-text-providers]
+            coverageIds: [hosted-providers.speech-to-text-providers]
             description: Covers Speech-to-text providers across text-to-speech, speech-to-text, realtime transcription, telephony audio, and related hosted speech, transcription, and audio providers behavior.
           - name: Realtime transcription providers
-            coverageIds: [realtime-transcription-providers]
+            coverageIds: [models.realtime-transcription-providers]
             description: Covers Realtime transcription providers across text-to-speech, speech-to-text, realtime transcription, telephony audio, and related hosted speech, transcription, and audio providers behavior.
           - name: Audio format diagnostics
-            coverageIds: [audio-format-diagnostics]
+            coverageIds: [hosted-providers.audio-format-diagnostics]
             description: Covers Audio format diagnostics across text-to-speech, speech-to-text, realtime transcription, telephony audio, and related hosted speech, transcription, and audio providers behavior.
         docs:
           - docs/plugins/manifest.md
@@ -9751,40 +9751,40 @@ surfaces:
         id: provider-operations
         features:
           - name: Provider directory
-            coverageIds: [provider-directory]
+            coverageIds: [hosted-providers.provider-directory]
             description: Covers Provider directory across public provider directory, provider docs links, model provider overview tables, manifest provider metadata, and related provider catalog and discovery behavior.
           - name: Provider install catalog
-            coverageIds: [provider-install-catalog]
+            coverageIds: [hosted-providers.provider-install-catalog]
             description: Covers Provider install catalog across public provider directory, provider docs links, model provider overview tables, manifest provider metadata, and related provider catalog and discovery behavior.
           - name: Model catalog metadata
-            coverageIds: [model-catalog-metadata]
+            coverageIds: [hosted-providers.model-catalog-metadata]
             description: Covers Model catalog metadata across public provider directory, provider docs links, model provider overview tables, manifest provider metadata, and related provider catalog and discovery behavior.
           - name: Catalog parity checks
-            coverageIds: [catalog-parity-checks]
+            coverageIds: [hosted-providers.catalog-parity-checks]
             description: Covers Catalog parity checks across public provider directory, provider docs links, model provider overview tables, manifest provider metadata, and related provider catalog and discovery behavior.
           - name: Provider setup descriptors
-            coverageIds: [provider-setup-descriptors]
+            coverageIds: [hosted-providers.provider-setup-descriptors]
             description: Covers Provider setup descriptors across provider setup descriptors, provider auth choices, auth env-var metadata, auth aliases, and related setup and credential health behavior.
           - name: Auth profiles and aliases
-            coverageIds: [auth-profiles-and-aliases]
+            coverageIds: [hosted-providers.auth-profiles-and-aliases]
             description: Covers Auth profiles and aliases across provider setup descriptors, provider auth choices, auth env-var metadata, auth aliases, and related setup and credential health behavior.
           - name: Credential health probes
-            coverageIds: [credential-health-probes]
+            coverageIds: [hosted-providers.credential-health-probes]
             description: Covers Credential health probes across provider setup descriptors, provider auth choices, auth env-var metadata, auth aliases, and related setup and credential health behavior.
           - name: Key rotation and recovery
-            coverageIds: [key-rotation-and-recovery]
+            coverageIds: [hosted-providers.key-rotation-and-recovery]
             description: Covers Key rotation and recovery across provider setup descriptors, provider auth choices, auth env-var metadata, auth aliases, and related setup and credential health behavior.
           - name: Direct provider smoke
-            coverageIds: [direct-provider-smoke]
+            coverageIds: [hosted-providers.direct-provider-smoke]
             description: Covers Direct provider smoke across direct live provider/model smoke, Gateway live profile smoke, `models status --probe`, auth/status buckets, and related provider diagnostics and fallback repair behavior.
           - name: Gateway live smoke
-            coverageIds: [gateway-live-smoke]
+            coverageIds: [hosted-providers.gateway-live-smoke]
             description: Covers Gateway live smoke across direct live provider/model smoke, Gateway live profile smoke, `models status --probe`, auth/status buckets, and related provider diagnostics and fallback repair behavior.
           - name: Models status probes
-            coverageIds: [models-status-probes]
+            coverageIds: [hosted-providers.models-status-probes]
             description: Covers Models status probes across direct live provider/model smoke, Gateway live profile smoke, `models status --probe`, auth/status buckets, and related provider diagnostics and fallback repair behavior.
           - name: Fallback trace and repair
-            coverageIds: [fallback-trace-and-repair]
+            coverageIds: [hosted-providers.fallback-trace-and-repair]
             description: Covers Fallback trace and repair across direct live provider/model smoke, Gateway live profile smoke, `models status --probe`, auth/status buckets, and related provider diagnostics and fallback repair behavior.
         docs:
           - docs/providers/index.md
@@ -9828,58 +9828,58 @@ surfaces:
             coverageIds: [tools.tavily-search]
             description: Covers API-backed providers provider routing, request shaping, streaming, and response normalization for Structured Search Providers.
           - name: Keyless and self-hosted providers
-            coverageIds: [keyless-and-self-hosted-providers]
+            coverageIds: [web-search.keyless-and-self-hosted-providers]
             description: Covers Keyless and self-hosted providers provider routing, request shaping, streaming, and response normalization for Structured Search Providers.
           - name: Provider comparison and auto-detection
-            coverageIds: [provider-comparison-and-auto-detection]
+            coverageIds: [web-search.provider-comparison-and-auto-detection]
             description: Covers Provider comparison and auto-detection provider routing, request shaping, streaming, and response normalization for Structured Search Providers.
           - name: Provider-specific filters and extraction
-            coverageIds: [provider-specific-filters-and-extraction]
+            coverageIds: [web-search.provider-specific-filters-and-extraction]
             description: Covers Provider-specific filters and extraction provider routing, request shaping, streaming, and response normalization for Structured Search Providers.
           - name: Result normalization
-            coverageIds: [result-normalization]
+            coverageIds: [web-search.result-normalization]
             description: Covers Result normalization provider routing, request shaping, streaming, and response normalization for Structured Search Providers.
           - name: OpenAI native web_search
-            coverageIds: [openai-native-web-search]
+            coverageIds: [web-search.openai-native-web-search]
             description: Covers OpenAI native web_search routing, session binding, history, and conversation context for Provider-Native Grounded Search.
           - name: Codex native web_search
-            coverageIds: [codex-native-web-search]
+            coverageIds: [web-search.codex-native-web-search]
             description: Covers Codex native web_search routing, session binding, history, and conversation context for Provider-Native Grounded Search.
           - name: Gemini grounding
-            coverageIds: [gemini-grounding]
+            coverageIds: [web-search.gemini-grounding]
             description: Covers Gemini grounding routing, session binding, history, and conversation context for Provider-Native Grounded Search.
           - name: Grok web grounding
-            coverageIds: [grok-web-grounding]
+            coverageIds: [web-search.grok-web-grounding]
             description: Covers Grok web grounding routing, session binding, history, and conversation context for Provider-Native Grounded Search.
           - name: Kimi web search
-            coverageIds: [kimi-web-search]
+            coverageIds: [web-search.kimi-web-search]
             description: Covers Kimi web search routing, session binding, history, and conversation context for Provider-Native Grounded Search.
           - name: Provider-native citations
-            coverageIds: [provider-native-citations]
+            coverageIds: [web-search.provider-native-citations]
             description: Covers Provider-native citations routing, session binding, history, and conversation context for Provider-Native Grounded Search.
           - name: Model and filter routing
-            coverageIds: [model-and-filter-routing]
+            coverageIds: [web-search.model-and-filter-routing]
             description: Covers Model and filter routing routing, session binding, history, and conversation context for Provider-Native Grounded Search.
           - name: webSearchProviders
-            coverageIds: [websearchproviders]
+            coverageIds: [web-search.websearchproviders]
             description: Defines webSearchProviders setup, credential, configuration, and operator verification behavior for Web Provider Plugin Contracts.
           - name: registerWebSearchProvider
-            coverageIds: [registerwebsearchprovider]
+            coverageIds: [web-search.registerwebsearchprovider]
             description: Defines registerWebSearchProvider setup, credential, configuration, and operator verification behavior for Web Provider Plugin Contracts.
           - name: webFetchProviders
-            coverageIds: [webfetchproviders]
+            coverageIds: [web-search.webfetchproviders]
             description: Defines webFetchProviders setup, credential, configuration, and operator verification behavior for Web Provider Plugin Contracts.
           - name: registerWebFetchProvider
-            coverageIds: [registerwebfetchprovider]
+            coverageIds: [web-search.registerwebfetchprovider]
             description: Defines registerWebFetchProvider setup, credential, configuration, and operator verification behavior for Web Provider Plugin Contracts.
           - name: public-artifact loading
-            coverageIds: [public-artifact-loading]
+            coverageIds: [web-search.public-artifact-loading]
             description: Defines public-artifact loading setup, credential, configuration, and operator verification behavior for Web Provider Plugin Contracts.
           - name: runtime resolution
-            coverageIds: [runtime-resolution]
+            coverageIds: [web-search.runtime-resolution]
             description: Defines runtime resolution setup, credential, configuration, and operator verification behavior for Web Provider Plugin Contracts.
           - name: contract tests
-            coverageIds: [contract-tests]
+            coverageIds: [web-search.contract-tests]
             description: Defines contract tests setup, credential, configuration, and operator verification behavior for Web Provider Plugin Contracts.
         docs:
           - docs/tools/web.md
@@ -9924,31 +9924,31 @@ surfaces:
         id: setup-and-diagnostics
         features:
           - name: Provider credentials
-            coverageIds: [provider-credentials]
+            coverageIds: [security.provider-credentials]
             description: Defines Provider credentials setup, credential, configuration, and operator verification behavior for Setup and Credential Repair.
           - name: Default provider selection
-            coverageIds: [default-provider-selection]
+            coverageIds: [web-search.default-provider-selection]
             description: Defines Default provider selection setup, credential, configuration, and operator verification behavior for Setup and Credential Repair.
           - name: Credential repair
-            coverageIds: [credential-repair]
+            coverageIds: [web-search.credential-repair]
             description: Defines Credential repair setup, credential, configuration, and operator verification behavior for Setup and Credential Repair.
           - name: Status checks
-            coverageIds: [status-checks]
+            coverageIds: [web-search.status-checks]
             description: Defines Status checks setup, credential, configuration, and operator verification behavior for Setup and Credential Repair.
           - name: Quota errors
-            coverageIds: [quota-errors]
+            coverageIds: [web-search.quota-errors]
             description: Covers Quota errors status, diagnostics, failure handling, and operator repair for Provider Reliability and Diagnostics.
           - name: Cache controls
-            coverageIds: [cache-controls]
+            coverageIds: [web-search.cache-controls]
             description: Covers Cache controls status, diagnostics, failure handling, and operator repair for Provider Reliability and Diagnostics.
           - name: Provider diagnostics
-            coverageIds: [provider-diagnostics]
+            coverageIds: [models.diagnostics]
             description: Covers Provider diagnostics status, diagnostics, failure handling, and operator repair for Provider Reliability and Diagnostics.
           - name: Retry and fallback
-            coverageIds: [retry-and-fallback]
+            coverageIds: [web-search.retry-and-fallback]
             description: Covers Retry and fallback status, diagnostics, failure handling, and operator repair for Provider Reliability and Diagnostics.
           - name: Operator repair
-            coverageIds: [operator-repair]
+            coverageIds: [codex.operator-repair]
             description: Covers Operator repair status, diagnostics, failure handling, and operator repair for Provider Reliability and Diagnostics.
         docs:
           - docs/tools/web.md
@@ -9975,16 +9975,16 @@ surfaces:
         id: network-safety
         features:
           - name: Network Safety
-            coverageIds: [network-safety]
+            coverageIds: [web-search.network-safety]
             description: Defines Network Safety authorization, trust, safety boundaries, and operator controls for Network Safety, Ssrf, Redirects, and Untrusted Content.
           - name: SSRF
-            coverageIds: [ssrf]
+            coverageIds: [browser-tools.ssrf]
             description: Defines SSRF authorization, trust, safety boundaries, and operator controls for Network Safety, Ssrf, Redirects, and Untrusted Content.
           - name: Redirects
-            coverageIds: [redirects]
+            coverageIds: [web-search.redirects]
             description: Defines Redirects authorization, trust, safety boundaries, and operator controls for Network Safety, Ssrf, Redirects, and Untrusted Content.
           - name: Untrusted Content
-            coverageIds: [untrusted-content]
+            coverageIds: [web-search.untrusted-content]
             description: Defines Untrusted Content authorization, trust, safety boundaries, and operator controls for Network Safety, Ssrf, Redirects, and Untrusted Content.
         docs:
           - docs/tools/web.md
@@ -10010,31 +10010,31 @@ surfaces:
             coverageIds: [tools.web-fetch]
             description: Defines web_fetch exposure setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
           - name: x_search exposure
-            coverageIds: [x-search-exposure]
+            coverageIds: [web-search.x-search-exposure]
             description: Defines x_search exposure setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
           - name: group:web policy
-            coverageIds: [group-web-policy]
+            coverageIds: [web-search.group-web-policy]
             description: Defines group:web policy setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
           - name: disabled-state diagnostics
-            coverageIds: [disabled-state-diagnostics]
+            coverageIds: [web-search.disabled-state-diagnostics]
             description: Defines disabled-state diagnostics setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
           - name: provider/model gating
-            coverageIds: [provider-model-gating]
+            coverageIds: [web-search.provider-model-gating]
             description: Defines provider/model gating setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
           - name: URL fetch
-            coverageIds: [url-fetch]
+            coverageIds: [web-search.url-fetch]
             description: Covers URL fetch tool invocation, host execution, sandbox policy, and artifact handling for Web Fetch and Content Extraction.
           - name: HTML extraction
             coverageIds: [tools.tavily-extract]
             description: Covers HTML extraction tool invocation, host execution, sandbox policy, and artifact handling for Web Fetch and Content Extraction.
           - name: PDF/text extraction
-            coverageIds: [pdf-text-extraction]
+            coverageIds: [web-search.pdf-text-extraction]
             description: Covers PDF/text extraction tool invocation, host execution, sandbox policy, and artifact handling for Web Fetch and Content Extraction.
           - name: Safe truncation
-            coverageIds: [safe-truncation]
+            coverageIds: [web-search.safe-truncation]
             description: Covers Safe truncation tool invocation, host execution, sandbox policy, and artifact handling for Web Fetch and Content Extraction.
           - name: Content citation handoff
-            coverageIds: [content-citation-handoff]
+            coverageIds: [web-search.content-citation-handoff]
             description: Covers Content citation handoff tool invocation, host execution, sandbox policy, and artifact handling for Web Fetch and Content Extraction.
         docs:
           - docs/gateway/config-tools.md
@@ -10073,28 +10073,28 @@ surfaces:
         id: browser-automation
         features:
           - name: Browser Actions
-            coverageIds: [browser-actions]
+            coverageIds: [browser-tools.browser-actions]
             description: Covers Browser Actions across browser tool action schemas, navigate/act/snapshot/screenshot operations, AI/role/ARIA snapshot formats, action ref storage, and related browser actions, snapshots, and artifacts behavior.
           - name: Snapshots
-            coverageIds: [snapshots]
+            coverageIds: [browser-tools.snapshots]
             description: Covers Snapshots across browser tool action schemas, navigate/act/snapshot/screenshot operations, AI/role/ARIA snapshot formats, action ref storage, and related browser actions, snapshots, and artifacts behavior.
           - name: Artifacts
             coverageIds: [workspace.artifacts]
             description: Covers Artifacts across browser tool action schemas, navigate/act/snapshot/screenshot operations, AI/role/ARIA snapshot formats, action ref storage, and related browser actions, snapshots, and artifacts behavior.
           - name: Browser Plugin Service
-            coverageIds: [browser-plugin-service]
+            coverageIds: [browser-tools.browser-plugin-service]
             description: Covers Browser Plugin Service across bundled browser plugin activation, browser CLI registration, `browser.request` Gateway routing, control-service startup, and related browser plugin service and profiles behavior.
           - name: Profiles
-            coverageIds: [profiles]
+            coverageIds: [browser-tools.profiles]
             description: Covers Profiles across bundled browser plugin activation, browser CLI registration, `browser.request` Gateway routing, control-service startup, and related browser plugin service and profiles behavior.
           - name: Browser Security
-            coverageIds: [browser-security]
+            coverageIds: [browser-tools.browser-security]
             description: Covers Browser Security across browser-control auth, navigation URL validation, delayed navigation guards, strict private-network SSRF policy, and related browser security, ssrf, and remote control behavior.
           - name: SSRF
-            coverageIds: [ssrf]
+            coverageIds: [browser-tools.ssrf]
             description: Covers SSRF across browser-control auth, navigation URL validation, delayed navigation guards, strict private-network SSRF policy, and related browser security, ssrf, and remote control behavior.
           - name: Remote Control
-            coverageIds: [remote-control]
+            coverageIds: [browser-tools.remote-control]
             description: Covers Remote Control across browser-control auth, navigation URL validation, delayed navigation guards, strict private-network SSRF policy, and related browser security, ssrf, and remote control behavior.
         docs:
           - docs/tools/browser-control.md
@@ -10132,13 +10132,13 @@ surfaces:
             coverageIds: [plugins.mcp-tools, tools.invocation]
             description: Covers Direct Tool Invoke API across HTTP `POST /tools/invoke`, Gateway RPC `tools.invoke`, request body and auth semantics, shared-secret operator scope restoration, and related direct tool invoke api and node system.run behavior.
           - name: Node System.run
-            coverageIds: [node-system-run]
+            coverageIds: [browser-tools.node-system-run]
             description: Covers Node System.run across HTTP `POST /tools/invoke`, Gateway RPC `tools.invoke`, request body and auth semantics, shared-secret operator scope restoration, and related direct tool invoke api and node system.run behavior.
           - name: Host Exec Approvals
-            coverageIds: [host-exec-approvals]
+            coverageIds: [browser-tools.host-exec-approvals]
             description: Covers Host Exec Approvals across exec approval policy, local approvals state, approval request registration and waiting, allow-once consumption, and related host exec approvals and elevated mode behavior.
           - name: Elevated Mode
-            coverageIds: [elevated-mode]
+            coverageIds: [browser-tools.elevated-mode]
             description: Covers Elevated Mode across exec approval policy, local approvals state, approval request registration and waiting, allow-once consumption, and related host exec approvals and elevated mode behavior.
         docs:
           - docs/tools/exec.md
@@ -10168,22 +10168,22 @@ surfaces:
         id: sandbox-and-tool-policy
         features:
           - name: Sandbox Backends
-            coverageIds: [sandbox-backends]
+            coverageIds: [browser-tools.sandbox-backends]
             description: Covers Sandbox Backends across sandbox modes, scopes, workspace roots, workspaceAccess, and related sandbox backends and workspace isolation behavior.
           - name: Workspace Isolation
-            coverageIds: [workspace-isolation]
+            coverageIds: [browser-tools.workspace-isolation]
             description: Covers Workspace Isolation across sandbox modes, scopes, workspace roots, workspaceAccess, and related sandbox backends and workspace isolation behavior.
           - name: Sandboxed Browser
-            coverageIds: [sandboxed-browser]
+            coverageIds: [browser-tools.sandboxed-browser]
             description: Covers Sandboxed Browser across sandbox browser config, Docker browser container creation, CDP relay authentication, noVNC password/token flow, and related sandboxed browser and codex dynamic tools behavior.
           - name: Codex Dynamic Tools
-            coverageIds: [codex-dynamic-tools]
+            coverageIds: [browser-tools.codex-dynamic-tools]
             description: Covers Codex Dynamic Tools across sandbox browser config, Docker browser container creation, CDP relay authentication, noVNC password/token flow, and related sandboxed browser and codex dynamic tools behavior.
           - name: Tool Policy
-            coverageIds: [tool-policy]
+            coverageIds: [browser-tools.tool-policy]
             description: Covers Tool Policy across tool profiles, tool groups, allow/deny policy, provider policy, and related tool policy and sandbox tool gates behavior.
           - name: Sandbox Tool Gates
-            coverageIds: [sandbox-tool-gates]
+            coverageIds: [browser-tools.sandbox-tool-gates]
             description: Covers Sandbox Tool Gates across tool profiles, tool groups, allow/deny policy, provider policy, and related tool policy and sandbox tool gates behavior.
         docs:
           - docs/gateway/sandboxing.md
@@ -10224,16 +10224,16 @@ surfaces:
         id: media-routing-and-discovery
         features:
           - name: default media model config
-            coverageIds: [default-media-model-config]
+            coverageIds: [media-tools.default-media-model-config]
             description: Covers default media model config across `imageGenerationModel`, `videoGenerationModel`, `musicGenerationModel`, provider/model refs, and related model routing and tool discovery behavior.
           - name: per-call model refs and fallbacks
-            coverageIds: [per-call-model-refs-and-fallbacks]
+            coverageIds: [media-tools.per-call-model-refs-and-fallbacks]
             description: Covers per-call model refs and fallbacks across `imageGenerationModel`, `videoGenerationModel`, `musicGenerationModel`, provider/model refs, and related model routing and tool discovery behavior.
           - name: auth-backed tool discovery
-            coverageIds: [auth-backed-tool-discovery]
+            coverageIds: [media-tools.auth-backed-tool-discovery]
             description: Covers auth-backed tool discovery across `imageGenerationModel`, `videoGenerationModel`, `musicGenerationModel`, provider/model refs, and related model routing and tool discovery behavior.
           - name: action=list provider inspection
-            coverageIds: [action-list-provider-inspection]
+            coverageIds: [media-tools.action-list-provider-inspection]
             description: Covers action=list provider inspection across `imageGenerationModel`, `videoGenerationModel`, `musicGenerationModel`, provider/model refs, and related model routing and tool discovery behavior.
         docs:
           - docs/gateway/config-agents.md
@@ -10251,40 +10251,40 @@ surfaces:
         id: task-lifecycle-and-delivery
         features:
           - name: background task creation
-            coverageIds: [background-task-creation]
+            coverageIds: [media-tools.background-task-creation]
             description: Covers background task creation across `image_generate`, `video_generate`, and `music_generate` tool exposure, background task scheduling, and related async task lifecycle behavior.
           - name: task status/list/show/cancel
-            coverageIds: [task-status-list-show-cancel]
+            coverageIds: [media-tools.task-status-list-show-cancel]
             description: Covers task status/list/show/cancel across `image_generate`, `video_generate`, and `music_generate` tool exposure, background task scheduling, and related async task lifecycle behavior.
           - name: duplicate guards
-            coverageIds: [duplicate-guards]
+            coverageIds: [media-tools.duplicate-guards]
             description: Covers duplicate guards across `image_generate`, `video_generate`, and `music_generate` tool exposure, background task scheduling, and related async task lifecycle behavior.
           - name: progress keepalive
-            coverageIds: [progress-keepalive]
+            coverageIds: [media-tools.progress-keepalive]
             description: Covers progress keepalive across `image_generate`, `video_generate`, and `music_generate` tool exposure, background task scheduling, and related async task lifecycle behavior.
           - name: completion/failure wake
-            coverageIds: [completion-failure-wake]
+            coverageIds: [media-tools.completion-failure-wake]
             description: Covers completion/failure wake across `image_generate`, `video_generate`, and `music_generate` tool exposure, background task scheduling, and related async task lifecycle behavior.
           - name: no-session inline fallback
-            coverageIds: [no-session-inline-fallback]
+            coverageIds: [media-tools.no-session-inline-fallback]
             description: Covers no-session inline fallback across `image_generate`, `video_generate`, and `music_generate` tool exposure, background task scheduling, and related async task lifecycle behavior.
           - name: local media persistence
-            coverageIds: [local-media-persistence]
+            coverageIds: [media-tools.local-media-persistence]
             description: Covers local media persistence across generated image/audio/video artifact objects, MIME and filename inference, local media paths, hosted media URLs, and related generated media delivery behavior.
           - name: MIME/filename inference
-            coverageIds: [mime-filename-inference]
+            coverageIds: [media-tools.mime-filename-inference]
             description: Covers MIME/filename inference across generated image/audio/video artifact objects, MIME and filename inference, local media paths, hosted media URLs, and related generated media delivery behavior.
           - name: Hosted URL fallback
-            coverageIds: [hosted-url-fallback]
+            coverageIds: [media-tools.hosted-url-fallback]
             description: Covers hosted URL fallback across generated image/audio/video artifact objects, MIME and filename inference, local media paths, hosted media URLs, and related generated media delivery behavior.
           - name: message-tool handoff
-            coverageIds: [message-tool-handoff]
+            coverageIds: [media-tools.message-tool-handoff]
             description: Covers message-tool handoff across generated image/audio/video artifact objects, MIME and filename inference, local media paths, hosted media URLs, and related generated media delivery behavior.
           - name: idempotent missing-media fallback
-            coverageIds: [idempotent-missing-media-fallback]
+            coverageIds: [media-tools.idempotent-missing-media-fallback]
             description: Covers idempotent missing-media fallback across generated image/audio/video artifact objects, MIME and filename inference, local media paths, hosted media URLs, and related generated media delivery behavior.
           - name: channel attachment proof
-            coverageIds: [channel-attachment-proof]
+            coverageIds: [media-tools.channel-attachment-proof]
             description: Covers channel attachment proof across generated image/audio/video artifact objects, MIME and filename inference, local media paths, hosted media URLs, and related generated media delivery behavior.
         docs:
           - docs/tools/media-overview.md
@@ -10310,31 +10310,31 @@ surfaces:
         id: image-generation
         features:
           - name: text-to-image
-            coverageIds: [text-to-image]
+            coverageIds: [media-tools.text-to-image]
             description: 'Covers text-to-image across image generation and editing runtime behavior after a provider candidate has been selected: request normalization, timeout handling, reference-image inputs, image response parsing, and related image generation and editing behavior.'
           - name: reference-image editing
-            coverageIds: [reference-image-editing]
+            coverageIds: [media.reference-image-editing]
             description: 'Covers reference-image editing across image generation and editing runtime behavior after a provider candidate has been selected: request normalization, timeout handling, reference-image inputs, image response parsing, and related image generation and editing behavior.'
           - name: output hints
-            coverageIds: [output-hints]
+            coverageIds: [media-tools.output-hints]
             description: 'Covers output hints across image generation and editing runtime behavior after a provider candidate has been selected: request normalization, timeout handling, reference-image inputs, image response parsing, and related image generation and editing behavior.'
           - name: action=status
-            coverageIds: [action-status]
+            coverageIds: [media-tools.action-status]
             description: 'Covers action=status across image generation and editing runtime behavior after a provider candidate has been selected: request normalization, timeout handling, reference-image inputs, image response parsing, and related image generation and editing behavior.'
           - name: provider attempt metadata
-            coverageIds: [provider-attempt-metadata]
+            coverageIds: [media-tools.provider-attempt-metadata]
             description: 'Covers provider attempt metadata across image generation and editing runtime behavior after a provider candidate has been selected: request normalization, timeout handling, reference-image inputs, image response parsing, and related image generation and editing behavior.'
           - name: OpenAI/Codex OAuth
-            coverageIds: [openai-codex-oauth]
+            coverageIds: [media-tools.openai-codex-oauth]
             description: Covers OpenAI/Codex OAuth across provider registrations and auth paths for image generation and editing, including OpenAI/Codex OAuth, OpenRouter, xAI, and related image providers and auth behavior.
           - name: API-key OpenAI
-            coverageIds: [api-key-openai]
+            coverageIds: [media-tools.api-key-openai]
             description: Covers API-key OpenAI across provider registrations and auth paths for image generation and editing, including OpenAI/Codex OAuth, OpenRouter, xAI, and related image providers and auth behavior.
           - name: OpenRouter/xAI/fal/LiteLLM/DeepInfra/Google/MiniMax/ComfyUI auth
-            coverageIds: [openrouter-xai-fal-litellm-deepinfra-google-minimax-comfyui-auth]
+            coverageIds: [media-tools.openrouter-xai-fal-litellm-deepinfra-google-minimax-comfyui-auth]
             description: Covers OpenRouter/xAI/fal/LiteLLM/DeepInfra/Google/MiniMax/ComfyUI auth across provider registrations and auth paths for image generation and editing, including OpenAI/Codex OAuth, OpenRouter, xAI, and related image providers and auth behavior.
           - name: provider error diagnostics
-            coverageIds: [provider-error-diagnostics]
+            coverageIds: [media-tools.provider-error-diagnostics]
             description: Covers provider error diagnostics across provider registrations and auth paths for image generation and editing, including OpenAI/Codex OAuth, OpenRouter, xAI, and related image providers and auth behavior.
         docs:
           - docs/tools/image-generation.md
@@ -10356,37 +10356,37 @@ surfaces:
         id: video-generation
         features:
           - name: text-to-video
-            coverageIds: [text-to-video]
+            coverageIds: [media-tools.text-to-video]
             description: 'Covers text-to-video across video generation request normalization before provider execution: `generate`, `imageToVideo`, and `videoToVideo` modes, reference media typing and roles, and related video generation modes behavior.'
           - name: image-to-video
-            coverageIds: [image-to-video]
+            coverageIds: [media-tools.image-to-video]
             description: 'Covers image-to-video across video generation request normalization before provider execution: `generate`, `imageToVideo`, and `videoToVideo` modes, reference media typing and roles, and related video generation modes behavior.'
           - name: video-to-video
-            coverageIds: [video-to-video]
+            coverageIds: [media-tools.video-to-video]
             description: 'Covers video-to-video across video generation request normalization before provider execution: `generate`, `imageToVideo`, and `videoToVideo` modes, reference media typing and roles, and related video generation modes behavior.'
           - name: reference role validation
-            coverageIds: [reference-role-validation]
+            coverageIds: [media-tools.reference-role-validation]
             description: 'Covers reference role validation across video generation request normalization before provider execution: `generate`, `imageToVideo`, and `videoToVideo` modes, reference media typing and roles, and related video generation modes behavior.'
           - name: audio refs
-            coverageIds: [audio-refs]
+            coverageIds: [media-tools.audio-refs]
             description: 'Covers audio refs across video generation request normalization before provider execution: `generate`, `imageToVideo`, and `videoToVideo` modes, reference media typing and roles, and related video generation modes behavior.'
           - name: typed providerOptions
-            coverageIds: [typed-provideroptions]
+            coverageIds: [media-tools.typed-provideroptions]
             description: 'Covers typed providerOptions across video generation request normalization before provider execution: `generate`, `imageToVideo`, and `videoToVideo` modes, reference media typing and roles, and related video generation modes behavior.'
           - name: queue-backed jobs
-            coverageIds: [queue-backed-jobs]
+            coverageIds: [media-tools.queue-backed-jobs]
             description: 'Covers queue-backed jobs across provider integration and async polling for video generation after request normalization: OpenAI Sora, OpenRouter, fal, Runway, and related video providers and polling behavior.'
           - name: polling/timeout handling
-            coverageIds: [polling-timeout-handling]
+            coverageIds: [media-tools.polling-timeout-handling]
             description: 'Covers polling/timeout handling across provider integration and async polling for video generation after request normalization: OpenAI Sora, OpenRouter, fal, Runway, and related video providers and polling behavior.'
           - name: Hosted URL download
-            coverageIds: [hosted-url-download]
+            coverageIds: [media-tools.hosted-url-download]
             description: 'Covers hosted URL download across provider integration and async polling for video generation after request normalization: OpenAI Sora, OpenRouter, fal, Runway, and related video providers and polling behavior.'
           - name: provider skip explanations
-            coverageIds: [provider-skip-explanations]
+            coverageIds: [media-tools.provider-skip-explanations]
             description: 'Covers provider skip explanations across provider integration and async polling for video generation after request normalization: OpenAI Sora, OpenRouter, fal, Runway, and related video providers and polling behavior.'
           - name: returned asset metadata
-            coverageIds: [returned-asset-metadata]
+            coverageIds: [media-tools.returned-asset-metadata]
             description: 'Covers returned asset metadata across provider integration and async polling for video generation after request normalization: OpenAI Sora, OpenRouter, fal, Runway, and related video providers and polling behavior.'
         docs:
           - docs/tools/video-generation.md
@@ -10412,22 +10412,22 @@ surfaces:
         id: music-generation
         features:
           - name: prompt and lyrics input
-            coverageIds: [prompt-and-lyrics-input]
+            coverageIds: [media-tools.prompt-and-lyrics-input]
             description: Covers prompt and lyrics input across `music_generate`, prompt and lyrics inputs, instrumental mode, duration, and related music generation behavior.
           - name: instrumental mode
-            coverageIds: [instrumental-mode]
+            coverageIds: [media-tools.instrumental-mode]
             description: Covers instrumental mode across `music_generate`, prompt and lyrics inputs, instrumental mode, duration, and related music generation behavior.
           - name: duration/format controls
-            coverageIds: [duration-format-controls]
+            coverageIds: [media-tools.duration-format-controls]
             description: Covers duration/format controls across `music_generate`, prompt and lyrics inputs, instrumental mode, duration, and related music generation behavior.
           - name: image-reference edit lanes
-            coverageIds: [image-reference-edit-lanes]
+            coverageIds: [media-tools.image-reference-edit-lanes]
             description: Covers image-reference edit lanes across `music_generate`, prompt and lyrics inputs, instrumental mode, duration, and related music generation behavior.
           - name: generated audio outputs
-            coverageIds: [generated-audio-outputs]
+            coverageIds: [media-tools.generated-audio-outputs]
             description: Covers generated audio outputs across `music_generate`, prompt and lyrics inputs, instrumental mode, duration, and related music generation behavior.
           - name: provider fallback
-            coverageIds: [provider-fallback]
+            coverageIds: [media-tools.provider-fallback]
             description: Covers provider fallback across `music_generate`, prompt and lyrics inputs, instrumental mode, duration, and related music generation behavior.
         docs:
           - docs/tools/music-generation.md


### PR DESCRIPTION
Cleaning up after my own trash, I originally did not notice that coverage ids in the current qa scenarios were all `namespace.item` format.

## Summary
- Rename QA taxonomy and scenario coverage IDs to dotted `namespace.behavior` names.
- Keep profile/category/surface scorecard IDs compatible while enforcing dotted format for coverage IDs in QA scenario and taxonomy schemas.
- Update QA Lab fixtures, UX matrix evidence production, and scorecard docs/skill guidance to use the canonical coverage IDs.

## Verification
- `pnpm docs:list`
- `node scripts/run-node.mjs qa coverage --json --output /tmp/openclaw-qa-coverage-dotted.json`
  - 122 scenarios
  - 163 scenario coverage IDs
  - 0 missing scenario coverage refs
  - 0 unknown taxonomy coverage IDs
  - 0 scorecard `*-not-found` issues
- structural YAML audit: 1,665 unique taxonomy coverage IDs, 0 non-dotted taxonomy IDs, 163 unique scenario coverage IDs, 0 non-dotted scenario IDs, 0 scenario-only IDs
- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/coverage-report.test.ts extensions/qa-lab/src/evidence-gallery.test.ts extensions/qa-lab/src/evidence-summary.test.ts extensions/qa-lab/src/test-file-scenario-runner.test.ts extensions/qa-lab/web/src/ui-render.test.ts`
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 extensions/qa-lab/src/coverage-report.test.ts extensions/qa-lab/src/evidence-gallery.test.ts extensions/qa-lab/src/evidence-summary.test.ts extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/scenario-catalog.ts extensions/qa-lab/src/scorecard-taxonomy.ts extensions/qa-lab/src/test-file-scenario-runner.test.ts extensions/qa-lab/web/src/ui-render.test.ts scripts/qa/ux-matrix-evidence-producer.ts`
- `node scripts/format-docs.mjs --check docs/concepts/qa-e2e-automation.md .agents/skills/claw-score/SKILL.md qa/scenarios/index.yaml`
- `.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` clean after fixes
