### PR TITLE
fix(dispatch): allow isReasoning payloads through shared dispatch

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -7292,7 +7292,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(receivedCfg).toBe(cfg);
   });
 
-  it("suppresses isReasoning payloads from final replies (WhatsApp channel)", async () => {
+  it("delivers isReasoning final payloads (WhatsApp channel)", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();
     const ctx = buildTestCtx({ Provider: "whatsapp" });
@@ -7303,11 +7303,12 @@ describe("dispatchReplyFromConfig", () => {
       ] satisfies ReplyPayload[];
     await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
     const finalCalls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
-    expect(finalCalls).toHaveLength(1);
-    expect((finalCalls[0]?.[0] as ReplyPayload | undefined)?.text).toBe("The answer is 42");
+    expect(finalCalls).toHaveLength(2);
+    expect((finalCalls[0]?.[0] as ReplyPayload | undefined)?.text).toBe("thinking...");
+    expect((finalCalls[1]?.[0] as ReplyPayload | undefined)?.text).toBe("The answer is 42");
   });
 
-  it("suppresses isReasoning payloads from block replies (generic dispatch path)", async () => {
+  it("delivers isReasoning block payloads (generic dispatch path)", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();
     const ctx = buildTestCtx({ Provider: "whatsapp" });
@@ -7331,7 +7332,7 @@ describe("dispatchReplyFromConfig", () => {
       },
     );
     await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
-    expect(blockReplySentTexts).not.toContain("thinking...");
+    expect(blockReplySentTexts).toContain("thinking...");
     expect(blockReplySentTexts).toContain("The answer is 42");
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -3101,12 +3101,6 @@ export async function dispatchReplyFromConfig(
                 if (suppressDelivery) {
                   return;
                 }
-                // Suppress reasoning payloads — channels using this generic dispatch
-                // path (WhatsApp, web, etc.) do not have a dedicated reasoning lane.
-                // Telegram has its own dispatch path that handles reasoning splitting.
-                if (payload.isReasoning === true) {
-                  return;
-                }
                 // Accumulate block text for TTS generation after streaming.
                 // Exclude status notices — they are informational UI signals
                 // and must not be synthesised into the spoken reply.
@@ -3274,11 +3268,6 @@ export async function dispatchReplyFromConfig(
       (ctx.InboundEventKind !== "room_event" || explicitCommandTurnCtx);
     for (const [replyIndex, reply] of replies.entries()) {
       throwIfDispatchOperationAborted();
-      // Suppress reasoning payloads from channel delivery — channels using this
-      // generic dispatch path do not have a dedicated reasoning lane.
-      if (reply.isReasoning === true) {
-        continue;
-      }
       if (suppressDelivery && !shouldDeliverDespiteSourceReplySuppression(reply)) {
         if (hasOutboundReplyContent(reply, { trimText: true })) {
           logVerbose(


### PR DESCRIPTION
Closes #94937, closes #94936

## Summary
The shared `dispatch-from-config` had two `isReasoning` suppression guards that silently discarded reasoning block/final payloads before any channel delivery path could process them. This broke both Discord and Telegram `/reasoning on` — the agent emits reasoning, but the dispatcher drops it.

Combined with #95014 (Discord-side suppression removal), this completes the reasoning delivery fix for both channels.

## Changes
Removed two `isReasoning` suppression guards:
1. Block reply delivery loop
2. Final reply delivery loop

Updated tests from "suppresses" to "delivers" assertions.

## Fixed: 2 files, +6/-16
- `src/auto-reply/reply/dispatch-from-config.ts`
- `src/auto-reply/reply/dispatch-from-config.test.ts`

## Test results
- dispatch-from-config: 210/210 pass ✅
- Discord message-handler.process: 107/107 pass ✅ (fix in #95014)