### PR TITLE
fix(agent): keep replies deliverable when compaction fails

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -827,10 +827,11 @@ type FallbackRunnerParams = {
 };
 
 type ModelSwitchOptions = ConstructorParameters<typeof LiveSessionModelSwitchError>[0];
+type TestPayload = { text: string; isError?: boolean; isReasoning?: boolean };
 
 function makeSuccessResult(provider: string, model: string) {
   return {
-    payloads: [{ text: "ok" }],
+    payloads: [{ text: "ok" }] as TestPayload[],
     meta: {
       durationMs: 100,
       aborted: false,
@@ -842,7 +843,7 @@ function makeSuccessResult(provider: string, model: string) {
 
 function makeEmptyResult(provider: string, model: string) {
   return {
-    payloads: [],
+    payloads: [] as TestPayload[],
     meta: {
       durationMs: 30_000,
       aborted: false,

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1822,6 +1822,38 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     });
   });
 
+  it("still delivers a persisted CLI reply when post-turn compaction fails", async () => {
+    setupSingleAttemptFallback();
+    setupSessionTouchStore();
+    const result = makeSuccessResult("openai", "gpt-5.4") as ReturnType<
+      typeof makeSuccessResult
+    > & {
+      meta: Record<string, unknown> & { executionTrace: Record<string, unknown> };
+    };
+    result.meta.executionTrace = {
+      runner: "cli",
+      fallbackUsed: false,
+      winnerProvider: "openai",
+      winnerModel: "gpt-5.4",
+    };
+    state.runAgentAttemptMock.mockResolvedValue(result);
+    state.runCliTurnCompactionLifecycleMock.mockRejectedValue(
+      new Error("Summarization failed: Connection error"),
+    );
+
+    await runBasicAgentCommand();
+
+    expect(state.persistCliTurnTranscriptMock).toHaveBeenCalledTimes(1);
+    expect(state.runCliTurnCompactionLifecycleMock).toHaveBeenCalledTimes(1);
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledTimes(1);
+    expect(state.emitAgentEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "lifecycle",
+        data: expect.objectContaining({ phase: "end" }),
+      }),
+    );
+  });
+
   it("skips post-run persistence after the session is deleted", async () => {
     setupSingleAttemptFallback();
     setupSessionTouchStore();

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1854,6 +1854,30 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     );
   });
 
+  it("rethrows post-turn compaction failures when no CLI reply is deliverable", async () => {
+    setupSingleAttemptFallback();
+    setupSessionTouchStore();
+    const result = makeEmptyResult("openai", "gpt-5.4") as ReturnType<typeof makeEmptyResult> & {
+      meta: Record<string, unknown> & { executionTrace: Record<string, unknown> };
+    };
+    result.meta.executionTrace = {
+      runner: "cli",
+      fallbackUsed: false,
+      winnerProvider: "openai",
+      winnerModel: "gpt-5.4",
+    };
+    state.runAgentAttemptMock.mockResolvedValue(result);
+    state.runCliTurnCompactionLifecycleMock.mockRejectedValue(
+      new Error("Summarization failed: Connection error"),
+    );
+
+    await expect(runBasicAgentCommand()).rejects.toThrow("Summarization failed");
+
+    expect(state.persistCliTurnTranscriptMock).toHaveBeenCalledTimes(1);
+    expect(state.runCliTurnCompactionLifecycleMock).toHaveBeenCalledTimes(1);
+    expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+  });
+
   it("skips post-run persistence after the session is deleted", async () => {
     setupSingleAttemptFallback();
     setupSessionTouchStore();

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1878,6 +1878,56 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
   });
 
+  it("rethrows post-turn compaction failures for error-only CLI payload text", async () => {
+    setupSingleAttemptFallback();
+    setupSessionTouchStore();
+    const result = makeEmptyResult("openai", "gpt-5.4") as ReturnType<typeof makeEmptyResult> & {
+      meta: Record<string, unknown> & { executionTrace: Record<string, unknown> };
+    };
+    result.meta.executionTrace = {
+      runner: "cli",
+      fallbackUsed: false,
+      winnerProvider: "openai",
+      winnerModel: "gpt-5.4",
+    };
+    result.payloads = [{ text: "Command failed", isError: true }];
+    state.runAgentAttemptMock.mockResolvedValue(result);
+    state.runCliTurnCompactionLifecycleMock.mockRejectedValue(
+      new Error("Summarization failed: Connection error"),
+    );
+
+    await expect(runBasicAgentCommand()).rejects.toThrow("Summarization failed");
+
+    expect(state.persistCliTurnTranscriptMock).toHaveBeenCalledTimes(1);
+    expect(state.runCliTurnCompactionLifecycleMock).toHaveBeenCalledTimes(1);
+    expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+  });
+
+  it("rethrows post-turn compaction failures for reasoning-only CLI payload text", async () => {
+    setupSingleAttemptFallback();
+    setupSessionTouchStore();
+    const result = makeEmptyResult("openai", "gpt-5.4") as ReturnType<typeof makeEmptyResult> & {
+      meta: Record<string, unknown> & { executionTrace: Record<string, unknown> };
+    };
+    result.meta.executionTrace = {
+      runner: "cli",
+      fallbackUsed: false,
+      winnerProvider: "openai",
+      winnerModel: "gpt-5.4",
+    };
+    result.payloads = [{ text: "Thinking through the command", isReasoning: true }];
+    state.runAgentAttemptMock.mockResolvedValue(result);
+    state.runCliTurnCompactionLifecycleMock.mockRejectedValue(
+      new Error("Summarization failed: Connection error"),
+    );
+
+    await expect(runBasicAgentCommand()).rejects.toThrow("Summarization failed");
+
+    expect(state.persistCliTurnTranscriptMock).toHaveBeenCalledTimes(1);
+    expect(state.runCliTurnCompactionLifecycleMock).toHaveBeenCalledTimes(1);
+    expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+  });
+
   it("skips post-run persistence after the session is deleted", async () => {
     setupSingleAttemptFallback();
     setupSessionTouchStore();

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2164,9 +2164,15 @@ async function agentCommandInternal(
       }
 
       const payloads = result.payloads ?? [];
-      const hasDeliverableCliReply = payloads.some(
-        (payload) => typeof payload.text === "string" && payload.text.trim().length > 0,
-      );
+      const hasDeliverableCliReply =
+        Boolean(result.meta.finalAssistantVisibleText?.trim()) ||
+        payloads.some(
+          (payload) =>
+            !payload.isError &&
+            !payload.isReasoning &&
+            typeof payload.text === "string" &&
+            payload.text.trim().length > 0,
+        );
       const transcriptPersistenceRunner = result.meta.executionTrace?.runner;
       const embeddedAssistantGapFill =
         transcriptPersistenceRunner === "embedded" ||

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2163,6 +2163,10 @@ async function agentCommandInternal(
         sessionEntry = sessionStore[sessionKey] ?? sessionEntry;
       }
 
+      const payloads = result.payloads ?? [];
+      const hasDeliverableCliReply = payloads.some(
+        (payload) => typeof payload.text === "string" && payload.text.trim().length > 0,
+      );
       const transcriptPersistenceRunner = result.meta.executionTrace?.runner;
       const embeddedAssistantGapFill =
         transcriptPersistenceRunner === "embedded" ||
@@ -2236,6 +2240,9 @@ async function agentCommandInternal(
               extraSystemPrompt: opts.extraSystemPrompt,
             });
           } catch (error) {
+            if (!hasDeliverableCliReply) {
+              throw error;
+            }
             log.warn(
               `Post-turn CLI transcript compaction failed after reply persistence for ${sessionKey ?? effectiveSessionId}: ${error instanceof Error ? error.message : String(error)}`,
             );
@@ -2243,7 +2250,6 @@ async function agentCommandInternal(
         }
       }
 
-      const payloads = result.payloads ?? [];
       let pendingFinalDeliveryTextForThisRun: string | undefined;
 
       // Phase 2: Persist pending final delivery for main sessions before attempting delivery.

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2212,28 +2212,34 @@ async function agentCommandInternal(
           );
         }
         if (persistedCliTurnTranscript && !suppressVisibleSessionEffects) {
-          sessionEntry = await (
-            await loadCliCompactionRuntime()
-          ).runCliTurnCompactionLifecycle({
-            cfg,
-            sessionId: effectiveSessionId,
-            sessionKey: sessionKey ?? effectiveSessionId,
-            sessionEntry,
-            sessionStore,
-            storePath,
-            sessionAgentId,
-            workspaceDir,
-            cwd: effectiveCwd,
-            agentDir,
-            provider: result.meta.agentMeta?.provider ?? provider,
-            model: result.meta.agentMeta?.model ?? model,
-            skillsSnapshot,
-            messageChannel,
-            agentAccountId: runContext.accountId,
-            senderIsOwner: opts.senderIsOwner,
-            thinkLevel: resolvedThinkLevel,
-            extraSystemPrompt: opts.extraSystemPrompt,
-          });
+          try {
+            sessionEntry = await (
+              await loadCliCompactionRuntime()
+            ).runCliTurnCompactionLifecycle({
+              cfg,
+              sessionId: effectiveSessionId,
+              sessionKey: sessionKey ?? effectiveSessionId,
+              sessionEntry,
+              sessionStore,
+              storePath,
+              sessionAgentId,
+              workspaceDir,
+              cwd: effectiveCwd,
+              agentDir,
+              provider: result.meta.agentMeta?.provider ?? provider,
+              model: result.meta.agentMeta?.model ?? model,
+              skillsSnapshot,
+              messageChannel,
+              agentAccountId: runContext.accountId,
+              senderIsOwner: opts.senderIsOwner,
+              thinkLevel: resolvedThinkLevel,
+              extraSystemPrompt: opts.extraSystemPrompt,
+            });
+          } catch (error) {
+            log.warn(
+              `Post-turn CLI transcript compaction failed after reply persistence for ${sessionKey ?? effectiveSessionId}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
         }
       }
 


### PR DESCRIPTION
Summary
- keep post-turn CLI compaction failures from failing the whole turn after the reply transcript was already persisted
- log the compaction failure and continue into normal delivery
- add coverage for a persisted CLI reply where compaction throws before delivery

## Real behavior proof

Behavior or issue addressed: A CLI-backed turn can persist the assistant reply and then hit a post-turn compaction error. After this patch, that compaction error is logged and delivery still runs instead of surfacing the whole turn as unavailable.

Real environment tested: Local OpenClaw checkout on macOS arm64 with Node v24.13.0, using the patched `agent-command.ts` and focused agent command test shard.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts --maxWorkers=1`

Evidence after fix: Terminal capture from the local OpenClaw checkout after applying this patch:

```text
$ node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts --maxWorkers=1
[test] starting test/vitest/vitest.agents.config.ts

 RUN  v4.1.7 /Users/little_shuai/.openclaw/agents/coo/workspace/projects/opensource-workshop/repos/openclaw

 Test Files  1 passed (1)
      Tests  59 passed (59)
   Start at  00:28:00
   Duration  8.61s (transform 4.42s, setup 183ms, import 63ms, tests 8.28s, environment 0ms)

[test] passed 1 Vitest shard in 11.03s
```

Observed result after fix: The focused shard includes the new post-success compaction failure case. It confirms the CLI transcript is persisted, compaction throws `Summarization failed: Connection error`, `deliverAgentCommandResult` still runs once, and the lifecycle reaches `end` instead of rethrowing the compaction error.

What was not tested: I did not stage a live provider/network failure that forces Codex compaction to fail on demand; this proof uses the existing agent command harness to force that post-persistence failure path deterministically.

Testing
- `node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts --maxWorkers=1`

Fixes #94688
