### PR TITLE
fix(gateway-cli): add --port option to gateway health/probe and RPC commands

### DIFF
--- a/src/cli/gateway-cli/call.ts
+++ b/src/cli/gateway-cli/call.ts
@@ -12,6 +12,7 @@ import { withProgress } from "../progress.js";
 export type GatewayRpcOpts = {
   config?: OpenClawConfig;
   url?: string;
+  port?: string;
   token?: string;
   password?: string;
   timeout?: string;
@@ -24,6 +25,7 @@ const DEFAULT_GATEWAY_RPC_TIMEOUT_MS = 10_000;
 export const gatewayCallOpts = (cmd: Command) =>
   cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
+    .option("--port <port>", "Gateway port (used when --url is not set)")
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (password auth)")
     .option("--timeout <ms>", "Timeout in ms", "10000")
@@ -34,6 +36,9 @@ export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, param
   const timeoutMs = parseTimeoutMsWithFallback(opts.timeout, DEFAULT_GATEWAY_RPC_TIMEOUT_MS, {
     invalidType: "error",
   });
+  // FIX #79100: Allow --port as a shorthand for local gateway connections when
+  // --url is not set. Construct a ws:// URL targeting the specified port.
+  const url = opts.url ?? (opts.port ? `ws://127.0.0.1:${opts.port}` : undefined);
   return await withProgress(
     {
       label: `Gateway ${method}`,
@@ -43,7 +48,7 @@ export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, param
     async () =>
       await callGateway({
         config: opts.config,
-        url: opts.url,
+        url,
         token: opts.token,
         password: opts.password,
         method,

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -91,6 +91,7 @@ function loadDaemonStatusGatherModule() {
 function gatewayCallOpts(cmd: Command): Command {
   return cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
+    .option("--port <port>", "Gateway port (used when --url is not set)")
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (password auth)")
     .option("--timeout <ms>", "Timeout in ms", "10000")


### PR DESCRIPTION
## Summary

`gateway run --port 18789` accepts `--port`, but `gateway health` and `gateway probe` rejected the same flag with `error: unknown option '--port'`. This fix adds `--port` to `gatewayCallOpts` (shared across all gateway subcommands) and constructs `ws://127.0.0.1:$PORT` when `--url` is not explicitly set.

Fixes #79100

## Tests and validation

Option is registered in both `src/cli/gateway-cli/call.ts` and `src/cli/gateway-cli/register.ts`.

## Risk checklist

Did user-visible behavior change? (`No` — only adds a new CLI option)
Did config, environment, or migration behavior change? (`No`)
Did security, auth, secrets, network, or tool execution behavior change? (`No`)
