### PR TITLE
fix(feishu): emit non-empty value schema for bitable write tools (#94547)

### DIFF
--- a/extensions/feishu/src/bitable.test.ts
+++ b/extensions/feishu/src/bitable.test.ts
@@ -172,3 +172,29 @@ describe("feishu bitable create app cleanup", () => {
     expect(client.bitable.appTableRecord.list).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("feishu bitable write tool schemas (#94547)", () => {
+  it.each([
+    ["feishu_bitable_create_record", "fields"],
+    ["feishu_bitable_update_record", "fields"],
+    ["feishu_bitable_create_field", "property"],
+  ])("%s emits a non-empty value schema for %s", (toolName, propName) => {
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuBitableTools(api);
+
+    const tool = resolveTool(toolName) as unknown as {
+      parameters?: {
+        properties?: Record<
+          string,
+          { patternProperties?: Record<string, Record<string, unknown>> }
+        >;
+      };
+    };
+    const patternSchemas = Object.values(
+      tool.parameters?.properties?.[propName]?.patternProperties ?? {},
+    );
+    expect(patternSchemas).toEqual([
+      { type: ["string", "number", "boolean", "object", "array", "null"] },
+    ]);
+  });
+});

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -517,12 +517,18 @@ const GetRecordSchema = Type.Object({
   record_id: Type.String({ description: "Record ID to retrieve" }),
 });
 
+// TypeBox emits an empty schema for Any/Unknown, which Bedrock-backed validators
+// can reject inside patternProperties. Keep the existing any-JSON-value contract explicit.
+const BitableFieldValueSchema = Type.Unsafe<unknown>({
+  type: ["string", "number", "boolean", "object", "array", "null"],
+});
+
 const CreateRecordSchema = Type.Object({
   app_token: Type.String({
     description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
-  fields: Type.Record(Type.String(), Type.Any(), {
+  fields: Type.Record(Type.String(), BitableFieldValueSchema, {
     description:
       "Field values keyed by field name. Format by type: Text='string', Number=123, SingleSelect='Option', MultiSelect=['A','B'], DateTime=timestamp_ms, User=[{id:'ou_xxx'}], URL={text:'Display',link:'https://...'}",
   }),
@@ -552,7 +558,7 @@ const CreateFieldSchema = Type.Object({
     minimum: 1,
   }),
   property: Type.Optional(
-    Type.Record(Type.String(), Type.Any(), {
+    Type.Record(Type.String(), BitableFieldValueSchema, {
       description: "Field-specific properties (e.g., options for SingleSelect, format for Number)",
     }),
   ),
@@ -564,7 +570,7 @@ const UpdateRecordSchema = Type.Object({
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
   record_id: Type.String({ description: "Record ID to update" }),
-  fields: Type.Record(Type.String(), Type.Any(), {
+  fields: Type.Record(Type.String(), BitableFieldValueSchema, {
     description: "Field values to update (same format as create_record)",
   }),
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes #94547.

The Feishu bitable write tools used `Type.Record(Type.String(), Type.Any())`.
TypeBox 1.3.3 serializes that value schema as `{}`, and Bedrock-backed
validators can reject the resulting empty nested `patternProperties` schema.
Because providers receive the whole tool list, one rejected Feishu schema can
block otherwise unrelated agent turns.

## Why This Change Was Made

The three affected parameters now share one explicit schema containing every
JSON value type:

```json
{"type":["string","number","boolean","object","array","null"]}
```

This keeps the existing free-form contract, including Feishu object arrays,
without adding a provider-wide compatibility rewrite. `Type.Unknown()` is not
used because TypeBox also serializes it as `{}`.

The regression test resolves the registered tools and checks the exact emitted
value schema for:

- `feishu_bitable_create_record.fields`
- `feishu_bitable_update_record.fields`
- `feishu_bitable_create_field.property`

## User Impact

Bedrock-backed users can expose the Feishu bitable write tools without the
empty nested schema causing the provider to reject the tool list.

## Evidence

Exact PR head: `2f01557aa160deadeeda8154e35a84694269e182`

- Blacksmith Testbox `tbx_01kwqr1t24b8cv4mqkkejrkv3p`
- `pnpm test:serial extensions/feishu/src/bitable.test.ts`: 5/5 passed
- `pnpm check:changed`: passed
- fresh autoreview against `origin/main`: no findings, confidence 0.96
- hosted CI run `28723694478`

No live Bedrock credentialed request was run. The failure path is supported by
the linked reporter evidence, direct TypeBox 1.3.3 source inspection, and the
Bedrock runtime forwarding tool parameters as `inputSchema.json`.
