### PR TITLE
docs: document exact model.usage diagnostic event fields and clarify event bus dispatch

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -371,10 +371,25 @@ to them directly without OTLP export.
 
 **Model usage**
 
-- `model.usage` - tokens, cost, duration, context, provider/model/channel,
-  session ids. `usage` is provider/turn accounting for cost and telemetry;
-  `context.used` is the current prompt/context snapshot and can be lower than
-  provider `usage.total` when cached input or tool-loop calls are involved.
+- `model.usage` — emitted after each agent turn when diagnostics are enabled and usage is nonzero. Fields:
+  - `type`: `"model.usage"`
+  - `sessionKey`: session identifier string
+  - `sessionId`: session identifier string
+  - `channel`: originating channel (e.g. `"telegram"`, `"discord"`, `"web"`)
+  - `agentId`: active agent id
+  - `provider`: model provider name (e.g. `"openai"`, `"anthropic"`)
+  - `model`: model identifier (e.g. `"gpt-4o"`, `"claude-sonnet-4-20250514"`)
+  - `usage.input`: input token count
+  - `usage.output`: output token count
+  - `usage.cacheRead`: cached input tokens read from provider prompt cache
+  - `usage.cacheWrite`: cached input tokens written to provider prompt cache
+  - `usage.promptTokens`: prompt tokens (may differ from `input` when caching is involved)
+  - `usage.total`: total token count
+  - `context.limit`: context window token limit for the model
+  - `context.used`: actual context tokens used (optional; can be lower than `usage.total` when cached input or tool-loop calls are involved)
+  - `costUsd`: estimated cost in USD (omitted when cost config is unavailable)
+  - `durationMs`: total turn duration in milliseconds
+  - `lastCallUsage`: per-call usage breakdown from the last individual API call (optional)
 
 **Message flow**
 

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -390,6 +390,9 @@ to them directly without OTLP export.
   - `costUsd`: estimated cost in USD (omitted when cost config is unavailable)
   - `durationMs`: total turn duration in milliseconds
   - `lastCallUsage`: per-call usage breakdown from the last individual API call (optional)
+  - `ts`: unix-ms timestamp when the event was dispatched (shared envelope)
+  - `seq`: monotonically increasing sequence number per diagnostic session (shared envelope)
+  - `trace`: optional distributed-trace context (shared envelope)
 
 **Message flow**
 

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -390,6 +390,11 @@ to them directly without OTLP export.
   - `costUsd`: estimated cost in USD (omitted when cost config is unavailable)
   - `durationMs`: total turn duration in milliseconds
   - `lastCallUsage`: per-call usage breakdown from the last individual API call (optional)
+    - `lastCallUsage.input`: input token count for the last API call
+    - `lastCallUsage.output`: output token count for the last API call
+    - `lastCallUsage.cacheRead`: cached input tokens read from provider prompt cache
+    - `lastCallUsage.cacheWrite`: cached input tokens written to provider prompt cache
+    - `lastCallUsage.total`: total token count for the last API call
   - `ts`: unix-ms timestamp when the event was dispatched (shared envelope)
   - `seq`: monotonically increasing sequence number per diagnostic session (shared envelope)
   - `trace`: optional distributed-trace context (shared envelope)

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -118,6 +118,13 @@ available:
 OpenClaw preserves the original structured log arguments alongside these fields
 so existing parsers that read numbered tslog argument keys keep working.
 
+Diagnostic events (such as `model.usage`, `session.state`, or `message.delivery`)
+are dispatched through the diagnostic event bus and consumed by the stability
+recorder, OTLP exporter, and other diagnostic listeners — they are not written
+to the JSONL file log. See
+[Diagnostic event catalog](/gateway/opentelemetry#diagnostic-event-catalog) for
+the exact field names and structure of each event type.
+
 Talk, realtime voice, and managed-room activity emits bounded lifecycle log
 records through this same file-log pipeline. These records include event type,
 mode, transport, provider, and size/timing measurements when available, but omit

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -118,7 +118,7 @@ available:
 OpenClaw preserves the original structured log arguments alongside these fields
 so existing parsers that read numbered tslog argument keys keep working.
 
-Diagnostic events (such as `model.usage`, `session.state`, or `message.delivery`)
+Diagnostic events (such as `model.usage`, `session.state`, or `message.delivery.*`)
 are dispatched through the diagnostic event bus and consumed by the stability
 recorder, OTLP exporter, and other diagnostic listeners — they are not written
 to the JSONL file log. See


### PR DESCRIPTION
## What

Expand the `model.usage` diagnostic event documentation from a brief 4-line summary to a complete field-by-field reference, and clarify that diagnostic events are dispatched through the event bus rather than written to the JSONL file log.

## Why

The existing `model.usage` documentation in `docs/gateway/opentelemetry.md` was a single sentence covering only a few fields. The actual `DiagnosticModelUsageEvent` type in `src/infra/diagnostic-events.ts` has 15+ fields organized across `usage.*`, `context.*`, `lastCallUsage.*`, and top-level properties. Contributors and integrators building OTLP exporters or custom diagnostic consumers need the complete field reference.

The `docs/logging.md` addition clarifies a common confusion: diagnostic events (like `model.usage`, `session.state`) are NOT written to the JSONL file log — they go through the diagnostic event bus to the stability recorder, OTLP exporter, and other listeners.

## Changes

- `docs/gateway/opentelemetry.md`: Replace the brief `model.usage` description with a complete field reference matching `DiagnosticModelUsageEvent` in `src/infra/diagnostic-events.ts`
- `docs/logging.md`: Add a note clarifying diagnostic events are dispatched through the event bus, not the JSONL file log

## Real behavior proof

- **Behavior addressed:** The `model.usage` diagnostic event field documentation was incomplete (4 lines covering ~4 fields); the actual TypeScript type has 15+ fields across nested objects
- **Environment tested:** macOS 26.4.1, Node v22.22.3, pnpm build of the openclaw monorepo
- **Steps run after the patch:** Built the project with `pnpm build`, then verified the documentation changes by reading the modified files and comparing field names against `src/infra/diagnostic-events.ts`
- **Evidence after fix:**
```
$ node -e "const fs=require('fs'); const c=fs.readFileSync('docs/gateway/opentelemetry.md','utf8'); console.log('model.usage present:', c.includes('model.usage')); console.log('sessionKey field:', c.includes('sessionKey')); console.log('costUsd field:', c.includes('costUsd')); console.log('lastCallUsage field:', c.includes('lastCallUsage'));"
model.usage present: true
sessionKey field: true
costUsd field: true
lastCallUsage field: true

$ grep -n 'diagnostic event bus' docs/logging.md
122:are dispatched through the diagnostic event bus and consumed by the stability

$ grep -n 'model.usage.*emitted' docs/gateway/opentelemetry.md
374:- `model.usage` — emitted after each agent turn when diagnostics are enabled and usage is nonzero. Fields:
```
- **Observed result after fix:** The `model.usage` section now documents all 15+ fields from the TypeScript type definition. The `logging.md` note clarifies that diagnostic events use the event bus, not the file log. Build passes cleanly.
- **What was not tested:** No runtime behavior changed — this is a documentation-only update. The OTLP exporter and diagnostic event bus were not exercised since no code was modified.
