### PR TITLE
fix(test): stabilize tooling guard probes

### DIFF
--- a/scripts/e2e/kitchen-sink-rpc-walk.mjs
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mjs
@@ -996,25 +996,31 @@ export async function readBoundedResponseText(response, byteLimit, timeoutPromis
   }
   const chunks = [];
   let totalBytes = 0;
-  for (;;) {
-    const read = reader.read();
-    const { done, value } = await withOptionalTimeout(
-      read,
-      timeoutPromise?.catch((error) => {
-        cancelReaderSoon(reader);
-        throw error;
-      }),
-    );
-    if (done) {
-      break;
+  try {
+    for (;;) {
+      const read = reader.read();
+      const { done, value } = await withOptionalTimeout(
+        read,
+        timeoutPromise?.catch((error) => {
+          cancelReaderSoon(reader);
+          throw error;
+        }),
+      );
+      if (done) {
+        break;
+      }
+      const chunk = Buffer.from(value);
+      totalBytes += chunk.byteLength;
+      if (totalBytes > resolvedByteLimit) {
+        await reader.cancel().catch(() => undefined);
+        throw createFetchBodyTooLargeError(resolvedByteLimit);
+      }
+      chunks.push(chunk);
     }
-    const chunk = Buffer.from(value);
-    totalBytes += chunk.byteLength;
-    if (totalBytes > resolvedByteLimit) {
-      await reader.cancel().catch(() => undefined);
-      throw createFetchBodyTooLargeError(resolvedByteLimit);
-    }
-    chunks.push(chunk);
+  } finally {
+    try {
+      reader.releaseLock?.();
+    } catch {}
   }
   return Buffer.concat(chunks, totalBytes).toString("utf8");
 }

--- a/test/scripts/kitchen-sink-rpc-walk.test.ts
+++ b/test/scripts/kitchen-sink-rpc-walk.test.ts
@@ -1976,6 +1976,30 @@ describe("kitchen-sink RPC process sampling", () => {
     );
   });
 
+  it("releases HTTP probe response stream readers after bounded reads", async () => {
+    const releaseLock = vi.fn();
+    const response = {
+      headers: new Headers(),
+      body: {
+        getReader() {
+          return {
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode("ok") })
+              .mockResolvedValueOnce({ done: true }),
+            releaseLock,
+          };
+        },
+      },
+      text: vi.fn(async () => "not read"),
+    };
+
+    await expect(readBoundedResponseText(response, 1024)).resolves.toBe("ok");
+
+    expect(releaseLock).toHaveBeenCalledOnce();
+    expect(response.text).not.toHaveBeenCalled();
+  });
+
   it("cancels stalled HTTP probe response streams when the timeout wins", async () => {
     let canceled = false;
     const timeoutError = Object.assign(new Error("fetch probe timed out"), {

--- a/test/scripts/security-sensitive-guard-workflow.test.ts
+++ b/test/scripts/security-sensitive-guard-workflow.test.ts
@@ -136,6 +136,8 @@ describe("security-sensitive guard workflow", () => {
   it("uses a dedicated checked-in script and detects the intended file surfaces", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
     const script = readFileSync("scripts/github/security-sensitive-guard.mjs", "utf8");
+    const sharedScript = readFileSync("scripts/github/guard-shared.mjs", "utf8");
+    const guardSources = `${script}\n${sharedScript}`;
 
     expect(workflow).toContain("scripts/github/security-sensitive-guard.mjs");
     expect(script).toContain('"security-sensitive-changed"');
@@ -143,7 +145,7 @@ describe("security-sensitive guard workflow", () => {
     expect(script).toContain(".env");
     expect(script).toContain("/allow-security-sensitive-change");
     expect(script).toContain("openclaw-secops");
-    expect(script).toContain("/memberships/");
+    expect(guardSources).toContain("/memberships/");
     expect(script).toContain("A later push requires a fresh approval.");
     expect(script).toContain("process.exitCode = 1");
   });


### PR DESCRIPTION
## Summary

- release the Kitchen Sink RPC probe response reader lock after bounded stream reads
- add focused coverage so the QA probe proves the reader is released without falling back to `response.text()`
- fix stale security-sensitive guard workflow coverage after the membership check moved into the shared guard helper

## Verification

- `node --check scripts/e2e/kitchen-sink-rpc-walk.mjs`
- `node --check --experimental-strip-types test/scripts/kitchen-sink-rpc-walk.test.ts`
- `node --check --experimental-strip-types test/scripts/security-sensitive-guard-workflow.test.ts`
- `git diff --check`
- Fresh autoreview: no actionable findings

`node scripts/run-vitest.mjs test/scripts/kitchen-sink-rpc-walk.test.ts` was not run locally because this Codex worktree has no `node_modules` and exits with `OPENCLAW_MISSING_VITEST`; dependencies were intentionally not installed in the Codex worktree.

The first exact-head CI release gate on `2823bd6f8da` failed in `checks-node-core-tooling` on unrelated stale guard workflow coverage (`test/scripts/security-sensitive-guard-workflow.test.ts` expected `/memberships/` in the security-sensitive guard script after the helper had moved to `scripts/github/guard-shared.mjs`). This PR now includes that narrow test fix.
