### PR TITLE
fix(sandbox): create missing skill mount directories to enforce read-only protection

### DIFF
--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -41,16 +41,26 @@ export function resolveMaterializedSandboxSkillsWorkspaceDir(rootDir: string): s
   return path.join(rootDir, ...MATERIALIZED_SANDBOX_SKILLS_WORKSPACE_PARTS);
 }
 
-/** Returns true when a skill mount source exists inside the canonical mount root. */
+/** Returns true when a skill mount source exists inside the canonical mount root.
+ *  When the host directory does not exist yet (first agent creation), it is
+ *  created so the read-only mount is not silently skipped. (#94425) */
 export function isExistingWorkspaceSkillMountSource(params: {
   rootDir: string;
   hostPath: string;
 }): boolean {
+  let stat: fs.Stats | undefined;
   try {
-    if (!fs.lstatSync(params.hostPath).isDirectory()) {
+    stat = fs.lstatSync(params.hostPath);
+  } catch {
+    // Directory does not exist yet — create it so the read-only mount applies.
+    try {
+      fs.mkdirSync(params.hostPath, { recursive: true });
+      return true;
+    } catch {
       return false;
     }
-  } catch {
+  }
+  if (!stat.isDirectory()) {
     return false;
   }
 


### PR DESCRIPTION
Closes #94425

## What Problem This Solves

Sandbox skill directories were not mounted read-only on first agent creation. `isExistingWorkspaceSkillMountSource` returned `false` when the host directory didn't exist, causing the read-only bind mount to be silently skipped.

## Why This Change Was Made

In the `catch` block (when `lstatSync` throws), create the missing directory so the read-only mount is always applied.

## Evidence

```text
$ npx tsx -e ...

=== Before fix (dir does not exist) ===
  isExistingWorkspaceSkillMountSource → false
  Mount result: SILENTLY SKIPPED (read-only protection lost)

=== After fix (dir does not exist) ===
  isExistingWorkspaceSkillMountSource → true
  Directory created: true
  Docker mount args: -v /tmp/../sandbox-skills:ro,z
  Mount result: APPLIED with :ro,z (read-only)
```

The Docker bind mount now includes `:ro,z` (read-only) even on first agent creation. When the directory already exists, behavior is identical (no regression).