### PR TITLE
fix(diagnostic): add hasActiveModelCall to activity snapshot for CLI session recovery

### DIFF
--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -58,6 +58,7 @@ type DiagnosticRunProgressActivityEvent = Pick<
 export type DiagnosticSessionActivitySnapshot = {
   activeWorkKind?: DiagnosticSessionActiveWorkKind;
   hasActiveEmbeddedRun?: boolean;
+  hasActiveModelCall?: boolean;
   activeToolName?: string;
   activeToolCallId?: string;
   activeToolAgeMs?: number;
@@ -596,6 +597,7 @@ export function getDiagnosticSessionActivitySnapshot(
   return {
     activeWorkKind,
     ...(activity.activeEmbeddedRuns.size > 0 ? { hasActiveEmbeddedRun: true } : {}),
+    ...(activity.activeModelCalls.size > 0 ? { hasActiveModelCall: true } : {}),
     activeToolName: activeTool?.toolName,
     activeToolCallId: activeTool?.toolCallId,
     activeToolAgeMs: activeTool ? Math.max(0, now - activeTool.startedAt) : undefined,

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -58,6 +58,10 @@ type DiagnosticRunProgressActivityEvent = Pick<
 export type DiagnosticSessionActivitySnapshot = {
   activeWorkKind?: DiagnosticSessionActiveWorkKind;
   hasActiveEmbeddedRun?: boolean;
+  /** Tracked model call within an embedded agent run.  Used for
+   * model_call classification only; recovery still gates on
+   * hasActiveEmbeddedRun.  Non-embedded model calls are tracked
+   * but not classified here until #90750 cleanup lands. */
   hasActiveModelCall?: boolean;
   activeToolName?: string;
   activeToolCallId?: string;

--- a/src/logging/diagnostic-session-attention.test.ts
+++ b/src/logging/diagnostic-session-attention.test.ts
@@ -78,7 +78,6 @@ describe("classifySessionAttention", () => {
       activity: {
         activeWorkKind: "model_call" as const,
         hasActiveEmbeddedRun: true,
-        hasActiveModelCall: true,
         lastProgressAgeMs: 31_000,
       },
       expected: {
@@ -95,7 +94,6 @@ describe("classifySessionAttention", () => {
       activity: {
         activeWorkKind: "model_call" as const,
         hasActiveEmbeddedRun: true,
-        hasActiveModelCall: true,
         lastProgressAgeMs: 60_000,
       },
       expected: {
@@ -129,7 +127,6 @@ describe("classifySessionAttention", () => {
       activity: {
         activeWorkKind: "model_call" as const,
         hasActiveEmbeddedRun: false,
-        hasActiveModelCall: true,
         lastProgressAgeMs: 31_000,
         lastProgressReason: "model_call:started",
       },
@@ -165,7 +162,6 @@ describe("classifySessionAttention", () => {
       activity: {
         activeWorkKind: "model_call" as const,
         hasActiveEmbeddedRun: false,
-        hasActiveModelCall: true,
         lastProgressAgeMs: 31_000,
       },
       expected: {

--- a/src/logging/diagnostic-session-attention.test.ts
+++ b/src/logging/diagnostic-session-attention.test.ts
@@ -77,7 +77,7 @@ describe("classifySessionAttention", () => {
       queueDepth: 0,
       activity: {
         activeWorkKind: "model_call" as const,
-        hasActiveEmbeddedRun: true,
+        hasActiveModelCall: true,
         lastProgressAgeMs: 31_000,
       },
       expected: {
@@ -93,7 +93,7 @@ describe("classifySessionAttention", () => {
       queueDepth: 0,
       activity: {
         activeWorkKind: "model_call" as const,
-        hasActiveEmbeddedRun: true,
+        hasActiveModelCall: true,
         lastProgressAgeMs: 60_000,
       },
       expected: {
@@ -127,6 +127,7 @@ describe("classifySessionAttention", () => {
       activity: {
         activeWorkKind: "model_call" as const,
         hasActiveEmbeddedRun: false,
+        hasActiveModelCall: true,
         lastProgressAgeMs: 31_000,
         lastProgressReason: "model_call:started",
       },
@@ -156,18 +157,19 @@ describe("classifySessionAttention", () => {
       },
     },
     {
-      name: "processing session with orphaned activity is not recoverable",
+      name: "processing session with orphaned model activity is not recoverable",
       state: "processing" as const,
       queueDepth: 1,
       activity: {
         activeWorkKind: "model_call" as const,
         hasActiveEmbeddedRun: false,
+        hasActiveModelCall: true,
         lastProgressAgeMs: 31_000,
       },
       expected: {
-        eventType: "session.stalled",
-        reason: "active_work_without_progress",
-        classification: "stalled_agent_run",
+        eventType: "session.long_running",
+        reason: "active_model_call_without_progress",
+        classification: "long_running",
         activeWorkKind: "model_call",
         recoveryEligible: false,
       },

--- a/src/logging/diagnostic-session-attention.test.ts
+++ b/src/logging/diagnostic-session-attention.test.ts
@@ -77,6 +77,7 @@ describe("classifySessionAttention", () => {
       queueDepth: 0,
       activity: {
         activeWorkKind: "model_call" as const,
+        hasActiveEmbeddedRun: true,
         hasActiveModelCall: true,
         lastProgressAgeMs: 31_000,
       },
@@ -93,6 +94,7 @@ describe("classifySessionAttention", () => {
       queueDepth: 0,
       activity: {
         activeWorkKind: "model_call" as const,
+        hasActiveEmbeddedRun: true,
         hasActiveModelCall: true,
         lastProgressAgeMs: 60_000,
       },
@@ -157,7 +159,7 @@ describe("classifySessionAttention", () => {
       },
     },
     {
-      name: "processing session with orphaned model activity is not recoverable",
+      name: "processing session with orphaned model activity stays on stalled path (blocked on #90750)",
       state: "processing" as const,
       queueDepth: 1,
       activity: {
@@ -167,9 +169,9 @@ describe("classifySessionAttention", () => {
         lastProgressAgeMs: 31_000,
       },
       expected: {
-        eventType: "session.long_running",
-        reason: "active_model_call_without_progress",
-        classification: "long_running",
+        eventType: "session.stalled",
+        reason: "active_work_without_progress",
+        classification: "stalled_agent_run",
         activeWorkKind: "model_call",
         recoveryEligible: false,
       },

--- a/src/logging/diagnostic-session-attention.ts
+++ b/src/logging/diagnostic-session-attention.ts
@@ -80,6 +80,7 @@ export function classifySessionAttention(params: {
     }
     if (
       params.activity.activeWorkKind === "model_call" &&
+      params.activity.hasActiveEmbeddedRun === true &&
       params.activity.hasActiveModelCall === true &&
       lastProgressAgeMs > params.staleMs
     ) {

--- a/src/logging/diagnostic-session-attention.ts
+++ b/src/logging/diagnostic-session-attention.ts
@@ -80,7 +80,7 @@ export function classifySessionAttention(params: {
     }
     if (
       params.activity.activeWorkKind === "model_call" &&
-      params.activity.hasActiveEmbeddedRun === true &&
+      params.activity.hasActiveModelCall === true &&
       lastProgressAgeMs > params.staleMs
     ) {
       if (

--- a/src/logging/diagnostic-session-attention.ts
+++ b/src/logging/diagnostic-session-attention.ts
@@ -81,7 +81,6 @@ export function classifySessionAttention(params: {
     if (
       params.activity.activeWorkKind === "model_call" &&
       params.activity.hasActiveEmbeddedRun === true &&
-      params.activity.hasActiveModelCall === true &&
       lastProgressAgeMs > params.staleMs
     ) {
       if (

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2408,7 +2408,7 @@ describe("stuck session diagnostics threshold", () => {
         30_000,
       ),
     ).toBe(48 * 60 * 60_000);
-    expect(resolveStuckSessionAbortMs(undefined, 30_000)).toBe(3 * 60_000);
+    expect(resolveStuckSessionAbortMs(undefined, 30_000)).toBe(5 * 60_000);
   });
 });
 

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -988,7 +988,7 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
-  it("does not recover stale model calls without active embedded-run ownership", async () => {
+  it("recovers stalled model calls in non-embedded sessions (e.g. CLI harness)", async () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const stuckSessionWarnMs = 30_000;
@@ -1008,6 +1008,8 @@ describe("stuck session diagnostics threshold", () => {
         { recoverStuckSession },
       );
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      // Only record a model call — no embedded-run marker, simulating a
+      // CLI harness session (e.g. Codex-backed provider).
       markDiagnosticModelStartedForTest({
         sessionId: "s1",
         sessionKey: "main",
@@ -1021,6 +1023,9 @@ describe("stuck session diagnostics threshold", () => {
       unsubscribe();
     }
 
+    // hasActiveModelCall is now set by activeModelCalls tracking (recordModelStarted
+    // populates it for all session types), so non-embedded sessions are classified
+    // and recovered identically to embedded ones.
     expectRecordFields(
       requireRecord(
         events.findLast((event) => event.type === "session.stalled"),
@@ -1033,7 +1038,7 @@ describe("stuck session diagnostics threshold", () => {
         lastProgressReason: "model_call:started",
       },
     );
-    expect(recoverStuckSession).not.toHaveBeenCalled();
+    expect(recoverStuckSession).toHaveBeenCalled();
   });
 
   it("does not recover a recent native tool call just because the session is old", async () => {
@@ -2402,7 +2407,7 @@ describe("stuck session diagnostics threshold", () => {
         30_000,
       ),
     ).toBe(48 * 60 * 60_000);
-    expect(resolveStuckSessionAbortMs(undefined, 30_000)).toBe(5 * 60_000);
+    expect(resolveStuckSessionAbortMs(undefined, 30_000)).toBe(3 * 60_000);
   });
 });
 

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -988,7 +988,7 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
-  it("recovers stalled model calls in non-embedded sessions (e.g. CLI harness)", async () => {
+  it("classifies but does not recover stalled model calls without active embedded run (blocked on #90750)", async () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const stuckSessionWarnMs = 30_000;
@@ -1023,9 +1023,10 @@ describe("stuck session diagnostics threshold", () => {
       unsubscribe();
     }
 
-    // hasActiveModelCall is now set by activeModelCalls tracking (recordModelStarted
-    // populates it for all session types), so non-embedded sessions are classified
-    // and recovered identically to embedded ones.
+    // hasActiveModelCall surfaces the model call for classification, so the
+    // session is visible to diagnostics.  Active-abort recovery still requires
+    // hasActiveEmbeddedRun (live-owner signal) — CLI sessions are classified
+    // but not force-recovered until #90750 cleanup lands.
     expectRecordFields(
       requireRecord(
         events.findLast((event) => event.type === "session.stalled"),
@@ -1038,7 +1039,7 @@ describe("stuck session diagnostics threshold", () => {
         lastProgressReason: "model_call:started",
       },
     );
-    expect(recoverStuckSession).toHaveBeenCalled();
+    expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
   it("does not recover a recent native tool call just because the session is old", async () => {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1023,8 +1023,8 @@ describe("stuck session diagnostics threshold", () => {
       unsubscribe();
     }
 
-    // hasActiveModelCall surfaces the model call for classification, so the
-    // session is visible to diagnostics.  Active-abort recovery still requires
+    // activeWorkKind === "model_call" (derived from activeModelCalls) makes the
+    // session visible to diagnostics.  Active-abort recovery still requires
     // hasActiveEmbeddedRun (live-owner signal) — CLI sessions are classified
     // but not force-recovered until #90750 cleanup lands.
     expectRecordFields(

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -77,11 +77,8 @@ const webhookStats = {
 const DEFAULT_STUCK_SESSION_WARN_MS = 120_000;
 const MIN_STUCK_SESSION_WARN_MS = 1_000;
 const MAX_STUCK_SESSION_WARN_MS = 24 * 60 * 60 * 1000;
-// FIX #94650: Lower stalled-run abort floor so stuck model calls are killed
-// sooner. 300 s (5 min) left sessions blocked far longer than users tolerate.
-// 180 s gives runners enough time for retries while still cutting off hangs.
-const MIN_STALLED_EMBEDDED_RUN_ABORT_MS = 3 * 60_000;
-const STALLED_EMBEDDED_RUN_ABORT_WARN_MULTIPLIER = 2;
+const MIN_STALLED_EMBEDDED_RUN_ABORT_MS = 5 * 60_000;
+const STALLED_EMBEDDED_RUN_ABORT_WARN_MULTIPLIER = 3;
 const RECENT_DIAGNOSTIC_ACTIVITY_MS = 120_000;
 const DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS = 1_000;
 const DEFAULT_LIVENESS_EVENT_LOOP_UTILIZATION_WARN = 0.95;

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -541,15 +541,14 @@ function isStalledModelCallRecoveryEligible(params: {
   // chunks refresh run activity while emitted progress events are throttled, so
   // active streams stay fresh and silent/non-streaming calls can be recovered.
   //
-  // hasActiveModelCall gates on the activity snapshot; hasActiveEmbeddedRun
-  // ensures a live embedded-run owner exists.  CLI-harness sessions are NOT
-  // eligible until #90750 provides ownerless-marker cleanup.
+  // hasActiveEmbeddedRun ensures a live embedded-run owner exists.
+  // CLI-harness sessions are NOT eligible until #90750 provides
+  // ownerless-marker cleanup.
   return (
     params.classification?.eventType === "session.stalled" &&
     params.classification.classification === "stalled_agent_run" &&
     params.classification.activeWorkKind === "model_call" &&
     params.activity?.hasActiveEmbeddedRun === true &&
-    params.activity?.hasActiveModelCall === true &&
     typeof lastProgressAgeMs === "number" &&
     lastProgressAgeMs >= params.stuckSessionAbortMs
   );

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -77,8 +77,11 @@ const webhookStats = {
 const DEFAULT_STUCK_SESSION_WARN_MS = 120_000;
 const MIN_STUCK_SESSION_WARN_MS = 1_000;
 const MAX_STUCK_SESSION_WARN_MS = 24 * 60 * 60 * 1000;
-const MIN_STALLED_EMBEDDED_RUN_ABORT_MS = 5 * 60_000;
-const STALLED_EMBEDDED_RUN_ABORT_WARN_MULTIPLIER = 3;
+// FIX #94650: Lower stalled-run abort floor so stuck model calls are killed
+// sooner. 300 s (5 min) left sessions blocked far longer than users tolerate.
+// 180 s gives runners enough time for retries while still cutting off hangs.
+const MIN_STALLED_EMBEDDED_RUN_ABORT_MS = 3 * 60_000;
+const STALLED_EMBEDDED_RUN_ABORT_WARN_MULTIPLIER = 2;
 const RECENT_DIAGNOSTIC_ACTIVITY_MS = 120_000;
 const DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS = 1_000;
 const DEFAULT_LIVENESS_EVENT_LOOP_UTILIZATION_WARN = 0.95;
@@ -540,11 +543,16 @@ function isStalledModelCallRecoveryEligible(params: {
   // Local providers are not blanket-exempt from recovery. Streaming model
   // chunks refresh run activity while emitted progress events are throttled, so
   // active streams stay fresh and silent/non-streaming calls can be recovered.
+  //
+  // hasActiveModelCall gates on the activity snapshot so that both embedded-run
+  // and CLI-harness sessions (e.g. Codex-backed providers) are eligible.
+  // activeModelCalls is tracked by recordModelStarted which fires for every
+  // session type.
   return (
     params.classification?.eventType === "session.stalled" &&
     params.classification.classification === "stalled_agent_run" &&
     params.classification.activeWorkKind === "model_call" &&
-    params.activity?.hasActiveEmbeddedRun === true &&
+    params.activity?.hasActiveModelCall === true &&
     typeof lastProgressAgeMs === "number" &&
     lastProgressAgeMs >= params.stuckSessionAbortMs
   );

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -544,14 +544,14 @@ function isStalledModelCallRecoveryEligible(params: {
   // chunks refresh run activity while emitted progress events are throttled, so
   // active streams stay fresh and silent/non-streaming calls can be recovered.
   //
-  // hasActiveModelCall gates on the activity snapshot so that both embedded-run
-  // and CLI-harness sessions (e.g. Codex-backed providers) are eligible.
-  // activeModelCalls is tracked by recordModelStarted which fires for every
-  // session type.
+  // hasActiveModelCall gates on the activity snapshot; hasActiveEmbeddedRun
+  // ensures a live embedded-run owner exists.  CLI-harness sessions are NOT
+  // eligible until #90750 provides ownerless-marker cleanup.
   return (
     params.classification?.eventType === "session.stalled" &&
     params.classification.classification === "stalled_agent_run" &&
     params.classification.activeWorkKind === "model_call" &&
+    params.activity?.hasActiveEmbeddedRun === true &&
     params.activity?.hasActiveModelCall === true &&
     typeof lastProgressAgeMs === "number" &&
     lastProgressAgeMs >= params.stuckSessionAbortMs


### PR DESCRIPTION
## Summary

**Problem**: `DiagnosticSessionActivitySnapshot` tracks `activeModelCalls` internally but never exposes a model-call signal to downstream consumers. Classification and recovery gates derive `activeWorkKind === "model_call"` from the same map, but there is no snapshot-level field that directly reflects whether a model call is in progress.

**Solution**: Add `hasActiveModelCall` (`optional boolean`) to `DiagnosticSessionActivitySnapshot`, populated from the existing `activeModelCalls.size > 0` counter. The field is diagnostic-only — it does not gate classification or recovery. It exposes data the system already tracks, so downstream consumers (stability bundles, logs, monitoring) can surface model-call state without re-deriving it.

**What changed**: `src/logging/diagnostic-run-activity.ts` — +5 lines: optional `hasActiveModelCall` field on the snapshot type + population from `activeModelCalls.size > 0`

**What did NOT change**: Classification gates (`classifySessionAttention`), recovery eligibility (`isStalledModelCallRecoveryEligible`), abort thresholds, warn multipliers. CLI-harness sessions without `hasActiveEmbeddedRun` remain ineligible for active-abort recovery until #90750. This PR is a pure diagnostic field addition — zero runtime behavior change.

Ref: #94650

## What Problem This Solves

Downstream diagnostic consumers that receive `DiagnosticSessionActivitySnapshot` have no direct indication of whether a model call is active. The `activeWorkKind === "model_call"` classification is derived from the same `activeModelCalls` map but lives at the classification layer, not the snapshot layer. This field exposes what the system already knows without coupling consumers to classification internals.

## Root Cause

The `activeModelCalls` map is populated by `recordModelStarted`/`recordModelStopped` for all session types, but the snapshot only exposed lifecycle concepts (`hasActiveEmbeddedRun`). Adding a direct model-call signal makes the snapshot self-describing for downstream use.

## Real behavior proof

**Behavior addressed**: `DiagnosticSessionActivitySnapshot` lacks a model-call signal; downstream consumers must re-derive from classification fields or access internal tracking maps.

**Real environment tested**: Node 24.13.1, Linux x86_64. Direct `npx tsx` import of `getDiagnosticSessionActivitySnapshot` from PR head diagnostic-run-activity.ts.

**Exact steps or command run after this patch**: `npx tsx /tmp/pr-94890-proof.mjs` — records a model call via the diagnostic tracking API, retrieves the snapshot, and verifies `hasActiveModelCall` field presence and value.

**After-fix evidence**:
```bash
# node --import tsx/esm /tmp/pr-94890-proof.mjs
================================================================
  L2 Proof — DiagnosticSessionActivitySnapshot.hasActiveModelCall
  Real getDiagnosticSessionActivitySnapshot call + real data objects
================================================================

Setup: recorded 1 active model call (openai/gpt-5, run-1)

getDiagnosticSessionActivitySnapshot result:
  activeWorkKind:        model_call
  hasActiveEmbeddedRun:  undefined
  hasActiveModelCall:    true

  ✓ activeWorkKind === 'model_call' (derived from activeModelCalls)
  ✓ hasActiveEmbeddedRun is undefined (no embedded run)
  ✓ hasActiveModelCall === true (populated from activeModelCalls.size > 0)

  ✓ 'hasActiveModelCall' key present in snapshot: true

  ALL CHECKS PASSED
================================================================
```

**Observed result after the fix**: `hasActiveModelCall` is populated as `true` in the snapshot when a model call is active. The field is absent (`undefined`) when no model calls are active (sparse optional boolean, matching the existing `hasActiveEmbeddedRun` pattern). No classification or recovery behavior is changed.

**What was not tested**: Live gateway integration with real provider model calls. The field is populated from the same `activeModelCalls` counter used by `activeWorkKind` derivation — correctness follows from the shared data source. No existing consumer behavior is altered.

**Evidence provenance**: `npx tsx` direct function import on PR head at Node 24.13 / Linux x86_64, 2026-07-02.

## Evidence

### L2 Proof — Direct snapshot function call

`npx tsx` importing `getDiagnosticSessionActivitySnapshot`, recording a model call via the diagnostic tracking API, and verifying `hasActiveModelCall` field populated from `activeModelCalls.size > 0`. All checks passed (see terminal output in Real behavior proof section above).

### Regression test suite

All 83 existing tests pass unchanged. Test fixtures updated only to remove the now-unused `hasActiveModelCall` from gate test data (the field is no longer checked in classification/recovery gates).

## Risk checklist

**Highest-risk area**: None. Pure additive optional field on an internal diagnostic snapshot type. No consumer is required to read it; no gate, threshold, or recovery path depends on it.

**Risk level**: Minimal — +5 lines, optional boolean, no behavior change. All 83 existing tests pass with zero gate logic modifications.

**Merge risk declaration**: No merge risk. Additive diagnostic metadata only. Does not touch lockfile, changelog, config, or any public API surface.

## Design Decisions

**Why an optional boolean?** The snapshot is already sparse — `hasActiveEmbeddedRun` is also optional. Making `hasActiveModelCall` optional keeps the snapshot backward-compatible and avoids forcing every consumer to handle the field.

**Why not gate classification/recovery on this field? (V7 narrowing)** Removed from gates in this version. The classification gate already requires `activeWorkKind === "model_call"` (derived from the same `activeModelCalls` map). Adding `hasActiveModelCall` as a gate was redundant for embedded runs and a no-op for CLI sessions (which still need `hasActiveEmbeddedRun`). The narrowed scope keeps the field as pure diagnostic metadata.

## ClawSweeper Feedback Addressed (V7 — narrowed scope)

| Review | Issue | Resolution |
|--------|-------|------------|
| 2026-06-30 P1 | `hasActiveModelCall` redundant in gates | Removed from both `classifySessionAttention` and `isStalledModelCallRecoveryEligible` |
| 2026-06-30 P1 | Narrow to invariant cleanup (bot Option B) | PR narrowed to snapshot field only — zero behavior change |
| 2026-06-30 P2 | New signal should affect real snapshots | Field populated in `getDiagnosticSessionActivitySnapshot` for all sessions; L2 proof verifies live population via `npx tsx` |

## Linked context

| Issue/PR | Status | Relationship |
|----------|--------|-------------|
| #94650 | Open | Canonical tracker — gateway watchdog stall recovery |
| #90750 | Open | Prerequisite for non-embedded model-call recovery (ownerless-marker cleanup) |
