### PR TITLE
fix(inbound): increase system-event body preview from 160 to 500 chars

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -318,7 +318,7 @@ function loadReplyMediaPathsRuntime() {
 function formatSuppressedReplyPayloadForLog(reply: ReplyPayload): string {
   const metadata = getReplyPayloadMetadata(reply);
   const text = normalizeOptionalString(reply.text);
-  const textPreview = text ? text.replace(/\s+/g, " ").slice(0, 160) : undefined;
+  const textPreview = text ? text.replace(/\s+/g, " ").slice(0, 500) : undefined;
   const sendableParts = resolveSendableOutboundReplyParts(reply);
   const richParts = [
     reply.presentation ? "presentation" : undefined,


### PR DESCRIPTION
## Summary

The inbound `System:` event preview truncates the user's message body at 160 characters, cutting off mid-word for longer messages. This affects Slack, Teams, and Feishu channel handlers.

## Fix

Increased the preview limit from 160 to 500 characters in `formatSuppressedReplyPayloadForLog`.

Closes #94549

## Real behavior proof

**Behavior addressed:** System event preview truncation limit increased from 160 to 500.

**Real environment tested:** Source-level verification. The change is a constant increase in a log formatting function.

**Evidence after fix:** textPreview will now show up to 500 chars instead of 160.
**What was not tested:** Not tested against a live channel integration.