### PR TITLE
feat(usage): append provider quota windows to /usage full footer (fixes #7379)

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -39,6 +39,11 @@ import {
   freezeDiagnosticTraceContext,
 } from "../../infra/diagnostic-trace-context.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
+import {
+  formatUsageWindowSummary,
+  loadProviderUsageSummary,
+  resolveUsageProviderId,
+} from "../../infra/provider-usage.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { PluginHookReplyUsageState } from "../../plugins/hook-types.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
@@ -2265,6 +2270,46 @@ export async function runReplyAgent(params: {
         formatted = renderedUsageLine;
       } else if (formatted && responseUsageMode === "full" && sessionKey) {
         formatted = `${formatted} · session \`${sessionKey}\``;
+      }
+      // Extend the full usage footer with provider quota windows (premium
+      // requests, chat quota, etc.) so users do not need a separate /status
+      // command to check quota. Best-effort with a short timeout; failures
+      // silently fall back to the token/cost-only footer.
+      if (formatted && responseUsageMode === "full" && providerUsed) {
+        const quotaProvider = resolveUsageProviderId(providerUsed);
+        if (quotaProvider) {
+          try {
+            const footerQuotaTimeoutMs = 2000;
+            const quotaSummary = await Promise.race([
+              loadProviderUsageSummary({
+                timeoutMs: footerQuotaTimeoutMs,
+                providers: [quotaProvider],
+                config: cfg,
+              }),
+              new Promise<never>((_, reject) =>
+                setTimeout(
+                  () => reject(new Error("usage footer quota timeout")),
+                  footerQuotaTimeoutMs,
+                ),
+              ),
+            ]);
+            const quotaEntry = quotaSummary.providers.find(
+              (p) => p.windows.length > 0 && !p.error,
+            );
+            if (quotaEntry) {
+              const windowLine = formatUsageWindowSummary(quotaEntry, {
+                now: Date.now(),
+                maxWindows: 2,
+                includeResets: false,
+              });
+              if (windowLine) {
+                formatted = `${formatted} · ${windowLine}`;
+              }
+            }
+          } catch {
+            // Provider quota fetch is best-effort.
+          }
+        }
       }
       if (formatted) {
         responseUsageLine = formatted;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2286,12 +2286,12 @@ export async function runReplyAgent(params: {
                 providers: [quotaProvider],
                 config: cfg,
               }),
-              new Promise<never>((_, reject) =>
+              new Promise<never>((_, reject) => {
                 setTimeout(
                   () => reject(new Error("usage footer quota timeout")),
                   footerQuotaTimeoutMs,
-                ),
-              ),
+                );
+              }),
             ]);
             const quotaEntry = quotaSummary.providers.find(
               (p) => p.windows.length > 0 && !p.error,


### PR DESCRIPTION
## Summary

Extends the `/usage full` footer with provider quota windows (premium requests, chat quota, etc.) so users no longer need to run `/status` separately to check their quota.

**Current `/usage full` footer:**
```
Usage: 2.3k in / 1.6k out · 63k/128k (49%) · session `default`
```

**After this change (when provider supports quota windows):**
```
Usage: 2.3k in / 1.6k out · 63k/128k (49%) · session `default` · Premium 86% left · Chat 100% left
```

## Implementation

- Imports `loadProviderUsageSummary`, `formatUsageWindowSummary`, and `resolveUsageProviderId` from the existing `src/infra/provider-usage.js` facade — the same infrastructure already used by `/status`
- After building the token/cost usage line in `agent-runner.ts`, if `responseUsageMode === "full"` and the active provider supports usage windows, fetches the quota summary with a 2-second timeout
- The fetch is best-effort: on timeout or error, the footer silently falls back to the existing token/cost-only format — no behavioral change for providers without quota windows
- Uses `formatUsageWindowSummary` (same formatter as `/status`) to produce consistent output like "Premium 86% left · Chat 100% left"

Fixes #7379.

## Real behavior proof

- **Behavior addressed:** The `/usage full` footer now includes provider quota windows (premium request %, chat %) when the provider supports it, matching the format already used by `/status`.
- **Environment tested:** Local OpenClaw checkout at `upstream/main` (commit `e802fb8a`), Node v22.x on macOS.
- **Steps run after the patch:**
  1. Verified TypeScript compilation: `npx tsgo --noEmit` — 0 errors in `agent-runner.ts` (4 pre-existing errors in `task-registry.test.ts` unrelated to this change)
  2. Verified import chain resolves: all three functions (`loadProviderUsageSummary`, `formatUsageWindowSummary`, `resolveUsageProviderId`) are exported from `src/infra/provider-usage.ts` and already used by `src/status/status-text.ts`
  3. Verified the code path: `resolveUsageProviderId` maps provider names to `UsageProviderId` type (github-copilot, anthropic, etc.); `loadProviderUsageSummary` fetches from the provider's API with timeout; `formatUsageWindowSummary` formats the result

- **Evidence after fix:**
```
$ npx tsgo --noEmit 2>&1 | grep "agent-runner"
(no output — zero errors in the changed file)

$ grep -n "loadProviderUsageSummary\|formatUsageWindowSummary\|resolveUsageProviderId" src/auto-reply/reply/agent-runner.ts
43:  formatUsageWindowSummary,
44:  loadProviderUsageSummary,
45:  resolveUsageProviderId,
2279:        const quotaProvider = resolveUsageProviderId(providerUsed);
2284:              loadProviderUsageSummary({
2300:              const windowLine = formatUsageWindowSummary(quotaEntry, {

$ grep -n "export" src/infra/provider-usage.ts
2:export {
5:  formatUsageWindowSummary,
7:export { loadProviderUsageSummary } from "./provider-usage.load.js";
8:export { resolveUsageProviderId } from "./provider-usage.shared.js";

$ grep -n "loadProviderUsageSummary" src/status/status-text.ts
463:        loadProviderUsageSummary({
```

- **Observed result after fix:** The import chain resolves cleanly, TypeScript compiles without errors, and the three functions are already proven in production by `/status`. The new footer code reuses the exact same `loadProviderUsageSummary` → `formatUsageWindowSummary` pipeline.
- **What was not tested:** Live provider API calls (requires authenticated GitHub Copilot OAuth token). The `Promise.race` timeout and `catch` fallback were verified by code inspection — on timeout/error, the formatted line retains its token/cost-only value without modification.
