### PR TITLE
fix(gateway): propagate allowModelOverride policies from auto-enabled config at startup

### DIFF
--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -111,6 +111,13 @@ export function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
   // Runtime bindings must be installed before loadGatewayPlugins so plugin
   // hooks that inspect gateway/node/subagent helpers see current config.
   installGatewayPluginRuntimeEnvironment(resolvedConfig);
+  // Always propagate subagent override policies from the full auto-enabled
+  // config. The merged resolvedConfig may drop subagent.allowModelOverride /
+  // allowedModels for entries the runtime config does not yet carry, leaving
+  // the plugin runtime authorizer with stale (empty) policies until a config
+  // hot-reload event. The hot-reload path uses autoEnabled.config directly,
+  // so the startup path must match that view.
+  setPluginSubagentOverridePolicies(autoEnabled.config);
   const loaded = loadGatewayPlugins({
     cfg: resolvedConfig,
     activationSourceConfig,


### PR DESCRIPTION
## Summary

Fixes #94289 — The startup path merges activation config into runtime config via `mergeActivationSectionsIntoRuntimeConfig`, which only propagates the `enabled` field for plugin entries. This strips `subagent.allowModelOverride` and `subagent.allowedModels` for plugin entries the runtime config does not yet carry. The hot-reload path uses `autoEnabled.config` directly and was unaffected.

## Fix

Ensure `setPluginSubagentOverridePolicies` always receives the full auto-enabled config so the plugin subagent runtime authorizer sees the correct policies from the first request, matching hot-reload behavior.

## Changes

- `src/gateway/server-plugin-bootstrap.ts`: Added `setPluginSubagentOverridePolicies` call in `prepareGatewayPluginLoad` right after `installGatewayPluginRuntimeEnvironment`

## Verification

Source-level: the added call uses the same `autoEnabled.config` that the hot-reload path already uses, ensuring consistent policy propagation across both paths.

Fixes #94289

🤖 Generated with [Claude Code](https://claude.com/claude-code)
