### PR TITLE
fix(telegram): honor ingest config before skipping unaddressed group media

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -886,6 +886,13 @@ export const registerTelegramHandlers = ({
         commandAuthorized: commandGate.authorized,
       },
     });
+    // Honor explicit ingest opt-in: ingest-enabled groups/topics should not
+    // skip media download even when the bot was not mentioned.
+    const ingestEnabled = topicConfig?.ingest ?? groupConfig?.ingest;
+    if (ingestEnabled === true) {
+      return false;
+    }
+
     if (mentionDecision.shouldSkip) {
       logger.info({ chatId, reason: "no-mention" }, "skipping group media before download");
       return true;


### PR DESCRIPTION
## Summary

When a Telegram group/topic has `ingest: true` configured, media messages (photos, videos, documents) that don't @mention the bot should still be processed by the ingest hook. Currently, `shouldSkipMediaDownloadForUnaddressedMentionGroup` returns `true` (skip media download) **before** the ingest config is consulted — so media-bearing messages are silently dropped for ingest-enabled groups, while text messages flow through correctly.

This is the media-path counterpart to the text-message ingest behavior already working in `bot-message-context.body.ts:438-442`.

## Fix

Insert an ingest opt-in check before the `mentionDecision.shouldSkip` guard in `shouldSkipMediaDownloadForUnaddressedMentionGroup`. If `topicConfig?.ingest ?? groupConfig?.ingest` is `true`, return `false` (don't skip) — matching the existing resolution order used for text messages.

**1 file changed, 7 insertions(+)**

## How to Test

1. Configure a Telegram supergroup with `requireMention: true` and `ingest: true`
2. Register a `message:received` plugin hook
3. Send a photo without text and without @mentioning the bot
4. Before this patch: hook never fires, log shows "skipping group media before download"
5. After this patch: hook fires with the media message

## Real behavior proof

- **Behavior addressed:** `shouldSkipMediaDownloadForUnaddressedMentionGroup` now checks `topicConfig?.ingest ?? groupConfig?.ingest` before returning true for unaddressed group media, so ingest-enabled groups receive media messages through the ingest hook path.
- **Environment tested:** macOS, Node v25.8.2, pnpm build of openclaw/openclaw at 330545f3
- **Steps run after the patch:** `pnpm build` completed in 84s. Ran the verification suite for the telegram extension module — 4 tests in `bot-handlers.runtime.test.ts` and 82 tests in `bot.test.ts` all pass. Verified the bundled dist output contains the ingest guard.
- **Evidence after fix:**
```
$ grep -n "ingest" extensions/telegram/src/bot-handlers.runtime.ts
889:    // Honor explicit ingest opt-in: ingest-enabled groups/topics should not
891:    const ingestEnabled = topicConfig?.ingest ?? groupConfig?.ingest;
892:    if (ingestEnabled === true) {

$ node -e "const fs=require('fs'); const c=fs.readFileSync('dist/bot-DSeNTaDb.js','utf8'); const idx=c.indexOf('shouldSkipMediaDownload'); const s=c.substring(idx,idx+300); console.log(s.includes('ingest') ? 'PASS: ingest guard present in dist' : 'FAIL');"
PASS: ingest guard present in dist
```
- **Observed result after fix:** The ingest guard compiles cleanly, passes all existing telegram tests (4 + 82), and is present in the bundled dist output. The fix follows the identical `topicConfig?.ingest ?? groupConfig?.ingest` resolution pattern already used in `bot-message-context.body.ts:438-441` for text messages.
- **What was not tested:** Live Telegram supergroup media delivery (requires a running Telegram bot with forum topics and a plugin hook). The fix is a bounded guard addition that mirrors an existing proven pattern — the text-message ingest path has been in production since the feature shipped.
