### PR TITLE
fix(trello): add curl to requires.bins

### DIFF
--- a/skills/trello/SKILL.md
+++ b/skills/trello/SKILL.md
@@ -7,14 +7,14 @@ metadata:
     "openclaw":
       {
         "emoji": "📋",
-        "requires": { "bins": ["jq"], "env": ["TRELLO_API_KEY", "TRELLO_TOKEN"] },
+        "requires": { "bins": ["jq", "curl"], "env": ["TRELLO_API_KEY", "TRELLO_TOKEN"] },
         "install":
           [
             {
               "id": "brew",
               "kind": "brew",
               "formula": "jq",
-              "bins": ["jq"],
+              "bins": ["jq", "curl"],
               "label": "Install jq (brew)",
             },
           ],


### PR DESCRIPTION
Closes #94727

## Real behavior proof

**Behavior addressed:** Trello skill requires curl but only declares jq.
**Real environment tested:** Source-level declaration change.
**Evidence after fix:** curl now listed in requires.bins.
**What was not tested:** Not tested against live Trello API.