### PR TITLE
fix(discord): deliver isReasoning payloads as formatted Thinking messages

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2639,17 +2639,22 @@ describe("processDiscordMessage draft streaming", () => {
     expect(deliverDiscordReply).not.toHaveBeenCalled();
   });
 
-  it("suppresses reasoning payload delivery to Discord", async () => {
+  it("formats reasoning payload as Thinking message on Discord", async () => {
     mockDispatchSingleBlockReply({ text: "thinking...", isReasoning: true });
     await processStreamOffDiscordMessage();
 
-    expect(deliverDiscordReply).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalled();
+    const params = firstMockArg(deliverDiscordReply, "deliverDiscordReply");
+    expect(params.replies[0]).toHaveProperty("isReasoning", true);
+    // isReasoning payload text is formatted as "Thinking\n\n_<text>_"
+    expect(params.replies[0].text).toContain("Thinking");
+    expect(params.replies[0].text).toContain("_thinking..._");
   });
 
-  it("suppresses reasoning-tagged final payload delivery to Discord", async () => {
+  it("formats reasoning-tagged final payload as Thinking message", async () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({
-        text: "Reasoning:\nthis should stay internal",
+        text: "Reasoning:\nthis should be shown",
         isReasoning: true,
       });
       return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
@@ -2661,8 +2666,11 @@ describe("processDiscordMessage draft streaming", () => {
 
     await runProcessDiscordMessage(ctx);
 
-    expect(deliverDiscordReply).not.toHaveBeenCalled();
-    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalled();
+    const params = firstMockArg(deliverDiscordReply, "deliverDiscordReply");
+    expect(params.replies[0]).toHaveProperty("isReasoning", true);
+    expect(params.replies[0].text).toContain("Thinking");
+    expect(params.replies[0].text).toContain("_Reasoning:_");
   });
 
   it("delivers non-reasoning block payloads to Discord", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -1,7 +1,11 @@
 // Discord plugin module implements message handler.process behavior.
 import path from "node:path";
 import { MessageFlags } from "discord-api-types/v10";
-import { resolveAckReaction, resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  resolveAckReaction,
+  resolveHumanDelayConfig,
+  formatReasoningMessage,
+} from "openclaw/plugin-sdk/agent-runtime";
 import {
   createStatusReactionController,
   DEFAULT_TIMING,
@@ -609,17 +613,10 @@ async function processDiscordMessageInner(
       );
       return null;
     }
-    if (payload.isReasoning) {
-      // Reasoning/thinking payloads should not be delivered to Discord.
-      logVerbose(
-        formatDiscordReplySkip({
-          kind: info.kind,
-          reason: "reasoning payload",
-          target: deliverTarget,
-          sessionKey: ctxPayload.SessionKey,
-        }),
-      );
-      return null;
+    if (payload.isReasoning && typeof payload.text === "string") {
+      // Format reasoning as a Thinking message matching the documented /reasoning
+      // contract (separate visible message prefixed with Thinking).
+      payload.text = formatReasoningMessage(payload.text);
     }
     if (draftPreview.draftStream && draftPreview.isProgressMode && info.kind === "block") {
       const reply = resolveSendableOutboundReplyParts(payload);
@@ -652,17 +649,8 @@ async function processDiscordMessageInner(
       return { visibleReplySent: false };
     }
     const isFinal = info.kind === "final";
-    if (payload.isReasoning) {
-      // Reasoning/thinking payloads should not be delivered to Discord.
-      logVerbose(
-        formatDiscordReplySkip({
-          kind: info.kind,
-          reason: "reasoning payload",
-          target: deliverTarget,
-          sessionKey: ctxPayload.SessionKey,
-        }),
-      );
-      return { visibleReplySent: false };
+    if (payload.isReasoning && typeof payload.text === "string") {
+      payload.text = formatReasoningMessage(payload.text);
     }
     if (
       isFinal &&


### PR DESCRIPTION
Closes #94936

## Summary
Per sweeper P1 review feedback on the earlier PR: removes Discord isReasoning suppression and formats reasoning payloads as the documented Thinking message ("Thinking\n\n_<text>_").

Previous version had two issues: (1) bundled an unrelated skills CLI commit, (2) sent raw reasoning text which would look like an ordinary reply instead of the documented separate Thinking message.

## Changes: 2 files, +25/-29
- `extensions/discord/src/monitor/message-handler.process.ts`: Remove two isReasoning suppression guards → replace with `formatReasoningMessage` call
- `extensions/discord/src/monitor/message-handler.process.test.ts`: Update tests to verify Thinking message format in delivered text

## Verification
- All 107 Discord process tests pass
- Delivered reasoning text contains "Thinking\n\n_<text>_" format matching docs