### PR TITLE
fix(memory): keep cleaning reindex sidecars after lock errors

### DIFF
--- a/extensions/memory-core/src/memory/manager-db.test.ts
+++ b/extensions/memory-core/src/memory/manager-db.test.ts
@@ -1,4 +1,5 @@
 // Memory Core tests cover shared agent database publication and shadow cleanup.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -7,11 +8,12 @@ import {
   ensureMemoryIndexSchema,
   loadSqliteVecExtension,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   cleanupAgedMemoryReindexTempFiles,
   publishMemoryDatabaseTables,
   readMemoryDatabaseRevision,
+  removeMemoryDatabaseFiles,
 } from "./manager-db.js";
 import { acquireMemoryReindexLock } from "./manager-reindex-lock.js";
 
@@ -35,6 +37,7 @@ describe("memory manager database publication", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await fs.rm(fixtureRoot, { recursive: true, force: true });
   });
 
@@ -233,5 +236,28 @@ describe("memory manager database publication", () => {
     await expectPathMissing(`${oldShadow}-journal`);
     await expectPathMissing(lockedShadow);
     await expect(fs.access(youngShadow)).resolves.toBeUndefined();
+  });
+
+  it("continues removing shadow sidecars after one cleanup failure", () => {
+    const databasePath = path.join(fixtureRoot, "agent.sqlite.memory-reindex-shadow");
+    const removedPaths: string[] = [];
+    const lockedError = Object.assign(new Error("EBUSY: resource busy or locked"), {
+      code: "EBUSY",
+    });
+    vi.spyOn(fsSync, "rmSync").mockImplementation((filePath) => {
+      const resolvedPath = String(filePath);
+      removedPaths.push(resolvedPath);
+      if (resolvedPath.endsWith("-wal")) {
+        throw lockedError;
+      }
+    });
+
+    expect(() => removeMemoryDatabaseFiles(databasePath)).toThrow("EBUSY");
+    expect(removedPaths).toEqual([
+      databasePath,
+      `${databasePath}-wal`,
+      `${databasePath}-shm`,
+      `${databasePath}-journal`,
+    ]);
   });
 });

--- a/extensions/memory-core/src/memory/manager-db.test.ts
+++ b/extensions/memory-core/src/memory/manager-db.test.ts
@@ -238,7 +238,7 @@ describe("memory manager database publication", () => {
     await expect(fs.access(youngShadow)).resolves.toBeUndefined();
   });
 
-  it("reports the first aged orphan cleanup error after attempting every sidecar", async () => {
+  it("keeps aged orphan cleanup best-effort after sidecar errors", async () => {
     const databasePath = path.join(fixtureRoot, "agent.sqlite");
     const database = new DatabaseSync(databasePath);
     database.close();
@@ -267,7 +267,7 @@ describe("memory manager database publication", () => {
       }
     });
 
-    expect(() => cleanupAgedMemoryReindexTempFiles(databasePath)).toThrow("EBUSY");
+    expect(() => cleanupAgedMemoryReindexTempFiles(databasePath)).not.toThrow();
     expect(removedPaths).toEqual([
       oldShadow,
       `${oldShadow}-wal`,

--- a/extensions/memory-core/src/memory/manager-db.test.ts
+++ b/extensions/memory-core/src/memory/manager-db.test.ts
@@ -238,6 +238,44 @@ describe("memory manager database publication", () => {
     await expect(fs.access(youngShadow)).resolves.toBeUndefined();
   });
 
+  it("reports the first aged orphan cleanup error after attempting every sidecar", async () => {
+    const databasePath = path.join(fixtureRoot, "agent.sqlite");
+    const database = new DatabaseSync(databasePath);
+    database.close();
+    const oldShadow = `${databasePath}.memory-reindex-11111111-2222-3333-4444-555555555555`;
+    const old = new Date(Date.now() - 48 * 60 * 60_000);
+    for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+      await fs.writeFile(`${oldShadow}${suffix}`, "orphan");
+      await fs.utimes(`${oldShadow}${suffix}`, old, old);
+    }
+
+    const removedPaths: string[] = [];
+    const lockedError = Object.assign(new Error("EBUSY: resource busy or locked"), {
+      code: "EBUSY",
+    });
+    const laterError = Object.assign(new Error("EPERM: operation not permitted"), {
+      code: "EPERM",
+    });
+    vi.spyOn(fsSync, "rmSync").mockImplementation((filePath) => {
+      const resolvedPath = String(filePath);
+      removedPaths.push(resolvedPath);
+      if (resolvedPath.endsWith("-wal")) {
+        throw lockedError;
+      }
+      if (resolvedPath.endsWith("-journal")) {
+        throw laterError;
+      }
+    });
+
+    expect(() => cleanupAgedMemoryReindexTempFiles(databasePath)).toThrow("EBUSY");
+    expect(removedPaths).toEqual([
+      oldShadow,
+      `${oldShadow}-wal`,
+      `${oldShadow}-shm`,
+      `${oldShadow}-journal`,
+    ]);
+  });
+
   it("continues removing shadow sidecars after one cleanup failure", () => {
     const databasePath = path.join(fixtureRoot, "agent.sqlite.memory-reindex-shadow");
     const removedPaths: string[] = [];

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -54,6 +54,10 @@ function isRegularFile(filePath: string): boolean {
   }
 }
 
+function asError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
 function tableExists(db: DatabaseSync, schema: string, tableName: string): boolean {
   const row = db
     .prepare(`SELECT 1 AS ok FROM ${schema}.sqlite_master WHERE type = 'table' AND name = ?`)
@@ -205,12 +209,12 @@ export async function publishMemoryDatabaseTables(params: {
 
 /** Remove one closed shadow memory database and its journal-mode sidecars. */
 export function removeMemoryDatabaseFiles(dbPath: string): void {
-  let firstError: unknown;
+  let firstError: Error | undefined;
   for (const suffix of MEMORY_DATABASE_FILE_SUFFIXES) {
     try {
       fs.rmSync(`${dbPath}${suffix}`, { force: true });
     } catch (err) {
-      firstError ??= err;
+      firstError ??= asError(err);
     }
   }
   if (firstError) {
@@ -255,7 +259,7 @@ export function cleanupAgedMemoryReindexTempFiles(dbPath: string, nowMs = Date.n
       }
     }
 
-    let firstCleanupError: unknown;
+    let firstCleanupError: Error | undefined;
     for (const shadowBaseName of shadowBaseNames) {
       const filePaths = MEMORY_DATABASE_FILE_SUFFIXES.map((suffix) =>
         path.join(dir, `${shadowBaseName}${suffix}`),
@@ -284,7 +288,7 @@ export function cleanupAgedMemoryReindexTempFiles(dbPath: string, nowMs = Date.n
       try {
         removeMemoryDatabaseFiles(path.join(dir, shadowBaseName));
       } catch (err) {
-        firstCleanupError ??= err;
+        firstCleanupError ??= asError(err);
       }
     }
     if (firstCleanupError) {

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -255,6 +255,7 @@ export function cleanupAgedMemoryReindexTempFiles(dbPath: string, nowMs = Date.n
       }
     }
 
+    let firstCleanupError: unknown;
     for (const shadowBaseName of shadowBaseNames) {
       const filePaths = MEMORY_DATABASE_FILE_SUFFIXES.map((suffix) =>
         path.join(dir, `${shadowBaseName}${suffix}`),
@@ -280,11 +281,14 @@ export function cleanupAgedMemoryReindexTempFiles(dbPath: string, nowMs = Date.n
       ) {
         continue;
       }
-      for (const filePath of filePaths) {
-        try {
-          fs.rmSync(filePath, { force: true });
-        } catch {}
+      try {
+        removeMemoryDatabaseFiles(path.join(dir, shadowBaseName));
+      } catch (err) {
+        firstCleanupError ??= err;
       }
+    }
+    if (firstCleanupError) {
+      throw firstCleanupError;
     }
   } finally {
     try {

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -205,8 +205,16 @@ export async function publishMemoryDatabaseTables(params: {
 
 /** Remove one closed shadow memory database and its journal-mode sidecars. */
 export function removeMemoryDatabaseFiles(dbPath: string): void {
+  let firstError: unknown;
   for (const suffix of MEMORY_DATABASE_FILE_SUFFIXES) {
-    fs.rmSync(`${dbPath}${suffix}`, { force: true });
+    try {
+      fs.rmSync(`${dbPath}${suffix}`, { force: true });
+    } catch (err) {
+      firstError ??= err;
+    }
+  }
+  if (firstError) {
+    throw firstError;
   }
 }
 

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -259,7 +259,6 @@ export function cleanupAgedMemoryReindexTempFiles(dbPath: string, nowMs = Date.n
       }
     }
 
-    let firstCleanupError: Error | undefined;
     for (const shadowBaseName of shadowBaseNames) {
       const filePaths = MEMORY_DATABASE_FILE_SUFFIXES.map((suffix) =>
         path.join(dir, `${shadowBaseName}${suffix}`),
@@ -287,12 +286,11 @@ export function cleanupAgedMemoryReindexTempFiles(dbPath: string, nowMs = Date.n
       }
       try {
         removeMemoryDatabaseFiles(path.join(dir, shadowBaseName));
-      } catch (err) {
-        firstCleanupError ??= asError(err);
+      } catch {
+        // This is startup preflight for stale crash leftovers. A locked old
+        // sidecar should not block the new full reindex from doing useful work.
+        continue;
       }
-    }
-    if (firstCleanupError) {
-      throw firstCleanupError;
     }
   } finally {
     try {


### PR DESCRIPTION
## What Problem This Solves

Refs #78640.

#94646 already removed the old full-file `renameWithRetry` publish path that made `openclaw memory index --force` fail on Windows when the live SQLite file could not be renamed. Current main now builds a per-agent shadow database and publishes memory-owned tables back into the live agent database.

This PR hardens the remaining cleanup edge in that current-main path: if Windows or the filesystem reports an error while deleting one closed `.memory-reindex-*` shadow sidecar, OpenClaw should still attempt to delete the other sidecars instead of stopping at the first failed suffix.

## Why This Change Was Made

`removeMemoryDatabaseFiles` previously called `fs.rmSync` in a loop and stopped on the first thrown error. That preserved the warning behavior at the caller, but it could leave unlocked sidecars behind when only one suffix was locked or otherwise failed deletion.

The helper now attempts every SQLite sidecar cleanup and then rethrows the first error so `runInPlaceReindex` still logs the cleanup failure exactly as before.

## User Impact

Users who hit transient Windows file locks during memory reindex shadow cleanup should accumulate fewer leftover `.memory-reindex-*` sidecars. The runtime publish semantics are unchanged: a cleanup failure still surfaces through the existing warning path, and the live memory index remains protected by the database-first publish flow from #94646.

## Evidence

Unit regression proof:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 ./node_modules/.bin/vitest run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-core/src/memory/manager-db.test.ts
```

Result: 1 file / 6 tests passed.

Real filesystem cleanup proof after this patch:

```bash
pnpm exec tsx -e '
import fs from "node:fs";
import os from "node:os";
import path from "node:path";
import { removeMemoryDatabaseFiles } from "./extensions/memory-core/src/memory/manager-db.ts";

const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-reindex-cleanup-proof-"));
const base = path.join(root, "agent.sqlite.memory-reindex-proof");
fs.writeFileSync(base, "main shadow");
fs.mkdirSync(`${base}-wal`);
fs.writeFileSync(`${base}-shm`, "shm shadow");
fs.writeFileSync(`${base}-journal`, "journal shadow");

try {
  removeMemoryDatabaseFiles(base);
  console.log("cleanup unexpectedly succeeded");
} catch (error) {
  console.log(`cleanup error code: ${(error as NodeJS.ErrnoException).code ?? error}`);
}

console.log(`base exists after cleanup: ${fs.existsSync(base)}`);
console.log(`wal directory exists after cleanup: ${fs.existsSync(`${base}-wal`)}`);
console.log(`shm exists after cleanup: ${fs.existsSync(`${base}-shm`)}`);
console.log(`journal exists after cleanup: ${fs.existsSync(`${base}-journal`)}`);
fs.rmSync(root, { recursive: true, force: true });
'
```

Output:

```text
cleanup error code: ERR_FS_EISDIR
base exists after cleanup: false
wal directory exists after cleanup: true
shm exists after cleanup: false
journal exists after cleanup: false
```

This is not a unit mock: it creates real shadow files on disk, makes the `-wal` sidecar fail deletion through the filesystem, then confirms cleanup continues and removes the later `-shm` and `-journal` sidecars before rethrowing the first error.

Other checks:

```bash
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Autoreview result: `autoreview clean: no accepted/actionable findings reported`.

Notes:

- Current main no longer has `extensions/memory-core/src/memory/manager-atomic-reindex.ts` or `renameWithRetry`; the old production rename failure from #78640 is superseded by #94646.
- I posted this current-main proof on #78640, but this token does not have permission to close the issue.
- I did not include an agent transcript because a local candidate was found but transcript insertion requires explicit user approval.
