### PR TITLE
fix: respect replace mode in default models list

### DIFF
--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -632,6 +632,129 @@ describe("models list/status", () => {
     expect(payload.models[0]?.key).toBe("google-antigravity/claude-opus-4-6-thinking");
   });
 
+  it("models list replace mode skips auth-backed built-in catalogs without provider wildcards", async () => {
+    getRuntimeConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: "deepseek/deepseek-v4-pro",
+          models: {
+            "deepseek/deepseek-v4-pro": {},
+          },
+        },
+      },
+      models: {
+        mode: "replace",
+        providers: {
+          deepseek: {
+            api: "openai-responses",
+            baseUrl: "https://api.deepseek.test/v1",
+            models: [
+              {
+                id: "deepseek-v4-pro",
+                name: "DeepSeek V4 Pro",
+                input: ["text"],
+                contextWindow: 128000,
+              },
+            ],
+          },
+          xai: {
+            api: "openai-responses",
+            baseUrl: "https://api.xai.test/v1",
+            models: [
+              {
+                id: "grok-4.3",
+                name: "Grok 4.3",
+                input: ["text"],
+                contextWindow: 128000,
+              },
+            ],
+          },
+        },
+      },
+    });
+    loadModelCatalog.mockResolvedValue([
+      OPENAI_MODEL,
+      {
+        provider: "groq",
+        id: "llama-4",
+        name: "Llama 4",
+        input: ["text"],
+        baseUrl: "https://api.groq.com/openai/v1",
+        contextWindow: 128000,
+      },
+    ]);
+    listProfilesForProvider.mockImplementation((_: unknown, provider: string) =>
+      ["openai", "groq", "deepseek", "xai"].includes(provider)
+        ? ([{ id: `${provider}-profile` }] as Array<Record<string, unknown>>)
+        : [],
+    );
+    const runtime = makeRuntime();
+
+    await modelsListCommand({ json: true }, runtime);
+
+    const payload = parseJsonLog(runtime);
+    expect(payload.models.map((model: { key: string }) => model.key)).toEqual([
+      "deepseek/deepseek-v4-pro",
+      "xai/grok-4.3",
+    ]);
+  });
+
+  it("models list replace mode scopes auth-backed catalogs to provider wildcards", async () => {
+    getRuntimeConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: "deepseek/deepseek-v4-pro",
+          models: {
+            "deepseek/*": {},
+            "xai/grok-4.3": {},
+          },
+        },
+      },
+      models: {
+        mode: "replace",
+        providers: {
+          xai: {
+            api: "openai-responses",
+            baseUrl: "https://api.xai.test/v1",
+            models: [
+              {
+                id: "grok-4.3",
+                name: "Grok 4.3",
+                input: ["text"],
+                contextWindow: 128000,
+              },
+            ],
+          },
+        },
+      },
+    });
+    loadModelCatalog.mockResolvedValue([
+      {
+        provider: "deepseek",
+        id: "deepseek-v4-pro",
+        name: "DeepSeek V4 Pro",
+        input: ["text"],
+        baseUrl: "https://api.deepseek.test/v1",
+        contextWindow: 128000,
+      },
+      OPENAI_MODEL,
+    ]);
+    listProfilesForProvider.mockImplementation((_: unknown, provider: string) =>
+      ["openai", "deepseek", "xai"].includes(provider)
+        ? ([{ id: `${provider}-profile` }] as Array<Record<string, unknown>>)
+        : [],
+    );
+    const runtime = makeRuntime();
+
+    await modelsListCommand({ json: true }, runtime);
+
+    const payload = parseJsonLog(runtime);
+    expect(payload.models.map((model: { key: string }) => model.key)).toEqual([
+      "deepseek/deepseek-v4-pro",
+      "xai/grok-4.3",
+    ]);
+  });
+
   it("models list fails fast when configured registry lookup is unavailable", async () => {
     configureGoogleAntigravityModel("claude-opus-4-6-thinking");
     enableGoogleAntigravityAuthProfile();

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -261,6 +261,18 @@ function shouldListConfiguredProviderModel(params: {
   return params.providerConfig.api !== undefined || params.model.api !== undefined;
 }
 
+function configuredWildcardProviders(cfg: OpenClawConfig): Set<string> {
+  const providers = new Set<string>();
+  for (const key of Object.keys(cfg.agents?.defaults?.models ?? {})) {
+    const normalizedKey = key.trim().toLowerCase();
+    if (!normalizedKey.endsWith("/*")) {
+      continue;
+    }
+    providers.add(normalizedKey.slice(0, -2));
+  }
+  return providers;
+}
+
 function findConfiguredProviderModel(params: {
   cfg: OpenClawConfig;
   provider: string;
@@ -379,6 +391,13 @@ export async function appendAuthenticatedCatalogRows(params: {
   context: RowBuilderContext;
   seenKeys: Set<string>;
 }): Promise<void> {
+  const wildcardProviders =
+    params.context.cfg.models?.mode === "replace"
+      ? configuredWildcardProviders(params.context.cfg)
+      : undefined;
+  if (wildcardProviders?.size === 0) {
+    return;
+  }
   const { loadModelCatalog } = await loadModelCatalogModule();
   const catalog = await loadModelCatalog({
     config: params.context.cfg,
@@ -387,6 +406,9 @@ export async function appendAuthenticatedCatalogRows(params: {
   });
   for (const entry of catalog) {
     if (!params.context.authIndex.hasProviderAuth(entry.provider)) {
+      continue;
+    }
+    if (wildcardProviders && !wildcardProviders.has(normalizeProviderId(entry.provider))) {
       continue;
     }
     const key = modelKey(entry.provider, entry.id);


### PR DESCRIPTION
Summary
- make default `openclaw models list` stop appending auth-backed built-in catalogs when `models.mode` is `"replace"` and the config does not opt into provider wildcard visibility
- keep replace-mode wildcard behavior narrow by allowing dynamic catalog rows only for providers explicitly allowed via `agents.defaults.models["provider/*"]`
- add focused regression coverage for both replace-mode paths

Verification
- `node scripts/run-vitest.mjs src/commands/models.list.e2e.test.ts`
- `git diff --check`
- Real behavior proof:
  - Behavior addressed: `openclaw models list --json` no longer shows unrelated auth-backed providers when `models.mode` is `"replace"` with a restricted provider config.
  - Real environment tested: source-checkout OpenClaw CLI command path via `node --import tsx src/entry.ts models list --json` on June 19, 2026 with a temporary `OPENCLAW_CONFIG_PATH`, `OPENCLAW_HOME`, and `OPENCLAW_STATE_DIR`.
  - Exact steps or command run after this patch: `OPENCLAW_HOME="$home" OPENCLAW_STATE_DIR="$state" OPENAI_API_KEY=test-openai GROQ_API_KEY=test-groq DEEPSEEK_API_KEY=test-deepseek XAI_API_KEY=test-xai OPENCLAW_CONFIG_PATH="$config" node --import tsx src/entry.ts models list --json`
  - Evidence after fix: terminal JSON output reported `count: 3` with keys `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`, and `xai/grok-4.3`; no `openai/*` or `groq/*` rows were present.
  - Observed result after fix: the default list matched the replace-mode allowlist/configured-provider scope instead of leaking other authenticated built-in providers into the visible model list.
  - What was not tested: packaged dist launcher output, `--all` behavior, and wildcard-provider CLI evidence outside the focused unit regression coverage.

Closes #94705
