### PR TITLE
feat(android): show cron job details

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -3,6 +3,22 @@
   "entries": [
     {
       "kind": "conditional-branch",
+      "line": 218,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/CronJobDetail.kt",
+      "source": "Off",
+      "surface": "android",
+      "id": "native.android.d55616e142c8be0f"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 219,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/CronJobDetail.kt",
+      "source": "Default",
+      "surface": "android",
+      "id": "native.android.f59b83f58086eb89"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 101,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Ready",
@@ -131,7 +147,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 192,
+      "line": 193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -139,7 +155,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 202,
+      "line": 203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -187,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2223,
+      "line": 2243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -195,7 +211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2225,
+      "line": 2245,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -203,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2227,
+      "line": 2247,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -2635,7 +2651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 205,
+      "line": 214,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Usage",
       "surface": "android",
@@ -2643,7 +2659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 225,
+      "line": 234,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load usage.",
       "surface": "android",
@@ -2651,7 +2667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 230,
+      "line": 239,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No usage data yet.",
       "surface": "android",
@@ -2659,7 +2675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 231,
+      "line": 240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits will appear here when your gateway reports them.",
       "surface": "android",
@@ -2667,23 +2683,15 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 256,
+      "line": 275,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cron Jobs",
       "surface": "android",
       "id": "native.android.962a15bdb26cb6e1"
     },
     {
-      "kind": "conditional-branch",
-      "line": 260,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Enabled",
-      "surface": "android",
-      "id": "native.android.4a583b7a36684ed7"
-    },
-    {
       "kind": "ui-named-argument",
-      "line": 267,
+      "line": 286,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android shows scheduled work status. Create and edit schedules from the desktop app.",
       "surface": "android",
@@ -2691,7 +2699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 277,
+      "line": 296,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load cron jobs.",
       "surface": "android",
@@ -2699,7 +2707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 282,
+      "line": 301,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No scheduled jobs.",
       "surface": "android",
@@ -2707,7 +2715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 283,
+      "line": 302,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Create recurring OpenClaw work from the desktop app.",
       "surface": "android",
@@ -2715,7 +2723,31 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 306,
+      "line": 351,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Connect the gateway to inspect cron jobs.",
+      "surface": "android",
+      "id": "native.android.e3a6337e3c28d3f5"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 359,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Cron job not loaded.",
+      "surface": "android",
+      "id": "native.android.2d3daa5032913461"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 359,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Loading cron job…",
+      "surface": "android",
+      "id": "native.android.401993832e04f790"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 381,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agents",
       "surface": "android",
@@ -2723,7 +2755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 317,
+      "line": 392,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load agents.",
       "surface": "android",
@@ -2731,7 +2763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 321,
+      "line": 396,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No agents loaded yet.",
       "surface": "android",
@@ -2739,7 +2771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 347,
+      "line": 422,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approvals",
       "surface": "android",
@@ -2747,7 +2779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 358,
+      "line": 433,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refresh",
       "surface": "android",
@@ -2755,7 +2787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 358,
+      "line": 433,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -2763,7 +2795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 371,
+      "line": 446,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway disconnected.",
       "surface": "android",
@@ -2771,7 +2803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 372,
+      "line": 447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load approval requests in the app.",
       "surface": "android",
@@ -2779,7 +2811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 378,
+      "line": 453,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateway approvals.",
       "surface": "android",
@@ -2787,7 +2819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 379,
+      "line": 454,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Exec approval requests will appear here while this phone is connected.",
       "surface": "android",
@@ -2795,7 +2827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 386,
+      "line": 461,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session activity",
       "surface": "android",
@@ -2803,7 +2835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 387,
+      "line": 462,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Chat tool calls waiting in the active session remain visible here.",
       "surface": "android",
@@ -2811,7 +2843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 401,
+      "line": 476,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Profile",
       "surface": "android",
@@ -2819,7 +2851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 404,
+      "line": 479,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Device name",
       "surface": "android",
@@ -2827,7 +2859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 405,
+      "line": 480,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save Profile",
       "surface": "android",
@@ -2835,7 +2867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 424,
+      "line": 499,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Talk Provider Setup",
       "surface": "android",
@@ -2843,7 +2875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 427,
+      "line": 502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Audio Test",
       "surface": "android",
@@ -2851,7 +2883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 428,
+      "line": 503,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check that OpenClaw can speak clearly on this phone.",
       "surface": "android",
@@ -2859,7 +2891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 431,
+      "line": 506,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enable speaker",
       "surface": "android",
@@ -2867,7 +2899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 431,
+      "line": 506,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Mute speaker",
       "surface": "android",
@@ -2875,7 +2907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 432,
+      "line": 507,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Assistant speech muted",
       "surface": "android",
@@ -2883,7 +2915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 432,
+      "line": 507,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replies play aloud",
       "surface": "android",
@@ -2891,7 +2923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 434,
+      "line": 509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Muted",
       "surface": "android",
@@ -2899,7 +2931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 434,
+      "line": 509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On",
       "surface": "android",
@@ -2907,7 +2939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 438,
+      "line": 513,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Done",
       "surface": "android",
@@ -2915,7 +2947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 448,
+      "line": 523,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Realtime Talk",
       "surface": "android",
@@ -2923,7 +2955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 449,
+      "line": 524,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dictation",
       "surface": "android",
@@ -2931,7 +2963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 577,
+      "line": 652,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowlist",
       "surface": "android",
@@ -2939,7 +2971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 577,
+      "line": 652,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Blocklist",
       "surface": "android",
@@ -2947,7 +2979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 610,
+      "line": 685,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
@@ -2955,7 +2987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 614,
+      "line": 689,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Alerts stay on this phone.",
       "surface": "android",
@@ -2963,7 +2995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 614,
+      "line": 689,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can receive selected alerts.",
       "surface": "android",
@@ -2971,7 +3003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 626,
+      "line": 701,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Granted",
       "surface": "android",
@@ -2979,7 +3011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 626,
+      "line": 701,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup",
       "surface": "android",
@@ -2987,7 +3019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 631,
+      "line": 706,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check Access",
       "surface": "android",
@@ -2995,7 +3027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 631,
+      "line": 706,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open System Access",
       "surface": "android",
@@ -3003,7 +3035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 641,
+      "line": 716,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forwarding Mode",
       "surface": "android",
@@ -3011,7 +3043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 690,
+      "line": 765,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App Filter",
       "surface": "android",
@@ -3019,7 +3051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 697,
+      "line": 772,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Close App Picker",
       "surface": "android",
@@ -3027,7 +3059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 697,
+      "line": 772,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open App Picker",
       "surface": "android",
@@ -3035,7 +3067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 702,
+      "line": 777,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search apps",
       "surface": "android",
@@ -3043,7 +3075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 705,
+      "line": 780,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show System Apps",
       "surface": "android",
@@ -3051,7 +3083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 713,
+      "line": 788,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
       "surface": "android",
@@ -3059,7 +3091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 724,
+      "line": 799,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
@@ -3067,7 +3099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 859,
+      "line": 934,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -3075,7 +3107,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 868,
+      "line": 943,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow photo library access.",
       "surface": "android",
@@ -3083,7 +3115,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 868,
+      "line": 943,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected or full photo access granted.",
       "surface": "android",
@@ -3091,7 +3123,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 878,
+      "line": 953,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App list stays on this phone.",
       "surface": "android",
@@ -3099,7 +3131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 878,
+      "line": 953,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
@@ -3107,7 +3139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 889,
+      "line": 964,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
@@ -3115,7 +3147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 892,
+      "line": 967,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "While Using",
       "surface": "android",
@@ -3123,7 +3155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 931,
+      "line": 1006,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace gateway setup?",
       "surface": "android",
@@ -3131,7 +3163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 946,
+      "line": 1021,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace setup",
       "surface": "android",
@@ -3139,7 +3171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 951,
+      "line": 1026,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cancel",
       "surface": "android",
@@ -3147,7 +3179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 962,
+      "line": 1037,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
@@ -3155,7 +3187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 962,
+      "line": 1037,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
@@ -3163,7 +3195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 963,
+      "line": 1038,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
@@ -3171,7 +3203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 963,
+      "line": 1038,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
@@ -3179,7 +3211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 973,
+      "line": 1048,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
@@ -3187,7 +3219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 974,
+      "line": 1049,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
@@ -3195,7 +3227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 980,
+      "line": 1055,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
       "surface": "android",
@@ -3203,7 +3235,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 987,
+      "line": 1062,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pair New Gateway",
       "surface": "android",
@@ -3211,7 +3243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 988,
+      "line": 1063,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup Code",
       "surface": "android",
@@ -3219,7 +3251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 992,
+      "line": 1067,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -3227,7 +3259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1001,
+      "line": 1076,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection Setup",
       "surface": "android",
@@ -3235,7 +3267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1002,
+      "line": 1077,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -3243,7 +3275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1004,
+      "line": 1079,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -3251,7 +3283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1005,
+      "line": 1080,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -3259,7 +3291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1009,
+      "line": 1084,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Local",
       "surface": "android",
@@ -3267,7 +3299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1013,
+      "line": 1088,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -3275,7 +3307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1014,
+      "line": 1089,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -3283,7 +3315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1016,
+      "line": 1091,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -3291,7 +3323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1021,
+      "line": 1096,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -3299,7 +3331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1061,
+      "line": 1136,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -3307,7 +3339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1072,
+      "line": 1147,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
@@ -3315,7 +3347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1095,
+      "line": 1170,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -3323,7 +3355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1124,
+      "line": 1199,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -3331,7 +3363,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1136,
+      "line": 1211,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -3339,7 +3371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1138,
+      "line": 1213,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -3347,7 +3379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1141,
+      "line": 1216,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -3355,7 +3387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1171,
+      "line": 1246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
@@ -3363,7 +3395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1172,
+      "line": 1247,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
@@ -3371,7 +3403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1181,
+      "line": 1256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
@@ -3379,7 +3411,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1207,
+      "line": 1282,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
@@ -3387,7 +3419,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1242,
+      "line": 1317,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -3395,7 +3427,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1275,
+      "line": 1350,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -3403,7 +3435,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1348,
+      "line": 1424,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -3411,7 +3443,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1357,
+      "line": 1433,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -3419,7 +3451,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1357,
+      "line": 1433,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowing",
       "surface": "android",
@@ -3427,7 +3459,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1365,
+      "line": 1441,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -3435,7 +3467,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1365,
+      "line": 1441,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Saving",
       "surface": "android",
@@ -3443,7 +3475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1373,
+      "line": 1449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -3451,7 +3483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1373,
+      "line": 1449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Denying",
       "surface": "android",
@@ -3459,7 +3491,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1398,
+      "line": 1474,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -3467,7 +3499,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1423,
+      "line": 1502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -3475,7 +3507,63 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1454,
+      "line": 1532,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Enabled",
+      "surface": "android",
+      "id": "native.android.4a583b7a36684ed7"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1546,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "No",
+      "surface": "android",
+      "id": "native.android.1a3b13c02f53120f"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1546,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Yes",
+      "surface": "android",
+      "id": "native.android.9f6111d68ea1c273"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1564,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Last Error",
+      "surface": "android",
+      "id": "native.android.4fcad8b85203f5a8"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1567,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Delivery Error",
+      "surface": "android",
+      "id": "native.android.369f2775636e8fd4"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1606,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Tap to copy",
+      "surface": "android",
+      "id": "native.android.d02323bcac09c67f"
+    },
+    {
+      "kind": "ui-toast",
+      "line": 1621,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "$title copied",
+      "surface": "android",
+      "id": "native.android.09641868d42a68fb"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1659,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -3483,7 +3571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1456,
+      "line": 1661,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -3491,7 +3579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1512,
+      "line": 1717,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -3499,7 +3587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1515,
+      "line": 1720,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -3507,7 +3595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1515,
+      "line": 1720,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -3515,7 +3603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1543,
+      "line": 1748,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -3523,7 +3611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1550,
+      "line": 1755,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -3531,11 +3619,43 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1571,
+      "line": 1786,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
       "id": "native.android.35d4bc86e9ba395d"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1807,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "System Event Text",
+      "surface": "android",
+      "id": "native.android.22f3549d0fab271d"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1808,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Agent Prompt",
+      "surface": "android",
+      "id": "native.android.35e7850777bd6c6a"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1809,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Command",
+      "surface": "android",
+      "id": "native.android.c49027320aa3f807"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1810,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Payload Text",
+      "surface": "android",
+      "id": "native.android.f36439e78187c554"
     },
     {
       "kind": "ui-call",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 The OpenClaw mascot now comes alive across onboarding and the app headers with the same float, blink, antenna-wiggle, and claw-snap animation as openclaw.ai.
 
+Adds read-only Cron Job details in Settings, including schedule, payload and delivery state, job ID copy, refresh, and nested back navigation.
+
 ## 2026.6.11 - 2026-07-01
 
 Improves Android gateway setup with localized onboarding, QR pairing fixes, and support for local mDNS gateway hosts.

--- a/apps/android/app/src/main/java/ai/openclaw/app/CronJobDetail.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/CronJobDetail.kt
@@ -1,0 +1,243 @@
+package ai.openclaw.app
+
+import ai.openclaw.app.node.asObjectOrNull
+import ai.openclaw.app.node.asStringOrNull
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+
+data class GatewayCronJobDetail(
+  val id: String,
+  val name: String,
+  val description: String,
+  val enabled: Boolean,
+  val deleteAfterRun: Boolean,
+  val scheduleLabel: String,
+  val scheduleDetail: String,
+  val sessionTarget: String,
+  val wakeMode: String,
+  val payloadKind: String,
+  val payloadText: String?,
+  val payloadLabel: String,
+  val deliveryLabel: String,
+  val failureAlertLabel: String,
+  val createdAtMs: Long,
+  val updatedAtMs: Long,
+  val nextRunAtMs: Long?,
+  val runningAtMs: Long?,
+  val lastRunAtMs: Long?,
+  val lastRunStatus: String?,
+  val lastError: String?,
+  val lastDurationMs: Long?,
+  val consecutiveErrors: Long?,
+  val consecutiveSkipped: Long?,
+  val lastDeliveryStatus: String?,
+  val lastDeliveryError: String?,
+)
+
+sealed interface GatewayCronJobDetailState {
+  data object Idle : GatewayCronJobDetailState
+
+  data class Loading(
+    val id: String,
+  ) : GatewayCronJobDetailState
+
+  data class Loaded(
+    val job: GatewayCronJobDetail,
+  ) : GatewayCronJobDetailState
+
+  data class Error(
+    val id: String,
+    val message: String,
+  ) : GatewayCronJobDetailState
+}
+
+internal data class CronJobDetailRequest(
+  val id: String,
+  val generation: Long,
+)
+
+/** Couples the selected job id to its generation so older RPCs cannot publish into a new screen. */
+internal class CronJobDetailRequestGuard {
+  private val lock = Any()
+  private var generation = 0L
+  private var selectedId: String? = null
+
+  fun begin(rawId: String): CronJobDetailRequest? {
+    val id = rawId.trim().takeIf { it.isNotEmpty() } ?: return null
+    return synchronized(lock) {
+      generation += 1
+      selectedId = id
+      CronJobDetailRequest(id = id, generation = generation)
+    }
+  }
+
+  fun cancel(onCancel: () -> Unit = {}) {
+    synchronized(lock) {
+      generation += 1
+      selectedId = null
+      onCancel()
+    }
+  }
+
+  fun publishIfCurrent(
+    request: CronJobDetailRequest,
+    publish: () -> Unit,
+  ): Boolean =
+    synchronized(lock) {
+      if (request.generation != generation || request.id != selectedId) return@synchronized false
+      publish()
+      true
+    }
+}
+
+internal fun cronJobGetParams(id: String): String =
+  buildJsonObject {
+    put("id", JsonPrimitive(id))
+  }.toString()
+
+internal fun parseGatewayCronJobDetail(job: JsonObject?): GatewayCronJobDetail? {
+  val value = job ?: return null
+  val id = value.string("id") ?: return null
+  val name = value.string("name") ?: return null
+  val createdAtMs = value.long("createdAtMs") ?: return null
+  val updatedAtMs = value.long("updatedAtMs") ?: return null
+  val schedule = value["schedule"].asObjectOrNull() ?: return null
+  val payload = value["payload"].asObjectOrNull() ?: return null
+  val sessionTarget = value.string("sessionTarget") ?: return null
+  val wakeMode = value.string("wakeMode") ?: return null
+  val payloadKind = payload.string("kind") ?: return null
+  val state = value["state"].asObjectOrNull() ?: return null
+
+  return GatewayCronJobDetail(
+    id = id,
+    name = name,
+    description = value.string("description").orEmpty(),
+    enabled = value.boolean("enabled"),
+    deleteAfterRun = value.boolean("deleteAfterRun"),
+    scheduleLabel = cronScheduleLabel(schedule),
+    scheduleDetail = cronScheduleDetail(schedule),
+    sessionTarget = sessionTarget,
+    wakeMode = wakeMode,
+    payloadKind = payloadKind,
+    payloadText = cronPayloadText(payload),
+    payloadLabel = cronPayloadLabel(payload),
+    deliveryLabel = cronDeliveryLabel(value["delivery"].asObjectOrNull()),
+    failureAlertLabel = cronFailureAlertLabel(value["failureAlert"]),
+    createdAtMs = createdAtMs,
+    updatedAtMs = updatedAtMs,
+    nextRunAtMs = state.long("nextRunAtMs"),
+    runningAtMs = state.long("runningAtMs"),
+    lastRunAtMs = state.long("lastRunAtMs"),
+    lastRunStatus = cronJobLastRunStatus(state),
+    lastError = state.string("lastError"),
+    lastDurationMs = state.long("lastDurationMs"),
+    consecutiveErrors = state.long("consecutiveErrors"),
+    consecutiveSkipped = state.long("consecutiveSkipped"),
+    lastDeliveryStatus = state.string("lastDeliveryStatus"),
+    lastDeliveryError = state.string("lastDeliveryError"),
+  )
+}
+
+internal fun formatCronInterval(everyMs: Long): String {
+  val minutes = everyMs / 60_000L
+  val hours = minutes / 60L
+  val days = hours / 24L
+  return when {
+    days >= 1 && hours % 24L == 0L -> "Every ${days}d"
+    hours >= 1 && minutes % 60L == 0L -> "Every ${hours}h"
+    minutes >= 1 -> "Every ${minutes}m"
+    else -> "Repeating"
+  }
+}
+
+private fun cronScheduleLabel(schedule: JsonObject): String =
+  when (schedule.string("kind")) {
+    "at" -> "One time"
+    "every" -> schedule.long("everyMs")?.let(::formatCronInterval) ?: "Repeating"
+    "cron" -> schedule.string("expr") ?: "Cron"
+    else -> "Scheduled"
+  }
+
+private fun cronScheduleDetail(schedule: JsonObject): String =
+  when (schedule.string("kind")) {
+    "at" -> schedule.string("at") ?: "One time"
+    "every" -> {
+      val every = schedule.long("everyMs")?.let(::formatCronInterval) ?: "Repeating"
+      val anchor = schedule.long("anchorMs")?.let { "Anchor $it" }
+      listOfNotNull(every, anchor).joinToString(" · ")
+    }
+    "cron" -> {
+      val expression = schedule.string("expr") ?: "Cron"
+      val timezone = schedule.string("tz")
+      val stagger = schedule.long("staggerMs")?.takeIf { it > 0L }?.let { "Stagger ${formatCronInterval(it)}" }
+      listOfNotNull(expression, timezone, stagger).joinToString(" · ")
+    }
+    else -> "Scheduled"
+  }
+
+private fun cronPayloadText(payload: JsonObject): String? =
+  when (payload.string("kind")) {
+    "systemEvent" -> payload.string("text")
+    "agentTurn" -> payload.string("message")
+    "command" ->
+      (payload["argv"] as? JsonArray)
+        ?.mapNotNull { it.asStringOrNull()?.trim()?.takeIf { value -> value.isNotEmpty() } }
+        ?.joinToString(" ")
+    else -> null
+  }
+
+private fun cronPayloadLabel(payload: JsonObject): String =
+  when (payload.string("kind")) {
+    "systemEvent" -> "System event"
+    "agentTurn" -> {
+      val model = payload.string("model")
+      val thinking = payload.string("thinking")?.let { "Thinking $it" }
+      listOfNotNull("Agent turn", model, thinking).joinToString(" · ")
+    }
+    "command" -> "Command"
+    else -> "Payload"
+  }
+
+private fun cronDeliveryLabel(delivery: JsonObject?): String {
+  val value = delivery ?: return "Default"
+  val mode = value.string("mode") ?: return "Default"
+  return listOfNotNull(
+      mode.replaceFirstChar { it.uppercaseChar() },
+      value.string("channel"),
+      value.string("to"),
+      value.string("accountId")?.let { "Account $it" },
+    )
+    .joinToString(" · ")
+}
+
+private fun cronFailureAlertLabel(failureAlert: JsonElement?): String {
+  if ((failureAlert as? JsonPrimitive)?.booleanOrNull == false) return "Off"
+  val alert = failureAlert.asObjectOrNull() ?: return "Default"
+  return listOfNotNull(
+      alert.long("after")?.let { "After $it" },
+      alert.string("mode")?.replaceFirstChar { it.uppercaseChar() },
+      alert.string("channel"),
+      alert.string("to"),
+      alert.long("cooldownMs")?.takeIf { it > 0L }?.let { "Cooldown ${formatCronInterval(it)}" },
+    )
+    .joinToString(" · ")
+    .ifBlank { "On" }
+}
+
+private fun JsonObject.string(key: String): String? =
+  this[key]
+    .asStringOrNull()
+    ?.trim()
+    ?.takeIf { it.isNotEmpty() }
+
+private fun JsonObject.long(key: String): Long? =
+  (this[key] as? JsonPrimitive)
+    ?.content
+    ?.trim()
+    ?.toLongOrNull()
+
+private fun JsonObject.boolean(key: String): Boolean = (this[key] as? JsonPrimitive)?.booleanOrNull == true

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -139,6 +139,9 @@ class MainViewModel(
   val cronJobs: StateFlow<List<GatewayCronJobSummary>> = runtimeState(initial = emptyList()) { it.cronJobs }
   val cronRefreshing: StateFlow<Boolean> = runtimeState(initial = false) { it.cronRefreshing }
   val cronErrorText: StateFlow<String?> = runtimeState(initial = null) { it.cronErrorText }
+  val cronJobDetail: StateFlow<GatewayCronJobDetail?> = runtimeState(initial = null) { it.cronJobDetail }
+  val cronJobDetailLoading: StateFlow<Boolean> = runtimeState(initial = false) { it.cronJobDetailLoading }
+  val cronJobDetailErrorText: StateFlow<String?> = runtimeState(initial = null) { it.cronJobDetailErrorText }
   val usageSummary: StateFlow<GatewayUsageSummary> = runtimeState(initial = GatewayUsageSummary(updatedAtMs = null, providers = emptyList())) { it.usageSummary }
   val usageRefreshing: StateFlow<Boolean> = runtimeState(initial = false) { it.usageRefreshing }
   val usageErrorText: StateFlow<String?> = runtimeState(initial = null) { it.usageErrorText }
@@ -559,6 +562,10 @@ class MainViewModel(
 
   fun refreshCronJobs() {
     ensureRuntime().refreshCronJobs()
+  }
+
+  fun loadCronJobDetail(id: String) {
+    ensureRuntime().loadCronJobDetail(id)
   }
 
   fun refreshUsage() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -139,9 +139,7 @@ class MainViewModel(
   val cronJobs: StateFlow<List<GatewayCronJobSummary>> = runtimeState(initial = emptyList()) { it.cronJobs }
   val cronRefreshing: StateFlow<Boolean> = runtimeState(initial = false) { it.cronRefreshing }
   val cronErrorText: StateFlow<String?> = runtimeState(initial = null) { it.cronErrorText }
-  val cronJobDetail: StateFlow<GatewayCronJobDetail?> = runtimeState(initial = null) { it.cronJobDetail }
-  val cronJobDetailLoading: StateFlow<Boolean> = runtimeState(initial = false) { it.cronJobDetailLoading }
-  val cronJobDetailErrorText: StateFlow<String?> = runtimeState(initial = null) { it.cronJobDetailErrorText }
+  val cronJobDetailState: StateFlow<GatewayCronJobDetailState> = runtimeState(initial = GatewayCronJobDetailState.Idle) { it.cronJobDetailState }
   val usageSummary: StateFlow<GatewayUsageSummary> = runtimeState(initial = GatewayUsageSummary(updatedAtMs = null, providers = emptyList())) { it.usageSummary }
   val usageRefreshing: StateFlow<Boolean> = runtimeState(initial = false) { it.usageRefreshing }
   val usageErrorText: StateFlow<String?> = runtimeState(initial = null) { it.usageErrorText }
@@ -566,6 +564,10 @@ class MainViewModel(
 
   fun loadCronJobDetail(id: String) {
     ensureRuntime().loadCronJobDetail(id)
+  }
+
+  fun clearCronJobDetail() {
+    ensureRuntime().clearCronJobDetail()
   }
 
   fun refreshUsage() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -637,14 +637,9 @@ class NodeRuntime private constructor(
   val cronRefreshing: StateFlow<Boolean> = _cronRefreshing.asStateFlow()
   private val _cronErrorText = MutableStateFlow<String?>(null)
   val cronErrorText: StateFlow<String?> = _cronErrorText.asStateFlow()
-  private val _cronJobDetail = MutableStateFlow<GatewayCronJobDetail?>(null)
-  val cronJobDetail: StateFlow<GatewayCronJobDetail?> = _cronJobDetail.asStateFlow()
-  private val _cronJobDetailLoading = MutableStateFlow(false)
-  val cronJobDetailLoading: StateFlow<Boolean> = _cronJobDetailLoading.asStateFlow()
-  private val _cronJobDetailErrorText = MutableStateFlow<String?>(null)
-  val cronJobDetailErrorText: StateFlow<String?> = _cronJobDetailErrorText.asStateFlow()
-  private var cronJobDetailRequestId: String? = null
-  private val cronJobDetailRequestSeq = AtomicLong(0)
+  private val _cronJobDetailState = MutableStateFlow<GatewayCronJobDetailState>(GatewayCronJobDetailState.Idle)
+  val cronJobDetailState: StateFlow<GatewayCronJobDetailState> = _cronJobDetailState.asStateFlow()
+  private val cronJobDetailRequestGuard = CronJobDetailRequestGuard()
   private val _usageSummary = MutableStateFlow(GatewayUsageSummary(updatedAtMs = null, providers = emptyList()))
   val usageSummary: StateFlow<GatewayUsageSummary> = _usageSummary.asStateFlow()
   private val _usageRefreshing = MutableStateFlow(false)
@@ -757,11 +752,9 @@ class NodeRuntime private constructor(
         _talkSetupReadiness.value = GatewayTalkSetupReadiness.unverified()
         _cronStatus.value = GatewayCronStatus(enabled = false, jobs = 0, nextWakeAtMs = null)
         _cronJobs.value = emptyList()
-        _cronJobDetail.value = null
-        cronJobDetailRequestId = null
-        cronJobDetailRequestSeq.incrementAndGet()
-        _cronJobDetailLoading.value = false
-        _cronJobDetailErrorText.value = null
+        cronJobDetailRequestGuard.cancel {
+          _cronJobDetailState.value = GatewayCronJobDetailState.Idle
+        }
         _usageSummary.value = GatewayUsageSummary(updatedAtMs = null, providers = emptyList())
         _skillsSummary.value = GatewaySkillsSummary(skills = emptyList())
         _nodesDevicesSummary.value =
@@ -1208,17 +1201,16 @@ class NodeRuntime private constructor(
   }
 
   fun loadCronJobDetail(id: String) {
-    val trimmedId = id.trim()
-    if (trimmedId.isEmpty()) return
-    val requestSeq = cronJobDetailRequestSeq.incrementAndGet()
-    cronJobDetailRequestId = trimmedId
-    _cronJobDetailLoading.value = true
-    _cronJobDetailErrorText.value = null
-    if (_cronJobDetail.value?.id == trimmedId) {
-      _cronJobDetail.value = null
-    }
+    val request = cronJobDetailRequestGuard.begin(id) ?: return
+    _cronJobDetailState.value = GatewayCronJobDetailState.Loading(request.id)
     scope.launch {
-      loadCronJobDetailFromGateway(trimmedId, requestSeq)
+      loadCronJobDetailFromGateway(request)
+    }
+  }
+
+  fun clearCronJobDetail() {
+    cronJobDetailRequestGuard.cancel {
+      _cronJobDetailState.value = GatewayCronJobDetailState.Idle
     }
   }
 
@@ -2658,7 +2650,7 @@ class NodeRuntime private constructor(
           nextWakeAtMs = statusRoot.long("nextWakeAtMs"),
         )
 
-      val listRes = operatorSession.request("cron.list", """{"includeDisabled":true,"limit":100,"sortBy":"nextRunAtMs","sortDir":"asc"}""")
+      val listRes = operatorSession.request("cron.list", """{"includeDisabled":true,"limit":20,"sortBy":"nextRunAtMs","sortDir":"asc"}""")
       val listRoot = json.parseToJsonElement(listRes).asObjectOrNull()
       _cronJobs.value = parseCronJobs(listRoot?.get("jobs") as? JsonArray)
     } catch (_: Throwable) {
@@ -2668,38 +2660,27 @@ class NodeRuntime private constructor(
     }
   }
 
-  private suspend fun loadCronJobDetailFromGateway(
-    trimmedId: String,
-    requestSeq: Long,
-  ) {
+  private suspend fun loadCronJobDetailFromGateway(request: CronJobDetailRequest) {
     if (!operatorConnected) {
-      if (isCurrentCronJobDetailRequest(trimmedId, requestSeq)) {
-        _cronJobDetail.value = null
-        _cronJobDetailLoading.value = false
+      cronJobDetailRequestGuard.publishIfCurrent(request) {
+        _cronJobDetailState.value = GatewayCronJobDetailState.Error(request.id, "Connect the gateway to inspect cron jobs.")
       }
       return
     }
     try {
-      val res = operatorSession.request("cron.get", buildJsonObject { put("id", JsonPrimitive(trimmedId)) }.toString())
+      val res = operatorSession.request("cron.get", cronJobGetParams(request.id))
       val root = json.parseToJsonElement(res).asObjectOrNull()
-      if (isCurrentCronJobDetailRequest(trimmedId, requestSeq)) {
-        _cronJobDetail.value = parseCronJobDetail(root)
+      cronJobDetailRequestGuard.publishIfCurrent(request) {
+        _cronJobDetailState.value =
+          parseGatewayCronJobDetail(root)?.let(GatewayCronJobDetailState::Loaded)
+            ?: GatewayCronJobDetailState.Error(request.id, "Gateway returned an invalid cron job.")
       }
     } catch (_: Throwable) {
-      if (isCurrentCronJobDetailRequest(trimmedId, requestSeq)) {
-        _cronJobDetailErrorText.value = "Could not load cron job."
-      }
-    } finally {
-      if (isCurrentCronJobDetailRequest(trimmedId, requestSeq)) {
-        _cronJobDetailLoading.value = false
+      cronJobDetailRequestGuard.publishIfCurrent(request) {
+        _cronJobDetailState.value = GatewayCronJobDetailState.Error(request.id, "Could not load cron job.")
       }
     }
   }
-
-  private fun isCurrentCronJobDetailRequest(
-    id: String,
-    seq: Long,
-  ): Boolean = cronJobDetailRequestId == id && cronJobDetailRequestSeq.get() == seq
 
   private suspend fun refreshUsageFromGateway() {
     _usageRefreshing.value = true
@@ -3255,90 +3236,6 @@ class NodeRuntime private constructor(
         )
       }.orEmpty()
 
-  private fun parseCronJobDetail(obj: JsonObject?): GatewayCronJobDetail? {
-    val id =
-      obj
-        ?.get("id")
-        .asStringOrNull()
-        ?.trim()
-        .orEmpty()
-    val name =
-      obj
-        ?.get("name")
-        .asStringOrNull()
-        ?.trim()
-        .orEmpty()
-    if (id.isEmpty() || name.isEmpty()) return null
-    val job = obj ?: return null
-    val schedule = job["schedule"].asObjectOrNull()
-    val payload = job["payload"].asObjectOrNull()
-    val delivery = job["delivery"].asObjectOrNull()
-    val failureAlert = job["failureAlert"]
-    val state = job["state"].asObjectOrNull()
-    return GatewayCronJobDetail(
-      id = id,
-      name = name,
-      description = job["description"].asStringOrNull()?.trim().orEmpty(),
-      enabled = job.boolean("enabled"),
-      deleteAfterRun = job.optionalBoolean("deleteAfterRun") ?: false,
-      scheduleKind =
-        schedule
-          ?.get("kind")
-          .asStringOrNull()
-          ?.trim()
-          .orEmpty(),
-      scheduleLabel = cronScheduleLabel(schedule),
-      scheduleDetail = cronScheduleDetail(schedule),
-      sessionTarget =
-        job["sessionTarget"]
-          .asStringOrNull()
-          ?.trim()
-          ?.takeIf { it.isNotEmpty() } ?: "unknown",
-      wakeMode =
-        job["wakeMode"]
-          .asStringOrNull()
-          ?.trim()
-          ?.takeIf { it.isNotEmpty() } ?: "unknown",
-      payloadKind =
-        payload
-          ?.get("kind")
-          .asStringOrNull()
-          ?.trim()
-          .orEmpty(),
-      payloadText = cronPayloadText(payload),
-      payloadLabel = cronPayloadLabel(payload),
-      deliveryLabel = cronDeliveryLabel(delivery),
-      failureAlertLabel = cronFailureAlertLabel(failureAlert),
-      createdAtMs = job.long("createdAtMs"),
-      updatedAtMs = job.long("updatedAtMs"),
-      nextRunAtMs = state.long("nextRunAtMs"),
-      runningAtMs = state.long("runningAtMs"),
-      lastRunAtMs = state.long("lastRunAtMs"),
-      lastRunStatus = cronJobLastRunStatus(state),
-      lastError =
-        state
-          ?.get("lastError")
-          .asStringOrNull()
-          ?.trim()
-          ?.takeIf { it.isNotEmpty() },
-      lastDurationMs = state.long("lastDurationMs"),
-      consecutiveErrors = state.long("consecutiveErrors")?.toInt(),
-      consecutiveSkipped = state.long("consecutiveSkipped")?.toInt(),
-      lastDeliveryStatus =
-        state
-          ?.get("lastDeliveryStatus")
-          .asStringOrNull()
-          ?.trim()
-          ?.takeIf { it.isNotEmpty() },
-      lastDeliveryError =
-        state
-          ?.get("lastDeliveryError")
-          .asStringOrNull()
-          ?.trim()
-          ?.takeIf { it.isNotEmpty() },
-    )
-  }
-
   private fun parseUsageProviders(providers: JsonArray?): List<GatewayUsageProviderSummary> =
     providers
       ?.mapNotNull { item ->
@@ -3593,7 +3490,7 @@ class NodeRuntime private constructor(
   private fun cronScheduleLabel(schedule: JsonObject?): String =
     when (schedule?.get("kind").asStringOrNull()) {
       "at" -> "One time"
-      "every" -> schedule.long("everyMs")?.let(::formatEverySchedule) ?: "Repeating"
+      "every" -> schedule.long("everyMs")?.let(::formatCronInterval) ?: "Repeating"
       "cron" ->
         schedule
           ?.get("expr")
@@ -3611,78 +3508,6 @@ class NodeRuntime private constructor(
         else -> null
       }
     return text?.trim()?.replace(Regex("\\s+"), " ")?.takeIf { it.isNotEmpty() } ?: "No prompt"
-  }
-
-  private fun cronScheduleDetail(schedule: JsonObject?): String {
-    val value = schedule ?: return "Scheduled"
-    return when (value["kind"].asStringOrNull()) {
-      "at" -> value["at"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: "One time"
-      "every" -> {
-        val every = value.long("everyMs")?.let(::formatEverySchedule) ?: "Repeating"
-        val anchor = value.long("anchorMs")?.let { "Anchor $it" }
-        listOfNotNull(every, anchor).joinToString(" · ")
-      }
-      "cron" -> {
-        val expr = value["expr"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: "Cron"
-        val timezone = value["tz"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
-        val stagger = value.long("staggerMs")?.takeIf { it > 0L }?.let { "Stagger ${formatEverySchedule(it)}" }
-        listOfNotNull(expr, timezone, stagger).joinToString(" · ")
-      }
-      else -> "Scheduled"
-    }
-  }
-
-  private fun cronPayloadText(payload: JsonObject?): String? {
-    val value = payload ?: return null
-    return when (value["kind"].asStringOrNull()) {
-      "systemEvent" -> value["text"].asStringOrNull()
-      "agentTurn" -> value["message"].asStringOrNull()
-      "command" -> (value["argv"] as? JsonArray)?.mapNotNull { it.asStringOrNull() }?.joinToString(" ")
-      else -> null
-    }?.trim()?.takeIf { it.isNotEmpty() }
-  }
-
-  private fun cronPayloadLabel(payload: JsonObject?): String {
-    val value = payload ?: return "Payload"
-    return when (value["kind"].asStringOrNull()) {
-      "systemEvent" -> "System event"
-      "agentTurn" -> {
-        val model = value["model"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
-        val thinking = value["thinking"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
-        listOfNotNull("Agent turn", model, thinking?.let { "Thinking $it" }).joinToString(" · ")
-      }
-      "command" -> "Command"
-      else -> "Payload"
-    }
-  }
-
-  private fun cronDeliveryLabel(delivery: JsonObject?): String {
-    val value = delivery ?: return "Default"
-    val mode = value["mode"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: return "Default"
-    val channel = value["channel"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
-    val to = value["to"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
-    return listOfNotNull(mode.replaceFirstChar { it.uppercaseChar() }, channel, to).joinToString(" · ")
-  }
-
-  private fun cronFailureAlertLabel(failureAlert: JsonElement?): String {
-    if (failureAlert == null) return "Default"
-    if ((failureAlert as? JsonPrimitive)?.content == "false") return "Off"
-    val alert = failureAlert.asObjectOrNull() ?: return "Default"
-    val after = alert.long("after")?.let { "After $it" }
-    val cooldown = alert.long("cooldownMs")?.takeIf { it > 0L }?.let { "Cooldown ${formatEverySchedule(it)}" }
-    return listOfNotNull(after, cooldown).joinToString(" · ").ifBlank { "On" }
-  }
-
-  private fun formatEverySchedule(everyMs: Long): String {
-    val minutes = everyMs / 60_000L
-    val hours = minutes / 60L
-    val days = hours / 24L
-    return when {
-      days >= 1 && hours % 24L == 0L -> "Every ${days}d"
-      hours >= 1 && minutes % 60L == 0L -> "Every ${hours}h"
-      minutes >= 1 -> "Every ${minutes}m"
-      else -> "Repeating"
-    }
   }
 
   private fun updateHomeCanvasState() {
@@ -3991,36 +3816,6 @@ data class GatewayCronJobSummary(
   val promptPreview: String,
   val nextRunAtMs: Long?,
   val lastRunStatus: String?,
-)
-
-data class GatewayCronJobDetail(
-  val id: String,
-  val name: String,
-  val description: String,
-  val enabled: Boolean,
-  val deleteAfterRun: Boolean,
-  val scheduleKind: String,
-  val scheduleLabel: String,
-  val scheduleDetail: String,
-  val sessionTarget: String,
-  val wakeMode: String,
-  val payloadKind: String,
-  val payloadText: String?,
-  val payloadLabel: String,
-  val deliveryLabel: String,
-  val failureAlertLabel: String,
-  val createdAtMs: Long?,
-  val updatedAtMs: Long?,
-  val nextRunAtMs: Long?,
-  val runningAtMs: Long?,
-  val lastRunAtMs: Long?,
-  val lastRunStatus: String?,
-  val lastError: String?,
-  val lastDurationMs: Long?,
-  val consecutiveErrors: Int?,
-  val consecutiveSkipped: Int?,
-  val lastDeliveryStatus: String?,
-  val lastDeliveryError: String?,
 )
 
 data class GatewayUsageSummary(

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -637,6 +637,14 @@ class NodeRuntime private constructor(
   val cronRefreshing: StateFlow<Boolean> = _cronRefreshing.asStateFlow()
   private val _cronErrorText = MutableStateFlow<String?>(null)
   val cronErrorText: StateFlow<String?> = _cronErrorText.asStateFlow()
+  private val _cronJobDetail = MutableStateFlow<GatewayCronJobDetail?>(null)
+  val cronJobDetail: StateFlow<GatewayCronJobDetail?> = _cronJobDetail.asStateFlow()
+  private val _cronJobDetailLoading = MutableStateFlow(false)
+  val cronJobDetailLoading: StateFlow<Boolean> = _cronJobDetailLoading.asStateFlow()
+  private val _cronJobDetailErrorText = MutableStateFlow<String?>(null)
+  val cronJobDetailErrorText: StateFlow<String?> = _cronJobDetailErrorText.asStateFlow()
+  private var cronJobDetailRequestId: String? = null
+  private val cronJobDetailRequestSeq = AtomicLong(0)
   private val _usageSummary = MutableStateFlow(GatewayUsageSummary(updatedAtMs = null, providers = emptyList()))
   val usageSummary: StateFlow<GatewayUsageSummary> = _usageSummary.asStateFlow()
   private val _usageRefreshing = MutableStateFlow(false)
@@ -749,6 +757,11 @@ class NodeRuntime private constructor(
         _talkSetupReadiness.value = GatewayTalkSetupReadiness.unverified()
         _cronStatus.value = GatewayCronStatus(enabled = false, jobs = 0, nextWakeAtMs = null)
         _cronJobs.value = emptyList()
+        _cronJobDetail.value = null
+        cronJobDetailRequestId = null
+        cronJobDetailRequestSeq.incrementAndGet()
+        _cronJobDetailLoading.value = false
+        _cronJobDetailErrorText.value = null
         _usageSummary.value = GatewayUsageSummary(updatedAtMs = null, providers = emptyList())
         _skillsSummary.value = GatewaySkillsSummary(skills = emptyList())
         _nodesDevicesSummary.value =
@@ -1191,6 +1204,21 @@ class NodeRuntime private constructor(
   fun refreshCronJobs() {
     scope.launch {
       refreshCronFromGateway()
+    }
+  }
+
+  fun loadCronJobDetail(id: String) {
+    val trimmedId = id.trim()
+    if (trimmedId.isEmpty()) return
+    val requestSeq = cronJobDetailRequestSeq.incrementAndGet()
+    cronJobDetailRequestId = trimmedId
+    _cronJobDetailLoading.value = true
+    _cronJobDetailErrorText.value = null
+    if (_cronJobDetail.value?.id == trimmedId) {
+      _cronJobDetail.value = null
+    }
+    scope.launch {
+      loadCronJobDetailFromGateway(trimmedId, requestSeq)
     }
   }
 
@@ -2630,7 +2658,7 @@ class NodeRuntime private constructor(
           nextWakeAtMs = statusRoot.long("nextWakeAtMs"),
         )
 
-      val listRes = operatorSession.request("cron.list", """{"includeDisabled":true,"limit":20,"sortBy":"nextRunAtMs","sortDir":"asc"}""")
+      val listRes = operatorSession.request("cron.list", """{"includeDisabled":true,"limit":100,"sortBy":"nextRunAtMs","sortDir":"asc"}""")
       val listRoot = json.parseToJsonElement(listRes).asObjectOrNull()
       _cronJobs.value = parseCronJobs(listRoot?.get("jobs") as? JsonArray)
     } catch (_: Throwable) {
@@ -2639,6 +2667,39 @@ class NodeRuntime private constructor(
       _cronRefreshing.value = false
     }
   }
+
+  private suspend fun loadCronJobDetailFromGateway(
+    trimmedId: String,
+    requestSeq: Long,
+  ) {
+    if (!operatorConnected) {
+      if (isCurrentCronJobDetailRequest(trimmedId, requestSeq)) {
+        _cronJobDetail.value = null
+        _cronJobDetailLoading.value = false
+      }
+      return
+    }
+    try {
+      val res = operatorSession.request("cron.get", buildJsonObject { put("id", JsonPrimitive(trimmedId)) }.toString())
+      val root = json.parseToJsonElement(res).asObjectOrNull()
+      if (isCurrentCronJobDetailRequest(trimmedId, requestSeq)) {
+        _cronJobDetail.value = parseCronJobDetail(root)
+      }
+    } catch (_: Throwable) {
+      if (isCurrentCronJobDetailRequest(trimmedId, requestSeq)) {
+        _cronJobDetailErrorText.value = "Could not load cron job."
+      }
+    } finally {
+      if (isCurrentCronJobDetailRequest(trimmedId, requestSeq)) {
+        _cronJobDetailLoading.value = false
+      }
+    }
+  }
+
+  private fun isCurrentCronJobDetailRequest(
+    id: String,
+    seq: Long,
+  ): Boolean = cronJobDetailRequestId == id && cronJobDetailRequestSeq.get() == seq
 
   private suspend fun refreshUsageFromGateway() {
     _usageRefreshing.value = true
@@ -3194,6 +3255,90 @@ class NodeRuntime private constructor(
         )
       }.orEmpty()
 
+  private fun parseCronJobDetail(obj: JsonObject?): GatewayCronJobDetail? {
+    val id =
+      obj
+        ?.get("id")
+        .asStringOrNull()
+        ?.trim()
+        .orEmpty()
+    val name =
+      obj
+        ?.get("name")
+        .asStringOrNull()
+        ?.trim()
+        .orEmpty()
+    if (id.isEmpty() || name.isEmpty()) return null
+    val job = obj ?: return null
+    val schedule = job["schedule"].asObjectOrNull()
+    val payload = job["payload"].asObjectOrNull()
+    val delivery = job["delivery"].asObjectOrNull()
+    val failureAlert = job["failureAlert"]
+    val state = job["state"].asObjectOrNull()
+    return GatewayCronJobDetail(
+      id = id,
+      name = name,
+      description = job["description"].asStringOrNull()?.trim().orEmpty(),
+      enabled = job.boolean("enabled"),
+      deleteAfterRun = job.optionalBoolean("deleteAfterRun") ?: false,
+      scheduleKind =
+        schedule
+          ?.get("kind")
+          .asStringOrNull()
+          ?.trim()
+          .orEmpty(),
+      scheduleLabel = cronScheduleLabel(schedule),
+      scheduleDetail = cronScheduleDetail(schedule),
+      sessionTarget =
+        job["sessionTarget"]
+          .asStringOrNull()
+          ?.trim()
+          ?.takeIf { it.isNotEmpty() } ?: "unknown",
+      wakeMode =
+        job["wakeMode"]
+          .asStringOrNull()
+          ?.trim()
+          ?.takeIf { it.isNotEmpty() } ?: "unknown",
+      payloadKind =
+        payload
+          ?.get("kind")
+          .asStringOrNull()
+          ?.trim()
+          .orEmpty(),
+      payloadText = cronPayloadText(payload),
+      payloadLabel = cronPayloadLabel(payload),
+      deliveryLabel = cronDeliveryLabel(delivery),
+      failureAlertLabel = cronFailureAlertLabel(failureAlert),
+      createdAtMs = job.long("createdAtMs"),
+      updatedAtMs = job.long("updatedAtMs"),
+      nextRunAtMs = state.long("nextRunAtMs"),
+      runningAtMs = state.long("runningAtMs"),
+      lastRunAtMs = state.long("lastRunAtMs"),
+      lastRunStatus = cronJobLastRunStatus(state),
+      lastError =
+        state
+          ?.get("lastError")
+          .asStringOrNull()
+          ?.trim()
+          ?.takeIf { it.isNotEmpty() },
+      lastDurationMs = state.long("lastDurationMs"),
+      consecutiveErrors = state.long("consecutiveErrors")?.toInt(),
+      consecutiveSkipped = state.long("consecutiveSkipped")?.toInt(),
+      lastDeliveryStatus =
+        state
+          ?.get("lastDeliveryStatus")
+          .asStringOrNull()
+          ?.trim()
+          ?.takeIf { it.isNotEmpty() },
+      lastDeliveryError =
+        state
+          ?.get("lastDeliveryError")
+          .asStringOrNull()
+          ?.trim()
+          ?.takeIf { it.isNotEmpty() },
+    )
+  }
+
   private fun parseUsageProviders(providers: JsonArray?): List<GatewayUsageProviderSummary> =
     providers
       ?.mapNotNull { item ->
@@ -3466,6 +3611,66 @@ class NodeRuntime private constructor(
         else -> null
       }
     return text?.trim()?.replace(Regex("\\s+"), " ")?.takeIf { it.isNotEmpty() } ?: "No prompt"
+  }
+
+  private fun cronScheduleDetail(schedule: JsonObject?): String {
+    val value = schedule ?: return "Scheduled"
+    return when (value["kind"].asStringOrNull()) {
+      "at" -> value["at"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: "One time"
+      "every" -> {
+        val every = value.long("everyMs")?.let(::formatEverySchedule) ?: "Repeating"
+        val anchor = value.long("anchorMs")?.let { "Anchor $it" }
+        listOfNotNull(every, anchor).joinToString(" · ")
+      }
+      "cron" -> {
+        val expr = value["expr"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: "Cron"
+        val timezone = value["tz"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+        val stagger = value.long("staggerMs")?.takeIf { it > 0L }?.let { "Stagger ${formatEverySchedule(it)}" }
+        listOfNotNull(expr, timezone, stagger).joinToString(" · ")
+      }
+      else -> "Scheduled"
+    }
+  }
+
+  private fun cronPayloadText(payload: JsonObject?): String? {
+    val value = payload ?: return null
+    return when (value["kind"].asStringOrNull()) {
+      "systemEvent" -> value["text"].asStringOrNull()
+      "agentTurn" -> value["message"].asStringOrNull()
+      "command" -> (value["argv"] as? JsonArray)?.mapNotNull { it.asStringOrNull() }?.joinToString(" ")
+      else -> null
+    }?.trim()?.takeIf { it.isNotEmpty() }
+  }
+
+  private fun cronPayloadLabel(payload: JsonObject?): String {
+    val value = payload ?: return "Payload"
+    return when (value["kind"].asStringOrNull()) {
+      "systemEvent" -> "System event"
+      "agentTurn" -> {
+        val model = value["model"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+        val thinking = value["thinking"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+        listOfNotNull("Agent turn", model, thinking?.let { "Thinking $it" }).joinToString(" · ")
+      }
+      "command" -> "Command"
+      else -> "Payload"
+    }
+  }
+
+  private fun cronDeliveryLabel(delivery: JsonObject?): String {
+    val value = delivery ?: return "Default"
+    val mode = value["mode"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: return "Default"
+    val channel = value["channel"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+    val to = value["to"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+    return listOfNotNull(mode.replaceFirstChar { it.uppercaseChar() }, channel, to).joinToString(" · ")
+  }
+
+  private fun cronFailureAlertLabel(failureAlert: JsonElement?): String {
+    if (failureAlert == null) return "Default"
+    if ((failureAlert as? JsonPrimitive)?.content == "false") return "Off"
+    val alert = failureAlert.asObjectOrNull() ?: return "Default"
+    val after = alert.long("after")?.let { "After $it" }
+    val cooldown = alert.long("cooldownMs")?.takeIf { it > 0L }?.let { "Cooldown ${formatEverySchedule(it)}" }
+    return listOfNotNull(after, cooldown).joinToString(" · ").ifBlank { "On" }
   }
 
   private fun formatEverySchedule(everyMs: Long): String {
@@ -3786,6 +3991,36 @@ data class GatewayCronJobSummary(
   val promptPreview: String,
   val nextRunAtMs: Long?,
   val lastRunStatus: String?,
+)
+
+data class GatewayCronJobDetail(
+  val id: String,
+  val name: String,
+  val description: String,
+  val enabled: Boolean,
+  val deleteAfterRun: Boolean,
+  val scheduleKind: String,
+  val scheduleLabel: String,
+  val scheduleDetail: String,
+  val sessionTarget: String,
+  val wakeMode: String,
+  val payloadKind: String,
+  val payloadText: String?,
+  val payloadLabel: String,
+  val deliveryLabel: String,
+  val failureAlertLabel: String,
+  val createdAtMs: Long?,
+  val updatedAtMs: Long?,
+  val nextRunAtMs: Long?,
+  val runningAtMs: Long?,
+  val lastRunAtMs: Long?,
+  val lastRunStatus: String?,
+  val lastError: String?,
+  val lastDurationMs: Long?,
+  val consecutiveErrors: Int?,
+  val consecutiveSkipped: Int?,
+  val lastDeliveryStatus: String?,
+  val lastDeliveryError: String?,
 )
 
 data class GatewayUsageSummary(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -7,6 +7,7 @@ import ai.openclaw.app.GatewayAgentSummary
 import ai.openclaw.app.GatewayConnectionDisplay
 import ai.openclaw.app.GatewayConnectionProblem
 import ai.openclaw.app.GatewayCronJobDetail
+import ai.openclaw.app.GatewayCronJobDetailState
 import ai.openclaw.app.GatewayCronJobSummary
 import ai.openclaw.app.GatewayExecApprovalSummary
 import ai.openclaw.app.GatewayTalkSetupReadiness
@@ -113,6 +114,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -248,17 +250,21 @@ private fun CronJobsSettingsScreen(
   viewModel: MainViewModel,
   onBack: () -> Unit,
 ) {
-  var selectedJobId by remember { mutableStateOf<String?>(null) }
-  selectedJobId?.let { jobId ->
-    CronJobDetailSettingsScreen(viewModel = viewModel, jobId = jobId, onBack = { selectedJobId = null })
-    return
-  }
-
   val cronStatus by viewModel.cronStatus.collectAsState()
   val cronJobs by viewModel.cronJobs.collectAsState()
   val cronRefreshing by viewModel.cronRefreshing.collectAsState()
   val cronErrorText by viewModel.cronErrorText.collectAsState()
   val isConnected by viewModel.isConnected.collectAsState()
+  var selectedJobId by rememberSaveable { mutableStateOf<String?>(null) }
+  selectedJobId?.let { jobId ->
+    CronJobDetailSettingsScreen(
+      viewModel = viewModel,
+      jobId = jobId,
+      jobName = cronJobs.firstOrNull { it.id == jobId }?.name,
+      onBack = { selectedJobId = null },
+    )
+    return
+  }
 
   LaunchedEffect(isConnected) {
     if (isConnected) {
@@ -305,14 +311,17 @@ private fun CronJobsSettingsScreen(
 private fun CronJobDetailSettingsScreen(
   viewModel: MainViewModel,
   jobId: String,
+  jobName: String?,
   onBack: () -> Unit,
 ) {
   BackHandler(onBack = onBack)
 
-  val job by viewModel.cronJobDetail.collectAsState()
-  val loading by viewModel.cronJobDetailLoading.collectAsState()
-  val errorText by viewModel.cronJobDetailErrorText.collectAsState()
+  val detailState by viewModel.cronJobDetailState.collectAsState()
   val isConnected by viewModel.isConnected.collectAsState()
+
+  DisposableEffect(viewModel, jobId) {
+    onDispose { viewModel.clearCronJobDetail() }
+  }
 
   LaunchedEffect(isConnected, jobId) {
     if (isConnected) {
@@ -320,9 +329,11 @@ private fun CronJobDetailSettingsScreen(
     }
   }
 
-  val current = job?.takeIf { it.id == jobId }
+  val current = (detailState as? GatewayCronJobDetailState.Loaded)?.job?.takeIf { it.id == jobId }
+  val loading = (detailState as? GatewayCronJobDetailState.Loading)?.id == jobId
+  val errorText = (detailState as? GatewayCronJobDetailState.Error)?.takeIf { it.id == jobId }?.message
   SettingsDetailFrame(
-    title = current?.name ?: "Cron Job",
+    title = current?.name ?: jobName ?: "Cron Job",
     subtitle = "Inspect scheduled gateway work.",
     icon = Icons.Default.Bolt,
     onBack = onBack,
@@ -334,16 +345,14 @@ private fun CronJobDetailSettingsScreen(
       modifier = Modifier.fillMaxWidth(),
     )
 
-    errorText?.let { text ->
-      ClawPanel {
-        Text(text = text, style = ClawTheme.type.body, color = ClawTheme.colors.warning)
-      }
-    }
-
     when {
       !isConnected ->
         ClawPanel {
           Text(text = "Connect the gateway to inspect cron jobs.", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
+        }
+      errorText != null ->
+        ClawPanel {
+          Text(text = errorText, style = ClawTheme.type.body, color = ClawTheme.colors.warning)
         }
       current == null ->
         ClawPanel {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -6,6 +6,7 @@ import ai.openclaw.app.BuildConfig
 import ai.openclaw.app.GatewayAgentSummary
 import ai.openclaw.app.GatewayConnectionDisplay
 import ai.openclaw.app.GatewayConnectionProblem
+import ai.openclaw.app.GatewayCronJobDetail
 import ai.openclaw.app.GatewayCronJobSummary
 import ai.openclaw.app.GatewayExecApprovalSummary
 import ai.openclaw.app.GatewayTalkSetupReadiness
@@ -40,6 +41,8 @@ import ai.openclaw.app.ui.design.ClawTextBadge
 import ai.openclaw.app.ui.design.ClawTextField
 import ai.openclaw.app.ui.design.ClawTheme
 import android.Manifest
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -50,6 +53,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -82,6 +86,7 @@ import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.GraphicEq
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Info
@@ -122,6 +127,8 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import java.text.DateFormat
+import java.util.Date
 
 /**
  * Detail routes reachable from the Android settings home surface.
@@ -241,6 +248,12 @@ private fun CronJobsSettingsScreen(
   viewModel: MainViewModel,
   onBack: () -> Unit,
 ) {
+  var selectedJobId by remember { mutableStateOf<String?>(null) }
+  selectedJobId?.let { jobId ->
+    CronJobDetailSettingsScreen(viewModel = viewModel, jobId = jobId, onBack = { selectedJobId = null })
+    return
+  }
+
   val cronStatus by viewModel.cronStatus.collectAsState()
   val cronJobs by viewModel.cronJobs.collectAsState()
   val cronRefreshing by viewModel.cronRefreshing.collectAsState()
@@ -283,7 +296,60 @@ private fun CronJobsSettingsScreen(
             Text(text = "Create recurring OpenClaw work from the desktop app.", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
           }
         }
-      else -> CronJobsPanel(jobs = cronJobs)
+      else -> CronJobsPanel(jobs = cronJobs, onJobClick = { selectedJobId = it.id })
+    }
+  }
+}
+
+@Composable
+private fun CronJobDetailSettingsScreen(
+  viewModel: MainViewModel,
+  jobId: String,
+  onBack: () -> Unit,
+) {
+  BackHandler(onBack = onBack)
+
+  val job by viewModel.cronJobDetail.collectAsState()
+  val loading by viewModel.cronJobDetailLoading.collectAsState()
+  val errorText by viewModel.cronJobDetailErrorText.collectAsState()
+  val isConnected by viewModel.isConnected.collectAsState()
+
+  LaunchedEffect(isConnected, jobId) {
+    if (isConnected) {
+      viewModel.loadCronJobDetail(jobId)
+    }
+  }
+
+  val current = job?.takeIf { it.id == jobId }
+  SettingsDetailFrame(
+    title = current?.name ?: "Cron Job",
+    subtitle = "Inspect scheduled gateway work.",
+    icon = Icons.Default.Bolt,
+    onBack = onBack,
+  ) {
+    ClawSecondaryButton(
+      text = if (loading) "Refreshing" else "Refresh",
+      onClick = { viewModel.loadCronJobDetail(jobId) },
+      enabled = isConnected && !loading,
+      modifier = Modifier.fillMaxWidth(),
+    )
+
+    errorText?.let { text ->
+      ClawPanel {
+        Text(text = text, style = ClawTheme.type.body, color = ClawTheme.colors.warning)
+      }
+    }
+
+    when {
+      !isConnected ->
+        ClawPanel {
+          Text(text = "Connect the gateway to inspect cron jobs.", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
+        }
+      current == null ->
+        ClawPanel {
+          Text(text = if (loading) "Loading cron job…" else "Cron job not loaded.", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
+        }
+      else -> CronJobDetailPanel(current)
     }
   }
 }
@@ -1316,6 +1382,7 @@ private data class SettingsToggleRow(
 internal data class SettingsMetric(
   val title: String,
   val value: String,
+  val copyable: Boolean = false,
 )
 
 @Composable
@@ -1400,9 +1467,12 @@ private fun ApprovalListRow(toolCall: ChatPendingToolCall) {
 }
 
 @Composable
-private fun CronJobsPanel(jobs: List<GatewayCronJobSummary>) {
+private fun CronJobsPanel(
+  jobs: List<GatewayCronJobSummary>,
+  onJobClick: (GatewayCronJobSummary) -> Unit,
+) {
   ClawListPanel(items = jobs) { job ->
-    CronJobListRow(job = job)
+    CronJobListRow(job = job, onClick = { onJobClick(job) })
   }
 }
 
@@ -1425,13 +1495,139 @@ private fun UsageProviderListRow(provider: GatewayUsageProviderSummary) {
 }
 
 @Composable
-private fun CronJobListRow(job: GatewayCronJobSummary) {
+private fun CronJobListRow(
+  job: GatewayCronJobSummary,
+  onClick: () -> Unit,
+) {
   ClawDetailRow(
     title = job.name,
     subtitle = cronJobSubtitle(job),
+    modifier = Modifier.clickable(onClick = onClick),
     leading = { ClawIconBadge(icon = Icons.Default.Bolt) },
-    trailing = { ClawStatusPill(text = cronJobStatusText(job), status = cronJobStatus(job)) },
+    trailing = {
+      Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        ClawStatusPill(text = cronJobStatusText(job), status = cronJobStatus(job))
+        Icon(imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, modifier = Modifier.size(17.dp), tint = ClawTheme.colors.textSubtle)
+      }
+    },
   )
+}
+
+@Composable
+private fun CronJobDetailPanel(
+  job: GatewayCronJobDetail,
+) {
+  SettingsMetricPanel(
+    rows =
+      listOf(
+        SettingsMetric("Status", if (job.enabled) "Enabled" else "Off"),
+        SettingsMetric("Schedule", job.scheduleLabel),
+        SettingsMetric("Next Wake", formatCronWake(job.nextRunAtMs)),
+        SettingsMetric("Last Run", formatCronTimestamp(job.lastRunAtMs)),
+      ),
+  )
+  CronJobFieldsPanel(
+    rows =
+      listOf(
+        SettingsMetric("ID", job.id, copyable = true),
+        SettingsMetric("Description", job.description.ifBlank { "None" }),
+        SettingsMetric("Schedule Detail", job.scheduleDetail),
+        SettingsMetric("Session Target", job.sessionTarget),
+        SettingsMetric("Wake Mode", job.wakeMode),
+        SettingsMetric("Delete After Run", if (job.deleteAfterRun) "Yes" else "No"),
+        SettingsMetric("Payload", job.payloadLabel),
+        SettingsMetric("Delivery", job.deliveryLabel),
+        SettingsMetric("Failure Alert", job.failureAlertLabel),
+        SettingsMetric("Created", formatCronTimestamp(job.createdAtMs)),
+        SettingsMetric("Updated", formatCronTimestamp(job.updatedAtMs)),
+        SettingsMetric("Running Since", formatCronTimestamp(job.runningAtMs)),
+        SettingsMetric("Last Status", cronJobStatusText(job)),
+        SettingsMetric("Last Duration", job.lastDurationMs?.let { "${it}ms" } ?: "None"),
+        SettingsMetric("Consecutive Errors", job.consecutiveErrors?.toString() ?: "0"),
+        SettingsMetric("Consecutive Skips", job.consecutiveSkipped?.toString() ?: "0"),
+        SettingsMetric("Delivery Status", job.lastDeliveryStatus ?: "None"),
+      ),
+  )
+  job.payloadText?.let { text ->
+    CronJobTextPanel(title = cronPayloadTextTitle(job), text = text)
+  }
+  job.lastError?.let { text ->
+    CronJobTextPanel(title = "Last Error", text = text, warning = true)
+  }
+  job.lastDeliveryError?.let { text ->
+    CronJobTextPanel(title = "Delivery Error", text = text, warning = true)
+  }
+}
+
+@Composable
+private fun CronJobFieldsPanel(rows: List<SettingsMetric>) {
+  val context = LocalContext.current
+  ClawPanel(contentPadding = PaddingValues(horizontal = 14.dp, vertical = 4.dp)) {
+    ClawSeparatedColumn(items = rows) { row ->
+      val rowModifier =
+        if (row.copyable) {
+          Modifier
+            .fillMaxWidth()
+            .heightIn(min = 46.dp)
+            .clickable(onClickLabel = "Copy ${row.title}") { copyCronDetailValue(context, row.title, row.value) }
+            .padding(vertical = 6.dp)
+        } else {
+          Modifier
+            .fillMaxWidth()
+            .heightIn(min = 46.dp)
+            .padding(vertical = 6.dp)
+        }
+      Row(modifier = rowModifier, horizontalArrangement = Arrangement.spacedBy(10.dp), verticalAlignment = Alignment.Top) {
+        Text(text = row.title, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, modifier = Modifier.weight(0.42f), maxLines = 2, overflow = TextOverflow.Ellipsis)
+        Column(modifier = Modifier.weight(0.58f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+          Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+            Text(
+              text = row.value,
+              style = ClawTheme.type.caption,
+              color = if (row.copyable) ClawTheme.colors.primary else ClawTheme.colors.text,
+              modifier = Modifier.weight(1f),
+              maxLines = 3,
+              overflow = TextOverflow.Ellipsis,
+            )
+            if (row.copyable) {
+              Icon(imageVector = Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(14.dp), tint = ClawTheme.colors.primary)
+            }
+          }
+          if (row.copyable) {
+            Text(text = "Tap to copy", style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted)
+          }
+        }
+      }
+    }
+  }
+}
+
+private fun copyCronDetailValue(
+  context: Context,
+  title: String,
+  value: String,
+) {
+  val clipboard = context.getSystemService(ClipboardManager::class.java) ?: return
+  clipboard.setPrimaryClip(ClipData.newPlainText("OpenClaw cron job $title", value))
+  Toast.makeText(context, "$title copied", Toast.LENGTH_SHORT).show()
+}
+
+@Composable
+private fun CronJobTextPanel(
+  title: String,
+  text: String,
+  warning: Boolean = false,
+) {
+  ClawPanel {
+    Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
+      Text(text = title, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted)
+      Text(
+        text = text,
+        style = ClawTheme.type.body,
+        color = if (warning) ClawTheme.colors.warning else ClawTheme.colors.text,
+      )
+    }
+  }
 }
 
 @Composable
@@ -1577,6 +1773,16 @@ private fun cronJobStatusText(job: GatewayCronJobSummary): String {
   }
 }
 
+private fun cronJobStatusText(job: GatewayCronJobDetail): String {
+  if (!job.enabled) return "Off"
+  return when (job.lastRunStatus?.lowercase()) {
+    "error" -> "Issue"
+    "ok" -> "OK"
+    "skipped" -> "Skipped"
+    else -> "Ready"
+  }
+}
+
 /** Maps gateway cron status text to app status colors. */
 private fun cronJobStatus(job: GatewayCronJobSummary): ClawStatus {
   if (!job.enabled) return ClawStatus.Neutral
@@ -1586,6 +1792,14 @@ private fun cronJobStatus(job: GatewayCronJobSummary): ClawStatus {
     else -> ClawStatus.Success
   }
 }
+
+private fun cronPayloadTextTitle(job: GatewayCronJobDetail): String =
+  when (job.payloadKind) {
+    "systemEvent" -> "System Event Text"
+    "agentTurn" -> "Agent Prompt"
+    "command" -> "Command"
+    else -> "Payload Text"
+  }
 
 /** Applies query/system visibility rules while always preserving selected packages. */
 internal fun filterNotificationAppsForPicker(
@@ -1655,6 +1869,11 @@ private fun formatCronWake(timeMs: Long?): String {
     minutes > 0 -> "${minutes}m"
     else -> "Soon"
   }
+}
+
+private fun formatCronTimestamp(timeMs: Long?): String {
+  val value = timeMs ?: return "None"
+  return DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).format(Date(value))
 }
 
 @Composable

--- a/apps/android/app/src/test/java/ai/openclaw/app/CronJobDetailTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/CronJobDetailTest.kt
@@ -1,0 +1,113 @@
+package ai.openclaw.app
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CronJobDetailTest {
+  @Test
+  fun parsesFullGatewayCronJob() {
+    val detail = parseGatewayCronJobDetail(parseJob())
+
+    requireNotNull(detail)
+    assertEquals("job-1", detail.id)
+    assertEquals("Daily report", detail.name)
+    assertEquals("0 9 * * *", detail.scheduleLabel)
+    assertEquals("0 9 * * * · Europe/Vienna · Stagger Every 5m", detail.scheduleDetail)
+    assertEquals("Agent turn · openai/gpt-5.5 · Thinking high", detail.payloadLabel)
+    assertEquals("Summarize the day", detail.payloadText)
+    assertEquals("Announce · telegram · chat-42 · Account primary", detail.deliveryLabel)
+    assertEquals("After 3 · Announce · telegram · ops · Cooldown Every 1h", detail.failureAlertLabel)
+    assertEquals(2L, detail.consecutiveErrors)
+    assertEquals("error", detail.lastRunStatus)
+  }
+
+  @Test
+  fun commandDetailsDoNotExposeEnvironmentValues() {
+    val job =
+      parseJob(
+        payload =
+          """{"kind":"command","argv":["printf","done"],"env":{"API_TOKEN":"secret-value"}}""",
+      )
+
+    val detail = parseGatewayCronJobDetail(job)
+
+    requireNotNull(detail)
+    assertEquals("printf done", detail.payloadText)
+    assertFalse(detail.payloadText.orEmpty().contains("secret-value"))
+  }
+
+  @Test
+  fun rejectsIncompleteGatewayCronJob() {
+    val incomplete = Json.parseToJsonElement("""{"id":"job-1","name":"Missing fields"}""").jsonObject
+
+    assertNull(parseGatewayCronJobDetail(incomplete))
+  }
+
+  @Test
+  fun encodesCronGetIdAsJson() {
+    val encoded = Json.parseToJsonElement(cronJobGetParams("job-\"quoted\\path")).jsonObject
+
+    assertEquals("job-\"quoted\\path", encoded.getValue("id").jsonPrimitive.content)
+  }
+
+  @Test
+  fun requestGuardRejectsOlderSelectionAndCancellation() {
+    val guard = CronJobDetailRequestGuard()
+    val first = requireNotNull(guard.begin(" job-1 "))
+    val second = requireNotNull(guard.begin("job-2"))
+    var published = "none"
+
+    assertEquals("job-1", first.id)
+    assertFalse(guard.publishIfCurrent(first) { published = first.id })
+    assertTrue(guard.publishIfCurrent(second) { published = second.id })
+    assertEquals("job-2", published)
+
+    guard.cancel()
+    assertFalse(guard.publishIfCurrent(second) { published = "stale" })
+    assertEquals("job-2", published)
+    assertNull(guard.begin("   "))
+  }
+
+  private fun parseJob(
+    payload: String =
+      """{"kind":"agentTurn","message":"Summarize the day","model":"openai/gpt-5.5","thinking":"high"}""",
+  ): JsonObject =
+    Json.parseToJsonElement(
+        """
+        {
+          "id": "job-1",
+          "name": "Daily report",
+          "description": "Daily digest",
+          "enabled": true,
+          "deleteAfterRun": false,
+          "createdAtMs": 1000,
+          "updatedAtMs": 2000,
+          "schedule": {"kind":"cron","expr":"0 9 * * *","tz":"Europe/Vienna","staggerMs":300000},
+          "sessionTarget": "isolated",
+          "wakeMode": "now",
+          "payload": $payload,
+          "delivery": {"mode":"announce","channel":"telegram","to":"chat-42","accountId":"primary"},
+          "failureAlert": {"after":3,"mode":"announce","channel":"telegram","to":"ops","cooldownMs":3600000},
+          "state": {
+            "nextRunAtMs": 3000,
+            "lastRunAtMs": 2500,
+            "lastRunStatus": "error",
+            "lastError": "boom",
+            "lastDurationMs": 500,
+            "consecutiveErrors": 2,
+            "consecutiveSkipped": 1,
+            "lastDeliveryStatus": "not-delivered",
+            "lastDeliveryError": "offline"
+          }
+        }
+        """.trimIndent(),
+      )
+      .jsonObject
+}

--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -23,6 +23,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_FILES = [
   "extensions/memory-core/src/dreaming.ts",
   "extensions/memory-lancedb/index.ts",
   "extensions/thread-ownership/index.ts",
+  "extensions/workboard/index.ts",
 ] as const;
 const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/acpx/index.ts": ["reply_dispatch"],
@@ -35,6 +36,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/memory-core/src/dreaming.ts": ["before_agent_reply", "gateway_start", "gateway_stop"],
   "extensions/memory-lancedb/index.ts": ["agent_end", "before_prompt_build", "session_end"],
   "extensions/thread-ownership/index.ts": ["message_received", "message_sending"],
+  "extensions/workboard/index.ts": ["subagent_ended"],
 } as const satisfies Record<
   (typeof BUNDLED_TYPED_HOOK_REGISTRATION_FILES)[number],
   readonly string[]


### PR DESCRIPTION
No linked issue. This is a narrow Android settings usability improvement.

## What Problem This Solves

Android users could see the Cron Jobs settings summary and list, but tapping a cron job did not open the job itself. That made it hard to inspect the schedule, payload, delivery state, or copy the job id when discussing a cron job in chat or support.

## Why This Change Was Made

This adds an Android-only cron job detail view that uses the existing `cron.get` gateway method. The view stays read-only: it does not add cron editing, new gateway methods, protocol changes, auth scopes, or command actions.

The cron job id row is now copyable, with a copy affordance and a toast, so users can quickly reference the exact job id elsewhere.

## User Impact

Users can now open `Settings > Cron Jobs`, tap a scheduled job, inspect the gateway-provided details, copy the cron job id, refresh the detail view, and use either the toolbar back button or Android system back to return to the Cron Jobs list.

## Evidence

Redacted local Android emulator proof against a running OpenClaw gateway:

| View | What it proves | Proof |
| --- | --- | --- |
| Cron Jobs list | Cron jobs render as tappable rows with status and chevrons. Private cron names/prompts are redacted. | ![Cron Jobs list](https://raw.githubusercontent.com/Tosko4/openclaw/7ba5a7fa1535238bf81db792c426b2d57e8cc9dd/proof/android-cron-detail/cron-list-redacted.png) |
| Cron job detail | Tapping a row opens the read-only `cron.get` detail view. Private title/id are redacted. | ![Cron job detail](https://raw.githubusercontent.com/Tosko4/openclaw/7ba5a7fa1535238bf81db792c426b2d57e8cc9dd/proof/android-cron-detail/cron-detail-redacted.png) |
| Copy id affordance | The ID row exposes a copy icon and `Tap to copy`; Android clipboard preview is redacted. | ![Copy cron id](https://raw.githubusercontent.com/Tosko4/openclaw/7ba5a7fa1535238bf81db792c426b2d57e8cc9dd/proof/android-cron-detail/cron-copy-redacted.png) |
| System back | Android system back from detail returns to the Cron Jobs list instead of Settings home. Private cron names/prompts are redacted. | ![System back returns to list](https://raw.githubusercontent.com/Tosko4/openclaw/7ba5a7fa1535238bf81db792c426b2d57e8cc9dd/proof/android-cron-detail/cron-system-back-redacted.png) |

Validation run after rebasing onto current `upstream/main`:

```text
ANDROID_HOME=/home/nabu/Android/Sdk ./gradlew :app:testThirdPartyDebugUnitTest --no-daemon --stacktrace
ANDROID_HOME=/home/nabu/Android/Sdk ./gradlew :app:assembleThirdPartyDebug --no-daemon --stacktrace
git diff --check
/home/nabu/.openclaw/workspace/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
```

All four checks passed.

Additional note: `:app:ktlintMainSourceSetCheck` was attempted, but it is currently blocked by pre-existing unrelated ktlint violations in `ChatController.kt` and `ChatScreen.kt` that are outside this Android cron detail patch.

AI-assisted: implemented and validated with Codex, then manually inspected and tested in a local Android/OpenClaw setup.
