### PR TITLE
Target changed lint checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ Skills own workflows; root owns hard policy and routing.
 - If raw Vitest is unavoidable, use `vitest run ...`; bare `vitest ...` starts local watch mode and will not exit on its own.
 - Tests in a Codex worktree or linked/sparse checkout: avoid direct local `pnpm test*`; use `node scripts/run-vitest.mjs <path-or-filter>` for tiny explicit-file proof, or Crabbox/Testbox for anything broader.
 - Checks in a normal source checkout: `pnpm check:changed` delegates to Crabbox/Testbox; lanes: `pnpm changed:lanes --json`; staged: `pnpm check:changed --staged`; full: `pnpm check`.
+- Lint/changed-file proof: do not run `pnpm lint` locally unless full lint is required. Use `pnpm check:changed --dry-run`, `pnpm check:changed --staged`, or `pnpm check:changed -- <files...>`; small core/extension/script diffs use targeted oxlint inside that planner.
 - Checks in a Codex worktree or linked/sparse checkout: avoid direct local `pnpm check*`; use `node scripts/crabbox-wrapper.mjs run ... -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` so pnpm runs inside Testbox, not locally.
 - Extension tests: `pnpm test:extensions`, `pnpm test extensions`, `pnpm test extensions/<id>`.
 - Typecheck: `tsgo` lanes only (`pnpm tsgo*`, `pnpm check:test-types`); never add `tsc --noEmit`, `typecheck`, `check:types`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,12 +118,11 @@ Skills own workflows; root owns hard policy and routing.
 - Tests in a normal source checkout: `pnpm test <path-or-filter> [vitest args...]`, `pnpm test:changed`, `pnpm test:serial`, `pnpm test:coverage`; never raw `vitest`.
 - If raw Vitest is unavoidable, use `vitest run ...`; bare `vitest ...` starts local watch mode and will not exit on its own.
 - Tests in a Codex worktree or linked/sparse checkout: avoid direct local `pnpm test*`; use `node scripts/run-vitest.mjs <path-or-filter>` for tiny explicit-file proof, or Crabbox/Testbox for anything broader.
-- Checks in a normal source checkout: `pnpm check:changed` delegates to Crabbox/Testbox; lanes: `pnpm changed:lanes --json`; staged: `pnpm check:changed --staged`; full: `pnpm check`.
-- Lint/changed-file proof: do not run `pnpm lint` locally unless full lint is required. Use `pnpm check:changed --dry-run`, `pnpm check:changed --staged`, or `pnpm check:changed -- <files...>`; small core/extension/script diffs use targeted oxlint inside that planner.
+- Checks/lint in a normal source checkout: `pnpm check:changed` delegates to Crabbox/Testbox; lanes: `pnpm changed:lanes --json`; staged/path-scoped: `pnpm check:changed --staged` or `pnpm check:changed -- <files...>`; full `pnpm check`/`pnpm lint` only when required.
 - Checks in a Codex worktree or linked/sparse checkout: avoid direct local `pnpm check*`; use `node scripts/crabbox-wrapper.mjs run ... -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` so pnpm runs inside Testbox, not locally.
 - Extension tests: `pnpm test:extensions`, `pnpm test extensions`, `pnpm test extensions/<id>`.
 - Typecheck: `tsgo` lanes only (`pnpm tsgo*`, `pnpm check:test-types`); never add `tsc --noEmit`, `typecheck`, `check:types`.
-- Formatting: `oxfmt`, not Prettier. Use repo wrappers (`pnpm format:*`, `pnpm lint:*`, `scripts/run-oxlint.mjs`).
+- Formatting: `oxfmt`, not Prettier. Use repo wrappers (`pnpm format:*`, `scripts/run-oxlint.mjs`; full `pnpm lint:*` only when scope requires).
 - Build before push when build output, packaging, lazy/module boundaries, dynamic imports, or published surfaces can change.
 
 ## Validation

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -8,7 +8,8 @@ This directory owns local tooling, script wrappers, and generated-artifact helpe
 - For tests, prefer `scripts/run-vitest.mjs` or the root `pnpm test ...` entrypoints over raw `vitest run` calls.
 - Never use bare `vitest ...` in automation; it starts local watch mode unless `run` or `--run` is explicit.
 - For lint/typecheck flows, prefer `scripts/run-oxlint.mjs` and `scripts/run-tsgo.mjs` when adding or editing package scripts or CI steps that should honor repo-local runtime behavior.
-- For changed-file verification, prefer `scripts/check-changed.mjs` and keep lane classification in `scripts/changed-lanes.mjs`. Do not copy path-scope rules into new hooks or ad hoc CI snippets.
+- For changed-file verification, prefer `scripts/check-changed.mjs` and keep lane classification in `scripts/changed-lanes.mjs`. Use `node scripts/check-changed.mjs --dry-run [--staged|-- <files...>]` to inspect the plan before running anything expensive. Do not copy path-scope rules into new hooks or ad hoc CI snippets.
+- For one/few lint files, prefer direct `node scripts/run-oxlint.mjs --tsconfig <matching config> <files...>` over sharded `pnpm lint`; `check-changed.mjs` owns this targeting for core, extension, and script diffs.
 
 ## Local Heavy-Check Lock
 

--- a/scripts/check-changed.mjs
+++ b/scripts/check-changed.mjs
@@ -57,7 +57,7 @@ const LINTABLE_EXTENSION_PATH_RE = /^extensions\/[^/]+\/.+\.[cm]?[jt]sx?$/u;
 const LINTABLE_SCRIPT_PATH_RE = /^scripts\/.+\.[cm]?[jt]sx?$/u;
 const MARKDOWN_LINT_OPTIMIZATION_NEUTRAL_PATH_RE = /^(?:docs\/|README\.md$|.*\.mdx?$)/u;
 const CORE_LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
-  /^(?:scripts|test\/scripts)\/|^\.github\/workflows\/ci\.yml$|^(?:docs\/|README\.md$|.*\.mdx?$)/u;
+  /^(?:scripts|test\/scripts)\/|^\.github\/workflows\/ci\.yml$/u;
 const EXTENSION_LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
   /^(?:test\/scripts\/|\.github\/workflows\/ci\.yml$)/u;
 const SCRIPT_LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
@@ -643,7 +643,7 @@ function formatPlanCommand(command) {
 }
 
 function formatShellToken(token) {
-  return /^[A-Za-z0-9_./:@=-]+$/u.test(token) ? token : JSON.stringify(token);
+  return /^[A-Za-z0-9_./:@=-]+$/u.test(token) ? token : `'${token.replaceAll("'", "'\\''")}'`;
 }
 
 export function createPnpmManagedCommand(command, env = process.env) {

--- a/scripts/check-changed.mjs
+++ b/scripts/check-changed.mjs
@@ -49,10 +49,19 @@ const RUNTIME_SIDECAR_BASELINE_PATH_RE =
 const CANVAS_A2UI_NATIVE_RESOURCE_PATH_RE =
   /^(?:pnpm-lock\.yaml$|apps\/shared\/OpenClawKit\/Sources\/OpenClawKit\/Resources\/CanvasA2UI\/|extensions\/canvas\/(?:package\.json$|scripts\/bundle-a2ui\.mjs$|src\/host\/a2ui(?:\/(?:index\.html|a2ui\.bundle\.js|\.bundle\.hash)$|-app\/))|scripts\/(?:bundle-a2ui|sync-native-a2ui)\.mjs$)/u;
 const CORE_OXLINT_TS_CONFIG = "config/tsconfig/oxlint.core.json";
-const TARGETED_CORE_LINT_PATH_LIMIT = 8;
+const EXTENSIONS_OXLINT_TS_CONFIG = "config/tsconfig/oxlint.extensions.json";
+const SCRIPTS_OXLINT_TS_CONFIG = "config/tsconfig/oxlint.scripts.json";
+const TARGETED_LINT_PATH_LIMIT = 8;
 const LINTABLE_CORE_PATH_RE = /^(?:src|ui|packages)\/.+\.[cm]?[jt]sx?$/u;
+const LINTABLE_EXTENSION_PATH_RE = /^extensions\/[^/]+\/.+\.[cm]?[jt]sx?$/u;
+const LINTABLE_SCRIPT_PATH_RE = /^scripts\/.+\.[cm]?[jt]sx?$/u;
+const MARKDOWN_LINT_OPTIMIZATION_NEUTRAL_PATH_RE = /^(?:docs\/|README\.md$|.*\.mdx?$)/u;
 const CORE_LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
-  /^(?:scripts|test\/scripts)\/|^\.github\/workflows\/ci\.yml$/u;
+  /^(?:scripts|test\/scripts)\/|^\.github\/workflows\/ci\.yml$|^(?:docs\/|README\.md$|.*\.mdx?$)/u;
+const EXTENSION_LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
+  /^(?:test\/scripts\/|\.github\/workflows\/ci\.yml$)/u;
+const SCRIPT_LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
+  /^(?:test\/scripts\/|\.github\/workflows\/ci\.yml$)/u;
 const ANDROID_VERSION_SYNC_PATHS = new Set([
   "apps/android/CHANGELOG.md",
   "apps/android/Config/Version.properties",
@@ -413,10 +422,32 @@ export function createChangedCheckPlan(result, options = {}) {
     addLint("lint core", ["lint:core"]);
   }
   if (lanes.extensions || lanes.extensionTests) {
-    addLint("lint extensions", ["lint:extensions"]);
+    const extensionLintCommand = createTargetedExtensionLintCommand(result.paths, baseEnv);
+    if (extensionLintCommand) {
+      addCommand(
+        extensionLintCommand.name,
+        extensionLintCommand.bin,
+        extensionLintCommand.args,
+        extensionLintCommand.env,
+      );
+    } else {
+      addLint("lint extensions", ["lint:extensions"]);
+    }
   }
   if (lanes.tooling || lanes.liveDockerTooling) {
-    addLint("lint scripts", ["lint:scripts"]);
+    const scriptLintCommand = createTargetedScriptLintCommand(result.paths, baseEnv);
+    if (scriptLintCommand) {
+      addLint("lint docker-e2e", ["lint:docker-e2e"]);
+      addLint("raw HTTP/2 import guard", ["lint:tmp:no-raw-http2-imports"]);
+      addCommand(
+        scriptLintCommand.name,
+        scriptLintCommand.bin,
+        scriptLintCommand.args,
+        scriptLintCommand.env,
+      );
+    } else {
+      addLint("lint scripts", ["lint:scripts"]);
+    }
   }
   if (lanes.apps && shouldSkipAppLintForMissingSwiftlint({ ...options, env: baseEnv })) {
     addCommand(
@@ -466,29 +497,73 @@ export function createChangedCheckPlan(result, options = {}) {
 }
 
 export function createTargetedCoreLintCommand(paths, env = process.env, options = {}) {
+  return createTargetedOxlintCommand({
+    env,
+    label: "core",
+    lintablePathRe: LINTABLE_CORE_PATH_RE,
+    neutralPathRe: CORE_LINT_OPTIMIZATION_NEUTRAL_PATH_RE,
+    paths,
+    tsconfig: CORE_OXLINT_TS_CONFIG,
+    ...options,
+  });
+}
+
+export function createTargetedExtensionLintCommand(paths, env = process.env, options = {}) {
+  return createTargetedOxlintCommand({
+    env,
+    label: "extension",
+    lintablePathRe: LINTABLE_EXTENSION_PATH_RE,
+    neutralPathRe: EXTENSION_LINT_OPTIMIZATION_NEUTRAL_PATH_RE,
+    paths,
+    tsconfig: EXTENSIONS_OXLINT_TS_CONFIG,
+    ...options,
+  });
+}
+
+export function createTargetedScriptLintCommand(paths, env = process.env, options = {}) {
+  return createTargetedOxlintCommand({
+    env,
+    label: "script",
+    lintablePathRe: LINTABLE_SCRIPT_PATH_RE,
+    neutralPathRe: SCRIPT_LINT_OPTIMIZATION_NEUTRAL_PATH_RE,
+    paths,
+    tsconfig: SCRIPTS_OXLINT_TS_CONFIG,
+    ...options,
+  });
+}
+
+function createTargetedOxlintCommand({
+  env = process.env,
+  fileExists = existsSync,
+  label,
+  lintablePathRe,
+  neutralPathRe,
+  paths,
+  tsconfig,
+}) {
   if (
     paths.some(
       (changedPath) =>
-        !LINTABLE_CORE_PATH_RE.test(changedPath) &&
-        !CORE_LINT_OPTIMIZATION_NEUTRAL_PATH_RE.test(changedPath),
+        !lintablePathRe.test(changedPath) &&
+        !neutralPathRe.test(changedPath) &&
+        !MARKDOWN_LINT_OPTIMIZATION_NEUTRAL_PATH_RE.test(changedPath),
     )
   ) {
     return null;
   }
   const targets = paths
-    .filter((changedPath) => LINTABLE_CORE_PATH_RE.test(changedPath))
+    .filter((changedPath) => lintablePathRe.test(changedPath))
     .toSorted((left, right) => left.localeCompare(right));
-  if (targets.length === 0 || targets.length > TARGETED_CORE_LINT_PATH_LIMIT) {
+  if (targets.length === 0 || targets.length > TARGETED_LINT_PATH_LIMIT) {
     return null;
   }
-  const fileExists = options.fileExists ?? existsSync;
   if (!targets.every((target) => fileExists(target))) {
     return null;
   }
   return {
-    name: targets.length === 1 ? "lint core changed file" : "lint core changed files",
+    name: targets.length === 1 ? `lint ${label} changed file` : `lint ${label} changed files`,
     bin: "node",
-    args: ["scripts/run-oxlint.mjs", "--tsconfig", CORE_OXLINT_TS_CONFIG, ...targets],
+    args: ["scripts/run-oxlint.mjs", "--tsconfig", tsconfig, ...targets],
     env,
   };
 }
@@ -544,6 +619,11 @@ function printPlan(result, plan, options) {
   for (const reason of result.reasons) {
     console.error(`${prefix} ${reason}`);
   }
+  if (options.dryRun) {
+    for (const command of plan.commands) {
+      console.error(`${prefix} would run: ${formatPlanCommand(command)}`);
+    }
+  }
 }
 
 async function runPnpm(command, timings) {
@@ -555,6 +635,15 @@ async function runPlanCommand(command, timings) {
     return await runCommand(command, timings);
   }
   return await runPnpm(command, timings);
+}
+
+function formatPlanCommand(command) {
+  const argv = command.bin ? [command.bin, ...command.args] : ["pnpm", ...command.args];
+  return argv.map(formatShellToken).join(" ");
+}
+
+function formatShellToken(token) {
+  return /^[A-Za-z0-9_./:@=-]+$/u.test(token) ? token : JSON.stringify(token);
 }
 
 export function createPnpmManagedCommand(command, env = process.env) {

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -18,6 +18,8 @@ import {
   createChangedCheckPlan,
   createPnpmManagedCommand,
   createTargetedCoreLintCommand,
+  createTargetedExtensionLintCommand,
+  createTargetedScriptLintCommand,
   shouldDelegateChangedCheckToCrabbox,
   shouldRunAppcastOwnerTest,
   shouldRunCanvasA2uiNativeResourceCheck,
@@ -253,6 +255,24 @@ describe("scripts/changed-lanes", () => {
       "--",
       "--no-changes",
     ]);
+  });
+
+  it("prints changed check dry-run commands", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/check-changed.mjs", "--dry-run", "--", "extensions/lmstudio/src/api.ts"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: createNestedGitEnv(),
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("[check:changed:dry-run] lanes=extensions, extensionTests");
+    expect(result.stderr).toContain(
+      "[check:changed:dry-run] would run: node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/lmstudio/src/api.ts",
+    );
   });
 
   it("includes untracked worktree files in the default local diff", () => {
@@ -579,6 +599,16 @@ describe("scripts/changed-lanes", () => {
     expect(command).toBeNull();
   });
 
+  it("falls back to full extension lint for broad extension diffs", () => {
+    const targets = Array.from(
+      { length: 9 },
+      (_, index) => `extensions/discord/src/file-${index}.ts`,
+    );
+    const command = createTargetedExtensionLintCommand(targets, { PATH: "/usr/bin" });
+
+    expect(command).toBeNull();
+  });
+
   it("falls back to full core lint when a changed core target was deleted", () => {
     expect(
       createTargetedCoreLintCommand(
@@ -624,6 +654,50 @@ describe("scripts/changed-lanes", () => {
         "--tsconfig",
         "config/tsconfig/oxlint.core.json",
         "src/agents/auth-profiles/usage.ts",
+      ],
+      env: {
+        PATH: "/usr/bin",
+      },
+    });
+  });
+
+  it("targets small extension lint diffs", () => {
+    expect(
+      createTargetedExtensionLintCommand(
+        ["extensions/lmstudio/src/api.ts", "docs/help/testing.md"],
+        { PATH: "/usr/bin" },
+        { fileExists: () => true },
+      ),
+    ).toEqual({
+      name: "lint extension changed file",
+      bin: "node",
+      args: [
+        "scripts/run-oxlint.mjs",
+        "--tsconfig",
+        "config/tsconfig/oxlint.extensions.json",
+        "extensions/lmstudio/src/api.ts",
+      ],
+      env: {
+        PATH: "/usr/bin",
+      },
+    });
+  });
+
+  it("targets small script lint diffs", () => {
+    expect(
+      createTargetedScriptLintCommand(
+        ["scripts/check-changed.mjs", "test/scripts/changed-lanes.test.ts"],
+        { PATH: "/usr/bin" },
+        { fileExists: () => true },
+      ),
+    ).toEqual({
+      name: "lint script changed file",
+      bin: "node",
+      args: [
+        "scripts/run-oxlint.mjs",
+        "--tsconfig",
+        "config/tsconfig/oxlint.scripts.json",
+        "scripts/check-changed.mjs",
       ],
       env: {
         PATH: "/usr/bin",
@@ -796,9 +870,11 @@ describe("scripts/changed-lanes", () => {
   });
 
   it("runs changed-check lint lanes under the parent heavy-check lock", () => {
-    const result = detectChangedLanes(["extensions/discord/src/index.ts"]);
+    const result = detectChangedLanes(["extensions/lmstudio/src/api.ts"]);
     const plan = createChangedCheckPlan(result, { env: { PATH: "/usr/bin" } });
-    const lintCommand = plan.commands.find((command) => command.args[0] === "lint:extensions");
+    const lintCommand = plan.commands.find(
+      (command) => command.name === "lint extension changed file",
+    );
 
     expect(lintCommand?.env).toEqual({
       OPENCLAW_OXLINT_SKIP_LOCK: "1",
@@ -840,7 +916,7 @@ describe("scripts/changed-lanes", () => {
   });
 
   it("routes extension production changes to extension prod and extension test lanes", () => {
-    const result = detectChangedLanes(["extensions/discord/src/index.ts"]);
+    const result = detectChangedLanes(["extensions/lmstudio/src/api.ts"]);
 
     expectLanes(result.lanes, {
       extensions: true,


### PR DESCRIPTION
## Summary

- clarify agent instructions to use changed-file lint/check planning instead of local full lint by default
- extend `check:changed` targeted oxlint planning from core files to small extension and script diffs
- make `check:changed --dry-run` print the exact commands it would run

## Verification

- `node scripts/run-vitest.mjs test/scripts/changed-lanes.test.ts`
- `node scripts/check-changed.mjs --dry-run -- extensions/lmstudio/src/api.ts`
- `node scripts/check-changed.mjs --dry-run -- scripts/check-changed.mjs`
- `node scripts/check-changed.mjs --dry-run -- src/agents/gpt5-prompt-overlay.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/check-changed.mjs`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/lmstudio/src/api.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
