### PR TITLE
fix(memory): abort batch upload response reads

### DIFF
--- a/packages/memory-host-sdk/src/host/batch-upload.test.ts
+++ b/packages/memory-host-sdk/src/host/batch-upload.test.ts
@@ -32,16 +32,20 @@ function streamingTextResponse(params: {
 }
 
 function stallingResponse(params: { status: number; onCancel: () => void }): Response {
-  const stream = new ReadableStream<Uint8Array>({
-    start() {
-      // Leave the body open until the caller aborts.
-    },
-    cancel() {
+  const reader = {
+    read: () => new Promise<ReadableStreamReadResult<Uint8Array>>(() => {}),
+    cancel: async () => {
       params.onCancel();
     },
-  });
+    releaseLock: () => undefined,
+  } as ReadableStreamDefaultReader<Uint8Array>;
 
-  return new Response(stream, { status: params.status });
+  return {
+    status: params.status,
+    ok: params.status >= 200 && params.status < 300,
+    headers: new Headers(),
+    body: { getReader: () => reader },
+  } as Response;
 }
 
 describe("uploadBatchJsonlFile", () => {

--- a/packages/memory-host-sdk/src/host/batch-upload.test.ts
+++ b/packages/memory-host-sdk/src/host/batch-upload.test.ts
@@ -31,6 +31,19 @@ function streamingTextResponse(params: {
   return new Response(stream, { status: params.status, headers: params.headers });
 }
 
+function stallingResponse(params: { status: number; onCancel: () => void }): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start() {
+      // Leave the body open until the caller aborts.
+    },
+    cancel() {
+      params.onCancel();
+    },
+  });
+
+  return new Response(stream, { status: params.status });
+}
+
 describe("uploadBatchJsonlFile", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -107,5 +120,71 @@ describe("uploadBatchJsonlFile", () => {
       }),
     ).rejects.toThrow("file upload failed: response body too large: 64 bytes (limit: 8 bytes)");
     expect(canceled).toBe(true);
+  });
+
+  it("passes caller abort signals through non-ok file-upload response snippets", async () => {
+    let canceled = false;
+    remoteHttpMock.mockImplementationOnce(async (params) => {
+      return await params.onResponse(
+        stallingResponse({
+          status: 500,
+          onCancel: () => {
+            canceled = true;
+          },
+        }),
+      );
+    });
+    const controller = new AbortController();
+    const upload = uploadBatchJsonlFile({
+      client: {
+        baseUrl: "https://memory.example/v1",
+        headers: { Authorization: "Bearer test" },
+      },
+      requests: [{ input: "one" }],
+      errorPrefix: "file upload failed",
+      signal: controller.signal,
+    });
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    controller.abort(new Error("upload aborted"));
+
+    await expect(upload).rejects.toThrow("upload aborted");
+    expect(canceled).toBe(true);
+    expect(remoteHttpMock.mock.calls[0]?.[0].signal).toBe(controller.signal);
+  });
+
+  it("passes caller abort signals through successful file-upload JSON reads", async () => {
+    let canceled = false;
+    remoteHttpMock.mockImplementationOnce(async (params) => {
+      return await params.onResponse(
+        stallingResponse({
+          status: 200,
+          onCancel: () => {
+            canceled = true;
+          },
+        }),
+      );
+    });
+    const controller = new AbortController();
+    const upload = uploadBatchJsonlFile({
+      client: {
+        baseUrl: "https://memory.example/v1",
+        headers: { Authorization: "Bearer test" },
+      },
+      requests: [{ input: "one" }],
+      errorPrefix: "file upload failed",
+      signal: controller.signal,
+    });
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    controller.abort(new Error("upload json aborted"));
+
+    await expect(upload).rejects.toThrow("upload json aborted");
+    expect(canceled).toBe(true);
+    expect(remoteHttpMock.mock.calls[0]?.[0].signal).toBe(controller.signal);
   });
 });

--- a/packages/memory-host-sdk/src/host/batch-upload.ts
+++ b/packages/memory-host-sdk/src/host/batch-upload.ts
@@ -16,6 +16,7 @@ export async function uploadBatchJsonlFile(params: {
   requests: unknown[];
   errorPrefix: string;
   maxResponseBytes?: number;
+  signal?: AbortSignal;
 }): Promise<string> {
   const baseUrl = normalizeBatchBaseUrl(params.client);
   const jsonl = params.requests.map((request) => JSON.stringify(request)).join("\n");
@@ -31,6 +32,7 @@ export async function uploadBatchJsonlFile(params: {
     url: `${baseUrl}/files`,
     ssrfPolicy: params.client.ssrfPolicy,
     fetchImpl: params.client.fetchImpl,
+    signal: params.signal,
     init: {
       method: "POST",
       headers: buildBatchHeaders(params.client, { json: false }),
@@ -38,12 +40,13 @@ export async function uploadBatchJsonlFile(params: {
     },
     onResponse: async (fileRes) => {
       if (!fileRes.ok) {
-        const text = await readResponseTextSnippet(fileRes);
+        const text = await readResponseTextSnippet(fileRes, { signal: params.signal });
         throw new Error(`${params.errorPrefix}: ${fileRes.status} ${text}`);
       }
       return (await readResponseJsonWithLimit(fileRes, {
         errorPrefix: params.errorPrefix,
         maxBytes: params.maxResponseBytes,
+        signal: params.signal,
       })) as { id?: string };
     },
   });


### PR DESCRIPTION
Summary
- Add an optional caller abort signal to `uploadBatchJsonlFile`.
- Thread the signal through guarded remote fetch, non-OK response snippets, and successful JSON response reads.
- Cover abort propagation for stalled file-upload error bodies and stalled successful JSON bodies.

Verification
- `node --check --experimental-strip-types packages/memory-host-sdk/src/host/batch-upload.ts`
- `node --check --experimental-strip-types packages/memory-host-sdk/src/host/batch-upload.test.ts`
- `git diff --check`
- Fresh autoreview: no actionable findings

Proof gaps
- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/batch-upload.test.ts` is blocked in this Codex worktree because `node_modules` is absent (`OPENCLAW_MISSING_VITEST`); dependencies were not installed in the Codex worktree.
