### PR TITLE
fix: keep text transform runtime imports hashed

### DIFF
--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -56,7 +56,13 @@ const LEGACY_ROOT_RUNTIME_COMPAT_ALIASES = [
   // nested dist entries, but live gateways may still import them after update.
   ["manager-DzRWrKSA.js", "acp/control-plane/manager.js"],
   ["runtime-CeGN4XUC.js", "web-fetch/runtime.js"],
+  // v2026.5.22 and v2026.6.8 text-transform runtimes. The stable alias remains
+  // for old chunks, but new chunks keep hashed imports because the alias export
+  // set expanded in v2026.6.8 and may already be cached in a live gateway.
+  ["text-transforms.runtime-D9-SpAmI.js", "text-transforms.runtime.js"],
+  ["text-transforms.runtime-sEqsN4pN.js", "text-transforms.runtime.js"],
 ];
+const ROOT_RUNTIME_STABLE_IMPORT_SKIP_ALIASES = new Set(["text-transforms.runtime.js"]);
 const LEGACY_PLUGIN_INSTALL_RUNTIME_MARKERS = [
   "scanPackageInstallSource",
   "scanFileInstallSource",
@@ -354,6 +360,9 @@ export function rewriteRootRuntimeImportsToStableAliases(params = {}) {
       candidates,
     });
     if (candidate) {
+      if (ROOT_RUNTIME_STABLE_IMPORT_SKIP_ALIASES.has(aliasFileName)) {
+        continue;
+      }
       runtimeAliasFiles.set(candidate, aliasFileName);
     }
   }

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -497,6 +497,40 @@ describe("runtime postbuild static assets", () => {
     );
   });
 
+  it("keeps text-transform runtime imports hashed after the stable alias export surface grew", async () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-");
+    const distDir = path.join(rootDir, "dist");
+    await fs.mkdir(distDir, { recursive: true });
+    await fs.writeFile(
+      path.join(distDir, "text-transforms.runtime-NewHash.js"),
+      "export const n = true;\nexport const t = true;\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(distDir, "provider-runtime-NewHash.js"),
+      [
+        'import { n as applyPluginTextReplacements } from "./text-transforms.runtime-NewHash.js";',
+        "export { applyPluginTextReplacements };",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    rewriteRootRuntimeImportsToStableAliases({ rootDir });
+    writeStableRootRuntimeAliases({ rootDir });
+
+    expect(await fs.readFile(path.join(distDir, "provider-runtime-NewHash.js"), "utf8")).toBe(
+      [
+        'import { n as applyPluginTextReplacements } from "./text-transforms.runtime-NewHash.js";',
+        "export { applyPluginTextReplacements };",
+        "",
+      ].join("\n"),
+    );
+    expect(await fs.readFile(path.join(distDir, "text-transforms.runtime.js"), "utf8")).toBe(
+      'export * from "./text-transforms.runtime-NewHash.js";\n',
+    );
+  });
+
   it("rewrites gateway shutdown imports to stable runtime aliases", async () => {
     const rootDir = createTempDir("openclaw-runtime-postbuild-");
     const distDir = path.join(rootDir, "dist");
@@ -726,6 +760,26 @@ describe("runtime postbuild static assets", () => {
     expect(await fs.readFile(path.join(distDir, "install.runtime-CNHwKOIb.js"), "utf8")).toBe(
       'export * from "./install.runtime-NewPluginHash.js";\n',
     );
+  });
+
+  it("writes compatibility aliases for previous text-transform runtime chunk names", async () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-");
+    const distDir = path.join(rootDir, "dist");
+    await fs.mkdir(distDir, { recursive: true });
+    await fs.writeFile(
+      path.join(distDir, "text-transforms.runtime.js"),
+      'export * from "./text-transforms.runtime-NewHash.js";\n',
+      "utf8",
+    );
+
+    writeLegacyRootRuntimeCompatAliases({ rootDir });
+
+    expect(
+      await fs.readFile(path.join(distDir, "text-transforms.runtime-D9-SpAmI.js"), "utf8"),
+    ).toBe('export * from "./text-transforms.runtime.js";\n');
+    expect(
+      await fs.readFile(path.join(distDir, "text-transforms.runtime-sEqsN4pN.js"), "utf8"),
+    ).toBe('export * from "./text-transforms.runtime.js";\n');
   });
 
   it("writes compatibility aliases for previous gateway shutdown chunk names", async () => {


### PR DESCRIPTION
## Summary

- Fixes a released-package gateway crash-loop path where new chunks can import expanded text-transform exports through a stable alias that an already-running gateway may have cached from an older package.
- Keeps new `text-transforms.runtime` imports on the hashed runtime chunk while still generating the stable wrapper for old chunks.
- Adds legacy compat wrappers for the shipped v2026.5.22 and v2026.6.8 text-transform runtime hashes.
- Out of scope: changing provider runtime behavior or plugin text-transform semantics.

## Linked context

Closes #95057

Related #95057

Was this requested by a maintainer or owner?

- Requested in maintainer workflow to repair the P1 release regression.

## Real behavior proof (required for external PRs)

- Behavior addressed: macOS LaunchAgent-managed gateway can crash-loop after upgrading when new provider/CLI chunks import `n/i/a/r/t` from `./text-transforms.runtime.js` but the live process has an older stable wrapper cached that only exposed `t`.
- Real environment tested: local source checkout on macOS with Node 22 toolchain and npm package inspection of published `openclaw@2026.5.22` and `openclaw@2026.6.8`.
- Exact steps or command run after this patch: `node scripts/runtime-postbuild.mjs` after a source build had produced `dist`; then inspected generated importers with `rg -n "text-transforms\.runtime\.js|text-transforms\.runtime-[A-Za-z0-9_-]+\.js" dist/provider-runtime*.js dist/cli-backends*.js dist/prepare.runtime*.js dist/execute.runtime*.js dist/selection*.js dist/compact*.js` and inspected `dist/text-transforms.runtime-D9-SpAmI.js` plus `dist/text-transforms.runtime-sEqsN4pN.js`.
- Evidence after fix:

```text
--- runtime-postbuild stderr ---
runtime-postbuild: stable root runtime imports completed in 5858ms
runtime-postbuild: stable root runtime aliases completed in 572ms
runtime-postbuild: legacy root runtime compat aliases completed in 1ms
--- importers ---
dist/cli-backends-uScbGHoe.js:4:import { r as mergePluginTextTransforms, t as resolveRuntimeTextTransforms } from "./text-transforms.runtime-DhZfO7FJ.js";
dist/provider-runtime-Cqktwbuy.js:10:import { n as applyPluginTextReplacements, r as mergePluginTextTransforms, t as resolveRuntimeTextTransforms } from "./text-transforms.runtime-DhZfO7FJ.js";
dist/compact-pRQItHot.js:12:import { i as wrapStreamFnTextTransforms } from "./text-transforms.runtime-DhZfO7FJ.js";
dist/execute.runtime-DCIHvX5t.js:5:import { n as applyPluginTextReplacements } from "./text-transforms.runtime-DhZfO7FJ.js";
dist/prepare.runtime-Db3n21Sv.js:11:import { n as applyPluginTextReplacements } from "./text-transforms.runtime-DhZfO7FJ.js";
dist/selection-DS_psmoB.js:34:import { a as createStreamIteratorWrapper, i as wrapStreamFnTextTransforms } from "./text-transforms.runtime-DhZfO7FJ.js";
--- compat ---
export * from "./text-transforms.runtime.js";
export * from "./text-transforms.runtime.js";
```

- Observed result after fix: new chunks no longer depend on the stable `text-transforms.runtime.js` module namespace for expanded exports, while old shipped hashed runtime names still resolve through compat wrappers.
- What was not tested: a full macOS Apple Silicon LaunchAgent upgrade from `openclaw@2026.5.22` to this unpublished branch package.
- Proof limitations or environment constraints: `pnpm build` completed `tsdown` and `runtime-postbuild` but timed out at 15 minutes during the later plugin SDK d.ts stage, so the package-level proof is based on the completed generated `dist` runtime-postbuild output plus focused tests rather than a full build command exit 0.
- Before evidence:

```text
2026.5.22 dist/text-transforms.runtime.js:
export * from "./text-transforms.runtime-D9-SpAmI.js";

2026.5.22 dist/text-transforms.runtime-D9-SpAmI.js export surface:
export { resolveRuntimeTextTransforms as t };

2026.6.8 importer examples:
dist/provider-runtime-Cp9BfFXg.js imports n/r/t from "./text-transforms.runtime.js"
dist/cli-backends-f9hsjoJk.js imports r/t from "./text-transforms.runtime.js"
dist/selection-kQiC501t.js imports a/i from "./text-transforms.runtime.js"
```

## Tests and validation

Which commands did you run?

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs test/scripts/runtime-postbuild.test.ts`
- `pnpm exec oxfmt --check --threads=1 scripts/runtime-postbuild.mjs test/scripts/runtime-postbuild.test.ts`
- `node scripts/runtime-postbuild.mjs`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `git diff --check`

What regression coverage was added or updated?

- Added runtime-postbuild tests proving text-transform runtime importers stay hashed after the stable alias export surface expansion.
- Added runtime-postbuild tests proving previous published text-transform runtime hash names get compat wrappers.

What failed before this fix, if known?

- The package comparison shows the old stable wrapper exposed only `t`, while the new released chunks import more aliases through the same stable module path. That can fail in a live process with a cached older wrapper namespace.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

- Yes. It changes generated package runtime import paths to avoid upgrade-time gateway crashes.

Did config, environment, or migration behavior change? (`Yes/No`)

- No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

- No.

What is the highest-risk area?

- Runtime package postbuild aliasing for live upgrades.

How is that risk mitigated?

- The change is scoped to one runtime alias skip and two shipped hash compat entries, with focused fixture tests and generated `dist` proof that old compat wrappers and new hashed importers coexist.

## Current review state

What is the next action?

- Waiting for CI and ClawSweeper review.

What is still waiting on author, maintainer, CI, or external proof?

- Maintainer/CI may still choose to run full package acceptance or a macOS LaunchAgent package-upgrade proof.

Which bot or reviewer comments were addressed?

- Real behavior proof body was updated with copied postbuild output after the initial gate did not recognize the evidence line as copied live output.
