### PR TITLE
fix(macos): cache CLLocationManager to avoid repeated TCC permission requests (fixes #94147)

### DIFF
--- a/apps/macos/Sources/OpenClaw/PermissionManager.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionManager.swift
@@ -10,6 +10,11 @@ import Speech
 import UserNotifications
 
 enum PermissionManager {
+    /// Cached CLLocationManager for authorization-status queries.
+    /// Allocating a new CLLocationManager per query triggers a TCC IPC round-trip every time,
+    /// which spams system logs and wastes cycles when the permission-monitor timer fires (1 Hz).
+    nonisolated(unsafe) static let cachedLocationManager = CLLocationManager()
+
     static func isLocationAuthorized(status: CLAuthorizationStatus, requireAlways: Bool) -> Bool {
         if requireAlways { return status == .authorizedAlways }
         switch status {
@@ -156,7 +161,7 @@ enum PermissionManager {
             }
             return false
         }
-        let status = CLLocationManager().authorizationStatus
+        let status = cachedLocationManager.authorizationStatus
         switch status {
         case .authorizedAlways, .authorizedWhenInUse, .authorized:
             return true
@@ -218,7 +223,7 @@ enum PermissionManager {
                 results[cap] = AVCaptureDevice.authorizationStatus(for: .video) == .authorized
 
             case .location:
-                let status = CLLocationManager().authorizationStatus
+                let status = cachedLocationManager.authorizationStatus
                 results[cap] = CLLocationManager.locationServicesEnabled()
                     && self.isLocationAuthorized(status: status, requireAlways: false)
             }

--- a/apps/macos/Sources/OpenClaw/PermissionsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionsSettings.swift
@@ -142,7 +142,7 @@ private struct LocationAccessSettings: View {
             return false
         }
 
-        let status = CLLocationManager().authorizationStatus
+        let status = PermissionManager.cachedLocationManager.authorizationStatus
         let requireAlways = mode == .always
         if PermissionManager.isLocationAuthorized(status: status, requireAlways: requireAlways) {
             return true


### PR DESCRIPTION
## What

Cache the `CLLocationManager` used for authorization-status queries instead of allocating a new instance on every call. The 1-second permission-monitor timer in `PermissionStatusMonitor` triggered a fresh `CLLocationManager()` allocation (and associated TCC IPC) on every tick.

## Why

Fixes #94147 — `CLLocationManager()` was created 3 times per permission check cycle (once in `ensureLocation`, once in `status()`, once in `PermissionsSettings`), causing ~45 TCC IPC requests per 10 seconds as observed in system logs.

## How

- Added `nonisolated(unsafe) static let cachedLocationManager = CLLocationManager()` to `PermissionManager` enum
- Replaced 3 `CLLocationManager()` allocations with the cached instance:
  - `PermissionManager.ensureLocation()` line 164
  - `PermissionManager.status()` `.location` case line 226
  - `LocationAccessSettings.requestLocationAuthorization()` line 145

## Changes

- `apps/macos/Sources/OpenClaw/PermissionManager.swift` — add cached property, 2 call-site replacements
- `apps/macos/Sources/OpenClaw/PermissionsSettings.swift` — 1 call-site replacement

## Real behavior proof

- **Behavior addressed:** CLLocationManager was allocated fresh on every 1-second permission-monitor tick, triggering TCC IPC round-trips and spamming system logs.
- **Environment tested:** macOS 26.4.1 (arm64), Xcode 16, swift build + swift test --filter PermissionManagerTests
- **Steps run after the patch:** Built with `swift build` (286 modules, 0 errors). Ran `swift test --filter PermissionManagerTests` — 5/5 tests passed.
- **Evidence after fix:**
```
$ swift test --filter PermissionManagerTests
✔ Test "voice wake permission helpers match status" passed after 0.013 seconds.
✔ Test "status can query non interactive caps" passed after 0.006 seconds.
✔ Test "ensure non interactive does not throw" passed after 0.005 seconds.
✔ Test "location status matches authorization always" passed after 0.005 seconds.
✔ Test "ensure location non interactive matches authorization always" passed after 0.001 seconds.
✔ Test run with 5 tests in 1 suite passed after 0.031 seconds.
```
```
$ grep -n 'cachedLocationManager\|CLLocationManager()' apps/macos/Sources/OpenClaw/PermissionManager.swift apps/macos/Sources/OpenClaw/PermissionsSettings.swift
PermissionManager.swift:16:    nonisolated(unsafe) static let cachedLocationManager = CLLocationManager()
PermissionManager.swift:164:        let status = cachedLocationManager.authorizationStatus
PermissionManager.swift:226:                let status = cachedLocationManager.authorizationStatus
PermissionsSettings.swift:145:        let status = PermissionManager.cachedLocationManager.authorizationStatus
```
- **Observed result after fix:** All 3 `CLLocationManager()` allocations replaced with cached instance. No new `CLLocationManager()` in production code paths.
- **What was not tested:** Live TCC log reduction (requires running macOS app with Instruments or `log show`); runtime behavior on macOS versions < 14.
