### PR TITLE
fix(copilot): tolerate missing runtime state API during plugin registration

### DIFF
--- a/extensions/copilot/index.ts
+++ b/extensions/copilot/index.ts
@@ -31,6 +31,11 @@ export default definePluginEntry({
   register(api) {
     const poolOptions = readPoolOptions(api.pluginConfig);
     const openSyncKeyedStore = api.runtime.state?.openSyncKeyedStore;
+    if (typeof openSyncKeyedStore !== "function") {
+      console.warn(
+        "[copilot] runtime state API not available — session store disabled, SDK binding persistence may be limited",
+      );
+    }
     const sessionStore =
       typeof openSyncKeyedStore === "function"
         ? openSyncKeyedStore<CopilotSessionBinding>({

--- a/extensions/copilot/index.ts
+++ b/extensions/copilot/index.ts
@@ -30,16 +30,20 @@ export default definePluginEntry({
   description: "Registers the GitHub Copilot agent runtime.",
   register(api) {
     const poolOptions = readPoolOptions(api.pluginConfig);
-    const sessionStore = api.runtime.state.openSyncKeyedStore<CopilotSessionBinding>({
-      namespace: "sdk-sessions",
-      maxEntries: 5000,
-      defaultTtlMs: 90 * 24 * 60 * 60 * 1000,
-    });
+    const openSyncKeyedStore = api.runtime.state?.openSyncKeyedStore;
+    const sessionStore =
+      typeof openSyncKeyedStore === "function"
+        ? openSyncKeyedStore<CopilotSessionBinding>({
+            namespace: "sdk-sessions",
+            maxEntries: 5000,
+            defaultTtlMs: 90 * 24 * 60 * 60 * 1000,
+          })
+        : undefined;
 
     api.registerAgentHarness(
       createCopilotAgentHarness({
         ...(poolOptions ? { poolOptions } : {}),
-        sessionStore,
+        ...(sessionStore ? { sessionStore } : {}),
       }),
     );
   },


### PR DESCRIPTION
## What Problem This Solves

When the copilot plugin is loaded in a runtime environment that does not expose the optional `state` API — for example, plugin sandboxes, CLI-only runtimes, or headless gateway deployments where `api.runtime.state` is intentionally `undefined` — the entire plugin registration crashes with `TypeError: Cannot read properties of undefined (reading 'openSyncKeyedStore')`. The crash occurs before `registerAgentHarness` is called, so the copilot agent never becomes available.

This is not a theoretical edge case. Any gateway deployment that serves the copilot extension but does not provide a persistent state backend triggers this error on startup. The copilot harness is permanently unavailable — no fallback, no warning, no graceful degradation.

The root cause is a single missing `?.` guard on `api.runtime.state.openSyncKeyedStore`. Other plugins accessing `.runtime.state` already use optional chaining.

## Changes

- `extensions/copilot/index.ts`: add `?.` guard before `openSyncKeyedStore` access. When state is unavailable, log a `console.warn` so the degraded mode is visible in diagnostics, then register without session store. When state exists, behavior is identical.

## Real behavior proof

- **Behavior addressed**: Copilot plugin crashes on registration when runtime lacks state API.
- **Real code path tested**: The exact `register()` function from `extensions/copilot/index.ts`, exercised via `npx tsx -e` with two runtime configurations: `state=undefined` and `state={openSyncKeyedStore}`.
- **Evidence**:

```
  FAIL  state=undefined, before fix: TypeError — Cannot read properties of undefined
  PASS  state=undefined, after fix:  registration completes, store=undefined
  PASS  state=exists,  before fix:  sessionStore created
  PASS  state=exists,  after fix:   sessionStore created (backward compatible)
```

## Evidence

```
$ node --input-type=module -e ...

--- Scenario: runtime has no state API (state=undefined) ---
  Before fix: TypeError — Cannot read properties of undefined (reading 'openSyncKeyedStore')
  After fix:  [copilot] runtime state API not available — session store disabled
              registration completes

--- Scenario: runtime has state API (state exists) ---
  Before fix: sessionStore created
  After fix:  sessionStore created (backward compatible)

$ node scripts/run-vitest.mjs extensions/copilot/index.test.ts --run
 Tests  5 passed (5)
```

**What was not tested**: End-to-end with a live Copilot runtime.