### PR TITLE
fix: preserve Windows path separators in splitShellArgs (#92302)

### DIFF
--- a/src/utils/shell-argv.ts
+++ b/src/utils/shell-argv.ts
@@ -30,6 +30,15 @@ export function splitShellArgs(raw: string): string[] | null {
       continue;
     }
     if (!inSingle && !inDouble && ch === "\\") {
+      // POSIX shells escape the next character with backslash outside quotes,
+      // but on Windows absolute paths (e.g. C:\Users\...) the backslash is a
+      // path separator, not an escape. Only consume the backslash when the
+      // next character is a shell metacharacter that actually needs escaping.
+      const next = raw[i + 1];
+      if (next && !/[\s'"\\$`\n\r]/.test(next)) {
+        buf += ch;
+        continue;
+      }
       escaped = true;
       continue;
     }


### PR DESCRIPTION
## Description

splitShellArgs treated all backslashes as POSIX escape characters, consuming them. This broke Windows absolute paths like C:\Users\... that were passed as QMD command paths, causing the backslashes to be stripped and the resulting path to be treated as relative to the workspace.

## Changes
- **`src/utils/shell-argv.ts`**: Only consume backslash as escape when the following character is a shell metacharacter (space, quote, backslash, $, backtick); preserve backslashes before regular characters like path separators.

## Related Issue
Fixes #92302

## AI Assistance
This PR was created with assistance from AI (Claude Code).

## Real behavior proof

**Behavior or issue addressed:** On Windows, absolute paths like C:\Users\...\qmd.js passed as QMD backend commands had their backslashes consumed by splitShellArgs, producing malformed paths like C:Users...qm.js.

**Real environment tested:** Verified with 6 test scenarios covering Windows paths, simple commands, quoted paths, escaped spaces, multiple args, and path with args. All produce correct output.

**Exact steps or command run after the patch:**
```
Input:  "C:\Users\foo\qmd.js"
Output: ["C:\Users\foo\qmd.js"]  (backslashes preserved)

Input:  "my\ file.txt"
Output: ["my file.txt"]  (escaped space still works)

Input:  "node script.js"
Output: ["node", "script.js"]  (normal args unchanged)
```

**After-fix evidence:**
All 6 test cases pass: Windows path preserves backslashes, escaped spaces still consume backslash, quoted paths work, normal args unchanged.

**Observed result after fix:**
- Windows absolute paths (e.g. C:\Users\...\qmd.js) now preserve their backslashes
- Escaped spaces (e.g. my\ file.txt) still correctly consume the backslash
- Simple commands, quoted strings, and multiple args continue to work as before
- The fix is 9 lines in the backslash handling logic

**What was not tested:** Full integration test with QMD on a Windows system (requires Windows environment with QMD installed).