### PR TITLE
fix(ci): cancel stale CodeQL runs

### DIFF
--- a/.github/workflows/codeql-android-critical-security.yml
+++ b/.github/workflows/codeql-android-critical-security.yml
@@ -6,8 +6,8 @@ on:
     - cron: "0 7 * * *"
 
 concurrency:
-  group: codeql-android-critical-security-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.sha }}
-  cancel-in-progress: false
+  group: codeql-android-critical-security-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('manual-{0}', github.run_id) || format('ref-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'schedule' }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/codeql-android-critical-security.yml
+++ b/.github/workflows/codeql-android-critical-security.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: codeql-android-critical-security-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('manual-{0}', github.run_id) || format('ref-{0}', github.ref) }}
-  cancel-in-progress: ${{ github.event_name == 'schedule' }}
+  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -136,8 +136,8 @@ on:
     - cron: "30 6 * * *"
 
 concurrency:
-  group: codeql-critical-quality-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: codeql-critical-quality-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('manual-{0}', github.run_id) || github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('ref-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.event_name == 'schedule' }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -137,7 +137,7 @@ on:
 
 concurrency:
   group: codeql-critical-quality-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('manual-{0}', github.run_id) || github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('ref-{0}', github.ref) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.event_name == 'schedule' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/codeql-macos-critical-security.yml
+++ b/.github/workflows/codeql-macos-critical-security.yml
@@ -6,8 +6,8 @@ on:
     - cron: "0 8 * * 1"
 
 concurrency:
-  group: codeql-macos-critical-security-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.sha }}
-  cancel-in-progress: false
+  group: codeql-macos-critical-security-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('manual-{0}', github.run_id) || format('ref-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'schedule' }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/codeql-macos-critical-security.yml
+++ b/.github/workflows/codeql-macos-critical-security.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: codeql-macos-critical-security-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('manual-{0}', github.run_id) || format('ref-{0}', github.ref) }}
-  cancel-in-progress: ${{ github.event_name == 'schedule' }}
+  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,8 +32,8 @@ on:
     - cron: "0 6 * * *"
 
 concurrency:
-  group: codeql-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: codeql-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('manual-{0}', github.run_id) || github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('ref-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.event_name == 'schedule' }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ on:
 
 concurrency:
   group: codeql-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('manual-{0}', github.run_id) || github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('ref-{0}', github.ref) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.event_name == 'schedule' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"


### PR DESCRIPTION
## Summary
- switch CodeQL concurrency groups from SHA-based fallback keys to event-aware manual, PR, and ref keys
- keep PR CodeQL cancellation behavior while allowing an already-running default-branch scan to finish
- collapse stale queued default-branch and scheduled CodeQL runs into the latest pending run instead of accumulating one queue item per commit

## Verification
- `git diff --check -- .github/workflows/codeql.yml .github/workflows/codeql-critical-quality.yml .github/workflows/codeql-android-critical-security.yml .github/workflows/codeql-macos-critical-security.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/codeql.yml .github/workflows/codeql-critical-quality.yml .github/workflows/codeql-android-critical-security.yml .github/workflows/codeql-macos-critical-security.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/codeql.yml .github/workflows/codeql-critical-quality.yml .github/workflows/codeql-android-critical-security.yml .github/workflows/codeql-macos-critical-security.yml`
