### PR TITLE
fix(utils): handle Windows absolute paths in splitShellArgs (#92302)

### DIFF
--- a/src/utils/shell-argv.test.ts
+++ b/src/utils/shell-argv.test.ts
@@ -1,0 +1,136 @@
+// FIX #92302: Test Windows absolute path handling in splitShellArgs
+import { describe, it, expect } from "vitest";
+import { splitShellArgs } from "./shell-argv.js";
+
+describe("splitShellArgs", () => {
+  describe("Windows absolute paths (FIX #92302)", () => {
+    it("should preserve backslashes in Windows absolute path C:\\path\\to\\file", () => {
+      const result = splitShellArgs("C:\\Users\\test\\AppData\\qmd.js");
+      expect(result).toEqual(["C:\\Users\\test\\AppData\\qmd.js"]);
+    });
+
+    it("should handle Windows path with forward slashes", () => {
+      const result = splitShellArgs("C:/Users/test/AppData/qmd.js");
+      expect(result).toEqual(["C:/Users/test/AppData/qmd.js"]);
+    });
+
+    it("should parse Windows executable path correctly (quoted)", () => {
+      // Paths with spaces should be quoted in shell context
+      const result = splitShellArgs('"C:\\Program Files\\NodeJS\\node.exe"');
+      expect(result).toEqual(["C:\\Program Files\\NodeJS\\node.exe"]);
+    });
+
+    it("should handle Windows path with arguments", () => {
+      const result = splitShellArgs("C:\\path\\to\\node.exe script.js arg2");
+      expect(result).toEqual(["C:\\path\\to\\node.exe", "script.js", "arg2"]);
+    });
+
+    it("should handle UNC paths (quoted)", () => {
+      // UNC path: \\server\share\file.exe
+      // In the shell parser with double quotes, backslash is mostly literal
+      // except before ", $, `, \n, \r. So \\server becomes \server in the output.
+      // To get \\server in output, we need to escape each backslash: \\\\server
+      const result = splitShellArgs('"\\\\\\\\server\\\\share\\\\file.exe"');
+      expect(result).toEqual(["\\\\server\\share\\file.exe"]);
+    });
+
+    it("should handle lowercase drive letter", () => {
+      const result = splitShellArgs("c:\\users\\test\\file.txt");
+      expect(result).toEqual(["c:\\users\\test\\file.txt"]);
+    });
+
+    it("should handle mixed case drive letter", () => {
+      const result = splitShellArgs("D:\\Projects\\openclaw\\dist\\index.js");
+      expect(result).toEqual(["D:\\Projects\\openclaw\\dist\\index.js"]);
+    });
+  });
+
+  describe("POSIX shell behavior (regression tests)", () => {
+    it("should handle simple command without arguments", () => {
+      const result = splitShellArgs("qmd");
+      expect(result).toEqual(["qmd"]);
+    });
+
+    it("should handle command with arguments", () => {
+      const result = splitShellArgs("node script.js --verbose");
+      expect(result).toEqual(["node", "script.js", "--verbose"]);
+    });
+
+    it("should handle double-quoted strings", () => {
+      const result = splitShellArgs('echo "hello world"');
+      expect(result).toEqual(["echo", "hello world"]);
+    });
+
+    it("should handle single-quoted strings", () => {
+      const result = splitShellArgs("echo 'hello world'");
+      expect(result).toEqual(["echo", "hello world"]);
+    });
+
+    it("should handle escaped double quotes inside double quotes", () => {
+      const result = splitShellArgs('echo "hello\\"world"');
+      expect(result).toEqual(["echo", 'hello"world']);
+    });
+
+    it("should handle escaped characters in POSIX shell", () => {
+      const result = splitShellArgs("echo hello\\ world");
+      expect(result).toEqual(["echo", "hello world"]);
+    });
+
+    it("should handle Unix absolute paths", () => {
+      const result = splitShellArgs("/usr/bin/node script.js");
+      expect(result).toEqual(["/usr/bin/node", "script.js"]);
+    });
+
+    it("should handle paths with spaces in quotes", () => {
+      const result = splitShellArgs('"/path/with spaces/file.js"');
+      expect(result).toEqual(["/path/with spaces/file.js"]);
+    });
+
+    it("should return null for unterminated double quote", () => {
+      const result = splitShellArgs('echo "hello');
+      expect(result).toBeNull();
+    });
+
+    it("should return null for unterminated single quote", () => {
+      const result = splitShellArgs("echo 'hello");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for trailing escape character", () => {
+      const result = splitShellArgs("echo hello\\");
+      expect(result).toBeNull();
+    });
+
+    it("should handle comments", () => {
+      const result = splitShellArgs("echo hello # this is a comment");
+      expect(result).toEqual(["echo", "hello"]);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty string", () => {
+      const result = splitShellArgs("");
+      expect(result).toEqual([]);
+    });
+
+    it("should handle whitespace-only string", () => {
+      const result = splitShellArgs("   \t\n  ");
+      expect(result).toEqual([]);
+    });
+
+    it("should handle multiple spaces between arguments", () => {
+      const result = splitShellArgs("cmd   arg1    arg2");
+      expect(result).toEqual(["cmd", "arg1", "arg2"]);
+    });
+
+    it("should handle Windows path in quotes", () => {
+      const result = splitShellArgs('"C:\\Program Files\\app.exe" --flag');
+      expect(result).toEqual(["C:\\Program Files\\app.exe", "--flag"]);
+    });
+
+    it("should handle Windows path with special characters in quotes", () => {
+      const result = splitShellArgs('"C:\\My App (v1.0)\\bin.exe"');
+      expect(result).toEqual(["C:\\My App (v1.0)\\bin.exe"]);
+    });
+  });
+});

--- a/src/utils/shell-argv.ts
+++ b/src/utils/shell-argv.ts
@@ -22,6 +22,10 @@ export function splitShellArgs(raw: string): string[] | null {
     }
   };
 
+  // Detect if the input looks like a Windows absolute path to avoid
+  // misinterpreting backslashes as escape characters.
+  const isWindowsAbsolutePath = /^[A-Za-z]:[\\/]/.test(raw.trim());
+
   for (let i = 0; i < raw.length; i += 1) {
     const ch = raw[i];
     if (escaped) {
@@ -29,7 +33,7 @@ export function splitShellArgs(raw: string): string[] | null {
       escaped = false;
       continue;
     }
-    if (!inSingle && !inDouble && ch === "\\") {
+    if (!inSingle && !inDouble && ch === "\\" && !isWindowsAbsolutePath) {
       escaped = true;
       continue;
     }


### PR DESCRIPTION
## Summary

Fix #92302 where Windows absolute paths in `memory.qmd.command` configuration were being mangled due to backslashes being misinterpreted as escape characters in the POSIX shell-style argument parser.

The root cause was in `src/utils/shell-argv.ts` where the `splitShellArgs()` function treated all backslashes as escape characters, which is correct for POSIX shell syntax but breaks Windows absolute paths like `C:\Users\...\file.js`.

The fix detects Windows absolute paths (matching `/^[A-Za-z]:[\\/]/`) and skips the backslash-as-escape logic for such inputs, preserving path separators correctly.

Fixes #92302

## Real behavior proof (required for external PRs)

**Behavior addressed**: Windows users configuring `memory.qmd.command` with an absolute path like `"C:\\Users\\<user>\\AppData\\Roaming\\npm\\node_modules\\@tobilu\\qmd\\dist\\cli\\qmd.js"` would see the path mangled to `"C:Users<user>AppDataRoamingnpmnode_modules@tobiluqmddistcliqmd.js"` (all backslashes removed).

**Real setup tested**:
- **Runtime**: Node v22.x (Linux test environment)
- **Test coverage**: 24 new test cases covering Windows paths, UNC paths, and regression tests for POSIX shell behavior

**Exact steps or command run after fix**:

```bash
pnpm test src/utils/shell-argv.test.ts
```

**After-fix evidence**:

```
 RUN  v4.1.8 /home/0668000603/workspace/openclaw-worktrees/fix/issue-92302


 Test Files  1 passed (1)
      Tests  24 passed (24)
   Start at  01:24:09
   Duration  541ms (transform 99ms, setup 0ms, import 134ms, tests 11ms, environment 0ms)

[test] passed 1 Vitest shard in 11.01s
```

**Observed result after the fix**: All 24 tests pass, including 8 new tests specifically for Windows path handling.

**What was not tested**: Live Windows environment testing (this fix was developed and tested on Linux, but the logic is platform-agnostic and the test cases cover the expected string parsing behavior).

## Tests and validation

All existing tests continue to pass, confirming no regression in POSIX shell behavior:

```
 Test Files  9 passed (9)
      Tests  98 passed (98)

 Test Files  7 passed (7)
      Tests  92 passed (92)
```

| Test Type | Result | Details |
|-----------|--------|---------|
| Unit Tests | ✅ | 24/24 passed (shell-argv.test.ts) |
| Regression | ✅ | 98/98 passed (all utils tests) |
| Type Check | ✅ | No type errors introduced |
| Lint | ✅ | No lint warnings |
| UI Verify | N/A | Backend utility function |

## Risk checklist

Did user-visible behavior change? `No` - This is a bug fix that restores correct behavior for Windows users; POSIX shell behavior is unchanged.

Did config, environment, or migration behavior change? `No` - The fix is transparent to users; existing configurations will now work correctly.

Did security, auth, secrets, network, or tool execution behavior change? `No` - Only affects path string parsing.

What is the highest-risk area?
- Minimal risk: The change is narrowly scoped to Windows absolute path detection
- All existing POSIX shell tests continue to pass

How is that risk mitigated?
- Comprehensive test coverage (24 tests)
- Backward compatible with existing behavior
- Simple regex-based detection (`/^[A-Za-z]:[\\/]/`)

## Current review state

What is the next action?
- Maintainer review
