### PR TITLE
fix(telegram): deliver durable reasoning replies

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -549,6 +549,15 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
   }
 
+  function createReasoningOnContext(): TelegramMessageContext {
+    loadSessionStore.mockReturnValue({
+      s1: { reasoningLevel: "on" },
+    });
+    return createContext({
+      ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+    });
+  }
+
   function createReasoningDefaultContext(): TelegramMessageContext {
     loadSessionStore.mockReturnValue({
       s1: {},
@@ -3369,6 +3378,48 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(reasoningDraftStream.update).toHaveBeenCalledWith("Thinking\n\n_Thinking_");
     expect(answerDraftStream.update).toHaveBeenCalledWith("Answer");
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("persists durable reasoning payloads on the reasoning lane", async () => {
+    deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+      status: "handled_visible",
+      delivery: {
+        messageIds: ["1002"],
+        visibleReplySent: true,
+      },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        { text: "checking source", isReasoning: true },
+        { kind: "final" },
+      );
+      await dispatcherOptions.deliver({ text: "Answer" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context: createReasoningOnContext() });
+
+    expect(deliverInboundReplyWithMessageSendContext).toHaveBeenCalledTimes(2);
+    const reasoningOutbound = expectRecordFields(
+      mockCallArg(deliverInboundReplyWithMessageSendContext),
+      {
+        channel: "telegram",
+        info: { kind: "final" },
+      },
+    );
+    expectRecordFields(reasoningOutbound.payload, {
+      text: "Thinking\n\n_checking source_",
+    });
+    expect(reasoningOutbound.payload).not.toHaveProperty("isReasoning");
+    const answerOutbound = expectRecordFields(
+      mockCallArg(deliverInboundReplyWithMessageSendContext, 1),
+      {
+        channel: "telegram",
+        info: { kind: "final" },
+      },
+    );
+    expectRecordFields(answerOutbound.payload, { text: "Answer" });
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1637,6 +1637,19 @@ export const dispatchTelegramMessage = async ({
         }),
       )[0];
     };
+    const prepareReasoningLanePayload = (
+      payload: ReplyPayload,
+    ): { payload: ReplyPayload; text: string } | undefined => {
+      if (payload.isReasoning !== true || typeof payload.text !== "string") {
+        return undefined;
+      }
+      const reasoningText = splitTelegramReasoningText(payload.text, true).reasoningText;
+      if (!reasoningText?.trim()) {
+        return undefined;
+      }
+      const { isReasoning: _isReasoning, ...deliverablePayload } = payload;
+      return { payload: deliverablePayload, text: reasoningText };
+    };
     const usesNativeTelegramQuote = (payload: ReplyPayload): boolean => {
       if (replyQuoteText != null) {
         return true;
@@ -1975,6 +1988,27 @@ export const dispatchTelegramMessage = async ({
                   },
                   deliver: async (payload, info) => {
                     if (isDispatchSuperseded()) {
+                      return;
+                    }
+
+                    const reasoningPayload = prepareReasoningLanePayload(payload);
+                    if (reasoningPayload) {
+                      reasoningStepState.noteReasoningHint();
+                      const result = await deliverLaneText({
+                        laneName: "reasoning",
+                        text: reasoningPayload.text,
+                        payload: reasoningPayload.payload,
+                        infoKind: info.kind,
+                      });
+                      if (result.kind !== "skipped") {
+                        reasoningStepState.noteReasoningDelivered();
+                      }
+                      if (info.kind === "final") {
+                        reasoningStepState.resetForNextStep();
+                      }
+                      return;
+                    }
+                    if (payload.isReasoning === true) {
                       return;
                     }
 

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -7380,6 +7380,38 @@ describe("dispatchReplyFromConfig", () => {
     expect(blockReplySentTexts).toContain("The answer is 42");
   });
 
+  it("keeps Telegram isReasoning block replies out of final TTS fallback", async () => {
+    setNoAbort();
+    ttsMocks.state.synthesizeFinalAudio = true;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const blockReplySentTexts: string[] = [];
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "thinking...", isReasoning: true });
+      await opts?.onBlockReply?.({ text: "The answer is 42" });
+      return undefined;
+    };
+    (dispatcher.sendBlockReply as ReturnType<typeof vi.fn>).mockImplementation(
+      (payload: ReplyPayload) => {
+        if (payload.text) {
+          blockReplySentTexts.push(payload.text);
+        }
+        return true;
+      },
+    );
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(blockReplySentTexts).toEqual(["thinking...", "The answer is 42"]);
+    const ttsCall = ttsMocks.maybeApplyTtsToPayload.mock.calls
+      .map(([call]) => call as { kind?: unknown; payload?: ReplyPayload })
+      .find((call) => call.kind === "final");
+    expect(ttsCall?.payload).toEqual({ text: "The answer is 42" });
+  });
+
   it("strips split TTS directives from streamed block text before delivery", async () => {
     setNoAbort();
     ttsMocks.state.synthesizeFinalAudio = true;

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -7307,6 +7307,25 @@ describe("dispatchReplyFromConfig", () => {
     expect((finalCalls[0]?.[0] as ReplyPayload | undefined)?.text).toBe("The answer is 42");
   });
 
+  it("delivers isReasoning final replies to Telegram", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const replyResolver = async () =>
+      [
+        { text: "thinking...", isReasoning: true },
+        { text: "The answer is 42" },
+      ] satisfies ReplyPayload[];
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+    const finalCalls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
+    expect(finalCalls).toHaveLength(2);
+    expect(finalCalls.map((call) => (call[0] as ReplyPayload).text)).toEqual([
+      "thinking...",
+      "The answer is 42",
+    ]);
+    expect((finalCalls[0]?.[0] as ReplyPayload | undefined)?.isReasoning).toBe(true);
+  });
+
   it("suppresses isReasoning payloads from block replies (generic dispatch path)", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();
@@ -7332,6 +7351,32 @@ describe("dispatchReplyFromConfig", () => {
     );
     await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
     expect(blockReplySentTexts).not.toContain("thinking...");
+    expect(blockReplySentTexts).toContain("The answer is 42");
+  });
+
+  it("delivers isReasoning block replies to Telegram", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const blockReplySentTexts: string[] = [];
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload> => {
+      await opts?.onBlockReply?.({ text: "thinking...", isReasoning: true });
+      await opts?.onBlockReply?.({ text: "The answer is 42" });
+      return { text: "The answer is 42" };
+    };
+    (dispatcher.sendBlockReply as ReturnType<typeof vi.fn>).mockImplementation(
+      (payload: ReplyPayload) => {
+        if (payload.text) {
+          blockReplySentTexts.push(payload.text);
+        }
+        return true;
+      },
+    );
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+    expect(blockReplySentTexts).toContain("thinking...");
     expect(blockReplySentTexts).toContain("The answer is 42");
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2867,6 +2867,9 @@ export async function dispatchReplyFromConfig(
       params.configOverride ? (applyMergePatch(cfg, params.configOverride) as OpenClawConfig) : cfg,
     );
     recordAgentDispatchStarted();
+    const shouldSuppressReasoningPayloadForDelivery = (payload: ReplyPayload) =>
+      payload.isReasoning === true && deliveryChannel !== "telegram";
+
     const replyResult = await runWithDispatchAbortSignal(getDispatchAbortSignal(), () =>
       traceReplyPhase("reply.run_reply_resolver", () =>
         replyResolver(
@@ -3101,10 +3104,9 @@ export async function dispatchReplyFromConfig(
                 if (suppressDelivery) {
                   return;
                 }
-                // Suppress reasoning payloads — channels using this generic dispatch
-                // path (WhatsApp, web, etc.) do not have a dedicated reasoning lane.
-                // Telegram has its own dispatch path that handles reasoning splitting.
-                if (payload.isReasoning === true) {
+                // Telegram owns a durable reasoning lane and strips the marker
+                // before outbound normalization; generic channels keep suppression.
+                if (shouldSuppressReasoningPayloadForDelivery(payload)) {
                   return;
                 }
                 // Accumulate block text for TTS generation after streaming.
@@ -3274,9 +3276,9 @@ export async function dispatchReplyFromConfig(
       (ctx.InboundEventKind !== "room_event" || explicitCommandTurnCtx);
     for (const [replyIndex, reply] of replies.entries()) {
       throwIfDispatchOperationAborted();
-      // Suppress reasoning payloads from channel delivery — channels using this
-      // generic dispatch path do not have a dedicated reasoning lane.
-      if (reply.isReasoning === true) {
+      // Telegram owns a durable reasoning lane and strips the marker before
+      // outbound normalization; generic channels keep suppression.
+      if (shouldSuppressReasoningPayloadForDelivery(reply)) {
         continue;
       }
       if (suppressDelivery && !shouldDeliverDespiteSourceReplySuppression(reply)) {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -3113,7 +3113,7 @@ export async function dispatchReplyFromConfig(
                 // Exclude status notices — they are informational UI signals
                 // and must not be synthesised into the spoken reply.
                 const isStatusNotice = isReplyPayloadStatusNotice(payload);
-                if (payload.text && !isStatusNotice) {
+                if (payload.text && !isStatusNotice && payload.isReasoning !== true) {
                   const joinsBufferedTtsDirective =
                     cleanBlockTtsDirectiveText?.hasBufferedDirectiveText() === true;
                   if (accumulatedBlockText.length > 0) {


### PR DESCRIPTION
Summary:
- allow Telegram durable `isReasoning` payloads through the shared reply dispatcher while keeping generic-channel suppression intact
- convert Telegram durable reasoning payloads into reasoning-lane text before outbound normalization, then strip the `isReasoning` marker before durable send
- add shared-dispatch and Telegram regression coverage for `/reasoning on`

Fixes #94937

Verification:
- `git diff --check origin/main...HEAD`
- `pnpm dlx oxfmt@0.52.0 --check --threads=1 src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- Blacksmith Testbox `tbx_01kvges5ey90zzz1tcazgqxwtx`, run https://github.com/openclaw/openclaw/actions/runs/27839833383: `OPENCLAW_TESTBOX=1 corepack pnpm test:serial src/auto-reply/reply/dispatch-from-config.test.ts extensions/telegram/src/bot-message-dispatch.test.ts src/infra/outbound/payloads.test.ts` passed 3 shards: outbound payloads 36 tests, auto-reply dispatch 212 tests, Telegram dispatch 130 tests.
- Exact-head Testbox retry `tbx_01kvgey69931q64p96ddcnt5z5`, run https://github.com/openclaw/openclaw/actions/runs/27839945637, did not reach tests: Blacksmith SSH/rsync sync failed with `Network is unreachable` before command execution.
