### PR TITLE
fix(telegram): render progress draft rows as plain readable text

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -69,6 +69,17 @@
         "fileName"
       ]
     },
+    "api": {
+      "emoji": "🌐",
+      "title": "API",
+      "detailKeys": [
+        "url",
+        "endpoint",
+        "path",
+        "method",
+        "name"
+      ]
+    },
     "browser": {
       "emoji": "🌐",
       "title": "Browser",

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -384,8 +384,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
   function telegramProgressPreview(text: string, html: string) {
     return {
       text,
-      richMessage: { html, skip_entity_detection: true },
-      plainTextTransport: true,
+      richMessage: { html: html.replaceAll("\n", "<br>"), skip_entity_detection: true },
     };
   }
 
@@ -2658,7 +2657,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Short");
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Short answer");
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b>"),
+      telegramProgressPreview("Shelling", "<b>Shelling</b>"),
     );
   });
 
@@ -2750,7 +2749,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
+      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
     );
     expectDeliveredReply(0, { text: "Tool output visible to Telegram" });
     expectDeliveredReply(0, { text: "Final answer" }, 1);
@@ -2780,7 +2779,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
+      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
     );
     expectDeliveredReply(0, { mediaUrl: "https://example.com/validation.txt" });
     expectDeliveredReply(0, { text: "Final answer" }, 1);

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -640,7 +640,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
       chatId: 123,
       thread: { id: 777, scope: "dm" },
       minInitialChars: 30,
-      minInitialDelayMs: 5000,
     });
     expect(draftStream.update).toHaveBeenCalledWith("Hello");
     const delivery = expectDeliverRepliesParams({ thread: { id: 777, scope: "dm" } });
@@ -2640,27 +2639,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
-  it("shows a stable progress placeholder for progress-mode answer activity", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
-      await replyOptions?.onPartialReply?.({ text: "Short" });
-      await replyOptions?.onPartialReply?.({ text: "Short answer" });
-      return { queuedFinal: false };
-    });
-
-    await dispatchWithContext({
-      context: createContext(),
-      streamMode: "progress",
-      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
-    });
-
-    expect(answerDraftStream.update).not.toHaveBeenCalledWith("Short");
-    expect(answerDraftStream.update).not.toHaveBeenCalledWith("Short answer");
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramProgressPreview("Shelling", "<b>Shelling</b>"),
-    );
-  });
-
   it("replaces Telegram command progress items with matching command output", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
@@ -2727,67 +2705,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
 
-  it("clears progress drafts before durable verbose tool output", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-        replyOptions?.onVerboseProgressVisibility?.(() => true);
-        await dispatcherOptions.deliver(
-          { text: "Tool output visible to Telegram" },
-          { kind: "tool" },
-        );
-        await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
-        return { queuedFinal: true };
-      },
-    );
-
-    await dispatchWithContext({
-      context: createContext(),
-      streamMode: "progress",
-      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
-    });
-
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
-    );
-    expectDeliveredReply(0, { text: "Tool output visible to Telegram" });
-    expectDeliveredReply(0, { text: "Final answer" }, 1);
-    expect(answerDraftStream.clear.mock.invocationCallOrder[0]).toBeLessThan(
-      deliverReplies.mock.invocationCallOrder[0],
-    );
-  });
-
-  it("clears progress drafts before visible tool artifacts", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-        await dispatcherOptions.deliver(
-          { mediaUrl: "https://example.com/validation.txt" },
-          { kind: "tool" },
-        );
-        await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
-        return { queuedFinal: true };
-      },
-    );
-
-    await dispatchWithContext({
-      context: createContext(),
-      streamMode: "progress",
-      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
-    });
-
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
-    );
-    expectDeliveredReply(0, { mediaUrl: "https://example.com/validation.txt" });
-    expectDeliveredReply(0, { text: "Final answer" }, 1);
-    expect(answerDraftStream.clear.mock.invocationCallOrder[0]).toBeLessThan(
-      deliverReplies.mock.invocationCallOrder[0],
-    );
-  });
-
   it("does not stream text-only tool results into progress drafts", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -2819,7 +2736,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
-  it("renders api progress item edge cases as plain transport previews", async () => {
+  it("renders api progress item edge cases as HTML transport previews", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
       await replyOptions?.onItemEvent?.({ kind: "api", progressText: "GET /v1/users" });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -385,6 +385,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     return {
       text,
       richMessage: { html, skip_entity_detection: true },
+      plainTextTransport: true,
     };
   }
 
@@ -2819,6 +2820,33 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("renders api progress item edge cases as plain transport previews", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onItemEvent?.({ kind: "api", progressText: "GET /v1/users" });
+      await replyOptions?.onItemEvent?.({
+        kind: "api",
+        name: "api",
+        progressText: "POST /v1/jobs",
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+    });
+
+    expect(answerDraftStream.updatePreview).toHaveBeenLastCalledWith(
+      telegramProgressPreview(
+        "Shelling\n\n🌐 API: GET /v1/users\n🌐 API: POST /v1/jobs",
+        "<b>Shelling</b>\n<b>🌐 API</b> <code>GET /v1/users</code>\n<b>🌐 API</b> <code>POST /v1/jobs</code>",
+      ),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("does not restart progress drafts after final answer delivery", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -3257,34 +3285,34 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.flush).toHaveBeenCalled();
   });
 
-  it.each([
-    { label: false },
-    { label: "Shelling", maxLines: 1 },
-  ] as const)("does not duplicate Telegram progress HTML rows without a visible label", async (progress) => {
-    const draftStream = createSequencedDraftStream(2001);
-    createTelegramDraftStream.mockReturnValue(draftStream);
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
-      await replyOptions?.onReplyStart?.();
-      await replyOptions?.onAssistantMessageStart?.();
-      await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      return { queuedFinal: false };
-    });
+  it.each([{ label: false }, { label: "Shelling", maxLines: 1 }] as const)(
+    "does not duplicate Telegram progress HTML rows without a visible label",
+    async (progress) => {
+      const draftStream = createSequencedDraftStream(2001);
+      createTelegramDraftStream.mockReturnValue(draftStream);
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+        await replyOptions?.onReplyStart?.();
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        return { queuedFinal: false };
+      });
 
-    await dispatchWithContext({
-      context: createContext(),
-      streamMode: "progress",
-      telegramCfg: {
-        streaming: {
-          mode: "progress",
-          progress,
+      await dispatchWithContext({
+        context: createContext(),
+        streamMode: "progress",
+        telegramCfg: {
+          streaming: {
+            mode: "progress",
+            progress,
+          },
         },
-      },
-    });
+      });
 
-    expect(draftStream.updatePreview).toHaveBeenCalledWith(
-      telegramProgressPreview("🛠️ Exec", "<b>🛠️ Exec</b>"),
-    );
-  });
+      expect(draftStream.updatePreview).toHaveBeenCalledWith(
+        telegramProgressPreview("🛠️ Exec", "<b>🛠️ Exec</b>"),
+      );
+    },
+  );
 
   it("keeps progress draft labels static while the draft is active", async () => {
     const draftStream = createSequencedDraftStream(2001);

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -398,10 +398,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
     return expectRecordFields(mockCallArg(dispatchReplyWithBufferedBlockDispatcher), expected);
   }
 
-  function telegramHtmlPreview(html: string) {
-    return { text: html, parseMode: "HTML" as const };
-  }
-
   function createContext(overrides?: Partial<TelegramMessageContext>): TelegramMessageContext {
     const base = {
       ctxPayload: {},
@@ -2475,7 +2471,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Site A shows X.");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site A shows X.");
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringMatching(/<b>🛠️ Exec<\/b>$/) }),
+      expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(3, "Final answer");
     expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
@@ -2502,7 +2498,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Site A shows X.");
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringMatching(/<b>🛠️ Exec<\/b>$/) }),
+      expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site B shows Y.");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(3, "Final answer");
@@ -2544,7 +2540,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createContext() });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringMatching(/<b>🛠️ Exec<\/b>$/) }),
+      expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Branch is up to date");
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
@@ -2570,7 +2566,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createContext() });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringMatching(/<b>🛠️ Exec<\/b>$/) }),
+      expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Branch is up to date");
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
@@ -2624,11 +2620,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress" } },
     });
 
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview(
-        "<b>Cracking</b><br><b>🛠️ Exec</b><br><b>🛠️ Exec</b> <code>git rev-parse --abbrev-ref HEAD</code>",
-      ),
-    );
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith({
+      text: "Cracking\n\n🛠️ Exec\n🛠️ git rev-parse --abbrev-ref HEAD",
+    });
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Branch is up to date");
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
@@ -2686,9 +2680,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const lastUpdate = answerDraftStream.updatePreview.mock.calls.at(-1)?.[0];
     expect(lastUpdate?.text).toContain("install dependencies");
     expect(lastUpdate?.text).not.toContain("completed");
-    expect(lastUpdate).toEqual(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b> <code>install dependencies</code>"),
-    );
+    expect(lastUpdate).toEqual({
+      text: "Shelling\n\n🛠️ install dependencies",
+    });
   });
 
   it("sends trailing verbose status after a progress-mode final answer", async () => {
@@ -2708,9 +2702,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress" } },
     });
 
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Cracking</b><br><b>🛠️ Exec</b>"),
-    );
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith({
+      text: "Cracking\n\n🛠️ Exec",
+    });
     expect(answerDraftStream.update).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, trailingFinalStatusText);
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(2);
@@ -2806,7 +2800,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     expect(answerDraftStream.updatePreview).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        text: "<b>Shelling</b><br><b>🛠️ Exec</b><br><b>🔎 Web Search</b> <code>docs lookup</code>",
+        text: "Shelling\n\n🛠️ Exec\n🔎 Web Search: docs lookup",
       }),
     );
     expect(deliverReplies).not.toHaveBeenCalled();
@@ -2830,9 +2824,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
-    );
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith({
+      text: "Shelling\n\n🛠️ Exec",
+    });
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
 
@@ -2860,9 +2854,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
-    );
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith({
+      text: "Shelling\n\n🛠️ Exec",
+    });
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
 
@@ -2894,9 +2888,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
-    );
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith({
+      text: "Shelling\n\n🛠️ Exec",
+    });
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
 
@@ -3044,9 +3038,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
-    );
+    expect(draftStream.updatePreview).toHaveBeenCalledWith({
+      text: "Shelling\n\n🛠️ Exec",
+    });
     expect(draftStream.flush).toHaveBeenCalled();
   });
 
@@ -3084,11 +3078,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
-      telegramHtmlPreview(
-        "<b>Shelling</b><br><b>🛠️ Exec</b> <code>command false</code> <i>exit 2</i>",
-      ),
-    );
+    expect(draftStream.updatePreview).toHaveBeenLastCalledWith({
+      text: "Shelling\n\n🛠️ exit 2; command false",
+    });
   });
 
   it("hides command titles in Telegram status-only progress draft previews", async () => {
@@ -3125,9 +3117,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b> <code>exit 2</code>"),
-    );
+    expect(draftStream.updatePreview).toHaveBeenLastCalledWith({
+      text: "Shelling\n\n🛠️ exit 2",
+    });
   });
 
   it("composes streamed reasoning with tool progress in Telegram progress drafts", async () => {
@@ -3148,9 +3140,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(createTelegramDraftStream).toHaveBeenCalledTimes(1);
-    expect(draftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b><br><i>Checking files</i>"),
-    );
+    expect(draftStream.updatePreview).toHaveBeenCalledWith({
+      text: "Shelling\n\n🛠️ Exec\n• Checking files",
+    });
   });
 
   it("renders configured Telegram commentary progress from preamble item events", async () => {
@@ -3177,9 +3169,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><i>Checking recent context</i>"),
-    );
+    expect(draftStream.updatePreview).toHaveBeenCalledWith({
+      text: "Shelling\n\nChecking recent context",
+    });
   });
 
   it("suppresses Telegram preamble progress when commentary is disabled", async () => {
@@ -3234,7 +3226,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenCalledWith(telegramHtmlPreview("<b>Shelling</b>"));
+    expect(draftStream.updatePreview).toHaveBeenCalledWith({ text: "Shelling" });
     expect(draftStream.flush).toHaveBeenCalled();
   });
 
@@ -3264,17 +3256,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     await vi.waitFor(() =>
-      expect(draftStream.updatePreview).toHaveBeenCalledWith(telegramHtmlPreview("<b>Working</b>")),
+      expect(draftStream.updatePreview).toHaveBeenCalledWith({ text: "Working" }),
     );
-    expect(draftStream.updatePreview).not.toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Working.</b>"),
-    );
-    expect(draftStream.updatePreview).not.toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Working..</b>"),
-    );
-    expect(draftStream.updatePreview).not.toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Working...</b>"),
-    );
+    expect(draftStream.updatePreview).not.toHaveBeenCalledWith({ text: "Working." });
+    expect(draftStream.updatePreview).not.toHaveBeenCalledWith({ text: "Working.." });
+    expect(draftStream.updatePreview).not.toHaveBeenCalledWith({ text: "Working..." });
     finishRun?.();
     await run;
   });
@@ -3297,7 +3283,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       const updateBeforeStatusReaction = draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text;
       releaseSetTool?.();
       await pendingToolStart;
-      expect(updateBeforeStatusReaction).toBe("<b>Shelling</b><br><b>🛠️ Exec</b>");
+      expect(updateBeforeStatusReaction).toBe("Shelling\n\n🛠️ Exec");
       return { queuedFinal: false };
     });
 
@@ -3333,11 +3319,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview(
-        "<b>Shelling</b><br><b>🔎 Web Search</b> <code>docs lookup</code><br><b>Update</b> <code>tests passed</code>",
-      ),
-    );
+    expect(draftStream.updatePreview).toHaveBeenCalledWith({
+      text: "Shelling\n\n🔎 Web Search: docs lookup\n• tests passed",
+    });
     expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(draftStream.materialize).not.toHaveBeenCalled();
     expect(draftStream.clear).toHaveBeenCalledTimes(1);

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -381,6 +381,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
     return expectRecordFields(mockCallArg(createTelegramDraftStream), expected);
   }
 
+  function telegramProgressPreview(text: string, html: string) {
+    return {
+      text,
+      richMessage: { html, skip_entity_detection: true },
+    };
+  }
+
   function expectDeliverRepliesParams(expected: Record<string, unknown>, callIndex = 0) {
     return expectRecordFields(mockCallArg(deliverReplies, callIndex), expected);
   }
@@ -2620,9 +2627,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress" } },
     });
 
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Cracking\n\n🛠️ Exec\n🛠️ git rev-parse --abbrev-ref HEAD",
-    });
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+      telegramProgressPreview(
+        "Cracking\n\n🛠️ Exec\n🛠️ git rev-parse --abbrev-ref HEAD",
+        "<b>Cracking</b>\n<b>🛠️ Exec</b>\n<b>🛠️ Exec</b> <code>git rev-parse --abbrev-ref HEAD</code>",
+      ),
+    );
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Branch is up to date");
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
@@ -2680,9 +2690,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const lastUpdate = answerDraftStream.updatePreview.mock.calls.at(-1)?.[0];
     expect(lastUpdate?.text).toContain("install dependencies");
     expect(lastUpdate?.text).not.toContain("completed");
-    expect(lastUpdate).toEqual({
-      text: "Shelling\n\n🛠️ install dependencies",
-    });
+    expect(lastUpdate).toEqual(
+      telegramProgressPreview(
+        "Shelling\n\n🛠️ install dependencies",
+        "<b>Shelling</b>\n<b>🛠️ Exec</b> <code>install dependencies</code>",
+      ),
+    );
   });
 
   it("sends trailing verbose status after a progress-mode final answer", async () => {
@@ -2702,9 +2715,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress" } },
     });
 
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Cracking\n\n🛠️ Exec",
-    });
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+      telegramProgressPreview("Cracking\n\n🛠️ Exec", "<b>Cracking</b>\n<b>🛠️ Exec</b>"),
+    );
     expect(answerDraftStream.update).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, trailingFinalStatusText);
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(2);
@@ -2824,9 +2837,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Shelling\n\n🛠️ Exec",
-    });
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
+    );
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
 
@@ -2854,9 +2867,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Shelling\n\n🛠️ Exec",
-    });
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
+    );
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
 
@@ -2888,9 +2901,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Shelling\n\n🛠️ Exec",
-    });
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
+    );
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
 
@@ -3038,9 +3051,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Shelling\n\n🛠️ Exec",
-    });
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(
+      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
+    );
     expect(draftStream.flush).toHaveBeenCalled();
   });
 
@@ -3078,9 +3091,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenLastCalledWith({
-      text: "Shelling\n\n🛠️ exit 2; command false",
-    });
+    expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
+      telegramProgressPreview(
+        "Shelling\n\n🛠️ exit 2; command false",
+        "<b>Shelling</b>\n<b>🛠️ Exec</b> <code>command false</code> <i>exit 2</i>",
+      ),
+    );
   });
 
   it("hides command titles in Telegram status-only progress draft previews", async () => {
@@ -3117,9 +3133,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenLastCalledWith({
-      text: "Shelling\n\n🛠️ exit 2",
-    });
+    expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
+      telegramProgressPreview(
+        "Shelling\n\n🛠️ exit 2",
+        "<b>Shelling</b>\n<b>🛠️ Exec</b> <code>exit 2</code>",
+      ),
+    );
   });
 
   it("composes streamed reasoning with tool progress in Telegram progress drafts", async () => {
@@ -3140,9 +3159,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(createTelegramDraftStream).toHaveBeenCalledTimes(1);
-    expect(draftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Shelling\n\n🛠️ Exec\n• Checking files",
-    });
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(
+      telegramProgressPreview(
+        "Shelling\n\n🛠️ Exec\n• Checking files",
+        "<b>Shelling</b>\n<b>🛠️ Exec</b>\n<i>Checking files</i>",
+      ),
+    );
   });
 
   it("renders configured Telegram commentary progress from preamble item events", async () => {
@@ -3169,9 +3191,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Shelling\n\nChecking recent context",
-    });
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(
+      telegramProgressPreview(
+        "Shelling\n\nChecking recent context",
+        "<b>Shelling</b>\n<i>Checking recent context</i>",
+      ),
+    );
   });
 
   it("suppresses Telegram preamble progress when commentary is disabled", async () => {
@@ -3226,8 +3251,39 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenCalledWith({ text: "Shelling" });
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(
+      telegramProgressPreview("Shelling", "<b>Shelling</b>"),
+    );
     expect(draftStream.flush).toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: false },
+    { label: "Shelling", maxLines: 1 },
+  ] as const)("does not duplicate Telegram progress HTML rows without a visible label", async (progress) => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onAssistantMessageStart?.();
+      await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: {
+          mode: "progress",
+          progress,
+        },
+      },
+    });
+
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(
+      telegramProgressPreview("🛠️ Exec", "<b>🛠️ Exec</b>"),
+    );
   });
 
   it("keeps progress draft labels static while the draft is active", async () => {
@@ -3256,7 +3312,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     await vi.waitFor(() =>
-      expect(draftStream.updatePreview).toHaveBeenCalledWith({ text: "Working" }),
+      expect(draftStream.updatePreview).toHaveBeenCalledWith(
+        telegramProgressPreview("Working", "<b>Working</b>"),
+      ),
     );
     expect(draftStream.updatePreview).not.toHaveBeenCalledWith({ text: "Working." });
     expect(draftStream.updatePreview).not.toHaveBeenCalledWith({ text: "Working.." });
@@ -3319,9 +3377,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenCalledWith({
-      text: "Shelling\n\n🔎 Web Search: docs lookup\n• tests passed",
-    });
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(
+      telegramProgressPreview(
+        "Shelling\n\n🔎 Web Search: docs lookup\n• tests passed",
+        "<b>Shelling</b>\n<b>🔎 Web Search</b> <code>docs lookup</code>\n<b>Update</b> <code>tests passed</code>",
+      ),
+    );
     expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(draftStream.materialize).not.toHaveBeenCalled();
     expect(draftStream.clear).toHaveBeenCalledTimes(1);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -30,6 +30,7 @@ import {
   type ChannelProgressDraftLine,
   type ChannelProgressDraftCompositorLine,
   createChannelProgressDraftCompositor,
+  resolveChannelProgressDraftLabel,
   resolveChannelStreamingBlockEnabled,
   resolveTranscriptBackedChannelFinalText,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -434,15 +435,6 @@ function sanitizeProgressMarkdownText(text: string): string {
   return text.replaceAll("`", "'");
 }
 
-function formatTelegramProgressLine(text: string): string {
-  const trimmed = text.trim();
-  const italic = trimmed.match(/^_(.*)_$/u);
-  if (italic) {
-    return sanitizeProgressMarkdownText(clipProgressMarkdownText(italic[1] ?? ""));
-  }
-  return sanitizeProgressMarkdownText(clipProgressMarkdownText(text));
-}
-
 function escapeTelegramProgressHtml(text: string): string {
   return text
     .replaceAll("&", "&amp;")
@@ -451,8 +443,9 @@ function escapeTelegramProgressHtml(text: string): string {
     .replaceAll('"', "&quot;");
 }
 
-function normalizeTelegramProgressPlainLine(text: string): string {
-  const clipped = clipProgressMarkdownText(text.trim());
+function normalizeTelegramProgressText(text: string, options?: { trim?: boolean }): string {
+  const source = options?.trim === false ? text : text.trim();
+  const clipped = clipProgressMarkdownText(source);
   const italic = clipped.match(/^_(.*)_$/u);
   if (italic) {
     return italic[1] ?? "";
@@ -460,50 +453,66 @@ function normalizeTelegramProgressPlainLine(text: string): string {
   return clipped;
 }
 
-function renderTelegramProgressStringLine(text: string): string {
-  return escapeTelegramProgressHtml(normalizeTelegramProgressPlainLine(text));
+function formatTelegramProgressLine(text: string): string {
+  return sanitizeProgressMarkdownText(normalizeTelegramProgressText(text, { trim: false }));
 }
 
-function formatTelegramProgressStructuredLine(line: ChannelProgressDraftCompositorLine): string {
+function renderTelegramProgressHtmlStringLine(text: string): string {
+  const normalized = normalizeTelegramProgressText(text);
+  const italic = text.trim().match(/^_(.*)_$/u);
+  if (italic) {
+    return `<i>${escapeTelegramProgressHtml(normalized)}</i>`;
+  }
+  return `<code>${escapeTelegramProgressHtml(normalized)}</code>`;
+}
+
+function renderTelegramProgressHtmlLine(line: ChannelProgressDraftCompositorLine): string {
   if (typeof line === "string") {
-    return line;
+    return line
+      .split(/\r?\n/u)
+      .map(renderTelegramProgressHtmlStringLine)
+      .filter(Boolean)
+      .join("\n");
   }
-  const status = line.status?.trim();
-  const normalizedText = normalizeTelegramProgressPlainLine(line.text);
-  if (
-    status &&
-    status !== "completed" &&
-    status !== line.detail &&
-    !normalizedText.includes(status)
-  ) {
-    return `${normalizedText} ${status}`.trim();
+  if (!line.icon && line.label === "Commentary") {
+    return renderTelegramProgressHtmlStringLine(line.text);
   }
-  return normalizedText;
-}
-
-function renderTelegramProgressLine(line: ChannelProgressDraftCompositorLine): string {
-  return formatTelegramProgressStructuredLine(line)
-    .split(/\r?\n/u)
-    .map(renderTelegramProgressStringLine)
-    .filter(Boolean)
-    .join("<br>");
+  const label = [line.icon, line.label].filter(Boolean).join(" ");
+  const parts = [`<b>${escapeTelegramProgressHtml(label)}</b>`];
+  const detail = line.detail && line.detail !== line.label ? line.detail : undefined;
+  if (detail) {
+    parts.push(`<code>${escapeTelegramProgressHtml(clipProgressMarkdownText(detail))}</code>`);
+  } else {
+    const text = line.text.trim();
+    if (text && text !== label) {
+      parts.push(renderTelegramProgressHtmlStringLine(text));
+    }
+  }
+  if (line.status && line.status !== "completed" && line.status !== line.detail) {
+    parts.push(`<i>${escapeTelegramProgressHtml(line.status)}</i>`);
+  }
+  return parts.join(" ");
 }
 
 function renderTelegramProgressDraftPreview(
   text: string,
   lines: readonly ChannelProgressDraftCompositorLine[],
-  richMessages: boolean,
+  label: string | undefined,
 ): TelegramDraftPreview {
   const trimmed = text.trimEnd();
-  const [heading] = trimmed.split(/\r?\n/u, 1);
-  const renderedLines = lines.map(renderTelegramProgressLine).filter(Boolean);
-  const htmlParts = heading?.trim()
-    ? [`<b>${escapeTelegramProgressHtml(heading.trim())}</b>`, ...renderedLines]
-    : renderedLines;
-  const html = htmlParts.join("<br>");
-  if (!richMessages) {
-    return { text: trimmed };
-  }
+  const textLines = trimmed.split(/\r?\n/u);
+  const labelVisible =
+    label !== undefined &&
+    (trimmed === label || (textLines[0] === label && textLines[1] === ""));
+  const bodyLines = labelVisible
+    ? textLines.slice(textLines[1] === "" ? 2 : 1)
+    : textLines;
+  const renderedLines = lines.map(renderTelegramProgressHtmlLine).filter(Boolean);
+  const visibleLines = renderedLines.slice(-bodyLines.filter(Boolean).length);
+  const htmlParts = labelVisible
+    ? [`<b>${escapeTelegramProgressHtml(label)}</b>`, ...visibleLines]
+    : visibleLines;
+  const html = htmlParts.join("\n");
   return {
     text: trimmed,
     richMessage: buildTelegramRichHtml(html, { skipEntityDetection: true }),
@@ -1109,7 +1118,7 @@ export const dispatchTelegramMessage = async ({
         renderTelegramProgressDraftPreview(
           streamText,
           options?.lines ?? [],
-          telegramCfg.richMessages === true,
+          resolveChannelProgressDraftLabel({ entry: telegramCfg, seed: progressSeed }),
         ),
       );
       if (options?.flush) {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -434,16 +434,13 @@ function sanitizeProgressMarkdownText(text: string): string {
   return text.replaceAll("`", "'");
 }
 
-function formatProgressAsMarkdownCode(text: string): string {
-  const clipped = clipProgressMarkdownText(text);
-  return `\`${sanitizeProgressMarkdownText(clipped)}\``;
-}
-
 function formatTelegramProgressLine(text: string): string {
   const trimmed = text.trim();
-  return trimmed.startsWith("_") && trimmed.endsWith("_")
-    ? trimmed
-    : formatProgressAsMarkdownCode(text);
+  const italic = trimmed.match(/^_(.*)_$/u);
+  if (italic) {
+    return sanitizeProgressMarkdownText(clipProgressMarkdownText(italic[1] ?? ""));
+  }
+  return sanitizeProgressMarkdownText(clipProgressMarkdownText(text));
 }
 
 function escapeTelegramProgressHtml(text: string): string {
@@ -454,37 +451,42 @@ function escapeTelegramProgressHtml(text: string): string {
     .replaceAll('"', "&quot;");
 }
 
-function renderTelegramProgressStringLine(text: string): string {
+function normalizeTelegramProgressPlainLine(text: string): string {
   const clipped = clipProgressMarkdownText(text.trim());
   const italic = clipped.match(/^_(.*)_$/u);
   if (italic) {
-    return `<i>${escapeTelegramProgressHtml(italic[1] ?? "")}</i>`;
+    return italic[1] ?? "";
   }
-  return `<code>${escapeTelegramProgressHtml(clipped)}</code>`;
+  return clipped;
+}
+
+function renderTelegramProgressStringLine(text: string): string {
+  return escapeTelegramProgressHtml(normalizeTelegramProgressPlainLine(text));
+}
+
+function formatTelegramProgressStructuredLine(line: ChannelProgressDraftCompositorLine): string {
+  if (typeof line === "string") {
+    return line;
+  }
+  const status = line.status?.trim();
+  const normalizedText = normalizeTelegramProgressPlainLine(line.text);
+  if (
+    status &&
+    status !== "completed" &&
+    status !== line.detail &&
+    !normalizedText.includes(status)
+  ) {
+    return `${normalizedText} ${status}`.trim();
+  }
+  return normalizedText;
 }
 
 function renderTelegramProgressLine(line: ChannelProgressDraftCompositorLine): string {
-  if (typeof line === "string") {
-    return line.split(/\r?\n/u).map(renderTelegramProgressStringLine).filter(Boolean).join("<br>");
-  }
-  if (!line.icon && line.label === "Commentary") {
-    return renderTelegramProgressStringLine(line.text);
-  }
-  const label = [line.icon, line.label].filter(Boolean).join(" ");
-  const parts = [`<b>${escapeTelegramProgressHtml(label)}</b>`];
-  const detail = line.detail && line.detail !== line.label ? line.detail : undefined;
-  if (detail) {
-    parts.push(`<code>${escapeTelegramProgressHtml(clipProgressMarkdownText(detail))}</code>`);
-  } else {
-    const text = line.text.trim();
-    if (text && text !== label) {
-      parts.push(renderTelegramProgressStringLine(text));
-    }
-  }
-  if (line.status && line.status !== "completed" && line.status !== line.detail) {
-    parts.push(`<i>${escapeTelegramProgressHtml(line.status)}</i>`);
-  }
-  return parts.join(" ");
+  return formatTelegramProgressStructuredLine(line)
+    .split(/\r?\n/u)
+    .map(renderTelegramProgressStringLine)
+    .filter(Boolean)
+    .join("<br>");
 }
 
 function renderTelegramProgressDraftPreview(
@@ -500,7 +502,7 @@ function renderTelegramProgressDraftPreview(
     : renderedLines;
   const html = htmlParts.join("<br>");
   if (!richMessages) {
-    return { text: html, parseMode: "HTML" };
+    return { text: trimmed };
   }
   return {
     text: trimmed,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -513,7 +513,6 @@ function renderTelegramProgressDraftPreview(
   return {
     text: trimmed,
     richMessage: buildTelegramRichHtml(html, { skipEntityDetection: true }),
-    plainTextTransport: true,
   };
 }
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -153,7 +153,6 @@ const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-d
 
 /** Minimum chars before sending first streaming message (improves push notification UX) */
 const DRAFT_MIN_INITIAL_CHARS = 30;
-const DRAFT_MIN_INITIAL_DELAY_MS = 5_000;
 
 type DraftPartialTextUpdate = {
   text: string;
@@ -1037,7 +1036,6 @@ export const dispatchTelegramMessage = async ({
           replyToMessageId: draftReplyToMessageId,
           richMessages: telegramCfg.richMessages,
           minInitialChars: draftMinInitialChars,
-          minInitialDelayMs: draftMinInitialChars > 0 ? DRAFT_MIN_INITIAL_DELAY_MS : undefined,
           renderText: renderStreamText,
           onSupersededPreview: (superseded) => {
             if (superseded.retain) {
@@ -1397,7 +1395,7 @@ export const dispatchTelegramMessage = async ({
       recomputeQueuedAnswerBlockRotations();
     }
   };
-  const updateDraftFromPartial = async (lane: DraftLaneState, update: DraftPartialTextUpdate) => {
+  const updateDraftFromPartial = (lane: DraftLaneState, update: DraftPartialTextUpdate) => {
     const laneStream = lane.stream;
     if (!laneStream || !update.text) {
       return;
@@ -1409,7 +1407,6 @@ export const dispatchTelegramMessage = async ({
     }
     if (lane === answerLane) {
       if (streamMode === "progress") {
-        await progressDraft.noteActivity();
         return;
       }
       resetAnswerToolProgressDraft();
@@ -1436,7 +1433,7 @@ export const dispatchTelegramMessage = async ({
         reasoningStepState.noteReasoningHint();
         reasoningStepState.noteReasoningDelivered();
       }
-      await updateDraftFromPartial(lanes[segment.lane], segment.update);
+      updateDraftFromPartial(lanes[segment.lane], segment.update);
     }
   };
   const flushDraftLane = async (lane: DraftLaneState) => {
@@ -2153,9 +2150,6 @@ export const dispatchTelegramMessage = async ({
                       }
                       if (segment.lane === "answer" && info.kind === "tool") {
                         if (verboseProgressActive()) {
-                          if (streamMode === "progress") {
-                            await rotateAnswerLaneAfterToolProgress();
-                          }
                           if (
                             await sendPayload(
                               applyTextToPayload(effectivePayload, segment.update.text),
@@ -2306,9 +2300,6 @@ export const dispatchTelegramMessage = async ({
                         await flushBufferedFinalAnswer();
                       }
                       return;
-                    }
-                    if (streamMode === "progress" && info.kind === "tool") {
-                      await rotateAnswerLaneAfterToolProgress();
                     }
                     const delivered = await sendPayload(effectivePayload, {
                       durable: info.kind === "final",

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -502,11 +502,8 @@ function renderTelegramProgressDraftPreview(
   const trimmed = text.trimEnd();
   const textLines = trimmed.split(/\r?\n/u);
   const labelVisible =
-    label !== undefined &&
-    (trimmed === label || (textLines[0] === label && textLines[1] === ""));
-  const bodyLines = labelVisible
-    ? textLines.slice(textLines[1] === "" ? 2 : 1)
-    : textLines;
+    label !== undefined && (trimmed === label || (textLines[0] === label && textLines[1] === ""));
+  const bodyLines = labelVisible ? textLines.slice(textLines[1] === "" ? 2 : 1) : textLines;
   const renderedLines = lines.map(renderTelegramProgressHtmlLine).filter(Boolean);
   const visibleLines = renderedLines.slice(-bodyLines.filter(Boolean).length);
   const htmlParts = labelVisible
@@ -516,6 +513,7 @@ function renderTelegramProgressDraftPreview(
   return {
     text: trimmed,
     richMessage: buildTelegramRichHtml(html, { skipEntityDetection: true }),
+    plainTextTransport: true,
   };
 }
 

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -602,6 +602,41 @@ describe("createTelegramDraftStream", () => {
     expect(api.raw.editMessageText).not.toHaveBeenCalled();
   });
 
+  it("sends marked progress rich previews through plain text transport", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api);
+
+    stream.updatePreview({
+      text: "Shelling\n\n🛠️ Exec",
+      richMessage: {
+        html: "<b>Shelling</b>\n<b>🛠️ Exec</b>",
+        skip_entity_detection: true,
+      },
+      plainTextTransport: true,
+    });
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "Shelling\n\n🛠️ Exec", {});
+    expect(api.raw.sendRichMessage).not.toHaveBeenCalled();
+
+    stream.updatePreview({
+      text: "Shelling\n\n🛠️ Exec\n• Checking files",
+      richMessage: {
+        html: "<b>Shelling</b>\n<b>🛠️ Exec</b>\n<b>Update</b> <code>Checking files</code>",
+        skip_entity_detection: true,
+      },
+      plainTextTransport: true,
+    });
+    await stream.flush();
+
+    expect(api.editMessageText).toHaveBeenCalledWith(
+      123,
+      17,
+      "Shelling\n\n🛠️ Exec\n• Checking files",
+    );
+    expect(api.raw.editMessageText).not.toHaveBeenCalled();
+  });
+
   it("falls back to plain preview text when rich preview HTML parsing fails", async () => {
     const api = createMockDraftApi();
     api.sendMessage
@@ -618,12 +653,9 @@ describe("createTelegramDraftStream", () => {
     });
     await stream.flush();
 
-    expect(api.sendMessage).toHaveBeenNthCalledWith(
-      1,
-      123,
-      "<b>Shelling</b>\n<b>🛠️ Exec</b>",
-      { parse_mode: "HTML" },
-    );
+    expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "<b>Shelling</b>\n<b>🛠️ Exec</b>", {
+      parse_mode: "HTML",
+    });
     expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "Shelling\n\n🛠️ Exec", {});
   });
 

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -573,13 +573,13 @@ describe("createTelegramDraftStream", () => {
     stream.updatePreview({
       text: "Shelling\n\n`🛠️ Exec`",
       richMessage: {
-        html: "<b>Shelling</b><br><b>🛠️ Exec</b>",
+        html: "<b>Shelling</b>\n<b>🛠️ Exec</b>",
         skip_entity_detection: true,
       },
     });
     await stream.flush();
 
-    expect(api.sendMessage).toHaveBeenCalledWith(123, "<b>Shelling</b><br><b>🛠️ Exec</b>", {
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "<b>Shelling</b>\n<b>🛠️ Exec</b>", {
       parse_mode: "HTML",
     });
     expect(api.raw.sendRichMessage).not.toHaveBeenCalled();
@@ -587,7 +587,7 @@ describe("createTelegramDraftStream", () => {
     stream.updatePreview({
       text: "Shelling\n\n`🛠️ Exec`\n• _Checking files_",
       richMessage: {
-        html: "<b>Shelling</b><br><b>🛠️ Exec</b><br><i>Checking files</i>",
+        html: "<b>Shelling</b>\n<b>🛠️ Exec</b>\n<i>Checking files</i>",
         skip_entity_detection: true,
       },
     });
@@ -596,10 +596,35 @@ describe("createTelegramDraftStream", () => {
     expect(api.editMessageText).toHaveBeenCalledWith(
       123,
       17,
-      "<b>Shelling</b><br><b>🛠️ Exec</b><br><i>Checking files</i>",
+      "<b>Shelling</b>\n<b>🛠️ Exec</b>\n<i>Checking files</i>",
       { parse_mode: "HTML" },
     );
     expect(api.raw.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to plain preview text when rich preview HTML parsing fails", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockRejectedValueOnce(new Error("can't parse entities: unsupported tag"))
+      .mockResolvedValueOnce({ message_id: 17 });
+    const stream = createDraftStream(api);
+
+    stream.updatePreview({
+      text: "Shelling\n\n🛠️ Exec",
+      richMessage: {
+        html: "<b>Shelling</b>\n<b>🛠️ Exec</b>",
+        skip_entity_detection: true,
+      },
+    });
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenNthCalledWith(
+      1,
+      123,
+      "<b>Shelling</b>\n<b>🛠️ Exec</b>",
+      { parse_mode: "HTML" },
+    );
+    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "Shelling\n\n🛠️ Exec", {});
   });
 
   it("uses rich send and edit for previews when explicitly enabled", async () => {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -602,37 +602,38 @@ describe("createTelegramDraftStream", () => {
     expect(api.raw.editMessageText).not.toHaveBeenCalled();
   });
 
-  it("sends marked progress rich previews through plain text transport", async () => {
+  it("sends marked progress rich previews through HTML text transport", async () => {
     const api = createMockDraftApi();
     const stream = createDraftStream(api);
 
     stream.updatePreview({
       text: "Shelling\n\n🛠️ Exec",
       richMessage: {
-        html: "<b>Shelling</b>\n<b>🛠️ Exec</b>",
+        html: "<b>Shelling</b><br><b>🛠️ Exec</b>",
         skip_entity_detection: true,
       },
-      plainTextTransport: true,
     });
     await stream.flush();
 
-    expect(api.sendMessage).toHaveBeenCalledWith(123, "Shelling\n\n🛠️ Exec", {});
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "<b>Shelling</b><br><b>🛠️ Exec</b>", {
+      parse_mode: "HTML",
+    });
     expect(api.raw.sendRichMessage).not.toHaveBeenCalled();
 
     stream.updatePreview({
       text: "Shelling\n\n🛠️ Exec\n• Checking files",
       richMessage: {
-        html: "<b>Shelling</b>\n<b>🛠️ Exec</b>\n<b>Update</b> <code>Checking files</code>",
+        html: "<b>Shelling</b><br><b>🛠️ Exec</b><br><b>Update</b> <code>Checking files</code>",
         skip_entity_detection: true,
       },
-      plainTextTransport: true,
     });
     await stream.flush();
 
     expect(api.editMessageText).toHaveBeenCalledWith(
       123,
       17,
-      "Shelling\n\n🛠️ Exec\n• Checking files",
+      "<b>Shelling</b><br><b>🛠️ Exec</b><br><b>Update</b> <code>Checking files</code>",
+      { parse_mode: "HTML" },
     );
     expect(api.raw.editMessageText).not.toHaveBeenCalled();
   });

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -615,7 +615,7 @@ describe("createTelegramDraftStream", () => {
     });
     await stream.flush();
 
-    expect(api.sendMessage).toHaveBeenCalledWith(123, "<b>Shelling</b><br><b>🛠️ Exec</b>", {
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "<b>Shelling</b>\n<b>🛠️ Exec</b>", {
       parse_mode: "HTML",
     });
     expect(api.raw.sendRichMessage).not.toHaveBeenCalled();
@@ -632,7 +632,7 @@ describe("createTelegramDraftStream", () => {
     expect(api.editMessageText).toHaveBeenCalledWith(
       123,
       17,
-      "<b>Shelling</b><br><b>🛠️ Exec</b><br><b>Update</b> <code>Checking files</code>",
+      "<b>Shelling</b>\n<b>🛠️ Exec</b>\n<b>Update</b> <code>Checking files</code>",
       { parse_mode: "HTML" },
     );
     expect(api.raw.editMessageText).not.toHaveBeenCalled();

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -901,16 +901,11 @@ describe("createTelegramDraftStream", () => {
 describe("draft stream initial message debounce", () => {
   const createMockApi = () => createMockDraftApi(async () => ({ message_id: 42 }));
 
-  function createDebouncedStream(
-    api: ReturnType<typeof createMockApi>,
-    minInitialChars = 30,
-    minInitialDelayMs?: number,
-  ) {
+  function createDebouncedStream(api: ReturnType<typeof createMockApi>, minInitialChars = 30) {
     return createTelegramDraftStream({
       api: api as unknown as Bot["api"],
       chatId: 123,
       minInitialChars,
-      minInitialDelayMs,
     });
   }
 
@@ -977,36 +972,6 @@ describe("draft stream initial message debounce", () => {
       await stream.flush();
 
       expect(api.sendMessage).toHaveBeenCalled();
-    });
-
-    it("materializes a short first message after the initial delay", async () => {
-      const api = createMockApi();
-      const stream = createDebouncedStream(api, 30, 5000);
-
-      stream.update("Processing");
-      await stream.flush();
-      expect(api.sendMessage).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(5000);
-
-      expectPreviewSend(api, "Processing");
-    });
-
-    it("cancels a delayed first message when clear() removes the draft", async () => {
-      const api = createMockApi();
-      const stream = createDebouncedStream(api, 30, 5000);
-
-      stream.update("Processing");
-      await stream.flush();
-      expect(api.sendMessage).not.toHaveBeenCalled();
-      expect(vi.getTimerCount()).toBe(1);
-
-      await stream.clear();
-      expect(vi.getTimerCount()).toBe(0);
-
-      await vi.advanceTimersByTimeAsync(5000);
-      expect(api.sendMessage).not.toHaveBeenCalled();
-      expect(api.editMessageText).not.toHaveBeenCalled();
     });
 
     it("works with longer text above threshold", async () => {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -61,6 +61,7 @@ export type TelegramDraftPreview = {
   text: string;
   parseMode?: "HTML";
   richMessage?: TelegramInputRichMessage;
+  plainTextTransport?: boolean;
 };
 
 type SupersededTelegramPreview = {
@@ -91,6 +92,12 @@ function isTelegramHtmlParseError(err: unknown): boolean {
 function normalizeTelegramDraftTransportPreview(
   preview: TelegramDraftPreview,
 ): TelegramDraftTransportPreview {
+  if (preview.plainTextTransport) {
+    return {
+      text: preview.text,
+      plainText: preview.text,
+    };
+  }
   if (preview.richMessage?.html) {
     return {
       text: preview.richMessage.html,
@@ -123,6 +130,7 @@ function telegramDraftPreviewKey(preview: TelegramDraftPreview): string {
     text: preview.text,
     parseMode: preview.parseMode ?? "plain",
     richMessage: preview.richMessage,
+    plainTextTransport: preview.plainTextTransport === true,
   });
 }
 

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -88,12 +88,16 @@ function isTelegramHtmlParseError(err: unknown): boolean {
   return TELEGRAM_PARSE_ERR_RE.test(formatErrorMessage(err));
 }
 
+function telegramRichHtmlToParseModeHtml(html: string): string {
+  return html.replace(/<br\s*\/?>/giu, "\n");
+}
+
 function normalizeTelegramDraftTransportPreview(
   preview: TelegramDraftPreview,
 ): TelegramDraftTransportPreview {
   if (preview.richMessage?.html) {
     return {
-      text: preview.richMessage.html,
+      text: telegramRichHtmlToParseModeHtml(preview.richMessage.html),
       parseMode: "HTML",
       plainText: preview.text,
     };

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -376,8 +376,7 @@ export function createTelegramDraftStream(params: {
     const renderedPayloadLength = richMessages
       ? telegramDraftRichPayloadLength(rendered)
       : renderedText.length;
-    const renderedPreview = { ...rendered, text: renderedText };
-    const renderedPreviewKey = telegramDraftPreviewKey(renderedPreview);
+    const renderedPreviewKey = telegramDraftPreviewKey({ ...rendered, text: renderedText });
     if (!renderedText) {
       return false;
     }
@@ -454,7 +453,7 @@ export function createTelegramDraftStream(params: {
     lastSentPreviewKey = renderedPreviewKey;
     try {
       const sent = await sendMessageTransportPreview({
-        preview: renderedPreview,
+        preview: rendered,
         sendGeneration,
       });
       if (sent) {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -61,7 +61,6 @@ export type TelegramDraftPreview = {
   text: string;
   parseMode?: "HTML";
   richMessage?: TelegramInputRichMessage;
-  plainTextTransport?: boolean;
 };
 
 type SupersededTelegramPreview = {
@@ -92,12 +91,6 @@ function isTelegramHtmlParseError(err: unknown): boolean {
 function normalizeTelegramDraftTransportPreview(
   preview: TelegramDraftPreview,
 ): TelegramDraftTransportPreview {
-  if (preview.plainTextTransport) {
-    return {
-      text: preview.text,
-      plainText: preview.text,
-    };
-  }
   if (preview.richMessage?.html) {
     return {
       text: preview.richMessage.html,
@@ -130,7 +123,6 @@ function telegramDraftPreviewKey(preview: TelegramDraftPreview): string {
     text: preview.text,
     parseMode: preview.parseMode ?? "plain",
     richMessage: preview.richMessage,
-    plainTextTransport: preview.plainTextTransport === true,
   });
 }
 

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -182,8 +182,6 @@ export function createTelegramDraftStream(params: {
   throttleMs?: number;
   /** Minimum chars before sending first message (debounce for push notifications) */
   minInitialChars?: number;
-  /** Maximum time to hold a short first preview before materializing it anyway. */
-  minInitialDelayMs?: number;
   /** Optional preview renderer (e.g. markdown -> HTML + parse mode). */
   renderText?: (text: string) => TelegramDraftPreview;
   /** Called when a late send resolves after forceNewMessage() switched generations. */
@@ -196,7 +194,6 @@ export function createTelegramDraftStream(params: {
   const maxChars = Math.min(params.maxChars ?? transportLimit, transportLimit);
   const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
   const minInitialChars = params.minInitialChars;
-  const minInitialDelayMs = params.minInitialDelayMs;
   const chatId = params.chatId;
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyToMessageId = normalizeTelegramReplyToMessageId(params.replyToMessageId);
@@ -231,8 +228,6 @@ export function createTelegramDraftStream(params: {
   let lastDeliveredText = "";
   let lastRequestedText = "";
   let lastRequestedPreview: TelegramDraftPreview | undefined;
-  let firstShortPreviewSeenMs: number | undefined;
-  let initialPreviewTimer: ReturnType<typeof setTimeout> | undefined;
   let previewRevision = 0;
   let generation = 0;
   let deliveredTextOffset = 0;
@@ -328,26 +323,6 @@ export function createTelegramDraftStream(params: {
     streamVisibleSinceMs = visibleSinceMs;
     return true;
   };
-  const clearInitialPreviewTimer = () => {
-    if (initialPreviewTimer) {
-      clearTimeout(initialPreviewTimer);
-      initialPreviewTimer = undefined;
-    }
-  };
-  const scheduleInitialPreviewFlush = (delayMs: number) => {
-    if (initialPreviewTimer) {
-      return;
-    }
-    initialPreviewTimer = setTimeout(
-      () => {
-        initialPreviewTimer = undefined;
-        void flushInitialPreview().catch((err: unknown) => {
-          params.warn?.(`telegram stream preview delayed send failed: ${formatErrorMessage(err)}`);
-        });
-      },
-      Math.max(0, delayMs),
-    );
-  };
   const stopOversizedPreview = (payloadLength: number): false => {
     streamState.stopped = true;
     params.warn?.(`telegram stream preview stopped (text length ${payloadLength} > ${maxChars})`);
@@ -433,24 +408,8 @@ export function createTelegramDraftStream(params: {
 
     if (typeof streamMessageId !== "number" && minInitialChars != null && !streamState.final) {
       if (renderedText.length < minInitialChars) {
-        if (minInitialDelayMs == null) {
-          return false;
-        }
-        const now = Date.now();
-        firstShortPreviewSeenMs ??= now;
-        const remainingDelayMs = minInitialDelayMs - (now - firstShortPreviewSeenMs);
-        if (remainingDelayMs > 0) {
-          scheduleInitialPreviewFlush(remainingDelayMs);
-          return false;
-        }
-        clearInitialPreviewTimer();
-      } else {
-        firstShortPreviewSeenMs = undefined;
-        clearInitialPreviewTimer();
+        return false;
       }
-    } else {
-      firstShortPreviewSeenMs = undefined;
-      clearInitialPreviewTimer();
     }
 
     const previousSentPreviewKey = lastSentPreviewKey;
@@ -511,7 +470,6 @@ export function createTelegramDraftStream(params: {
     state: streamState,
     sendOrEditStreamMessage,
   });
-  const flushInitialPreview = loop.flush;
 
   const requestDraftUpdate = (text: string, preview?: TelegramDraftPreview) => {
     if (streamState.stopped || streamState.final) {
@@ -558,8 +516,6 @@ export function createTelegramDraftStream(params: {
     messageSendAttempted = false;
     streamMessageId = undefined;
     streamVisibleSinceMs = undefined;
-    firstShortPreviewSeenMs = undefined;
-    clearInitialPreviewTimer();
     lastSentPreviewKey = "";
     if (options?.resetOffset !== false) {
       deliveredTextOffset = 0;
@@ -573,7 +529,6 @@ export function createTelegramDraftStream(params: {
   };
 
   const clear = async () => {
-    clearInitialPreviewTimer();
     const messageId = await takeMessageIdAfterStop({
       stopForClear,
       readMessageId: () => streamMessageId,
@@ -592,7 +547,6 @@ export function createTelegramDraftStream(params: {
   };
 
   const discard = async () => {
-    clearInitialPreviewTimer();
     await stopForClear();
   };
 

--- a/src/agents/tool-display-config.ts
+++ b/src/agents/tool-display-config.ts
@@ -74,6 +74,11 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       title: "Attach",
       detailKeys: ["path", "url", "fileName"],
     },
+    api: {
+      emoji: "🌐",
+      title: "API",
+      detailKeys: ["url", "endpoint", "path", "method", "name"],
+    },
     browser: {
       emoji: "🌐",
       title: "Browser",

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -372,6 +372,8 @@ function itemKindToToolName(kind: string | undefined): string | undefined {
       return "apply_patch";
     case "search":
       return "web_search";
+    case "api":
+      return "api";
     case "tool":
       return "tool_call";
     default:


### PR DESCRIPTION
## Summary

Fixes #95002.

Telegram progress draft previews now keep their canonical preview text readable while preserving Telegram's native HTML transport for non-rich progress drafts.

## What Problem This Solves

The Telegram progress draft renderer used HTML/code-oriented progress rows as the primary draft representation. That made command/tool progress noisy when fallback or sanitized paths surfaced transport markup, and it left the `api` progress edge to generic fallback rendering.

A review also caught that the previous revision solved readability by adding a new `plainTextTransport` path. This revision removes that path and keeps the existing Telegram HTML draft transport instead.

## Changes

- Normalize Telegram progress draft rows through a plain readable line model first.
- Generate escaped Telegram HTML from the same normalized progress lines for transport.
- Preserve the default non-rich Telegram draft transport path: previews with `richMessage.html` are sent with `parse_mode: "HTML"`, with `TelegramDraftPreview.text` retained as the plain fallback if Telegram rejects the HTML parse.
- Convert rich-message `<br>` line breaks to real newlines at the non-rich `parse_mode: "HTML"` transport boundary, because Telegram parse-mode HTML accepts newlines but rejects `<br>` tags.
- Remove the reverted `plainTextTransport` path and its test expectations.
- Map `itemKind: "api"` to the API tool display and add a first-class `API` display config.
- Update Telegram draft/dispatch regression coverage for readable text, preserved HTML transport, parse-mode-safe line breaks, HTML-parse fallback, and both `api` progress shapes.

## Current-head behavior

At head `24c8774c98d54d01f884adbded289b9a4c97bff5`:

- `extensions/telegram/src/bot-message-dispatch.ts` returns `TelegramDraftPreview.text` as readable plain text and attaches escaped `richMessage.html` for Telegram transport.
- `extensions/telegram/src/draft-stream.ts` sends attached HTML previews through `parse_mode: "HTML"`, converts rich `<br>` breaks to parse-mode-safe newlines, and keeps plain text as fallback only when Telegram rejects the HTML parse.
- `src/channels/streaming.ts` maps `itemKind: "api"` to `api`, and `src/agents/tool-display-config.ts` / the OpenClawKit resource snapshot include the API display entry.

## Evidence

Current-head external Linux VM validation on `24c8774c98d54d01f884adbded289b9a4c97bff5`:

- Telegram Bot API proof: passed.
  - `sendMessage` used `parse_mode: "HTML"` with `<b>` / `<code>` tags and real newline separators.
  - `editMessageText` used `parse_mode: "HTML"` on the same message id.
  - No plain fallback send/edit occurred.
  - Telegram returned readable text containing `Shelling`, `API`, and `Exec` with no visible HTML tags.
  - `richRawTransportNotUsed: true` for the non-rich path.
- Target Telegram tests: passed, 3 files / 226 tests.
  - `extensions/telegram/src/bot-message-dispatch.test.ts`
  - `extensions/telegram/src/draft-stream.test.ts`
  - `extensions/telegram/src/lane-delivery.test.ts`
- Target core display/streaming tests: passed, 2 files / 45 tests.
  - `src/channels/streaming.test.ts`
  - `src/agents/tool-display.test.ts`
- `node --import tsx scripts/tool-display.ts --check`: passed.
- `git diff --check`: passed locally as a static whitespace check before push.

GitHub Actions:

- Upstream Real behavior proof is green for the current head: https://github.com/openclaw/openclaw/actions/runs/27918119274
- Upstream PR checks for the current head have no failures reported yet; most broad CI jobs remain queued on upstream runners.
- Self-owned fork CI was manually dispatched for the current target ref: https://github.com/snowzlmbot/openclaw/actions/runs/27918092997
  - `check-test-types`: passed.
  - `check-guards`: passed.
  - `src/agents/tool-display.test.ts`: passed inside `checks-node-core-fast`.
  - `src/channels/streaming.test.ts`: passed inside `checks-node-core-fast`.
  - `test/scripts/telegram-bot-api.test.ts`: passed inside `checks-node-core-tooling`.
  - Current fork CI failures are outside this PR surface: docs formatting in `docs/gateway/doctor.md`, `test/scripts/resolve-openclaw-ref.test.ts`, `src/scripts/test-projects.test.ts`, `test/scripts/bench-gateway-restart.test.ts`, and `src/agents/cli-runner.spawn.test.ts` / Claude live-session capacity. None of these mention the Telegram progress draft files, `tool-display` snapshot, `telegramHtmlPreview`, or `plainTextTransport`.

Previous broad CI failures on `0df89a764914e0786060ae775c68687d4d29f28a` showed the same unrelated pattern (`resolve-openclaw-ref`, test-projects/bench-gateway-restart, and MCP/Claude runner flakes). The current head supersedes that run with the parse-mode-safe HTML transport fix.

## Risk

Low-to-moderate Telegram presentation risk:

- This changes transient Telegram progress draft row formatting, not final answer delivery.
- Telegram HTML transport remains the default for attached progress preview HTML.
- Plain preview text is retained only as fallback when Telegram rejects HTML parsing.
- API progress now has an explicit display mapping instead of generic item fallback.

## Not addressed

This PR does not change Telegram draft materialization policy, including first-preview debounce/minimum length or progress-mode answer-lane suppression. That behavior remains separate from the progress-row formatting fix.

