### PR TITLE
fix(dev): bound realtime SDP answer reads

### DIFF
--- a/scripts/dev/realtime-talk-live-smoke.ts
+++ b/scripts/dev/realtime-talk-live-smoke.ts
@@ -44,7 +44,7 @@ type OpenAIHttpOptions = {
 };
 
 type OpenAIWebRtcSmokeGlobal = typeof globalThis & {
-  __openclawRequestOpenAIRealtimeSdpAnswer?: (offerSdp: string) => Promise<string>;
+  openclawRequestOpenAIRealtimeSdpAnswer?: (offerSdp: string) => Promise<string>;
 };
 
 function getEnv(name: string): string | undefined {
@@ -257,7 +257,7 @@ async function smokeOpenAIWebRtc(browser: Browser, apiKey: string): Promise<Smok
       const page = await context.newPage();
       await page.evaluate("globalThis.__name = (fn) => fn");
       await page.exposeFunction(
-        "__openclawRequestOpenAIRealtimeSdpAnswer",
+        "openclawRequestOpenAIRealtimeSdpAnswer",
         async (offerSdp: string) => {
           return await requestOpenAIRealtimeSdpAnswer(clientSecret, offerSdp, {
             timeoutMs: openAIHttpTimeoutMs,
@@ -266,7 +266,7 @@ async function smokeOpenAIWebRtc(browser: Browser, apiKey: string): Promise<Smok
       );
       const result = await page.evaluate(async () => {
         const requestSdpAnswer = (globalThis as OpenAIWebRtcSmokeGlobal)
-          .__openclawRequestOpenAIRealtimeSdpAnswer;
+          .openclawRequestOpenAIRealtimeSdpAnswer;
         if (!requestSdpAnswer) {
           throw new Error("OpenAI Realtime SDP answer bridge was not installed");
         }

--- a/scripts/dev/realtime-talk-live-smoke.ts
+++ b/scripts/dev/realtime-talk-live-smoke.ts
@@ -43,8 +43,14 @@ type OpenAIHttpOptions = {
   timeoutMs?: number;
 };
 
+type OpenAIRealtimeBrowserResponseReader = (
+  response: Response,
+  label: string,
+  maxBytes: number,
+) => Promise<string>;
+
 type OpenAIWebRtcSmokeGlobal = typeof globalThis & {
-  openclawRequestOpenAIRealtimeSdpAnswer?: (offerSdp: string) => Promise<string>;
+  openclawReadBoundedRealtimeResponseText?: OpenAIRealtimeBrowserResponseReader;
 };
 
 function getEnv(name: string): string | undefined {
@@ -118,6 +124,63 @@ function compareStrings(left: string | undefined, right: string | undefined): nu
   return (left ?? "").localeCompare(right ?? "");
 }
 
+async function readOpenAIRealtimeBrowserResponseText(
+  response: Response,
+  label: string,
+  maxBytes: number,
+): Promise<string> {
+  const responseBodyTooLargeError = (label: string, maxBytes: number): Error =>
+    new Error(`${label} response body exceeded ${maxBytes} bytes`);
+  const rawContentLength = response.headers.get("content-length");
+  if (rawContentLength && /^\d+$/u.test(rawContentLength)) {
+    const contentLength = Number(rawContentLength);
+    if (!Number.isSafeInteger(contentLength) || contentLength > maxBytes) {
+      await response.body?.cancel().catch(() => undefined);
+      throw responseBodyTooLargeError(label, maxBytes);
+    }
+  }
+  if (!response.body) {
+    return "";
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  let totalBytes = 0;
+  let canceled = false;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        const tail = decoder.decode();
+        if (tail) {
+          chunks.push(tail);
+        }
+        break;
+      }
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        canceled = true;
+        await reader.cancel().catch(() => undefined);
+        throw responseBodyTooLargeError(label, maxBytes);
+      }
+      chunks.push(decoder.decode(value, { stream: true }));
+    }
+  } finally {
+    if (!canceled) {
+      reader.releaseLock();
+    }
+  }
+
+  return chunks.join("");
+}
+
+function openAIRealtimeBrowserResponseReaderInitScript(): string {
+  return `globalThis.openclawReadBoundedRealtimeResponseText = ${readOpenAIRealtimeBrowserResponseText.toString()};`;
+}
+
 async function createOpenAIClientSecret(
   apiKey: string,
   options: OpenAIHttpOptions = {},
@@ -174,39 +237,6 @@ async function createOpenAIClientSecret(
   return secret;
 }
 
-async function requestOpenAIRealtimeSdpAnswer(
-  clientSecret: string,
-  offerSdp: string,
-  options: OpenAIHttpOptions = {},
-): Promise<string> {
-  const fetchImpl = options.fetchImpl ?? fetch;
-  const timeoutMs = options.timeoutMs ?? resolveOpenAIHttpTimeoutMs();
-  return await withTimeout({
-    label: "OpenAI Realtime SDP offer request",
-    timeoutMs,
-    run: async (signal) => {
-      const response = await fetchImpl("https://api.openai.com/v1/realtime/calls", {
-        method: "POST",
-        body: offerSdp,
-        headers: {
-          Authorization: `Bearer ${clientSecret}`,
-          "Content-Type": "application/sdp",
-        },
-        signal,
-      });
-      if (!response.ok) {
-        throw new Error(`OpenAI Realtime SDP offer failed (${response.status})`);
-      }
-      return await readBoundedText(
-        response,
-        "OpenAI Realtime SDP answer",
-        OPENAI_HTTP_RESPONSE_MAX_BYTES,
-        signal,
-      );
-    },
-  });
-}
-
 async function smokeOpenAIBackendBridge(apiKey: string): Promise<SmokeResult> {
   const provider = buildOpenAIRealtimeVoiceProvider();
   const events: string[] = [];
@@ -256,73 +286,115 @@ async function smokeOpenAIWebRtc(browser: Browser, apiKey: string): Promise<Smok
     try {
       const page = await context.newPage();
       await page.evaluate("globalThis.__name = (fn) => fn");
-      await page.exposeFunction(
-        "openclawRequestOpenAIRealtimeSdpAnswer",
-        async (offerSdp: string) => {
-          return await requestOpenAIRealtimeSdpAnswer(clientSecret, offerSdp, {
-            timeoutMs: openAIHttpTimeoutMs,
-          });
+      await page.evaluate(openAIRealtimeBrowserResponseReaderInitScript());
+      const result = await page.evaluate(
+        async ({ clientSecret: secret, sdpAnswerMaxBytes, timeoutMs }) => {
+          const readBoundedTextLocal = (globalThis as OpenAIWebRtcSmokeGlobal)
+            .openclawReadBoundedRealtimeResponseText;
+          if (!readBoundedTextLocal) {
+            throw new Error("OpenAI Realtime bounded response reader was not installed");
+          }
+          const withBrowserTimeout = async <T>(
+            label: string,
+            run: (signal: AbortSignal) => Promise<T>,
+          ): Promise<T> => {
+            const controller = new AbortController();
+            let timeout: number | undefined;
+            const timeoutPromise = new Promise<T>((_resolve, reject) => {
+              timeout = window.setTimeout(() => {
+                const error = new Error(`${label} exceeded timeout of ${timeoutMs}ms`);
+                reject(error);
+                controller.abort(error);
+              }, timeoutMs);
+            });
+            try {
+              return await Promise.race([run(controller.signal), timeoutPromise]);
+            } finally {
+              if (timeout !== undefined) {
+                window.clearTimeout(timeout);
+              }
+            }
+          };
+          let media: MediaStream | undefined;
+          let peer: RTCPeerConnection | undefined;
+          try {
+            if (navigator.mediaDevices?.getUserMedia) {
+              media = await navigator.mediaDevices.getUserMedia({ audio: true });
+            } else {
+              const audioContext = new AudioContext();
+              const destination = audioContext.createMediaStreamDestination();
+              const oscillator = audioContext.createOscillator();
+              oscillator.connect(destination);
+              oscillator.start();
+              media = destination.stream;
+            }
+            peer = new RTCPeerConnection();
+            for (const track of media.getAudioTracks()) {
+              peer.addTrack(track, media);
+            }
+            const channel = peer.createDataChannel("oai-events");
+            const connectionState = new Promise<string>((resolve) => {
+              const timeout = window.setTimeout(
+                () => resolve(peer?.connectionState ?? "timeout"),
+                12_000,
+              );
+              peer?.addEventListener("connectionstatechange", () => {
+                if (peer?.connectionState === "connected" || peer?.connectionState === "failed") {
+                  window.clearTimeout(timeout);
+                  resolve(peer.connectionState);
+                }
+              });
+              channel.addEventListener("open", () => {
+                window.clearTimeout(timeout);
+                resolve(peer?.connectionState || "data-channel-open");
+              });
+            });
+            const offer = await peer.createOffer();
+            await peer.setLocalDescription(offer);
+            const offerSdp = offer.sdp;
+            if (!offerSdp) {
+              throw new Error("OpenAI Realtime SDP offer did not include SDP");
+            }
+            const answer = await withBrowserTimeout(
+              "OpenAI Realtime SDP offer request",
+              async (signal) => {
+                const response = await fetch("https://api.openai.com/v1/realtime/calls", {
+                  method: "POST",
+                  body: offerSdp,
+                  headers: {
+                    Authorization: `Bearer ${secret}`,
+                    "Content-Type": "application/sdp",
+                  },
+                  signal,
+                });
+                if (!response.ok) {
+                  throw new Error(`OpenAI Realtime SDP offer failed (${response.status})`);
+                }
+                return await readBoundedTextLocal(
+                  response,
+                  "OpenAI Realtime SDP answer",
+                  sdpAnswerMaxBytes,
+                );
+              },
+            );
+            await peer.setRemoteDescription({ type: "answer", sdp: answer });
+            const state = await connectionState;
+            return {
+              answerHasAudio: answer.includes("m=audio"),
+              remoteDescriptionApplied: peer.remoteDescription?.type === "answer",
+              connectionState: state,
+            };
+          } finally {
+            peer?.close();
+            media?.getTracks().forEach((track) => track.stop());
+          }
+        },
+        {
+          clientSecret,
+          sdpAnswerMaxBytes: OPENAI_HTTP_RESPONSE_MAX_BYTES,
+          timeoutMs: openAIHttpTimeoutMs,
         },
       );
-      const result = await page.evaluate(async () => {
-        const requestSdpAnswer = (globalThis as OpenAIWebRtcSmokeGlobal)
-          .openclawRequestOpenAIRealtimeSdpAnswer;
-        if (!requestSdpAnswer) {
-          throw new Error("OpenAI Realtime SDP answer bridge was not installed");
-        }
-        let media: MediaStream | undefined;
-        let peer: RTCPeerConnection | undefined;
-        try {
-          if (navigator.mediaDevices?.getUserMedia) {
-            media = await navigator.mediaDevices.getUserMedia({ audio: true });
-          } else {
-            const audioContext = new AudioContext();
-            const destination = audioContext.createMediaStreamDestination();
-            const oscillator = audioContext.createOscillator();
-            oscillator.connect(destination);
-            oscillator.start();
-            media = destination.stream;
-          }
-          peer = new RTCPeerConnection();
-          for (const track of media.getAudioTracks()) {
-            peer.addTrack(track, media);
-          }
-          const channel = peer.createDataChannel("oai-events");
-          const connectionState = new Promise<string>((resolve) => {
-            const timeout = window.setTimeout(
-              () => resolve(peer?.connectionState ?? "timeout"),
-              12_000,
-            );
-            peer?.addEventListener("connectionstatechange", () => {
-              if (peer?.connectionState === "connected" || peer?.connectionState === "failed") {
-                window.clearTimeout(timeout);
-                resolve(peer.connectionState);
-              }
-            });
-            channel.addEventListener("open", () => {
-              window.clearTimeout(timeout);
-              resolve(peer?.connectionState || "data-channel-open");
-            });
-          });
-          const offer = await peer.createOffer();
-          await peer.setLocalDescription(offer);
-          const offerSdp = offer.sdp;
-          if (!offerSdp) {
-            throw new Error("OpenAI Realtime SDP offer did not include SDP");
-          }
-          const answer = await requestSdpAnswer(offerSdp);
-          await peer.setRemoteDescription({ type: "answer", sdp: answer });
-          const state = await connectionState;
-          return {
-            answerHasAudio: answer.includes("m=audio"),
-            remoteDescriptionApplied: peer.remoteDescription?.type === "answer",
-            connectionState: state,
-          };
-        } finally {
-          peer?.close();
-          media?.getTracks().forEach((track) => track.stop());
-        }
-      });
       return {
         name: "openai-webrtc-browser",
         ok: result.answerHasAudio && result.remoteDescriptionApplied,
@@ -717,8 +789,8 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
 export const testing = {
   OPENAI_HTTP_RESPONSE_MAX_BYTES,
   createOpenAIClientSecret,
+  readOpenAIRealtimeBrowserResponseText,
   readBoundedText,
-  requestOpenAIRealtimeSdpAnswer,
   resolveOpenAIHttpTimeoutMs,
 };
 

--- a/scripts/dev/realtime-talk-live-smoke.ts
+++ b/scripts/dev/realtime-talk-live-smoke.ts
@@ -129,8 +129,8 @@ async function readOpenAIRealtimeBrowserResponseText(
   label: string,
   maxBytes: number,
 ): Promise<string> {
-  const responseBodyTooLargeError = (label: string, maxBytes: number): Error =>
-    new Error(`${label} response body exceeded ${maxBytes} bytes`);
+  const responseBodyTooLargeError = (errorLabel: string, errorMaxBytes: number): Error =>
+    new Error(`${errorLabel} response body exceeded ${errorMaxBytes} bytes`);
   const rawContentLength = response.headers.get("content-length");
   if (rawContentLength && /^\d+$/u.test(rawContentLength)) {
     const contentLength = Number(rawContentLength);

--- a/scripts/dev/realtime-talk-live-smoke.ts
+++ b/scripts/dev/realtime-talk-live-smoke.ts
@@ -43,6 +43,10 @@ type OpenAIHttpOptions = {
   timeoutMs?: number;
 };
 
+type OpenAIWebRtcSmokeGlobal = typeof globalThis & {
+  __openclawRequestOpenAIRealtimeSdpAnswer?: (offerSdp: string) => Promise<string>;
+};
+
 function getEnv(name: string): string | undefined {
   const value = process.env[name]?.trim();
   return value ? value : undefined;
@@ -170,6 +174,39 @@ async function createOpenAIClientSecret(
   return secret;
 }
 
+async function requestOpenAIRealtimeSdpAnswer(
+  clientSecret: string,
+  offerSdp: string,
+  options: OpenAIHttpOptions = {},
+): Promise<string> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? resolveOpenAIHttpTimeoutMs();
+  return await withTimeout({
+    label: "OpenAI Realtime SDP offer request",
+    timeoutMs,
+    run: async (signal) => {
+      const response = await fetchImpl("https://api.openai.com/v1/realtime/calls", {
+        method: "POST",
+        body: offerSdp,
+        headers: {
+          Authorization: `Bearer ${clientSecret}`,
+          "Content-Type": "application/sdp",
+        },
+        signal,
+      });
+      if (!response.ok) {
+        throw new Error(`OpenAI Realtime SDP offer failed (${response.status})`);
+      }
+      return await readBoundedText(
+        response,
+        "OpenAI Realtime SDP answer",
+        OPENAI_HTTP_RESPONSE_MAX_BYTES,
+        signal,
+      );
+    },
+  });
+}
+
 async function smokeOpenAIBackendBridge(apiKey: string): Promise<SmokeResult> {
   const provider = buildOpenAIRealtimeVoiceProvider();
   const events: string[] = [];
@@ -219,154 +256,73 @@ async function smokeOpenAIWebRtc(browser: Browser, apiKey: string): Promise<Smok
     try {
       const page = await context.newPage();
       await page.evaluate("globalThis.__name = (fn) => fn");
-      const result = await page.evaluate(
-        async ({ clientSecret: secret, sdpAnswerMaxBytes, timeoutMs }) => {
-          const responseBodyTooLargeError = (label: string, maxBytes: number): Error =>
-            new Error(`${label} response body exceeded ${maxBytes} bytes`);
-          const readBoundedTextLocal = async (
-            response: Response,
-            label: string,
-            maxBytes: number,
-          ): Promise<string> => {
-            const contentLength = Number(response.headers.get("content-length") ?? "");
-            if (Number.isSafeInteger(contentLength) && contentLength > maxBytes) {
-              await response.body?.cancel().catch(() => undefined);
-              throw responseBodyTooLargeError(label, maxBytes);
-            }
-            if (!response.body) {
-              return "";
-            }
-
-            const reader = response.body.getReader();
-            const decoder = new TextDecoder();
-            const chunks: string[] = [];
-            let totalBytes = 0;
-            let canceled = false;
-
-            try {
-              for (;;) {
-                const { done, value } = await reader.read();
-                if (done) {
-                  const tail = decoder.decode();
-                  if (tail) {
-                    chunks.push(tail);
-                  }
-                  break;
-                }
-
-                totalBytes += value.byteLength;
-                if (totalBytes > maxBytes) {
-                  canceled = true;
-                  await reader.cancel().catch(() => undefined);
-                  throw responseBodyTooLargeError(label, maxBytes);
-                }
-                chunks.push(decoder.decode(value, { stream: true }));
-              }
-            } finally {
-              if (!canceled) {
-                reader.releaseLock();
-              }
-            }
-
-            return chunks.join("");
-          };
-          const withBrowserTimeout = async <T>(
-            label: string,
-            run: (signal: AbortSignal) => Promise<T>,
-          ): Promise<T> => {
-            const controller = new AbortController();
-            let timeout: number | undefined;
-            const timeoutPromise = new Promise<T>((_resolve, reject) => {
-              timeout = window.setTimeout(() => {
-                const error = new Error(`${label} exceeded timeout of ${timeoutMs}ms`);
-                reject(error);
-                controller.abort(error);
-              }, timeoutMs);
-            });
-            try {
-              return await Promise.race([run(controller.signal), timeoutPromise]);
-            } finally {
-              if (timeout !== undefined) {
-                window.clearTimeout(timeout);
-              }
-            }
-          };
-          let media: MediaStream | undefined;
-          let peer: RTCPeerConnection | undefined;
-          try {
-            if (navigator.mediaDevices?.getUserMedia) {
-              media = await navigator.mediaDevices.getUserMedia({ audio: true });
-            } else {
-              const audioContext = new AudioContext();
-              const destination = audioContext.createMediaStreamDestination();
-              const oscillator = audioContext.createOscillator();
-              oscillator.connect(destination);
-              oscillator.start();
-              media = destination.stream;
-            }
-            peer = new RTCPeerConnection();
-            for (const track of media.getAudioTracks()) {
-              peer.addTrack(track, media);
-            }
-            const channel = peer.createDataChannel("oai-events");
-            const connectionState = new Promise<string>((resolve) => {
-              const timeout = window.setTimeout(
-                () => resolve(peer?.connectionState ?? "timeout"),
-                12_000,
-              );
-              peer?.addEventListener("connectionstatechange", () => {
-                if (peer?.connectionState === "connected" || peer?.connectionState === "failed") {
-                  window.clearTimeout(timeout);
-                  resolve(peer.connectionState);
-                }
-              });
-              channel.addEventListener("open", () => {
-                window.clearTimeout(timeout);
-                resolve(peer?.connectionState || "data-channel-open");
-              });
-            });
-            const offer = await peer.createOffer();
-            await peer.setLocalDescription(offer);
-            const answer = await withBrowserTimeout(
-              "OpenAI Realtime SDP offer request",
-              async (signal) => {
-                const response = await fetch("https://api.openai.com/v1/realtime/calls", {
-                  method: "POST",
-                  body: offer.sdp,
-                  headers: {
-                    Authorization: `Bearer ${secret}`,
-                    "Content-Type": "application/sdp",
-                  },
-                  signal,
-                });
-                if (!response.ok) {
-                  throw new Error(`OpenAI Realtime SDP offer failed (${response.status})`);
-                }
-                return await readBoundedTextLocal(
-                  response,
-                  "OpenAI Realtime SDP answer",
-                  sdpAnswerMaxBytes,
-                );
-              },
-            );
-            await peer.setRemoteDescription({ type: "answer", sdp: answer });
-            const state = await connectionState;
-            return {
-              answerHasAudio: answer.includes("m=audio"),
-              remoteDescriptionApplied: peer.remoteDescription?.type === "answer",
-              connectionState: state,
-            };
-          } finally {
-            peer?.close();
-            media?.getTracks().forEach((track) => track.stop());
-          }
-        },
-        {
-          clientSecret,
-          sdpAnswerMaxBytes: OPENAI_HTTP_RESPONSE_MAX_BYTES,
-          timeoutMs: openAIHttpTimeoutMs,
+      await page.exposeFunction(
+        "__openclawRequestOpenAIRealtimeSdpAnswer",
+        async (offerSdp: string) => {
+          return await requestOpenAIRealtimeSdpAnswer(clientSecret, offerSdp, {
+            timeoutMs: openAIHttpTimeoutMs,
+          });
         },
       );
+      const result = await page.evaluate(async () => {
+        const requestSdpAnswer = (globalThis as OpenAIWebRtcSmokeGlobal)
+          .__openclawRequestOpenAIRealtimeSdpAnswer;
+        if (!requestSdpAnswer) {
+          throw new Error("OpenAI Realtime SDP answer bridge was not installed");
+        }
+        let media: MediaStream | undefined;
+        let peer: RTCPeerConnection | undefined;
+        try {
+          if (navigator.mediaDevices?.getUserMedia) {
+            media = await navigator.mediaDevices.getUserMedia({ audio: true });
+          } else {
+            const audioContext = new AudioContext();
+            const destination = audioContext.createMediaStreamDestination();
+            const oscillator = audioContext.createOscillator();
+            oscillator.connect(destination);
+            oscillator.start();
+            media = destination.stream;
+          }
+          peer = new RTCPeerConnection();
+          for (const track of media.getAudioTracks()) {
+            peer.addTrack(track, media);
+          }
+          const channel = peer.createDataChannel("oai-events");
+          const connectionState = new Promise<string>((resolve) => {
+            const timeout = window.setTimeout(
+              () => resolve(peer?.connectionState ?? "timeout"),
+              12_000,
+            );
+            peer?.addEventListener("connectionstatechange", () => {
+              if (peer?.connectionState === "connected" || peer?.connectionState === "failed") {
+                window.clearTimeout(timeout);
+                resolve(peer.connectionState);
+              }
+            });
+            channel.addEventListener("open", () => {
+              window.clearTimeout(timeout);
+              resolve(peer?.connectionState || "data-channel-open");
+            });
+          });
+          const offer = await peer.createOffer();
+          await peer.setLocalDescription(offer);
+          const offerSdp = offer.sdp;
+          if (!offerSdp) {
+            throw new Error("OpenAI Realtime SDP offer did not include SDP");
+          }
+          const answer = await requestSdpAnswer(offerSdp);
+          await peer.setRemoteDescription({ type: "answer", sdp: answer });
+          const state = await connectionState;
+          return {
+            answerHasAudio: answer.includes("m=audio"),
+            remoteDescriptionApplied: peer.remoteDescription?.type === "answer",
+            connectionState: state,
+          };
+        } finally {
+          peer?.close();
+          media?.getTracks().forEach((track) => track.stop());
+        }
+      });
       return {
         name: "openai-webrtc-browser",
         ok: result.answerHasAudio && result.remoteDescriptionApplied,
@@ -762,6 +718,7 @@ export const testing = {
   OPENAI_HTTP_RESPONSE_MAX_BYTES,
   createOpenAIClientSecret,
   readBoundedText,
+  requestOpenAIRealtimeSdpAnswer,
   resolveOpenAIHttpTimeoutMs,
 };
 

--- a/test/scripts/dev-tooling-safety.test.ts
+++ b/test/scripts/dev-tooling-safety.test.ts
@@ -379,16 +379,16 @@ describe("script-specific dev tooling hardening", () => {
       }),
     };
     const response = {
-      ok: true,
       headers: new Headers({ "content-length": "9007199254740993" }),
       body,
     } as unknown as Response;
 
     await expect(
-      realtimeSmokeTesting.requestOpenAIRealtimeSdpAnswer("client-secret", "v=0", {
-        timeoutMs: 50,
-        fetchImpl: (() => Promise.resolve(response)) as typeof fetch,
-      }),
+      realtimeSmokeTesting.readOpenAIRealtimeBrowserResponseText(
+        response,
+        "OpenAI Realtime SDP answer",
+        maxBytes,
+      ),
     ).rejects.toThrow(`OpenAI Realtime SDP answer response body exceeded ${maxBytes} bytes`);
     expect(body.getReader).not.toHaveBeenCalled();
     expect(body.cancel).toHaveBeenCalledTimes(1);

--- a/test/scripts/dev-tooling-safety.test.ts
+++ b/test/scripts/dev-tooling-safety.test.ts
@@ -370,6 +370,33 @@ describe("script-specific dev tooling hardening", () => {
     ).rejects.toThrow(`OpenAI Realtime test response body exceeded ${maxBytes} bytes`);
   });
 
+  it("rejects unsafe OpenAI realtime SDP answer content-length values before reading", async () => {
+    const maxBytes = realtimeSmokeTesting.OPENAI_HTTP_RESPONSE_MAX_BYTES;
+    let readStarted = false;
+    let canceled = false;
+    const response = new Response(
+      new ReadableStream({
+        pull() {
+          readStarted = true;
+          return new Promise(() => {});
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      { headers: { "content-length": "9007199254740993" } },
+    );
+
+    await expect(
+      realtimeSmokeTesting.requestOpenAIRealtimeSdpAnswer("client-secret", "v=0", {
+        timeoutMs: 50,
+        fetchImpl: (() => Promise.resolve(response)) as typeof fetch,
+      }),
+    ).rejects.toThrow(`OpenAI Realtime SDP answer response body exceeded ${maxBytes} bytes`);
+    expect(readStarted).toBe(false);
+    expect(canceled).toBe(true);
+  });
+
   it("bounds OpenAI realtime smoke response body reads by streamed bytes", async () => {
     const maxBytes = realtimeSmokeTesting.OPENAI_HTTP_RESPONSE_MAX_BYTES;
     const response = new Response(

--- a/test/scripts/dev-tooling-safety.test.ts
+++ b/test/scripts/dev-tooling-safety.test.ts
@@ -372,20 +372,17 @@ describe("script-specific dev tooling hardening", () => {
 
   it("rejects unsafe OpenAI realtime SDP answer content-length values before reading", async () => {
     const maxBytes = realtimeSmokeTesting.OPENAI_HTTP_RESPONSE_MAX_BYTES;
-    let readStarted = false;
-    let canceled = false;
-    const response = new Response(
-      new ReadableStream({
-        pull() {
-          readStarted = true;
-          return new Promise(() => {});
-        },
-        cancel() {
-          canceled = true;
-        },
+    const body = {
+      cancel: vi.fn(() => Promise.resolve()),
+      getReader: vi.fn(() => {
+        throw new Error("reader should not be acquired");
       }),
-      { headers: { "content-length": "9007199254740993" } },
-    );
+    };
+    const response = {
+      ok: true,
+      headers: new Headers({ "content-length": "9007199254740993" }),
+      body,
+    } as unknown as Response;
 
     await expect(
       realtimeSmokeTesting.requestOpenAIRealtimeSdpAnswer("client-secret", "v=0", {
@@ -393,8 +390,8 @@ describe("script-specific dev tooling hardening", () => {
         fetchImpl: (() => Promise.resolve(response)) as typeof fetch,
       }),
     ).rejects.toThrow(`OpenAI Realtime SDP answer response body exceeded ${maxBytes} bytes`);
-    expect(readStarted).toBe(false);
-    expect(canceled).toBe(true);
+    expect(body.getReader).not.toHaveBeenCalled();
+    expect(body.cancel).toHaveBeenCalledTimes(1);
   });
 
   it("bounds OpenAI realtime smoke response body reads by streamed bytes", async () => {


### PR DESCRIPTION
## Summary

- Keep the OpenAI Realtime WebRTC smoke's SDP offer request in the browser fetch path.
- Move the browser-side bounded SDP answer reader into a testable helper and reject unsafe decimal `Content-Length` values before acquiring a body reader.
- Preserve streamed byte limiting for responses without a safe decimal `Content-Length`.

## Real behavior proof

Behavior addressed: unsafe digit-only `Content-Length` values larger than JavaScript's safe integer range no longer make the realtime SDP answer reader acquire a response body reader before rejecting.

Real environment tested: GitHub Actions exact-head release gate for `cf17007fd3d767b4527e84fb039a2bfa1b1c38ad`; local sparse-worktree proof used syntax checks, direct bounded-reader repro, diff sanity, and autoreview.

Exact steps or command run after this patch:
- `node --check --experimental-strip-types scripts/dev/realtime-talk-live-smoke.ts`
- `node --check --experimental-strip-types test/scripts/dev-tooling-safety.test.ts`
- direct bounded-reader repro for `content-length: 9007199254740993`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- exact-head release gate: https://github.com/openclaw/openclaw/actions/runs/27848673438

Evidence after fix: the browser-compatible reader rejects with `OpenAI Realtime SDP answer response body exceeded 16 bytes`, calls `body.cancel()`, and does not call `body.getReader()` for the unsafe declared length case.

Observed result after fix: final autoreview clean with overall patch correctness `0.84`; exact-head release gate completed successfully on `cf17007fd3d767b4527e84fb039a2bfa1b1c38ad`.

What was not tested: focused Vitest was not run locally because this sparse GWT has no `node_modules`, and repo rules say not to install dependencies in Codex worktrees. The hosted release gate ran the tooling shard that includes the focused test.
