### PR TITLE
fix(plugins): pin HTTP route registry during gateway plugin bootstrap

### DIFF
--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -64,6 +64,7 @@ function installGatewayPluginRuntimeEnvironment(cfg: OpenClawConfig) {
 function pinGatewayPluginRuntimeRegistries(pluginRegistry: PluginRegistry): void {
   pinActivePluginChannelRegistry(pluginRegistry);
   pinActivePluginSessionExtensionRegistry(pluginRegistry);
+  pinActivePluginHttpRouteRegistry(pluginRegistry);
 }
 
 // Diagnostics are logged after registry priming so startup output contains

--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -8,6 +8,7 @@ import type { PluginRegistryParams } from "../plugins/registry-types.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import {
   pinActivePluginChannelRegistry,
+  pinActivePluginHttpRouteRegistry,
   pinActivePluginSessionExtensionRegistry,
 } from "../plugins/runtime.js";
 import {


### PR DESCRIPTION
## Summary

- `pinGatewayPluginRuntimeRegistries` was missing `pinActivePluginHttpRouteRegistry`, so workspace plugins loaded via `plugins.load.paths` had their HTTP routes registered but never wired into the running gateway
- `replaceAttachedPluginRuntime` (used during reloads) already calls all three pin functions; this fix aligns the bootstrap path

## Real behavior proof

**Behavior addressed:** Workspace plugin HTTP routes are now wired into the gateway during initial bootstrap.

**Environment tested:** Node 22.x on Linux, openclaw upstream/main at 2ef0589b76.

**Steps run after the patch:**
```bash
grep -n -A3 "pinGatewayPluginRuntimeRegistries" src/gateway/server-plugin-bootstrap.ts
```

**Evidence after fix:**
```typescript
import {
  pinActivePluginChannelRegistry,
  pinActivePluginHttpRouteRegistry,   // ← added
  pinActivePluginSessionExtensionRegistry,
} from "../plugins/runtime.js";

function pinGatewayPluginRuntimeRegistries(pluginRegistry: PluginRegistry): void {
  pinActivePluginChannelRegistry(pluginRegistry);
  pinActivePluginSessionExtensionRegistry(pluginRegistry);
  pinActivePluginHttpRouteRegistry(pluginRegistry);   // ← added
}
```

Before: only `pinActivePluginChannelRegistry` + `pinActivePluginSessionExtensionRegistry` were called.
After: all three pin functions match `replaceAttachedPluginRuntime` pattern.

**Observed result:** `pinGatewayPluginRuntimeRegistries` now calls the same three registry pin functions as `replaceAttachedPluginRuntime`.

**Not tested:** Live gateway with a workspace plugin loaded via `plugins.load.paths` without `activation.onStartup` — requires running gateway + test plugin.

Closes #94572