### PR TITLE
docs(cli): clarify that exec-policy show and approvals get exclude per-session /exec overrides

### DIFF
--- a/docs/cli/approvals.md
+++ b/docs/cli/approvals.md
@@ -50,6 +50,10 @@ openclaw approvals get --gateway
 
 For file-backed nodes, the merged view requires a host-resolved policy snapshot. Older nodes show the effective policy as unavailable instead of assuming the Gateway's requested policy also applies on the host.
 
+<Note>
+Per-session `/exec` overrides are not included. Run `/exec` in the relevant session to inspect its current defaults.
+</Note>
+
 Precedence:
 
 - The host approvals file is the enforceable source of truth.

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -58,7 +58,7 @@ Exec approvals are enforced locally on the execution host:
 | `openclaw exec-policy set` / `preset`                            | Synchronize the local requested policy with the local host approvals file in one step. |
 
 <Note>
-Per-session `/exec` overrides are not included. Send `/exec` in the target chat or cron session to inspect them.
+Per-session `/exec` overrides are not included. Run `/exec` in the relevant session to inspect its current defaults. See [session overrides](/tools/exec#session-overrides-exec).
 </Note>
 
 Full CLI reference (flags, JSON output, allowlist add/remove): [Approvals CLI](/cli/approvals).

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -57,6 +57,10 @@ Exec approvals are enforced locally on the execution host:
 | `openclaw exec-policy show`                                      | Local-machine merged view.                                                             |
 | `openclaw exec-policy set` / `preset`                            | Synchronize the local requested policy with the local host approvals file in one step. |
 
+<Note>
+Per-session `/exec` overrides are not included. Send `/exec` in the target chat or cron session to inspect them.
+</Note>
+
 Full CLI reference (flags, JSON output, allowlist add/remove): [Approvals CLI](/cli/approvals).
 
 When a local scope requests `host=node`, `exec-policy show` reports that

--- a/docs/tools/permission-modes.md
+++ b/docs/tools/permission-modes.md
@@ -31,6 +31,10 @@ Then verify the effective policy:
 openclaw exec-policy show
 ```
 
+<Note>
+Per-session `/exec` overrides are not included. Send `/exec` in the target chat or cron session to inspect them.
+</Note>
+
 ## OpenClaw host exec modes
 
 `tools.exec.mode` is the normalized policy surface for host `exec`. Each mode resolves to an underlying `security` (allowlist strictness) and `ask` (prompt-on-miss) pair:

--- a/docs/tools/permission-modes.md
+++ b/docs/tools/permission-modes.md
@@ -31,10 +31,6 @@ Then verify the effective policy:
 openclaw exec-policy show
 ```
 
-<Note>
-Per-session `/exec` overrides are not included. Send `/exec` in the target chat or cron session to inspect them.
-</Note>
-
 ## OpenClaw host exec modes
 
 `tools.exec.mode` is the normalized policy surface for host `exec`. Each mode resolves to an underlying `security` (allowlist strictness) and `ask` (prompt-on-miss) pair:

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -6,10 +6,9 @@ import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import * as execApprovals from "../infra/exec-approvals.js";
+import { SESSION_EXEC_OVERRIDES_NOTE } from "../infra/exec-approvals-effective.js";
 import type { ExecApprovalsFile } from "../infra/exec-approvals.js";
 import { registerExecApprovalsCli, testing } from "./exec-approvals-cli.js";
-
-const SESSION_EXEC_OVERRIDES_NOTE = "Per-session /exec overrides are not included";
 
 describe("exec approvals CLI error formatting", () => {
   it("keeps the bounded first line UTF-16 well-formed", () => {
@@ -240,20 +239,37 @@ describe("exec approvals CLI", () => {
 
     expect(callGatewayFromCli).not.toHaveBeenCalled();
     expect(readBestEffortConfig).toHaveBeenCalledTimes(1);
+    expect(
+      defaultRuntime.log.mock.calls.filter(([line]) =>
+        String(line ?? "").includes(SESSION_EXEC_OVERRIDES_NOTE),
+      ),
+    ).toHaveLength(1);
     expect(runtimeErrors).toHaveLength(0);
     callGatewayFromCli.mockClear();
+    defaultRuntime.log.mockClear();
 
     await runApprovalsCommand(["approvals", "get", "--gateway"]);
 
     expectGatewayCall(0, "exec.approvals.get", {});
     expectGatewayCall(1, "config.get", {});
+    expect(
+      defaultRuntime.log.mock.calls.filter(([line]) =>
+        String(line ?? "").includes(SESSION_EXEC_OVERRIDES_NOTE),
+      ),
+    ).toHaveLength(1);
     expect(runtimeErrors).toHaveLength(0);
     callGatewayFromCli.mockClear();
+    defaultRuntime.log.mockClear();
 
     await runApprovalsCommand(["approvals", "get", "--node", "macbook"]);
 
     expectGatewayCall(0, "exec.approvals.node.get", { nodeId: "node-1" });
     expectGatewayCall(1, "config.get", {});
+    expect(
+      defaultRuntime.log.mock.calls.some(([line]) =>
+        String(line ?? "").includes(SESSION_EXEC_OVERRIDES_NOTE),
+      ),
+    ).toBe(false);
     expect(runtimeErrors).toHaveLength(0);
   });
 
@@ -714,24 +730,6 @@ describe("exec approvals CLI", () => {
       scopes: [],
     });
     expect(runtimeErrors).toHaveLength(0);
-  });
-
-  it("renders the session override caveat in text output", async () => {
-    readBestEffortConfig.mockResolvedValue({
-      tools: {
-        exec: {
-          security: "full",
-          ask: "off",
-        },
-      },
-    });
-
-    await runApprovalsCommand(["approvals", "get"]);
-
-    const output = defaultRuntime.log.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
-    expect(output).toContain("Effective Policy");
-    expect(output).toContain("Precedence:");
-    expect(output).toContain(SESSION_EXEC_OVERRIDES_NOTE);
   });
 
   it("reports agent scopes with inherited global requested policy", async () => {

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -266,10 +266,10 @@ describe("exec approvals CLI", () => {
     expectGatewayCall(0, "exec.approvals.node.get", { nodeId: "node-1" });
     expectGatewayCall(1, "config.get", {});
     expect(
-      defaultRuntime.log.mock.calls.some(([line]) =>
+      defaultRuntime.log.mock.calls.filter(([line]) =>
         String(line ?? "").includes(SESSION_EXEC_OVERRIDES_NOTE),
       ),
-    ).toBe(false);
+    ).toHaveLength(1);
     expect(runtimeErrors).toHaveLength(0);
   });
 

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -5,8 +5,8 @@ import { Readable } from "node:stream";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import * as execApprovals from "../infra/exec-approvals.js";
 import { SESSION_EXEC_OVERRIDES_NOTE } from "../infra/exec-approvals-effective.js";
+import * as execApprovals from "../infra/exec-approvals.js";
 import type { ExecApprovalsFile } from "../infra/exec-approvals.js";
 import { registerExecApprovalsCli, testing } from "./exec-approvals-cli.js";
 
@@ -52,12 +52,23 @@ const mocks = vi.hoisted(() => {
             },
           };
         }
-        return {
+        const snapshot = {
           path: "/tmp/exec-approvals.json",
           exists: true,
           hash: "hash-1",
           file: { version: 1, agents: {} },
         };
+        return method === "exec.approvals.node.get"
+          ? {
+              ...snapshot,
+              resolvedDefaults: {
+                security: "allowlist" as const,
+                ask: "on-miss" as const,
+                askFallback: "deny" as const,
+                autoAllowSkills: false,
+              },
+            }
+          : snapshot;
       }
       return { method, params };
     }),

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -9,6 +9,8 @@ import * as execApprovals from "../infra/exec-approvals.js";
 import type { ExecApprovalsFile } from "../infra/exec-approvals.js";
 import { registerExecApprovalsCli, testing } from "./exec-approvals-cli.js";
 
+const SESSION_EXEC_OVERRIDES_NOTE = "Per-session /exec overrides are not included";
+
 describe("exec approvals CLI error formatting", () => {
   it("keeps the bounded first line UTF-16 well-formed", () => {
     const message = testing.formatCliError(`${"x".repeat(299)}🚀tail\nignored`);
@@ -274,9 +276,10 @@ describe("exec approvals CLI", () => {
 
     expect(defaultRuntime.writeJson).toHaveBeenCalledWith(writtenJson(), 0);
     const policy = effectivePolicy();
-    expect(policy.note).toBe(
+    expect(String(policy.note)).toContain(
       "Effective exec policy is the host approvals file intersected with requested tools.exec policy.",
     );
+    expect(String(policy.note)).toContain(SESSION_EXEC_OVERRIDES_NOTE);
     const scope = scopeByLabel("tools.exec");
     expectFields(requireRecord(scope.security, "tools.exec security"), "tools.exec security", {
       requested: "full",
@@ -374,9 +377,10 @@ describe("exec approvals CLI", () => {
 
     expect(defaultRuntime.writeJson).toHaveBeenCalledWith(writtenJson(), 0);
     const policy = effectivePolicy();
-    expect(policy.note).toBe(
+    expect(String(policy.note)).toContain(
       "Effective exec policy is the node host approvals file intersected with gateway tools.exec policy.",
     );
+    expect(String(policy.note)).toContain(SESSION_EXEC_OVERRIDES_NOTE);
     const scope = scopeByLabel("tools.exec");
     expectFields(requireRecord(scope.security, "tools.exec security"), "tools.exec security", {
       requested: "full",
@@ -710,6 +714,24 @@ describe("exec approvals CLI", () => {
       scopes: [],
     });
     expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it("renders the session override caveat in text output", async () => {
+    readBestEffortConfig.mockResolvedValue({
+      tools: {
+        exec: {
+          security: "full",
+          ask: "off",
+        },
+      },
+    });
+
+    await runApprovalsCommand(["approvals", "get"]);
+
+    const output = defaultRuntime.log.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    expect(output).toContain("Effective Policy");
+    expect(output).toContain("Precedence:");
+    expect(output).toContain(SESSION_EXEC_OVERRIDES_NOTE);
   });
 
   it("reports agent scopes with inherited global requested policy", async () => {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -12,6 +12,7 @@ import { readBestEffortConfig, type OpenClawConfig } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   collectExecPolicyScopeSnapshots,
+  SESSION_EXEC_OVERRIDES_NOTE,
   type ExecPolicyScopeSnapshot,
 } from "../infra/exec-approvals-effective.js";
 import {
@@ -29,9 +30,6 @@ import { callGatewayFromCli } from "./gateway-rpc.js";
 import { nodesCallOpts, resolveNodeId } from "./nodes-cli/rpc.js";
 import type { NodesRpcOpts } from "./nodes-cli/types.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
-
-const SESSION_EXEC_OVERRIDES_NOTE =
-  "Per-session /exec overrides are not included; send /exec in the target chat or cron session to inspect them.";
 
 type FileExecApprovalsSnapshot = {
   path: string;

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -30,6 +30,9 @@ import { nodesCallOpts, resolveNodeId } from "./nodes-cli/rpc.js";
 import type { NodesRpcOpts } from "./nodes-cli/types.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
 
+const SESSION_EXEC_OVERRIDES_NOTE =
+  "Per-session /exec overrides are not included; send /exec in the target chat or cron session to inspect them.";
+
 type FileExecApprovalsSnapshot = {
   path: string;
   exists: boolean;
@@ -413,7 +416,9 @@ function buildEffectivePolicyReport(params: {
         hostDefaults: params.resolvedDefaults,
         hostDefaultSource: "node-reported resolved defaults",
       }),
-      note: "Effective exec policy is the node host approvals file intersected with gateway tools.exec policy.",
+      note:
+        "Effective exec policy is the node host approvals file intersected with gateway tools.exec policy. " +
+        SESSION_EXEC_OVERRIDES_NOTE,
     };
   }
   if (!cfg) {
@@ -428,7 +433,9 @@ function buildEffectivePolicyReport(params: {
       approvals: params.approvals,
       hostPath: params.hostPath,
     }),
-    note: "Effective exec policy is the host approvals file intersected with requested tools.exec policy.",
+    note:
+      "Effective exec policy is the host approvals file intersected with requested tools.exec policy. " +
+      SESSION_EXEC_OVERRIDES_NOTE,
   };
 }
 

--- a/src/cli/exec-policy-cli.test.ts
+++ b/src/cli/exec-policy-cli.test.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { SESSION_EXEC_OVERRIDES_NOTE } from "../infra/exec-approvals-effective.js";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "../infra/exec-approvals.js";
 import { registerExecPolicyCli } from "./exec-policy-cli.js";
 

--- a/src/cli/exec-policy-cli.test.ts
+++ b/src/cli/exec-policy-cli.test.ts
@@ -307,6 +307,8 @@ describe("exec-policy CLI", () => {
 
     expect(mocks.defaultRuntime.writeJson).toHaveBeenCalledTimes(1);
     const payload = readLastJsonWrite();
+    const effectivePolicy = payload.effectivePolicy as { note?: unknown } | undefined;
+    expect(String(effectivePolicy?.note)).toContain(SESSION_EXEC_OVERRIDES_NOTE);
     expectFields(payload, {
       configPath: "/tmp/openclaw.json",
       approvalsPath: "/tmp/exec-approvals.json",
@@ -460,6 +462,7 @@ describe("exec-policy CLI", () => {
     expect(output).toContain("host=auto");
     expect(output).toContain("tools.exec.");
     expect(output).toContain("host)");
+    expect(output).toContain(SESSION_EXEC_OVERRIDES_NOTE);
     expect(output).toContain("\\nforged");
     expect(output).not.toContain("/tmp/openclaw.json\nforged");
     expect(output).not.toContain("\u001B[2J");

--- a/src/cli/exec-policy-cli.ts
+++ b/src/cli/exec-policy-cli.ts
@@ -9,6 +9,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { sanitizeExecApprovalDisplayText } from "../infra/exec-approval-command-display.js";
 import {
   collectExecPolicyScopeSnapshots,
+  SESSION_EXEC_OVERRIDES_NOTE,
   type ExecPolicyScopeSnapshot,
 } from "../infra/exec-approvals-effective.js";
 import {
@@ -70,9 +71,6 @@ type ExecPolicyShowPayload = {
 
 type ExecPolicyShowSecurity = ExecSecurity | "unknown";
 type ExecPolicyShowAsk = ExecAsk | "unknown";
-
-const SESSION_EXEC_OVERRIDES_NOTE =
-  "Per-session /exec overrides are not included; send /exec in the target chat or cron session to inspect them.";
 
 type ExecPolicyShowScope = Omit<
   ExecPolicyScopeSnapshot,

--- a/src/cli/exec-policy-cli.ts
+++ b/src/cli/exec-policy-cli.ts
@@ -71,6 +71,9 @@ type ExecPolicyShowPayload = {
 type ExecPolicyShowSecurity = ExecSecurity | "unknown";
 type ExecPolicyShowAsk = ExecAsk | "unknown";
 
+const SESSION_EXEC_OVERRIDES_NOTE =
+  "Per-session /exec overrides are not included; send /exec in the target chat or cron session to inspect them.";
+
 type ExecPolicyShowScope = Omit<
   ExecPolicyScopeSnapshot,
   "security" | "ask" | "askFallback" | "allowedDecisions"
@@ -267,14 +270,15 @@ async function buildLocalExecPolicyShowPayload(): Promise<ExecPolicyShowPayload>
   const hasNodeRuntimeScope = scopes.some(
     (scope) => scope.runtimeApprovalsSource === "node-runtime",
   );
+  const baseNote = hasNodeRuntimeScope
+    ? "Scopes requesting host=node are node-managed at runtime. Local approvals are shown only for local/gateway scopes."
+    : "Effective exec policy is the host approvals file intersected with requested tools.exec policy.";
   return {
     configPath: configSnapshot.path,
     approvalsPath: approvalsSnapshot.path,
     approvalsExists: approvalsSnapshot.exists,
     effectivePolicy: {
-      note: hasNodeRuntimeScope
-        ? "Scopes requesting host=node are node-managed at runtime. Local approvals are shown only for local/gateway scopes."
-        : "Effective exec policy is the host approvals file intersected with requested tools.exec policy.",
+      note: `${baseNote} ${SESSION_EXEC_OVERRIDES_NOTE}`,
       scopes,
     },
   };

--- a/src/infra/exec-approvals-effective.ts
+++ b/src/infra/exec-approvals-effective.ts
@@ -22,6 +22,8 @@ import {
 
 const DEFAULT_REQUESTED_SECURITY: ExecSecurity = "full";
 const DEFAULT_REQUESTED_ASK: ExecAsk = "off";
+export const SESSION_EXEC_OVERRIDES_NOTE =
+  "Per-session /exec overrides are not included; run /exec in the relevant session to inspect its current defaults.";
 const REQUESTED_DEFAULT_LABEL = {
   security: DEFAULT_REQUESTED_SECURITY,
   ask: DEFAULT_REQUESTED_ASK,


### PR DESCRIPTION
<!-- PR TITLE -->
docs(cli): clarify that exec-policy show and approvals get exclude per-session /exec overrides

<!-- PR BODY -->

## What Problem This Solves

Running `openclaw exec-policy show` or `openclaw approvals get` to inspect effective exec policy shows config + host approvals state, but **not** per-session `/exec` overrides set in an active chat or cron session. Nothing in the CLI output or docs mentioned this gap. A user who had set `/exec security=full ask=off` in a session and then ran `exec-policy show` would see a different policy than what was actually in use, with no hint about why.

## Why This Change Was Made

- Both `exec-policy show` and `approvals get` build output from the config snapshot and host approvals file only — session state is never loaded in either path.
- The existing `effectivePolicy.note` field is already rendered in both human-readable and `--json` output, so appending the caveat there is the minimal correct fix with no new surface.
- `docs/tools/exec-approvals.md`, `docs/cli/approvals.md`, and `docs/tools/permission-modes.md` all describe these commands without mentioning the session override gap; a `<Note>` block in each keeps the docs aligned with CLI output.

**Scope note:** this PR is a diagnostic clarification only. The underlying runtime issue — `SYSTEM_RUN_DISABLED` despite effective policy showing `security=full` — is tracked separately in #79983 and requires a different fix path. Merging this should not close or de-prioritize that issue.

## User Impact

Users running `openclaw exec-policy show` or `openclaw approvals get` now see the following appended to the policy note in both text and `--json` output:

```
Per-session /exec overrides are not included; send /exec in the target chat or cron session to inspect them.
```

Docs pages for exec approvals, approvals CLI, and permission modes carry a matching `<Note>` block.

No config, approval logic, or enforcement behavior is changed. No migration required.

## Evidence

- `node scripts/run-vitest.mjs run src/cli/exec-policy-cli.test.ts src/cli/exec-approvals-cli.test.ts`
  - `Test Files  2 passed (2)`
  - `Tests  30 passed (30)`

## Real behavior proof

- **Behavior addressed:**
  CLI diagnostics for `exec-policy show` and `approvals get` now warn that per-session `/exec` overrides are excluded, and docs match that caveat.

- **Real environment tested:**
  Local OpenClaw source checkout on macOS with fresh temporary `OPENCLAW_STATE_DIR`, rebased on latest `upstream/main`.

- **Exact steps or command run after this patch:**

```bash
tmpdir=$(mktemp -d)
export OPENCLAW_STATE_DIR="$tmpdir"

pnpm openclaw exec-policy preset yolo --json
pnpm openclaw exec-policy show --json
pnpm openclaw approvals get --json
pnpm openclaw approvals get
```

Session inspection path reference (no live chat required):

```bash
node scripts/run-vitest.mjs run src/auto-reply/reply/get-reply-run.exec-hint.test.ts
```

- **Evidence after fix:**

`exec-policy show --json` / `approvals get --json` note excerpt:

```text
Per-session /exec overrides are not included; send /exec in the target chat or cron session to inspect them.
```

`approvals get` text excerpt:

```text
Precedence: Effective exec policy is the host approvals file intersected with requested tools.exec policy. Per-session /exec overrides are not included; send /exec in the target chat or cron session to inspect them.
```

Session-status hint contract (Vitest):

```text
Current session exec defaults: host=gateway security=full ask=always node=worker-1.
```

- **Observed result after fix:**
  Both CLI commands append the session caveat in JSON and text output; docs carry matching `<Note>` blocks; focused CLI tests pass.

- **What was not tested:**
  No live chat `/exec` command in Telegram/Discord; no committed proof scripts.