### PR TITLE
fix(exec): recognize heartbeat as a headless exec trigger

### DIFF
--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./bash-tools.exec-approval-followup-state.js";
 import {
   buildExecApprovalPendingToolResult,
+  buildHeadlessExecApprovalDeniedMessage,
   createExecApprovalPendingState,
   enforceStrictInlineEvalApprovalBoundary,
   MAX_EXEC_APPROVAL_FOLLOWUP_FAILURE_LOG_KEYS as maxExecApprovalFollowupFailureLogKeys,
@@ -20,6 +21,7 @@ import {
   resolveExecApprovalUnavailableState,
   resolveExecHostApprovalContext,
   sendExecApprovalFollowupResult,
+  shouldResolveExecApprovalUnavailableInline,
 } from "./bash-tools.exec-host-shared.js";
 
 const mocks = vi.hoisted(() => ({
@@ -594,5 +596,107 @@ describe("buildExecApprovalPendingToolResult", () => {
     expect(text).not.toContain("/approve");
     expect(text).not.toContain("Pending command:");
     expect(text).not.toContain("Approver DMs were sent");
+  });
+});
+
+describe("shouldResolveExecApprovalUnavailableInline", () => {
+  it("returns true for cron trigger with no-approval-route and null preResolvedDecision", () => {
+    expect(
+      shouldResolveExecApprovalUnavailableInline({
+        trigger: "cron",
+        unavailableReason: "no-approval-route",
+        preResolvedDecision: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for heartbeat trigger with no-approval-route and null preResolvedDecision", () => {
+    expect(
+      shouldResolveExecApprovalUnavailableInline({
+        trigger: "heartbeat",
+        unavailableReason: "no-approval-route",
+        preResolvedDecision: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for heartbeat trigger with non-null preResolvedDecision", () => {
+    expect(
+      shouldResolveExecApprovalUnavailableInline({
+        trigger: "heartbeat",
+        unavailableReason: "no-approval-route",
+        preResolvedDecision: "allow-once",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for heartbeat trigger with unavailableReason other than no-approval-route", () => {
+    expect(
+      shouldResolveExecApprovalUnavailableInline({
+        trigger: "heartbeat",
+        unavailableReason: "initiating-platform-disabled",
+        preResolvedDecision: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for manual/default trigger even with no-approval-route", () => {
+    expect(
+      shouldResolveExecApprovalUnavailableInline({
+        trigger: "manual",
+        unavailableReason: "no-approval-route",
+        preResolvedDecision: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when trigger is undefined", () => {
+    expect(
+      shouldResolveExecApprovalUnavailableInline({
+        trigger: undefined,
+        unavailableReason: "no-approval-route",
+        preResolvedDecision: null,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("buildHeadlessExecApprovalDeniedMessage", () => {
+  const defaultParams = {
+    host: "gateway" as const,
+    security: "full" as const,
+    ask: "always" as const,
+    askFallback: "deny" as const,
+  };
+
+  it("includes Cron runs label for cron trigger", () => {
+    const msg = buildHeadlessExecApprovalDeniedMessage({
+      ...defaultParams,
+      trigger: "cron",
+    });
+    expect(msg).toContain("Cron runs cannot wait for interactive exec approval");
+  });
+
+  it("includes Heartbeat runs label for heartbeat trigger", () => {
+    const msg = buildHeadlessExecApprovalDeniedMessage({
+      ...defaultParams,
+      trigger: "heartbeat",
+    });
+    expect(msg).toContain("Heartbeat runs cannot wait for interactive exec approval");
+  });
+
+  it("falls back to Headless runs label for unrecognized triggers", () => {
+    const msg = buildHeadlessExecApprovalDeniedMessage({
+      ...defaultParams,
+      trigger: "manual",
+    });
+    expect(msg).toContain("Headless runs cannot wait for interactive exec approval");
+  });
+
+  it("falls back to Headless runs label when trigger is undefined", () => {
+    const msg = buildHeadlessExecApprovalDeniedMessage({
+      ...defaultParams,
+    });
+    expect(msg).toContain("Headless runs cannot wait for interactive exec approval");
   });
 });

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -83,7 +83,7 @@ export type ExecApprovalUnavailableReason =
   | "initiating-platform-unsupported";
 
 function isHeadlessExecTrigger(trigger?: string): boolean {
-  return trigger === "cron";
+  return trigger === "cron" || trigger === "heartbeat";
 }
 
 /** Context returned after a default approval request is registered. */
@@ -434,7 +434,12 @@ export function buildHeadlessExecApprovalDeniedMessage(params: {
   ask: ExecAsk;
   askFallback: ResolvedExecApprovals["agent"]["askFallback"];
 }): string {
-  const runLabel = params.trigger === "cron" ? "Cron runs" : "Headless runs";
+  const runLabel =
+    params.trigger === "cron"
+      ? "Cron runs"
+      : params.trigger === "heartbeat"
+        ? "Heartbeat runs"
+        : "Headless runs";
   return [
     `exec denied: ${runLabel} cannot wait for interactive exec approval.`,
     `Effective host exec policy: security=${params.security} ask=${params.ask} askFallback=${params.askFallback}`,


### PR DESCRIPTION
## Summary

Fix: heartbeat exec approvals now follow the same headless resolution path as cron triggers.

The `isHeadlessExecTrigger` function in `src/agents/bash-tools.exec-host-shared.ts` only matched "cron" triggers, causing heartbeat-driven exec approval requests to stall when no interactive approval route was available. This prevented heartbeat agents from executing commands autonomously.

Fixes #94599

## Real behavior proof (required for external PRs)

**Behavior addressed**: Heartbeat-triggered exec approvals were not recognized as headless runs, causing agents to wait indefinitely for human approval in headless contexts.

**Real setup tested**:
- **Runtime**: Node 24.16.0, Linux

**Exact steps or command run after fix**:

```bash
pnpm test -- src/agents/bash-tools.exec-host-shared.test.ts
pnpm test -- src/agents/bash-tools.exec-host-gateway.test.ts
pnpm test -- src/agents/bash-tools.exec-host-node.test.ts
```

**After-fix evidence**:

```
 Tests  34 passed (34)  # exec-host-shared (includes 9 new tests)
 Tests  53 passed (53)  # exec-host-gateway
 Tests  47 passed (47)  # exec-host-node
```

**Observed result after the fix**:
- `shouldResolveExecApprovalUnavailableInline` returns true for heartbeat triggers with no-approval-route
- `buildHeadlessExecApprovalDeniedMessage` correctly labels heartbeat runs as "Heartbeat runs"
- All existing cron/interactive/manual behavior unchanged

**What was not tested**: End-to-end heartbeat agent run with exec approvals (requires a full gateway setup). The fix is unit-test-verified at the approval routing level.

## Tests and validation

- 9 new tests covering `shouldResolveExecApprovalUnavailableInline` and `buildHeadlessExecApprovalDeniedMessage`
- 25 existing tests continue to pass (no regressions)
- 53 gateway host tests pass
- 47 node host tests pass

## Risk checklist

Did user-visible behavior change? (`Yes` — heartbeat agents can now auto-resolve exec approvals when no interactive route is available, matching cron behavior)

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`Yes` — exec approval resolution for heartbeat triggers now follows the same headless policy as cron. The effective security/ask/askFallback policy still governs whether the approval is allowed or denied; this change only fixes the routing so the policy is applied rather than the agent stalling.)

What is the highest-risk area?
- Heartbeat agents that previously stalled on exec approval will now proceed (or be denied) based on their configured exec approval policy

How is that risk mitigated?
- The same security/ask/askFallback policy that governs cron runs also governs heartbeat runs
- Heartbeat calls already set `askFallback` through the standard approval context resolution
- No new auto-approval paths are added; only the routing parity is fixed

## Current review state

What is the next action?
- Maintainer review

