### PR TITLE
fix(infra): pin SSH tunnel port preflight to IPv4 loopback; fix(workboard): filter archived cards in CLI list

### DIFF
--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -130,14 +130,22 @@ export function registerWorkboardCli(params: { program: Command; store: Workboar
     .description("List Workboard cards")
     .option("--board <id>", "Board id")
     .option("--status <status>", "Filter by status")
+    .option("--include-archived", "Include archived cards (default false)")
     .option("--json", "Print JSON", false)
-    .action(async (options: JsonOptions & { board?: string; status?: string }) => {
-      let cards = await params.store.list({ boardId: options.board });
-      if (options.status) {
-        cards = cards.filter((card) => card.status === options.status);
-      }
-      writeCards(cards, options);
-    });
+    .action(
+      async (
+        options: JsonOptions & { board?: string; status?: string; includeArchived?: boolean },
+      ) => {
+        let cards = await params.store.list({ boardId: options.board });
+        if (!options.includeArchived) {
+          cards = cards.filter((card) => !card.metadata?.archivedAt);
+        }
+        if (options.status) {
+          cards = cards.filter((card) => card.status === options.status);
+        }
+        writeCards(cards, options);
+      },
+    );
 
   workboard
     .command("create")

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -119,7 +119,7 @@ export async function startSshPortForward(opts: {
 
   let localPort = opts.localPortPreferred;
   try {
-    await ensurePortAvailable(localPort);
+    await ensurePortAvailable(localPort, "127.0.0.1");
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {
       localPort = await pickEphemeralPort();


### PR DESCRIPTION
## 变更说明

两个独立修复：

### 1. fix(infra): SSH tunnel 端口预检 pin 到 IPv4 loopback

`startSshPortForward` 调用 `ensurePortAvailable(localPort)` 时未传 host，在双栈主机上会绑定 IPv6 通配符 `::`，漏检 IPv4-only 端口占用。改为 `ensurePortAvailable(localPort, "127.0.0.1")`，与该模块其他所有探针一致。

### 2. fix(workboard): CLI list 默认过滤已归档卡片

`openclaw workboard list` CLI 命令不过滤软归档卡片，与 API tool 行为不一致。新增 `--include-archived` 标志，默认隐藏 `metadata.archivedAt` 已设置的卡片。

## 关联 Issue

Closes #94596
Closes #94555

## 变更类型

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Code refactor
- [ ] Test update
- [ ] Dependency update

## 风险等级

low

## 测试情况

- `pnpm vitest run src/infra/ports.test.ts` — 14 tests pass
- `pnpm vitest run extensions/workboard/src/cli.test.ts` — 4 tests pass