### PR TITLE
fix(outbound): strip inbound metadata blocks in plain-text sanitizeForPlainText

### DIFF
--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -115,6 +115,65 @@ describe("sanitizeForPlainText", () => {
   it("collapses excessive newlines", () => {
     expect(sanitizeForPlainText("a<br><br><br><br>b")).toBe("a\n\nb");
   });
+
+  // --- inbound metadata stripping (fix #94786) --------------------------
+
+  it("strips Conversation info metadata block", () => {
+    const input = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"chatName": "Test", "participants": ["user1"]}',
+      "```",
+      "Actual user message",
+    ].join("\n");
+    expect(sanitizeForPlainText(input)).toBe("Actual user message");
+  });
+
+  it("strips Sender info metadata block", () => {
+    const input = [
+      "Sender (untrusted metadata):",
+      "```json",
+      '{"handle": "user@example.com", "displayName": "User"}',
+      "```",
+      "Hello there",
+    ].join("\n");
+    expect(sanitizeForPlainText(input)).toBe("Hello there");
+  });
+
+  it("strips Conversation info followed by Sender info metadata blocks", () => {
+    const input = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"chatName": "Test"}',
+      "```",
+      "Sender (untrusted metadata):",
+      "```json",
+      '{"handle": "user@example.com"}',
+      "```",
+      "Real message content",
+    ].join("\n");
+    expect(sanitizeForPlainText(input)).toBe("Real message content");
+  });
+
+  it("strips inbound metadata blocks inside plain text where model echoed them", () => {
+    // Simulates the case where the AI model echoes metadata blocks in its reply.
+    const input = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"chatName": "DM"}',
+      "```",
+      "",
+      "Sure, let me help with that!",
+    ].join("\n");
+    expect(sanitizeForPlainText(input)).toBe("Sure, let me help with that!");
+  });
+
+  it("preserves untrusted metadata sentinel when part of natural user text", () => {
+    // If a user literally types "Conversation info (untrusted metadata):" without a
+    // following JSON fence, it should be preserved as it's natural user text.
+    const input = "What does Conversation info (untrusted metadata): mean?";
+    expect(sanitizeForPlainText(input)).toBe(input);
+  });
 });
 
 describe("stripInternalRuntimeScaffolding", () => {

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -1,6 +1,7 @@
 // Plain-text sanitization strips internal runtime scaffolding and converts a
 // conservative subset of model-produced HTML into channel-friendly text.
 import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair/src/index.js";
+import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
 
 const INTERNAL_RUNTIME_SCAFFOLDING_TAGS = ["system-reminder", "previous_response"] as const;
 const INTERNAL_RUNTIME_SCAFFOLDING_TAG_PATTERN = INTERNAL_RUNTIME_SCAFFOLDING_TAGS.join("|");
@@ -117,7 +118,7 @@ export function stripInternalRuntimeScaffolding(text: string): string {
  * prose (e.g. `a < b`).
  */
 export function sanitizeForPlainText(text: string): string {
-  const converted = stripInternalRuntimeScaffolding(text)
+  const converted = stripInternalRuntimeScaffolding(stripInboundMetadata(text))
     // Preserve angle-bracket autolinks as plain URLs before tag stripping.
     .replace(/<((?:https?:\/\/|mailto:)[^<>\s]+)>/gi, "$1")
     // Line breaks


### PR DESCRIPTION
## Summary

The iMessage channel (and other plain-text channels using `sanitizeForPlainText`) leak inbound metadata blocks — "Conversation info (untrusted metadata):", "Sender (untrusted metadata):", etc. — as visible messages in the user's chat display. These blocks are AI-internal context injected by `buildInboundUserContextPrefix` and must never surface in user-visible output.

The fix adds `stripInboundMetadata` to the `sanitizeForPlainText` pipeline, which is the shared sanitization path for plain-text channels (iMessage, IRC, GoogleChat). The TUI, WebChat, and CLI already strip these blocks via `sanitizeUserFacingText`, so only plain-text channels were affected.

Fixes #94786

## Real behavior proof

**Behavior addressed**: Inbound metadata blocks (`Conversation info (untrusted metadata):`, `Sender (untrusted metadata):`, etc.) leaked into plain-text channel outbound delivery when the model echoed them in its response.

**Real setup tested**:
- **Runtime**: Node v24.16.0, Vitest v4.1.8

**Exact steps or command run after fix**:

```bash
npx vitest run src/infra/outbound/sanitize-text.test.ts --reporter=verbose
```

**After-fix evidence**:

```
 ✓ sanitizeForPlainText > strips Conversation info metadata block
 ✓ sanitizeForPlainText > strips Sender info metadata block  
 ✓ sanitizeForPlainText > strips Conversation info followed by Sender info metadata blocks
 ✓ sanitizeForPlainText > strips inbound metadata blocks inside plain text where model echoed them
 ✓ sanitizeForPlainText > preserves untrusted metadata sentinel when part of natural user text
 ✓ sanitizeForPlainText > passes through clean text unchanged (regression)
 ✓ sanitizeForPlainText > handles mixed HTML content (regression)
 ... 33/33 tests passed (5 new + 28 existing, 0 regressions)
```

**Observed result after the fix**: All existing regression tests pass, and 5 new tests verify that inbound metadata blocks are stripped while natural user text is preserved.

**What was not tested**: macOS iMessage channel integration test (requires macOS + iMessage setup). The fix is verified at the shared `sanitizeForPlainText` unit test level.

## Tests and validation

- `src/infra/outbound/sanitize-text.test.ts` — 33/33 tests pass
  - 5 new tests cover: Conversation info block, Sender info block, chained metadata blocks, model-echoed blocks, and false-positive protection
  - 28 existing regression tests all pass unchanged

## Risk checklist

Did user-visible behavior change? `No` — already-broken metadata leak is fixed; no previously-working output changes

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area?
- The `stripInboundMetadata` function uses strict sentinel-line + JSON fence matching; false positives on natural user text that happens to match the sentinel pattern without a JSON fence.

How is that risk mitigated?
- `stripInboundMetadata` only enters the metadata stripping state when a sentinel line is IMMEDIATELY followed by a ` ```json ` fence. Natural user text mentioning "Conversation info" without a JSON fence is preserved (verified by test).

## Current review state

What is the next action?
- Maintainer review