### PR TITLE
perf(memory-lancedb): cache query embeddings per embeddings instance

### DIFF
--- a/docs/plugins/memory-lancedb.md
+++ b/docs/plugins/memory-lancedb.md
@@ -227,6 +227,56 @@ for automatic capture. It does not cap recall query embeddings.
 regular expressions. The built-in triggers include common English, Czech,
 Chinese, Japanese, and Korean memory phrases.
 
+## Query embedding cache
+
+`memory-lancedb` embeds the recall query before every vector search. A single
+turn can embed the same query more than once (the `memory_recall` tool, the
+auto-recall hook, and capture deduplication), and each embed is a provider
+round-trip. Recall-query embeddings are therefore cached in a small
+per-instance LRU so identical embeds collapse to one provider call.
+
+| Setting                           | Default | Range     | Applies to                                           |
+| --------------------------------- | ------- | --------- | ---------------------------------------------------- |
+| `query.embeddingCache.enabled`    | `true`  | boolean   | whether recall-query embeddings are cached           |
+| `query.embeddingCache.maxEntries` | `512`   | 1-1000000 | maximum cached query vectors per embeddings instance |
+
+The cache is on by default. `(model, text)` to `embedding` is deterministic, so
+a cached vector never goes stale for a fixed embedding identity; eviction is
+purely by capacity (least-recently-used) with no TTL. Failed or degenerate
+embeds (empty, all-zero, or non-finite vectors) are never cached, so a transient
+provider failure is always retried.
+
+The cache is in-memory and per-instance. It is not persisted: it starts empty on
+Gateway restart, and any reconfiguration that rebuilds the embeddings instance
+(for example changing the model, provider, or dimensions) starts a fresh cache
+keyed to the new identity. It is separate from memory-core's persistent
+chunk-embedding cache, which stores index-time chunk vectors in SQLite; this
+cache only holds recall-query vectors at search time.
+
+To turn it off, set `query.embeddingCache.enabled` to `false`. Lower
+`maxEntries` to bound memory on a long-running instance that sees a very large
+variety of distinct recall queries.
+
+```json5
+{
+  plugins: {
+    entries: {
+      "memory-lancedb": {
+        enabled: true,
+        config: {
+          query: {
+            embeddingCache: {
+              enabled: true,
+              maxEntries: 512,
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
 ## Commands
 
 When `memory-lancedb` is the active memory plugin, it registers the `ltm` CLI

--- a/extensions/memory-lancedb/config.test.ts
+++ b/extensions/memory-lancedb/config.test.ts
@@ -213,4 +213,95 @@ describe("memory-lancedb config", () => {
       });
     }).toThrow("dreaming config must be an object");
   });
+
+  it("defaults the query embedding recall cache to enabled with no maxEntries override", () => {
+    const parsed = memoryConfigSchema.parse({
+      embedding: {
+        apiKey: "sk-test",
+      },
+    });
+    expect(parsed.queryEmbeddingCache).toEqual({ enabled: true });
+  });
+
+  it("surfaces query.embeddingCache in the manifest schema and runtime parser", () => {
+    const value = {
+      embedding: {
+        apiKey: "sk-test",
+      },
+      query: {
+        embeddingCache: {
+          enabled: false,
+          maxEntries: 64,
+        },
+      },
+    };
+    const manifestResult = validateJsonSchemaValue({
+      schema: manifest.configSchema,
+      cacheKey: "memory-lancedb.manifest.query-embedding-cache",
+      value,
+    });
+    const parsed = memoryConfigSchema.parse(value);
+
+    expect(manifestResult.ok).toBe(true);
+    expect(parsed.queryEmbeddingCache).toEqual({ enabled: false, maxEntries: 64 });
+  });
+
+  it("treats an omitted enabled flag as enabled while honoring maxEntries", () => {
+    const parsed = memoryConfigSchema.parse({
+      embedding: {
+        apiKey: "sk-test",
+      },
+      query: {
+        embeddingCache: {
+          maxEntries: 128,
+        },
+      },
+    });
+    expect(parsed.queryEmbeddingCache).toEqual({ enabled: true, maxEntries: 128 });
+  });
+
+  it("rejects a non-integer or out-of-range query.embeddingCache.maxEntries", () => {
+    expect(() => {
+      memoryConfigSchema.parse({
+        embedding: { apiKey: "sk-test" },
+        query: { embeddingCache: { maxEntries: 0 } },
+      });
+    }).toThrow("query.embeddingCache.maxEntries must be between 1 and 1000000");
+    expect(() => {
+      memoryConfigSchema.parse({
+        embedding: { apiKey: "sk-test" },
+        query: { embeddingCache: { maxEntries: "64" } },
+      });
+    }).toThrow("query.embeddingCache.maxEntries must be between 1 and 1000000");
+    expect(() => {
+      memoryConfigSchema.parse({
+        embedding: { apiKey: "sk-test" },
+        query: { embeddingCache: { maxEntries: 1.5 } },
+      });
+    }).toThrow("query.embeddingCache.maxEntries must be between 1 and 1000000");
+  });
+
+  it("rejects unknown keys under query and query.embeddingCache", () => {
+    expect(() => {
+      memoryConfigSchema.parse({
+        embedding: { apiKey: "sk-test" },
+        query: { embeddingCache: { ttlMs: 1000 } },
+      });
+    }).toThrow("query.embeddingCache has unknown keys: ttlMs");
+    expect(() => {
+      memoryConfigSchema.parse({
+        embedding: { apiKey: "sk-test" },
+        query: { hybrid: {} },
+      });
+    }).toThrow("query config has unknown keys: hybrid");
+  });
+
+  it("rejects a non-boolean query.embeddingCache.enabled", () => {
+    expect(() => {
+      memoryConfigSchema.parse({
+        embedding: { apiKey: "sk-test" },
+        query: { embeddingCache: { enabled: "yes" } },
+      });
+    }).toThrow("query.embeddingCache.enabled must be a boolean");
+  });
 });

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { parseFiniteNumber } from "openclaw/plugin-sdk/number-runtime";
+import { QUERY_EMBED_CACHE_MAX_ENTRIES as DEFAULT_QUERY_EMBED_CACHE_MAX_ENTRIES } from "./query-embedding-cache.js";
 
 export type MemoryConfig = {
   embedding: {
@@ -20,6 +21,15 @@ export type MemoryConfig = {
   customTriggers?: string[];
   recallMaxChars?: number;
   storageOptions?: Record<string, string>;
+  // Resolved query-embedding recall cache settings (always present after parse).
+  // This is the in-memory LRU that collapses repeated recall-query embeds within
+  // a turn; it is distinct from the host's `memorySearch.cache` (chunk embeddings
+  // in SQLite). maxEntries is left undefined when unset so the cache applies its
+  // own default capacity (QUERY_EMBED_CACHE_MAX_ENTRIES).
+  queryEmbeddingCache: {
+    enabled: boolean;
+    maxEntries?: number;
+  };
 };
 
 export const MEMORY_CATEGORIES = ["preference", "fact", "decision", "entity", "other"] as const;
@@ -122,6 +132,58 @@ function resolveBoundedIntegerConfig(params: {
   return resolved;
 }
 
+// Upper bound for the configurable query-embedding cache capacity. Generous on
+// purpose: the cache is a small per-instance LRU of recall-query vectors, so the
+// only real constraint is memory, and the sane default (when unset) is the
+// QUERY_EMBED_CACHE_MAX_ENTRIES constant applied by the cache itself.
+const MAX_QUERY_EMBED_CACHE_ENTRIES = 1_000_000;
+
+function resolveQueryEmbeddingCacheConfig(query: unknown): MemoryConfig["queryEmbeddingCache"] {
+  if (query === undefined) {
+    return { enabled: true };
+  }
+  if (!query || typeof query !== "object" || Array.isArray(query)) {
+    throw new Error("query config must be an object");
+  }
+  const queryCfg = query as Record<string, unknown>;
+  assertAllowedKeys(queryCfg, ["embeddingCache"], "query config");
+
+  const rawCache = queryCfg.embeddingCache;
+  if (rawCache === undefined) {
+    return { enabled: true };
+  }
+  if (!rawCache || typeof rawCache !== "object" || Array.isArray(rawCache)) {
+    throw new Error("query.embeddingCache must be an object");
+  }
+  const cache = rawCache as Record<string, unknown>;
+  assertAllowedKeys(cache, ["enabled", "maxEntries"], "query.embeddingCache");
+
+  if (cache.enabled !== undefined && typeof cache.enabled !== "boolean") {
+    throw new Error("query.embeddingCache.enabled must be a boolean");
+  }
+  // Default-on, matching the host memorySearch.cache convention.
+  const enabled = cache.enabled !== false;
+
+  let maxEntries: number | undefined;
+  if (cache.maxEntries !== undefined) {
+    const parsedMaxEntries =
+      typeof cache.maxEntries === "number" ? parseFiniteNumber(cache.maxEntries) : undefined;
+    if (
+      parsedMaxEntries === undefined ||
+      !Number.isInteger(parsedMaxEntries) ||
+      parsedMaxEntries < 1 ||
+      parsedMaxEntries > MAX_QUERY_EMBED_CACHE_ENTRIES
+    ) {
+      throw new Error(
+        `query.embeddingCache.maxEntries must be between 1 and ${MAX_QUERY_EMBED_CACHE_ENTRIES}`,
+      );
+    }
+    maxEntries = parsedMaxEntries;
+  }
+
+  return maxEntries === undefined ? { enabled } : { enabled, maxEntries };
+}
+
 function resolveEmbeddingDimensions(embedding: Record<string, unknown>): number | undefined {
   if (embedding.dimensions === undefined) {
     return undefined;
@@ -152,6 +214,7 @@ export const memoryConfigSchema = {
         "customTriggers",
         "recallMaxChars",
         "storageOptions",
+        "query",
       ],
       "memory config",
     );
@@ -209,6 +272,8 @@ export const memoryConfigSchema = {
       }
     }
 
+    const queryEmbeddingCache = resolveQueryEmbeddingCacheConfig(cfg.query);
+
     const dreaming =
       cfg.dreaming === undefined
         ? undefined
@@ -252,6 +317,7 @@ export const memoryConfigSchema = {
       ...(customTriggers ? { customTriggers } : {}),
       recallMaxChars,
       ...(storageOptions ? { storageOptions } : {}),
+      queryEmbeddingCache,
     };
   },
   uiHints: {
@@ -319,6 +385,17 @@ export const memoryConfigSchema = {
       sensitive: true,
       advanced: true,
       help: "Storage configuration options (access_key, secret_key, endpoint, etc.); supports ${ENV_VAR} values",
+    },
+    "query.embeddingCache.enabled": {
+      label: "Query Embedding Recall Cache",
+      advanced: true,
+      help: "Reuse the embedding vector for an identical recall query within a turn (memory_recall, auto-recall, and capture can otherwise embed the same query several times). In-memory only; distinct from the host Memory Search Embedding Cache, which caches chunk embeddings in SQLite.",
+    },
+    "query.embeddingCache.maxEntries": {
+      label: "Query Embedding Cache Max Entries",
+      advanced: true,
+      placeholder: String(DEFAULT_QUERY_EMBED_CACHE_MAX_ENTRIES),
+      help: "Maximum number of recall-query embeddings kept in the in-memory LRU before the least-recently-used entry is evicted.",
     },
   },
 };

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -2433,8 +2433,13 @@ describe("memory plugin e2e", () => {
       );
       await harness.agentEnd?.(event, { sessionKey: "session-ended" });
 
-      expect(harness.embeddingsCreate).toHaveBeenCalledTimes(2);
+      // The capture runs again after the session-end cursor eviction (this is
+      // the behavior under test) -> the row is stored twice. The query-embedding
+      // cache is per-instance and identity+text keyed, so the identical capture
+      // text reuses the cached vector and only embeds once; storage still runs
+      // both times, which is what the cursor-eviction assertion guards.
       expect(harness.add).toHaveBeenCalledTimes(2);
+      expect(harness.embeddingsCreate).toHaveBeenCalledTimes(1);
     } finally {
       await cleanupAutoCaptureCursorHarness();
     }
@@ -3935,5 +3940,110 @@ describe("lancedb runtime loader", () => {
     await expect(loader.load()).resolves.toBe(runtimeModule);
 
     expect(importBundled).toHaveBeenCalledTimes(2);
+  });
+});
+
+// The QueryEmbeddingCache / canonicalizeEmbeddingIdentity / isCacheableEmbeddingVector
+// primitives are unit tested in ./query-embedding-cache.test.ts. These tests cover
+// the cache wired into the real ProviderAdapterEmbeddings (production code path).
+describe("query-embedding cache (wired into embeddings)", () => {
+  async function withProviderAdapter(
+    cacheKeyData: Record<string, unknown> | undefined,
+    embedQuery: ReturnType<typeof vi.fn>,
+  ): Promise<{ embed: (text: string) => Promise<number[]> }> {
+    const getMemoryEmbeddingProvider = vi.fn(() => ({
+      id: "adapter",
+      create: vi.fn(async (options: Record<string, unknown>) => ({
+        provider: {
+          id: "adapter",
+          model: options.model,
+          embedQuery,
+          embedBatch: vi.fn(async () => [[0.1]]),
+        },
+        ...(cacheKeyData ? { runtime: { id: "adapter", cacheKeyData } } : {}),
+      })),
+    }));
+    vi.doMock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", () => ({
+      getMemoryEmbeddingProvider,
+    }));
+    vi.doMock("openclaw/plugin-sdk/memory-host-core", async () => {
+      const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/memory-host-core")>(
+        "openclaw/plugin-sdk/memory-host-core",
+      );
+      return { ...actual, resolveDefaultAgentId: () => "main" };
+    });
+    const mod = await import("./index.js");
+    const cfg = { models: { providers: {} } };
+    const api = {
+      config: cfg,
+      runtime: {
+        config: { current: () => cfg },
+        agent: { resolveAgentDir: () => "/tmp/openclaw-agent" },
+      },
+    };
+    return new mod.testing.ProviderAdapterEmbeddings(
+      api as any,
+      {
+        provider: "adapter",
+        model: "embed-model",
+      } as any,
+    );
+  }
+
+  test("ProviderAdapterEmbeddings caches identical embeds (one provider call)", async () => {
+    vi.resetModules();
+    try {
+      const embedQuery = vi.fn(async () => [0.1, 0.2, 0.3]);
+      const embeddings = await withProviderAdapter({ provider: "adapter" }, embedQuery);
+      const a = await embeddings.embed("hello world");
+      const b = await embeddings.embed("hello world");
+      expect(embedQuery).toHaveBeenCalledTimes(1);
+      expect(a).toEqual([0.1, 0.2, 0.3]);
+      expect(b).toEqual(a);
+      // A different query text is a fresh provider call.
+      await embeddings.embed("different query");
+      expect(embedQuery).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/memory-core-host-engine-embeddings");
+      vi.doUnmock("openclaw/plugin-sdk/memory-host-core");
+      vi.resetModules();
+    }
+  });
+
+  test("ProviderAdapterEmbeddings never collides across distinct identities", async () => {
+    vi.resetModules();
+    try {
+      const embedA = vi.fn(async () => [1, 1, 1]);
+      const adapterA = await withProviderAdapter(
+        { provider: "adapter", model: "model-a", outputDimensionality: 3 },
+        embedA,
+      );
+      await adapterA.embed("same text");
+      await adapterA.embed("same text");
+      expect(embedA).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/memory-core-host-engine-embeddings");
+      vi.doUnmock("openclaw/plugin-sdk/memory-host-core");
+      vi.resetModules();
+    }
+
+    vi.resetModules();
+    try {
+      // A separate instance with a DIFFERENT cacheKeyData (model/dims) must not
+      // reuse the first instance's vector — caches are per-instance and the key
+      // pins model identity, so identical text under a new identity re-embeds.
+      const embedB = vi.fn(async () => [2, 2, 2, 2]);
+      const adapterB = await withProviderAdapter(
+        { provider: "adapter", model: "model-b", outputDimensionality: 4 },
+        embedB,
+      );
+      const result = await adapterB.embed("same text");
+      expect(embedB).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([2, 2, 2, 2]);
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/memory-core-host-engine-embeddings");
+      vi.doUnmock("openclaw/plugin-sdk/memory-host-core");
+      vi.resetModules();
+    }
   });
 });

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -379,7 +379,7 @@ type Embeddings = {
 
 class OpenAiCompatibleEmbeddings implements Embeddings {
   private clientPromise: Promise<OpenAiEmbeddingClient>;
-  private readonly cache = new QueryEmbeddingCache();
+  private readonly cache: QueryEmbeddingCache;
   // Identity is fixed for this instance's lifetime; encode it in the key anyway
   // as a defensive guard so a cached vector can never be served under a
   // different model/dims/endpoint.
@@ -395,7 +395,9 @@ class OpenAiCompatibleEmbeddings implements Embeddings {
     private model: string,
     private baseUrl?: string,
     private dimensions?: number,
+    cacheOptions?: { enabled?: boolean; maxEntries?: number },
   ) {
+    this.cache = new QueryEmbeddingCache(cacheOptions);
     this.clientPromise = loadOpenAiModule().then(
       ({ default: OpenAI }) => new OpenAI({ apiKey, baseURL: baseUrl }) as OpenAiEmbeddingClient,
     );
@@ -431,7 +433,7 @@ class OpenAiCompatibleEmbeddings implements Embeddings {
 
 class ProviderAdapterEmbeddings implements Embeddings {
   private providerPromise: Promise<MemoryEmbeddingProvider> | undefined;
-  private readonly cache = new QueryEmbeddingCache();
+  private readonly cache: QueryEmbeddingCache;
   // Resolved once the provider is created. `cacheKeyData` is the adapter's own
   // identity (provider/baseUrl/model/outputDimensionality/headers); when an
   // adapter does not supply it we fall back to the configured provider/model/dims
@@ -441,7 +443,10 @@ class ProviderAdapterEmbeddings implements Embeddings {
   constructor(
     private api: OpenClawPluginApi,
     private embedding: MemoryConfig["embedding"],
-  ) {}
+    cacheOptions?: { enabled?: boolean; maxEntries?: number },
+  ) {
+    this.cache = new QueryEmbeddingCache(cacheOptions);
+  }
 
   private getProvider(): Promise<MemoryEmbeddingProvider> {
     // Auth profiles and local providers can be repaired while the Gateway stays up.
@@ -596,10 +601,11 @@ export const testing = {
 
 function createEmbeddings(api: OpenClawPluginApi, cfg: MemoryConfig): Embeddings {
   const { provider, model, dimensions, apiKey, baseUrl } = cfg.embedding;
+  const cacheOptions = cfg.queryEmbeddingCache;
   if (provider === "openai" && apiKey) {
-    return new OpenAiCompatibleEmbeddings(apiKey, model, baseUrl, dimensions);
+    return new OpenAiCompatibleEmbeddings(apiKey, model, baseUrl, dimensions, cacheOptions);
   }
-  return new ProviderAdapterEmbeddings(api, cfg.embedding);
+  return new ProviderAdapterEmbeddings(api, cfg.embedding, cacheOptions);
 }
 
 type EmbeddingCreateResponse = {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -42,7 +42,11 @@ import {
   vectorDimsForModel,
 } from "./config.js";
 import { loadLanceDbModule } from "./lancedb-runtime.js";
-import { canonicalizeEmbeddingIdentity, QueryEmbeddingCache } from "./query-embedding-cache.js";
+import {
+  canonicalizeEmbeddingIdentity,
+  QueryEmbeddingCache,
+  queryCacheKey,
+} from "./query-embedding-cache.js";
 
 // ============================================================================
 // Types
@@ -408,7 +412,7 @@ class OpenAiCompatibleEmbeddings implements Embeddings {
     // part of the settled key — a cache hit short-circuits the request entirely.
     // In-flight work is keyed by cancellation policy so an untimed store/capture
     // call never inherits a recall timeout for identical text.
-    const key = JSON.stringify([this.identity, text]);
+    const key = queryCacheKey(this.identity, text);
     const inFlightKey = JSON.stringify([
       key,
       options?.timeoutMs ? `timeout:${options.timeoutMs}` : "untimed",
@@ -518,7 +522,7 @@ class ProviderAdapterEmbeddings implements Embeddings {
   async embed(text: string, options?: { timeoutMs?: number }): Promise<number[]> {
     const provider = await this.getProvider();
     // identity is populated by createProvider() before getProvider() resolves.
-    const key = JSON.stringify([this.identity ?? "", text]);
+    const key = queryCacheKey(this.identity ?? "", text);
     const inFlightKey = JSON.stringify([
       key,
       options?.timeoutMs ? `timeout:${options.timeoutMs}` : "untimed",

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -405,29 +405,39 @@ class OpenAiCompatibleEmbeddings implements Embeddings {
 
   async embed(text: string, options?: { timeoutMs?: number }): Promise<number[]> {
     // timeoutMs governs how long we wait, not the produced vector, so it is not
-    // part of the key — a cache hit short-circuits the request entirely.
+    // part of the settled key — a cache hit short-circuits the request entirely.
+    // In-flight work is keyed by cancellation policy so an untimed store/capture
+    // call never inherits a recall timeout for identical text.
     const key = JSON.stringify([this.identity, text]);
-    return this.cache.getOrCompute(key, async () => {
-      const params: Record<string, unknown> = {
-        model: this.model,
-        input: text,
-      };
-      if (this.dimensions) {
-        params.dimensions = this.dimensions;
-      }
-      ensureGlobalUndiciEnvProxyDispatcher();
-      // The OpenAI SDK's embeddings helper injects encoding_format=base64 when
-      // omitted, then decodes the response. Several compatible providers either
-      // reject encoding_format or always return float arrays, so use the generic
-      // transport and normalize the response ourselves.
-      const response = await (
-        await this.clientPromise
-      ).post<EmbeddingCreateResponse>("/embeddings", {
-        body: params,
-        ...(options?.timeoutMs ? { timeout: options.timeoutMs, maxRetries: 0 } : {}),
-      });
-      return normalizeEmbeddingVector(response.data?.[0]?.embedding);
-    });
+    const inFlightKey = JSON.stringify([
+      key,
+      options?.timeoutMs ? `timeout:${options.timeoutMs}` : "untimed",
+    ]);
+    return this.cache.getOrCompute(
+      key,
+      async () => {
+        const params: Record<string, unknown> = {
+          model: this.model,
+          input: text,
+        };
+        if (this.dimensions) {
+          params.dimensions = this.dimensions;
+        }
+        ensureGlobalUndiciEnvProxyDispatcher();
+        // The OpenAI SDK's embeddings helper injects encoding_format=base64 when
+        // omitted, then decodes the response. Several compatible providers either
+        // reject encoding_format or always return float arrays, so use the generic
+        // transport and normalize the response ourselves.
+        const response = await (
+          await this.clientPromise
+        ).post<EmbeddingCreateResponse>("/embeddings", {
+          body: params,
+          ...(options?.timeoutMs ? { timeout: options.timeoutMs, maxRetries: 0 } : {}),
+        });
+        return normalizeEmbeddingVector(response.data?.[0]?.embedding);
+      },
+      { inFlightKey },
+    );
   }
 }
 
@@ -509,7 +519,13 @@ class ProviderAdapterEmbeddings implements Embeddings {
     const provider = await this.getProvider();
     // identity is populated by createProvider() before getProvider() resolves.
     const key = JSON.stringify([this.identity ?? "", text]);
-    return this.cache.getOrCompute(key, () => this.embedUncached(provider, text, options));
+    const inFlightKey = JSON.stringify([
+      key,
+      options?.timeoutMs ? `timeout:${options.timeoutMs}` : "untimed",
+    ]);
+    return this.cache.getOrCompute(key, () => this.embedUncached(provider, text, options), {
+      inFlightKey,
+    });
   }
 
   private async embedUncached(

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -42,6 +42,7 @@ import {
   vectorDimsForModel,
 } from "./config.js";
 import { loadLanceDbModule } from "./lancedb-runtime.js";
+import { canonicalizeEmbeddingIdentity, QueryEmbeddingCache } from "./query-embedding-cache.js";
 
 // ============================================================================
 // Types
@@ -365,17 +366,34 @@ class MemoryDB {
 // Embeddings
 // ============================================================================
 
+// The per-instance query-embedding cache lives in ./query-embedding-cache.ts:
+// the query-embedding round-trip dominates the LanceDB vector scan, and a single
+// user turn can embed the same recall query up to three times (memory_recall
+// tool, auto-recall hook, capture/dedup). Each Embeddings impl owns one cache
+// and feeds it an identity-pinned key so a model/provider/dims switch can never
+// return a stale or wrong-dimension vector.
+
 type Embeddings = {
   embed(text: string, options?: { timeoutMs?: number }): Promise<number[]>;
 };
 
 class OpenAiCompatibleEmbeddings implements Embeddings {
   private clientPromise: Promise<OpenAiEmbeddingClient>;
+  private readonly cache = new QueryEmbeddingCache();
+  // Identity is fixed for this instance's lifetime; encode it in the key anyway
+  // as a defensive guard so a cached vector can never be served under a
+  // different model/dims/endpoint.
+  private readonly identity = canonicalizeEmbeddingIdentity({
+    provider: "openai",
+    model: this.model,
+    dimensions: this.dimensions,
+    baseUrl: this.baseUrl,
+  });
 
   constructor(
     apiKey: string,
     private model: string,
-    baseUrl?: string,
+    private baseUrl?: string,
     private dimensions?: number,
   ) {
     this.clientPromise = loadOpenAiModule().then(
@@ -384,30 +402,41 @@ class OpenAiCompatibleEmbeddings implements Embeddings {
   }
 
   async embed(text: string, options?: { timeoutMs?: number }): Promise<number[]> {
-    const params: Record<string, unknown> = {
-      model: this.model,
-      input: text,
-    };
-    if (this.dimensions) {
-      params.dimensions = this.dimensions;
-    }
-    ensureGlobalUndiciEnvProxyDispatcher();
-    // The OpenAI SDK's embeddings helper injects encoding_format=base64 when
-    // omitted, then decodes the response. Several compatible providers either
-    // reject encoding_format or always return float arrays, so use the generic
-    // transport and normalize the response ourselves.
-    const response = await (
-      await this.clientPromise
-    ).post<EmbeddingCreateResponse>("/embeddings", {
-      body: params,
-      ...(options?.timeoutMs ? { timeout: options.timeoutMs, maxRetries: 0 } : {}),
+    // timeoutMs governs how long we wait, not the produced vector, so it is not
+    // part of the key — a cache hit short-circuits the request entirely.
+    const key = JSON.stringify([this.identity, text]);
+    return this.cache.getOrCompute(key, async () => {
+      const params: Record<string, unknown> = {
+        model: this.model,
+        input: text,
+      };
+      if (this.dimensions) {
+        params.dimensions = this.dimensions;
+      }
+      ensureGlobalUndiciEnvProxyDispatcher();
+      // The OpenAI SDK's embeddings helper injects encoding_format=base64 when
+      // omitted, then decodes the response. Several compatible providers either
+      // reject encoding_format or always return float arrays, so use the generic
+      // transport and normalize the response ourselves.
+      const response = await (
+        await this.clientPromise
+      ).post<EmbeddingCreateResponse>("/embeddings", {
+        body: params,
+        ...(options?.timeoutMs ? { timeout: options.timeoutMs, maxRetries: 0 } : {}),
+      });
+      return normalizeEmbeddingVector(response.data?.[0]?.embedding);
     });
-    return normalizeEmbeddingVector(response.data?.[0]?.embedding);
   }
 }
 
 class ProviderAdapterEmbeddings implements Embeddings {
   private providerPromise: Promise<MemoryEmbeddingProvider> | undefined;
+  private readonly cache = new QueryEmbeddingCache();
+  // Resolved once the provider is created. `cacheKeyData` is the adapter's own
+  // identity (provider/baseUrl/model/outputDimensionality/headers); when an
+  // adapter does not supply it we fall back to the configured provider/model/dims
+  // plus the resolved provider id+model so the key still pins the exact model.
+  private identity: string | undefined;
 
   constructor(
     private api: OpenClawPluginApi,
@@ -456,11 +485,33 @@ class ProviderAdapterEmbeddings implements Embeddings {
     if (!result.provider) {
       throw new Error(`Memory embedding provider ${providerId} is unavailable.`);
     }
+    // Resolve the cache identity once the provider exists. Prefer the adapter's
+    // cacheKeyData (its canonical identity); otherwise fall back to the
+    // configured provider/model/dims plus the resolved provider id+model so the
+    // key still encodes the exact model and can never serve a wrong-dim vector.
+    this.identity = canonicalizeEmbeddingIdentity(
+      result.runtime?.cacheKeyData ?? {
+        provider: providerId,
+        resolvedId: result.provider.id,
+        model: result.provider.model ?? this.embedding.model,
+        dimensions: this.embedding.dimensions,
+      },
+    );
     return result.provider;
   }
 
   async embed(text: string, options?: { timeoutMs?: number }): Promise<number[]> {
     const provider = await this.getProvider();
+    // identity is populated by createProvider() before getProvider() resolves.
+    const key = JSON.stringify([this.identity ?? "", text]);
+    return this.cache.getOrCompute(key, () => this.embedUncached(provider, text, options));
+  }
+
+  private async embedUncached(
+    provider: MemoryEmbeddingProvider,
+    text: string,
+    options?: { timeoutMs?: number },
+  ): Promise<number[]> {
     if (!options?.timeoutMs) {
       return await provider.embedQuery(text);
     }
@@ -537,6 +588,10 @@ class MemoryRecallEmbeddingError extends Error {
 
 export const testing = {
   runWithTimeout,
+  // Exposed so the embeddings integration tests can drive the real cache wiring
+  // through ProviderAdapterEmbeddings. The cache primitives themselves are unit
+  // tested directly via ./query-embedding-cache.ts.
+  ProviderAdapterEmbeddings,
 } as const;
 
 function createEmbeddings(api: OpenClawPluginApi, cfg: MemoryConfig): Embeddings {

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -144,6 +144,26 @@
         "additionalProperties": {
           "type": "string"
         }
+      },
+      "query": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "embeddingCache": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "maxEntries": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1000000
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -78,6 +78,17 @@
       "label": "Storage Options",
       "advanced": true,
       "help": "Storage configuration options (access_key, secret_key, endpoint, etc.); supports ${ENV_VAR} values"
+    },
+    "query.embeddingCache.enabled": {
+      "label": "Query Embedding Cache",
+      "help": "Cache recall-query embeddings in a per-instance in-memory LRU so identical embeds collapse to one provider call. Default on.",
+      "advanced": true
+    },
+    "query.embeddingCache.maxEntries": {
+      "label": "Query Embedding Cache Max Entries",
+      "help": "Maximum cached query vectors per embeddings instance (in-memory, not persisted). Default 512.",
+      "advanced": true,
+      "placeholder": "512"
     }
   },
   "configSchema": {

--- a/extensions/memory-lancedb/query-embedding-cache.test.ts
+++ b/extensions/memory-lancedb/query-embedding-cache.test.ts
@@ -99,6 +99,28 @@ describe("QueryEmbeddingCache", () => {
     expect(a).toEqual([1, 2]);
     expect(b).toEqual([1, 2]);
   });
+
+  test("does not share timeout-bound in-flight work with untimed callers", async () => {
+    const cache = new QueryEmbeddingCache();
+    const timed = vi.fn(async () => {
+      throw new Error("timed out");
+    });
+    const untimed = vi.fn(async () => [3, 4]);
+
+    const timedResult = cache.getOrCompute("k", timed, { inFlightKey: "k:timeout:100" });
+    const untimedResult = cache.getOrCompute("k", untimed, { inFlightKey: "k:untimed" });
+
+    await expect(timedResult).rejects.toThrow("timed out");
+    await expect(untimedResult).resolves.toEqual([3, 4]);
+    expect(timed).toHaveBeenCalledTimes(1);
+    expect(untimed).toHaveBeenCalledTimes(1);
+
+    const afterSettled = vi.fn(async () => [5, 6]);
+    await expect(
+      cache.getOrCompute("k", afterSettled, { inFlightKey: "k:timeout:200" }),
+    ).resolves.toEqual([3, 4]);
+    expect(afterSettled).not.toHaveBeenCalled();
+  });
 });
 
 describe("canonicalizeEmbeddingIdentity", () => {

--- a/extensions/memory-lancedb/query-embedding-cache.test.ts
+++ b/extensions/memory-lancedb/query-embedding-cache.test.ts
@@ -24,6 +24,29 @@ describe("queryCacheKey", () => {
     expect(queryCacheKey("provider=openai;model=text-embedding-3-small", "other")).not.toBe(key);
     expect(queryCacheKey("provider=ollama;model=nomic-embed-text", secret)).not.toBe(key);
   });
+
+  test("inFlightKey derived from queryCacheKey also contains no plaintext", () => {
+    // The Embeddings classes build inFlightKey as JSON.stringify([key, policy]) where
+    // key = queryCacheKey(...). Verify the full construction retains no user text.
+    // This closes the residual security-boundary risk: even in-flight pending entries
+    // are keyed only by hashes, not by raw recall/store/capture text.
+    const sensitiveText = "What is my salary and home address?";
+    const identity = "provider=openai;model=text-embedding-3-small";
+    const settledKey = queryCacheKey(identity, sensitiveText);
+
+    // Simulate the inFlightKey construction used in both Embeddings implementations.
+    const timedInFlightKey = JSON.stringify([settledKey, "timeout:15000"]);
+    const untimedInFlightKey = JSON.stringify([settledKey, "untimed"]);
+
+    expect(timedInFlightKey).not.toContain(sensitiveText);
+    expect(timedInFlightKey).not.toContain("salary");
+    expect(timedInFlightKey).not.toContain("address");
+    expect(untimedInFlightKey).not.toContain(sensitiveText);
+    // Both contain the SHA-256 digest (still identifiable as a hash).
+    expect(timedInFlightKey).toMatch(/[0-9a-f]{64}/);
+    // Timed and untimed keys for the same text are distinct (different policy suffix).
+    expect(timedInFlightKey).not.toBe(untimedInFlightKey);
+  });
 });
 
 describe("QueryEmbeddingCache", () => {
@@ -118,6 +141,58 @@ describe("QueryEmbeddingCache", () => {
     expect(compute).toHaveBeenCalledTimes(1);
     expect(a).toEqual([1, 2]);
     expect(b).toEqual([1, 2]);
+  });
+
+  test("concurrent distinct-key flood stays within maxEntries bound", async () => {
+    const maxEntries = 4;
+    const cache = new QueryEmbeddingCache({ maxEntries });
+
+    // Launch many distinct keys concurrently: more than the cache capacity.
+    // After all settle, the cache must not retain more than maxEntries vectors.
+    const keyCount = 12;
+    const computes = Array.from({ length: keyCount }, (_, i) => vi.fn(async () => [i + 1, 0, 0]));
+    await Promise.all(computes.map((compute, i) => cache.getOrCompute(`key-${i}`, compute)));
+
+    // The cache is bounded: at most maxEntries entries can be resident after
+    // all promises settle. Verify by requesting the last `maxEntries` keys —
+    // they must be served from cache (compute not called again), while earlier
+    // keys were evicted and would recompute (we don't assert which specific
+    // keys survive since settle order is implementation-defined, but we assert
+    // total distinct resident entries ≤ maxEntries).
+    let cacheHits = 0;
+    for (let i = 0; i < keyCount; i++) {
+      const callsBefore = computes[i]!.mock.calls.length;
+      await cache.getOrCompute(`key-${i}`, computes[i]!);
+      if (computes[i]!.mock.calls.length === callsBefore) {
+        cacheHits += 1;
+      }
+    }
+    // The number of keys still resident (cache hits) must not exceed the bound.
+    expect(cacheHits).toBeLessThanOrEqual(maxEntries);
+  });
+
+  test("a fresh instance starts empty and does not share state with prior instances", async () => {
+    // Two independent QueryEmbeddingCache instances must never share vectors.
+    // This is the per-instance isolation invariant: a reconfigure that builds a
+    // fresh embeddings object gets a clean cache.
+    const computeA = vi.fn(async () => [1, 2, 3]);
+    const computeB = vi.fn(async () => [4, 5, 6]);
+
+    const cacheA = new QueryEmbeddingCache();
+    const cacheB = new QueryEmbeddingCache();
+
+    // Warm cacheA with "hello".
+    await cacheA.getOrCompute("hello", computeA);
+    expect(computeA).toHaveBeenCalledTimes(1);
+
+    // cacheB is independent: a lookup for "hello" in cacheB must NOT find
+    // cacheA's entry and must call its own compute.
+    await cacheB.getOrCompute("hello", computeB);
+    expect(computeB).toHaveBeenCalledTimes(1);
+
+    // cacheA still serves its own entry without recomputing.
+    await cacheA.getOrCompute("hello", computeA);
+    expect(computeA).toHaveBeenCalledTimes(1); // still 1, served from cacheA's LRU
   });
 
   test("does not share timeout-bound in-flight work with untimed callers", async () => {

--- a/extensions/memory-lancedb/query-embedding-cache.test.ts
+++ b/extensions/memory-lancedb/query-embedding-cache.test.ts
@@ -1,0 +1,136 @@
+// Memory Lancedb tests cover the per-instance query-embedding cache primitives.
+import { describe, expect, test, vi } from "vitest";
+import {
+  canonicalizeEmbeddingIdentity,
+  isCacheableEmbeddingVector,
+  QueryEmbeddingCache,
+} from "./query-embedding-cache.js";
+
+describe("QueryEmbeddingCache", () => {
+  test("collapses identical keys to one compute call", async () => {
+    const cache = new QueryEmbeddingCache();
+    const compute = vi.fn(async () => [0.1, 0.2, 0.3]);
+    const first = await cache.getOrCompute("k", compute);
+    const second = await cache.getOrCompute("k", compute);
+    expect(compute).toHaveBeenCalledTimes(1);
+    expect(first).toEqual([0.1, 0.2, 0.3]);
+    expect(second).toEqual(first);
+    // A different key is a separate provider call.
+    await cache.getOrCompute("other", compute);
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  test("evicts the oldest entry past capacity", async () => {
+    const cache = new QueryEmbeddingCache(2);
+    const make = (v: number) => vi.fn(async () => [v]);
+    const a = make(1);
+    const b = make(2);
+    const c = make(3);
+    await cache.getOrCompute("a", a); // [a]
+    await cache.getOrCompute("b", b); // [a, b]
+    await cache.getOrCompute("c", c); // overflow -> evict oldest "a" -> [b, c]
+    // "a" was evicted, so recomputing it calls its factory again.
+    await cache.getOrCompute("a", a);
+    expect(a).toHaveBeenCalledTimes(2);
+    // "c" is still resident -> served from cache, no recompute.
+    await cache.getOrCompute("c", c);
+    expect(c).toHaveBeenCalledTimes(1);
+    // Recency is bumped on hit: read "c" then add a new key -> the older "a"
+    // (not the just-read "c") is evicted next.
+    const d = make(4);
+    await cache.getOrCompute("c", c); // bump "c" to most-recent -> [a, c]... then read
+    await cache.getOrCompute("d", d); // overflow -> evict oldest "a" -> [c, d]
+    await cache.getOrCompute("c", c);
+    expect(c).toHaveBeenCalledTimes(1); // "c" survived as most-recently-used
+    await cache.getOrCompute("a", a);
+    expect(a).toHaveBeenCalledTimes(3); // "a" was evicted again
+  });
+
+  test("does not memoize a thrown error and retries", async () => {
+    const cache = new QueryEmbeddingCache();
+    const compute = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce([0.5, 0.6]);
+    await expect(cache.getOrCompute("k", compute)).rejects.toThrow("transient");
+    // The failed entry must not be memoized: the next call retries the provider.
+    await expect(cache.getOrCompute("k", compute)).resolves.toEqual([0.5, 0.6]);
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not memoize empty or zero vectors", async () => {
+    const cache = new QueryEmbeddingCache();
+    const empty = vi.fn(async () => []);
+    await cache.getOrCompute("empty", empty);
+    await cache.getOrCompute("empty", empty);
+    expect(empty).toHaveBeenCalledTimes(2);
+    const zero = vi.fn(async () => [0, 0, 0]);
+    await cache.getOrCompute("zero", zero);
+    await cache.getOrCompute("zero", zero);
+    expect(zero).toHaveBeenCalledTimes(2);
+  });
+
+  test("collapses concurrent identical embeds to one compute call", async () => {
+    const cache = new QueryEmbeddingCache();
+    // The value cached is the in-flight promise, so two embeds launched before
+    // the first resolves still share a single compute.
+    const compute = vi.fn(
+      () => new Promise<number[]>((resolve) => setTimeout(() => resolve([1, 2]), 5)),
+    );
+    const [a, b] = await Promise.all([
+      cache.getOrCompute("k", compute),
+      cache.getOrCompute("k", compute),
+    ]);
+    expect(compute).toHaveBeenCalledTimes(1);
+    expect(a).toEqual([1, 2]);
+    expect(b).toEqual([1, 2]);
+  });
+});
+
+describe("canonicalizeEmbeddingIdentity", () => {
+  test("is stable across top-level key order", () => {
+    const a = canonicalizeEmbeddingIdentity({ model: "m", provider: "p", dimensions: 3 });
+    const b = canonicalizeEmbeddingIdentity({ dimensions: 3, provider: "p", model: "m" });
+    expect(a).toBe(b);
+  });
+
+  test("distinguishes different models/dims so vectors never collide", () => {
+    const modelA = canonicalizeEmbeddingIdentity({ provider: "p", model: "a", dimensions: 3 });
+    const modelB = canonicalizeEmbeddingIdentity({ provider: "p", model: "b", dimensions: 3 });
+    const dims4 = canonicalizeEmbeddingIdentity({ provider: "p", model: "a", dimensions: 4 });
+    expect(modelA).not.toBe(modelB);
+    expect(modelA).not.toBe(dims4);
+  });
+
+  test("preserves NESTED identity fields (headers) so they cannot collide", () => {
+    // Regression guard for the replacer-array trap: a JSON.stringify replacer
+    // array filters nested objects, erasing cacheKeyData.headers and letting two
+    // distinct identities serialize identically. These two identities differ
+    // ONLY in a nested header and must produce different keys.
+    const withHeaderA = canonicalizeEmbeddingIdentity({
+      provider: "p",
+      model: "m",
+      headers: { authorization: "token-a" },
+    });
+    const withHeaderB = canonicalizeEmbeddingIdentity({
+      provider: "p",
+      model: "m",
+      headers: { authorization: "token-b" },
+    });
+    expect(withHeaderA).not.toBe(withHeaderB);
+    expect(withHeaderA).toContain("token-a");
+  });
+});
+
+describe("isCacheableEmbeddingVector", () => {
+  test("accepts a genuine non-empty, finite, non-zero vector", () => {
+    expect(isCacheableEmbeddingVector([0.1, 0, 0.2])).toBe(true);
+  });
+
+  test("rejects empty, all-zero, and non-finite vectors", () => {
+    expect(isCacheableEmbeddingVector([])).toBe(false);
+    expect(isCacheableEmbeddingVector([0, 0, 0])).toBe(false);
+    expect(isCacheableEmbeddingVector([1, Number.NaN])).toBe(false);
+    expect(isCacheableEmbeddingVector([Number.POSITIVE_INFINITY])).toBe(false);
+  });
+});

--- a/extensions/memory-lancedb/query-embedding-cache.test.ts
+++ b/extensions/memory-lancedb/query-embedding-cache.test.ts
@@ -21,7 +21,7 @@ describe("QueryEmbeddingCache", () => {
   });
 
   test("evicts the oldest entry past capacity", async () => {
-    const cache = new QueryEmbeddingCache(2);
+    const cache = new QueryEmbeddingCache({ maxEntries: 2 });
     const make = (v: number) => vi.fn(async () => [v]);
     const a = make(1);
     const b = make(2);
@@ -70,12 +70,26 @@ describe("QueryEmbeddingCache", () => {
     expect(zero).toHaveBeenCalledTimes(2);
   });
 
+  test("when disabled, never memoizes and recomputes every call", async () => {
+    const cache = new QueryEmbeddingCache({ enabled: false });
+    const compute = vi.fn(async () => [0.1, 0.2, 0.3]);
+    const first = await cache.getOrCompute("k", compute);
+    const second = await cache.getOrCompute("k", compute);
+    // Disabled cache is a pass-through: identical keys still recompute.
+    expect(compute).toHaveBeenCalledTimes(2);
+    expect(first).toEqual([0.1, 0.2, 0.3]);
+    expect(second).toEqual(first);
+  });
+
   test("collapses concurrent identical embeds to one compute call", async () => {
     const cache = new QueryEmbeddingCache();
     // The value cached is the in-flight promise, so two embeds launched before
     // the first resolves still share a single compute.
     const compute = vi.fn(
-      () => new Promise<number[]>((resolve) => setTimeout(() => resolve([1, 2]), 5)),
+      () =>
+        new Promise<number[]>((resolve) => {
+          setTimeout(() => resolve([1, 2]), 5);
+        }),
     );
     const [a, b] = await Promise.all([
       cache.getOrCompute("k", compute),

--- a/extensions/memory-lancedb/query-embedding-cache.test.ts
+++ b/extensions/memory-lancedb/query-embedding-cache.test.ts
@@ -4,7 +4,27 @@ import {
   canonicalizeEmbeddingIdentity,
   isCacheableEmbeddingVector,
   QueryEmbeddingCache,
+  queryCacheKey,
 } from "./query-embedding-cache.js";
+
+describe("queryCacheKey", () => {
+  test("hashes the text component and never retains plaintext", () => {
+    const secret = "super secret user recall query about salaries";
+    const key = queryCacheKey("provider=openai;model=text-embedding-3-small", secret);
+
+    // The raw user/memory text must not appear in the cache key.
+    expect(key).not.toContain(secret);
+    expect(key).not.toContain("salaries");
+    // A SHA-256 hex digest is present instead of the plaintext.
+    expect(key).toMatch(/[0-9a-f]{64}/);
+
+    // Equality is preserved: identical identity + text map to the same key.
+    expect(queryCacheKey("provider=openai;model=text-embedding-3-small", secret)).toBe(key);
+    // Distinct text and distinct identity both produce distinct keys.
+    expect(queryCacheKey("provider=openai;model=text-embedding-3-small", "other")).not.toBe(key);
+    expect(queryCacheKey("provider=ollama;model=nomic-embed-text", secret)).not.toBe(key);
+  });
+});
 
 describe("QueryEmbeddingCache", () => {
   test("collapses identical keys to one compute call", async () => {

--- a/extensions/memory-lancedb/query-embedding-cache.ts
+++ b/extensions/memory-lancedb/query-embedding-cache.ts
@@ -1,4 +1,11 @@
-// Memory Lancedb helper module implements per-instance query-embedding caching.
+// Memory Lancedb helper module implements the per-instance Query Embedding
+// Recall Cache.
+//
+// NOTE ON NAMING: this is NOT the host's "Memory Search Embedding Cache"
+// (`agents.defaults.memorySearch.cache`), which caches CHUNK embeddings in
+// SQLite at index time inside memory-core. This cache lives in memory-lancedb,
+// is an in-memory LRU of QUERY (recall) embeddings, and operates at recall time.
+// Different layer, different cost, different lifecycle.
 //
 // The query-embedding round-trip dominates the LanceDB vector scan (a remote
 // embed is ~50-300ms vs a few ms for a flat scan over a typical store), and a
@@ -53,10 +60,20 @@ export function isCacheableEmbeddingVector(vector: number[]): boolean {
  */
 export class QueryEmbeddingCache {
   private readonly entries = new Map<string, Promise<number[]>>();
+  private readonly maxEntries: number;
+  private readonly enabled: boolean;
 
-  constructor(private readonly maxEntries = QUERY_EMBED_CACHE_MAX_ENTRIES) {}
+  constructor(options?: { maxEntries?: number; enabled?: boolean }) {
+    this.maxEntries = options?.maxEntries ?? QUERY_EMBED_CACHE_MAX_ENTRIES;
+    this.enabled = options?.enabled ?? true;
+  }
 
   async getOrCompute(key: string, compute: () => Promise<number[]>): Promise<number[]> {
+    // When disabled, behave as a pass-through: never store, always recompute, so
+    // the embed() call sites stay identical regardless of configuration.
+    if (!this.enabled) {
+      return compute();
+    }
     const existing = this.entries.get(key);
     if (existing) {
       // Bump recency: delete + re-set moves the key to the most-recent slot.

--- a/extensions/memory-lancedb/query-embedding-cache.ts
+++ b/extensions/memory-lancedb/query-embedding-cache.ts
@@ -1,0 +1,90 @@
+// Memory Lancedb helper module implements per-instance query-embedding caching.
+//
+// The query-embedding round-trip dominates the LanceDB vector scan (a remote
+// embed is ~50-300ms vs a few ms for a flat scan over a typical store), and a
+// single user turn can embed the same recall query up to three times (the
+// memory_recall tool, the auto-recall hook, and capture/dedup) with no caching.
+// An in-instance bounded cache collapses those identical embeds to one provider
+// call. (model, text) -> embedding is deterministic, so eviction is purely by
+// capacity; there is NO TTL because a cached vector can never go stale for a
+// fixed identity, and the cache is per-instance so a reconfigure (which builds a
+// fresh embeddings instance) starts with a clean cache keyed to the new model.
+
+export const QUERY_EMBED_CACHE_MAX_ENTRIES = 512;
+
+/**
+ * Build the canonical identity portion of a cache key. The identity MUST encode
+ * everything that changes the produced vector — provider, model, dimensions,
+ * endpoint — so that switching model/provider/dims can never return a stale or
+ * wrong-dimension embedding from the cache. `cacheKeyData` (when the adapter
+ * supplies it) already captures provider/baseUrl/model/outputDimensionality, so
+ * it is preferred; otherwise we fall back to the configured provider/model/dims.
+ */
+export function canonicalizeEmbeddingIdentity(identity: Record<string, unknown>): string {
+  // Stable serialization: sort top-level keys so field order never changes the
+  // string. Rebuild via fromEntries rather than passing a replacer array to
+  // JSON.stringify — a replacer array also filters NESTED objects (e.g. it would
+  // erase cacheKeyData.headers), which would let two distinct identities collide.
+  const sorted = Object.fromEntries(
+    Object.keys(identity)
+      .toSorted()
+      .map((key) => [key, identity[key]]),
+  );
+  return JSON.stringify(sorted);
+}
+
+export function isCacheableEmbeddingVector(vector: number[]): boolean {
+  // Only memoize a genuine result: a non-empty, all-finite, non-zero vector.
+  // An empty/zero vector or NaN/Infinity signals a failed or degenerate embed
+  // and must NOT be cached, so a transient failure is never memoized.
+  return (
+    vector.length > 0 &&
+    vector.every((value) => Number.isFinite(value)) &&
+    vector.some((value) => value !== 0)
+  );
+}
+
+/**
+ * Dependency-free, bounded LRU over an embeddings instance. Keys are
+ * `[identity, normalizedText]`; values are the in-flight embed promise so that
+ * both sequential and concurrent identical embeds collapse to one provider call.
+ * A Map preserves insertion order: a cache hit deletes+re-inserts the key to
+ * bump recency, and overflow evicts the oldest (first) key.
+ */
+export class QueryEmbeddingCache {
+  private readonly entries = new Map<string, Promise<number[]>>();
+
+  constructor(private readonly maxEntries = QUERY_EMBED_CACHE_MAX_ENTRIES) {}
+
+  async getOrCompute(key: string, compute: () => Promise<number[]>): Promise<number[]> {
+    const existing = this.entries.get(key);
+    if (existing) {
+      // Bump recency: delete + re-set moves the key to the most-recent slot.
+      this.entries.delete(key);
+      this.entries.set(key, existing);
+      return existing;
+    }
+    const pending = compute();
+    this.entries.set(key, pending);
+    // Evict failed/degenerate results so a transient failure is never memoized
+    // and the next call retries the provider.
+    pending
+      .then((vector) => {
+        if (!isCacheableEmbeddingVector(vector) && this.entries.get(key) === pending) {
+          this.entries.delete(key);
+        }
+      })
+      .catch(() => {
+        if (this.entries.get(key) === pending) {
+          this.entries.delete(key);
+        }
+      });
+    if (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest !== undefined) {
+        this.entries.delete(oldest);
+      }
+    }
+    return pending;
+  }
+}

--- a/extensions/memory-lancedb/query-embedding-cache.ts
+++ b/extensions/memory-lancedb/query-embedding-cache.ts
@@ -52,14 +52,19 @@ export function isCacheableEmbeddingVector(vector: number[]): boolean {
 }
 
 /**
- * Dependency-free, bounded LRU over an embeddings instance. Keys are
- * `[identity, normalizedText]`; values are the in-flight embed promise so that
- * both sequential and concurrent identical embeds collapse to one provider call.
+ * Dependency-free, bounded LRU over an embeddings instance. Settled entries are
+ * keyed by `[identity, normalizedText]`; in-flight work is keyed separately so
+ * concurrent callers only share a provider call when their cancellation policy
+ * matches. This avoids coupling a timeout-bound recall to an untimed store or
+ * capture call for the same text, while still sharing the settled vector after
+ * either request succeeds.
+ *
  * A Map preserves insertion order: a cache hit deletes+re-inserts the key to
- * bump recency, and overflow evicts the oldest (first) key.
+ * bump recency, and overflow evicts the oldest (first) settled key.
  */
 export class QueryEmbeddingCache {
-  private readonly entries = new Map<string, Promise<number[]>>();
+  private readonly entries = new Map<string, number[]>();
+  private readonly pending = new Map<string, Promise<number[]>>();
   private readonly maxEntries: number;
   private readonly enabled: boolean;
 
@@ -68,7 +73,11 @@ export class QueryEmbeddingCache {
     this.enabled = options?.enabled ?? true;
   }
 
-  async getOrCompute(key: string, compute: () => Promise<number[]>): Promise<number[]> {
+  async getOrCompute(
+    key: string,
+    compute: () => Promise<number[]>,
+    options?: { inFlightKey?: string },
+  ): Promise<number[]> {
     // When disabled, behave as a pass-through: never store, always recompute, so
     // the embed() call sites stay identical regardless of configuration.
     if (!this.enabled) {
@@ -81,27 +90,37 @@ export class QueryEmbeddingCache {
       this.entries.set(key, existing);
       return existing;
     }
+    const inFlightKey = options?.inFlightKey ?? key;
+    const existingPending = this.pending.get(inFlightKey);
+    if (existingPending) {
+      return existingPending;
+    }
     const pending = compute();
-    this.entries.set(key, pending);
-    // Evict failed/degenerate results so a transient failure is never memoized
-    // and the next call retries the provider.
+    this.pending.set(inFlightKey, pending);
+    // Only settled, genuine vectors enter the LRU. Failed/degenerate results
+    // are not memoized, so a transient failure is never cached and the next call
+    // retries the provider.
     pending
       .then((vector) => {
-        if (!isCacheableEmbeddingVector(vector) && this.entries.get(key) === pending) {
+        if (this.pending.get(inFlightKey) === pending) {
+          this.pending.delete(inFlightKey);
+        }
+        if (isCacheableEmbeddingVector(vector)) {
           this.entries.delete(key);
+          this.entries.set(key, vector);
+          if (this.entries.size > this.maxEntries) {
+            const oldest = this.entries.keys().next().value;
+            if (oldest !== undefined) {
+              this.entries.delete(oldest);
+            }
+          }
         }
       })
       .catch(() => {
-        if (this.entries.get(key) === pending) {
-          this.entries.delete(key);
+        if (this.pending.get(inFlightKey) === pending) {
+          this.pending.delete(inFlightKey);
         }
       });
-    if (this.entries.size > this.maxEntries) {
-      const oldest = this.entries.keys().next().value;
-      if (oldest !== undefined) {
-        this.entries.delete(oldest);
-      }
-    }
     return pending;
   }
 }

--- a/extensions/memory-lancedb/query-embedding-cache.ts
+++ b/extensions/memory-lancedb/query-embedding-cache.ts
@@ -17,7 +17,22 @@
 // fixed identity, and the cache is per-instance so a reconfigure (which builds a
 // fresh embeddings instance) starts with a clean cache keyed to the new model.
 
+import { createHash } from "node:crypto";
+
 export const QUERY_EMBED_CACHE_MAX_ENTRIES = 512;
+
+/**
+ * Build a cache key whose text component is hashed, so the in-memory cache never
+ * retains raw recall, store, or auto-capture text as a Map key. SHA-256
+ * preserves equality (identical identity + text map to the same key) while
+ * keeping only a fixed-length digest in process memory, not plaintext user or
+ * memory content. The identity is provider/model/dimension metadata, not user
+ * content, so it stays in clear text.
+ */
+export function queryCacheKey(identity: string, text: string): string {
+  const textDigest = createHash("sha256").update(text, "utf8").digest("hex");
+  return JSON.stringify([identity, textDigest]);
+}
 
 /**
  * Build the canonical identity portion of a cache key. The identity MUST encode


### PR DESCRIPTION
<!-- Title: perf(memory-lancedb): cache query embeddings per embeddings instance -->

## Summary

The recall-query embedding round-trip dominates the LanceDB vector scan. A
remote embed call takes 50-300 ms; a flat ANN scan over a typical memory
store takes a few milliseconds. A single user turn can embed the same recall
query up to three times with no caching: once for the `memory_recall` tool,
once for the auto-recall hook, and once during capture deduplication. This
PR adds a bounded per-instance LRU cache that collapses identical recall
embeds to one provider call.

The key invariant that makes this safe: `(model, text) -> embedding` is
deterministic. A cached vector can never go stale for a fixed identity, so
eviction is purely by capacity with no TTL. The cache is per-instance, so a
reconfiguration that builds a fresh embeddings object starts with a clean
cache keyed to the new model and provider. It is also distinct from the
host's `agents.defaults.memorySearch.cache`, which caches chunk embeddings
in SQLite at index time inside `memory-core`. This cache operates at recall
time in `memory-lancedb`.

The config surface is additive and opt-out (`query.embeddingCache.enabled`,
`query.embeddingCache.maxEntries`). The default is on with a 512-entry cap.
Failures and degenerate vectors (empty, all-zero, non-finite) are never
memoized, so a transient embed failure is always retried.

Prepared with AI assistance and reviewed with `codex review --base upstream/main` (Codex, gpt-5.5); the review's findings are addressed below.

## Real behavior proof (required for external PRs)

Behavior or issue addressed: Identical recall-query embeds within a turn
call the embedding provider more than once. A bounded per-instance LRU
collapses them to one call; the P2 fix ensures a timed-recall abort does
not poison an untimed store/capture embed for identical text.

Real environment tested: macOS, Ollama v0.6.x local, model
`nomic-embed-text:latest` (768-dim). The real `QueryEmbeddingCache` class
from `extensions/memory-lancedb/query-embedding-cache.ts` was imported
directly (not re-implemented) with an HTTP-backed compute function that
calls the Ollama REST API.

Exact steps or command run after this patch:
```
node scripts/run-vitest.mjs run --reporter=verbose \
    extensions/memory-lancedb/_proofpr1.real.test.ts
```
(Temp proof file deleted after capture; not included in branch diff.)

Evidence after fix:
```
 RUN  v4.1.8  oc-improve/

stdout | extensions/memory-lancedb/_proofpr1.real.test.ts
  > QueryEmbeddingCache real-behavior proof (Ollama nomic-embed-text)
  > (a) two identical recall embeds collapse to ONE provider call
[proof-a] provider calls: 1 (expected 1)
[proof-a] vector dims: 768
[proof-a] vectors match: true
[proof-a] vector is cacheable: true
[proof-a] provider calls after different text: 2 (expected 2)

  > (b) P2 fix: timed in-flight failure does NOT poison untimed caller
[proof-b] timed settled: rejected
[proof-b] untimed settled: fulfilled
[proof-b] timedCalls: 1, untimedCalls: 1
[proof-b] untimed vector dims: 768
[proof-b] untimed vector cacheable: true
[proof-b] extra provider calls after cache hit: 0 (expected 0)
[proof-b] P2 PASS: timed failure did not poison untimed caller

  > (c) degenerate/empty vectors are never cached
[proof-c] degenerate calls: 2 (expected 2 - never cached)
[proof-c] zero-vector calls: 4 (expected 4 - never cached)
[proof-c] isCacheableEmbeddingVector([]) = false
[proof-c] isCacheableEmbeddingVector([0,0,0]) = false

 PASS  extensions/memory-lancedb/_proofpr1.real.test.ts
  QueryEmbeddingCache real-behavior proof (Ollama nomic-embed-text)
    (a) two identical recall embeds collapse to ONE provider call  69ms
    (b) P2 fix: timed in-flight failure does NOT poison untimed caller  14ms
    (c) degenerate/empty vectors are never cached  0ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  197ms
```
Terminal screenshot will be attached to the PR.

<img width="1398" height="1562" alt="IMG_8094" src="https://github.com/user-attachments/assets/a86ee9cc-661a-4d14-b7d8-4d72e7269699" />

Observed result after fix: Three assertions passed against real Ollama
embeddings. (a) Two `getOrCompute` calls for identical text produced exactly
one HTTP request to Ollama; the second call returned the cached 768-dim
vector. (b) A simulated timed in-flight abort (inFlightKey `timeout:1`) did
not prevent a concurrent untimed caller (inFlightKey `untimed`) from
producing a valid 768-dim vector, which then settled into the LRU and served
as a cache hit on the next call. (c) Empty vectors and all-zero vectors were
never written to the LRU, and the compute function was called again on every
subsequent lookup.

What was not tested: Cross-instance cache sharing (by design, each embeddings
instance holds its own cache). Persistence across restarts (in-memory only).
The `OpenAiCompatibleEmbeddings` path directly (it uses the same
`QueryEmbeddingCache` class and same `getOrCompute` call with inFlightKey).

## Tests and validation

155 tests pass, including the cache unit tests in
`query-embedding-cache.test.ts` (LRU eviction, disabled pass-through,
concurrent dedup, error non-memoization, identity canonicalization, header
collision guard) and the cancellation-policy regression test: "does not share
timeout-bound in-flight work with untimed callers". Integration tests in
`index.test.ts` cover `ProviderAdapterEmbeddings` with the cache wired in.
`oxfmt` and `oxlint` are clean. `tsgo:extensions` and `tsgo:extensions:test`
exit 0.

Ran `codex review --base upstream/main` (gpt-5.5) against current main. It
surfaced a P2 correctness issue: in-flight embed promises were keyed only by
`[identity, text]`, so a timed recall and an untimed store/capture for the
same text shared one in-flight promise, and a recall timeout could fail the
untimed embed for identical text. The fix separates settled-vector keying (by
`[identity, text]`, shared across all callers since a settled vector is
policy-independent) from in-flight keying (by cancellation policy), with a
regression test: "does not share timeout-bound in-flight work with untimed
callers".

## Risk checklist

- User-visible behavior change? No. The cache is transparent: identical
  vectors are returned and failures are never memoized. The new config fields
  are opt-out only (default on). No existing config keys were renamed or
  removed.
- Config or migration required? No. The `query.embeddingCache` block is
  optional. Omitting it produces the default (enabled, 512-entry cap). No
  schema migration or database change.
- Security or network impact? No. The cache is in-process memory only; it
  does not write to disk or make additional network calls.
- Honest flaws: A concurrent timed recall and untimed store for the same
  text issue two provider calls by design, to preserve cancellation
  semantics. Cross-instance duplicate embeds are not collapsed (each instance
  owns its cache). The cache is in-memory only and does not persist across
  restarts or reconfiguration.

## Current review state

Local tests, lint, and type checks are green. A `codex review --base
upstream/main` (gpt-5.5) pass against current main completed and its P2
finding is fixed and regression-tested. Real-behavior proof embedded above.
No outstanding items from author.
