### PR TITLE
fix(workboard): hide archived cards from cli list

### DIFF
--- a/docs/cli/workboard.md
+++ b/docs/cli/workboard.md
@@ -22,7 +22,7 @@ openclaw gateway restart
 ## Usage
 
 ```bash
-openclaw workboard list [--board <id>] [--status <status>] [--json]
+openclaw workboard list [--board <id>] [--status <status>] [--include-archived] [--json]
 openclaw workboard create <title...> [--notes <text>] [--status <status>] [--priority <priority>] [--agent <id>] [--board <id>] [--labels <items>] [--json]
 openclaw workboard show <id> [--json]
 openclaw workboard dispatch [--url <url>] [--token <token>] [--timeout <ms>] [--json]
@@ -37,6 +37,7 @@ unambiguous prefix when a command accepts a card id.
 ```bash
 openclaw workboard list
 openclaw workboard list --board default --status ready
+openclaw workboard list --include-archived
 openclaw workboard list --json
 ```
 
@@ -47,14 +48,16 @@ Text output is compact:
 ```
 
 Columns are id prefix, status, priority, board id, optional agent id, and title.
+Archived cards are hidden by default; pass `--include-archived` to show them.
 
 Flags:
 
-| Flag                | Purpose                                  |
-| ------------------- | ---------------------------------------- |
-| `--board <id>`      | Limit results to one board namespace     |
-| `--status <status>` | Limit results to one Workboard status    |
-| `--json`            | Print the full card list as machine JSON |
+| Flag                 | Purpose                                  |
+| -------------------- | ---------------------------------------- |
+| `--board <id>`       | Limit results to one board namespace     |
+| `--status <status>`  | Limit results to one Workboard status    |
+| `--include-archived` | Include archived cards                   |
+| `--json`             | Print the full card list as machine JSON |
 
 ## `create`
 

--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -106,6 +106,48 @@ describe("registerWorkboardCli", () => {
     expect(showOutput).toContain("[redacted]");
   });
 
+  it("hides archived cards from list output by default", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    await store.create({ title: "Active card" });
+    const archived = await store.create({ title: "Archived card" });
+    await store.archive(archived.id, true);
+    const program = createProgram(store);
+
+    const textOutput = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list"], { from: "user" });
+    });
+    const jsonOutput = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list", "--json"], { from: "user" });
+    });
+
+    expect(textOutput).toContain("Active card");
+    expect(textOutput).not.toContain("Archived card");
+    expect(jsonOutput).toContain("Active card");
+    expect(jsonOutput).not.toContain("Archived card");
+  });
+
+  it("includes archived cards when list uses include-archived", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    await store.create({ title: "Active card" });
+    const archived = await store.create({ title: "Archived card" });
+    await store.archive(archived.id, true);
+    const program = createProgram(store);
+
+    const textOutput = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list", "--include-archived"], { from: "user" });
+    });
+    const jsonOutput = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list", "--include-archived", "--json"], {
+        from: "user",
+      });
+    });
+
+    expect(textOutput).toContain("Active card");
+    expect(textOutput).toContain("Archived card");
+    expect(jsonOutput).toContain("Active card");
+    expect(jsonOutput).toContain("Archived card");
+  });
+
   it("does not fall back to local dispatch for explicit gateway targets", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const card = await store.create({ title: "Remote target", status: "ready" });

--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -11,6 +11,12 @@ type JsonOptions = {
   json?: boolean;
 };
 
+type WorkboardListOptions = JsonOptions & {
+  board?: string;
+  includeArchived?: boolean;
+  status?: string;
+};
+
 type GatewayOptions = JsonOptions & {
   url?: string;
   token?: string;
@@ -130,9 +136,13 @@ export function registerWorkboardCli(params: { program: Command; store: Workboar
     .description("List Workboard cards")
     .option("--board <id>", "Board id")
     .option("--status <status>", "Filter by status")
+    .option("--include-archived", "Include archived cards", false)
     .option("--json", "Print JSON", false)
-    .action(async (options: JsonOptions & { board?: string; status?: string }) => {
+    .action(async (options: WorkboardListOptions) => {
       let cards = await params.store.list({ boardId: options.board });
+      if (!options.includeArchived) {
+        cards = cards.filter((card) => !card.metadata?.archivedAt);
+      }
       if (options.status) {
         cards = cards.filter((card) => card.status === options.status);
       }


### PR DESCRIPTION
## Summary

- Hide archived Workboard cards from `openclaw workboard list` by default, matching the Workboard tool and slash-command list behavior.
- Add `--include-archived` so operators can still inspect archived cards from the terminal.
- Document the default filtering behavior and new flag.
- Out of scope: changing `WorkboardStore.list`, archive semantics, or non-CLI Workboard surfaces.

## Linked context

Closes #94555

Related #94555

Was this requested by a maintainer or owner?

No direct maintainer request; this follows the issue-fix-agent qualified path for a queueable, source-reproduced issue.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw workboard list` no longer prints archived cards unless `--include-archived` is set.
- Real environment tested: Local OpenClaw checkout running the real Workboard commander CLI against a temporary Workboard SQLite database under `/private/tmp`.
- Exact steps or command run after this patch: `env NODE_PATH=$PWD/node_modules node --import tsx /private/tmp/workboard-cli-proof.ts`
- Evidence after fix:

```text
$ openclaw workboard create Active proof card
c56e640c  todo      normal  default  Active proof card
$ openclaw workboard create Archived proof card
d83be64f  todo      normal  default  Archived proof card
$ openclaw workboard list
c56e640c  todo      normal  default  Active proof card
$ openclaw workboard list --include-archived
c56e640c  todo      normal  default  Active proof card
d83be64f  todo      normal  default  Archived proof card
```

- Observed result after fix: Default terminal list output hid the archived card; `--include-archived` showed both active and archived cards.
- What was not tested: A packaged installed `openclaw workboard list` run against a real user state database.
- Proof limitations or environment constraints: `pnpm docs:list` was attempted before editing docs but failed because pnpm's dependency status check triggered `pnpm install` and timed out downloading registry tarballs even after a network-enabled retry.
- Before evidence: Issue #94555 includes the source-level before behavior and reproduction.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/workboard/src/cli.test.ts extensions/workboard/src/tools.test.ts extensions/workboard/src/command.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review the local diff for issue #94555 only: Workboard terminal CLI list should hide archived cards by default and expose --include-archived, matching existing Workboard tool/slash-command behavior. Scope is extensions/workboard/src/cli.ts, cli tests, and docs/cli/workboard.md."`
- `env NODE_PATH=$PWD/node_modules node --import tsx /private/tmp/workboard-cli-proof.ts`

Regression coverage added:

- CLI list text and JSON output hide archived cards by default.
- CLI list text and JSON output include archived cards with `--include-archived`.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Archived Workboard cards are hidden from terminal list output by default.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Operators who depended on `workboard list` showing archived cards by default now need `--include-archived`.

How is that risk mitigated?

The new flag preserves access to archived cards, and the default now matches existing Workboard tool and slash-command behavior.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

CI and any maintainer-requested real packaged CLI proof.

Which bot or reviewer comments were addressed?

Local autoreview reported no accepted/actionable findings.
