### PR TITLE
feat(plugins): add normalizeArgs option to registerTool for plugin argument repair

### DIFF
--- a/src/plugins/captured-registration.test.ts
+++ b/src/plugins/captured-registration.test.ts
@@ -153,3 +153,85 @@ describe("captured plugin registration", () => {
     ]);
   });
 });
+
+describe("captured plugin registration normalizeArgs", () => {
+  function makeTool(name: string): AnyAgentTool {
+    return {
+      name,
+      label: name,
+      description: `${name} tool`,
+      parameters: { type: "object", properties: {} },
+      async execute() {
+        return { content: [], details: {} };
+      },
+    } as unknown as AnyAgentTool;
+  }
+
+  it("wires normalizeArgs as prepareArguments on concrete tools", () => {
+    const tool = makeTool("test-tool");
+    const normalizeArgs = (args: unknown) => ({
+      ...(args as Record<string, unknown>),
+      fixed: true,
+    });
+    const captured = capturePluginRegistration({
+      id: "test-plugin",
+      register(api) {
+        api.registerTool(tool, { normalizeArgs });
+      },
+    });
+    expect(captured.tools).toHaveLength(1);
+    expect(captured.tools[0].prepareArguments).toBeDefined();
+    const raw = { input: "hello" };
+    expect(captured.tools[0].prepareArguments!(raw)).toEqual({ input: "hello", fixed: true });
+  });
+
+  it("chains normalizeArgs with existing prepareArguments", () => {
+    const tool = makeTool("test-tool");
+    tool.prepareArguments = (args: unknown) => ({
+      ...(args as Record<string, unknown>),
+      prepped: true,
+    });
+    const normalizeArgs = (args: unknown) => ({
+      ...(args as Record<string, unknown>),
+      normalized: true,
+    });
+    const captured = capturePluginRegistration({
+      id: "test-plugin",
+      register(api) {
+        api.registerTool(tool, { normalizeArgs });
+      },
+    });
+    expect(captured.tools[0].prepareArguments).toBeDefined();
+    const raw = { input: "hello" };
+    expect(captured.tools[0].prepareArguments!(raw)).toEqual({
+      input: "hello",
+      prepped: true,
+      normalized: true,
+    });
+  });
+
+  it("does not set prepareArguments when normalizeArgs is not provided", () => {
+    const tool = makeTool("test-tool");
+    const captured = capturePluginRegistration({
+      id: "test-plugin",
+      register(api) {
+        api.registerTool(tool);
+      },
+    });
+    expect(captured.tools).toHaveLength(1);
+    expect(captured.tools[0].prepareArguments).toBeUndefined();
+  });
+
+  it("does not set prepareArguments when tool is a factory function", () => {
+    const factory = () => makeTool("factory-tool");
+    const normalizeArgs = (args: unknown) => args as Record<string, unknown>;
+    const captured = capturePluginRegistration({
+      id: "test-plugin",
+      register(api) {
+        api.registerTool(factory, { normalizeArgs });
+      },
+    });
+    // Factory tools are not pushed to captured.tools (only concrete tools are)
+    expect(captured.tools).toHaveLength(0);
+  });
+});

--- a/src/plugins/captured-registration.ts
+++ b/src/plugins/captured-registration.ts
@@ -311,8 +311,14 @@ export function createCapturedPluginRegistration(params?: {
           };
         },
         unscheduleSessionTurnsByTag: async () => ({ removed: 0, failed: 0 }),
-        registerTool(tool) {
+        registerTool(tool, opts) {
           if (typeof tool !== "function") {
+            if (opts?.normalizeArgs) {
+              const existingPrepare = tool.prepareArguments;
+              tool.prepareArguments = existingPrepare
+                ? (args: unknown) => opts.normalizeArgs!(existingPrepare(args))
+                : opts.normalizeArgs;
+            }
             tools.push(tool);
           }
         },

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -602,7 +602,12 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
   const registerTool = (
     record: PluginRecord,
     tool: AnyAgentTool | OpenClawPluginToolFactory,
-    opts?: { name?: string; names?: string[]; optional?: boolean },
+    opts?: {
+      name?: string;
+      names?: string[];
+      optional?: boolean;
+      normalizeArgs?: (args: unknown) => Record<string, unknown>;
+    },
   ) => {
     if (pluginsWithChannelRegistrationConflict.has(record.id)) {
       return;
@@ -624,6 +629,12 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
 
     if (typeof tool !== "function") {
       names.push(tool.name);
+      if (opts?.normalizeArgs) {
+        const existingPrepare = tool.prepareArguments;
+        tool.prepareArguments = existingPrepare
+          ? (args: unknown) => opts.normalizeArgs!(existingPrepare(args))
+          : opts.normalizeArgs;
+      }
     }
 
     const normalized = normalizePluginToolNames(names);

--- a/src/plugins/tool-types.ts
+++ b/src/plugins/tool-types.ts
@@ -62,6 +62,8 @@ export type OpenClawPluginToolOptions = {
   name?: string;
   names?: string[];
   optional?: boolean;
+  /** Optional callback to normalize/repair tool arguments before schema validation and execute(). Applied as prepareArguments on concrete (non-factory) tools. */
+  normalizeArgs?: (args: unknown) => Record<string, unknown>;
 };
 
 export type OpenClawPluginHookOptions = {


### PR DESCRIPTION
## Summary

Add an optional `normalizeArgs` callback to `registerTool`'s opts so third-party plugin authors can normalize/repair tool arguments before they reach `execute()` and schema validation.

The callback is wired to the existing `AgentTool.prepareArguments` hook, which already runs before TypeBox schema validation in the agent loop. When a tool already has `prepareArguments`, the two are chained: existing prepare → normalizeArgs → validation.

Fixes #94916

## Real behavior proof

**Behavior addressed**: Third-party plugins lack an SDK hook to repair malformed model tool-call arguments before execution. The existing `registerTrustedToolPolicy` is restricted to bundled/trusted plugins only.

**Real setup tested**:
- **Runtime**: Node 24.16.0, Linux
- **Test framework**: Vitest 4.1.8

**Exact steps or command run after fix**:

```bash
pnpm test src/plugins/captured-registration.test.ts
```

**After-fix evidence**:

```
Test Files  1 passed (1)
     Tests  6 passed (6)
```

**Observed result after the fix**: `normalizeArgs` is correctly wired as `prepareArguments` on concrete tools. When chained with existing `prepareArguments`, both run in correct order. Factory tools and tools without `normalizeArgs` are unaffected.

**What was not tested**: End-to-end agent run with a real model producing malformed tool arguments. The behavior relies on the existing `prepareArguments` → `validateToolArguments` pipeline which is already covered by agent-core tests.

## Tests and validation

| Check | Result |
|-------|--------|
| Unit tests (captured-registration) | 6/6 passed |
| Regression: plugin-registry | 24/24 passed |
| Regression: plugin-tool-contracts | 2/2 passed |
| Type check | No new errors |
| Format (oxfmt) | Clean |

## Risk checklist

Did user-visible behavior change? `No`
- Only adds an optional callback; existing tools and plugins are unaffected.

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`
- The callback runs within the existing `wrapPluginToolCallbacks` error isolation (plugin-scoped proxied handlers).

What is the highest-risk area?
- None. The new field is purely additive and optional; when not provided, behavior is identical to before.

How is that risk mitigated?
- Existing call path unchanged; `prepareArguments` wrapping via `addEmptyObjectArgumentPreparation` continues to work as before; no core agent-loop changes.

## Current review state

What is the next action?
- Maintainer review
