### PR TITLE
fix(dreaming): increase narrative timeout from 60s to 120s for ARM devices (fixes #92494)

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -1064,7 +1064,7 @@ describe("generateAndAppendDreamNarrative", () => {
     });
 
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
-    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(60_000);
+    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(120_000);
     expectLogIncludes(logger.warn, "narrative session cleanup failed for rem phase");
   });
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -97,10 +97,11 @@ const NARRATIVE_SYSTEM_PROMPT = [
 // many minutes after the reports have already been written. The previous 15 s
 // limit was empirically too tight for warm-gateway runs across light, REM, and
 // deep phases — even unblocked LLM calls hit it on the first sweep after a
-// restart. 60 s gives realistic latency headroom while still capping the
-// worst case at one minute, well below the multi-minute stall the original
-// comment warned against.
-const NARRATIVE_TIMEOUT_MS = 60_000;
+// restart. 60 s was still too tight for ARM devices with 600+ skills where
+// cold-loading tool definitions takes ~57 s on the first narrative phase,
+// leaving almost no headroom for the LLM call itself. 120 s gives realistic
+// latency headroom while still capping worst case at two minutes.
+const NARRATIVE_TIMEOUT_MS = 120_000;
 const NARRATIVE_MESSAGE_FETCH_LIMIT = 5;
 // A completed run can reach the session reader before the final assistant text
 // is visible, so retry briefly before falling back to synthetic diary text.


### PR DESCRIPTION
## What

Increase `NARRATIVE_TIMEOUT_MS` from 60s to 120s in the dreaming narrative subsystem.

## Why

ARM devices with 600+ skills cold-load all skill tool definitions on the first narrative phase (~57s), leaving almost no headroom for the LLM call within the 60s timeout. The second and third phases benefit from caching and finish well within 60s, but the first phase consistently times out.

## Changes

- `extensions/memory-core/src/dreaming-narrative.ts`: bump `NARRATIVE_TIMEOUT_MS` from `60_000` to `120_000` and update the rationale comment
- `extensions/memory-core/src/dreaming-narrative.test.ts`: update the expected timeout assertion from `60_000` to `120_000`

Fixes #92494

## Real behavior proof

- **Behavior addressed:** Dreaming narrative phase timeout on ARM devices with 600+ skills
- **Environment tested:** macOS 26.4.1, Node v22, OpenClaw main at e6743eb7
- **Steps run after the patch:** Verified constant change via grep, ran extension-memory test suite, ran full build
- **Evidence after fix:**

```
$ grep -n "NARRATIVE_TIMEOUT_MS" extensions/memory-core/src/dreaming-narrative.ts
104:const NARRATIVE_TIMEOUT_MS = 120_000;
1052:            timeoutMs: NARRATIVE_TIMEOUT_MS,

$ node scripts/run-vitest.mjs run extensions/memory-core/src/dreaming-narrative.test.ts
✓ extension-memory (58 tests) 505ms
Test Files 1 passed (1)
Tests 58 passed (58)

$ pnpm build
[build-all] phase timings: total 100.2s
```

- **Observed result after fix:** All 58 dreaming narrative tests pass with the new 120s timeout. Build succeeds cleanly.
- **What was not tested:** Actual ARM device with 600+ skills (issue reporter provided empirical timing data showing ~57s cold-load)
