### PR TITLE
fix(telegram): classify sendChatAction 401 by error code, not bare "401" substring

### DIFF
--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -270,6 +270,14 @@ export function isTelegramRateLimitError(err: unknown): boolean {
   );
 }
 
+export function hasTelegramHttpErrorCode(err: unknown): boolean {
+  return hasTelegramErrorCode(err, () => true);
+}
+
+export function isTelegramUnauthorizedError(err: unknown): boolean {
+  return hasTelegramErrorCode(err, (code) => code === 401);
+}
+
 const MESSAGE_NOT_MODIFIED_RE =
   /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
 const MESSAGE_HAS_NO_TEXT_RE = /400:\s*Bad Request:\s*there is no text in the message to edit/i;

--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -197,6 +197,25 @@ describe("createTelegramSendChatActionHandler", () => {
     ]);
   });
 
+  it("treats a recoverable network error whose message contains '401' as transient, not a 401 suspension", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("read ECONNRESET 401"), { code: "ECONNRESET" }));
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      maxConsecutive401: 1,
+    });
+
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow();
+
+    expect(handler.isSuspended()).toBe(false);
+    expect(logger.mock.calls.at(-1)).toEqual([
+      "sendChatAction transient error (1). Cooling down 1000ms before retry.",
+    ]);
+  });
+
   it.each([
     ["recoverable network", () => makeNetworkError(), 1000],
     ["Telegram 429", () => makeTelegramError("Too Many Requests", 429, { retry_after: 2 }), 2000],

--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -176,6 +176,27 @@ describe("createTelegramSendChatActionHandler", () => {
     expect(handler.isSuspended()).toBe(false);
   });
 
+  it("treats a structured 429 whose message contains '401' as transient, not a 401 suspension", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValue(
+        makeTelegramError("Too Many Requests: retry after 401", 429, { retry_after: 401 }),
+      );
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      maxConsecutive401: 1,
+    });
+
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow();
+
+    expect(handler.isSuspended()).toBe(false);
+    expect(logger.mock.calls.at(-1)).toEqual([
+      "sendChatAction transient error (1). Cooling down 401000ms before retry.",
+    ]);
+  });
+
   it.each([
     ["recoverable network", () => makeNetworkError(), 1000],
     ["Telegram 429", () => makeTelegramError("Too Many Requests", 429, { retry_after: 2 }), 2000],

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -7,9 +7,11 @@ import {
 } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
+  hasTelegramHttpErrorCode,
   isRecoverableTelegramNetworkError,
   isTelegramRateLimitError,
   isTelegramServerError,
+  isTelegramUnauthorizedError,
   readTelegramRetryAfterMs,
 } from "./network-errors.js";
 
@@ -67,6 +69,12 @@ const BACKOFF_POLICY: BackoffPolicy = {
 
 function is401Error(error: unknown): boolean {
   if (!error) {
+    return false;
+  }
+  if (isTelegramUnauthorizedError(error)) {
+    return true;
+  }
+  if (hasTelegramHttpErrorCode(error)) {
     return false;
   }
   const message = error instanceof Error ? error.message : JSON.stringify(error);

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -77,6 +77,9 @@ function is401Error(error: unknown): boolean {
   if (hasTelegramHttpErrorCode(error)) {
     return false;
   }
+  if (isRecoverableTelegramNetworkError(error, { context: "send" })) {
+    return false;
+  }
   const message = error instanceof Error ? error.message : JSON.stringify(error);
   return (
     message.includes("401") || normalizeLowercaseStringOrEmpty(message).includes("unauthorized")


### PR DESCRIPTION
## Summary

- `is401Error` in the Telegram `sendChatAction` handler classified failures with a bare `message.includes("401")` substring check, evaluated **before** the transient-error branch. So a structured 429/5xx/network error whose rendered message merely contains the digits `401` - e.g. grammY renders a flood-wait into `Call to 'sendChatAction' failed! (429: Too Many Requests: retry after 401)` - was counted as a consecutive 401.
- After `maxConsecutive401` such errors the handler suspends **all** chat actions for the account and logs the CRITICAL "token likely invalid, Telegram may DELETE the bot" alarm - for a perfectly valid bot that is merely being rate-limited.
- This PR makes `is401Error` trust the **structured Telegram `error_code`** when present: a structured `401` is a 401; any other structured code (429/5xx/4xx) is not. The existing `message.includes("401")` / `"unauthorized"` heuristic is kept only as a fallback for errors that carry no structured `error_code` (e.g. a plain `new Error("401 Unauthorized")`).
- Out of scope: the catch-order, backoff policy, and suspension mechanism are unchanged; this only narrows the 401 classification so transient errors are no longer misclassified.

## Linked context

Which issue does this close?

Closes #94787

Was this requested by a maintainer or owner?

No

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** a structured Telegram **429** rate-limit (or 5xx / recoverable network error) whose rendered message contains the substring `401` is no longer miscounted as a 401; it is routed to the transient-cooldown path and never trips account-wide suspension or the token-deletion alarm.
- **Real environment tested:** Node 24 (`node:24-bookworm`, Docker under WSL2) exercising the **unchanged-shape** `createTelegramSendChatActionHandler` with byte-identical source and the repo's own test mocks. I could **not** drive a live Telegram bot into a real 429 flood-wait of exactly 401 seconds, so the proof is at the handler's real classification logic, not a live API capture.
- **Exact steps or command run after this patch:** ran the extension's full Vitest suite for this module (`sendchataction-401-backoff.test.ts`) against the patched source, plus `oxfmt --check` and `oxlint` on the changed files using the repo's pinned `oxfmt@0.52.0` / `oxlint@1.67.0` and `.oxfmtrc.jsonc` / `.oxlintrc.json`.

- **Evidence after fix:**
```text
BEFORE (upstream main b28fda9ef8 — bare-substring is401Error)
  --- grammY 429 flood-wait, message 'retry after 401' ---
    [telegram] sendChatAction 401 error (1/3). Retrying with exponential backoff.
    [telegram] sendChatAction 401 error (2/3). Retrying with exponential backoff.
    [telegram] CRITICAL: sendChatAction suspended after 3 consecutive 401 errors. Bot token is likely invalid. Telegram may DELETE the bot if requests continue. Replace the token and restart: openclaw channels restart telegram
    => handler.isSuspended() === true          # WRONG: valid bot, just rate-limited
  --- network ECONNRESET, message 'read ECONNRESET 401' ---
    [telegram] CRITICAL: sendChatAction suspended after 3 consecutive 401 errors. ... Telegram may DELETE the bot ...
    => handler.isSuspended() === true          # WRONG: transient network drop
  --- genuine 401 Unauthorized (invalid token) ---
    [telegram] CRITICAL: sendChatAction suspended after 3 consecutive 401 errors. ...
    => handler.isSuspended() === true          # correct

AFTER (this branch — structured error_code + recoverable-network classification)
  --- grammY 429 flood-wait, message 'retry after 401' ---
    [telegram] sendChatAction transient error (1). Cooling down 401000ms before retry.
    => handler.isSuspended() === false         # FIXED
  --- network ECONNRESET, message 'read ECONNRESET 401' ---
    [telegram] sendChatAction transient error (1). Cooling down 1000ms before retry.
    => handler.isSuspended() === false         # FIXED
  --- genuine 401 Unauthorized (invalid token) ---
    [telegram] CRITICAL: sendChatAction suspended after 3 consecutive 401 errors. ... Telegram may DELETE the bot ...
    => handler.isSuspended() === true          # safeguard preserved
```

- **Observed result after fix:** before the fix a 429 flood-wait and an `ECONNRESET` (both valid-bot transient errors) suspend the account and fire the CRITICAL "Telegram may DELETE the bot" alarm. After the fix both route to the transient-cooldown path (`isSuspended() === false`, no alarm), while a genuine `error_code: 401` still suspends and alarms — the token-invalid safeguard is intact.
- **What was not tested:** a live Telegram Bot API session (trigger not forceable on demand); the full-monorepo `tsgo` typecheck and sharded type-aware `oxlint` lane.
- **Proof limitations or environment constraints:** the plugin-sdk timing helpers (`computeBackoff`/`sleepWithAbort`) are stubbed; everything above is the real classification, branching, and logging code, not a live API capture. The mechanism is deterministic, as the before/after console output shows; the real-world hit-rate depends on whether a transient error's rendered text contains `401`.
- **Before evidence:** the BEFORE block above (CRITICAL alarm + `isSuspended() === true` for the 429 and the `ECONNRESET`) is upstream `main`'s behavior for those two valid-bot transient errors.


<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

- **Commands run:** Vitest on `extensions/telegram/src/sendchataction-401-backoff.test.ts` (before fix: 1 failed / 14 passed; after fix: 15 passed); `oxfmt@0.52.0 --check` and `oxlint@1.67.0` on the three changed files (both clean).
- **Regression coverage added:** one test - "treats a structured 429 whose message contains '401' as transient, not a 401 suspension" - asserting that a structured 429 with `401` in its message takes the transient path and does not suspend. The existing tests already cover genuine `"401 Unauthorized"` strings, which still classify as 401 via the fallback.
- **What failed before this fix:** the new test (`isSuspended()` returned `true` and the CRITICAL token-deletion line was logged for a 429).
- All 14 pre-existing tests in this file remain green, including the string-based 401 backoff/suspension tests and the transient 429/5xx/network cooldown tests.

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

- **Did user-visible behavior change?** Yes — a bot hitting a transient error whose message contains `401` is no longer suspended account-wide and no longer emits the false "replace your token / Telegram may DELETE the bot" alarm.
- **Did config, environment, or migration behavior change?** No.
- **Did security, auth, secrets, network, or tool execution behavior change?** Error *classification* on the outbound Telegram path only — no requests, credentials, or secrets are touched. A genuine 401 is still detected (structured `error_code === 401`, or the message fallback for code-less errors), so the token-invalid safeguard still fires when it should.
- **Highest-risk area:** a real 401 must keep tripping suspension. 
- **Mitigation:** structured `error_code === 401` returns `true` directly; code-less `new Error("401 Unauthorized")` still matches the retained message heuristic — both paths are covered by the existing (green) tests.

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

Which bot or reviewer comments were addressed?
YES

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
