### PR TITLE
feat(cron): expose --fallbacks option on cron create and edit commands

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -124,6 +124,7 @@ export function registerCronAddCommand(cron: Command) {
         "Thinking level for agent jobs (off|minimal|low|medium|high|xhigh)",
       )
       .option("--model <model>", "Model override for agent jobs (provider/model or alias)")
+      .option("--fallbacks <models>", "Comma-separated fallback models for agent jobs")
       .option("--timeout-seconds <n>", "Timeout seconds for agent or command jobs")
       .option("--no-output-timeout-seconds <n>", "No-output timeout seconds for command jobs")
       .option("--output-max-bytes <n>", "Maximum captured stdout/stderr bytes for command jobs")
@@ -250,6 +251,10 @@ export function registerCronAddCommand(cron: Command) {
                     outputMaxBytes && Number.isFinite(outputMaxBytes) ? outputMaxBytes : undefined,
                 };
               }
+              const fallbacks = normalizeOptionalString(opts.fallbacks)
+                ?.split(",")
+                .map((s) => s.trim())
+                .filter(Boolean);
               return {
                 kind: "agentTurn" as const,
                 message,
@@ -259,6 +264,7 @@ export function registerCronAddCommand(cron: Command) {
                   timeoutSeconds && Number.isFinite(timeoutSeconds) ? timeoutSeconds : undefined,
                 lightContext: opts.lightContext === true ? true : undefined,
                 toolsAllow: parseCronToolsAllow(opts.tools),
+                fallbacks: fallbacks?.length ? fallbacks : undefined,
               };
             })();
 

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -117,6 +117,8 @@ export function registerCronEditCommand(cron: Command) {
         "Remove the per-job model override (restore normal cron model precedence)",
         false,
       )
+      .option("--fallbacks <models>", "Comma-separated fallback models for agent jobs")
+      .option("--clear-fallbacks", "Remove the per-job fallback models", false)
       .option("--timeout-seconds <n>", "Timeout seconds for agent or command jobs")
       .option("--no-output-timeout-seconds <n>", "No-output timeout seconds for command jobs")
       .option("--output-max-bytes <n>", "Maximum captured stdout/stderr bytes for command jobs")
@@ -373,6 +375,8 @@ export function registerCronEditCommand(cron: Command) {
             typeof opts.message === "string" ||
             Boolean(model) ||
             Boolean(opts.clearModel) ||
+            Boolean(opts.fallbacks) ||
+            Boolean(opts.clearFallbacks) ||
             Boolean(thinking) ||
             (hasTimeoutSeconds &&
               !hasCommandSpecificPayloadField &&
@@ -406,6 +410,15 @@ export function registerCronEditCommand(cron: Command) {
               assignIf(payload, "model", model, Boolean(model));
             }
             assignIf(payload, "thinking", thinking, Boolean(thinking));
+            if (opts.clearFallbacks) {
+              payload.fallbacks = null;
+            } else {
+              const fallbacks = normalizeOptionalString(opts.fallbacks)
+                ?.split(",")
+                .map((s: string) => s.trim())
+                .filter(Boolean);
+              assignIf(payload, "fallbacks", fallbacks, Boolean(fallbacks?.length));
+            }
             assignIf(payload, "timeoutSeconds", timeoutSeconds, hasTimeoutSeconds);
             assignIf(
               payload,


### PR DESCRIPTION
## Summary

The `fallbacks` field already exists in `CronAgentTurnPayloadFields` (allowing per-job fallback model overrides) but was never exposed via the CLI. This adds `--fallbacks <models>` (comma-separated model list) to `openclaw cron create` and `openclaw cron edit`, plus `--clear-fallbacks` to `cron edit`.

Fixes #90302

## Tests and validation

The `fallbacks` field is already handled by the cron runtime — this only exposes the existing field through the CLI option.
