### PR TITLE
fix(telegram): check error_code for 401 detection instead of message substring (fixes #94787)

### DIFF
--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -301,4 +301,43 @@ describe("createTelegramSendChatActionHandler", () => {
     await handler.sendChatAction(444, "typing");
     expect(fn).toHaveBeenCalledTimes(3);
   });
+
+  it("does not treat 429 with retry_after=401 as a 401 error", async () => {
+    // grammY renders this as: "Call to 'sendChatAction' failed! (429: Too Many Requests: retry after 401)"
+    // The substring "401" in the message must NOT trigger the 401 suspension path.
+    const make429WithRetryAfter401 = () =>
+      Object.assign(
+        new Error("Call to 'sendChatAction' failed! (429: Too Many Requests: retry after 401)"),
+        { error_code: 429, parameters: { retry_after: 401 } },
+      );
+
+    let now = 0;
+    const fn = vi.fn().mockRejectedValue(make429WithRetryAfter401());
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      maxConsecutive401: 3,
+      now: () => now,
+    });
+
+    // All calls should fail but as transient errors, NOT 401 errors
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("429");
+
+    // Advance past the 401s cooldown (retry_after=401 → 401000ms)
+    now += 402_000;
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("429");
+
+    now += 402_000;
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("429");
+
+    // Handler must NOT be suspended — this is a transient 429, not a 401
+    expect(handler.isSuspended()).toBe(false);
+
+    // Must NOT have logged the CRITICAL token-deletion alarm
+    const criticalLogs = logger.mock.calls.filter(([msg]) =>
+      String(msg).includes("CRITICAL"),
+    );
+    expect(criticalLogs).toEqual([]);
+  });
 });

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -69,10 +69,18 @@ function is401Error(error: unknown): boolean {
   if (!error) {
     return false;
   }
+  // Check structured Telegram error_code first to avoid substring false positives.
+  // A 429 with retry_after=401 produces a message like "(429: Too Many Requests: retry after 401)"
+  // which contains "401" as a substring — this must NOT trigger the 401 suspension path.
+  if (typeof error === "object" && "error_code" in error) {
+    const code = (error as { error_code: unknown }).error_code;
+    if (typeof code === "number") {
+      return code === 401;
+    }
+  }
+  // Fallback for non-Telegram errors (plain Error objects without error_code).
   const message = error instanceof Error ? error.message : JSON.stringify(error);
-  return (
-    message.includes("401") || normalizeLowercaseStringOrEmpty(message).includes("unauthorized")
-  );
+  return normalizeLowercaseStringOrEmpty(message).includes("unauthorized");
 }
 
 class TelegramSendChatActionTransientCooldownError extends Error {


### PR DESCRIPTION
## Summary

`is401Error` in the Telegram `sendChatAction` handler used `message.includes("401")` — a substring check on the rendered error message. When Telegram returns a 429 rate-limit with `retry_after: 401`, grammY renders the message as `"Call to 'sendChatAction' failed! (429: Too Many Requests: retry after 401)"`. The substring "401" matches, so the handler counts the error toward the consecutive-401 suspension counter instead of the transient cooldown path. After 10 such occurrences (or fewer with `maxConsecutive401`), the handler suspends all chat actions and logs a CRITICAL "token likely invalid, Telegram may DELETE the bot" alarm — for a perfectly valid bot.

## Fix

Check the structured `error_code` field on the error object first (matching the pattern used by `isTelegramRateLimitError`, `isTelegramServerError`, and other sibling classifiers in `extensions/telegram/src/network-errors.ts`). Fall back to case-insensitive "unauthorized" message matching only for non-Telegram errors that lack `error_code`.

## Changes

- `extensions/telegram/src/sendchataction-401-backoff.ts`: `is401Error` now checks `error_code === 401` before falling back to message matching; removed `message.includes("401")` substring check
- `extensions/telegram/src/sendchataction-401-backoff.test.ts`: added test case verifying 429 with `retry_after=401` is treated as transient, not as a 401

## Real behavior proof
- **Behavior addressed:** The `is401Error` function in the Telegram `sendChatAction` handler incorrectly classified 429 rate-limit errors containing "401" in the message substring as 401 authentication errors, triggering bot suspension
- **Environment tested:** macOS, Node.js, OpenClaw repository at commit `778348f0`
- **Steps run after the patch:** Ran `node scripts/run-vitest.mjs run extensions/telegram/src/sendchataction-401-backoff.test.ts` — all 15 verification cases pass including the new 429-with-retry-after-401 case. Ran `npx tsgo --noEmit` — zero type errors. Verified the source with `node -e` confirming `error_code` check is present and `message.includes("401")` is removed.
- **Evidence after fix:**
```
✓  extension-telegram  extensions/telegram/src/sendchataction-401-backoff.test.ts (15 tests) 295ms
Test Files  1 passed (1)
Tests  15 passed (15)

error_code check present: true
message.includes(401) removed: true
unauthorized fallback present: true
ALL CHECKS PASSED: true
```
- **Observed result after fix:** 429 errors with `retry_after=401` are correctly routed to the transient cooldown path. The handler no longer suspends or logs the CRITICAL alarm. All existing 401 detection tests continue to pass (plain `Error("401 Unauthorized")` without `error_code` still triggers the 401 path via the "unauthorized" message fallback).
- **What was not tested:** Live Telegram API interaction (the fix is a deterministic logic change verified by the existing and new verification cases; the Telegram API contract for `error_code` is stable and documented)
