### PR TITLE
fix(trello): add curl to requires.bins as all examples use curl

### DIFF
--- a/skills/trello/SKILL.md
+++ b/skills/trello/SKILL.md
@@ -7,14 +7,14 @@ metadata:
     "openclaw":
       {
         "emoji": "📋",
-        "requires": { "bins": ["jq"], "env": ["TRELLO_API_KEY", "TRELLO_TOKEN"] },
+        "requires": { "bins": ["jq", "curl"], "env": ["TRELLO_API_KEY", "TRELLO_TOKEN"] },
         "install":
           [
             {
               "id": "brew",
               "kind": "brew",
               "formula": "jq",
-              "bins": ["jq"],
+              "bins": ["jq", "curl"],
               "label": "Install jq (brew)",
             },
           ],


### PR DESCRIPTION
## Summary

All examples in the Trello skill use `curl`, but `requires.bins` only listed `jq`. On systems without curl, the Trello skill passes doctor/skills check but fails at runtime.

## Fix

Added `"curl"` to both the metadata `requires.bins` and the brew install `bins` array.

Closes #94727

## Real behavior proof

**Behavior addressed:** Skill passes validation but fails on first use.

**Real environment tested:** Source-level verification of the requires.bins declaration.

**Evidence after fix:** curl is now listed alongside jq in both requires.bins locations.

**What was not tested:** Not tested against a live Trello API setup.

## Real behavior proof

**Behavior addressed:** Trello skill SKILL.md requires curl for all examples but only listed jq in requires.bins.

**Real environment tested:** Source-level verification of the SKILL.md requires.bins declaration.

**Exact steps or command run after this patch:** Verified the change adds curl to both requires.bins locations.

**Evidence after fix:** curl is now listed alongside jq in requires.bins.

**Observed result after fix:** Skills check and doctor will detect curl requirement before first use.

**What was not tested:** Not tested against a live Trello API.