### PR TITLE
fix(heartbeat): suppress raw text leak in message_tool_only mode

### DIFF
--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -443,4 +443,31 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       expect(calledOpts.sourceReplyDeliveryMode).toBeUndefined();
     });
   });
+
+  it("suppresses raw text reply in message_tool_only mode when heartbeat_respond not used", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath, visibleReplies: "message_tool" });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      // Model produces raw text without calling heartbeat_respond
+      replySpy.mockResolvedValue({ text: "All tasks complete." });
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      // Raw text must not leak to the channel in message_tool_only mode
+      expect(sendTelegram).not.toHaveBeenCalled();
+      expect(result.status).toBe("ran");
+      expect(getLastHeartbeatEvent()).toMatchObject({
+        status: "ok-empty",
+        channel: "telegram",
+      });
+    });
+  });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1878,7 +1878,13 @@ export async function runHeartbeatOnce(opts: {
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
-    if (!heartbeatToolResponse && (!replyPayload || !hasOutboundReplyContent(replyPayload))) {
+    // In message_tool_only mode, raw model output produced without the heartbeat
+    // response tool must not leak to the channel. Suppress it as if empty.
+    const suppressRawReply = usesHeartbeatResponseTool && !heartbeatToolResponse;
+    if (
+      !heartbeatToolResponse &&
+      (!replyPayload || !hasOutboundReplyContent(replyPayload) || suppressRawReply)
+    ) {
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,


### PR DESCRIPTION
## Summary

Fixes #94053 — When `visibleReplies` is `message_tool` (privacy mode), the heartbeat runner no longer leaks raw model text to the channel when the model does not invoke `heartbeat_respond`.

## Root cause

In `runHeartbeatOnce`, when the heartbeat response tool is enabled (`usesHeartbeatResponseTool`), the config sets `sourceReplyDeliveryMode: "message_tool_only"`. However, the raw reply path did not check whether `message_tool_only` was active — if the model produced text without calling `heartbeat_respond`, that text was delivered to the channel, bypassing the privacy contract.

## Fix

Add a `suppressRawReply` guard: when `usesHeartbeatResponseTool` is true and the model did NOT invoke `heartbeat_respond`, treat the raw reply as if it were empty, preventing delivery to the channel.

## Changes

- `src/infra/heartbeat-runner.ts`: Add `suppressRawReply` flag and include it in the early-return condition
- `src/infra/heartbeat-runner.tool-response.test.ts`: Add test verifying raw text is suppressed in message_tool_only mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
