### PR TITLE
[AI-assisted] fix(cli): support --port in gateway health and probe

### DIFF
--- a/src/cli/gateway-cli/call.ts
+++ b/src/cli/gateway-cli/call.ts
@@ -14,6 +14,7 @@ export type GatewayRpcOpts = {
   url?: string;
   token?: string;
   password?: string;
+  port?: string;
   timeout?: string;
   expectFinal?: boolean;
   json?: boolean;
@@ -24,6 +25,7 @@ const DEFAULT_GATEWAY_RPC_TIMEOUT_MS = 10_000;
 export const gatewayCallOpts = (cmd: Command) =>
   cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
+    .option("--port <port>", "Gateway port")
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (password auth)")
     .option("--timeout <ms>", "Timeout in ms", "10000")
@@ -46,6 +48,7 @@ export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, param
         url: opts.url,
         token: opts.token,
         password: opts.password,
+        port: opts.port,
         method,
         params,
         expectFinal: Boolean(opts.expectFinal),

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -91,6 +91,7 @@ function loadDaemonStatusGatherModule() {
 function gatewayCallOpts(cmd: Command): Command {
   return cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
+    .option("--port <port>", "Gateway port")
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (password auth)")
     .option("--timeout <ms>", "Timeout in ms", "10000")
@@ -703,6 +704,7 @@ export function registerGatewayCli(program: Command) {
     .option("--log-lines <count>", "Maximum sanitized log lines to include", "5000")
     .option("--log-bytes <bytes>", "Maximum log bytes to inspect", "1000000")
     .option("--url <url>", "Gateway WebSocket URL for health snapshot")
+    .option("--port <port>", "Gateway port for health snapshot")
     .option("--token <token>", "Gateway token for health snapshot")
     .option("--password <password>", "Gateway password for health snapshot")
     .option("--timeout <ms>", "Status/health snapshot timeout in ms", "3000")
@@ -728,6 +730,7 @@ export function registerGatewayCli(program: Command) {
       "Show gateway reachability, auth capability, and read-probe summary (local + remote)",
     )
     .option("--url <url>", "Explicit Gateway WebSocket URL (still probes localhost)")
+    .option("--port <port>", "Gateway port (applies to all probes)")
     .option("--ssh <target>", "SSH target for remote gateway tunnel (user@host or user@host:port)")
     .option("--ssh-identity <path>", "SSH identity file path")
     .option("--ssh-auto", "Try to derive an SSH target from Bonjour discovery", false)

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -47,6 +47,7 @@ export async function gatewayStatusCommand(
     ssh?: string;
     sshIdentity?: string;
     sshAuto?: boolean;
+    port?: string;
   },
   runtime: RuntimeEnv,
 ) {
@@ -58,9 +59,11 @@ export async function gatewayStatusCommand(
   const wideAreaDomain = resolveWideAreaDiscoveryDomain({
     configDomain: cfg.discovery?.wideArea?.domain,
   });
-  const baseTargets = resolveTargets(cfg, opts.url);
-  const network = buildNetworkHints(cfg);
-  const remotePort = resolveGatewayPort(cfg);
+  const explicitPort =
+    typeof opts.port === "string" || typeof opts.port === "number" ? String(opts.port) : undefined;
+  const baseTargets = resolveTargets(cfg, opts.url, explicitPort);
+  const network = buildNetworkHints(cfg, explicitPort);
+  const remotePort = explicitPort !== undefined ? Number(explicitPort) : resolveGatewayPort(cfg);
   const discoveryTimeoutMs = Math.min(1200, overallTimeoutMs);
 
   let sshTarget = sanitizeSshTarget(opts.ssh) ?? sanitizeSshTarget(cfg.gateway?.remote?.sshTarget);

--- a/src/commands/gateway-status/helpers.test.ts
+++ b/src/commands/gateway-status/helpers.test.ts
@@ -316,6 +316,21 @@ describe("gateway-status local target scheme", () => {
     const hints = buildNetworkHints(cfg as never);
     expect(hints.localLoopbackUrl).toBe("wss://127.0.0.1:18789");
   });
+
+  it("respects explicitPort when provided to resolveTargets and buildNetworkHints", () => {
+    const cfg = {
+      gateway: {
+        mode: "local",
+      },
+    };
+
+    const targets = resolveTargets(cfg as never, undefined, "19999");
+    const localLoopbackTarget = targets.find((target) => target.id === "localLoopback");
+    expect(localLoopbackTarget?.url).toBe("ws://127.0.0.1:19999");
+
+    const hints = buildNetworkHints(cfg as never, "19999");
+    expect(hints.localLoopbackUrl).toBe("ws://127.0.0.1:19999");
+  });
 });
 
 describe("resolveProbeBudgetMs", () => {

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -87,7 +87,11 @@ function normalizeWsUrl(value: string): string | null {
 }
 
 /** Builds the deduplicated ordered gateway probe targets from CLI input and config. */
-export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): GatewayStatusTarget[] {
+export function resolveTargets(
+  cfg: OpenClawConfig,
+  explicitUrl?: string,
+  explicitPort?: string,
+): GatewayStatusTarget[] {
   const targets: GatewayStatusTarget[] = [];
   const add = (t: GatewayStatusTarget) => {
     if (!targets.some((x) => x.url === t.url)) {
@@ -111,7 +115,7 @@ export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): Gatew
     });
   }
 
-  const port = resolveGatewayPort(cfg);
+  const port = explicitPort !== undefined ? Number(explicitPort) : resolveGatewayPort(cfg);
   const localScheme = cfg.gateway?.tls?.enabled === true ? "wss" : "ws";
   add({
     id: "localLoopback",
@@ -253,9 +257,9 @@ export function extractConfigSummary(snapshotUnknown: unknown): GatewayConfigSum
 }
 
 /** Builds local and tailnet gateway URL hints for the configured gateway port. */
-export function buildNetworkHints(cfg: OpenClawConfig) {
+export function buildNetworkHints(cfg: OpenClawConfig, explicitPort?: string) {
   const { tailnetIPv4 } = inspectBestEffortPrimaryTailnetIPv4();
-  const port = resolveGatewayPort(cfg);
+  const port = explicitPort !== undefined ? Number(explicitPort) : resolveGatewayPort(cfg);
   const localScheme = cfg.gateway?.tls?.enabled === true ? "wss" : "ws";
   return {
     localLoopbackUrl: `${localScheme}://127.0.0.1:${port}`,

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -70,6 +70,7 @@ type CallGatewayBaseOptions = {
   url?: string;
   token?: string;
   password?: string;
+  port?: string;
   tlsFingerprint?: string;
   config?: OpenClawConfig;
   method: string;
@@ -421,6 +422,7 @@ export function buildGatewayConnectionDetails(
     url?: string;
     configPath?: string;
     urlSource?: "cli" | "env";
+    port?: string;
   } = {},
 ): GatewayConnectionDetails {
   return buildGatewayConnectionDetailsWithResolvers(options, {
@@ -1127,6 +1129,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     config: context.config,
     url: context.urlOverride,
     urlSource: context.urlOverrideSource,
+    port: opts.port,
     ...(opts.configPath ? { configPath: opts.configPath } : {}),
   });
   const url = connectionDetails.url;

--- a/src/gateway/connection-details.ts
+++ b/src/gateway/connection-details.ts
@@ -28,6 +28,7 @@ export function buildGatewayConnectionDetailsWithResolvers(
     configPath?: string;
     urlSource?: "cli" | "env";
     ignoreEnvUrlOverride?: boolean;
+    port?: string;
   } = {},
   resolvers: GatewayConnectionDetailResolvers = {},
 ): GatewayConnectionDetails {
@@ -40,7 +41,9 @@ export function buildGatewayConnectionDetailsWithResolvers(
   const remote = isRemoteMode ? config.gateway?.remote : undefined;
   const tlsEnabled = config.gateway?.tls?.enabled === true;
   const localPort =
-    resolvers.resolveGatewayPort?.(config, process.env) ?? resolveGatewayPort(config);
+    options.port !== undefined
+      ? Number(options.port)
+      : (resolvers.resolveGatewayPort?.(config, process.env) ?? resolveGatewayPort(config));
   const bindMode = config.gateway?.bind ?? "loopback";
   const scheme = tlsEnabled ? "wss" : "ws";
   const localUrl = `${scheme}://127.0.0.1:${localPort}`;


### PR DESCRIPTION
Fixes #79100. This PR adds the \--port\ option to \gateway health\ and \gateway probe\ commands to allow targeting a custom gateway port. Proof of execution: running the health command with \--port 18789\ parses correctly instead of throwing an 'unknown option' error.