### PR TITLE
[codex] docs: clarify PR body evidence updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,7 @@ For coordinated change sets that genuinely need more than 20 PRs, join the **#cl
 
 - Test locally with your OpenClaw instance
 - External PRs must describe the user, product, or operational problem in **What Problem This Solves** and include useful validation in **Evidence**. Focused tests, CI results, screenshots, recordings, terminal output, live observations, redacted logs, and artifact links all count. Reviewers will inspect the code, tests, and CI; use the PR body to explain intent and make validation easy to understand.
+- When ClawSweeper, Codex, Barnacle, or a maintainer asks for more context or evidence, edit the PR description instead of only replying in a new comment. Keep **What Problem This Solves**, **Why This Change Was Made**, **User Impact**, and **Evidence** current; a short comment can point reviewers to the update, but the PR body should remain the durable explanation for maintainers and bots.
 - Keep PRs takeover-ready: open them from a branch maintainers can push to. For fork PRs, leave GitHub's **Allow edits by maintainers** option enabled so maintainers can finish urgent fixes, changelog entries, or merge prep when needed. If GitHub shows **Allow edits and access to secrets by maintainers**, enable it only when that workflow/secrets access is acceptable and say so in the PR.
 - Do not edit `CHANGELOG.md` in contributor PRs. Maintainers or ClawSweeper add the changelog entry when landing user-facing changes.
 - Run tests: `pnpm build && pnpm check && pnpm test`


### PR DESCRIPTION
Related: #94676

## What Problem This Solves

After #94676 simplified PR context around **What Problem This Solves** and **Evidence**, the contributor guidance no longer explicitly tells authors or agents what to do when follow-up context or evidence is requested after review starts.

That creates a practical failure mode: a contributor or coding agent can add useful evidence in a new comment, while the PR body stays stale and maintainers or bots have to reconstruct the current state from comment history.

## Why This Change Was Made

Adds one `CONTRIBUTING.md` bullet under **Before You PR** that tells contributors to edit the PR description when ClawSweeper, Codex, Barnacle, or a maintainer asks for more context or evidence.

The wording follows the current PR template sections: **What Problem This Solves**, **Why This Change Was Made**, **User Impact**, and **Evidence**. It intentionally avoids the retired real-behavior-proof wording from the pre-#94676 template.

## User Impact

Contributors and AI-assisted PR authors get clearer follow-up guidance in the contributor docs. Maintainers get a more durable PR body with current context and evidence, while comments can still be used to point reviewers to the update.

There is no runtime, config, security, auth, network, migration, or tool-execution behavior change.

## Evidence

- Rebased onto current `origin/main` at `6f5fdb1e6bea447c4bda499eea68a0cee2d07115`.
- Confirmed the branch diff is still one Markdown line:

```text
CONTRIBUTING.md | 1 +
1 file changed, 1 insertion(+)
```

- Confirmed the added line uses the new context/evidence terminology:

```text
PS C:\oc-work\openclaw-pr-body-proof-guidance> Select-String -Path CONTRIBUTING.md -Pattern "When ClawSweeper"

CONTRIBUTING.md:110:- When ClawSweeper, Codex, Barnacle, or a maintainer asks for more context or evidence, edit the
PR description instead of only replying in a new comment. Keep **What Problem This Solves**, **Why This Change Was
Made**, **User Impact**, and **Evidence** current; a short comment can point reviewers to the update, but the PR body
should remain the durable explanation for maintainers and bots.
```

- Whitespace validation passed:

```text
PS C:\oc-work\openclaw-pr-body-proof-guidance> git diff --check origin/main...HEAD
PS C:\oc-work\openclaw-pr-body-proof-guidance>
```

No app runtime tests were run because this is a documentation-only change.