### PR TITLE
fix(feishu): use sender name as conversation label for DM sessions

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1416,7 +1416,9 @@ export async function handleFeishuMessage(params: {
         conversation: {
           kind: isGroup ? "group" : "direct",
           id: ctx.chatId,
-          label: isGroup && groupName && !isTopicSessionForThread ? groupName : undefined,
+          label: isGroup && groupName && !isTopicSessionForThread
+            ? groupName
+            : ctx.senderName ?? undefined,
           threadId: ctx.rootId && isTopicSessionForThread ? ctx.rootId : undefined,
         },
         route: {


### PR DESCRIPTION
## What

Set the conversation label to `ctx.senderName` for direct message conversations in the Feishu channel extension. Without this, DM sessions display raw `ou_xxx` open_id or opaque session keys in the TUI and web dashboard session picker.

## Why

Currently, Feishu only sets a conversation label for group conversations (using `groupName`). DM conversations get `label: undefined`, which causes the session picker to fall back to raw identifiers. Telegram (`buildSenderLabel`) and Slack (`envelopeFrom`) already set sender names as the DM label — this brings Feishu in line.

## How

Single-line change in `extensions/feishu/src/bot.ts`: the existing ternary that selects the conversation label now falls back to `ctx.senderName ?? undefined` instead of bare `undefined` for non-group conversations.

## Real behavior proof

- **Behavior addressed:** Feishu DM conversations now get a human-readable session label (sender name) instead of raw identifiers
- **Environment tested:** OpenClaw local build, pnpm build + feishu extension verification suite
- **Steps run after the patch:** Built the project with `pnpm build`, ran the feishu extension verification suite
- **Evidence after fix:**
```
extensions/feishu/src/bot.ts | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)

$ node scripts/run-vitest.mjs run extensions/feishu/src/bot.test.ts
 ✓  extension-feishu  extensions/feishu/src/bot.test.ts (87 tests) 204ms
 Test Files  1 passed (1)
      Tests  87 passed (87)

$ node -e "const fs=require('fs'); const c=fs.readFileSync('extensions/feishu/src/bot.ts','utf8'); console.log('senderName label:', c.includes('ctx.senderName ?? undefined'));"
senderName label: true

$ grep -n 'ctx.senderName ?? undefined' extensions/feishu/src/bot.ts
1419:            : ctx.senderName ?? undefined,
```
- **Observed result after fix:** All 87 feishu extension tests pass. The conversation.label field for DM conversations now resolves to `ctx.senderName` (the sender's display name) instead of `undefined`.
- **What was not tested:** Live Telegram/Feishu round-trip (no Feishu credentials available locally); the actual TUI/web session picker display with the new label.
