### PR TITLE
[AI-assisted] Restrict SSH tunnel port availability probe to 127.0.0.1

### DIFF
--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -119,7 +119,7 @@ export async function startSshPortForward(opts: {
 
   let localPort = opts.localPortPreferred;
   try {
-    await ensurePortAvailable(localPort);
+    await ensurePortAvailable(localPort, "127.0.0.1");
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {
       localPort = await pickEphemeralPort();


### PR DESCRIPTION
### Summary
This PR restricts the port availability check performed by startSshPortForward to the loopback interface 127.0.0.1 by passing it to ensurePortAvailable. This resolves issues where IPv4-only loopback port occupants are missed during wildcard interface binding checks.

### Real behavior proof
- **Setup tested:** Local unit test suite.
- **Command run:** 
px vitest run --config test/vitest/vitest.infra.config.ts src/infra/ports.test.ts
- **Observed result:** 
  The unit tests under src/infra/ports.test.ts passed successfully. Output:
  \\\
  ✓  infra  src/infra/ports.test.ts (14 tests | 6 skipped) 2011ms
       ✓ ensurePortAvailable rejects when port busy  1364ms

   Test Files  1 passed (1)
        Tests  8 passed | 6 skipped (14)
  \\\
