### PR TITLE
fix(ui): keep dashboard mounted during reconnect

### DIFF
--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -166,6 +166,8 @@ function createHost(): TestGatewayHost {
     clientInstanceId: "instance-test",
     client: null,
     connected: false,
+    hasConnectedGateway: false,
+    gatewayDeviceTokenRetryPending: false,
     hello: null,
     lastError: null,
     lastErrorCode: null,
@@ -1156,6 +1158,7 @@ describe("connectGateway", () => {
 
     client.emitHello();
 
+    expect(host.hasConnectedGateway).toBe(true);
     await vi.waitFor(() => expect(loadControlUiBootstrapConfigMock).toHaveBeenCalledTimes(1));
     expect(loadControlUiBootstrapConfigMock).toHaveBeenCalledWith(host, { applyIdentity: false });
   });

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -109,6 +109,8 @@ type GatewayHost = {
   clientInstanceId: string;
   client: GatewayBrowserClient | null;
   connected: boolean;
+  hasConnectedGateway: boolean;
+  gatewayDeviceTokenRetryPending: boolean;
   hello: GatewayHelloOk | null;
   lastError: string | null;
   lastErrorCode: string | null;
@@ -777,6 +779,7 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
   host.chatError = null;
   host.hello = null;
   host.connected = false;
+  host.gatewayDeviceTokenRetryPending = false;
   if (reconnectReason === "seq-gap") {
     host.execApprovalQueue = pruneExecApprovalQueue(host.execApprovalQueue);
     clearPendingQueueItemsForRun(
@@ -808,6 +811,8 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       }
       shutdownHost.pendingShutdownMessage = null;
       host.connected = true;
+      host.hasConnectedGateway = true;
+      host.gatewayDeviceTokenRetryPending = false;
       host.lastError = null;
       host.lastErrorCode = null;
       host.chatError = null;
@@ -906,11 +911,12 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
         void verifyPendingUpdateVersion(host, client);
       });
     },
-    onClose: ({ code, reason, error }) => {
+    onClose: ({ code, reason, error, deviceTokenRetryPending }) => {
       if (host.client !== client) {
         return;
       }
       host.connected = false;
+      host.gatewayDeviceTokenRetryPending = deviceTokenRetryPending === true;
       markQueuedChatSendsWaitingForReconnect(
         host as unknown as Parameters<typeof markQueuedChatSendsWaitingForReconnect>[0],
       );

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -2,6 +2,7 @@
 
 import { html, render } from "lit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { i18n } from "../i18n/index.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import type { ChatProps } from "./views/chat.ts";
@@ -81,6 +82,8 @@ function createState(overrides: Partial<AppViewState> = {}): AppViewState {
     onboarding: false,
     basePath: "",
     connected: true,
+    hasConnectedGateway: true,
+    gatewayDeviceTokenRetryPending: false,
     theme: "claw",
     themeMode: "dark",
     themeResolved: "dark",
@@ -220,6 +223,7 @@ function createState(overrides: Partial<AppViewState> = {}): AppViewState {
     clearCustomTheme: vi.fn(),
     setBorderRadius: vi.fn(),
     setTextScale: vi.fn(),
+    setGatewayPassword: vi.fn(),
     applySettings: vi.fn(),
     applyLocalUserIdentity: vi.fn(),
     loadOverview: vi.fn(),
@@ -448,6 +452,86 @@ describe("renderApp assistant avatar routing", () => {
     );
 
     expect(chatProps.current?.error).toBe("gateway disconnected");
+  });
+
+  it("keeps the dashboard mounted during transient reconnects after a successful connection", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderApp(
+        createState({
+          tab: "chat",
+          connected: false,
+          hasConnectedGateway: true,
+          lastError: "disconnected (1006): no reason",
+        } as Partial<AppViewState>),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".shell")).toBeInstanceOf(HTMLElement);
+    expect(container.querySelector(".login-gate")).toBeNull();
+    expect(chatProps.current?.error).toBe("disconnected (1006): no reason");
+  });
+
+  it("shows the login gate after a successful connection when auth is rejected", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderApp(
+        createState({
+          connected: false,
+          hasConnectedGateway: true,
+          lastError: "gateway token mismatch",
+          lastErrorCode: "AUTH_TOKEN_MISMATCH",
+        } as Partial<AppViewState>),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".login-gate")).toBeInstanceOf(HTMLElement);
+    expect(container.querySelector(".shell")).toBeNull();
+  });
+
+  it("keeps the dashboard mounted during automatic device token retries", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderApp(
+        createState({
+          tab: "chat",
+          connected: false,
+          hasConnectedGateway: true,
+          gatewayDeviceTokenRetryPending: true,
+          lastError: "gateway token mismatch",
+          lastErrorCode: ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH,
+        } as Partial<AppViewState>),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".shell")).toBeInstanceOf(HTMLElement);
+    expect(container.querySelector(".login-gate")).toBeNull();
+    expect(chatProps.current?.error).toBe("gateway token mismatch");
+  });
+
+  it("shows the login gate after a successful connection when auth scope must change", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderApp(
+        createState({
+          connected: false,
+          hasConnectedGateway: true,
+          lastError: "requested scopes are not approved",
+          lastErrorCode: ConnectErrorDetailCodes.AUTH_SCOPE_MISMATCH,
+        } as Partial<AppViewState>),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".login-gate")).toBeInstanceOf(HTMLElement);
+    expect(container.querySelector(".shell")).toBeNull();
   });
 
   it("does not rebuild chat composer controls for draft-only rerenders", () => {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2,6 +2,7 @@
 import { html, nothing } from "lit";
 import { guard } from "lit/directives/guard.js";
 import { styleMap } from "lit/directives/style-map.js";
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { i18n, t } from "../i18n/index.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
 import {
@@ -158,6 +159,7 @@ import { getCronJobPayload } from "./cron-payload.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { formatTimeMs } from "./format.ts";
 import { formatRelativeTimestamp } from "./format.ts";
+import { isNonRecoverableAuthErrorCode } from "./gateway.ts";
 import { icons } from "./icons.ts";
 import { createLazyView, renderLazyView } from "./lazy-view.ts";
 import {
@@ -217,6 +219,11 @@ import { renderExecApprovalPrompt } from "./views/exec-approval.ts";
 import { renderGatewayUrlConfirmation } from "./views/gateway-url-confirmation.ts";
 import { renderLoginGate } from "./views/login-gate.ts";
 import { renderMcp } from "./views/mcp.ts";
+import {
+  resolveAuthHintKind,
+  resolvePairingHint,
+  shouldShowInsecureContextHint,
+} from "./views/overview-hints.ts";
 import { renderOverview } from "./views/overview.ts";
 
 let pendingUpdate: (() => void) | undefined;
@@ -259,6 +266,46 @@ function setSkillWorkshopUseCurrentChatForRevisions(state: AppViewState, enabled
   } catch {
     // Preference persistence is optional; the active toggle still controls this handoff.
   }
+}
+
+function shouldRenderLoginGate(state: AppViewState): boolean {
+  if (state.connected) {
+    return false;
+  }
+  if (!state.hasConnectedGateway) {
+    return true;
+  }
+  if (!state.lastError) {
+    return false;
+  }
+  if (state.gatewayDeviceTokenRetryPending) {
+    return false;
+  }
+
+  if (resolvePairingHint(false, state.lastError, state.lastErrorCode)) {
+    return true;
+  }
+  if (
+    resolveAuthHintKind({
+      connected: false,
+      lastError: state.lastError,
+      lastErrorCode: state.lastErrorCode,
+      hasToken: Boolean(state.settings.token?.trim()),
+      hasPassword: Boolean(state.password?.trim()),
+    })
+  ) {
+    return true;
+  }
+  if (shouldShowInsecureContextHint(false, state.lastError, state.lastErrorCode)) {
+    return true;
+  }
+  if (isNonRecoverableAuthErrorCode(state.lastErrorCode)) {
+    return true;
+  }
+  if (state.lastErrorCode === ConnectErrorDetailCodes.CONTROL_UI_ORIGIN_NOT_ALLOWED) {
+    return true;
+  }
+  return state.lastError.toLowerCase().includes("protocol mismatch");
 }
 
 function setSkillWorkshopMode(state: AppViewState, mode: "board" | "today"): void {
@@ -1386,9 +1433,10 @@ export function renderApp(state: AppViewState) {
       : undefined;
   pendingUpdate = requestHostUpdate;
 
-  // Gate: require successful gateway connection before showing the dashboard.
+  // Gate only first-connect and explicit auth/config failures; transient reconnects
+  // keep the mounted dashboard visible so tab refocus does not flash credentials.
   // The gateway URL confirmation overlay is always rendered so URL-param flows still work.
-  if (!state.connected) {
+  if (shouldRenderLoginGate(state)) {
     return html` ${renderLoginGate(state)} ${renderGatewayUrlConfirmation(state)} `;
   }
 
@@ -2761,7 +2809,7 @@ export function renderApp(state: AppViewState) {
               showGatewayToken: state.overviewShowGatewayToken,
               showGatewayPassword: state.overviewShowGatewayPassword,
               onSettingsChange: (next) => state.applySettings(next),
-              onPasswordChange: (next) => (state.password = next),
+              onPasswordChange: (next) => state.setGatewayPassword(next),
               onSessionKeyChange: (next) => {
                 switchChatSession(state, next);
               },

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -4,8 +4,8 @@ import type { ChatAbortOptions, ChatSendOptions } from "./app-chat.ts";
 import type { EventLogEntry } from "./app-events.ts";
 import type { CompactionStatus, FallbackStatus } from "./app-tool-stream.ts";
 import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "./chat/input-history.ts";
-import type { RealtimeTalkConversationEntry } from "./chat/realtime-talk-conversation.ts";
 import type { RealtimeTalkCatalogProvider } from "./chat/realtime-talk-catalog.ts";
+import type { RealtimeTalkConversationEntry } from "./chat/realtime-talk-conversation.ts";
 import type { RealtimeTalkStatus } from "./chat/realtime-talk.ts";
 import type { ChatRunUiStatus } from "./chat/run-lifecycle.ts";
 import type { ChatMessageCache } from "./chat/session-message-cache.ts";
@@ -66,6 +66,8 @@ export type AppViewState = {
   onboarding: boolean;
   basePath: string;
   connected: boolean;
+  hasConnectedGateway: boolean;
+  gatewayDeviceTokenRetryPending: boolean;
   theme: ThemeName;
   themeMode: ThemeMode;
   themeResolved: ResolvedTheme;
@@ -489,6 +491,7 @@ export type AppViewState = {
     clearCustomTheme: () => void;
     setBorderRadius: (value: number) => void;
     setTextScale: (value: number) => void;
+    setGatewayPassword: (value: string) => void;
     applySettings: (next: UiSettings) => void;
     applyLocalUserIdentity?: (next: { name?: string | null; avatar?: string | null }) => void;
     loadOverview: (opts?: { refresh?: boolean }) => Promise<void>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -78,15 +78,15 @@ import { normalizeAssistantIdentity } from "./assistant-identity.ts";
 import { restoreChatComposerState } from "./chat/composer-persistence.ts";
 import { exportChatMarkdown } from "./chat/export.ts";
 import {
+  reconcileRealtimeTalkCatalogSelection,
+  type RealtimeTalkCatalogProvider,
+} from "./chat/realtime-talk-catalog.ts";
+import {
   createRealtimeTalkConversationState,
   updateRealtimeTalkConversation,
   type RealtimeTalkConversationEntry,
   type RealtimeTalkConversationState,
 } from "./chat/realtime-talk-conversation.ts";
-import {
-  reconcileRealtimeTalkCatalogSelection,
-  type RealtimeTalkCatalogProvider,
-} from "./chat/realtime-talk-catalog.ts";
 import {
   RealtimeTalkSession,
   type RealtimeTalkLaunchOptions,
@@ -223,6 +223,8 @@ export class OpenClawApp extends LitElement {
   @state() tab: Tab = "chat";
   @state() onboarding = resolveOnboardingMode();
   @state() connected = false;
+  @state() hasConnectedGateway = false;
+  @state() gatewayDeviceTokenRetryPending = false;
   @state() theme: ThemeName = this.settings.theme ?? "claw";
   @state() themeMode: ThemeMode = this.settings.themeMode ?? "system";
   @state() themeResolved: ResolvedTheme = "dark";
@@ -983,6 +985,9 @@ export class OpenClawApp extends LitElement {
   }
 
   applySettings(next: UiSettings) {
+    if (next.gatewayUrl !== this.settings.gatewayUrl || next.token !== this.settings.token) {
+      this.hasConnectedGateway = false;
+    }
     applySettingsInternal(this as unknown as Parameters<typeof applySettingsInternal>[0], next);
   }
 
@@ -1121,6 +1126,13 @@ export class OpenClawApp extends LitElement {
       textScale: value as typeof this.settings.textScale,
     });
     this.requestUpdate();
+  }
+
+  setGatewayPassword(value: string) {
+    if (value !== this.password) {
+      this.hasConnectedGateway = false;
+    }
+    this.password = value;
   }
 
   announceSessionSwitch(sessionKey: string, label: string) {
@@ -1431,7 +1443,7 @@ export class OpenClawApp extends LitElement {
     const nextToken = this.pendingGatewayToken?.trim() || "";
     this.pendingGatewayUrl = null;
     this.pendingGatewayToken = null;
-    applySettingsInternal(this as unknown as Parameters<typeof applySettingsInternal>[0], {
+    this.applySettings({
       ...this.settings,
       gatewayUrl: nextGatewayUrl,
       token: nextToken,

--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -309,9 +309,11 @@ async function expectRetriedDeviceTokenConnect(params: {
   token: string;
   retryNonce?: string;
 }) {
+  const onClose = vi.fn();
   const client = new GatewayBrowserClient({
     url: params.url,
     token: params.token,
+    onClose,
   });
   const { ws: firstWs, connectFrame: firstConnect } = await startConnect(client);
   expect(firstConnect.params?.auth?.token).toBe(params.token);
@@ -320,6 +322,18 @@ async function expectRetriedDeviceTokenConnect(params: {
   emitRetryableTokenMismatch(firstWs, firstConnect.id);
   await expectSocketClosed(firstWs);
   firstWs.emitClose(4008, "connect failed");
+  expect(onClose).toHaveBeenCalledWith({
+    code: 4008,
+    reason: "connect failed",
+    error: {
+      code: "INVALID_REQUEST",
+      message: "unauthorized",
+      details: { code: "AUTH_TOKEN_MISMATCH", canRetryWithDeviceToken: true },
+      retryable: false,
+      retryAfterMs: undefined,
+    },
+    deviceTokenRetryPending: true,
+  });
 
   await vi.advanceTimersByTimeAsync(800);
   const secondWs = getLatestWebSocket();
@@ -850,6 +864,7 @@ describe("GatewayBrowserClient", () => {
           retryable: false,
           retryAfterMs: undefined,
         },
+        deviceTokenRetryPending: false,
       });
     } finally {
       client.stop();
@@ -947,6 +962,7 @@ describe("GatewayBrowserClient", () => {
         retryable: false,
         retryAfterMs: undefined,
       },
+      deviceTokenRetryPending: false,
     });
 
     client.stop();

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -105,22 +105,13 @@ function shouldContinueReconnectForPairingRequired(details: unknown): boolean {
   );
 }
 
-/**
- * Auth errors that won't resolve without user action — don't auto-reconnect.
- *
- * NOTE: AUTH_TOKEN_MISMATCH is intentionally NOT included here because the
- * browser client supports a bounded one-time retry with a cached device token
- * when the endpoint is trusted. Reconnect suppression for mismatch is handled
- * with client state (after retry budget is exhausted).
- */
-export function isNonRecoverableAuthError(error: GatewayErrorInfo | undefined): boolean {
-  if (!error) {
-    return false;
-  }
-  const code = resolveGatewayErrorDetailCode(error);
+export function isNonRecoverableAuthErrorCode(
+  code: string | null | undefined,
+  details?: unknown,
+): boolean {
   if (
     code === ConnectErrorDetailCodes.PAIRING_REQUIRED &&
-    shouldContinueReconnectForPairingRequired(error.details)
+    shouldContinueReconnectForPairingRequired(details)
   ) {
     return false;
   }
@@ -136,6 +127,22 @@ export function isNonRecoverableAuthError(error: GatewayErrorInfo | undefined): 
     code === ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED ||
     code === ConnectErrorDetailCodes.DEVICE_IDENTITY_REQUIRED
   );
+}
+
+/**
+ * Auth errors that won't resolve without user action — don't auto-reconnect.
+ *
+ * NOTE: AUTH_TOKEN_MISMATCH is intentionally NOT included here because the
+ * browser client supports a bounded one-time retry with a cached device token
+ * when the endpoint is trusted. Reconnect suppression for mismatch is handled
+ * with client state (after retry budget is exhausted).
+ */
+export function isNonRecoverableAuthError(error: GatewayErrorInfo | undefined): boolean {
+  if (!error) {
+    return false;
+  }
+  const code = resolveGatewayErrorDetailCode(error);
+  return isNonRecoverableAuthErrorCode(code, error.details);
 }
 
 function isLoopbackIPv4Host(host: string): boolean {
@@ -281,7 +288,12 @@ export type GatewayBrowserClientOptions = {
   instanceId?: string;
   onHello?: (hello: GatewayHelloOk) => void;
   onEvent?: (evt: GatewayEventFrame) => void;
-  onClose?: (info: { code: number; reason: string; error?: GatewayErrorInfo }) => void;
+  onClose?: (info: {
+    code: number;
+    reason: string;
+    error?: GatewayErrorInfo;
+    deviceTokenRetryPending?: boolean;
+  }) => void;
   onGap?: (info: { expected: number; received: number }) => void;
   onRequestTiming?: (timing: GatewayRequestTiming) => void;
   onConnectTiming?: (timing: GatewayConnectTiming) => void;
@@ -561,11 +573,19 @@ export class GatewayBrowserClient {
         this.scheduleReconnect();
         return;
       }
-      this.flushPending(new Error(`gateway closed (${ev.code}): ${reason}`));
-      this.opts.onClose?.({ code: ev.code, reason, error: connectError });
       const connectErrorCode = resolveGatewayErrorDetailCode(connectError);
+      const deviceTokenRetryPending =
+        connectErrorCode === ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH &&
+        this.pendingDeviceTokenRetry;
+      this.flushPending(new Error(`gateway closed (${ev.code}): ${reason}`));
+      this.opts.onClose?.({
+        code: ev.code,
+        reason,
+        error: connectError,
+        deviceTokenRetryPending,
+      });
       if (connectErrorCode === ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH) {
-        if (this.pendingDeviceTokenRetry) {
+        if (deviceTokenRetryPending) {
           this.scheduleReconnect();
         }
         return;

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -827,6 +827,48 @@ describe("control UI routing", () => {
     expect(refreshed.settings.token).toBe("other-token");
   });
 
+  it("resets first-connect state when gateway identity settings change", async () => {
+    const app = mountApp("/ui/overview");
+    await app.updateComplete;
+    app.hasConnectedGateway = true;
+
+    app.applySettings({
+      ...app.settings,
+      token: "new-token",
+    });
+    await app.updateComplete;
+
+    expect(app.hasConnectedGateway).toBe(false);
+  });
+
+  it("resets first-connect state when the gateway password changes", async () => {
+    const app = mountApp("/ui/overview");
+    await app.updateComplete;
+    app.hasConnectedGateway = true;
+
+    app.setGatewayPassword("new-password");
+    await app.updateComplete;
+
+    expect(app.hasConnectedGateway).toBe(false);
+  });
+
+  it("routes overview gateway password edits through first-connect reset", async () => {
+    const app = mountApp("/ui/overview");
+    await app.updateComplete;
+    app.hasConnectedGateway = true;
+
+    const passwordField = Array.from(app.querySelectorAll("label.field")).find((label) =>
+      label.textContent?.includes("Password"),
+    );
+    expect(passwordField).toBeInstanceOf(HTMLLabelElement);
+    const passwordInput = expectElement(passwordField!, "input", HTMLInputElement);
+    passwordInput.value = "new-password";
+    passwordInput.dispatchEvent(new Event("input", { bubbles: true }));
+    await app.updateComplete;
+
+    expect(app.hasConnectedGateway).toBe(false);
+  });
+
   it("keeps a hash token pending until the gateway URL change is confirmed", async () => {
     const app = mountApp(
       "/ui/overview?gatewayUrl=wss://other-gateway.example/openclaw#token=abc123",
@@ -835,9 +877,11 @@ describe("control UI routing", () => {
 
     expect(app.settings.gatewayUrl).not.toBe("wss://other-gateway.example/openclaw");
     expect(app.settings.token).toBe("");
+    app.hasConnectedGateway = true;
 
     await confirmPendingGatewayChange(app);
 
     expectConfirmedGatewayChange(app);
+    expect(app.hasConnectedGateway).toBe(false);
   });
 });

--- a/ui/src/ui/views/login-gate.ts
+++ b/ui/src/ui/views/login-gate.ts
@@ -344,7 +344,7 @@ export function renderLoginGate(state: AppViewState) {
                 .value=${state.password}
                 @input=${(e: Event) => {
                   const v = (e.target as HTMLInputElement).value;
-                  state.password = v;
+                  state.setGatewayPassword(v);
                 }}
                 placeholder="${t("login.passwordPlaceholder")}"
                 @keydown=${(e: KeyboardEvent) => {


### PR DESCRIPTION
## Summary

Fixes the Control UI reconnect gate so a transient Gateway disconnect after a successful connection keeps the dashboard/chat shell mounted instead of replacing it with the login gate.

The fix tracks whether the current Gateway identity has connected successfully, resets that state when the Gateway URL/token/password changes, and preserves the mounted dashboard during the bounded cached-device-token retry path for `AUTH_TOKEN_MISMATCH`.

## Verification

- `node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.ui.config.ts --reporter=verbose ui/src/ui/app-render.assistant-avatar.test.ts`
- `node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.ui.config.ts --reporter=dot ui/src/ui/app-gateway.node.test.ts`
- `node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.ui.config.ts --reporter=dot ui/src/ui/navigation.browser.test.ts`
- `node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.ui.config.ts --reporter=dot ui/src/ui/gateway.node.test.ts`
- `node_modules/oxfmt/bin/oxfmt --check --threads=1 ui/src/ui/app-render.ts ui/src/ui/app-gateway.ts ui/src/ui/app.ts ui/src/ui/app-view-state.ts ui/src/ui/app-render.assistant-avatar.test.ts ui/src/ui/app-gateway.node.test.ts ui/src/ui/gateway.ts ui/src/ui/gateway.node.test.ts ui/src/ui/navigation.browser.test.ts ui/src/ui/views/login-gate.ts`
- `git diff --check`
- `node node_modules/@typescript/native-preview/bin/tsgo.js -p test/tsconfig/tsconfig.test.ui.json --pretty false --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.local-fix.tsbuildinfo`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: Control UI no longer replaces an already-mounted dashboard/chat view with the login gate during transient reconnects after a successful Gateway connection.

Real environment tested: Local Control UI E2E server with mocked Gateway WebSocket in Chrome on macOS, plus focused Vitest/jsdom coverage for reconnect, auth failure, device-token retry, and Gateway identity edit paths.

Exact steps or command run after this patch: `node --import tsx .artifacts/control-ui-e2e/reconnect-gate/capture.mjs` against the patched branch; focused Vitest, oxfmt, diff check, tsgo, and autoreview commands listed above.

Evidence after fix: Screenshot artifacts were generated locally under `.artifacts/control-ui-e2e/reconnect-gate/` and intentionally not committed per repository policy. `transient-reconnect-dashboard.png` shows the dashboard/chat shell still mounted with a disconnect warning; `auth-scope-login-gate.png` shows explicit auth-scope failure still routes to the login gate. `transient-reconnect-before-login-gate.png` was captured from `origin/main` and shows the previous behavior returning to the login gate for the same transient disconnect.

Observed result after fix: A generic `disconnected (1006): no reason` after a prior successful connection keeps `.shell` visible and keeps `.login-gate` detached. Explicit auth/config failures still render the login gate, and cached device-token retry windows do not flash the credential screen.

What was not tested: Full packaged app flow, live remote Gateway, and cross-OS browser proof were not run; coverage is scoped to the Control UI reconnect behavior and mocked Gateway protocol paths.

AI-assisted: yes.

## Agent Transcript

<details>
<summary>Redacted agent session transcript</summary>

````text
[user]
扫描有没有适合修复的issue

[assistant]
Scanned open issues and excluded duplicates or already-covered items. Selected #72500 because the current Control UI render path still returned to the login gate whenever connected became false, while Gateway reconnect paths set connected=false for transient disconnects.

[user]
修复

[assistant]
Implemented a Control UI reconnect gate: keep the shell mounted after a successful connection during generic reconnects, reset first-connect state when Gateway URL/token/password changes, keep explicit auth/config failures on the login gate, and avoid flashing the login gate during the cached device-token retry path.

[user]
可以提供截图验证吗

[assistant]
Generated local screenshot proof with a mocked Gateway WebSocket: before on origin/main, after on the patched branch, and an auth-scope regression guard. The screenshots were kept under .artifacts and not committed, per repo policy.

[assistant]
Ran focused verification: render tests, app gateway tests, navigation tests, Gateway client tests, oxfmt, git diff --check, tsgo, and repeated autoreview. Addressed review findings for Gateway identity changes, password edits, overview password edits, and cached device-token retry behavior.
````
</details>
