### PR TITLE
fix(line): auto-capitalize lowercase c/u/r for LINE-shaped recipients

### DIFF
--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -359,19 +359,18 @@ describe("LINE send helpers", () => {
     );
   });
 
-  it("rejects lowercased LINE-shaped recipients (#81628 safety net)", async () => {
+  it("auto-capitalizes lowercased LINE-shaped recipients to handle core normalization", async () => {
     // 33-char value with lowercase leading char — what an upstream session-key
-    // fragment looked like before the cron-tool fix. LINE rejects with HTTP 400
-    // anyway; throwing locally keeps the failure permanent so delivery-recovery
-    // moves the entry to failed/ immediately instead of silently retrying 5×.
-    await expect(
-      sendModule.pushMessagesLine(
-        "cabcdef0123456789abcdef0123456789",
-        [{ type: "text", text: "hello" }],
-        { cfg: LINE_TEST_CFG },
-      ),
-    ).rejects.toThrow(/Recipient is not a valid LINE id/);
-    expect(pushMessageMock).not.toHaveBeenCalled();
+    // fragment looked like before this fix. We now auto-capitalize the first letter.
+    await sendModule.pushMessagesLine(
+      "cabcdef0123456789abcdef0123456789",
+      [{ type: "text", text: "hello" }],
+      { cfg: LINE_TEST_CFG },
+    );
+    expect(pushMessageMock).toHaveBeenCalledWith({
+      to: "Cabcdef0123456789abcdef0123456789",
+      messages: [{ type: "text", text: "hello" }],
+    });
   });
 
   it("accepts case-exact LINE recipients with the leading capital preserved", async () => {

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -59,7 +59,7 @@ function normalizeTarget(to: string): string {
     throw new Error("Recipient is required for LINE sends");
   }
 
-  const normalized = trimmed
+  let normalized = trimmed
     .replace(/^line:group:/i, "")
     .replace(/^line:room:/i, "")
     .replace(/^line:user:/i, "")
@@ -71,6 +71,12 @@ function normalizeTarget(to: string): string {
 
   // Real LINE chat ids are a capital C/U/R followed by 32 lowercase hex chars
   // (33 chars total) and are case-sensitive — push returns HTTP 400 otherwise.
+  // Auto-capitalize the first letter if it is a lowercase c/u/r to handle
+  // case-insensitive normalization from OpenClaw core session keys.
+  if (normalized.length >= 33 && /^[cur]/.test(normalized)) {
+    normalized = normalized.charAt(0).toUpperCase() + normalized.slice(1);
+  }
+
   // Reject values that match the LINE id shape but lost their leading capital
   // so the failure is surfaced as a permanent error (recovery moves the entry
   // to failed/ immediately instead of silently retrying 5 times). Short test


### PR DESCRIPTION
Auto-capitalizes 33-char LINE-shaped recipient IDs starting with lowercase c/u/r to handle case-insensitive normalization from OpenClaw core session keys and prevent delivery deadlocks.