### PR TITLE
fix(inbound): suppress raw text reply in message_tool_only heartbeat to prevent leak to Telegram (fixes #94053)

### DIFF
--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -443,4 +443,31 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       expect(calledOpts.sourceReplyDeliveryMode).toBeUndefined();
     });
   });
+
+  it("suppresses raw text reply in message_tool_only mode when heartbeat_respond not used", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath, visibleReplies: "message_tool" });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      // Model produces raw text without calling heartbeat_respond
+      replySpy.mockResolvedValue({ text: "All tasks complete." });
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      // Raw text must not leak to the channel in message_tool_only mode
+      expect(sendTelegram).not.toHaveBeenCalled();
+      expect(result.status).toBe("ran");
+      expect(getLastHeartbeatEvent()).toMatchObject({
+        status: "ok-empty",
+        channel: "telegram",
+      });
+    });
+  });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -27,6 +27,7 @@ import { resolveModelRefFromString, type ModelRef } from "../agents/model-select
 import { resolvePersistedSessionRuntimeId } from "../agents/session-runtime-compat.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
+import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import {
   getHeartbeatToolNotificationText,
   resolveHeartbeatToolResponseFromReplyResult,
@@ -1878,7 +1879,18 @@ export async function runHeartbeatOnce(opts: {
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
-    if (!heartbeatToolResponse && (!replyPayload || !hasOutboundReplyContent(replyPayload))) {
+    // In message_tool_only mode, raw model output produced without the heartbeat
+    // response tool must not leak to the channel. Suppress it as if empty.
+    // Payloads marked with deliverDespiteSourceReplySuppression — error notices
+    // and system messages — bypass this guard so critical failures still surface.
+    const suppressRawReply =
+      usesHeartbeatResponseTool &&
+      !heartbeatToolResponse &&
+      getReplyPayloadMetadata(replyPayload)?.deliverDespiteSourceReplySuppression !== true;
+    if (
+      !heartbeatToolResponse &&
+      (!replyPayload || !hasOutboundReplyContent(replyPayload) || suppressRawReply)
+    ) {
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,


### PR DESCRIPTION
## Summary
- Heartbeat runner was leaking raw text replies to Telegram when `visibleReplies: "message_tool"` is set and the model produces text without calling `heartbeat_respond`
- Added a `suppressRawReply` guard that respects `deliverDespiteSourceReplySuppression` metadata so error/system notices still surface

## Changes
- `src/infra/heartbeat-runner.ts`: Added suppressRawReply guard before the empty-reply check (usesHeartbeatResponseTool without heartbeat_respond call suppresses raw text)
- `src/infra/heartbeat-runner.tool-response.test.ts`: Added test verifying raw text suppression in message_tool_only mode

## Verification
- All 16 tests pass (15 existing + 1 new)
- Behavior: suppresses raw text reply when private mode is on and heartbeat_respond tool was not called

Fixes #94053

🤖 Generated with [Claude Code](https://claude.com/claude-code)