### PR TITLE
fix(agents): strip truncation sentinels from replies

### DIFF
--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -244,6 +244,41 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("A\n[tool calls omitted]\n[tool calls omitted]\nB")).toBe("A\nB");
   });
 
+  it("strips standalone truncation sentinel lines from user-facing replies", () => {
+    expect(sanitizeUserFacingText("...(truncated)...")).toBe("");
+    expect(sanitizeUserFacingText("Before\n...(truncated)...\nAfter")).toBe("Before\nAfter");
+    expect(sanitizeUserFacingText("Before\n...[truncated]...\nAfter")).toBe("Before\nAfter");
+    expect(
+      sanitizeUserFacingText("Before\n...[additional startup memory truncated]...\nAfter"),
+    ).toBe("Before\nAfter");
+    expect(sanitizeUserFacingText("Before\n…13 chars truncated…\nAfter")).toBe("Before\nAfter");
+    expect(sanitizeUserFacingText("Before\n…3 tokens truncated…\nAfter")).toBe("Before\nAfter");
+    expect(sanitizeUserFacingText("Before\n[..., 42 more characters truncated]\nAfter")).toBe(
+      "Before\nAfter",
+    );
+    expect(
+      sanitizeUserFacingText(
+        "Before\n[... 123 more characters truncated; rerun with narrower args if needed]\nAfter",
+      ),
+    ).toBe("Before\nAfter");
+    expect(
+      sanitizeUserFacingText("Before\n[...truncated, read AGENTS.md for full content...]\nAfter"),
+    ).toBe("Before\nAfter");
+    expect(sanitizeUserFacingText("Before\n[…truncated 200+100/5000]\nAfter")).toBe(
+      "Before\nAfter",
+    );
+  });
+
+  it("preserves truncation sentinel examples in prose and fenced code", () => {
+    const inline = "What does ...(truncated)... mean?";
+    const fenced = ["Example:", "```text", "...(truncated)...", "```"].join("\n");
+    const indentedFence = ["- Example:", "  ```text", "  ...(truncated)...", "  ```"].join("\n");
+
+    expect(sanitizeUserFacingText(inline)).toBe(inline);
+    expect(sanitizeUserFacingText(fenced)).toBe(fenced);
+    expect(sanitizeUserFacingText(indentedFence)).toBe(indentedFence);
+  });
+
   it("strips legacy uppercase TOOL_CALL blocks before user-facing delivery", () => {
     const input = [
       "Before",

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -73,6 +73,8 @@ const MODEL_CAPACITY_ERROR_USER_MESSAGE =
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
 const TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE = /^[ \t]*\[tool calls omitted\][ \t]*$/i;
+const TRUNCATION_SENTINEL_LINE_RE =
+  /^[ \t]*(?:\.\.\.\(truncated\)\.\.\.|\.\.\.\[[^\]]*truncated[^\]]*\]\.\.\.|\.\.\.<truncated>|…\(truncated(?:\s[^)]*)?\)…|…\d+\s+(?:tokens?|chars?)\s+truncated…|\[\.\.\.,?\s*\d+\s+more\s+characters?\s+truncated(?:;[^\]]+)?\]|\[…truncated(?:\s[^\]]*)?\]|\[\.\.\.truncated,\s*read\s+\S+\s+for\s+full\s+content\.\.\.\])[ \t]*$/i;
 const ERROR_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|codex\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
@@ -380,6 +382,42 @@ function stripToolCallsOmittedPlaceholderLines(text: string): string {
   return result;
 }
 
+function stripTruncationSentinelLines(text: string): string {
+  let result = "";
+  let start = 0;
+  let fence: { char: "`" | "~"; length: number } | null = null;
+  while (start < text.length) {
+    const newlineIndex = text.indexOf("\n", start);
+    const end = newlineIndex === -1 ? text.length : newlineIndex + 1;
+    const chunk = text.slice(start, end);
+    const line = chunk.endsWith("\n") ? chunk.slice(0, -1).replace(/\r$/, "") : chunk;
+    const insideFence = Boolean(fence);
+    if (!TRUNCATION_SENTINEL_LINE_RE.test(line) || insideFence) {
+      result += chunk;
+    }
+    fence = updateMarkdownFenceState(line, fence);
+    start = end;
+  }
+  return result;
+}
+
+function updateMarkdownFenceState(
+  line: string,
+  fence: { char: "`" | "~"; length: number } | null,
+): { char: "`" | "~"; length: number } | null {
+  const match = /^(?: {0,3})(`{3,}|~{3,})/.exec(line);
+  if (!match) {
+    return fence;
+  }
+
+  const marker = match[1] ?? "";
+  const char = marker[0] as "`" | "~";
+  if (fence) {
+    return fence.char === char && marker.length >= fence.length ? null : fence;
+  }
+  return { char, length: marker.length };
+}
+
 function collapseConsecutiveDuplicateBlocks(text: string): string {
   const trimmed = text.trim();
   if (!trimmed) {
@@ -438,9 +476,10 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
   // It is internal scaffolding, so drop standalone placeholder lines before delivery
   // while preserving ordinary inline mentions a user may be discussing.
   const withoutPlaceholder = stripToolCallsOmittedPlaceholderLines(withoutToolCallXml);
+  const withoutTruncationSentinels = stripTruncationSentinelLines(withoutPlaceholder);
   const withoutInternalTraceLines = errorContext
-    ? stripAssistantInternalTraceLines(withoutPlaceholder)
-    : withoutPlaceholder;
+    ? stripAssistantInternalTraceLines(withoutTruncationSentinels)
+    : withoutTruncationSentinels;
   const withoutToolCallBlocks = stripPlainTextToolCallBlocks(
     stripLegacyBracketToolCallBlocks(withoutInternalTraceLines),
   );


### PR DESCRIPTION
Fixes #82121

## Summary

- Strip standalone truncation sentinel lines from final user-facing assistant text.
- Cover OpenClaw and Codex-produced marker forms such as `...(truncated)...`, `...[truncated]...`, `...[additional startup memory truncated]...`, `[... N more characters truncated; rerun with narrower args if needed]`, and `…N tokens/chars truncated…`.
- Preserve ordinary inline prose and fenced Markdown examples, including indented fenced code blocks.

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.agents.json --noEmit`
- `git diff --check HEAD~1..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`

## Real behavior proof

Behavior addressed: final reply sanitization now removes standalone internal truncation sentinel lines before user-facing delivery.

Real environment tested: Local OpenClaw source checkout with the final-text sanitizer regression suite.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts && node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.agents.json --noEmit && git diff --check HEAD~1..HEAD`.

Evidence after fix: The sanitizer test shard passed with 120 tests, the core agents tsgo lane passed, `git diff --check HEAD~1..HEAD` passed, and the final commit-mode Codex autoreview reported no accepted/actionable findings.

Observed result after fix: standalone truncation sentinels are stripped while inline discussion and fenced-code examples remain unchanged.

What was not tested: A live end-to-end model conversation that causes a provider or tool to echo one of these markers; this patch is covered at the final sanitizer boundary where the leak is removed.

## Dependency/source notes

- Checked OpenClaw producers in `src/auto-reply/reply/startup-context.ts`, `src/auto-reply/reply/post-compaction-context.ts`, `src/agents/agent-hooks/compaction-safeguard.ts`, and `src/agents/embedded-agent-runner/context-truncation-notice.ts`.
- Checked Codex truncation marker production in sibling `../codex/codex-rs/utils/string/src/truncate.rs` and `../codex/codex-rs/utils/output-truncation/src/lib.rs`.
