### PR TITLE
fix(ssh-tunnel): pass host to ensurePortAvailable for correct address-family check

### DIFF
--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -119,7 +119,10 @@ export async function startSshPortForward(opts: {
 
   let localPort = opts.localPortPreferred;
   try {
-    await ensurePortAvailable(localPort);
+    // FIX #94596: Pass parsed.host so ensurePortAvailable checks the correct
+    // address family (IPv4 vs IPv6) instead of defaulting to "localhost" which
+    // can miss IPv4-only occupants on dual-stack hosts.
+    await ensurePortAvailable(localPort, parsed.host);
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {
       localPort = await pickEphemeralPort();


### PR DESCRIPTION
## Summary

`startSshPortForward` called `ensurePortAvailable(localPort)` without the `host` parameter, defaulting to `"localhost"` which can miss IPv4-only occupants on dual-stack hosts when the SSH target resolves to an IPv4 address.

Pass `parsed.host` to `ensurePortAvailable` so the port availability check uses the correct address family.

Fixes #94596

## Tests and validation

```bash
$ node scripts/run-vitest.mjs src/infra/ssh-tunnel.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```
