### PR TITLE
fix(embedded-agent): auto-recover provider-rejected image history (closes #94906)

### DIFF
--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -690,3 +690,30 @@ describe("sanitizeUserFacingText — streaming JSON parse error (#59076)", () =>
     expect(result).toBe(text);
   });
 });
+
+describe("formatUserFacingAssistantErrorText — sensitive image rejection (follow-up to #94906)", () => {
+  const makeAssistantError = (errorMessage: string): AssistantMessage =>
+    makeAssistantMessageFixture({
+      errorMessage,
+      content: [{ type: "text", text: errorMessage }],
+    });
+  // Regression: previously isRawAssistantErrorPassthrough classified the
+  // "LLM error api_error: ..." friendly text as a passthrough and dropped the
+  // rich error into GENERIC_ASSISTANT_ERROR_TEXT ("LLM request failed.").
+  // The actionable copy must surface even when the raw payload parses cleanly
+  // and produces a "LLM error api_error: ..." friendly prefix.
+  it("returns the actionable copy for MiniMax 1026 raw payload", () => {
+    const raw =
+      '{"type":"error","error":{"type":"api_error","message":"input new_sensitive, messages[18] content[1] image is sensitive, please check your input (1026)"},"request_id":"sha256:e47bcf6e81c9"}';
+    const msg = makeAssistantError(raw);
+    const result = formatUserFacingAssistantErrorText(msg, {
+      provider: "minimax",
+      model: "MiniMax-M3",
+    });
+    expect(result).toBe(
+      "LLM request failed: provider rejected a recent image block as sensitive. " +
+        "OpenClaw removed the image data from session history while keeping text context; " +
+        "please retry or continue.",
+    );
+  });
+});

--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -19,6 +19,19 @@ import {
 } from "./internal-events.js";
 
 describe("sanitizeUserFacingText", () => {
+  it("surfaces actionable sensitive-image provider rejection copy", () => {
+    expect(
+      sanitizeUserFacingText(
+        "input new_sensitive, messages[18]'s content[1] image is sensitive, please check your input (1026)",
+        { errorContext: true },
+      ),
+    ).toBe(
+      "LLM request failed: provider rejected a recent image block as sensitive. " +
+        "OpenClaw removed the image data from session history while keeping text context; " +
+        "please retry or continue.",
+    );
+  });
+
   it("strips final tags", () => {
     expect(sanitizeUserFacingText("<final>Hello</final>")).toBe("Hello");
     expect(sanitizeUserFacingText("Hi <final>there</final>!")).toBe("Hi there!");

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -36,6 +36,7 @@ import {
   isTimeoutErrorMessage,
   matchesFormatErrorPattern,
 } from "./failover-matches.js";
+import { formatSensitiveImageRejectionErrorCopy } from "./image-rejection-error.js";
 import {
   classifyProviderPluginError,
   classifyProviderSpecificError,
@@ -1562,8 +1563,21 @@ export function formatUserFacingAssistantErrorText(
   msg: AssistantMessage,
   opts?: { cfg?: OpenClawConfig; sessionKey?: string; provider?: string; model?: string },
 ): string {
+  // Check the raw provider error first for sensitive-image rejection. This is intentionally
+  // checked BEFORE isRawAssistantErrorPassthrough, which would otherwise classify the
+  // "LLM error api_error: ..." prefix as a passthrough and drop the rich error into the
+  // GENERIC_ASSISTANT_ERROR_TEXT fallback, hiding the actionable context from the user.
+  const rawErrorForSensitiveImageCheck = msg.errorMessage?.trim();
+  if (rawErrorForSensitiveImageCheck) {
+    const sensitiveImageCopy = formatSensitiveImageRejectionErrorCopy(
+      rawErrorForSensitiveImageCheck,
+    );
+    if (sensitiveImageCopy) {
+      return sensitiveImageCopy;
+    }
+  }
   const friendlyError = formatAssistantErrorText(msg, opts);
-  const rawError = msg.errorMessage?.trim();
+  const rawError = rawErrorForSensitiveImageCheck;
   const rawPassthrough = isRawAssistantErrorPassthrough({ friendlyError, rawError });
   const parsedErrorType = parseApiErrorInfo(rawError ?? "")?.type?.toLowerCase() ?? "";
   const rawProviderSchemaError =

--- a/src/agents/embedded-agent-helpers/image-rejection-error.ts
+++ b/src/agents/embedded-agent-helpers/image-rejection-error.ts
@@ -1,0 +1,29 @@
+function normalizeErrorText(raw: string): string {
+  return raw.toLowerCase().replace(/[\s_-]+/g, " ");
+}
+
+/**
+ * Narrowly match provider errors that explicitly say an image was rejected for
+ * sensitive/safety moderation. This intentionally does not match generic
+ * schema, network, or unsupported-image errors.
+ */
+export function isSensitiveImageRejectionError(raw: string | undefined): boolean {
+  if (!raw) {
+    return false;
+  }
+  const normalized = normalizeErrorText(raw);
+  if (normalized.includes("new sensitive") && normalized.includes("image")) {
+    return true;
+  }
+  if (normalized.includes("image is sensitive")) {
+    return true;
+  }
+  if (
+    normalized.includes("image") &&
+    normalized.includes("sensitive") &&
+    /messages?\[\d+\].*content\[\d+\]/i.test(raw)
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/src/agents/embedded-agent-helpers/image-rejection-error.ts
+++ b/src/agents/embedded-agent-helpers/image-rejection-error.ts
@@ -27,3 +27,11 @@ export function isSensitiveImageRejectionError(raw: string | undefined): boolean
   }
   return false;
 }
+
+export function formatSensitiveImageRejectionErrorCopy(raw: string): string | undefined {
+  return isSensitiveImageRejectionError(raw)
+    ? "LLM request failed: provider rejected a recent image block as sensitive. " +
+        "OpenClaw removed the image data from session history while keeping text context; " +
+        "please retry or continue."
+    : undefined;
+}

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -33,6 +33,7 @@ import {
   isRateLimitErrorMessage,
   isTimeoutErrorMessage,
 } from "./failover-matches.js";
+import { formatSensitiveImageRejectionErrorCopy } from "./image-rejection-error.js";
 
 /** Format the billing failure copy with optional provider/model context. */
 export function formatBillingErrorMessage(provider?: string, model?: string): string {
@@ -442,6 +443,11 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
     const diskSpaceCopy = formatDiskSpaceErrorCopy(trimmed);
     if (diskSpaceCopy) {
       return diskSpaceCopy;
+    }
+
+    const sensitiveImageCopy = formatSensitiveImageRejectionErrorCopy(trimmed);
+    if (sensitiveImageCopy) {
+      return sensitiveImageCopy;
     }
 
     if (/incorrect role information|roles must alternate/i.test(trimmed)) {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -339,6 +339,7 @@ import {
   isPrimaryBootstrapRun,
   remapInjectedContextFilesToWorkspace,
 } from "./attempt.bootstrap-context.js";
+import { recoverRecentSensitiveImageRejection } from "./image-rejection-recovery.js";
 export { buildContextEnginePromptCacheInfo } from "./attempt.context-engine-helpers.js";
 import { resolveUserTimezone } from "../../date-time.js";
 import {
@@ -4891,6 +4892,24 @@ export async function runEmbeddedAttempt(
           });
 
           if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
+            const rawPromptError = formatErrorMessage(promptError);
+            try {
+              const imageRecovery = recoverRecentSensitiveImageRejection({
+                sessionManager: activeSessionManager,
+                rawError: rawPromptError,
+                sessionFile: params.sessionFile,
+                sessionKey: params.sessionKey,
+                agentId: sessionAgentId,
+                runId: params.runId,
+                sessionId: params.sessionId,
+              });
+              if (imageRecovery.recovered) {
+                activeSession.agent.state.messages =
+                  activeSessionManager.buildSessionContext().messages;
+              }
+            } catch (recoveryErr) {
+              log.warn(`failed to recover provider-rejected image history: ${String(recoveryErr)}`);
+            }
             try {
               activeSessionManager.appendCustomEntry("openclaw:prompt-error", {
                 timestamp: Date.now(),
@@ -4899,7 +4918,7 @@ export async function runEmbeddedAttempt(
                 provider: params.provider,
                 model: params.modelId,
                 api: params.model.api,
-                error: formatErrorMessage(promptError),
+                error: rawPromptError,
               });
             } catch (entryErr) {
               log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -681,6 +681,17 @@ function isMidTurnPrecheckAssistantError(message: AgentMessage | undefined): boo
   return record.stopReason === "error" && record.errorMessage === MID_TURN_PRECHECK_ERROR_MESSAGE;
 }
 
+function getAssistantTerminalErrorMessage(message: AgentMessage | undefined): string | null {
+  if (!message || message.role !== "assistant") {
+    return null;
+  }
+  const record = message as unknown as { stopReason?: unknown; errorMessage?: unknown };
+  if (record.stopReason !== "error" || typeof record.errorMessage !== "string") {
+    return null;
+  }
+  return record.errorMessage;
+}
+
 function removeTrailingMidTurnPrecheckAssistantError(params: {
   activeSession: { agent: { state: { messages: AgentMessage[] } } };
   sessionManager: ReturnType<typeof guardSessionManager>;
@@ -4891,12 +4902,11 @@ export async function runEmbeddedAttempt(
             }),
           });
 
-          if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
-            const rawPromptError = formatErrorMessage(promptError);
+          const recoverSensitiveImageRejection = (rawError: string): boolean => {
             try {
               const imageRecovery = recoverRecentSensitiveImageRejection({
                 sessionManager: activeSessionManager,
-                rawError: rawPromptError,
+                rawError,
                 sessionFile: params.sessionFile,
                 sessionKey: params.sessionKey,
                 agentId: sessionAgentId,
@@ -4907,9 +4917,16 @@ export async function runEmbeddedAttempt(
                 activeSession.agent.state.messages =
                   activeSessionManager.buildSessionContext().messages;
               }
+              return imageRecovery.recovered;
             } catch (recoveryErr) {
               log.warn(`failed to recover provider-rejected image history: ${String(recoveryErr)}`);
+              return false;
             }
+          };
+
+          if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
+            const rawPromptError = formatErrorMessage(promptError);
+            recoverSensitiveImageRejection(rawPromptError);
             try {
               activeSessionManager.appendCustomEntry("openclaw:prompt-error", {
                 timestamp: Date.now(),
@@ -4922,6 +4939,12 @@ export async function runEmbeddedAttempt(
               });
             } catch (entryErr) {
               log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);
+            }
+          } else if (!promptError && !compactionOccurredThisAttempt) {
+            const terminalAssistantError =
+              getAssistantTerminalErrorMessage(currentAttemptAssistant);
+            if (terminalAssistantError) {
+              recoverSensitiveImageRejection(terminalAssistantError);
             }
           }
         });

--- a/src/agents/embedded-agent-runner/run/image-rejection-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/image-rejection-recovery.test.ts
@@ -42,6 +42,26 @@ function imageToolResult(): AgentMessage {
   } as AgentMessage;
 }
 
+function multiImageToolResult(): AgentMessage {
+  return {
+    role: "toolResult",
+    content: [
+      { type: "text", text: "Read 2 image files" },
+      { type: "image", data: "alpha", mimeType: "image/png" },
+      { type: "image", data: "beta", mimeType: "image/png" },
+    ],
+  } as AgentMessage;
+}
+
+function getImageBlockCount(message: AgentMessage | undefined): number {
+  if (!message) return 0;
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) return 0;
+  return content.filter(
+    (b) => !!b && typeof b === "object" && (b as { type?: unknown }).type === "image",
+  ).length;
+}
+
 describe("sensitive image rejection recovery", () => {
   test("matches only explicit sensitive image rejection errors", () => {
     expect(
@@ -74,6 +94,106 @@ describe("sensitive image rejection recovery", () => {
     expect(plan.replacements[0]?.entryId).toBe(recentImageId);
     expect(plan.replacements[0]?.entryId).not.toBe(oldImageId);
     expect(JSON.stringify(plan.replacements[0]?.message)).toContain(IMAGE_REJECTION_PLACEHOLDER);
+  });
+
+  test("does not touch earlier images when a newer image is rejected in a later turn", async () => {
+    const manager = await createSessionManager();
+    // Turn 1: A is read.
+    manager.appendMessage(imageToolResult());
+    manager.appendMessage({ role: "assistant", content: "ok, A processed" });
+    // Turn 2: B is read and rejected.
+    manager.appendMessage(imageToolResult());
+
+    const result = recoverRecentSensitiveImageRejection({
+      sessionManager: manager,
+      rawError: "input new_sensitive, messages[18] content[1] image is sensitive (1026)",
+    });
+    expect(result.recovered).toBe(true);
+    expect(result.imageBlocks).toBe(1);
+
+    const branch = manager.getBranch();
+    const messages = branch
+      .filter((e): e is Extract<typeof e, { type: "message" }> => e.type === "message")
+      .map((e) => e.message);
+    // The first image toolResult (A) must still have its image block.
+    const msgA = messages[0];
+    const msgB = messages[messages.length - 1];
+    expect(getImageBlockCount(msgA)).toBe(1);
+    expect(getImageBlockCount(msgB)).toBe(0);
+    expect(JSON.stringify(msgA)).not.toContain(IMAGE_REJECTION_PLACEHOLDER);
+    expect(JSON.stringify(msgB)).toContain(IMAGE_REJECTION_PLACEHOLDER);
+  });
+
+  test("after recovery, subsequent turns with new images are not affected by old recovery", async () => {
+    const manager = await createSessionManager();
+    // Turn 1: image A is read and rejected.
+    manager.appendMessage(imageToolResult());
+    const firstRecovery = recoverRecentSensitiveImageRejection({
+      sessionManager: manager,
+      rawError: "input new_sensitive, messages[0] content[1] image is sensitive (1026)",
+    });
+    expect(firstRecovery.recovered).toBe(true);
+
+    // Turn 2: image C is read and processed normally (no rejection).
+    manager.appendMessage(imageToolResult());
+    manager.appendMessage({ role: "assistant", content: "ok, C" });
+
+    // Turn 3: image D is read and rejected.
+    manager.appendMessage(imageToolResult());
+    const secondRecovery = recoverRecentSensitiveImageRejection({
+      sessionManager: manager,
+      rawError: "input new_sensitive, messages[N] content[1] image is sensitive (1026)",
+    });
+    expect(secondRecovery.recovered).toBe(true);
+    expect(secondRecovery.imageBlocks).toBe(1);
+
+    // After both recoveries: A is text (recovered), C is still image, D is text (just recovered).
+    const finalMessages = manager
+      .getBranch()
+      .filter((e): e is Extract<typeof e, { type: "message" }> => e.type === "message")
+      .map((e) => e.message);
+    // Filter to only toolResult messages (ignore assistant "ok, C" and the recovery entries).
+    const imageMessages = finalMessages.filter(
+      (m) => (m as { role?: unknown }).role === "toolResult",
+    );
+    expect(imageMessages).toHaveLength(3);
+    expect(getImageBlockCount(imageMessages[0])).toBe(0); // A: stripped by first recovery
+    expect(getImageBlockCount(imageMessages[1])).toBe(1); // C: untouched
+    expect(getImageBlockCount(imageMessages[2])).toBe(0); // D: stripped by second recovery
+
+    // The placeholder count should be 2 across the whole branch (one for A, one for D).
+    const allSerialized = JSON.stringify(finalMessages);
+    // Use split to count literal occurrences (avoids regex escaping of [, ;, etc in placeholder text)
+    const placeholderCount = allSerialized.split(IMAGE_REJECTION_PLACEHOLDER).length - 1;
+    expect(placeholderCount).toBe(2);
+  });
+
+  test("multi-image toolResult: recovery strips ALL images in that message (known precision trade-off)", async () => {
+    const manager = await createSessionManager();
+    // Single toolResult carrying 2 images in its content array.
+    // The provider's rejection hints at messages[N] content[M], but our walk-from-end
+    // matches the whole message and strips every image in it.
+    manager.appendMessage(multiImageToolResult());
+
+    const result = recoverRecentSensitiveImageRejection({
+      sessionManager: manager,
+      rawError: "input new_sensitive, messages[0] content[1] image is sensitive (1026)",
+    });
+    expect(result.recovered).toBe(true);
+    // KNOWN LIMITATION: both images get stripped, even though the rejection may have
+    // been about only one of them. The user loses the other (still-valid) image's data.
+    expect(result.imageBlocks).toBe(2);
+
+    const imageMessages = manager
+      .getBranch()
+      .filter((e): e is Extract<typeof e, { type: "message" }> => e.type === "message")
+      .filter((e) => (e.message as { role?: unknown }).role === "toolResult")
+      .map((e) => e.message);
+    expect(imageMessages).toHaveLength(1);
+    expect(getImageBlockCount(imageMessages[0])).toBe(0);
+    const serialized = JSON.stringify(imageMessages[0]);
+    const occurrences = serialized.split(IMAGE_REJECTION_PLACEHOLDER).length - 1;
+    expect(occurrences).toBe(2); // placeholder appears for BOTH images
   });
 
   test("rewrites recent image block and appends recovery context for future prompts", async () => {

--- a/src/agents/embedded-agent-runner/run/image-rejection-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/image-rejection-recovery.test.ts
@@ -1,0 +1,111 @@
+import { mkdirSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test, afterEach } from "vitest";
+import { isSensitiveImageRejectionError } from "../../embedded-agent-helpers/image-rejection-error.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import { SessionManager } from "../../sessions/index.js";
+import {
+  IMAGE_REJECTION_PLACEHOLDER,
+  IMAGE_REJECTION_RECOVERY_CUSTOM_TYPE,
+  buildRecentImageRejectionRecoveryReplacements,
+  recoverRecentSensitiveImageRejection,
+} from "./image-rejection-recovery.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  while (tempDirs.length) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+async function createSessionManager(): Promise<SessionManager> {
+  const dir = await mkdtemp(join(tmpdir(), "openclaw-image-recovery-"));
+  tempDirs.push(dir);
+  const sessionDir = join(dir, "sessions");
+  mkdirSync(sessionDir, { recursive: true });
+  return SessionManager.create(dir, sessionDir);
+}
+
+function imageToolResult(): AgentMessage {
+  return {
+    role: "toolResult",
+    content: [
+      { type: "text", text: "Read image file [image/png] /tmp/sensitive.png" },
+      { type: "image", data: "abc123", mimeType: "image/png" },
+    ],
+  } as AgentMessage;
+}
+
+describe("sensitive image rejection recovery", () => {
+  test("matches only explicit sensitive image rejection errors", () => {
+    expect(
+      isSensitiveImageRejectionError(
+        "input new_sensitive, messages[18]'s content[1] image is sensitive, please check your input (1026)",
+      ),
+    ).toBe(true);
+    expect(isSensitiveImageRejectionError("400 image is sensitive, please check your input")).toBe(
+      true,
+    );
+
+    expect(isSensitiveImageRejectionError("400 invalid image schema: missing mime type")).toBe(
+      false,
+    );
+    expect(isSensitiveImageRejectionError("network is unreachable")).toBe(false);
+    expect(isSensitiveImageRejectionError("model does not support images")).toBe(false);
+  });
+
+  test("plans replacement for the most recent user/toolResult image block only", async () => {
+    const manager = await createSessionManager();
+    manager.appendMessage({ role: "user", content: "hello" });
+    const oldImageId = manager.appendMessage(imageToolResult());
+    manager.appendMessage({ role: "assistant", content: "old image processed" });
+    const recentImageId = manager.appendMessage(imageToolResult());
+
+    const plan = buildRecentImageRejectionRecoveryReplacements({ sessionManager: manager });
+
+    expect(plan.imageBlocks).toBe(1);
+    expect(plan.replacements).toHaveLength(1);
+    expect(plan.replacements[0]?.entryId).toBe(recentImageId);
+    expect(plan.replacements[0]?.entryId).not.toBe(oldImageId);
+    expect(JSON.stringify(plan.replacements[0]?.message)).toContain(IMAGE_REJECTION_PLACEHOLDER);
+  });
+
+  test("rewrites recent image block and appends recovery context for future prompts", async () => {
+    const manager = await createSessionManager();
+    manager.appendMessage({ role: "user", content: "please inspect" });
+    manager.appendMessage(imageToolResult());
+
+    const result = recoverRecentSensitiveImageRejection({
+      sessionManager: manager,
+      rawError:
+        "input new_sensitive, messages[18]'s content[1] image is sensitive, please check your input (1026)",
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+
+    expect(result.recovered).toBe(true);
+    expect(result.imageBlocks).toBe(1);
+
+    const branch = manager.getBranch();
+    const serialized = JSON.stringify(branch);
+    expect(serialized).toContain(IMAGE_REJECTION_PLACEHOLDER);
+    expect(serialized).not.toContain('"type":"image"');
+    const recoveryEntry = branch.find(
+      (entry) =>
+        entry.type === "custom_message" &&
+        entry.customType === IMAGE_REJECTION_RECOVERY_CUSTOM_TYPE,
+    );
+    expect(recoveryEntry).toBeTruthy();
+
+    const context = manager.buildSessionContext();
+    expect(JSON.stringify(context.messages)).toContain(
+      "provider rejected a recent image block as sensitive",
+    );
+  });
+});

--- a/src/agents/embedded-agent-runner/run/image-rejection-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/image-rejection-recovery.ts
@@ -1,0 +1,162 @@
+import { emitSessionTranscriptUpdate } from "../../../sessions/transcript-events.js";
+import { isSensitiveImageRejectionError } from "../../embedded-agent-helpers/image-rejection-error.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import type { SessionManager } from "../../sessions/index.js";
+import { log } from "../logger.js";
+import { rewriteTranscriptEntriesInSessionManager } from "../transcript-rewrite.js";
+
+export const IMAGE_REJECTION_RECOVERY_CUSTOM_TYPE = "openclaw:image-rejection-recovery";
+
+export const IMAGE_REJECTION_PLACEHOLDER =
+  "[image data removed after the provider rejected a recent image as sensitive; " +
+  "the original image is no longer included in prompt history]";
+
+export const IMAGE_REJECTION_RECOVERY_MESSAGE =
+  "System recovery: the previous model request failed because the provider rejected a recent " +
+  "image block as sensitive. OpenClaw removed that image data from this session's prompt " +
+  "history and kept the surrounding text context. Continue from the remaining text context; " +
+  "do not assume the removed image is still visible.";
+
+function replaceImageBlocksInMessage(message: AgentMessage): {
+  message: AgentMessage;
+  replacedImages: number;
+} {
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return { message, replacedImages: 0 };
+  }
+
+  let replacedImages = 0;
+  const nextContent = content.map((block) => {
+    if (!block || typeof block !== "object") {
+      return block;
+    }
+    if ((block as { type?: unknown }).type !== "image") {
+      return block;
+    }
+    replacedImages += 1;
+    return { type: "text", text: IMAGE_REJECTION_PLACEHOLDER };
+  }) as typeof content;
+
+  if (replacedImages === 0) {
+    return { message, replacedImages: 0 };
+  }
+
+  return {
+    message: { ...message, content: nextContent } as AgentMessage,
+    replacedImages,
+  };
+}
+
+export function buildRecentImageRejectionRecoveryReplacements(params: {
+  sessionManager: Pick<SessionManager, "getBranch">;
+  maxMessagesToScan?: number;
+}): { replacements: Array<{ entryId: string; message: AgentMessage }>; imageBlocks: number } {
+  const branch = params.sessionManager.getBranch();
+  const maxMessagesToScan = Math.max(1, params.maxMessagesToScan ?? 12);
+  let scannedMessages = 0;
+
+  for (let index = branch.length - 1; index >= 0; index--) {
+    const entry = branch[index];
+    if (entry?.type !== "message") {
+      continue;
+    }
+    scannedMessages += 1;
+    const role = (entry.message as { role?: unknown }).role;
+    if (role !== "toolResult" && role !== "user") {
+      if (scannedMessages >= maxMessagesToScan) {
+        break;
+      }
+      continue;
+    }
+    const replacement = replaceImageBlocksInMessage(entry.message);
+    if (replacement.replacedImages > 0) {
+      return {
+        replacements: [{ entryId: entry.id, message: replacement.message }],
+        imageBlocks: replacement.replacedImages,
+      };
+    }
+    if (scannedMessages >= maxMessagesToScan) {
+      break;
+    }
+  }
+
+  return { replacements: [], imageBlocks: 0 };
+}
+
+export function recoverRecentSensitiveImageRejection(params: {
+  sessionManager: SessionManager;
+  rawError: string;
+  sessionFile?: string;
+  sessionKey?: string;
+  agentId?: string;
+  runId?: string;
+  sessionId?: string;
+}): { recovered: boolean; imageBlocks: number; rewrittenEntries: number; reason?: string } {
+  if (!isSensitiveImageRejectionError(params.rawError)) {
+    return {
+      recovered: false,
+      imageBlocks: 0,
+      rewrittenEntries: 0,
+      reason: "not sensitive image rejection",
+    };
+  }
+
+  const plan = buildRecentImageRejectionRecoveryReplacements({
+    sessionManager: params.sessionManager,
+  });
+  if (plan.replacements.length === 0) {
+    return {
+      recovered: false,
+      imageBlocks: 0,
+      rewrittenEntries: 0,
+      reason: "no recent image block",
+    };
+  }
+
+  const rewrite = rewriteTranscriptEntriesInSessionManager({
+    sessionManager: params.sessionManager,
+    replacements: plan.replacements,
+  });
+  if (!rewrite.changed) {
+    return {
+      recovered: false,
+      imageBlocks: 0,
+      rewrittenEntries: 0,
+      reason: rewrite.reason ?? "rewrite did not change transcript",
+    };
+  }
+
+  params.sessionManager.appendCustomMessageEntry(
+    IMAGE_REJECTION_RECOVERY_CUSTOM_TYPE,
+    IMAGE_REJECTION_RECOVERY_MESSAGE,
+    true,
+    {
+      runId: params.runId,
+      sessionId: params.sessionId,
+      imageBlocks: plan.imageBlocks,
+      rewrittenEntries: rewrite.rewrittenEntries,
+      errorClass: "sensitive_image_rejection",
+    },
+  );
+
+  if (params.sessionFile) {
+    emitSessionTranscriptUpdate({
+      sessionFile: params.sessionFile,
+      sessionKey: params.sessionKey,
+      ...(params.agentId ? { agentId: params.agentId } : {}),
+    });
+  }
+
+  log.warn(
+    `[image-rejection-recovery] Removed ${plan.imageBlocks} image block(s) from recent ` +
+      `session history after provider sensitive-image rejection ` +
+      `runId=${params.runId ?? "unknown"} sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
+  );
+
+  return {
+    recovered: true,
+    imageBlocks: plan.imageBlocks,
+    rewrittenEntries: rewrite.rewrittenEntries,
+  };
+}


### PR DESCRIPTION
## Summary

When a provider (e.g. MiniMax-M3 1026 "image is sensitive") rejects a recent image tool result as sensitive, the offending image block was already persisted into the session transcript. The existing `pruneProcessedHistoryImages()` only prunes images after several successful assistant turns, so every retry replayed the same rejected image and wedged the session. Operators had to `/reset` or hand-edit the transcript to recover.

This change adds a narrow recovery path and surfaces an actionable error message to chat users.

## Changes

- **`src/agents/embedded-agent-helpers/image-rejection-error.ts` (new)**: narrow `isSensitiveImageRejectionError` detector matching `image is sensitive` / `new_sensitive` / `messages[N].content[M]` patterns, plus `formatSensitiveImageRejectionErrorCopy` for the user-facing string.
- **`src/agents/embedded-agent-runner/run/image-rejection-recovery.ts` (new)**: planner + recovery that walks the most recent toolResult/user branch, replaces image blocks with a text placeholder while keeping text context, appends an `openclaw:image-rejection-recovery` custom entry, and rebuilds the in-memory session messages.
- **`src/agents/embedded-agent-runner/run/image-rejection-recovery.test.ts` (new)**: 6 cases covering detector narrowness, planner targeting only the most recent toolResult/user image, turn-by-turn precision (older images untouched, placeholder retained across recoveries, new images untouched), and the documented multi-image toolResult limitation.
- **`src/agents/embedded-agent-runner/run/attempt.ts`**: invoke the recovery in the promptError path, and also when the terminal assistant `errorMessage` carries the sensitive-image pattern even without an outer promptError.
- **`src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts`**: route the actionable copy through `sanitizeUserFacingText` for last-mile sanitization of `isError` payloads.
- **`src/agents/embedded-agent-helpers/errors.ts`**: in `formatUserFacingAssistantErrorText`, check the raw provider `errorMessage` for the sensitive-image pattern **before** the `isRawAssistantErrorPassthrough` check, so the rich error isn't dropped into `GENERIC_ASSISTANT_ERROR_TEXT` ("LLM request failed.") just because the parsed friendly text starts with "LLM error api_error: ".

## User-visible result

Before this change, a rejected image gave a wedged session and the user only saw a generic "LLM request failed." with no signal that the image was the cause.

After this change, the user sees:

> LLM request failed: provider rejected a recent image block as sensitive. OpenClaw removed the image data from session history while keeping text context; please retry or continue.

The next turn works (the image block has been replaced with a text placeholder in the active branch), so a manual `/reset` is no longer required.

## Known limitations

- Multi-image toolResult (a single read returning N images in its content array) has every image stripped, not just the rejected one. The most common case is single-image reads, which is correctly targeted. This trade-off is documented in `image-rejection-recovery.test.ts`.
- The error text is exposed to the user (not silently auto-retried), so the user is always told when an image was rejected.

## Test plan

- `pnpm test --run src/agents/embedded-agent-runner/run/image-rejection-recovery.test.ts` — 6/6 pass
- `pnpm test --run src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts` — 82/82 pass
- `pnpm test --run src/agents/embedded-agent-helpers` — 55/55 pass
- Manually reproduced end-to-end against MiniMax-M3 on a Feishu session: recovery log fires, next turn succeeds, actionable message is delivered to the chat.

Closes #94906.