### PR TITLE
fix(config): accept transport:stdio in MCP server schema

### DIFF
--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -392,7 +392,9 @@ const McpServerSchema = z
     cwd: z.string().optional(),
     workingDirectory: z.string().optional(),
     url: HttpUrlSchema.optional(),
-    transport: z.union([z.literal("sse"), z.literal("streamable-http")]).optional(),
+    transport: z
+      .union([z.literal("stdio"), z.literal("sse"), z.literal("streamable-http")])
+      .optional(),
     headers: z
       .record(
         z.string(),


### PR DESCRIPTION
## Summary

Add "stdio" to the MCP server transport enum in the config schema so
`openclaw config validate` accepts the same config the runtime runs.

## Problem

`config validate` rejects `transport: "stdio"` on command-bearing MCP
servers. The Zod schema only allows `sse | streamable-http`, but the
runtime already resolves any command-bearing server as stdio.

## Root Cause

`src/config/zod-schema.ts` transport union missing `"stdio"` literal.

## Changes

- `src/config/zod-schema.ts` — one line: add `z.literal("stdio")` to
  the transport union

## Related

Closes #95082

🤖 Generated with [Claude Code](https://claude.com/claude-code)