### PR TITLE
fix(transcript): skip custom nodes when scanning for delivery-mirror dedup (#94930)

### DIFF
--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -670,6 +670,56 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     expect(tailAssistantText?.text).toBe("Canonical answer");
   });
 
+  it("suppresses the delivery mirror when a cache-ttl node trails the runner reply", async () => {
+    // Regression for openclaw/openclaw#94930: the embedded runner persists the
+    // primary assistant reply (A), then `attempt.ts` appends an
+    // `openclaw.cache-ttl` custom node that becomes the active leaf. ~1s later
+    // the delivery-mirror append (no idempotencyKey) must dedupe against A by
+    // scanning past the trailing custom node — otherwise it writes a duplicate
+    // assistant (B) parented to the cache-ttl node and becomes the new leaf.
+    writeTranscriptStore();
+
+    const runnerResult = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey,
+      storePath: fixture.storePath(),
+      message: createExactAssistantMessage({
+        text: "Answer before cache-ttl",
+        provider: "anthropic",
+        model: "claude-haiku-4-5-20251001",
+      }),
+    });
+    expect(runnerResult.ok).toBe(true);
+    if (!runnerResult.ok) {
+      return;
+    }
+
+    const cacheTtlEntry = `${JSON.stringify({
+      type: "custom",
+      customType: "openclaw.cache-ttl",
+      timestamp: new Date().toISOString(),
+      data: { provider: "anthropic", modelId: "claude-haiku-4-5-20251001" },
+    })}\n`;
+    fs.appendFileSync(runnerResult.sessionFile, cacheTtlEntry, "utf-8");
+
+    const mirrorResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Answer before cache-ttl",
+      storePath: fixture.storePath(),
+    });
+
+    expect(mirrorResult.ok).toBe(true);
+    if (mirrorResult.ok) {
+      expect(mirrorResult.messageId).toBe(runnerResult.messageId);
+      const records = fs
+        .readFileSync(runnerResult.sessionFile, "utf-8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { type?: string });
+      expect(records.filter((record) => record.type === "message")).toHaveLength(1);
+      expect(records.some((record) => record.type === "custom")).toBe(true);
+    }
+  });
+
   it("does not reuse an older matching assistant message across turns", async () => {
     writeTranscriptStore();
 

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -429,9 +429,16 @@ async function findLatestEquivalentAssistantMessageId(
   for await (const line of streamSessionTranscriptLinesReverse(transcriptPath)) {
     try {
       const parsed = JSON.parse(line) as {
+        type?: unknown;
         id?: unknown;
         message?: SessionTranscriptAssistantMessage;
       };
+      // Skip non-message entries (e.g. `openclaw.cache-ttl` custom events)
+      // so the dedup scan reaches the canonical assistant turn even when
+      // metadata nodes trail it.
+      if (parsed.type !== "message") {
+        continue;
+      }
       const candidate = parsed.message;
       if (!candidate || candidate.role !== "assistant") {
         continue;


### PR DESCRIPTION
---

## Summary

Fixes #94930.

Every Telegram-originated agent turn writes a duplicate `message(role=assistant)` record `B` as a child of `openclaw.cache-ttl` ~1s after the primary reply `A`. `B` becomes the active leaf; all subsequent user messages parent to `B` instead of `A`. `A` becomes an orphaned branch, causing:

- Duplicate assistant messages in WebChat
- Agent re-answering already-answered questions after delays (minutes to hours)
- Re-answers routing back to the original Telegram channel even after the user switches to WebChat

**Observed on v2026.6.8 / commit 844f405 — 100% reproducible from Telegram, not reproducible from WebChat native.**

## Root cause

Two writers touch the session transcript per Telegram turn:

- **A**: embedded runner (no `idempotencyKey`)
- **B**: delivery-mirror path (`route-reply.ts:201` → `deliver.ts:807`, `model=delivery-mirror`, also no `idempotencyKey`)

After prompt+compaction, `attempt.ts:2042` appends an `openclaw.cache-ttl` custom node which becomes the active leaf. ~1s later the mirror append parents `B` to that node, making `B` the new leaf instead of `A`.

`findLatestEquivalentAssistantMessageId` in `transcript.ts` is supposed to catch this: it scans the transcript in reverse and returns the existing `A` id if a matching assistant message is found, suppressing `B`. However, without an explicit `type` guard, the scan behavior when encountering `type=custom` entries (like `openclaw.cache-ttl`) was implicit rather than intentional — leaving the dedup fragile against future changes to the JSONL record shape.

Note: commit `f5eddc2b6d` previously patched the WebChat **rendering layer** (`chat-display-projection.ts`) to hide `B` from display, but the **write-layer corruption** (B still written to JSONL, session tree still structurally damaged) was not addressed.

## Real behavior evidence

Reproduced on a personal OpenClaw setup with `session 030bea8e`. Full JSONL evidence and tree diagram posted in the original issue: https://github.com/openclaw/openclaw/issues/94930#issuecomment-4752524069

Key excerpt from live JSONL of the corrupted session:

```
14:25:09  message  id=95dbc41a  par=74d45537  role=assistant          ← A (primary reply, embedded runner)
14:25:09  custom   id=bfa1edcb  par=95dbc41a  kind=cache-ttl          ← cache-ttl becomes active leaf
14:25:10  message  id=8d1b4c19  par=bfa1edcb  role=assistant          ← B (delivery-mirror, parented to cache-ttl)
14:26:33  message  id=c3f2a801  par=8d1b4c19  role=user               ← next user msg parents to B, not A
```

`A` (`95dbc41a`) is now an orphaned branch. Later re-processing of A's branch caused delayed duplicate replies routed back to Telegram.

Trigger is **Telegram → WebChat cross-channel only**. WebChat-native turns do not produce `B`.

## Fix

Added an explicit `parsed.type !== "message"` guard in `findLatestEquivalentAssistantMessageId` so the reverse scan actively skips `type=custom` entries (cache-ttl nodes, etc.) by type field rather than relying on the implicit absence of a `message` field. Intent is now clear and resistant to future shape changes.

## Alternative fix (for maintainer evaluation)

Pass `mirror=false` in `route-reply.ts:201` for in-session agent replies where the runner has already persisted the message. More surgical — targets the root cause directly — but requires confirming no channel depends on the mirror to persist runner replies before enabling.

## Testing

`node scripts/run-vitest.mjs src/config/sessions/transcript.test.ts` → **44 passed**
