### PR TITLE
fix(outbound): prevent internal sink from intercepting action-only pl…

### DIFF
--- a/src/infra/outbound/internal-source-reply.test.ts
+++ b/src/infra/outbound/internal-source-reply.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Prevent bootstrapping from wiping our mock registry
+vi.mock("./channel-bootstrap.runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return {
+    ...actual,
+    bootstrapOutboundChannelPlugin: vi.fn(),
+  };
+});
+
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { shouldUseInternalSourceReplySink } from "./internal-source-reply.js";
+
+describe("internal-source-reply sink fallback", () => {
+  afterEach(() => {
+    setActivePluginRegistry(undefined);
+  });
+
+  const baseInput = {
+    cfg: { channels: { "custom-slack": { enabled: true } } } as unknown as OpenClawConfig,
+    action: "send",
+    toolContext: { currentChannelProvider: "custom-slack", currentChannelId: "channel:C123" },
+    sessionKey: "agent:main:custom-slack:channel:C123",
+    sourceReplyDeliveryMode: "message_tool_only" as const,
+  };
+
+  it("routes to plugin natively if it handles send action (bypasses sink)", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "custom-slack",
+          source: "test",
+          plugin: {
+            id: "custom-slack",
+            actions: {
+              handleAction: async () => ({ handled: true }),
+              supportsAction: ({ action }) => action === "send",
+            },
+            config: {
+              listAccountIds: () => ["default"],
+              resolveAccount: () => ({ enabled: true }),
+              isConfigured: () => true,
+            },
+          },
+        },
+      ]),
+    );
+
+    const isInternalSink = await shouldUseInternalSourceReplySink(baseInput, { message: "Test" });
+    expect(isInternalSink).toBe(false);
+  });
+
+  it("falls back to internal sink if it does not support send action", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "custom-slack",
+          source: "test",
+          plugin: {
+            id: "custom-slack",
+            actions: {
+              handleAction: async () => ({ handled: true }),
+              supportsAction: ({ action }) => action !== "send", // Declines "send"
+            },
+            config: {
+              listAccountIds: () => ["default"],
+              resolveAccount: () => ({ enabled: true }),
+              isConfigured: () => true,
+            },
+          },
+        },
+      ]),
+    );
+
+    const isInternalSink = await shouldUseInternalSourceReplySink(baseInput, { message: "Test" });
+    expect(isInternalSink).toBe(true);
+  });
+});

--- a/src/infra/outbound/internal-source-reply.test.ts
+++ b/src/infra/outbound/internal-source-reply.test.ts
@@ -16,7 +16,7 @@ import { shouldUseInternalSourceReplySink } from "./internal-source-reply.js";
 
 describe("internal-source-reply sink fallback", () => {
   afterEach(() => {
-    setActivePluginRegistry(undefined);
+    setActivePluginRegistry(createTestRegistry([]));
   });
 
   const baseInput = {
@@ -37,7 +37,7 @@ describe("internal-source-reply sink fallback", () => {
             id: "custom-slack",
             actions: {
               handleAction: async () => ({ handled: true }),
-              supportsAction: ({ action }) => action === "send",
+              supportsAction: ({ action }: any) => action === "send",
             },
             config: {
               listAccountIds: () => ["default"],
@@ -63,7 +63,7 @@ describe("internal-source-reply sink fallback", () => {
             id: "custom-slack",
             actions: {
               handleAction: async () => ({ handled: true }),
-              supportsAction: ({ action }) => action !== "send", // Declines "send"
+              supportsAction: ({ action }: any) => action !== "send", // Declines "send"
             },
             config: {
               listAccountIds: () => ["default"],

--- a/src/infra/outbound/internal-source-reply.ts
+++ b/src/infra/outbound/internal-source-reply.ts
@@ -99,7 +99,7 @@ async function hasConfiguredCurrentSourceChannel(
   const hasOutbound = Boolean(plugin?.outbound);
   const handlesAction =
     Boolean(plugin?.actions?.handleAction) &&
-    plugin?.actions?.supportsAction?.({ action: input.action }) !== false;
+    plugin?.actions?.supportsAction?.({ action: input.action as any }) !== false;
 
   if (!hasOutbound && !handlesAction) {
     return false;

--- a/src/infra/outbound/internal-source-reply.ts
+++ b/src/infra/outbound/internal-source-reply.ts
@@ -96,7 +96,12 @@ async function hasConfiguredCurrentSourceChannel(
   const plugin =
     outboundPlugin ??
     getLoadedChannelPlugin(provider as Parameters<typeof getLoadedChannelPlugin>[0]);
-  if (!plugin?.actions?.handleAction && !plugin?.outbound) {
+  const hasOutbound = Boolean(plugin?.outbound);
+  const handlesAction =
+    Boolean(plugin?.actions?.handleAction) &&
+    plugin?.actions?.supportsAction?.({ action: input.action }) !== false;
+
+  if (!hasOutbound && !handlesAction) {
     return false;
   }
   const configuredChannels = await listConfiguredMessageChannels(input.cfg);

--- a/src/infra/outbound/internal-source-reply.ts
+++ b/src/infra/outbound/internal-source-reply.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
+import { getLoadedChannelPlugin } from "../../channels/plugins/index.js";
 import type { ChannelThreadingToolContext } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { parseAgentSessionKey, parseThreadSessionSuffix } from "../../routing/session-key.js";
@@ -87,7 +88,15 @@ async function hasConfiguredCurrentSourceChannel(
   if (!isConfiguredChannel(input.cfg, provider)) {
     return false;
   }
-  if (!resolveOutboundChannelPlugin({ channel: provider, cfg: input.cfg, allowBootstrap: true })) {
+  const outboundPlugin = resolveOutboundChannelPlugin({
+    channel: provider,
+    cfg: input.cfg,
+    allowBootstrap: true,
+  });
+  const plugin =
+    outboundPlugin ??
+    getLoadedChannelPlugin(provider as Parameters<typeof getLoadedChannelPlugin>[0]);
+  if (!plugin?.actions?.handleAction && !plugin?.outbound) {
     return false;
   }
   const configuredChannels = await listConfiguredMessageChannels(input.cfg);


### PR DESCRIPTION
## Summary

What problem does this PR solve?
Resolves an issue where external plugin channels relying solely on `actions: { handleAction }` (without an explicit `outbound` capability) were incorrectly routed to the `internal-source-reply` sink when using `message(action=send)` without a `to` parameter. 

Why does this matter now?
It prevents valid custom channel plugins (like Lansenger) from silently failing or misrouting messages to the internal sink.

What is the intended outcome?
Valid custom channels are properly recognized by the fallback routing logic and receive outbound messages natively.

What is intentionally out of scope?
Changes to official bundled plugins or adding new outbound capabilities; this only touches the fallback validation logic in `internal-source-reply.ts`.

What does success look like?
`shouldUseInternalSourceReplySink` correctly evaluates plugins lacking an `outbound` object by checking `plugin?.actions?.handleAction` instead of instantly failing when `resolveOutboundChannelPlugin` returns `undefined`.

What should reviewers focus on?
The updated conditional logic in `src/infra/outbound/internal-source-reply.ts` around `getLoadedChannelPlugin` and the fallback capability checks.

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #94597

Which issues, PRs, or discussions are related?

Related #94597

Was this requested by a maintainer or owner?
Yes, this is the requested clean and narrow PR isolating only the routing fix, replacing the previous dirty branch containing unrelated MCP changes.

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Valid custom channel plugins lacking an `outbound` capability were incorrectly captured by the internal sink.
- Real environment tested: Local dev environment testing custom plugin routing bounds.
- Exact steps or command run after this patch: Triggered a test tool execution using `message(action=send)` without specifying the `to` parameter from within the custom channel context.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
<img width="700" height="256" alt="Screenshot 2026-06-19 at 1 36 07 PM" src="https://github.com/user-attachments/assets/697309ff-e6fe-4737-bc44-fe305d92421c" />

- Observed result after fix: Message correctly arrived at the external channel rather than being captured by the internal source-reply policy.
- What was not tested: Unrelated official plugins that already define the `outbound` capability (they were unaffected).
- Proof limitations or environment constraints: None.
- Before evidence (optional but encouraged):
 
<img width="732" height="327" alt="Screenshot 2026-06-19 at 1 04 53 PM" src="https://github.com/user-attachments/assets/1462173e-ad5f-4b8f-8005-d2bfa6fd4cbd" />


<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?
`pnpm test src/infra/outbound`
`pnpm check:test-types`

<img width="755" height="475" alt="Screenshot 2026-06-19 at 1 29 49 PM" src="https://github.com/user-attachments/assets/a921c984-6a8f-4b97-8d56-45674355535a" />


What regression coverage was added or updated?
The fix relies on the extensive existing test suite for outbound routing. All existing tests cover the core channel validation behavior successfully.

What failed before this fix, if known?
Plugins lacking `plugin.outbound` resulted in `resolveOutboundChannelPlugin` returning `undefined`, causing the channel validation to instantly evaluate to `false`.

If no test was added, why not?
All 709 tests across the 36 test files in `src/infra/outbound` pass perfectly with this change, confirming no regressions to the existing routing logic. We did not permanently add the temporary bug-repro test file because it uses a mocked custom plugin which interferes with standard test-suite channel bootstrapping rules.

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
Yes (fixes broken routing for custom plugins).

Did config, environment, or migration behavior change? (`Yes/No`)
No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
No.

What is the highest-risk area?
The channel fallback logic in `internal-source-reply.ts`. 

How is that risk mitigated?
By explicitly ensuring we only return `false` if *both* `plugin?.actions?.handleAction` and `plugin?.outbound` are falsy, which strictly narrows the fix to the exact intended plugins without disrupting official ones.

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?
Maintainer review and merge.

What is still waiting on author, maintainer, CI, or external proof?
Waiting for CI to pass.

Which bot or reviewer comments were addressed?
Created a clean branch isolating only the routing fix, per maintainer feedback on the previous dirty branch.

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>