### PR TITLE
feat(telegram): set ThreadLabel from topicName for forum sessions (#7406)

### DIFF
--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -592,6 +592,7 @@ export async function buildTelegramInboundContextPayload(params: {
       ...locationContext,
       IsForum: isForum,
       TopicName: isForum && topicName ? topicName : undefined,
+      ThreadLabel: isForum && topicName ? topicName : undefined,
     },
   } satisfies BuildChannelInboundEventContextAsyncParams);
   if (inboundEventKind === "room_event" && historyKey) {


### PR DESCRIPTION
## What

Map the already-captured `topicName` to `ThreadLabel` in the Telegram inbound context so forum topic sessions display human-readable topic names instead of raw numeric IDs in the session picker and TUI dropdown.

Currently, Telegram forum topic sessions show keys like `agent:main:telegram:group:-123456789:topic:42` in the session list. With this change, the topic name captured from `forum_topic_created` service messages is surfaced as `ThreadLabel`, which the session display system uses to render friendly labels.

## Why

Fixes #7406. The `TopicName` field was already being set from the captured `topicName`, but `ThreadLabel` — which the session display and conversation-label systems actually consume — was never mapped. Other channels (Slack, qa-channel) already set `ThreadLabel` on their inbound context.

## How

Single-line addition in `extensions/telegram/src/bot-message-context.session.ts`:595, directly after the existing `TopicName` mapping with the same guard condition.

## How to Test

1. Build: `pnpm build`
2. Verification: `node -e` + `grep -n` confirms the change
3. Related check: conversation-label and Telegram handler verification both pass

## Real behavior proof

- **Behavior addressed:** Telegram forum topic sessions display raw numeric topic IDs instead of human-readable topic names in the session picker
- **Environment tested:** OpenClaw local build on macOS, pnpm build, extension-telegram verification suite
- **Steps run after the patch:** Built the project with `pnpm build`, verified `ThreadLabel` field present in source at line 595, ran Telegram handler and conversation-label verification
- **Evidence after fix:**
```
$ node -e "const fs=require('fs'); const c=fs.readFileSync('extensions/telegram/src/bot-message-context.session.ts','utf8'); console.log('ThreadLabel present:', c.includes('ThreadLabel')); console.log('Line:', c.split('\\n').findIndex(l=>l.includes('ThreadLabel'))+1);"
ThreadLabel present: true
Line: 595
$ grep -n 'ThreadLabel' extensions/telegram/src/bot-message-context.session.ts
595:      ThreadLabel: isForum && topicName ? topicName : undefined,
```
- **Observed result after fix:** `ThreadLabel` is correctly mapped from `topicName` with the same `isForum && topicName` guard as `TopicName`. The field flows through `inbound-meta.ts:615`, `session.ts:419/739`, and `conversation-label.ts:43` to produce human-readable session labels.
- **What was not tested:** Live Telegram forum topic messages (requires real Telegram bot + forum group). The change follows the identical pattern as the existing `TopicName` field which is already proven in production.
