### PR TITLE
fix(channels): preserve command progress detail

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -3057,8 +3057,8 @@ describe("processDiscordMessage draft streaming", () => {
     await runProcessDiscordMessage(ctx);
 
     const lastUpdate = draftStream.update.mock.calls.at(-1)?.[0];
-    expect(lastUpdate).toContain("completed");
-    expect(lastUpdate).not.toContain("install dependencies");
+    expect(lastUpdate).toContain("install dependencies");
+    expect(lastUpdate).not.toContain("completed");
   });
 
   it("drops later tool warning finals after progress preview final replies", async () => {

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3229,13 +3229,13 @@ describe("matrix monitor handler draft streaming", () => {
     expect(editMessageMatrixMock).toHaveBeenCalledWith(
       "!room:example.org",
       "$draft1",
-      expect.stringContaining("completed"),
+      expect.stringContaining("Exec"),
       expect.any(Object),
     );
     const recoveredEdit = mockCalls(editMessageMatrixMock, "editMessageMatrix").find(
-      ([, eventId, body]) =>
-        eventId === "$draft1" && typeof body === "string" && body.includes("completed"),
+      ([, eventId, body]) => eventId === "$draft1" && typeof body === "string",
     );
+    expect(recoveredEdit?.[2]).not.toContain("completed");
     expect(recoveredEdit?.[2]).not.toContain("failed");
     expect(recoveredEdit?.[2]).not.toContain("run openclaw cron -> run jq");
   });
@@ -3293,7 +3293,8 @@ describe("matrix monitor handler draft streaming", () => {
       ([, eventId, body]) =>
         eventId === "$draft1" && typeof body === "string" && body.includes("completed"),
     );
-    expect(completedEdit?.[2]).not.toContain("install dependencies");
+    expect(completedEdit).toBeUndefined();
+    expect(singleTextMessageBody()).toContain("install dependencies");
   });
 
   it("replaces Matrix patch progress when the patch summary completes", async () => {

--- a/extensions/msteams/src/reply-dispatcher.test.ts
+++ b/extensions/msteams/src/reply-dispatcher.test.ts
@@ -454,8 +454,8 @@ describe("createMSTeamsReplyDispatcher", () => {
     });
 
     const lastUpdate = getStreamMock().update.mock.calls.at(-1)?.[0];
-    expect(lastUpdate).toContain("completed");
-    expect(lastUpdate).not.toContain("install dependencies");
+    expect(lastUpdate).toContain("install dependencies");
+    expect(lastUpdate).not.toContain("completed");
   });
 
   it("replaces reasoning progress snapshots in progress mode", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2625,10 +2625,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     const lastUpdate = answerDraftStream.updatePreview.mock.calls.at(-1)?.[0];
-    expect(lastUpdate?.text).toContain("completed");
-    expect(lastUpdate?.text).not.toContain("install dependencies");
+    expect(lastUpdate?.text).toContain("install dependencies");
+    expect(lastUpdate?.text).not.toContain("completed");
     expect(lastUpdate?.richMessage).toEqual({
-      html: "<b>Shelling</b><br><b>🛠️ Exec</b> <code>completed</code>",
+      html: "<b>Shelling</b><br><b>🛠️ Exec</b> <code>install dependencies</code>",
       skip_entity_detection: true,
     });
   });

--- a/src/channels/streaming.test.ts
+++ b/src/channels/streaming.test.ts
@@ -24,7 +24,7 @@ describe("buildChannelProgressDraftLine", () => {
     });
   });
 
-  it("uses completed status when successful command output has no title", () => {
+  it("uses the tool label when successful command output has no title", () => {
     const line = buildChannelProgressDraftLine({
       event: "command-output",
       phase: "end",
@@ -34,10 +34,10 @@ describe("buildChannelProgressDraftLine", () => {
 
     expect(line).toMatchObject({
       kind: "command-output",
-      text: "🛠️ completed",
-      detail: "completed",
+      text: "🛠️ Exec",
       status: "completed",
     });
+    expect(line?.detail).toBeUndefined();
   });
 
   it("keeps command status and title in raw command progress lines", () => {

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -411,6 +411,15 @@ function resolveCommandProgressCorrelationKey(input: { toolCallId?: string }): s
   return toolCallId ? `command:${toolCallId}` : undefined;
 }
 
+function isTerminalProgressStatus(status: string | undefined): boolean {
+  const normalized = normalizeOptionalLowercaseString(status);
+  return (
+    normalized === "completed" ||
+    normalized === "failed" ||
+    normalized?.startsWith("exit ") === true
+  );
+}
+
 function isEmptyReasoningProgressItem(
   input: Extract<ChannelProgressDraftLineInput, { event: "item" }>,
   meta: string | undefined,
@@ -444,15 +453,6 @@ function buildCommandOutputProgressLine(
     return line;
   }
   if (status === "completed") {
-    if (!line.detail) {
-      const statusLine = {
-        ...line,
-        detail: status,
-        text: formatToolAggregate(name, [status], { markdown: options?.markdown }),
-      };
-      setProgressDraftLineCorrelationKey(statusLine, correlationKey);
-      return statusLine;
-    }
     return line;
   }
   if (!line.detail || line.detail === status) {
@@ -1153,13 +1153,16 @@ function mergeProgressDraftLineUpdate<TLine extends string | ChannelProgressDraf
   if (
     line.kind !== "command-output" ||
     !line.status ||
-    line.status === "completed" ||
     (line.detail && line.detail !== line.status)
   ) {
     return line;
   }
   const previousDetail = previous.detail?.trim();
-  if (!previousDetail || previousDetail === previous.status) {
+  if (
+    !previousDetail ||
+    previousDetail === previous.status ||
+    isTerminalProgressStatus(previous.status)
+  ) {
     return line;
   }
   const replacement = {

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -601,16 +601,16 @@ describe("channel-streaming", () => {
     expect(updated[0]).toMatchObject({
       id: "tool:call-1-output",
       kind: "command-output",
-      detail: "completed",
+      detail: "install dependencies",
       status: "completed",
-      text: "🛠️ completed",
+      text: "🛠️ install dependencies",
     });
     expect(
       formatChannelProgressDraftText({
         lines: updated,
         entry: { streaming: { progress: { label: false } } },
       }),
-    ).toBe("🛠️ completed");
+    ).toBe("🛠️ install dependencies");
 
     const recoveredItemLine = buildChannelProgressDraftLine({
       event: "item",
@@ -632,19 +632,20 @@ describe("channel-streaming", () => {
     if (!recoveredItemLine || !recoveredCommandLine) {
       throw new Error("expected recovered command progress lines");
     }
-    expect(
-      mergeChannelProgressDraftLine([recoveredItemLine], recoveredCommandLine, {
-        maxLines: 4,
-      }),
-    ).toMatchObject([
+    const recoveredUpdated = mergeChannelProgressDraftLine(
+      [recoveredItemLine],
+      recoveredCommandLine,
+      { maxLines: 4 },
+    );
+    expect(recoveredUpdated).toMatchObject([
       {
         id: "command-2",
         kind: "command-output",
-        detail: "completed",
         status: "completed",
-        text: "🛠️ completed",
+        text: "🛠️ Bash",
       },
     ]);
+    expect(recoveredUpdated[0]).not.toHaveProperty("detail");
   });
 
   it("starts progress drafts after five seconds or a second work event", async () => {


### PR DESCRIPTION
## Summary
- preserve useful command progress text when successful command output completes
- avoid replacing Discord/Telegram/Matrix/MS Teams draft lines with generic `completed`
- keep successful command output authoritative when the previous command detail was terminal/failed

## Root cause
PR #93711 fixed command progress drafts by keeping command text visible after completion. Commit `5ee0f13a54` later reintroduced generic `completed` detail for successful command output with no title and blocked completed command-output merges from preserving the previous useful detail.

## Verification
- `pnpm test src/channels/streaming.test.ts src/plugin-sdk/channel-streaming.test.ts extensions/discord/src/monitor/message-handler.process.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/matrix/src/matrix/monitor/handler.test.ts extensions/msteams/src/reply-dispatcher.test.ts -- --reporter=verbose`
- `git diff --check origin/release/2026.6.9...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/release/2026.6.9`
