### PR TITLE
fix(memory): align session file counter denominator with indexer filter (fixes #77338)

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -9,6 +9,7 @@ import {
   resolveMemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
+import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import {
   colorize,
@@ -526,7 +527,7 @@ async function scanSessionFiles(agentId: string): Promise<SourceScan> {
   try {
     const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
     const totalFiles = entries.filter(
-      (entry) => entry.isFile() && entry.name.endsWith(".jsonl"),
+      (entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name),
     ).length;
     return { source: "sessions", totalFiles, issues };
   } catch (err) {


### PR DESCRIPTION
## Real behavior proof

- **Behavior addressed:** `openclaw memory --status` session file counter uses `.endsWith(".jsonl")` as the denominator filter, but the usage indexer in `src/infra/session-cost-usage.ts:413` uses `isUsageCountedSessionTranscriptFileName()` which excludes `.deleted.*`, `.reset.*`, `.bak.*`, and `.trajectory.jsonl` files. This mismatch inflates the session file count in the `--status` output.

- **Environment tested:** macOS 26.4.1, Node v22, OpenClaw built from source at `b554c470`.

- **Steps run after the patch:**
  1. Verified the bug still exists on current `upstream/main`: `grep -n 'endsWith.*jsonl' extensions/memory-core/src/cli.runtime.ts` → line 529 confirms the stale `.endsWith(".jsonl")` filter.
  2. Verified the correct filter is used elsewhere: `grep -n 'isUsageCountedSessionTranscriptFileName' src/infra/session-cost-usage.ts` → line 413 confirms the indexer uses the canonical filter.
  3. Applied the 2-line fix (import + filter replacement).

- **Evidence after fix:**

```
$ grep -n 'isUsageCountedSessionTranscriptFileName' extensions/memory-core/src/cli.runtime.ts
12:import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
530:      (entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name),

$ grep -n 'isUsageCountedSessionTranscriptFileName' src/infra/session-cost-usage.ts
13:  isUsageCountedSessionTranscriptFileName,
413:    .filter((entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name))
```

- **Observed result after fix:** The `scanSessionFiles` function now uses the same canonical filter as the usage indexer, ensuring `.deleted.*`, `.reset.*`, `.bak.*`, and `.trajectory.jsonl` files are excluded from the session file count denominator.

- **What was not tested:** Live `openclaw memory --status` output (requires full runtime setup with session transcripts directory). The fix is a direct alignment of the filter function — behavior is deterministic from the source code.
