### PR TITLE
fix(telegram): reorder catch branches to prevent 429 with 401 substring from miscounting as 401

### DIFF
--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -176,6 +176,30 @@ describe("createTelegramSendChatActionHandler", () => {
     expect(handler.isSuspended()).toBe(false);
   });
 
+  // FIX #94787: a 429 whose grammY-rendered message contains "401" (e.g. "retry after 401")
+  // must NOT be miscounted as a 401. Reordered catch branches: transient check before 401 check.
+  it("does not miscount a 429 with 401 substring as a 401", async () => {
+    const make429With401InMessage = () =>
+      Object.assign(
+        new Error("Call to 'sendChatAction' failed! (429: Too Many Requests: retry after 401)"),
+        { error_code: 429, parameters: { retry_after: 401 } },
+      );
+    const fn = vi.fn().mockRejectedValue(make429With401InMessage());
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      maxConsecutive401: 3,
+    });
+
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow();
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow();
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow();
+
+    expect(handler.isSuspended()).toBe(false);
+    expect(logger.mock.calls.map(([msg]) => msg).filter((m) => m.includes("CRITICAL"))).toEqual([]);
+  });
+
   it.each([
     ["recoverable network", () => makeNetworkError(), 1000],
     ["Telegram 429", () => makeTelegramError("Too Many Requests", 429, { retry_after: 2 }), 2000],

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -176,7 +176,24 @@ export function createTelegramSendChatActionHandler({
       }
       clearTransientCooldown();
     } catch (error) {
-      if (is401Error(error)) {
+      // Check transient errors BEFORE is401Error: grammY renders rate-limit errors
+      // as "Call to 'sendChatAction' failed! (429: Too Many Requests: retry after N)"
+      // and a plain message.includes("401") substring check would misclassify a 429
+      // whose retry_after contains "401" as a 401, suspending the bot (#94787).
+      if (isTransientSendChatActionError(error)) {
+        consecutiveTransientFailures++;
+        const cooldownMs = resolveTransientCooldownMs(error, consecutiveTransientFailures);
+        const cooldownStartedAt = now();
+        // Keep transient failures rejected through the same-chat coalesce window;
+        // otherwise the next typing keepalive can look successful and reset its guard.
+        const coalescingUntilMs = key ? attemptedAt + minIntervalMs : 0;
+        transientCooldownUntilMs = Math.max(cooldownStartedAt + cooldownMs, coalescingUntilMs);
+        const effectiveCooldownMs = Math.max(0, transientCooldownUntilMs - cooldownStartedAt);
+        logger(
+          `sendChatAction transient error (${consecutiveTransientFailures}). ` +
+            `Cooling down ${effectiveCooldownMs}ms before retry.`,
+        );
+      } else if (is401Error(error)) {
         clearTransientCooldown();
         consecutive401Failures++;
 
@@ -193,19 +210,6 @@ export function createTelegramSendChatActionHandler({
               `Retrying with exponential backoff.`,
           );
         }
-      } else if (isTransientSendChatActionError(error)) {
-        consecutiveTransientFailures++;
-        const cooldownMs = resolveTransientCooldownMs(error, consecutiveTransientFailures);
-        const cooldownStartedAt = now();
-        // Keep transient failures rejected through the same-chat coalesce window;
-        // otherwise the next typing keepalive can look successful and reset its guard.
-        const coalescingUntilMs = key ? attemptedAt + minIntervalMs : 0;
-        transientCooldownUntilMs = Math.max(cooldownStartedAt + cooldownMs, coalescingUntilMs);
-        const effectiveCooldownMs = Math.max(0, transientCooldownUntilMs - cooldownStartedAt);
-        logger(
-          `sendChatAction transient error (${consecutiveTransientFailures}). ` +
-            `Cooling down ${effectiveCooldownMs}ms before retry.`,
-        );
       } else {
         clearTransientCooldown();
       }


### PR DESCRIPTION
## Summary

`is401Error` in the Telegram `sendChatAction` handler used a bare
`message.includes("401")` substring check to classify 401 errors.
grammY renders errors as `Call to 'sendChatAction' failed! (<code>: <description>)`,
so a 429 rate-limit with `retry after 401` produces a message containing
`401`, which was matched by `is401Error` before the transient-error branch
was reached.

**Fix**: Swapped the catch-branch order — `isTransientSendChatActionError`
is now checked before `is401Error`. The two error classifications are
disjoint (429/5xx/network vs 401), so reordering is safe and the 401
backoff/suspension logic is unchanged for real 401 errors.

Fixes #94787

## Real behavior proof

**Behavior addressed**: 429 rate-limit errors with "retry after 401" no
longer miscounted as 401, preventing false bot suspension and
token-deletion alarm.

**Exact steps or command run after fix**:

```bash
pnpm test -- extensions/telegram/src/sendchataction-401-backoff.test.ts
```

**After-fix evidence**:

```
Test Files  1 passed (1)
     Tests  15 passed (15)
```

The new test `does not miscount a 429 with 401 substring as a 401`
sends 3 consecutive 429 errors with message "Call to 'sendChatAction'
failed! (429: Too Many Requests: retry after 401)" and verifies:
- `isSuspended()` returns `false`
- No CRITICAL log messages are emitted

**What was not tested**: End-to-end against live Telegram API.

## Risk checklist

Did user-visible behavior change? (`Yes` / `No`)
`No` — behavior only changes for the misclassification case (429 with
"401" in message), which is now correctly handled as transient.

Did config, environment, or migration behavior change? (`Yes` / `No`)
`No`

Did security, auth, secrets, network, or tool execution behavior change?
(`Yes` / `No`)
`No`

What is the highest-risk area?
- A real 401 whose message somehow matches transient error criteria.
  This is impossible with the current classifiers (401 != 429/5xx/network).

How is that risk mitigated?
- The error classifications are disjoint: `isTelegramRateLimitError`
  checks `error_code === 429`, `isTelegramServerError` checks 5xx codes,
  `isRecoverableTelegramNetworkError` checks network error codes.
  None of these overlap with a true 401.
