### PR TITLE
fix(doctor): improve labels and manual instructions for cron store issues [AI-assisted]

### DIFF
--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -370,16 +370,25 @@ export async function maybeRepairLegacyCronStore(params: {
 
   const noteHeading = legacyStoreDetected
     ? `Legacy cron job storage detected at ${shortenHomePath(storePath)}.`
-    : `Cron store issues detected at ${shortenHomePath(storePath)}.`;
+    : "Cron store issues detected in SQLite store.";
 
-  note(
-    [
-      noteHeading,
-      ...previewLines,
-      `Repair with ${formatCliCommand("openclaw doctor --fix")} to normalize the store before the next scheduler run.`,
-    ].join("\n"),
-    "Cron",
-  );
+  const hasAutoFixable =
+    legacyStoreDetected ||
+    legacyRunLogDetected ||
+    sqliteProjectionBackfillCount > 0 ||
+    normalized.mutated ||
+    notifyCount > 0 ||
+    dreamingStaleCount > 0;
+
+  const fixPrompt = hasAutoFixable
+    ? `\nRepair with ${formatCliCommand("openclaw doctor --fix")} to normalize the store before the next scheduler run.`
+    : "";
+
+  note([noteHeading, ...previewLines].join("\n") + fixPrompt, "Cron");
+
+  if (!hasAutoFixable) {
+    return;
+  }
 
   const shouldRepair = await params.prompter.confirm({
     message: "Repair legacy cron jobs now?",

--- a/src/commands/doctor/cron/repair-plan.ts
+++ b/src/commands/doctor/cron/repair-plan.ts
@@ -60,7 +60,7 @@ export function formatLegacyIssuePreview(
   }
   if (issues.unresolvedAgentTurnShellToolPrompt) {
     lines.push(
-      `- ${pluralize(issues.unresolvedAgentTurnShellToolPrompt, "job")} asks an isolated agent for shell/process tools and needs manual command conversion${formatJobNameList(details.unresolvedAgentTurnShellToolPrompt)}`,
+      `- ${pluralize(issues.unresolvedAgentTurnShellToolPrompt, "job")} asks an isolated agent for shell/process tools and needs manual command conversion${formatJobNameList(details.unresolvedAgentTurnShellToolPrompt)} (convert payload kind from "agentTurn" to "command" and provide an explicit "argv" array, e.g., via 'openclaw cron edit <id>')`,
     );
   }
   if (issues.legacyPayloadProvider) {


### PR DESCRIPTION
### Summary
This PR improves the labels and instructions displayed by `openclaw doctor` when resolving cron store issues, particularly on SQLite-backed stores where the legacy `jobs.json` file has been migrated.

### Changes
- Updated the finding heading in `src/commands/doctor/cron/index.ts` to refer to `"SQLite store"` instead of the non-existent `jobs.json` file when `legacyStoreDetected` is false.
- Refined the unresolved agent-turn command warning in `src/commands/doctor/cron/repair-plan.ts` to provide a concrete explanation of what manual command conversion requires (e.g. converting payload kind to `"command"` and specifying `argv` via `openclaw cron edit <id>`).
- Avoid printing the `--fix` instruction and prompting for auto-repair when there are only manual fixes required (i.e. `hasAutoFixable` is false).

### Real behavior proof
All unit tests in `src/commands/doctor/cron/index.test.ts` pass successfully:
```
 ✓  commands  ../../src/commands/doctor/cron/index.test.ts (28 tests) 1630ms
     ✓ reports quarantined cron rows even when the active store is already sanitized  764ms
```
