### PR TITLE
fix(ci): remove stale activation-scoped web search filter from contract tests

### DIFF
--- a/src/plugins/contracts/loader.contract.test.ts
+++ b/src/plugins/contracts/loader.contract.test.ts
@@ -10,8 +10,6 @@ function resolveBundledManifestProviderPluginIds() {
   return uniqueSortedStrings(resolveBundledContractSnapshotPluginIds("providerIds"));
 }
 
-const ACTIVATION_SCOPED_WEB_SEARCH_PLUGIN_IDS = ["codex", "qa-lab"] as const;
-
 function expectPluginAllowlistEquals(
   allow: string[] | undefined,
   pluginIds: string[],
@@ -61,13 +59,6 @@ describe("plugin loader contract", () => {
   });
 
   it("keeps bundled web search loading scoped to the web search registry", () => {
-    const expectedPluginIds = uniqueSortedStrings([
-      ...bundledWebSearchPluginIds,
-      ...ACTIVATION_SCOPED_WEB_SEARCH_PLUGIN_IDS,
-    ]);
-    expect(webSearchPluginIds).toEqual(expectedPluginIds);
-    expect(
-      webSearchPluginIds.filter((pluginId) => !bundledWebSearchPluginIds.includes(pluginId)),
-    ).toEqual([...ACTIVATION_SCOPED_WEB_SEARCH_PLUGIN_IDS]);
+    expect(webSearchPluginIds).toEqual(uniqueSortedStrings(bundledWebSearchPluginIds));
   });
 });

--- a/src/plugins/contracts/registry.contract.test.ts
+++ b/src/plugins/contracts/registry.contract.test.ts
@@ -10,8 +10,6 @@ import {
   providerContractPluginIds,
 } from "./registry.js";
 
-const ACTIVATION_SCOPED_WEB_SEARCH_PLUGIN_IDS = ["codex", "qa-lab"] as const;
-
 describe("plugin contract registry", () => {
   function expectUniqueIds(ids: readonly string[]) {
     expect(ids).toEqual([...new Set(ids)]);
@@ -248,20 +246,13 @@ describe("plugin contract registry", () => {
       contract: "webSearchProviders",
       origin: "bundled",
     });
-    const expectedPluginIds = uniqueSortedStrings([
-      ...bundledWebSearchPluginIds,
-      ...ACTIVATION_SCOPED_WEB_SEARCH_PLUGIN_IDS,
-    ]);
     const actualPluginIds = uniqueSortedStrings(
       pluginRegistrationContractRegistry
         .filter((entry) => entry.webSearchProviderIds.length > 0)
         .map((entry) => entry.pluginId),
     );
 
-    expect(actualPluginIds).toEqual(expectedPluginIds);
-    expect(
-      actualPluginIds.filter((pluginId) => !bundledWebSearchPluginIds.includes(pluginId)),
-    ).toEqual([...ACTIVATION_SCOPED_WEB_SEARCH_PLUGIN_IDS]);
+    expect(actualPluginIds).toEqual(uniqueSortedStrings(bundledWebSearchPluginIds));
   });
 
   it("covers every bundled migration provider plugin discovered from manifests", () => {


### PR DESCRIPTION
## Summary

- Problem: Contract tests `registry.contract.test.ts` and `loader.contract.test.ts` fail with `expected [] to deeply equal ['codex', 'qa-lab']` because they expect these plugins to be separate from the bundled web search registry.
- What changed: Removed stale `ACTIVATION_SCOPED_WEB_SEARCH_PLUGIN_IDS` filter. Both `codex` and `qa-lab` are now properly bundled plugins with `webSearchProviders` in their manifests and are included in `BUNDLED_PLUGIN_CONTRACT_SNAPSHOTS`.
- What did NOT change: No runtime code changes. Only test expectations updated.
- Outcome: Contract tests pass. CI `checks-fast-contracts-plugins-b` will no longer fail on unrelated PRs.

Fixes #94957

## Verification

```bash
node scripts/run-vitest.mjs src/plugins/contracts/registry.contract.test.ts
node scripts/run-vitest.mjs src/plugins/contracts/loader.contract.test.ts
```

## Impact Assessment

- Scope: Contract tests only
- Downstream: Unblocks CI for all PRs affected by this test failure
- Edge cases: None — codex and qa-lab are confirmed bundled plugins

## Real behavior proof

**Behavior addressed:** Contract tests incorrectly expected codex and qa-lab to be activation-scoped (separate from bundled registry), causing CI failures across multiple PRs.

**Environment tested:** Node.js v22, branch fix/issue-94957

**Steps run after the patch:**

```bash
node --import tsx --input-type=module -e '
import { pluginRegistrationContractRegistry } from "./src/plugins/contracts/registry.ts";
import { resolveManifestContractPluginIds } from "./src/plugins/plugin-registry-contributions.ts";

const bundledWebSearchPluginIds = resolveManifestContractPluginIds({
  contract: "webSearchProviders",
  origin: "bundled",
});

const actualPluginIds = pluginRegistrationContractRegistry
  .filter((entry) => entry.webSearchProviderIds.length > 0)
  .map((entry) => entry.pluginId)
  .sort();

const diff = actualPluginIds.filter(id => !bundledWebSearchPluginIds.includes(id));
console.log("bundled count:", bundledWebSearchPluginIds.length);
console.log("registry count:", actualPluginIds.length);
console.log("diff (should be empty):", JSON.stringify(diff));
'
```

**Evidence after fix (console output):**

```text
bundled count: 15
registry count: 15
diff (should be empty): []
```

**Observed result:** codex and qa-lab are in both bundledWebSearchPluginIds and actualPluginIds. The filter returns empty, confirming the plugins are properly bundled.

**Not tested:** Not tested against live CI — the proof validates the test logic locally.
