### PR TITLE
fix(cli): wire remote eligibility into CLI skills status commands

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -233,6 +233,14 @@ vi.mock("../skills/discovery/status.js", async (importOriginal) => ({
     mocks.buildWorkspaceSkillStatusMock(workspaceDir, options),
 }));
 
+vi.mock("../skills/runtime/remote.js", () => ({
+  getRemoteSkillEligibility: () => undefined,
+}));
+
+vi.mock("../agents/exec-defaults.js", () => ({
+  canExecRequestNode: () => false,
+}));
+
 describe("skills cli commands", () => {
   const createProgram = () => {
     const program = new Command();

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -130,9 +130,16 @@ async function loadSkillsStatusReport(
     return gatewayReport;
   }
   const { buildWorkspaceSkillStatus } = await import("../skills/discovery/status.js");
+  const { getRemoteSkillEligibility } = await import("../skills/runtime/remote.js");
+  const { canExecRequestNode } = await import("../agents/exec-defaults.js");
   return buildWorkspaceSkillStatus(resolved.workspaceDir, {
     config: resolved.config,
     agentId: resolved.agentId,
+    eligibility: {
+      remote: getRemoteSkillEligibility({
+        advertiseExecNode: canExecRequestNode({ cfg: resolved.config, agentId: resolved.agentId }),
+      }),
+    },
   });
 }
 


### PR DESCRIPTION
## Summary

The CLI skills status commands (`openclaw skills list`, `openclaw skills check`, `openclaw skills info`) use a local-only `loadSkillsStatusReport` path that bypasses the existing remote-aware Gateway `skills.status` implementation. This causes macOS-only skills like `apple-notes` to report as ineligible on Linux gateway hosts even when a paired, connected macOS exec node resolves the required `memo` binary via `system.which`.

The Gateway's `skills.status` handler already builds remote-aware status via `buildRemoteAwareWorkspaceSkillStatus`, which passes `eligibility.remote` from `getRemoteSkillEligibility`. However, the CLI path in `loadSkillsStatusReport` calls `buildWorkspaceSkillStatus` without the remote eligibility option, creating a CLI/Gateway status mismatch.

This fix wires remote eligibility into the CLI path by adding dynamic imports for `getRemoteSkillEligibility` and `canExecRequestNode`, matching the exact pattern used by the Gateway, `status-all/report-data`, and `chat-commands` modules. The change is purely structural — no new logic is introduced — and when no remote macOS node is connected, `getRemoteSkillEligibility` returns `undefined` making behavior identical to before the fix.

Fixes #94956

## Real behavior proof

**Behavior addressed**: CLI skills status commands (list, check, info) did not consider remote macOS exec nodes when evaluating skill eligibility, causing apple-notes to report os:darwin and bins:memo as missing even when a connected macOS node resolves memo via system.which.

**Real environment tested**: Linux x86_64 (Ubuntu 24.04.4 LTS, kernel 6.8.0-124-generic), Node.js v25.9.0, OpenClaw main @ b3dfa0f1b1

**Exact steps or command run after this patch**: node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts src/skills/runtime/remote.test.ts src/skills/discovery/status.test.ts (all 3 test suites)

**After-fix evidence**:
```
> node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts
Test Files  1 passed (1), Tests  52 passed (52)

> node scripts/run-vitest.mjs src/skills/runtime/remote.test.ts
Test Files  1 passed (1), Tests  12 passed (12)

> node scripts/run-vitest.mjs src/skills/discovery/status.test.ts
Test Files  1 passed (1), Tests  12 passed (12)
```

**Observed result after the fix**: All 76 tests across 3 suites pass. The loadSkillsStatusReport function now includes eligibility.remote in its buildWorkspaceSkillStatus call, matching the Gateway's buildRemoteAwareWorkspaceSkillStatus pattern. When a remote macOS node is connected with memo available, getRemoteSkillEligibility will return platforms:darwin with resolved bins, making apple-notes eligible. The existing remote.test.ts suite validates this logic and passes unchanged.

**What was not tested**: End-to-end verification with a live macOS remote node was not performed (no macOS node available in this environment). The fix follows the identical import and call pattern used by src/gateway/server-methods/skills.ts, src/commands/status-all/report-data.ts, and src/skills/discovery/chat-commands.ts, all validated in production. The remote eligibility logic itself is unchanged and covered by its existing test suite.

## Tests and validation

### Unit tests

All 76 tests across 3 test suites pass:

```
> node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts
Test Files  1 passed (1)
     Tests  52 passed (52)

> node scripts/run-vitest.mjs src/skills/runtime/remote.test.ts
Test Files  1 passed (1)
     Tests  12 passed (12)

> node scripts/run-vitest.mjs src/skills/discovery/status.test.ts
Test Files  1 passed (1)
     Tests  12 passed (12)
```

### Integration / E2E

The fix is purely structural — it wires an existing, tested code path (`getRemoteSkillEligibility` + `canExecRequestNode`) into the CLI entry point. No new logic is introduced. The Gateway's `skills.status` handler and the `status-all` report already use this exact pattern and have been verified in production. Both functions are called dynamically (no new static module dependencies), preserving the existing lazy-load architecture of the CLI module.

## Risk checklist

- [x] This change is backwards compatible — when no remote macOS node is connected, `getRemoteSkillEligibility` returns `undefined` and behavior is identical to before
- [x] This change has been tested with existing configurations — all 76 related unit tests pass; CLI test suite explicitly mocks `getRemoteSkillEligibility` returning `undefined` (default case)
- [x] I have updated relevant documentation — no API or config changes; the fix aligns CLI behavior with documented Gateway behavior
- [x] Breaking changes (if any) are documented in Summary — no breaking changes

## Current review state

- [x] Self-review completed
- [ ] At least one maintainer review
- [ ] All CI checks passed
