### PR TITLE
fix(doctor): suppress false-positive local embedding warning when probe was skipped (fixes #92582)

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -259,6 +259,24 @@ describe("noteMemorySearchHealth", () => {
     expect(message).toContain("gateway timeout after 8000ms");
   });
 
+  it("does not warn when local provider probe was skipped (skipped: true)", async () => {
+    // When `openclaw doctor` runs without --deep, the probe is skipped and returns
+    // { checked: false, ready: false, skipped: true }. This must NOT produce a
+    // false-positive warning for the local provider — it means readiness was
+    // never checked, not that local embeddings are unavailable.
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: { checked: false, ready: false, skipped: true },
+    });
+
+    expect(note).not.toHaveBeenCalled();
+  });
+
   it("warns when local provider has an explicit hf: modelPath but readiness was not confirmed", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "local",

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -472,6 +472,16 @@ export async function noteMemorySearchHealth(
     if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
       return;
     }
+    // When the probe was intentionally skipped (skipped: true / checked: false
+    // due to probe:false path), we have no embedding status information — do
+    // not warn. A skipped probe means the user ran `openclaw doctor` without
+    // --deep; it does not mean local embeddings are unavailable.
+    // NOTE: a transport timeout also sets checked: false, but skipped stays
+    // false/absent — a timeout is a real diagnostic signal and should fall
+    // through to the warning below.
+    if (opts?.gatewayMemoryProbe?.skipped) {
+      return;
+    }
     const hasExplicitLocalModel = hasLocalEmbeddings(resolved.local);
     const detail = opts?.gatewayMemoryProbe?.error?.trim();
     note(


### PR DESCRIPTION
## What

Suppress false-positive "local embeddings are not confirmed ready" warning when `openclaw doctor` runs without `--deep` and the gateway memory embedding probe was intentionally skipped.

The `local` provider code path in `noteMemorySearchHealth` has a dedicated early-return block (line 470) that checks `checked && ready` but was missing the `skipped` guard already present for other key-optional providers (lmstudio, ollama, openai-compatible) in the shared `isKeyOptionalMemoryProvider` block (line 546).

## Why

When `openclaw doctor` runs without `--deep`, `probeGatewayMemoryStatus` passes `probe: false` to the gateway. The gateway returns `checked: false, skipped: true`. The `local` provider path treated this as a failure and emitted a warning suggesting the user install plugins or switch providers — even though nothing was actually broken.

The shared key-optional provider path already handles this correctly by checking `opts?.gatewayMemoryProbe?.skipped` and returning silently. The `local` provider's early-return block was simply missed when this guard was added.

Fixes #92582

## How

Added a `skipped` guard between the `checked && ready` check and the warning emission in the `local` provider block, matching the existing pattern at line 546.

## Real behavior proof

- **Behavior addressed:** `openclaw doctor` falsely warns "local embeddings are not confirmed ready" when the memory embedding probe was skipped (non-deep mode)
- **Environment tested:** macOS, OpenClaw upstream/main at cbff4fa5, Node.js
- **Steps run after the patch:** Applied the fix to `src/commands/doctor-memory-search.ts`, added regression test to `doctor-memory-search.test.ts`, ran the verification suite for the changed file
- **Evidence after fix:**

```
$ node -e "const fs=require('fs'); const src=fs.readFileSync('src/commands/doctor-memory-search.ts','utf8'); const hasSkippedGuard=src.includes('opts?.gatewayMemoryProbe?.skipped') && src.includes('provider === \"local\"'); console.log('local provider skipped guard present:', hasSkippedGuard);"
local provider skipped guard present: true

$ grep -n 'skipped' src/commands/doctor-memory-search.ts | head -5
482:    if (opts?.gatewayMemoryProbe?.skipped) {
546:    if (opts?.gatewayMemoryProbe?.skipped) {

$ node scripts/run-vitest.mjs run src/commands/doctor-memory-search.test.ts
 ✓  commands  src/commands/doctor-memory-search.test.ts (50 tests) 121ms
 Test Files  1 passed (1)
      Tests  50 passed (50)
```

- **Observed result after fix:** The `local` provider now correctly returns silently when the probe was skipped (`skipped: true`), matching the behavior of lmstudio/ollama/openai-compatible providers. The new regression test confirms the fix.
- **What was not tested:** Live `openclaw doctor` run against a real gateway (requires full daemon setup); behavior when `--deep` is used (separate enhancement to actually run the probe)
