### PR TITLE
[AI-assisted] fix(memory): close cached agent and state databases in test teardowns

### DIFF
--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -5,6 +5,10 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  closeOpenClawStateDatabaseForTest,
+} from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
 import type { MemoryIndexMeta } from "./manager-reindex-state.js";
@@ -67,11 +71,16 @@ describe("memory manager FTS-only reindex", () => {
       manager = null;
     }
     await closeAllMemorySearchManagers();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
     restoreFtsOnlyStateDir();
+    vi.unstubAllEnvs();
   });
 
   afterAll(async () => {
     await closeAllMemorySearchManagers();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
     if (fixtureRoot) {
       await fs.rm(fixtureRoot, { recursive: true, force: true });
     }

--- a/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
@@ -5,6 +5,10 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  closeOpenClawStateDatabaseForTest,
+} from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetEmbeddingMocks } from "./embedding.test-mocks.js";
 import type { MemoryIndexManager } from "./index.js";
@@ -59,14 +63,18 @@ describe("memory manager reindex recovery", () => {
   });
 
   afterEach(async () => {
-    restoreReindexStateDir();
-    vi.restoreAllMocks();
+
     if (manager) {
       await manager.close();
       manager = null;
     }
     const { closeAllMemorySearchManagers } = await import("./index.js");
     await closeAllMemorySearchManagers();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    restoreReindexStateDir();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
     await fs.rm(fixtureRoot, { recursive: true, force: true });
   });
 

--- a/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
+++ b/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  closeOpenClawStateDatabaseForTest,
+} from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
 import type { MemoryIndexManager } from "./manager.js";
@@ -72,11 +76,16 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
       manager = null;
     }
     await closeAllMemorySearchManagers();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
     restoreSelfHealStateDir();
+    vi.unstubAllEnvs();
   });
 
   afterAll(async () => {
     await closeAllMemorySearchManagers();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
     if (fixtureRoot) {
       await fs.rm(fixtureRoot, { recursive: true, force: true });
     }

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -7,6 +7,10 @@ import type {
   MemorySearchConfig,
   OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  closeOpenClawStateDatabaseForTest,
+} from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type WatchIgnoredFn = (watchPath: string, stats?: { isDirectory?: () => boolean }) => boolean;
@@ -206,6 +210,8 @@ describe("memory watcher config", () => {
       manager = null;
     }
     await closeAllMemorySearchManagers();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
     clearRegistry();
     restoreWatcherStateDir();
     if (workspaceDir) {


### PR DESCRIPTION
﻿Closes #78640

### What Problem This Solves
This PR resolves Windows file locking (EBUSY/EPERM) errors during test cleanup in the memory-core extension. The test suites failed to clean up temporary directories on Windows due to an open file handle locking the SQLite state database file.

### Why This Change Was Made
When tests instantiate MemoryIndexManager, the state database connection is cached globally and was never closed during test teardowns, locking the database file on Windows. This PR adds calls to closeOpenClawAgentDatabasesForTest() and closeOpenClawStateDatabaseForTest() in test hooks to release database connections before deleting test directories.

### User Impact
No user-facing impact. This stabilizes test runs for developers on Windows.

### Evidence
Ran tests locally on a Windows host and confirmed they pass cleanly without EBUSY errors.

```
$ node scripts/test-projects.mjs "extensions/memory-core/src/memory/manager.reindex-recovery.test.ts"
[test] starting test/vitest/vitest.extension-memory.config.ts

 RUN  v4.1.8

 ✓  extension-memory  extensions/memory-core/src/memory/manager.reindex-recovery.test.ts (8 tests) 5640ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
```
