### PR TITLE
fix(models): filter models list by configured providers in replace mode [AI-assisted]

### DIFF
--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -175,6 +175,7 @@ export async function modelsListCommand(
       provider: providerFilter,
       local: opts.local,
     },
+    browse: enableSourcePlanCascade,
     skipRuntimeModelSuppression,
     metadataSnapshot,
     workspaceDir,

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -191,6 +191,63 @@ describe("appendProviderCatalogRows", () => {
     expect(row.available).toBe(true);
     expect(row.tags).toEqual(["configured"]);
   });
+
+  it("filters out providers not in models.providers when mode is replace", async () => {
+    const rows: ModelRow[] = [];
+
+    await appendProviderCatalogRows({
+      rows,
+      seenKeys: new Set(),
+      catalogModels: [
+        {
+          id: "gpt-5.5",
+          name: "gpt-5.5",
+          provider: "openai",
+          api: "openai-responses",
+          baseUrl: "https://api.openai.com/v1",
+          input: ["text"],
+          reasoning: false,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 8192,
+          maxTokens: 4096,
+        },
+        {
+          id: "grok-4",
+          name: "grok-4",
+          provider: "xai",
+          api: "xai-responses",
+          baseUrl: "https://api.xai.com/v1",
+          input: ["text"],
+          reasoning: false,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 8192,
+          maxTokens: 4096,
+        },
+      ],
+      context: {
+        cfg: {
+          models: {
+            mode: "replace",
+            providers: {
+              xai: {},
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-agent",
+        authIndex: {
+          hasProviderAuth: () => true,
+          allowsProviderAuthAvailabilityFallback: () => false,
+        },
+        configuredByKey: new Map(),
+        discoveredKeys: new Set(),
+        filter: { local: false },
+        skipRuntimeModelSuppression: true,
+      },
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].key).toBe("xai/grok-4");
+  });
 });
 
 describe("appendConfiguredProviderRows", () => {

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -248,6 +248,65 @@ describe("appendProviderCatalogRows", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].key).toBe("xai/grok-4");
   });
+
+  it("does not filter out providers when mode is replace but browse is true", async () => {
+    const rows: ModelRow[] = [];
+
+    await appendProviderCatalogRows({
+      rows,
+      seenKeys: new Set(),
+      catalogModels: [
+        {
+          id: "gpt-5.5",
+          name: "gpt-5.5",
+          provider: "openai",
+          api: "openai-responses",
+          baseUrl: "https://api.openai.com/v1",
+          input: ["text"],
+          reasoning: false,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 8192,
+          maxTokens: 4096,
+        },
+        {
+          id: "grok-4",
+          name: "grok-4",
+          provider: "xai",
+          api: "xai-responses",
+          baseUrl: "https://api.xai.com/v1",
+          input: ["text"],
+          reasoning: false,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 8192,
+          maxTokens: 4096,
+        },
+      ],
+      context: {
+        cfg: {
+          models: {
+            mode: "replace",
+            providers: {
+              xai: {},
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-agent",
+        authIndex: {
+          hasProviderAuth: () => true,
+          allowsProviderAuthAvailabilityFallback: () => false,
+        },
+        configuredByKey: new Map(),
+        discoveredKeys: new Set(),
+        filter: { local: false },
+        browse: true,
+        skipRuntimeModelSuppression: true,
+      },
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].key).toBe("openai/gpt-5.5");
+    expect(rows[1].key).toBe("xai/grok-4");
+  });
 });
 
 describe("appendConfiguredProviderRows", () => {

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -41,6 +41,7 @@ export type RowBuilderContext = {
   configuredByKey: ConfiguredByKey;
   discoveredKeys: Set<string>;
   filter: RowFilter;
+  browse?: boolean;
   skipRuntimeModelSuppression?: boolean;
   metadataSnapshot?: PluginMetadataSnapshot;
   workspaceDir?: string;
@@ -81,6 +82,9 @@ function matchesProviderFilter(context: RowBuilderContext, provider: string): bo
 }
 
 function isProviderAllowed(context: RowBuilderContext, provider: string): boolean {
+  if (context.browse) {
+    return true;
+  }
   if (context.cfg.models?.mode !== "replace") {
     return true;
   }
@@ -411,6 +415,9 @@ export async function appendAuthenticatedCatalogRows(params: {
     metadataSnapshot: params.context.metadataSnapshot,
   });
   for (const entry of catalog) {
+    if (!isProviderAllowed(params.context, entry.provider)) {
+      continue;
+    }
     if (!params.context.authIndex.hasProviderAuth(entry.provider)) {
       continue;
     }

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -80,10 +80,26 @@ function matchesProviderFilter(context: RowBuilderContext, provider: string): bo
   return normalizeProviderId(canonicalProvider) === providerFilter;
 }
 
+function isProviderAllowed(context: RowBuilderContext, provider: string): boolean {
+  if (context.cfg.models?.mode !== "replace") {
+    return true;
+  }
+  const configuredProviders = context.cfg.models.providers ?? {};
+  const canonicalProvider = canonicalizeModelCatalogProviderAlias(provider, {
+    cfg: context.cfg,
+    metadataSnapshot: context.metadataSnapshot,
+  });
+  const normProvider = normalizeProviderId(canonicalProvider);
+  return Object.keys(configuredProviders).some((key) => normalizeProviderId(key) === normProvider);
+}
+
 function matchesRowFilter(
   context: RowBuilderContext,
   model: { provider: string; baseUrl?: string },
 ) {
+  if (!isProviderAllowed(context, model.provider)) {
+    return false;
+  }
   if (!matchesProviderFilter(context, model.provider)) {
     return false;
   }
@@ -552,6 +568,9 @@ export async function appendConfiguredRows(params: {
     ? (await loadModelResolverModule()).resolveModelWithRegistry
     : undefined;
   for (const entry of params.entries) {
+    if (!isProviderAllowed(params.context, entry.ref.provider)) {
+      continue;
+    }
     if (!matchesProviderFilter(params.context, entry.ref.provider)) {
       continue;
     }


### PR DESCRIPTION
﻿Closes #94705

### What Problem This Solves
The output of openclaw models list was not filtered when models.mode is set to "replace" with a restricted list of providers, leading to a default list leak where unauthorized provider models were shown.

### Why This Change Was Made
To correctly enforce the models.mode "replace" configuration. The fix applies provider allowlisting to the shared model-list row filtering when in replace mode, but explicitly bypasses this restriction when the user explicitly requests full catalog browsing (e.g., using --all or a specific provider filter).

### User Impact
Users relying on models.mode "replace" will correctly only see models from their configured models.providers. Explicit browsing (--all) remains unaffected.

### Evidence
Unit tests added and passed on Windows.
