### PR TITLE
fix(note): prevent clack from re-breaking copy-sensitive tokens

### DIFF
--- a/packages/terminal-core/src/note.ts
+++ b/packages/terminal-core/src/note.ts
@@ -207,8 +207,13 @@ export function note(message: unknown, title?: string) {
     return;
   }
   const columns = resolveNoteColumns(process.stdout.columns);
-  clackNote(wrapNoteMessage(message, { columns }), stylePromptTitle(title), {
-    output: createNoteOutput(columns),
+  const wrapped = wrapNoteMessage(message, { columns });
+  // Use a wide virtual stream so clack's internal wrap (which runs after our
+  // format callback) does not re-break copy-sensitive tokens that
+  // wrapNoteMessage intentionally kept intact.
+  const wideOutput = createNoteOutput(Math.max(columns, visibleWidth(wrapped) + 12));
+  clackNote(wrapped, stylePromptTitle(title), {
+    output: wideOutput,
     format: (line) => line,
   });
 }

--- a/packages/terminal-core/src/note.ts
+++ b/packages/terminal-core/src/note.ts
@@ -186,6 +186,13 @@ export function resolveNoteColumns(columns: number | undefined): number {
   return columns;
 }
 
+export function resolveNoteOutputColumns(message: string, columns: number): number {
+  const widestLine = message
+    .split("\n")
+    .reduce((max, line) => Math.max(max, visibleWidth(line)), 0);
+  return Math.max(columns, widestLine + 6);
+}
+
 function createNoteOutput(columns: number): NodeJS.WriteStream {
   if (process.stdout.columns === columns) {
     return process.stdout;
@@ -207,13 +214,9 @@ export function note(message: unknown, title?: string) {
     return;
   }
   const columns = resolveNoteColumns(process.stdout.columns);
-  const wrapped = wrapNoteMessage(message, { columns });
-  // Use a wide virtual stream so clack's internal wrap (which runs after our
-  // format callback) does not re-break copy-sensitive tokens that
-  // wrapNoteMessage intentionally kept intact.
-  const wideOutput = createNoteOutput(Math.max(columns, visibleWidth(wrapped) + 12));
-  clackNote(wrapped, stylePromptTitle(title), {
-    output: wideOutput,
+  const wrappedMessage = wrapNoteMessage(message, { columns });
+  clackNote(wrappedMessage, stylePromptTitle(title), {
+    output: createNoteOutput(resolveNoteOutputColumns(wrappedMessage, columns)),
     format: (line) => line,
   });
 }

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -1,7 +1,8 @@
+import { note as clackNote } from "@clack/prompts";
 // Terminal Core tests cover table behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { visibleWidth } from "./ansi.js";
-import { resolveNoteColumns, wrapNoteMessage } from "./note.js";
+import { resolveNoteColumns, resolveNoteOutputColumns, wrapNoteMessage } from "./note.js";
 import { renderTable } from "./table.js";
 
 function mockProcessPlatform(platform: NodeJS.Platform): void {
@@ -346,6 +347,33 @@ describe("wrapNoteMessage", () => {
     expect(resolveNoteColumns(1)).toBe(80);
     expect(resolveNoteColumns(79)).toBe(80);
     expect(resolveNoteColumns(120)).toBe(120);
+  });
+
+  it("widens note output columns so clack does not re-wrap copy-sensitive lines", () => {
+    const wrapped = wrapNoteMessage(
+      [
+        "- Found 1 session lock file.",
+        "- ~/.openclaw/agents/main/sessions/9c2acae5-841f-4aea-936b-fdb513b60202.jsonl.lock pid=86519 (alive) age=2m47s stale=no",
+      ].join("\n"),
+      { columns: 80 },
+    );
+    const writes: string[] = [];
+    const output = {
+      columns: resolveNoteOutputColumns(wrapped, 80),
+      write(chunk: string) {
+        writes.push(chunk);
+        return true;
+      },
+    } as unknown as NodeJS.WriteStream;
+
+    clackNote(wrapped, "Session locks", { output, format: (line) => line });
+
+    const rendered = writes.join("");
+    expect(rendered).toContain(".jsonl.lock");
+    expect(rendered).not.toContain(".js\n");
+    expect(rendered).toContain(
+      "- ~/.openclaw/agents/main/sessions/9c2acae5-841f-4aea-936b-fdb513b60202.jsonl.lock",
+    );
   });
 
   it("coerces nullish and non-string note messages before wrapping", () => {


### PR DESCRIPTION
Fixes #94730

## Summary

- Problem: `openclaw doctor` mangles long file paths inside `note(...)` boxes. `wrapNoteMessage` correctly preserves copy-sensitive tokens as unbroken lines, but clack's `note()` applies its own internal wrap after our `format` callback, re-breaking the line at the terminal width.
- Why now: This affects every user running `openclaw doctor` in a terminal narrower than the longest path/URL in the output. The mangled path cannot be copy-pasted, defeating the purpose of surfacing it.
- What changed: Use a wide virtual stream (`columns = max(80, longestLine + 12)`) in the `note()` function so clack's internal wrap never triggers, letting `wrapNoteMessage`'s output pass through to the terminal intact.
- What did NOT change: No changes to `wrapNoteMessage`, `wrapLine`, `isCopySensitiveToken`, or `splitLongWord`. The fix is in the `note()` function only.
- Outcome: Long paths and URLs in `note()` boxes are now displayed as a single line that can be copy-pasted, regardless of terminal width.
- Reviewer focus: The 5-line change in `packages/terminal-core/src/note.ts` lines 209-215.

## Verification

```bash
# Reproduce the bug: clack re-breaks copy-sensitive tokens
node -e "
const { note } = require('@clack/prompts');
const longPath = '~/.openclaw/agents/main/sessions/9c2acae5-841f-4aea-936b-fdb513b60202.jsonl.lock';
const message = 'Session lock: ' + longPath;
const output = [];
note(message, 'Test', {
  output: { columns: 80, write: (c) => { output.push(c); return true; }, isTTY: true },
  format: (line) => line,
});
const result = output.join('');
console.log('Path intact:', result.includes(longPath));
"
```

## Real behavior proof

**Behavior addressed:** Long file paths in `openclaw doctor` note boxes are split across multiple lines, making them impossible to copy-paste.

**Environment tested:** Linux 6.18.33.1-microsoft-standard-WSL2 (x64), Node.js v24.16.0.

**Steps run after the patch:**

```bash
cd /mnt/g/code/openclaw-worktrees/issue-94730

# Test 1: Old behavior (80 col) - path gets broken
node -e "
const { note } = require('@clack/prompts');
const longPath = '~/.openclaw/agents/main/sessions/9c2acae5-841f-4aea-936b-fdb513b60202.jsonl.lock';
const message = 'Session lock: ' + longPath;
const output1 = [];
note(message, 'Old (80 col)', {
  output: { columns: 80, write: (c) => { output1.push(c); return true; }, isTTY: true },
  format: (line) => line,
});
const output2 = [];
const wideColumns = Math.max(80, message.length + 12);
note(message, 'New (wide)', {
  output: { columns: wideColumns, write: (c) => { output2.push(c); return true; }, isTTY: true },
  format: (line) => line,
});
console.log('Old (80 col) - path intact:', output1.join('').includes(longPath));
console.log('New (wide)   - path intact:', output2.join('').includes(longPath));
"
```

**Evidence after fix (console output):**

```text
Old (80 col) - path intact: false
New (wide)   - path intact: true
```

**Observed result:** With the old 80-column stream, clack's internal wrap breaks the path at character 74. With the wide virtual stream, the path remains intact as a single line.

**Not tested:** Live `openclaw doctor` run (requires full gateway setup). The fix only changes the virtual stream width passed to clack's `note()`.
