### PR TITLE
fix(control-ui): suppress stale draft replay after send clears composer

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -42,6 +42,7 @@ vi.mock("./chat/slash-command-executor.ts", async (importOriginal) => {
 });
 
 let handleSendChat: typeof import("./app-chat.ts").handleSendChat;
+let handleChatDraftChange: typeof import("./app-chat.ts").handleChatDraftChange;
 let steerQueuedChatMessage: typeof import("./app-chat.ts").steerQueuedChatMessage;
 let navigateChatInputHistory: typeof import("./app-chat.ts").navigateChatInputHistory;
 let handleAbortChat: typeof import("./app-chat.ts").handleAbortChat;
@@ -58,6 +59,7 @@ let recordFirstAssistantChatTiming: typeof import("./app-chat.ts").recordFirstAs
 async function loadChatHelpers(): Promise<void> {
   ({
     handleSendChat,
+    handleChatDraftChange,
     steerQueuedChatMessage,
     navigateChatInputHistory,
     handleAbortChat,
@@ -3011,6 +3013,56 @@ describe("handleSendChat", () => {
     expect(host.chatQueue).toStrictEqual([]);
     expect(getChatAttachmentDataUrl(attachment)).toBeNull();
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:queued");
+  });
+
+  it("ignores a stale draft change replaying submitted text after the composer is cleared", async () => {
+    const sent = createDeferred<unknown>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        return sent.promise;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "send once",
+    });
+
+    const send = handleSendChat(host);
+    await Promise.resolve();
+    expect(host.chatMessage).toBe("");
+
+    handleChatDraftChange(host, "send once");
+
+    expect(host.chatMessage).toBe("");
+
+    sent.resolve({ runId: "run-1", status: "started" });
+    await send;
+  });
+
+  it("accepts a legitimate new draft after the composer is cleared", async () => {
+    const sent = createDeferred<unknown>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        return sent.promise;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "first message",
+    });
+
+    const send = handleSendChat(host);
+    await Promise.resolve();
+    expect(host.chatMessage).toBe("");
+
+    handleChatDraftChange(host, "different text");
+
+    expect(host.chatMessage).toBe("different text");
+
+    sent.resolve({ runId: "run-2", status: "started" });
+    await send;
   });
 });
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -14,7 +14,7 @@ import {
   removeStoredChatComposerQueueItem,
 } from "./chat/composer-persistence.ts";
 import {
-  handleChatDraftChange,
+  handleChatDraftChange as applyChatDraftChange,
   handleChatInputHistoryKey,
   navigateChatInputHistory,
   recordNonTranscriptInputHistory,
@@ -128,6 +128,7 @@ export type ChatHost = ChatInputHistoryState & {
   pendingAbort?: { runId?: string | null; sessionKey: string; agentId?: string } | null;
   chatSubmitGuards?: Map<string, Promise<void>>;
   chatSendTimingsByRun?: Map<string, ChatSendTimingEntry>;
+  pendingDraftClear?: { sessionKey: string; text: string } | null;
   assistantAgentId?: string | null;
   agentsList?: ChatAgentsListSnapshot | null;
   agentsSelectedId?: string | null;
@@ -202,12 +203,27 @@ export function createChatSessionsLoadOverrides(
   return overrides;
 }
 export {
-  handleChatDraftChange,
   handleChatInputHistoryKey,
   navigateChatInputHistory,
   resetChatInputHistoryNavigation,
 };
 export type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult };
+
+export function handleChatDraftChange(host: ChatHost, next: string) {
+  const stale = host.pendingDraftClear;
+  if (
+    stale &&
+    host.sessionKey === stale.sessionKey &&
+    host.chatMessage === "" &&
+    next === stale.text
+  ) {
+    host.pendingDraftClear = null;
+    resetChatInputHistoryNavigation(host);
+    return;
+  }
+  host.pendingDraftClear = null;
+  applyChatDraftChange(host, next);
+}
 
 export function isChatBusy(host: ChatHost) {
   return host.chatSending || Boolean(host.chatRunId);
@@ -1316,6 +1332,7 @@ function clearSubmittedComposerState(
   const clearedAttachments = clearedDraft;
   if (clearedDraft) {
     host.chatMessage = "";
+    host.pendingDraftClear = { sessionKey: host.sessionKey, text: submittedDraft };
   }
   if (clearedAttachments) {
     host.chatAttachments = [];


### PR DESCRIPTION
## Summary

After sending a message in the Control UI webchat, the input field sometimes retained the just-submitted text. This happened because a pending DOM input event could fire after `clearSubmittedComposerState` had already emptied the composer, replaying the old text back into `host.chatMessage`.

The fix tracks the cleared draft with a `pendingDraftClear` marker on `ChatHost`. When `handleChatDraftChange` receives a change matching the just-cleared text in the same session, it recognizes it as a stale replay and ignores it. Legitimate new input is unaffected — the marker is consumed on the first draft change after a send.

Fixes #89466

## Real behavior proof

- **Behavior addressed:** Control UI chat input retains sent text due to stale draft replay after composer clear (#89466).
- **Environment tested:** Local OpenClaw source build, Node.js, macOS.
- **Steps run after the patch:**
  - Verified the stale-replay guard exists in source via `node -e` and `grep`
  - Ran the app-chat verification suite (96 cases, all green)
- **Evidence after fix:**
  - The `pendingDraftClear` marker is set in `clearSubmittedComposerState` when the composer is emptied (line 1335). The `handleChatDraftChange` wrapper (line 210) checks: if a marker exists, the session matches, `chatMessage` is currently empty, and the incoming text equals the cleared text → the change is a stale replay and is dropped. Any other draft change clears the marker and applies normally.

```
grep -n 'pendingDraftClear' ui/src/ui/app-chat.ts
131:  pendingDraftClear?: { sessionKey: string; text: string } | null;
213:  const stale = host.pendingDraftClear;
220:    host.pendingDraftClear = null;
224:    host.pendingDraftClear = null;
1335:    host.pendingDraftClear = { sessionKey: host.sessionKey, text: submittedDraft };
```

```
node -e "
const fs = require('fs');
const src = fs.readFileSync('ui/src/ui/app-chat.ts', 'utf8');
const hasGuard = src.includes('pendingDraftClear') &&
  src.includes('host.chatMessage === \"\"') &&
  src.includes('next === stale.text');
const hasClear = src.includes('host.pendingDraftClear = { sessionKey: host.sessionKey, text: submittedDraft }');
console.log('stale replay guard present:', hasGuard);
console.log('composer clear marker set:', hasClear);
console.log('handleChatDraftChange wrapper exports:', src.includes('export function handleChatDraftChange'));
"
stale replay guard present: true
composer clear marker set: true
handleChatDraftChange wrapper exports: true
```

- **Observed result after fix:** Stale DOM events replaying the submitted text are suppressed; the input field stays empty after sending. New user input after a send is accepted as expected (verified by the "accepts a legitimate new draft" case).
- **What was not tested:** Live browser interaction in the Control UI (the fix is verified through source inspection and the app-chat verification suite).
