### PR TITLE
fix(test): align kitchen-sink-rpc lane timeout assertion with extended watchdog

### DIFF
--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -183,7 +183,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
       retryPatterns: [],
       retries: 0,
       stateScenario: "empty",
-      timeoutMs: 900000,
+      timeoutMs: 1500000,
       weight: 3,
     });
     expect(script).toContain("OPENCLAW_ENTRY=/app/openclaw.mjs");


### PR DESCRIPTION
## Summary

- `main` is currently red: `test/scripts/plugin-prerelease-test-plan.test.ts > keeps kitchen-sink RPC coverage package-backed and resource-guarded` fails with `timeoutMs` expected `900000`, received `1500000`.
- Root cause: `eedb6678f1` (*"fix(e2e): extend kitchen rpc watchdog"*) bumped the `kitchen-sink-rpc` lane in `scripts/lib/docker-e2e-scenarios.mjs` from `15 * 60 * 1000` → `25 * 60 * 1000`. That commit updated `docker-build-helper.test.ts` and `docker-e2e-plan.test.ts` but left the assertion in `plugin-prerelease-test-plan.test.ts` at the old `900000`.
- Fix: update the single stale assertion to `1500000` to match the lane. One line, test-only.

## Tests

- `node scripts/run-vitest.mjs run test/scripts/plugin-prerelease-test-plan.test.ts` → **11/11 passing** (was 10 passed / 1 failed before the change).

## Real behavior proof

- Behavior addressed: the lane source-of-truth (`getDockerLane("kitchen-sink-rpc").timeoutMs`) returns `1500000` after `eedb6678f1`, but the prerelease test plan assertion still pinned `900000`, so the unit suite fails on a clean `main` checkout.
- Real environment tested: clean `main` checkout, Node v25, `vitest` via `scripts/run-vitest.mjs` (macOS).
- Exact command run: `node scripts/run-vitest.mjs run test/scripts/plugin-prerelease-test-plan.test.ts`.
- Evidence (copied live output) — before:
  ```
   × keeps kitchen-sink RPC coverage package-backed and resource-guarded
  -   "timeoutMs": 900000,
  +   "timeoutMs": 1500000,
   Tests  1 failed | 10 passed (11)
  ```
  after:
  ```
   Test Files  1 passed (1)
        Tests  11 passed (11)
  ```
- Observed result: assertion now matches the extended watchdog; suite green.
- What was not tested: the docker e2e lane itself is not executed here — this only aligns the unit assertion with the lane definition the same commit already shipped.
- Proof limitations: none; deterministic one-line assertion fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)