### PR TITLE
Add core snapshot CLI

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -260,6 +260,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   { commandPath: ["acp"], policy: { networkProxy: "bypass" } },
   { commandPath: ["approvals"], policy: { networkProxy: "bypass" } },
   { commandPath: ["backup"], policy: { bypassConfigGuard: true, networkProxy: "bypass" } },
+  { commandPath: ["snapshot"], policy: { bypassConfigGuard: true, networkProxy: "bypass" } },
   { commandPath: ["chat"], policy: { networkProxy: "bypass" } },
   { commandPath: ["config"], policy: { networkProxy: "bypass" } },
   { commandPath: ["cron"], policy: { networkProxy: "bypass" } },

--- a/src/cli/program/command-registry-core.ts
+++ b/src/cli/program/command-registry-core.ts
@@ -83,6 +83,11 @@ const coreEntrySpecs: readonly CommandGroupDescriptorSpec<
         exportName: "registerBackupCommand",
       },
       {
+        commandNames: ["snapshot"],
+        loadModule: () => import("./register.snapshot.js"),
+        exportName: "registerSnapshotCommand",
+      },
+      {
         commandNames: ["migrate"],
         loadModule: () => import("./register.migrate.js"),
         exportName: "registerMigrateCommand",

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -38,6 +38,11 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
     hasSubcommands: true,
   },
   {
+    name: "snapshot",
+    description: "Create, verify, list, and restore SQLite snapshots",
+    hasSubcommands: true,
+  },
+  {
     name: "migrate",
     description: "Import state from another agent system",
     hasSubcommands: true,

--- a/src/cli/program/register.snapshot.test.ts
+++ b/src/cli/program/register.snapshot.test.ts
@@ -1,0 +1,120 @@
+// Register snapshot tests cover core command registration and option wiring.
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerSnapshotCommand } from "./register.snapshot.js";
+
+const mocks = vi.hoisted(() => ({
+  snapshotCreateCommand: vi.fn(),
+  snapshotListCommand: vi.fn(),
+  snapshotRestoreCommand: vi.fn(),
+  snapshotVerifyCommand: vi.fn(),
+  runtime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../../commands/snapshot.js", () => ({
+  snapshotCreateCommand: mocks.snapshotCreateCommand,
+  snapshotListCommand: mocks.snapshotListCommand,
+  snapshotRestoreCommand: mocks.snapshotRestoreCommand,
+  snapshotVerifyCommand: mocks.snapshotVerifyCommand,
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+describe("registerSnapshotCommand", () => {
+  async function runCli(args: string[]) {
+    const program = new Command();
+    registerSnapshotCommand(program);
+    await program.parseAsync(args, { from: "user" });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.snapshotCreateCommand.mockResolvedValue(0);
+    mocks.snapshotListCommand.mockResolvedValue(0);
+    mocks.snapshotRestoreCommand.mockResolvedValue(0);
+    mocks.snapshotVerifyCommand.mockResolvedValue(0);
+  });
+
+  it("registers the snapshot command group", () => {
+    const program = new Command();
+
+    registerSnapshotCommand(program);
+
+    const snapshot = program.commands.find((command) => command.name() === "snapshot");
+    expect(snapshot?.commands.map((command) => command.name()).toSorted()).toEqual([
+      "create",
+      "list",
+      "restore",
+      "verify",
+    ]);
+  });
+
+  it("runs snapshot create with forwarded options", async () => {
+    await runCli([
+      "snapshot",
+      "create",
+      "--db",
+      "/tmp/source.sqlite",
+      "--repository",
+      "/tmp/snapshots",
+      "--id",
+      "global",
+      "--kind",
+      "control-plane",
+      "--json",
+    ]);
+
+    expect(mocks.snapshotCreateCommand).toHaveBeenCalledWith(
+      {
+        db: "/tmp/source.sqlite",
+        repository: "/tmp/snapshots",
+        id: "global",
+        kind: "control-plane",
+        json: true,
+      },
+      mocks.runtime,
+    );
+  });
+
+  it("runs snapshot list with forwarded options", async () => {
+    await runCli(["snapshot", "list", "--repository", "/tmp/snapshots", "--json"]);
+
+    expect(mocks.snapshotListCommand).toHaveBeenCalledWith(
+      { repository: "/tmp/snapshots", json: true },
+      mocks.runtime,
+    );
+  });
+
+  it("runs snapshot verify with forwarded options", async () => {
+    await runCli(["snapshot", "verify", "/tmp/snapshots/one", "--json"]);
+
+    expect(mocks.snapshotVerifyCommand).toHaveBeenCalledWith(
+      "/tmp/snapshots/one",
+      { json: true },
+      mocks.runtime,
+    );
+  });
+
+  it("runs snapshot restore with forwarded options", async () => {
+    await runCli([
+      "snapshot",
+      "restore",
+      "/tmp/snapshots/one",
+      "--target",
+      "/tmp/restore.sqlite",
+      "--json",
+    ]);
+
+    expect(mocks.snapshotRestoreCommand).toHaveBeenCalledWith(
+      "/tmp/snapshots/one",
+      { target: "/tmp/restore.sqlite", json: true },
+      mocks.runtime,
+    );
+  });
+});

--- a/src/cli/program/register.snapshot.ts
+++ b/src/cli/program/register.snapshot.ts
@@ -1,0 +1,73 @@
+// Snapshot command registration for SQLite-safe snapshot artifacts.
+import type { Command } from "commander";
+import {
+  snapshotCreateCommand,
+  snapshotListCommand,
+  snapshotRestoreCommand,
+  snapshotVerifyCommand,
+  type SnapshotCreateOptions,
+  type SnapshotJsonOptions,
+  type SnapshotRepositoryOptions,
+  type SnapshotRestoreOptions,
+} from "../../commands/snapshot.js";
+import { defaultRuntime } from "../../runtime.js";
+import { runCommandWithRuntime } from "../cli-utils.js";
+
+/** Register snapshot create/list/verify/restore subcommands. */
+export function registerSnapshotCommand(program: Command): void {
+  const snapshot = program
+    .command("snapshot")
+    .description("Create, verify, list, and restore SQLite snapshots")
+    .action(() => {
+      snapshot.outputHelp();
+      process.exitCode = 1;
+    });
+
+  snapshot
+    .command("create")
+    .description("Create a consistent SQLite snapshot in a local repository")
+    .requiredOption("--db <path>", "SQLite database path")
+    .requiredOption("--repository <path>", "Snapshot repository directory")
+    .option("--id <id>", "Logical database id recorded in the manifest")
+    .option("--kind <kind>", "Logical database kind recorded in the manifest")
+    .option("--json", "Emit JSON output")
+    .action(async (options: SnapshotCreateOptions) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        process.exitCode = await snapshotCreateCommand(options, defaultRuntime);
+      });
+    });
+
+  snapshot
+    .command("verify")
+    .description("Verify a snapshot manifest, artifact hash, and SQLite integrity")
+    .argument("<snapshot>", "Snapshot directory")
+    .option("--json", "Emit JSON output")
+    .action(async (snapshotPath: string, options: SnapshotJsonOptions) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        process.exitCode = await snapshotVerifyCommand(snapshotPath, options, defaultRuntime);
+      });
+    });
+
+  snapshot
+    .command("restore")
+    .description("Restore a verified snapshot to a new SQLite database path")
+    .argument("<snapshot>", "Snapshot directory")
+    .requiredOption("--target <path>", "Target SQLite database path; must not already exist")
+    .option("--json", "Emit JSON output")
+    .action(async (snapshotPath: string, options: SnapshotRestoreOptions) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        process.exitCode = await snapshotRestoreCommand(snapshotPath, options, defaultRuntime);
+      });
+    });
+
+  snapshot
+    .command("list")
+    .description("List snapshots in a local repository")
+    .requiredOption("--repository <path>", "Snapshot repository directory")
+    .option("--json", "Emit JSON output")
+    .action(async (options: SnapshotRepositoryOptions) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        process.exitCode = await snapshotListCommand(options, defaultRuntime);
+      });
+    });
+}

--- a/src/commands/snapshot.test.ts
+++ b/src/commands/snapshot.test.ts
@@ -1,0 +1,133 @@
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  snapshotCreateCommand,
+  snapshotListCommand,
+  snapshotRestoreCommand,
+  snapshotVerifyCommand,
+} from "./snapshot.js";
+
+let workspaceDir: string;
+
+describe("snapshot cli", () => {
+  beforeEach(async () => {
+    workspaceDir = await fs.mkdtemp(path.join(tmpdir(), "snapshot-cli-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("creates, lists, verifies, and restores a SQLite snapshot", async () => {
+    const runtime = createRuntimeCapture();
+    const dbPath = path.join(workspaceDir, "source.sqlite");
+    const repositoryPath = path.join(workspaceDir, "snapshots");
+    const restorePath = path.join(workspaceDir, "restore", "source.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        PRAGMA journal_mode = WAL;
+        PRAGMA user_version = 12;
+        CREATE TABLE entries (value TEXT NOT NULL);
+        INSERT INTO entries (value) VALUES ('from-cli');
+      `);
+    } finally {
+      db.close();
+    }
+
+    await expect(
+      snapshotCreateCommand(
+        {
+          db: dbPath,
+          repository: repositoryPath,
+          id: "cli-db",
+          kind: "test",
+          json: true,
+        },
+        runtime,
+      ),
+    ).resolves.toBe(0);
+    const createReport = JSON.parse(runtime.logs.shift() ?? "{}") as {
+      snapshotPath?: string;
+      manifest?: { database?: { id?: string; kind?: string; userVersion?: number } };
+    };
+    expect(createReport.snapshotPath).toBeTruthy();
+    expect(createReport.manifest?.database).toMatchObject({
+      id: "cli-db",
+      kind: "test",
+      userVersion: 12,
+    });
+
+    await expect(
+      snapshotListCommand({ repository: repositoryPath, json: true }, runtime),
+    ).resolves.toBe(0);
+    const listReport = JSON.parse(runtime.logs.shift() ?? "{}") as {
+      snapshots?: unknown[];
+    };
+    expect(listReport.snapshots).toHaveLength(1);
+
+    await expect(
+      snapshotVerifyCommand(createReport.snapshotPath ?? "", { json: true }, runtime),
+    ).resolves.toBe(0);
+    const verifyReport = JSON.parse(runtime.logs.shift() ?? "{}") as {
+      ok?: boolean;
+      integrityCheck?: string[];
+    };
+    expect(verifyReport).toMatchObject({ ok: true, integrityCheck: ["ok"] });
+
+    await expect(
+      snapshotRestoreCommand(
+        createReport.snapshotPath ?? "",
+        { target: restorePath, json: true },
+        runtime,
+      ),
+    ).resolves.toBe(0);
+    const restoreReport = JSON.parse(runtime.logs.shift() ?? "{}") as {
+      ok?: boolean;
+      targetPath?: string;
+    };
+    expect(restoreReport).toMatchObject({ ok: true, targetPath: restorePath });
+    expect(runtime.errors).toEqual([]);
+
+    const restored = new DatabaseSync(restorePath, { readOnly: true });
+    try {
+      expect(restored.prepare("SELECT value FROM entries").all()).toEqual([{ value: "from-cli" }]);
+    } finally {
+      restored.close();
+    }
+  });
+
+  it("returns command usage errors without throwing", async () => {
+    const runtime = createRuntimeCapture();
+
+    await expect(snapshotCreateCommand({ repository: workspaceDir }, runtime)).resolves.toBe(2);
+
+    expect(runtime.logs).toEqual([]);
+    expect(runtime.errors).toEqual(["Missing required --db value."]);
+  });
+});
+
+function createRuntimeCapture(): RuntimeEnv & {
+  readonly logs: string[];
+  readonly errors: string[];
+} {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return {
+    logs,
+    errors,
+    log(value) {
+      logs.push(String(value));
+    },
+    error(value) {
+      errors.push(String(value));
+    },
+    exit(code) {
+      throw new Error(`exit ${code}`);
+    },
+  };
+}

--- a/src/commands/snapshot.ts
+++ b/src/commands/snapshot.ts
@@ -1,0 +1,201 @@
+// Core command handlers for SQLite snapshot artifacts.
+import { createLocalSqliteSnapshotProvider } from "../snapshot/local-repository.js";
+import type {
+  SnapshotManifest,
+  SnapshotSummary,
+  SnapshotVerificationResult,
+} from "../snapshot/snapshot-provider.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+
+export interface SnapshotCreateOptions {
+  readonly db?: string;
+  readonly repository?: string;
+  readonly id?: string;
+  readonly kind?: string;
+  readonly json?: boolean;
+}
+
+export interface SnapshotRepositoryOptions {
+  readonly repository?: string;
+  readonly json?: boolean;
+}
+
+export interface SnapshotJsonOptions {
+  readonly json?: boolean;
+}
+
+export interface SnapshotRestoreOptions extends SnapshotJsonOptions {
+  readonly target?: string;
+}
+
+type SnapshotCreateReport = {
+  readonly ok: true;
+  readonly snapshotPath: string;
+  readonly manifest: SnapshotManifest;
+};
+
+type SnapshotVerifyReport = SnapshotVerificationResult & {
+  readonly snapshotPath: string;
+};
+
+type SnapshotRestoreReport = SnapshotVerificationResult & {
+  readonly snapshotPath: string;
+  readonly targetPath: string;
+};
+
+type SnapshotListReport = {
+  readonly ok: true;
+  readonly snapshots: readonly SnapshotSummary[];
+};
+
+export async function snapshotCreateCommand(
+  options: SnapshotCreateOptions,
+  runtime: RuntimeEnv,
+): Promise<number> {
+  try {
+    const repositoryPath = requireOption(options.repository, "--repository");
+    const dbPath = requireOption(options.db, "--db");
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath });
+    const result = await provider.create({
+      path: dbPath,
+      ...(options.id ? { id: options.id } : {}),
+      ...(options.kind ? { kind: options.kind } : {}),
+    });
+    writeCreateReport(
+      { ok: true, snapshotPath: result.ref.path, manifest: result.manifest },
+      options,
+      runtime,
+    );
+    return 0;
+  } catch (err) {
+    runtime.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+}
+
+export async function snapshotVerifyCommand(
+  snapshotPath: string,
+  options: SnapshotJsonOptions,
+  runtime: RuntimeEnv,
+): Promise<number> {
+  try {
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath: "." });
+    const verified = await provider.verify({ path: requireValue(snapshotPath, "<snapshot>") });
+    writeVerifyReport({ ...verified, snapshotPath }, options, runtime);
+    return 0;
+  } catch (err) {
+    runtime.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+}
+
+export async function snapshotRestoreCommand(
+  snapshotPath: string,
+  options: SnapshotRestoreOptions,
+  runtime: RuntimeEnv,
+): Promise<number> {
+  try {
+    const targetPath = requireOption(options.target, "--target");
+    const provider = createLocalSqliteSnapshotProvider({ repositoryPath: "." });
+    const verified = await provider.restore(
+      { path: requireValue(snapshotPath, "<snapshot>") },
+      targetPath,
+    );
+    writeRestoreReport({ ...verified, snapshotPath, targetPath }, options, runtime);
+    return 0;
+  } catch (err) {
+    runtime.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+}
+
+export async function snapshotListCommand(
+  options: SnapshotRepositoryOptions,
+  runtime: RuntimeEnv,
+): Promise<number> {
+  try {
+    const provider = createLocalSqliteSnapshotProvider({
+      repositoryPath: requireOption(options.repository, "--repository"),
+    });
+    writeListReport({ ok: true, snapshots: (await provider.list?.()) ?? [] }, options, runtime);
+    return 0;
+  } catch (err) {
+    runtime.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+}
+
+function writeCreateReport(
+  report: SnapshotCreateReport,
+  options: SnapshotJsonOptions,
+  runtime: RuntimeEnv,
+): void {
+  if (options.json === true) {
+    writeJson(report, runtime);
+    return;
+  }
+  runtime.log(
+    `snapshot create: ${report.snapshotPath} (${report.manifest.database.id}, ${report.manifest.artifact.sizeBytes} bytes)`,
+  );
+}
+
+function writeVerifyReport(
+  report: SnapshotVerifyReport,
+  options: SnapshotJsonOptions,
+  runtime: RuntimeEnv,
+): void {
+  if (options.json === true) {
+    writeJson(report, runtime);
+    return;
+  }
+  runtime.log(
+    `snapshot verify: ok (${report.manifest.database.id}, ${report.manifest.artifact.sizeBytes} bytes)`,
+  );
+}
+
+function writeRestoreReport(
+  report: SnapshotRestoreReport,
+  options: SnapshotJsonOptions,
+  runtime: RuntimeEnv,
+): void {
+  if (options.json === true) {
+    writeJson(report, runtime);
+    return;
+  }
+  runtime.log(`snapshot restore: ${report.targetPath} (${report.manifest.database.id})`);
+}
+
+function writeListReport(
+  report: SnapshotListReport,
+  options: SnapshotJsonOptions,
+  runtime: RuntimeEnv,
+): void {
+  if (options.json === true) {
+    writeJson(report, runtime);
+    return;
+  }
+  if (report.snapshots.length === 0) {
+    runtime.log("snapshot list: no snapshots");
+    return;
+  }
+  for (const snapshot of report.snapshots) {
+    runtime.log(
+      `${snapshot.manifest.createdAt} ${snapshot.manifest.database.id} ${snapshot.ref.path}`,
+    );
+  }
+}
+
+function writeJson(value: unknown, runtime: RuntimeEnv): void {
+  writeRuntimeJson(runtime, value, 0);
+}
+
+function requireOption(value: string | undefined, flag: string): string {
+  return requireValue(value, flag);
+}
+
+function requireValue(value: string | undefined, label: string): string {
+  if (value === undefined || value.trim() === "") {
+    throw new Error(`Missing required ${label} value.`);
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

- Adds a core `openclaw snapshot` CLI surface, not a plugin/extension command.
- Wires `snapshot create`, `snapshot list`, `snapshot verify`, and `snapshot restore` to the local SQLite snapshot provider from PR 1.
- Makes the safe-sync-file workflow user-accessible: create a verified SQLite artifact + manifest that a file-syncing host can persist instead of syncing the live SQLite working set.
- Registers `snapshot` in the core command descriptor catalog, lazy command registry, and command startup policy.
- Positions the CLI as the proof surface for #94646's database-first SQLite layout: today it accepts explicit DB paths, and later PRs can map friendly names to global/control-plane and per-agent/data-plane DBs.
- Covers command registration plus create/list/verify/restore command behavior against a real SQLite database.

## Stack

- Depends on #94694
- Database-first state layout: https://github.com/openclaw/openclaw/pull/94646
- RFC: https://github.com/openclaw/rfcs/pull/20

## Scope

This PR keeps snapshot explicit and opt-in, but core-owned. It does not make every OpenClaw SQLite database automatically durable, does not add object storage, does not add scheduling, and does not change the runtime database choice.

The point is narrower: give operators and Scout/Lobster-style hosts a command surface that can produce and verify the completed artifact set. Hosts should sync that artifact set, not live `*.sqlite`, `*.sqlite-wal`, `*.sqlite-shm`, or `*.sqlite-journal` churn. WAL bundles remain a metrics-gated Phase 2 after the full snapshot command is proven.

## Verification

- `node scripts/run-vitest.mjs run src/commands/snapshot.test.ts src/snapshot/snapshot-provider.test.ts src/cli/program/register.snapshot.test.ts` - passed, 3 files / 13 tests
- `node scripts/run-vitest.mjs run src/cli/program/register.backup.test.ts src/cli/program/subcli-descriptors.test.ts` - passed, 2 files / 8 tests
- `node_modules\.bin\oxlint src\commands\snapshot.ts src\commands\snapshot.test.ts src\snapshot src\cli\program\register.snapshot.ts src\cli\program\register.snapshot.test.ts src\cli\program\core-command-descriptors.ts src\cli\program\command-registry-core.ts src\cli\command-catalog.ts` - passed
- `git diff --check` - passed

## Real behavior proof

Behavior or issue addressed:
Core `openclaw snapshot` command handlers can create, list, verify, and restore SQLite-safe snapshot artifacts. This is the CLI proof layer for the safe sync artifact boundary and the database-first SQLite target model from #94646.

Real environment tested:
Windows source checkout at `C:\src\openclaw-snapshot-pr1`, Node/Vitest source harness, core Commander registration tests, and snapshot command functions backed by a real `node:sqlite` database.

Exact steps or command run after this patch:
1. `node scripts/run-vitest.mjs run src/commands/snapshot.test.ts src/snapshot/snapshot-provider.test.ts src/cli/program/register.snapshot.test.ts`
2. `node scripts/run-vitest.mjs run src/cli/program/register.backup.test.ts src/cli/program/subcli-descriptors.test.ts`
3. `node_modules\.bin\oxlint src\commands\snapshot.ts src\commands\snapshot.test.ts src\snapshot src\cli\program\register.snapshot.ts src\cli\program\register.snapshot.test.ts src\cli\program\core-command-descriptors.ts src\cli\program\command-registry-core.ts src\cli\command-catalog.ts`
4. `git diff --check`

Evidence after fix:
- Snapshot command/provider/registration tests passed: 3 files / 13 tests.
- Backup registration and sub-CLI descriptor regression tests passed: 2 files / 8 tests.
- Oxlint completed cleanly for the changed core command/provider files.
- `git diff --check` completed with no whitespace errors.

Observed result after fix:
The core `snapshot` command group is registered with `create`, `list`, `verify`, and `restore`. The command functions create a snapshot from a real SQLite database, list it, verify manifest/hash/integrity, restore it, and read the restored row successfully.

What was not tested:
Full packaged CLI execution was not tested in this PR; the source harness covers command registration and command behavior directly. Cloud/object-store snapshot repositories, friendly target names for global/per-agent DBs, backup integration, file-sync host integration, SQLite-aware WAL bundles, and failover integration remain follow-up work.