### PR TITLE
fix(skills): point gog brew install at homebrew-core gogcli (#95017)

### DIFF
--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -13,7 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
-              "formula": "steipete/tap/gogcli",
+              "formula": "gogcli",
               "bins": ["gog"],
               "label": "Install gog (brew)",
             },


### PR DESCRIPTION
## Summary

Onboarding's skill-dependency installer fails to install the `gog` skill because its bundled metadata points at a Homebrew formula that no longer exists in that tap:

```json
"formula": "steipete/tap/gogcli"
```

`gogcli` has since graduated to **homebrew-core**, and the formula was removed from `steipete/tap`. The installer builds `brew install steipete/tap/gogcli`, which now fails with:

```text
Warning: Skipping steipete/tap because it is not trusted. Run `brew trust steipete/tap` to trust it.
Warning: No available formula or cask with the name "steipete/tap/gogcli".
```

This PR points the `gog` skill at the canonical core formula `gogcli`, so the install command becomes `brew install gogcli`. Using the core formula (vs. `openclaw/tap/gogcli`) also avoids the third-party-tap trust prompt the reporter hit.

Fixes #95017.

### Scope note

Only `gog`'s formula graduated to core. The other `steipete/tap/*` skills (`songsee`, `camsnap`, `peekaboo`, `imsg`, etc.) still resolve in that tap, so they are intentionally left unchanged — verified `steipete/tap` still serves those formulae and no longer serves `gogcli`.

## Verification

### Real behavior proof

- **Behavior addressed:** `gog` skill dependency install during onboarding fails because metadata references the removed `steipete/tap/gogcli` formula; switching to the homebrew-core `gogcli` formula makes the resolved `brew install gogcli` command succeed against Homebrew core.
- **Real environment tested:** Linux (WSL2) checkout, live network. The dependency contract was checked directly against the live Homebrew formulae API and the `steipete/homebrew-tap` git repo, and the skill install-spec resolution was exercised through the real skill frontmatter parser and the real install-argv builder.
- **Exact steps or command run after this patch:**
  ```bash
  curl -fsSL https://formulae.brew.sh/api/formula/gogcli.json | head -c 200
  curl -fsSL -o /dev/null -w "%{http_code}\n" https://raw.githubusercontent.com/steipete/homebrew-tap/main/Formula/gogcli.rb
  curl -fsSL -o /dev/null -w "%{http_code}\n" https://raw.githubusercontent.com/steipete/homebrew-tap/main/Formula/songsee.rb
  node scripts/run-vitest.mjs <disposable spec exercising parseFrontmatter + resolveOpenClawMetadata against the patched skills/gog/SKILL.md>
  ```
- **Evidence after fix:** Live output captured after this patch.

  Homebrew core now owns `gogcli` (matches the reporter's working manual install):
  ```text
  $ curl -fsSL https://formulae.brew.sh/api/formula/gogcli.json | head -c 200
  {"name":"gogcli","full_name":"gogcli","tap":"homebrew/core","oldnames":[],"aliases":[],
  "versioned_formulae":[],"desc":"Google Suite CLI","license":"MIT",
  "homepage":"https://gogcli.sh","versions":{"stable":"0.29.0","head":"HEAD","bottle":true}
  ```

  The old tapped formula is gone, while sibling tap formulae still resolve (so only `gog` needs changing):
  ```text
  $ curl ... steipete/homebrew-tap/main/Formula/gogcli.rb   -> 404
  $ curl ... steipete/homebrew-tap/main/Formula/songsee.rb  -> 200
  ```

  Running the real frontmatter parser + install-argv builder against the patched `skills/gog/SKILL.md`:
  ```text
  $ node scripts/run-vitest.mjs <spec>
  Test Files  1 passed (1)
       Tests  1 passed (1)
  # resolved brew install spec: formula === "gogcli"
  # buildInstallArgv output:    ["brew", "install", "gogcli"]
  ```
- **Observed result after fix:** The resolved install command for `gog` is now `brew install gogcli`, which resolves against homebrew-core (HTTP 200 / formula present) instead of the removed, untrusted `steipete/tap/gogcli` (HTTP 404), eliminating the onboarding install failure.
- **What was not tested:** A full end-to-end `openclaw onboard` run on a fresh VPS that performs the actual `brew install` (no clean VPS + Homebrew sandbox available here). The failure and fix are fully determined by the resolved `brew install <formula>` argument and the live Homebrew formula availability shown above.

### Notes

- Data/metadata-only change (one line). No new permanent test added — there is no per-skill-formula test harness, and asserting a single data literal is low value; the disposable parser spec above was used only to capture the proof and then removed.
- AI-assisted.
