### PR TITLE
fix: preserve copy-safe doctor paths in note boxes

### DIFF
--- a/packages/terminal-core/src/note.ts
+++ b/packages/terminal-core/src/note.ts
@@ -186,6 +186,13 @@ export function resolveNoteColumns(columns: number | undefined): number {
   return columns;
 }
 
+export function resolveNoteOutputColumns(message: string, columns: number): number {
+  const widestLine = message
+    .split("\n")
+    .reduce((max, line) => Math.max(max, visibleWidth(line)), 0);
+  return Math.max(columns, widestLine + 6);
+}
+
 function createNoteOutput(columns: number): NodeJS.WriteStream {
   if (process.stdout.columns === columns) {
     return process.stdout;
@@ -207,8 +214,9 @@ export function note(message: unknown, title?: string) {
     return;
   }
   const columns = resolveNoteColumns(process.stdout.columns);
-  clackNote(wrapNoteMessage(message, { columns }), stylePromptTitle(title), {
-    output: createNoteOutput(columns),
+  const wrappedMessage = wrapNoteMessage(message, { columns });
+  clackNote(wrappedMessage, stylePromptTitle(title), {
+    output: createNoteOutput(resolveNoteOutputColumns(wrappedMessage, columns)),
     format: (line) => line,
   });
 }

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -1,7 +1,8 @@
+import { note as clackNote } from "@clack/prompts";
 // Terminal Core tests cover table behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { visibleWidth } from "./ansi.js";
-import { resolveNoteColumns, wrapNoteMessage } from "./note.js";
+import { resolveNoteColumns, resolveNoteOutputColumns, wrapNoteMessage } from "./note.js";
 import { renderTable } from "./table.js";
 
 function mockProcessPlatform(platform: NodeJS.Platform): void {
@@ -346,6 +347,33 @@ describe("wrapNoteMessage", () => {
     expect(resolveNoteColumns(1)).toBe(80);
     expect(resolveNoteColumns(79)).toBe(80);
     expect(resolveNoteColumns(120)).toBe(120);
+  });
+
+  it("widens note output columns so clack does not re-wrap copy-sensitive lines", () => {
+    const wrapped = wrapNoteMessage(
+      [
+        "- Found 1 session lock file.",
+        "- ~/.openclaw/agents/main/sessions/9c2acae5-841f-4aea-936b-fdb513b60202.jsonl.lock pid=86519 (alive) age=2m47s stale=no",
+      ].join("\n"),
+      { columns: 80 },
+    );
+    const writes: string[] = [];
+    const output = {
+      columns: resolveNoteOutputColumns(wrapped, 80),
+      write(chunk: string) {
+        writes.push(chunk);
+        return true;
+      },
+    } as unknown as NodeJS.WriteStream;
+
+    clackNote(wrapped, "Session locks", { output, format: (line) => line });
+
+    const rendered = writes.join("");
+    expect(rendered).toContain(".jsonl.lock");
+    expect(rendered).not.toContain(".js\n");
+    expect(rendered).toContain(
+      "- ~/.openclaw/agents/main/sessions/9c2acae5-841f-4aea-936b-fdb513b60202.jsonl.lock",
+    );
   });
 
   it("coerces nullish and non-string note messages before wrapping", () => {


### PR DESCRIPTION
## Summary
- widen note output columns to fit already-wrapped copy-sensitive lines before handing them to clack
- keep long doctor/session-lock paths intact instead of letting the note box split `.jsonl.lock` mid-token
- add a regression test that renders the clack note with the adjusted output width

## Testing
- node scripts/run-vitest.mjs packages/terminal-core/src/table.test.ts

Fixes openclaw/openclaw#94730