### PR TITLE
fix(claude-cli): also disable native background Bash and Monitor in --print runs

### DIFF
--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -49,7 +49,7 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
         "--allowedTools",
         "mcp__openclaw__*",
         "--disallowedTools",
-        "ScheduleWakeup,CronCreate",
+        "ScheduleWakeup,CronCreate,Bash(run_in_background:true),Monitor",
       ],
       resumeArgs: [
         "-p",
@@ -62,7 +62,7 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
         "--allowedTools",
         "mcp__openclaw__*",
         "--disallowedTools",
-        "ScheduleWakeup,CronCreate",
+        "ScheduleWakeup,CronCreate,Bash(run_in_background:true),Monitor",
         "--resume",
         "{sessionId}",
       ],

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -10,10 +10,13 @@ import {
   resolveClaudeCliExecutionArgs,
 } from "./cli-shared.js";
 
+const CLAUDE_CLI_DISALLOWED_TOOLS =
+  "ScheduleWakeup,CronCreate,Bash(run_in_background:true),Monitor";
+
 function expectDefaultDisallowedTools(args: readonly string[] | undefined) {
   const disallowedIndex = args?.indexOf("--disallowedTools") ?? -1;
   expect(disallowedIndex).toBeGreaterThanOrEqual(0);
-  expect(args?.[disallowedIndex + 1]).toBe("ScheduleWakeup,CronCreate");
+  expect(args?.[disallowedIndex + 1]).toBe(CLAUDE_CLI_DISALLOWED_TOOLS);
 }
 
 describe("normalizeClaudePermissionArgs", () => {
@@ -385,12 +388,8 @@ describe("normalizeClaudeBackendConfig", () => {
 
   it("disables native background Bash and Monitor tools in args and resumeArgs", () => {
     const backend = buildAnthropicCliBackend();
-    for (const args of [backend.config.args, backend.config.resumeArgs]) {
-      const idx = args.indexOf("--disallowedTools");
-      expect(idx).toBeGreaterThanOrEqual(0);
-      const deny = args[idx + 1] ?? "";
-      expect(deny).toContain("Bash(run_in_background:true)");
-      expect(deny).toContain("Monitor");
-    }
+
+    expectDefaultDisallowedTools(backend.config.args);
+    expectDefaultDisallowedTools(backend.config.resumeArgs);
   });
 });

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -382,4 +382,15 @@ describe("normalizeClaudeBackendConfig", () => {
     expect(backend.config.clearEnv).toContain("OTEL_EXPORTER_OTLP_PROTOCOL");
     expect(backend.config.clearEnv).toContain("OTEL_SDK_DISABLED");
   });
+
+  it("disables native background Bash and Monitor tools in args and resumeArgs", () => {
+    const backend = buildAnthropicCliBackend();
+    for (const args of [backend.config.args, backend.config.resumeArgs]) {
+      const idx = args.indexOf("--disallowedTools");
+      expect(idx).toBeGreaterThanOrEqual(0);
+      const deny = args[idx + 1] ?? "";
+      expect(deny).toContain("Bash(run_in_background:true)");
+      expect(deny).toContain("Monitor");
+    }
+  });
 });


### PR DESCRIPTION
## What

Extend the `claude-cli` backend's existing `--disallowedTools` list to also deny the two native background tools, in both fresh `args` and `resumeArgs`:

```
"ScheduleWakeup,CronCreate"  ->  "ScheduleWakeup,CronCreate,Bash(run_in_background:true),Monitor"
```

This follows the exact pattern established in #84434 (which disabled `ScheduleWakeup`/`CronCreate` in `--print` Claude runs) — same flag, same rationale, two more tools.

## Why

`Bash(run_in_background:true)` and `Monitor` promise the model a completion callback ("I'll re-wake you when the background process exits / when output changes"). The `claude-cli` backend has no mechanism to re-wake the agent on that signal, so the model strands deferred work in a process it will never hear back from — the same failure mode #84434 fixed for the native scheduler tools. Deferred / long-running work should route through OpenClaw cron wake (#83738 merged, #92037 open), which the backend *can* deliver.

## Scope boundary

- `claude-cli` backend only; no other backend touched.
- Denial is scoped to the `run_in_background:true` **variant** of `Bash` (foreground `Bash` is untouched) and to the `Monitor` tool specifically. No general Bash restriction.
- Two values changed (fresh + resume args); nothing else in `cli-backend.ts` changes.

## Proof

Local behavioral proof on real Claude CLI **2.1.183**, using the exact shipped deny value. Recording deliberately omitted — this is a backend-argv default with no transport-visible surface (telegram-visible proof not applicable).

Invoked `claude -p ... --disallowedTools "ScheduleWakeup,CronCreate,Bash(run_in_background:true),Monitor"`:
- Background Bash denied — `tool_result` `is_error:true`: `"Permission to use Bash with run_in_background:true has been denied."` (denial events present in the run).
- `Monitor` **absent** from the init `tools` list.
- `ScheduleWakeup` / `CronCreate` also absent (the pre-existing denials still hold).
- Foreground Bash in the same run succeeds (`fg-ok`) — only the background variant is denied, not Bash generally.

Contrast (no deny flags, same CLI): background Bash launches and `Monitor` is present — isolating the flag as the cause. A focused regression test asserts both `args` and `resumeArgs` carry the two new deny rules.

## Risk / mitigation

- **Risk:** an agent relying on native fire-and-forget background work or `Monitor` loses it. **Mitigation:** that path was already broken on this backend (no completion delivery); OpenClaw cron wake (#83738 / #92037) is the supported replacement and is unaffected — and #84434 already set this precedent for the scheduler tools.
- **Risk:** a future Claude CLI rename silently no-ops the deny rule. **Mitigation:** the regression test pins the values; a real regression surfaces as the tool reappearing in the init tool list / denial events disappearing.

## Not tested

- End-to-end through a live OpenClaw-spawned session (effect proven via a faithful `claude -p` invocation with the exact shipped value; the backend wiring is a static arg-array change verified by the unit test).
- Backends other than `claude-cli` (intentionally out of scope).

## Test command

```
$ node scripts/test-projects.mjs extensions/anthropic/cli-shared.test.ts
 Test Files  1 passed (1)
      Tests  21 passed (21)
```
The added `it("disables native background Bash and Monitor tools in args and resumeArgs")` asserts both `args` and `resumeArgs` carry the two new deny rules.

## OpenClaw-spawned proof (per ClawSweeper review)

Built this branch (`532635e`) and ran a real embedded OpenClaw turn (`openclaw agent --local --model claude-cli/claude-sonnet-4-6`).

**1. The OpenClaw-spawned `claude` argv carries the deny value** — captured from `/proc/<pid>/cmdline` of the gateway-spawned process:
```
claude -p --include-partial-messages --verbose --setting-sources user \
  --allowedTools mcp__openclaw__* \
  --disallowedTools ScheduleWakeup,CronCreate,Bash(run_in_background:true),Monitor \
  --strict-mcp-config --mcp-config <redacted> --plugin-dir <redacted> --effort low \
  --model claude-sonnet-4-6 --append-system-prompt-file <redacted> \
  --input-format stream-json --output-format stream-json \
  --permission-prompt-tool stdio --replay-user-messages --permission-mode bypassPermissions
```

**2. That exact flag combination denies background Bash and hides Monitor** — raw `claude` stream-json (same `--allowedTools mcp__openclaw__* --disallowedTools … --permission-mode bypassPermissions`, attempting a background bash):
```
"name":"Bash" … "run_in_background":true
tool_result is_error:true: "Permission to use Bash with run_in_background:true has been denied."
result.permission_denials:[{"tool_name":"Bash", … "run_in_background":true, "command":"echo hi"}]
```
`Monitor` is absent from the session's init tool list; foreground Bash is unaffected.

**On self-report vs ground truth:** driven through the OpenClaw agent turn, the model's *prose* claimed the background task "completed … I received a completion notification." That is confabulation — the tool-layer denial above is ground truth, and the phantom "completion notification" is precisely the misleading affordance this PR removes. (OpenClaw's `agent` CLI surfaces only final assistant text, not raw tool events, so the raw `claude` stream-json is shown here.)
