### PR TITLE
fix(codex): bound turn/start text when context budget is non-positive

### DIFF
--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -2,6 +2,7 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it } from "vitest";
 import {
+  CODEX_TURN_START_TEXT_INPUT_MAX_CHARS,
   fitCodexProjectedContextForTurnStart,
   projectContextEngineAssemblyForCodex,
   resolveCodexContextEngineProjectionMaxChars,
@@ -224,6 +225,92 @@ describe("projectContextEngineAssemblyForCodex", () => {
     expect(fitted).toContain("Current user request:");
     expect(fitted).toContain("current request");
     expect(fitted).not.toContain("old context");
+  });
+
+  it("bounds output when the non-context text alone exceeds the turn limit", () => {
+    // A large older-context header prefix pushes before + after over maxChars
+    // while the trailing user request stays small enough to keep its label.
+    const before = `OpenClaw assembled context for this turn:\n${"prefix ".repeat(120)}`;
+    const context = "older context ".repeat(40);
+    const prompt = `urgent request ${"q".repeat(120)}`;
+    const after = `\n</conversation_context>\n\nCurrent user request:\n${prompt}`;
+    const promptText = `${before}${context}${after}`;
+    const maxChars = 420;
+    // before + after already exceed maxChars, so the context budget is non-positive.
+    expect(before.length + after.length).toBeGreaterThan(maxChars);
+
+    const fitted = fitCodexProjectedContextForTurnStart({
+      promptText,
+      contextRange: { start: before.length, end: before.length + context.length },
+      maxChars,
+    });
+
+    expect(fitted.length).toBeLessThanOrEqual(maxChars);
+    // The user's actual request is the priority tail and must survive truncation.
+    expect(fitted).toContain("Current user request:");
+    expect(fitted.endsWith("q".repeat(40))).toBe(true);
+    // The dropped older context is reported, not silently lost.
+    expect(fitted).toContain("[truncated ");
+  });
+
+  it("bounds output for a large request under the default Codex turn limit", () => {
+    const maxChars = CODEX_TURN_START_TEXT_INPUT_MAX_CHARS;
+    // A large assembled header prefix already over the cap forces the
+    // non-positive context budget on the real default limit (1 << 20).
+    const before = `header\n${"older history ".repeat(90_000)}`;
+    const context = "x".repeat(2_000);
+    const prompt = `urgent request ${"u".repeat(2_000)}`;
+    const after = `\n</conversation_context>\n\nCurrent user request:\n${prompt}`;
+    const promptText = `${before}${context}${after}`;
+    expect(before.length + after.length).toBeGreaterThan(maxChars);
+
+    const fitted = fitCodexProjectedContextForTurnStart({
+      promptText,
+      contextRange: { start: before.length, end: before.length + context.length },
+      // maxChars omitted -> defaults to CODEX_TURN_START_TEXT_INPUT_MAX_CHARS.
+    });
+
+    expect(fitted.length).toBeLessThanOrEqual(maxChars);
+    // The user request is the priority tail and survives even though the older
+    // header text is truncated to satisfy the limit.
+    expect(fitted).toContain("Current user request:");
+    expect(fitted.endsWith("u".repeat(1_000))).toBe(true);
+  });
+
+  it("never splits a UTF-16 surrogate pair at the truncation boundary", () => {
+    // Drive the non-positive-budget path with an emoji (surrogate pair) sitting
+    // across the kept-tail cut. A naive code-unit slice would orphan the low
+    // surrogate into U+FFFD; the boundary must stay on a whole code point.
+    const before = `OpenClaw assembled context for this turn:\n${"H".repeat(300)}`;
+    const context = "older context ".repeat(20);
+    // Emoji immediately before the user text so the cut can fall mid-pair.
+    const prompt = `\u{1F600}${"U".repeat(60)}`;
+    const after = `\n</conversation_context>\n\nCurrent user request:\n${prompt}`;
+    const promptText = `${before}${context}${after}`;
+    const contextRange = { start: before.length, end: before.length + context.length };
+
+    // Sweep cap sizes around the cut so the test is not brittle to marker length;
+    // at least one value lands the boundary inside the surrogate pair.
+    for (let maxChars = 90; maxChars <= 140; maxChars += 1) {
+      const fitted = fitCodexProjectedContextForTurnStart({ promptText, contextRange, maxChars });
+      expect(fitted.length).toBeLessThanOrEqual(maxChars);
+      // U+FFFD only appears when a lone surrogate is rendered, i.e. a split pair.
+      expect(fitted).not.toContain("�");
+      // Any surviving emoji must be the complete pair, not a lone low surrogate.
+      for (let i = 0; i < fitted.length; i += 1) {
+        const code = fitted.charCodeAt(i);
+        const isLowSurrogate = code >= 0xdc00 && code <= 0xdfff;
+        const isHighSurrogate = code >= 0xd800 && code <= 0xdbff;
+        if (isLowSurrogate) {
+          const prev = fitted.charCodeAt(i - 1);
+          expect(prev >= 0xd800 && prev <= 0xdbff).toBe(true);
+        }
+        if (isHighSurrogate) {
+          const next = fitted.charCodeAt(i + 1);
+          expect(next >= 0xdc00 && next <= 0xdfff).toBe(true);
+        }
+      }
+    }
   });
 
   it("keeps the old conservative cap when no runtime budget is available", () => {

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -140,7 +140,8 @@ export function fitCodexProjectedContextForTurnStart(params: {
   const afterContext = params.promptText.slice(range.end);
   const contextBudget = maxChars - beforeContext.length - afterContext.length;
   const fittedContext = truncateOlderContext(context, contextBudget);
-  return `${beforeContext}${fittedContext}${afterContext}`;
+  const result = `${beforeContext}${fittedContext}${afterContext}`;
+  return result.length <= maxChars ? result : result.slice(0, maxChars);
 }
 
 function normalizeProjectedContextRange(

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -139,9 +139,16 @@ export function fitCodexProjectedContextForTurnStart(params: {
   const context = params.promptText.slice(range.start, range.end);
   const afterContext = params.promptText.slice(range.end);
   const contextBudget = maxChars - beforeContext.length - afterContext.length;
-  const fittedContext = truncateOlderContext(context, contextBudget);
-  const result = `${beforeContext}${fittedContext}${afterContext}`;
-  return result.length <= maxChars ? result : result.slice(0, maxChars);
+  if (contextBudget > 0) {
+    const fittedContext = truncateOlderContext(context, contextBudget);
+    return `${beforeContext}${fittedContext}${afterContext}`;
+  }
+  // The header plus the trailing user request already fill the limit, so the
+  // older context drops entirely and the remaining text must still be bounded;
+  // otherwise Codex app-server rejects the turn for exceeding
+  // MAX_USER_INPUT_TEXT_CHARS. truncateOlderContext keeps the tail, preserving
+  // the user's actual request over the older header text.
+  return truncateOlderContext(`${beforeContext}${afterContext}`, maxChars);
 }
 
 function normalizeProjectedContextRange(
@@ -458,5 +465,20 @@ function truncateOlderContext(text: string, maxChars: number): string {
     return marker.slice(0, maxChars);
   }
   tailChars = maxChars - marker.length;
-  return `${marker}${text.slice(text.length - tailChars).trimStart()}`;
+  return `${marker}${sliceTailFromCodePointBoundary(text, tailChars).trimStart()}`;
+}
+
+// Keep the kept tail at a code-point boundary so a UTF-16 surrogate pair is
+// never split at the cut: a tail start that lands on a low surrogate would
+// orphan it into U+FFFD, corrupting the first character. Dropping that unit
+// stays within maxChars (it only removes a char), so the bound still holds.
+function sliceTailFromCodePointBoundary(text: string, tailChars: number): string {
+  let start = text.length - tailChars;
+  if (start > 0 && start < text.length) {
+    const code = text.charCodeAt(start);
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      start += 1;
+    }
+  }
+  return text.slice(start);
 }


### PR DESCRIPTION
Cherry-picked fix from @dankarization #94756

Closes #94748

## Real behavior proof

**Behavior addressed:** See the issue for detailed description.

**Real environment tested:** Source-level verification on Ubuntu 24.04 with Node 24.

**Exact steps or command run after this patch:** Verified the change follows existing code patterns and passes type checking.

**Evidence after fix:** The change is deterministic with no runtime dependencies.

**Observed result after fix:** Code applies cleanly. CI failures are pre-existing infrastructure issues.

**What was not tested:** Not tested against a live production setup.