### PR TITLE
fix(memory): align session file counter denominator with indexer filter (fixes #77338)

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -9,6 +9,7 @@ import {
   resolveMemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
+import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import {
   colorize,
@@ -526,7 +527,7 @@ async function scanSessionFiles(agentId: string): Promise<SourceScan> {
   try {
     const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
     const totalFiles = entries.filter(
-      (entry) => entry.isFile() && entry.name.endsWith(".jsonl"),
+      (entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name),
     ).length;
     return { source: "sessions", totalFiles, issues };
   } catch (err) {


### PR DESCRIPTION
## fix(memory): align session file counter denominator with indexer filter (fixes #77338)

`openclaw memory status` reports `sessions · N/M` where N > M because the denominator scanner (`scanSessionFiles`) only counts `*.jsonl` files, while the indexer also ingests `*.jsonl.reset.*` snapshots and `*.jsonl.deleted.*` tombstones.

This 1-line fix replaces the `.endsWith(".jsonl")` filter with the existing `isUsageCountedSessionTranscriptFileName()` helper — already used by the indexer (`packages/memory-host-sdk/src/host/session-files.ts:83`) and session-cost-usage (`src/infra/session-cost-usage.ts:413`) — so both sides agree on which filenames count.

### Changes

- `extensions/memory-core/src/cli.runtime.ts`: import `isUsageCountedSessionTranscriptFileName` from `openclaw/plugin-sdk/memory-core-host-engine-qmd` and use it in `scanSessionFiles()` denominator filter.

## Real behavior proof

- **Behavior addressed:** Session file counter denominator now excludes `.jsonl.reset.*` and `.jsonl.deleted.*` artifacts, matching the indexer's filter.
- **Environment tested:** macOS, Node 24, pnpm build, OpenClaw main branch (55323103)
- **Steps run after the patch:** Applied the 1-line filter change in `scanSessionFiles()`, ran `pnpm build` (278.9s), verified bundled output contains `isUsageCountedSessionTranscriptFileName` in the session file scanner path.
- **Evidence after fix:**

```
$ grep -n "isUsageCountedSessionTranscriptFileName" extensions/memory-core/src/cli.runtime.ts
12:import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
530:      (entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name),

$ node -e "const fs=require('fs'); const c=fs.readdirSync('dist').filter(f=>f.includes('cli')&&f.endsWith('.js')); for(const f of c){const t=fs.readFileSync('dist/'+f,'utf8'); if(t.includes('isUsageCountedSessionTranscriptFileName')&&t.includes('scanSessionFiles')){console.log('bundled:',f); break;}}"
bundled: cli.runtime-CC_mxqX-.js
```

- **Observed result after fix:** The bundled `cli.runtime` now uses `isUsageCountedSessionTranscriptFileName` for the session file count denominator, matching the indexer's behavior. Counter will no longer show N > M.
- **What was not tested:** Live runtime with actual `.jsonl.reset.*` / `.jsonl.deleted.*` files (requires a long-running OpenClaw instance with session history).
