### PR TITLE
fix(tui): handle /status and /compact in local mode instead of falling through to model (fixes #71592)

### DIFF
--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -709,6 +709,16 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       case "quit":
         requestExit();
         break;
+      case "status":
+      case "compact":
+        if (opts.local === true) {
+          chatLog.addSystem(
+            `/${name} is not supported in local TUI mode — use gateway-connected TUI for this command`,
+          );
+        } else {
+          await sendMessage(raw);
+        }
+        break;
       default:
         await sendMessage(raw);
         break;


### PR DESCRIPTION
## Summary

In local TUI mode (`openclaw tui --local`), typed slash commands `/status` and `/compact` are parsed by the slash submit path but not handled by the command switch. They fall through to `sendMessage(raw)`, appear as user messages, and start a local embedded agent/model run.

This PR adds explicit `case "status"` and `case "compact"` handlers that show a system message in local mode instead of sending the command as a user message.

## Changes

- `src/tui/tui-command-handlers.ts`: Add `/status` and `/compact` case handlers before `default` — in local mode, show a system message; in gateway mode, forward to model as before.

## How to Test

Run `openclaw tui --local`, type `/status` or `/compact`, and verify a system message appears instead of the command being sent to the model.

## Real behavior proof

- **Behavior addressed:** `/status` and `/compact` slash commands in local TUI mode fall through to model instead of being handled locally
- **Environment tested:** macOS, OpenClaw main @ 6cfb0251, Node.js
- **Steps run after the patch:** Ran the TUI command handler verification suite; verified the switch case handles `/status` and `/compact` for `opts.local === true`
- **Evidence after fix:**

```
$ node scripts/run-vitest.mjs run src/tui/tui-command-handlers.test.ts
 ✓  tui  src/tui/tui-command-handlers.test.ts (59 tests) 31ms
 Test Files  1 passed (1)
      Tests  59 passed (59)

$ grep -n 'case "status"\|case "compact"\|not supported in local' src/tui/tui-command-handlers.ts
712:      case "status":
713:      case "compact":
716:            `/${name} is not supported in local TUI mode — use gateway-connected TUI for this command`,
```

- **Observed result after fix:** All 59 TUI command handler tests pass. The `/status` and `/compact` cases are handled in local mode with a system message, and forwarded to the model in gateway mode.
- **What was not tested:** Live TUI local mode interaction (requires terminal UI), gateway-connected mode forwarding (covered by existing tests)
