### PR TITLE
fix(telegram): handle EADDRNOTAVAIL local socket exhaustion correctly [AI-assisted]

### DIFF
--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -1193,6 +1193,27 @@ describe("resolveTelegramFetch", () => {
     expect(undiciFetch).toHaveBeenCalledTimes(1);
   });
 
+  it("does not retry on EADDRNOTAVAIL local socket allocation failure", async () => {
+    const fetchError = buildFetchFallbackError("EADDRNOTAVAIL");
+    undiciFetch.mockRejectedValue(fetchError);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+      },
+    });
+
+    await expect(resolved("https://api.telegram.org/botx/sendMessage")).rejects.toThrow(
+      "fetch failed",
+    );
+
+    expect(undiciFetch).toHaveBeenCalledTimes(1);
+    expectLoggerMessageContaining(
+      loggerWarn,
+      "telegram transport encountered local socket allocation failure (EADDRNOTAVAIL)",
+    );
+  });
+
   it("retries sticky fallback when the local network is down during connect", async () => {
     undiciFetch
       .mockRejectedValueOnce(buildFetchFallbackError("ENETDOWN"))

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -473,6 +473,12 @@ function shouldUseTelegramTransportFallback(err: unknown): boolean {
         : "",
     codes: collectErrorCodes(err),
   };
+  if (ctx.codes.has("EADDRNOTAVAIL") || ctx.message.includes("eaddrnotavail")) {
+    log.warn(
+      "telegram transport encountered local socket allocation failure (EADDRNOTAVAIL) — check ephemeral ports / mbuf zones / network extensions; remote IP rotation will not help",
+    );
+    return false;
+  }
   const hasFetchFailedEnvelope = ctx.message.includes("fetch failed");
   const hasKnownNetworkCode = FALLBACK_RETRY_ERROR_CODES.some((code) => ctx.codes.has(code));
   return hasKnownNetworkCode || (hasFetchFailedEnvelope && ctx.codes.size === 0);


### PR DESCRIPTION
### Summary
This PR resolves an issue where the Telegram transport incorrectly attempts IP-rotation fallback retries when hitting a local socket allocation failure (`EADDRNOTAVAIL`).

### Changes
- Updated `shouldUseTelegramTransportFallback` in `extensions/telegram/src/fetch.ts` to detect `EADDRNOTAVAIL` error codes or socket allocation failure error messages.
- If `EADDRNOTAVAIL` is detected, it logs an accurate warning message ("telegram transport encountered local socket allocation failure (EADDRNOTAVAIL) — check ephemeral ports / mbuf zones / network extensions; remote IP rotation will not help") and returns `false` to immediately throw the error, skipping unnecessary IP-rotation retries.
- Added a unit test in `extensions/telegram/src/fetch.test.ts` to verify the correct handling of `EADDRNOTAVAIL` socket allocation failures.

### Real behavior proof
All tests in `extensions/telegram/src/fetch.test.ts` pass successfully:
```
 ✓  extension-telegram  ../../extensions/telegram/src/fetch.test.ts (43 tests) 2246ms
     ✓ normalizes a full bot endpoint apiRoot before callers append bot paths  305ms
```
