### PR TITLE
fix(memory-core): skip markdown placeholder snippets in short-term promotion (#80582) [AI-assisted]

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -448,6 +448,184 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("does not record bare markdown placeholder markers as short-term recalls", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "notes",
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            source: "memory",
+            startLine: 1,
+            endLine: 1,
+            score: 0.9,
+            snippet: "-",
+          },
+          {
+            path: "memory/2026-04-03.md",
+            source: "memory",
+            startLine: 2,
+            endLine: 2,
+            score: 0.9,
+            snippet: "*",
+          },
+          {
+            path: "memory/2026-04-03.md",
+            source: "memory",
+            startLine: 3,
+            endLine: 3,
+            score: 0.9,
+            snippet: "Real actionable note about the deploy plan.",
+          },
+        ],
+      });
+
+      const entries = Object.values(await readRecallStoreEntries(workspaceDir));
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.snippet).toBe("Real actionable note about the deploy plan.");
+    });
+  });
+
+  it("does not record markdown skeleton ranges as short-term recalls", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "notes",
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            source: "memory",
+            startLine: 1,
+            endLine: 4,
+            score: 0.9,
+            snippet: ["## Tagesnotizen", "-", "## Entscheidungen", "-"].join("\n"),
+          },
+          {
+            path: "memory/2026-04-03.md",
+            source: "memory",
+            startLine: 5,
+            endLine: 5,
+            score: 0.9,
+            snippet: "Heading with body - kept because it carries real content.",
+          },
+        ],
+      });
+
+      const entries = Object.values(await readRecallStoreEntries(workspaceDir));
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.snippet).toBe("Heading with body - kept because it carries real content.");
+    });
+  });
+
+  it("does not record bare markdown placeholders as grounded short-term candidates", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordGroundedShortTermCandidates({
+        workspaceDir,
+        query: "notes",
+        items: [
+          {
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 1,
+            snippet: "-",
+            score: 0.9,
+          },
+          {
+            path: "memory/2026-04-03.md",
+            startLine: 2,
+            endLine: 2,
+            snippet: "Grounded note about the rollback runbook.",
+            score: 0.9,
+          },
+        ],
+      });
+
+      const entries = Object.values(await readRecallStoreEntries(workspaceDir));
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.snippet).toBe("Grounded note about the rollback runbook.");
+    });
+  });
+
+  it("drops markdown placeholder entries when loading the recall store", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await testing.writeRawRecallStore(workspaceDir, {
+        version: 1,
+        updatedAt: "2026-04-03T00:00:00.000Z",
+        entries: {
+          "memory:memory/2026-04-03.md:1:1": {
+            key: "memory:memory/2026-04-03.md:1:1",
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 1,
+            source: "memory",
+            snippet: "-",
+            recallCount: 3,
+            dailyCount: 0,
+            groundedCount: 0,
+            totalScore: 2.7,
+            maxScore: 0.9,
+            firstRecalledAt: "2026-04-01T00:00:00.000Z",
+            lastRecalledAt: "2026-04-03T00:00:00.000Z",
+            queryHashes: ["a", "b", "c"],
+            recallDays: ["2026-04-01", "2026-04-02", "2026-04-03"],
+            conceptTags: [],
+          },
+        },
+      });
+
+      const store = await testing.readRecallStore(workspaceDir, "2026-04-03T00:00:00.000Z");
+      expect(Object.values(store.entries)).toHaveLength(0);
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      expect(ranked).toEqual([]);
+    });
+  });
+
+  it("does not relocate a candidate onto a bare markdown placeholder line", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-04-01", ["unrelated shipping note", "-"]);
+      // The recorded snippet does not match its original line, forcing
+      // relocation to search the live note. Without the placeholder guard the
+      // bare "-" on line 2 substring-matches "deploy - done" (quality 1) and
+      // the candidate relocates onto the empty marker line.
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "deploy",
+        results: [
+          {
+            path: "memory/2026-04-01.md",
+            source: "memory",
+            startLine: 1,
+            endLine: 1,
+            score: 0.94,
+            snippet: "deploy - done",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      expect(applied.applied).toBe(0);
+    });
+  });
+
   it("records recalls and ranks candidates with weighted scores", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await recordShortTermRecalls({

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -424,6 +424,39 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
   return hasNarrativeLead && hasConfidence && hasEvidence && hasStatus && hasRecalls;
 }
 
+// Markdown skeleton placeholders (bare list markers, heading-only lines, and
+// heading + empty-bullet ranges) carry no durable content. Without filtering
+// they get recorded as short-term recall candidates and can later be promoted
+// into MEMORY.md as empty blocks, or anchor relocation substring matches onto
+// structurally meaningless ranges. See issue #80582.
+function isMarkdownPlaceholderLine(raw: string): boolean {
+  const line = raw.trim();
+  if (!line || /^[-*+]$/.test(line)) {
+    return true;
+  }
+  // A heading line is a placeholder unless it also carries a list item with
+  // real body text on the same line (e.g. "## Notes - real content").
+  if (/^#{1,6}\s+\S/.test(line)) {
+    return !/\s[-*+]\s+\S/.test(line);
+  }
+  return false;
+}
+
+function isPlaceholderShortTermSnippet(raw: string): boolean {
+  const snippet = normalizeSnippet(raw);
+  if (!snippet || /^[-*+]$/.test(snippet)) {
+    return true;
+  }
+  const lines = raw.split(/\r?\n/);
+  const nonEmpty = lines.map((line) => line.trim()).filter(Boolean);
+  return nonEmpty.length > 0 && lines.every(isMarkdownPlaceholderLine);
+}
+
+function isUnpromotableShortTermSnippet(raw: string): boolean {
+  const snippet = normalizeSnippet(raw);
+  return !snippet || isPlaceholderShortTermSnippet(raw) || isContaminatedDreamingSnippet(snippet);
+}
+
 function normalizeMemoryPath(rawPath: string): string {
   return rawPath.replaceAll("\\", "/").replace(/^\.\//, "");
 }
@@ -597,8 +630,9 @@ export function normalizeShortTermRecallStore(raw: unknown, nowIso: string): Sho
         typeof entry.claimHash === "string" && entry.claimHash.trim().length > 0
           ? entry.claimHash.trim()
           : undefined;
-      const fullSnippet = typeof entry.snippet === "string" ? normalizeSnippet(entry.snippet) : "";
-      if (fullSnippet && isContaminatedDreamingSnippet(fullSnippet)) {
+      const rawEntrySnippet = typeof entry.snippet === "string" ? entry.snippet : "";
+      const fullSnippet = normalizeSnippet(rawEntrySnippet);
+      if (fullSnippet && isUnpromotableShortTermSnippet(rawEntrySnippet)) {
         continue;
       }
       const snippet = truncateShortTermSnippet(fullSnippet);
@@ -1423,7 +1457,7 @@ export async function recordShortTermRecalls(params: {
       const normalizedPath = normalizeMemoryPath(result.path);
       const rawSnippet = normalizeSnippet(result.snippet);
       const snippet = truncateShortTermSnippet(rawSnippet);
-      if (!rawSnippet || isContaminatedDreamingSnippet(rawSnippet)) {
+      if (!rawSnippet || isUnpromotableShortTermSnippet(result.snippet)) {
         continue;
       }
       const claimHash = buildClaimHash(rawSnippet);
@@ -1543,7 +1577,7 @@ export async function recordGroundedShortTermCandidates(params: {
       const normalizedPath = normalizeMemoryPath(item.path);
       if (
         !rawSnippet ||
-        isContaminatedDreamingSnippet(rawSnippet) ||
+        isUnpromotableShortTermSnippet(item.snippet) ||
         !normalizedPath ||
         !isShortTermMemoryPath(normalizedPath) ||
         !Number.isFinite(item.startLine) ||
@@ -1807,7 +1841,7 @@ export async function rankShortTermPromotionCandidates(
     if (!entry || entry.source !== "memory" || !isShortTermMemoryPath(entry.path)) {
       continue;
     }
-    if (isContaminatedDreamingSnippet(entry.snippet)) {
+    if (isUnpromotableShortTermSnippet(entry.snippet)) {
       continue;
     }
     if (!includePromoted && entry.promotedAt) {
@@ -2076,6 +2110,21 @@ function compareCandidateWindow(
   }
   if (windowSnippet === targetSnippet) {
     return { matched: true, quality: 3 };
+  }
+  // Substring matching can anchor onto markdown skeleton placeholders (a bare
+  // list marker window matches any target that contains "-", or a placeholder
+  // target matches a meaningful window). Require both sides to carry real
+  // content before accepting a partial match so candidates do not relocate
+  // onto empty bullet/heading ranges. The exact-match branch above is
+  // unaffected because equality already rules out a placeholder-vs-content
+  // pair. This placeholder-only guard is intentionally narrower than a token
+  // count: an ASCII-only token check would split CJK text into separators and
+  // reject legitimate non-English relocations.
+  if (
+    isPlaceholderShortTermSnippet(targetSnippet) ||
+    isPlaceholderShortTermSnippet(windowSnippet)
+  ) {
+    return { matched: false, quality: 0 };
   }
   if (windowSnippet.includes(targetSnippet)) {
     return { matched: true, quality: 2 };


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

## Summary

- **Problem:** The short-term memory promotion pipeline in `extensions/memory-core` recorded markdown skeleton placeholders — bare list markers (`-`, `*`, `+`), heading-only lines, and heading + empty-bullet ranges — as promotable recall candidates. During relocation, broad substring matching could also anchor a meaningful candidate onto a bare-marker window (e.g. a target containing `-` matching a `-` line at quality 1), so empty/structurally meaningless blocks could be appended into `MEMORY.md`.
- **Why it matters now:** These placeholders carry no durable content but still consume recall-store slots, accrue ranking signals, and can be promoted as empty blocks into long-term memory, contaminating it with markdown skeleton noise (issue #80582).
- **Intended outcome:** Placeholder snippets are dropped at every entry point (recall recording, grounded-candidate recording, store load/normalization, and ranking), and relocation substring matching refuses to anchor onto placeholder ranges. Real notes (including CJK and heading-with-body lines) are unaffected.
- **Out of scope:** No change to dreaming-contamination filtering (already present), no change to scoring weights, no change to the on-disk store format.
- **Success looks like:** Placeholder snippets never reach the recall store or ranking, and a meaningful candidate no longer relocates onto a bare marker line.
- **Reviewer focus:** The placeholder detection helpers (`isMarkdownPlaceholderLine`, `isPlaceholderShortTermSnippet`, `isUnpromotableShortTermSnippet`) and the narrow guard added to `compareCandidateWindow`.

## Linked context

Closes #80582

Related: the issue includes a patch sketch; this PR implements it with one justified deviation (see "Risk checklist").

## Real behavior proof

- Behavior or issue addressed: Short-term memory promotion recorded markdown skeleton placeholders (bare `-`/`*`/`+`, heading-only lines, heading + empty-bullet ranges) as promotable candidates and anchored relocation substring matches onto them (#80582).
- Real environment tested: Windows 10 Enterprise LTSC 2019, Node v22.22.3, OpenClaw `extensions/memory-core` short-term-promotion shard.
- Exact steps or command run after this patch: Ran the memory-core short-term-promotion vitest shard via `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts` with the shard include filter pointed at `extensions/memory-core/src/short-term-promotion.test.ts`, once with the production fix reverted and once with the fix applied.
- Evidence after fix (terminal capture): Shard run via `node scripts/run-vitest.mjs` after the fix. Terminal capture (console output):
```
 Test Files  1 passed (1)
      Tests  83 passed (83)
   Start at  22:04:49
   Duration  57.06s
```
- Observed result after fix: After the fix all 83 tests pass, including the 5 new regression tests (bare markers, skeleton ranges, grounded placeholders, store-load drop, and relocation-onto-placeholder). Before the fix the same shard reported `5 failed | 78 passed (83)` — the 5 new tests failed because placeholders were recorded/ranked and a candidate relocated onto a bare `-` line (`applied` was 1, expected 0).
- What was not tested: macOS/Linux not tested; the full `pnpm test` suite was not run locally (scoped to the memory-core shard plus format/tsgo/lint/build); `pnpm check:host-env-policy:swift` is skipped on Windows (no Swift); a live long-term dreaming promotion run against a real workspace was not executed end-to-end.
- Proof limitations or environment constraints: Local verification is Windows-only. The placeholder filtering is pure logic exercised directly through the real `recordShortTermRecalls` / `recordGroundedShortTermCandidates` / `rankShortTermPromotionCandidates` / store-normalization / relocation code paths in the extension shard; CI runs the same shard on Linux Node 24.
- Before evidence: Shard run with the production fix reverted (placeholders not filtered). Terminal capture (console output):
```
 Test Files  1 failed (1)
      Tests  5 failed | 78 passed (83)
```
The relocation regression failed with `expected 1 to be 0` (`applied.applied` was 1), confirming the candidate relocated onto the bare `-` line before the fix.

## Tests and validation

- Commands run: `pnpm exec oxfmt --check` (both files clean), `pnpm tsgo` (clean), `pnpm exec oxlint --type-aware` on the changed files (clean), `pnpm build`, and `pnpm test:extension memory-core` (short-term-promotion shard: 83/83 pass).
- Regression coverage added: 5 new tests in `extensions/memory-core/src/short-term-promotion.test.ts` — bare marker recording, multi-line skeleton range recording, grounded placeholder recording, store-load placeholder drop, and relocation-onto-placeholder refusal.
- What failed before this fix: the 5 new tests failed against the unpatched production code (`5 failed | 78 passed`); they pass after the fix (`83 passed`).
- Pre-existing unrelated Windows failures observed in the broader memory-core shard (`manager.watcher-config.test.ts` chokidar watcher tests and one `qmd-manager.test.ts` case failing on `ENOENT mkdir '...Notes #1: blue'` because Windows disallows `:` in directory names) were confirmed to also fail on clean `main` without this PR's changes.

## Risk checklist

Did user-visible behavior change? `No`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area? Correctness of the placeholder detector — it must not drop legitimate notes. A heading line that also carries a list item with body text (e.g. `## Notes - real content`) is intentionally kept, and ordinary prose/list lines are never placeholders.

How is that risk mitigated? The detector only treats a line as a placeholder when it is empty, a bare `-`/`*`/`+`, or a heading line without an inline list item carrying body text. The existing 78 tests (including CJK heading-prefixed relocations and bullet-prefixed dreaming snippets) still pass, and the new tests assert real notes are kept while placeholders are dropped.

Deviation from the issue's patch sketch: the issue suggests an `isMeaningfulRelocationSubstring` token-count guard for relocation. That check splits on `[^A-Za-z0-9_]+`, which treats CJK characters as separators and would reject legitimate non-English relocations (the suite has CJK rehydration tests). This PR instead uses a narrower placeholder-only guard in `compareCandidateWindow` that blocks substring matches only when either side is a placeholder — achieving the issue's stated goal ("avoid matching onto placeholders") without regressing CJK relocations. The exact-match branch is unchanged.

## Current review state

Next action: await CI and maintainer/ClawSweeper review.

Waiting on: CI (format/lint/tsgo/build + memory-core shard on Linux Node 24).

Bot/reviewer comments addressed: none yet (PR just opened).
