### PR TITLE
fix(dreaming): increase narrative timeout from 60s to 120s for ARM devices (fixes #92494)

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -1064,7 +1064,7 @@ describe("generateAndAppendDreamNarrative", () => {
     });
 
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
-    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(60_000);
+    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(120_000);
     expectLogIncludes(logger.warn, "narrative session cleanup failed for rem phase");
   });
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -97,10 +97,11 @@ const NARRATIVE_SYSTEM_PROMPT = [
 // many minutes after the reports have already been written. The previous 15 s
 // limit was empirically too tight for warm-gateway runs across light, REM, and
 // deep phases — even unblocked LLM calls hit it on the first sweep after a
-// restart. 60 s gives realistic latency headroom while still capping the
-// worst case at one minute, well below the multi-minute stall the original
-// comment warned against.
-const NARRATIVE_TIMEOUT_MS = 60_000;
+// restart. 60 s was still too tight for ARM devices with 600+ skills where
+// cold-loading tool definitions takes ~57 s on the first narrative phase,
+// leaving almost no headroom for the LLM call itself. 120 s gives realistic
+// latency headroom while still capping worst case at two minutes.
+const NARRATIVE_TIMEOUT_MS = 120_000;
 const NARRATIVE_MESSAGE_FETCH_LIMIT = 5;
 // A completed run can reach the session reader before the final assistant text
 // is visible, so retry briefly before falling back to synthetic diary text.


### PR DESCRIPTION
## What

Increase the dreaming narrative timeout from 60s to 120s to accommodate ARM devices with large skill counts.

## Why

ARM devices with 600+ skills need ~57 seconds just for cold-loading tool definitions on the first narrative phase (light). The previous 60s timeout left almost no headroom for the LLM call itself, causing consistent timeouts on light and rem phases. The deep phase usually succeeded because it benefits from cached tool bundles (~20s).

## Changes

- `extensions/memory-core/src/dreaming-narrative.ts`: bump `NARRATIVE_TIMEOUT_MS` from `60_000` to `120_000`, update comment to explain the ARM rationale
- `extensions/memory-core/src/dreaming-narrative.test.ts`: update corresponding test assertion

Fixes #92494

## Real behavior proof

- **Behavior addressed:** Dreaming narrative phases timeout on ARM devices with 600+ skills due to insufficient timeout budget for cold-loading tool definitions
- **Environment tested:** macOS, Node.js, openclaw/openclaw at commit 38807ffb
- **Steps run after the patch:**
  - Confirmed `NARRATIVE_TIMEOUT_MS` constant changed to `120_000` in source
  - Ran the dreaming-narrative verification suite — all 58 checks pass
  - Verified no other references to the old 60_000 value remain
- **Evidence after fix:**
```
$ grep -n 'NARRATIVE_TIMEOUT_MS' extensions/memory-core/src/dreaming-narrative.ts
104:const NARRATIVE_TIMEOUT_MS = 120_000;
1052:            timeoutMs: NARRATIVE_TIMEOUT_MS,

$ node scripts/run-vitest.mjs run extensions/memory-core/src/dreaming-narrative.test.ts
 ✓  extension-memory  extensions/memory-core/src/dreaming-narrative.test.ts (58 tests) 501ms
 Test Files  1 passed (1)
      Tests  58 passed (58)
```
- **Observed result after fix:** Timeout constant is 120_000, all 58 narrative checks pass, comment explains ARM rationale
- **What was not tested:** Actual dreaming run on ARM hardware with 600+ skills (requires specific device)
