### PR TITLE
fix(gateway): report draining state in readiness

### DIFF
--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -53,7 +53,7 @@ import {
   pinActivePluginSessionExtensionRegistry,
 } from "../plugins/runtime.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
-import { getTotalQueueSize } from "../process/command-queue.js";
+import { getTotalQueueSize, isGatewayDraining } from "../process/command-queue.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   clearSecretsRuntimeSnapshot,
@@ -876,6 +876,7 @@ export async function startGatewayServer(
     startedAt: serverStartedAt,
     getStartupPending: isGatewayStartupPending,
     getStartupPendingReason: () => startupPendingReason,
+    getGatewayDraining: isGatewayDraining,
     getEventLoopHealth: readinessEventLoopHealth.snapshot,
     shouldSkipChannelReadiness: () =>
       isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -68,6 +68,7 @@ function createReadinessHarness(params: {
   accounts?: Record<string, Partial<ChannelAccountSnapshot>>;
   getStartupPending?: () => boolean;
   getStartupPendingReason?: Parameters<typeof createReadinessChecker>[0]["getStartupPendingReason"];
+  getGatewayDraining?: Parameters<typeof createReadinessChecker>[0]["getGatewayDraining"];
   getEventLoopHealth?: Parameters<typeof createReadinessChecker>[0]["getEventLoopHealth"];
   shouldSkipChannelReadiness?: Parameters<
     typeof createReadinessChecker
@@ -83,6 +84,7 @@ function createReadinessHarness(params: {
       startedAt,
       getStartupPending: params.getStartupPending,
       getStartupPendingReason: params.getStartupPendingReason,
+      getGatewayDraining: params.getGatewayDraining,
       getEventLoopHealth: params.getEventLoopHealth,
       shouldSkipChannelReadiness: params.shouldSkipChannelReadiness,
       cacheTtlMs: params.cacheTtlMs,
@@ -173,6 +175,35 @@ describe("createReadinessChecker", () => {
       expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
 
       startupPending = false;
+      expect(readiness()).toEqual(readySnapshot());
+      expect(manager.getRuntimeSnapshot).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("reports not ready while the gateway command queue is draining for restart", () => {
+    withReadinessClock(() => {
+      const { manager, readiness } = createReadinessHarness({
+        getGatewayDraining: () => true,
+        cacheTtlMs: 1_000,
+      });
+
+      expect(readiness()).toEqual(failingSnapshot(["gateway-draining"]));
+      expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not cache gateway-draining readiness", () => {
+    withReadinessClock(() => {
+      let gatewayDraining = true;
+      const { manager, readiness } = createReadinessHarness({
+        getGatewayDraining: () => gatewayDraining,
+        cacheTtlMs: 1_000,
+      });
+
+      expect(readiness()).toEqual(failingSnapshot(["gateway-draining"]));
+      expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
+
+      gatewayDraining = false;
       expect(readiness()).toEqual(readySnapshot());
       expect(manager.getRuntimeSnapshot).toHaveBeenCalledTimes(1);
     });

--- a/src/gateway/server/readiness.ts
+++ b/src/gateway/server/readiness.ts
@@ -42,6 +42,7 @@ export function createReadinessChecker(deps: {
   startedAt: number;
   getStartupPending?: () => boolean;
   getStartupPendingReason?: () => string | undefined;
+  getGatewayDraining?: () => boolean;
   getEventLoopHealth?: () => GatewayEventLoopHealth | undefined;
   shouldSkipChannelReadiness?: () => boolean;
   cacheTtlMs?: number;
@@ -58,6 +59,12 @@ export function createReadinessChecker(deps: {
       const reason = deps.getStartupPendingReason?.() ?? "startup-sidecars";
       return withEventLoopHealth(
         { ready: false, failing: [reason], uptimeMs },
+        deps.getEventLoopHealth,
+      );
+    }
+    if (deps.getGatewayDraining?.()) {
+      return withEventLoopHealth(
+        { ready: false, failing: ["gateway-draining"], uptimeMs },
         deps.getEventLoopHealth,
       );
     }


### PR DESCRIPTION
## Summary
- Makes `/readyz` report not ready while the gateway command queue is draining for restart.
- Reuses the existing `isGatewayDraining()` queue state; `/healthz`, queue admission, restart reset, and channel readiness behavior stay unchanged.
- Keeps the drain state outside the cached channel readiness snapshot so a cached green result cannot hide a current drain gate.
- Out of scope: clearing stuck drain state or changing restart/queue admission semantics; current `main` already clears stale drain state on in-process restart via `resetAllLanes()`.

## Linked context
Which issue does this close?
Closes #78136

Which issues, PRs, or discussions are related?
Related #78144

Was this requested by a maintainer or owner?
ClawSweeper marked #78136 as source-reproducible and queueable on June 18, 2026; #78144 was closed for active-PR queue policy, not a technical rejection.

## Real behavior proof (required for external PRs)
- Behavior or issue addressed: `/readyz` could report ready while the command queue was rejecting new work with `GatewayDrainingError`.
- Real environment tested: local OpenClaw source checkout on macOS, Node v26.3.0, temp `HOME`/`OPENCLAW_STATE_DIR`, real gateway server in minimal test-gateway mode (`VITEST=1 OPENCLAW_TEST_MINIMAL_GATEWAY=1`) with channels, providers, cron, browser-control, Gmail watcher, canvas host, and bundled plugins disabled.
- Exact steps or command run after this patch: started the real gateway via `startGatewayServer()`, fetched `/readyz`, called `markGatewayDraining()`, fetched `/readyz`, called `resetAllLanes()`, fetched `/readyz`, then closed the server cleanly.
- Evidence after fix: copied live output from the local gateway proof command:

```json
{
  "before": { "status": 200, "body": { "ready": true, "failing": [] } },
  "draining": { "status": 503, "body": { "ready": false, "failing": ["gateway-draining"] } },
  "recovered": { "status": 200, "body": { "ready": true, "failing": [] } }
}
```

- Observed result after fix: `/readyz` flips to HTTP 503 with `gateway-draining` during drain and recovers to HTTP 200 after `resetAllLanes()`.
- What was not tested: full Docker/Raspberry Pi restart reproduction.
- Proof limitations or environment constraints: Blacksmith Testbox was unavailable because local Blacksmith auth is missing; the default Crabbox Azure provider was unavailable because Azure CLI/subscription is not configured. Local `check:changed` passed with Corepack bin prepended.
- Before evidence: current `main` already has `isGatewayDraining()` and rejects enqueues while draining, but `createReadinessChecker()` had no `getGatewayDraining` input and only reported startup/channel/event-loop readiness; ClawSweeper's source review on #78136 reported the same source-level mismatch.

## Tests and validation
- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs src/gateway/server/readiness.test.ts src/gateway/server-http.probe.test.ts src/process/command-queue.test.ts`
- `git diff --check origin/main...HEAD`
- `CI=1 PATH="/opt/homebrew/Cellar/corepack/0.35.0/bin:$PATH" pnpm check:changed`
- Real gateway `/readyz` proof described above
- `codex review --base origin/main`: no regression found in the changed gateway readiness path

## Risk checklist
Did user-visible behavior change? Yes

Did config, environment, or migration behavior change? No

Did security, auth, secrets, network, or tool execution behavior change? No

Highest-risk area: readiness semantics during restart drain.

Mitigation: check is transient, uncached, uses existing `isGatewayDraining()` state; `/healthz` remains shallow liveness and reset behavior remains in `resetAllLanes()`.

## Current review state
Next action: maintainer review and CI.

Waiting on: CI and maintainer review.

Bot/reviewer comments addressed: ClawSweeper's #78136 source-repro/fix-shape-clear guidance; prior #78144 shape resubmitted narrowly after queue-policy closure.

AI-assisted: Implemented with AI assistance; reviewed locally by Marko with focused tests, live gateway proof, changed gate, and Codex review.
