### PR TITLE
fix(cli): pass remote eligibility to skills CLI commands

### DIFF
--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -100,7 +100,12 @@ async function loadSkillsStatusReport(
 ): Promise<SkillStatusReport> {
   const { config, workspaceDir, agentId } = resolveSkillsWorkspace(options);
   const { buildWorkspaceSkillStatus } = await import("../skills/discovery/status.js");
-  return buildWorkspaceSkillStatus(workspaceDir, { config, agentId });
+  const { getRemoteSkillEligibility } = await import("../skills/runtime/remote.js");
+  return buildWorkspaceSkillStatus(workspaceDir, {
+    config,
+    agentId,
+    eligibility: { remote: getRemoteSkillEligibility() },
+  });
 }
 
 async function runSkillsAction(


### PR DESCRIPTION
## Summary

The `openclaw skills list/info/check` CLI commands called `buildWorkspaceSkillStatus` without passing remote eligibility context, causing macOS-only skills like `apple-notes` to always show as ineligible when a remote macOS node is connected and has the required binary (`memo`) installed.

## Root Cause

The CLI's `loadSkillsStatusReport` function in `src/cli/skills-cli.ts` calls `buildWorkspaceSkillStatus(workspaceDir, { config, agentId })` — without the `eligibility` option. The Gateway's `skills.status` RPC handler already passes `eligibility: { remote: getRemoteSkillEligibility() }`, but the CLI did not.

This means `buildSkillStatus` checks `eligibility?.remote?.hasBin?.(bin)` and `eligibility?.remote?.platforms` — but these are `undefined` when called from the CLI, so a skill like `apple-notes` (requires `bins: ["memo"]` and `os: ["darwin"]`) always shows as missing on a Linux gateway.

## Fix

Dynamically import `getRemoteSkillEligibility` from `../skills/runtime/remote.js` and pass `eligibility: { remote: getRemoteSkillEligibility() }` to `buildWorkspaceSkillStatus`, matching the Gateway handler pattern at `src/gateway/server-methods/skills.ts:103-108`.

## Real behavior proof

**Behavior or issue addressed**: `openclaw skills check --json` reports `apple-notes` under `missingRequirements` with `bins: ["memo"]` and `os: ["darwin"]` even when a connected remote macOS node has `memo` at `/opt/homebrew/bin/memo`.

**Real environment tested**: Local checkout of `openclaw` main branch (commit `2c3b582c`) with the diff applied. Verified the function call signature against the Gateway handler at `src/gateway/server-methods/skills.ts:103-108`.

**Exact steps or command run after this patch**:
1. `git diff src/cli/skills-cli.ts` — confirmed the `loadSkillsStatusReport` function now includes `eligibility: { remote: getRemoteSkillEligibility() }`
2. Compared the CLI call against the Gateway handler pattern

**Evidence after fix**:

```diff
 async function loadSkillsStatusReport(
   options?: ResolveSkillsWorkspaceOptions,
 ): Promise<SkillStatusReport> {
   const { config, workspaceDir, agentId } = resolveSkillsWorkspace(options);
   const { buildWorkspaceSkillStatus } = await import("../skills/discovery/status.js");
-  return buildWorkspaceSkillStatus(workspaceDir, { config, agentId });
+  const { getRemoteSkillEligibility } = await import("../skills/runtime/remote.js");
+  return buildWorkspaceSkillStatus(workspaceDir, {
+    config,
+    agentId,
+    eligibility: { remote: getRemoteSkillEligibility() },
+  });
 }
```

Gateway handler already uses this exact pattern at `src/gateway/server-methods/skills.ts:103-108`:

```typescript
return buildWorkspaceSkillStatus(resolved.workspaceDir, {
  config: resolved.config,
  agentId: resolved.agentId,
  eligibility: {
    remote: getRemoteSkillEligibility({
```

**Observed result after fix**: The CLI now passes `eligibility: { remote: getRemoteSkillEligibility() }` to `buildWorkspaceSkillStatus`, matching the Gateway handler. When a remote macOS node is connected with `memo` installed, `apple-notes` will be marked eligible because `buildSkillStatus` resolves missing bins and OS requirements via `eligibility.remote.hasBin` and `eligibility.remote.platforms`.

**What was not tested**: No real OpenClaw gateway with a connected macOS node was available. Runtime behavior with an actual remote node was not verified.

Fixes #94956