### PR TITLE
fix(infra): probe IPv4 loopback in SSH tunnel port preflight to match tunnel binding

### DIFF
--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -119,7 +119,10 @@ export async function startSshPortForward(opts: {
 
   let localPort = opts.localPortPreferred;
   try {
-    await ensurePortAvailable(localPort);
+    // #94596: Probe 127.0.0.1 so the preflight matches the IPv4-only
+    // interface this tunnel actually binds (pickEphemeralPort, canConnectLocal,
+    // and the ssh -L forward are all pinned to 127.0.0.1).
+    await ensurePortAvailable(localPort, "127.0.0.1");
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {
       localPort = await pickEphemeralPort();


### PR DESCRIPTION
## Summary

`startSshPortForward` calls `ensurePortAvailable(localPort)` without a host
parameter, which causes the preflight to bind the IPv6 wildcard and miss
IPv4-only occupants on dual-stack hosts. This is the same root cause as
#94379, already fixed for the Chrome CDP path in #94394.

The rest of this SSH tunnel module is already IPv4-scoped:
- `pickEphemeralPort` → `listen(0, "127.0.0.1")`
- `canConnectLocal` → `connect({ host: "127.0.0.1" })`
- the `ssh -L` forward → `${localPort}:127.0.0.1:${remotePort}`

**Fix**: Pass `"127.0.0.1"` as the host parameter to `ensurePortAvailable`,
matching #94394's pattern and the rest of the module.

Fixes #94596

## Real behavior proof

**Behavior addressed**:
SSH tunnel port preflight now probes `127.0.0.1` instead of the IPv6
wildcard, so it correctly detects IPv4-only port occupants on dual-stack
hosts and falls back to an ephemeral port.

**Real environment tested**:
Linux 4.19.112-2.el8.x86_64, Node.js v24.13.1, pnpm, vitest 4.1.8

**Exact steps or command run after this patch**:
```bash
node scripts/run-vitest.mjs src/infra/ssh-tunnel.test.ts --reporter=verbose
node scripts/run-vitest.mjs src/infra/ports.test.ts --reporter=verbose
node scripts/run-oxlint.mjs src/infra/ssh-tunnel.ts
```

**After-fix evidence**:
```
$ node scripts/run-vitest.mjs src/infra/ssh-tunnel.test.ts
Test Files  1 passed (1)  Tests  3 passed (3)

$ node scripts/run-vitest.mjs src/infra/ports.test.ts
Test Files  1 passed (1)  Tests  14 passed (14)
```

**Observed result after the fix**:
The SSH tunnel `ensurePortAvailable` call is now consistent with the
rest of the module — it probes `127.0.0.1` just like `pickEphemeralPort`,
`canConnectLocal`, and the `ssh -L` binding already do.

**What was not tested**:
- Live dual-stack host reproduction (requires an actual dual-stack Linux
  host with an IPv4-only occupant on the preferred SSH tunnel port)

## Risk / scope

- User-visible behavior change: No — only corrects port availability
  detection on dual-stack hosts
- Config/API change: No
- Breaking: No
- Highest risk: None — one-line change, scoped to SSH tunnel preflight

---

*AI-assisted: built with Claude Code*