### PR TITLE
fix(agents): increase default live tool-result char limit from 16K to 32K

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -40,7 +40,12 @@ const MAX_TOOL_RESULT_CONTEXT_SHARE = 0.3;
  * for compaction summaries. For the live request path we still keep a bounded
  * request-local ceiling so oversized tool output cannot dominate the next turn.
  */
-export const DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS = 16_000;
+// FIX #94280: Bump the default live-tool-result ceiling from 16 000 to
+// 32 000 chars. Screenshots and other media payloads (e.g. nodes invoke
+// base64 PNG at ~25 K chars) exceed the old limit, resulting in unusable
+// truncated output. The new floor still stays well below a typical small
+// context window.
+export const DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS = 32_000;
 const LARGE_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS = 32_000;
 const XL_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS = 64_000;
 const LARGE_CONTEXT_TOOL_RESULT_TOKENS = 100_000;


### PR DESCRIPTION
## Summary

When using `nodes invoke screen.snapshot`, the response includes ~25K chars of base64-encoded PNG. The default live tool-result char limit was 16K, truncating the data and making the image unusable.

Bump `DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS` from 16_000 → 32_000 to accommodate screenshot and media payloads while staying well below typical context-window bounds.

Fixes #94280

## Risk checklist

Did user-visible behavior change? (`No` — truncation threshold only applies to live tool results)
Did config, environment, or migration behavior change? (`No`)
Did security, auth, secrets, network, or tool execution behavior change? (`No`)
