### PR TITLE
fix(telegram): convert newlines to <br> in rich HTML for paragraph breaks

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -100,6 +100,9 @@ describe("markdownToTelegramHtml", () => {
       "<tg-math-block>\\int_0^1 x^2 dx</tg-math-block>",
     ].join("\n");
 
+    // Rich HTML mode preserves structural \n between HTML tags (it's whitespace
+    // that Telegram's rich renderer ignores) and only converts \n in plain text
+    // to <br> so paragraph breaks render correctly via sendRichMessage.
     expect(markdownToTelegramRichHtml(input)).toBe(input);
   });
 
@@ -140,7 +143,7 @@ describe("markdownToTelegramHtml", () => {
     );
 
     expect(html).toContain(
-      '\n\n<figure><img src="https://example.com/a.jpg" alt="A"/></figure>\n\n',
+      '<br><br><figure><img src="https://example.com/a.jpg" alt="A"/></figure><br><br>',
     );
     expect(html).toContain('<a href="https://example.com/page">https://example.com/page</a>');
     expect(html).not.toContain("&lt;img");
@@ -263,6 +266,31 @@ describe("markdownToTelegramHtml", () => {
     expect(markdownToTelegramRichHtml("# Title\n\n### Detail")).toBe(
       "<h1>Title</h1>\n\n<h3>Detail</h3>",
     );
+  });
+
+  it("converts paragraph breaks to <br> in rich HTML mode", () => {
+    // Telegram's sendRichMessage parses HTML properly, treating \n as whitespace.
+    // Paragraph breaks (\n\n) must become <br> so paragraphs don't collapse.
+    expect(markdownToTelegramRichHtml("First paragraph.\n\nSecond paragraph.")).toBe(
+      "First paragraph.<br><br>Second paragraph.",
+    );
+    // Single newline (soft break) also becomes <br> in rich HTML mode.
+    expect(markdownToTelegramRichHtml("Line one\nLine two")).toBe("Line one<br>Line two");
+  });
+
+  it("preserves newlines inside <pre> blocks in rich HTML mode", () => {
+    // Newlines inside <pre> blocks must stay as \n, not become <br>,
+    // because <pre> treats whitespace literally.
+    expect(markdownToTelegramRichHtml("```python\nprint('hello')\nprint('world')\n```")).toBe(
+      "<pre><code class=\"language-python\">print('hello')\nprint('world')\n</code></pre>",
+    );
+  });
+
+  it("preserves newlines inside <tg-math-block> in rich HTML mode", () => {
+    // Newlines inside <tg-math-block> must stay as \n because the content is
+    // raw LaTeX — inserting <br> would corrupt the formula.
+    const input = "<tg-math-block>\\int_0^1 x^2 dx\n\\cdot y^2 dy</tg-math-block>";
+    expect(markdownToTelegramRichHtml(input)).toBe(input);
   });
 
   it("normalizes raw code language HTML without leaking tags", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -1016,6 +1016,95 @@ function renderTelegramRichHtmlDocument(
   );
 }
 
+function convertNewlinesToBrsForRichHtml(html: string): string {
+  // Telegram's sendRichMessage API parses HTML properly, treating \n as whitespace.
+  // This collapses paragraph breaks in plain text. Convert \n to <br> so line and
+  // paragraph breaks render correctly in rich message mode.
+  //
+  // Rules:
+  //   1. Don't convert \n inside <pre>, <tg-math-block>, or <tg-math> —
+  //      whitespace is semantically significant there.
+  //   2. Don't convert \n that is purely structural whitespace between two
+  //      block-level/container tags (e.g. </tr>\n<tr>, </table>\n<details>).
+  //      Inserting <br> there would create invalid children inside containers.
+  //   3. Convert all other \n (plain text, text between inline tags, text
+  //      between text and tags) to <br>.
+  const blockTags = new Set([
+    "table",
+    "thead",
+    "tbody",
+    "tfoot",
+    "tr",
+    "td",
+    "th",
+    "caption",
+    "ul",
+    "ol",
+    "li",
+    "figure",
+    "figcaption",
+    "pre",
+    "blockquote",
+    "details",
+    "summary",
+    "aside",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "hr",
+    "tg-collage",
+    "tg-slideshow",
+    "tg-map",
+    "tg-math-block",
+    "audio",
+    "video",
+    "img",
+    "p",
+  ]);
+  const parts = html.split(/(<[^>]+>)/g);
+  let inPre = false;
+  let inMath = false;
+  return parts
+    .map((part, index) => {
+      if (index % 2 === 1) {
+        const tagMatch = /^<\/?(\w[\w-]*)/.exec(part);
+        if (tagMatch) {
+          const tagName = tagMatch[1].toLowerCase();
+          const isClosing = part.startsWith("</");
+          if (tagName === "pre") {
+            inPre = !isClosing;
+          } else if (tagName === "tg-math-block" || tagName === "tg-math") {
+            inMath = !isClosing;
+          }
+        }
+        return part;
+      }
+      if (inPre || inMath) {
+        return part;
+      }
+      // Only skip \n for purely-whitespace segments adjacent to block-level tags.
+      // If either the preceding closing tag or the following opening tag is
+      // block-level, the whitespace is structural (e.g. </a>\n<h2>, </tr>\n<tr>).
+      // Only convert when both sides are inline tags or text.
+      if (/^\s*$/.test(part)) {
+        const prevPart = index > 0 ? parts[index - 1] : "";
+        const nextPart = index < parts.length - 1 ? parts[index + 1] : "";
+        const prevTagMatch = /^<\/(\w[\w-]*)/.exec(prevPart);
+        const nextTagMatch = /^<(?!\/)(\w[\w-]*)/.exec(nextPart);
+        const prevIsBlock = prevTagMatch && blockTags.has(prevTagMatch[1].toLowerCase());
+        const nextIsBlock = nextTagMatch && blockTags.has(nextTagMatch[1].toLowerCase());
+        if (prevIsBlock || nextIsBlock) {
+          return part;
+        }
+      }
+      return part.replace(/\n/g, "<br>");
+    })
+    .join("");
+}
+
 export function markdownToTelegramRichHtml(
   markdown: string,
   options: { tableMode?: MarkdownTableMode; skipEntityDetection?: boolean } = {},
@@ -1032,10 +1121,12 @@ export function markdownToTelegramRichHtml(
       tableMode,
     },
   );
-  return isolateTelegramRichMediaBlocks(
-    replaceTelegramRichMarkdownMediaPlaceholders(
-      renderTelegramRichHtmlDocument(ir, tables),
-      normalized.mediaBlocks,
+  return convertNewlinesToBrsForRichHtml(
+    isolateTelegramRichMediaBlocks(
+      replaceTelegramRichMarkdownMediaPlaceholders(
+        renderTelegramRichHtmlDocument(ir, tables),
+        normalized.mediaBlocks,
+      ),
     ),
   );
 }


### PR DESCRIPTION
## Summary

Telegram's `sendRichMessage` API (Bot API 10.1) parses HTML properly, treating literal `\n` as whitespace. This collapses paragraph breaks in plain text — multi-paragraph messages render as a single block with no visual separation.

### Root cause

`markdownToTelegramRichHtml` renders Markdown IR to HTML via `renderMarkdownWithMarkers`, which uses `escapeHtml` as the text escape function. This preserves `\n` characters literally in the output HTML. For the standard `sendMessage` path (`parse_mode: "HTML"`), Telegram treats `\n` as a line break — so this works fine. But for `sendRichMessage` (`{ html: "..." }`), `\n` is parsed as whitespace and collapsed.

### Fix

Add `convertNewlinesToBrsForRichHtml()` to the rich HTML pipeline that:
- Converts `\n` to `<br>` in plain text and between inline tags (e.g. `</b>\n\n<b>`)
- Preserves `\n` inside `<pre>`, `<tg-math-block>`, and `<tg-math>` (whitespace is semantically significant)
- Preserves structural whitespace between block-level/container tags (e.g. `</tr>\n<tr>`, `</table>\n<details>`) to avoid inserting invalid `<br>` children inside containers

### Test plan

- [x] All 55 `format.test.ts` tests pass (3 existing tests updated, 3 new tests added)
- [x] All 2160 telegram extension tests pass (`pnpm vitest run extensions/telegram/src/`)
- [x] `tsc --noEmit` clean
- [x] `codex review --base origin/main` — clean (no accepted/actionable findings)

### Real behavior proof

**Setup:** OpenClaw v2026.6.9-beta.1, Telegram DM, `channels.telegram.richMessages: true`, `channels.telegram.streaming.mode: "partial"`.

**Before fix (observed by user):** Multi-paragraph assistant replies render as a single block in Telegram — paragraph breaks (`\n\n`) are collapsed, all text runs together:

```
搞定，改了 3 个文件： AGENTS.md (Cha) — 删掉了 Discord/WhatsApp/Telegram 三条限制，替换为一条 Telegram rich text 说明 AGENTS.md (WoCha) — 同上 TOOLS.md (Cha) md2pdf 章节 — 去掉了表格相关触发条件： • "Why it exists" 去掉 GFM tables ...
```

**After fix:** Applied the patch to the running gateway. Multi-paragraph replies now render with proper paragraph separation — each paragraph is visually distinct with `<br>` line breaks between them.

Tables, code blocks, headings, and blockquotes all render correctly. Code blocks (`<pre>`) preserve their internal `\n` formatting.

**Not tested:** `<tg-math-block>` with multi-line LaTeX in a live Telegram message (no math content in test conversation), but covered by unit test.

## AI-assisted

This PR was authored with AI assistance (OpenClaw agent). The agent:
1. Identified the bug by tracing the `markdownToTelegramRichHtml` → `renderMarkdownWithMarkers` → `escapeHtml` pipeline
2. Implemented the fix and iterated through 3 rounds of `codex review` / autoreview until clean
3. Ran the full telegram extension test suite (2160 tests)

I (Jet) reviewed each iteration and confirmed the fix resolves the paragraph break collapse in live Telegram messages.

## Checklist

- [x] Mark as AI-assisted in PR description
- [x] Human-run real behavior proof included
- [x] `codex review --base origin/main` run locally, findings addressed
- [x] Tests pass locally
- [x] PR is focused (one fix, no unrelated changes)
- [x] No `CHANGELOG.md` changes