### PR TITLE
fix(terminal-core): replace clackNote with own box rendering to prevent path splitting

### DIFF
--- a/packages/terminal-core/src/note.test.ts
+++ b/packages/terminal-core/src/note.test.ts
@@ -1,0 +1,143 @@
+// Terminal Core tests cover note behavior.
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { stripAnsi } from "./ansi.js";
+import { note, withSuppressedNotes, wrapNoteMessage } from "./note.js";
+
+function spyStdoutWrite() {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    if (typeof chunk === "string") chunks.push(chunk);
+    return true;
+  });
+  return { spy, chunks };
+}
+
+function setColumns(n: number) {
+  Object.defineProperty(process.stdout, "columns", {
+    value: n,
+    configurable: true,
+  });
+}
+
+describe("wrapNoteMessage", () => {
+  it("preserves a copy-sensitive path that exceeds the wrap width", () => {
+    const longPath =
+      "~/.openclaw/agents/main/sessions/9c2acae5-841f-4aea-936b-fdb513b60202.jsonl.lock";
+    const msg = `- Found lock at ${longPath} pid=86519 (alive)`;
+    const result = wrapNoteMessage(msg, { columns: 80, maxWidth: 68 });
+    const lines = result.split("\n");
+    const pathLine = lines.find((l) => l.includes(".jsonl.lock"));
+    expect(pathLine).toBeDefined();
+    expect(pathLine!).toContain(longPath);
+  });
+
+  it("preserves a URL that exceeds the wrap width", () => {
+    const url =
+      "https://example.com/very/long/path/that/exceeds/normal/line/width/endpoint/v1/users";
+    const msg = `- See ${url} for details`;
+    const result = wrapNoteMessage(msg, { columns: 80, maxWidth: 70 });
+    const lines = result.split("\n");
+    const urlLine = lines.find((l) => l.includes("https://"));
+    expect(urlLine).toBeDefined();
+    expect(urlLine!).toContain(url);
+  });
+
+  it("wraps long non-copy-sensitive words at the wrap width", () => {
+    const longWord = "supercalifragilisticexpialidocious";
+    const result = wrapNoteMessage(`- ${longWord}`, {
+      columns: 80,
+      maxWidth: 20,
+    });
+    const lines = result.split("\n");
+    expect(lines.length).toBeGreaterThan(1);
+  });
+});
+
+describe("note box rendering", () => {
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+  let chunks: string[];
+
+  beforeEach(() => {
+    setColumns(80);
+    const spied = spyStdoutWrite();
+    writeSpy = spied.spy;
+    chunks = spied.chunks;
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+  });
+
+  function getOutput(): string {
+    return stripAnsi(chunks.join(""));
+  }
+
+  it("renders a note box with title and message", () => {
+    note("hello world", "Title");
+    const out = getOutput();
+    expect(out).toContain("◇");
+    expect(out).toContain("Title");
+    expect(out).toContain("hello world");
+    expect(out).toContain("╮");
+    expect(out).toContain("╰");
+    expect(out).toContain("╯");
+  });
+
+  it("renders content lines with proper box borders", () => {
+    note("- item one\n- item two", "List");
+    const out = getOutput();
+    expect(out).toContain("│");
+    expect(out).toContain("- item one");
+    expect(out).toContain("- item two");
+  });
+
+  it("does not re-wrap a copy-sensitive path inside the box", () => {
+    const lockPath =
+      "~/.openclaw/agents/main/sessions/9c2acae5-841f-4aea-936b-fdb513b60202.jsonl.lock";
+    const msg = `- Found 1 session lock file.\n- ${lockPath} pid=86519 (alive) age=2m47s stale=no`;
+    note(msg, "Session locks");
+    const out = getOutput();
+    // The path must appear intact — not split across lines inside the box.
+    expect(out).toContain(lockPath);
+    // The extension ".jsonl.lock" must appear as one unbroken unit.
+    expect(out).toContain(".jsonl.lock");
+  });
+
+  it("allows a copy-sensitive line to overflow the box right border", () => {
+    const longPath = "/" + "a/".repeat(30) + "very-long-filename.jsonl.lock";
+    const msg = `- ${longPath}`;
+    note(msg, "Path overflow");
+    const out = getOutput();
+    // The path must appear intact.
+    expect(out).toContain(longPath);
+    // The bottom border should still be rendered.
+    expect(out).toContain("╰");
+  });
+});
+
+describe("note suppression", () => {
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setColumns(80);
+    writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it("suppresses output when OPENCLAW_SUPPRESS_NOTES is set", () => {
+    vi.stubEnv("OPENCLAW_SUPPRESS_NOTES", "1");
+    note("should not appear");
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it("suppresses output inside withSuppressedNotes callback", () => {
+    withSuppressedNotes(() => {
+      note("should not appear");
+    });
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/terminal-core/src/note.ts
+++ b/packages/terminal-core/src/note.ts
@@ -1,9 +1,9 @@
 // Terminal Core module implements note behavior.
 import { AsyncLocalStorage } from "node:async_hooks";
-import { note as clackNote } from "@clack/prompts";
 import { visibleWidth } from "./ansi.js";
 import { stylePromptTitle } from "./prompt-style.js";
 import { normalizeLowercaseStringOrEmpty } from "./string.js";
+import { isRich, theme } from "./theme.js";
 
 const MIN_NOTE_COLUMNS = 80;
 const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
@@ -199,6 +199,86 @@ function createNoteOutput(columns: number): NodeJS.WriteStream {
   return output;
 }
 
+/**
+ * Returns true when a line exceeds maxWidth and at least one of the words on
+ * that line is a copy-sensitive token (path, URL, file-like name).  Such lines
+ * are allowed to overflow the note box rather than being re-wrapped, because
+ * breaking them mid-token defeats the reason they are surfaced — the user needs
+ * to copy-paste them unbroken.
+ */
+function hasCopySensitiveOverflow(line: string, maxWidth: number): boolean {
+  if (visibleWidth(line) <= maxWidth) return false;
+  const words = line.split(/\s+/);
+  return words.some((w) => isCopySensitiveToken(w));
+}
+
+/**
+ * Render a bordered note box directly, bypassing @clack/prompts' note() so that
+ * OpenClaw owns the text-wrapping decisions end-to-end.  wrapNoteMessage already
+ * produces correctly-wrapped lines (copy-sensitive tokens are kept intact and
+ * allowed to overflow the wrap width).  clackNote would re-wrap them at the box
+ * border, splitting paths mid-token.  Building the box ourselves eliminates that
+ * second pass.
+ *
+ * Lines that contain copy-sensitive tokens and exceed the content area width are
+ * allowed to overflow past the right border of the box.
+ */
+function renderNoteBox(
+  message: string,
+  title: string | undefined,
+  columns: number,
+  output: NodeJS.WriteStream,
+) {
+  const rich = isRich();
+  const dim = (s: string) => (rich ? theme.muted(s) : s);
+  const accent = (s: string) => (rich ? theme.accent(s) : s);
+
+  const titleText = title ?? "";
+  const titleWidth = visibleWidth(titleText);
+  const contentLines = message.split("\n");
+
+  const boxH = dim("─");
+  const boxV = dim("│");
+  const cornerTR = dim("╮");
+  const cornerBL = dim("╰");
+  const cornerBR = dim("╯");
+  const step = accent("◇");
+
+  const borderLeftWidth = 3; // "│  "
+  const borderRightWidth = 3; // "  │"
+  const borderOverhead = borderLeftWidth + borderRightWidth; // 6
+
+  // Content area width: max of title and non-copy-sensitive lines.
+  // Copy-sensitive overflow lines are allowed to exceed this.
+  let contentWidth = Math.max(titleWidth, 40);
+  for (const line of contentLines) {
+    const w = visibleWidth(line);
+    if (w > contentWidth && !hasCopySensitiveOverflow(line, columns - borderOverhead)) {
+      contentWidth = w;
+    }
+  }
+  contentWidth = Math.min(contentWidth, columns - borderOverhead);
+
+  // Title line: ◇  Title ───╮
+  const titleDashLen = Math.max(1, contentWidth - titleWidth + 1);
+  output.write(`${step}  ${titleText} ${boxH.repeat(titleDashLen)}${cornerTR}\n`);
+
+  // Content lines
+  for (const line of contentLines) {
+    const lineWidth = visibleWidth(line);
+    if (lineWidth > contentWidth && hasCopySensitiveOverflow(line, contentWidth)) {
+      // Copy-sensitive overflow: let the line extend past the box right border.
+      output.write(`${boxV}  ${line}\n`);
+    } else {
+      const pad = Math.max(0, contentWidth - lineWidth);
+      output.write(`${boxV}  ${line}${" ".repeat(pad)}  ${boxV}\n`);
+    }
+  }
+
+  // Bottom line: ╰───╯
+  output.write(`${cornerBL}${boxH.repeat(contentWidth + 4)}${cornerBR}\n`);
+}
+
 export function note(message: unknown, title?: string) {
   if (
     suppressNotesStorage.getStore() === true ||
@@ -207,10 +287,9 @@ export function note(message: unknown, title?: string) {
     return;
   }
   const columns = resolveNoteColumns(process.stdout.columns);
-  clackNote(wrapNoteMessage(message, { columns }), stylePromptTitle(title), {
-    output: createNoteOutput(columns),
-    format: (line) => line,
-  });
+  const wrapped = wrapNoteMessage(message, { columns });
+  const output = createNoteOutput(columns);
+  renderNoteBox(wrapped, stylePromptTitle(title), columns, output);
 }
 
 export function withSuppressedNotes<T>(callback: () => T): T {


### PR DESCRIPTION
## Summary

`openclaw doctor` mangles long file paths inside `note(...)` boxes because the downstream `clackNote()` call re-wraps text that `wrapNoteMessage()` already correctly preserved. The fix replaces the `@clack/prompts` note box rendering with an OpenClaw-owned box renderer so copy-sensitive tokens (paths, URLs) stay intact.

Fixes #94730

## Root cause

`wrapNoteMessage` in `packages/terminal-core/src/note.ts` correctly identifies copy-sensitive tokens (paths starting with `/`, `~/`, `./`, URLs, Windows drives, etc.) and allows them to overflow the wrap width rather than being broken mid-token. However, `note()` then calls `clackNote()` which performs its own width-based wrapping via `fast-wrap-ansi`, unaware of the copy-sensitive semantics. The double-wrap causes the path to be split at the box border, breaking file extensions like `.jsonl.lock` into `.js` + `onl.lock`.

## Fix

Remove the `clackNote()` call and build the bordered note box directly in `renderNoteBox()`. The new renderer:
- Uses the output of `wrapNoteMessage()` as-is (no re-wrapping)
- Allows lines containing copy-sensitive tokens to overflow the box right border
- Renders the same visual format (`◇ Title ─╮`, `│ content │`, `╰───╯`)
- Supports rich (colored) and plain terminal output via the existing `theme`/`isRich` helpers

## Real behavior proof

**Behavior addressed**: Copy-sensitive file paths were split mid-extension inside `openclaw doctor` note boxes

**Real setup tested**:
- **Runtime**: Node 22.19+, Linux
- **Environment**: 80-column terminal (`COLUMNS=80`)

**Exact steps or command run after fix**:

```bash
pnpm test packages/terminal-core/src/note.test.ts
```

**After-fix evidence**:

```
✓ |unit| packages/terminal-core/src/note.test.ts (9 tests) 151ms
  ✓ wrapNoteMessage (3)
    ✓ preserves a copy-sensitive path that exceeds the wrap width
    ✓ preserves a URL that exceeds the wrap width
    ✓ wraps long non-copy-sensitive words at the wrap width
  ✓ note box rendering (4)
    ✓ renders a note box with title and message
    ✓ renders content lines with proper box borders
    ✓ does not re-wrap a copy-sensitive path inside the box
    ✓ allows a copy-sensitive line to overflow the box right border
  ✓ note suppression (2)
    ✓ suppresses output when OPENCLAW_SUPPRESS_NOTES is set
    ✓ suppresses output inside withSuppressedNotes callback
```

**Observed result after the fix**: All 9 tests pass. The `.jsonl.lock` path remains unbroken in the box. Copy-sensitive overflow lines extend past the right border without being split. No regressions in `wrapNoteMessage` or note suppression behavior.

**What was not tested**: Full end-to-end `openclaw doctor` run with a real gateway session lock. The box rendering is verified via unit tests that exercise the exact same code path used by `src/commands/doctor-session-locks.ts`.

## Tests and validation

- **New test file**: `packages/terminal-core/src/note.test.ts` (9 tests)
  - 3 tests for `wrapNoteMessage` (path, URL, long-word wrapping)
  - 4 tests for `note()` box rendering (title, borders, path preservation, overflow)
  - 2 tests for note suppression (env var, AsyncLocalStorage)
- **TypeScript**: `pnpm tsgo` — no errors related to note.ts
- **Regression**: All existing terminal-core tests pass

## Risk checklist

**Did user-visible behavior change?** `Yes` — copy-sensitive paths inside note boxes are no longer split; they overflow the right border instead.

**Did config, environment, or migration behavior change?** `No`

**Did security, auth, secrets, network, or tool execution behavior change?** `No`

**What is the highest-risk area?**
- Visual rendering of note boxes may differ slightly from `@clack/prompts` in edge cases (e.g., very narrow terminals, right-to-left text).

**How is that risk mitigated?**
- The box format uses the same Unicode characters and layout measurements as `@clack/prompts`.
- Test coverage validates title, content, borders, and overflow behavior.
- The `note()` function signature is unchanged; callers are unaffected.

## Current review state

- Maintainer review
