### PR TITLE
Respect explicit compaction reserve tokens

### DIFF
--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -337,9 +337,14 @@ OpenClaw runtime's compaction settings live in agent settings:
 
 OpenClaw also enforces a safety floor for embedded runs:
 
-- If `compaction.reserveTokens < reserveTokensFloor`, OpenClaw bumps it.
-- Default floor is `20000` tokens.
-- Set `agents.defaults.compaction.reserveTokensFloor: 0` to disable the floor.
+- If both `compaction.reserveTokens` and `reserveTokensFloor` are set and
+  `compaction.reserveTokens < reserveTokensFloor`, OpenClaw bumps it.
+- If `compaction.reserveTokens` is set and `reserveTokensFloor` is omitted,
+  OpenClaw treats the explicit reserve as intentional instead of applying the
+  default floor.
+- Default floor is `20000` tokens when neither reserve value is set.
+- Set `agents.defaults.compaction.reserveTokensFloor: 0` to disable the floor
+  explicitly.
 - If it's already higher, OpenClaw leaves it alone.
 - Manual `/compact` honors an explicit `agents.defaults.compaction.keepRecentTokens`
   and keeps OpenClaw runtime's recent-tail cut point. Without an explicit keep budget,

--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -245,7 +245,7 @@ describe("projectContextEngineAssemblyForCodex", () => {
       resolveCodexContextEngineProjectionReserveTokens({
         config: { agents: { defaults: { compaction: { reserveTokens: 12_000 } } } },
       }),
-    ).toBe(20_000);
+    ).toBe(12_000);
     expect(
       resolveCodexContextEngineProjectionReserveTokens({
         config: {

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -106,10 +106,7 @@ export function resolveCodexContextEngineProjectionReserveTokens(params: {
   const configuredReserveTokensFloor = toNonNegativeInt(asRecord(compaction)?.reserveTokensFloor);
 
   if (configuredReserveTokens !== undefined) {
-    return Math.max(
-      configuredReserveTokens,
-      configuredReserveTokensFloor ?? DEFAULT_CODEX_PROJECTION_RESERVE_TOKENS,
-    );
+    return Math.max(configuredReserveTokens, configuredReserveTokensFloor ?? 0);
   }
   if (configuredReserveTokensFloor !== undefined) {
     return configuredReserveTokensFloor;

--- a/extensions/codex/src/app-server/startup-binding.test.ts
+++ b/extensions/codex/src/app-server/startup-binding.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readCodexAppServerBinding, writeCodexAppServerBinding } from "./session-binding.js";
-import { rotateOversizedCodexAppServerStartupBinding } from "./startup-binding.js";
+import { rotateOversizedCodexAppServerStartupBinding, testing } from "./startup-binding.js";
 
 describe("Codex app-server startup binding", () => {
   let tempDir: string;
@@ -44,6 +44,22 @@ describe("Codex app-server startup binding", () => {
       }),
     );
   }
+
+  it("respects explicit native thread reserveTokens when reserveTokensFloor is omitted", () => {
+    expect(
+      testing.resolveCodexAppServerNativeThreadReserveTokens({
+        agents: { defaults: { compaction: { reserveTokens: 8_192 } } },
+      } as never),
+    ).toBe(8_192);
+  });
+
+  it("keeps explicit native thread reserveTokensFloor as a lower bound", () => {
+    expect(
+      testing.resolveCodexAppServerNativeThreadReserveTokens({
+        agents: { defaults: { compaction: { reserveTokens: 8_192, reserveTokensFloor: 20_000 } } },
+      } as never),
+    ).toBe(20_000);
+  });
 
   it("does not use a default byte limit when maxActiveTranscriptBytes is unset", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");

--- a/extensions/codex/src/app-server/startup-binding.ts
+++ b/extensions/codex/src/app-server/startup-binding.ts
@@ -268,10 +268,7 @@ function resolveCodexAppServerNativeThreadReserveTokens(
   const reserveTokens = toNonNegativeInt(compaction?.reserveTokens);
   const reserveTokensFloor = toNonNegativeInt(compaction?.reserveTokensFloor);
   if (reserveTokens !== undefined) {
-    return Math.max(
-      reserveTokens,
-      reserveTokensFloor ?? CODEX_APP_SERVER_NATIVE_THREAD_DEFAULT_RESERVE_TOKENS,
-    );
+    return Math.max(reserveTokens, reserveTokensFloor ?? 0);
   }
   return reserveTokensFloor ?? CODEX_APP_SERVER_NATIVE_THREAD_DEFAULT_RESERVE_TOKENS;
 }

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -218,6 +218,23 @@ describe("buildMemoryFlushPlan", () => {
     expect(plan?.reserveTokensFloor).toBe(20_000);
   });
 
+  it("uses explicit reserveTokens as the memory flush reserve floor fallback", () => {
+    const plan = buildMemoryFlushPlan({
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              reserveTokens: 8_192,
+              memoryFlush: {},
+            },
+          },
+        },
+      },
+    });
+
+    expect(plan?.reserveTokensFloor).toBe(8_192);
+  });
+
   it("parses forceFlushTranscriptBytes from byte-size strings", () => {
     const plan = buildMemoryFlushPlan({
       cfg: {

--- a/extensions/memory-core/src/flush-plan.ts
+++ b/extensions/memory-core/src/flush-plan.ts
@@ -113,8 +113,10 @@ export function buildMemoryFlushPlan(
   const forceFlushTranscriptBytes =
     parseNonNegativeByteSize(defaults?.forceFlushTranscriptBytes) ??
     DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES;
+  const compactionDefaults = cfg?.agents?.defaults?.compaction;
   const reserveTokensFloor =
-    normalizeNonNegativeInt(cfg?.agents?.defaults?.compaction?.reserveTokensFloor) ??
+    normalizeNonNegativeInt(compactionDefaults?.reserveTokensFloor) ??
+    normalizeNonNegativeInt(compactionDefaults?.reserveTokens) ??
     DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR;
 
   const { timeLine, userTimezone } = resolveCronStyleNow(cfg ?? {}, nowMs);

--- a/src/agents/agent-settings.test.ts
+++ b/src/agents/agent-settings.test.ts
@@ -189,16 +189,15 @@ describe("applyAgentCompactionSettingsFromConfig", () => {
     expect(settingsManager.applyOverrides).not.toHaveBeenCalled();
   });
 
-  it("applies capped floor over user-configured reserveTokens when default floor exceeds context window", () => {
+  it("respects explicit reserveTokens when reserveTokensFloor is not configured", () => {
     const settingsManager = {
       getCompactionReserveTokens: () => 16_384,
       getCompactionKeepRecentTokens: () => 20_000,
       applyOverrides: vi.fn(),
     };
 
-    // User sets reserveTokens=2048 but NOT reserveTokensFloor (default 20_000 applies).
-    // Pre-fix: target = max(2048, 20_000) = 20_000 → exceeds 16_384 context → infinite loop.
-    // Post-fix: floor capped to 8_384 → target = max(2048, 8_384) = 8_384 → works.
+    // User sets reserveTokens=2048 but NOT reserveTokensFloor.
+    // The implicit default floor must not override the explicit reserveTokens choice.
     const result = applyAgentCompactionSettingsFromConfig({
       settingsManager,
       cfg: {
@@ -212,7 +211,59 @@ describe("applyAgentCompactionSettingsFromConfig", () => {
     });
 
     expect(result.didOverride).toBe(true);
-    expect(result.compaction.reserveTokens).toBe(8_384); // capped floor wins over user's 2_048
+    expect(result.compaction.reserveTokens).toBe(2_048);
+    expect(settingsManager.applyOverrides).toHaveBeenCalledWith({
+      compaction: { reserveTokens: 2_048 },
+    });
+  });
+
+  it("applies explicit reserveTokensFloor over lower explicit reserveTokens", () => {
+    const settingsManager = {
+      getCompactionReserveTokens: () => 16_384,
+      getCompactionKeepRecentTokens: () => 20_000,
+      applyOverrides: vi.fn(),
+    };
+
+    const result = applyAgentCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: { reserveTokens: 2_048, reserveTokensFloor: 8_384 },
+          },
+        },
+      },
+      contextTokenBudget: 16_384,
+    });
+
+    expect(result.didOverride).toBe(true);
+    expect(result.compaction.reserveTokens).toBe(8_384);
+    expect(settingsManager.applyOverrides).toHaveBeenCalledWith({
+      compaction: { reserveTokens: 8_384 },
+    });
+  });
+
+  it("caps explicit reserveTokensFloor over lower explicit reserveTokens on small-context models", () => {
+    const settingsManager = {
+      getCompactionReserveTokens: () => 16_384,
+      getCompactionKeepRecentTokens: () => 20_000,
+      applyOverrides: vi.fn(),
+    };
+
+    const result = applyAgentCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: { reserveTokens: 2_048, reserveTokensFloor: 20_000 },
+          },
+        },
+      },
+      contextTokenBudget: 16_384,
+    });
+
+    expect(result.didOverride).toBe(true);
+    expect(result.compaction.reserveTokens).toBe(8_384);
     expect(settingsManager.applyOverrides).toHaveBeenCalledWith({
       compaction: { reserveTokens: 8_384 },
     });

--- a/src/agents/agent-settings.ts
+++ b/src/agents/agent-settings.ts
@@ -58,6 +58,7 @@ export function applyAgentCompactionSettingsFromConfig(params: {
   const compactionCfg = params.cfg?.agents?.defaults?.compaction;
 
   const configuredReserveTokens = toNonNegativeInt(compactionCfg?.reserveTokens);
+  const configuredReserveTokensFloor = toNonNegativeInt(compactionCfg?.reserveTokensFloor);
   const configuredKeepRecentTokens = toPositiveInt(compactionCfg?.keepRecentTokens);
   let reserveTokensFloor = resolveCompactionReserveTokensFloor(params.cfg);
 
@@ -76,10 +77,12 @@ export function applyAgentCompactionSettingsFromConfig(params: {
     reserveTokensFloor = Math.min(reserveTokensFloor, maxReserve);
   }
 
-  const targetReserveTokens = Math.max(
-    configuredReserveTokens ?? currentReserveTokens,
-    reserveTokensFloor,
-  );
+  const effectiveConfiguredReserveTokensFloor =
+    configuredReserveTokensFloor !== undefined ? reserveTokensFloor : undefined;
+  const targetReserveTokens =
+    configuredReserveTokens !== undefined
+      ? Math.max(configuredReserveTokens, effectiveConfiguredReserveTokensFloor ?? 0)
+      : Math.max(currentReserveTokens, reserveTokensFloor);
   const targetKeepRecentTokens = configuredKeepRecentTokens ?? currentKeepRecentTokens;
 
   const overrides: { reserveTokens?: number; keepRecentTokens?: number } = {};

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -188,6 +188,13 @@ function estimatePromptTokensForMemoryFlush(prompt?: string): number | undefined
   return Math.ceil(tokens);
 }
 
+function toNonNegativeInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
 function resolveEffectivePromptTokens(
   basePromptTokens?: number,
   lastOutputTokens?: number,
@@ -789,9 +796,13 @@ export async function runPreflightCompactionIfNeeded(params: {
     agentCfgContextTokens: params.agentCfgContextTokens,
   });
   const memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
+  const configuredReserveTokens = toNonNegativeInt(
+    params.cfg.agents?.defaults?.compaction?.reserveTokens,
+  );
   const reserveTokensFloor =
     memoryFlushPlan?.reserveTokensFloor ??
     params.cfg.agents?.defaults?.compaction?.reserveTokensFloor ??
+    configuredReserveTokens ??
     20_000;
   const softThresholdTokens = memoryFlushPlan?.softThresholdTokens ?? 4_000;
   const freshPersistedTokens = resolveFreshSessionTotalTokens(entry);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1470,7 +1470,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.compaction.keepRecentTokens":
     "Minimum token budget preserved from the most recent conversation window during compaction. Use higher values to protect immediate context continuity and lower values to keep more long-tail history.",
   "agents.defaults.compaction.reserveTokensFloor":
-    "Minimum floor enforced for reserveTokens in embedded OpenClaw compaction paths (0 disables the floor guard). Use a non-zero floor to avoid over-aggressive compression under fluctuating token estimates.",
+    "Minimum floor enforced for reserveTokens in embedded OpenClaw compaction paths when explicitly configured. If reserveTokens is set and this is omitted, the explicit reserve is used as-is. Use a non-zero floor to avoid over-aggressive compression under fluctuating token estimates, or set 0 to disable the floor explicitly.",
   "agents.defaults.compaction.maxHistoryShare":
     "Maximum fraction of total context budget allowed for retained history after compaction (range 0.1-0.9). Use lower shares for more generation headroom or higher shares for deeper historical continuity.",
   "agents.defaults.compaction.identifierPolicy":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -508,11 +508,11 @@ export type AgentCompactionMidTurnPrecheckConfig = {
 export type AgentCompactionConfig = {
   /** Compaction summarization mode. */
   mode?: AgentCompactionMode;
-  /** Embedded OpenClaw reserve tokens target before floor enforcement. */
+  /** Embedded OpenClaw reserve tokens target. */
   reserveTokens?: number;
   /** Embedded OpenClaw keepRecentTokens budget used for cut-point selection. */
   keepRecentTokens?: number;
-  /** Minimum reserve tokens enforced for embedded OpenClaw compaction (0 disables the floor). */
+  /** Minimum reserve tokens enforced for embedded OpenClaw compaction when explicitly configured. */
   reserveTokensFloor?: number;
   /** Max share of context window for history during safeguard pruning (0.1–0.9, default 0.5). */
   maxHistoryShare?: number;


### PR DESCRIPTION
## Summary

- Respect an explicitly configured `agents.defaults.compaction.reserveTokens` when `reserveTokensFloor` is omitted.
- Keep `reserveTokensFloor` as a lower bound only when it is explicitly configured.
- Align agent settings, runtime memory flush planning, memory-core flush plans, Codex context projection, Codex native startup binding, tests, and config docs.

## Real behavior proof

- Behavior or issue addressed: A real OpenClaw setup had `reserveTokens: 8192` configured, but hidden default `reserveTokensFloor: 20000` behavior could still be applied in runtime and Codex budget paths. That made the configured reserve misleading and could shrink usable prompt budget unexpectedly.
- Real environment tested: Local OpenClaw install on Linux/WSL2, package `openclaw@2026.6.1`, with equivalent dist patches applied before preparing this source PR. Source branch head for this PR proof: `286494ff8278da50f5669c50fb23043177fbfd3c`.
- Exact steps or command run after this patch: Ran copied live terminal commands against the installed OpenClaw setup: `node -p "require('/home/nblue/.npm-global/lib/node_modules/openclaw/package.json').version"`, `jq '.agents.defaults.compaction | {reserveTokens, reserveTokensFloor}' /home/nblue/.openclaw/openclaw.json`, and `rg -n "DEFAULT_RESERVE_TOKENS|resolveCompactionSettings|reserveTokensFloor" /home/nblue/.npm-global/lib/node_modules/openclaw/dist/agent-settings-*.js /home/nblue/.npm-global/lib/node_modules/openclaw/dist/agent-runner.runtime-*.js /home/nblue/.npm-global/lib/node_modules/openclaw/dist/extensions/memory-core/index.js /home/nblue/.npm-global/lib/node_modules/openclaw/dist/thread-lifecycle-*.js`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live terminal output from the real setup:

```text
$ node -p "require('/home/nblue/.npm-global/lib/node_modules/openclaw/package.json').version"
2026.6.1

$ jq '.agents.defaults.compaction | {reserveTokens, reserveTokensFloor}' /home/nblue/.openclaw/openclaw.json
{
  "reserveTokens": 8192,
  "reserveTokensFloor": null
}

$ rg -n "DEFAULT_RESERVE_TOKENS|resolveCompactionSettings|reserveTokensFloor" /home/nblue/.npm-global/lib/node_modules/openclaw/dist/agent-settings-*.js /home/nblue/.npm-global/lib/node_modules/openclaw/dist/agent-runner.runtime-*.js /home/nblue/.npm-global/lib/node_modules/openclaw/dist/extensions/memory-core/index.js /home/nblue/.npm-global/lib/node_modules/openclaw/dist/thread-lifecycle-*.js
/home/nblue/.npm-global/lib/node_modules/openclaw/dist/thread-lifecycle-DIl_avGC.js:82: const configuredReserveTokensFloor = toNonNegativeInt(asRecord(compaction)?.reserveTokensFloor);
/home/nblue/.npm-global/lib/node_modules/openclaw/dist/extensions/memory-core/index.js:81: const reserveTokensFloor = normalizeNonNegativeInt(compactionDefaults?.reserveTokensFloor) ?? normalizeNonNegativeInt(compactionDefaults?.reserveTokens) ?? 2e4;
/home/nblue/.npm-global/lib/node_modules/openclaw/dist/agent-settings-BrNIdcFH.js:24: const configuredReserveTokensFloor = toNonNegativeInt(compactionCfg?.reserveTokensFloor);
/home/nblue/.npm-global/lib/node_modules/openclaw/dist/agent-settings-BrNIdcFH.js:33: const targetReserveTokens = configuredReserveTokens !== void 0 ? Math.max(configuredReserveTokens, configuredReserveTokensFloor ?? 0) : Math.max(currentReserveTokens, reserveTokensFloor);
/home/nblue/.npm-global/lib/node_modules/openclaw/dist/agent-runner.runtime-CCReftdY.js:676: const reserveTokensFloor = memoryFlushPlan?.reserveTokensFloor ?? configuredReserveTokensFloor ?? configuredReserveTokens ?? 2e4;
```

- Observed result after fix: In the real setup, `reserveTokens: 8192` with no configured floor is no longer forced through the hidden `20000` floor in the patched runtime paths. The source PR now also covers the Codex native startup binding path that ClawSweeper flagged after the first pass.
- What was not tested: I did not run a full end-to-end GitHub Actions runner locally; this PR body proof addresses the external PR real-behavior gate, while the source tests and type checks below cover regression behavior.
- Proof limitations or environment constraints: The proof is from a local installed OpenClaw package with equivalent dist patches applied before this source PR. It is copied live terminal output, not a screenshot.
- Before evidence (optional but encouraged): Prior behavior was `max(reserveTokens, default reserveTokensFloor)` in several paths, so `reserveTokens: 8192` could become an effective 20000 reserve when the floor was omitted.

## Tests and validation

Focused commands run locally in `/home/nblue/.openclaw/workspace/openclaw-upstream`:

```text
node scripts/run-vitest.mjs run extensions/codex/src/app-server/startup-binding.test.ts src/agents/agent-settings.test.ts extensions/codex/src/app-server/context-engine-projection.test.ts extensions/memory-core/index.test.ts
node scripts/run-vitest.mjs run src/auto-reply/reply/agent-runner-memory.test.ts
corepack pnpm exec oxfmt --check extensions/codex/src/app-server/startup-binding.ts extensions/codex/src/app-server/startup-binding.test.ts src/agents/agent-settings.ts src/agents/agent-settings.test.ts src/auto-reply/reply/agent-runner-memory.ts src/auto-reply/reply/agent-runner-memory.test.ts extensions/memory-core/src/flush-plan.ts extensions/memory-core/index.test.ts extensions/codex/src/app-server/context-engine-projection.ts extensions/codex/src/app-server/context-engine-projection.test.ts docs/reference/session-management-compaction.md src/config/schema.help.ts src/config/types.agent-defaults.ts
corepack pnpm tsgo:core
corepack pnpm tsgo:extensions
```

Regression coverage added or updated:

- Explicit `reserveTokens` no longer gets raised by the implicit default floor.
- Explicit `reserveTokensFloor` still acts as a lower bound.
- Explicit floor is capped on small-context models before it is used as a lower bound.
- Memory flush planning falls back to explicit `reserveTokens` before `20000`.
- Codex context projection mirrors the same rule.
- Codex native startup binding mirrors the same rule.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `Yes`
