### PR TITLE
feat(plugin-sdk): add normalizeArgs callback to tool registration

### DIFF
--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -83,6 +83,8 @@ export type PluginToolRegistration = {
   optional: boolean;
   source: string;
   rootDir?: string;
+  /** Optional callback to normalize/repair tool arguments before execute(). */
+  normalizeArgs?: (args: Record<string, unknown>) => Record<string, unknown>;
 };
 
 export type PluginCliRegistration = {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -602,7 +602,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
   const registerTool = (
     record: PluginRecord,
     tool: AnyAgentTool | OpenClawPluginToolFactory,
-    opts?: { name?: string; names?: string[]; optional?: boolean },
+    opts?: { name?: string; names?: string[]; optional?: boolean; normalizeArgs?: (args: Record<string, unknown>) => Record<string, unknown> },
   ) => {
     if (pluginsWithChannelRegistrationConflict.has(record.id)) {
       return;
@@ -648,6 +648,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       pluginName: record.name,
       factory,
       names: normalized,
+      normalizeArgs: opts?.normalizeArgs,
       declaredNames,
       optional,
       source: record.source,

--- a/src/plugins/tool-types.ts
+++ b/src/plugins/tool-types.ts
@@ -62,6 +62,8 @@ export type OpenClawPluginToolOptions = {
   name?: string;
   names?: string[];
   optional?: boolean;
+  /** Optional callback to normalize/repair tool arguments before execute(). */
+  normalizeArgs?: (args: Record<string, unknown>) => Record<string, unknown>;
 };
 
 export type OpenClawPluginHookOptions = {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -135,6 +135,7 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
     ? (args: unknown) =>
         runWithPluginToolScope(entry, () => Reflect.apply(prepareArguments, tool, [args]))
     : undefined;
+  const normalizeToolArgs = entry.normalizeArgs;
   const scopedExecute = (
     toolCallId: string,
     params: unknown,
@@ -143,10 +144,18 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
   ) =>
     runWithPluginToolScope(
       entry,
-      () =>
-        Reflect.apply(tool.execute, tool, [toolCallId, params, signal, onUpdate]) as ReturnType<
-          AnyAgentTool["execute"]
-        >,
+      () => {
+        const normalizedParams =
+          normalizeToolArgs && params && typeof params === "object" && !Array.isArray(params)
+            ? normalizeToolArgs(params as Record<string, unknown>)
+            : params;
+        return Reflect.apply(tool.execute, tool, [
+          toolCallId,
+          normalizedParams,
+          signal,
+          onUpdate,
+        ]) as ReturnType<AnyAgentTool["execute"]>;
+      },
     );
   const wrapped = new Proxy<AnyAgentTool>(tool, {
     get(target, prop) {


### PR DESCRIPTION
## Summary

- Add an optional `normalizeArgs` callback to `registerTool` opts so plugin authors can repair malformed tool arguments before `execute()` runs.
- This mirrors `registerTrustedToolPolicy` functionality for third-party plugins, which previously had to duplicate validation logic inside every tool's `execute` function.
- The callback is called in the scoped execute wrapper, receiving raw args and returning normalized args.

## Changes

- `src/plugins/tool-types.ts`: add `normalizeArgs` to `OpenClawPluginToolOptions`
- `src/plugins/registry-types.ts`: add `normalizeArgs` to `PluginToolRegistration`
- `src/plugins/registry.ts`: store `normalizeArgs` when registering tools
- `src/plugins/tools.ts`: call `normalizeArgs` in the scoped execute wrapper before `execute()`

## Verification

- `node scripts/run-vitest.mjs run src/plugins/tools.optional.test.ts src/plugins/agent-tool-result-middleware.test.ts src/plugins/contracts/plugin-tool-contracts.test.ts` → **73/73 passed**
- Production evidence: `node --import tsx` verified `normalizeArgs` is correctly stored in registry and can normalize args (e.g. `{value: 42}` → `{value: "42"}`)

## Impact Assessment

- Scope: plugin SDK — adds optional callback to tool registration, called before `execute()`
- Downstream: no breaking changes; the callback is optional and defaults to no-op
- Edge cases: non-object args pass through unchanged; the callback runs in the plugin's tool scope
- Hard-coded values: none

## Real behavior proof

**Behavior addressed:** Plugin authors can now provide a `normalizeArgs` callback in `registerTool` opts to repair malformed arguments before `execute()`.

**Environment tested:** Node 22.x on Linux, vitest + `node --import tsx`.

**Steps run after the patch:** Ran plugin tool tests and verified `normalizeArgs` storage and invocation.

```bash
node --import tsx --no-warnings -e "
import { createPluginRegistryFixture, registerVirtualTestPlugin } from 'openclaw/plugin-sdk/plugin-test-contracts';
const { config, registry } = createPluginRegistryFixture();
registerVirtualTestPlugin({
  registry, config, id: 'test-norm', name: 'Test', contracts: { tools: ['t'] },
  register(api) {
    api.registerTool({ name: 't', description: '', parameters: {}, execute: async () => ({}) },
      { normalizeArgs: (args) => ({ ...args, value: String(args.value) }) });
  },
});
const entry = registry.registry.tools.find(t => t.pluginId === 'test-norm');
console.log('normalizeArgs({value: 42}):', JSON.stringify(entry.normalizeArgs({ value: 42 })));
"
```

**Evidence after fix:**

```text
normalizeArgs({value: 42}): {"value":"42"}
```

**Observed result:** The `normalizeArgs` callback is correctly stored and invoked, transforming `{value: 42}` to `{value: "42"}`. All 73 existing tests pass.

**Not tested:** End-to-end agent run with a malformed tool call exercising normalizeArgs was not performed.

Closes #94916
