### PR TITLE
fix(ci): cancel stale Testbox PR runs

### DIFF
--- a/.github/workflows/ci-build-artifacts-testbox.yml
+++ b/.github/workflows/ci-build-artifacts-testbox.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('{0}-pr-v1-{1}', github.workflow, github.event.pull_request.number) || format('{0}-manual-v1-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 

--- a/.github/workflows/ci-check-arm-testbox.yml
+++ b/.github/workflows/ci-check-arm-testbox.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('{0}-pr-v1-{1}', github.workflow, github.event.pull_request.number) || format('{0}-manual-v1-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   PNPM_CONFIG_STORE_DIR: "/tmp/openclaw-pnpm-store"

--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('{0}-pr-v1-{1}', github.workflow, github.event.pull_request.number) || format('{0}-manual-v1-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   PNPM_CONFIG_STORE_DIR: "/tmp/openclaw-pnpm-store"


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where repeated PR updates to the Blacksmith Testbox workflows could leave stale queued runs behind, increasing Testbox queue pressure for work that had already been superseded.

## Why This Change Was Made

The x64 check, build-artifacts, and ARM Testbox workflows now use PR-scoped GitHub Actions concurrency groups with `cancel-in-progress` enabled for pull requests. Manual dispatches keep unique run-id groups so explicit ad hoc Testbox sessions are not cancelled by unrelated manual runs.

## User Impact

Maintainers and contributors should see less stale Testbox queue buildup after force-pushes or follow-up commits to workflow-touching PRs, while manual Testbox dispatch behavior remains independent across the Testbox workflow family.

## Evidence

- `git diff --check -- .github/workflows/ci-check-testbox.yml .github/workflows/ci-build-artifacts-testbox.yml .github/workflows/ci-check-arm-testbox.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "parsed #{f}" }' .github/workflows/ci-check-testbox.yml .github/workflows/ci-build-artifacts-testbox.yml .github/workflows/ci-check-arm-testbox.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/ci-check-testbox.yml .github/workflows/ci-build-artifacts-testbox.yml .github/workflows/ci-check-arm-testbox.yml`
