### PR TITLE
fix(telegram): honor outbound reaction directives

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -39,7 +39,7 @@ import {
 } from "../format.js";
 import { resolveTelegramInteractiveTextFallback } from "../interactive-fallback.js";
 import { splitTelegramRichMessageTextChunks, TELEGRAM_RICH_TEXT_LIMIT } from "../rich-message.js";
-import { buildInlineKeyboard } from "../send.js";
+import { buildInlineKeyboard, reactMessageTelegram } from "../send.js";
 import { resolveTelegramVoiceSend } from "../voice.js";
 import {
   buildTelegramSendParams,
@@ -67,6 +67,9 @@ type DeliveryProgress = ReplyThreadDeliveryProgress & {
 type TelegramReplyChannelData = {
   buttons?: TelegramInlineButtons;
   pin?: boolean;
+  reaction?: {
+    emoji?: unknown;
+  };
 };
 
 type TelegramReplyQuoteForSend = {
@@ -823,7 +826,16 @@ export async function deliverReplies(params: {
     if (reply && resolvedReplyText !== (reply.text ?? "")) {
       reply = { ...reply, text: resolvedReplyText };
     }
-    if (!resolvedReplyText && !hasMedia) {
+    const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;
+    const reactionEmoji =
+      typeof telegramData?.reaction?.emoji === "string" ? telegramData.reaction.emoji : undefined;
+    const replyToId =
+      params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
+    if (reactionEmoji && typeof replyToId !== "number") {
+      params.runtime.error?.(danger("Telegram reaction requires a reply target"));
+      continue;
+    }
+    if (!resolvedReplyText && !hasMedia && !reactionEmoji) {
       if (reply?.audioAsVoice) {
         logVerbose("telegram reply has audioAsVoice without media/text; skipping");
         continue;
@@ -838,8 +850,6 @@ export async function deliverReplies(params: {
         ? reply.spokenText
         : undefined;
     const hookContent = spokenHookContent ?? rawContent;
-    const replyToId =
-      params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
     const replyQuote = resolveReplyQuoteForSend({
       replyToId,
       replyQuoteByMessageId: params.replyQuoteByMessageId,
@@ -882,7 +892,6 @@ export async function deliverReplies(params: {
 
     try {
       const deliveredCountBeforeReply = progress.deliveredCount;
-      const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;
       const replyMarkup = buildInlineKeyboard(
         resolveTelegramInlineButtons({
           buttons: telegramData?.buttons,
@@ -891,7 +900,23 @@ export async function deliverReplies(params: {
         }),
       );
       let firstDeliveredMessageId: number | undefined;
-      if (mediaList.length === 0) {
+      if (reactionEmoji && typeof replyToId === "number") {
+        const reactionResult = await reactMessageTelegram(params.chatId, replyToId, reactionEmoji, {
+          cfg: params.cfg ?? { channels: { telegram: { botToken: params.token } } },
+          token: params.token,
+          accountId: params.accountId,
+          api: params.bot.api,
+          verbose: false,
+        });
+        if (reactionResult.ok) {
+          progress.hasDelivered = true;
+          progress.deliveredCount += 1;
+        } else {
+          params.runtime.error?.(danger(reactionResult.warning));
+          continue;
+        }
+      }
+      if (mediaList.length === 0 && resolvedReplyText) {
         firstDeliveredMessageId = await deliverTextReply({
           bot: params.bot,
           chatId: params.chatId,
@@ -912,7 +937,7 @@ export async function deliverReplies(params: {
           replyToMode: params.replyToMode,
           progress,
         });
-      } else {
+      } else if (mediaList.length > 0) {
         const mediaDelivery = await deliverMediaReply({
           reply,
           mediaList,

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -122,7 +122,7 @@ function createBot(api: Record<string, unknown> = {}): Bot {
 }
 
 async function deliverWith(params: DeliverWithParams) {
-  await deliverReplies({
+  return await deliverReplies({
     ...baseDeliveryParams,
     ...params,
     mediaLoader: params.mediaLoader ?? loadWebMedia,
@@ -275,6 +275,103 @@ describe("deliverReplies", () => {
     expect(runtime.error).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(firstMockCallArg(sendMessage, 1)).toBe("hello");
+  });
+
+  it("applies reaction-only replies without logging missing text/media", async () => {
+    const runtime = createRuntime(false);
+    const setMessageReaction = vi.fn().mockResolvedValue(true);
+    const sendMessage = vi.fn();
+    const bot = createBot({ sendMessage, setMessageReaction });
+
+    await deliverWith({
+      replies: [
+        {
+          replyToId: "456",
+          channelData: {
+            telegram: {
+              reaction: { emoji: "🔥" },
+            },
+          },
+        },
+      ],
+      replyToMode: "all",
+      runtime,
+      bot,
+    });
+
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(setMessageReaction).toHaveBeenCalledWith("123", 456, [{ type: "emoji", emoji: "🔥" }]);
+  });
+
+  it("does not mark rejected reaction-only replies as delivered", async () => {
+    const runtime = createRuntime(false);
+    const setMessageReaction = vi.fn().mockRejectedValue(new Error("REACTION_INVALID"));
+    const bot = createBot({ sendMessage: vi.fn(), setMessageReaction });
+
+    const result = await deliverWith({
+      replies: [
+        {
+          replyToId: "456",
+          channelData: { telegram: { reaction: { emoji: "not-supported" } } },
+        },
+      ],
+      replyToMode: "all",
+      runtime,
+      bot,
+    });
+
+    expect(result).toEqual({ delivered: false });
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Reaction unavailable"));
+  });
+
+  it("does not send text when a reaction reply has no target", async () => {
+    const runtime = createRuntime(false);
+    const setMessageReaction = vi.fn();
+    const sendMessage = vi.fn();
+    const bot = createBot({ sendMessage, setMessageReaction });
+
+    const result = await deliverWith({
+      replies: [
+        {
+          text: "Done",
+          replyToId: "456",
+          channelData: { telegram: { reaction: { emoji: "🔥" } } },
+        },
+      ],
+      replyToMode: "off",
+      runtime,
+      bot,
+    });
+
+    expect(result).toEqual({ delivered: false });
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("requires a reply target"));
+    expect(setMessageReaction).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not send text when Telegram rejects the reaction", async () => {
+    const runtime = createRuntime(false);
+    const setMessageReaction = vi.fn().mockRejectedValue(new Error("REACTION_INVALID"));
+    const sendMessage = vi.fn();
+    const bot = createBot({ sendMessage, setMessageReaction });
+
+    const result = await deliverWith({
+      replies: [
+        {
+          text: "Done",
+          replyToId: "456",
+          channelData: { telegram: { reaction: { emoji: "not-supported" } } },
+        },
+      ],
+      replyToMode: "all",
+      runtime,
+      bot,
+    });
+
+    expect(result).toEqual({ delivered: false });
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Reaction unavailable"));
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it("mirrors delivered replies once after successful sends", async () => {

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -5,10 +5,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMessageTelegramMock = vi.fn();
 const pinMessageTelegramMock = vi.fn();
+const reactMessageTelegramMock = vi.fn();
 const sendPollTelegramMock = vi.fn();
 
 vi.mock("./send.js", () => ({
   pinMessageTelegram: (...args: unknown[]) => pinMessageTelegramMock(...args),
+  reactMessageTelegram: (...args: unknown[]) => reactMessageTelegramMock(...args),
   sendPollTelegram: (...args: unknown[]) => sendPollTelegramMock(...args),
   sendMessageTelegram: (...args: unknown[]) => sendMessageTelegramMock(...args),
 }));
@@ -60,6 +62,7 @@ function callOptionsFromEnd(
 describe("telegramOutbound", () => {
   beforeEach(() => {
     pinMessageTelegramMock.mockReset();
+    reactMessageTelegramMock.mockReset();
     sendPollTelegramMock.mockReset();
     sendMessageTelegramMock.mockReset();
   });
@@ -153,6 +156,151 @@ describe("telegramOutbound", () => {
     const options = callOptionsAt(sendMessageTelegramMock, 0, "12345", "- Retry");
     expect(options.buttons).toEqual([[{ text: "Retry", callback_data: "cmd:retry" }]]);
     expect(result).toEqual({ channel: "telegram", messageId: "tg-buttons", chatId: "12345" });
+  });
+
+  it("applies reaction-only payloads without sending empty Telegram text", async () => {
+    reactMessageTelegramMock.mockResolvedValueOnce({ ok: true });
+
+    const result = await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      replyToId: "777",
+      payload: {
+        channelData: {
+          telegram: {
+            reaction: { emoji: "🔥" },
+          },
+        },
+      },
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    expect(reactMessageTelegramMock).toHaveBeenCalledWith("12345", 777, "🔥", {
+      cfg: {},
+      verbose: false,
+      accountId: undefined,
+      gatewayClientScopes: undefined,
+    });
+    expect(sendMessageTelegramMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ channel: "telegram", messageId: "777", chatId: "12345" });
+  });
+
+  it("applies reaction payloads before sending visible text", async () => {
+    reactMessageTelegramMock.mockResolvedValueOnce({ ok: true });
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-text", chatId: "12345" });
+
+    await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      accountId: "ops",
+      replyToId: "777",
+      payload: {
+        text: "Done",
+        channelData: {
+          telegram: {
+            reaction: { emoji: "✅" },
+          },
+        },
+      },
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    expect(reactMessageTelegramMock).toHaveBeenCalledWith(
+      "12345",
+      777,
+      "✅",
+      expect.objectContaining({ accountId: "ops" }),
+    );
+    expect(sendMessageTelegramMock).toHaveBeenCalledWith(
+      "12345",
+      "Done",
+      expect.objectContaining({ accountId: "ops", replyToMessageId: 777 }),
+    );
+    expect(reactMessageTelegramMock.mock.invocationCallOrder[0]).toBeLessThan(
+      sendMessageTelegramMock.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("rejects text plus reaction payloads without a reply target", async () => {
+    await expect(
+      telegramOutbound.sendPayload!({
+        cfg: {} as never,
+        to: "12345",
+        text: "",
+        payload: {
+          text: "Done",
+          channelData: { telegram: { reaction: { emoji: "🔥" } } },
+        },
+        deps: { sendTelegram: sendMessageTelegramMock },
+      }),
+    ).rejects.toThrow("Telegram reaction requires a reply target");
+
+    expect(reactMessageTelegramMock).not.toHaveBeenCalled();
+    expect(sendMessageTelegramMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects text plus reaction payloads when Telegram refuses the emoji", async () => {
+    reactMessageTelegramMock.mockResolvedValueOnce({
+      ok: false,
+      warning: "Reaction unavailable: not-supported",
+    });
+
+    await expect(
+      telegramOutbound.sendPayload!({
+        cfg: {} as never,
+        to: "12345",
+        text: "",
+        replyToId: "777",
+        payload: {
+          text: "Done",
+          channelData: { telegram: { reaction: { emoji: "not-supported" } } },
+        },
+        deps: { sendTelegram: sendMessageTelegramMock },
+      }),
+    ).rejects.toThrow("Reaction unavailable: not-supported");
+
+    expect(sendMessageTelegramMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects reaction-only payloads without a reply target", async () => {
+    await expect(
+      telegramOutbound.sendPayload!({
+        cfg: {} as never,
+        to: "12345",
+        text: "",
+        payload: {
+          channelData: { telegram: { reaction: { emoji: "🔥" } } },
+        },
+        deps: { sendTelegram: sendMessageTelegramMock },
+      }),
+    ).rejects.toThrow("Telegram reaction requires a reply target");
+
+    expect(reactMessageTelegramMock).not.toHaveBeenCalled();
+    expect(sendMessageTelegramMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects reaction-only payloads when Telegram refuses the emoji", async () => {
+    reactMessageTelegramMock.mockResolvedValueOnce({
+      ok: false,
+      warning: "Reaction unavailable: not-supported",
+    });
+
+    await expect(
+      telegramOutbound.sendPayload!({
+        cfg: {} as never,
+        to: "12345",
+        text: "",
+        replyToId: "777",
+        payload: {
+          channelData: { telegram: { reaction: { emoji: "not-supported" } } },
+        },
+        deps: { sendTelegram: sendMessageTelegramMock },
+      }),
+    ).rejects.toThrow("Reaction unavailable: not-supported");
+
+    expect(sendMessageTelegramMock).not.toHaveBeenCalled();
   });
 
   it("uses presentation button labels as fallback text for presentation-only payloads", async () => {

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -32,6 +32,7 @@ export const TELEGRAM_POLL_OPTION_LIMIT = 10;
 
 type TelegramSendFn = typeof import("./send.js").sendMessageTelegram;
 type TelegramSendOpts = Parameters<TelegramSendFn>[2];
+type TelegramReactionFn = typeof import("./send.js").reactMessageTelegram;
 type ResolveTelegramSendFn = (deps?: OutboundSendDeps) => Promise<TelegramSendFn>;
 type LoadTelegramSendModuleFn = () => Promise<TelegramSendModule>;
 
@@ -113,15 +114,22 @@ export type CreateTelegramOutboundAdapterOptions = {
 
 export async function sendTelegramPayloadMessages(params: {
   send: TelegramSendFn;
+  react: TelegramReactionFn;
   to: string;
   payload: ReplyPayload;
   baseOpts: Omit<NonNullable<TelegramSendOpts>, "buttons" | "mediaUrl" | "quoteText">;
 }): Promise<Awaited<ReturnType<TelegramSendFn>>> {
   const telegramData = params.payload.channelData?.telegram as
-    | { buttons?: TelegramInlineButtons; quoteText?: string }
+    | {
+        buttons?: TelegramInlineButtons;
+        quoteText?: string;
+        reaction?: { emoji?: unknown; replyToId?: unknown; replyToCurrent?: unknown };
+      }
     | undefined;
   const quoteText =
     typeof telegramData?.quoteText === "string" ? telegramData.quoteText : undefined;
+  const reactionEmoji =
+    typeof telegramData?.reaction?.emoji === "string" ? telegramData.reaction.emoji : undefined;
   const presentation = normalizeMessagePresentation(params.payload.presentation);
   const text =
     resolveTelegramInteractiveTextFallback({
@@ -135,11 +143,29 @@ export async function sendTelegramPayloadMessages(params: {
     presentation,
     interactive: params.payload.interactive,
   });
+  const replyToMessageId = params.baseOpts.replyToMessageId;
   const payloadOpts = {
     ...params.baseOpts,
     quoteText,
     ...(params.payload.audioAsVoice === true ? { asVoice: true } : {}),
   };
+  if (reactionEmoji) {
+    if (typeof replyToMessageId !== "number") {
+      throw new Error("Telegram reaction requires a reply target");
+    }
+    const reactionResult = await params.react(params.to, replyToMessageId, reactionEmoji, {
+      cfg: params.baseOpts.cfg,
+      accountId: params.baseOpts.accountId,
+      gatewayClientScopes: params.baseOpts.gatewayClientScopes,
+      verbose: false,
+    });
+    if (!reactionResult.ok) {
+      throw new Error(reactionResult.warning);
+    }
+  }
+  if (reactionEmoji && !text && mediaUrls.length === 0 && !buttons?.length) {
+    return { messageId: String(replyToMessageId), chatId: params.to };
+  }
 
   // Telegram allows reply_markup on media; attach buttons only to the first send.
   return await sendPayloadMediaSequenceOrFallback({
@@ -278,8 +304,10 @@ export function createTelegramOutboundAdapter(
         ...params,
         resolveSend,
       });
+      const { reactMessageTelegram } = await loadSendModule();
       const result = await sendTelegramPayloadMessages({
         send,
+        react: reactMessageTelegram,
         to: outboundTo,
         payload: params.payload,
         baseOpts: {

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -304,6 +304,30 @@ describe("createBlockReplyDeliveryHandler", () => {
     expect(normalized.payload.replyToCurrent).toBeUndefined();
   });
 
+  it("normalizes reaction directives into Telegram channel data", () => {
+    const normalized = normalizeReplyPayloadDirectives({
+      payload: { text: "[[react_to_current:✅]]" },
+      currentMessageId: "msg-123",
+      trimLeadingWhitespace: true,
+      parseMode: "auto",
+    });
+
+    expect(normalized.payload).toMatchObject({
+      text: undefined,
+      replyToId: "msg-123",
+      replyToCurrent: true,
+      channelData: {
+        telegram: {
+          reaction: {
+            emoji: "✅",
+            replyToCurrent: true,
+            replyToId: "msg-123",
+          },
+        },
+      },
+    });
+  });
+
   it("passes structured media block replies through media path normalization", async () => {
     const blockReplyPipeline = {
       enqueue: vi.fn(),

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -6,7 +6,7 @@ import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { BlockReplyContext, ReplyPayload, ReplyThreadingPolicy } from "../types.js";
 import type { BlockReplyPipeline } from "./block-reply-pipeline.js";
 import { createBlockReplyContentKey } from "./block-reply-pipeline.js";
-import { parseReplyDirectives } from "./reply-directives.js";
+import { mergeReactionDirectiveChannelData, parseReplyDirectives } from "./reply-directives.js";
 import { applyReplyTagsToPayload, isRenderablePayload } from "./reply-payloads.js";
 import type { TypingSignaler } from "./typing-mode.js";
 
@@ -51,6 +51,10 @@ export function normalizeReplyPayloadDirectives(params: {
   const mediaUrls = params.payload.mediaUrls ?? parsed?.mediaUrls;
   const mediaUrl = params.payload.mediaUrl ?? parsed?.mediaUrl ?? mediaUrls?.[0];
 
+  const channelData = mergeReactionDirectiveChannelData(
+    params.payload.channelData,
+    parsed?.reaction,
+  );
   return {
     payload: copyReplyPayloadMetadata(params.payload, {
       ...params.payload,
@@ -61,6 +65,7 @@ export function normalizeReplyPayloadDirectives(params: {
       replyToTag: params.payload.replyToTag || parsed?.replyToTag,
       replyToCurrent: params.payload.replyToCurrent || parsed?.replyToCurrent,
       audioAsVoice: Boolean(params.payload.audioAsVoice || parsed?.audioAsVoice),
+      ...(channelData ? { channelData } : {}),
     }),
     isSilent: parsed?.isSilent ?? false,
   };

--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -8,6 +8,11 @@ export type ReplyDirectiveParseResult = {
   text: string;
   mediaUrls?: string[];
   mediaUrl?: string;
+  reaction?: {
+    emoji: string;
+    replyToCurrent?: boolean;
+    replyToId?: string;
+  };
   replyToId?: string;
   replyToCurrent?: boolean;
   replyToTag: boolean;
@@ -23,6 +28,53 @@ type ReplyDirectiveParseOptions = {
   extractMediaDirectives?: boolean;
 };
 
+const REACTION_DIRECTIVE_RE = /\[\[\s*(react|react_to_current)\s*:\s*([^\]\n]+?)\s*\]\]/giu;
+
+function parseReactionDirective(text: string, currentMessageId?: string) {
+  let reaction:
+    | {
+        emoji: string;
+        replyToCurrent?: boolean;
+        replyToId?: string;
+      }
+    | undefined;
+  const cleaned = text.replace(REACTION_DIRECTIVE_RE, (_match, kind: string, rawEmoji: string) => {
+    const emoji = rawEmoji.trim();
+    if (emoji && !reaction) {
+      const replyToCurrent = kind.toLowerCase() === "react_to_current";
+      reaction = {
+        emoji,
+        ...(replyToCurrent ? { replyToCurrent: true } : {}),
+        ...(replyToCurrent && currentMessageId ? { replyToId: currentMessageId } : {}),
+      };
+    }
+    return "";
+  });
+  return { text: reaction ? cleaned.trimStart() : cleaned, reaction };
+}
+
+export function mergeReactionDirectiveChannelData(
+  channelData: Record<string, unknown> | undefined,
+  reaction: ReplyDirectiveParseResult["reaction"] | undefined,
+): Record<string, unknown> | undefined {
+  if (!reaction) {
+    return channelData;
+  }
+  const telegramData =
+    channelData?.telegram &&
+    typeof channelData.telegram === "object" &&
+    !Array.isArray(channelData.telegram)
+      ? (channelData.telegram as Record<string, unknown>)
+      : {};
+  if ("reaction" in telegramData) {
+    return channelData;
+  }
+  return {
+    ...channelData,
+    telegram: { ...telegramData, reaction },
+  };
+}
+
 /** Parses media, reply-target, audio, and silent directives from reply text. */
 export function parseReplyDirectives(
   raw: string,
@@ -33,6 +85,9 @@ export function parseReplyDirectives(
     extractMediaDirectives: options.extractMediaDirectives,
   });
   let text = split.text ?? "";
+
+  const reactionParsed = parseReactionDirective(text, options.currentMessageId);
+  text = reactionParsed.text;
 
   const replyParsed = parseInlineDirectives(text, {
     currentMessageId: options.currentMessageId,
@@ -55,8 +110,10 @@ export function parseReplyDirectives(
     text,
     mediaUrls: split.mediaUrls,
     mediaUrl: split.mediaUrl,
-    replyToId: replyParsed.replyToId,
-    replyToCurrent: replyParsed.replyToCurrent || undefined,
+    reaction: reactionParsed.reaction,
+    replyToId: replyParsed.replyToId ?? reactionParsed.reaction?.replyToId,
+    replyToCurrent:
+      replyParsed.replyToCurrent || reactionParsed.reaction?.replyToCurrent || undefined,
     replyToTag: replyParsed.hasReplyTag,
     audioAsVoice: split.audioAsVoice,
     isSilent,

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -268,6 +268,33 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     expect(twice).toEqual(once);
   });
 
+  it("parses Telegram reaction directives into channel data without visible text", () => {
+    expect(
+      normalizeReplyPayloadsForDelivery([
+        {
+          text: "[[react_to_current:🔥]] Thanks",
+          channelData: { telegram: { quoteText: "quoted" } },
+        },
+      ]),
+    ).toEqual([
+      {
+        text: "Thanks",
+        mediaUrls: undefined,
+        mediaUrl: undefined,
+        replyToId: undefined,
+        replyToCurrent: true,
+        replyToTag: false,
+        audioAsVoice: false,
+        channelData: {
+          telegram: {
+            quoteText: "quoted",
+            reaction: { emoji: "🔥", replyToCurrent: true },
+          },
+        },
+      },
+    ]);
+  });
+
   it("captures a tricky payload matrix snapshot", () => {
     const input: ReplyPayload[] = [
       { text: "NO_REPLY" },

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -1,7 +1,10 @@
 // Outbound payload planning normalizes reply payloads into sendable text,
 // media, presentation, interactive, and mirror projections.
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
+import {
+  mergeReactionDirectiveChannelData,
+  parseReplyDirectives,
+} from "../../auto-reply/reply/reply-directives.js";
 import {
   formatBtwTextForExternalDelivery,
   isRenderablePayload,
@@ -226,6 +229,7 @@ function createOutboundPayloadPlanEntry(
   const isSilent = strippedParsed.isSilent && mergedMedia.length === 0;
   const hasMultipleMedia = (explicitMediaUrls?.length ?? 0) > 1;
   const resolvedMediaUrl = hasMultipleMedia ? undefined : explicitMediaUrl;
+  const channelData = mergeReactionDirectiveChannelData(payload.channelData, parsed.reaction);
   const normalizedPayload: ReplyPayload = {
     ...payload,
     text:
@@ -239,6 +243,7 @@ function createOutboundPayloadPlanEntry(
     replyToTag: payload.replyToTag || parsed.replyToTag,
     replyToCurrent: payload.replyToCurrent || parsed.replyToCurrent,
     audioAsVoice: Boolean(payload.audioAsVoice || parsed.audioAsVoice),
+    ...(channelData ? { channelData } : {}),
   };
   if (!isRenderablePayload(normalizedPayload) && !isSilent) {
     return null;


### PR DESCRIPTION
## Summary

- Parse Telegram reaction directives without leaking them into visible chat text.
- Preserve reaction intent in structured `channelData.telegram.reaction`.
- Support reaction-only replies when a valid target exists.
- Use Telegram's native reaction API instead of simulating the behavior in text.
- Reject missing targets and unsuccessful reaction delivery.

## Linked context

Closes #71140

## Real behavior proof

- Behavior addressed: Telegram reaction directives now normalize into native reaction payloads instead of leaking as visible text or being dropped.
- Real environment tested: OpenClaw Telegram SUT on macOS source checkout, with focused Vitest coverage for the production reply normalization and Telegram delivery paths.
- Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs src/auto-reply/reply/reply-delivery.test.ts src/infra/outbound/payloads.test.ts extensions/telegram/src/outbound-adapter.test.ts extensions/telegram/src/bot/delivery.test.ts
```

- Evidence after fix:

```text
Test Files  4 passed (4)
Tests       134 passed (134)
[test] passed 3 Vitest shards
```

- Observed result after fix: Reaction directives are stripped from visible text, reaction-only payloads reach the Telegram reaction API, and rejected or targetless reactions are not reported as successful delivery.
- What was not tested: A live Telegram account was not exercised from this source checkout. The linked issue contains live Telegram reproduction and prior installed-build validation.
- Negative control / before evidence: Current `main` does not parse reaction directives into structured channel data and rejects reaction-only replies as missing text/media.

## Tests and validation

- Targeted Vitest: 134 tests passed
- Focused core and Telegram lint passed
- Formatting check passed
- `git diff --check` passed
- Core-to-plugin boundary check passed

## Risk checklist

- Did user-visible behavior change? Yes
- Did config, environment, or migration behavior change? No
- Did security, auth, secrets, network, or tool execution behavior change? No
- Highest-risk area: Telegram reaction-only delivery
- Mitigation: Focused parser, normalization, adapter, invalid-reaction, and delivery regression tests

## Current review state

- AI-assisted: Yes, Codex
- Next action: Awaiting maintainer review
- Bot comments addressed: None yet
