### PR TITLE
fix(ollama): honor memory embedding output dimensionality

### DIFF
--- a/extensions/ollama/src/embedding-provider.test.ts
+++ b/extensions/ollama/src/embedding-provider.test.ts
@@ -125,6 +125,25 @@ describe("ollama embedding provider", () => {
     expect(vector[1]).toBeCloseTo(0.8, 5);
   });
 
+  it("applies outputDimensionality before normalizing vectors", async () => {
+    mockEmbeddingFetch([3, 4, 12]);
+
+    const { provider } = await createOllamaEmbeddingProvider({
+      config: {} as OpenClawConfig,
+      provider: "ollama",
+      model: "unknown-embedder",
+      fallback: "none",
+      remote: { baseUrl: "http://127.0.0.1:11434" },
+      outputDimensionality: 2,
+    });
+
+    const vector = await provider.embedQuery("hi");
+
+    expect(vector).toHaveLength(2);
+    expect(vector[0]).toBeCloseTo(0.6, 5);
+    expect(vector[1]).toBeCloseTo(0.8, 5);
+  });
+
   it("marks the configured Ollama origin for managed-proxy direct routing", async () => {
     const fetchMock = mockEmbeddingFetch([1, 0]);
 
@@ -607,6 +626,23 @@ describe("ollama embedding provider", () => {
     const init = firstFetchInit(fetchMock);
     const headers = init?.headers as Record<string, string> | undefined;
     expect(headers?.Authorization).toBeUndefined();
+  });
+
+  it("includes outputDimensionality in the memory embedding cache identity", async () => {
+    const result = await ollamaMemoryEmbeddingProviderAdapter.create({
+      config: {} as OpenClawConfig,
+      provider: "ollama",
+      model: "nomic-embed-text",
+      fallback: "none",
+      remote: { baseUrl: "http://127.0.0.1:11434" },
+      outputDimensionality: 2,
+    });
+
+    expect(result.runtime?.cacheKeyData).toMatchObject({
+      provider: "ollama",
+      model: "nomic-embed-text",
+      outputDimensionality: 2,
+    });
   });
 
   it("marks inline memory batches as local-server timeout work", async () => {

--- a/extensions/ollama/src/embedding-provider.ts
+++ b/extensions/ollama/src/embedding-provider.ts
@@ -51,6 +51,7 @@ export type OllamaEmbeddingClient = {
   headers: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
   model: string;
+  outputDimensionality?: number;
   embedBatch: (texts: string[]) => Promise<number[][]>;
 };
 
@@ -74,8 +75,10 @@ const QUERY_INSTRUCTION_TEMPLATES = [
   },
 ] as const;
 
-function sanitizeAndNormalizeEmbedding(vec: unknown[]): number[] {
-  const sanitized = vec.map((value) => {
+function sanitizeAndNormalizeEmbedding(vec: unknown[], outputDimensionality?: number): number[] {
+  const selected =
+    typeof outputDimensionality === "number" ? vec.slice(0, outputDimensionality) : vec;
+  const sanitized = selected.map((value) => {
     if (typeof value !== "number") {
       throw new Error("Ollama embed response contains a non-number embedding value");
     }
@@ -318,6 +321,7 @@ function resolveOllamaEmbeddingClient(
     headers,
     ssrfPolicy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(baseUrl),
     model,
+    outputDimensionality: options.outputDimensionality,
   };
 }
 
@@ -358,7 +362,7 @@ export async function createOllamaEmbeddingProvider(
       if (!Array.isArray(embedding)) {
         throw new Error("Ollama embed response contains a non-array embedding");
       }
-      return sanitizeAndNormalizeEmbedding(embedding);
+      return sanitizeAndNormalizeEmbedding(embedding, client.outputDimensionality);
     });
   };
 

--- a/extensions/ollama/src/memory-embedding-adapter.ts
+++ b/extensions/ollama/src/memory-embedding-adapter.ts
@@ -24,6 +24,7 @@ export const ollamaMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapte
         cacheKeyData: {
           provider: "ollama",
           model: client.model,
+          outputDimensionality: client.outputDimensionality,
         },
       },
     };


### PR DESCRIPTION
## Summary

- Honor `agents.*.memorySearch.outputDimensionality` for Ollama memory embeddings by truncating returned vectors before normalization.
- Include Ollama `outputDimensionality` in the memory embedding runtime cache identity so dimension changes do not reuse an incompatible index.
- Add focused regression coverage for the provider behavior and adapter cache key.

## Origin / follow-up

- **Follows / completes:** #93758.
- **Gap this fills:** #93758 made local GGUF embeddings apply `outputDimensionality` before normalization and include the dimension in cache/index identity. Ollama memory embeddings already accepted the same option in its provider options, but the provider ignored it and the adapter cache key omitted it.
- **Consistency:** This patch applies the same rule to the Ollama sibling path: truncate before normalization, and make the selected dimension part of the embedding identity.

## Root Cause

- **Root cause:** `createOllamaEmbeddingProvider` carried `outputDimensionality` in its options type but never stored it on the resolved client or applied it to returned embedding vectors. `ollamaMemoryEmbeddingProviderAdapter` also built `cacheKeyData` only from provider/model, so different configured dimensions shared the same memory embedding identity.
- **Why this is root-cause fix:** The fix wires the existing option into the Ollama provider's source-of-truth embedding client, applies it at the vector normalization boundary, and records it in the adapter runtime identity. It does not add a downstream fallback or special-case index repair.
- **Architecture / source-of-truth check:** The source-of-truth boundary is the Ollama memory embedding provider client plus the memory adapter runtime identity. This does not change the public config schema, validation rules, defaults, provider routing, migrations, or memory index storage contract.
- **Fix classification:** Root-cause sibling follow-up to an existing memory embedding dimensionality fix.

## Real behavior proof

- **Behavior or issue addressed:** Ollama memory embeddings now honor configured output dimensionality and produce a distinct cache identity for dimension-specific memory indexes.
- **Real environment tested:** Local OpenClaw Gateway runtime from this patched branch, using a temporary official Ollama v0.30.10 Linux binary on `127.0.0.1:11435` with the downloaded `all-minilm` embedding model and Gateway `/v1/embeddings` on `127.0.0.1:18791`.
- **Exact steps or command run after this patch:**

```bash
# Temporary config used by the Gateway proof:
# agents.defaults.memorySearch.provider = "ollama"
# agents.defaults.memorySearch.model = "all-minilm"
# agents.defaults.memorySearch.remote.baseUrl = "http://127.0.0.1:11435"
# agents.defaults.memorySearch.outputDimensionality = 2

OPENCLAW_HOME="/media/vdb/code/ai/aispace/openclaw-followup-93758-evidence/gateway-proof-home" \
OPENCLAW_CONFIG_PATH="/media/vdb/code/ai/aispace/openclaw-followup-93758-evidence/gateway-ollama-proof.openclaw.json" \
OPENCLAW_STATE_DIR="/media/vdb/code/ai/aispace/openclaw-followup-93758-evidence/gateway-proof-state-3" \
OPENCLAW_GATEWAY_PORT=18791 \
OPENCLAW_SKIP_CHANNELS=1 \
pnpm --dir "/media/vdb/code/ai/aispace/openclaw-worktrees/followup-93758" gateway:dev

python3 - <<'PY'
import json, urllib.request

def post_json(url, payload):
    req=urllib.request.Request(url, data=json.dumps(payload).encode(), headers={'Content-Type':'application/json'}, method='POST')
    with urllib.request.urlopen(req, timeout=120) as resp:
        return resp.status, json.load(resp)

raw_status, raw_data = post_json('http://127.0.0.1:11435/api/embed', {
    'model': 'all-minilm',
    'input': 'openclaw configured dimensionality proof',
})
raw_embeddings = raw_data.get('embeddings') or []
raw_vec = raw_embeddings[0] if raw_embeddings else []

gw_status, gw_data = post_json('http://127.0.0.1:18791/v1/embeddings', {
    'model': 'openclaw/default',
    'input': ['openclaw configured dimensionality proof', 'second sample'],
})
gw_embeddings = [item.get('embedding') for item in gw_data.get('data', [])]

probe_status, probe_data = post_json('http://127.0.0.1:18791/v1/embeddings', {
    'model': 'openclaw/default',
    'input': 'openclaw request dimensions override proof',
    'dimensions': 3,
})
probe_embeddings = [item.get('embedding') for item in probe_data.get('data', [])]

print(json.dumps({
    'ollama_direct': {
        'status': raw_status,
        'model': 'all-minilm',
        'embedding_count': len(raw_embeddings),
        'first_vector_length': len(raw_vec),
        'first3': raw_vec[:3],
    },
    'gateway_configured_output_dimensionality': {
        'status': gw_status,
        'request_model': gw_data.get('model'),
        'embedding_lengths': [len(v) if isinstance(v, list) else None for v in gw_embeddings],
        'first_embedding': gw_embeddings[0] if gw_embeddings else None,
    },
    'gateway_dimensions_probe': {
        'status': probe_status,
        'request_dimensions': 3,
        'embedding_lengths': [len(v) if isinstance(v, list) else None for v in probe_embeddings],
        'first_embedding': probe_embeddings[0] if probe_embeddings else None,
    },
}, ensure_ascii=False, indent=2))
PY
```

- **Evidence after fix:**

```json
{
  "ollama_direct": {
    "status": 200,
    "model": "all-minilm",
    "embedding_count": 1,
    "first_vector_length": 384,
    "first3": [
      -0.026465453,
      0.026134023,
      -0.028530085
    ]
  },
  "gateway_configured_output_dimensionality": {
    "status": 200,
    "request_model": "openclaw/default",
    "embedding_lengths": [
      2,
      2
    ],
    "first_embedding": [
      -0.7115481453725724,
      0.7026373437391814
    ]
  },
  "gateway_dimensions_probe": {
    "status": 200,
    "request_dimensions": 3,
    "embedding_lengths": [
      3
    ],
    "first_embedding": [
      -0.6263598420395023,
      0.7354533291563625,
      -0.2584216494666664
    ]
  }
}
```

- **Observed result after fix:** The live Ollama daemon returned a native 384-dimensional embedding directly, while the real OpenClaw Gateway `/v1/embeddings` path returned 2-dimensional vectors for the same Ollama-backed agent when `outputDimensionality: 2` was configured. The adjacent `dimensions: 3` Gateway probe returned a 3-dimensional vector through the same runtime path.
- **What was not tested:** Third-party channel delivery was not tested because this patch does not touch channel transport. Non-Linux Ollama binaries were not tested; this proof used the official Linux binary in a temporary local runtime.

## Review findings addressed

- **RF-001 / RF-002 / RF-003:** Added live terminal proof from a real Ollama daemon plus the real OpenClaw Gateway `/v1/embeddings` path. The daemon returned native 384-dimensional `all-minilm` embeddings directly, while Gateway returned 2-dimensional embeddings with `agents.defaults.memorySearch.outputDimensionality = 2`.
- **RF-004:** Added the upgrade compatibility / reindex note under Merge risk. Configured Ollama memory indexes now receive a dimension-specific embedding identity, so affected users should rebuild/reindex instead of reusing a full-width index.
- **RF-005:** No code repair beyond this patch is required from the bot finding. The remaining acceptance question is maintainer acceptance of the intentional compatibility boundary described below.

## Regression Test Plan

- **Target test file:** `extensions/ollama/src/embedding-provider.test.ts`.
- **Scenario locked in:** An Ollama embedding response with a longer vector and configured `outputDimensionality: 2` must return a 2-dimensional normalized vector, and the adapter cache identity must differ for that dimension.
- **Why this is the smallest reliable guardrail:** The regression test exercises the provider response normalization boundary and the adapter identity boundary directly, while the live Gateway proof above exercises the real HTTP runtime surface against an Ollama daemon.
- Added coverage for truncating Ollama vectors before normalization when `outputDimensionality` is configured.
- Added coverage for preserving `outputDimensionality` in `ollamaMemoryEmbeddingProviderAdapter` runtime cache identity.
- Also ran `git diff --check`; it produced no output.

## Competition / linked PR analysis

- Searched open PRs for `Ollama outputDimensionality` and `ollama embeddings dimensions memory`.
- The only nearby open result was #94763, which targets OpenAI-compatible embedding dimensions and self-hosted server resets. It does not touch Ollama memory embedding vector handling or Ollama memory embedding cache identity.
- No open PR was found that already applies the #93758 dimensionality follow-up to the Ollama memory embedding provider.

## Merge risk

- **Why it matters / User impact:** Without this fix, users configuring a reduced memory embedding dimension for Ollama can keep receiving full-width vectors and can reuse a memory index identity across incompatible dimensions.
- **Risk labels considered:** `merge-risk: memory`, `merge-risk: provider-adapter`, `merge-risk: compatibility`, `proof: supplied`.
- **Risk explanation:** The patch touches only the Ollama memory embedding provider, its memory adapter cache identity, and focused tests. It does not change chat model routing, provider auth selection, third-party channel delivery, session state, or plugin hook contracts.
- **Upgrade compatibility / reindex note:** Ollama memory indexes configured with `outputDimensionality` now get a dimension-specific embedding cache identity. Affected users should expect the existing memory index identity check to require/recommend rebuilding or reindexing those Ollama memory vectors instead of reusing a full-width index. Unset/default Ollama configs keep native model vector width behavior.
- **What did NOT change:** Out of scope and unchanged: `agents.*.memorySearch.outputDimensionality` config schema/validation/defaults, non-Ollama embedding providers, memory storage migrations, session state, provider routing, auth selection, and all channel delivery paths.
- **Why acceptable:** The existing option already exists on the Ollama provider options surface. The behavior now matches the sibling dimensionality handling merged in #93758, the live Gateway proof exercises the real Ollama runtime path, and the regression proof exercises the changed local code path.
- **Maintainer-ready confidence:** High for a small follow-up patch with focused red/green coverage and bounded provider-adapter scope.
- **Patch quality notes:** Three files changed; production change is limited to carrying the existing option through the Ollama client, truncating before normalization, and including the option in cache identity. Patch-quality warning reviewed: the added `fallback: "none"` lines are existing test fixture arguments required by `createOllamaEmbeddingProvider`, not runtime fallback logic or a masking guard.
