### PR TITLE
fix(telegram): prevent false 401 detection from substring match

### DIFF
--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -69,9 +69,23 @@ function is401Error(error: unknown): boolean {
   if (!error) {
     return false;
   }
+  // Prefer numeric status fields to avoid false-positives from bare
+  // substring matching (e.g. "5401" contains "401" but is not 401).
+  // openclaw/openclaw#94787
+  const asError = error as Record<string, unknown>;
+  if (
+    asError.status === 401 ||
+    asError.statusCode === 401 ||
+    (typeof asError.status === "string" && asError.status === "401") ||
+    (typeof asError.statusCode === "string" && asError.statusCode === "401") ||
+    (typeof asError.error_code === "number" && asError.error_code === 401) ||
+    (typeof asError.error_code === "string" && asError.error_code === "401")
+  ) {
+    return true;
+  }
   const message = error instanceof Error ? error.message : JSON.stringify(error);
   return (
-    message.includes("401") || normalizeLowercaseStringOrEmpty(message).includes("unauthorized")
+    /\b401\b/.test(message) || normalizeLowercaseStringOrEmpty(message).includes("unauthorized")
   );
 }
 


### PR DESCRIPTION
## Summary

Fix `is401Error` to use word-boundary matching instead of naive
substring `message.includes("401")` which matches any number
containing "401" (e.g. "5401", "2401").

## Problem

`sendChatAction` is401Error used bare `String.includes("401")` which
triggers false positives on transient errors (429, 5xx) whose error
messages happen to contain "401" as a substring.  This falsely
increments the 401 counter and can:
- Apply exponential backoff to healthy requests
- Suspend the bot with a false "token is likely invalid" alarm

## Root Cause

In `is401Error`, `message.includes("401")` matches "5401", "1401",
etc.  The error object's numeric status fields were not checked at all.

## Changes

- `extensions/telegram/src/sendchataction-401-backoff.ts` —
  prefer numeric `status`/`statusCode`/`error_code` fields (checking
  for exact value 401), then fall back to word-boundary regex
  `/\b401\b/` instead of bare `includes`

## Related

Closes #94787

🤖 Generated with [Claude Code](https://claude.com/claude-code)