### PR TITLE
fix(codex): bound turn/start text when context budget is non-positive

### DIFF
--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -2,6 +2,7 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it } from "vitest";
 import {
+  CODEX_TURN_START_TEXT_INPUT_MAX_CHARS,
   fitCodexProjectedContextForTurnStart,
   projectContextEngineAssemblyForCodex,
   resolveCodexContextEngineProjectionMaxChars,
@@ -224,6 +225,92 @@ describe("projectContextEngineAssemblyForCodex", () => {
     expect(fitted).toContain("Current user request:");
     expect(fitted).toContain("current request");
     expect(fitted).not.toContain("old context");
+  });
+
+  it("bounds output when the non-context text alone exceeds the turn limit", () => {
+    // A large older-context header prefix pushes before + after over maxChars
+    // while the trailing user request stays small enough to keep its label.
+    const before = `OpenClaw assembled context for this turn:\n${"prefix ".repeat(120)}`;
+    const context = "older context ".repeat(40);
+    const prompt = `urgent request ${"q".repeat(120)}`;
+    const after = `\n</conversation_context>\n\nCurrent user request:\n${prompt}`;
+    const promptText = `${before}${context}${after}`;
+    const maxChars = 420;
+    // before + after already exceed maxChars, so the context budget is non-positive.
+    expect(before.length + after.length).toBeGreaterThan(maxChars);
+
+    const fitted = fitCodexProjectedContextForTurnStart({
+      promptText,
+      contextRange: { start: before.length, end: before.length + context.length },
+      maxChars,
+    });
+
+    expect(fitted.length).toBeLessThanOrEqual(maxChars);
+    // The user's actual request is the priority tail and must survive truncation.
+    expect(fitted).toContain("Current user request:");
+    expect(fitted.endsWith("q".repeat(40))).toBe(true);
+    // The dropped older context is reported, not silently lost.
+    expect(fitted).toContain("[truncated ");
+  });
+
+  it("bounds output for a large request under the default Codex turn limit", () => {
+    const maxChars = CODEX_TURN_START_TEXT_INPUT_MAX_CHARS;
+    // A large assembled header prefix already over the cap forces the
+    // non-positive context budget on the real default limit (1 << 20).
+    const before = `header\n${"older history ".repeat(90_000)}`;
+    const context = "x".repeat(2_000);
+    const prompt = `urgent request ${"u".repeat(2_000)}`;
+    const after = `\n</conversation_context>\n\nCurrent user request:\n${prompt}`;
+    const promptText = `${before}${context}${after}`;
+    expect(before.length + after.length).toBeGreaterThan(maxChars);
+
+    const fitted = fitCodexProjectedContextForTurnStart({
+      promptText,
+      contextRange: { start: before.length, end: before.length + context.length },
+      // maxChars omitted -> defaults to CODEX_TURN_START_TEXT_INPUT_MAX_CHARS.
+    });
+
+    expect(fitted.length).toBeLessThanOrEqual(maxChars);
+    // The user request is the priority tail and survives even though the older
+    // header text is truncated to satisfy the limit.
+    expect(fitted).toContain("Current user request:");
+    expect(fitted.endsWith("u".repeat(1_000))).toBe(true);
+  });
+
+  it("never splits a UTF-16 surrogate pair at the truncation boundary", () => {
+    // Drive the non-positive-budget path with an emoji (surrogate pair) sitting
+    // across the kept-tail cut. A naive code-unit slice would orphan the low
+    // surrogate into U+FFFD; the boundary must stay on a whole code point.
+    const before = `OpenClaw assembled context for this turn:\n${"H".repeat(300)}`;
+    const context = "older context ".repeat(20);
+    // Emoji immediately before the user text so the cut can fall mid-pair.
+    const prompt = `\u{1F600}${"U".repeat(60)}`;
+    const after = `\n</conversation_context>\n\nCurrent user request:\n${prompt}`;
+    const promptText = `${before}${context}${after}`;
+    const contextRange = { start: before.length, end: before.length + context.length };
+
+    // Sweep cap sizes around the cut so the test is not brittle to marker length;
+    // at least one value lands the boundary inside the surrogate pair.
+    for (let maxChars = 90; maxChars <= 140; maxChars += 1) {
+      const fitted = fitCodexProjectedContextForTurnStart({ promptText, contextRange, maxChars });
+      expect(fitted.length).toBeLessThanOrEqual(maxChars);
+      // U+FFFD only appears when a lone surrogate is rendered, i.e. a split pair.
+      expect(fitted).not.toContain("�");
+      // Any surviving emoji must be the complete pair, not a lone low surrogate.
+      for (let i = 0; i < fitted.length; i += 1) {
+        const code = fitted.charCodeAt(i);
+        const isLowSurrogate = code >= 0xdc00 && code <= 0xdfff;
+        const isHighSurrogate = code >= 0xd800 && code <= 0xdbff;
+        if (isLowSurrogate) {
+          const prev = fitted.charCodeAt(i - 1);
+          expect(prev >= 0xd800 && prev <= 0xdbff).toBe(true);
+        }
+        if (isHighSurrogate) {
+          const next = fitted.charCodeAt(i + 1);
+          expect(next >= 0xdc00 && next <= 0xdfff).toBe(true);
+        }
+      }
+    }
   });
 
   it("keeps the old conservative cap when no runtime budget is available", () => {

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -139,8 +139,16 @@ export function fitCodexProjectedContextForTurnStart(params: {
   const context = params.promptText.slice(range.start, range.end);
   const afterContext = params.promptText.slice(range.end);
   const contextBudget = maxChars - beforeContext.length - afterContext.length;
-  const fittedContext = truncateOlderContext(context, contextBudget);
-  return `${beforeContext}${fittedContext}${afterContext}`;
+  if (contextBudget > 0) {
+    const fittedContext = truncateOlderContext(context, contextBudget);
+    return `${beforeContext}${fittedContext}${afterContext}`;
+  }
+  // The header plus the trailing user request already fill the limit, so the
+  // older context drops entirely and the remaining text must still be bounded;
+  // otherwise Codex app-server rejects the turn for exceeding
+  // MAX_USER_INPUT_TEXT_CHARS. truncateOlderContext keeps the tail, preserving
+  // the user's actual request over the older header text.
+  return truncateOlderContext(`${beforeContext}${afterContext}`, maxChars);
 }
 
 function normalizeProjectedContextRange(
@@ -457,5 +465,20 @@ function truncateOlderContext(text: string, maxChars: number): string {
     return marker.slice(0, maxChars);
   }
   tailChars = maxChars - marker.length;
-  return `${marker}${text.slice(text.length - tailChars).trimStart()}`;
+  return `${marker}${sliceTailFromCodePointBoundary(text, tailChars).trimStart()}`;
+}
+
+// Keep the kept tail at a code-point boundary so a UTF-16 surrogate pair is
+// never split at the cut: a tail start that lands on a low surrogate would
+// orphan it into U+FFFD, corrupting the first character. Dropping that unit
+// stays within maxChars (it only removes a char), so the bound still holds.
+function sliceTailFromCodePointBoundary(text: string, tailChars: number): string {
+  let start = text.length - tailChars;
+  if (start > 0 && start < text.length) {
+    const code = text.charCodeAt(start);
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      start += 1;
+    }
+  }
+  return text.slice(start);
 }


### PR DESCRIPTION
## Summary

Fixes #94748.

`fitCodexProjectedContextForTurnStart` (`extensions/codex/src/app-server/context-engine-projection.ts`) is contractually required to return prompt text no longer than `maxChars`. When the assembled-context header prefix plus the trailing user request already exceed `maxChars`, the context budget went non-positive, the older context dropped to `""`, and the function returned `beforeContext + "" + afterContext` **unbounded** — longer than `maxChars`.

That overflowing string is then rejected by the Codex app-server v2 turn/start input cap `MAX_USER_INPUT_TEXT_CHARS = 1 << 20` (`codex-rs/protocol/src/user_input.rs`), so the turn fails with "Input exceeds the maximum length" instead of being sent.

This restores the postcondition (`result.length <= maxChars`) while keeping the trailing user request — the part that actually matters — intact.

## The bug

`extensions/codex/src/app-server/context-engine-projection.ts:141` (pre-fix):

```ts
const contextBudget = maxChars - beforeContext.length - afterContext.length;
const fittedContext = truncateOlderContext(context, contextBudget);
return `${beforeContext}${fittedContext}${afterContext}`;
```

When `beforeContext.length + afterContext.length >= maxChars`, `contextBudget <= 0`, so `truncateOlderContext(context, contextBudget)` returns `""` and the function returns `beforeContext + afterContext` with no upper bound. `afterContext` is the request tail `\n</conversation_context>\n\nCurrent user request:\n${prompt}`, so a large assembled history overflows the return value past `maxChars`.

Downstream, the Codex app-server validates the summed turn/start text against `MAX_USER_INPUT_TEXT_CHARS = 1 << 20` (`codex-rs/protocol/src/user_input.rs`); the app-server turn processor rejects an over-length input rather than truncating it, so the whole turn fails.

## The fix

Bound the remaining text in the non-positive-budget branch by reusing `truncateOlderContext`, which keeps the **tail**. This drops the older header text first and preserves the user's actual request — the opposite priority from clamping the front of the string. The happy path (budget positive, or text already under `maxChars`) is unchanged. A truncation marker is still emitted, so dropped context is reported, not silently lost.

Additionally, `truncateOlderContext`'s kept-tail slice is made surrogate-safe: a raw code-unit `slice` whose boundary lands between a UTF-16 high/low surrogate would orphan the low surrogate into U+FFFD and corrupt the first character. The new boundary advances past a leading low surrogate so a code point is never split; dropping that one unit stays within `maxChars`, so the bound still holds.

```ts
if (contextBudget > 0) {
  const fittedContext = truncateOlderContext(context, contextBudget);
  return `${beforeContext}${fittedContext}${afterContext}`;
}
// older context drops entirely; bound the remaining text so Codex app-server
// does not reject the turn for exceeding MAX_USER_INPUT_TEXT_CHARS.
// truncateOlderContext keeps the tail, preserving the user's actual request.
return truncateOlderContext(`${beforeContext}${afterContext}`, maxChars);
```

### Alternative considered

A simpler clamp — concatenating the parts and returning `result.slice(0, maxChars)` when it overflows — also satisfies `length <= maxChars`, but it truncates the **end** of the string. The end is `\n</conversation_context>\n\nCurrent user request:\n${prompt}`, so a front-`slice(0, maxChars)` drops the user's actual request and keeps stale older context — the wrong priority. A raw code-unit `slice` can also split a UTF-16 surrogate pair at the boundary, corrupting a character. Truncating from the tail (keeping the request) and guarding the surrogate boundary avoids both.

## Tests

`extensions/codex/src/app-server/context-engine-projection.test.ts`, reproduce-first (each fails before the fix):

- `bounds output when the non-context text alone exceeds the turn limit` — small cap (420); asserts `length <= maxChars`, the `Current user request:` label and request tail survive, and the truncation marker is present.
- `bounds output for a large request under the default Codex turn limit` — real default cap `1 << 20`; asserts the bound holds and the request tail survives.
- `never splits a UTF-16 surrogate pair at the truncation boundary` — sweeps caps so the cut lands inside an emoji's surrogate pair; asserts no U+FFFD and no lone surrogate in the output.

## Real behavior proof

Behavior addressed: `fitCodexProjectedContextForTurnStart` returned text longer than `maxChars` when the header prefix plus the trailing user request already exceeded the limit, which the Codex app-server then rejects (`MAX_USER_INPUT_TEXT_CHARS = 1 << 20`, `codex-rs/protocol/src/user_input.rs`).

Real environment tested: ran the real exported function from `extensions/codex/src/app-server/context-engine-projection.ts` directly under Node 26 via `tsx` (no mocks, no test harness), on an input whose assembled history overflows the `1 << 20` cap.

Exact steps or command run after this patch: built a small driver that imports the real function and ran `node_modules/.bin/tsx repro.mts`, calling `fitCodexProjectedContextForTurnStart({ promptText, contextRange })` with `before = "OpenClaw assembled context for this turn:\n" + "older history ".repeat(90000)`, a 2,000-char context, and the trailing request `URGENT: delete the staging row id=42 and report back ...`.

Evidence after fix: live `tsx` console output, after fix:

```
input promptText length        : 1262183
Codex MAX_USER_INPUT_TEXT_CHARS : 1048576
output length                  : 1048575
output <= limit (Codex accepts): true
user request survived in tail  : true
output tail (last 80 chars)    : "e the staging row id=42 and report back uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu"
```

Before the fix, the same `tsx` driver on the same input printed `output length : 1260183` and `output <= limit (Codex accepts): false` — an over-length return that the Codex app-server rejects.

Observed result after fix: the real function returns 1,048,575 chars (within the `1 << 20` Codex cap), and the user's request `URGENT: delete the staging row id=42 and report back` is preserved at the tail of the output. A front-clamping `result.slice(0, maxChars)` on the same input instead leaves the tail as stale `older history` text (`user request survived: false`), confirming the tail-preserving direction is the correct one.

What was not tested: not exercised against a live Codex app-server process end-to-end; the `MAX_USER_INPUT_TEXT_CHARS` rejection is verified from the Codex source (`codex-rs/protocol/src/user_input.rs`) plus the real function's now-bounded output, not by observing the app-server reject path live.
