### PR TITLE
fix(skills/trello): add curl to requires.bins to match body examples (fixes #94727)

### DIFF
--- a/skills/trello/SKILL.md
+++ b/skills/trello/SKILL.md
@@ -7,7 +7,7 @@ metadata:
     "openclaw":
       {
         "emoji": "📋",
-        "requires": { "bins": ["jq"], "env": ["TRELLO_API_KEY", "TRELLO_TOKEN"] },
+        "requires": { "bins": ["curl", "jq"], "env": ["TRELLO_API_KEY", "TRELLO_TOKEN"] },
         "install":
           [
             {


### PR DESCRIPTION
## Summary

`skills/trello/SKILL.md` declares `requires.bins: ["jq"]` in its frontmatter, but every code example in the body uses `curl` (12 occurrences across all documented commands — list boards, list lists, list cards, create card, move card, update card, comment on card).

This means `openclaw skills check` / `openclaw doctor` marks the Trello skill as ready on systems without `curl`, but the agent's first command will fail at the shell.

## Changes

Added `"curl"` to `requires.bins` in the skill frontmatter, changing:

```yaml
"requires": { "bins": ["jq"], "env": ["TRELLO_API_KEY", "TRELLO_TOKEN"] }
```

to:

```yaml
"requires": { "bins": ["curl", "jq"], "env": ["TRELLO_API_KEY", "TRELLO_TOKEN"] }
```

This aligns the gate with actual usage, matching the pattern used by sibling skills:
- `skills/notion/SKILL.md` — `anyBins: ["ntn", "curl"]`
- `skills/openai-whisper-api/SKILL.md` — `bins: ["curl", "node"]`

## Real behavior proof

- **Behavior addressed:** Trello skill `requires.bins` gate missing `curl` despite all body examples using it
- **Environment tested:** macOS 26.4.1, openclaw upstream/main (HEAD 55323103)
- **Steps run after the patch:** Verified `requires.bins` now includes `curl`, confirmed all 12 curl occurrences in body are now covered by the gate, confirmed sibling skills (notion, openai-whisper-api) use the same pattern
- **Evidence after fix:**

```
$ node -e "const fs = require('fs'); const c = fs.readFileSync('skills/trello/SKILL.md', 'utf8'); const m = c.match(/\"requires\":\\s*\\{[^}]*\"bins\":\\s*\\[([^\\]]*)\\]/); console.log('requires.bins:', m ? m[1] : 'NOT FOUND'); console.log('curl in body:', (c.match(/curl/g)||[]).length);"
requires.bins: "curl", "jq"
curl in body: 12

$ grep -n 'requires.*bins' skills/trello/SKILL.md
10:        "requires": { "bins": ["curl", "jq"], "env": ["TRELLO_API_KEY", "TRELLO_TOKEN"] },
```

- **Observed result after fix:** The `requires.bins` array now includes both `curl` and `jq`, correctly gating on all binaries the skill actually uses. `openclaw skills check` will no longer report Trello as ready on curl-less systems.
- **What was not tested:** Runtime behavior of `openclaw skills check` (requires full OpenClaw installation). The fix is a metadata-only change with no runtime code impact.
