### PR TITLE
fix(feishu): skip reply anchor for DM streaming cards (fixes #94922)

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -2108,4 +2108,129 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       nowSpy.mockRestore();
     }
   });
+
+  it("skips reply anchor for ordinary DM with streaming enabled (fixes #94922)", async () => {
+    // Arrange: Ordinary DM session (not group, not thread reply)
+    // skipReplyToInMessages=true simulates what bot.ts calculates for P2P DMs
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "auto",
+        streaming: true,
+      },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_dm_chat",
+      replyToMessageId: "om_parent",
+      skipReplyToInMessages: true, // Key fix: DM should skip reply anchor
+      replyInThread: false,
+      threadReply: false,
+    });
+
+    const options = firstTypingDispatcherOptions();
+
+    // Act: Send a streaming reply
+    await options.deliver({ text: "DM reply without reply anchor" }, { kind: "final" });
+    await options.onIdle?.();
+
+    // Assert: streaming.start should be called with replyToMessageId: undefined
+    expect(streamingInstances).toHaveLength(1);
+    const startOptions = firstMockArg(streamingInstances[0].start, "streaming start", 2) as Record<
+      string,
+      unknown
+    >;
+    expect(startOptions.replyToMessageId).toBeUndefined();
+    expect(startOptions.replyInThread).toBe(false);
+  });
+
+  it("preserves reply anchor for group topic with streaming enabled", async () => {
+    // Arrange: Group topic session
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "auto",
+        streaming: true,
+      },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_group_chat",
+      replyToMessageId: "om_topic_root",
+      rootId: "om_topic_root",
+      isGroup: true,
+      directThreadReply: false,
+      replyInThread: true,
+    });
+
+    const options = firstTypingDispatcherOptions();
+
+    // Act: Send a streaming reply to group topic
+    await options.deliver({ text: "Group topic reply" }, { kind: "final" });
+    await options.onIdle?.();
+
+    // Assert: streaming.start should preserve replyToMessageId for group topics
+    expect(streamingInstances).toHaveLength(1);
+    const startOptions = firstMockArg(streamingInstances[0].start, "streaming start", 2) as Record<
+      string,
+      unknown
+    >;
+    expect(startOptions.replyToMessageId).toBe("om_topic_root");
+    expect(startOptions.rootId).toBe("om_topic_root");
+    expect(startOptions.replyInThread).toBe(true);
+  });
+
+  it("preserves reply anchor for P2P thread reply with streaming enabled", async () => {
+    // Arrange: P2P thread reply session
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "auto",
+        streaming: true,
+      },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_dm_thread",
+      replyToMessageId: "om_dm_thread_root",
+      rootId: "om_dm_thread_root",
+      isGroup: false,
+      directThreadReply: true,
+      threadReply: true,
+    });
+
+    const options = firstTypingDispatcherOptions();
+
+    // Act: Send a streaming reply in P2P thread
+    await options.deliver({ text: "P2P thread reply" }, { kind: "final" });
+    await options.onIdle?.();
+
+    // Assert: streaming.start should preserve replyToMessageId for P2P threads
+    expect(streamingInstances).toHaveLength(1);
+    const startOptions = firstMockArg(streamingInstances[0].start, "streaming start", 2) as Record<
+      string,
+      unknown
+    >;
+    expect(startOptions.replyToMessageId).toBe("om_dm_thread_root");
+    expect(startOptions.rootId).toBe("om_dm_thread_root");
+    expect(startOptions.replyInThread).toBe(true);
+  });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -392,7 +392,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         const cardHeader = resolveCardHeader(agentId, identity);
         const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
         await streaming.start(chatId, resolveReceiveIdType(chatId), {
-          replyToMessageId,
+          replyToMessageId: sendReplyToMessageId,
           replyInThread: effectiveReplyInThread,
           rootId,
           header: cardHeader,


### PR DESCRIPTION
## Summary

Fix Feishu streaming cards incorrectly using reply mode for ordinary direct messages, causing "Reply to [User]" labels and slower message delivery.

Fixes #94922

## Real behavior proof (required for external PRs)

**Behavior addressed**: 
Feishu DM replies were showing "Reply to [User]" labels due to streaming path not respecting the `skipReplyToInMessages` decision that was already correctly applied to non-streaming path.

**Real setup tested**:
- **Runtime**: Unit tests with mocked Feishu client and streaming session

**Exact steps or command run after fix**:

```bash
node scripts/run-vitest.mjs extensions/feishu/src/reply-dispatcher.test.ts --reporter=verbose
```

**After-fix evidence**:

```
✓ |extension-feishu| extensions/feishu/src/reply-dispatcher.test.ts > createFeishuReplyDispatcher streaming behavior > skips reply anchor for ordinary DM with streaming enabled (fixes #94922) 2ms
✓ |extension-feishu| extensions/feishu/src/reply-dispatcher.test.ts > createFeishuReplyDispatcher streaming behavior > preserves reply anchor for group topic with streaming enabled 2ms
✓ |extension-feishu| extensions/feishu/src/reply-dispatcher.test.ts > createFeishuReplyDispatcher streaming behavior > preserves reply anchor for P2P thread reply with streaming enabled 2ms

Test Files  1 passed (1)
     Tests  85 passed (85)
```

**Observed result after the fix**: 
All unit tests pass including 3 new tests specifically covering the reported bug scenario and regression prevention.

**What was not tested**: 
Live Feishu tenant validation - requires maintainer access to Feishu environment to verify the visual "Reply to" label is removed in actual DM conversations.

## Tests and validation

- Added 3 new test cases in `reply-dispatcher.test.ts`:
  1. DM skip reply anchor (regression test for #94922)
  2. Group topic preserve reply anchor (regression prevention)
  3. P2P thread preserve reply anchor (regression prevention)
  
- All existing tests pass: 85/85 in reply-dispatcher.test.ts, 87/87 in bot.test.ts
- No breaking changes to existing functionality

## Risk checklist

Did user-visible behavior change? (`Yes` / `No`)

**Yes** - Intentional fix: Feishu DM replies will no longer show "Reply to [User]" labels when streaming is enabled (default behavior). This restores the correct behavior that existed before the streaming feature was added.

Did config, environment, or migration behavior change? (`Yes` / `No`)

**No** - No configuration changes required. The fix uses existing `skipReplyToInMessages` logic that was already calculated but not applied to streaming path.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes` / `No`)

**No** - Only affects message routing mode (reply vs create), no security implications.

What is the highest-risk area?
- Streaming card delivery for Feishu channel

How is that risk mitigated?
- Comprehensive test coverage of all three scenarios (DM, group topic, P2P thread)
- Minimal one-line code change using existing well-tested logic
- Preserves backward compatibility for group chats and thread replies

## Current review state

What is the next action?
- Maintainer review
- Live Feishu validation (verify DM replies no longer show "Reply to" label)
