### PR TITLE
fix(tools): warn on empty allOf/anyOf availability groups

### DIFF
--- a/src/tools/availability.ts
+++ b/src/tools/availability.ts
@@ -131,6 +131,7 @@ function evaluateExpression(
   }
   if ("allOf" in expression) {
     if (expression.allOf.length === 0) {
+      console.warn("Empty availability allOf group in tool descriptor");
       return [
         {
           reason: "unsupported-signal",
@@ -142,6 +143,7 @@ function evaluateExpression(
   }
   if ("anyOf" in expression) {
     if (expression.anyOf.length === 0) {
+      console.warn("Empty availability anyOf group in tool descriptor");
       return [
         {
           reason: "unsupported-signal",


### PR DESCRIPTION
## 变更说明

Tool availability evaluator 遇到空 `allOf`/`anyOf` 组时只返回 `unsupported-signal` diagnostic，但这些 diagnostic 从未被日志输出——工具直接进入 hidden 列表，作者无法发现描述符编写错误。

在空组分支增加 `console.warn`，使问题在描述符注册时就能被开发者看到。

## 关联 Issue

Closes #92361

## 变更类型

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Code refactor
- [ ] Test update
- [ ] Dependency update

## 风险等级

low

## 测试情况

`pnpm vitest run src/tools/availability.test.ts` — 9 tests pass, 0 fail。