### PR TITLE
fix(tasks): wake parent on blocked subagent delivery

### DIFF
--- a/src/tasks/task-executor-policy.test.ts
+++ b/src/tasks/task-executor-policy.test.ts
@@ -153,6 +153,42 @@ describe("task-executor-policy", () => {
       ),
     ).toBe(false);
     expect(
+      shouldAutoDeliverTaskTerminalUpdate(
+        createTask({
+          runtime: "subagent",
+          status: "succeeded",
+          deliveryStatus: "pending",
+          terminalOutcome: "blocked",
+          terminalSummary:
+            "Required completion delivery failed before reaching the requester: retry-limit.",
+          error: "retry-limit",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldAutoDeliverTaskTerminalUpdate(
+        createTask({
+          runtime: "subagent",
+          status: "succeeded",
+          deliveryStatus: "pending",
+          terminalOutcome: "blocked",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldAutoDeliverTaskTerminalUpdate(
+        createTask({
+          runtime: "subagent",
+          status: "succeeded",
+          deliveryStatus: "pending",
+          terminalOutcome: "blocked",
+          terminalSummary:
+            "Required completion ended with progress-only text, not a final deliverable.",
+          error: "stale delivery error",
+        }),
+      ),
+    ).toBe(false);
+    expect(
       shouldAutoDeliverTaskStateChange(
         createTask({
           status: "running",

--- a/src/tasks/task-executor-policy.ts
+++ b/src/tasks/task-executor-policy.ts
@@ -113,7 +113,19 @@ export function shouldAutoDeliverTaskTerminalUpdate(task: TaskRecord): boolean {
   if (task.notifyPolicy === "silent") {
     return false;
   }
-  if (task.runtime === "subagent" && task.status !== "cancelled") {
+  const isSubagentBlockedDeliveryRecovery =
+    task.runtime === "subagent" &&
+    task.status === "succeeded" &&
+    task.terminalOutcome === "blocked" &&
+    Boolean(task.error?.trim()) &&
+    task.terminalSummary
+      ?.trim()
+      .startsWith("Required completion delivery failed before reaching the requester:") === true;
+  if (
+    task.runtime === "subagent" &&
+    task.status !== "cancelled" &&
+    !isSubagentBlockedDeliveryRecovery
+  ) {
     return false;
   }
   if (!isTerminalTaskStatus(task.status)) {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1785,7 +1785,9 @@ describe("task-registry", () => {
           "Required completion ended with progress-only text, not a final deliverable.",
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await new Promise((resolve) => {
+        setTimeout(resolve, 10);
+      });
 
       expectRecordFields(requireTaskByRunId("run-subagent-progress-only"), {
         status: "succeeded",

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -50,6 +50,7 @@ import {
   resetTaskRegistryDeliveryRuntimeForTests,
   resetTaskRegistryForTests,
   resolveTaskForLookupToken,
+  setTaskRunDeliveryStatusByRunId,
   setTaskRegistryControlRuntimeForTests,
   setTaskRegistryDeliveryRuntimeForTests,
   setTaskProgressById,
@@ -1696,6 +1697,103 @@ describe("task-registry", () => {
         "Task needs follow-up: ACP background task (run run-sess). Writable session or apply_patch authorization required.",
       ]);
       expect(hasPendingHeartbeatWake()).toBe(true);
+      expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("wakes the parent when subagent completion delivery is blocked", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:subagent:reader",
+        runId: "run-subagent-blocked",
+        task: "Read the source files",
+        status: "running",
+        deliveryStatus: "pending",
+        startedAt: 100,
+      });
+
+      setTaskRunDeliveryStatusByRunId({
+        runId: "run-subagent-blocked",
+        runtime: "subagent",
+        sessionKey: "agent:main:subagent:reader",
+        deliveryStatus: "failed",
+        error: "retry-limit",
+      });
+      expectRecordFields(requireTaskByRunId("run-subagent-blocked"), {
+        deliveryStatus: "failed",
+        error: "retry-limit",
+      });
+
+      markTaskTerminalByRunId({
+        runId: "run-subagent-blocked",
+        runtime: "subagent",
+        sessionKey: "agent:main:subagent:reader",
+        status: "succeeded",
+        endedAt: 250,
+        terminalOutcome: "blocked",
+        terminalSummary:
+          "Required completion delivery failed before reaching the requester: retry-limit.",
+      });
+
+      await waitForAssertion(() =>
+        expectRecordFields(requireTaskByRunId("run-subagent-blocked"), {
+          status: "succeeded",
+          deliveryStatus: "session_queued",
+        }),
+      );
+      expect(peekSystemEvents("agent:main:main")).toEqual([
+        "Background task blocked: Subagent task (run run-suba). Required completion delivery failed before reaching the requester: retry-limit.",
+        "Task needs follow-up: Subagent task (run run-suba). Required completion delivery failed before reaching the requester: retry-limit.",
+      ]);
+      expect(hasPendingHeartbeatWake()).toBe(true);
+      expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
+
+      markTaskTerminalByRunId({
+        runId: "run-subagent-blocked",
+        runtime: "subagent",
+        sessionKey: "agent:main:subagent:reader",
+        status: "succeeded",
+        endedAt: 250,
+        terminalOutcome: "blocked",
+        terminalSummary:
+          "Required completion delivery failed before reaching the requester: retry-limit.",
+      });
+      expect(peekSystemEvents("agent:main:main")).toHaveLength(2);
+    });
+  });
+
+  it("keeps ordinary blocked subagent completions on the announce path", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:subagent:reader",
+        runId: "run-subagent-progress-only",
+        task: "Read the source files",
+        status: "succeeded",
+        deliveryStatus: "pending",
+        terminalOutcome: "blocked",
+        terminalSummary:
+          "Required completion ended with progress-only text, not a final deliverable.",
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expectRecordFields(requireTaskByRunId("run-subagent-progress-only"), {
+        status: "succeeded",
+        deliveryStatus: "pending",
+        terminalOutcome: "blocked",
+      });
+      expect(peekSystemEvents("agent:main:main")).toEqual([]);
+      expect(hasPendingHeartbeatWake()).toBe(false);
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
     });
   });

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1926,6 +1926,14 @@ function updateTaskStateByRunId(params: {
         terminalOutcome: params.terminalOutcome,
       });
     }
+    if (
+      current.runtime === "subagent" &&
+      nextStatus === "succeeded" &&
+      patch.terminalOutcome === "blocked" &&
+      current.deliveryStatus === "failed"
+    ) {
+      patch.deliveryStatus = "pending";
+    }
     const eventSummary =
       normalizeTaskSummary(params.eventSummary) ??
       (nextStatus === "failed"


### PR DESCRIPTION
## Summary

- Wakes the parent/requester session when a subagent completion announce gives up and the required completion is marked blocked.
- Keeps normal subagent successful completions and ordinary missing/progress-only blocked completions on the existing announce path, avoiding duplicate task delivery.
- Re-queues only the real give-up sequence where delivery was already marked `failed`, then the same run becomes `terminalOutcome: blocked` with the required-completion delivery-failure summary.
- Preserves idempotency after the blocked event is queued; replaying the terminal update does not re-open delivery.
- Intentionally out of scope: adding retry/expiry config knobs from #90178, which ClawSweeper flagged as a separate maintainer/product decision.

Reviewers should focus on the `subagent` blocked completion delivery policy and the `failed -> pending -> session_queued` transition in the task registry.

## Linked context

Addresses the parent wake-up bug in #90178.

Related: #91650, #87330.

Requested by maintainer workflow through issue #90178.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: subagent announce give-up can mark required completion delivery blocked without waking the parent waiting through `sessions_yield`.
- Real environment tested: local OpenClaw source checkout on this branch using real task registry/system-event/heartbeat modules with an isolated `OPENCLAW_STATE_DIR`.
- Exact steps or command run after this patch:
  - `OPENCLAW_STATE_DIR=$(mktemp -d) node --import tsx --eval '<create subagent task; mark delivery failed; mark terminalOutcome blocked; print final task/events/heartbeat>'`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "deliveryStatus": "session_queued",
  "terminalOutcome": "blocked",
  "eventCount": 2,
  "events": [
    "Background task blocked: Subagent task (run run-suba). Required completion delivery failed before reaching the requester: retry-limit.",
    "Task needs follow-up: Subagent task (run run-suba). Required completion delivery failed before reaching the requester: retry-limit."
  ],
  "heartbeatWake": true
}
```

- Observed result after fix: the blocked subagent completion is queued into the parent session and requests an immediate heartbeat wake, so a yielded parent has a bounded failure/follow-up event instead of remaining silent.
- What was not tested: live Signal/K8s multi-agent timing with real transport delivery.
- Proof limitations or environment constraints: the proof is a local runtime-level task/session wake proof, not a full transport capture.
- Before evidence (optional but encouraged): current main had `shouldAutoDeliverTaskTerminalUpdate()` return false for non-cancelled subagent tasks, so the blocked task update created by the give-up path was not auto-delivered to the requester session.

## Tests and validation

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs src/agents/subagent-registry-cleanup.test.ts src/agents/subagent-registry-lifecycle.test.ts src/tasks/task-executor-policy.test.ts src/tasks/task-registry.test.ts`
- `node scripts/run-vitest.mjs src/tasks/task-executor-policy.test.ts src/tasks/task-registry.test.ts`
- `pnpm -s exec oxfmt --check src/tasks/task-executor-policy.ts src/tasks/task-executor-policy.test.ts src/tasks/task-registry.ts src/tasks/task-registry.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`

Regression coverage added:

- `src/tasks/task-executor-policy.test.ts`: blocked subagent completions are eligible for terminal delivery only when they carry the explicit delivery-failure summary and recorded error; normal subagent success and ordinary blocked completions remain suppressed.
- `src/tasks/task-registry.test.ts`: real failed-delivery then blocked-terminal sequence queues parent events, triggers heartbeat, and stays idempotent on replay.
- `src/tasks/task-registry.test.ts`: ordinary progress-only blocked subagent completion stays pending with no task event, no heartbeat wake, and no direct channel send.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. A previously silent subagent completion give-up now surfaces as a blocked background task event in the parent session.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Duplicate or misrouted completion delivery.

How is that risk mitigated?

The policy still suppresses ordinary non-cancelled subagent terminal updates. The recovery path requires `subagent + succeeded + terminalOutcome: blocked` plus the required-completion delivery-failure summary and recorded error. The registry only requeues from `deliveryStatus: failed`, and tests cover replay idempotency plus the ordinary blocked-completion sibling path.

## Current review state

What is the next action?

ClawSweeper re-review on head `30ce8faa80`.

What is still waiting on author, maintainer, CI, or external proof?

Nothing known from the author side beyond normal CI/ClawSweeper re-review. Maintainers may still decide separately whether #90178 should add retry/expiry configurability.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's finding to constrain blocked subagent task delivery to the announce give-up recovery path, and added sibling regression coverage for ordinary blocked required completions.
