### PR TITLE
fix(memory-qmd): preserve unquoted Windows absolute paths in qmd command [AI-assisted]

### DIFF
--- a/packages/memory-host-sdk/src/host/backend-config.test.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.test.ts
@@ -166,6 +166,64 @@ describe("resolveMemoryBackendConfig", () => {
     expect(requireQmdConfig(resolved).command).toBe("/Applications/QMD Tools/qmd");
   });
 
+  it("preserves unquoted Windows drive-letter qmd command paths", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/memory-test" } },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          command: "C:\\Users\\bin\\qmd.exe",
+        },
+      },
+    } as OpenClawConfig;
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    // splitShellArgs treats backslashes as POSIX escapes and would mangle this
+    // to "C:Usersbinqmd.exe"; the drive-letter path must reach spawn intact.
+    expect(requireQmdConfig(resolved).command).toBe("C:\\Users\\bin\\qmd.exe");
+  });
+
+  it("preserves unquoted Windows UNC qmd command paths", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/memory-test" } },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          command: "\\\\server\\share\\qmd.exe",
+        },
+      },
+    } as OpenClawConfig;
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    expect(requireQmdConfig(resolved).command).toBe("\\\\server\\share\\qmd.exe");
+  });
+
+  it("preserves forward-slash Windows drive-letter qmd command paths", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/memory-test" } },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          command: "C:/Users/bin/qmd.exe",
+        },
+      },
+    } as OpenClawConfig;
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    expect(requireQmdConfig(resolved).command).toBe("C:/Users/bin/qmd.exe");
+  });
+
+  it("keeps trailing args out of an unquoted Windows qmd command path", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/memory-test" } },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          command: "C:\\Users\\bin\\qmd.exe --rerank",
+        },
+      },
+    } as OpenClawConfig;
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    expect(requireQmdConfig(resolved).command).toBe("C:\\Users\\bin\\qmd.exe");
+  });
+
   it("resolves custom paths relative to workspace", () => {
     const cfg = {
       agents: {

--- a/packages/memory-host-sdk/src/host/backend-config.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.ts
@@ -439,7 +439,14 @@ export function resolveMemoryBackendConfig(params: {
   ];
 
   const rawCommand = qmdCfg?.command?.trim() || "qmd";
-  const parsedCommand = splitShellArgs(rawCommand);
+  // Quoted commands (paths with spaces plus extra args) parse correctly through
+  // the shell tokenizer. Unquoted Windows absolute paths (drive-letter or UNC)
+  // use backslashes as separators, but splitShellArgs treats them as POSIX
+  // escapes and strips them, mangling the path so spawn cannot find it (#92302).
+  // For those, split on whitespace only so the executable reaches spawn intact.
+  const isQuoted = rawCommand.startsWith('"') || rawCommand.startsWith("'");
+  const isWindowsAbsolute = /^[A-Za-z]:[\\/]/.test(rawCommand) || /^([/\\])\1/.test(rawCommand);
+  const parsedCommand = isQuoted || !isWindowsAbsolute ? splitShellArgs(rawCommand) : null;
   const command = parsedCommand?.[0] || rawCommand.split(/\s+/)[0] || "qmd";
   const resolved: ResolvedQmdConfig = {
     command,


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

## Summary

- **Problem:** On Windows, an unquoted absolute `memory.qmd.command` path (e.g. `C:\Users\bin\qmd.exe` or `\\server\share\qmd.exe`) is mangled before QMD spawn. `resolveMemoryBackendQmdConfig` runs the configured command through `splitShellArgs`, a POSIX shell tokenizer that treats `\` as an escape character and strips it, so `C:\Users\bin\qmd.exe` collapses to `C:Usersbinqmd.exe`. The mangled token is then resolved relative to the workspace and spawn fails with `Cannot find module`, leaving the QMD memory backend unusable on Windows (#92302).
- **Why it matters now:** QMD is the documented opt-in memory backend; on Windows the only workaround is to abandon QMD for `memory.backend = "builtin"`. Quoted commands already parse correctly; only unquoted Windows absolute paths are broken.
- **What changed:** In `packages/memory-host-sdk/src/host/backend-config.ts`, detect unquoted Windows absolute command paths (drive-letter `C:\…` / `C:/…` or UNC `\\server\share\…` / `//server/share/…`) and split them on whitespace only, preserving backslashes, instead of routing them through the POSIX tokenizer. Quoted commands (paths with spaces + extra args) and non-Windows commands keep the existing `splitShellArgs` path unchanged.
- **What did NOT change:** The shared `splitShellArgs` tokenizer (`src/utils/shell-argv.ts`) is untouched — its POSIX escape semantics are correct for command-risk analysis elsewhere. No config option, config shape, default, or migration is added or changed. Downstream spawn (`resolveCliSpawnInvocation` → `resolveWindowsSpawnProgram`) is unchanged; it already handles `.js`/`.cmd` once the command path reaches it intact.
- **Success looks like:** A Windows user can set `memory.qmd.command` to an unquoted absolute path and QMD spawns the correct executable.
- **Reviewer focus:** The Windows-absolute-path predicate (drive-letter + UNC) and the regression coverage in `backend-config.test.ts`; confirm quoted-command and default-`qmd` behavior is unchanged.

## Linked context

Closes #92302

Related: prior closed unmerged attempts #92308, #92560, #92867 (the last was blocked at 🦪 silver for (a) missing UNC coverage and (b) proof being a string-logic check rather than a real Windows spawn run — both gaps are addressed here).

## Real behavior proof

- Behavior or issue addressed: `memory.qmd.command` set to an unquoted Windows absolute path was mangled by `splitShellArgs` (backslashes stripped as POSIX escapes), so QMD spawn failed with `Cannot find module` on Windows.
- Real environment tested: Windows 10 (win32 x64), Node v22.22.3, OpenClaw main @ 2c3b582c04 with this patch.
- Exact steps or command run after this patch: A Node script (run via `tsx`) imports the real `resolveMemoryBackendConfig` and `resolveCliSpawnInvocation` from source, creates a real stub executable at a Windows absolute path `C:\Users\<redacted>\.openclaw-qmd-proof\qmd-stub.js`, configures `memory.qmd.command` to that unquoted absolute path, resolves the QMD command the same way `qmd-manager` does, and actually `spawnSync`s it. Run before the patch and after the patch on the same Windows machine.
- Evidence after fix (terminal capture):
```
platform           : win32 x64
node               : v22.22.3
configured command : C:\Users\<redacted>\.openclaw-qmd-proof\qmd-stub.js
resolved command   : C:\Users\<redacted>\.openclaw-qmd-proof\qmd-stub.js
separators preserved: true
spawn exit code    : 0
spawn stdout       : {"ok":true,"argv":["--probe","--probe"]}
spawn stderr       :
```
- Observed result after fix: After the patch the resolved command preserves every backslash (`separators preserved: true`), the real `spawnSync` exits 0, and the stub executable runs and prints `{"ok":true,...}`. Before the patch (same machine, same script) the resolved command was mangled to `C:Users<redacted>.openclaw-qmd-proofqmd-stub.js`, `separators preserved: false`, spawn exited 1 with `Error: Cannot find module 'C:\Users\<redacted>\...qmd-stub.js' { code: 'MODULE_NOT_FOUND' }` — matching the reporter's error exactly.
- What was not tested: A live QMD index/search against a real `@tobilu/qmd` install (QMD itself is confirmed working by the reporter; this fix is isolated to OpenClaw's command-path resolution). macOS/Linux not tested (POSIX paths are unaffected by the change). UNC paths verified by unit test, not by a live UNC share spawn.
- Proof limitations or environment constraints: The stub is a trivial `.js` marker executable, not the full QMD binary, but it exercises the exact command-resolution + spawn path (`resolveMemoryBackendConfig` → `resolveCliSpawnInvocation` → `spawnSync`) that the QMD manager uses, so it proves the path reaches spawn intact. Username path segment redacted in the capture.

Before evidence (optional but encouraged):
```
platform           : win32 x64
node               : v22.22.3
configured command : C:\Users\<redacted>\.openclaw-qmd-proof\qmd-stub.js
resolved command   : C:Users<redacted>.openclaw-qmd-proofqmd-stub.js
separators preserved: false
spawn exit code    : 1
spawn stdout       :
spawn stderr       : node:internal/modules/cjs/loader:1433
  throw err;
  ^
Error: Cannot find module 'C:\Users\<redacted>\.openclaw-qmd-proofqmd-stub.js'
  code: 'MODULE_NOT_FOUND'
```

## Tests and validation

- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/backend-config.test.ts` — 30 passed (includes 4 new regression cases: unquoted drive-letter, unquoted UNC, forward-slash drive-letter, and trailing-args stripping; plus the existing quoted-command case).
- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/qmd-process.test.ts` — 16 passed.
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/qmd-manager.test.ts` — 128 passed, 1 pre-existing Windows-only failure unrelated to this change (`refreshes qmd index config with quoted collection values during update repair` fails on Windows because the test fixture does `mkdir("Notes #1: blue")` and `:` is illegal in Windows filenames; it passes on Linux CI and does not touch `qmd.command` parsing).
- `pnpm tsgo` — clean. `pnpm exec oxfmt --check` on changed files — clean. `node scripts/run-oxlint.mjs <changed files>` — clean.
- What failed before this fix: the new regression tests (`preserves unquoted Windows drive-letter/UNC qmd command paths`) fail on unpatched main with `Expected "C:\\Users\\bin\\qmd.exe" Received "C:Usersbinqmd.exe"` (and `\\server\share\qmd.exe` → `\servershareqmd.exe`).
- Swift host-env-policy check (`pnpm check:host-env-policy:swift`) skipped on Windows (no Swift).

## Risk checklist

- Did user-visible behavior change? `Yes` — on Windows, an unquoted absolute `memory.qmd.command` now resolves to the correct executable instead of a mangled path that fails to spawn. This is the bug fix; users who configured a quoted command or the default `qmd` see no change.
- Did config, environment, or migration behavior change? `No` — no config key, default, or migration is added/removed/renamed. Only the parsing of the existing `memory.qmd.command` value changes, and only for values that previously could not work (unquoted Windows absolute paths).
- Did security, auth, secrets, network, or tool execution behavior change? `No` — the resolved command is the same executable the operator configured; this fix makes spawn match operator intent, it does not broaden what is spawned.
- What is the highest-risk area? QMD command resolution on Windows.
- How is that risk mitigated? The predicate only changes behavior for values that look like Windows absolute paths (drive-letter or UNC) and are unquoted; quoted commands and all other commands keep the existing tokenizer. Regression tests pin drive-letter, UNC, forward-slash, trailing-args, and quoted cases. No new spawn surface is introduced.

## Current review state

- Next action: await ClawSweeper rating + CI.
- Waiting on: maintainer/bot review. Prior closed attempts were blocked on UNC coverage + real Windows spawn proof; both are addressed (UNC covered by predicate + test; real Windows spawn run captured above).
- Bot comments addressed: n/a (new PR).
