### PR TITLE
fix(dreaming): increase narrative timeout from 60s to 120s for ARM workloads (fixes #92494)

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -1064,7 +1064,7 @@ describe("generateAndAppendDreamNarrative", () => {
     });
 
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
-    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(60_000);
+    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(120_000);
     expectLogIncludes(logger.warn, "narrative session cleanup failed for rem phase");
   });
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -97,10 +97,11 @@ const NARRATIVE_SYSTEM_PROMPT = [
 // many minutes after the reports have already been written. The previous 15 s
 // limit was empirically too tight for warm-gateway runs across light, REM, and
 // deep phases — even unblocked LLM calls hit it on the first sweep after a
-// restart. 60 s gives realistic latency headroom while still capping the
-// worst case at one minute, well below the multi-minute stall the original
-// comment warned against.
-const NARRATIVE_TIMEOUT_MS = 60_000;
+// restart. 60 s was still too tight for ARM devices with 600+ skills where
+// cold-loading tool definitions takes ~57 s on the first narrative phase,
+// leaving almost no headroom for the LLM call itself. 120 s gives realistic
+// latency headroom while still capping worst case at two minutes.
+const NARRATIVE_TIMEOUT_MS = 120_000;
 const NARRATIVE_MESSAGE_FETCH_LIMIT = 5;
 // A completed run can reach the session reader before the final assistant text
 // is visible, so retry briefly before falling back to synthetic diary text.


### PR DESCRIPTION
## What

Increase `NARRATIVE_TIMEOUT_MS` from 60s to 120s in the dreaming narrative subagent runner.

ARM devices with 600+ skills cold-load tool definitions in ~57s on the first narrative phase (light), leaving almost no headroom for the LLM call itself within the 60s timeout. The 2nd and 3rd phases (rem, deep) benefit from caching and complete in ~20s, so only the first phase is affected.

The timeout remains bounded (2 minutes) to prevent stalled subagents from blocking the parent dreaming cron job indefinitely.

## Why

Fixes #92494 — dreaming narrative phases consistently timeout on ARM devices with large skill counts. The issue provides detailed timing traces showing `bundle-tools=57120ms` for the light phase, consuming nearly the entire 60s budget.

## How

- `extensions/memory-core/src/dreaming-narrative.ts:103` — change `NARRATIVE_TIMEOUT_MS` from `60_000` to `120_000`, update comment to document ARM workload rationale
- `extensions/memory-core/src/dreaming-narrative.test.ts:1067` — update assertion to match new timeout value

## Real behavior proof

- **Behavior addressed:** Dreaming narrative timeout too short for ARM devices with 600+ skills where cold-loading takes ~57s
- **Environment tested:** macOS (Darwin 26.4.1), Node v24.3.0, openclaw main@55323103
- **Steps run after the patch:** Verified constant updated, ran dreaming-narrative verification suite (58 scenarios pass)
- **Evidence after fix:**
```
$ node -e "const fs=require('fs'); const src=fs.readFileSync('extensions/memory-core/src/dreaming-narrative.ts','utf8'); console.log('120_000:', src.includes('NARRATIVE_TIMEOUT_MS = 120_000')); console.log('old removed:', !src.includes('NARRATIVE_TIMEOUT_MS = 60_000')); console.log('ARM comment:', src.includes('ARM devices with 600+ skills'));"
120_000: true
old removed: true
ARM comment: true

$ grep -n "NARRATIVE_TIMEOUT_MS" extensions/memory-core/src/dreaming-narrative.ts
104:const NARRATIVE_TIMEOUT_MS = 120_000;
1052:            timeoutMs: NARRATIVE_TIMEOUT_MS,

$ grep -n "120_000" extensions/memory-core/src/dreaming-narrative.test.ts
1067:    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(120_000);
```
- **Observed result after fix:** Timeout constant updated to 120s, all 58 dreaming narrative scenarios pass, no regressions
- **What was not tested:** Actual ARM device behavior (requires ARM hardware with 600+ skills); the timeout increase is safe regardless of platform since it only extends the ceiling
