### PR TITLE
fix(session): avoid misleading rejection message for stale auto overrides in allowlist

### DIFF
--- a/src/auto-reply/reply/get-reply-directives-apply.test.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.test.ts
@@ -21,4 +21,13 @@ describe("formatModelOverrideResetEvent", () => {
       }),
     ).toBe("Model override not allowed for this agent; reverted to github-copilot/gpt-4o.");
   });
+
+  it("describes stale auto override reset without claiming the model is disallowed (#94713)", () => {
+    expect(
+      formatModelOverrideResetEvent({
+        staleRef: "openai/gpt-5.5",
+        initialModelLabel: "openai/gpt-5.5",
+      }),
+    ).toBe("Previous auto-selected model openai/gpt-5.5 reset to default (openai/gpt-5.5).");
+  });
 });

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -67,10 +67,14 @@ function hasOnlyModelDirective(directives: InlineDirectives): boolean {
 
 export function formatModelOverrideResetEvent(params: {
   rejectedRef?: string;
+  staleRef?: string;
   initialModelLabel: string;
 }): string {
   if (params.rejectedRef) {
     return `Model override ${params.rejectedRef} is not allowed for this agent; reverted to ${params.initialModelLabel}. Add ${params.rejectedRef} to agents.defaults.models or pick an allowed model with /model list.`;
+  }
+  if (params.staleRef) {
+    return `Previous auto-selected model ${params.staleRef} reset to default (${params.initialModelLabel}).`;
   }
   return `Model override not allowed for this agent; reverted to ${params.initialModelLabel}.`;
 }
@@ -193,6 +197,7 @@ export async function applyInlineDirectiveOverrides(params: {
     enqueueSystemEvent(
       formatModelOverrideResetEvent({
         rejectedRef: modelState.resetModelOverrideRef,
+        staleRef: modelState.resetStaleOverrideRef,
         initialModelLabel,
       }),
       {

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1205,7 +1205,7 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
     expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
     expect(state.resetModelOverride).toBe(true);
-    expect(state.resetModelOverrideRef).toBe("openrouter/minimax/minimax-m2.7");
+    expect(state.resetStaleOverrideRef).toBe("openrouter/minimax/minimax-m2.7");
   });
 
   it("preserves auto-failover overrides that still carry origin metadata on normal turns", async () => {
@@ -1275,7 +1275,7 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(state.provider).toBe("openai");
     expect(state.model).toBe("gpt-5.5");
     expect(state.resetModelOverride).toBe(true);
-    expect(state.resetModelOverrideRef).toBe("openai/gpt-5.5");
+    expect(state.resetStaleOverrideRef).toBe("openai/gpt-5.5");
     expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
     expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
     expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
@@ -1504,7 +1504,7 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(state.provider).toBe(defaultProvider);
     expect(state.model).toBe(defaultModel);
     expect(state.resetModelOverride).toBe(true);
-    expect(state.resetModelOverrideRef).toBe("openrouter/minimax/minimax-m2.7");
+    expect(state.resetStaleOverrideRef).toBe("openrouter/minimax/minimax-m2.7");
     expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
     expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
     expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
@@ -1706,6 +1706,120 @@ describe("createModelSelectionState auto-failover overrides", () => {
     // Parent session entry is not modified by the child's selection logic.
     expect(sessionStore[parentKey]?.providerOverride).toBe("openrouter");
     expect(state.resetModelOverride).toBe(false);
+  });
+
+  it("does not produce a misleading rejection message when a stale auto override matches a configured allowlist model (#94713)", async () => {
+    // Regression: a stale auto override (modelOverrideSource="auto" without
+    // origin metadata) that matches the primary model must not produce a
+    // "not allowed" rejection when the model IS configured in
+    // agents.defaults.models.  The old code used a single branch for
+    // "stale OR not-allowed" and always set resetModelOverrideRef, which
+    // fed into an error message that told the user the model was forbidden.
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+          models: {
+            "openai/gpt-5.5": {},
+            "openai/gpt-5.4": {},
+          },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            models: [
+              { id: "gpt-5.5", name: "GPT-5.5", input: ["text"] as const },
+              { id: "gpt-5.4", name: "GPT-5.4", input: ["text"] as const },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const sessionKey = "agent:main:dashboard:c1";
+    // Simulate a child session entry that received an auto-fallback model
+    // override matching the configured primary.
+    const sessionEntry = makeEntry({
+      providerOverride: "openai",
+      modelOverride: "gpt-5.5",
+      modelOverrideSource: "auto",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      provider: "openai",
+      model: "gpt-5.5",
+      hasModelDirective: false,
+    });
+
+    // The auto override is stale, but the model IS in agents.defaults.models.
+    // We clear the stale override but must NOT emit a rejection message that
+    // says the model is "not allowed".
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-5.5");
+    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverrideRef).toBeUndefined();
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
+  });
+
+  it("resets model override with rejectedRef when model is absent from allowlist", async () => {
+    // Complementary case: the stale override model is genuinely absent from
+    // agents.defaults.models.  resetModelOverrideRef must be set so the
+    // user-facing message names the forbidden model.
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+          models: {
+            "openai/gpt-5.5": {},
+          },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            models: [{ id: "gpt-5.5", name: "GPT-5.5", input: ["text"] as const }],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const sessionKey = "agent:main:dashboard:c2";
+    const sessionEntry = makeEntry({
+      providerOverride: "openai",
+      modelOverride: "gpt-5.4",
+      modelOverrideSource: "auto",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      provider: "openai",
+      model: "gpt-5.5",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-5.5");
+    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverrideRef).toBe("openai/gpt-5.4");
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
   });
 });
 

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -53,6 +53,7 @@ type ModelSelectionState = {
   allowedModelCatalog: ModelCatalog;
   resetModelOverride: boolean;
   resetModelOverrideRef?: string;
+  resetStaleOverrideRef?: string;
   resolveThinkingCatalog: () => Promise<ModelCatalog | undefined>;
   resolveDefaultThinkingLevel: () => Promise<ThinkLevel>;
   /** Default reasoning level from model capability: "on" if model has reasoning, else "off". */
@@ -75,6 +76,7 @@ export function createFastTestModelSelectionState(params: {
     allowedModelCatalog: [],
     resetModelOverride: false,
     resetModelOverrideRef: undefined,
+    resetStaleOverrideRef: undefined,
     resolveThinkingCatalog: async () => [],
     resolveDefaultThinkingLevel: async () => params.agentCfg?.thinkingDefault as ThinkLevel,
     resolveDefaultReasoningLevel: async () => "off",
@@ -192,6 +194,7 @@ export async function createModelSelectionState(params: {
   let modelCatalog: ModelCatalog | null = null;
   let resetModelOverride = false;
   let resetModelOverrideRef: string | undefined;
+  let resetStaleOverrideRef: string | undefined;
   const agentEntry = params.agentId ? resolveAgentConfig(cfg, params.agentId) : undefined;
   const directStoredOverride = resolvePersistedOverrideModelRef({
     defaultProvider,
@@ -301,7 +304,15 @@ export async function createModelSelectionState(params: {
       }
       resetModelOverride = updated;
       if (updated) {
-        resetModelOverrideRef = key;
+        // Only set the rejected model ref when the model is genuinely absent from
+        // the allowlist.  Stale auto overrides (cleared by lifecycle, not policy)
+        // use a separate key so the user-facing message does not misleadingly claim
+        // the model is forbidden when it is in fact allowed (#94713).
+        if (!visibilityPolicy.allowsKey(key)) {
+          resetModelOverrideRef = key;
+        } else {
+          resetStaleOverrideRef = key;
+        }
       }
     }
   }
@@ -592,7 +603,8 @@ export async function createModelSelectionState(params: {
     allowedModelKeys,
     allowedModelCatalog,
     resetModelOverride,
-    resetModelOverrideRef,
+    resetModelOverrideRef: resetModelOverrideRef,
+    resetStaleOverrideRef: resetStaleOverrideRef,
     resolveThinkingCatalog,
     resolveDefaultThinkingLevel,
     resolveDefaultReasoningLevel,


### PR DESCRIPTION
## Summary

Fix misleading "Model override is not allowed" rejection message during dashboard child-session rollover when the model IS configured in `agents.defaults.models`.

When a stale auto model override is cleared during session lifecycle (e.g. dashboard child-session rollover), the old code always set `resetModelOverrideRef` which produced a "Model override \<X\> is not allowed" event — even when \<X\> IS configured in the allowlist. This made the system appear to reject its own configured model and directed users to add a model that was already present.

The fix separates stale-auto from not-allowed override resets: only `resetModelOverrideRef` is set when the model is genuinely absent from the visibility policy. Stale auto overrides that are still allowed use a new `resetStaleOverrideRef` field, which yields a neutral "Previous auto-selected model reset to default" message.

Fixes #94713

## Real behavior proof

**Behavior addressed**: Stale auto model overrides matching an allowlist entry produced "not allowed" messages

**Real setup tested**:
- **Runtime**: Node 24.16.0, pnpm 7.9.0, Linux x86_64

**Exact steps or command run after fix**:

```bash
pnpm test -- src/auto-reply/reply/model-selection.test.ts src/auto-reply/reply/get-reply-directives-apply.test.ts
```

**After-fix evidence**:

```
 ✓ 62 passed (59 model-selection + 3 formatModelOverrideResetEvent)
```

**Observed result after the fix**: `resetModelOverrideRef` is now `undefined` for stale overrides where the model IS in the allowlist, producing a neutral "Previous auto-selected model reset to default" message instead of the misleading "not allowed" message.

**What was not tested**: Live dashboard child-session rollover scenario (requires full dashboard infrastructure).

## Tests and validation

- 59 model-selection tests pass, including 2 new targeted regression tests
- 3 formatModelOverrideResetEvent tests pass, including 1 new test for the staleRef path
- 3 existing tests updated to expect `resetStaleOverrideRef` instead of `resetModelOverrideRef`

## Risk checklist

Did user-visible behavior change? `Yes` — stale auto override reset message changes from "not allowed" to "reset to default"

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area?
- Edge case where a stale auto override model is genuinely absent from the allowlist

How is that risk mitigated?
- The complementary test case (`resetModelOverrideRef` still set when model absent from allowlist) ensures the disallowed path remains unchanged
- All existing tests pass without modification to the disallowed override detection logic

## Change summary

| File | Change | Details |
|------|--------|---------|
| `src/auto-reply/reply/model-selection.ts` | 6 insertions | Add `resetStaleOverrideRef` field, separate stale from disallowed |
| `src/auto-reply/reply/get-reply-directives-apply.ts` | 3 insertions | Add `staleRef` param to `formatModelOverrideResetEvent` |
| `src/auto-reply/reply/model-selection.test.ts` | 122 insertions | 2 new tests + 3 updated expectations |
| `src/auto-reply/reply/get-reply-directives-apply.test.ts` | 11 insertions | New test for staleRef message |

## Current review state

What is the next action?
- Maintainer review
