### PR TITLE
fix(scripts): reject unsafe bounded response lengths

### DIFF
--- a/scripts/lib/bounded-response.mjs
+++ b/scripts/lib/bounded-response.mjs
@@ -19,7 +19,7 @@ function parseContentLengthHeader(headers) {
     return undefined;
   }
   const parsed = Number(raw);
-  return Number.isSafeInteger(parsed) ? parsed : undefined;
+  return Number.isSafeInteger(parsed) ? parsed : Number.POSITIVE_INFINITY;
 }
 
 async function readResponseChunk(reader, label, signal, markCanceled) {

--- a/scripts/lib/bounded-response.ts
+++ b/scripts/lib/bounded-response.ts
@@ -23,7 +23,7 @@ function parseContentLengthHeader(headers: Headers): number | undefined {
     return undefined;
   }
   const parsed = Number(raw);
-  return Number.isSafeInteger(parsed) ? parsed : undefined;
+  return Number.isSafeInteger(parsed) ? parsed : Number.POSITIVE_INFINITY;
 }
 
 async function readResponseChunk(

--- a/test/scripts/bounded-response.test.ts
+++ b/test/scripts/bounded-response.test.ts
@@ -98,4 +98,39 @@ describe("scripts bounded response reader", () => {
       expect(canceled).toBe(true);
     },
   );
+
+  it.each(helpers)(
+    "rejects unsafe decimal %s content-length values before reading",
+    async (_name, read) => {
+      let readStarted = false;
+      let canceled = false;
+      const response = {
+        headers: new Headers({ "content-length": "9007199254740993" }),
+        body: {
+          async cancel() {
+            canceled = true;
+          },
+          getReader() {
+            return {
+              async read() {
+                readStarted = true;
+                return new Promise<ReadableStreamReadResult<Uint8Array>>(() => {});
+              },
+              async cancel() {
+                canceled = true;
+              },
+              releaseLock() {},
+            };
+          },
+        },
+      } as unknown as Response;
+
+      await expect(read(response, "probe", 16)).rejects.toThrow(
+        "probe response body exceeded 16 bytes",
+      );
+
+      expect(readStarted).toBe(false);
+      expect(canceled).toBe(true);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- Reject unsafe decimal `Content-Length` values in the shared scripts bounded-response reader before streaming response bodies.
- Keep non-decimal `Content-Length` values on the existing streaming byte-limit path.
- Add regression coverage for both TS and MJS exports proving unsafe declared lengths cancel without starting a read.

## Verification

- `node --check scripts/lib/bounded-response.mjs`
- Direct MJS repro with `content-length: 9007199254740993`, `maxBytes: 16`, and a never-completing body reader now fails with `probe response body exceeded 16 bytes`; `readStarted=false`, `canceled=true`.
- Same repro against `origin/main` before the patch started reading first: `readStarted=true`, `canceled=true`.
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, overall patch correct `0.88`.
- Exact-head release gate on `486b8cc1891ab55c769ebda2c1b836ad391e5e87`: https://github.com/openclaw/openclaw/actions/runs/27845767740 succeeded.

## Notes

Focused Vitest was not run locally because this sparse GWT has no `node_modules`, and repo rules say not to install dependencies in Codex worktrees. The hosted exact-head release gate covered the broad suite.
