### PR TITLE
fix(heartbeat): suppress private text delivery when heartbeat_respond tool is available but unused

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -42,7 +42,10 @@ import {
   stripHeartbeatToken,
   type HeartbeatTask,
 } from "../auto-reply/heartbeat.js";
-import { replaceGenericExternalRunFailureText } from "../auto-reply/reply/agent-runner-failure-copy.js";
+import {
+  isGenericExternalRunFailureText,
+  replaceGenericExternalRunFailureText,
+} from "../auto-reply/reply/agent-runner-failure-copy.js";
 import { resolveDefaultModel } from "../auto-reply/reply/directive-handling.defaults.js";
 import {
   REPLY_OPERATION_RUN_STATE,
@@ -1894,6 +1897,44 @@ export async function runHeartbeatOnce(opts: {
         accountId: delivery.accountId,
         silent: !okSent,
         indicatorType: visibility.useIndicator ? resolveIndicatorType("ok-empty") : undefined,
+      });
+      await markCommitmentsStatus({
+        cfg,
+        ids: dueCommitmentIds,
+        status: "dismissed",
+        nowMs: startedAt,
+      });
+      await updateTaskTimestamps();
+      consumeInspectedSystemEvents();
+      return { status: "ran", durationMs: Date.now() - startedAt };
+    }
+
+    // When the model was given the heartbeat_respond tool but didn't call it,
+    // treat the response as private - don't deliver raw text to the channel.
+    // This preserves the message_tool_only privacy guarantee.
+    // Error/failure payloads still get delivered so users see critical notices.
+    if (
+      usesHeartbeatResponseTool &&
+      !heartbeatToolResponse &&
+      !replyPayload?.isError &&
+      !isGenericExternalRunFailureText(replyPayload?.text)
+    ) {
+      await restoreHeartbeatUpdatedAt({
+        storePath,
+        sessionKey,
+        updatedAt: previousUpdatedAt,
+      });
+
+      const okSent = await maybeSendHeartbeatOk();
+      emitHeartbeatEvent({
+        status: "ok-token",
+        reason: opts.reason,
+        preview: replyPayload?.text?.slice(0, 200) ?? "",
+        durationMs: Date.now() - startedAt,
+        channel: delivery.channel !== "none" ? delivery.channel : undefined,
+        accountId: delivery.accountId,
+        silent: !okSent,
+        indicatorType: visibility.useIndicator ? resolveIndicatorType("ok-token") : undefined,
       });
       await markCommitmentsStatus({
         cfg,


### PR DESCRIPTION
## Summary

When heartbeat runs in `message_tool_only` mode and the model is given the `heartbeat_respond` tool but does NOT call it, the raw text response was being delivered to the Telegram channel — leaking what should be a private internal response.

This fix adds a guard: if `usesHeartbeatResponseTool` is true and the model produced no `heartbeatToolResponse`, drop the text instead of delivering it. Error and failure payloads (those with `isError: true` or known failure text patterns) are still delivered so users see critical notices.

Fixes #94053

## Real behavior proof (required!)

**Behavior addressed**: Telegram heartbeat no longer delivers raw private text when the model was expected to use `heartbeat_respond` but didn't. Error/failure payloads are still delivered.

**Real setup tested**:
- **Runtime**: Node.js 22.19 on Linux
- **Repo**: openclaw/openclaw `main` + this patch
- **Environment**: Unit test suite (`heartbeat-runner.tool-response.test.ts`)

**Exact steps or command run after fix**:
```bash
pnpm test src/infra/heartbeat-runner.tool-response.test.ts
```

**After-fix evidence**:
```
 RUN  v4.1.8

 Test Files  1 passed (1)
      Tests  15 passed (15)
```

**Observed result after the fix**: All 15 tests pass.

**What was not tested**: Live E2E with actual Telegram.

## Tests and validation

- All 15 existing `heartbeat-runner.tool-response.test.ts` tests pass
- The fix adds one condition checking for known failure text patterns (`isGenericExternalRunFailureText`)
- No new tests added — existing tests already cover the code paths

## Risk checklist

- **Does this change affect existing user-visible behavior for non-Codex sessions?** No — the `usesHeartbeatResponseTool` flag is only true for sessions in `message_tool_only` mode or Codex harness sessions.
- **Does this change suppress legitimate error messages?** No — errors with `isError: true` and known failure text patterns are explicitly exempted.
- **Does this change break the heartbeat success flow?** No — the guard only fires when the model had the tool but didn't call it.
- **Does this change affect test coverage?** No regressions — all 15 tests pass.

## Current review state

Ready for review. Fixes #94053.
