### PR TITLE
fix(discord): deliver reasoning replies

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.abort-skip.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.abort-skip.test.ts
@@ -16,16 +16,16 @@ describe("formatDiscordReplySkip", () => {
     );
   });
 
-  it("renders the reasoning-payload reason with the same shape", () => {
+  it("renders the internal-only-payload reason with the same shape", () => {
     expect(
       formatDiscordReplySkip({
         kind: "block",
-        reason: "reasoning payload",
+        reason: "internal-only payload",
         target: "channel:456",
         sessionKey: "agent:friday:discord:channel:456",
       }),
     ).toBe(
-      "discord block reply skipped (reasoning payload): target=channel:456 session=agent:friday:discord:channel:456",
+      "discord block reply skipped (internal-only payload): target=channel:456 session=agent:friday:discord:channel:456",
     );
   });
 
@@ -43,11 +43,11 @@ describe("formatDiscordReplySkip", () => {
     expect(
       formatDiscordReplySkip({
         kind: "tool",
-        reason: "reasoning payload",
+        reason: "internal-only payload",
         target: "channel:c1",
         sessionKey: "",
       }),
-    ).toBe("discord tool reply skipped (reasoning payload): target=channel:c1");
+    ).toBe("discord tool reply skipped (internal-only payload): target=channel:c1");
   });
 
   it("preserves the kind discriminant in the message prefix", () => {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2639,17 +2639,20 @@ describe("processDiscordMessage draft streaming", () => {
     expect(deliverDiscordReply).not.toHaveBeenCalled();
   });
 
-  it("suppresses reasoning payload delivery to Discord", async () => {
+  it("delivers reasoning block payloads to Discord", async () => {
     mockDispatchSingleBlockReply({ text: "thinking...", isReasoning: true });
     await processStreamOffDiscordMessage();
 
-    expect(deliverDiscordReply).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
+      replies: [{ text: "thinking...", isReasoning: true }],
+    });
   });
 
-  it("suppresses reasoning-tagged final payload delivery to Discord", async () => {
+  it("delivers reasoning-tagged final payload to Discord", async () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({
-        text: "Reasoning:\nthis should stay internal",
+        text: "Reasoning:\nthis should be visible",
         isReasoning: true,
       });
       return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
@@ -2661,8 +2664,10 @@ describe("processDiscordMessage draft streaming", () => {
 
     await runProcessDiscordMessage(ctx);
 
-    expect(deliverDiscordReply).not.toHaveBeenCalled();
-    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
+      replies: [{ text: "this should be visible", isReasoning: true }],
+    });
   });
 
   it("delivers non-reasoning block payloads to Discord", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -113,10 +113,7 @@ function isFallbackOnlyToolWarningFinal(payload: ReplyPayload): boolean {
   return !resolveSendableOutboundReplyParts(payload).hasMedia;
 }
 
-type DiscordReplySkipReason =
-  | "aborted before delivery"
-  | "reasoning payload"
-  | "internal-only payload";
+type DiscordReplySkipReason = "aborted before delivery" | "internal-only payload";
 
 export function formatDiscordReplySkip(params: {
   kind: "tool" | "block" | "final";
@@ -609,18 +606,6 @@ async function processDiscordMessageInner(
       );
       return null;
     }
-    if (payload.isReasoning) {
-      // Reasoning/thinking payloads should not be delivered to Discord.
-      logVerbose(
-        formatDiscordReplySkip({
-          kind: info.kind,
-          reason: "reasoning payload",
-          target: deliverTarget,
-          sessionKey: ctxPayload.SessionKey,
-        }),
-      );
-      return null;
-    }
     if (draftPreview.draftStream && draftPreview.isProgressMode && info.kind === "block") {
       const reply = resolveSendableOutboundReplyParts(payload);
       if (!reply.hasMedia && !payload.isError) {
@@ -652,18 +637,6 @@ async function processDiscordMessageInner(
       return { visibleReplySent: false };
     }
     const isFinal = info.kind === "final";
-    if (payload.isReasoning) {
-      // Reasoning/thinking payloads should not be delivered to Discord.
-      logVerbose(
-        formatDiscordReplySkip({
-          kind: info.kind,
-          reason: "reasoning payload",
-          target: deliverTarget,
-          sessionKey: ctxPayload.SessionKey,
-        }),
-      );
-      return { visibleReplySent: false };
-    }
     if (
       isFinal &&
       !options?.allowFallbackOnlyToolWarning &&

--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -141,6 +141,21 @@ describe("deliverDiscordReply", () => {
     expect(sendOptions.rest).toBe(rest);
   });
 
+  it("formats reasoning replies as visible Discord payloads before shared outbound", async () => {
+    await deliverDiscordReply({
+      replies: [{ text: "Because it helps", isReasoning: true }],
+      target: "channel:101",
+      token: "token",
+      accountId: "default",
+      runtime,
+      cfg,
+      textLimit: 2000,
+      kind: "block",
+    });
+
+    expect(firstDeliverParams().payloads).toEqual([{ text: "Thinking\n\n_Because it helps_" }]);
+  });
+
   it("fails when shared outbound accepts a final reply but delivers no Discord message", async () => {
     sendDurableMessageBatchMock.mockResolvedValueOnce({ status: "sent", results: [] });
 

--- a/extensions/discord/src/monitor/reply-delivery.ts
+++ b/extensions/discord/src/monitor/reply-delivery.ts
@@ -1,5 +1,5 @@
 // Discord plugin module implements reply delivery behavior.
-import { resolveAgentAvatar } from "openclaw/plugin-sdk/agent-runtime";
+import { formatReasoningMessage, resolveAgentAvatar } from "openclaw/plugin-sdk/agent-runtime";
 import {
   buildOutboundSessionContext,
   sendDurableMessageBatch,
@@ -156,6 +156,19 @@ function resolveDiscordDeliveryOptions(params: {
   };
 }
 
+function formatDiscordReasoningPayload(payload: ReplyPayload): ReplyPayload {
+  if (payload.isReasoning !== true) {
+    return payload;
+  }
+  const text = typeof payload.text === "string" ? payload.text.trim() : "";
+  const nextPayload: ReplyPayload = {
+    ...payload,
+    text: formatReasoningMessage(text),
+  };
+  delete nextPayload.isReasoning;
+  return nextPayload;
+}
+
 export async function deliverDiscordReply(params: {
   cfg: OpenClawConfig;
   replies: ReplyPayload[];
@@ -178,7 +191,9 @@ export async function deliverDiscordReply(params: {
   void params.runtime;
 
   const delivery = resolveDiscordDeliveryOptions(params);
-  const payloads = sanitizeDiscordFrontChannelReplyPayloads(params.replies, { kind: params.kind });
+  const payloads = sanitizeDiscordFrontChannelReplyPayloads(params.replies, {
+    kind: params.kind,
+  }).map(formatDiscordReasoningPayload);
   if (payloads.length === 0) {
     return;
   }


### PR DESCRIPTION
Summary:
- Allow Discord to deliver `isReasoning` block/final payloads instead of dropping them in the message delivery hooks.
- Format opted-in Discord reasoning replies with the shared markdown-friendly `formatReasoningMessage` helper and clear the internal `isReasoning` marker before shared durable outbound delivery.
- Add regression coverage for both the Discord message-handler boundary and the durable reply-delivery boundary.

Verification:
- `git diff --check`
- `pnpm dlx oxfmt@0.52.0 --check --threads=1 extensions/discord/src/monitor/message-handler.process.ts extensions/discord/src/monitor/message-handler.process.test.ts extensions/discord/src/monitor/message-handler.process.abort-skip.test.ts extensions/discord/src/monitor/reply-delivery.ts extensions/discord/src/monitor/reply-delivery.test.ts`
- Blacksmith Testbox `tbx_01kvgdjkney55xkbmqbr8v9m1x`, run `https://github.com/openclaw/openclaw/actions/runs/27838962847`: `corepack pnpm test:serial extensions/discord/src/monitor/message-handler.process.test.ts extensions/discord/src/monitor/reply-delivery.test.ts src/infra/outbound/payloads.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.emits-reasoning-as-separate-message-enabled.test.ts` passed. Shards: outbound payloads 36 tests; agent reasoning 8 tests; Discord handler/delivery 124 tests.

Fixes #94936
