### PR TITLE
fix(scripts): reject unsafe package download lengths

### DIFF
--- a/scripts/resolve-openclaw-package-candidate.mjs
+++ b/scripts/resolve-openclaw-package-candidate.mjs
@@ -1209,7 +1209,10 @@ export async function downloadUrl(url, target, options = {}) {
     const rawContentLength = responseHeader(response, "content-length");
     const contentLength =
       rawContentLength && /^\d+$/u.test(rawContentLength) ? Number(rawContentLength) : undefined;
-    if (Number.isSafeInteger(contentLength) && contentLength > maxBytes) {
+    if (
+      contentLength !== undefined &&
+      (!Number.isSafeInteger(contentLength) || contentLength > maxBytes)
+    ) {
       throw new Error(`package_url exceeds maximum download size of ${maxBytes} bytes`);
     }
     await fs.rm(tempTarget, { force: true });

--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -726,6 +726,50 @@ describe("resolve-openclaw-package-candidate", () => {
     expect(bodyCancelled).toBe(true);
   });
 
+  it("rejects unsafe decimal package_url content-length values before reading", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "openclaw-package-download-"));
+    tempDirs.push(dir);
+    const target = path.join(dir, "openclaw.tgz");
+    let readStarted = false;
+    let bodyCancelled = false;
+
+    await expect(
+      downloadUrl("https://packages.example/openclaw.tgz", target, {
+        fetchImpl: async () =>
+          ({
+            body: {
+              cancel() {
+                bodyCancelled = true;
+                return Promise.resolve();
+              },
+              getReader() {
+                return {
+                  cancel() {
+                    bodyCancelled = true;
+                    return Promise.resolve();
+                  },
+                  read() {
+                    readStarted = true;
+                    return new Promise(() => {});
+                  },
+                  releaseLock() {},
+                };
+              },
+            },
+            headers: new Headers({ "content-length": "9007199254740993" }),
+            status: 200,
+          }) as Response,
+        lookupHost: lookupAddresses([{ address: "93.184.216.34", family: 4 }]),
+        maxBytes: 1024,
+        timeoutMs: 25,
+      }),
+    ).rejects.toThrow(/exceeds maximum download size/u);
+    expect(readStarted).toBe(false);
+    expect(bodyCancelled).toBe(true);
+    await expect(missing(target)).resolves.toBe(true);
+    await expect(missing(`${target}.tmp`)).resolves.toBe(true);
+  });
+
   it("bounds package_url downloads and writes completed files atomically", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "openclaw-package-download-"));
     tempDirs.push(dir);


### PR DESCRIPTION
## Summary

- Reject unsafe decimal `Content-Length` values for `package_url` downloads before streaming the response body.
- Add regression coverage that proves the unsafe declared length is rejected before the body reader starts and still cancels/cleans temporary output.

## Verification

- `node --check scripts/resolve-openclaw-package-candidate.mjs`
- Direct `downloadUrl()` repro with injected `fetchImpl`/`lookupHost`, `content-length: 9007199254740993`, `maxBytes: 64`, and a custom never-completing body reader now fails in 5ms with `package_url exceeds maximum download size of 64 bytes`; `readStarted=false`, `bodyCancelled=true`, `targetExists=false`, `tmpExists=false`.
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, overall patch correct `0.9`.
- Exact-head release gate on `758e0875ad1553447e0e7b43c05af75737d575c7`: https://github.com/openclaw/openclaw/actions/runs/27844538401 succeeded. First attempt on this head only failed `ci-timings-summary` due GitHub installation API rate limit; rerun of failed jobs succeeded.

## Notes

Focused Vitest was not run locally because this sparse GWT has no `node_modules`, and repo rules say not to install dependencies in Codex worktrees. The hosted exact-head release gate covered the broad suite.
