### PR TITLE
fix(ci): keep markdown-only PR jobs off Blacksmith

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,88 @@ jobs:
         if: github.event_name != 'push' || github.repository != 'openclaw/openclaw' || github.ref != 'refs/heads/main'
         run: echo "No canonical main debounce required"
 
+  # Scope gate: compute docs-only routing on a GitHub-hosted runner before any
+  # canonical PR job chooses a Blacksmith runner label.
+  ci_scope:
+    name: CI scope gate
+    permissions:
+      contents: read
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      docs_only: ${{ steps.scope.outputs.docs_only }}
+      docs_changed: ${{ steps.scope.outputs.docs_changed }}
+    steps:
+      - name: Checkout
+        if: github.event_name != 'workflow_dispatch'
+        env:
+          CHECKOUT_REPO: ${{ github.repository }}
+          CHECKOUT_REF: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git init "$GITHUB_WORKSPACE"
+          git -C "$GITHUB_WORKSPACE" config gc.auto 0
+          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
+          fetch_checkout_ref() {
+            local ref="$1"
+            local fetch_status
+            for attempt in 1 2 3; do
+              timeout --signal=TERM --kill-after=10s 120s git -C "$GITHUB_WORKSPACE" \
+                -c protocol.version=2 \
+                fetch --no-tags --prune --no-recurse-submodules --depth=2 origin \
+                "+${ref}:refs/remotes/origin/checkout" && return 0
+              fetch_status="$?"
+              if [ "$fetch_status" != "124" ] && [ "$fetch_status" != "137" ]; then
+                return "$fetch_status"
+              fi
+              if [ "$attempt" = "3" ]; then
+                return "$fetch_status"
+              fi
+              echo "::warning::checkout fetch for '$ref' timed out on attempt $attempt; retrying"
+              sleep 5
+            done
+          }
+          if fetch_checkout_ref "$CHECKOUT_REF"; then
+            :
+          else
+            fetch_status="$?"
+            if [ "$fetch_status" = "124" ] || [ "$fetch_status" = "137" ]; then
+              echo "::error::checkout fetch for '$CHECKOUT_REF' timed out"
+            fi
+            exit "$fetch_status"
+          fi
+          git -C "$GITHUB_WORKSPACE" checkout --detach refs/remotes/origin/checkout
+
+      - name: Ensure scope base commit
+        if: github.event_name != 'workflow_dispatch'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+
+      - name: Detect docs-only changes
+        id: docs_scope
+        if: github.event_name != 'workflow_dispatch'
+        uses: ./.github/actions/detect-docs-changes
+
+      - name: Publish scope outputs
+        id: scope
+        env:
+          DOCS_ONLY: ${{ github.event_name == 'workflow_dispatch' && 'false' || steps.docs_scope.outputs.docs_only || 'false' }}
+          DOCS_CHANGED: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.docs_scope.outputs.docs_changed || 'false' }}
+        run: |
+          echo "docs_only=${DOCS_ONLY}" >> "$GITHUB_OUTPUT"
+          echo "docs_changed=${DOCS_CHANGED}" >> "$GITHUB_OUTPUT"
+
   # Preflight: establish routing truth and job matrices once, then let real
   # work fan out from a single source of truth.
   preflight:
     permissions:
       contents: read
-    needs: [runner-admission]
+    needs: [runner-admission, ci_scope]
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.event_name == 'pull_request' && needs.ci_scope.outputs.docs_only == 'true' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04')) }}
     timeout-minutes: 20
     outputs:
       checkout_revision: ${{ steps.checkout_ref.outputs.sha }}
@@ -387,14 +461,14 @@ jobs:
           }
           EOF
 
-  # Run dependency-free security checks in parallel with scope detection so the
-  # main Node jobs do not have to wait for Python/pre-commit setup.
+  # Run dependency-free security checks after the lightweight scope gate so
+  # Markdown-only PRs do not reserve Blacksmith while still keeping the check.
   security-fast:
     permissions:
       contents: read
-    needs: [runner-admission]
+    needs: [runner-admission, ci_scope]
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.event_name == 'pull_request' && needs.ci_scope.outputs.docs_only == 'true' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04')) }}
     timeout-minutes: 20
     env:
       PRE_COMMIT_HOME: .cache/pre-commit-security-fast
@@ -536,7 +610,7 @@ jobs:
       contents: read
     needs: [preflight]
     if: needs.preflight.outputs.run_node == 'true' || needs.preflight.outputs.run_check_docs == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.event_name == 'pull_request' && needs.preflight.outputs.docs_only == 'true' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04')) }}
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -1676,7 +1750,7 @@ jobs:
       contents: read
     needs: [preflight]
     if: needs.preflight.outputs.run_check_docs == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.event_name == 'pull_request' && needs.preflight.outputs.docs_only == 'true' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04')) }}
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -25,6 +25,7 @@ or an explicit manual dispatch.
 
 | Job                                | Purpose                                                                                                   | When it runs                                        |
 | ---------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `ci_scope`                         | Detect Markdown/docs-only changes early on a GitHub-hosted runner so trivial PRs avoid Blacksmith queues  | Always on non-draft pushes and PRs                  |
 | `preflight`                        | Detect docs-only changes, changed scopes, changed extensions, and build the CI manifest                   | Always on non-draft pushes and PRs                  |
 | `runner-admission`                 | Hosted 90-second debounce for canonical `main` pushes before Blacksmith work is registered                | Every CI run; sleep only on canonical `main` pushes |
 | `security-fast`                    | Private key detection, changed-workflow audit via `zizmor`, and production lockfile audit                 | Always on non-draft pushes and PRs                  |
@@ -50,10 +51,11 @@ or an explicit manual dispatch.
 ## Fail-fast order
 
 1. `runner-admission` waits only for canonical `main` pushes; a newer push cancels the run before Blacksmith registration.
-2. `preflight` decides which lanes exist at all. The `docs-scope` and `changed-scope` logic are steps inside this job, not standalone jobs.
-3. `security-fast`, `check-*`, `check-additional-*`, `check-docs`, and `skills-python` fail quickly without waiting on the heavier artifact and platform matrix jobs.
-4. `build-artifacts` overlaps with the fast Linux lanes so downstream consumers can start as soon as the shared build is ready.
-5. Heavier platform and runtime lanes fan out after that: `checks-fast-core`, `checks-fast-contracts-plugins-*`, `checks-fast-contracts-channels-*`, `checks-node-core-*`, `checks-windows`, `macos-node`, `macos-swift`, `ios-build`, and `android`.
+2. `ci_scope` computes the docs-only signal on `ubuntu-24.04` before canonical pull requests choose Blacksmith-backed runner labels.
+3. `preflight` decides which lanes exist at all. It reuses the same docs-scope detector and then runs `changed-scope` only when the diff is not docs-only.
+4. `security-fast`, `check-*`, `check-additional-*`, `check-docs`, and `skills-python` fail quickly without waiting on the heavier artifact and platform matrix jobs.
+5. `build-artifacts` overlaps with the fast Linux lanes so downstream consumers can start as soon as the shared build is ready.
+6. Heavier platform and runtime lanes fan out after that: `checks-fast-core`, `checks-fast-contracts-plugins-*`, `checks-fast-contracts-channels-*`, `checks-node-core-*`, `checks-windows`, `macos-node`, `macos-swift`, `ios-build`, and `android`.
 
 GitHub may mark superseded jobs as `cancelled` when a newer push lands on the same PR or `main` ref. Treat that as CI noise unless the newest run for the same ref is also failing. Matrix jobs use `fail-fast: false`, and `build-artifacts` reports embedded channel, core-support-boundary, and gateway-watch failures directly instead of queuing tiny verifier jobs. The automatic CI concurrency key is versioned (`CI-v7-*`) so a GitHub-side zombie in an old queue group cannot indefinitely block newer main runs. Manual full-suite runs use `CI-manual-v1-*` and do not cancel in-progress runs.
 
@@ -133,15 +135,15 @@ gh workflow run full-release-validation.yml --ref main -f ref=<branch-or-sha>
 
 ## Runners
 
-| Runner                          | Jobs                                                                                                                                                                                                                                                                                 |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ubuntu-24.04`                  | Manual CI dispatch and non-canonical repository fallbacks, CodeQL JavaScript/actions quality scans, workflow-sanity, labeler, auto-response, docs workflows outside CI, and install-smoke preflight so the Blacksmith matrix can queue earlier                                       |
-| `blacksmith-4vcpu-ubuntu-2404`  | `preflight`, `security-fast`, lower-weight extension shards, `checks-fast-core`, plugin/channel contract shards, most bundled/lower-weight Linux Node shards, `check-guards`, `check-prod-types`, `check-test-types`, selected `check-additional-*` shards, and `check-dependencies` |
-| `blacksmith-8vcpu-ubuntu-2404`  | Retained heavy Linux Node suites, boundary/extension-heavy `check-additional-*` shards, and `android`                                                                                                                                                                                |
-| `blacksmith-16vcpu-ubuntu-2404` | `build-artifacts`, `check-lint` (CPU-sensitive enough that 8 vCPU cost more than they saved); install-smoke Docker builds (32-vCPU queue time cost more than it saved)                                                                                                               |
-| `blacksmith-8vcpu-windows-2025` | `checks-windows`                                                                                                                                                                                                                                                                     |
-| `blacksmith-6vcpu-macos-15`     | `macos-node` on `openclaw/openclaw`; forks fall back to `macos-15`                                                                                                                                                                                                                   |
-| `blacksmith-12vcpu-macos-26`    | `macos-swift` and `ios-build` on `openclaw/openclaw`; forks fall back to `macos-26`                                                                                                                                                                                                  |
+| Runner                          | Jobs                                                                                                                                                                                                                                                                                                           |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ubuntu-24.04`                  | `ci_scope`, manual CI dispatch and non-canonical repository fallbacks, CodeQL Critical Quality and JavaScript/actions quality scans, workflow-sanity, labeler, auto-response, docs workflows outside CI, Markdown-only PR CI docs jobs, and install-smoke preflight so the Blacksmith matrix can queue earlier |
+| `blacksmith-4vcpu-ubuntu-2404`  | `preflight`, `security-fast`, lower-weight extension shards, `checks-fast-core`, plugin/channel contract shards, most bundled/lower-weight Linux Node shards, `check-guards`, `check-prod-types`, `check-test-types`, selected `check-additional-*` shards, and `check-dependencies`                           |
+| `blacksmith-8vcpu-ubuntu-2404`  | Retained heavy Linux Node suites, boundary/extension-heavy `check-additional-*` shards, and `android`                                                                                                                                                                                                          |
+| `blacksmith-16vcpu-ubuntu-2404` | `build-artifacts`, `check-lint` (CPU-sensitive enough that 8 vCPU cost more than they saved); install-smoke Docker builds (32-vCPU queue time cost more than it saved)                                                                                                                                         |
+| `blacksmith-8vcpu-windows-2025` | `checks-windows`                                                                                                                                                                                                                                                                                               |
+| `blacksmith-6vcpu-macos-15`     | `macos-node` on `openclaw/openclaw`; forks fall back to `macos-15`                                                                                                                                                                                                                                             |
+| `blacksmith-12vcpu-macos-26`    | `macos-swift` and `ios-build` on `openclaw/openclaw`; forks fall back to `macos-26`                                                                                                                                                                                                                            |
 
 ## Runner registration budget
 
@@ -157,7 +159,6 @@ needs. Any new Blacksmith matrix, larger `max-parallel`, or high-frequency
 workflow must show its worst-case registration count and keep the org-level
 target below 1,000 registrations per 5 minutes, leaving headroom for concurrent
 repositories and retried jobs.
-
 Canonical-repo CI keeps Blacksmith as the default runner path for normal push and pull-request runs. `workflow_dispatch` and non-canonical repository runs use GitHub-hosted runners, but normal canonical runs do not currently probe Blacksmith queue health or automatically fall back to GitHub-hosted labels when Blacksmith is unavailable.
 
 ## Local equivalents

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -335,7 +335,14 @@ describe("ci workflow guards", () => {
   it("bounds early unauthenticated checkout fetches", () => {
     const workflow = readCiWorkflow();
 
-    for (const jobName of ["preflight", "security-fast", "skills-python"]) {
+    const expectedFetchDepths = new Map([
+      ["ci_scope", 2],
+      ["preflight", 2],
+      ["security-fast", 1],
+      ["skills-python", 1],
+    ]);
+
+    for (const [jobName, expectedDepth] of expectedFetchDepths) {
       const checkoutStep = workflow.jobs[jobName].steps.find((step) => step.name === "Checkout");
 
       expect(checkoutStep.run, jobName).toContain(
@@ -345,7 +352,6 @@ describe("ci workflow guards", () => {
       expect(checkoutStep.run, jobName).toContain("timed out on attempt $attempt; retrying");
       expect(checkoutStep.run, jobName).not.toContain("if timeout --signal=TERM");
       expect(checkoutStep.run, jobName).toContain("-c protocol.version=2");
-      const expectedDepth = jobName === "preflight" ? 2 : 1;
       expect(checkoutStep.run, jobName).toContain(
         `fetch --no-tags --prune --no-recurse-submodules --depth=${expectedDepth} origin`,
       );
@@ -357,6 +363,42 @@ describe("ci workflow guards", () => {
         'git -C "$GITHUB_WORKSPACE" fetch --no-tags --depth=1',
       );
     }
+  });
+
+  it("keeps Markdown-only PR CI scope checks off Blacksmith runners", () => {
+    const workflow = readCiWorkflow();
+    const scopeGate = workflow.jobs.ci_scope;
+    const preflight = workflow.jobs.preflight;
+    const securityFast = workflow.jobs["security-fast"];
+    const pnpmStoreWarmup = workflow.jobs["pnpm-store-warmup"];
+    const checkDocs = workflow.jobs["check-docs"];
+    const markdownOnlyHostedRunner =
+      "github.event_name == 'pull_request' && needs.ci_scope.outputs.docs_only == 'true' && 'ubuntu-24.04'";
+    const markdownOnlyDocsHostedRunner =
+      "github.event_name == 'pull_request' && needs.preflight.outputs.docs_only == 'true' && 'ubuntu-24.04'";
+
+    expect(scopeGate["runs-on"]).toBe("ubuntu-24.04");
+    expect(scopeGate.outputs).toMatchObject({
+      docs_only: "${{ steps.scope.outputs.docs_only }}",
+      docs_changed: "${{ steps.scope.outputs.docs_changed }}",
+    });
+    expect(scopeGate.steps.map((step) => step.name)).toEqual([
+      "Checkout",
+      "Ensure scope base commit",
+      "Detect docs-only changes",
+      "Publish scope outputs",
+    ]);
+
+    expect(preflight.needs).toEqual(["runner-admission", "ci_scope"]);
+    expect(preflight["runs-on"]).toContain(markdownOnlyHostedRunner);
+    expect(preflight["runs-on"]).toContain("'blacksmith-4vcpu-ubuntu-2404'");
+    expect(securityFast.needs).toEqual(["runner-admission", "ci_scope"]);
+    expect(securityFast["runs-on"]).toContain(markdownOnlyHostedRunner);
+    expect(securityFast["runs-on"]).toContain("'blacksmith-4vcpu-ubuntu-2404'");
+    expect(pnpmStoreWarmup["runs-on"]).toContain(markdownOnlyDocsHostedRunner);
+    expect(pnpmStoreWarmup["runs-on"]).toContain("'blacksmith-4vcpu-ubuntu-2404'");
+    expect(checkDocs["runs-on"]).toContain(markdownOnlyDocsHostedRunner);
+    expect(checkDocs["runs-on"]).toContain("'blacksmith-4vcpu-ubuntu-2404'");
   });
 
   it("retries workflow sanity checkout fetch timeouts", () => {


### PR DESCRIPTION
Fixes #95089

## What Problem This Solves

Fixes an issue where Markdown-only pull requests could still reserve Blacksmith-backed CI jobs before the workflow had enough routing information to keep trivial docs changes on lightweight hosted runners.

AI-assisted: yes. I used Codex to prepare and review this change, then validated the workflow behavior locally and with a fork-only live Actions proof run.

## Why This Change Was Made

This adds a small `ci_scope` job on `ubuntu-24.04` to compute the existing docs-only signal before canonical PR jobs choose a runner label. Markdown-only PRs now keep `preflight`, `security-fast`, `pnpm-store-warmup`, and `check-docs` on `ubuntu-24.04`, while non-docs canonical CI keeps the existing Blacksmith runner paths.

The change reuses `.github/actions/detect-docs-changes` instead of broadening `pull_request.paths-ignore`, so docs and security checks remain present.

## User Impact

Contributors and maintainers should see Markdown-only PR CI start without waiting on Blacksmith capacity. Normal source, workflow, package, and platform changes continue to use the existing CI routing and Blacksmith labels.

## Evidence

Local validation:

- `pnpm install --frozen-lockfile`
- `git diff --check`
- `node scripts/check-workflows.mjs`
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts`
- `pnpm check:docs`
- `codex review --base origin/main` found the initial downstream docs-job gap; after fixing `pnpm-store-warmup` and `check-docs`, rerun reported no actionable correctness issues.

Focused workflow guard proof:

- The workflow guard asserts that `ci_scope` runs on `ubuntu-24.04`, that Markdown-only PR routing sends `preflight` and `security-fast` to `ubuntu-24.04` from `needs.ci_scope.outputs.docs_only`, and that `pnpm-store-warmup` plus `check-docs` also use `ubuntu-24.04` from `needs.preflight.outputs.docs_only`.
- The same assertions preserve the existing Blacksmith fallback strings for non-docs canonical CI.

Live Markdown-only Actions proof:

- Proof PR: https://github.com/markoub/openclaw/pull/1
- Proof CI run: https://github.com/markoub/openclaw/actions/runs/27864555046
- Proof head: `73988a6f66c4d229155ff049f862bf3d580cdbe2`, base: `9bc662eac72e70f3a38beb432594c224d4fbf137`
- The proof PR changes only `docs/ci-markdown-only-proof.md` on top of this branch, so it exercises the new workflow as a Markdown-only pull request.
- The `CI scope gate` log shows `Docs-only change detected`, then publishes `DOCS_ONLY: true` and `DOCS_CHANGED: true`.
- The following jobs completed successfully and each log shows GitHub-hosted Ubuntu 24.04 with `Runner Image` -> `Image: ubuntu-24.04`:
  - `CI scope gate`: https://github.com/markoub/openclaw/actions/runs/27864555046/job/82466323975
  - `preflight`: https://github.com/markoub/openclaw/actions/runs/27864555046/job/82466335917
  - `security-fast`: https://github.com/markoub/openclaw/actions/runs/27864555046/job/82466335918
  - `pnpm-store-warmup`: https://github.com/markoub/openclaw/actions/runs/27864555046/job/82466347842
  - `check-docs`: https://github.com/markoub/openclaw/actions/runs/27864555046/job/82466347855
