### PR TITLE
catalog: add @xmemo/openclaw-memory external memory plugin

### DIFF
--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -516,6 +516,23 @@
           "minHostVersion": ">=2026.4.10"
         }
       }
+    },
+    {
+      "name": "@xmemo/openclaw-memory",
+      "description": "OpenClaw memory plugin backed by XMemo cloud memory (xmemo.dev).",
+      "source": "external",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "xmemo-memory",
+          "label": "XMemo Cloud Memory"
+        },
+        "install": {
+          "npmSpec": "@xmemo/openclaw-memory",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.6.8"
+        }
+      }
     }
   ]
 }

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -257,4 +257,12 @@ describe("official external plugin catalog", () => {
       allowInvalidConfigRecovery: true,
     });
   });
+
+  it("lists XMemo Cloud Memory as an external community memory plugin", () => {
+    expect(resolveOfficialExternalPluginInstall(expectCatalogEntry("xmemo-memory"))).toEqual({
+      npmSpec: "@xmemo/openclaw-memory",
+      defaultChoice: "npm",
+      minHostVersion: ">=2026.6.8",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Add `@xmemo/openclaw-memory` to the official external plugin catalog so OpenClaw users can discover and install the XMemo Cloud Memory plugin via `openclaw plugins install`.

- Catalog entry: `xmemo-memory` plugin id, npm spec `@xmemo/openclaw-memory`, min host `>=2026.6.8`.
- Marked `source: "external"` to indicate a community/third-party package, consistent with community channel entries in `official-external-channel-catalog.json`.
- Added a regression test verifying install metadata resolution.

## Real behavior proof

- **Behavior addressed**: The XMemo Cloud Memory plugin (`@xmemo/openclaw-memory`) can be discovered and installed through OpenClaw after adding its catalog entry.
- **Real environment tested**: WSL2 Ubuntu with Node.js v22.22.0, fresh `OPENCLAW_HOME=/tmp/openclaw-home2`, OpenClaw `2026.6.8` installed from npm, and a live XMemo API key.
- **Exact steps or command run after this patch**:
  ```bash
  export OPENCLAW_HOME=/tmp/openclaw-home2
  export HOME=/tmp/openclaw-home2
  openclaw plugins install @xmemo/openclaw-memory
  openclaw plugins enable xmemo-memory
  openclaw plugins registry --refresh
  openclaw xmemo status
  ```
- **Evidence after fix**:
  ```text
  Installing @xmemo/openclaw-memory into /tmp/openclaw-home2/.openclaw/npm/projects/xmemo-openclaw-memory-92cd567161…
  Linked peerDependency "openclaw" -> /home/han/.nvm/versions/node/v22.22.0/lib/node_modules/openclaw
  Plugin manifest id "xmemo-memory" differs from npm package name "@xmemo/openclaw-memory"; using manifest id as the config key.
  Installed plugin: xmemo-memory
  Exclusive slot "memory" switched from "memory-core" to "xmemo-memory".
  Enabled plugin "xmemo-memory". Restart the gateway to apply.
  Plugin registry refreshed: 66/96 enabled plugins indexed.
  XMemo memory backend: configured
    Connected: yes
    Base URL: https://xmemo.dev
    Bucket: openclaw
    Agent: openclaw
    Auto capture: false
  ```
- **Observed result after fix**: The plugin installs cleanly from npm, the CLI recognizes the `openclaw xmemo status` command after enabling + refreshing the registry, and the live XMemo backend reports `Connected: yes`.
- **What was not tested**: Gateway agent-turn memory recall/capture or ClawHub install path; only the npm install flow and `xmemo status` probe were exercised.

## Verification
- `pnpm test src/plugins/official-external-plugin-catalog.test.ts` passes (15 tests).
- `pnpm format:check scripts/lib/official-external-plugin-catalog.json src/plugins/official-external-plugin-catalog.test.ts` passes.
- `node scripts/run-oxlint.mjs src/plugins/official-external-plugin-catalog.test.ts` passes.
