### PR TITLE
fix(nodes): show pending requestIds when approve fails with unknown requestId

### DIFF
--- a/src/cli/nodes-cli/register.pairing.ts
+++ b/src/cli/nodes-cli/register.pairing.ts
@@ -65,6 +65,43 @@ async function resolveApproveScopesForRequest(
   }
 }
 
+function isUnknownNodePairRequestIdError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === "GatewayClientRequestError" &&
+    (error as Error & { gatewayCode?: unknown }).gatewayCode === "INVALID_REQUEST" &&
+    error.message.includes("unknown requestId")
+  );
+}
+
+async function buildUnknownRequestIdHint(
+  opts: NodesRpcOpts,
+  requestId: string,
+): Promise<string> {
+  let pendingIds: string[] = [];
+  try {
+    const result = await callNodePairApprovalGatewayCli(
+      "node.pair.list",
+      opts,
+      {},
+      { scopes: DEFAULT_NODE_PAIR_APPROVE_SCOPES },
+    );
+    pendingIds = parsePairingList(result)
+      .pending.map((request) => request.requestId)
+      .filter((id): id is string => typeof id === "string" && id.length > 0);
+  } catch {
+    // If we can't list pending requests, skip the hint listing
+  }
+  const lines = [`Unknown node pairing requestId: ${requestId}`];
+  if (pendingIds.length > 0) {
+    lines.push(`Currently pending requestIds: ${pendingIds.join(", ")}`);
+  } else {
+    lines.push("No pending node pairing requests are currently visible.");
+  }
+  lines.push(`Run ${formatCliCommand("openclaw nodes pending")} to inspect current requests.`);
+  return lines.join("\n");
+}
+
 /** Register node pairing management commands. */
 export function registerNodesPairingCommands(nodes: Command) {
   nodesCallOpts(
@@ -107,16 +144,24 @@ export function registerNodesPairingCommands(nodes: Command) {
       .action(async (requestId: string, opts: NodesRpcOpts) => {
         await runNodesCommand("approve", async () => {
           const scopes = await resolveApproveScopesForRequest(opts, requestId);
-          const result = await callNodePairApprovalGatewayCli(
-            "node.pair.approve",
-            opts,
-            {
-              requestId,
-            },
-            {
-              scopes,
-            },
-          );
+          let result: unknown;
+          try {
+            result = await callNodePairApprovalGatewayCli(
+              "node.pair.approve",
+              opts,
+              {
+                requestId,
+              },
+              {
+                scopes,
+              },
+            );
+          } catch (error) {
+            if (!isUnknownNodePairRequestIdError(error)) {
+              throw error;
+            }
+            throw new Error(await buildUnknownRequestIdHint(opts, requestId));
+          }
           defaultRuntime.writeJson(result);
         });
       }),

--- a/src/cli/nodes-cli/register.pairing.unknown-request-id.test.ts
+++ b/src/cli/nodes-cli/register.pairing.unknown-request-id.test.ts
@@ -1,0 +1,162 @@
+// Tests for node.pair.approve unknown requestId hint (fixes #94040).
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCallPairApprovalGateway = vi.fn();
+const mockParsePairingList = vi.fn(() => ({ pending: [], paired: [] }));
+const mockError = vi.fn();
+const mockExit = vi.fn();
+const mockWriteJson = vi.fn();
+const mockWriteStdout = vi.fn();
+const mockLog = vi.fn();
+
+vi.mock("./rpc.js", () => ({
+  callGatewayCli: vi.fn(),
+  callNodePairApprovalGatewayCli: (...args: unknown[]) =>
+    mockCallPairApprovalGateway(...args),
+  nodesCallOpts: (cmd: Command) => cmd,
+  resolveNodeId: vi.fn(),
+}));
+
+vi.mock("./format.js", () => ({
+  parsePairingList: (...args: unknown[]) => mockParsePairingList(...args),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: (...args: unknown[]) => mockLog(...args),
+    error: (...args: unknown[]) => mockError(...args),
+    writeJson: (...args: unknown[]) => mockWriteJson(...args),
+    writeStdout: (...args: unknown[]) => mockWriteStdout(...args),
+    exit: (...args: unknown[]) => mockExit(...args),
+  },
+}));
+
+const { registerNodesPairingCommands } =
+  await import("./register.pairing.js");
+
+function createApproveProgram() {
+  const program = new Command();
+  program.name("test");
+  program.exitOverride();
+  const nodes = program.command("nodes");
+  registerNodesPairingCommands(nodes);
+  return program;
+}
+
+function createGatewayUnknownRequestIdError(): Error {
+  const error = new Error("unknown requestId");
+  error.name = "GatewayClientRequestError";
+  (error as Error & { gatewayCode: string }).gatewayCode = "INVALID_REQUEST";
+  return error;
+}
+
+describe("nodes approve unknown requestId hint", () => {
+  beforeEach(() => {
+    mockCallPairApprovalGateway.mockReset();
+    mockParsePairingList.mockReset();
+    mockParsePairingList.mockReturnValue({ pending: [], paired: [] });
+    mockError.mockReset();
+    mockExit.mockReset();
+    mockWriteJson.mockReset();
+    mockWriteStdout.mockReset();
+    mockLog.mockReset();
+  });
+
+  it("shows pending requestIds when approve fails with unknown requestId", async () => {
+    // First call: resolveApproveScopesForRequest → node.pair.list
+    mockCallPairApprovalGateway.mockResolvedValueOnce({});
+    mockParsePairingList.mockReturnValueOnce({
+      pending: [
+        { requestId: "req-abc", nodeId: "n1" },
+        { requestId: "req-def", nodeId: "n2" },
+      ],
+      paired: [],
+    });
+    // Second call: approve throws unknown requestId
+    mockCallPairApprovalGateway.mockRejectedValueOnce(
+      createGatewayUnknownRequestIdError(),
+    );
+    // Third call: buildUnknownRequestIdHint → node.pair.list
+    mockCallPairApprovalGateway.mockResolvedValueOnce({});
+    mockParsePairingList.mockReturnValueOnce({
+      pending: [
+        { requestId: "req-abc", nodeId: "n1" },
+        { requestId: "req-def", nodeId: "n2" },
+      ],
+      paired: [],
+    });
+
+    const program = createApproveProgram();
+    try {
+      await program.parseAsync(["nodes", "approve", "stale-request"], {
+        from: "user",
+      });
+    } catch {
+      // exitOverride converts exit(1) to CommanderError
+    }
+
+    expect(mockError).toHaveBeenCalled();
+    const errorCalls = mockError.mock.calls.flat() as string[];
+    const errorText = errorCalls.join(" ");
+    expect(errorText).toContain(
+      "Unknown node pairing requestId: stale-request",
+    );
+    expect(errorText).toContain("req-abc");
+    expect(errorText).toContain("req-def");
+    expect(errorText).toContain("openclaw nodes pending");
+  });
+
+  it("shows fallback when list fails during hint building", async () => {
+    // resolveApproveScopesForRequest list fails silently
+    mockCallPairApprovalGateway.mockRejectedValueOnce(new Error("gateway down"));
+    // approve fails with unknown requestId
+    mockCallPairApprovalGateway.mockRejectedValueOnce(
+      createGatewayUnknownRequestIdError(),
+    );
+    // buildUnknownRequestIdHint list also fails
+    mockCallPairApprovalGateway.mockRejectedValueOnce(new Error("gateway down"));
+
+    const program = createApproveProgram();
+    try {
+      await program.parseAsync(["nodes", "approve", "orphan-request"], {
+        from: "user",
+      });
+    } catch {
+      // exitOverride
+    }
+
+    expect(mockError).toHaveBeenCalled();
+    const errorCalls = mockError.mock.calls.flat() as string[];
+    const errorText = errorCalls.join(" ");
+    expect(errorText).toContain(
+      "Unknown node pairing requestId: orphan-request",
+    );
+    expect(errorText).toContain(
+      "No pending node pairing requests are currently visible",
+    );
+  });
+
+  it("does not intercept non-unknown-requestId errors", async () => {
+    mockCallPairApprovalGateway.mockResolvedValueOnce({});
+    mockParsePairingList.mockReturnValueOnce({ pending: [], paired: [] });
+    mockCallPairApprovalGateway.mockRejectedValueOnce(
+      new Error("some other error"),
+    );
+
+    const program = createApproveProgram();
+    try {
+      await program.parseAsync(["nodes", "approve", "req-1"], {
+        from: "user",
+      });
+    } catch {
+      // exitOverride
+    }
+
+    expect(mockError).toHaveBeenCalled();
+    const errorCalls = mockError.mock.calls.flat() as string[];
+    const errorText = errorCalls.join(" ");
+    expect(errorText).toContain("some other error");
+    expect(errorText).not.toContain("openclaw nodes pending");
+  });
+});


### PR DESCRIPTION
## Summary

When `openclaw nodes approve <requestId>` fails with "unknown requestId", the CLI now lists the current valid pending requestIds so users can identify the correct request without guessing.

## Problem

Running `openclaw nodes approve <requestId>` with a stale or typo'd requestId produces an opaque `GatewayClientRequestError: unknown requestId` error. Users have no way to discover which requestIds are valid without running `openclaw nodes pending` separately.

## Root Cause

The gateway returns `INVALID_REQUEST / "unknown requestId"` when the requestId is not found in the pending list, but the CLI passes this error through without surfacing the currently valid pending requestIds. See `src/cli/nodes-cli/register.pairing.ts:107-121`.

## Changes

- **`src/cli/nodes-cli/register.pairing.ts`** — add `isUnknownNodePairRequestIdError` detector and `buildUnknownRequestIdHint` that fetches pending requests; wrap approve call in try/catch to surface the hint when the specific error is detected
- **`src/cli/nodes-cli/register.pairing.unknown-request-id.test.ts`** — add tests for the hint with pending IDs, fallback when list fails, and non-intercept of unrelated errors

## Testing

3 new tests cover: pending IDs displayed, fallback when listing fails, non-unknown-requestId errors pass through unchanged. Full CI needed (no local pnpm).

## Related

Closes #94040
参考 #94452 — 采用相同的 error detection + hint 模式，改进 toString/error 处理方式
参考 #94532 — 该 PR 尝试在 gateway 端做 idempotent 修复但引用了不存在的 getPairedNode 函数