### PR TITLE
fix(auto-reply): surface preserved fallback notices

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1300,7 +1300,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
         modelProvider: "openai",
         model: "gpt-5.5",
         responseUsage: "tokens",
-        ...(existingFallbackState ?? {}),
+        ...existingFallbackState,
       };
       const expectedStoredFallbackState = {
         selectedModel: existingFallbackState?.fallbackNoticeSelectedModel,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -6,6 +6,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { saveSessionStore, type SessionEntry } from "../../config/sessions.js";
 import { readSessionStoreForTest } from "../../config/sessions/test-helpers.js";
 import type { TypingMode } from "../../config/types.js";
+import { getReplyPayloadMetadata } from "../reply-payload.js";
 import type { TemplateContext } from "../templating.js";
 import type { GetReplyOptions } from "../types.js";
 import {
@@ -1280,94 +1281,142 @@ describe("runReplyAgent typing (heartbeat)", () => {
     }
   });
 
-  it("does not persist active fallback state for internal subagent announce fallback", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      modelProvider: "openai",
-      model: "gpt-5.5",
-      responseUsage: "tokens",
-    };
-    const sessionStore = { main: sessionEntry };
-    const storeRoot = await mkdtemp(join(tmpdir(), "openclaw-internal-fallback-"));
-    const storePath = join(storeRoot, "sessions.json");
-    await saveSessionStore(storePath, sessionStore, { skipMaintenance: true });
-    try {
-      state.runEmbeddedAgentMock.mockResolvedValueOnce({
-        payloads: [{ text: "subagent timed out" }],
-        meta: {
-          agentMeta: {
-            usage: {
-              input: 100,
-              output: 50,
+  it.each([
+    ["without stored fallback state", undefined],
+    [
+      "with matching stored fallback state",
+      {
+        fallbackNoticeSelectedModel: "openai/gpt-5.5",
+        fallbackNoticeActiveModel: "google/gemini-2.5-flash",
+        fallbackNoticeReason: "timeout",
+      },
+    ],
+  ])(
+    "surfaces fallback notice for internal subagent announce without mutating fallback state %s",
+    async (_name, existingFallbackState) => {
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        modelProvider: "openai",
+        model: "gpt-5.5",
+        responseUsage: "tokens",
+        ...(existingFallbackState ?? {}),
+      };
+      const expectedStoredFallbackState = {
+        selectedModel: existingFallbackState?.fallbackNoticeSelectedModel,
+        activeModel: existingFallbackState?.fallbackNoticeActiveModel,
+        reason: existingFallbackState?.fallbackNoticeReason,
+      };
+      const sessionStore = { main: sessionEntry };
+      const storeRoot = await mkdtemp(join(tmpdir(), "openclaw-internal-fallback-"));
+      const storePath = join(storeRoot, "sessions.json");
+      await saveSessionStore(storePath, sessionStore, { skipMaintenance: true });
+      try {
+        state.runEmbeddedAgentMock.mockResolvedValueOnce({
+          payloads: [{ text: "subagent timed out" }],
+          meta: {
+            agentMeta: {
+              usage: {
+                input: 100,
+                output: 50,
+              },
             },
           },
-        },
-      });
-      vi.spyOn(modelFallbackModule, "runWithModelFallback").mockImplementationOnce(async (args) => {
-        const { run, onFallbackStep } = args;
-        await onFallbackStep?.({
-          fallbackStepType: "fallback_step",
-          fallbackStepFromModel: "openai/gpt-5.5",
-          fallbackStepToModel: "google/gemini-2.5-flash",
-          fallbackStepFromFailureReason: "timeout",
-          fallbackStepFinalOutcome: "succeeded",
         });
-        return {
-          outcome: "completed" as const,
-          result: await run("google", "gemini-2.5-flash"),
-          provider: "google",
-          model: "gemini-2.5-flash",
-          attempts: [
-            {
-              provider: "openai",
-              model: "gpt-5.5",
-              error: "codex app-server attempt timed out",
-              reason: "timeout",
-            },
-          ],
-        };
-      });
-
-      const { run } = createMinimalRun({
-        sessionEntry,
-        sessionStore,
-        sessionKey: "main",
-        storePath,
-        runOverrides: {
-          inputProvenance: {
-            kind: "inter_session",
-            sourceSessionKey: "agent:codex:subagent:c34fca91",
-            sourceChannel: "__internal__",
-            sourceTool: "subagent_announce",
+        vi.spyOn(modelFallbackModule, "runWithModelFallback").mockImplementationOnce(
+          async (args) => {
+            const { run, onFallbackStep } = args;
+            await onFallbackStep?.({
+              fallbackStepType: "fallback_step",
+              fallbackStepFromModel: "openai/gpt-5.5",
+              fallbackStepToModel: "google/gemini-2.5-flash",
+              fallbackStepFromFailureReason: "timeout",
+              fallbackStepFinalOutcome: "succeeded",
+            });
+            return {
+              outcome: "completed" as const,
+              result: await run("google", "gemini-2.5-flash"),
+              provider: "google",
+              model: "gemini-2.5-flash",
+              attempts: [
+                {
+                  provider: "openai",
+                  model: "gpt-5.5",
+                  error: "codex app-server attempt timed out",
+                  reason: "timeout",
+                },
+              ],
+            };
           },
-        },
-      });
-      const res = await run();
+        );
 
-      expect(sessionEntry.modelProvider).toBe("openai");
-      expect(sessionEntry.model).toBe("gpt-5.5");
-      expect(sessionEntry.providerOverride).toBeUndefined();
-      expect(sessionEntry.modelOverride).toBeUndefined();
-      expect(sessionEntry.modelOverrideSource).toBeUndefined();
-      expect(sessionEntry.fallbackNoticeSelectedModel).toBeUndefined();
-      expect(sessionEntry.fallbackNoticeActiveModel).toBeUndefined();
-      expect(sessionEntry.fallbackNoticeReason).toBeUndefined();
-      const persistedSession = requireStoredSessionEntry(storePath);
-      expect(persistedSession.modelProvider).toBe("openai");
-      expect(persistedSession.model).toBe("gpt-5.5");
-      expect(persistedSession.providerOverride).toBeUndefined();
-      expect(persistedSession.modelOverride).toBeUndefined();
-      expect(persistedSession.modelOverrideSource).toBeUndefined();
-      expect(persistedSession.fallbackNoticeSelectedModel).toBeUndefined();
-      expect(persistedSession.fallbackNoticeActiveModel).toBeUndefined();
-      const payloads = Array.isArray(res) ? res : res ? [res] : [];
-      expect(payloads.some((payload) => payload.text?.includes("Model Fallback:"))).toBe(false);
-      expect(payloads.some((payload) => payload.text?.includes("Usage:"))).toBe(false);
-    } finally {
-      await rm(storeRoot, { recursive: true, force: true });
-    }
-  });
+        const { run } = createMinimalRun({
+          sessionEntry,
+          sessionStore,
+          sessionKey: "main",
+          storePath,
+          runOverrides: {
+            provider: "openai",
+            model: "gpt-5.5",
+            inputProvenance: {
+              kind: "inter_session",
+              sourceSessionKey: "agent:codex:subagent:c34fca91",
+              sourceChannel: "__internal__",
+              sourceTool: "subagent_announce",
+            },
+          },
+        });
+        const phases: string[] = [];
+        const off = onAgentEvent((evt) => {
+          const phase = typeof evt.data?.phase === "string" ? evt.data.phase : null;
+          if (evt.stream === "lifecycle" && phase) {
+            phases.push(phase);
+          }
+        });
+        const res = await run();
+        off();
+
+        expect(sessionEntry.modelProvider).toBe("openai");
+        expect(sessionEntry.model).toBe("gpt-5.5");
+        expect(sessionEntry.providerOverride).toBeUndefined();
+        expect(sessionEntry.modelOverride).toBeUndefined();
+        expect(sessionEntry.modelOverrideSource).toBeUndefined();
+        expect(sessionEntry.fallbackNoticeSelectedModel).toBe(
+          expectedStoredFallbackState.selectedModel,
+        );
+        expect(sessionEntry.fallbackNoticeActiveModel).toBe(
+          expectedStoredFallbackState.activeModel,
+        );
+        expect(sessionEntry.fallbackNoticeReason).toBe(expectedStoredFallbackState.reason);
+        const persistedSession = requireStoredSessionEntry(storePath);
+        expect(persistedSession.modelProvider).toBe("openai");
+        expect(persistedSession.model).toBe("gpt-5.5");
+        expect(persistedSession.providerOverride).toBeUndefined();
+        expect(persistedSession.modelOverride).toBeUndefined();
+        expect(persistedSession.modelOverrideSource).toBeUndefined();
+        expect(persistedSession.fallbackNoticeSelectedModel).toBe(
+          expectedStoredFallbackState.selectedModel,
+        );
+        expect(persistedSession.fallbackNoticeActiveModel).toBe(
+          expectedStoredFallbackState.activeModel,
+        );
+        expect(persistedSession.fallbackNoticeReason).toBe(expectedStoredFallbackState.reason);
+        const payloads = Array.isArray(res) ? res : res ? [res] : [];
+        const fallbackPayload = payloads.find((payload) =>
+          payload.text?.includes("Model Fallback:"),
+        );
+        expect(fallbackPayload?.text).toContain("google/gemini-2.5-flash");
+        expect(fallbackPayload?.text).toContain("selected openai/gpt-5.5");
+        expect(
+          getReplyPayloadMetadata(fallbackPayload ?? {})?.deliverDespiteSourceReplySuppression,
+        ).toBe(true);
+        expect(countMatching(phases, (phase) => phase === "fallback")).toBe(1);
+        expect(payloads.some((payload) => payload.text?.includes("Usage:"))).toBe(false);
+      } finally {
+        await rm(storeRoot, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("surfaces empty internal fallback failures without persisting visible fallback state", async () => {
     const sessionEntry: SessionEntry = {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1891,7 +1891,14 @@ export async function runReplyAgent(params: {
       state: fallbackStateEntry,
       cfg,
     });
-    if (fallbackTransition.stateChanged && !fallbackExhausted && !preserveUserFacingSessionState) {
+    // Source-preserving handoffs may report this run's fallback, but they must
+    // not create or clear sticky fallback state on the user-facing session.
+    const canPersistUserFacingFallbackState = !preserveUserFacingSessionState;
+    if (
+      fallbackTransition.stateChanged &&
+      !fallbackExhausted &&
+      canPersistUserFacingFallbackState
+    ) {
       if (fallbackStateEntry) {
         fallbackStateEntry.fallbackNoticeSelectedModel = fallbackTransition.nextState.selectedModel;
         fallbackStateEntry.fallbackNoticeActiveModel = fallbackTransition.nextState.activeModel;
@@ -2016,11 +2023,10 @@ export async function runReplyAgent(params: {
     };
 
     const fallbackNoticePayloads: ReplyPayload[] = [];
-    if (
-      !fallbackExhausted &&
-      !preserveUserFacingSessionState &&
-      fallbackTransition.fallbackTransitioned
-    ) {
+    const shouldEmitFallbackNotice = preserveUserFacingSessionState
+      ? fallbackTransition.fallbackActive && fallbackAttempts.length > 0
+      : fallbackTransition.fallbackTransitioned;
+    if (!fallbackExhausted && shouldEmitFallbackNotice) {
       emitAgentEvent({
         runId,
         sessionKey,
@@ -2055,7 +2061,7 @@ export async function runReplyAgent(params: {
     }
     if (
       !fallbackExhausted &&
-      !preserveUserFacingSessionState &&
+      canPersistUserFacingFallbackState &&
       fallbackTransition.fallbackCleared
     ) {
       emitAgentEvent({


### PR DESCRIPTION
## Summary

- Decouple model fallback notice emission from user-facing fallback-state persistence for source-preserving inter-session/subagent handoffs.
- Preserve-mode runs now emit the current run's fallback notice when the run records fallback attempts, even if the user-facing session already has the same sticky fallback pair.
- Keep sticky fallback state writes and fallback-cleared notices gated to non-preserving user-facing runs.

Refs #94919.

## Root Cause

`runReplyAgent` used `fallbackTransition.fallbackTransitioned` for both persisted fallback-state changes and visible fallback notices. That transition flag is derived from the user-facing session's stored `fallbackNotice*` fields. For source-preserving provenance such as `subagent_announce`, OpenClaw intentionally does not mutate those fields, so fallback notices could be suppressed or buried when the source run fell back.

## Verification

- `node scripts/run-oxlint.mjs src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts --configLoader runner src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`
- `git diff --check`
- GitHub `Real behavior proof` workflow passed on exact PR head `39d5ee55683689b7f45083e865be3c68a9e72aa7`: https://github.com/openclaw/openclaw/actions/runs/27858006964
- One Codex autoreview pass found a preserve-mode sticky-state suppression gap; this patch includes the follow-up fix before opening the draft.

## Proof status

Issue #94919 includes real user-environment proof for the affected behavior: OpenClaw 2026.6.8 in Docker on Linux with `zai/glm-5-turbo` as primary, `minimax/MiniMax-M3` as fallback, gateway logs showing `zai` `ECONNRESET`, fallback selection, and the reporter-observed symptom that the fallback notice is written to the spawned/async agent's local output rather than the originating user-visible reply.

This PR's after-fix proof drives the same owner path in the OpenClaw reply runtime: a source-preserving `inter_session` run with `sourceTool: "subagent_announce"`, a fallback step from `openai/gpt-5.5` to `google/gemini-2.5-flash`, and both no-stored-state plus matching-stored-state cases. The test asserts that the returned payload now includes `Model Fallback:`, carries `deliverDespiteSourceReplySuppression`, leaves user-facing fallback state unchanged, emits one fallback lifecycle event, and does not add a usage line.

## Real behavior proof

Behavior addressed: Source-preserving inter-session/subagent fallback runs should return the `Model Fallback` notice for the current fallback run without mutating the user-facing session's fallback/model override state.

Real environment tested: Original affected environment from #94919: OpenClaw `2026.6.8` Docker image on Linux `6.18.33-Unraid` x64, `zai/glm-5-turbo` primary through `https://api.z.ai/api/coding/paas/v4`, fallback chain observed as `zai/glm-5-turbo -> minimax/MiniMax-M3`. Patched environment: local macOS OpenClaw source checkout at PR head `39d5ee55683689b7f45083e865be3c68a9e72aa7`, running the focused OpenClaw reply-agent E2E path for preserved subagent fallback delivery.

Exact steps or command run after this patch:

```text
node scripts/run-oxlint.mjs src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts --configLoader runner src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
git diff --check
```

Issue #94919 real-world reproduction evidence, redacted by the reporter:

```text
[model-fetch] start provider=zai api=openai-completions model=glm-5-turbo method=POST url=https://api.z.ai/api/coding/paas/v4/chat/completions timeoutMs=300000 proxy=none policy=custom
[model-fetch] error provider=zai api=openai-completions model=glm-5-turbo elapsedMs=4200 name=SocketError causeCode=ECONNRESET message=read ECONNRESET
[model-fallback] requestedProvider=zai requestedModel=glm-5-turbo decision=candidate_failed attempt=1 fallbackStepFromFailureReason=timeout fallbackStepFromFailureDetail="fetch failed"
[model-fetch] start provider=minimax api=anthropic-messages model=MiniMax-M3 ...
[model-fallback] decision=candidate_succeeded ... fallbackStepToModel=minimax/MiniMax-M3 ...

The fallback notice that the agent-runner would emit:

Model Fallback: minimax/MiniMax-M3 (selected zai/glm-5-turbo; timeout)

In an async context (cron job, sub-agent, isolated run) it is written into the spawned agent's own context and the user who triggered the run does not see it.
```

Evidence after fix: The focused E2E regression at PR head drives `runReplyAgent` with preserved `subagent_announce` provenance and a simulated model fallback attempt. The test now verifies both relevant preserved-run states:

```text
surfaces fallback notice for internal subagent announce without mutating fallback state without stored fallback state
surfaces fallback notice for internal subagent announce without mutating fallback state with matching stored fallback state
```

For each case, the patched runtime returns a payload containing `Model Fallback:`, includes the active fallback model `google/gemini-2.5-flash`, includes the selected primary `openai/gpt-5.5`, marks the payload with `deliverDespiteSourceReplySuppression: true`, preserves the stored `fallbackNotice*` fields, preserves `modelProvider`, `model`, `providerOverride`, `modelOverride`, and `modelOverrideSource`, emits exactly one fallback lifecycle event, and does not add a `Usage:` line.

Current command output from the patched head:

```text
$ node scripts/run-oxlint.mjs src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
# no output; exit 0

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts --configLoader runner src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
Test Files  1 passed (1)
Tests  61 passed (61)

$ git diff --check
# no output; exit 0
```

Observed result after fix: The preserved subagent fallback path now returns the fallback notice payload to the originating reply payload list while keeping preserve-mode sticky fallback state unchanged. GitHub `Real behavior proof` passed on current head `39d5ee55683689b7f45083e865be3c68a9e72aa7`.

What was not tested: The reporter's live Z.AI account/endpoint was not rerun after this patch, and the separate per-provider transport connection/serialization knob requested in #94919 is not implemented here. Native Telegram/Desktop visual capture was not used; the proof for this PR is the original real issue log evidence plus the focused preserved-subagent reply-runtime regression on the patched head.
