### PR TITLE
feat(docker): add opt-in Claude Code CLI install build arg (fixes #66874)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -300,6 +300,17 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
         docker-ce-cli docker-compose-plugin; \
     fi
 
+# Optionally install Claude Code CLI for anthropic/* provider CLI reuse.
+# Build with: docker build --build-arg OPENCLAW_INSTALL_CLAUDE_CLI=1 ...
+# Enables Claude Max / Pro subscription reuse via the cli-backends path.
+# Mount a volume at /home/node/.claude to persist OAuth credentials across
+# container upgrades: docker run -v openclaw-claude:/home/node/.claude ...
+ARG OPENCLAW_INSTALL_CLAUDE_CLI=""
+RUN if [ -n "$OPENCLAW_INSTALL_CLAUDE_CLI" ]; then \
+      npm install -g @anthropic-ai/claude-code && \
+      install -d -m 0700 -o node -g node /home/node/.claude; \
+    fi
+
 # Expose the CLI binary without requiring npm global writes as non-root.
 RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
  && chmod 755 /app/openclaw.mjs


### PR DESCRIPTION
## What

Add an opt-in `OPENCLAW_INSTALL_CLAUDE_CLI` build arg to the official Docker image, following the same pattern as `OPENCLAW_INSTALL_BROWSER` and `OPENCLAW_INSTALL_DOCKER_CLI`.

When enabled, the build:
1. Installs `@anthropic-ai/claude-code` globally via npm
2. Pre-creates `/home/node/.claude` (0700, node-owned) for persistent OAuth credential volume mounts

## Why

Fixes #66874 — Docker users running OpenClaw with `anthropic/*` providers cannot reuse their Claude Max / Pro subscriptions because:

- `claude` CLI is not in the official image
- Manual `npm install -g` inside containers is lost on image upgrades
- `~/.claude/.credentials.json` has no documented persistent volume path

The existing Dockerfile already has two opt-in CLI install patterns (`OPENCLAW_INSTALL_BROWSER`, `OPENCLAW_INSTALL_DOCKER_CLI`). This adds a third using the same convention.

## How to Test

```bash
docker build --build-arg OPENCLAW_INSTALL_CLAUDE_CLI=1 -t openclaw-claude .
docker run --rm openclaw-claude claude --version
docker run -v openclaw-claude:/home/node/.claude openclaw-claude ls -la /home/node/.claude
```

Default builds (no build arg) are unchanged — no additional image size.

## Real behavior proof

- **Behavior addressed:** Docker image optionally installs Claude Code CLI and pre-creates credential directory
- **Environment tested:** Dockerfile inspection on upstream/main (78b56180)
- **Steps run after the patch:** Verified Dockerfile contains the new ARG, RUN block, and directory creation matching the existing `OPENCLAW_INSTALL_DOCKER_CLI` pattern
- **Evidence after fix:**
```
$ node -e "const fs=require('fs'); const d=fs.readFileSync('Dockerfile','utf8'); console.log('ARG declared:', d.includes('OPENCLAW_INSTALL_CLAUDE_CLI=\"\"')); console.log('npm install present:', d.includes('npm install -g @anthropic-ai/claude-code')); console.log('.claude dir created:', d.includes('install -d -m 0700 -o node -g node /home/node/.claude'));"
ARG declared: true
npm install present: true
.claude dir created: true

$ grep -n 'OPENCLAW_INSTALL_CLAUDE_CLI\|claude-code\|/home/node/.claude' Dockerfile
304:# Build with: docker build --build-arg OPENCLAW_INSTALL_CLAUDE_CLI=1 ...
306:# Mount a volume at /home/node/.claude to persist OAuth credentials across
307:# container upgrades: docker run -v openclaw-claude:/home/node/.claude ...
308:ARG OPENCLAW_INSTALL_CLAUDE_CLI=""
309:RUN if [ -n "$OPENCLAW_INSTALL_CLAUDE_CLI" ]; then \
310:      npm install -g @anthropic-ai/claude-code && \
311:      install -d -m 0700 -o node -g node /home/node/.claude; \
```
- **Observed result after fix:** 11 lines added to Dockerfile, following the exact pattern of `OPENCLAW_INSTALL_DOCKER_CLI` (ARG declaration → conditional RUN → directory pre-creation). Default builds unaffected.
- **What was not tested:** Full `docker build` with the new arg (requires Docker daemon and network access for npm install). The Dockerfile syntax and pattern correctness were verified via source inspection.
