### PR TITLE
fix: allow detached respawn on Windows for /restart

### DIFF
--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -61,6 +61,7 @@ function spawnDetachedGatewayProcess(opts: GatewayRespawnOptions = {}): {
  * Attempt to restart this process with a fresh PID.
  * - supervised environments (launchd/systemd/schtasks): caller should exit and let supervisor restart
  * - OPENCLAW_NO_RESPAWN=1: caller should keep in-process restart behavior (tests/dev)
+ * - Windows (no supervisor): attempts detached respawn so /restart actually restarts
  * - unmanaged environments: caller should keep in-process restart behavior so
  *   custom supervisors keep tracking the same gateway PID
  */
@@ -87,12 +88,19 @@ export function restartGatewayProcessWithFreshPid(
     return { mode: "supervised" };
   }
   if (process.platform === "win32") {
-    // Detached respawn is unsafe on Windows without an identified Scheduled Task:
-    // the child becomes orphaned if the original process exits.
-    return {
-      mode: "disabled",
-      detail: "win32: detached respawn unsupported without Scheduled Task markers",
-    };
+    // Try detached respawn on Windows. Without a Scheduled Task supervisor the
+    // child is technically orphaned, but a clean exit followed by spawn is the
+    // only way to actually restart the process. The update path already allows
+    // this — apply the same behaviour to normal restarts so /restart works.
+    try {
+      const { child, pid } = spawnDetachedGatewayProcess(_opts);
+      return { mode: "spawned", pid, detail: "win32: detached respawn" };
+    } catch (err) {
+      return {
+        mode: "failed",
+        detail: `win32: detached respawn failed: ${formatErrorMessage(err)}`,
+      };
+    }
   }
   if (isContainerEnvironment()) {
     return {


### PR DESCRIPTION
## Summary

On Windows (without Scheduled Task supervisor), `/restart` completes successfully but the gateway process is **never actually restarted** — the PID and uptime remain unchanged.

## Root Cause

`restartGatewayProcessWithFreshPid()` in `src/infra/process-respawn.ts` returns `mode: "disabled"` on Windows when no `OPENCLAW_WINDOWS_TASK_NAME` env var is detected, forcing the run-loop into **in-process restart** (HTTP server close+reopen), which doesn't actually restart the process.

The update path (`respawnGatewayProcessForUpdate()`) already attempts detached spawn on Windows — the normal restart path should do the same.

## Fix

Replace the `mode: "disabled"` return with a detached spawn attempt. On failure, return `mode: "failed"` so the run-loop can fallback to supervisor or in-process restart.

## Test

1. Run OpenClaw gateway on Windows (no Scheduled Task)
2. Send `/restart` from Telegram/Discord
3. Verify PID changes and uptime resets via `/status`

Closes #95072
