### PR TITLE
fix(tool-result): increase default max tool result chars

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -40,8 +40,8 @@ const MAX_TOOL_RESULT_CONTEXT_SHARE = 0.3;
  * for compaction summaries. For the live request path we still keep a bounded
  * request-local ceiling so oversized tool output cannot dominate the next turn.
  */
-export const DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS = 16_000;
-const LARGE_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS = 32_000;
+export const DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS = 32_000;
+const LARGE_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS = 64_000;
 const XL_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS = 64_000;
 const LARGE_CONTEXT_TOOL_RESULT_TOKENS = 100_000;
 const XL_CONTEXT_TOOL_RESULT_TOKENS = 200_000;


### PR DESCRIPTION
Closes #94280

Increases DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS from 16K to 32K so base64 screenshot payloads (~25K) pass without truncation.