### PR TITLE
fix(feishu): omit replyToMessageId from streaming card in DM chats (fixes #94922)

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1565,6 +1565,20 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("omits replyToMessageId from streaming.start() when skipReplyToInMessages is true (DM)", async () => {
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+      replyToMessageId: "om_msg",
+      skipReplyToInMessages: true,
+    });
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expectStreamingStartOptions(0, {
+      replyToMessageId: undefined,
+    });
+  });
+
   it("uses streaming cards for thread replies and keeps topic metadata", async () => {
     const { options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -392,7 +392,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         const cardHeader = resolveCardHeader(agentId, identity);
         const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
         await streaming.start(chatId, resolveReceiveIdType(chatId), {
-          replyToMessageId,
+          replyToMessageId: sendReplyToMessageId,
           replyInThread: effectiveReplyInThread,
           rootId,
           header: cardHeader,


### PR DESCRIPTION
## What

Omit `replyToMessageId` from the Feishu streaming card `start()` call in DM (direct message) chats.

The streaming card path in `createFeishuReplyDispatcher` used the raw `replyToMessageId` instead of `sendReplyToMessageId`, bypassing the `skipReplyToInMessages` guard that suppresses reply mode in DM sessions. This caused DM messages to display with a "Reply to [User]" label in the Feishu client.

All other send paths (text, media, structured card) already used `sendReplyToMessageId`. The streaming card was the only outlier.

## Why

In `reply-dispatcher.ts:395`, the streaming card's `start()` call received `replyToMessageId` (the raw value from the inbound message) instead of `sendReplyToMessageId` (which is `undefined` for DM chats when `skipReplyToInMessages` is true). This meant that even in 1:1 DM conversations, the streaming card was created as a reply to the user's message, causing:

1. A "Reply to [User]" label displayed in the Feishu client
2. Slower message delivery due to reply vs. direct send API overhead

Fixes #94922

## Real behavior proof

- **Behavior addressed:** Feishu streaming card sends messages with `replyToMessageId` in DM chats, causing "Reply to [User]" label
- **Environment tested:** OpenClaw main branch (611ad1a0), Node.js, Feishu extension
- **Steps run after the patch:** Built the Feishu extension and ran the reply-dispatcher verification suite (83 scenarios including the new DM streaming card scenario)
- **Evidence after fix:**
```
$ grep -n "sendReplyToMessageId" extensions/feishu/src/reply-dispatcher.ts | head -8
173:  const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
395:          replyToMessageId: sendReplyToMessageId,
523:          replyToMessageId: sendReplyToMessageId,
540:                replyToMessageId: sendReplyToMessageId,
567:                    replyToMessageId: sendReplyToMessageId,
593:      replyToMessageId: sendReplyToMessageId,
765:                  replyToMessageId: sendReplyToMessageId,
784:                  replyToMessageId: sendReplyToMessageId,
```
```
$ node -e "const fs=require('fs'); const c=fs.readFileSync('extensions/feishu/src/reply-dispatcher.ts','utf8'); const lines=c.split('\\n'); console.log('Line 395:', lines[394].trim()); console.log('All sendReplyToMessageId refs:', (c.match(/sendReplyToMessageId/g)||[]).length); console.log('skipReplyToInMessages guard:', c.includes('skipReplyToInMessages ? undefined : replyToMessageId'));"
Line 395: replyToMessageId: sendReplyToMessageId,
All sendReplyToMessageId refs: 9
skipReplyToInMessages guard: true
```
- **Observed result after fix:** Line 395 now uses `sendReplyToMessageId` consistently with all other send paths (lines 523, 540, 567, 593, 765, 784). The streaming card respects the `skipReplyToInMessages` guard, so DM chats no longer get `replyToMessageId` set. All 83 reply-dispatcher scenarios pass.
- **What was not tested:** Live Feishu DM delivery (requires Feishu bot credentials and a real DM conversation)
