### PR TITLE
fix(feishu): use sendReplyToMessageId in streaming card start() for DM chats

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1565,22 +1565,43 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
-  it("omits replyToMessageId from streaming.start() in DM chats (skipReplyToInMessages)", async () => {
-    // In DM chats, skipReplyToInMessages=true means sendReplyToMessageId=undefined.
-    // The streaming card start() should receive undefined replyToMessageId,
-    // so resolveStreamingCardSendMode returns "create" (no Reply-to label in DM).
+  it("omits both replyToMessageId and rootId from streaming.start() in DM chats (skipReplyToInMessages)", async () => {
+    // In DM chats, skipReplyToInMessages=true means both sendReplyToMessageId and
+    // streamingRootId are undefined. The streaming card start() should receive
+    // undefined for both, so resolveStreamingCardSendMode returns "create" (no
+    // Reply-to label, no root_create fallback in DM).
     const { options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),
-      replyToMessageId: "om_dm_msg",
+      replyToMessageId: "dm_msg",
       skipReplyToInMessages: true,
+      rootId: "dm_root",
     });
     await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
 
     expect(streamingInstances).toHaveLength(1);
     expectStreamingStartOptions(0, {
       replyToMessageId: undefined,
+      rootId: undefined,
       header: { title: "agent", template: "blue" },
       note: "Agent: agent",
+    });
+  });
+
+  it("preserves rootId for group/thread streaming when skipReplyToInMessages is false", async () => {
+    // In group chats, skipReplyToInMessages=false so rootId is passed through,
+    // enabling root_create mode for proper threading.
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+      replyToMessageId: "group_msg",
+      skipReplyToInMessages: false,
+      rootId: "group_root",
+    });
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expectStreamingStartOptions(0, {
+      replyToMessageId: "group_msg",
+      rootId: "group_root",
     });
   });
 

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1565,6 +1565,25 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("omits replyToMessageId from streaming.start() in DM chats (skipReplyToInMessages)", async () => {
+    // In DM chats, skipReplyToInMessages=true means sendReplyToMessageId=undefined.
+    // The streaming card start() should receive undefined replyToMessageId,
+    // so resolveStreamingCardSendMode returns "create" (no Reply-to label in DM).
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+      replyToMessageId: "om_dm_msg",
+      skipReplyToInMessages: true,
+    });
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expectStreamingStartOptions(0, {
+      replyToMessageId: undefined,
+      header: { title: "agent", template: "blue" },
+      note: "Agent: agent",
+    });
+  });
+
   it("uses streaming cards for thread replies and keeps topic metadata", async () => {
     const { options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -392,7 +392,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         const cardHeader = resolveCardHeader(agentId, identity);
         const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
         await streaming.start(chatId, resolveReceiveIdType(chatId), {
-          replyToMessageId,
+          replyToMessageId: sendReplyToMessageId,
           replyInThread: effectiveReplyInThread,
           rootId,
           header: cardHeader,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -171,6 +171,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     mentionTargets,
   } = params;
   const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
+  // In DM chats (skipReplyToInMessages=true), ordinary DM rootId should also be
+  // omitted so streaming.start() chooses "create" mode, matching plain-text and
+  // static-card sends. Group/thread rootId is preserved for correct threading.
+  const streamingRootId = skipReplyToInMessages ? undefined : rootId;
   const typingTargetMessageId = explicitTypingTargetMessageId?.trim() || replyToMessageId;
   const threadReplyMode = threadReply === true;
   const effectiveReplyInThread = threadReplyMode ? true : replyInThread;
@@ -394,7 +398,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         await streaming.start(chatId, resolveReceiveIdType(chatId), {
           replyToMessageId: sendReplyToMessageId,
           replyInThread: effectiveReplyInThread,
-          rootId,
+          rootId: streamingRootId,
           header: cardHeader,
           note: cardNote,
         });


### PR DESCRIPTION
Fixes #94922

## Summary

- The streaming card `start()` call in `createFeishuReplyDispatcher` used the raw `replyToMessageId` instead of `sendReplyToMessageId`, bypassing the `skipReplyToInMessages` guard that suppresses reply mode in DM sessions.
- This caused DM streaming cards to display a "Reply to [User]" label in the Feishu client, while all other send paths (text, media, structured card) correctly used `sendReplyToMessageId`.
- Fix: align the streaming card path by passing `sendReplyToMessageId` at line 395, making it consistent with all 8 other send paths in the dispatcher.

## Root Cause

The `skipReplyToInMessages` guard (line 173) computes `sendReplyToMessageId` as `undefined` when `!isGroup && !directThreadReply` (DM sessions). This correctly suppresses reply metadata for plain-text, media, and structured-card sends. But the streaming card `start()` bypassed this guard by using the raw `replyToMessageId` directly, so DM streaming cards always fell into `resolveStreamingCardSendMode` → `"reply"` → `im.message.reply` API → visible "Reply to" label.

## Change Type

- [x] Bug fix

## Scope

- [ ] Gateway / [ ] Skills / [ ] Auth / [ ] Memory / [x] Integrations / [ ] API / [ ] UI/UX / [ ] CI

## Real behavior proof

**Behavior addressed:** Feishu streaming card sends messages with `replyToMessageId` in DM chats, causing "Reply to [User]" label instead of direct create mode.

**Environment tested:** Node.js v24.13.1 on Linux, OpenClaw main branch and PR branch, Feishu extension source.

**Exact steps run after the patch:** Called the actual `resolveStreamingCardSendMode` production function from source via `node --import tsx` to verify the send mode for DM, group, and thread scenarios.

**Evidence after fix:**

Before (upstream/main — bug present):
```text
DM on main (bug - uses raw replyToMessageId): reply
```
When the streaming card `start()` receives the raw `replyToMessageId` from the inbound message, `resolveStreamingCardSendMode` returns `"reply"`, causing the "Reply to [User]" label in Feishu DMs.

After (PR branch — bug fixed):
```text
DM (replyToMessageId=undefined): create
Group (replyToMessageId=msg_abc123): reply
Thread (rootId=root_xyz789): root_create
No options: create
```
With the fix, DM streaming cards receive `sendReplyToMessageId` which is `undefined` when `skipReplyToInMessages` is true, so `resolveStreamingCardSendMode` correctly returns `"create"` → no Reply-to label. Group and thread modes are unchanged.

**Observed result after the fix:** DM streaming cards now use `create` mode (no Reply-to label). Group replies still use `reply` mode (correct threading). Thread replies still use `root_create` mode (correct root attachment). All reply-dispatcher test scenarios pass.

**What was not tested:** Live Feishu DM delivery with real bot credentials and a production Feishu tenant.
