### PR TITLE
Add needed sandbox activation mode

### DIFF
--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -236,7 +236,7 @@ agent id instead of skipping it.
     },
   },
   "sandbox": {
-    "requireMode": ["all", "non-main"],
+    "requireMode": ["all", "non-main", "needed"],
   },
   "scopes": {
     "release-workspace": {
@@ -392,16 +392,16 @@ node command should update `policy.jsonc` after review instead of relying on
 
 #### Sandbox posture
 
-| Policy field                                          | Observed state                                          | Use when                                                       |
-| ----------------------------------------------------- | ------------------------------------------------------- | -------------------------------------------------------------- |
-| `sandbox.requireMode`                                 | `agents.defaults.sandbox.mode` and per-agent mode       | Allow only reviewed sandbox modes such as `all` or `non-main`. |
-| `sandbox.allowBackends`                               | `agents.defaults.sandbox.backend` and per-agent backend | Allow only reviewed sandbox backends such as `docker`.         |
-| `sandbox.containers.denyHostNetwork`                  | Container-backed sandbox/browser network mode           | Deny host network mode.                                        |
-| `sandbox.containers.denyContainerNamespaceJoin`       | Container-backed sandbox/browser network mode           | Deny joining another container network namespace.              |
-| `sandbox.containers.requireReadOnlyMounts`            | Container-backed sandbox/browser mount mode             | Require mounts to be read-only.                                |
-| `sandbox.containers.denyContainerRuntimeSocketMounts` | Container-backed sandbox/browser mount targets          | Deny container runtime socket mounts.                          |
-| `sandbox.containers.denyUnconfinedProfiles`           | Container security profile posture                      | Deny unconfined container security profiles.                   |
-| `sandbox.browser.requireCdpSourceRange`               | Sandbox browser CDP source range                        | Require browser CDP exposure to declare a source range.        |
+| Policy field                                          | Observed state                                          | Use when                                                                  |
+| ----------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `sandbox.requireMode`                                 | `agents.defaults.sandbox.mode` and per-agent mode       | Allow only reviewed sandbox modes such as `all`, `needed`, or `non-main`. |
+| `sandbox.allowBackends`                               | `agents.defaults.sandbox.backend` and per-agent backend | Allow only reviewed sandbox backends such as `docker`.                    |
+| `sandbox.containers.denyHostNetwork`                  | Container-backed sandbox/browser network mode           | Deny host network mode.                                                   |
+| `sandbox.containers.denyContainerNamespaceJoin`       | Container-backed sandbox/browser network mode           | Deny joining another container network namespace.                         |
+| `sandbox.containers.requireReadOnlyMounts`            | Container-backed sandbox/browser mount mode             | Require mounts to be read-only.                                           |
+| `sandbox.containers.denyContainerRuntimeSocketMounts` | Container-backed sandbox/browser mount targets          | Deny container runtime socket mounts.                                     |
+| `sandbox.containers.denyUnconfinedProfiles`           | Container security profile posture                      | Deny unconfined container security profiles.                              |
+| `sandbox.browser.requireCdpSourceRange`               | Sandbox browser CDP source range                        | Require browser CDP exposure to declare a source range.                   |
 
 Policy treats missing `sandbox.mode` as its implicit default `off`, so
 `sandbox.requireMode` reports a fresh or unconfigured sandbox as outside an

--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -47,6 +47,8 @@ For `ssh` and OpenShell `remote`, recreate matters more than with Docker: the re
 
 Inspect the effective sandbox mode/scope/workspace access, sandbox tool policy, and elevated-tool gates (with fix-it config key paths).
 
+For `mode: "needed"`, the report distinguishes the direct chat runtime from the sandbox that activates only when a sandbox-bound tool runs.
+
 The report keeps `workspaceRoot` as the configured sandbox root and separately shows the effective host workspace, backend runtime workdir, and Docker mount table. For `workspaceAccess: "rw"`, the effective host workspace is the agent workspace rather than a directory below `workspaceRoot`.
 
 ```bash
@@ -99,7 +101,7 @@ Sandbox settings live in `~/.openclaw/openclaw.json` under `agents.defaults.sand
   "agents": {
     "defaults": {
       "sandbox": {
-        "mode": "all", // off, non-main, all
+        "mode": "all", // off, non-main, needed, all
         "backend": "docker", // docker, ssh, openshell (plugin-provided)
         "scope": "agent", // session, agent, shared
         "docker": {

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -720,7 +720,7 @@ Optional sandboxing for the embedded agent. See [Sandboxing](/gateway/sandboxing
   agents: {
     defaults: {
       sandbox: {
-        mode: "non-main", // off (default) | non-main | all
+        mode: "non-main", // off (default) | non-main | needed | all
         backend: "docker", // docker (default) | ssh | openshell
         scope: "agent", // session | agent (default) | shared
         workspaceAccess: "none", // none (default) | ro | rw

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -309,7 +309,7 @@ candidate contains a redacted secret placeholder such as `***` or `[redacted]`.
       agents: {
         defaults: {
           sandbox: {
-            mode: "non-main",  // off | non-main | all
+            mode: "non-main",  // off | non-main | needed | all
             scope: "agent",    // session | agent | shared
           },
         },

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -25,7 +25,7 @@ openclaw sandbox explain --json
 It prints:
 
 - effective sandbox mode/scope/workspace access
-- whether the session is currently sandboxed (main vs non-main)
+- whether the session is currently sandboxed, or will sandbox only when sandbox-bound tools run
 - effective sandbox tool allow/deny (and whether it came from agent/global/default)
 - elevated gates and fix-it key paths
 
@@ -35,6 +35,7 @@ Sandboxing is controlled by `agents.defaults.sandbox.mode`:
 
 - `"off"`: everything runs on the host.
 - `"non-main"`: only non-main sessions are sandboxed (common "surprise" for groups/channels).
+- `"needed"`: chat-only turns run direct; sandbox-bound tools such as `exec` start the sandbox when called and fail closed if the backend is unavailable.
 - `"all"`: everything is sandboxed.
 
 `agents.defaults.sandbox.workspaceAccess` controls what the sandbox can see: `"none"`, `"ro"`, or `"rw"`.

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -26,16 +26,17 @@ Not sandboxed:
 
 Three independent settings control sandbox behavior:
 
-| Setting | Key                               | Values                       | Default  |
-| ------- | --------------------------------- | ---------------------------- | -------- |
-| Mode    | `agents.defaults.sandbox.mode`    | `off`, `non-main`, `all`     | `off`    |
-| Scope   | `agents.defaults.sandbox.scope`   | `agent`, `session`, `shared` | `agent`  |
-| Backend | `agents.defaults.sandbox.backend` | `docker`, `ssh`, `openshell` | `docker` |
+| Setting | Key                               | Values                             | Default  |
+| ------- | --------------------------------- | ---------------------------------- | -------- |
+| Mode    | `agents.defaults.sandbox.mode`    | `off`, `non-main`, `needed`, `all` | `off`    |
+| Scope   | `agents.defaults.sandbox.scope`   | `agent`, `session`, `shared`       | `agent`  |
+| Backend | `agents.defaults.sandbox.backend` | `docker`, `ssh`, `openshell`       | `docker` |
 
 **Mode** controls when sandboxing applies:
 
 - `off`: no sandboxing.
 - `non-main`: sandbox every session except the agent's main session. The main session key is always `agent:<agentId>:main` (or `global` when `session.scope` is `"global"`); it is not configurable. Group/channel sessions use their own keys, so they always count as non-main and get sandboxed.
+- `needed`: chat-only turns run direct. Sandbox-bound OpenClaw tools such as `exec` start the configured backend when called and fail closed if it is unavailable. Codex native execution stays disabled until an OpenClaw sandbox environment exists, so it cannot fall back to host execution.
 - `all`: every session runs in a sandbox.
 
 **Scope** controls how many containers/environments are created:

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -549,7 +549,7 @@ For full configuration, images, security notes, and multi-agent profiles:
   agents: {
     defaults: {
       sandbox: {
-        mode: "non-main", // off | non-main | all
+        mode: "non-main", // off | non-main | needed | all
         scope: "agent", // session | agent | shared
       },
     },

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -1543,6 +1543,40 @@ describe("Codex app-server dynamic tool build", () => {
     expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
   });
 
+  it("disables Codex native tools while needed mode waits for sandbox-bound tools", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "needed-session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.sessionKey = "agent:main:main";
+    params.config = {
+      agents: { defaults: { sandbox: { mode: "needed" } } },
+      tools: { exec: { host: "auto" } },
+    } as never;
+
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+    expect(
+      shouldEnableCodexAppServerNativeToolSurface(params, {
+        enabled: true,
+        backendId: "docker",
+      } as never),
+    ).toBe(false);
+    expect(
+      shouldEnableCodexAppServerNativeToolSurface(
+        params,
+        {
+          enabled: true,
+          backendId: "docker",
+          backend: {},
+          tools: {
+            allow: ["exec", "process", "read", "write", "edit", "apply_patch"],
+            deny: [],
+          },
+        } as never,
+        { sandboxExecServerEnabled: true },
+      ),
+    ).toBe(true);
+  });
+
   it("keeps Codex native tool surfaces when the effective exec target is node", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const sessionParams = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -513,6 +513,18 @@ export function shouldEnableCodexAppServerNativeToolSurface(
   if (params.disableTools) {
     return false;
   }
+  const nativeExecutionPolicy = resolveCodexNativeExecutionPolicy({
+    config: params.config,
+    sessionKey: resolveCodexRuntimePolicySessionKey(params, options.runtimeSessionKey),
+    sessionId: params.sessionId,
+    agentId: options.agentId,
+    execOverrides: params.execOverrides,
+    sandboxAvailable: sandbox?.enabled,
+    readRuntimeSessionEntry: true,
+  });
+  if (nativeExecutionPolicy.blockKind === "sandbox-activation-required") {
+    return false;
+  }
   const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
   if (toolsAllow === undefined) {
     return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options);

--- a/extensions/codex/src/app-server/native-execution-policy.test.ts
+++ b/extensions/codex/src/app-server/native-execution-policy.test.ts
@@ -47,6 +47,77 @@ describe("resolveCodexNativeExecutionPolicy", () => {
     });
   });
 
+  it("blocks native execution while needed mode is waiting for tool activation", () => {
+    expect(
+      resolveCodexNativeExecutionPolicy({
+        config: {
+          agents: { defaults: { sandbox: { mode: "needed" } } },
+          tools: { exec: { host: "auto" } },
+        },
+        sessionKey: "agent:main:main",
+        sandboxAvailable: false,
+      }),
+    ).toMatchObject({
+      nativeToolSurfaceAllowed: false,
+      requestedExecHost: "auto",
+      effectiveExecHost: "gateway",
+      blockKind: "sandbox-activation-required",
+    });
+  });
+
+  it("allows native execution after needed mode has an active sandbox", () => {
+    expect(
+      resolveCodexNativeExecutionPolicy({
+        config: {
+          agents: { defaults: { sandbox: { mode: "needed" } } },
+          tools: { exec: { host: "auto" } },
+        },
+        sessionKey: "agent:main:main",
+        sandboxAvailable: true,
+      }),
+    ).toMatchObject({
+      nativeToolSurfaceAllowed: true,
+      requestedExecHost: "auto",
+      effectiveExecHost: "sandbox",
+    });
+  });
+
+  it("keeps an explicit gateway host available in needed mode", () => {
+    expect(
+      resolveCodexNativeExecutionPolicy({
+        config: {
+          agents: { defaults: { sandbox: { mode: "needed" } } },
+          tools: { exec: { host: "gateway" } },
+        },
+        sessionKey: "agent:main:main",
+        sandboxAvailable: false,
+      }),
+    ).toMatchObject({
+      nativeToolSurfaceAllowed: true,
+      requestedExecHost: "gateway",
+      effectiveExecHost: "gateway",
+    });
+  });
+
+  it("keeps node routing blocked as node execution in needed mode", () => {
+    expect(
+      resolveCodexNativeExecutionPolicy({
+        config: {
+          agents: { defaults: { sandbox: { mode: "needed" } } },
+          tools: { exec: { host: "node", node: "worker-needed" } },
+        },
+        sessionKey: "agent:main:main",
+        sandboxAvailable: false,
+      }),
+    ).toMatchObject({
+      nativeToolSurfaceAllowed: false,
+      requestedExecHost: "node",
+      effectiveExecHost: "node",
+      blockKind: "node-exec",
+      node: "worker-needed",
+    });
+  });
+
   it("resolves auto to sandbox when a sandbox is active", () => {
     expect(
       resolveCodexNativeExecutionPolicy({

--- a/extensions/codex/src/app-server/native-execution-policy.ts
+++ b/extensions/codex/src/app-server/native-execution-policy.ts
@@ -28,6 +28,7 @@ export type CodexNativeExecutionPolicy = {
   requestedExecHost: ExecTarget;
   effectiveExecHost: ExecHost;
   node?: string;
+  blockKind?: "node-exec" | "sandbox-activation-required";
   blockReason?: string;
 };
 
@@ -64,14 +65,13 @@ export function resolveCodexNativeExecutionPolicy(params: {
     (canReadSessionEntry && sessionKey
       ? readRuntimeSessionEntryBestEffort({ sessionKey, agentId })
       : undefined);
+  const sandboxRuntime = resolveSandboxRuntimeStatus({
+    cfg: config,
+    sessionKey,
+    agentId,
+  });
   const sandboxAvailable =
-    params.sandboxAvailable ??
-    (sessionKey
-      ? resolveSandboxRuntimeStatus({
-          cfg: config,
-          sessionKey,
-        }).sandboxed
-      : false);
+    params.sandboxAvailable ?? (sessionKey ? sandboxRuntime.sandboxed : false);
   const agentExec = resolvePolicyAgentExec({ config, agentId });
   const globalExec = config.tools?.exec;
   const requestedExecHost =
@@ -86,6 +86,21 @@ export function resolveCodexNativeExecutionPolicy(params: {
   });
   const node =
     params.execOverrides?.node ?? sessionEntry?.execNode ?? agentExec?.node ?? globalExec?.node;
+  const sandboxActivationRequired =
+    sandboxRuntime.mode === "needed" &&
+    !sandboxAvailable &&
+    (requestedExecHost === "auto" || requestedExecHost === "sandbox");
+  if (sandboxActivationRequired) {
+    return {
+      nativeToolSurfaceAllowed: false,
+      requestedExecHost,
+      effectiveExecHost,
+      node,
+      blockKind: "sandbox-activation-required",
+      blockReason:
+        "OpenClaw sandbox mode=needed has not activated the configured sandbox backend. Codex app-server native shell, filesystem, MCP, and app-backed work cannot be routed through the pending OpenClaw sandbox.",
+    };
+  }
   if (effectiveExecHost !== "node") {
     return {
       nativeToolSurfaceAllowed: true,
@@ -99,19 +114,28 @@ export function resolveCodexNativeExecutionPolicy(params: {
     requestedExecHost,
     effectiveExecHost,
     node,
+    blockKind: "node-exec",
     blockReason:
       "OpenClaw exec host=node is active for this session. Codex app-server native execution cannot route shell, filesystem, MCP, or app-backed work through the selected OpenClaw node.",
   };
 }
 
-/** Formats the user-facing explanation shown when native tools are blocked by exec host=node. */
-export function formatCodexNativeNodeExecBlock(params: {
+/** Formats the user-facing explanation shown when native execution cannot honor OpenClaw policy. */
+export function formatCodexNativeExecutionBlock(params: {
   surface: string;
-  reason?: string;
+  policy: CodexNativeExecutionPolicy;
 }): string {
+  if (params.policy.blockKind === "sandbox-activation-required") {
+    return [
+      `Codex-native ${params.surface} is unavailable because OpenClaw sandbox mode=needed has not activated its sandbox backend for this turn.`,
+      params.policy.blockReason ??
+        "Codex app-server native execution cannot route through a pending OpenClaw sandbox.",
+      "Use a normal Codex harness turn so sandbox-bound OpenClaw tools can activate the backend; native execution will not fall back to the host.",
+    ].join(" ");
+  }
   return [
     `Codex-native ${params.surface} is unavailable because OpenClaw exec host=node is active for this session.`,
-    params.reason ??
+    params.policy.blockReason ??
       "Codex app-server native execution cannot route execution through the selected OpenClaw node.",
     "Use a normal Codex harness turn so OpenClaw exec/process tools run on the node, or switch exec host to gateway for native Codex app-server execution.",
   ].join(" ");

--- a/extensions/codex/src/app-server/sandbox-guard.ts
+++ b/extensions/codex/src/app-server/sandbox-guard.ts
@@ -5,7 +5,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveSandboxRuntimeStatus } from "openclaw/plugin-sdk/sandbox";
 import {
-  formatCodexNativeNodeExecBlock,
+  formatCodexNativeExecutionBlock,
   resolveCodexNativeExecutionPolicy,
 } from "./native-execution-policy.js";
 
@@ -215,8 +215,8 @@ function resolveCodexNativeNodeExecBlock(params: {
   if (policy.nativeToolSurfaceAllowed) {
     return undefined;
   }
-  return formatCodexNativeNodeExecBlock({
+  return formatCodexNativeExecutionBlock({
     surface: params.surface,
-    reason: policy.blockReason,
+    policy,
   });
 }

--- a/extensions/policy/src/doctor/metadata.ts
+++ b/extensions/policy/src/doctor/metadata.ts
@@ -67,7 +67,7 @@ const SANDBOX_POLICY_RULE_METADATA = [
     valueType: "string-list",
     checkIds: [CHECK_IDS.policySandboxModeUnapproved],
     emptyList: "disabled",
-    allowedValues: ["off", "non-main", "all"],
+    allowedValues: ["off", "non-main", "needed", "all"],
     scopeSelectors: ["agentIds"],
   },
   {

--- a/extensions/policy/src/doctor/policy-constants.ts
+++ b/extensions/policy/src/doctor/policy-constants.ts
@@ -73,4 +73,4 @@ export const SUPPORTED_TOOL_EXEC_HOST = ["auto", "sandbox", "gateway", "node"] a
 
 export const SUPPORTED_EXEC_APPROVAL_SECURITY = ["deny", "allowlist", "full"] as const;
 
-export const SUPPORTED_SANDBOX_MODES = ["off", "non-main", "all"] as const;
+export const SUPPORTED_SANDBOX_MODES = ["off", "non-main", "needed", "all"] as const;

--- a/extensions/policy/src/doctor/register.sandbox-and-tools.test-utils.ts
+++ b/extensions/policy/src/doctor/register.sandbox-and-tools.test-utils.ts
@@ -445,6 +445,28 @@ describe("registerPolicyDoctorChecks", () => {
     expect(result.findings).toEqual([]);
   });
 
+  it("accepts needed as a reviewed sandbox mode", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      agents: {
+        defaults: {
+          sandbox: { mode: "needed" },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ sandbox: { requireMode: ["needed"] } }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([]);
+  });
+
   it("applies agent-scoped sandbox claims only to matching agents", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {

--- a/extensions/policy/src/policy-state-tool-posture.ts
+++ b/extensions/policy/src/policy-state-tool-posture.ts
@@ -115,7 +115,7 @@ function pushToolExecPosture(
   const inheritedSecurity = readString(inheritedExec.security);
   // Config conformance intentionally ignores exec-approvals.json runtime/operator state.
   const sandboxMode = readString(params.sandbox.mode) ?? readString(params.inheritedSandbox.mode);
-  const sandboxCanApply = sandboxMode === "all";
+  const sandboxCanApply = sandboxMode === "all" || sandboxMode === "needed";
   pushToolPostureValue(entries, params, {
     suffix: "exec/security",
     kind: "execSecurity",

--- a/extensions/policy/src/policy-state-workspace.ts
+++ b/extensions/policy/src/policy-state-workspace.ts
@@ -73,6 +73,7 @@ function pushAgentWorkspaceEvidence(
   const explicitSandboxMode = readString(params.sandbox.mode);
   const inheritedSandboxMode = readString(params.inheritedSandbox.mode);
   const sandboxMode = explicitSandboxMode ?? inheritedSandboxMode ?? "off";
+  // `needed` activates execution isolation without sandboxing the chat turn's workspace.
   const sandboxModeCoversAgentMain = sandboxMode === "all";
   const sandboxModeSource =
     explicitSandboxMode !== undefined

--- a/extensions/policy/src/policy-state.test.ts
+++ b/extensions/policy/src/policy-state.test.ts
@@ -55,6 +55,24 @@ describe("scanPolicyRouting", () => {
   });
 });
 
+describe("scanPolicyToolPosture", () => {
+  it("reports sandbox-default exec security for needed mode", () => {
+    const evidence = collectPolicyEvidence({
+      agents: { defaults: { sandbox: { mode: "needed" } } },
+      tools: { exec: { host: "auto" } },
+    }).toolPosture;
+
+    expect(evidence).toContainEqual(
+      expect.objectContaining({
+        kind: "execSecurity",
+        scope: "global",
+        value: "deny",
+        explicit: false,
+      }),
+    );
+  });
+});
+
 describe("scanPolicyTools", () => {
   it("scans documented bullet tool declarations", async () => {
     await expect(

--- a/src/agents/agent-tools-agent-config.exec.test.ts
+++ b/src/agents/agent-tools-agent-config.exec.test.ts
@@ -4,7 +4,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -12,6 +12,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createSessionConversationTestRegistry } from "../test-utils/session-conversation-registry.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
+import { registerSandboxBackend } from "./sandbox/backend.js";
 
 function createExecHostDefaultsConfig(
   agents: Array<{ id: string; execHost?: "auto" | "gateway" | "sandbox" }>,
@@ -114,6 +115,60 @@ describe("Agent-specific exec tool defaults", () => {
     });
     const resultDetails = result?.details as { status?: string } | undefined;
     expect(resultDetails?.status).toBe("completed");
+  });
+
+  it("creates a needed sandbox only when exec is called", async () => {
+    const backendFactory = vi.fn(async () => ({
+      id: "test-needed-exec",
+      runtimeId: "needed-exec-runtime",
+      runtimeLabel: "Needed Exec Runtime",
+      workdir: "/runtime/workspace",
+      buildExecSpec: async () => ({
+        argv: [process.execPath, "-e", 'process.stdout.write("needed sandbox")'],
+        env: process.env,
+        stdinMode: "pipe-closed" as const,
+      }),
+      runShellCommand: async () => ({
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      }),
+    }));
+    const restore = registerSandboxBackend("test-needed-exec", {
+      factory: backendFactory,
+      resolveWorkdir: () => "/runtime/workspace",
+    });
+    try {
+      const tools = createOpenClawCodingTools({
+        config: {
+          agents: {
+            defaults: {
+              sandbox: {
+                mode: "needed",
+                backend: "test-needed-exec",
+                scope: "session",
+                workspaceAccess: "rw",
+                prune: { idleHours: 0, maxAgeDays: 0 },
+              },
+            },
+          },
+          tools: { exec: { host: "auto", mode: "full" } },
+        },
+        sessionKey: "agent:main:main",
+        ...createTempAgentDirs("test-main-needed-sandbox"),
+      });
+      const execTool = requireExecTool(tools);
+
+      expect(backendFactory).not.toHaveBeenCalled();
+      const result = await execTool.execute("call-needed-sandbox", { command: "ignored" });
+
+      expect(backendFactory).toHaveBeenCalledTimes(1);
+      expect((result.content[0] as { text?: string } | undefined)?.text).toContain(
+        "needed sandbox",
+      );
+    } finally {
+      restore();
+    }
   });
 
   it("passes normalized exec mode defaults into the exec tool", async () => {
@@ -230,7 +285,7 @@ describe("Agent-specific exec tool defaults", () => {
         command: "echo done",
         host: "sandbox",
       }),
-    ).rejects.toThrow(/requires a sandbox runtime/);
+    ).rejects.toThrow(/no sandbox runtime is available/);
   });
 
   it("should apply agent-specific exec host defaults over global defaults", async () => {
@@ -276,7 +331,7 @@ describe("Agent-specific exec tool defaults", () => {
         host: "sandbox",
         yieldMs: 1000,
       }),
-    ).rejects.toThrow(/requires a sandbox runtime/);
+    ).rejects.toThrow(/no sandbox runtime is available/);
   });
 
   it("applies explicit agentId exec defaults when sessionKey is opaque", async () => {

--- a/src/agents/agent-tools.policy.ts
+++ b/src/agents/agent-tools.policy.ts
@@ -24,7 +24,7 @@ import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentConfig, resolveAgentIdFromSessionKey } from "./agent-scope.js";
 import { resolveProviderToolPolicy } from "./provider-tool-policy.js";
 import { pickSandboxToolPolicy } from "./sandbox-tool-policy.js";
-import type { SandboxToolPolicy } from "./sandbox.js";
+import type { SandboxMode, SandboxToolPolicy } from "./sandbox.js";
 import { resolveSandboxToolPolicyForAgent } from "./sandbox/tool-policy.js";
 import {
   resolveSubagentCapabilityStore,
@@ -156,7 +156,7 @@ export function filterToolsByPolicy<TTool extends { name: string }>(
 export function resolveConfiguredToolPolicies(params: {
   cfg: OpenClawConfig;
   agentTools?: AgentToolsConfig;
-  sandboxMode?: "off" | "non-main" | "all";
+  sandboxMode?: SandboxMode;
   agentId?: string | null;
   extraPolicies?: readonly (SandboxToolPolicy | undefined)[];
 }): SandboxToolPolicy[] {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -88,6 +88,7 @@ import { createOpenClawTools, filterToolsByClientCaps } from "./openclaw-tools.j
 import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.js";
 import type { SandboxContext } from "./sandbox.js";
 import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./sandbox/constants.js";
+import { resolveSandboxExecRuntime } from "./sandbox/exec-runtime.js";
 import { resolveReadOnlyWorkspaceSkillMounts } from "./sandbox/workspace-mounts.js";
 import type { ScheduledToolPolicyContext } from "./scheduled-tool-policy.js";
 import { createCodingTools, createReadTool } from "./sessions/index.js";
@@ -594,6 +595,15 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   ]);
   options?.recordToolPrepStage?.("tool-policy");
   const execConfig = resolveExecToolConfig({ cfg: options?.config, agentId });
+  const sandboxExecRuntime = resolveSandboxExecRuntime({
+    config: options?.config,
+    agentId,
+    execOverrides: options?.exec,
+    sessionKey: options?.sessionKey,
+    workspaceDir: options?.workspaceDir,
+    sandbox,
+    resolveSandbox: options?.exec?.resolveSandbox,
+  });
   const fsConfig = resolveToolFsConfig({ cfg: options?.config, agentId });
   const fsPolicy = createToolFsPolicy({
     workspaceOnly: isMemoryFlushRun || fsConfig.workspaceOnly,
@@ -755,22 +765,11 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
         notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
         notifyOnExitEmptySuccess:
           options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
-        sandbox: sandbox
-          ? {
-              containerName: sandbox.containerName,
-              workspaceDir: sandbox.workspaceDir,
-              containerWorkdir: sandbox.containerWorkdir,
-              workdirValidation: sandbox.backend?.workdirValidation,
-              validateWorkdir: sandbox.backend?.validateWorkdir?.bind(sandbox.backend),
-              discardPreparedWorkdir: sandbox.backend?.discardPreparedWorkdir?.bind(
-                sandbox.backend,
-              ),
-              workdirRoots: sandbox.backend?.workdirRoots,
-              env: sandbox.backend?.env ?? sandbox.docker.env,
-              buildExecSpec: sandbox.backend?.buildExecSpec.bind(sandbox.backend),
-              finalizeExec: sandbox.backend?.finalizeExec?.bind(sandbox.backend),
-            }
-          : undefined,
+        ...(sandboxExecRuntime.kind === "active"
+          ? { sandbox: sandboxExecRuntime.sandbox }
+          : sandboxExecRuntime.kind === "lazy"
+            ? { resolveSandbox: sandboxExecRuntime.resolveSandbox }
+            : {}),
       })
     : null;
   const processTool = includeShellTools

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -50,6 +50,7 @@ export type ExecToolDefaults = {
   approvalFollowupMode?: "agent" | "direct";
   approvalRunningNoticeMs?: number;
   sandbox?: BashSandboxConfig;
+  resolveSandbox?: () => BashSandboxConfig | undefined | Promise<BashSandboxConfig | undefined>;
   elevated?: ExecElevatedDefaults;
   allowBackground?: boolean;
   scopeKey?: string;

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -433,7 +433,23 @@ describe("exec host env validation", () => {
       tool.execute("call1", {
         command: "echo ok",
       }),
-    ).rejects.toThrow(/requires a sandbox runtime/);
+    ).rejects.toThrow(/no sandbox runtime is available/);
+  });
+
+  it("fails closed instead of falling back to gateway when lazy sandbox is unavailable", async () => {
+    const resolveSandbox = vi.fn(async () => undefined);
+    const tool = createExecTool({
+      security: "full",
+      ask: "off",
+      resolveSandbox,
+    });
+
+    await expect(
+      tool.execute("call-lazy-sandbox", {
+        command: "echo ok",
+      }),
+    ).rejects.toThrow(/resolved to sandbox/);
+    expect(resolveSandbox).toHaveBeenCalledTimes(1);
   });
 
   it.each([

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1377,6 +1377,7 @@ export function createExecTool(
   const agentId =
     defaults?.agentId ??
     (parsedAgentSession ? resolveAgentIdFromSessionKey(defaults?.sessionKey) : undefined);
+  const hasSandboxRuntime = () => Boolean(defaults?.sandbox || defaults?.resolveSandbox);
   const resolveHostForParams = (params: ExecToolArgs): ExecHost => {
     const elevatedDefaults = defaults?.elevated;
     const elevatedAllowed = Boolean(elevatedDefaults?.enabled && elevatedDefaults.allowed);
@@ -1402,7 +1403,7 @@ export function createExecTool(
       configuredTarget: defaults?.host,
       requestedTarget,
       elevatedRequested: elevatedMode !== "off",
-      sandboxAvailable: Boolean(defaults?.sandbox),
+      sandboxAvailable: hasSandboxRuntime(),
     }).effectiveHost;
   };
   const buildUnavailableWorkdirResult = (params: {
@@ -1641,7 +1642,7 @@ export function createExecTool(
       const elevatedRequested = elevatedMode !== "off";
       if (elevatedRequested) {
         if (!elevatedDefaults?.enabled || !elevatedDefaults.allowed) {
-          const runtime = defaults?.sandbox ? "sandboxed" : "direct";
+          const runtime = hasSandboxRuntime() ? "sandboxed" : "direct";
           const gates: string[] = [];
           const contextParts: string[] = [];
           const provider = normalizeOptionalString(defaults?.messageProvider);
@@ -1680,7 +1681,7 @@ export function createExecTool(
         configuredTarget: defaults?.host,
         requestedTarget,
         elevatedRequested,
-        sandboxAvailable: Boolean(defaults?.sandbox),
+        sandboxAvailable: hasSandboxRuntime(),
       });
       const host: ExecHost = target.effectiveHost;
 
@@ -1738,12 +1739,15 @@ export function createExecTool(
       }
       const autoReview = modePolicy.autoReview && ask === modePolicy.ask && !bypassApprovals;
 
-      const sandbox = host === "sandbox" ? defaults?.sandbox : undefined;
-      if (target.selectedTarget === "sandbox" && !sandbox) {
+      let sandbox = host === "sandbox" ? defaults?.sandbox : undefined;
+      if (host === "sandbox" && !sandbox && defaults?.resolveSandbox) {
+        sandbox = await defaults.resolveSandbox();
+      }
+      if (host === "sandbox" && !sandbox) {
         throw new Error(
           [
-            "exec host=sandbox requires a sandbox runtime for this session.",
-            'Enable sandbox mode (`agents.defaults.sandbox.mode="non-main"` or `"all"`) or use host=auto/gateway/node.',
+            "exec resolved to sandbox, but no sandbox runtime is available for this session.",
+            'Enable sandbox mode (`agents.defaults.sandbox.mode="needed"`, `"non-main"`, or `"all"`) or configure tools.exec.host=gateway/node.',
           ].join("\n"),
         );
       }

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
@@ -95,11 +95,21 @@ export async function prepareEmbeddedAttemptSystemPrompt(params: {
           accountId: attempt.agentAccountId,
         })
       : undefined;
+  const sandboxAvailableOnToolActivation = resolveSandboxRuntimeStatus({
+    cfg: attempt.config,
+    agentId: params.sessionAgentId,
+    sessionKey: params.sandboxSessionKey,
+    activation: "tool",
+  }).sandboxed;
   const sandboxInfoExecPolicy = resolveEmbeddedSandboxInfoExecPolicy({
     config: attempt.config,
     agentId: params.sessionAgentId,
-    sessionKey: attempt.sessionKey,
-    sandboxAvailable: params.sandbox?.enabled === true,
+    sessionKey: params.sandboxSessionKey,
+    ...(params.sandbox?.enabled === true
+      ? { sandboxAvailable: true }
+      : sandboxAvailableOnToolActivation
+        ? {}
+        : { sandboxAvailable: false }),
     execOverrides: attempt.execOverrides,
   });
   const sandboxInfo = buildEmbeddedSandboxInfo(

--- a/src/agents/exec-defaults.test.ts
+++ b/src/agents/exec-defaults.test.ts
@@ -119,6 +119,29 @@ describe("resolveExecDefaults", () => {
     expect(defaults.ask).toBe("off");
   });
 
+  it("treats needed sandbox mode as available for exec tool activation", () => {
+    const defaults = resolveExecDefaults({
+      cfg: {
+        agents: {
+          defaults: {
+            sandbox: { mode: "needed", scope: "agent" },
+          },
+        },
+        tools: {
+          exec: {
+            host: "auto",
+          },
+        },
+      },
+      sessionKey: "agent:main:main",
+    });
+
+    expect(defaults.host).toBe("auto");
+    expect(defaults.effectiveHost).toBe("sandbox");
+    expect(defaults.mode).toBe("deny");
+    expect(defaults.canRequestNode).toBe(false);
+  });
+
   it("ignores host approval defaults when auto resolves to sandbox", () => {
     vi.mocked(execApprovals.loadExecApprovals).mockReturnValue({
       version: 1,

--- a/src/agents/exec-defaults.ts
+++ b/src/agents/exec-defaults.ts
@@ -156,6 +156,7 @@ export function resolveExecDefaults(params: {
       ? resolveSandboxRuntimeStatus({
           cfg,
           sessionKey: params.sessionKey,
+          activation: "tool",
         }).sandboxed
       : false);
   const resolved = resolveExecTarget({

--- a/src/agents/sandbox.resolveSandboxContext.test.ts
+++ b/src/agents/sandbox.resolveSandboxContext.test.ts
@@ -160,6 +160,65 @@ describe("resolveSandboxContext", () => {
     }
   }, 15_000);
 
+  it("defers needed mode backend creation until tool activation", async () => {
+    const backendFactory = vi.fn(async () => ({
+      id: "test-needed-backend",
+      runtimeId: "needed-runtime",
+      runtimeLabel: "Needed Runtime",
+      workdir: "/runtime/workspace",
+      buildExecSpec: async () => ({
+        argv: ["needed-backend", "exec"],
+        env: process.env,
+        stdinMode: "pipe-closed" as const,
+      }),
+      runShellCommand: async () => ({
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      }),
+    }));
+    const restore = registerSandboxBackend("test-needed-backend", {
+      factory: backendFactory,
+      resolveWorkdir: () => "/runtime/workspace",
+    });
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "needed",
+              backend: "test-needed-backend",
+              scope: "session",
+              workspaceAccess: "rw",
+              prune: { idleHours: 0, maxAgeDays: 0 },
+            },
+          },
+        },
+      };
+
+      await expect(
+        resolveSandboxContext({
+          config: cfg,
+          sessionKey: "agent:main:main",
+          workspaceDir: "/tmp/openclaw-test",
+        }),
+      ).resolves.toBeNull();
+      expect(backendFactory).not.toHaveBeenCalled();
+
+      const result = await resolveSandboxContext({
+        config: cfg,
+        sessionKey: "agent:main:main",
+        workspaceDir: "/tmp/openclaw-test",
+        activation: "tool",
+      });
+      expect(result?.backendId).toBe("test-needed-backend");
+      expect(result?.runtimeId).toBe("needed-runtime");
+      expect(backendFactory).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+    }
+  }, 15_000);
+
   it("treats main session aliases as main in non-main mode", async () => {
     const cfg: OpenClawConfig = {
       session: { mainKey: "work" },

--- a/src/agents/sandbox.ts
+++ b/src/agents/sandbox.ts
@@ -74,7 +74,9 @@ export type {
 } from "./sandbox/ssh.js";
 
 export type {
+  SandboxActivation,
   SandboxContext,
+  SandboxMode,
   SandboxSshConfig,
   SandboxToolPolicy,
   SandboxWorkspaceAccess,

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -25,7 +25,7 @@ import { updateRegistry } from "./registry.js";
 import { resolveSandboxRuntimeStatus } from "./runtime-status.js";
 import { assertSshSandboxSecretOwnerAvailable } from "./secret-owner.js";
 import { resolveSandboxWorkspaceLayoutPaths } from "./shared.js";
-import type { SandboxContext, SandboxWorkspaceInfo } from "./types.js";
+import type { SandboxActivation, SandboxContext, SandboxWorkspaceInfo } from "./types.js";
 import { ensureSandboxWorkspace } from "./workspace.js";
 
 async function syncSandboxSkillsToWorkspace(params: {
@@ -140,6 +140,7 @@ function resolveSandboxSession(params: {
   config?: OpenClawConfig;
   agentId?: string;
   sessionKey?: string;
+  activation?: SandboxActivation;
 }) {
   const rawSessionKey = params.sessionKey?.trim();
   if (!rawSessionKey) {
@@ -150,6 +151,7 @@ function resolveSandboxSession(params: {
     cfg: params.config,
     agentId: params.agentId,
     sessionKey: rawSessionKey,
+    activation: params.activation,
   });
   if (!runtime.sandboxed) {
     return null;
@@ -193,6 +195,7 @@ export async function resolveSandboxContext(params: {
   requireCurrentConfig?: boolean;
   sessionKey?: string;
   workspaceDir?: string;
+  activation?: SandboxActivation;
 }): Promise<SandboxContext | null> {
   const resolved = resolveSandboxSession(params);
   if (!resolved) {
@@ -323,6 +326,7 @@ export async function ensureSandboxWorkspaceForSession(params: {
   config?: OpenClawConfig;
   sessionKey?: string;
   workspaceDir?: string;
+  activation?: SandboxActivation;
 }): Promise<SandboxWorkspaceInfo | null> {
   const resolved = resolveSandboxSession(params);
   if (!resolved) {

--- a/src/agents/sandbox/exec-runtime.ts
+++ b/src/agents/sandbox/exec-runtime.ts
@@ -1,0 +1,75 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ExecToolDefaults } from "../bash-tools.exec-types.js";
+import type { ExecPolicyOverrides } from "../exec-defaults.js";
+import { resolveSandboxRuntimeStatus } from "./runtime-status.js";
+import type { SandboxContext } from "./types.js";
+
+type BashSandboxConfig = NonNullable<ExecToolDefaults["sandbox"]>;
+type SandboxResolver = NonNullable<ExecToolDefaults["resolveSandbox"]>;
+
+export type SandboxExecRuntime =
+  | { kind: "active"; sandbox: BashSandboxConfig }
+  | { kind: "lazy"; resolveSandbox: SandboxResolver }
+  | { kind: "direct" };
+
+function toBashSandboxConfig(sandbox: SandboxContext): BashSandboxConfig {
+  return {
+    containerName: sandbox.containerName,
+    workspaceDir: sandbox.workspaceDir,
+    containerWorkdir: sandbox.containerWorkdir,
+    workdirValidation: sandbox.backend?.workdirValidation,
+    validateWorkdir: sandbox.backend?.validateWorkdir?.bind(sandbox.backend),
+    discardPreparedWorkdir: sandbox.backend?.discardPreparedWorkdir?.bind(sandbox.backend),
+    workdirRoots: sandbox.backend?.workdirRoots,
+    env: sandbox.backend?.env ?? sandbox.docker.env,
+    buildExecSpec: sandbox.backend?.buildExecSpec.bind(sandbox.backend),
+    finalizeExec: sandbox.backend?.finalizeExec?.bind(sandbox.backend),
+  };
+}
+
+/** Resolves eager, tool-activated, or direct execution ownership for the exec tool. */
+export function resolveSandboxExecRuntime(params: {
+  config?: OpenClawConfig;
+  agentId?: string;
+  execOverrides?: ExecPolicyOverrides;
+  sessionKey?: string;
+  workspaceDir?: string;
+  sandbox?: SandboxContext;
+  resolveSandbox?: SandboxResolver;
+}): SandboxExecRuntime {
+  if (params.sandbox?.enabled) {
+    return { kind: "active", sandbox: toBashSandboxConfig(params.sandbox) };
+  }
+  if (params.resolveSandbox) {
+    return { kind: "lazy", resolveSandbox: params.resolveSandbox };
+  }
+
+  const toolRuntime = resolveSandboxRuntimeStatus({
+    cfg: params.config,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    activation: "tool",
+  });
+  if (!toolRuntime.sandboxed && toolRuntime.mode !== "needed") {
+    return { kind: "direct" };
+  }
+
+  let lazySandboxPromise: Promise<BashSandboxConfig | undefined> | undefined;
+  return {
+    kind: "lazy",
+    resolveSandbox: () => {
+      lazySandboxPromise ??= import("./context.js").then(async ({ resolveSandboxContext }) => {
+        const sandbox = await resolveSandboxContext({
+          config: params.config,
+          agentId: params.agentId,
+          execOverrides: params.execOverrides,
+          sessionKey: params.sessionKey,
+          workspaceDir: params.workspaceDir,
+          activation: "tool",
+        });
+        return sandbox?.enabled ? toBashSandboxConfig(sandbox) : undefined;
+      });
+      return lazySandboxPromise;
+    },
+  };
+}

--- a/src/agents/sandbox/runtime-status.ts
+++ b/src/agents/sandbox/runtime-status.ts
@@ -18,14 +18,23 @@ import {
   classifyToolAgainstSandboxToolPolicy,
   resolveSandboxToolPolicyForAgent,
 } from "./tool-policy.js";
-import type { SandboxConfig, SandboxToolPolicyResolved } from "./types.js";
+import type { SandboxActivation, SandboxConfig, SandboxToolPolicyResolved } from "./types.js";
 
-function shouldSandboxSession(cfg: SandboxConfig, sessionKey: string, mainSessionKey: string) {
+function shouldSandboxSession(params: {
+  cfg: SandboxConfig;
+  sessionKey: string;
+  mainSessionKey: string;
+  activation: SandboxActivation;
+}) {
+  const { cfg, sessionKey, mainSessionKey, activation } = params;
   if (cfg.mode === "off") {
     return false;
   }
   if (cfg.mode === "all") {
     return true;
+  }
+  if (cfg.mode === "needed") {
+    return activation === "tool";
   }
   return sessionKey.trim() !== mainSessionKey.trim();
 }
@@ -60,15 +69,18 @@ export function resolveSandboxRuntimeStatus(params: {
   cfg?: OpenClawConfig;
   sessionKey?: string;
   agentId?: string;
+  activation?: SandboxActivation;
 }): {
   agentId: string;
   sessionKey: string;
   mainSessionKey: string;
   mode: SandboxConfig["mode"];
+  activation: SandboxActivation;
   sandboxed: boolean;
   toolPolicy: SandboxToolPolicyResolved;
 } {
   const sessionKey = params.sessionKey?.trim() ?? "";
+  const activation = params.activation ?? "run";
   const agentId = resolveSessionAgentId({
     sessionKey,
     config: params.cfg,
@@ -78,17 +90,19 @@ export function resolveSandboxRuntimeStatus(params: {
   const sandboxCfg = resolveSandboxConfigForAgent(cfg, agentId);
   const mainSessionKey = resolveMainSessionKeyForSandbox({ cfg, agentId });
   const sandboxed = sessionKey
-    ? shouldSandboxSession(
-        sandboxCfg,
-        resolveComparableSessionKeyForSandbox({ cfg, agentId, sessionKey }),
+    ? shouldSandboxSession({
+        cfg: sandboxCfg,
+        sessionKey: resolveComparableSessionKeyForSandbox({ cfg, agentId, sessionKey }),
         mainSessionKey,
-      )
+        activation,
+      })
     : false;
   return {
     agentId,
     sessionKey,
     mainSessionKey,
     mode: sandboxCfg.mode,
+    activation,
     sandboxed,
     toolPolicy: resolveSandboxToolPolicyForAgent(cfg, agentId),
   };

--- a/src/agents/sandbox/tool-policy.test.ts
+++ b/src/agents/sandbox/tool-policy.test.ts
@@ -208,6 +208,44 @@ describe("sandbox/tool-policy", () => {
     ).toBe(true);
   });
 
+  it("defers needed mode sandboxing until tool activation", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "needed", scope: "agent" },
+        },
+        list: [{ id: "main" }],
+      },
+    };
+
+    expect(
+      resolveSandboxRuntimeStatus({
+        cfg,
+        sessionKey: "agent:main:main",
+      }).sandboxed,
+    ).toBe(false);
+    expect(
+      resolveSandboxRuntimeStatus({
+        cfg,
+        sessionKey: "agent:main:telegram:default:direct:42",
+      }).sandboxed,
+    ).toBe(false);
+    expect(
+      resolveSandboxRuntimeStatus({
+        cfg,
+        sessionKey: "agent:main:main",
+        activation: "tool",
+      }).sandboxed,
+    ).toBe(true);
+    expect(
+      resolveSandboxRuntimeStatus({
+        cfg,
+        sessionKey: "agent:main:telegram:default:direct:42",
+        activation: "tool",
+      }).sandboxed,
+    ).toBe(true);
+  });
+
   it("keeps explicit sandbox deny precedence over allow and alsoAllow", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -35,6 +35,10 @@ export type SandboxToolPolicyResolved = {
 
 export type SandboxWorkspaceAccess = "none" | "ro" | "rw";
 
+export type SandboxActivation = "run" | "tool";
+
+export type SandboxMode = "off" | "non-main" | "all" | "needed";
+
 export type SandboxBrowserConfig = {
   enabled: boolean;
   image: string;
@@ -74,7 +78,7 @@ export type SandboxSshConfig = {
 export type SandboxScope = "session" | "agent" | "shared";
 
 export type SandboxConfig = {
-  mode: "off" | "non-main" | "all";
+  mode: SandboxMode;
   backend: SandboxBackendId;
   scope: SandboxScope;
   workspaceAccess: SandboxWorkspaceAccess;

--- a/src/auto-reply/reply/bash-command.stop.test.ts
+++ b/src/auto-reply/reply/bash-command.stop.test.ts
@@ -155,6 +155,7 @@ describe("handleBashChatCommand stop", () => {
         sessionKey: "agent:target:telegram:direct:target-session",
         mainSessionKey: "agent:target:main",
         mode: "non-main",
+        activation: "run",
         sandboxed: true,
         toolPolicy: {
           allow: [],

--- a/src/claws/schema.test.ts
+++ b/src/claws/schema.test.ts
@@ -103,6 +103,15 @@ describe("parseClawManifest", () => {
     expect(manifest.cronJobs[0]?.id).toBe("weekday-triage");
   });
 
+  it("accepts needed sandbox mode", () => {
+    const manifest = requireManifest({
+      schemaVersion: 1,
+      agent: { id: "chat-first", sandbox: { mode: "needed" } },
+    });
+
+    expect(manifest.agent.sandbox?.mode).toBe("needed");
+  });
+
   it("defaults optional ownership groups without inventing agent settings", () => {
     const manifest = requireManifest({ schemaVersion: 1, agent: { id: "minimal-agent" } });
 

--- a/src/claws/schema.ts
+++ b/src/claws/schema.ts
@@ -73,7 +73,7 @@ const agentSchema = z
       .optional(),
     sandbox: z
       .object({
-        mode: z.enum(["off", "non-main", "all"]).optional(),
+        mode: z.enum(["off", "non-main", "needed", "all"]).optional(),
         scope: z.enum(["session", "agent", "shared"]).optional(),
         workspaceAccess: z.enum(["none", "ro", "rw"]).optional(),
       })

--- a/src/claws/types.ts
+++ b/src/claws/types.ts
@@ -29,7 +29,7 @@ type ClawAgent = {
     mentionPatterns?: string[];
   };
   sandbox?: {
-    mode?: "off" | "non-main" | "all";
+    mode?: "off" | "non-main" | "needed" | "all";
     scope?: "session" | "agent" | "shared";
     workspaceAccess?: "none" | "ro" | "rw";
   };

--- a/src/commands/doctor-sandbox.ts
+++ b/src/commands/doctor-sandbox.ts
@@ -310,8 +310,8 @@ export async function maybeRepairSandboxImages(
   if (!dockerAvailable) {
     const lines = [
       `Sandbox mode is enabled (mode: "${mode}") but Docker is not available.`,
-      "Docker is required for sandbox mode to function.",
-      "Isolated sessions (cron jobs, sub-agents) will fail without Docker.",
+      "Docker is required for Docker-backed sandbox execution.",
+      "Sandbox-bound sessions or tools will fail without Docker.",
       "",
       "Options:",
       "- Install Docker and restart the gateway",

--- a/src/commands/sandbox-explain.test.ts
+++ b/src/commands/sandbox-explain.test.ts
@@ -390,6 +390,36 @@ describe("sandbox explain command", () => {
     expect(parsed.sandbox.workspaceMounts).toEqual([]);
   });
 
+  it("reports needed mode as direct until sandbox-bound tool activation", async () => {
+    mockCfg = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "needed",
+            scope: "agent",
+            workspaceAccess: "none",
+          },
+        },
+      },
+      session: { store: "/tmp/openclaw-test-sessions-{agentId}.json" },
+    };
+
+    const logs: string[] = [];
+    await sandboxExplainCommand({ json: true, agent: "main" }, {
+      log: (msg: string) => logs.push(msg),
+      error: (msg: string) => logs.push(msg),
+      exit: (_code: number) => {},
+    } as unknown as Parameters<typeof sandboxExplainCommand>[1]);
+
+    const parsed = JSON.parse(logs.join(""));
+    expect(parsed.sandbox).toMatchObject({
+      mode: "needed",
+      sessionIsSandboxed: false,
+      toolActivationIsSandboxed: true,
+      workspaceSource: "direct",
+    });
+  });
+
   it("uses the configured default agent for global sessions", async () => {
     mockCfg = {
       agents: {

--- a/src/commands/sandbox-explain.ts
+++ b/src/commands/sandbox-explain.ts
@@ -184,6 +184,11 @@ export async function sandboxExplainCommand(
   });
   const mainSessionKey = sandboxRuntime.mainSessionKey;
   const sessionIsSandboxed = sandboxRuntime.sandboxed;
+  const toolActivationIsSandboxed = resolveSandboxRuntimeStatus({
+    cfg,
+    sessionKey,
+    activation: "tool",
+  }).sandboxed;
   const storePath = resolveStorePath(cfg.session?.store, {
     agentId: resolvedAgentId,
   });
@@ -325,6 +330,7 @@ export async function sandboxExplainCommand(
       workspaceMounts,
       workspaceSource,
       sessionIsSandboxed,
+      toolActivationIsSandboxed,
       tools: {
         allow: toolPolicy.allow,
         deny: toolPolicy.deny,
@@ -360,13 +366,16 @@ export async function sandboxExplainCommand(
   const bool = (flag: boolean) => (flag ? ok("true") : err("false"));
 
   const lines: string[] = [];
+  const runtimeLabel = payload.sandbox.sessionIsSandboxed
+    ? warn("sandboxed")
+    : payload.sandbox.toolActivationIsSandboxed
+      ? warn("direct (sandbox-on-tool)")
+      : ok("direct");
   lines.push(heading("Effective sandbox:"));
   lines.push(`  ${key("agentId:")} ${value(payload.agentId)}`);
   lines.push(`  ${key("sessionKey:")} ${value(payload.sessionKey)}`);
   lines.push(`  ${key("mainSessionKey:")} ${value(payload.mainSessionKey)}`);
-  lines.push(
-    `  ${key("runtime:")} ${payload.sandbox.sessionIsSandboxed ? warn("sandboxed") : ok("direct")}`,
-  );
+  lines.push(`  ${key("runtime:")} ${runtimeLabel}`);
   lines.push(
     `  ${key("mode:")} ${value(payload.sandbox.mode)} ${key("scope:")} ${value(
       payload.sandbox.scope,
@@ -425,6 +434,12 @@ export async function sandboxExplainCommand(
       `${warn("Hint:")} sandbox mode is non-main; use main session key to run direct: ${value(
         payload.mainSessionKey,
       )}`,
+    );
+  }
+  if (payload.sandbox.mode === "needed" && payload.sandbox.toolActivationIsSandboxed) {
+    lines.push("");
+    lines.push(
+      `${warn("Hint:")} sandbox mode is needed; chat-only turns run direct, and sandbox-bound tools start the sandbox when called.`,
     );
   }
   lines.push("");

--- a/src/config/types.agents-shared.ts
+++ b/src/config/types.agents-shared.ts
@@ -37,7 +37,7 @@ export type AgentRuntimePolicyConfig = {
 /** Per-agent sandbox policy shared by embedded agents and sandbox backends. */
 export type AgentSandboxConfig = {
   /** Sandbox activation mode for this agent. */
-  mode?: "off" | "non-main" | "all";
+  mode?: "off" | "non-main" | "all" | "needed";
   /** Sandbox runtime backend id. Default: "docker". */
   backend?: string;
   /** Agent workspace access inside the sandbox. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -651,7 +651,9 @@ const SandboxSshSchema = z
 
 export const AgentSandboxSchema = z
   .object({
-    mode: z.union([z.literal("off"), z.literal("non-main"), z.literal("all")]).optional(),
+    mode: z
+      .union([z.literal("off"), z.literal("non-main"), z.literal("all"), z.literal("needed")])
+      .optional(),
     backend: z.string().min(1).optional(),
     workspaceAccess: z.union([z.literal("none"), z.literal("ro"), z.literal("rw")]).optional(),
     sessionToolsVisibility: z.union([z.literal("spawned"), z.literal("all")]).optional(),

--- a/src/security/audit-extra.summary.ts
+++ b/src/security/audit-extra.summary.ts
@@ -6,7 +6,7 @@ import {
 } from "../agents/agent-tools.policy.js";
 import { parseModelRef } from "../agents/model-selection-normalize.js";
 import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
-import type { SandboxToolPolicy } from "../agents/sandbox/types.js";
+import type { SandboxMode, SandboxToolPolicy } from "../agents/sandbox/types.js";
 import { isToolAllowedByPolicies } from "../agents/tool-policy-match.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { AgentToolsConfig } from "../config/types.tools.js";
@@ -65,7 +65,7 @@ function extractAgentIdFromSource(source: string): string | null {
 function resolveToolPolicies(params: {
   cfg: OpenClawConfig;
   agentTools?: AgentToolsConfig;
-  sandboxMode?: "off" | "non-main" | "all";
+  sandboxMode?: SandboxMode;
   agentId?: string | null;
   modelProvider?: string;
   modelId?: string;

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -839,7 +839,7 @@ export function collectSandboxDockerNoopFindings(cfg: OpenClawConfig): SecurityA
       "These docker settings will not take effect until sandbox mode is enabled:\n" +
       configuredPaths.map((entry) => `- ${entry}`).join("\n"),
     remediation:
-      'Enable sandbox mode (`agents.defaults.sandbox.mode="non-main"` or `"all"`) where needed, or remove unused docker settings.',
+      'Enable sandbox mode (`agents.defaults.sandbox.mode="needed"`, `"non-main"`, or `"all"`) where needed, or remove unused docker settings.',
   });
 
   return findings;

--- a/src/security/audit-plugins-trust.ts
+++ b/src/security/audit-plugins-trust.ts
@@ -20,6 +20,7 @@ import type { SecurityAuditFinding } from "./audit.types.js";
 import { listInstalledPluginDirs } from "./installed-plugin-dirs.js";
 
 type SandboxToolPolicy = import("../agents/sandbox/types.js").SandboxToolPolicy;
+type SandboxMode = import("../agents/sandbox/types.js").SandboxMode;
 
 type PluginTrustPolicyDeps = {
   isToolAllowedByPolicies: typeof import("../agents/tool-policy-match.js").isToolAllowedByPolicies;
@@ -131,7 +132,7 @@ function resolveToolPolicies(params: {
   cfg: OpenClawConfig;
   deps: PluginTrustPolicyDeps;
   agentTools?: AgentToolsConfig;
-  sandboxMode?: "off" | "non-main" | "all";
+  sandboxMode?: SandboxMode;
   agentId?: string | null;
 }): Array<SandboxToolPolicy | undefined> {
   const profile = params.agentTools?.profile ?? params.cfg.tools?.profile;

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -639,7 +639,7 @@ function collectExecRuntimeFindings(cfg: OpenClawConfig): SecurityAuditFinding[]
         "tools.exec.host is explicitly set to sandbox while agents.defaults.sandbox.mode=off. " +
         "In this mode, exec fails closed because no sandbox runtime is available.",
       remediation:
-        'Enable sandbox mode (`agents.defaults.sandbox.mode="non-main"` or `"all"`) or set tools.exec.host to "gateway" with approvals.',
+        'Enable sandbox mode (`agents.defaults.sandbox.mode="needed"`, `"non-main"`, or `"all"`) or set tools.exec.host to "gateway" with approvals.',
     });
   }
 

--- a/src/security/exec-filesystem-policy.ts
+++ b/src/security/exec-filesystem-policy.ts
@@ -1,6 +1,7 @@
 // Resolves filesystem policy for exec and sandbox tool use.
 import { resolveConfiguredToolPolicies } from "../agents/agent-tools.policy.js";
 import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
+import type { SandboxMode } from "../agents/sandbox/types.js";
 import { isToolAllowedByPolicies } from "../agents/tool-policy-match.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { AgentToolsConfig, ExecToolConfig } from "../config/types.tools.js";
@@ -13,7 +14,7 @@ type ExecFilesystemPolicyDriftHit = {
   scopeLabel: string;
   runtimeTools: string[];
   disabledFilesystemTools: string[];
-  sandboxMode: "off" | "non-main" | "all";
+  sandboxMode: SandboxMode;
   sandboxWorkspaceAccess: "none" | "ro" | "rw";
   execHost: NonNullable<ExecToolConfig["host"]>;
 };
@@ -26,7 +27,7 @@ function resolveExecHost(params: {
 }
 
 function isExecFilesystemConstrained(params: {
-  sandboxMode: "off" | "non-main" | "all";
+  sandboxMode: SandboxMode;
   sandboxWorkspaceAccess: "none" | "ro" | "rw";
   execHost: NonNullable<ExecToolConfig["host"]>;
 }): boolean {

--- a/src/system-agent/rescue-policy.ts
+++ b/src/system-agent/rescue-policy.ts
@@ -1,4 +1,5 @@
 // OpenClaw rescue policy gates remote writes by owner, DM, sandbox, and YOLO posture.
+import type { SandboxMode } from "../agents/sandbox/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveExecModePolicy } from "../infra/exec-approvals.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -50,10 +51,7 @@ function resolveScopedExecConfig(cfg: OpenClawConfig, agentId?: string) {
   return resolveAgentEntry(cfg, agentId)?.tools?.exec;
 }
 
-function resolveScopedSandboxMode(
-  cfg: OpenClawConfig,
-  agentId?: string,
-): "off" | "non-main" | "all" {
+function resolveScopedSandboxMode(cfg: OpenClawConfig, agentId?: string): SandboxMode {
   return (
     resolveAgentEntry(cfg, agentId)?.sandbox?.mode ?? cfg.agents?.defaults?.sandbox?.mode ?? "off"
   );


### PR DESCRIPTION
Fixes #80296

## What Problem This Solves

Resolves a problem where chat-only turns can fail whenever Docker is unavailable because `sandbox.mode: "all"` creates the backend before the model can answer, even when the turn never invokes execution.

## Why This Change Was Made

This adds an opt-in `sandbox.mode: "needed"` while leaving existing defaults unchanged. Chat setup uses run activation and does not create a backend; `exec` uses tool activation, lazily resolves the configured sandbox once, and fails closed if the backend is unavailable. Codex app-server native shell, filesystem, MCP, and app-backed tools stay disabled while an auto/sandbox target is waiting for OpenClaw sandbox activation, while explicit `gateway` and existing `node` semantics remain intact.

The policy extension now validates and publishes `needed`, and its effective exec-security evidence reports the sandbox default instead of host `full`.

## User Impact

Operators can keep normal chat available during a temporary Docker outage without allowing sandbox-bound exec to fall back to the host. `openclaw sandbox explain` now reports the direct run and sandbox-on-tool states separately.

## Evidence

- Final focused acceptance run: 10 test files across 6 Vitest shards, 475 tests passed.
- Final type checks passed: `pnpm tsgo:core`, `pnpm tsgo:extensions`, and `pnpm tsgo:extensions:test`.
- Full `pnpm build` passed.
- Full `pnpm lint:core` and `pnpm lint:extensions` passed during this follow-up.
- Formatting and `git diff --check` passed.
- Existing Telegram UI proof remains available from the [Mantis run](https://github.com/openclaw/openclaw/actions/runs/27879744883).

## Real behavior proof

**Behavior addressed:** With `mode: "needed"`, chat-only OpenClaw and Codex turns must work without Docker, while embedded exec and Codex-native execution must not fall back to the host.

**Real environment tested:** An isolated macOS checkout running the actual OpenClaw Gateway, the managed QA mock provider, and a real Codex app-server. The Docker CLI was absent and `DOCKER_HOST` pointed at a nonexistent Unix socket.

**Exact steps or command run after this patch:** Installed the exact lockfile with `pnpm install --frozen-lockfile`, configured `agents.defaults.sandbox.mode="needed"`, then ran `node --import tsx scripts/needed-sandbox-proof.ts` from a disposable local proof harness. The harness sent chat and exec-canary turns through the real Gateway and Codex app-server.

**Evidence after fix:**

```text
docker.cliAvailable=false
sandbox.explain: mode=needed sessionIsSandboxed=false toolActivationIsSandboxed=true

openclaw.chat: status=ok marker=NEEDED_CHAT_OK
openclaw.exec: hostMarkerExists=false
openclaw.exec.error: Sandbox mode requires Docker, but the "docker" command was not found in PATH.

codex.chat: status=ok marker=NEEDED_CODEX_CHAT_OK
codex.providerRequest.tools=[]
codex.nativeShellTools=[]
codex.exec: hostMarkerExists=false
```

**Observed result after fix:** Both chat-only paths completed successfully. Embedded exec attempted lazy sandbox activation, returned the Docker-unavailable error, and did not create its host canary. Codex exposed no native execution schema under pending `needed` activation and also did not create its host canary.

**What was not tested:** This follow-up did not repeat the Docker-off case through the live Telegram transport; the linked Mantis artifact covers Telegram-visible behavior but not Docker availability. Live SSH and OpenShell backends were not exercised; registered-backend unit coverage verifies activation timing independently of Docker.

### Focused command

```bash
node scripts/run-vitest.mjs \
  src/agents/sandbox/tool-policy.test.ts \
  src/agents/sandbox.resolveSandboxContext.test.ts \
  src/agents/exec-defaults.test.ts \
  src/agents/bash-tools.exec.path.test.ts \
  src/commands/sandbox-explain.test.ts \
  src/auto-reply/reply/bash-command.stop.test.ts \
  extensions/codex/src/app-server/native-execution-policy.test.ts \
  extensions/codex/src/app-server/dynamic-tool-build.test.ts \
  extensions/policy/src/policy-state.test.ts \
  extensions/policy/src/doctor/register.test.ts \
  --reporter=verbose
```

### Codex boundary basis

Codex's app-server protocol exposes fixed sandbox selections rather than an OpenClaw-owned lazy `needed` transition: see [`SandboxMode`](https://github.com/openai/codex/blob/6e5a2d6b8d148a5554fdceb6f399ca45bd1c78d9/codex-rs/app-server-protocol/src/protocol/v2/shared.rs#L288-L313) and [turn sandbox policy](https://github.com/openai/codex/blob/6e5a2d6b8d148a5554fdceb6f399ca45bd1c78d9/codex-rs/app-server-protocol/src/protocol/v2/permissions.rs#L525-L555). Therefore, while OpenClaw has no active sandbox context, disabling the native surface is the fail-closed boundary; OpenClaw-owned dynamic tools remain the activation path where available.
