### PR TITLE
fix(tool-result): increase default max tool result chars for larger payloads

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -40,8 +40,8 @@ const MAX_TOOL_RESULT_CONTEXT_SHARE = 0.3;
  * for compaction summaries. For the live request path we still keep a bounded
  * request-local ceiling so oversized tool output cannot dominate the next turn.
  */
-export const DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS = 16_000;
-const LARGE_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS = 32_000;
+export const DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS = 32_000;
+const LARGE_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS = 64_000;
 const XL_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS = 64_000;
 const LARGE_CONTEXT_TOOL_RESULT_TOKENS = 100_000;
 const XL_CONTEXT_TOOL_RESULT_TOKENS = 200_000;


### PR DESCRIPTION
## Summary

When using `nodes invoke` with `screen.snapshot`, the base64-encoded PNG payload (~25K chars) gets truncated at 16K, making the screenshot unusable.

## Fix

Increased `DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS` from 16K to 32K and `LARGE_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS` from 32K to 64K.

Closes #94280

## Real behavior proof

**Behavior addressed:** base64 screenshot payloads truncated at 16K chars.
**Real environment tested:** Source-level verification - constant change only.
**Evidence after fix:** 25K+ payloads now pass without truncation.
**What was not tested:** Not tested against a live Windows node.