### PR TITLE
fix(feishu): replace empty Type.Any() with non-empty FlexibleValue in bitable schemas

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -525,12 +525,19 @@ const GetRecordSchema = Type.Object({
   record_id: Type.String({ description: "Record ID to retrieve" }),
 });
 
+// FIX #94547: Type.Any() / Type.Unknown() serialize to {} in TypeBox 1.1.x,
+// producing an empty sub-schema that AWS Bedrock rejects. Use a non-empty
+// flexible-value schema that accepts any JSON-compatible value.
+const FlexibleValue = Type.Unsafe<unknown>({
+  description: "Any JSON-compatible value (string, number, boolean, array, or object)",
+});
+
 const CreateRecordSchema = Type.Object({
   app_token: Type.String({
     description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
-  fields: Type.Record(Type.String(), Type.Any(), {
+  fields: Type.Record(Type.String(), FlexibleValue, {
     description:
       "Field values keyed by field name. Format by type: Text='string', Number=123, SingleSelect='Option', MultiSelect=['A','B'], DateTime=timestamp_ms, User=[{id:'ou_xxx'}], URL={text:'Display',link:'https://...'}",
   }),
@@ -560,7 +567,7 @@ const CreateFieldSchema = Type.Object({
     minimum: 1,
   }),
   property: Type.Optional(
-    Type.Record(Type.String(), Type.Any(), {
+    Type.Record(Type.String(), FlexibleValue, {
       description: "Field-specific properties (e.g., options for SingleSelect, format for Number)",
     }),
   ),
@@ -572,7 +579,7 @@ const UpdateRecordSchema = Type.Object({
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
   record_id: Type.String({ description: "Record ID to update" }),
-  fields: Type.Record(Type.String(), Type.Any(), {
+  fields: Type.Record(Type.String(), FlexibleValue, {
     description: "Field values to update (same format as create_record)",
   }),
 });


### PR DESCRIPTION
## Summary

The `@openclaw/feishu` bitable write tools (`create_record`, `update_record`, `create_field`) emit invalid JSON Schema with empty `patternProperties` sub-schemas. TypeBox 1.1.x serializes `Type.Any()` and `Type.Unknown()` to `{}`, which AWS Bedrock rejects as invalid.

The fix replaces `Type.Any()` with a non-empty `FlexibleValue` schema using `Type.Unsafe<unknown>({description: ...})` that generates a valid JSON Schema while still accepting any JSON-compatible value.

Fixes #94547

## Real behavior proof

**Behavior addressed**: Feishu bitable tool parameter schemas contain empty patternProperties value schemas that break Anthropic via AWS Bedrock.

**Real setup tested**:
- **Runtime**: OpenClaw test harness (vitest)
- **Command**: `node scripts/run-vitest.mjs extensions/feishu/src/bitable.test.ts`

**After-fix evidence**:
```
Test Files  1 passed (1)
     Tests  2 passed (2)
```

**What was not tested**: Live AWS Bedrock request with the fixed schemas.

## Tests and validation

- Existing bitable tests (2 tests) — all pass

## Risk checklist

Did user-visible behavior change? (`No`)
Did config, environment, or migration behavior change? (`No`)
Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?
- `Type.Unsafe` bypasses TypeBox type checking. If the FlexibleValue schema needs adjustment, it must be done manually.

How is that risk mitigated?
- The schema already had `Type.Any()` (also unchecked); FlexibleValue simply adds a description to make the JSON Schema non-empty.
- Existing tests verify schema-dependent tool behavior.

## Current review state

What is the next action?
- Maintainer review
