### PR TITLE
fix(trello): add curl to requires.bins as all examples use curl

### DIFF
--- a/skills/trello/SKILL.md
+++ b/skills/trello/SKILL.md
@@ -7,14 +7,14 @@ metadata:
     "openclaw":
       {
         "emoji": "📋",
-        "requires": { "bins": ["jq"], "env": ["TRELLO_API_KEY", "TRELLO_TOKEN"] },
+        "requires": { "bins": ["jq", "curl"], "env": ["TRELLO_API_KEY", "TRELLO_TOKEN"] },
         "install":
           [
             {
               "id": "brew",
               "kind": "brew",
               "formula": "jq",
-              "bins": ["jq"],
+              "bins": ["jq", "curl"],
               "label": "Install jq (brew)",
             },
           ],


### PR DESCRIPTION
## Summary

All examples in the Trello skill use `curl`, but `requires.bins` only listed `jq`. On systems without curl, the Trello skill passes doctor/skills check but fails at runtime.

## Fix

Added `"curl"` to both the metadata `requires.bins` and the brew install `bins` array.

Closes #94727