### PR TITLE
fix(cli): pass remote eligibility to skills CLI commands

### DIFF
--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -6,6 +6,7 @@ import {
   type SkillStatusReport,
 } from "../agents/skills-status.js";
 import { loadConfig } from "../config/config.js";
+import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { renderTable } from "../terminal/table.js";
@@ -359,7 +360,10 @@ export function registerSkillsCli(program: Command) {
       try {
         const config = loadConfig();
         const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
-        const report = buildWorkspaceSkillStatus(workspaceDir, { config });
+        const report = buildWorkspaceSkillStatus(workspaceDir, {
+          config,
+          eligibility: { remote: getRemoteSkillEligibility() },
+        });
         defaultRuntime.log(formatSkillsList(report, opts));
       } catch (err) {
         defaultRuntime.error(String(err));
@@ -376,7 +380,10 @@ export function registerSkillsCli(program: Command) {
       try {
         const config = loadConfig();
         const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
-        const report = buildWorkspaceSkillStatus(workspaceDir, { config });
+        const report = buildWorkspaceSkillStatus(workspaceDir, {
+          config,
+          eligibility: { remote: getRemoteSkillEligibility() },
+        });
         defaultRuntime.log(formatSkillInfo(report, name, opts));
       } catch (err) {
         defaultRuntime.error(String(err));
@@ -392,7 +399,10 @@ export function registerSkillsCli(program: Command) {
       try {
         const config = loadConfig();
         const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
-        const report = buildWorkspaceSkillStatus(workspaceDir, { config });
+        const report = buildWorkspaceSkillStatus(workspaceDir, {
+          config,
+          eligibility: { remote: getRemoteSkillEligibility() },
+        });
         defaultRuntime.log(formatSkillsCheck(report, opts));
       } catch (err) {
         defaultRuntime.error(String(err));
@@ -405,7 +415,10 @@ export function registerSkillsCli(program: Command) {
     try {
       const config = loadConfig();
       const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
-      const report = buildWorkspaceSkillStatus(workspaceDir, { config });
+      const report = buildWorkspaceSkillStatus(workspaceDir, {
+        config,
+        eligibility: { remote: getRemoteSkillEligibility() },
+      });
       defaultRuntime.log(formatSkillsList(report, {}));
     } catch (err) {
       defaultRuntime.error(String(err));


### PR DESCRIPTION
## Summary

The `openclaw skills list/info/check` CLI commands called `buildWorkspaceSkillStatus` without passing remote eligibility context, causing macOS-only skills like `apple-notes` to always show as ineligible when a remote macOS node is connected and has the required binary (`memo`) installed.

## Root Cause

The CLI in `src/cli/skills-cli.ts` calls `buildWorkspaceSkillStatus(workspaceDir, { config })` — without the `eligibility` option. The Gateway's `skills.status` RPC handler in `src/gateway/server-methods/skills.ts` already passes `eligibility: { remote: getRemoteSkillEligibility() }`, but the CLI did not.

## Fix

Pass `eligibility: { remote: getRemoteSkillEligibility() }` to all four `buildWorkspaceSkillStatus` call sites in `src/cli/skills-cli.ts`, matching the pattern already used by the Gateway handler.

## Real behavior proof

**Behavior or issue addressed**: `openclaw skills check --json` reports `apple-notes` under `missingRequirements` with `bins: ["memo"]` and `os: ["darwin"]` even when a connected remote macOS node has `memo` at `/opt/homebrew/bin/memo`. The CLI does not consult remote node capabilities.

**Real environment tested**: Local checkout of `openclaw` main branch with the diff applied. Verified the function call signature against the Gateway handler at `src/gateway/server-methods/skills.ts:98-101`.

**Exact steps or command run after this patch**:
1. `git diff src/cli/skills-cli.ts` — confirmed all 4 `buildWorkspaceSkillStatus` calls now include `eligibility: { remote: getRemoteSkillEligibility() }`
2. Compared CLI call sites against Gateway handler pattern

**Evidence after fix**:

```diff
- const report = buildWorkspaceSkillStatus(workspaceDir, { config });
+ const report = buildWorkspaceSkillStatus(workspaceDir, {
+   config,
+   eligibility: { remote: getRemoteSkillEligibility() },
+ });
```

Gateway handler already uses this exact pattern:

```typescript
const report = buildWorkspaceSkillStatus(workspaceDir, {
  config: cfg,
  eligibility: { remote: getRemoteSkillEligibility() },
});
```

With `eligibility.remote` provided, `buildSkillStatus` resolves missing bins and OS via remote nodes:

```typescript
// src/agents/skills-status.ts line 209-211
if (eligibility?.remote?.hasBin?.(bin)) {
  return false;
}
// line 225
eligibility?.remote?.platforms?.some((platform) => requiredOs.includes(platform))
```

**Observed result after fix**: All four CLI call sites (`skills list`, `skills info`, `skills check`, default action) now pass `eligibility: { remote: getRemoteSkillEligibility() }`, matching the Gateway handler. When a remote macOS node is connected with `memo` installed, `apple-notes` will be marked eligible.

**What was not tested**: No real OpenClaw gateway with a connected macOS node was available. Runtime behavior with an actual remote node connection was not verified.

Fixes #94956