### PR TITLE
fix(agents): downgrade post-turn compaction failure from fatal error to warning

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2243,7 +2243,7 @@ async function agentCommandInternal(
               compactionError instanceof Error
                 ? compactionError.message
                 : String(compactionError);
-            logger.warn(
+            log.warn(
               `post-turn compaction failed but turn continues: ${errorMsg}`,
             );
           }

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2212,28 +2212,41 @@ async function agentCommandInternal(
           );
         }
         if (persistedCliTurnTranscript && !suppressVisibleSessionEffects) {
-          sessionEntry = await (
-            await loadCliCompactionRuntime()
-          ).runCliTurnCompactionLifecycle({
-            cfg,
-            sessionId: effectiveSessionId,
-            sessionKey: sessionKey ?? effectiveSessionId,
-            sessionEntry,
-            sessionStore,
-            storePath,
-            sessionAgentId,
-            workspaceDir,
-            cwd: effectiveCwd,
-            agentDir,
-            provider: result.meta.agentMeta?.provider ?? provider,
-            model: result.meta.agentMeta?.model ?? model,
-            skillsSnapshot,
-            messageChannel,
-            agentAccountId: runContext.accountId,
-            senderIsOwner: opts.senderIsOwner,
-            thinkLevel: resolvedThinkLevel,
-            extraSystemPrompt: opts.extraSystemPrompt,
-          });
+          try {
+            sessionEntry = await (
+              await loadCliCompactionRuntime()
+            ).runCliTurnCompactionLifecycle({
+              cfg,
+              sessionId: effectiveSessionId,
+              sessionKey: sessionKey ?? effectiveSessionId,
+              sessionEntry,
+              sessionStore,
+              storePath,
+              sessionAgentId,
+              workspaceDir,
+              cwd: effectiveCwd,
+              agentDir,
+              provider: result.meta.agentMeta?.provider ?? provider,
+              model: result.meta.agentMeta?.model ?? model,
+              skillsSnapshot,
+              messageChannel,
+              agentAccountId: runContext.accountId,
+              senderIsOwner: opts.senderIsOwner,
+              thinkLevel: resolvedThinkLevel,
+              extraSystemPrompt: opts.extraSystemPrompt,
+            });
+          } catch (compactionError: unknown) {
+            // Post-turn compaction failure should not abort the turn. The
+            // assistant reply has already been generated and persisted. Log the
+            // error and continue so the reply is still delivered.
+            const errorMsg =
+              compactionError instanceof Error
+                ? compactionError.message
+                : String(compactionError);
+            logger.warn(
+              `post-turn compaction failed but turn continues: ${errorMsg}`,
+            );
+          }
         }
       }
 

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -529,7 +529,7 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(compactCalls).toHaveLength(1);
   });
 
-  it("surfaces nonrecoverable native harness CLI compaction failures", async () => {
+  it("logs warning for nonrecoverable native harness CLI compaction failures without aborting turn", async () => {
     const sessionKey = "agent:main:codex-native-failure";
     const sessionId = "session-codex-native-failure";
     const sessionFile = path.join(tmpDir, "session-codex-native-failure.jsonl");
@@ -578,24 +578,24 @@ describe("runCliTurnCompactionLifecycle", () => {
       recordCliCompactionInStore,
     });
 
-    await expect(
-      runCliTurnCompactionLifecycle({
-        cfg: {} as OpenClawConfig,
-        sessionId,
-        sessionKey,
-        sessionEntry,
-        sessionStore,
-        storePath,
-        sessionAgentId: "main",
-        workspaceDir: tmpDir,
-        agentDir: tmpDir,
-        provider: "codex",
-        model: "gpt-5.5",
-      }),
-    ).rejects.toThrow(
-      "CLI native harness compaction failed for codex/gpt-5.5: timed out waiting for codex app-server compaction",
-    );
+    // After the fix, compaction failure is downgraded from a fatal error to a
+    // warning. The function should return without throwing so the turn continues.
+    const result = await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "codex",
+      model: "gpt-5.5",
+    });
 
+    // The function returned without throwing — the turn is preserved.
+    expect(result).toBeDefined();
     expect(compactAgentHarnessSession).toHaveBeenCalledTimes(1);
     expect(compactCalls).toHaveLength(0);
     expect(recordCliCompactionInStore).not.toHaveBeenCalled();
@@ -689,7 +689,7 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(result?.compactionCount).toBe(1);
   });
 
-  it("does not fall back when native harness compaction returns no result", async () => {
+  it("logs warning when native harness compaction returns no result without aborting turn", async () => {
     const sessionKey = "agent:main:codex-native-empty";
     const sessionId = "session-codex-native-empty";
     const sessionFile = path.join(tmpDir, "session-codex-native-empty.jsonl");
@@ -730,23 +730,24 @@ describe("runCliTurnCompactionLifecycle", () => {
       resolveLiveToolResultMaxChars: () => 20_000,
     });
 
-    await expect(
-      runCliTurnCompactionLifecycle({
-        cfg: {} as OpenClawConfig,
-        sessionId,
-        sessionKey,
-        sessionEntry,
-        sessionStore,
-        storePath,
-        sessionAgentId: "main",
-        workspaceDir: tmpDir,
-        agentDir: tmpDir,
-        provider: "codex",
-        model: "gpt-5.5",
-      }),
-    ).rejects.toThrow(
-      "CLI native harness compaction failed for codex/gpt-5.5: native harness compaction did not reduce context",
-    );
+    // After the fix, compaction failure is downgraded from a fatal error to a
+    // warning. The function should return without throwing so the turn continues.
+    const result = await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "codex",
+      model: "gpt-5.5",
+    });
+
+    // The function returned without throwing — the turn is preserved.
+    expect(result).toBeDefined();
     expect(compactCalls).toHaveLength(0);
   });
 
@@ -1328,7 +1329,7 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(calls).toEqual(["ensure", "resolve"]);
   });
 
-  it("bounds a hung CLI context-engine compaction and leaves resume state intact", async () => {
+  it("logs warning for hung CLI context-engine compaction without aborting turn", async () => {
     const sessionKey = "agent:main:cli";
     const sessionId = "session-cli-timeout";
     const sessionFile = path.join(tmpDir, "session-timeout.jsonl");
@@ -1398,13 +1399,14 @@ describe("runCliTurnCompactionLifecycle", () => {
       model: "opus",
     });
 
-    const rejection = expect(pending).rejects.toThrow(
-      "CLI transcript compaction failed for claude-cli/opus: Compaction timed out",
-    );
+    // After the fix, timeout compaction failure is downgraded from fatal error to
+    // warning. The function should resolve (not reject) so the turn continues.
     await vi.advanceTimersByTimeAsync(1_000);
-    await rejection;
+    const result = await pending;
     vi.useRealTimers();
 
+    // The function returned without throwing — the turn is preserved.
+    expect(result).toBeDefined();
     expect(compactCalls).toHaveLength(1);
     expect(compactCalls[0]?.abortSignal).toBeInstanceOf(AbortSignal);
     expect(compactCalls[0]?.abortSignal?.aborted).toBe(true);

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -625,6 +625,11 @@ export async function runCliTurnCompactionLifecycle(params: {
       // post-turn optimization — the assistant reply has already been generated
       // and persisted. Treat the failure as a warning rather than a fatal error
       // so the turn remains successful and the reply is still delivered.
+      // Since this is an unrecoverable failure (not a fallback-worthy code like
+      // unsupported harness or recoverable binding failure), skip the
+      // context-engine compaction path as well — it would waste a network
+      // round-trip on a session that may already be in a broken state.
+      useContextEngineCompaction = false;
       log.warn(
         `CLI native harness compaction failed for ${params.provider}/${params.model}: ${
           nativeOutcome.failureReason ?? "compaction did not reduce context"

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -570,6 +570,7 @@ export async function runCliTurnCompactionLifecycle(params: {
   let useContextEngineCompaction = true;
   let nativeFallbackToContextEngine = false;
   let nativeFallbackNeedsBindingClear = false;
+  let nativeCompactionFailureReason: string | undefined;
   let resolvedContextEngine: ContextEngine | undefined;
   let autoCompactionGuardApplied = false;
   const authProfileId = params.sessionEntry?.authProfileOverride?.trim() || undefined;
@@ -621,7 +622,12 @@ export async function runCliTurnCompactionLifecycle(params: {
       nativeFallbackToContextEngine = true;
       nativeFallbackNeedsBindingClear = nativeOutcome.clearCliSessionBinding === true;
     } else if (nativeOutcome.failureReason) {
-      throw new Error(
+      // Native harness compaction failed (e.g. Connection error). This is a
+      // post-turn optimization — the assistant reply has already been generated
+      // and persisted. Treat the failure as a warning rather than a fatal error
+      // so the turn remains successful and the reply is still delivered.
+      nativeCompactionFailureReason = nativeOutcome.failureReason;
+      log.warn(
         `CLI native harness compaction failed for ${params.provider}/${params.model}: ${
           nativeOutcome.failureReason ?? "compaction did not reduce context"
         }`,
@@ -664,7 +670,11 @@ export async function runCliTurnCompactionLifecycle(params: {
     });
     compacted = contextOutcome.compacted;
     if (!compacted && contextOutcome.failureReason) {
-      throw new Error(
+      // Context engine compaction failed (e.g. "Connection error"). This is a
+      // post-turn optimization — the assistant reply has already been generated
+      // and persisted. Treat the failure as a warning rather than a fatal error
+      // so the turn remains successful and the reply is still delivered.
+      log.warn(
         `CLI transcript compaction failed for ${params.provider}/${params.model}: ${
           contextOutcome.failureReason ?? "compaction did not reduce context"
         }`,

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -570,7 +570,6 @@ export async function runCliTurnCompactionLifecycle(params: {
   let useContextEngineCompaction = true;
   let nativeFallbackToContextEngine = false;
   let nativeFallbackNeedsBindingClear = false;
-  let nativeCompactionFailureReason: string | undefined;
   let resolvedContextEngine: ContextEngine | undefined;
   let autoCompactionGuardApplied = false;
   const authProfileId = params.sessionEntry?.authProfileOverride?.trim() || undefined;
@@ -626,7 +625,6 @@ export async function runCliTurnCompactionLifecycle(params: {
       // post-turn optimization — the assistant reply has already been generated
       // and persisted. Treat the failure as a warning rather than a fatal error
       // so the turn remains successful and the reply is still delivered.
-      nativeCompactionFailureReason = nativeOutcome.failureReason;
       log.warn(
         `CLI native harness compaction failed for ${params.provider}/${params.model}: ${
           nativeOutcome.failureReason ?? "compaction did not reduce context"


### PR DESCRIPTION
### Summary

When CLI transcript compaction fails after the assistant reply has already been generated and persisted (e.g. "Connection error" during context engine summarization), the runtime currently throws an exception that causes the entire turn to be marked as UNAVAILABLE — discarding an already-successful reply from the user's perspective.

The compaction step is a post-turn optimization that reduces the context window for future turns. Its failure only affects future context size, not the correctness or existence of the current reply. Treating it as fatal violates the principle already stated in the code:

> "Unsupported or recoverable native compaction should not abort the CLI turn" (line 619-622)

Two changes:

1. **cli-compaction.ts**: Replace both `throw` statements (native harness `failureReason` at line 623-628 and context engine `failureReason` at line 666-671) with `log.warn` + `continue`. The compaction result is `{ compacted: false }` which is already the correct outcome — the turn proceeds with the un-compacted transcript.

2. **agent-command.ts**: Add a defensive `try/catch` around the `runCliTurnCompactionLifecycle` call so any unexpected compaction error (even from future code changes) is caught, logged as a warning, and the turn continues. This prevents compaction failures from ever reaching `emitLifecyclePostTurnError` and marking the turn as failed.

### What changed

- `src/agents/command/cli-compaction.ts` — two throw sites converted to `log.warn` + continue (native harness + context engine paths)
- `src/agents/command/cli-compaction.test.ts` — three tests updated from `rejects.toThrow` to normal return assertions (compaction failure no longer throws)
- `src/agents/agent-command.ts` — defensive try/catch wrapper around `runCliTurnCompactionLifecycle`, ensuring compaction failures can never bubble up to turn-level error handling. Fixed `logger.warn` → `log.warn` (module binding is `log`, not `logger`).

### What did NOT change (scope boundary)

- Embedded agent runner compaction — already handles this correctly via `promptErrorSource = "compaction"`
- Compaction retry/failover logic (e.g., native→context-engine fallback)
- The logged warning preserves observability for operators

### Linked context

Closes #94688

### Real behavior proof

- **Behavior addressed**: Post-turn CLI compaction failure (native harness or context engine) no longer throws and aborts the turn. Instead it logs a warning and the turn continues, preserving the already-generated reply.
- **Environment tested**: Node v24.13.1 on Linux x86_64; imported real production function `runCliTurnCompactionLifecycle` from `src/agents/command/cli-compaction.ts`
- **Steps run after the patch**: `node --import tsx --no-warnings proof-compaction-no-throw.mjs`
- **Evidence after fix**: Terminal capture of console output from running `node --import tsx`:

  ```
  === Real behavior proof: compaction failure no longer throws ===

  --- Proof 1: runCliTurnCompactionLifecycle does not throw on failure ---
  Result: { "authProfileOverride": "" }
  ✅ PASS: Function returned without throwing. Before the patch, this would have thrown an Error.

  --- Proof 2: Source code no longer contains throw for compaction failure ---
  ✅ PASS: No 'throw new Error(`CLI ... compaction failed' found in either file.
     cli-compaction.ts: throw sites replaced with log.warn + continue.
     agent-command.ts: defensive try/catch added around compaction call.

  --- Proof 3: Defensive try/catch exists in agent-command.ts ---
  ✅ PASS: Defensive try/catch found in agent-command.ts around runCliTurnCompactionLifecycle.

  --- Proof 4: log.warn replaces throw at both compaction failure sites ---
  ✅ PASS: Both throw sites replaced with log.warn in cli-compaction.ts.

  === Proof complete ===
  ```

- **Observed result after the fix**: All 4 proof checks pass. The patched `runCliTurnCompactionLifecycle` returns `{ authProfileOverride: "" }` (i.e. `{ compacted: false }` effectively) without throwing. Source code analysis confirms both former throw sites are replaced with `log.warn`, and the defensive `try/catch` in `agent-command.ts` catches any residual compaction error.
- **What was not tested**: Full end-to-end turn execution with a live model (requires a working Codex/OpenAI API key). Only the compaction lifecycle function was tested directly. The defensive catch in `agent-command.ts` was verified via source code inspection (Proof 3) rather than runtime injection of an artificial throw, because the caller-level catch is structurally simple and its correctness follows from Proof 1 (the source-level throws are already removed).
- **Proof limitations or environment constraints**: CMake 3.18 on this machine (< 3.19 required by node-llama-cpp), so `pnpm install --frozen-lockfile` fails at node-llama-cpp postinstall. Core dependencies (vitest, tsx) are installed and functional. No live model API available for end-to-end testing; proof focuses on the compaction function's behavior under failure conditions.

### Differentiation from #94698

This PR includes a **defensive try/catch in `agent-command.ts`** (change #2) that the other PR does not. This ensures that even if future code changes introduce new throw paths in the compaction lifecycle, they will still be caught and logged as warnings rather than causing turn failure. This two-layer defense (source-level removal of throws + caller-level catch) makes the fix more robust against regressions.

### Tests and validation

- `node --import tsx --no-warnings proof-compaction-no-throw.mjs` — real behavior proof (4 checks, all pass)
- `node_modules/.bin/vitest run src/agents/command/cli-compaction.test.ts` — updated 3 test cases from `rejects.toThrow` to normal return assertions

### Risk checklist

- Did user-visible behavior change? **Yes** — compaction failure no longer surfaces as turn UNAVAILABLE; instead logged as warning and turn continues.
- Did config, environment, or migration behavior change? **No**
- Did security, auth, secrets, network, or tool execution behavior change? **No**
- Highest-risk area: `agent-command.ts` try/catch — could silently swallow a compaction error that should actually fail the turn. Mitigation: compaction is explicitly a post-turn optimization per existing code comment ("should not abort the CLI turn"), so swallowing is correct behavior. The log.warn preserves operator observability.
- Risk mitigation: Two-layer defense (source-level warn + caller-level catch). Warn log preserved for observability. No data is lost — the reply is still delivered.
