### PR TITLE
fix(ui): restore in-flight streaming assistant reply on Control UI session switch-back

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -3748,4 +3748,87 @@ describe("loadChatHistory inFlightRun adoption (#90755)", () => {
     expect(state.chatRunId).toBe("run-fresh");
     expect(state.chatStream).toBe("fresh live text");
   });
+
+  it("reconciles overlap when the buffer has leading whitespace not present in the committed message", async () => {
+    // Normalize whitespace before comparison: if the buffer starts with \n but
+    // the committed assistant message does not, the dedup should still work.
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "go ahead" }] },
+      { role: "assistant", content: [{ type: "text", text: "Starting analysis..." }] },
+    ];
+    const request = vi.fn().mockResolvedValue({
+      messages,
+      inFlightRun: { runId: "run-ws", text: "\nStarting analysis...\nPhase 1 complete.\nPhase 2 in progress..." },
+    });
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+      chatRunId: null,
+      chatStream: null,
+      chatStreamStartedAt: null,
+      chatError: "previous stale error",
+      lastError: "another stale error",
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-ws");
+    // The leading \n from the buffer is preserved; only the overlapping text is deduped
+    expect(state.chatStream).toContain("Phase 1 complete");
+    expect(state.chatStream).toContain("Phase 2 in progress");
+    expect(state.chatStream).not.toContain("Starting analysis...");
+    expect(state.chatStreamStartedAt).toEqual(expect.any(Number));
+    // Stale errors cleared on adoption
+    expect(state.chatError).toBeNull();
+    expect(state.lastError).toBeNull();
+  });
+
+  it("preserves full buffer when last visible message is not an assistant reply", async () => {
+    // Only assistant messages participate in reconciliation; user messages
+    // should not cause the buffer to be trimmed.
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "run lint" }] },
+    ];
+    const request = vi.fn().mockResolvedValue({
+      messages,
+      inFlightRun: { runId: "run-nonassist", text: "Lint output:\n35 errors found" },
+    });
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+      chatRunId: null,
+      chatStream: null,
+      chatStreamStartedAt: null,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-nonassist");
+    // Full buffer adopted since last message is user, not assistant
+    expect(state.chatStream).toBe("Lint output:\n35 errors found");
+  });
+
+  it("clears stale errors when adopting an in-flight run", async () => {
+    const messages = [{ role: "user", content: [{ type: "text", text: "Hello" }] }];
+    const request = vi.fn().mockResolvedValue({
+      messages,
+      inFlightRun: { runId: "run-err", text: "fresh stream" },
+    });
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+      chatRunId: null,
+      chatStream: null,
+      chatStreamStartedAt: null,
+      chatError: "gateway timeout",
+      lastError: "request failed",
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-err");
+    expect(state.chatStream).toBe("fresh stream");
+    expect(state.chatError).toBeNull();
+    expect(state.lastError).toBeNull();
+  });
 });

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -3635,3 +3635,117 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatThinkingLevel).toBeNull();
   });
 });
+
+describe("loadChatHistory inFlightRun adoption (#90755)", () => {
+  it("restores a buffered in-flight assistant stream on session switch-back", async () => {
+    const messages = [{ role: "user", content: [{ type: "text", text: "Hello" }] }];
+    const request = vi.fn().mockResolvedValue({
+      messages,
+      inFlightRun: { runId: "run-live", text: "Partial assistant repl" },
+    });
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+      chatRunId: null,
+      chatStream: null,
+      chatStreamStartedAt: null,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-live");
+    expect(state.chatStream).toBe("Partial assistant repl");
+    expect(state.chatStreamStartedAt).toEqual(expect.any(Number));
+    expect(state.chatMessages).toEqual(messages);
+  });
+
+  it("adopts an empty-text in-flight run so the thread shows streaming, not idle", async () => {
+    const messages = [{ role: "user", content: [{ type: "text", text: "Run it" }] }];
+    const request = vi.fn().mockResolvedValue({
+      messages,
+      inFlightRun: { runId: "run-codex", text: "" },
+    });
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+      chatRunId: null,
+      chatStream: null,
+      chatStreamStartedAt: null,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-codex");
+    expect(state.chatStream).toBe("");
+    expect(state.chatStreamStartedAt).toEqual(expect.any(Number));
+  });
+
+  it("reconciles in-flight text that overlaps with the last committed assistant message", async () => {
+    // The in-flight text is the cumulative buffer. If the last committed
+    // assistant message already contains the prefix, only the new suffix
+    // should be adopted to avoid duplicating text.
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "Write a haiku" }] },
+      { role: "assistant", content: [{ type: "text", text: "Silent pond," }] },
+    ];
+    const request = vi.fn().mockResolvedValue({
+      messages,
+      inFlightRun: { runId: "run-poem", text: "Silent pond,\nA frog jumps in—\nSplash!" },
+    });
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+      chatRunId: null,
+      chatStream: null,
+      chatStreamStartedAt: null,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-poem");
+    // Only the suffix beyond the committed text should be adopted
+    expect(state.chatStream).toBe("\nA frog jumps in—\nSplash!");
+    expect(state.chatStreamStartedAt).toEqual(expect.any(Number));
+  });
+
+  it("ignores inFlightRun without a run id", async () => {
+    const messages = [{ role: "user", content: [{ type: "text", text: "hi" }] }];
+    const request = vi.fn().mockResolvedValue({
+      messages,
+      inFlightRun: { text: "orphan partial" },
+    });
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+      chatRunId: null,
+      chatStream: null,
+      chatStreamStartedAt: null,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+  });
+
+  it("does not clobber a fresher local run that survived stream reconciliation", async () => {
+    // A live local run started/continued during reload must win over a stale
+    // history snapshot's inFlightRun.
+    const request = vi.fn().mockResolvedValue({
+      messages: [{ role: "user", content: [{ type: "text", text: "newer turn" }] }],
+      inFlightRun: { runId: "run-stale", text: "stale partial" },
+    });
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+      chatRunId: "run-fresh",
+      chatStream: "fresh live text",
+      chatStreamStartedAt: 999,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-fresh");
+    expect(state.chatStream).toBe("fresh live text");
+  });
+});

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -699,6 +699,10 @@ function adoptInFlightRunFromChatHistory(
   // Reconcile overlap with the last committed assistant message: if the
   // cumulative in-flight buffer starts with text already persisted as an
   // assistant reply, only adopt the new suffix.
+  // Normalize whitespace on both sides before comparing so that small framing
+  // differences (e.g. leading newlines the gateway buffer includes but the
+  // committed message omits) do not silently defeat the dedup and cause
+  // duplicated text to render.
   if (text && visibleMessages.length > 0) {
     const lastVisible = visibleMessages[visibleMessages.length - 1];
     const lastRole =
@@ -707,17 +711,32 @@ function adoptInFlightRunFromChatHistory(
         : undefined;
     if (lastRole === "assistant") {
       const lastText = extractText(lastVisible);
-      if (lastText && text.startsWith(lastText)) {
-        text = text.slice(lastText.length);
+      if (lastText) {
+        const committedTrimmed = lastText.replace(/^[\s﻿]+|[\s﻿]+$/g, "");
+        const bufferTrimmed = text.replace(/^[\s﻿]+|[\s﻿]+$/g, "");
+        if (committedTrimmed && bufferTrimmed.startsWith(committedTrimmed)) {
+          // Extract only the suffix, preserving the original buffer framing.
+          const overlapIdx = text.indexOf(committedTrimmed);
+          if (overlapIdx >= 0) {
+            text = text.slice(overlapIdx + committedTrimmed.length);
+          } else {
+            // Normalized text matches but framing whitespace differs (e.g.
+            // leading \n in the buffer not present in the committed message).
+            text = text.slice(text.length - (bufferTrimmed.length - committedTrimmed.length));
+          }
+        }
       }
     }
   }
 
   // Adopt the run: track the run id so live deltas/finals continue, set the
   // stream text so partial content renders (empty string shows a reading
-  // indicator instead of an idle thread), and mark the stream start time.
+  // indicator instead of an idle thread), clear stale errors from the previous
+  // session view, and mark the stream start time.
   state.chatRunId = runId;
   state.chatStream = text;
+  state.chatError = null;
+  state.lastError = null;
   state.chatStreamStartedAt = Date.now();
 }
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -418,6 +418,14 @@ export type ChatHistoryResult = {
   sessionInfo?: GatewaySessionRow;
   agentsList?: AgentsListResult;
   metadata?: ChatMetadataResult;
+  // A run still streaming for this session+agent that the gateway reports as
+  // in-flight (already bounded; `text` may be empty when no partial is buffered
+  // or for runtimes that only deliver assistant text at completion). A client
+  // that switched away stopped receiving this run's per-agent-delivered deltas,
+  // so the persisted `messages` above do not include it; the loader re-adopts
+  // the run on switch-back so the partial renders and further deltas continue.
+  // Fixes #90755.
+  inFlightRun?: { runId?: unknown; text?: unknown };
 };
 
 export type ChatMetadataResult = CommandsListResult & {
@@ -665,6 +673,54 @@ function applyChatStartupAgentsList(state: ChatState, agentsList: AgentsListResu
       : (agentsList.agents[0]?.id ?? null);
 }
 
+/**
+ * Adopt an in-flight run reported by the gateway via chat.history / chat.startup
+ * so the Control UI restores the streaming assistant reply on session switch-back.
+ *
+ * Reconciliation: `inFlightRun.text` is the cumulative gateway buffer and may
+ * overlap with the last committed assistant message.  We extract only the suffix
+ * that hasn't been committed yet to avoid duplicating already-persisted text.
+ * Fixes #90755 — mirrors the TUI loader in src/tui/tui-session-actions.ts.
+ */
+function adoptInFlightRunFromChatHistory(
+  state: ChatState,
+  inFlightRun: ChatHistoryResult["inFlightRun"],
+  visibleMessages: Array<unknown>,
+): void {
+  const runId =
+    typeof inFlightRun?.runId === "string" && inFlightRun.runId.trim()
+      ? inFlightRun.runId.trim()
+      : "";
+  if (!runId) {
+    return;
+  }
+  let text = typeof inFlightRun?.text === "string" ? inFlightRun.text : "";
+
+  // Reconcile overlap with the last committed assistant message: if the
+  // cumulative in-flight buffer starts with text already persisted as an
+  // assistant reply, only adopt the new suffix.
+  if (text && visibleMessages.length > 0) {
+    const lastVisible = visibleMessages[visibleMessages.length - 1];
+    const lastRole =
+      typeof lastVisible === "object" && lastVisible !== null
+        ? (lastVisible as Record<string, unknown>).role
+        : undefined;
+    if (lastRole === "assistant") {
+      const lastText = extractText(lastVisible);
+      if (lastText && text.startsWith(lastText)) {
+        text = text.slice(lastText.length);
+      }
+    }
+  }
+
+  // Adopt the run: track the run id so live deltas/finals continue, set the
+  // stream text so partial content renders (empty string shows a reading
+  // indicator instead of an idle thread), and mark the stream start time.
+  state.chatRunId = runId;
+  state.chatStream = text;
+  state.chatStreamStartedAt = Date.now();
+}
+
 async function loadChatHistoryUncached(
   state: ChatState,
   client: NonNullable<ChatState["client"]>,
@@ -830,6 +886,15 @@ async function loadChatHistoryUncached(
         }
         prunePersistedToolStreamMessages(state, persistedToolStreamIds);
       }
+    }
+    // Restore a run still streaming for this session+agent that the gateway
+    // reports as in-flight. Its live deltas were delivered to a per-agent key
+    // this client stopped watching after switching away, so the persisted
+    // history above does not contain it; re-adopt the run so its partial renders
+    // and further deltas (now that this session is active again) continue it.
+    // Fixes #90755 — mirrors the TUI loader in src/tui/tui-session-actions.ts.
+    if (resetStream && !state.chatRunId) {
+      adoptInFlightRunFromChatHistory(state, res.inFlightRun, visibleMessages);
     }
     recordChatHistoryTiming(state, "applied", startedAtMs, {
       requestSessionKey: sessionKey,


### PR DESCRIPTION
## What Problem This Solves

When you switch away from a Control UI chat session while the agent is actively generating a response and then switch back, the in-progress streaming reply was lost — only the last user message was shown.

The gateway already exposes the still-streaming run via `chat.history` / `chat.startup` responses (the `inFlightRun` field), and the TUI already uses this to restore state on reconnect. The Control UI was simply ignoring it.

Fixes #90755.

## Root cause

Three things were missing in `ui/src/ui/controllers/chat.ts`:

1. **`ChatHistoryResult` type** didn't include `inFlightRun` — the field was silently dropped
2. **No adoption logic** — the history loader ignored the gateway's in-flight run data
3. **The maintainer's concern from previous PRs**: `inFlightRun.text` is the cumulative gateway buffer that overlaps with already-persisted assistant messages; without reconciliation, the UI would show duplicate text

Three previous PRs attempted this fix (#90832, #92969, #93273) but all were closed — two because they lacked the text reconciliation step.

## Change

| File | Change |
|------|--------|
| `ui/src/ui/controllers/chat.ts` | Add `inFlightRun` to `ChatHistoryResult` type |
| `ui/src/ui/controllers/chat.ts` | Create `adoptInFlightRunFromChatHistory()` with text overlap reconciliation |
| `ui/src/ui/controllers/chat.ts` | Call adoption after stream reconciliation when no fresher local run exists |
| `ui/src/ui/controllers/chat.test.ts` | Add 5 tests covering: basic adoption, empty-text adoption, overlap reconciliation, missing runId, and local-run preservation |

### Reconciliation logic

```
inFlightRun.text: "Silent pond,\nA frog jumps in—\nSplash!"
last committed assistant: "Silent pond,"
→ Adopted stream text: "\nA frog jumps in—\nSplash!"
```

This prevents duplicating already-persisted text while preserving the new suffix.

## Evidence

- ✅ Restores buffered in-flight assistant stream on switch-back
- ✅ Adopts empty-text run for reading-in-progress state
- ✅ Applies text overlap reconciliation to avoid duplicated content
- ✅ Preserves the local in-progress run when one already exists
- ✅ Cleans up properly when runId is missing
- ✅ All 5 new tests pass in `ui/src/ui/controllers/chat.test.ts`

## Risk

- **Low risk**: only affects Control UI session switch-back edge case
- The `inFlightRun` field is already returned by the gateway for TUI usage
- Text reconciliation logic handles the overlap corner case that blocked prior PRs
- No changes to gateway, protocol, or other UI surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
