### PR TITLE
fix(gateway): bound pricing catalog streams

### DIFF
--- a/src/gateway/model-pricing-cache.test.ts
+++ b/src/gateway/model-pricing-cache.test.ts
@@ -1305,6 +1305,71 @@ describe("model-pricing-cache", () => {
       cacheWrite: 0,
     });
   });
+
+  it("bounds streamed LiteLLM catalog responses without content-length", async () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "kimi/kimi-k2.6" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const liteLLMCancel = vi.fn(async () => undefined);
+    let liteLLMPullCount = 0;
+    const fetchImpl = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("openrouter.ai")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "moonshotai/kimi-k2.6",
+                pricing: {
+                  prompt: "0.00000095",
+                  completion: "0.000004",
+                  input_cache_read: "0.00000016",
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      return new Response(
+        new ReadableStream({
+          pull(controller) {
+            liteLLMPullCount += 1;
+            controller.enqueue(new Uint8Array(liteLLMPullCount === 1 ? 5 * 1024 * 1024 : 1));
+          },
+          cancel: liteLLMCancel,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+
+    await refreshGatewayModelPricingCache({ config, fetchImpl });
+
+    expect(liteLLMPullCount).toBeGreaterThanOrEqual(2);
+    expect(liteLLMCancel).toHaveBeenCalledOnce();
+    const health = getGatewayModelPricingHealth();
+    expect(health.sources[0]?.source).toBe("litellm");
+    expect(health.sources[0]?.detail).toContain(
+      "LiteLLM pricing response too large: 5242881 bytes",
+    );
+    expect(getCachedGatewayModelPricing({ provider: "kimi", model: "kimi-k2.6" })).toEqual({
+      input: 0.95,
+      output: 4,
+      cacheRead: 0.16,
+      cacheWrite: 0,
+    });
+  });
 });
 
 function createManifestRecord(overrides: Partial<PluginManifestRecord>): PluginManifestRecord {

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -1,6 +1,7 @@
 // Gateway model-pricing refresh and normalization.
 // Fetches, normalizes, and schedules cached pricing for model usage estimates.
 import type { ModelCatalogCost } from "@openclaw/model-catalog-core/model-catalog-types";
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import {
   normalizeOptionalString,
   resolvePrimaryStringValue,
@@ -289,13 +290,12 @@ async function readPricingJsonObject(
   if (contentLength !== null && contentLength > MAX_PRICING_CATALOG_BYTES) {
     throw new Error(`${source} pricing response too large: ${contentLength} bytes`);
   }
-  const buffer = await response.arrayBuffer();
-  if (buffer.byteLength > MAX_PRICING_CATALOG_BYTES) {
-    throw new Error(`${source} pricing response too large: ${buffer.byteLength} bytes`);
-  }
+  const buffer = await readResponseWithLimit(response, MAX_PRICING_CATALOG_BYTES, {
+    onOverflow: ({ size }) => new Error(`${source} pricing response too large: ${size} bytes`),
+  });
   let payload: unknown;
   try {
-    payload = JSON.parse(Buffer.from(buffer).toString("utf8")) as unknown;
+    payload = JSON.parse(buffer.toString("utf8")) as unknown;
   } catch {
     throw new Error(`${source} pricing response is malformed JSON`);
   }


### PR DESCRIPTION
Summary
- Stream gateway model-pricing catalog responses through the shared byte-cap reader instead of buffering the full body with arrayBuffer().
- Preserve declared Content-Length rejection and malformed JSON/source-failure behavior.
- Add a regression for a LiteLLM catalog stream with no Content-Length that crosses the 5 MiB cap and cancels the body.

Verification
- node --check --experimental-strip-types src/gateway/model-pricing-cache.ts
- node --check --experimental-strip-types src/gateway/model-pricing-cache.test.ts
- git diff --check
- autoreview: clean, no actionable findings

Proof gaps
- Targeted Vitest was not run locally because this sparse Codex worktree has no node_modules and repo rules forbid installing dependencies there. Hosted validation will cover the test lane before ready/merge.
