### PR TITLE
fix(nextcloud-talk): silently ignore non-message Talk events instead of returning 400

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -182,7 +182,9 @@ describe("createNextcloudTalkWebhookServer replay handling", () => {
 });
 
 describe("createNextcloudTalkWebhookServer payload validation", () => {
-  it("rejects malformed webhook payloads after signature verification", async () => {
+  it("returns 200 for schema-mismatch payloads after signature verification", async () => {
+    // Valid JSON that does NOT match the message schema (target.id is empty)
+    // is a non-message Talk event — should be silently acknowledged per #81566.
     const payload = {
       type: "Create",
       actor: { type: "Person", id: "alice", name: "Alice" },
@@ -201,7 +203,34 @@ describe("createNextcloudTalkWebhookServer payload validation", () => {
       secret: "nextcloud-secret", // pragma: allowlist secret
     });
     const harness = await startWebhookServer({
-      path: "/nextcloud-invalid-payload",
+      path: "/nextcloud-schema-mismatch",
+      onMessage: vi.fn(),
+    });
+
+    const response = await fetch(harness.webhookUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-nextcloud-talk-random": random,
+        "x-nextcloud-talk-signature": signature,
+        "x-nextcloud-talk-backend": "https://nextcloud.example",
+      },
+      body,
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("rejects malformed JSON payloads with 400 after signature verification", async () => {
+    // Truly malformed payload (not valid JSON) should still return 400
+    // per #81566 — broken transports must not be silently accepted.
+    const body = "{ broken json payload";
+    const { random, signature } = generateNextcloudTalkSignature({
+      body,
+      secret: "nextcloud-secret", // pragma: allowlist secret
+    });
+    const harness = await startWebhookServer({
+      path: "/nextcloud-malformed-json",
       onMessage: vi.fn(),
     });
 

--- a/extensions/nextcloud-talk/src/monitor.ts
+++ b/extensions/nextcloud-talk/src/monitor.ts
@@ -1,6 +1,6 @@
 // Nextcloud Talk plugin module implements monitor behavior.
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { safeParseJsonWithSchema } from "openclaw/plugin-sdk/extension-shared";
+import { safeParseWithSchema } from "openclaw/plugin-sdk/extension-shared";
 import {
   WEBHOOK_RATE_LIMIT_DEFAULTS,
   createAuthRateLimiter,
@@ -110,10 +110,6 @@ function formatError(err: unknown): string {
   return typeof err === "string" ? err : JSON.stringify(err);
 }
 
-function parseWebhookPayload(body: string): NextcloudTalkWebhookPayload | null {
-  return safeParseJsonWithSchema(NextcloudTalkWebhookPayloadSchema, body);
-}
-
 function writeJsonResponse(
   res: ServerResponse,
   status: number,
@@ -184,10 +180,25 @@ function decodeWebhookCreateMessage(params: {
   | { kind: "message"; message: NextcloudTalkInboundMessage }
   | { kind: "ignore" }
   | { kind: "invalid" } {
-  const payload = parseWebhookPayload(params.body);
-  if (!payload) {
+  // Stage 1: Parse valid JSON first — malformed input should still
+  // return 400 so that genuinely broken payloads are not silently
+  // accepted.  JSON.parse errors are distinct from schema mismatches
+  // and signal a broken sender or transport issue.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(params.body);
+  } catch {
     writeWebhookError(params.res, 400, WEBHOOK_ERRORS.invalidPayloadFormat);
     return { kind: "invalid" };
+  }
+
+  // Stage 2: Validate against the message schema.  Schema mismatches
+  // here are non-message Talk events (system notifications, calls,
+  // file shares) that Nextcloud expects the bot to acknowledge with
+  // 200 rather than 400 — issue #81566.
+  const payload = safeParseWithSchema(NextcloudTalkWebhookPayloadSchema, parsed);
+  if (!payload) {
+    return { kind: "ignore" };
   }
   if (payload.type !== "Create") {
     return { kind: "ignore" };


### PR DESCRIPTION
## Summary

**Problem**: Nextcloud Talk sends various event types (calls, system notifications, file shares) whose webhook payloads may not have `object.type === "Note"` or `actor.type === "Person"`. The Zod schema was too strict, returning HTTP 400 "Invalid payload format" for any non-matching payload. This caused Nextcloud to log errors and could trigger retry loops for non-message events that the bot should simply acknowledge silently.

**Solution**: Two-stage webhook payload decoding — Stage 1: JSON.parse (malformed JSON still returns 400), Stage 2: schema validation (schema mismatches return 200 without dispatching). This preserves the error signal for genuinely broken payloads while silently ignoring non-message events.

**What changed**: 
- `extensions/nextcloud-talk/src/monitor.ts`: +18/-7 — switch from `safeParseJsonWithSchema` to `safeParseWithSchema` + explicit `JSON.parse` with two-stage error handling
- `extensions/nextcloud-talk/src/monitor.replay.test.ts`: +31/-2 — split test: schema-mismatch→200 + malformed JSON→400

**What did NOT change**:
- Valid chat message processing — unchanged
- Signature verification — unchanged
- Auth rate limiting — unchanged
- Protocol or config

Fixes #81566

## Real behavior proof (required for external PRs)

**Behavior addressed**: Nextcloud Talk webhook handler returned 400 for non-message Talk events whose payload passed signature verification but failed the chat-message schema check. The 400 caused Nextcloud to log errors and could trigger retry loops.

**Real setup tested**:
- **Runtime**: Node 24.13, Linux x86_64
- **Branch**: `fix/issue-81566-nextcloud-talk-400` rebased onto `upstream/main`
- **Test runner**: `scripts/run-vitest.mjs` (project-standard wrapper)
- **Vitest**: 4.1.8

**Root cause**: `decodeWebhookCreateMessage` in `monitor.ts` called `safeParseJsonWithSchema(NextcloudTalkWebhookPayloadSchema, body)` which performs JSON parse + Zod schema validation as a single atomic step. The helper function takes a raw string body and a Zod schema, internally calls `JSON.parse`, then validates the parsed object against the schema. If either step fails, it returns `null` — collapsing two semantically distinct failure modes into one undifferentiated error.

The caller interpreted the null result as `{ kind: "invalid" }` and wrote HTTP 400. But "not matching the chat message schema" and "not being valid JSON" have fundamentally different meanings:

- **Malformed JSON**: The HTTP body is not parseable as JSON at all. This is a genuine protocol error — the sender is not sending valid HTTP. Returning 400 is correct.
- **Schema mismatch**: The JSON is valid but the fields don't match the expected shape (e.g., `object.type` is `"Call"` instead of `"Note"`, or `actor.type` is `"Bot"` instead of `"Person"`). This is NOT an error — it's a legitimate Nextcloud Talk event of a different type. Nextcloud expects the webhook endpoint to acknowledge receipt with 200.

The fix splits the combined `safeParseJsonWithSchema` step into two explicit stages:

Stage 1 (`JSON.parse`): If the body is not valid JSON at all, return 400. This preserves the error signal for truly broken payloads where the sender or transport is malfunctioning.

Stage 2 (`safeParseWithSchema`): If JSON parsing succeeds but the schema validation fails (e.g., `object.type` is not `"Note"`, or `target.id` is empty), return `{ kind: "ignore" }` and write HTTP 200. This is the key behavioral change — non-message Talk events are now silently acknowledged instead of rejected.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs run extensions/nextcloud-talk/src/monitor.replay.test.ts` at Node 24.13 Linux x86_64

**After-fix evidence**:
```
[test] starting test/vitest/vitest.extension-nextcloud-talk.config.ts
 RUN  v4.1.8
 Test Files  1 passed (1)
      Tests  11 passed (11)
[test] passed 1 Vitest shard in 21.45s
```

Test behavior after fix:

| Test | Before | After |
|------|--------|-------|
| Schema-mismatch (valid JSON, invalid values) | Expected 400 | **Expected 200** — silently ignored |
| Malformed JSON (unparseable) | Expected 400 | Expected 400 — unchanged |

The new test "returns 200 for schema-mismatch payloads after signature verification" passes (changed from the old test name "rejects malformed webhook payloads") and confirms that a payload with valid JSON structure but schema-incompatible values (e.g., `target.id` is empty) returns 200. The test "rejects malformed JSON payloads with 400 after signature verification" confirms that truly broken JSON still returns 400.

**Observed result after the fix**: Non-message Talk events that pass Nextcloud's HMAC signature verification but fail the chat-message Zod schema now return HTTP 200 with `{ status: "ignored" }` instead of HTTP 400. Truly malformed JSON (unparseable input) continues to return HTTP 400. Valid chat messages continue to be processed with no change to the dispatch path or message handling. The 200 response tells Nextcloud "I received your webhook, this isn't a message I need to handle" — preventing the platform from logging errors or triggering webhook retry loops for call events, system notifications, and file share events.

**What was not tested**: Live Nextcloud Talk server with real non-message events (incoming calls, system notifications, file share events). This requires a self-hosted Nextcloud instance with the Talk app installed, configured webhooks pointing to the bot, and real Nextcloud activity generating non-message events. Nextcloud is a self-hosted platform — there are no public sandbox instances or QA credential pools available for external contributors.

**Evidence provenance**: Terminal output from real local checkout of rebased branch (`fix/issue-81566-nextcloud-talk-400`) on Node 24.13.1 / Linux x86_64, 2026-06-23. The branch was rebased onto `upstream/main` at `bde5be874a`. Three prior commits were squashed into one clean commit: the initial implementation (`5bd5ce0bc`), a merge with main (`58820ab1a`), and a review-feedback revision (`ccdb3b751`) that added explicit two-stage parsing after feedback identified that collapsing both failure modes into "ignore" would silently accept malformed JSON.

## Tests and validation
| Test Type | Result | Details |
|-----------|--------|---------|
| Unit Tests | ✅ 11/11 | monitor.replay.test.ts — all passing including new split tests |
| Rebase | ✅ | Clean rebase onto upstream/main, 1 commit, 2 nextcloud-talk files only |
| Scope | ✅ | 2 nextcloud-talk files only |

## Design decisions

**Why two explicit stages instead of a try-catch on `safeParseJsonWithSchema`?**

`safeParseJsonWithSchema` hides the distinction between JSON parse failures and schema validation failures behind a single `null` return value. A try-catch wrapper around it could catch the JSON parse error but would lose the type safety of the `safeParseWithSchema` path. The explicit two-stage approach makes the intent clear in code: Stage 1 is a protocol-level gate (valid JSON or reject), Stage 2 is a business-logic gate (is this a chat message or something else). This pattern is also easier for future maintainers to understand than a nested try-catch with a combined utility function.

**Why not just widen the Zod schema to accept all event types?**

A wider schema that accepts any `object.type` would silently pass through non-message events to the dispatch pipeline, where they would cause harder-to-diagnose failures downstream. The message handler expects chat-message-shaped data — passing it a call event or a system notification would result in confusing errors like "missing message content" at a deeper layer. Explicitly returning `{ kind: "ignore" }` at the webhook boundary is the correct place to filter: as early as possible, with clear intent, before any message processing begins.

**Why 200 instead of 204 (No Content)?**

Nextcloud Talk's webhook documentation expects a 200 response with optional JSON body for successful processing. While 204 would also signal success, 200 with `{ status: "ignored" }` provides a minimal payload that could be logged or inspected during debugging. The response body is small (under 30 bytes) and costs nothing extra in HTTP overhead compared to 204.

## Risk checklist

**What is the highest-risk area of this change?**

The two-stage parsing changes the error contract from a single opaque "invalid payload" response to a differentiated response. If there is a case where valid JSON that fails the schema should NOT be silently ignored (e.g., a new message format from a future Nextcloud version), this change would suppress what was previously a visible error.

**Risk level**: Low risk — Nextcloud Talk's webhook contract explicitly documents multiple event types, of which chat messages are only one category. Other channel handlers already follow the same "silently ignore unknown events" pattern. If Nextcloud introduces a new message format that fails the current schema, the schema would need to be updated to support it — but this was already true before the fix, as the old code would just reject it with 400 instead of ignoring it.

**Mitigation**: The two replay tests directly exercise the webhook server with real HTTP requests via `fetch`, testing the full stack from `createServer` through `decodeWebhookCreateMessage` to HTTP response. The schema-mismatch test uses a payload with `target.id: ""` (empty string) which is valid JSON according to `JSON.parse` but invalid according to the Zod schema's `z.string().min(1)` constraint on `target.id`. The malformed JSON test sends literally `"{ broken json payload"` which throws a `SyntaxError` from `JSON.parse`. Both paths are exercised through the actual HTTP handler to confirm the correct status code reaches the caller.

**Merge risk declaration**:
- `merge-risk: 🚨 message-delivery` — The change modifies the webhook handler's response for non-matching payloads from 400 to 200. This changes how Nextcloud perceives bot health for non-message events. However, 200 "I received this but am ignoring it" is the correct response per webhook best practices (RFC-compliant webhooks should not treat non-actionable events as errors).

## Current review state
**What is the next action?** Maintainer review requested. Code is mature (review feedback incorporated), all 11 tests pass, and the `triage: needs-real-behavior-proof` gate requires maintainer decision given the self-hosted nature of Nextcloud Talk.
