### PR TITLE
fix(googlechat): sanitize internal tool-trace lines from outbound text (#90684)

### DIFF
--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -23,6 +23,7 @@ import { createLazyRuntimeNamedExport } from "openclaw/plugin-sdk/lazy-runtime";
 import type { OutboundMediaLoadOptions } from "openclaw/plugin-sdk/outbound-media";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { shouldSuppressGoogleChatManualExecApprovalFollowupPayload } from "./approval-card-actions.js";
 import { formatGoogleChatAllowFromEntry } from "./channel-base.js";
 import {
@@ -194,7 +195,11 @@ export const googlechatOutboundAdapter = {
     chunker: chunkTextForOutbound,
     chunkerMode: "markdown" as const,
     textChunkLimit: 4000,
-    sanitizeText: ({ text }: { text: string }) => sanitizeForPlainText(text),
+    // Strip internal assistant trace lines (e.g. `⚠️ 🛠️ ... (agent) failed`
+    // banners from benign non-zero shell exits) before the plain-text pass, so
+    // they don't leak to users — mirrors Discord/WhatsApp outbound. See #90684.
+    sanitizeText: ({ text }: { text: string }) =>
+      sanitizeForPlainText(sanitizeAssistantVisibleText(text)),
     normalizePayload: ({ payload }: { payload: ReplyPayload }) =>
       shouldSuppressGoogleChatManualExecApprovalFollowupPayload(payload) ? null : payload,
     resolveTarget: ({ to }: { to?: string }) => {

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -195,9 +195,9 @@ export const googlechatOutboundAdapter = {
     chunker: chunkTextForOutbound,
     chunkerMode: "markdown" as const,
     textChunkLimit: 4000,
-    // Strip internal assistant trace lines (e.g. `⚠️ 🛠️ ... (agent) failed`
-    // banners from benign non-zero shell exits) before the plain-text pass, so
-    // they don't leak to users — mirrors Discord/WhatsApp outbound. See #90684.
+    // Google Chat's plain-text pass does not remove assistant scaffolding.
+    // Run the canonical delivery sanitizer first so internal tool traces are
+    // dropped before channel formatting.
     sanitizeText: ({ text }: { text: string }) =>
       sanitizeForPlainText(sanitizeAssistantVisibleText(text)),
     normalizePayload: ({ payload }: { payload: ReplyPayload }) =>

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -843,3 +843,22 @@ describe("googlechatPlugin security", () => {
     );
   });
 });
+
+describe("googlechatPlugin outbound sanitizeText", () => {
+  const sanitizeText = googlechatOutboundAdapter.base.sanitizeText;
+
+  it("strips internal tool-trace failure banners from outbound text (#90684)", () => {
+    const text =
+      "Listo, Javi — encontré el cron.\n" +
+      '⚠️ 🛠️ `search "Pipeline" in ~/.openclaw/workspace-* (agent)` failed';
+    const out = sanitizeText({ text });
+    expect(out).toBe("Listo, Javi — encontré el cron.");
+    expect(out).not.toContain("failed");
+    expect(out).not.toContain("🛠️");
+  });
+
+  it("preserves ordinary assistant prose untouched", () => {
+    const text = "El pipeline tiene 3 deals abiertos por USD 12.000.";
+    expect(sanitizeText({ text })).toBe(text);
+  });
+});

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -849,10 +849,9 @@ describe("googlechatPlugin outbound sanitizeText", () => {
 
   it("strips internal tool-trace failure banners from outbound text (#90684)", () => {
     const text =
-      "Listo, Javi — encontré el cron.\n" +
-      '⚠️ 🛠️ `search "Pipeline" in ~/.openclaw/workspace-* (agent)` failed';
+      "Visible answer.\n" + "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed";
     const out = sanitizeText({ text });
-    expect(out).toBe("Listo, Javi — encontré el cron.");
+    expect(out).toBe("Visible answer.");
     expect(out).not.toContain("failed");
     expect(out).not.toContain("🛠️");
   });


### PR DESCRIPTION
## Summary

- Google Chat outbound text only ran `sanitizeForPlainText()`, so internal assistant trace lines leaked to users — most visibly the `⚠️ 🛠️ \`<command> (agent)\` failed` banner produced for a benign non-zero shell exit (e.g. a `grep` that finds no match → exit 1). The turn completes successfully, but the user gets an alarming "failed" message.
- Fix: run `sanitizeAssistantVisibleText()` before `sanitizeForPlainText()` in the googlechat outbound `sanitizeText` hook — the same composition Discord (`sanitizeDiscordFrontChannelText`) and WhatsApp (`normalizeWhatsAppPayloadText`) already use. The hook runs pre-chunking in the shared deliver path, so it covers every text send (replies, sub-agent announces, cron deliveries).
- Out of scope: this does NOT close the broader cross-channel umbrella (#90684) for Telegram/Feishu/Slack/msteams, and it does not change the Codex-native warning taxonomy (#88332). It is one focused Google Chat instance.
- Success: a benign non-zero shell exit no longer emits a user-visible `⚠️ 🛠️ … failed` banner in Google Chat; ordinary prose is untouched.

## Linked context

Closes part of #90684 (Google Chat instance of the non-Discord assistant-visible sanitizer gap).
Related #88332, #87610.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Google Chat leaked the internal `⚠️ 🛠️ \`<command> (agent)\` failed` trace banner (and similar trace lines) to end users because outbound text skipped `sanitizeAssistantVisibleText()`. Reproduced live: a front-desk agent answered a user correctly, but the channel also posted a standalone bot message `⚠️ 🛠️ search "…" in ~/.openclaw/workspace-* (agent) failed` from a `grep` that exited 1 (no match).
- Real environment tested: Production OpenClaw `2026.6.8` gateway running the installed `@openclaw/googlechat` plugin with this patch applied to the live adapter, on a real Google Chat deployment. `/health` returned `{"ok":true,"status":"live"}`.
- Exact steps or command run after this patch: In the deployed plugin's own module context, ran `node` to exercise the patched outbound `sanitizeText` composition on the exact leaked banner and on ordinary prose, then scanned trajectories captured after the patch went live for the trigger condition (benign non-zero tool exits):

```
# 1) deployed outbound sanitize composition (exactly what the patched hook runs)
node -e 'import("openclaw/plugin-sdk/text-chunking").then(async tc => {
  const { sanitizeForPlainText } = await import("openclaw/plugin-sdk/channel-outbound");
  const hook = t => sanitizeForPlainText(tc.sanitizeAssistantVisibleText(t));
  console.log("OUT:", JSON.stringify(hook(
    "Listo.\n⚠️ 🛠️ `search \"Pipeline\" in ~/.openclaw/workspace-* (agent)` failed")));
  console.log("normal:", JSON.stringify(hook("El pipeline tiene 3 deals.")));
})'

# 2) did the trigger condition actually occur in live traffic since deploy?
node scan-trajectories.mjs   # counts tool failures / exit-1 captured after deploy
```

- Evidence after fix: copied live output / console output (stdout) from the patched `2026.6.8` deployment, captured with `node` against the live plugin module:

```
OUT: "Listo."
normal: "El pipeline tiene 3 deals."

trigger-events (tool fail / exit 1) after deploy: 11  (across 2 agents)
banner present in delivered/outbound payload after deploy: 0
```

- Observed result after fix: the patched `node` hook removes the `⚠️ 🛠️ … (agent) failed` banner line and returns only the real assistant prose (`"Listo."`); ordinary text passes through unchanged. Over ~16h of live traffic the benign-exit trigger fired 11 times and zero failed-tool banners reached the channel. No recurrence reported by the user who originally hit it.
- What was not tested: I did not capture a screenshot of the Google Chat client UI itself (proof is copied live `node`/stdout output from the patched deployment, not a client screen recording). I did not exercise the broader Telegram/Feishu/Slack/msteams paths (out of scope; tracked by #90684).
- Proof limitations or environment constraints: importing the full `channel.adapters` ESM module standalone fails outside the gateway process (runtime-context deps), so the after-fix proof exercises the exact same two-function composition the patched hook runs (`sanitizeForPlainText(sanitizeAssistantVisibleText(text))`) resolved from the live plugin's own module context, rather than re-instantiating the whole adapter object. Space IDs / account IDs / user details are intentionally omitted.
- Before evidence: pre-patch, the identical banner reached the user as a standalone bot message (`⚠️ 🛠️ search "…" in ~/.openclaw/workspace-* (agent) failed`) while the actual answer was delivered fine; on the same runtime `node` shows `sanitizeForPlainText(text)` alone returns the banner unchanged, whereas `sanitizeAssistantVisibleText(text)` strips it.

## Tests and validation

- `pnpm vitest run extensions/googlechat/src/channel.test.ts -t "sanitizeText"` → 2 passed (new `googlechatPlugin outbound sanitizeText` describe block): asserts the `(agent) failed` banner is stripped via the real `googlechatOutboundAdapter.base.sanitizeText` hook, and that ordinary prose is preserved.
- Regression coverage added in `channel.test.ts`. CI/unit tests are supplemental; the after-fix proof above is copied live output from a real deployment.

## Risk checklist

- Did user-visible behavior change? Yes — internal trace/failure banners are no longer shown in Google Chat; legitimate prose is unaffected.
- Did config, environment, or migration behavior change? No.
- Did security, auth, secrets, network, or tool execution behavior change? No — this narrows user-visible internal-trace leakage only; no deps/workflows/credentials/permissions touched.
- Highest-risk area: over-stripping legitimate content. Mitigated by reusing the canonical `sanitizeAssistantVisibleText()` (already used by Discord/WhatsApp) rather than new regexes, plus the new unit test asserting ordinary prose is preserved.

## Current review state

- Next action: maintainer review. Structured after-fix real-behavior proof from a live patched deployment added above (addressing the ClawSweeper proof blocker).
- Waiting on: maintainer review. The unrelated `checks-node-agentic-agents-core-tools` shard failure does not touch `extensions/googlechat`.
- Bot comments addressed: ClawSweeper "needs real behavior proof before merge" — added structured after-fix evidence and observed result from a real Google Chat deployment.

AI-assisted change.
