### PR TITLE
fix(discord): use configured statusReactions.timing instead of DEFAULT_TIMING

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1280,13 +1280,63 @@ describe("processDiscordMessage ack reactions", () => {
 
     expect(getReactionEmojis()).toContain(DEFAULT_EMOJIS.done);
 
-    await vi.advanceTimersByTimeAsync(2_000);
-    await vi.runAllTimersAsync();
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.doneHoldMs);
+    expect(sendMocks.removeReactionDiscord).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      DEFAULT_EMOJIS.done,
+      expect.anything(),
+    );
 
+    await vi.advanceTimersByTimeAsync(2_000 - DEFAULT_TIMING.doneHoldMs);
+    await vi.runAllTimersAsync();
     expect(sendMocks.removeReactionDiscord).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
       DEFAULT_EMOJIS.done,
+      expect.anything(),
+    );
+  });
+
+  it("uses configured statusReactions.timing.errorHoldMs for error terminal cleanup", async () => {
+    vi.useFakeTimers();
+    dispatchInboundMessage.mockResolvedValueOnce({
+      queuedFinal: false,
+      counts: { final: 0, tool: 0, block: 0 },
+      failedCounts: { final: 1 },
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      cfg: {
+        messages: {
+          ackReaction: "👀",
+          removeAckAfterReply: true,
+          statusReactions: {
+            timing: { errorHoldMs: 4_000, debounceMs: 0 },
+          },
+        },
+        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(getReactionEmojis()).toContain(DEFAULT_EMOJIS.error);
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.errorHoldMs);
+    expect(sendMocks.removeReactionDiscord).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      DEFAULT_EMOJIS.error,
+      expect.anything(),
+    );
+
+    await vi.advanceTimersByTimeAsync(4_000 - DEFAULT_TIMING.errorHoldMs);
+    await vi.runAllTimersAsync();
+    expect(sendMocks.removeReactionDiscord).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      DEFAULT_EMOJIS.error,
       expect.anything(),
     );
   });

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1256,90 +1256,69 @@ describe("processDiscordMessage ack reactions", () => {
     });
   });
 
-  it("uses configured statusReactions.timing.doneHoldMs/errorHoldMs instead of DEFAULT_TIMING", async () => {
-    vi.useFakeTimers();
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.replyOptions?.onReasoningStream?.();
-      return createNoQueuedDispatchResult();
-    });
+  it.each([
+    {
+      outcome: "done",
+      timingKey: "doneHoldMs",
+      configuredHoldMs: 2_000,
+      terminalEmoji: DEFAULT_EMOJIS.done,
+    },
+    {
+      outcome: "error",
+      timingKey: "errorHoldMs",
+      configuredHoldMs: 4_000,
+      terminalEmoji: DEFAULT_EMOJIS.error,
+    },
+  ] as const)(
+    "uses configured statusReactions.timing.$timingKey for $outcome cleanup",
+    async ({ outcome, timingKey, configuredHoldMs, terminalEmoji }) => {
+      vi.useFakeTimers();
+      dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+        if (outcome === "done") {
+          await params?.replyOptions?.onReasoningStream?.();
+          return createNoQueuedDispatchResult();
+        }
+        return {
+          queuedFinal: false,
+          counts: { final: 0, tool: 0, block: 0 },
+          failedCounts: { final: 1 },
+        };
+      });
 
-    const ctx = await createAutomaticSourceDeliveryContext({
-      cfg: {
-        messages: {
-          ackReaction: "👀",
-          removeAckAfterReply: true,
-          statusReactions: {
-            timing: { doneHoldMs: 2_000, debounceMs: 0 },
+      const ctx = await createAutomaticSourceDeliveryContext({
+        cfg: {
+          messages: {
+            ackReaction: "👀",
+            removeAckAfterReply: true,
+            statusReactions: {
+              timing: { [timingKey]: configuredHoldMs, debounceMs: 0 },
+            },
           },
+          session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
         },
-        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
-      },
-    });
+      });
 
-    await runProcessDiscordMessage(ctx);
+      await runProcessDiscordMessage(ctx);
+      expect(getReactionEmojis()).toContain(terminalEmoji);
 
-    expect(getReactionEmojis()).toContain(DEFAULT_EMOJIS.done);
+      await vi.advanceTimersByTimeAsync(configuredHoldMs - 1);
+      expect(sendMocks.removeReactionDiscord).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        terminalEmoji,
+        expect.anything(),
+      );
 
-    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.doneHoldMs);
-    expect(sendMocks.removeReactionDiscord).not.toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      DEFAULT_EMOJIS.done,
-      expect.anything(),
-    );
-
-    await vi.advanceTimersByTimeAsync(2_000 - DEFAULT_TIMING.doneHoldMs);
-    await vi.runAllTimersAsync();
-    expect(sendMocks.removeReactionDiscord).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      DEFAULT_EMOJIS.done,
-      expect.anything(),
-    );
-  });
-
-  it("uses configured statusReactions.timing.errorHoldMs for error terminal cleanup", async () => {
-    vi.useFakeTimers();
-    dispatchInboundMessage.mockResolvedValueOnce({
-      queuedFinal: false,
-      counts: { final: 0, tool: 0, block: 0 },
-      failedCounts: { final: 1 },
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      cfg: {
-        messages: {
-          ackReaction: "👀",
-          removeAckAfterReply: true,
-          statusReactions: {
-            timing: { errorHoldMs: 4_000, debounceMs: 0 },
-          },
-        },
-        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
-      },
-    });
-
-    await runProcessDiscordMessage(ctx);
-
-    expect(getReactionEmojis()).toContain(DEFAULT_EMOJIS.error);
-
-    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.errorHoldMs);
-    expect(sendMocks.removeReactionDiscord).not.toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      DEFAULT_EMOJIS.error,
-      expect.anything(),
-    );
-
-    await vi.advanceTimersByTimeAsync(4_000 - DEFAULT_TIMING.errorHoldMs);
-    await vi.runAllTimersAsync();
-    expect(sendMocks.removeReactionDiscord).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      DEFAULT_EMOJIS.error,
-      expect.anything(),
-    );
-  });
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.runAllTimersAsync();
+      expect(sendMocks.removeReactionDiscord).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        terminalEmoji,
+        expect.anything(),
+      );
+    },
+  );
 });
 
 describe("processDiscordMessage session routing", () => {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1255,6 +1255,41 @@ describe("processDiscordMessage ack reactions", () => {
       removeAckAfterReply: true,
     });
   });
+
+  it("uses configured statusReactions.timing.doneHoldMs/errorHoldMs instead of DEFAULT_TIMING", async () => {
+    vi.useFakeTimers();
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onReasoningStream?.();
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      cfg: {
+        messages: {
+          ackReaction: "👀",
+          removeAckAfterReply: true,
+          statusReactions: {
+            timing: { doneHoldMs: 2_000, debounceMs: 0 },
+          },
+        },
+        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(getReactionEmojis()).toContain(DEFAULT_EMOJIS.done);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.runAllTimersAsync();
+
+    expect(sendMocks.removeReactionDiscord).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      DEFAULT_EMOJIS.done,
+      expect.anything(),
+    );
+  });
 });
 
 describe("processDiscordMessage session routing", () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -301,6 +301,10 @@ async function processDiscordMessageInner(
     messageId: message.id,
     reactionContext: ackReactionContext,
   });
+  const statusReactionTiming = {
+    ...DEFAULT_TIMING,
+    ...cfg.messages?.statusReactions?.timing,
+  };
   let statusReactionTarget = `${messageChannelId}/${message.id}`;
   let statusReactionsActive = statusReactionsEnabled;
   let statusReactions = createStatusReactionController({
@@ -308,7 +312,7 @@ async function processDiscordMessageInner(
     adapter: discordAdapter,
     initialEmoji: ackReaction,
     emojis: cfg.messages?.statusReactions?.emojis,
-    timing: cfg.messages?.statusReactions?.timing,
+    timing: statusReactionTiming,
     onError: (err) => {
       logAckFailure({
         log: logVerbose,
@@ -318,7 +322,6 @@ async function processDiscordMessageInner(
       });
     },
   });
-  const resolvedTiming = { ...DEFAULT_TIMING, ...cfg.messages?.statusReactions?.timing };
   const resolveTrackedReactionChannelId = async (
     args: Record<string, unknown>,
   ): Promise<string> => {
@@ -394,7 +397,7 @@ async function processDiscordMessageInner(
       adapter: trackedAdapter,
       initialEmoji: emoji,
       emojis: cfg.messages?.statusReactions?.emojis,
-      timing: cfg.messages?.statusReactions?.timing,
+      timing: statusReactionTiming,
       onError: (err) => {
         logAckFailure({
           log: logVerbose,
@@ -1333,8 +1336,8 @@ async function processDiscordMessageInner(
           void (async () => {
             await sleep(
               dispatchError || finalDeliveryFailed
-                ? resolvedTiming.errorHoldMs
-                : resolvedTiming.doneHoldMs,
+                ? statusReactionTiming.errorHoldMs
+                : statusReactionTiming.doneHoldMs,
             );
             await statusReactions.clear();
           })();

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -318,6 +318,7 @@ async function processDiscordMessageInner(
       });
     },
   });
+  const resolvedTiming = { ...DEFAULT_TIMING, ...cfg.messages?.statusReactions?.timing };
   const resolveTrackedReactionChannelId = async (
     args: Record<string, unknown>,
   ): Promise<string> => {
@@ -1332,8 +1333,8 @@ async function processDiscordMessageInner(
           void (async () => {
             await sleep(
               dispatchError || finalDeliveryFailed
-                ? DEFAULT_TIMING.errorHoldMs
-                : DEFAULT_TIMING.doneHoldMs,
+                ? resolvedTiming.errorHoldMs
+                : resolvedTiming.doneHoldMs,
             );
             await statusReactions.clear();
           })();


### PR DESCRIPTION
## What Problem This Solves

Discord already passes `messages.statusReactions.timing` to the lifecycle controller, but terminal cleanup still slept the hardcoded `DEFAULT_TIMING.doneHoldMs` / `errorHoldMs`. Configured terminal hold windows were therefore ignored even though the same settings work in sibling channels.

Closes #78431.

## Why This Change Was Made

Resolve the status-reaction timing once from defaults plus config, pass that same snapshot to both Discord controller instances, and use it for terminal cleanup. This keeps partial-config fallback behavior while removing the split between controller timing and finalizer timing.

The regression is table-driven across successful and failed delivery, proving both configured terminal keys without duplicating the message-handler setup.

## User Impact

Discord done/error reactions remain visible for the configured `doneHoldMs` / `errorHoldMs` before cleanup. Defaults and `removeAckAfterReply: false` behavior remain unchanged. No new config or API surface.

## Evidence

- Exact maintained head: `52e420aa561d804ec445abb852b128af4d55af28`.
- Live Discord probe on that head with `doneHoldMs=30000`: terminal ✅ remained present across samples 9.93 seconds apart—well beyond the old 1.5-second default—and cleared on the later sample.
- Exact head built successfully in the dedicated maintainer QA environment; the host was then restored to its original source, config, and connected state.
- Table-driven fake-timer regression covers configured done and error cleanup thresholds.
- Fresh full-branch autoreview: no findings, confidence 0.98.
- `oxfmt` and `git diff --check`: clean.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/28815264612

The first CI attempt had one unrelated Telegram Crabbox child-liveness flake after 4,723 tests passed; that isolated shard was rerun.
