### PR TITLE
fix(telegram): send progress previews as html text

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -398,6 +398,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
     return expectRecordFields(mockCallArg(dispatchReplyWithBufferedBlockDispatcher), expected);
   }
 
+  function telegramHtmlPreview(html: string) {
+    return { text: html, parseMode: "HTML" as const };
+  }
+
   function createContext(overrides?: Partial<TelegramMessageContext>): TelegramMessageContext {
     const base = {
       ctxPayload: {},
@@ -2435,7 +2439,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Site A shows X.");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site A shows X.");
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringMatching(/`🛠️ Exec`$/) }),
+      expect.objectContaining({ text: expect.stringMatching(/<b>🛠️ Exec<\/b>$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(3, "Final answer");
     expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
@@ -2462,7 +2466,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Site A shows X.");
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringMatching(/`🛠️ Exec`$/) }),
+      expect.objectContaining({ text: expect.stringMatching(/<b>🛠️ Exec<\/b>$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site B shows Y.");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(3, "Final answer");
@@ -2504,7 +2508,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createContext() });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringMatching(/`🛠️ Exec`$/) }),
+      expect.objectContaining({ text: expect.stringMatching(/<b>🛠️ Exec<\/b>$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Branch is up to date");
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
@@ -2530,7 +2534,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createContext() });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringMatching(/`🛠️ Exec`$/) }),
+      expect.objectContaining({ text: expect.stringMatching(/<b>🛠️ Exec<\/b>$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Branch is up to date");
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
@@ -2584,13 +2588,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress" } },
     });
 
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Cracking\n\n`🛠️ Exec`\n`🛠️ git rev-parse --abbrev-ref HEAD`",
-      richMessage: {
-        html: "<b>Cracking</b><br><b>🛠️ Exec</b><br><b>🛠️ Exec</b> <code>git rev-parse --abbrev-ref HEAD</code>",
-        skip_entity_detection: true,
-      },
-    });
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+      telegramHtmlPreview(
+        "<b>Cracking</b><br><b>🛠️ Exec</b><br><b>🛠️ Exec</b> <code>git rev-parse --abbrev-ref HEAD</code>",
+      ),
+    );
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Branch is up to date");
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
@@ -2627,10 +2629,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const lastUpdate = answerDraftStream.updatePreview.mock.calls.at(-1)?.[0];
     expect(lastUpdate?.text).toContain("install dependencies");
     expect(lastUpdate?.text).not.toContain("completed");
-    expect(lastUpdate?.richMessage).toEqual({
-      html: "<b>Shelling</b><br><b>🛠️ Exec</b> <code>install dependencies</code>",
-      skip_entity_detection: true,
-    });
+    expect(lastUpdate).toEqual(
+      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b> <code>install dependencies</code>"),
+    );
   });
 
   it("sends trailing verbose status after a progress-mode final answer", async () => {
@@ -2650,13 +2651,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress" } },
     });
 
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Cracking\n\n`🛠️ Exec`",
-      richMessage: {
-        html: "<b>Cracking</b><br><b>🛠️ Exec</b>",
-        skip_entity_detection: true,
-      },
-    });
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+      telegramHtmlPreview("<b>Cracking</b><br><b>🛠️ Exec</b>"),
+    );
     expect(answerDraftStream.update).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, trailingFinalStatusText);
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(2);
@@ -2691,7 +2688,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     expect(answerDraftStream.updatePreview).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        text: "Shelling\n\n`🛠️ Exec`\n`🔎 Web Search: docs lookup`",
+        text: "<b>Shelling</b><br><b>🛠️ Exec</b><br><b>🔎 Web Search</b> <code>docs lookup</code>",
       }),
     );
     expect(deliverReplies).not.toHaveBeenCalled();
@@ -2716,7 +2713,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: "Shelling\n\n`🛠️ Exec`" }),
+      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
     );
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
@@ -2746,7 +2743,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: "Shelling\n\n`🛠️ Exec`" }),
+      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
     );
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
@@ -2780,7 +2777,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: "Shelling\n\n`🛠️ Exec`" }),
+      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
     );
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
@@ -2929,13 +2926,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Shelling\n\n`🛠️ Exec`",
-      richMessage: {
-        html: "<b>Shelling</b><br><b>🛠️ Exec</b>",
-        skip_entity_detection: true,
-      },
-    });
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(
+      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
+    );
     expect(draftStream.flush).toHaveBeenCalled();
   });
 
@@ -2973,13 +2966,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenLastCalledWith({
-      text: "Shelling\n\n`🛠️ exit 2; command false`",
-      richMessage: {
-        html: "<b>Shelling</b><br><b>🛠️ Exec</b> <code>command false</code> <i>exit 2</i>",
-        skip_entity_detection: true,
-      },
-    });
+    expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
+      telegramHtmlPreview(
+        "<b>Shelling</b><br><b>🛠️ Exec</b> <code>command false</code> <i>exit 2</i>",
+      ),
+    );
   });
 
   it("hides command titles in Telegram status-only progress draft previews", async () => {
@@ -3016,13 +3007,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenLastCalledWith({
-      text: "Shelling\n\n`🛠️ exit 2`",
-      richMessage: {
-        html: "<b>Shelling</b><br><b>🛠️ Exec</b> <code>exit 2</code>",
-        skip_entity_detection: true,
-      },
-    });
+    expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
+      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b> <code>exit 2</code>"),
+    );
   });
 
   it("composes streamed reasoning with tool progress in Telegram progress drafts", async () => {
@@ -3043,13 +3030,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(createTelegramDraftStream).toHaveBeenCalledTimes(1);
-    expect(draftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Shelling\n\n`🛠️ Exec`\n• _Checking files_",
-      richMessage: {
-        html: "<b>Shelling</b><br><b>🛠️ Exec</b><br><i>Checking files</i>",
-        skip_entity_detection: true,
-      },
-    });
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(
+      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b><br><i>Checking files</i>"),
+    );
   });
 
   it("renders configured Telegram commentary progress from preamble item events", async () => {
@@ -3076,13 +3059,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Shelling\n\n_Checking recent context_",
-      richMessage: {
-        html: "<b>Shelling</b><br><i>Checking recent context</i>",
-        skip_entity_detection: true,
-      },
-    });
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(
+      telegramHtmlPreview("<b>Shelling</b><br><i>Checking recent context</i>"),
+    );
   });
 
   it("suppresses Telegram preamble progress when commentary is disabled", async () => {
@@ -3137,10 +3116,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Shelling",
-      richMessage: { html: "<b>Shelling</b>", skip_entity_detection: true },
-    });
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(telegramHtmlPreview("<b>Shelling</b>"));
     expect(draftStream.flush).toHaveBeenCalled();
   });
 
@@ -3170,18 +3146,16 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     await vi.waitFor(() =>
-      expect(draftStream.updatePreview).toHaveBeenCalledWith(
-        expect.objectContaining({ text: "Working" }),
-      ),
+      expect(draftStream.updatePreview).toHaveBeenCalledWith(telegramHtmlPreview("<b>Working</b>")),
     );
     expect(draftStream.updatePreview).not.toHaveBeenCalledWith(
-      expect.objectContaining({ text: "Working." }),
+      telegramHtmlPreview("<b>Working.</b>"),
     );
     expect(draftStream.updatePreview).not.toHaveBeenCalledWith(
-      expect.objectContaining({ text: "Working.." }),
+      telegramHtmlPreview("<b>Working..</b>"),
     );
     expect(draftStream.updatePreview).not.toHaveBeenCalledWith(
-      expect.objectContaining({ text: "Working..." }),
+      telegramHtmlPreview("<b>Working...</b>"),
     );
     finishRun?.();
     await run;
@@ -3205,7 +3179,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       const updateBeforeStatusReaction = draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text;
       releaseSetTool?.();
       await pendingToolStart;
-      expect(updateBeforeStatusReaction).toBe("Shelling\n\n`🛠️ Exec`");
+      expect(updateBeforeStatusReaction).toBe("<b>Shelling</b><br><b>🛠️ Exec</b>");
       return { queuedFinal: false };
     });
 
@@ -3241,13 +3215,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Shelling\n\n`🔎 Web Search: docs lookup`\n• `tests passed`",
-      richMessage: {
-        html: "<b>Shelling</b><br><b>🔎 Web Search</b> <code>docs lookup</code><br><b>Update</b> <code>tests passed</code>",
-        skip_entity_detection: true,
-      },
-    });
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(
+      telegramHtmlPreview(
+        "<b>Shelling</b><br><b>🔎 Web Search</b> <code>docs lookup</code><br><b>Update</b> <code>tests passed</code>",
+      ),
+    );
     expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(draftStream.materialize).not.toHaveBeenCalled();
     expect(draftStream.clear).toHaveBeenCalledTimes(1);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -466,6 +466,7 @@ function renderTelegramProgressLine(line: ChannelProgressDraftCompositorLine): s
 function renderTelegramProgressDraftPreview(
   text: string,
   lines: readonly ChannelProgressDraftCompositorLine[],
+  richMessages: boolean,
 ): TelegramDraftPreview {
   const trimmed = text.trimEnd();
   const [heading] = trimmed.split(/\r?\n/u, 1);
@@ -473,9 +474,13 @@ function renderTelegramProgressDraftPreview(
   const htmlParts = heading?.trim()
     ? [`<b>${escapeTelegramProgressHtml(heading.trim())}</b>`, ...renderedLines]
     : renderedLines;
+  const html = htmlParts.join("<br>");
+  if (!richMessages) {
+    return { text: html, parseMode: "HTML" };
+  }
   return {
     text: trimmed,
-    richMessage: buildTelegramRichHtml(htmlParts.join("<br>"), { skipEntityDetection: true }),
+    richMessage: buildTelegramRichHtml(html, { skipEntityDetection: true }),
   };
 }
 
@@ -1074,7 +1079,11 @@ export const dispatchTelegramMessage = async ({
       answerLane.hasStreamedMessage = true;
       answerLane.finalized = false;
       answerLane.stream?.updatePreview(
-        renderTelegramProgressDraftPreview(streamText, options?.lines ?? []),
+        renderTelegramProgressDraftPreview(
+          streamText,
+          options?.lines ?? [],
+          telegramCfg.richMessages === true,
+        ),
       );
       if (options?.flush) {
         await answerLane.stream?.flush();


### PR DESCRIPTION
## Summary

- switch Telegram tool-progress previews to emit standard HTML previews when `richMessages` is off
- keep `richMessage` previews only for the explicit `richMessages === true` transport
- update progress-preview assertions to lock the false-mode contract to `parseMode: "HTML"`

## Root Cause

Telegram progress draft rendering always produced a `richMessage` HTML preview shape, even when account config had `richMessages` off. The draft stream usually normalized that shape back into standard `sendMessage/editMessageText` with `parse_mode: "HTML"`, but the producer contract was wrong and leak-prone: false-mode progress should never carry a raw rich-message payload.

## Distill / Greybeard Pass

Distill: fixed the producer boundary instead of adding another fallback in `draft-stream`; false-mode now emits its actual transport shape directly, while rich-mode remains the only path that produces `richMessage`.

Greybeard: no hot-path optimization needed. The branch is stable per account config, and the patch does not add new per-line work beyond the existing progress HTML render/join path.

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot-message-dispatch.test.ts -- --reporter=verbose`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
