### PR TITLE
fix(agent-command): prevent post-turn CLI compaction failure from discarding generated reply

### DIFF
--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -144,8 +144,9 @@ vi.mock("./command/attempt-execution.runtime.js", async () => {
 });
 
 vi.mock("./command/cli-compaction.js", () => ({
-  runCliTurnCompactionLifecycle: async (params: { sessionEntry?: SessionEntry }) =>
-    params.sessionEntry,
+  runCliTurnCompactionLifecycle: vi.fn(
+    async (params: { sessionEntry?: SessionEntry }) => params.sessionEntry,
+  ),
 }));
 
 vi.mock("./command/delivery.runtime.js", () => ({
@@ -408,5 +409,79 @@ describe("agentCommand compaction transcript rotation", () => {
       sessionId: "rotated-session",
       sessionFile: rotatedSessionFile,
     });
+  });
+
+  // FIX #94688: Post-turn CLI compaction failure must not discard an
+  // already-successfully-generated assistant reply.
+  it("delivers assistant reply when post-turn CLI compaction fails", async () => {
+    const storePath = requireStorePath();
+    const sessionsDir = await fs.realpath(path.dirname(storePath));
+    const sessionFile = path.join(sessionsDir, "compaction-fail-post-turn.jsonl");
+
+    // Pre-create a valid session file so transcript persistence succeeds.
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({
+        type: "session",
+        version: CURRENT_SESSION_VERSION,
+        id: "compaction-fail-post-turn",
+        timestamp: new Date(0).toISOString(),
+        cwd: state.workspaceDir,
+      })}\n`,
+      "utf-8",
+    );
+
+    const sessionKey = "agent:main:explicit:compaction-fail-post-turn";
+    await saveSessionStore(storePath, {
+      [sessionKey]: {
+        contextTokens: 128000,
+        sessionId: "compaction-fail-post-turn",
+        sessionFile,
+        updatedAt: Date.now(),
+        sessionStartedAt: Date.now(),
+      },
+    });
+
+    // Make runCliTurnCompactionLifecycle throw a connection error,
+    // simulating the exact scenario described in #94688.
+    const cliCompaction = await import("./command/cli-compaction.js");
+    const compactionError = new Error("Summarization failed: Connection error");
+    vi.mocked(cliCompaction.runCliTurnCompactionLifecycle).mockRejectedValueOnce(compactionError);
+
+    // Mock a successful assistant reply via CLI runner.
+    state.runAgentAttemptMock.mockResolvedValueOnce({
+      payloads: [{ text: "Here is the assistant reply" }],
+      meta: {
+        durationMs: 100,
+        stopReason: "end_turn",
+        executionTrace: {
+          runner: "cli" as const,
+          fallbackUsed: false,
+          winnerProvider: "openai",
+          winnerModel: "gpt-5.4",
+        },
+        finalAssistantVisibleText: "Here is the assistant reply",
+        agentMeta: {
+          sessionId: "compaction-fail-post-turn",
+          provider: "openai",
+          model: "gpt-5.4",
+        },
+      },
+    });
+
+    // The command must NOT throw — the already-generated reply must survive
+    // the post-turn compaction failure. It should complete normally even
+    // though compaction threw an error.
+    await expect(
+      agentCommand({
+        message: "test prompt for compaction failure",
+        sessionId: "compaction-fail-post-turn",
+        cwd: state.workspaceDir,
+      }),
+    ).resolves.toMatchObject({ deliverySucceeded: true });
+
+    // Restore the compaction mock to its default passthrough behavior
+    // for subsequent tests.
+    vi.mocked(cliCompaction.runCliTurnCompactionLifecycle).mockReset();
   });
 });

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2212,28 +2212,38 @@ async function agentCommandInternal(
           );
         }
         if (persistedCliTurnTranscript && !suppressVisibleSessionEffects) {
-          sessionEntry = await (
-            await loadCliCompactionRuntime()
-          ).runCliTurnCompactionLifecycle({
-            cfg,
-            sessionId: effectiveSessionId,
-            sessionKey: sessionKey ?? effectiveSessionId,
-            sessionEntry,
-            sessionStore,
-            storePath,
-            sessionAgentId,
-            workspaceDir,
-            cwd: effectiveCwd,
-            agentDir,
-            provider: result.meta.agentMeta?.provider ?? provider,
-            model: result.meta.agentMeta?.model ?? model,
-            skillsSnapshot,
-            messageChannel,
-            agentAccountId: runContext.accountId,
-            senderIsOwner: opts.senderIsOwner,
-            thinkLevel: resolvedThinkLevel,
-            extraSystemPrompt: opts.extraSystemPrompt,
-          });
+          // FIX #94688: Do not let post-turn CLI compaction failures override an
+          // already-successful assistant reply. The reply has already been generated
+          // and persisted; a compaction error should warn but not discard the turn.
+          try {
+            sessionEntry = await (
+              await loadCliCompactionRuntime()
+            ).runCliTurnCompactionLifecycle({
+              cfg,
+              sessionId: effectiveSessionId,
+              sessionKey: sessionKey ?? effectiveSessionId,
+              sessionEntry,
+              sessionStore,
+              storePath,
+              sessionAgentId,
+              workspaceDir,
+              cwd: effectiveCwd,
+              agentDir,
+              provider: result.meta.agentMeta?.provider ?? provider,
+              model: result.meta.agentMeta?.model ?? model,
+              skillsSnapshot,
+              messageChannel,
+              agentAccountId: runContext.accountId,
+              senderIsOwner: opts.senderIsOwner,
+              thinkLevel: resolvedThinkLevel,
+              extraSystemPrompt: opts.extraSystemPrompt,
+            });
+          } catch (error) {
+            log.warn(
+              `Post-turn CLI compaction failed for ${sessionKey ?? effectiveSessionId}: ` +
+                `${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

In a Codex/OpenAI fixed session, the assistant reply can already be generated and written into the live session transcript, but OpenClaw still runs post-turn CLI compaction afterwards. If that compaction summarization call fails with a `Connection error`, the whole turn is surfaced as UNAVAILABLE.

The fix wraps the `runCliTurnCompactionLifecycle` call in a try-catch so that post-turn CLI compaction failures log a warning instead of throwing and causing the entire agent turn to fail.

Fixes #94688

## Real behavior proof

**Behavior addressed**: Post-turn CLI compaction failure causes already-generated assistant reply to be discarded.

**Real setup tested**:
- **Runtime**: OpenClaw test harness (vitest, node v24.13.1)

**Exact steps or command run after fix**:

```bash
node scripts/run-vitest.mjs src/agents/agent-command.compaction-rotation.test.ts
```

**After-fix evidence**:

```
Test Files  1 passed (1)
     Tests  4 passed (4)
```

**Observed result after the fix**: `agentCommand()` completes successfully (`deliverySucceeded: true`) even when `runCliTurnCompactionLifecycle` throws a `Connection error`.

**What was not tested**: End-to-end Codex/OpenAI fixed session with live network errors.

## Tests and validation

- New test: `delivers assistant reply when post-turn CLI compaction fails` — passes
- Existing compaction rotation tests (3 tests) — all pass, no regression

## Risk checklist

Did user-visible behavior change? (`No`)

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?
- Session transcript growth if compaction consistently fails across turns.

How is that risk mitigated?
- Pre-flight compaction on next turn re-attempts; warning logs enable monitoring.

## Current review state

What is the next action?
- Maintainer review
