### PR TITLE
fix(feishu): replace Type.Any with Type.Unknown in bitable schemas [AI-assisted]

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -530,7 +530,7 @@ const CreateRecordSchema = Type.Object({
     description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
-  fields: Type.Record(Type.String(), Type.Any(), {
+  fields: Type.Record(Type.String(), Type.Unknown(), {
     description:
       "Field values keyed by field name. Format by type: Text='string', Number=123, SingleSelect='Option', MultiSelect=['A','B'], DateTime=timestamp_ms, User=[{id:'ou_xxx'}], URL={text:'Display',link:'https://...'}",
   }),
@@ -560,7 +560,7 @@ const CreateFieldSchema = Type.Object({
     minimum: 1,
   }),
   property: Type.Optional(
-    Type.Record(Type.String(), Type.Any(), {
+    Type.Record(Type.String(), Type.Unknown(), {
       description: "Field-specific properties (e.g., options for SingleSelect, format for Number)",
     }),
   ),
@@ -572,7 +572,7 @@ const UpdateRecordSchema = Type.Object({
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
   record_id: Type.String({ description: "Record ID to update" }),
-  fields: Type.Record(Type.String(), Type.Any(), {
+  fields: Type.Record(Type.String(), Type.Unknown(), {
     description: "Field values to update (same format as create_record)",
   }),
 });


### PR DESCRIPTION
### Summary
This PR fixes Issue #94547 where `@openclaw/feishu` bitable write tools have invalid schemas.
To prevent empty `{}` sub-schemas (which break Bedrock), this PR replaces `Type.Any()` usages in schemas with `Type.Unknown()`.

### Real behavior proof
- Verified this change by running the Feishu bitable unit tests.
- Command run: `npx vitest run extensions/feishu/src/bitable.test.ts`
- Result: All tests passed!
