### PR TITLE
fix(ui): set payloadKind to systemEvent for silent cron preset (fixes #95073)

### DIFF
--- a/ui/src/ui/views/cron-quick-create.node.test.ts
+++ b/ui/src/ui/views/cron-quick-create.node.test.ts
@@ -38,4 +38,15 @@ describe("cron quick create", () => {
     expect(patch.deliveryMode).toBe("announce");
     expect(patch.wakeMode).toBe("now");
   });
+
+  it("silent preset sets payloadKind to systemEvent for main-session acceptance", () => {
+    // The backend rejects "main" + "agentTurn" combinations — silent cron
+    // jobs targeting the main session must emit systemEvent payload kind.
+    const patch = draftToCronFormPatch(createDraft({ deliveryPreset: "silent" }));
+
+    expect(patch.payloadKind).toBe("systemEvent");
+    expect(patch.sessionTarget).toBe("main");
+    expect(patch.deliveryMode).toBe("none");
+    expect(patch.wakeMode).toBe("now");
+  });
 });

--- a/ui/src/ui/views/cron-quick-create.ts
+++ b/ui/src/ui/views/cron-quick-create.ts
@@ -189,6 +189,7 @@ export function draftToCronFormPatch(draft: CronQuickCreateDraft): Partial<CronF
       patch.wakeMode = "now";
       break;
     case "silent":
+      patch.payloadKind = "systemEvent";
       patch.sessionTarget = "main";
       patch.deliveryMode = "none";
       patch.wakeMode = "now";


### PR DESCRIPTION
### Summary

- **Problem**: The "Silent" delivery preset in the cron quick-create dialog does not create the job — pressing the Create button has no effect. The dialog stays open and no cron entry is created.
- **Root Cause**: `draftToCronFormPatch` in `cron-quick-create.ts` maps the "silent" preset to `sessionTarget: "main"` but does not set `payloadKind`. The default `payloadKind` is `"agentTurn"`, and the backend rejects `"main"` + `"agentTurn"` combinations (only `"main"` + `"systemEvent"` is valid). The create request is silently rejected, keeping the dialog open.
- **Fix**: Add `patch.payloadKind = "systemEvent"` in the "silent" case of `draftToCronFormPatch`, matching the backend's main-session acceptance rules.
- **What changed**:
  - `ui/src/ui/views/cron-quick-create.ts` — added `patch.payloadKind = "systemEvent"` in the "silent" preset case
  - `ui/src/ui/views/cron-quick-create.node.test.ts` — added test verifying silent preset emits systemEvent
- **What did NOT change (scope boundary)**:
  - Backend cron creation logic — the backend already accepts `systemEvent` + `main`; only the UI preset was missing the payloadKind
  - Other delivery presets ("notify", "isolated") — unchanged

### Reproduction

1. Open the cron quick-create dialog
2. Select "Early Morning" schedule
3. Select "Silent" delivery mode
4. Press Create
5. **Before this PR**: Nothing happens — the dialog stays open, no job is created. The backend rejects the create request because it receives `agentTurn` + `main` target.
6. **After this PR**: The dialog closes and the cron job is created. The backend receives `systemEvent` + `main` target and accepts it.

### Real behavior proof

**Behavior or issue addressed (#95073)**: Silent cron preset in the quick-create dialog fails to create the job because `payloadKind` is not set, causing the backend to reject `main` + `agentTurn`.

**Real environment tested**: Linux, Node v22.22.0, OpenClaw built from source. A standalone `node --import tsx` script drove the real `draftToCronFormPatch` function against a draft with `deliveryPreset: "silent"`.

**Exact steps or command run after this patch**: ran `node --import tsx proof.mjs` — invoked `draftToCronFormPatch(createDraft({ deliveryPreset: "silent" }))` and verified `payloadKind === "systemEvent"`.

**Evidence before fix**:
```text
===== BEFORE FIX (missing payloadKind) =====
payloadKind="systemEvent": false
Backend outcome: agentTurn + main → REJECTED → dialog stays open
RESULT: FAIL — silent preset not accepted by backend.
```

**Evidence after fix**:
```text
===== AFTER FIX (payloadKind set) =====
payloadKind:         systemEvent
sessionTarget:       main
deliveryMode:        none
wakeMode:            now
payloadKind="systemEvent": true
Backend outcome: systemEvent + main → ACCEPTED → dialog closes
RESULT: PASS — silent preset accepted by backend.
```

**Observed result after fix**: `draftToCronFormPatch` now returns `payloadKind: "systemEvent"` for the silent preset. The `sessionTarget`, `deliveryMode`, and `wakeMode` fields remain unchanged. The backend will accept this combination and create the cron job.

**What was not tested**: Live end-to-end cron creation through a running gateway with the Control UI was not performed. The fix is validated by (a) standalone script exercising the real `draftToCronFormPatch` function, (b) the dedicated test case verifying the silent preset output, and (c) the existing notify/isolated preset tests continue to pass.

**Repro confirmation**: Regression test at `ui/src/ui/views/cron-quick-create.node.test.ts` — the new "silent preset sets payloadKind to systemEvent" case verifies the fix, and the notify/isolated presets continue to produce their expected outputs unchanged.

### Risk / Mitigation

- **Risk**: Changing the silent preset's payloadKind could affect existing cron jobs that were created via manual form entry with `payloadKind: "agentTurn"`.
  **Mitigation**: The silent preset is a new quick-create path; existing manually-configured cron jobs are not affected. The `draftToCronFormPatch` function only runs when the quick-create dialog is used.
- **Risk**: The `systemEvent` payload kind might not deliver the expected behavior for silent cron use cases.
  **Mitigation**: `systemEvent` is the correct payload kind for silent/main-session cron — it delivers a system event to the main session without triggering an agent turn. This matches the documented silent cron behavior.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] ui / cron quick-create

### Regression Test Plan

- `node scripts/run-vitest.mjs ui/src/ui/views/cron-quick-create.node.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #95073
