### PR TITLE
fix(workboard): filter archived cards by default in list CLI [AI-assisted]

### DIFF
--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -106,6 +106,28 @@ describe("registerWorkboardCli", () => {
     expect(showOutput).toContain("[redacted]");
   });
 
+  it("filters archived cards by default and includes them with --include-archived", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const activeCard = await store.create({ title: "Active Card" });
+    const archivedCard = await store.create({ title: "Archived Card" });
+    await store.archive(archivedCard.id, true);
+    const program = createProgram(store);
+
+    const defaultOutput = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list"], { from: "user" });
+    });
+
+    const includeArchivedOutput = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list", "--include-archived"], { from: "user" });
+    });
+
+    expect(defaultOutput).toContain("Active Card");
+    expect(defaultOutput).not.toContain("Archived Card");
+
+    expect(includeArchivedOutput).toContain("Active Card");
+    expect(includeArchivedOutput).toContain("Archived Card");
+  });
+
   it("does not fall back to local dispatch for explicit gateway targets", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const card = await store.create({ title: "Remote target", status: "ready" });

--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -130,14 +130,26 @@ export function registerWorkboardCli(params: { program: Command; store: Workboar
     .description("List Workboard cards")
     .option("--board <id>", "Board id")
     .option("--status <status>", "Filter by status")
+    .option("--include-archived", "Include archived cards", false)
     .option("--json", "Print JSON", false)
-    .action(async (options: JsonOptions & { board?: string; status?: string }) => {
-      let cards = await params.store.list({ boardId: options.board });
-      if (options.status) {
-        cards = cards.filter((card) => card.status === options.status);
-      }
-      writeCards(cards, options);
-    });
+    .action(
+      async (
+        options: JsonOptions & {
+          board?: string;
+          status?: string;
+          includeArchived?: boolean;
+        },
+      ) => {
+        let cards = await params.store.list({ boardId: options.board });
+        if (!options.includeArchived) {
+          cards = cards.filter((card) => !card.metadata?.archivedAt);
+        }
+        if (options.status) {
+          cards = cards.filter((card) => card.status === options.status);
+        }
+        writeCards(cards, options);
+      },
+    );
 
   workboard
     .command("create")


### PR DESCRIPTION
### Summary
This PR fixes Issue #94555 where `openclaw workboard list` CLI did not filter archived cards by default, causing an inconsistency with the API/Tool behavior. We now add the `--include-archived` option to the list command (defaulting to false) and filter out archived cards by default.

### Real behavior proof
- Verified this change by adding a test case to `cli.test.ts` and running the workboard CLI tests.
- Command run: `npx vitest run extensions/workboard/src/cli.test.ts`
- Result: All tests passed successfully.
