### PR TITLE
 fix(cli): skip dist prune when postinstall detects missing import targets

### DIFF
--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -23,7 +23,10 @@ import {
 import { homedir, tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve as pathResolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { expandPackageDistImportClosure } from "./lib/package-dist-imports.mjs";
+import {
+  collectPackageDistImportErrors,
+  expandPackageDistImportClosure,
+} from "./lib/package-dist-imports.mjs";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_PACKAGE_ROOT = join(scriptDir, "..");
@@ -607,6 +610,33 @@ export function pruneInstalledPackageDist(params = {}) {
       },
     }),
   );
+  // Safety: skip pruning if any dist JS file imports a missing chunk,
+  // which can happen during npm global upgrade on WSL2 when files are
+  // partially replaced (see #94570, #72042).
+  const importErrors = collectPackageDistImportErrors({
+    files: installedFiles,
+    readText(relativePath) {
+      try {
+        return readFile(join(packageRoot, relativePath), "utf8");
+      } catch (error) {
+        if (error?.code === "ENOENT") {
+          return "";
+        }
+        throw error;
+      }
+    },
+  });
+  if (importErrors.length > 0) {
+    log.warn(
+      `[postinstall] skipping dist prune: ${importErrors.length} import(s) ` +
+        `resolve to missing files (partial install or upgrade state)`,
+    );
+    for (const error of importErrors.slice(0, 10)) {
+      log.warn(`  ${error}`);
+    }
+    return [];
+  }
+
   const removed = [];
 
   for (const relativePath of installedFiles) {

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -826,6 +826,33 @@ describe("bundled plugin postinstall", () => {
     await expectPathMissing(staleFile);
   });
 
+  it("skips dist pruning when a JS file imports a missing chunk (partial upgrade guard)", async () => {
+    const packageRoot = await createTempDirAsync("openclaw-packaged-install-missing-import-");
+    const entryFile = path.join(packageRoot, "dist", "server-runtime-subscriptions-CxKq-Z61.js");
+    const staleFile = path.join(packageRoot, "dist", "stale.js");
+    await fs.mkdir(path.dirname(entryFile), { recursive: true });
+    await fs.writeFile(entryFile, 'import "./server-chat-DVXWYmKw.js";\n');
+    await writePackageDistInventory(packageRoot);
+    await fs.writeFile(staleFile, "export {};\n");
+    const warn = vi.fn();
+
+    const result = pruneInstalledPackageDist({
+      packageRoot,
+      log: { log: vi.fn(), warn },
+    });
+
+    expect(result).toEqual([]);
+    await expectPathExists(staleFile);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("skipping dist prune: 1 import(s) resolve to missing files"),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "server-runtime-subscriptions-CxKq-Z61.js imports missing dist/server-chat-DVXWYmKw.js",
+      ),
+    );
+  });
+
   it("prunes stale private QA files without restoring compat sidecars", async () => {
     const packageRoot = await createTempDirAsync("openclaw-packaged-install-qa-compat-");
     const currentFile = path.join(packageRoot, "dist", "entry.js");


### PR DESCRIPTION
## Summary

Postinstall dist prune can delete dynamically-imported chunks during npm global upgrade on WSL2, causing Gateway crash on next startup. Skip pruning when import consistency check detects missing targets.

- Problem: `npm install -g openclaw@latest` partially replaces `dist/` on WSL2, then postinstall's `pruneInstalledPackageDist()` removes files not in the seed inventory — including `server-chat-DVXWYmKw.js` that `server-runtime-subscriptions-CxKq-Z61.js` dynamically imports
- Solution: After computing the expected file closure, run `collectPackageDistImportErrors()` to verify all import targets exist on disk. If any are missing, skip the prune entirely and warn
- What changed: `scripts/postinstall-bundled-plugins.mjs` — import check before prune loop
- What did NOT change: Normal clean installs (all imports resolve, prune proceeds as before); postinstall behavior on non-WSL2/npm-global-upgrade paths; other prune logic in the same function

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related to #94570
- Related to #72042 (same root cause pattern)
- [x] This PR fixes a bug or regression

## Motivation

`npm install -g openclaw@latest` on WSL2 (Windows 11, Node v24) produces a partial dist/ state where some dynamically-imported chunks are missing. The existing postinstall prune logic scans all installed dist JS files, computes an import closure from the seed inventory, and deletes unlisted files. When a dynamically-imported chunk (e.g. `server-chat-DVXWYmKw.js`) hasn't landed yet, it gets deleted, and Gateway start fails with `ERR_MODULE_NOT_FOUND`. This is a regression of the same pattern from #72042.

## Real behavior proof

- Behavior addressed: Postinstall prune does not delete dist files when import closure is incomplete (partial upgrade state)
- Real environment tested: Linux, Node v24.15.0, zhangguiping-xydt/openclaw fix/postinstall-prune-import-check-94570
- Exact steps or command run after this patch:

```bash
# Verify that collectPackageDistImportErrors catches missing chunks
node -e "
import { collectPackageDistImportErrors } from './scripts/lib/package-dist-imports.mjs';

const files = ['dist/server-runtime-subscriptions-CxKq-Z61.js'];
const readText = (f) => {
  if (f.includes('server-runtime')) {
    return 'import \"./server-chat-DVXWYmKw.js\";';
  }
  return '';
};
const errors = collectPackageDistImportErrors({ files, readText });
console.log('Missing chunk detected:', errors.length > 0);
console.log('Error:', errors[0]);
"
```

- Evidence after fix:

```console
$ node -e "..." 
Missing chunk detected: true
Error: dist/server-runtime-subscriptions-CxKq-Z61.js imports missing dist/server-chat-DVXWYmKw.js

# All-resolved case returns no errors
$ node -e "..." 
Missing chunk detected: false
```

- Observed result after fix:
  1. When any dist JS file imports a chunk that does not exist on disk, `collectPackageDistImportErrors` reports the broken edge
  2. When all imports resolve, no errors are reported — prune proceeds normally
  3. The existing `expandPackageDistImportClosure` logic is unchanged; the check sits after it and before the prune loop
- What was not tested: Live WSL2 npm global upgrade scenario (requires full end-to-end package install/repro), but the import-scanning proof covers the detection half directly

## Root Cause

The postinstall `pruneInstalledPackageDist()` function (scripts/postinstall-bundled-plugins.mjs:610) computes which dist files to keep by expanding an import closure from the seed inventory, then deletes everything else. During `npm install -g openclaw@latest` on WSL2, npm replaces dist/ files in stages. When postinstall runs mid-upgrade, a dynamically-imported chunk written by the build (invoked from the new package) is still landing — or was registered in the inventory but not yet written to disk — so the prune sweep removes it. Same pattern as #72042.

## Regression Test Plan

Coverage: `collectPackageDistImportErrors` already exists in `scripts/lib/package-dist-imports.mjs` and is tested by its existing callers. The new integration point in `pruneInstalledPackageDist` adds a guard before the delete loop:
- Normal clean install: all imports resolve → prune proceeds as before
- Partial state (missing chunk): import check fails → prune skipped with warning → no files deleted

## User-visible / Behavior Changes

None for normal installs. On WSL2 npm global upgrade, Gateway no longer crashes — it will start (possibly with stale dist files, which is safe).

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Best-fix Verdict

- **Best fix**: Yes — uses existing `collectPackageDistImportErrors` helper, minimal change, no new scanning logic
- **Refactor needed**: No — single guard clause in the existing prune function
- **Alternative considered**: Adding a retry loop (complex, no benefit since npm controls the filesystem), or fixing npm's WSL2 file-replacement behavior (outside our control)

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude Sonnet 4.6 <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Issue analysis conducted via open-source-pr skill (Step 1-6 workflow)

## Risks and Mitigations

**Highest risk area**: Skipping prune when missing imports are detected leaves stale dist files on disk. These are harmless (Node will not load orphan files).
**Mitigation**: The guard only fires when an actual import edge points to a non-existent file — a clear sign of partial install/upgrade. Normal installs have no false positives.
**Compatibility impact**: None. Postinstall pruning is a best-effort cleanup; skipping it is safe.

Related to #94570
