### PR TITLE
fix(skills): use remote-aware Gateway skills.status in CLI when available

### DIFF
--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -100,6 +100,35 @@ async function loadSkillsStatusReport(
 ): Promise<SkillStatusReport> {
   const { config, workspaceDir, agentId } = resolveSkillsWorkspace(options);
   const { buildWorkspaceSkillStatus } = await import("../skills/discovery/status.js");
+
+  // When a Gateway URL is configured (local or remote), prefer the remote-aware
+  // skills.status RPC so that remote node capabilities (e.g. darwin + memo from
+  // a connected macOS node for apple-notes) are reflected in skill eligibility.
+  // Fall back to local-only status when the Gateway is unreachable.
+  const gatewayUrl = config.gateway?.remote?.url;
+  if (gatewayUrl) {
+    try {
+      const { callGatewayFromCli } = await import("./gateway-rpc.js");
+      const result = await callGatewayFromCli(
+        "skills.status",
+        { url: gatewayUrl, timeout: "5000" },
+        { agentId: agentId || undefined },
+        { clientName: "openclaw-cli" },
+      );
+      if (result && typeof result === "object" && (result as { ok?: boolean }).ok) {
+        const skills = (result as { skills?: unknown[] }).skills;
+        if (Array.isArray(skills)) {
+          return {
+            skills: skills as SkillStatusReport["skills"],
+            workspaceDir,
+          };
+        }
+      }
+    } catch {
+      // Gateway unreachable — fall through to local-only status.
+    }
+  }
+
   return buildWorkspaceSkillStatus(workspaceDir, { config, agentId });
 }
 


### PR DESCRIPTION
Closes #94956

## Summary
CLI skills subcommands (list, check, info) used a local-only status build that did not account for remote macOS node capabilities. Even after the parser fix (#71877) for `system.which` object-map payloads, CLI status reports still showed `darwin` + `bins(memo)` as missing on Linux gateways with connected macOS nodes.

## Fix
`loadSkillsStatusReport` now tries the Gateway `skills.status` RPC (which already builds with `getRemoteSkillEligibility`) when `config.gateway.remote.url` is set, falling back to local-only `buildWorkspaceSkillStatus` when the Gateway is unreachable.

## Changed: 1 file, +29 lines
- `src/cli/skills-cli.ts`

## Test results
- skills-cli.commands: 52/52 pass ✅
- skills/runtime/remote: 12/12 pass ✅  
- gateway skills.proposals: 10/10 pass ✅