### PR TITLE
fix(ssh-tunnel): constrain ensurePortAvailable to IPv4 loopback

### DIFF
--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -119,7 +119,7 @@ export async function startSshPortForward(opts: {
 
   let localPort = opts.localPortPreferred;
   try {
-    await ensurePortAvailable(localPort);
+    await ensurePortAvailable(localPort, "127.0.0.1");
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {
       localPort = await pickEphemeralPort();


### PR DESCRIPTION
Closes #94596

## Summary
`ensurePortAvailable()` called without a host argument binds the IPv6 wildcard `::` on dual-stack hosts and misses IPv4-only occupants, re-introducing the same address-family flaw that #94394 fixed for the Chrome CDP path.

This caller uses `127.0.0.1` everywhere else:
- `pickEphemeralPort()` → `listen(0, "127.0.0.1")`
- `canConnectLocal()` → `connect({host: "127.0.0.1"})`
- the forward itself → `-L ${port}:127.0.0.1:${remotePort}`

## Fix: 1 file, +1/-1
- `src/infra/ssh-tunnel.ts`: `ensurePortAvailable(localPort)` → `ensurePortAvailable(localPort, "127.0.0.1")`