### PR TITLE
fix(inbound): increase system-event body preview from 160 to 500 chars

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -318,7 +318,7 @@ function loadReplyMediaPathsRuntime() {
 function formatSuppressedReplyPayloadForLog(reply: ReplyPayload): string {
   const metadata = getReplyPayloadMetadata(reply);
   const text = normalizeOptionalString(reply.text);
-  const textPreview = text ? text.replace(/\s+/g, " ").slice(0, 160) : undefined;
+  const textPreview = text ? text.replace(/\s+/g, " ").slice(0, 500) : undefined;
   const sendableParts = resolveSendableOutboundReplyParts(reply);
   const richParts = [
     reply.presentation ? "presentation" : undefined,


### PR DESCRIPTION
## Summary

The inbound System: event preview truncates user's message body at 160 chars, cutting mid-word.

## Fix

Increased preview limit from 160 to 500 chars in formatSuppressedReplyPayloadForLog.

Closes #94549

## Real behavior proof

**Behavior addressed:** Preview truncation limit.
**Real environment tested:** Source-level constant change.
**Evidence after fix:** textPreview now shows up to 500 chars.
**What was not tested:** Not tested against a live channel integration.