### PR TITLE
feat(cli): add --file input option to image generate command (fixes #91734)

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -1891,6 +1891,7 @@ describe("capability cli", () => {
 
     expect(firstJsonOutput()?.id).toBe("image.generate");
     expect(firstJsonOutput()?.flags).toEqual([
+      "--file",
       "--prompt",
       "--model",
       "--count",

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -199,6 +199,7 @@ const CAPABILITY_METADATA: CapabilityMetadata[] = [
     description: "Generate raster images with configured image providers.",
     transports: ["local"],
     flags: [
+      "--file",
       "--prompt",
       "--model",
       "--count",
@@ -2268,6 +2269,7 @@ export function registerCapabilityCli(program: Command) {
   image
     .command("generate")
     .description("Generate images")
+    .option("--file <path>", "Input file", collectOption, [])
     .requiredOption("--prompt <text>", "Prompt text")
     .option("--model <provider/model>", "Model override")
     .option("--count <n>", "Number of images")
@@ -2292,6 +2294,7 @@ export function registerCapabilityCli(program: Command) {
           size: opts.size as string | undefined,
           aspectRatio: opts.aspectRatio as string | undefined,
           resolution: opts.resolution as "1K" | "2K" | "4K" | undefined,
+          file: opts.file as string[] | undefined,
           outputFormat: normalizeImageOutputFormat(opts.outputFormat as string | undefined),
           background: normalizeImageBackground(opts.background as string | undefined),
           openaiBackground: normalizeImageBackground(


### PR DESCRIPTION
## What does this PR do?

Adds `--file` input option to the `image generate` CLI command, mirroring the existing `image edit` support. This allows CLI workflows to provide reference images (logos, style guides, product shots) to providers that support image-conditioned generation.

## Related Issue

Fixes #91734

## Type of Change

- [x] New feature (non-breaking)

## Changes Made

- `src/cli/capability-cli.ts`: Add `"--file"` to `image.generate` capability flags array; add `.option("--file <path>", ...)` to the generate command; pass `file` through to `runImageGenerate`.
- `src/cli/capability-cli.test.ts`: Update capability inspect test to expect `"--file"` in the `image.generate` flags list.

## How to Test

1. `openclaw infer image generate --prompt "Branded cover" --file ./logo.png --output ./cover.png`
2. Verify the file is read and passed to the provider as an input image.
3. Run `openclaw infer image generate --prompt "test" --json` without `--file` to confirm no regression.

## Real behavior proof

- **Behavior addressed:** The `image generate` CLI command did not accept `--file` for input/reference images, unlike `image edit` which already supports it. The internal `runImageGenerate` handler already accepts the `file` parameter — only the CLI wiring was missing.
- **Environment tested:** macOS, Node.js, openclaw local build from `d41a3d28`.
- **Steps run after the patch:**
```
grep -n '"--file"' src/cli/capability-cli.ts
grep -n '.option("--file <path>", "Input file"' src/cli/capability-cli.ts
```
- **Evidence after fix:**
```
202:      "--file",
2272:    .option("--file <path>", "Input file", collectOption, [])

node -e verification: generate command has --file option: true, generate capability has --file flag: true
```
- **Observed result after fix:** The `image.generate` capability now lists `--file` in its flags, and the CLI command accepts `--file <path>` with `collectOption` for multiple files. The `runImageGenerate` handler receives the file array and passes it as `inputImages` to the provider. Build passes (`pnpm build`), all 97 capability-cli tests pass.
- **What was not tested:** Live image generation with an actual provider (requires API credentials). Provider-side handling of input images for generation vs edit is unchanged.
