### PR TITLE
fix: avoid blocking stale PreToolUse relays

### DIFF
--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -247,15 +247,15 @@ describe("native hook relay registry", () => {
     );
     expect(relay.commandForEvent("pre_tool_use")).toBe(
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
-        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
+        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --pre-tool-use-unavailable noop --timeout 1234`,
     );
     expect(relay.commandForEvent("pre_tool_use", { timeoutMs: 900 })).toBe(
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
-        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --timeout 900`,
+        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --pre-tool-use-unavailable noop --timeout 900`,
     );
     expect(relay.commandForEvent("pre_tool_use", { timeoutMs: 2_000 })).toBe(
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
-        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
+        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --pre-tool-use-unavailable noop --timeout 1234`,
     );
   });
 
@@ -564,7 +564,7 @@ describe("native hook relay registry", () => {
     expect(relay.shouldRelayEvent("pre_tool_use")).toBe(true);
     expect(relay.commandForEvent("pre_tool_use")).toBe(
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
-        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
+        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --pre-tool-use-unavailable noop --timeout 1234`,
     );
   });
 
@@ -584,7 +584,7 @@ describe("native hook relay registry", () => {
     expect(relay.shouldRelayEvent("pre_tool_use")).toBe(true);
     expect(relay.commandForEvent("pre_tool_use")).toBe(
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
-        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
+        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --pre-tool-use-unavailable noop --timeout 1234`,
     );
   });
 

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -449,10 +449,7 @@ export function registerNativeHookRelay(
         relayId,
         generation: registration.generation,
         event,
-        preToolUseUnavailable:
-          event === "pre_tool_use" && !nativeHookRelayEventHasLocalWork(registration, event)
-            ? "noop"
-            : undefined,
+        preToolUseUnavailable: event === "pre_tool_use" ? "noop" : undefined,
         nice: params.command?.nice,
         timeoutMs: resolveNativeHookRelayCommandTimeoutMs(
           params.command?.timeoutMs,

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -393,7 +393,7 @@ describe("native hook relay CLI", () => {
     expect(callGateway).not.toHaveBeenCalled();
   });
 
-  it("fails closed for PreToolUse when the gateway relay is unavailable", async () => {
+  it("defaults PreToolUse unavailable handling to observational noop", async () => {
     const callGateway = vi.fn(async () => {
       throw new Error("gateway closed");
     });
@@ -411,13 +411,7 @@ describe("native hook relay CLI", () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(JSON.parse(stdout.text())).toEqual({
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "deny",
-        permissionDecisionReason: "Native hook relay unavailable",
-      },
-    });
+    expect(stdout.text()).toBe("");
     expect(stderr.text()).toContain("native hook relay unavailable");
   });
 

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -288,7 +288,10 @@ function writeNativeHookRelayUnavailableResponse(params: {
   const response = renderNativeHookRelayUnavailableResponse({
     provider: params.provider,
     event: params.event,
-    preToolUseUnavailable: params.opts.preToolUseUnavailable,
+    preToolUseUnavailable:
+      params.event === "pre_tool_use"
+        ? (params.opts.preToolUseUnavailable ?? "noop")
+        : params.opts.preToolUseUnavailable,
     message: params.message ?? "Native hook relay unavailable",
   });
   writeText(params.stdout, response.stdout);


### PR DESCRIPTION
## Summary

- default unavailable Codex `PreToolUse` native hook relays to an observational no-op
- keep unavailable `PermissionRequest` handling fail-closed
- update native hook relay command and CLI tests for the stale/missing relay fallback

## Rationale

When a Codex app-server subagent keeps a stale native hook relay command after the originating OpenClaw relay is gone, shell and patch tools can fail with `Native hook relay unavailable`.

For `PreToolUse`, this should not hard-block tool execution when the relay itself is missing. The relay cannot provide policy enforcement at that point, and blocking strands otherwise valid subagent work. This change preserves fail-closed behavior for permission requests while making `PreToolUse` unavailable handling observational.

## Validation

- `git diff --check`
- local runtime smoke, before preparing this upstream patch: stale/missing `PreToolUse` relay falls back to no-op and Codex subagent `pwd && true` succeeds

## Not Run

- Targeted upstream Vitest files could not run locally because `pnpm install` repeatedly timed out fetching native packages from npm (`@openai/codex`, `@github/copilot`, `@zed-industries/codex-acp-darwin-arm64`, `@lancedb/lancedb-darwin-arm64`, `@anthropic-ai/claude-agent-sdk-darwin-arm64`).
