### PR TITLE
fix(e2e): reject unsafe bounded response text lengths

### DIFF
--- a/scripts/e2e/lib/bounded-response-text.mjs
+++ b/scripts/e2e/lib/bounded-response-text.mjs
@@ -17,7 +17,7 @@ function parseContentLengthHeader(headers) {
     return undefined;
   }
   const parsed = Number(raw);
-  return Number.isSafeInteger(parsed) ? parsed : undefined;
+  return Number.isSafeInteger(parsed) ? parsed : Number.POSITIVE_INFINITY;
 }
 
 export async function readBoundedResponseText(response, label, byteLimit, timeoutPromise) {

--- a/test/scripts/bounded-response-text.test.ts
+++ b/test/scripts/bounded-response-text.test.ts
@@ -111,4 +111,36 @@ describe("scripts/e2e/lib/bounded-response-text.mjs", () => {
     expect(readStarted).toBe(true);
     expect(canceled).toBe(true);
   });
+
+  it("rejects unsafe decimal content-length values before reading", async () => {
+    let readStarted = false;
+    let canceled = false;
+    const response = {
+      headers: new Headers({ "content-length": "9007199254740993" }),
+      body: {
+        async cancel() {
+          canceled = true;
+        },
+        getReader() {
+          return {
+            async read() {
+              readStarted = true;
+              return new Promise<ReadableStreamReadResult<Uint8Array>>(() => {});
+            },
+            async cancel() {
+              canceled = true;
+            },
+            releaseLock() {},
+          };
+        },
+      },
+    };
+
+    await expect(readBoundedResponseText(response, "probe", 16)).rejects.toMatchObject({
+      code: "ETOOBIG",
+      message: "probe response body exceeded 16 bytes",
+    });
+    expect(readStarted).toBe(false);
+    expect(canceled).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- Reject unsafe decimal `Content-Length` values in the E2E bounded response text helper before streaming response bodies.
- Keep non-decimal `Content-Length` values on the existing streaming byte-limit path.
- Add regression coverage proving unsafe declared lengths cancel without starting a read.

## Real behavior proof

Behavior addressed: unsafe digit-only `Content-Length` values larger than JavaScript's safe integer range now fail before streaming in `scripts/e2e/lib/bounded-response-text.mjs`.

Real environment tested: GitHub Actions exact-head release gate for `5fb6e6c5edd219707fe0ba768f6fc2547dc537de`; local sparse-worktree proof used only `node --check`, direct MJS repros, diff sanity, and autoreview.

Exact steps or command run after this patch:
- `node --check scripts/e2e/lib/bounded-response-text.mjs`
- direct patched MJS repro with `content-length: 9007199254740993`, `maxBytes: 16`, and a never-completing body reader
- direct `origin/main` comparison repro for the same response shape
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- exact-head release gate: https://github.com/openclaw/openclaw/actions/runs/27846197115

Evidence after fix: the patched helper rejects with `probe response body exceeded 16 bytes`, reports `code=ETOOBIG`, never starts the reader, and cancels the response body.

Observed result after fix: `readStarted=false`, `canceled=true`; exact-head release gate completed successfully on `5fb6e6c5edd219707fe0ba768f6fc2547dc537de`.

What was not tested: focused Vitest was not run locally because this sparse GWT has no `node_modules`, and repo rules say not to install dependencies in Codex worktrees.
