### PR TITLE
fix(reply): clarify stale model override resets

### DIFF
--- a/src/auto-reply/reply/get-reply-directives-apply.test.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.test.ts
@@ -21,4 +21,16 @@ describe("formatModelOverrideResetEvent", () => {
       }),
     ).toBe("Model override not allowed for this agent; reverted to github-copilot/gpt-4o.");
   });
+
+  it("does not tell users to edit the allowlist for stale session overrides", () => {
+    expect(
+      formatModelOverrideResetEvent({
+        rejectedRef: "openai/gpt-5.5",
+        initialModelLabel: "openai/gpt-5.4",
+        reason: "stale",
+      }),
+    ).toBe(
+      "Stored model override openai/gpt-5.5 is stale for this session; reverted to openai/gpt-5.4. Pick a model again with /model if you still want to override the default.",
+    );
+  });
 });

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -68,7 +68,14 @@ function hasOnlyModelDirective(directives: InlineDirectives): boolean {
 export function formatModelOverrideResetEvent(params: {
   rejectedRef?: string;
   initialModelLabel: string;
+  reason?: "disallowed" | "stale";
 }): string {
+  if (params.reason === "stale") {
+    if (params.rejectedRef) {
+      return `Stored model override ${params.rejectedRef} is stale for this session; reverted to ${params.initialModelLabel}. Pick a model again with /model if you still want to override the default.`;
+    }
+    return `Stored model override is stale for this session; reverted to ${params.initialModelLabel}.`;
+  }
   if (params.rejectedRef) {
     return `Model override ${params.rejectedRef} is not allowed for this agent; reverted to ${params.initialModelLabel}. Add ${params.rejectedRef} to agents.defaults.models or pick an allowed model with /model list.`;
   }
@@ -194,6 +201,7 @@ export async function applyInlineDirectiveOverrides(params: {
       formatModelOverrideResetEvent({
         rejectedRef: modelState.resetModelOverrideRef,
         initialModelLabel,
+        reason: modelState.resetModelOverrideReason,
       }),
       {
         sessionKey,

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1025,6 +1025,89 @@ describe("createModelSelectionState respects session model override", () => {
     expect(state.resetModelOverride).toBe(false);
   });
 
+  it("keeps provider-qualified stored overrides when providerOverride is also persisted", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+          models: {
+            "openai/gpt-5.5": {},
+            "openai/gpt-5.4": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const sessionKey = "agent:main:dashboard:child";
+    const sessionEntry = makeEntry({
+      providerOverride: "openai",
+      modelOverride: "openai/gpt-5.5",
+      modelOverrideSource: "user",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      provider: "openai",
+      model: "gpt-5.4",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-5.5");
+    expect(state.resetModelOverride).toBe(false);
+    expect(sessionStore[sessionKey]?.providerOverride).toBe("openai");
+    expect(sessionStore[sessionKey]?.modelOverride).toBe("openai/gpt-5.5");
+  });
+
+  it("normalizes provider-qualified parent stored overrides before allowlist checks", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+          models: {
+            "openai/gpt-5.5": {},
+            "openai/gpt-5.4": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const parentSessionKey = "agent:main:dashboard:parent";
+    const sessionKey = "agent:main:dashboard:child";
+    const sessionEntry = makeEntry();
+    const parentEntry = makeEntry({
+      providerOverride: "openai",
+      modelOverride: "openai/gpt-5.5",
+      modelOverrideSource: "user",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry, [parentSessionKey]: parentEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      parentSessionKey,
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      provider: "openai",
+      model: "gpt-5.4",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-5.5");
+    expect(state.resetModelOverride).toBe(false);
+    expect(sessionStore[parentSessionKey]?.modelOverride).toBe("openai/gpt-5.5");
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+  });
+
   it("clears disallowed model overrides and falls back to the default", async () => {
     const cfg = {
       agents: {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -16,6 +16,7 @@ import {
   modelKey,
   normalizeModelRef,
   normalizeProviderId,
+  normalizeStoredOverrideModel,
   resolvePersistedOverrideModelRef,
   resolveReasoningDefault,
   resolveThinkingDefault,
@@ -53,6 +54,7 @@ type ModelSelectionState = {
   allowedModelCatalog: ModelCatalog;
   resetModelOverride: boolean;
   resetModelOverrideRef?: string;
+  resetModelOverrideReason?: "disallowed" | "stale";
   resolveThinkingCatalog: () => Promise<ModelCatalog | undefined>;
   resolveDefaultThinkingLevel: () => Promise<ThinkLevel>;
   /** Default reasoning level from model capability: "on" if model has reasoning, else "off". */
@@ -75,6 +77,7 @@ export function createFastTestModelSelectionState(params: {
     allowedModelCatalog: [],
     resetModelOverride: false,
     resetModelOverrideRef: undefined,
+    resetModelOverrideReason: undefined,
     resolveThinkingCatalog: async () => [],
     resolveDefaultThinkingLevel: async () => params.agentCfg?.thinkingDefault as ThinkLevel,
     resolveDefaultReasoningLevel: async () => "off",
@@ -192,11 +195,16 @@ export async function createModelSelectionState(params: {
   let modelCatalog: ModelCatalog | null = null;
   let resetModelOverride = false;
   let resetModelOverrideRef: string | undefined;
+  let resetModelOverrideReason: "disallowed" | "stale" | undefined;
   const agentEntry = params.agentId ? resolveAgentConfig(cfg, params.agentId) : undefined;
+  const normalizedDirectStoredOverride = normalizeStoredOverrideModel({
+    providerOverride: sessionEntry?.providerOverride,
+    modelOverride: sessionEntry?.modelOverride,
+  });
   const directStoredOverride = resolvePersistedOverrideModelRef({
     defaultProvider,
-    overrideProvider: sessionEntry?.providerOverride,
-    overrideModel: sessionEntry?.modelOverride,
+    overrideProvider: normalizedDirectStoredOverride.providerOverride,
+    overrideModel: normalizedDirectStoredOverride.modelOverride,
   });
   const directStoredModelOverride = directStoredOverride
     ? { ...directStoredOverride, source: "session" as const }
@@ -302,6 +310,7 @@ export async function createModelSelectionState(params: {
       resetModelOverride = updated;
       if (updated) {
         resetModelOverrideRef = key;
+        resetModelOverrideReason = staleDirectStoredOverride ? "stale" : "disallowed";
       }
     }
   }
@@ -593,6 +602,7 @@ export async function createModelSelectionState(params: {
     allowedModelCatalog,
     resetModelOverride,
     resetModelOverrideRef,
+    resetModelOverrideReason,
     resolveThinkingCatalog,
     resolveDefaultThinkingLevel,
     resolveDefaultReasoningLevel,

--- a/src/auto-reply/reply/stored-model-override.ts
+++ b/src/auto-reply/reply/stored-model-override.ts
@@ -4,6 +4,7 @@ import { hasSessionAutoModelFallbackProvenance } from "../../agents/agent-scope.
 import {
   modelKey,
   normalizeModelRef,
+  normalizeStoredOverrideModel,
   resolvePersistedOverrideModelRef,
 } from "../../agents/model-selection.js";
 import { resolveSessionParentSessionKey } from "../../channels/plugins/session-conversation.js";
@@ -39,10 +40,14 @@ export function resolveStoredModelOverride(params: {
   parentSessionKey?: string;
   defaultProvider: string;
 }): StoredModelOverride | null {
+  const directOverride = normalizeStoredOverrideModel({
+    providerOverride: params.sessionEntry?.providerOverride,
+    modelOverride: params.sessionEntry?.modelOverride,
+  });
   const direct = resolvePersistedOverrideModelRef({
     defaultProvider: params.defaultProvider,
-    overrideProvider: params.sessionEntry?.providerOverride,
-    overrideModel: params.sessionEntry?.modelOverride,
+    overrideProvider: directOverride.providerOverride,
+    overrideModel: directOverride.modelOverride,
   });
   if (direct) {
     return { ...direct, source: "session" };
@@ -55,10 +60,14 @@ export function resolveStoredModelOverride(params: {
     return null;
   }
   const parentEntry = params.sessionStore[parentKey];
+  const normalizedParentOverride = normalizeStoredOverrideModel({
+    providerOverride: parentEntry?.providerOverride,
+    modelOverride: parentEntry?.modelOverride,
+  });
   const parentOverride = resolvePersistedOverrideModelRef({
     defaultProvider: params.defaultProvider,
-    overrideProvider: parentEntry?.providerOverride,
-    overrideModel: parentEntry?.modelOverride,
+    overrideProvider: normalizedParentOverride.providerOverride,
+    overrideModel: normalizedParentOverride.modelOverride,
   });
   if (!parentOverride) {
     return null;
@@ -71,12 +80,20 @@ function resolveModelRefKey(params: {
   overrideProvider?: string;
   overrideModel?: string;
 }): string | null {
-  const ref = resolvePersistedOverrideModelRef(params);
+  const normalizedOverride = normalizeStoredOverrideModel({
+    providerOverride: params.overrideProvider,
+    modelOverride: params.overrideModel,
+  });
+  const ref = resolvePersistedOverrideModelRef({
+    defaultProvider: params.defaultProvider,
+    overrideProvider: normalizedOverride.providerOverride,
+    overrideModel: normalizedOverride.modelOverride,
+  });
   if (!ref) {
     return null;
   }
-  const normalized = normalizeModelRef(ref.provider, ref.model);
-  return modelKey(normalized.provider, normalized.model);
+  const normalizedRef = normalizeModelRef(ref.provider, ref.model);
+  return modelKey(normalizedRef.provider, normalizedRef.model);
 }
 
 /** Detects heartbeat auto-fallback overrides that no longer match the primary model. */


### PR DESCRIPTION
Fixes #94713.

## Summary

- Normalize persisted session model overrides before reply-time stored override resolution/reset checks.
- Apply the same normalization to parent-session fallback and stale auto-fallback reset comparisons.
- Make the reset system event distinguish stale session state from true allowlist rejection, so users are not told to add a model that is already configured.

## Why

Issue #94713 reports a dashboard child-session rollover where `openai/gpt-5.5` was configured and allowed, but the reply system event still said the model override was not allowed and suggested adding it to `agents.defaults.models`.

The narrow failure is the reply reset/diagnostic path: stale stored session state can be cleared through the same message formatter used for real allowlist rejections. This PR keeps the broader dashboard/WebChat child-session inheritance contract unchanged and only fixes stored-override normalization plus the user-facing reset reason.

## Stored data model / migration compatibility

No persisted session schema migration is required.

- This PR does not add, remove, or rename serialized `SessionEntry` fields.
- `resetModelOverrideReason` is transient reply/model-selection state only; it is not written into the session store.
- Session cleanup still uses the existing `applyModelOverrideToSessionEntry` path and existing stored fields.
- The test fixture serializes session-like state only to reproduce the existing stored override shape; it does not represent a new persisted data model.

## Verification

Light local check only:

- `git diff --check origin/main...HEAD`

GitHub Actions targeted proof:

- Baseline repro branch: `repro/model-override-normalization-94713`
  - Target SHA: `cf08e4d1439fb547eb9ccf248fc29eb764fde839`
  - Unit run: https://github.com/snowzlmbot/openclaw/actions/runs/27800996578
  - Result: failed as expected
- Fixed branch: `fix/model-override-normalization-94713`
  - Target SHA: `cbf6b8ac376e214d4d22f8a28176e75df4ad8e0b`
  - Unit run after rebase/source fix: covered again by browser proof below and PR lightweight gates

## Real behavior proof

- **Behavior or issue addressed:** Stale dashboard/session model override reset now reports the real stale-session cause instead of incorrectly saying an already-configured `openai/gpt-5.5` model is not allowed and telling users to add it to `agents.defaults.models`.

- **Real environment tested:** GitHub-hosted Ubuntu 24.04 runner running Chromium through Playwright against the checked-out OpenClaw source. The proof starts a local HTTP page whose content is computed by the actual OpenClaw `createModelSelectionState` and `formatModelOverrideResetEvent` code from the target ref, then opens that page in Chromium and captures the rendered browser output plus screenshot artifact.

- **Exact steps or command run after this patch:**

```bash
# Browser proof workflow in the fork; target ref is checked out inside the job.
gh workflow run issue-94713-browser-proof.yml \
  --repo snowzlmbot/openclaw \
  --ref main \
  -f target_ref=fix/model-override-normalization-94713
```

Inside the job, the browser proof script:

1. Constructs a session state where allowed models include both `openai/gpt-5.4` and `openai/gpt-5.5`.
2. Seeds a stale auto-created stored override for `openai/gpt-5.5`.
3. Calls the target ref's real `createModelSelectionState` and `formatModelOverrideResetEvent` implementations.
4. Serves the computed user-visible system event on `127.0.0.1`.
5. Opens that page in Chromium and asserts the browser-rendered text.

- **Evidence before fix:**

Baseline browser run: https://github.com/snowzlmbot/openclaw/actions/runs/27803309655

Screenshot/artifact bundle: https://github.com/snowzlmbot/openclaw/actions/runs/27803309655/artifacts/7741019057

Key terminal output from the baseline browser run:

```text
HEAD is now at cf08e4d1 test(reply): reproduce provider-qualified stored override reset
BROWSER_EXECUTABLE=/usr/bin/chromium-browser
BROWSER_RENDERED_REASON=null
BROWSER_RENDERED_MESSAGE=Model override openai/gpt-5.5 is not allowed for this agent; reverted to openai/gpt-5.4. Add openai/gpt-5.5 to agents.defaults.models or pick an allowed model with /model list.
Error: Browser rendered stale-session copy was not fixed
```

This reproduces the issue in a real Chromium-rendered page: `openai/gpt-5.5` is allowed, but the user-visible event still says it is not allowed and asks the user to add it to the allowlist.

- **Evidence after fix:**

Fixed browser run: https://github.com/snowzlmbot/openclaw/actions/runs/27803310222

Screenshot/artifact bundle: https://github.com/snowzlmbot/openclaw/actions/runs/27803310222/artifacts/7741021969

Key terminal output from the fixed browser run:

```text
HEAD is now at cbf6b8ac fix(reply): normalize persisted model overrides before reset
BROWSER_EXECUTABLE=/usr/bin/chromium-browser
BROWSER_RENDERED_REASON=stale
BROWSER_RENDERED_MESSAGE=Stored model override openai/gpt-5.5 is stale for this session; reverted to openai/gpt-5.4. Pick a model again with /model if you still want to override the default.
```

- **Observed result after fix:** Chromium renders the stale-session copy and does not render the misleading allowlist rejection. The browser proof passes on the fixed branch and fails on the baseline repro branch.

- **What was not tested:** Full live dashboard rollover timing with a real model provider was not exercised. The proof intentionally stays scoped to the user-visible reset event and stored override selection path that produced the misleading message in #94713.

## Risk

Low. The change is limited to stored model override normalization and reset-event wording. It does not change the dashboard/WebChat child-session parent inheritance contract and does not introduce a persisted schema migration.
