### PR TITLE
fix(telegram): materialize preview drafts

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2932,6 +2932,33 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.flush).toHaveBeenCalled();
   });
 
+  it("shows a progress label for answer-only progress-mode partials", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onReplyStart?.();
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Working", delta: "Working" });
+        expect(draftStream.updatePreview).not.toHaveBeenCalled();
+        await replyOptions?.onPartialReply?.({ text: "Working on it", delta: " on it" });
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Working" } } },
+    });
+
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(telegramHtmlPreview("<b>Working</b>"));
+    expect(draftStream.update).not.toHaveBeenCalledWith("Working on it");
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expectDeliveredReply(0, { text: "Done" });
+  });
+
   it("renders command status without command output in Telegram progress draft previews", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1364,7 +1364,7 @@ export const dispatchTelegramMessage = async ({
       recomputeQueuedAnswerBlockRotations();
     }
   };
-  const updateDraftFromPartial = (lane: DraftLaneState, update: DraftPartialTextUpdate) => {
+  const updateDraftFromPartial = async (lane: DraftLaneState, update: DraftPartialTextUpdate) => {
     const laneStream = lane.stream;
     if (!laneStream || !update.text) {
       return;
@@ -1376,6 +1376,7 @@ export const dispatchTelegramMessage = async ({
     }
     if (lane === answerLane) {
       if (streamMode === "progress") {
+        await progressDraft.noteActivity();
         return;
       }
       resetAnswerToolProgressDraft();
@@ -1402,7 +1403,7 @@ export const dispatchTelegramMessage = async ({
         reasoningStepState.noteReasoningHint();
         reasoningStepState.noteReasoningDelivered();
       }
-      updateDraftFromPartial(lanes[segment.lane], segment.update);
+      await updateDraftFromPartial(lanes[segment.lane], segment.update);
     }
   };
   const flushDraftLane = async (lane: DraftLaneState) => {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -894,6 +894,24 @@ describe("draft stream initial message debounce", () => {
       expect(api.sendMessage).not.toHaveBeenCalled();
     });
 
+    it("materializes the latest stable short first message after the initial debounce window", async () => {
+      const api = createMockApi();
+      const stream = createDebouncedStream(api);
+
+      stream.update("Processing");
+      await stream.flush();
+      stream.update("Still working");
+      await stream.flush();
+      await vi.advanceTimersByTimeAsync(1_999);
+
+      expect(api.sendMessage).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+
+      await vi.waitFor(() => expectPreviewSend(api, "Still working"));
+      expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    });
+
     it("does not send a first message when discard() supersedes a short partial", async () => {
       const api = createMockApi();
       const stream = createDebouncedStream(api);
@@ -901,6 +919,7 @@ describe("draft stream initial message debounce", () => {
       stream.update("Processing");
       await stream.discard?.();
       await stream.flush();
+      await vi.advanceTimersByTimeAsync(2_000);
 
       expect(api.sendMessage).not.toHaveBeenCalled();
       expect(api.editMessageText).not.toHaveBeenCalled();
@@ -914,6 +933,21 @@ describe("draft stream initial message debounce", () => {
       await stream.flush();
 
       expect(api.sendMessage).toHaveBeenCalled();
+    });
+
+    it("does not replay a delayed short first message after reaching the threshold", async () => {
+      const api = createMockApi();
+      const stream = createDebouncedStream(api);
+
+      stream.update("Processing");
+      await stream.flush();
+      stream.update("I am processing your request..");
+      await stream.flush();
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(api.sendMessage).toHaveBeenCalledTimes(1);
+      expectPreviewSend(api, "I am processing your request..");
+      expect(api.editMessageText).not.toHaveBeenCalled();
     });
 
     it("works with longer text above threshold", async () => {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -36,6 +36,9 @@ const MAX_CONSECUTIVE_PREVIEW_FAILURES = 3;
 // Flood waits beyond this freeze the preview longer than it is useful; clamp so
 // a large retry_after cannot park the suspension past the run's lifetime.
 const MAX_PREVIEW_FLOOD_SUSPEND_MS = 60_000;
+// Keep token-sized first previews quiet, but materialize a stable short draft
+// after two throttle windows so Telegram users still see active work.
+const MIN_INITIAL_PREVIEW_DELAY_THROTTLE_WINDOWS = 2;
 
 export type TelegramDraftStream = {
   update: (text: string) => void;
@@ -227,6 +230,39 @@ export function createTelegramDraftStream(params: {
   let previewRevision = 0;
   let generation = 0;
   let deliveredTextOffset = 0;
+  let shortInitialPreviewSinceMs: number | undefined;
+  let shortInitialPreviewTimer: ReturnType<typeof setTimeout> | undefined;
+  let rescheduleDraftUpdate: ((text: string) => void) | undefined;
+  const minInitialPreviewDelayMs =
+    minInitialChars == null ? undefined : throttleMs * MIN_INITIAL_PREVIEW_DELAY_THROTTLE_WINDOWS;
+  const clearShortInitialPreviewTimer = () => {
+    if (shortInitialPreviewTimer) {
+      clearTimeout(shortInitialPreviewTimer);
+      shortInitialPreviewTimer = undefined;
+    }
+  };
+  const resetShortInitialPreviewDelay = () => {
+    shortInitialPreviewSinceMs = undefined;
+    clearShortInitialPreviewTimer();
+  };
+  const scheduleShortInitialPreviewRetry = (delayMs: number) => {
+    if (shortInitialPreviewTimer || streamState.stopped || streamState.final) {
+      return;
+    }
+    shortInitialPreviewTimer = setTimeout(
+      () => {
+        shortInitialPreviewTimer = undefined;
+        if (streamState.stopped || streamState.final || typeof streamMessageId === "number") {
+          return;
+        }
+        const text = lastRequestedText;
+        if (text.trim()) {
+          rescheduleDraftUpdate?.(text);
+        }
+      },
+      Math.max(0, delayMs),
+    );
+  };
   type PreviewSendParams = {
     preview: TelegramDraftPreview;
     sendGeneration: number;
@@ -403,9 +439,22 @@ export function createTelegramDraftStream(params: {
     }
     const sendGeneration = generation;
 
-    if (typeof streamMessageId !== "number" && minInitialChars != null && !streamState.final) {
+    if (
+      typeof streamMessageId !== "number" &&
+      minInitialChars != null &&
+      minInitialPreviewDelayMs != null &&
+      !streamState.final
+    ) {
       if (renderedText.length < minInitialChars) {
-        return false;
+        const now = Date.now();
+        shortInitialPreviewSinceMs ??= now;
+        const elapsedMs = now - shortInitialPreviewSinceMs;
+        if (elapsedMs < minInitialPreviewDelayMs) {
+          scheduleShortInitialPreviewRetry(minInitialPreviewDelayMs - elapsedMs);
+          return false;
+        }
+      } else {
+        resetShortInitialPreviewDelay();
       }
     }
 
@@ -417,6 +466,7 @@ export function createTelegramDraftStream(params: {
         sendGeneration,
       });
       if (sent) {
+        resetShortInitialPreviewDelay();
         previewRevision += 1;
         lastDeliveredText = trimmed;
         consecutivePreviewFailures = 0;
@@ -467,10 +517,14 @@ export function createTelegramDraftStream(params: {
     state: streamState,
     sendOrEditStreamMessage,
   });
+  rescheduleDraftUpdate = updateDraft;
 
   const requestDraftUpdate = (text: string, preview?: TelegramDraftPreview) => {
     if (streamState.stopped || streamState.final) {
       return;
+    }
+    if (!text.trim()) {
+      resetShortInitialPreviewDelay();
     }
     lastRequestedPreview = preview;
     lastRequestedText = text;
@@ -490,6 +544,7 @@ export function createTelegramDraftStream(params: {
   };
 
   const stop = async () => {
+    resetShortInitialPreviewDelay();
     streamState.final = true;
     await loop.flush();
     if (streamState.stopped) {
@@ -507,6 +562,7 @@ export function createTelegramDraftStream(params: {
     keepPending?: boolean;
     resetOffset?: boolean;
   }) => void = (options) => {
+    resetShortInitialPreviewDelay();
     streamState.stopped = false;
     streamState.final = options?.keepFinal === true;
     generation += 1;
@@ -526,6 +582,7 @@ export function createTelegramDraftStream(params: {
   };
 
   const clear = async () => {
+    resetShortInitialPreviewDelay();
     const messageId = await takeMessageIdAfterStop({
       stopForClear,
       readMessageId: () => streamMessageId,
@@ -544,6 +601,7 @@ export function createTelegramDraftStream(params: {
   };
 
   const discard = async () => {
+    resetShortInitialPreviewDelay();
     await stopForClear();
   };
 

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -232,7 +232,9 @@ export function createTelegramDraftStream(params: {
   let deliveredTextOffset = 0;
   let shortInitialPreviewSinceMs: number | undefined;
   let shortInitialPreviewTimer: ReturnType<typeof setTimeout> | undefined;
-  let rescheduleDraftUpdate: ((text: string) => void) | undefined;
+  function rescheduleDraftUpdate(text: string) {
+    updateDraft(text);
+  }
   const minInitialPreviewDelayMs =
     minInitialChars == null ? undefined : throttleMs * MIN_INITIAL_PREVIEW_DELAY_THROTTLE_WINDOWS;
   const clearShortInitialPreviewTimer = () => {
@@ -257,7 +259,7 @@ export function createTelegramDraftStream(params: {
         }
         const text = lastRequestedText;
         if (text.trim()) {
-          rescheduleDraftUpdate?.(text);
+          rescheduleDraftUpdate(text);
         }
       },
       Math.max(0, delayMs),
@@ -517,7 +519,6 @@ export function createTelegramDraftStream(params: {
     state: streamState,
     sendOrEditStreamMessage,
   });
-  rescheduleDraftUpdate = updateDraft;
 
   const requestDraftUpdate = (text: string, preview?: TelegramDraftPreview) => {
     if (streamState.stopped || streamState.final) {

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -65,6 +65,24 @@ describe("createChannelProgressDraftCompositor", () => {
     expect(update.mock.calls.every(([text]) => !String(text).includes("Reading"))).toBe(true);
   });
 
+  it("shows the progress label for generic activity after the gate starts", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      update,
+    });
+
+    await progress.noteActivity();
+    expect(update).not.toHaveBeenCalled();
+
+    await progress.noteActivity();
+
+    expect(update).toHaveBeenCalledWith("Shelling", { flush: true, lines: [] });
+  });
+
   it("does not resurrect progress after suppression", async () => {
     const update = vi.fn();
     const progress = createChannelProgressDraftCompositor({

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -117,6 +117,24 @@ export function createChannelProgressDraftCompositor(params: {
     await params.deleteCurrent?.();
   };
 
+  const noteActivity = async () => {
+    if (
+      !params.active ||
+      params.mode !== "progress" ||
+      progressSuppressed ||
+      finalReplyStarted ||
+      finalReplyDelivered
+    ) {
+      return false;
+    }
+    const alreadyStarted = gate.hasStarted;
+    const progressActive = await gate.noteWork();
+    if ((alreadyStarted || progressActive) && gate.hasStarted) {
+      return await render();
+    }
+    return false;
+  };
+
   const noteProgress = async (
     line?: ChannelProgressDraftCompositorLine,
     options?: { toolName?: string; startImmediately?: boolean },
@@ -216,6 +234,7 @@ export function createChannelProgressDraftCompositor(params: {
     start() {
       return gate.startNow();
     },
+    noteActivity,
     pushToolProgress: noteProgress,
     async pushReasoningProgress(text?: string, options?: { snapshot?: boolean }) {
       if (


### PR DESCRIPTION
## Summary

Fixes #95004.

This updates Telegram preview streaming in two places:

- Short first previews that stay below `minInitialChars` now materialize after two throttle windows, using the latest pending text and cancelling cleanly on discard, clear, reset, or threshold send.
- Answer-only partials in progress mode now create the existing label-only progress preview through the progress draft compositor, while still keeping answer text out of the draft stream and preserving final durable delivery.

## Verification

- Red reproduction before the fix: `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts telegram/src/draft-stream.test.ts -t "minInitialChars"` failed on the new delayed-materialization expectation with zero `sendMessage` calls.
- Passed after the fix: `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts telegram/src/draft-stream.test.ts -t "minInitialChars"`.
- Passed after the fix: `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts telegram/src/bot-message-dispatch.test.ts -t "answer-only progress-mode"`.
- Passed after the fix: `node scripts/run-vitest.mjs run --config test/vitest/vitest.channels.config.ts src/channels/progress-draft-compositor.test.ts -t "generic activity"`.
- Passed full touched unit files: `node scripts/run-vitest.mjs run --config test/vitest/vitest.channels.config.ts src/channels/progress-draft-compositor.test.ts && node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts telegram/src/draft-stream.test.ts telegram/src/bot-message-dispatch.test.ts`.
- Passed: `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/draft-stream.ts`.
- Passed: `node scripts/run-bundled-extension-oxlint.mjs`.
- Passed: `node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/draft-stream.ts src/channels/progress-draft-compositor.test.ts src/channels/progress-draft-compositor.ts`.
- Passed: `git diff --check`.
- Passed: `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`.
- Passed: `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`.
- Passed: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`.
- Passed: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo`.
- Post-rebase lightweight proof passed in the linked worktree: `git diff --check origin/main...HEAD`.

Autoreview was attempted once per the draft-PR guardrail, but the helper failed before reviewing because the local Codex config uses `service_tier = priority`, which this Codex binary rejects. No autoreview findings were produced.

## Real behavior proof

Behavior addressed: Telegram preview streaming no longer stays silent for source-proven short first drafts below `minInitialChars`, and answer-only progress-mode streams now produce the existing label-only progress preview instead of suppressing all draft activity until final delivery.

Real environment tested: Source-level behavior proof in a real OpenClaw checkout, using the original issue's accepted current-main reproduction plus PR-head after-fix commands. ClawSweeper already reviewed #95004 as a high-confidence source repro and labeled it `clawsweeper:source-repro` / `issue-rating: 🦞 diamond lobster`: https://github.com/openclaw/openclaw/issues/95004#issuecomment-4752867865

Exact steps or command run after this patch: I compared the issue's current-main source proof against this PR head, then ran the focused after-fix commands below:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts telegram/src/draft-stream.test.ts -t "minInitialChars"
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts telegram/src/bot-message-dispatch.test.ts -t "answer-only progress-mode"
node scripts/run-vitest.mjs run --config test/vitest/vitest.channels.config.ts src/channels/progress-draft-compositor.test.ts -t "generic activity"
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/draft-stream.ts
node scripts/run-bundled-extension-oxlint.mjs
git diff --check
```

Evidence after fix: The original issue proof established that current main suppresses the first short Telegram preview below `minInitialChars`, sets `draftMinInitialChars` to 30 outside progress mode, and drops answer-lane partials in progress mode before they reach the Telegram draft stream. This PR changes those exact paths. After the patch, the delayed `minInitialChars` test observes a Telegram `sendMessage` after the bounded delay, and the answer-only progress-mode test observes a label-only draft update, no answer text draft update, draft cleanup, and final durable delivery.

Observed result after fix:

```text
RUN  v4.1.7 /Users/fallmonkey/Developer/openclaw-95004
Test Files  2 passed (2)
Tests  178 passed (178)

RUN  v4.1.7 /Users/fallmonkey/Developer/openclaw-95004
Test Files  1 passed (1)
Tests  13 passed (13)

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/draft-stream.ts
# passed

node scripts/run-bundled-extension-oxlint.mjs
# passed
```

What was not tested: Native Telegram Desktop / real-user visual proof was not captured from this contributor environment. Local `openclaw-telegram-user-crabbox-proof` was unavailable, the repo script dry-run failed without `~/.codex/skills/custom/telegram-e2e-bot-to-bot/convex.local.env`, and the Mantis proof workflow requires maintainer/write permission for comment triggers. The proof above is the issue-backed source-level reproduction plus after-fix source verification, not a native Telegram recording.
