### PR TITLE
refactor: add memory and QMD session identity mapping

### DIFF
--- a/extensions/memory-core/src/memory/manager-session-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-session-reindex.ts
@@ -1,18 +1,19 @@
 // Memory Core plugin module implements manager session reindex behavior.
+import type { MemorySyncParams } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+
 export function shouldSyncSessionsForReindex(params: {
   hasSessionSource: boolean;
   sessionsDirty: boolean;
   sessionsFullRetryDirty?: boolean;
   dirtySessionFileCount: number;
-  sync?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-  };
+  sync?: MemorySyncParams;
   needsFullReindex?: boolean;
 }): boolean {
   if (!params.hasSessionSource) {
     return false;
+  }
+  if (params.sync?.sessions?.some((session) => session.sessionId.trim().length > 0)) {
+    return true;
   }
   if (params.sync?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
     return true;

--- a/extensions/memory-core/src/memory/manager-session-sync-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-state.test.ts
@@ -66,6 +66,19 @@ describe("memory session sync state", () => {
     expect(plan.activePaths).toEqual(new Set(["sessions/incremental.jsonl"]));
   });
 
+  it("marks identity-targeted syncs as session work", async () => {
+    const { shouldSyncSessionsForReindex } = await import("./manager-session-reindex.js");
+
+    expect(
+      shouldSyncSessionsForReindex({
+        hasSessionSource: true,
+        sessionsDirty: false,
+        dirtySessionFileCount: 0,
+        sync: { sessions: [{ agentId: "main", sessionId: "targeted" }] },
+      }),
+    ).toBe(true);
+  });
+
   it("marks missing and changed startup session files dirty", () => {
     const dirtyFiles = resolveMemorySessionStartupDirtyFiles({
       files: [

--- a/extensions/memory-core/src/memory/manager-sync-control.ts
+++ b/extensions/memory-core/src/memory/manager-sync-control.ts
@@ -2,7 +2,11 @@
 import type { DatabaseSync } from "node:sqlite";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
-import type { MemorySyncProgressUpdate } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import type {
+  MemorySessionSyncTarget,
+  MemorySyncParams,
+  MemorySyncProgressUpdate,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 
 const log = createSubsystemLogger("memory");
 
@@ -19,6 +23,7 @@ export type MemoryReadonlyRecoveryState = {
   runSync: (params?: {
     reason?: string;
     force?: boolean;
+    sessions?: MemorySessionSyncTarget[];
     sessionFiles?: string[];
     progress?: (update: MemorySyncProgressUpdate) => void;
   }) => Promise<void>;
@@ -80,12 +85,7 @@ export function extractMemoryErrorReason(err: unknown): string {
 
 export async function runMemorySyncWithReadonlyRecovery(
   state: MemoryReadonlyRecoveryState,
-  params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  },
+  params?: MemorySyncParams,
 ): Promise<void> {
   try {
     await state.runSync(params);
@@ -121,25 +121,28 @@ export function enqueueMemoryTargetedSessionSync(
     isClosed: () => boolean;
     getSyncing: () => Promise<void> | null;
     getQueuedSessionFiles: () => Set<string>;
+    getQueuedSessions: () => Map<string, MemorySessionSyncTarget>;
     getQueuedSessionSync: () => Promise<void> | null;
     setQueuedSessionSync: (value: Promise<void> | null) => void;
-    sync: (params?: {
-      reason?: string;
-      force?: boolean;
-      sessionFiles?: string[];
-      progress?: (update: MemorySyncProgressUpdate) => void;
-    }) => Promise<void>;
+    sync: (params?: MemorySyncParams) => Promise<void>;
   },
-  sessionFiles?: string[],
+  targets?: Pick<MemorySyncParams, "sessions" | "sessionFiles">,
 ): Promise<void> {
   const queuedSessionFiles = state.getQueuedSessionFiles();
-  for (const sessionFile of sessionFiles ?? []) {
+  for (const sessionFile of targets?.sessionFiles ?? []) {
     const trimmed = sessionFile.trim();
     if (trimmed) {
       queuedSessionFiles.add(trimmed);
     }
   }
-  if (queuedSessionFiles.size === 0) {
+  const queuedSessions = state.getQueuedSessions();
+  for (const session of targets?.sessions ?? []) {
+    const normalized = normalizeQueuedMemorySessionSyncTarget(session);
+    if (normalized) {
+      queuedSessions.set(memorySessionSyncTargetKey(normalized), normalized);
+    }
+  }
+  if (queuedSessionFiles.size === 0 && queuedSessions.size === 0) {
     return state.getSyncing() ?? Promise.resolve();
   }
   if (!state.getQueuedSessionSync()) {
@@ -147,11 +150,17 @@ export function enqueueMemoryTargetedSessionSync(
       (async () => {
         try {
           await state.getSyncing()?.catch(() => undefined);
-          while (!state.isClosed() && state.getQueuedSessionFiles().size > 0) {
+          while (
+            !state.isClosed() &&
+            (state.getQueuedSessionFiles().size > 0 || state.getQueuedSessions().size > 0)
+          ) {
             const pendingSessionFiles = Array.from(state.getQueuedSessionFiles());
+            const pendingSessions = Array.from(state.getQueuedSessions().values());
             state.getQueuedSessionFiles().clear();
+            state.getQueuedSessions().clear();
             await state.sync({
-              reason: "queued-session-files",
+              reason: "queued-sessions",
+              sessions: pendingSessions,
               sessionFiles: pendingSessionFiles,
             });
           }
@@ -162,4 +171,24 @@ export function enqueueMemoryTargetedSessionSync(
     );
   }
   return state.getQueuedSessionSync() ?? Promise.resolve();
+}
+
+function normalizeQueuedMemorySessionSyncTarget(
+  target: MemorySessionSyncTarget,
+): MemorySessionSyncTarget | null {
+  const sessionId = target.sessionId.trim();
+  if (!sessionId) {
+    return null;
+  }
+  const agentId = target.agentId?.trim();
+  const sessionKey = target.sessionKey?.trim();
+  return {
+    ...(agentId ? { agentId } : {}),
+    sessionId,
+    ...(sessionKey ? { sessionKey } : {}),
+  };
+}
+
+function memorySessionSyncTargetKey(target: MemorySessionSyncTarget): string {
+  return [target.agentId ?? "", target.sessionId, target.sessionKey ?? ""].join("\0");
 }

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import type {
   MemorySource,
+  MemorySyncParams,
   MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -27,6 +28,7 @@ type MemoryIndexEntry = {
 type SyncParams = {
   reason?: string;
   force?: boolean;
+  sessions?: MemorySyncParams["sessions"];
   sessionFiles?: string[];
   progress?: (update: MemorySyncProgressUpdate) => void;
 };
@@ -38,6 +40,25 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
   protected readonly agentId = "main";
   protected readonly workspaceDir = "/tmp/openclaw-test-workspace";
   protected readonly settings = {
+    chunking: {
+      overlap: 0,
+      tokens: 256,
+    },
+    extraPaths: [],
+    multimodal: {
+      enabled: false,
+      modalities: [],
+      maxFileBytes: 0,
+    },
+    provider: "none",
+    store: {
+      fts: {
+        tokenizer: "unicode61",
+      },
+      vector: {
+        enabled: false,
+      },
+    },
     sync: {
       sessions: {
         deltaBytes: 100_000,
@@ -45,7 +66,7 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
         postCompactionForce: true,
       },
     },
-  } as ResolvedMemorySearchConfig;
+  } as unknown as ResolvedMemorySearchConfig;
   protected readonly batch = {
     enabled: false,
     wait: false,
@@ -60,6 +81,7 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
   protected db: DatabaseSync;
 
   readonly syncCalls: SyncParams[] = [];
+  readonly indexedPaths: string[] = [];
 
   constructor(sourceRows: SourceStateRow[]) {
     super();
@@ -81,6 +103,10 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
     return await this.markSessionStartupCatchupDirtyFiles();
   }
 
+  async runSyncForTest(params?: MemorySyncParams): Promise<void> {
+    await this.runSync(params);
+  }
+
   getDirtySessionFiles(): string[] {
     return Array.from(this.sessionsDirtyFiles);
   }
@@ -97,7 +123,7 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
     return [];
   }
 
-  protected async sync(params?: SyncParams): Promise<void> {
+  protected async sync(params?: MemorySyncParams): Promise<void> {
     this.syncCalls.push(params ?? {});
   }
 
@@ -120,9 +146,11 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
   protected assertRequiredProviderAvailable(): void {}
 
   protected async indexFile(
-    _entry: MemoryIndexEntry,
+    entry: MemoryIndexEntry,
     _options: { source: MemorySource; content?: string },
-  ): Promise<void> {}
+  ): Promise<void> {
+    this.indexedPaths.push(entry.path);
+  }
 }
 
 describe("session startup catch-up", () => {
@@ -303,5 +331,29 @@ describe("session startup catch-up", () => {
     } finally {
       openSpy.mockRestore();
     }
+  });
+
+  it("does not fall back to full session sync when identity targets normalize away", async () => {
+    await writeSessionFile("thread.jsonl");
+    const harness = new SessionStartupCatchupHarness([]);
+
+    await harness.runSyncForTest({
+      reason: "queued-sessions",
+      sessions: [{ agentId: "other", sessionId: "thread" }],
+    });
+
+    expect(harness.indexedPaths).toEqual([]);
+  });
+
+  it("does not fall back to full session sync for malformed identity session ids", async () => {
+    await writeSessionFile("thread.jsonl");
+    const harness = new SessionStartupCatchupHarness([]);
+
+    await harness.runSyncForTest({
+      reason: "queued-sessions",
+      sessions: [{ agentId: "main", sessionId: "bad/nested" }],
+    });
+
+    expect(harness.indexedPaths).toEqual([]);
   });
 });

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -21,6 +21,8 @@ import {
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
   listSessionFilesForAgent,
+  parseCanonicalSessionSyncTargetFromPath,
+  resolveSessionFileForSyncTarget,
   sessionPathForFile,
 } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import {
@@ -36,9 +38,12 @@ import {
   retryTransientMemoryRead,
   runWithConcurrency,
   type MemorySource,
+  type MemorySessionSyncTarget,
+  type MemorySyncParams,
   type MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   createEmbeddingProvider,
@@ -308,6 +313,7 @@ export abstract class MemoryManagerSyncOps {
   private readonly memoryWatchPressureWarning: MemoryWatchPressureWarningState = { shown: false };
   protected sessionsDirtyFiles = new Set<string>();
   protected sessionPendingFiles = new Set<string>();
+  protected sessionPendingTargets = new Map<string, MemorySessionSyncTarget>();
   protected sessionDeltas = new Map<string, MemorySessionDeltaState>();
   protected vectorDegradedWriteWarningShown = false;
   private lastMetaSerialized: string | null = null;
@@ -316,13 +322,7 @@ export abstract class MemoryManagerSyncOps {
   protected abstract db: DatabaseSync;
   protected abstract computeProviderKey(): string;
   protected abstract resolveProviderIndexIdentities(): MemoryIndexProviderIdentity[];
-  protected abstract sync(params?: {
-    reason?: string;
-    force?: boolean;
-    forceSessions?: boolean;
-    sessionFile?: string;
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }): Promise<void>;
+  protected abstract sync(params?: MemorySyncParams): Promise<void>;
   protected abstract withTimeout<T>(
     promise: Promise<T>,
     timeoutMs: number,
@@ -1430,6 +1430,11 @@ export abstract class MemoryManagerSyncOps {
       if (!this.isSessionFileForAgent(sessionFile)) {
         return;
       }
+      const target = this.resolveSessionTranscriptUpdateSyncTarget(update);
+      if (target) {
+        this.scheduleSessionDirty(target);
+        return;
+      }
       this.scheduleSessionDirty(sessionFile);
     });
   }
@@ -1501,8 +1506,12 @@ export abstract class MemoryManagerSyncOps {
     return dirtyFiles;
   }
 
-  private scheduleSessionDirty(sessionFile: string) {
-    this.sessionPendingFiles.add(sessionFile);
+  private scheduleSessionDirty(target: string | MemorySessionSyncTarget) {
+    if (typeof target === "string") {
+      this.sessionPendingFiles.add(target);
+    } else {
+      this.sessionPendingTargets.set(this.memorySessionSyncTargetKey(target), target);
+    }
     if (this.sessionWatchTimer) {
       return;
     }
@@ -1515,11 +1524,14 @@ export abstract class MemoryManagerSyncOps {
   }
 
   private async processSessionDeltaBatch(): Promise<void> {
-    if (this.sessionPendingFiles.size === 0) {
+    if (this.sessionPendingFiles.size === 0 && this.sessionPendingTargets.size === 0) {
       return;
     }
     const pending = Array.from(this.sessionPendingFiles);
+    const pendingTargets = Array.from(this.sessionPendingTargets.values());
     this.sessionPendingFiles.clear();
+    this.sessionPendingTargets.clear();
+    pending.push(...Array.from(this.resolveSessionFilesForSyncTargets(pendingTargets)));
     let shouldSync = false;
     for (const sessionFile of pending) {
       // Usage-counted session archives (`.jsonl.reset.<iso>` and
@@ -1691,6 +1703,27 @@ export abstract class MemoryManagerSyncOps {
     return resolvedFile.startsWith(`${resolvedDir}${path.sep}`);
   }
 
+  private resolveSessionTranscriptUpdateSyncTarget(update: {
+    agentId?: string;
+    sessionFile: string;
+    sessionKey?: string;
+  }): MemorySessionSyncTarget | null {
+    const parsed = parseCanonicalSessionSyncTargetFromPath(update.sessionFile);
+    if (!parsed || isSessionArchiveArtifactName(path.basename(update.sessionFile))) {
+      return null;
+    }
+    const agentId = update.agentId?.trim() || parsed.agentId;
+    if (!agentId || normalizeAgentId(agentId) !== normalizeAgentId(this.agentId)) {
+      return null;
+    }
+    const sessionKey = update.sessionKey?.trim();
+    return {
+      agentId,
+      sessionId: parsed.sessionId,
+      ...(sessionKey ? { sessionKey } : {}),
+    };
+  }
+
   private normalizeTargetSessionFiles(sessionFiles?: string[]): Set<string> | null {
     if (!sessionFiles || sessionFiles.length === 0) {
       return null;
@@ -1702,11 +1735,78 @@ export abstract class MemoryManagerSyncOps {
         continue;
       }
       const resolved = path.resolve(trimmed);
-      if (this.isSessionFileForAgent(resolved)) {
+      if (
+        this.isSessionFileForAgent(resolved) &&
+        parseCanonicalSessionSyncTargetFromPath(resolved)
+      ) {
         normalized.add(resolved);
       }
     }
     return normalized.size > 0 ? normalized : null;
+  }
+
+  private normalizeTargetSessions(
+    sessions?: MemorySessionSyncTarget[],
+  ): Map<string, MemorySessionSyncTarget> | null {
+    if (!sessions || sessions.length === 0) {
+      return null;
+    }
+    const normalized = new Map<string, MemorySessionSyncTarget>();
+    for (const session of sessions) {
+      const sessionId = session.sessionId.trim();
+      const agentId = session.agentId?.trim() || this.agentId;
+      if (!sessionId || normalizeAgentId(agentId) !== normalizeAgentId(this.agentId)) {
+        continue;
+      }
+      const sessionKey = session.sessionKey?.trim();
+      const target = {
+        agentId,
+        sessionId,
+        ...(sessionKey ? { sessionKey } : {}),
+      };
+      normalized.set(this.memorySessionSyncTargetKey(target), target);
+    }
+    return normalized.size > 0 ? normalized : null;
+  }
+
+  private resolveSessionFilesForSyncTargets(
+    sessions?: Iterable<MemorySessionSyncTarget> | null,
+  ): Set<string> {
+    const files = new Set<string>();
+    for (const session of sessions ?? []) {
+      const resolved = resolveSessionFileForSyncTarget(session, this.agentId);
+      if (!resolved || normalizeAgentId(resolved.agentId) !== normalizeAgentId(this.agentId)) {
+        continue;
+      }
+      const sessionFile = path.resolve(resolved.sessionFile);
+      if (
+        this.isSessionFileForAgent(sessionFile) &&
+        parseCanonicalSessionSyncTargetFromPath(sessionFile)
+      ) {
+        files.add(sessionFile);
+      }
+    }
+    return files;
+  }
+
+  private combineTargetSessionFiles(params: {
+    sessions?: MemorySessionSyncTarget[];
+    sessionFiles?: string[];
+  }): Set<string> | null {
+    const files = new Set<string>();
+    for (const file of this.normalizeTargetSessionFiles(params.sessionFiles) ?? []) {
+      files.add(file);
+    }
+    for (const file of this.resolveSessionFilesForSyncTargets(
+      this.normalizeTargetSessions(params.sessions)?.values(),
+    )) {
+      files.add(file);
+    }
+    return files.size > 0 ? files : null;
+  }
+
+  private memorySessionSyncTargetKey(target: MemorySessionSyncTarget): string {
+    return [target.agentId ?? "", target.sessionId, target.sessionKey ?? ""].join("\0");
   }
 
   protected ensureIntervalSync() {
@@ -1750,10 +1850,7 @@ export abstract class MemoryManagerSyncOps {
     }, this.settings.sync.watchDebounceMs);
   }
 
-  private shouldSyncSessions(
-    params?: { reason?: string; force?: boolean; sessionFiles?: string[] },
-    needsFullReindex = false,
-  ) {
+  private shouldSyncSessions(params?: MemorySyncParams, needsFullReindex = false) {
     return shouldSyncSessionsForReindex({
       hasSessionSource: this.sources.has("sessions"),
       sessionsDirty: this.sessionsDirty,
@@ -2180,12 +2277,7 @@ export abstract class MemoryManagerSyncOps {
     );
   }
 
-  protected async runSync(params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }) {
+  protected async runSync(params?: MemorySyncParams) {
     // Guard: if an embedding provider is configured but currently unavailable,
     // abort sync to prevent silently degrading an existing semantic vector index
     // to fts-only and wiping existing semantic vectors.
@@ -2203,8 +2295,14 @@ export abstract class MemoryManagerSyncOps {
     }
     const vectorReady = await this.ensureVectorReady();
     const meta = this.readMeta();
-    const targetSessionFiles = this.normalizeTargetSessionFiles(params?.sessionFiles);
+    const targetSessionFiles = this.combineTargetSessionFiles({
+      sessions: params?.sessions,
+      sessionFiles: params?.sessionFiles,
+    });
     const hasTargetSessionFiles = targetSessionFiles !== null;
+    if (this.hasRequestedTargetSessionSync(params) && !hasTargetSessionFiles) {
+      return;
+    }
     if (params?.reason === "cli" && !params.force && !hasTargetSessionFiles) {
       await this.markSessionStartupCatchupDirtyFiles();
     }
@@ -2368,6 +2466,13 @@ export abstract class MemoryManagerSyncOps {
 
   protected shouldFallbackOnError(err: unknown): boolean {
     return isMemoryEmbeddingOperationError(err);
+  }
+
+  private hasRequestedTargetSessionSync(params?: MemorySyncParams): boolean {
+    return Boolean(
+      params?.sessions?.some((session) => session.sessionId.trim().length > 0) ||
+      params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0),
+    );
   }
 
   protected resolveBatchConfig(): {

--- a/extensions/memory-core/src/memory/manager-sync-yield.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-yield.test.ts
@@ -34,6 +34,15 @@ vi.mock("openclaw/plugin-sdk/memory-core-host-engine-qmd", () => {
     isSessionArchiveArtifactName: (fileName: string) => /\.jsonl\.(reset|deleted)\./.test(fileName),
     isUsageCountedSessionTranscriptFileName: (fileName: string) => fileName.endsWith(".jsonl"),
     listSessionFilesForAgent: vi.fn(async () => []),
+    parseCanonicalSessionSyncTargetFromPath: (filePath: string) => ({
+      agentId: "main",
+      sessionId: basename(filePath).replace(/\.jsonl$/, ""),
+    }),
+    resolveSessionFileForSyncTarget: (target: { agentId?: string; sessionId: string }) => ({
+      agentId: target.agentId ?? "main",
+      sessionFile: `/tmp/${target.sessionId}.jsonl`,
+      sessionId: target.sessionId,
+    }),
     sessionPathForFile: (filePath: string) => `sessions/${basename(filePath)}`,
   };
 });

--- a/extensions/memory-core/src/memory/manager-targeted-sync.test.ts
+++ b/extensions/memory-core/src/memory/manager-targeted-sync.test.ts
@@ -1,5 +1,7 @@
 // Memory Core tests cover manager targeted sync plugin behavior.
+import type { MemorySessionSyncTarget } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { describe, expect, it, vi } from "vitest";
+import { enqueueMemoryTargetedSessionSync } from "./manager-sync-control.js";
 import {
   clearMemorySyncedSessionFiles,
   markMemoryTargetSessionFilesDirty,
@@ -83,5 +85,42 @@ describe("memory targeted session sync", () => {
 
     expect(result).toEqual({ handled: true, sessionsDirty: true });
     expect(sessionsDirtyFiles.size).toBe(0);
+  });
+
+  it("queues identity session targets while a sync is already running", async () => {
+    let resolveSyncing: (() => void) | undefined;
+    const syncing = new Promise<void>((resolve) => {
+      resolveSyncing = resolve;
+    });
+    const queuedSessionFiles = new Set<string>();
+    const queuedSessions = new Map<string, MemorySessionSyncTarget>();
+    let queuedSessionSync: Promise<void> | null = null;
+    const sync = vi.fn(async () => {});
+
+    const queued = enqueueMemoryTargetedSessionSync(
+      {
+        isClosed: () => false,
+        getSyncing: () => syncing,
+        getQueuedSessionFiles: () => queuedSessionFiles,
+        getQueuedSessions: () => queuedSessions,
+        getQueuedSessionSync: () => queuedSessionSync,
+        setQueuedSessionSync: (value) => {
+          queuedSessionSync = value;
+        },
+        sync,
+      },
+      {
+        sessions: [{ agentId: "main", sessionId: "targeted", sessionKey: "agent:main:targeted" }],
+      },
+    );
+
+    resolveSyncing?.();
+    await queued;
+
+    expect(sync).toHaveBeenCalledWith({
+      reason: "queued-sessions",
+      sessions: [{ agentId: "main", sessionId: "targeted", sessionKey: "agent:main:targeted" }],
+      sessionFiles: [],
+    });
   });
 });

--- a/extensions/memory-core/src/memory/manager.readonly-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager.readonly-recovery.test.ts
@@ -14,6 +14,7 @@ import {
 type ReadonlyRecoveryHarness = MemoryReadonlyRecoveryState & {
   syncing: Promise<void> | null;
   queuedSessionFiles: Set<string>;
+  queuedSessions: Map<string, unknown>;
   queuedSessionSync: Promise<void> | null;
   vectorDegradedWriteWarningShown: boolean;
   ensureProviderInitialized: ReturnType<typeof vi.fn>;
@@ -32,10 +33,12 @@ describe("memory manager readonly recovery", () => {
 
   function createQueuedSyncHarness(syncing: Promise<void>) {
     const queuedSessionFiles = new Set<string>();
+    const queuedSessions = new Map<string, never>();
     let queuedSessionSync: Promise<void> | null = null;
     const sync = vi.fn(async () => {});
     return {
       queuedSessionFiles,
+      queuedSessions,
       get queuedSessionSync() {
         return queuedSessionSync;
       },
@@ -44,6 +47,7 @@ describe("memory manager readonly recovery", () => {
         isClosed: () => false,
         getSyncing: () => syncing,
         getQueuedSessionFiles: () => queuedSessionFiles,
+        getQueuedSessions: () => queuedSessions,
         getQueuedSessionSync: () => queuedSessionSync,
         setQueuedSessionSync: (value: Promise<void> | null) => {
           queuedSessionSync = value;
@@ -61,6 +65,7 @@ describe("memory manager readonly recovery", () => {
       closed: false,
       syncing: null,
       queuedSessionFiles: new Set<string>(),
+      queuedSessions: new Map<string, never>(),
       queuedSessionSync: null,
       db: initialDb,
       vector: {
@@ -224,11 +229,9 @@ describe("memory manager readonly recovery", () => {
     });
     const harness = createQueuedSyncHarness(pendingSync);
 
-    const queued = enqueueMemoryTargetedSessionSync(harness.state, [
-      "  /tmp/first.jsonl ",
-      "",
-      "/tmp/second.jsonl",
-    ]);
+    const queued = enqueueMemoryTargetedSessionSync(harness.state, {
+      sessionFiles: ["  /tmp/first.jsonl ", "", "/tmp/second.jsonl"],
+    });
 
     expect(harness.sync).not.toHaveBeenCalled();
 
@@ -237,7 +240,8 @@ describe("memory manager readonly recovery", () => {
 
     expect(harness.sync).toHaveBeenCalledTimes(1);
     expect(harness.sync).toHaveBeenCalledWith({
-      reason: "queued-session-files",
+      reason: "queued-sessions",
+      sessions: [],
       sessionFiles: ["/tmp/first.jsonl", "/tmp/second.jsonl"],
     });
     expect(harness.queuedSessionSync).toBeNull();
@@ -250,14 +254,12 @@ describe("memory manager readonly recovery", () => {
     });
     const harness = createQueuedSyncHarness(pendingSync);
 
-    const first = enqueueMemoryTargetedSessionSync(harness.state, [
-      "/tmp/first.jsonl",
-      "/tmp/second.jsonl",
-    ]);
-    const second = enqueueMemoryTargetedSessionSync(harness.state, [
-      "/tmp/second.jsonl",
-      "/tmp/third.jsonl",
-    ]);
+    const first = enqueueMemoryTargetedSessionSync(harness.state, {
+      sessionFiles: ["/tmp/first.jsonl", "/tmp/second.jsonl"],
+    });
+    const second = enqueueMemoryTargetedSessionSync(harness.state, {
+      sessionFiles: ["/tmp/second.jsonl", "/tmp/third.jsonl"],
+    });
 
     expect(first).toBe(second);
 
@@ -266,7 +268,8 @@ describe("memory manager readonly recovery", () => {
 
     expect(harness.sync).toHaveBeenCalledTimes(1);
     expect(harness.sync).toHaveBeenCalledWith({
-      reason: "queued-session-files",
+      reason: "queued-sessions",
+      sessions: [],
       sessionFiles: ["/tmp/first.jsonl", "/tmp/second.jsonl", "/tmp/third.jsonl"],
     });
   });
@@ -278,7 +281,9 @@ describe("memory manager readonly recovery", () => {
     });
     const harness = createQueuedSyncHarness(pendingSync);
 
-    const queued = enqueueMemoryTargetedSessionSync(harness.state, ["", "   "]);
+    const queued = enqueueMemoryTargetedSessionSync(harness.state, {
+      sessionFiles: ["", "   "],
+    });
 
     expect(queued).toBe(pendingSync);
     releaseSync();

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -22,8 +22,9 @@ import {
   type MemorySearchManager,
   type MemorySearchRuntimeDebug,
   type MemorySearchResult,
+  type MemorySessionSyncTarget,
   type MemorySource,
-  type MemorySyncProgressUpdate,
+  type MemorySyncParams,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { uniqueValues } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -283,6 +284,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   protected override sessionsDirty = false;
   protected override sessionsDirtyFiles = new Set<string>();
   protected override sessionPendingFiles = new Set<string>();
+  protected override sessionPendingTargets = new Map<string, MemorySessionSyncTarget>();
   private indexIdentityDirty = false;
   protected override sessionDeltas = new Map<
     string,
@@ -291,6 +293,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private sessionWarm = new Set<string>();
   private syncing: Promise<void> | null = null;
   private queuedSessionFiles = new Set<string>();
+  private queuedSessions = new Map<string, MemorySessionSyncTarget>();
   private queuedSessionSync: Promise<void> | null = null;
   private readonlyRecoveryAttempts = 0;
   private readonlyRecoverySuccesses = 0;
@@ -989,18 +992,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }).then((entries) => entries.map((entry) => entry as MemorySearchResult));
   }
 
-  async sync(params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }): Promise<void> {
+  async sync(params?: MemorySyncParams): Promise<void> {
     if (this.closed) {
       return;
     }
     if (this.syncing) {
-      if (params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
-        return this.enqueueTargetedSessionSync(params.sessionFiles);
+      if (hasTargetedSessionSyncParams(params)) {
+        return this.enqueueTargetedSessionSync(params);
       }
       return this.syncing;
     }
@@ -1013,28 +1011,26 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     return this.syncing ?? Promise.resolve();
   }
 
-  private enqueueTargetedSessionSync(sessionFiles?: string[]): Promise<void> {
+  private enqueueTargetedSessionSync(
+    targets?: Pick<MemorySyncParams, "sessions" | "sessionFiles">,
+  ): Promise<void> {
     return enqueueMemoryTargetedSessionSync(
       {
         isClosed: () => this.closed,
         getSyncing: () => this.syncing,
         getQueuedSessionFiles: () => this.queuedSessionFiles,
+        getQueuedSessions: () => this.queuedSessions,
         getQueuedSessionSync: () => this.queuedSessionSync,
         setQueuedSessionSync: (value) => {
           this.queuedSessionSync = value;
         },
         sync: async (params) => await this.sync(params),
       },
-      sessionFiles,
+      targets,
     );
   }
 
-  private async runSyncWithReadonlyRecovery(params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }): Promise<void> {
+  private async runSyncWithReadonlyRecovery(params?: MemorySyncParams): Promise<void> {
     const getClosed = () => this.closed;
     const getDb = () => this.db;
     const setDb = (value: DatabaseSync) => {
@@ -1379,6 +1375,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       throw toLintErrorObject(closeError, "Non-Error thrown");
     }
   }
+}
+
+function hasTargetedSessionSyncParams(params: MemorySyncParams | undefined): boolean {
+  return Boolean(
+    params?.sessions?.some((session) => session.sessionId.trim().length > 0) ||
+    params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0),
+  );
 }
 
 function toLintErrorObject(value: unknown, fallbackMessage: string): Error {

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -203,6 +203,8 @@ import {
   resolveMemoryBackendConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
+import { formatSessionTranscriptMemoryHitKey } from "openclaw/plugin-sdk/session-transcript-hit";
+import { resolveQmdSessionArtifactIdentity } from "../qmd-session-artifacts.js";
 import { QmdMemoryManager, resolveQmdMcporterSearchProcessTimeoutMs } from "./qmd-manager.js";
 
 const spawnMock = mockedSpawn as unknown as Mock;
@@ -4819,6 +4821,61 @@ describe("QmdMemoryManager", () => {
       await first.manager.close();
       await second.manager.close();
     }
+  });
+
+  it("maps exported QMD artifacts to the persisted session identity", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 0, onBoot: false },
+          sessions: { enabled: true },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const sessionsDir = path.join(stateDir, "agents", agentId, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sessionsDir, "actual-session-topic-thread.jsonl"),
+      '{"type":"message","message":{"role":"user","content":"hello mapped session"}}\n',
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:chat:thread": {
+          sessionFile: "actual-session-topic-thread.jsonl",
+          sessionId: "actual-session",
+        },
+      }),
+      "utf-8",
+    );
+
+    const { manager } = await createManager({ mode: "status" });
+    await (manager as unknown as { exportSessions: () => Promise<void> }).exportSessions();
+    const indexPath = (manager as unknown as { indexPath: string }).indexPath;
+    const identity = resolveQmdSessionArtifactIdentity({
+      artifactPath: "actual-session-topic-thread.md",
+      collection: "sessions-main",
+      indexPath,
+      searchPath: "qmd/sessions-main/actual-session-topic-thread.md",
+    });
+
+    expect(identity).toEqual({
+      agentId,
+      archived: false,
+      memoryKey: formatSessionTranscriptMemoryHitKey({
+        agentId,
+        sessionId: "actual-session",
+      }),
+      sessionId: "actual-session",
+    });
+
+    await manager.close();
   });
 
   it("skips queued session export work after close while waiting on the shared update queue", async () => {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -23,9 +23,11 @@ import {
   buildSessionEntry,
   deriveQmdScopeChannel,
   deriveQmdScopeChatType,
+  isSessionArchiveArtifactName,
   isQmdScopeAllowed,
   listSessionFilesForAgent,
   parseQmdQueryJson,
+  resolveSessionIdentityForTranscriptFile,
   resolveCliSpawnInvocation,
   runCliCommand,
   type QmdQueryResult,
@@ -45,7 +47,7 @@ import {
   type MemorySearchRuntimeDebug,
   type MemorySearchResult,
   type MemorySource,
-  type MemorySyncProgressUpdate,
+  type MemorySyncParams,
   type ResolvedMemoryBackendConfig,
   type ResolvedQmdConfig,
   type ResolvedQmdMcporterConfig,
@@ -55,12 +57,21 @@ import {
   isFutureDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import { formatSessionTranscriptMemoryHitKey } from "openclaw/plugin-sdk/session-transcript-hit";
 import {
   localeLowercasePreservingWhitespace,
   normalizeLowercaseStringOrEmpty,
   uniqueValues,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { asRecord } from "../dreaming-shared.js";
+import {
+  attachQmdSessionArtifactHit,
+  copyQmdSessionArtifactHit,
+  refreshQmdSessionArtifactDocIds,
+  replaceQmdSessionArtifactMappings,
+  resolveQmdSessionArtifactIdentity,
+  type QmdSessionArtifactMapping,
+} from "../qmd-session-artifacts.js";
 import { resolveQmdCollectionPatternFlags, type QmdCollectionPatternFlag } from "./qmd-compat.js";
 import {
   countChokidarWatchedEntries,
@@ -269,6 +280,14 @@ type CollectionRoot = {
   kind: MemorySource;
 };
 
+type DocLocation = {
+  abs: string;
+  collection: string;
+  collectionRelativePath: string;
+  rel: string;
+  source: MemorySource;
+};
+
 type SessionExporterConfig = {
   dir: string;
   retentionMs?: number;
@@ -375,10 +394,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private readonly managedCollectionNames: string[];
   private readonly collectionRoots = new Map<string, CollectionRoot>();
   private readonly sources = new Set<MemorySource>();
-  private readonly docPathCache = new Map<
-    string,
-    { rel: string; abs: string; source: MemorySource }
-  >();
+  private readonly docPathCache = new Map<string, DocLocation>();
   private readonly exportedSessionState = new Map<
     string,
     {
@@ -1424,14 +1440,27 @@ export class QmdMemoryManager implements MemorySearchManager {
       if (score < minScore) {
         continue;
       }
-      results.push({
+      const result = {
         path: doc.rel,
         startLine: lines.startLine,
         endLine: lines.endLine,
         score,
         snippet,
         source: doc.source,
-      });
+      } satisfies MemorySearchResult;
+      const artifactIdentity =
+        doc.source === "sessions"
+          ? resolveQmdSessionArtifactIdentity({
+              artifactPath: doc.collectionRelativePath,
+              collection: doc.collection,
+              docid: entry.docid?.trim() || undefined,
+              indexPath: this.indexPath,
+              searchPath: doc.rel,
+            })
+          : null;
+      results.push(
+        artifactIdentity ? attachQmdSessionArtifactHit(result, artifactIdentity) : result,
+      );
     }
     opts?.onDebug?.({
       backend: "qmd",
@@ -1447,14 +1476,12 @@ export class QmdMemoryManager implements MemorySearchManager {
     return this.clampResultsByInjectedChars(this.diversifyResultsBySource(ranked, resultLimit));
   }
 
-  async sync(params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }): Promise<void> {
-    if (params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
-      log.debug("qmd sync ignoring targeted sessionFiles hint; running regular update");
+  async sync(params?: MemorySyncParams): Promise<void> {
+    if (
+      params?.sessions?.some((session) => session.sessionId.trim().length > 0) ||
+      params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)
+    ) {
+      log.debug("qmd sync ignoring targeted session hint; running regular update");
     }
     if (params?.progress) {
       params.progress({ completed: 0, total: 1, label: "Updating QMD index…" });
@@ -1674,6 +1701,9 @@ export class QmdMemoryManager implements MemorySearchManager {
           await this.exportSessions();
         }
         await this.runQmdUpdateWithRetry(reason);
+        if (this.sessionExporter) {
+          this.refreshSessionArtifactDocIds();
+        }
         this.dirty = false;
       });
       if (this.closed) {
@@ -2514,6 +2544,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     const files = await listSessionFilesForAgent(this.agentId);
     const keep = new Set<string>();
     const tracked = new Set<string>();
+    const artifactMappings: QmdSessionArtifactMapping[] = [];
     const cutoff = this.sessionExporter.retentionMs
       ? Date.now() - this.sessionExporter.retentionMs
       : null;
@@ -2528,6 +2559,10 @@ export class QmdMemoryManager implements MemorySearchManager {
       const targetName = `${path.basename(sessionFile, ".jsonl")}.md`;
       const target = path.join(exportDir, targetName);
       tracked.add(sessionFile);
+      const identity = this.buildSessionArtifactMapping(sessionFile, targetName, target);
+      if (identity) {
+        artifactMappings.push(identity);
+      }
       const state = this.exportedSessionState.get(sessionFile);
       if (!state || state.hash !== entry.hash || state.mtimeMs !== entry.mtimeMs) {
         await exportRoot.write(targetName, this.renderSessionMarkdown(entry), {
@@ -2555,6 +2590,56 @@ export class QmdMemoryManager implements MemorySearchManager {
       if (!tracked.has(sessionFile) || !isPathInside(exportDir, state.target)) {
         this.exportedSessionState.delete(sessionFile);
       }
+    }
+    replaceQmdSessionArtifactMappings({
+      collection: this.sessionExporter.collectionName,
+      indexPath: this.indexPath,
+      mappings: artifactMappings,
+    });
+  }
+
+  private buildSessionArtifactMapping(
+    sessionFile: string,
+    artifactPath: string,
+    target: string,
+  ): QmdSessionArtifactMapping | null {
+    if (!this.sessionExporter) {
+      return null;
+    }
+    const identity = resolveSessionIdentityForTranscriptFile(sessionFile);
+    if (!identity?.agentId) {
+      return null;
+    }
+    return {
+      agentId: identity.agentId,
+      archived: isSessionArchiveArtifactName(path.basename(sessionFile)),
+      artifactPath,
+      collection: this.sessionExporter.collectionName,
+      memoryKey: formatSessionTranscriptMemoryHitKey({
+        agentId: identity.agentId,
+        sessionId: identity.sessionId,
+      }),
+      searchPath: this.buildSearchPath(
+        this.sessionExporter.collectionName,
+        artifactPath,
+        path.relative(this.workspaceDir, target),
+        target,
+      ),
+      sessionId: identity.sessionId,
+    };
+  }
+
+  private refreshSessionArtifactDocIds(): void {
+    if (!this.sessionExporter) {
+      return;
+    }
+    try {
+      refreshQmdSessionArtifactDocIds({
+        collection: this.sessionExporter.collectionName,
+        indexPath: this.indexPath,
+      });
+    } catch (err) {
+      log.warn(`failed to refresh qmd session artifact identity docids: ${String(err)}`);
     }
   }
 
@@ -2588,7 +2673,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private async resolveDocLocation(
     docid?: string,
     hints?: { preferredCollection?: string; preferredFile?: string },
-  ): Promise<{ rel: string; abs: string; source: MemorySource } | null> {
+  ): Promise<DocLocation | null> {
     const normalizedHints = this.normalizeDocHints(hints);
     if (!docid) {
       return this.resolveDocLocationFromHints(normalizedHints);
@@ -2634,7 +2719,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private resolveDocLocationFromHints(hints: {
     preferredCollection?: string;
     preferredFile?: string;
-  }): { rel: string; abs: string; source: MemorySource } | null {
+  }): DocLocation | null {
     if (!hints.preferredCollection || !hints.preferredFile) {
       return null;
     }
@@ -2658,7 +2743,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private resolveIndexedDocLocationFromHint(
     collection: string,
     preferredFile: string,
-  ): { rel: string; abs: string; source: MemorySource } | null {
+  ): DocLocation | null {
     const trimmedCollection = collection.trim();
     const trimmedFile = preferredFile.trim();
     if (!trimmedCollection || !trimmedFile) {
@@ -2760,7 +2845,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private pickDocLocation(
     rows: Array<{ collection: string; path: string }>,
     hints?: { preferredCollection?: string; preferredFile?: string },
-  ): { rel: string; abs: string; source: MemorySource } | null {
+  ): DocLocation | null {
     if (hints?.preferredCollection) {
       for (const row of rows) {
         if (row.collection !== hints.preferredCollection) {
@@ -2955,10 +3040,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     return isQmdScopeAllowed(this.qmd.scope, sessionKey);
   }
 
-  private toDocLocation(
-    collection: string,
-    collectionRelativePath: string,
-  ): { rel: string; abs: string; source: MemorySource } | null {
+  private toDocLocation(collection: string, collectionRelativePath: string): DocLocation | null {
     const rootEntry = this.collectionRoots.get(collection);
     if (!rootEntry) {
       return null;
@@ -2972,7 +3054,13 @@ export class QmdMemoryManager implements MemorySearchManager {
       relativeToWorkspace,
       absPath,
     );
-    return { rel: relPath, abs: absPath, source: rootEntry.kind };
+    return {
+      rel: relPath,
+      abs: absPath,
+      collection,
+      collectionRelativePath: normalizedRelative,
+      source: rootEntry.kind,
+    };
   }
 
   private buildSearchPath(
@@ -3111,7 +3199,7 @@ export class QmdMemoryManager implements MemorySearchManager {
         remaining -= snippet.length;
       } else {
         const trimmed = snippet.slice(0, Math.max(0, remaining));
-        clamped.push({ ...entry, snippet: trimmed });
+        clamped.push(copyQmdSessionArtifactHit(entry, { ...entry, snippet: trimmed }));
         break;
       }
     }

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -19,7 +19,7 @@ import {
   type MemorySearchManager,
   type MemorySearchRuntimeDebug,
   type MemorySource,
-  type MemorySyncProgressUpdate,
+  type MemorySyncParams,
   type ResolvedQmdConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
@@ -385,12 +385,7 @@ class BorrowedMemoryManager implements MemorySearchManager {
     return this.inner.status();
   }
 
-  async sync(params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }) {
+  async sync(params?: MemorySyncParams) {
     await this.inner.sync?.(params);
   }
 
@@ -544,12 +539,7 @@ class FallbackMemoryManager implements MemorySearchManager {
     };
   }
 
-  async sync(params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }) {
+  async sync(params?: MemorySyncParams) {
     this.ensureOpen();
     if (!this.primaryFailed) {
       await this.deps.primary.sync?.(params);

--- a/extensions/memory-core/src/qmd-session-artifacts.ts
+++ b/extensions/memory-core/src/qmd-session-artifacts.ts
@@ -1,0 +1,301 @@
+import fsSync from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { requireNodeSqlite } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
+
+const QMD_SESSION_ARTIFACT_TABLE = "openclaw_qmd_session_artifacts";
+
+export const QMD_SESSION_ARTIFACT_HIT: unique symbol = Symbol("openclaw.qmdSessionArtifactHit");
+
+export type QmdSessionArtifactMapping = {
+  agentId: string;
+  archived: boolean;
+  artifactPath: string;
+  collection: string;
+  memoryKey: string;
+  searchPath: string;
+  sessionId: string;
+};
+
+export type QmdSessionArtifactLookup = {
+  artifactPath?: string;
+  collection?: string;
+  docid?: string;
+  indexPath: string;
+  searchPath: string;
+};
+
+export type QmdSessionArtifactIdentity = {
+  agentId: string;
+  archived: boolean;
+  memoryKey: string;
+  sessionId: string;
+};
+
+type QmdSessionArtifactHitCarrier = MemorySearchResult & {
+  [QMD_SESSION_ARTIFACT_HIT]?: QmdSessionArtifactIdentity;
+};
+
+type QmdSessionArtifactRow = {
+  agentId: string;
+  artifact_path: string;
+  archived: number;
+  collection: string;
+  docid: string | null;
+  memoryKey: string;
+  search_path: string;
+  sessionId: string;
+};
+
+function ensureQmdSessionArtifactSchema(db: DatabaseSync): void {
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS ${QMD_SESSION_ARTIFACT_TABLE} (
+      collection TEXT NOT NULL,
+      artifact_path TEXT NOT NULL,
+      search_path TEXT NOT NULL,
+      docid TEXT,
+      memory_key TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      archived INTEGER NOT NULL DEFAULT 0,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (collection, artifact_path)
+    )`,
+  );
+  try {
+    db.exec(
+      `ALTER TABLE ${QMD_SESSION_ARTIFACT_TABLE}
+       ADD COLUMN archived INTEGER NOT NULL DEFAULT 0`,
+    );
+  } catch {}
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_openclaw_qmd_session_artifacts_docid
+     ON ${QMD_SESSION_ARTIFACT_TABLE} (docid)`,
+  );
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_openclaw_qmd_session_artifacts_search_path
+     ON ${QMD_SESSION_ARTIFACT_TABLE} (search_path)`,
+  );
+}
+
+function openQmdSessionArtifactDb(indexPath: string, readOnly = false): DatabaseSync {
+  const { DatabaseSync: SqliteDatabase } = requireNodeSqlite();
+  if (!readOnly) {
+    fsSync.mkdirSync(path.dirname(indexPath), { recursive: true });
+  }
+  const db = new SqliteDatabase(indexPath, { readOnly });
+  db.exec("PRAGMA busy_timeout = 1000");
+  return db;
+}
+
+export function attachQmdSessionArtifactHit(
+  hit: MemorySearchResult,
+  identity: QmdSessionArtifactIdentity,
+): MemorySearchResult {
+  Object.defineProperty(hit, QMD_SESSION_ARTIFACT_HIT, {
+    configurable: true,
+    enumerable: false,
+    value: identity,
+  });
+  return hit;
+}
+
+export function copyQmdSessionArtifactHit(
+  source: MemorySearchResult,
+  target: MemorySearchResult,
+): MemorySearchResult {
+  const identity = readQmdSessionArtifactIdentity(source);
+  return identity ? attachQmdSessionArtifactHit(target, identity) : target;
+}
+
+export function readQmdSessionArtifactIdentity(
+  hit: MemorySearchResult,
+): QmdSessionArtifactIdentity | null {
+  return (hit as QmdSessionArtifactHitCarrier)[QMD_SESSION_ARTIFACT_HIT] ?? null;
+}
+
+export function replaceQmdSessionArtifactMappings(params: {
+  collection: string;
+  indexPath: string;
+  mappings: QmdSessionArtifactMapping[];
+}): void {
+  const db = openQmdSessionArtifactDb(params.indexPath);
+  let transactionStarted = false;
+  try {
+    ensureQmdSessionArtifactSchema(db);
+    const deleteCollection = db.prepare(
+      `DELETE FROM ${QMD_SESSION_ARTIFACT_TABLE} WHERE collection = ?`,
+    );
+    const upsert = db.prepare(
+      `INSERT INTO ${QMD_SESSION_ARTIFACT_TABLE}
+       (collection, artifact_path, search_path, docid, memory_key, agent_id, session_id, archived, updated_at)
+       VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?)
+       ON CONFLICT(collection, artifact_path) DO UPDATE SET
+         search_path=excluded.search_path,
+         docid=NULL,
+         memory_key=excluded.memory_key,
+         agent_id=excluded.agent_id,
+         session_id=excluded.session_id,
+         archived=excluded.archived,
+         updated_at=excluded.updated_at`,
+    );
+    db.exec("BEGIN");
+    transactionStarted = true;
+    deleteCollection.run(params.collection);
+    const updatedAt = Date.now();
+    for (const mapping of params.mappings) {
+      upsert.run(
+        mapping.collection,
+        mapping.artifactPath,
+        mapping.searchPath,
+        mapping.memoryKey,
+        mapping.agentId,
+        mapping.sessionId,
+        mapping.archived ? 1 : 0,
+        updatedAt,
+      );
+    }
+    db.exec("COMMIT");
+  } catch (err) {
+    if (transactionStarted) {
+      try {
+        db.exec("ROLLBACK");
+      } catch {}
+    }
+    throw err;
+  } finally {
+    db.close();
+  }
+}
+
+export function refreshQmdSessionArtifactDocIds(params: {
+  collection: string;
+  indexPath: string;
+}): void {
+  const db = openQmdSessionArtifactDb(params.indexPath);
+  let transactionStarted = false;
+  try {
+    ensureQmdSessionArtifactSchema(db);
+    const rows = db
+      .prepare(
+        `SELECT d.hash AS docid, m.artifact_path AS artifact_path
+         FROM ${QMD_SESSION_ARTIFACT_TABLE} m
+         JOIN documents d
+           ON d.collection = m.collection
+          AND d.path = m.artifact_path
+          AND d.active = 1
+         WHERE m.collection = ?`,
+      )
+      .all(params.collection) as Array<{ artifact_path: string; docid: string }>;
+    const updateDocId = db.prepare(
+      `UPDATE ${QMD_SESSION_ARTIFACT_TABLE}
+       SET docid = ?, updated_at = ?
+       WHERE collection = ? AND artifact_path = ?`,
+    );
+    db.exec("BEGIN");
+    transactionStarted = true;
+    const updatedAt = Date.now();
+    for (const row of rows) {
+      updateDocId.run(row.docid, updatedAt, params.collection, row.artifact_path);
+    }
+    db.exec("COMMIT");
+  } catch (err) {
+    if (transactionStarted) {
+      try {
+        db.exec("ROLLBACK");
+      } catch {}
+    }
+    throw err;
+  } finally {
+    db.close();
+  }
+}
+
+export function resolveQmdSessionArtifactIdentity(
+  lookup: QmdSessionArtifactLookup,
+): QmdSessionArtifactIdentity | null {
+  let db: DatabaseSync;
+  try {
+    db = openQmdSessionArtifactDb(lookup.indexPath, true);
+  } catch {
+    return null;
+  }
+  try {
+    const row =
+      findQmdSessionArtifactByDocId(db, lookup) ?? findQmdSessionArtifactByPath(db, lookup);
+    return row
+      ? {
+          agentId: row.agentId,
+          archived: row.archived === 1,
+          memoryKey: row.memoryKey,
+          sessionId: row.sessionId,
+        }
+      : null;
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
+}
+
+function findQmdSessionArtifactByDocId(
+  db: DatabaseSync,
+  lookup: QmdSessionArtifactLookup,
+): QmdSessionArtifactRow | null {
+  const docid = lookup.docid?.trim();
+  if (!docid) {
+    return null;
+  }
+  const rows = db
+    .prepare(
+      `SELECT collection, artifact_path, search_path, docid, archived, memory_key AS memoryKey,
+              agent_id AS agentId, session_id AS sessionId
+       FROM ${QMD_SESSION_ARTIFACT_TABLE}
+       WHERE docid = ?`,
+    )
+    .all(docid) as QmdSessionArtifactRow[];
+  return pickQmdSessionArtifactRow(rows, lookup);
+}
+
+function findQmdSessionArtifactByPath(
+  db: DatabaseSync,
+  lookup: QmdSessionArtifactLookup,
+): QmdSessionArtifactRow | null {
+  const rows = db
+    .prepare(
+      `SELECT collection, artifact_path, search_path, docid, archived, memory_key AS memoryKey,
+              agent_id AS agentId, session_id AS sessionId
+       FROM ${QMD_SESSION_ARTIFACT_TABLE}
+       WHERE search_path = ?
+          OR (collection = ? AND artifact_path = ?)`,
+    )
+    .all(
+      lookup.searchPath,
+      lookup.collection ?? "",
+      lookup.artifactPath ?? "",
+    ) as QmdSessionArtifactRow[];
+  return pickQmdSessionArtifactRow(rows, lookup);
+}
+
+function pickQmdSessionArtifactRow(
+  rows: QmdSessionArtifactRow[],
+  lookup: QmdSessionArtifactLookup,
+): QmdSessionArtifactRow | null {
+  if (rows.length === 0) {
+    return null;
+  }
+  const exact = rows.find((row) => {
+    if (lookup.collection && row.collection !== lookup.collection) {
+      return false;
+    }
+    if (lookup.artifactPath && row.artifact_path !== lookup.artifactPath) {
+      return false;
+    }
+    return row.search_path === lookup.searchPath;
+  });
+  if (exact) {
+    return exact;
+  }
+  return rows.length === 1 ? (rows[0] ?? null) : null;
+}

--- a/extensions/memory-core/src/session-search-visibility.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.test.ts
@@ -1,7 +1,16 @@
 // Memory Core tests cover session search visibility plugin behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import * as sessionTranscriptHit from "openclaw/plugin-sdk/session-transcript-hit";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  attachQmdSessionArtifactHit,
+  copyQmdSessionArtifactHit,
+  replaceQmdSessionArtifactMappings,
+  resolveQmdSessionArtifactIdentity,
+} from "./qmd-session-artifacts.js";
 import { filterMemorySearchHitsBySessionVisibility } from "./session-search-visibility.js";
 import { asOpenClawConfig } from "./tools.test-helpers.js";
 
@@ -19,6 +28,7 @@ const crossAgentStore: Record<string, TestSessionEntry> = {
   },
 };
 let combinedSessionStore: Record<string, TestSessionEntry> = crossAgentStore;
+const tempRoots: string[] = [];
 
 vi.mock("openclaw/plugin-sdk/session-transcript-hit", async (importOriginal) => {
   const actual =
@@ -33,10 +43,59 @@ vi.mock("openclaw/plugin-sdk/session-transcript-hit", async (importOriginal) => 
 });
 
 describe("filterMemorySearchHitsBySessionVisibility", () => {
-  afterEach(() => {
+  afterEach(async () => {
     vi.mocked(sessionTranscriptHit.loadCombinedSessionStoreForGateway).mockClear();
     combinedSessionStore = crossAgentStore;
+    while (tempRoots.length > 0) {
+      const root = tempRoots.pop();
+      if (root) {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    }
   });
+
+  async function createQmdArtifactIndex(params: {
+    agentId: string;
+    archived?: boolean;
+    artifactPath: string;
+    collection: string;
+    searchPath: string;
+    sessionId: string;
+  }): Promise<string> {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-qmd-session-artifact-"));
+    tempRoots.push(root);
+    const indexPath = path.join(root, "index.sqlite");
+    replaceQmdSessionArtifactMappings({
+      collection: params.collection,
+      indexPath,
+      mappings: [
+        {
+          agentId: params.agentId,
+          archived: params.archived === true,
+          artifactPath: params.artifactPath,
+          collection: params.collection,
+          memoryKey: sessionTranscriptHit.formatSessionTranscriptMemoryHitKey({
+            agentId: params.agentId,
+            sessionId: params.sessionId,
+          }),
+          searchPath: params.searchPath,
+          sessionId: params.sessionId,
+        },
+      ],
+    });
+    return indexPath;
+  }
+
+  function attachMappedQmdHit(
+    hit: MemorySearchResult,
+    lookup: Parameters<typeof resolveQmdSessionArtifactIdentity>[0],
+  ): MemorySearchResult {
+    const identity = resolveQmdSessionArtifactIdentity(lookup);
+    if (!identity) {
+      throw new Error("expected QMD session artifact identity mapping");
+    }
+    return attachQmdSessionArtifactHit(hit, identity);
+  }
 
   it("drops sessions-sourced hits when requester key is missing (fail closed)", async () => {
     const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "all" } } });
@@ -451,6 +510,189 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
     const filtered = await filterMemorySearchHitsBySessionVisibility({
       cfg,
       requesterSessionKey: "agent:main:foo_bar",
+      sandboxed: false,
+      hits: [hit],
+    });
+
+    expect(filtered).toStrictEqual([]);
+  });
+
+  it("keeps mapped QMD session hits when the artifact filename no longer matches the session id", async () => {
+    combinedSessionStore = {
+      "agent:main:actual-key": {
+        sessionId: "actual-session-id",
+        updatedAt: 1,
+        sessionFile: "/tmp/sessions/actual-session-id.jsonl",
+      },
+    };
+    const searchPath = "qmd/sessions-main/lossy-export-name.md";
+    const indexPath = await createQmdArtifactIndex({
+      agentId: "main",
+      artifactPath: "lossy-export-name.md",
+      collection: "sessions-main",
+      searchPath,
+      sessionId: "actual-session-id",
+    });
+    const hit = attachMappedQmdHit(
+      {
+        path: searchPath,
+        source: "sessions",
+        score: 1,
+        snippet: "x",
+        startLine: 1,
+        endLine: 2,
+      },
+      {
+        artifactPath: "lossy-export-name.md",
+        collection: "sessions-main",
+        indexPath,
+        searchPath,
+      },
+    );
+    const copiedHit = copyQmdSessionArtifactHit(hit, { ...hit, snippet: "trimmed" });
+    const cfg = asOpenClawConfig({
+      tools: {
+        sessions: { visibility: "self" },
+      },
+    });
+
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg,
+      requesterSessionKey: "agent:main:actual-key",
+      sandboxed: false,
+      hits: [copiedHit],
+    });
+
+    expect(filtered).toEqual([copiedHit]);
+  });
+
+  it("denies mapped live QMD session hits when no session-store key remains", async () => {
+    combinedSessionStore = {};
+    const searchPath = "qmd/sessions-main/orphan-live.md";
+    const indexPath = await createQmdArtifactIndex({
+      agentId: "main",
+      artifactPath: "orphan-live.md",
+      collection: "sessions-main",
+      searchPath,
+      sessionId: "orphan-live",
+    });
+    const hit = attachMappedQmdHit(
+      {
+        path: searchPath,
+        source: "sessions",
+        score: 1,
+        snippet: "x",
+        startLine: 1,
+        endLine: 2,
+      },
+      {
+        artifactPath: "orphan-live.md",
+        collection: "sessions-main",
+        indexPath,
+        searchPath,
+      },
+    );
+    const cfg = asOpenClawConfig({
+      tools: {
+        sessions: { visibility: "agent" },
+      },
+    });
+
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg,
+      requesterSessionKey: "agent:main:main",
+      sandboxed: false,
+      hits: [hit],
+    });
+
+    expect(filtered).toStrictEqual([]);
+  });
+
+  it("keeps mapped archived QMD session hits when no session-store key remains", async () => {
+    combinedSessionStore = {};
+    const searchPath = "qmd/sessions-main/archived-jsonl-deleted-2026-02-16t22-26-33-000z.md";
+    const indexPath = await createQmdArtifactIndex({
+      agentId: "main",
+      archived: true,
+      artifactPath: "archived-jsonl-deleted-2026-02-16t22-26-33-000z.md",
+      collection: "sessions-main",
+      searchPath,
+      sessionId: "archived",
+    });
+    const hit = attachMappedQmdHit(
+      {
+        path: searchPath,
+        source: "sessions",
+        score: 1,
+        snippet: "x",
+        startLine: 1,
+        endLine: 2,
+      },
+      {
+        artifactPath: "archived-jsonl-deleted-2026-02-16t22-26-33-000z.md",
+        collection: "sessions-main",
+        indexPath,
+        searchPath,
+      },
+    );
+    const cfg = asOpenClawConfig({
+      tools: {
+        sessions: { visibility: "all" },
+      },
+    });
+
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg,
+      requesterSessionKey: "agent:main:main",
+      sandboxed: false,
+      hits: [hit],
+    });
+
+    expect(filtered).toEqual([hit]);
+  });
+
+  it("denies mapped QMD session hits before deprecated filename fallback", async () => {
+    combinedSessionStore = {
+      "agent:main:visible": {
+        sessionId: "visible",
+        updatedAt: 1,
+        sessionFile: "/tmp/sessions/visible.jsonl",
+      },
+    };
+    const searchPath = "qmd/sessions-main/visible.md";
+    const indexPath = await createQmdArtifactIndex({
+      agentId: "peer",
+      artifactPath: "visible.md",
+      collection: "sessions-main",
+      searchPath,
+      sessionId: "peer-session",
+    });
+    const hit = attachMappedQmdHit(
+      {
+        path: searchPath,
+        source: "sessions",
+        score: 1,
+        snippet: "x",
+        startLine: 1,
+        endLine: 2,
+      },
+      {
+        artifactPath: "visible.md",
+        collection: "sessions-main",
+        indexPath,
+        searchPath,
+      },
+    );
+    const cfg = asOpenClawConfig({
+      tools: {
+        sessions: { visibility: "all" },
+        agentToAgent: { enabled: true, allow: ["*"] },
+      },
+    });
+
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg,
+      requesterSessionKey: "agent:main:visible",
       sandboxed: false,
       hits: [hit],
     });

--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -5,6 +5,7 @@ import { resolveSessionAgentId } from "openclaw/plugin-sdk/memory-host-core";
 import {
   extractTranscriptIdentityFromSessionsMemoryHit,
   loadCombinedSessionStoreForGateway,
+  resolveSessionTranscriptMemoryHitKeyToSessionKeys,
   resolveTranscriptStemToSessionKeys,
 } from "openclaw/plugin-sdk/session-transcript-hit";
 import {
@@ -12,6 +13,7 @@ import {
   createSessionVisibilityGuard,
   resolveEffectiveSessionToolsVisibility,
 } from "openclaw/plugin-sdk/session-visibility";
+import { readQmdSessionArtifactIdentity } from "./qmd-session-artifacts.js";
 
 function normalizeAgentIdForCompare(value: string | undefined): string | undefined {
   return value?.trim().toLowerCase() || undefined;
@@ -84,6 +86,38 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
     if (!params.requesterSessionKey || !guard) {
       continue;
     }
+    const artifactIdentity = readQmdSessionArtifactIdentity(hit);
+    if (artifactIdentity) {
+      const normalizedScopedAgentId = normalizeAgentIdForCompare(scopedAgentId);
+      const normalizedOwnerAgentId = normalizeAgentIdForCompare(artifactIdentity.agentId);
+      if (
+        normalizedScopedAgentId &&
+        normalizedOwnerAgentId &&
+        normalizedOwnerAgentId !== normalizedScopedAgentId
+      ) {
+        continue;
+      }
+      const keys = filterSessionKeysByScopedAgent({
+        cfg: params.cfg,
+        scopedAgentId,
+        keys: resolveSessionTranscriptMemoryHitKeyToSessionKeys({
+          store: combinedSessionStore,
+          key: artifactIdentity.memoryKey,
+          includeSyntheticFallback: artifactIdentity.archived,
+        }),
+      });
+      if (keys.length === 0) {
+        continue;
+      }
+      const allowed = keys.some((key) => guard.check(key).allowed);
+      if (!allowed) {
+        continue;
+      }
+      next.push(hit);
+      continue;
+    }
+    // Deprecated migration compatibility for older QMD/session rows that were
+    // indexed before memory-core stored artifact-to-transcript identity.
     const identity = extractTranscriptIdentityFromSessionsMemoryHit(hit.path);
     if (!identity) {
       continue;

--- a/packages/memory-host-sdk/src/engine-qmd.ts
+++ b/packages/memory-host-sdk/src/engine-qmd.ts
@@ -7,8 +7,13 @@ export {
   loadDreamingNarrativeTranscriptPathSetForAgent,
   loadSessionTranscriptClassificationForAgent,
   normalizeSessionTranscriptPathForComparison,
+  parseCanonicalSessionSyncTargetFromPath,
+  resolveSessionIdentityForTranscriptFile,
+  resolveSessionFileForSyncTarget,
   sessionPathForFile,
   type BuildSessionEntryOptions,
+  type ResolvedMemorySessionSyncTarget,
+  type ResolvedSessionTranscriptIdentity,
   type SessionFileEntry,
   type SessionTranscriptClassification,
 } from "./host/session-files.js";

--- a/packages/memory-host-sdk/src/engine-storage.ts
+++ b/packages/memory-host-sdk/src/engine-storage.ts
@@ -36,7 +36,9 @@ export type {
   MemorySearchManager,
   MemorySearchRuntimeDebug,
   MemorySearchResult,
+  MemorySessionSyncTarget,
   MemorySource,
+  MemorySyncParams,
   MemorySyncProgressUpdate,
 } from "./host/types.js";
 export {

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -6,6 +6,9 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import {
   buildSessionEntry,
   listSessionFilesForAgent,
+  parseCanonicalSessionSyncTargetFromPath,
+  resolveSessionIdentityForTranscriptFile,
+  resolveSessionFileForSyncTarget,
   sessionPathForFile,
   type SessionFileEntry,
 } from "./session-files.js";
@@ -103,6 +106,118 @@ describe("sessionPathForFile", () => {
     expect(sessionPathForFile(path.join(tmpDir, "loose-session.jsonl"))).toBe(
       "sessions/loose-session.jsonl",
     );
+  });
+});
+
+describe("memory session sync targets", () => {
+  it("parses deprecated canonical OpenClaw transcript paths into sync identity", () => {
+    const sessionFile = path.join(tmpDir, "agents", "main", "sessions", "active.jsonl");
+    fsSync.mkdirSync(path.dirname(sessionFile), { recursive: true });
+
+    expect(parseCanonicalSessionSyncTargetFromPath(sessionFile)).toEqual({
+      agentId: "main",
+      sessionId: "active",
+    });
+  });
+
+  it("rejects arbitrary deprecated transcript path hints", () => {
+    expect(parseCanonicalSessionSyncTargetFromPath(path.join(tmpDir, "active.jsonl"))).toBeNull();
+    expect(
+      parseCanonicalSessionSyncTargetFromPath(
+        path.join(tmpDir, "agents", "main", "sessions", "active.trajectory.jsonl"),
+      ),
+    ).toBeNull();
+  });
+
+  it("resolves identity sync targets to the current file-backed transcript", () => {
+    expect(resolveSessionFileForSyncTarget({ sessionId: "active" }, "main")).toEqual({
+      agentId: "main",
+      sessionId: "active",
+      sessionFile: path.join(tmpDir, "agents", "main", "sessions", "active.jsonl"),
+    });
+  });
+
+  it("normalizes agent ids before resolving identity sync targets", () => {
+    expect(resolveSessionFileForSyncTarget({ agentId: "MAIN", sessionId: "active" })).toEqual({
+      agentId: "main",
+      sessionId: "active",
+      sessionFile: path.join(tmpDir, "agents", "main", "sessions", "active.jsonl"),
+    });
+  });
+
+  it("rejects identity sync targets that would escape the sessions directory", () => {
+    expect(resolveSessionFileForSyncTarget({ sessionId: "../outside" }, "main")).toBeNull();
+  });
+
+  it("rejects identity sync targets that normalize to another transcript", () => {
+    expect(resolveSessionFileForSyncTarget({ sessionId: "foo/../active" }, "main")).toBeNull();
+  });
+
+  it("resolves identity sync targets through persisted session keys", () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:chat:thread-456": {
+          sessionFile: "active-thread-456.jsonl",
+          sessionId: "active",
+        },
+      }),
+    );
+
+    expect(
+      resolveSessionFileForSyncTarget({
+        agentId: "main",
+        sessionId: "active",
+        sessionKey: "agent:main:chat:thread-456",
+      }),
+    ).toEqual({
+      agentId: "main",
+      sessionId: "active",
+      sessionFile: path.join(sessionsDir, "active-thread-456.jsonl"),
+    });
+  });
+
+  it("resolves identity sync targets through persisted session ids", () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:chat:thread-456": {
+          sessionFile: "active-thread-456.jsonl",
+          sessionId: "active",
+        },
+      }),
+    );
+
+    expect(resolveSessionFileForSyncTarget({ agentId: "main", sessionId: "active" })).toEqual({
+      agentId: "main",
+      sessionId: "active",
+      sessionFile: path.join(sessionsDir, "active-thread-456.jsonl"),
+    });
+  });
+
+  it("resolves transcript file identities through persisted session keys", () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "active-thread-456.jsonl");
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:chat:thread-456": {
+          sessionFile: "active-thread-456.jsonl",
+          sessionId: "active",
+        },
+      }),
+    );
+
+    expect(resolveSessionIdentityForTranscriptFile(sessionFile)).toEqual({
+      agentId: "main",
+      sessionId: "active",
+      sessionKey: "agent:main:chat:thread-456",
+    });
   });
 });
 

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -2,6 +2,7 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { normalizeAgentId } from "./config-utils.js";
 import { readRegularFile, statRegularFile } from "./fs-utils.js";
 import { hashText } from "./hash.js";
 import { createSubsystemLogger, redactSensitiveText } from "./openclaw-runtime-io.js";
@@ -22,6 +23,7 @@ import {
   stripInternalRuntimeContext,
 } from "./openclaw-runtime-session.js";
 import { retryTransientMemoryRead } from "./read-retry.js";
+import type { MemorySessionSyncTarget } from "./types.js";
 
 const DREAMING_NARRATIVE_RUN_PREFIX = "dreaming-narrative-";
 // Keep the historical one-line-per-message export shape for normal turns, but
@@ -62,6 +64,18 @@ export type BuildSessionEntryOptions = {
 export type SessionTranscriptClassification = {
   dreamingNarrativeTranscriptPaths: ReadonlySet<string>;
   cronRunTranscriptPaths: ReadonlySet<string>;
+};
+
+export type ResolvedMemorySessionSyncTarget = {
+  agentId: string;
+  sessionFile: string;
+  sessionId: string;
+};
+
+export type ResolvedSessionTranscriptIdentity = {
+  agentId: string;
+  sessionId: string;
+  sessionKey?: string;
 };
 
 type SessionTranscriptStoreEntry = {
@@ -256,6 +270,15 @@ function readSessionTranscriptClassificationStore(
   }
 }
 
+function findSessionTranscriptStoreEntryBySessionId(
+  store: Record<string, SessionTranscriptStoreEntry>,
+  sessionId: string,
+): SessionTranscriptStoreEntry | undefined {
+  return Object.values(store).find((entry) => {
+    return typeof entry.sessionId === "string" && entry.sessionId.trim() === sessionId;
+  });
+}
+
 export function loadDreamingNarrativeTranscriptPathSetForAgent(
   agentId: string,
 ): ReadonlySet<string> {
@@ -321,6 +344,148 @@ export function sessionPathForFile(absPath: string): string {
   return path
     .join("sessions", ...(agentId ? [agentId] : []), path.basename(absPath))
     .replace(/\\/g, "/");
+}
+
+/**
+ * Parses a deprecated path-shaped memory sync hint only when it points at an
+ * OpenClaw-owned usage-counted transcript in the canonical agent sessions dir.
+ */
+export function parseCanonicalSessionSyncTargetFromPath(
+  sessionFile: string,
+): MemorySessionSyncTarget | null {
+  const trimmed = sessionFile.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const resolved = path.resolve(trimmed);
+  const fileName = path.basename(resolved);
+  const sessionId = parseUsageCountedSessionIdFromFileName(fileName);
+  if (!sessionId || !isUsageCountedSessionTranscriptFileName(fileName)) {
+    return null;
+  }
+  const agentId = extractAgentIdFromSessionPath(resolved);
+  if (!agentId) {
+    return null;
+  }
+  const canonicalSessionsDir = normalizeComparablePath(
+    resolveSessionTranscriptsDirForAgent(agentId),
+  );
+  if (normalizeComparablePath(path.dirname(resolved)) !== canonicalSessionsDir) {
+    return null;
+  }
+  return { agentId, sessionId };
+}
+
+/**
+ * Resolves a current transcript path back to the canonical session-store
+ * identity when available, falling back to the usage-counted file identity.
+ */
+export function resolveSessionIdentityForTranscriptFile(
+  sessionFile: string,
+): ResolvedSessionTranscriptIdentity | null {
+  const parsed = parseCanonicalSessionSyncTargetFromPath(sessionFile);
+  if (!parsed?.agentId) {
+    return null;
+  }
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(parsed.agentId);
+  const normalizedSessionFile = normalizeComparablePath(sessionFile);
+  const store = readSessionTranscriptClassificationStore(path.join(sessionsDir, "sessions.json"));
+  for (const [sessionKey, entry] of Object.entries(store)) {
+    const transcriptPath = resolveSessionStoreTranscriptPath(sessionsDir, entry);
+    if (transcriptPath !== normalizedSessionFile) {
+      continue;
+    }
+    const sessionId = typeof entry.sessionId === "string" ? entry.sessionId.trim() : "";
+    if (!sessionId) {
+      continue;
+    }
+    return {
+      agentId: parsed.agentId,
+      sessionId,
+      ...(sessionKey.trim() ? { sessionKey } : {}),
+    };
+  }
+  return {
+    agentId: parsed.agentId,
+    sessionId: parsed.sessionId,
+  };
+}
+
+/**
+ * Resolves a storage-neutral memory sync target to the current file-backed
+ * transcript. The SQLite adapter implements this identity contract without
+ * deriving a path.
+ */
+export function resolveSessionFileForSyncTarget(
+  target: MemorySessionSyncTarget,
+  defaultAgentId?: string,
+): ResolvedMemorySessionSyncTarget | null {
+  const sessionId = target.sessionId.trim();
+  const rawAgentId = (target.agentId ?? defaultAgentId ?? "").trim();
+  if (!rawAgentId || !sessionId) {
+    return null;
+  }
+  const agentId = normalizeAgentId(rawAgentId);
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
+  const sessionKey = target.sessionKey?.trim();
+  let store: Record<string, SessionTranscriptStoreEntry> | null = null;
+  if (sessionKey) {
+    store = readSessionTranscriptClassificationStore(path.join(sessionsDir, "sessions.json"));
+    const persistedPath = resolveSessionStoreTranscriptPath(sessionsDir, store[sessionKey]);
+    const canonicalPath = resolveCanonicalSessionSyncFilePath(agentId, persistedPath);
+    if (canonicalPath) {
+      return {
+        agentId,
+        sessionId,
+        sessionFile: canonicalPath,
+      };
+    }
+  }
+  store ??= readSessionTranscriptClassificationStore(path.join(sessionsDir, "sessions.json"));
+  const persistedPath = resolveSessionStoreTranscriptPath(
+    sessionsDir,
+    findSessionTranscriptStoreEntryBySessionId(store, sessionId),
+  );
+  const canonicalPath = resolveCanonicalSessionSyncFilePath(agentId, persistedPath);
+  if (canonicalPath) {
+    return {
+      agentId,
+      sessionId,
+      sessionFile: canonicalPath,
+    };
+  }
+  const sessionFile = resolveCanonicalSessionSyncFilePath(
+    agentId,
+    path.join(sessionsDir, `${sessionId}.jsonl`),
+    sessionId,
+  );
+  if (!sessionFile) {
+    return null;
+  }
+  return {
+    agentId,
+    sessionId,
+    sessionFile,
+  };
+}
+
+function resolveCanonicalSessionSyncFilePath(
+  agentId: string,
+  sessionFile?: string | null,
+  expectedSessionId?: string,
+): string | null {
+  if (!sessionFile) {
+    return null;
+  }
+  const resolved = path.resolve(sessionFile);
+  const parsed = parseCanonicalSessionSyncTargetFromPath(resolved);
+  if (parsed?.agentId !== agentId) {
+    return null;
+  }
+  if (expectedSessionId !== undefined && parsed.sessionId !== expectedSessionId) {
+    return null;
+  }
+  return resolved;
 }
 
 async function logSessionFileReadFailure(absPath: string, err: unknown): Promise<void> {

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -32,6 +32,28 @@ export type MemorySyncProgressUpdate = {
   label?: string;
 };
 
+export type MemorySessionSyncTarget = {
+  /** Owning OpenClaw agent. Omit only when the active manager scope already supplies it. */
+  agentId?: string;
+  /** Storage-neutral transcript/session identity. */
+  sessionId: string;
+  /** Optional visible session-store key for callers that already carry it. */
+  sessionKey?: string;
+};
+
+export type MemorySyncParams = {
+  reason?: string;
+  force?: boolean;
+  /** Storage-neutral session transcript targets to refresh. */
+  sessions?: MemorySessionSyncTarget[];
+  /**
+   * @deprecated Use `sessions` with `{ agentId, sessionId, sessionKey? }`.
+   * During the deprecation window only canonical OpenClaw transcript paths are accepted.
+   */
+  sessionFiles?: string[];
+  progress?: (update: MemorySyncProgressUpdate) => void;
+};
+
 /** Runtime backend/mode diagnostics for memory search. */
 export type MemorySearchRuntimeDebug = {
   backend: "builtin" | "qmd";
@@ -107,12 +129,7 @@ export interface MemorySearchManager {
   ): Promise<MemorySearchResult[]>;
   readFile(params: { relPath: string; from?: number; lines?: number }): Promise<MemoryReadResult>;
   status(): MemoryProviderStatus;
-  sync?(params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }): Promise<void>;
+  sync?(params?: MemorySyncParams): Promise<void>;
   getCachedEmbeddingAvailability?(): MemoryEmbeddingProbeResult | null;
   probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult>;
   probeVectorStoreAvailability?(): Promise<boolean>;

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -163,8 +163,8 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 321),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10329),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5186),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10336),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5189),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
       3247,

--- a/src/plugin-sdk/memory-core-host-engine-storage.ts
+++ b/src/plugin-sdk/memory-core-host-engine-storage.ts
@@ -71,6 +71,8 @@ export type {
   MemorySearchManager,
   MemorySearchRuntimeDebug,
   MemorySyncProgressUpdate,
+  MemorySessionSyncTarget,
+  MemorySyncParams,
   ResolvedMemoryBackendConfig,
   ResolvedQmdConfig,
   ResolvedQmdMcporterConfig,


### PR DESCRIPTION
## What
Combines the memory session sync identity API and QMD session artifact identity mapping into one Path 3 replacement slice. This is now based directly on current `main` after #95030 merged.

## Why
#89348 and #89360 both move memory search/session indexing away from filename-as-identity assumptions. Bundling them keeps the memory-core targeted sync API and the QMD artifact-to-session mapping under one review unit, so search visibility and targeted refresh behavior are proved together before the SQLite flip.

## Changes
- Add identity sync targets
- Keep deprecated sessionFiles compatibility
- Reject unsafe session paths
- Map QMD artifacts to sessions
- Preserve archived hit visibility
- Cover mapped search visibility
- Update SDK surface budgets

Supersedes #89348 and #89360. Refs #88838. #95030 has merged, so this branch was rebased onto current `main` at head `f40993a4d2ad40941238b3b6984d3cb64d870528`.

## Real behavior proof
Behavior addressed: Memory session sync can target storage-neutral session identity instead of deriving identity from transcript filenames, and QMD Markdown artifacts map back to persisted session identity before search visibility checks.

Real environment tested: Local live gateway from the maintainer checkout, loaded at #95087 pre-rebase head `0c90ccb6c280828cb0f65d008ce2d71810237b27`; `pnpm openclaw --version` reported `OpenClaw 2026.6.8 (0c90ccb)`. The gateway ran as the LaunchAgent on loopback port `18789`. After the later conflict-only rebase onto `upstream/main`, focused post-rebase proof was rerun on head `f40993a4d2ad40941238b3b6984d3cb64d870528`.

Exact steps or command run after this patch:

```bash
git fetch upstream pull/95087/head
git checkout --detach 0c90ccb6c280828cb0f65d008ce2d71810237b27
pnpm build
pnpm openclaw gateway restart
pnpm openclaw --version
curl -fsS http://127.0.0.1:18789/readyz
curl -fsS http://127.0.0.1:18789/healthz
pnpm openclaw gateway status --json
pnpm openclaw gateway call sessions.create --params '{"key":"agent:main:dashboard:direct:path3-memory-qmd-proof-95087","agentId":"main","label":"Path 3 memory QMD proof 95087"}' --json --timeout 30000
pnpm openclaw gateway call doctor.memory.status --params '{"agentId":"main"}' --json --timeout 30000
node --input-type=module -e '<read $HOME/.openclaw/agents/main/sessions/sessions.json and verify the proof session/transcript>'
pnpm openclaw gateway call sessions.list --params '{"agentId":"main"}' --json --timeout 30000
pnpm openclaw gateway call sessions.delete --params '{"key":"agent:main:dashboard:direct:path3-memory-qmd-proof-95087","agentId":"main"}' --json --timeout 30000
node --input-type=module -e '<verify the proof session key is absent and remove proof-only deleted transcript archive>'
git checkout --detach 08af39905b6bc45caf7ea03a761ebe5b719230f0
pnpm build
pnpm openclaw gateway restart
pnpm openclaw --version
curl -fsS http://127.0.0.1:18789/readyz
curl -fsS http://127.0.0.1:18789/healthz
```

Evidence after fix: `pnpm build` passed on the PR head. `/readyz` returned `{"ready":true,"failing":[]...}` and `/healthz` returned `{"ok":true,"status":"live"}` after the PR-head restart. `sessions.create` returned key `agent:main:dashboard:direct:path3-memory-qmd-proof-95087`, session id `cb4b92ec-5489-4acf-a17f-59c5ddaa22b0`, label `Path 3 memory QMD proof 95087`, and `runStarted:false`. The persisted store check found the same key in `$HOME/.openclaw/agents/main/sessions/sessions.json`, with transcript `$HOME/.openclaw/agents/main/sessions/cb4b92ec-5489-4acf-a17f-59c5ddaa22b0.jsonl`, `transcriptExists:true`, and `transcriptBytes:148`. `sessions.list` returned the same key/session id/label with `visible:true`. `doctor.memory.status` returned for `agentId:"main"` and reported the memory-core status payload, including `shortTermCount:512`, `totalSignalCount:574`, and `storePath:"plugin-state:memory-core/short-term-recall/..."`. `sessions.delete` returned `deleted:true`; the follow-up store check reported `storeContainsKey:false`, `liveTranscriptExists:false`, and the proof-only `.deleted` transcript archive was removed (`remainingProofArtifacts:0`). The live gateway was then restored to its previous checkout, where `pnpm openclaw --version` again reported `OpenClaw 2026.6.8 (08af399)` and `/readyz` plus `/healthz` were healthy. Post-rebase focused proof on `f40993a4d2ad40941238b3b6984d3cb64d870528` passed `node scripts/run-vitest.mjs test/scripts/plugin-sdk-surface-report.test.ts packages/memory-host-sdk/src/host/session-files.test.ts extensions/memory-core/src/session-search-visibility.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts`, `node scripts/plugin-sdk-surface-report.mjs --check`, `git diff --check`, `pnpm exec oxfmt --check scripts/plugin-sdk-surface-report.mjs`, `node scripts/run-oxlint.mjs scripts/plugin-sdk-surface-report.mjs`, and SDK API/export/subpath checks.

Observed result after fix: The PR head built and ran in the real local gateway, accepted real gateway session lifecycle calls, persisted the proof session identity and transcript, exposed that session identity back through `sessions.list`, served memory-core status through `doctor.memory.status`, and cleaned the proof session back out of the live session store.

What was not tested: This live pass did not run a model turn, forced compaction, Crabbox/Testbox, or the future SQLite adapter. The live gateway proof was not rerun after the later conflict-only rebase to `f40993a4d2ad40941238b3b6984d3cb64d870528`; the post-rebase proof was the focused memory-host-sdk, memory-core, SDK surface, lint/format, diff-check, and autoreview set below.

## Testing
- Post-conflict rebase proof on `f40993a4d2ad40941238b3b6984d3cb64d870528`: `node scripts/run-vitest.mjs test/scripts/plugin-sdk-surface-report.test.ts packages/memory-host-sdk/src/host/session-files.test.ts extensions/memory-core/src/session-search-visibility.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts`
- Post-conflict rebase proof on `f40993a4d2ad40941238b3b6984d3cb64d870528`: `node scripts/plugin-sdk-surface-report.mjs --check && git diff --check`
- Post-conflict rebase proof on `f40993a4d2ad40941238b3b6984d3cb64d870528`: `pnpm exec oxfmt --check scripts/plugin-sdk-surface-report.mjs && node scripts/run-oxlint.mjs scripts/plugin-sdk-surface-report.mjs`
- Post-conflict rebase proof on `f40993a4d2ad40941238b3b6984d3cb64d870528`: `pnpm plugin-sdk:api:check && pnpm plugin-sdk:check-exports && node scripts/check-plugin-sdk-subpath-exports.mjs`
- Post-conflict rebase autoreview on `f40993a4d2ad40941238b3b6984d3cb64d870528`: `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --prompt ...` clean
- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/session-files.test.ts extensions/memory-core/src/memory/manager-targeted-sync.test.ts extensions/memory-core/src/memory/manager-session-sync-state.test.ts extensions/memory-core/src/memory/manager.readonly-recovery.test.ts extensions/memory-core/src/memory/manager-sync-yield.test.ts extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts extensions/memory-core/src/session-search-visibility.test.ts extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts`
- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/session-files.test.ts test/scripts/plugin-sdk-surface-report.test.ts`
- `node scripts/run-vitest.mjs src/scripts/test-projects.test.ts`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `pnpm plugin-sdk:api:gen`
- `pnpm plugin-sdk:api:check && pnpm plugin-sdk:check-exports && node scripts/check-plugin-sdk-subpath-exports.mjs && pnpm lint:extensions:no-plugin-sdk-wildcard-reexports`
- `pnpm exec oxfmt --check <touched files>`
- `node scripts/run-oxlint.mjs <touched files>`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.packages.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-packages.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p tsconfig.plugin-sdk.dts.json --declaration true`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --prompt ...` clean after fixing the accepted unsafe normalized session-id finding and the persisted session-id resolver finding

