### PR TITLE
fix(infra): check for unable to open database file in isTransientSqliteError [AI-assisted]

### DIFF
--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -272,6 +272,12 @@ describe("isTransientSqliteError", () => {
 
     expect(isTransientSqliteError(error)).toBe(false);
   });
+
+  it("returns true for unable to open database file even without SQLite context", () => {
+    const error = new Error("unable to open database file");
+
+    expect(isTransientSqliteError(error)).toBe(true);
+  });
 });
 
 describe("isTransientFileWatchError", () => {

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -161,7 +161,7 @@ function hasSqliteSignal(err: unknown): boolean {
     "message" in err && typeof err.message === "string"
       ? normalizeLowercaseStringOrEmpty(err.message)
       : "";
-  if (message.includes("sqlite")) {
+  if (message.includes("sqlite") || message.includes("unable to open database file")) {
     return true;
   }
 


### PR DESCRIPTION
### Summary
This PR fixes Issue #94638 where `things-mac` SQLite reads fail with `unable to open database file`.
The error `unable to open database file` was not recognized as a transient SQLite error because `isTransientSqliteError` (via `hasSqliteSignal`) previously required the error name or message to contain the word `"sqlite"`. We now update `hasSqliteSignal` to recognize `"unable to open database file"` as a SQLite signal even if it does not contain the word `"sqlite"`.

### Real behavior proof
- I verified this change by adding a unit test case and running the unhandled rejections tests.
- Command run: `npx vitest run src/infra/unhandled-rejections.test.ts`
- Result: All tests passed successfully, including the new test.
