### PR TITLE
fix(openai-completions): keep cache-boundary suffix out of DeepSeek's implicit prefix cache

### DIFF
--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -381,7 +381,7 @@ describe("OpenAI-compatible completions params", () => {
     expect(capturedRetention).toBe("24h");
   });
 
-  it("strips the internal cache boundary from OpenAI-compatible system prompts", async () => {
+  it("relocates the dynamic cache-boundary suffix to a trailing message for prefix-cache providers", async () => {
     let capturedMessages: unknown;
     const stream = streamOpenAICompletions(
       createModel(32_000),
@@ -402,10 +402,43 @@ describe("OpenAI-compatible completions params", () => {
 
     expect(result.stopReason).toBe("error");
     const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    // Stable prefix stays a byte-identical leading system message so implicit
+    // prefix-cache providers (DeepSeek) keep caching it across turns (#94518).
+    expect(messages[0]).toEqual({ role: "system", content: "Stable prefix" });
+    // The user turn stays inside the cacheable region.
+    expect(messages[1]?.role).toBe("user");
+    // The dynamic suffix is relocated to a trailing message so per-turn changes
+    // no longer invalidate the cached prefix + conversation history.
+    expect(messages[messages.length - 1]).toEqual({ role: "system", content: "Dynamic suffix" });
+    expect(messages).toHaveLength(3);
+  });
+
+  it("keeps a boundary-less system prompt as a single leading system message", async () => {
+    let capturedMessages: unknown;
+    const stream = streamOpenAICompletions(
+      createModel(32_000),
+      {
+        systemPrompt: "Plain system prompt with no cache boundary",
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      },
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: unknown }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = capturedMessages as Array<{ role: string; content: unknown }>;
     expect(messages[0]).toEqual({
       role: "system",
-      content: "Stable prefix\nDynamic suffix",
+      content: "Plain system prompt with no cache boundary",
     });
+    expect(messages).toHaveLength(2);
   });
 
   it("splits the cache boundary before applying Anthropic cache control for OpenRouter Anthropic models", async () => {

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -935,16 +935,42 @@ export function convertMessages(
     normalizeToolCallId(id),
   );
 
+  // Set when the system prompt's dynamic below-boundary suffix is relocated to a
+  // trailing message (implicit prefix-cache path); appended after the loop.
+  let trailingSystemSuffixMessage: ChatCompletionMessageParam | undefined;
   if (context.systemPrompt) {
     const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;
     const role = useDeveloperRole ? "developer" : "system";
-    const systemPrompt = options.preserveSystemPromptCacheBoundary
-      ? context.systemPrompt
-      : stripSystemPromptCacheBoundary(context.systemPrompt);
-    params.push({
-      role,
-      content: sanitizeSurrogates(systemPrompt),
-    });
+    if (options.preserveSystemPromptCacheBoundary) {
+      // Explicit cache_control path keeps the boundary marker; a later pass splits
+      // it into cached prefix + uncached suffix content parts on the same message.
+      params.push({ role, content: sanitizeSurrogates(context.systemPrompt) });
+    } else {
+      // Implicit prefix-cache providers (e.g. DeepSeek) cache the literal request
+      // prefix from token 0, so per-turn-volatile content placed in the leading
+      // system message invalidates the cache for the whole conversation that
+      // follows it. Keep the stable prefix as a byte-identical leading message and
+      // relocate the dynamic below-boundary suffix to a trailing message so the
+      // cached prefix + history stay stable while the runtime context still
+      // reaches the model. (#94518)
+      const split = splitSystemPromptCacheBoundary(context.systemPrompt);
+      if (split) {
+        if (split.stablePrefix) {
+          params.push({ role, content: sanitizeSurrogates(split.stablePrefix) });
+        }
+        if (split.dynamicSuffix) {
+          trailingSystemSuffixMessage = {
+            role,
+            content: sanitizeSurrogates(split.dynamicSuffix),
+          };
+        }
+      } else {
+        params.push({
+          role,
+          content: sanitizeSurrogates(stripSystemPromptCacheBoundary(context.systemPrompt)),
+        });
+      }
+    }
   }
 
   let lastRole: string | null = null;
@@ -1168,6 +1194,10 @@ export function convertMessages(
     }
 
     lastRole = msg.role;
+  }
+
+  if (trailingSystemSuffixMessage) {
+    params.push(trailingSystemSuffixMessage);
   }
 
   return params;


### PR DESCRIPTION
## Summary

After 6.x, DeepSeek prompt-cache hit rate collapses (~95% → <10%, ~10× cost) because the boundary-aware system prompt places per-turn-volatile content in the leading system message for implicit prefix-cache providers.

DeepSeek (and other OpenAI-compatible implicit prefix-cache providers) cache the literal request prefix from token 0 in 64-token chunks; a change anywhere in that prefix misses the cache for everything after it. `convertMessages` sent the system prompt as one message = stable prefix **+ dynamic below-boundary suffix** (the `## Runtime` block, active background exec-session list, etc.). When that volatile suffix changes turn-to-turn, the cache misses on the whole conversation history that follows.

This keeps the stable prefix as a byte-identical leading system message and relocates the dynamic suffix to a trailing message, so the cached prefix + history stay stable while the runtime context still reaches the model — no context dropped, no new config.

- Explicit `cache_control` providers (e.g. Anthropic via OpenRouter) are unchanged — still split the boundary into cached/uncached content parts on the system message.
- Boundary-less system prompts are unchanged (single leading system message).

This is the config-free alternative to #94582, which adds a `compat.disableBoundaryAwareCache` opt-in and discards the dynamic suffix entirely.

## Real behavior proof

- **Behavior addressed:** for OpenAI-compatible providers without explicit `cache_control`, the volatile below-boundary suffix no longer sits in the cached request prefix.
- **Real environment tested:** Node 22.22.2, Linux.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs src/llm/providers/openai-completions.test.ts`; tsgo core typecheck; oxlint; oxfmt.
- **Evidence after fix:** 28/28 openai-completions tests pass, including a new assertion that `Stable prefix<boundary>Dynamic suffix` produces `[system "Stable prefix", user, system "Dynamic suffix"]` (stable prefix byte-identical and leading; suffix relocated to a trailing message) and that boundary-less prompts stay a single system message. Typecheck/lint/format clean.
- **Observed result after fix:** the leading system message + conversation history form a byte-identical prefix across turns for implicit prefix-cache providers, matching DeepSeek's documented contract (https://api-docs.deepseek.com/guides/kv_cache).
- **What was not tested:** no live DeepSeek request to measure actual `prompt_cache_hit_tokens` (no key in this environment); proof is structural + the documented contract. The change affects all openai-completions providers without explicit `cache_control` (the dynamic suffix moves from inline-in-system to a trailing system message) — a live cross-provider check before merge is recommended.

## Related

- Fixes #94518
- Config-free alternative to #94582
- Related prior reports: #91018, #90583, #19989
