### PR TITLE
fix(cron): treat cron tool warnings as non-fatal when run recovered

### DIFF
--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -312,8 +312,14 @@ export function resolveCronPayloadOutcome(params: {
   // cron announce output to the final assistant-visible answer.
   // A final assistant answer can replace textual warning payloads, but never
   // structured/media payloads that carry the actual delivery content.
+  // When a recovered tool warning is non-fatal and final assistant text exists,
+  // prefer the final text over the warning payload even without the channel
+  // preference flag set.
+  const hasRecoveredNonFatalWithFinalText =
+    hasNonTerminalToolErrorWarning && normalizedFinalAssistantVisibleText !== undefined;
   const shouldUseFinalAssistantVisibleText =
-    params.preferFinalAssistantVisibleText === true &&
+    (params.preferFinalAssistantVisibleText === true ||
+      hasRecoveredNonFatalWithFinalText) &&
     normalizedFinalAssistantVisibleText !== undefined &&
     !hasFatalStructuredErrorPayload &&
     !hasStructuredDeliveryPayloads;

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -280,7 +280,8 @@ export function resolveCronPayloadOutcome(params: {
     params.failureSignal?.fatalForCron !== true &&
     hasRecoveringTerminalOutput &&
     (isNonTerminalToolErrorWarning(lastErrorPayload) ||
-      isCronToolWarning(lastErrorPayloadText));
+      (isCronToolWarning(lastErrorPayloadText) &&
+        errorPayloads.every((payload) => isCronToolWarning(payload?.text))));
   const hasPendingPresentationWarning =
     !params.runLevelError &&
     params.failureSignal?.fatalForCron !== true &&

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -272,11 +272,15 @@ export function resolveCronPayloadOutcome(params: {
     hasSuccessfulPayloadBeforeLastError;
   // Some tools emit warning/error payloads before a final answer. Treat those
   // as non-terminal only when later visible output proves the run recovered.
+  // Also treat explicit cron tool warnings (⚠️ 🛠️) from recovered runs as
+  // non-terminal even when the payload lacks the nonTerminalToolErrorWarning
+  // metadata flag.
   const hasNonTerminalToolErrorWarning =
     !params.runLevelError &&
     params.failureSignal?.fatalForCron !== true &&
     hasRecoveringTerminalOutput &&
-    isNonTerminalToolErrorWarning(lastErrorPayload);
+    (isNonTerminalToolErrorWarning(lastErrorPayload) ||
+      isCronToolWarning(lastErrorPayloadText));
   const hasPendingPresentationWarning =
     !params.runLevelError &&
     params.failureSignal?.fatalForCron !== true &&


### PR DESCRIPTION
## Summary

- When an isolated cron agentTurn encounters a recoverable early tool error, the warning payload was classified as fatal even when the agent recovered and produced final output (#94846).
- Fix 1: Extend hasNonTerminalToolErrorWarning to also match the cron tool warning text pattern (isCronToolWarning), not only the metadata flag.
- Fix 2 (per ClawSweeper review): When a recovered tool warning is non-fatal and final assistant text exists, prefer the final text for delivery even without the channel preference flag. This prevents the warning payload from being dispatched instead of the recovered output.

## Verification

- node scripts/run-vitest.mjs run src/cron/isolated-agent/helpers.test.ts → **25/25 passed**

## Impact Assessment

- Scope: src/cron/isolated-agent/helpers.ts — widen non-terminal classification + prefer final text on recovery
- Fix 1: isCronToolWarning text pattern now triggers nonTerminalToolErrorWarning alongside metadata flag
- Fix 2: hasRecoveredNonFatalWithFinalText gate allows shouldUseFinalAssistantVisibleText without preferFinalAssistantVisibleText
- Structured/media payloads are never replaced by final text (guarded by hasStructuredDeliveryPayloads)

## Real behavior proof

**Behavior addressed:** Recovered cron tool warnings that produced final output had their warning text dispatched instead of the final assistant report. After both fixes, non-fatal classification + final-text preference ensures recovered output is delivered.

**Environment tested:** Node 22.x on Linux, vitest test suite.

**Steps run after the patch:** Ran the cron helpers test suite.



**Evidence after fix:**



**Observed result:** All 25 tests pass. The hasNonTerminalToolErrorWarning gate now covers both metadata and text patterns, and recovered final text is preferred over warning payloads.

**Not tested:** Live scheduled cron job with Feishu delivery was not exercised.

Closes #94846
