### PR TITLE
feat(release): add stable plugin support

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -73,6 +73,26 @@ on:
         required: false
         default: ""
         type: string
+      stable_plugin_targets_json:
+        description: Stable plugin target rows for suite_profile=stable-plugin package proof
+        required: false
+        default: ""
+        type: string
+      stable_plugin_package_specs:
+        description: Newline-delimited exact stable plugin package specs for Docker package proof
+        required: false
+        default: ""
+        type: string
+      stable_plugin_package_tarballs_json:
+        description: JSON object mapping stable plugin package names to workspace-relative tarball metadata
+        required: false
+        default: "{}"
+        type: string
+      stable_plugin_support_sha256:
+        description: Canonical SHA-256 for release/stable-plugin-support.json
+        required: false
+        default: ""
+        type: string
       include_live_suites:
         description: Whether to run live-provider coverage
         required: false
@@ -185,6 +205,26 @@ on:
         type: string
       codex_plugin_spec:
         description: Optional Codex plugin install spec for the live package lane; blank packs extensions/codex from the selected ref
+        required: false
+        default: ""
+        type: string
+      stable_plugin_targets_json:
+        description: Stable plugin target rows for suite_profile=stable-plugin package proof
+        required: false
+        default: ""
+        type: string
+      stable_plugin_package_specs:
+        description: Newline-delimited exact stable plugin package specs for Docker package proof
+        required: false
+        default: ""
+        type: string
+      stable_plugin_package_tarballs_json:
+        description: JSON object mapping stable plugin package names to workspace-relative tarball metadata
+        required: false
+        default: "{}"
+        type: string
+      stable_plugin_support_sha256:
+        description: Canonical SHA-256 for release/stable-plugin-support.json
         required: false
         default: ""
         type: string
@@ -730,6 +770,10 @@ jobs:
       OPENCLAW_DOCKER_E2E_SELECTED_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
       OPENCLAW_DOCKER_ALL_RELEASE_PROFILE: ${{ inputs.release_test_profile }}
       OPENCLAW_CODEX_NPM_PLUGIN_SPEC: ${{ inputs.codex_plugin_spec }}
+      OPENCLAW_STABLE_PLUGIN_TARGETS_JSON: ${{ inputs.stable_plugin_targets_json }}
+      OPENCLAW_STABLE_PLUGIN_PACKAGE_SPECS: ${{ inputs.stable_plugin_package_specs }}
+      OPENCLAW_STABLE_PLUGIN_PACKAGE_TARBALLS_JSON: ${{ inputs.stable_plugin_package_tarballs_json }}
+      OPENCLAW_STABLE_PLUGIN_SUPPORT_SHA256: ${{ inputs.stable_plugin_support_sha256 }}
       OPENCLAW_CURRENT_PACKAGE_TGZ: .artifacts/docker-e2e-package/openclaw-current.tgz
       OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC: ${{ inputs.published_upgrade_survivor_baseline }}
       OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS: ${{ inputs.published_upgrade_survivor_baselines }}
@@ -1139,6 +1183,168 @@ jobs:
           export OPENCLAW_DOCKER_ALL_BUILD=0
 
           node .release-harness/scripts/test-docker-all.mjs
+
+      - name: Write stable plugin Docker package proof
+        if: inputs.stable_plugin_support_sha256 != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          proof_dir=".artifacts/docker-tests/targeted-${{ steps.plan.outputs.artifact_suffix }}"
+          input_dir=".artifacts/docker-tests/stable-plugin-proof-input"
+          mkdir -p "${proof_dir}" "${input_dir}"
+
+          targets_path="${input_dir}/targets.json"
+          specs_path="${input_dir}/package-specs.txt"
+          tarballs_path="${input_dir}/package-tarballs.json"
+          inspector_path="${input_dir}/inspect-stable-plugin-packages.mjs"
+          proof_path="${proof_dir}/stable-plugin-docker-proof.json"
+
+          printf '%s\n' "${OPENCLAW_STABLE_PLUGIN_TARGETS_JSON}" > "${targets_path}"
+          printf '%s\n' "${OPENCLAW_STABLE_PLUGIN_PACKAGE_SPECS}" > "${specs_path}"
+          printf '%s\n' "${OPENCLAW_STABLE_PLUGIN_PACKAGE_TARBALLS_JSON:-[]}" > "${tarballs_path}"
+
+          cat > "${inspector_path}" <<'NODE'
+          import { execFileSync } from "node:child_process";
+          import { createHash } from "node:crypto";
+          import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+          import { dirname, join } from "node:path";
+          import { tmpdir } from "node:os";
+
+          const targets = JSON.parse(readFileSync(process.env.STABLE_PLUGIN_TARGETS_PATH, "utf8"));
+          const packageSpecs = readFileSync(process.env.STABLE_PLUGIN_PACKAGE_SPECS_PATH, "utf8")
+            .split(/\r?\n/u)
+            .map((line) => line.trim())
+            .filter(Boolean);
+          const tarballs = JSON.parse(readFileSync(process.env.STABLE_PLUGIN_TARBALLS_PATH, "utf8"));
+          if (!Array.isArray(targets) || targets.length === 0) {
+            throw new Error("stable plugin Docker proof requires non-empty targets");
+          }
+          if (!tarballs || typeof tarballs !== "object" || Array.isArray(tarballs)) {
+            throw new Error("stable plugin tarballs metadata must be an object keyed by package name");
+          }
+          const expectedSpecs = targets.map((target) => target.targetNpmSpec).sort();
+          if (JSON.stringify([...packageSpecs].sort()) !== JSON.stringify(expectedSpecs)) {
+            throw new Error("stable plugin Docker proof package specs do not match targets");
+          }
+          const expectedPackageNames = targets.map((target) => target.packageName).sort();
+          if (JSON.stringify(Object.keys(tarballs).sort()) !== JSON.stringify(expectedPackageNames)) {
+            throw new Error("stable plugin Docker proof tarball metadata does not match targets");
+          }
+
+          const packagePath = (packageName) => join(...packageName.split("/"));
+          const pluginProofs = targets.map((target) => {
+            const installDir = mkdtempSync(join(tmpdir(), "openclaw-stable-plugin-"));
+            const tarball = tarballs[target.packageName];
+            if (!tarball || typeof tarball !== "object") {
+              throw new Error(`stable plugin Docker proof tarball metadata is missing for ${target.packageName}`);
+            }
+            if (tarball.packageName !== target.packageName || tarball.version !== target.targetVersion) {
+              throw new Error(`stable plugin Docker proof tarball metadata mismatch for ${target.packageName}`);
+            }
+            if (
+              typeof tarball.path !== "string" ||
+              tarball.path.length === 0 ||
+              tarball.path.startsWith("/") ||
+              tarball.path.split("/").includes("..")
+            ) {
+              throw new Error(`stable plugin Docker proof tarball path must be workspace-relative for ${target.packageName}`);
+            }
+            if (typeof tarball.sha256 !== "string" || !/^[a-f0-9]{64}$/u.test(tarball.sha256)) {
+              throw new Error(`stable plugin Docker proof tarball sha256 is invalid for ${target.packageName}`);
+            }
+            const tarballPath = join(process.env.OPENCLAW_WORKSPACE_IN_CONTAINER ?? "/workspace", tarball.path);
+            if (!existsSync(tarballPath)) {
+              throw new Error(`stable plugin Docker proof tarball is missing for ${target.packageName}: ${tarball.path}`);
+            }
+            const observedSha256 = createHash("sha256").update(readFileSync(tarballPath)).digest("hex");
+            if (observedSha256 !== tarball.sha256) {
+              throw new Error(`stable plugin Docker proof tarball sha256 mismatch for ${target.packageName}`);
+            }
+            execFileSync(
+              "npm",
+              [
+                "install",
+                "--prefix",
+                installDir,
+                "--no-audit",
+                "--fund=false",
+                tarballPath,
+              ],
+              { stdio: "pipe" },
+            );
+            const packageJsonPath = join(
+              installDir,
+              "node_modules",
+              packagePath(target.packageName),
+              "package.json",
+            );
+            const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+            if (packageJson.name !== target.packageName) {
+              throw new Error(
+                `stable plugin Docker proof package name mismatch for ${target.packageName}: ${packageJson.name}`,
+              );
+            }
+            if (packageJson.version !== target.targetVersion) {
+              throw new Error(
+                `stable plugin Docker proof version mismatch for ${target.packageName}: ${packageJson.version}`,
+              );
+            }
+            return {
+              packageName: target.packageName,
+              pluginId: target.pluginId,
+              targetVersion: target.targetVersion,
+              targetNpmSpec: target.targetNpmSpec,
+              stableLine: target.stableLine,
+              stablePluginSupportSha256: process.env.STABLE_PLUGIN_SUPPORT_SHA256,
+              observedPackageName: packageJson.name,
+              observedVersion: packageJson.version,
+              source: "docker-npm-install",
+              installSource: "tarball",
+              tarballPath: tarball.path,
+              tarballSha256: observedSha256,
+              npmIntegrity: typeof tarball.integrity === "string" ? tarball.integrity : "",
+              result: "passed",
+            };
+          });
+
+          const outputPath = process.env.STABLE_PLUGIN_PROOF_PATH;
+          mkdirSync(dirname(outputPath), { recursive: true });
+          writeFileSync(
+            outputPath,
+            `${JSON.stringify(
+              {
+                schemaVersion: 1,
+                result: "passed",
+                stablePluginSupportSha256: process.env.STABLE_PLUGIN_SUPPORT_SHA256,
+                dockerImage: process.env.OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE,
+                dockerLanes: (process.env.DOCKER_E2E_LANES ?? "")
+                  .split(/[,\s]+/u)
+                  .map((lane) => lane.trim())
+                  .filter(Boolean),
+                completedAt: new Date().toISOString(),
+                pluginProofs,
+              },
+              null,
+              2,
+            )}\n`,
+          );
+          NODE
+
+          docker run --rm \
+            -v "${PWD}/.artifacts/docker-tests:/proof" \
+            -v "${PWD}:/workspace:ro" \
+            -e STABLE_PLUGIN_TARGETS_PATH=/proof/stable-plugin-proof-input/targets.json \
+            -e STABLE_PLUGIN_PACKAGE_SPECS_PATH=/proof/stable-plugin-proof-input/package-specs.txt \
+            -e STABLE_PLUGIN_TARBALLS_PATH=/proof/stable-plugin-proof-input/package-tarballs.json \
+            -e STABLE_PLUGIN_PROOF_PATH="/proof/targeted-${{ steps.plan.outputs.artifact_suffix }}/stable-plugin-docker-proof.json" \
+            -e STABLE_PLUGIN_SUPPORT_SHA256="${OPENCLAW_STABLE_PLUGIN_SUPPORT_SHA256}" \
+            -e OPENCLAW_WORKSPACE_IN_CONTAINER=/workspace \
+            -e OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE="${OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE}" \
+            -e DOCKER_E2E_LANES="${DOCKER_E2E_LANES}" \
+            "${OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE}" \
+            node /proof/stable-plugin-proof-input/inspect-stable-plugin-packages.mjs
+
+          test -f "${proof_path}"
 
       - name: Summarize targeted Docker E2E lanes
         if: always()

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -32,6 +32,7 @@ on:
         options:
           - alpha
           - beta
+          - stable
           - latest
 
 concurrency:
@@ -77,6 +78,10 @@ jobs:
           fi
           if [[ "${RELEASE_REF}" == *"-beta."* && "${RELEASE_NPM_DIST_TAG}" != "beta" ]]; then
             echo "Beta prerelease tags must publish to npm dist-tag beta."
+            exit 1
+          fi
+          if [[ "${RELEASE_REF}" != *"-alpha."* && "${RELEASE_REF}" != *"-beta."* && ! "${RELEASE_REF}" =~ ^[0-9a-fA-F]{40}$ && "${RELEASE_NPM_DIST_TAG}" == "latest" ]]; then
+            echo "Stable OpenClaw releases must publish to npm dist-tag stable; latest remains owned by the daily line."
             exit 1
           fi
 
@@ -406,8 +411,12 @@ jobs:
           if [[ "${RELEASE_TAG}" == *"-alpha."* && "${RELEASE_NPM_DIST_TAG}" == "alpha" && "${WORKFLOW_REF}" =~ ^refs/heads/tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
             tideclaw_alpha_publish=true
           fi
-          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]] && [[ ! "${WORKFLOW_REF}" =~ ^refs/heads/release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ ]] && [[ "${tideclaw_alpha_publish}" != "true" ]]; then
-            echo "Real publish runs must be dispatched from main, release/YYYY.M.PATCH, or a Tideclaw alpha branch for alpha prereleases. Use preflight_only=true for other branch validation."
+          stable_publish=false
+          if [[ "${RELEASE_TAG}" != *"-alpha."* && "${RELEASE_TAG}" != *"-beta."* && "${RELEASE_NPM_DIST_TAG}" == "stable" && "${WORKFLOW_REF}" =~ ^refs/heads/stable/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ ]]; then
+            stable_publish=true
+          fi
+          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]] && [[ ! "${WORKFLOW_REF}" =~ ^refs/heads/release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ ]] && [[ "${stable_publish}" != "true" ]] && [[ "${tideclaw_alpha_publish}" != "true" ]]; then
+            echo "Real publish runs must be dispatched from main, release/YYYY.M.PATCH, stable/YYYY.M.PATCH for stable publishes, or a Tideclaw alpha branch for alpha prereleases. Use preflight_only=true for other branch validation."
             exit 1
           fi
 
@@ -488,6 +497,10 @@ jobs:
           fi
           if [[ "${RELEASE_TAG}" == *"-beta."* && "${RELEASE_NPM_DIST_TAG}" != "beta" ]]; then
             echo "Beta prerelease tags must publish to npm dist-tag beta."
+            exit 1
+          fi
+          if [[ "${RELEASE_TAG}" != *"-alpha."* && "${RELEASE_TAG}" != *"-beta."* && "${RELEASE_NPM_DIST_TAG}" == "latest" ]]; then
+            echo "Stable OpenClaw releases must publish to npm dist-tag stable; latest remains owned by the daily line."
             exit 1
           fi
 

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -35,6 +35,7 @@ on:
         options:
           - alpha
           - beta
+          - stable
           - latest
       plugin_publish_scope:
         description: Plugin publish scope to run before OpenClaw publish
@@ -44,8 +45,35 @@ on:
         options:
           - selected
           - all-publishable
+          - stable-manifest
       plugins:
         description: Comma-separated plugin package names when plugin_publish_scope=selected
+        required: false
+        type: string
+      release_class:
+        description: Release class for selector-aware plugin publishes
+        required: true
+        default: daily
+        type: choice
+        options:
+          - daily
+          - stable-base
+          - stable-patch
+      stable_line:
+        description: Stable line month for stable-manifest plugin publish, for example 2026.6
+        required: false
+        type: string
+      stable_plugin_manifest_sha256:
+        description: SHA-256 digest for release/stable-plugin-support.json
+        required: false
+        type: string
+      stable_plugin_manifest_artifact:
+        description: Artifact name to upload and pass to Plugin NPM Release for stable manifest mode
+        required: false
+        default: stable-plugin-support
+        type: string
+      package_acceptance_run_id:
+        description: Successful Package Acceptance stable-plugin run id matching stable_plugin_manifest_sha256
         required: false
         type: string
       publish_openclaw_npm:
@@ -101,6 +129,10 @@ jobs:
           PUBLISH_OPENCLAW_NPM: ${{ inputs.publish_openclaw_npm && 'true' || 'false' }}
           PLUGIN_PUBLISH_SCOPE: ${{ inputs.plugin_publish_scope }}
           PLUGINS: ${{ inputs.plugins }}
+          RELEASE_CLASS: ${{ inputs.release_class }}
+          STABLE_LINE: ${{ inputs.stable_line }}
+          STABLE_PLUGIN_MANIFEST_SHA256: ${{ inputs.stable_plugin_manifest_sha256 }}
+          PACKAGE_ACCEPTANCE_RUN_ID: ${{ inputs.package_acceptance_run_id }}
           RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
           RELEASE_PROFILE: ${{ inputs.release_profile }}
           WORKFLOW_REF: ${{ github.ref }}
@@ -126,9 +158,9 @@ jobs:
             echo "publish_openclaw_npm=true requires full_release_validation_run_id." >&2
             exit 1
           fi
-          stable_release=true
-          if [[ "${RELEASE_TAG}" == *"-alpha."* || "${RELEASE_TAG}" == *"-beta."* ]]; then
-            stable_release=false
+          stable_release=false
+          if [[ "${RELEASE_CLASS}" == "stable-base" || "${RELEASE_CLASS}" == "stable-patch" ]]; then
+            stable_release=true
           fi
           if [[ -n "${WINDOWS_NODE_TAG}" && ! "${WINDOWS_NODE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
             echo "windows_node_tag must be an explicit openclaw-windows-node release tag, not latest: ${WINDOWS_NODE_TAG}" >&2
@@ -146,20 +178,57 @@ jobs:
           if [[ "${RELEASE_TAG}" == *"-alpha."* && "${RELEASE_NPM_DIST_TAG}" == "alpha" && "${WORKFLOW_REF}" =~ ^refs/heads/tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
             tideclaw_alpha_publish=true
           fi
-          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${WORKFLOW_REF}" != "refs/heads/main" && ! "${WORKFLOW_REF}" =~ ^refs/heads/release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ && "${tideclaw_alpha_publish}" != "true" ]]; then
-            echo "publish_openclaw_npm=true requires dispatching this workflow from main, release/YYYY.M.PATCH, or a Tideclaw alpha branch for alpha prereleases." >&2
+          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${WORKFLOW_REF}" != "refs/heads/main" && ! "${WORKFLOW_REF}" =~ ^refs/heads/release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ && ! "${WORKFLOW_REF}" =~ ^refs/heads/stable/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ && "${tideclaw_alpha_publish}" != "true" ]]; then
+            echo "publish_openclaw_npm=true requires dispatching this workflow from main, release/YYYY.M.PATCH, stable/YYYY.M.PATCH, or a Tideclaw alpha branch for alpha prereleases." >&2
             exit 1
           fi
-          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${PLUGIN_PUBLISH_SCOPE}" != "all-publishable" ]]; then
-            echo "publish_openclaw_npm=true requires plugin_publish_scope=all-publishable so every publishable official plugin is released with OpenClaw." >&2
+          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${stable_release}" == "true" ]]; then
+            if [[ "${RELEASE_NPM_DIST_TAG}" != "stable" ]]; then
+              echo "Stable releases must publish OpenClaw to npm dist-tag stable; latest remains owned by the daily line." >&2
+              exit 1
+            fi
+            if [[ "${PLUGIN_PUBLISH_SCOPE}" != "stable-manifest" ]]; then
+              echo "Stable publish_openclaw_npm=true requires plugin_publish_scope=stable-manifest so only manifest-covered plugins are released before OpenClaw." >&2
+              exit 1
+            fi
+            if [[ "${RELEASE_CLASS}" != "stable-base" && "${RELEASE_CLASS}" != "stable-patch" ]]; then
+              echo "Stable publish requires release_class=stable-base or stable-patch." >&2
+              exit 1
+            fi
+            if [[ -z "${STABLE_LINE// }" ]]; then
+              echo "Stable publish requires stable_line." >&2
+              exit 1
+            fi
+            if [[ ! "${STABLE_PLUGIN_MANIFEST_SHA256#sha256:}" =~ ^[a-f0-9]{64}$ ]]; then
+              echo "Stable publish requires stable_plugin_manifest_sha256 as a lowercase SHA-256 digest." >&2
+              exit 1
+            fi
+            if [[ -z "${PACKAGE_ACCEPTANCE_RUN_ID// }" ]]; then
+              echo "Stable publish requires package_acceptance_run_id for suite_profile=stable-plugin proof." >&2
+              exit 1
+            fi
+          elif [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${PLUGIN_PUBLISH_SCOPE}" != "all-publishable" ]]; then
+            echo "Daily/prerelease publish_openclaw_npm=true requires plugin_publish_scope=all-publishable so every publishable official plugin is released with OpenClaw." >&2
             exit 1
           fi
           if [[ "${PLUGIN_PUBLISH_SCOPE}" == "selected" && -z "${PLUGINS}" ]]; then
             echo "plugin_publish_scope=selected requires plugins." >&2
             exit 1
           fi
-          if [[ "${PLUGIN_PUBLISH_SCOPE}" == "all-publishable" && -n "${PLUGINS}" ]]; then
-            echo "plugin_publish_scope=all-publishable must not include plugins." >&2
+          if [[ "${PLUGIN_PUBLISH_SCOPE}" != "selected" && -n "${PLUGINS}" ]]; then
+            echo "plugins is only valid with plugin_publish_scope=selected." >&2
+            exit 1
+          fi
+          if [[ "${PLUGIN_PUBLISH_SCOPE}" != "stable-manifest" && -n "${STABLE_LINE}${STABLE_PLUGIN_MANIFEST_SHA256}${PACKAGE_ACCEPTANCE_RUN_ID}" ]]; then
+            echo "stable plugin manifest inputs require plugin_publish_scope=stable-manifest." >&2
+            exit 1
+          fi
+          if [[ "${PLUGIN_PUBLISH_SCOPE}" != "stable-manifest" && "${RELEASE_CLASS}" != "daily" ]]; then
+            echo "release_class must be daily unless plugin_publish_scope=stable-manifest." >&2
+            exit 1
+          fi
+          if [[ "${PLUGIN_PUBLISH_SCOPE}" != "stable-manifest" && "${RELEASE_NPM_DIST_TAG}" == "stable" ]]; then
+            echo "npm_dist_tag=stable is only valid with plugin_publish_scope=stable-manifest and release_class=stable-base or stable-patch." >&2
             exit 1
           fi
           case "$RELEASE_PROFILE" in
@@ -414,7 +483,8 @@ jobs:
           set -euo pipefail
           git fetch --no-tags origin \
             +refs/heads/main:refs/remotes/origin/main \
-            '+refs/heads/release/*:refs/remotes/origin/release/*'
+            '+refs/heads/release/*:refs/remotes/origin/release/*' \
+            '+refs/heads/stable/*:refs/remotes/origin/stable/*'
           if git merge-base --is-ancestor HEAD origin/main; then
             exit 0
           fi
@@ -423,6 +493,11 @@ jobs:
               exit 0
             fi
           done < <(git for-each-ref --format='%(refname)' refs/remotes/origin/release)
+          while IFS= read -r stable_ref; do
+            if git merge-base --is-ancestor HEAD "${stable_ref}"; then
+              exit 0
+            fi
+          done < <(git for-each-ref --format='%(refname)' refs/remotes/origin/stable)
           if [[ "${RELEASE_TAG}" == *"-alpha."* ]]; then
             if [[ ! "${WORKFLOW_REF_NAME}" =~ ^tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
               echo "Alpha publish tags must be dispatched from tideclaw/alpha/YYYY-MM-DD-HHMMZ." >&2
@@ -433,7 +508,7 @@ jobs:
               exit 0
             fi
           fi
-          echo "Release tag must point to a commit reachable from main, release/*, or the matching Tideclaw alpha branch for alpha prereleases." >&2
+          echo "Release tag must point to a commit reachable from main, release/*, stable/*, or the matching Tideclaw alpha branch for alpha prereleases." >&2
           exit 1
 
       - name: Summarize release target
@@ -487,6 +562,15 @@ jobs:
         with:
           install-bun: "false"
 
+      - name: Upload stable plugin manifest artifact
+        if: ${{ inputs.plugin_publish_scope == 'stable-manifest' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ inputs.stable_plugin_manifest_artifact }}
+          path: release/stable-plugin-support.json
+          retention-days: 30
+          if-no-files-found: error
+
       - name: Dispatch publish workflows
         env:
           GH_TOKEN: ${{ github.token }}
@@ -498,6 +582,11 @@ jobs:
           RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
           PLUGIN_PUBLISH_SCOPE: ${{ inputs.plugin_publish_scope }}
           PLUGINS: ${{ inputs.plugins }}
+          RELEASE_CLASS: ${{ inputs.release_class }}
+          STABLE_LINE: ${{ inputs.stable_line }}
+          STABLE_PLUGIN_MANIFEST_SHA256: ${{ inputs.stable_plugin_manifest_sha256 }}
+          STABLE_PLUGIN_MANIFEST_ARTIFACT: ${{ inputs.stable_plugin_manifest_artifact }}
+          PACKAGE_ACCEPTANCE_RUN_ID: ${{ inputs.package_acceptance_run_id }}
           PUBLISH_OPENCLAW_NPM: ${{ inputs.publish_openclaw_npm && 'true' || 'false' }}
           WAIT_FOR_CLAWHUB: ${{ inputs.wait_for_clawhub && 'true' || 'false' }}
           PREFLIGHT_ARTIFACT_NAME: ${{ needs.resolve_release_target.outputs.preflight_artifact_name }}
@@ -510,7 +599,7 @@ jobs:
           set -euo pipefail
 
           is_stable_release() {
-            [[ "${RELEASE_TAG}" != *"-alpha."* && "${RELEASE_TAG}" != *"-beta."* ]]
+            [[ "${RELEASE_CLASS}" == "stable-base" || "${RELEASE_CLASS}" == "stable-patch" ]]
           }
 
           dispatch_workflow_at_ref() {
@@ -843,14 +932,19 @@ jobs:
           }
 
           resolve_clawhub_release_plan() {
+            local clawhub_publish_scope
             local -a plan_args
 
+            clawhub_publish_scope="${PLUGIN_PUBLISH_SCOPE}"
+            if [[ "${clawhub_publish_scope}" == "stable-manifest" ]]; then
+              clawhub_publish_scope="all-publishable"
+            fi
             clawhub_plan_path="${RUNNER_TEMP}/openclaw-release-clawhub-plan.json"
             plan_args=(
               --release-tag "${RELEASE_TAG}"
               --release-publish-branch "${CHILD_WORKFLOW_REF}"
               --release-publish-run-id "${GITHUB_RUN_ID}"
-              --plugin-publish-scope "${PLUGIN_PUBLISH_SCOPE}"
+              --plugin-publish-scope "${clawhub_publish_scope}"
             )
             if [[ -n "${PLUGINS// }" ]]; then
               plan_args+=(--plugins "${PLUGINS}")
@@ -1306,9 +1400,189 @@ jobs:
           guard_openclaw_npm_not_already_published
           resolve_clawhub_release_plan
 
+          validate_stable_plugin_inputs() {
+            if [[ "${PLUGIN_PUBLISH_SCOPE}" != "stable-manifest" ]]; then
+              return 0
+            fi
+
+            manifest_sha="${STABLE_PLUGIN_MANIFEST_SHA256#sha256:}"
+            actual_sha="$(node --import tsx --input-type=module <<'NODE'
+          import { readFileSync } from "node:fs";
+          import { validateStablePluginSupportManifest } from "./src/plugins/stable-plugin-support.ts";
+
+          const manifest = JSON.parse(readFileSync("release/stable-plugin-support.json", "utf8"));
+          process.stdout.write(
+            validateStablePluginSupportManifest(manifest).stablePluginSupportSha256,
+          );
+          NODE
+            )"
+            if [[ "${actual_sha}" != "${manifest_sha}" ]]; then
+              echo "Stable plugin manifest digest mismatch: expected ${manifest_sha}, got ${actual_sha}." >&2
+              exit 1
+            fi
+            manifest_branch="$(node --import tsx --input-type=module <<'NODE'
+          import { readFileSync } from "node:fs";
+          import { validateStablePluginSupportManifest } from "./src/plugins/stable-plugin-support.ts";
+
+          const manifest = validateStablePluginSupportManifest(
+            JSON.parse(readFileSync("release/stable-plugin-support.json", "utf8")),
+          ).manifest;
+          const branches = [...new Set(manifest.coveredPlugins.map((entry) => entry.targetBranch))];
+          if (branches.length !== 1) {
+            throw new Error("stable plugin manifest must have exactly one covered-plugin target branch");
+          }
+          process.stdout.write(branches[0]);
+          NODE
+            )"
+            if [[ "${GITHUB_REF}" != "refs/heads/${manifest_branch}" ]]; then
+              echo "Stable plugin publish must be dispatched from manifest target branch ${manifest_branch}; got ${GITHUB_REF}." >&2
+              exit 1
+            fi
+            run_json="$(gh run view "${PACKAGE_ACCEPTANCE_RUN_ID}" --repo "$GITHUB_REPOSITORY" --json workflowName,event,status,conclusion,url)"
+            workflow_name="$(printf '%s' "${run_json}" | jq -r '.workflowName')"
+            run_status="$(printf '%s' "${run_json}" | jq -r '.status')"
+            run_conclusion="$(printf '%s' "${run_json}" | jq -r '.conclusion')"
+            run_url="$(printf '%s' "${run_json}" | jq -r '.url')"
+            if [[ "${workflow_name}" != "Package Acceptance" || "${run_status}" != "completed" || "${run_conclusion}" != "success" ]]; then
+              echo "Stable plugin publish requires a successful Package Acceptance run; got ${workflow_name} ${run_status}/${run_conclusion}: ${run_url}" >&2
+              exit 1
+            fi
+            acceptance_dir="${RUNNER_TEMP}/stable-plugin-package-acceptance-proof"
+            rm -rf "${acceptance_dir}"
+            mkdir -p "${acceptance_dir}"
+            acceptance_artifact="stable-plugin-acceptance-${manifest_sha}-proof"
+            if ! gh run download "${PACKAGE_ACCEPTANCE_RUN_ID}" \
+              --repo "$GITHUB_REPOSITORY" \
+              --name "${acceptance_artifact}" \
+              --dir "${acceptance_dir}"; then
+              echo "Stable plugin publish requires Package Acceptance artifact ${acceptance_artifact} from run ${PACKAGE_ACCEPTANCE_RUN_ID}." >&2
+              exit 1
+            fi
+            acceptance_inputs="$(find "${acceptance_dir}" -name stable-plugin-inputs.json -type f | sort | head -n 1)"
+            if [[ -z "${acceptance_inputs}" ]]; then
+              echo "Package Acceptance artifact ${acceptance_artifact} must contain stable-plugin-inputs.json." >&2
+              find "${acceptance_dir}" -maxdepth 3 -type f -print >&2 || true
+              exit 1
+            fi
+            acceptance_proof="$(find "${acceptance_dir}" -name stable-plugin-acceptance.json -type f | sort | head -n 1)"
+            if [[ -z "${acceptance_proof}" ]]; then
+              echo "Package Acceptance artifact ${acceptance_artifact} must contain stable-plugin-acceptance.json." >&2
+              find "${acceptance_dir}" -maxdepth 3 -type f -print >&2 || true
+              exit 1
+            fi
+            ACCEPTANCE_INPUTS="${acceptance_inputs}" ACCEPTANCE_PROOF="${acceptance_proof}" MANIFEST_SHA="${manifest_sha}" node --import tsx --input-type=module <<'NODE'
+          import { readFileSync } from "node:fs";
+          import { validateStablePluginSupportManifest } from "./src/plugins/stable-plugin-support.ts";
+
+          const manifest = validateStablePluginSupportManifest(
+            JSON.parse(readFileSync("release/stable-plugin-support.json", "utf8")),
+          );
+          const inputs = JSON.parse(readFileSync(process.env.ACCEPTANCE_INPUTS, "utf8"));
+          const proof = JSON.parse(readFileSync(process.env.ACCEPTANCE_PROOF, "utf8"));
+          const expectedSha = process.env.MANIFEST_SHA;
+          const releaseVersion = (process.env.RELEASE_TAG ?? "").replace(/^v/, "");
+          if (manifest.stablePluginSupportSha256 !== expectedSha) {
+            throw new Error("stable manifest digest changed during package acceptance proof validation");
+          }
+          if (inputs.stablePluginSupportSha256 !== expectedSha) {
+            throw new Error("stable-plugin package acceptance artifact digest mismatch");
+          }
+          if (
+            proof.result !== "passed" ||
+            proof.stablePluginSupportSha256 !== expectedSha ||
+            proof.stablePluginInputs?.stablePluginSupportSha256 !== expectedSha
+          ) {
+            throw new Error("stable-plugin package acceptance proof does not bind a passing run to the manifest digest");
+          }
+          if (inputs.packageSpec !== `openclaw@${releaseVersion}`) {
+            throw new Error(`stable-plugin package acceptance artifact packageSpec mismatch: ${inputs.packageSpec}`);
+          }
+          const expectedTargets = manifest.manifest.coveredPlugins
+            .map((entry) => ({
+              packageName: entry.packageName,
+              pluginId: entry.pluginId,
+              targetVersion: entry.targetVersion,
+              targetNpmSpec: entry.targetNpmSpec,
+              stableLine: entry.stableLine,
+              coreTarget: `openclaw@${releaseVersion}`,
+              targetBranch: entry.targetBranch,
+              stablePluginSupportSha256: expectedSha,
+            }))
+            .sort((left, right) => left.packageName.localeCompare(right.packageName));
+          const actualTargets = [...(inputs.stablePluginTargets ?? [])].sort((left, right) =>
+            String(left.packageName ?? "").localeCompare(String(right.packageName ?? "")),
+          );
+          if (JSON.stringify(actualTargets) !== JSON.stringify(expectedTargets)) {
+            throw new Error("stable-plugin package acceptance targets do not match the support manifest");
+          }
+          const expectedSpecs = expectedTargets.map((entry) => entry.targetNpmSpec).sort();
+          const actualSpecs = [...(inputs.stablePluginPackageSpecs ?? [])].sort();
+          if (JSON.stringify(actualSpecs) !== JSON.stringify(expectedSpecs)) {
+            throw new Error("stable-plugin package acceptance package specs do not match the support manifest");
+          }
+          const rawProofTargets = [...(proof.pluginProofs ?? [])];
+          if (
+            rawProofTargets.some(
+              (entry) =>
+                entry.source !== "docker-npm-install" ||
+                entry.installSource !== "tarball" ||
+                entry.result !== "passed" ||
+                entry.observedPackageName !== entry.packageName ||
+                entry.observedVersion !== entry.targetVersion ||
+                !/^[a-f0-9]{64}$/u.test(String(entry.tarballSha256 ?? "")),
+            )
+          ) {
+            throw new Error("stable-plugin package acceptance proof must come from Docker npm installs of exact target package tarballs");
+          }
+          const actualProofTargets = rawProofTargets
+            .map((entry) => ({
+              packageName: entry.packageName,
+              pluginId: entry.pluginId,
+              targetVersion: entry.targetVersion,
+              targetNpmSpec: entry.targetNpmSpec,
+              stableLine: entry.stableLine,
+              stablePluginSupportSha256: entry.stablePluginSupportSha256,
+              result: entry.result,
+            }))
+            .sort((left, right) =>
+              String(left.packageName ?? "").localeCompare(String(right.packageName ?? "")),
+            );
+          const expectedProofTargets = expectedTargets.map((entry) => ({
+            packageName: entry.packageName,
+            pluginId: entry.pluginId,
+            targetVersion: entry.targetVersion,
+            targetNpmSpec: entry.targetNpmSpec,
+            stableLine: entry.stableLine,
+            stablePluginSupportSha256: expectedSha,
+            result: "passed",
+          }));
+          if (JSON.stringify(actualProofTargets) !== JSON.stringify(expectedProofTargets)) {
+            throw new Error("stable-plugin package acceptance proof targets do not match the support manifest");
+          }
+          NODE
+            {
+              echo "- Stable plugin manifest: \`${manifest_sha}\`"
+              echo "- Stable plugin package acceptance: \`${PACKAGE_ACCEPTANCE_RUN_ID}\` (${acceptance_artifact})"
+            } >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          validate_stable_plugin_inputs
+
           npm_args=(-f publish_scope="${PLUGIN_PUBLISH_SCOPE}" -f ref="${TARGET_SHA}" -f release_publish_run_id="${GITHUB_RUN_ID}")
           if [[ -n "${PLUGINS}" ]]; then
             npm_args+=(-f plugins="${PLUGINS}")
+          fi
+          if [[ "${PLUGIN_PUBLISH_SCOPE}" == "stable-manifest" ]]; then
+            npm_args+=(
+              -f release_selector=stable
+              -f release_class="${RELEASE_CLASS}"
+              -f stable_line="${STABLE_LINE}"
+              -f stable_plugin_manifest_sha256="${STABLE_PLUGIN_MANIFEST_SHA256#sha256:}"
+              -f stable_plugin_manifest_artifact="${STABLE_PLUGIN_MANIFEST_ARTIFACT}"
+              -f package_acceptance_run_id="${PACKAGE_ACCEPTANCE_RUN_ID}"
+            )
+          else
+            npm_args+=(-f release_selector=daily -f release_class=daily)
           fi
 
           plugin_npm_run_id="$(dispatch_workflow plugin-npm-release.yml "${npm_args[@]}")"

--- a/.github/workflows/package-acceptance.yml
+++ b/.github/workflows/package-acceptance.yml
@@ -65,6 +65,32 @@ on:
           - product
           - full
           - custom
+          - stable-plugin
+      stable_plugin_manifest_ref:
+        description: Stable plugin support manifest ref or artifact identity for suite_profile=stable-plugin
+        required: false
+        default: ""
+        type: string
+      stable_plugin_targets_json:
+        description: Compact JSON array of manifest-covered stable plugin targets
+        required: false
+        default: ""
+        type: string
+      stable_plugin_package_specs:
+        description: Newline-delimited exact stable plugin package specs
+        required: false
+        default: ""
+        type: string
+      stable_plugin_package_tarballs_json:
+        description: JSON map of covered package names to prebuilt tarball proof; required for suite_profile=stable-plugin
+        required: false
+        default: ""
+        type: string
+      stable_plugin_acceptance_artifact_prefix:
+        description: Artifact prefix for stable-plugin package acceptance proof
+        required: false
+        default: stable-plugin-acceptance
+        type: string
       docker_lanes:
         description: Comma/space separated Docker lanes when suite_profile=custom
         required: false
@@ -156,9 +182,34 @@ on:
         default: package-under-test
         type: string
       suite_profile:
-        description: "Acceptance profile: smoke, package, product, full, or custom"
+        description: "Acceptance profile: smoke, package, product, full, custom, or stable-plugin"
         required: false
         default: package
+        type: string
+      stable_plugin_manifest_ref:
+        description: Stable plugin support manifest ref or artifact identity for suite_profile=stable-plugin
+        required: false
+        default: ""
+        type: string
+      stable_plugin_targets_json:
+        description: Compact JSON array of manifest-covered stable plugin targets
+        required: false
+        default: ""
+        type: string
+      stable_plugin_package_specs:
+        description: Newline-delimited exact stable plugin package specs
+        required: false
+        default: ""
+        type: string
+      stable_plugin_package_tarballs_json:
+        description: JSON map of covered package names to prebuilt tarball proof; required for suite_profile=stable-plugin
+        required: false
+        default: ""
+        type: string
+      stable_plugin_acceptance_artifact_prefix:
+        description: Artifact prefix for stable-plugin package acceptance proof
+        required: false
+        default: stable-plugin-acceptance
         type: string
       docker_lanes:
         description: Comma/space separated Docker lanes when suite_profile=custom
@@ -319,6 +370,8 @@ jobs:
       package_source_sha: ${{ steps.resolve.outputs.package_source_sha }}
       package_sha256: ${{ steps.resolve.outputs.sha256 }}
       package_version: ${{ steps.resolve.outputs.package_version }}
+      stable_plugin_inputs_artifact: ${{ steps.stable_plugin.outputs.artifact_name }}
+      stable_plugin_support_sha256: ${{ steps.stable_plugin.outputs.sha256 }}
       published_upgrade_survivor_baselines: ${{ steps.upgrade_survivor_baselines.outputs.baselines }}
       published_upgrade_survivor_scenarios: ${{ inputs.published_upgrade_survivor_scenarios }}
       telegram_enabled: ${{ steps.profile.outputs.telegram_enabled }}
@@ -422,6 +475,9 @@ jobs:
               include_release_path_suites=true
               include_openwebui=true
               ;;
+            stable-plugin)
+              docker_lanes="doctor-switch update-channel-switch plugins plugin-update published-upgrade-survivor"
+              ;;
             custom)
               docker_lanes="$CUSTOM_DOCKER_LANES"
               if [[ -z "${docker_lanes// }" ]]; then
@@ -451,6 +507,109 @@ jobs:
             echo "telegram_enabled=$telegram_enabled"
             echo "telegram_mode=$TELEGRAM_MODE"
             echo "package_artifact_name=${PACKAGE_ARTIFACT_NAME}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate stable plugin package inputs
+        id: stable_plugin
+        env:
+          PACKAGE_SPEC: ${{ inputs.package_spec }}
+          STABLE_PLUGIN_MANIFEST_REF: ${{ inputs.stable_plugin_manifest_ref }}
+          STABLE_PLUGIN_TARGETS_JSON: ${{ inputs.stable_plugin_targets_json }}
+          STABLE_PLUGIN_PACKAGE_SPECS: ${{ inputs.stable_plugin_package_specs }}
+          STABLE_PLUGIN_PACKAGE_TARBALLS_JSON: ${{ inputs.stable_plugin_package_tarballs_json }}
+          STABLE_PLUGIN_ACCEPTANCE_ARTIFACT_PREFIX: ${{ inputs.stable_plugin_acceptance_artifact_prefix }}
+          SUITE_PROFILE: ${{ inputs.suite_profile }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${SUITE_PROFILE}" != "stable-plugin" ]]; then
+            if [[ -n "${STABLE_PLUGIN_MANIFEST_REF}${STABLE_PLUGIN_TARGETS_JSON}${STABLE_PLUGIN_PACKAGE_SPECS}${STABLE_PLUGIN_PACKAGE_TARBALLS_JSON}" ]]; then
+              echo "stable_plugin_* inputs require suite_profile=stable-plugin." >&2
+              exit 1
+            fi
+            echo "artifact_name=" >> "$GITHUB_OUTPUT"
+            echo "sha256=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ -z "${STABLE_PLUGIN_MANIFEST_REF// }" ]]; then
+            echo "suite_profile=stable-plugin requires stable_plugin_manifest_ref." >&2
+            exit 1
+          fi
+          if [[ -z "${STABLE_PLUGIN_TARGETS_JSON// }" ]]; then
+            echo "suite_profile=stable-plugin requires stable_plugin_targets_json." >&2
+            exit 1
+          fi
+          if [[ -z "${STABLE_PLUGIN_PACKAGE_SPECS// }" ]]; then
+            echo "suite_profile=stable-plugin requires stable_plugin_package_specs." >&2
+            exit 1
+          fi
+          if [[ ! "${PACKAGE_SPEC}" =~ ^openclaw@[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*)?$ ]]; then
+            echo "suite_profile=stable-plugin requires package_spec to be an exact stable OpenClaw package." >&2
+            exit 1
+          fi
+
+          mkdir -p .artifacts/stable-plugin-acceptance
+          targets_path=.artifacts/stable-plugin-acceptance/targets.json
+          specs_path=.artifacts/stable-plugin-acceptance/package-specs.txt
+          tarballs_path=.artifacts/stable-plugin-acceptance/package-tarballs.json
+          printf '%s' "${STABLE_PLUGIN_TARGETS_JSON}" > "${targets_path}"
+          printf '%s\n' "${STABLE_PLUGIN_PACKAGE_SPECS}" > "${specs_path}"
+          if [[ -z "${STABLE_PLUGIN_PACKAGE_TARBALLS_JSON// }" ]]; then
+            echo "suite_profile=stable-plugin requires stable_plugin_package_tarballs_json so Docker proof installs exact candidate plugin tarballs before npm publish." >&2
+            exit 1
+          fi
+          printf '%s' "${STABLE_PLUGIN_PACKAGE_TARBALLS_JSON}" > "${tarballs_path}"
+
+          support_sha256="$(jq -r '
+            if type == "array" and length > 0 and
+              all(.[]; (.packageName | type == "string") and (.pluginId | type == "string") and (.targetVersion | type == "string") and (.targetNpmSpec | type == "string") and (.stableLine | type == "string") and (.coreTarget | type == "string") and (.targetBranch | type == "string") and (.stablePluginSupportSha256 | test("^[a-f0-9]{64}$"))) and
+              ([.[].stablePluginSupportSha256] | unique | length) == 1
+            then .[0].stablePluginSupportSha256
+            else error("invalid stable plugin targets json")
+            end
+          ' "${targets_path}")"
+          jq -e --arg package_spec "${PACKAGE_SPEC}" 'all(.[]; .coreTarget == $package_spec)' "${targets_path}" >/dev/null
+          expected_specs="$(jq -r '.[].targetNpmSpec' "${targets_path}" | LC_ALL=C sort)"
+          actual_specs="$(grep -v '^[[:space:]]*$' "${specs_path}" | LC_ALL=C sort)"
+          if [[ "${actual_specs}" != "${expected_specs}" ]]; then
+            echo "stable_plugin_package_specs must exactly match stable_plugin_targets_json targetNpmSpec values." >&2
+            diff -u <(printf '%s\n' "${expected_specs}") <(printf '%s\n' "${actual_specs}") >&2 || true
+            exit 1
+          fi
+          jq -e --slurpfile targets "${targets_path}" '
+            . as $tarballs |
+            type == "object" and
+            (($targets[0] | map(.packageName) | sort) == (keys | sort)) and
+            all($targets[0][]; . as $target |
+              ($tarballs[$target.packageName] | type == "object") and
+              ($tarballs[$target.packageName].packageName == $target.packageName) and
+              ($tarballs[$target.packageName].version == $target.targetVersion) and
+              (($tarballs[$target.packageName].path | type == "string") and ($tarballs[$target.packageName].path | length > 0) and (($tarballs[$target.packageName].path | startswith("/")) | not) and (($tarballs[$target.packageName].path | split("/") | index("..")) == null)) and
+              (($tarballs[$target.packageName].sha256 | type == "string") and ($tarballs[$target.packageName].sha256 | test("^[a-f0-9]{64}$"))) and
+              (($tarballs[$target.packageName].integrity? // "" | type == "string"))
+            )
+          ' "${tarballs_path}" >/dev/null
+
+          artifact_name="${STABLE_PLUGIN_ACCEPTANCE_ARTIFACT_PREFIX}-${support_sha256}"
+          jq -n \
+            --arg packageSpec "${PACKAGE_SPEC}" \
+            --arg manifestRef "${STABLE_PLUGIN_MANIFEST_REF}" \
+            --arg supportSha256 "${support_sha256}" \
+            --slurpfile targets "${targets_path}" \
+            --rawfile packageSpecs "${specs_path}" \
+            --slurpfile packageTarballs "${tarballs_path}" \
+            '{
+              packageSpec: $packageSpec,
+              stablePluginManifestRef: $manifestRef,
+              stablePluginSupportSha256: $supportSha256,
+              stablePluginTargets: $targets[0],
+              stablePluginPackageSpecs: ($packageSpecs | split("\n") | map(select(length > 0))),
+              stablePluginPackageTarballs: $packageTarballs[0]
+            }' > .artifacts/stable-plugin-acceptance/stable-plugin-inputs.json
+          {
+            echo "artifact_name=${artifact_name}"
+            echo "sha256=${support_sha256}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Resolve published upgrade survivor baselines
@@ -501,6 +660,15 @@ jobs:
           retention-days: 14
           if-no-files-found: error
 
+      - name: Upload stable plugin acceptance inputs
+        if: inputs.suite_profile == 'stable-plugin'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.stable_plugin.outputs.artifact_name }}
+          path: .artifacts/stable-plugin-acceptance/stable-plugin-inputs.json
+          retention-days: 30
+          if-no-files-found: error
+
       - name: Summarize package candidate
         env:
           PACKAGE_SHA256: ${{ steps.resolve.outputs.sha256 }}
@@ -513,6 +681,8 @@ jobs:
           PUBLISHED_UPGRADE_SURVIVOR_BASELINE: ${{ inputs.published_upgrade_survivor_baseline }}
           PUBLISHED_UPGRADE_SURVIVOR_BASELINES: ${{ steps.upgrade_survivor_baselines.outputs.baselines }}
           PUBLISHED_UPGRADE_SURVIVOR_SCENARIOS: ${{ inputs.published_upgrade_survivor_scenarios }}
+          STABLE_PLUGIN_INPUTS_ARTIFACT: ${{ steps.stable_plugin.outputs.artifact_name }}
+          STABLE_PLUGIN_SUPPORT_SHA256: ${{ steps.stable_plugin.outputs.sha256 }}
         shell: bash
         run: |
           {
@@ -532,6 +702,10 @@ jobs:
             echo "- Published upgrade survivor baseline: \`${PUBLISHED_UPGRADE_SURVIVOR_BASELINE}\`"
             echo "- Published upgrade survivor baselines: \`${PUBLISHED_UPGRADE_SURVIVOR_BASELINES}\`"
             echo "- Published upgrade survivor scenarios: \`${PUBLISHED_UPGRADE_SURVIVOR_SCENARIOS}\`"
+            if [[ -n "${STABLE_PLUGIN_INPUTS_ARTIFACT// }" ]]; then
+              echo "- Stable plugin support manifest SHA-256: \`${STABLE_PLUGIN_SUPPORT_SHA256}\`"
+              echo "- Stable plugin inputs artifact: \`${STABLE_PLUGIN_INPUTS_ARTIFACT}\`"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
   package_integrity:
@@ -576,6 +750,10 @@ jobs:
       include_release_path_suites: ${{ needs.resolve_package.outputs.include_release_path_suites == 'true' }}
       include_openwebui: ${{ needs.resolve_package.outputs.include_openwebui == 'true' }}
       docker_lanes: ${{ needs.resolve_package.outputs.docker_lanes }}
+      stable_plugin_targets_json: ${{ inputs.stable_plugin_targets_json }}
+      stable_plugin_package_specs: ${{ inputs.stable_plugin_package_specs }}
+      stable_plugin_package_tarballs_json: ${{ inputs.stable_plugin_package_tarballs_json }}
+      stable_plugin_support_sha256: ${{ needs.resolve_package.outputs.stable_plugin_support_sha256 }}
       published_upgrade_survivor_baseline: ${{ inputs.published_upgrade_survivor_baseline }}
       published_upgrade_survivor_baselines: ${{ needs.resolve_package.outputs.published_upgrade_survivor_baselines }}
       published_upgrade_survivor_scenarios: ${{ needs.resolve_package.outputs.published_upgrade_survivor_scenarios }}
@@ -630,6 +808,90 @@ jobs:
       OPENCLAW_GEMINI_SETTINGS_JSON: ${{ secrets.OPENCLAW_GEMINI_SETTINGS_JSON }}
       FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
 
+  stable_plugin_acceptance_proof:
+    name: Stable plugin acceptance proof
+    needs: [resolve_package, docker_acceptance]
+    if: inputs.suite_profile == 'stable-plugin'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Download stable plugin acceptance inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ needs.resolve_package.outputs.stable_plugin_inputs_artifact }}
+          path: .artifacts/stable-plugin-acceptance-proof
+
+      - name: Download stable plugin Docker proof
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: docker-e2e-*
+          path: .artifacts/stable-plugin-docker-proof
+          merge-multiple: true
+
+      - name: Write stable plugin acceptance proof
+        env:
+          DOCKER_LANES: ${{ needs.resolve_package.outputs.docker_lanes }}
+          PACKAGE_VERSION: ${{ needs.resolve_package.outputs.package_version }}
+          PACKAGE_SHA256: ${{ needs.resolve_package.outputs.package_sha256 }}
+          PACKAGE_SOURCE_SHA: ${{ needs.resolve_package.outputs.package_source_sha }}
+          STABLE_PLUGIN_SUPPORT_SHA256: ${{ needs.resolve_package.outputs.stable_plugin_support_sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          inputs_path=.artifacts/stable-plugin-acceptance-proof/stable-plugin-inputs.json
+          docker_proof_path="$(find .artifacts/stable-plugin-docker-proof -name stable-plugin-docker-proof.json -type f | sort | head -n 1)"
+          proof_path=.artifacts/stable-plugin-acceptance-proof/stable-plugin-acceptance.json
+          if [[ ! -f "${inputs_path}" ]]; then
+            echo "stable-plugin-inputs.json is missing from stable plugin acceptance artifact." >&2
+            exit 1
+          fi
+          if [[ -z "${docker_proof_path}" ]]; then
+            echo "stable-plugin Docker proof is missing from Docker E2E artifacts." >&2
+            find .artifacts/stable-plugin-docker-proof -maxdepth 4 -type f -print >&2 || true
+            exit 1
+          fi
+          jq -e --arg support_sha "${STABLE_PLUGIN_SUPPORT_SHA256}" '
+            .stablePluginSupportSha256 == $support_sha and
+            (.stablePluginTargets | type == "array" and length > 0) and
+            (.stablePluginPackageSpecs | type == "array" and length == (.stablePluginTargets | length))
+          ' "${inputs_path}" >/dev/null
+          jq -e --arg support_sha "${STABLE_PLUGIN_SUPPORT_SHA256}" '
+            .result == "passed" and
+            .stablePluginSupportSha256 == $support_sha and
+            (.pluginProofs | type == "array" and length > 0) and
+            all(.pluginProofs[]; .stablePluginSupportSha256 == $support_sha and .source == "docker-npm-install" and .installSource == "tarball" and .result == "passed")
+          ' "${docker_proof_path}" >/dev/null
+          jq -n \
+            --arg packageVersion "${PACKAGE_VERSION}" \
+            --arg packageSha256 "${PACKAGE_SHA256}" \
+            --arg packageSourceSha "${PACKAGE_SOURCE_SHA}" \
+            --arg supportSha256 "${STABLE_PLUGIN_SUPPORT_SHA256}" \
+            --arg dockerLanes "${DOCKER_LANES}" \
+            --arg completedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --slurpfile inputs "${inputs_path}" \
+            --slurpfile dockerProof "${docker_proof_path}" \
+            '{
+              schemaVersion: 1,
+              result: "passed",
+              packageVersion: $packageVersion,
+              packageSha256: $packageSha256,
+              packageSourceSha: $packageSourceSha,
+              stablePluginSupportSha256: $supportSha256,
+              dockerLanes: ($dockerLanes | split(" ") | map(select(length > 0))),
+              completedAt: $completedAt,
+              stablePluginInputs: $inputs[0],
+              dockerProof: $dockerProof[0],
+              pluginProofs: $dockerProof[0].pluginProofs
+            }' > "${proof_path}"
+
+      - name: Upload stable plugin acceptance proof
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ needs.resolve_package.outputs.stable_plugin_inputs_artifact }}-proof
+          path: .artifacts/stable-plugin-acceptance-proof
+          retention-days: 30
+          if-no-files-found: error
+
   package_telegram:
     name: Telegram package acceptance
     needs: [resolve_package, package_integrity]
@@ -650,7 +912,14 @@ jobs:
 
   summary:
     name: Verify package acceptance
-    needs: [resolve_package, package_integrity, docker_acceptance, package_telegram]
+    needs:
+      [
+        resolve_package,
+        package_integrity,
+        docker_acceptance,
+        stable_plugin_acceptance_proof,
+        package_telegram,
+      ]
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -659,6 +928,7 @@ jobs:
         env:
           DOCKER_RESULT: ${{ needs.docker_acceptance.result }}
           PACKAGE_INTEGRITY_RESULT: ${{ needs.package_integrity.result }}
+          STABLE_PLUGIN_PROOF_RESULT: ${{ needs.stable_plugin_acceptance_proof.result }}
           PACKAGE_TELEGRAM_RESULT: ${{ needs.package_telegram.result }}
           RESOLVE_RESULT: ${{ needs.resolve_package.result }}
         shell: bash
@@ -670,6 +940,7 @@ jobs:
             "resolve_package=${RESOLVE_RESULT}" \
             "package_integrity=${PACKAGE_INTEGRITY_RESULT}" \
             "docker_acceptance=${DOCKER_RESULT}" \
+            "stable_plugin_acceptance_proof=${STABLE_PLUGIN_PROOF_RESULT}" \
             "package_telegram=${PACKAGE_TELEGRAM_RESULT}"
           do
             name="${item%%=*}"

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/plugin-npm-release.yml"
       - "extensions/**"
       - "package.json"
+      - "release/stable-plugin-support.json"
       - "scripts/lib/plugin-npm-package-manifest.mjs"
       - "scripts/lib/plugin-npm-release.ts"
       - "scripts/plugin-npm-publish.sh"
@@ -24,8 +25,9 @@ on:
         options:
           - selected
           - all-publishable
+          - stable-manifest
       ref:
-        description: Commit SHA on main, a release branch, or the matching Tideclaw alpha branch to publish from
+        description: Commit SHA on main, a release branch, a stable branch, or the matching Tideclaw alpha branch to publish from
         required: true
         type: string
       plugins:
@@ -34,6 +36,39 @@ on:
         type: string
       release_publish_run_id:
         description: Approved OpenClaw Release Publish workflow run id
+        required: false
+        type: string
+      release_selector:
+        description: Release selector that owns npm tag behavior
+        required: true
+        default: daily
+        type: choice
+        options:
+          - daily
+          - stable
+      release_class:
+        description: Release class for selector-aware plugin publishes
+        required: true
+        default: daily
+        type: choice
+        options:
+          - daily
+          - stable-base
+          - stable-patch
+      stable_line:
+        description: Stable line month, for example 2026.6, when publish_scope=stable-manifest
+        required: false
+        type: string
+      stable_plugin_manifest_sha256:
+        description: SHA-256 digest for the stable plugin support manifest
+        required: false
+        type: string
+      stable_plugin_manifest_artifact:
+        description: Optional artifact name from release_publish_run_id containing stable-plugin-support.json
+        required: false
+        type: string
+      package_acceptance_run_id:
+        description: Successful package-acceptance stable-plugin run id matching the manifest digest
         required: false
         type: string
 
@@ -49,6 +84,7 @@ jobs:
   preview_plugins_npm:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     outputs:
       ref_revision: ${{ steps.ref.outputs.sha }}
@@ -73,6 +109,45 @@ jobs:
         id: ref
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve stable plugin manifest
+        id: stable_manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUBLISH_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_scope || '' }}
+          RELEASE_PUBLISH_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.release_publish_run_id || '' }}
+          STABLE_PLUGIN_MANIFEST_ARTIFACT: ${{ github.event_name == 'workflow_dispatch' && inputs.stable_plugin_manifest_artifact || '' }}
+        run: |
+          set -euo pipefail
+          if [[ "${PUBLISH_SCOPE}" != "stable-manifest" ]]; then
+            echo "path=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mkdir -p .local/stable-plugin-manifest
+          if [[ -n "${STABLE_PLUGIN_MANIFEST_ARTIFACT// }" ]]; then
+            if [[ -z "${RELEASE_PUBLISH_RUN_ID// }" ]]; then
+              echo "stable_plugin_manifest_artifact requires release_publish_run_id so the artifact source is auditable." >&2
+              exit 1
+            fi
+            gh run download "${RELEASE_PUBLISH_RUN_ID}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --name "${STABLE_PLUGIN_MANIFEST_ARTIFACT}" \
+              --dir .local/stable-plugin-manifest
+            manifest_path="$(find .local/stable-plugin-manifest -name stable-plugin-support.json -type f | sort | head -n 1)"
+            if [[ -z "${manifest_path}" ]]; then
+              echo "Stable plugin manifest artifact must contain stable-plugin-support.json." >&2
+              find .local/stable-plugin-manifest -maxdepth 3 -type f -print >&2 || true
+              exit 1
+            fi
+          else
+            manifest_path="release/stable-plugin-support.json"
+            if [[ ! -f "${manifest_path}" ]]; then
+              echo "publish_scope=stable-manifest requires release/stable-plugin-support.json or stable_plugin_manifest_artifact." >&2
+              exit 1
+            fi
+          fi
+          echo "path=${manifest_path}" >> "$GITHUB_OUTPUT"
+
       - name: Validate ref is on a trusted publish branch
         env:
           WORKFLOW_REF: ${{ github.ref }}
@@ -80,7 +155,8 @@ jobs:
           set -euo pipefail
           git fetch --no-tags origin \
             +refs/heads/main:refs/remotes/origin/main \
-            '+refs/heads/release/*:refs/remotes/origin/release/*'
+            '+refs/heads/release/*:refs/remotes/origin/release/*' \
+            '+refs/heads/stable/*:refs/remotes/origin/stable/*'
           if git merge-base --is-ancestor HEAD origin/main; then
             exit 0
           fi
@@ -89,6 +165,11 @@ jobs:
               exit 0
             fi
           done < <(git for-each-ref --format='%(refname)' refs/remotes/origin/release)
+          while IFS= read -r stable_ref; do
+            if git merge-base --is-ancestor HEAD "${stable_ref}"; then
+              exit 0
+            fi
+          done < <(git for-each-ref --format='%(refname)' refs/remotes/origin/stable)
           if [[ "${WORKFLOW_REF}" =~ ^refs/heads/tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
             alpha_branch="${WORKFLOW_REF#refs/heads/}"
             git fetch --no-tags origin "+refs/heads/${alpha_branch}:refs/remotes/origin/${alpha_branch}"
@@ -96,21 +177,35 @@ jobs:
               exit 0
             fi
           fi
-          echo "Plugin npm publishes must target a commit reachable from main, release/*, or the matching Tideclaw alpha branch." >&2
+          echo "Plugin npm publishes must target a commit reachable from main, release/*, stable/*, or the matching Tideclaw alpha branch." >&2
           exit 1
 
       - name: Validate publishable plugin metadata
         env:
           PUBLISH_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_scope || '' }}
           RELEASE_PLUGINS: ${{ github.event_name == 'workflow_dispatch' && inputs.plugins || '' }}
+          RELEASE_SELECTOR: ${{ github.event_name == 'workflow_dispatch' && inputs.release_selector || 'daily' }}
+          RELEASE_CLASS: ${{ github.event_name == 'workflow_dispatch' && inputs.release_class || 'daily' }}
+          STABLE_LINE: ${{ github.event_name == 'workflow_dispatch' && inputs.stable_line || '' }}
+          STABLE_PLUGIN_MANIFEST_PATH: ${{ steps.stable_manifest.outputs.path }}
+          STABLE_PLUGIN_MANIFEST_SHA256: ${{ github.event_name == 'workflow_dispatch' && inputs.stable_plugin_manifest_sha256 || '' }}
+          PACKAGE_ACCEPTANCE_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.package_acceptance_run_id || '' }}
           BASE_REF: ${{ github.event_name != 'workflow_dispatch' && github.event.before || '' }}
           HEAD_REF: ${{ steps.ref.outputs.sha }}
         run: |
           set -euo pipefail
           if [[ -n "${PUBLISH_SCOPE}" ]]; then
-            release_args=(--selection-mode "${PUBLISH_SCOPE}")
+            release_args=(--selection-mode "${PUBLISH_SCOPE}" --release-selector "${RELEASE_SELECTOR}" --release-class "${RELEASE_CLASS}")
             if [[ -n "${RELEASE_PLUGINS}" ]]; then
               release_args+=(--plugins "${RELEASE_PLUGINS}")
+            fi
+            if [[ "${PUBLISH_SCOPE}" == "stable-manifest" ]]; then
+              release_args+=(
+                --stable-line "${STABLE_LINE}"
+                --stable-plugin-manifest "${STABLE_PLUGIN_MANIFEST_PATH}"
+                --stable-plugin-manifest-sha256 "${STABLE_PLUGIN_MANIFEST_SHA256}"
+                --package-acceptance-run-id "${PACKAGE_ACCEPTANCE_RUN_ID}"
+              )
             fi
             pnpm release:plugins:npm:check -- "${release_args[@]}"
           elif [[ -n "${BASE_REF}" ]]; then
@@ -124,15 +219,29 @@ jobs:
         env:
           PUBLISH_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_scope || '' }}
           RELEASE_PLUGINS: ${{ github.event_name == 'workflow_dispatch' && inputs.plugins || '' }}
+          RELEASE_SELECTOR: ${{ github.event_name == 'workflow_dispatch' && inputs.release_selector || 'daily' }}
+          RELEASE_CLASS: ${{ github.event_name == 'workflow_dispatch' && inputs.release_class || 'daily' }}
+          STABLE_LINE: ${{ github.event_name == 'workflow_dispatch' && inputs.stable_line || '' }}
+          STABLE_PLUGIN_MANIFEST_PATH: ${{ steps.stable_manifest.outputs.path }}
+          STABLE_PLUGIN_MANIFEST_SHA256: ${{ github.event_name == 'workflow_dispatch' && inputs.stable_plugin_manifest_sha256 || '' }}
+          PACKAGE_ACCEPTANCE_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.package_acceptance_run_id || '' }}
           BASE_REF: ${{ github.event_name != 'workflow_dispatch' && github.event.before || '' }}
           HEAD_REF: ${{ steps.ref.outputs.sha }}
         run: |
           set -euo pipefail
           mkdir -p .local
           if [[ -n "${PUBLISH_SCOPE}" ]]; then
-            plan_args=(--selection-mode "${PUBLISH_SCOPE}")
+            plan_args=(--selection-mode "${PUBLISH_SCOPE}" --release-selector "${RELEASE_SELECTOR}" --release-class "${RELEASE_CLASS}")
             if [[ -n "${RELEASE_PLUGINS}" ]]; then
               plan_args+=(--plugins "${RELEASE_PLUGINS}")
+            fi
+            if [[ "${PUBLISH_SCOPE}" == "stable-manifest" ]]; then
+              plan_args+=(
+                --stable-line "${STABLE_LINE}"
+                --stable-plugin-manifest "${STABLE_PLUGIN_MANIFEST_PATH}"
+                --stable-plugin-manifest-sha256 "${STABLE_PLUGIN_MANIFEST_SHA256}"
+                --package-acceptance-run-id "${PACKAGE_ACCEPTANCE_RUN_ID}"
+              )
             fi
             node --import tsx scripts/plugin-npm-release-plan.ts "${plan_args[@]}" > .local/plugin-npm-release-plan.json
           elif [[ -n "${BASE_REF}" ]]; then
@@ -161,6 +270,45 @@ jobs:
 
           echo "Already published / skipped:"
           jq -r '.skippedPublished[]? | "- \(.packageName)@\(.version)"' .local/plugin-npm-release-plan.json
+
+      - name: Validate stable manifest plan
+        if: github.event_name == 'workflow_dispatch' && inputs.publish_scope == 'stable-manifest'
+        env:
+          STABLE_PLUGIN_MANIFEST_SHA256: ${{ inputs.stable_plugin_manifest_sha256 }}
+          PACKAGE_ACCEPTANCE_RUN_ID: ${{ inputs.package_acceptance_run_id }}
+          STABLE_PLUGIN_MANIFEST_PATH: ${{ steps.stable_manifest.outputs.path }}
+        run: |
+          set -euo pipefail
+          manifest_target_branch="$(
+            node --import tsx --input-type=module <<'NODE'
+          import { readFileSync } from "node:fs";
+          import { validateStablePluginSupportManifest } from "./src/plugins/stable-plugin-support.ts";
+
+          const manifest = validateStablePluginSupportManifest(
+            JSON.parse(readFileSync(process.env.STABLE_PLUGIN_MANIFEST_PATH, "utf8")),
+          );
+          const targetBranches = new Set(
+            manifest.coveredPlugins.map((entry) => entry.targetBranch),
+          );
+          if (targetBranches.size !== 1) {
+            throw new Error("stable plugin manifest must have exactly one covered-plugin target branch");
+          }
+          console.log([...targetBranches][0]);
+          NODE
+          )"
+          if [[ "${GITHUB_REF}" != "refs/heads/${manifest_target_branch}" ]]; then
+            echo "Stable plugin npm publish must be dispatched from manifest target branch ${manifest_target_branch}; got ${GITHUB_REF}." >&2
+            exit 1
+          fi
+          jq -e --arg sha "${STABLE_PLUGIN_MANIFEST_SHA256#sha256:}" --arg run_id "${PACKAGE_ACCEPTANCE_RUN_ID}" '
+            .releaseSelector == "stable" and
+            .selectionMode == "stable-manifest" and
+            .stablePluginSupportSha256 == $sha and
+            .packageAcceptanceRunId == $run_id and
+            (.skippedPublished | length) == 0 and
+            all(.all[]?; .publishTag == "stable" and .releaseSelector == "stable" and .stablePluginSupportSha256 == $sha and .packageAcceptanceRunId == $run_id) and
+            all(.all[]?; .publishTag != "latest" and .publishTag != "daily")
+          ' .local/plugin-npm-release-plan.json >/dev/null
 
       - name: Validate Tideclaw alpha plugin channels
         if: startsWith(github.ref, 'refs/heads/tideclaw/alpha/')
@@ -237,9 +385,27 @@ jobs:
           install-bun: "false"
 
       - name: Preview publish command
+        env:
+          OPENCLAW_PLUGIN_NPM_RELEASE_SELECTOR: ${{ matrix.plugin.releaseSelector || 'daily' }}
+          OPENCLAW_PLUGIN_NPM_RELEASE_CLASS: ${{ matrix.plugin.releaseClass || 'daily' }}
+          OPENCLAW_PLUGIN_NPM_EXPECTED_PACKAGE_NAME: ${{ matrix.plugin.packageName }}
+          OPENCLAW_PLUGIN_NPM_EXPECTED_PACKAGE_VERSION: ${{ matrix.plugin.version }}
+          OPENCLAW_PLUGIN_NPM_EXPECTED_NPM_TAG: ${{ matrix.plugin.publishTag }}
+          OPENCLAW_PLUGIN_NPM_STABLE_MANIFEST_SHA256: ${{ matrix.plugin.stablePluginSupportSha256 || '' }}
+          OPENCLAW_PLUGIN_NPM_STABLE_LINE: ${{ matrix.plugin.stableLine || '' }}
+          OPENCLAW_PLUGIN_NPM_PACKAGE_ACCEPTANCE_RUN_ID: ${{ matrix.plugin.packageAcceptanceRunId || '' }}
         run: bash scripts/plugin-npm-publish.sh --dry-run "${{ matrix.plugin.packageDir }}"
 
       - name: Preview npm pack contents
+        env:
+          OPENCLAW_PLUGIN_NPM_RELEASE_SELECTOR: ${{ matrix.plugin.releaseSelector || 'daily' }}
+          OPENCLAW_PLUGIN_NPM_RELEASE_CLASS: ${{ matrix.plugin.releaseClass || 'daily' }}
+          OPENCLAW_PLUGIN_NPM_EXPECTED_PACKAGE_NAME: ${{ matrix.plugin.packageName }}
+          OPENCLAW_PLUGIN_NPM_EXPECTED_PACKAGE_VERSION: ${{ matrix.plugin.version }}
+          OPENCLAW_PLUGIN_NPM_EXPECTED_NPM_TAG: ${{ matrix.plugin.publishTag }}
+          OPENCLAW_PLUGIN_NPM_STABLE_MANIFEST_SHA256: ${{ matrix.plugin.stablePluginSupportSha256 || '' }}
+          OPENCLAW_PLUGIN_NPM_STABLE_LINE: ${{ matrix.plugin.stableLine || '' }}
+          OPENCLAW_PLUGIN_NPM_PACKAGE_ACCEPTANCE_RUN_ID: ${{ matrix.plugin.packageAcceptanceRunId || '' }}
         run: bash scripts/plugin-npm-publish.sh --pack-dry-run "${{ matrix.plugin.packageDir }}"
 
   publish_plugins_npm:
@@ -289,6 +455,14 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           OPENCLAW_NPM_PUBLISH_AUTH_MODE: trusted-publisher
+          OPENCLAW_PLUGIN_NPM_RELEASE_SELECTOR: ${{ matrix.plugin.releaseSelector || 'daily' }}
+          OPENCLAW_PLUGIN_NPM_RELEASE_CLASS: ${{ matrix.plugin.releaseClass || 'daily' }}
+          OPENCLAW_PLUGIN_NPM_EXPECTED_PACKAGE_NAME: ${{ matrix.plugin.packageName }}
+          OPENCLAW_PLUGIN_NPM_EXPECTED_PACKAGE_VERSION: ${{ matrix.plugin.version }}
+          OPENCLAW_PLUGIN_NPM_EXPECTED_NPM_TAG: ${{ matrix.plugin.publishTag }}
+          OPENCLAW_PLUGIN_NPM_STABLE_MANIFEST_SHA256: ${{ matrix.plugin.stablePluginSupportSha256 || '' }}
+          OPENCLAW_PLUGIN_NPM_STABLE_LINE: ${{ matrix.plugin.stableLine || '' }}
+          OPENCLAW_PLUGIN_NPM_PACKAGE_ACCEPTANCE_RUN_ID: ${{ matrix.plugin.packageAcceptanceRunId || '' }}
         run: bash scripts/plugin-npm-publish.sh --publish "${{ matrix.plugin.packageDir }}"
 
       - name: Verify published runtime

--- a/.github/workflows/stable-plugin-support-drift.yml
+++ b/.github/workflows/stable-plugin-support-drift.yml
@@ -1,0 +1,244 @@
+name: Stable Plugin Support Drift
+
+on:
+  workflow_dispatch:
+    inputs:
+      stable_line:
+        description: Stable line month to inspect
+        required: true
+        default: "2026.6"
+        type: string
+      stable_plugin_manifest_sha256:
+        description: Expected canonical SHA-256 for release/stable-plugin-support.json
+        required: false
+        type: string
+      package_acceptance_run_id:
+        description: Optional Package Acceptance run id containing stable-plugin acceptance proof
+        required: false
+        type: string
+      update_issues:
+        description: Create or update drift issues instead of dry-run issue output
+        required: true
+        default: false
+        type: boolean
+  schedule:
+    - cron: "15 17 * * *"
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: stable-plugin-support-drift-${{ github.event_name == 'workflow_dispatch' && inputs.stable_line || '2026.6' }}
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    name: Stable plugin drift report
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Build stable plugin evidence inputs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SHA256: ${{ github.event_name == 'workflow_dispatch' && inputs.stable_plugin_manifest_sha256 || '' }}
+          PACKAGE_ACCEPTANCE_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.package_acceptance_run_id || '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p .artifacts/stable-plugin-drift
+          node --import tsx --input-type=module <<'NODE'
+          import { writeFileSync, readFileSync } from "node:fs";
+          import { execFileSync } from "node:child_process";
+          import { validateStablePluginSupportManifest } from "./src/plugins/stable-plugin-support.ts";
+
+          const manifest = validateStablePluginSupportManifest(
+            JSON.parse(readFileSync("release/stable-plugin-support.json", "utf8")),
+          );
+          const expected = (process.env.EXPECTED_SHA256 ?? "").replace(/^sha256:/, "");
+          if (expected && expected !== manifest.stablePluginSupportSha256) {
+            throw new Error(
+              `stable plugin manifest digest mismatch: expected ${expected}, got ${manifest.stablePluginSupportSha256}`,
+            );
+          }
+          const registryProofs = manifest.manifest.coveredPlugins.map((entry) => {
+            let version = "";
+            let exists = false;
+            try {
+              version = execFileSync("npm", ["view", entry.targetNpmSpec, "version"], {
+                encoding: "utf8",
+                stdio: ["ignore", "pipe", "ignore"],
+              }).trim();
+              exists = version === entry.targetVersion;
+            } catch {
+              exists = false;
+            }
+            return {
+              packageName: entry.packageName,
+              version,
+              targetNpmSpec: entry.targetNpmSpec,
+              exists,
+              observedAt: new Date().toISOString(),
+            };
+          });
+          const catalogEntries = manifest.manifest.coveredPlugins.map((entry) => ({
+            packageName: entry.packageName,
+            pluginId: entry.pluginId,
+            kind: entry.kind,
+            source: "official-external-catalog",
+          }));
+          writeFileSync(
+            ".artifacts/stable-plugin-drift/registry-proof.json",
+            `${JSON.stringify(registryProofs, null, 2)}\n`,
+          );
+          writeFileSync(
+            ".artifacts/stable-plugin-drift/catalog.json",
+            `${JSON.stringify(catalogEntries, null, 2)}\n`,
+          );
+          writeFileSync(".artifacts/stable-plugin-drift/package-acceptance.json", "[]\n");
+          writeFileSync(
+            ".artifacts/stable-plugin-drift/manifest-digest.txt",
+            `${manifest.stablePluginSupportSha256}\n`,
+          );
+          NODE
+          support_sha="$(cat .artifacts/stable-plugin-drift/manifest-digest.txt)"
+          proof_artifact="stable-plugin-acceptance-${support_sha}-proof"
+          proof_dir=.artifacts/stable-plugin-drift/package-acceptance-proof
+          mkdir -p "${proof_dir}"
+          if [[ -n "${PACKAGE_ACCEPTANCE_RUN_ID// }" ]]; then
+            gh run download "${PACKAGE_ACCEPTANCE_RUN_ID}" \
+              --repo "$GITHUB_REPOSITORY" \
+              --name "${proof_artifact}" \
+              --dir "${proof_dir}"
+          else
+            mapfile -t candidate_runs < <(
+              gh run list \
+                --repo "$GITHUB_REPOSITORY" \
+                --workflow package-acceptance.yml \
+                --status success \
+                --limit 20 \
+                --json databaseId \
+                --jq '.[].databaseId'
+            )
+            for run_id in "${candidate_runs[@]}"; do
+              if gh run download "${run_id}" \
+                --repo "$GITHUB_REPOSITORY" \
+                --name "${proof_artifact}" \
+                --dir "${proof_dir}" >/dev/null 2>&1; then
+                break
+              fi
+            done
+          fi
+          proof_path="$(find "${proof_dir}" -name stable-plugin-acceptance.json -type f | sort | head -n 1)"
+          if [[ -n "${proof_path}" ]]; then
+            completed_at="$(jq -r '.completedAt // ""' "${proof_path}")"
+            jq --arg completed_at "${completed_at}" '[.pluginProofs[]? | {
+              packageName,
+              targetVersion,
+              targetNpmSpec,
+              stableLine,
+              stablePluginSupportSha256,
+              result,
+              completedAt: (.completedAt // $completed_at)
+            }]' "${proof_path}" > .artifacts/stable-plugin-drift/package-acceptance.json
+          else
+            echo "No ${proof_artifact} artifact found; drift report will mark package acceptance proof missing." >&2
+            printf '[]\n' > .artifacts/stable-plugin-drift/package-acceptance.json
+          fi
+
+      - name: Generate stable plugin drift report
+        env:
+          STABLE_LINE: ${{ github.event_name == 'workflow_dispatch' && inputs.stable_line || '2026.6' }}
+          UPDATE_ISSUES: ${{ github.event_name == 'workflow_dispatch' && inputs.update_issues && 'true' || 'false' }}
+        run: |
+          set -euo pipefail
+          issue_mode=--dry-run-issues
+          if [[ "${UPDATE_ISSUES}" == "true" ]]; then
+            issue_mode=--update-issues
+          fi
+          node --import tsx scripts/stable-plugin-drift-report.ts \
+            --stable-line "${STABLE_LINE}" \
+            --manifest release/stable-plugin-support.json \
+            --registry-proof .artifacts/stable-plugin-drift/registry-proof.json \
+            --package-acceptance .artifacts/stable-plugin-drift/package-acceptance.json \
+            --catalog .artifacts/stable-plugin-drift/catalog.json \
+            --output .artifacts/stable-plugin-drift/report.json \
+            --issues-output .artifacts/stable-plugin-drift/issues.json \
+            "${issue_mode}" \
+            --json
+          jq -r '"blocking_drift_count=" + (.summary.blockingDriftCount | tostring)' \
+            .artifacts/stable-plugin-drift/report.json >> "$GITHUB_OUTPUT"
+
+      - name: Apply stable plugin drift issues
+        if: github.event_name == 'workflow_dispatch' && inputs.update_issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { execFileSync } from "node:child_process";
+          import { readFileSync, writeFileSync } from "node:fs";
+
+          const issues = JSON.parse(readFileSync(".artifacts/stable-plugin-drift/issues.json", "utf8"));
+          const applied = [];
+          for (const issue of issues) {
+            if (issue.action !== "create_or_update") {
+              continue;
+            }
+            const existing = execFileSync(
+              "gh",
+              [
+                "issue",
+                "list",
+                "--repo",
+                process.env.GITHUB_REPOSITORY,
+                "--state",
+                "open",
+                "--search",
+                issue.marker,
+                "--json",
+                "number",
+                "--jq",
+                ".[0].number // empty",
+              ],
+              { encoding: "utf8" },
+            ).trim();
+            const bodyPath = `.artifacts/stable-plugin-drift/issue-${issue.idempotencyKey.replaceAll(/[^a-zA-Z0-9_.-]/g, "_")}.md`;
+            writeFileSync(bodyPath, `${issue.body}\n`);
+            if (existing) {
+              execFileSync(
+                "gh",
+                ["issue", "edit", existing, "--repo", process.env.GITHUB_REPOSITORY, "--title", issue.title, "--body-file", bodyPath],
+                { stdio: "inherit" },
+              );
+              applied.push({ ...issue, number: Number(existing), operation: "updated" });
+            } else {
+              const url = execFileSync(
+                "gh",
+                ["issue", "create", "--repo", process.env.GITHUB_REPOSITORY, "--title", issue.title, "--body-file", bodyPath],
+                { encoding: "utf8" },
+              ).trim();
+              applied.push({ ...issue, url, operation: "created" });
+            }
+          }
+          writeFileSync(
+            ".artifacts/stable-plugin-drift/issues-applied.json",
+            `${JSON.stringify(applied, null, 2)}\n`,
+          );
+          NODE
+
+      - name: Upload stable plugin drift report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: stable-plugin-drift-report
+          path: .artifacts/stable-plugin-drift
+          retention-days: 30
+          if-no-files-found: error

--- a/package.json
+++ b/package.json
@@ -1718,6 +1718,7 @@
     "release:plugins:clawhub:plan": "node --import tsx scripts/plugin-clawhub-release-plan.ts",
     "release:plugins:npm:check": "node --import tsx scripts/plugin-npm-release-check.ts",
     "release:plugins:npm:plan": "node --import tsx scripts/plugin-npm-release-plan.ts",
+    "release:stable-plugin-drift": "node --import tsx scripts/stable-plugin-drift-report.ts",
     "release:verify-beta": "node --import tsx scripts/release-verify-beta.ts",
     "release:prep": "node scripts/release-preflight.mjs --fix",
     "runtime-sidecars:check": "node --import tsx scripts/generate-runtime-sidecar-paths-baseline.ts --check",

--- a/release/stable-plugin-support.json
+++ b/release/stable-plugin-support.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": 1,
+  "stableLine": {
+    "month": "2026.6",
+    "baseVersion": "2026.6.33"
+  },
+  "coveredPlugins": [
+    {
+      "packageName": "@openclaw/codex",
+      "pluginId": "codex",
+      "kind": "provider",
+      "sourceRepository": "openclaw/openclaw",
+      "packageDir": "extensions/codex",
+      "stableLine": "2026.6",
+      "targetVersion": "2026.6.33",
+      "targetNpmSpec": "@openclaw/codex@2026.6.33",
+      "targetBranch": "stable/2026.6.33",
+      "runtimeHarness": {
+        "harnessId": "codex",
+        "runtimePackage": "@openai/codex",
+        "installMode": "on_demand_runtime_dependencies",
+        "requiredPlatformPackages": [
+          "@openai/codex-linux-x64",
+          "@openai/codex-linux-arm64",
+          "@openai/codex-darwin-x64",
+          "@openai/codex-darwin-arm64",
+          "@openai/codex-win32-x64",
+          "@openai/codex-win32-arm64"
+        ]
+      },
+      "owners": []
+    },
+    {
+      "packageName": "@openclaw/discord",
+      "pluginId": "discord",
+      "kind": "channel",
+      "sourceRepository": "openclaw/openclaw",
+      "packageDir": "extensions/discord",
+      "stableLine": "2026.6",
+      "targetVersion": "2026.6.33",
+      "targetNpmSpec": "@openclaw/discord@2026.6.33",
+      "targetBranch": "stable/2026.6.33",
+      "owners": []
+    },
+    {
+      "packageName": "@openclaw/slack",
+      "pluginId": "slack",
+      "kind": "channel",
+      "sourceRepository": "openclaw/openclaw",
+      "packageDir": "extensions/slack",
+      "stableLine": "2026.6",
+      "targetVersion": "2026.6.33",
+      "targetNpmSpec": "@openclaw/slack@2026.6.33",
+      "targetBranch": "stable/2026.6.33",
+      "owners": []
+    }
+  ]
+}

--- a/scripts/lib/npm-publish-plan.mjs
+++ b/scripts/lib/npm-publish-plan.mjs
@@ -24,8 +24,8 @@ export const JUNE_2026_PATCH_FLOOR = 5;
 /**
  * @typedef {object} NpmPublishPlan
  * @property {"stable" | "alpha" | "beta"} channel
- * @property {"latest" | "alpha" | "beta"} publishTag
- * @property {("latest" | "alpha" | "beta")[]} mirrorDistTags
+ * @property {"latest" | "stable" | "alpha" | "beta"} publishTag
+ * @property {("latest" | "stable" | "alpha" | "beta")[]} mirrorDistTags
  */
 
 /**
@@ -199,9 +199,10 @@ export function compareReleaseVersions(left, right) {
 /**
  * @param {string} version
  * @param {string | null} [currentBetaVersion]
+ * @param {"daily" | "stable"} [releaseSelector]
  * @returns {NpmPublishPlan}
  */
-export function resolveNpmPublishPlan(version, currentBetaVersion) {
+export function resolveNpmPublishPlan(version, currentBetaVersion, releaseSelector = "daily") {
   const parsedVersion = parseReleaseVersion(version);
   if (parsedVersion === null) {
     throw new Error(`Unsupported release version "${version}".`);
@@ -228,10 +229,18 @@ export function resolveNpmPublishPlan(version, currentBetaVersion) {
     if (betaVsStable !== null && betaVsStable > 0) {
       return {
         channel: "stable",
-        publishTag: "latest",
+        publishTag: releaseSelector === "stable" ? "stable" : "latest",
         mirrorDistTags: [],
       };
     }
+  }
+
+  if (releaseSelector === "stable") {
+    return {
+      channel: "stable",
+      publishTag: "stable",
+      mirrorDistTags: [],
+    };
   }
 
   return {

--- a/scripts/lib/plugin-npm-release.ts
+++ b/scripts/lib/plugin-npm-release.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
 import { validateExternalCodePluginPackageJson } from "../../packages/plugin-package-contract/src/index.ts";
+import { validateStablePluginSupportManifest } from "../../src/plugins/stable-plugin-support.ts";
 import { parseReleaseVersion } from "../openclaw-npm-release-check.ts";
 import { collectReleaseVersionFloorErrors, resolveNpmPublishPlan } from "./npm-publish-plan.mjs";
 
@@ -46,8 +47,15 @@ export type PublishablePluginPackage = {
   packageName: string;
   version: string;
   channel: "stable" | "alpha" | "beta";
-  publishTag: "latest" | "alpha" | "beta";
+  publishTag: "latest" | "alpha" | "beta" | "stable";
   installNpmSpec?: string;
+  releaseClass?: PluginReleaseClass;
+  releaseSelector?: PluginReleaseSelector;
+  stableLine?: string;
+  stablePluginSupportSha256?: string;
+  targetBranch?: string;
+  targetNpmSpec?: string;
+  packageAcceptanceRunId?: string;
 };
 
 export type PluginReleasePlanItem = PublishablePluginPackage & {
@@ -58,9 +66,18 @@ export type PluginReleasePlan = {
   all: PluginReleasePlanItem[];
   candidates: PluginReleasePlanItem[];
   skippedPublished: PluginReleasePlanItem[];
+  packages: string[];
+  releaseClass: PluginReleaseClass;
+  releaseSelector: PluginReleaseSelector;
+  selectionMode: PluginReleaseSelectionMode;
+  stableLine?: string;
+  stablePluginSupportSha256?: string;
+  packageAcceptanceRunId?: string;
 };
 
-export type PluginReleaseSelectionMode = "selected" | "all-publishable";
+export type PluginReleaseSelectionMode = "selected" | "all-publishable" | "stable-manifest";
+export type PluginReleaseSelector = "daily" | "stable";
+export type PluginReleaseClass = "daily" | "stable-base" | "stable-patch";
 
 export type GitRangeSelection = {
   baseRef: string;
@@ -73,6 +90,28 @@ export type ParsedPluginReleaseArgs = {
   pluginsFlagProvided: boolean;
   baseRef?: string;
   headRef?: string;
+  releaseClass?: PluginReleaseClass;
+  releaseSelector?: PluginReleaseSelector;
+  stableLine?: string;
+  stablePluginManifestPath?: string;
+  stablePluginManifestSha256?: string;
+  packageAcceptanceRunId?: string;
+};
+
+export type ResolvedStablePluginSupportManifest = {
+  sha256: string;
+  stableLine: string;
+  baseVersion: string;
+  packages: StablePluginSupportPackage[];
+};
+
+export type StablePluginSupportPackage = {
+  packageName: string;
+  pluginId: string;
+  packageDir: string;
+  targetVersion: string;
+  targetNpmSpec: string;
+  targetBranch: string;
 };
 
 export type PublishablePluginPackageCandidate<
@@ -164,12 +203,34 @@ export function parsePluginReleaseSelection(value: string | undefined): string[]
 export function parsePluginReleaseSelectionMode(
   value: string | undefined,
 ): PluginReleaseSelectionMode {
-  if (value === "selected" || value === "all-publishable") {
+  if (value === "selected" || value === "all-publishable" || value === "stable-manifest") {
     return value;
   }
 
   throw new Error(
-    `Unknown selection mode: ${value ?? "<missing>"}. Expected "selected" or "all-publishable".`,
+    `Unknown selection mode: ${value ?? "<missing>"}. Expected "selected", "all-publishable", or "stable-manifest".`,
+  );
+}
+
+export function parsePluginReleaseSelector(value: string | undefined): PluginReleaseSelector {
+  if (value === undefined || value === "") {
+    return "daily";
+  }
+  if (value === "daily" || value === "stable") {
+    return value;
+  }
+  throw new Error(`Unknown release selector: ${value}. Expected "daily" or "stable".`);
+}
+
+export function parsePluginReleaseClass(value: string | undefined): PluginReleaseClass {
+  if (value === undefined || value === "") {
+    return "daily";
+  }
+  if (value === "daily" || value === "stable-base" || value === "stable-patch") {
+    return value;
+  }
+  throw new Error(
+    `Unknown release class: ${value}. Expected "daily", "stable-base", or "stable-patch".`,
   );
 }
 
@@ -179,6 +240,12 @@ export function parsePluginReleaseArgs(argv: string[]): ParsedPluginReleaseArgs 
   let pluginsFlagProvided = false;
   let baseRef: string | undefined;
   let headRef: string | undefined;
+  let releaseClass: PluginReleaseClass | undefined;
+  let releaseSelector: PluginReleaseSelector | undefined;
+  let stableLine: string | undefined;
+  let stablePluginManifestPath: string | undefined;
+  let stablePluginManifestSha256: string | undefined;
+  let packageAcceptanceRunId: string | undefined;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -206,8 +273,41 @@ export function parsePluginReleaseArgs(argv: string[]): ParsedPluginReleaseArgs 
       index += 1;
       continue;
     }
+    if (arg === "--release-selector") {
+      releaseSelector = parsePluginReleaseSelector(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    if (arg === "--release-class") {
+      releaseClass = parsePluginReleaseClass(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    if (arg === "--stable-line") {
+      stableLine = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--stable-plugin-manifest") {
+      stablePluginManifestPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--stable-plugin-manifest-sha256") {
+      stablePluginManifestSha256 = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--package-acceptance-run-id") {
+      packageAcceptanceRunId = argv[index + 1];
+      index += 1;
+      continue;
+    }
     throw new Error(`Unknown argument: ${arg}`);
   }
+
+  releaseSelector ??= "daily";
+  releaseClass ??= releaseSelector === "stable" ? "stable-base" : "daily";
 
   if (pluginsFlagProvided && selection.length === 0) {
     throw new Error("`--plugins` must include at least one package name.");
@@ -218,6 +318,9 @@ export function parsePluginReleaseArgs(argv: string[]): ParsedPluginReleaseArgs 
   if (selectionMode === "all-publishable" && pluginsFlagProvided) {
     throw new Error("`--selection-mode all-publishable` must not be combined with `--plugins`.");
   }
+  if (selectionMode === "stable-manifest" && pluginsFlagProvided) {
+    throw new Error("`--selection-mode stable-manifest` must not be combined with `--plugins`.");
+  }
   if (selection.length > 0 && (baseRef || headRef)) {
     throw new Error("Use either --plugins or --base-ref/--head-ref, not both.");
   }
@@ -227,8 +330,164 @@ export function parsePluginReleaseArgs(argv: string[]): ParsedPluginReleaseArgs 
   if ((baseRef && !headRef) || (!baseRef && headRef)) {
     throw new Error("Both --base-ref and --head-ref are required together.");
   }
+  if (releaseSelector === "stable" && selectionMode !== "stable-manifest") {
+    throw new Error("`--release-selector stable` requires `--selection-mode stable-manifest`.");
+  }
+  if (selectionMode === "stable-manifest" && releaseSelector !== "stable") {
+    throw new Error("`--selection-mode stable-manifest` requires `--release-selector stable`.");
+  }
+  if (releaseSelector === "daily" && releaseClass !== "daily") {
+    throw new Error("`--release-selector daily` requires `--release-class daily`.");
+  }
+  if (releaseSelector === "stable" && releaseClass === "daily") {
+    throw new Error(
+      "`--release-selector stable` requires `--release-class stable-base` or `stable-patch`.",
+    );
+  }
+  if (selectionMode === "stable-manifest") {
+    if (!stableLine?.trim()) {
+      throw new Error("`--selection-mode stable-manifest` requires `--stable-line`.");
+    }
+    if (!stablePluginManifestPath?.trim()) {
+      throw new Error("`--selection-mode stable-manifest` requires `--stable-plugin-manifest`.");
+    }
+    if (!stablePluginManifestSha256?.trim()) {
+      throw new Error(
+        "`--selection-mode stable-manifest` requires `--stable-plugin-manifest-sha256`.",
+      );
+    }
+    if (!packageAcceptanceRunId?.trim()) {
+      throw new Error("`--selection-mode stable-manifest` requires `--package-acceptance-run-id`.");
+    }
+  } else if (
+    stableLine?.trim() ||
+    stablePluginManifestPath?.trim() ||
+    stablePluginManifestSha256?.trim() ||
+    packageAcceptanceRunId?.trim()
+  ) {
+    throw new Error("Stable manifest inputs require `--selection-mode stable-manifest`.");
+  }
 
-  return { selection, selectionMode, pluginsFlagProvided, baseRef, headRef };
+  return {
+    selection,
+    selectionMode,
+    pluginsFlagProvided,
+    baseRef,
+    headRef,
+    releaseClass,
+    releaseSelector,
+    stableLine,
+    stablePluginManifestPath,
+    stablePluginManifestSha256,
+    packageAcceptanceRunId,
+  };
+}
+
+function normalizeSha256Digest(value: string, label: string): string {
+  const trimmed = value.trim();
+  const normalized = trimmed.startsWith("sha256:") ? trimmed.slice("sha256:".length) : trimmed;
+  if (!/^[a-f0-9]{64}$/u.test(normalized)) {
+    throw new Error(`${label} must be a lowercase SHA-256 digest, with optional sha256: prefix.`);
+  }
+  return normalized;
+}
+
+function requireManifestString(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`Stable plugin support manifest ${label} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+export function resolveStablePluginSupportManifest(params: {
+  path: string;
+  expectedSha256: string;
+  stableLine: string;
+}): ResolvedStablePluginSupportManifest {
+  const manifestText = readFileSync(params.path, "utf8");
+  const validatedManifest = validateStablePluginSupportManifest(JSON.parse(manifestText));
+  const manifest = validatedManifest.manifest;
+  const sha256 = validatedManifest.stablePluginSupportSha256;
+  const expectedSha256 = normalizeSha256Digest(
+    params.expectedSha256,
+    "--stable-plugin-manifest-sha256",
+  );
+  if (sha256 !== expectedSha256) {
+    throw new Error(
+      `Stable plugin support manifest digest mismatch: expected ${expectedSha256}, got ${sha256}.`,
+    );
+  }
+
+  const stableLine = requireManifestString(manifest.stableLine?.month, "stableLine.month");
+  if (stableLine !== params.stableLine.trim()) {
+    throw new Error(
+      `Stable plugin support manifest stable line mismatch: expected ${params.stableLine}, got ${stableLine}.`,
+    );
+  }
+  const baseVersion = requireManifestString(
+    manifest.stableLine?.baseVersion,
+    "stableLine.baseVersion",
+  );
+  const coveredPlugins = manifest.coveredPlugins;
+  if (!Array.isArray(coveredPlugins) || coveredPlugins.length === 0) {
+    throw new Error("Stable plugin support manifest coveredPlugins must be a non-empty array.");
+  }
+
+  const packages = coveredPlugins.map((entry, index): StablePluginSupportPackage => {
+    const packageName = requireManifestString(
+      entry.packageName,
+      `coveredPlugins[${index}].packageName`,
+    );
+    const targetVersion = requireManifestString(
+      entry.targetVersion,
+      `coveredPlugins[${index}].targetVersion`,
+    );
+    const targetNpmSpec = (entry.targetNpmSpec ?? `${packageName}@${targetVersion}`).trim();
+    const expectedSpec = `${packageName}@${targetVersion}`;
+    if (targetNpmSpec !== expectedSpec) {
+      throw new Error(
+        `Stable plugin support manifest ${packageName} targetNpmSpec must be ${expectedSpec}; got ${targetNpmSpec}.`,
+      );
+    }
+    const parsedVersion = parseReleaseVersion(targetVersion);
+    if (parsedVersion === null || parsedVersion.channel !== "stable") {
+      throw new Error(
+        `Stable plugin support manifest ${packageName} targetVersion must be a stable YYYY.M.PATCH version.`,
+      );
+    }
+    if (`${parsedVersion.year}.${parsedVersion.month}` !== stableLine) {
+      throw new Error(
+        `Stable plugin support manifest ${packageName} targetVersion ${targetVersion} is outside stable line ${stableLine}.`,
+      );
+    }
+    return {
+      packageName,
+      pluginId: requireManifestString(entry.pluginId, `coveredPlugins[${index}].pluginId`),
+      packageDir: requireManifestString(entry.packageDir, `coveredPlugins[${index}].packageDir`),
+      targetVersion,
+      targetNpmSpec,
+      targetBranch: requireManifestString(
+        entry.targetBranch,
+        `coveredPlugins[${index}].targetBranch`,
+      ),
+    };
+  });
+
+  const duplicatePackageNames = packages
+    .map((entry) => entry.packageName)
+    .filter((name, index, all) => all.indexOf(name) !== index);
+  if (duplicatePackageNames.length > 0) {
+    throw new Error(
+      `Stable plugin support manifest has duplicate packages: ${[...new Set(duplicatePackageNames)].join(", ")}.`,
+    );
+  }
+
+  return {
+    sha256,
+    stableLine,
+    baseVersion,
+    packages: packages.toSorted((left, right) => left.packageName.localeCompare(right.packageName)),
+  };
 }
 
 export function collectPublishablePluginPackageErrors(
@@ -378,6 +637,64 @@ export function resolveSelectedPublishablePluginPackages(params: {
   }
 
   return selected;
+}
+
+export function resolveStableManifestPublishablePluginPackages(params: {
+  plugins: PublishablePluginPackage[];
+  manifest: ResolvedStablePluginSupportManifest;
+  releaseClass: PluginReleaseClass;
+  releaseSelector: PluginReleaseSelector;
+  packageAcceptanceRunId: string;
+}): PublishablePluginPackage[] {
+  const byName = new Map(params.plugins.map((plugin) => [plugin.packageName, plugin]));
+  const resolved: PublishablePluginPackage[] = [];
+  const errors: string[] = [];
+
+  for (const manifestPackage of params.manifest.packages) {
+    const plugin = byName.get(manifestPackage.packageName);
+    if (!plugin) {
+      errors.push(
+        `${manifestPackage.packageName}: package is not a publishable plugin in this checkout.`,
+      );
+      continue;
+    }
+    if (plugin.version !== manifestPackage.targetVersion) {
+      errors.push(
+        `${manifestPackage.packageName}: package.json version ${plugin.version} does not match stable manifest target ${manifestPackage.targetVersion}.`,
+      );
+    }
+    if (plugin.packageDir !== manifestPackage.packageDir) {
+      errors.push(
+        `${manifestPackage.packageName}: packageDir ${plugin.packageDir} does not match stable manifest packageDir ${manifestPackage.packageDir}.`,
+      );
+    }
+    if (plugin.channel !== "stable") {
+      errors.push(
+        `${manifestPackage.packageName}: stable manifest releases require a stable final package version; got ${plugin.version}.`,
+      );
+    }
+    resolved.push({
+      ...plugin,
+      publishTag: "stable",
+      releaseClass: params.releaseClass,
+      releaseSelector: params.releaseSelector,
+      stableLine: params.manifest.stableLine,
+      stablePluginSupportSha256: params.manifest.sha256,
+      targetBranch: manifestPackage.targetBranch,
+      targetNpmSpec: manifestPackage.targetNpmSpec,
+      packageAcceptanceRunId: params.packageAcceptanceRunId,
+    });
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Stable manifest plugin release plan validation failed:\n${errors
+        .map((error) => `- ${error}`)
+        .join("\n")}`,
+    );
+  }
+
+  return resolved;
 }
 
 export function collectChangedExtensionIdsFromPaths(paths: readonly string[]): string[] {
@@ -534,7 +851,26 @@ export function collectPluginReleasePlan(params?: {
   selection?: string[];
   selectionMode?: PluginReleaseSelectionMode;
   gitRange?: GitRangeSelection;
+  releaseClass?: PluginReleaseClass;
+  releaseSelector?: PluginReleaseSelector;
+  stableLine?: string;
+  stablePluginManifestPath?: string;
+  stablePluginManifestSha256?: string;
+  packageAcceptanceRunId?: string;
 }): PluginReleasePlan {
+  const releaseSelector = params?.releaseSelector ?? "daily";
+  const releaseClass =
+    params?.releaseClass ?? (releaseSelector === "stable" ? "stable-base" : "daily");
+  const selectionMode =
+    params?.selectionMode ?? (params?.gitRange ? "selected" : "all-publishable");
+  const stableManifest =
+    selectionMode === "stable-manifest"
+      ? resolveStablePluginSupportManifest({
+          path: params?.stablePluginManifestPath ?? "",
+          expectedSha256: params?.stablePluginManifestSha256 ?? "",
+          stableLine: params?.stableLine ?? "",
+        })
+      : undefined;
   const changedExtensionIds = params?.gitRange
     ? collectChangedExtensionIdsFromGitRange({
         rootDir: params.rootDir,
@@ -543,25 +879,39 @@ export function collectPluginReleasePlan(params?: {
     : [];
   const allPublishable = collectPublishablePluginPackages(params?.rootDir, {
     extensionIds:
-      params?.selectionMode === "all-publishable" || !params?.gitRange
+      params?.selectionMode === "all-publishable" ||
+      params?.selectionMode === "stable-manifest" ||
+      !params?.gitRange
         ? undefined
         : changedExtensionIds,
-    packageNames: params?.selection && params.selection.length > 0 ? params.selection : undefined,
+    packageNames: stableManifest
+      ? stableManifest.packages.map((plugin) => plugin.packageName)
+      : params?.selection && params.selection.length > 0
+        ? params.selection
+        : undefined,
   });
   const selectedPublishable =
-    params?.selectionMode === "all-publishable"
-      ? allPublishable
-      : params?.selection && params.selection.length > 0
-        ? resolveSelectedPublishablePluginPackages({
-            plugins: allPublishable,
-            selection: params.selection,
-          })
-        : params?.gitRange
-          ? resolveChangedPublishablePluginPackages({
+    params?.selectionMode === "stable-manifest" && stableManifest
+      ? resolveStableManifestPublishablePluginPackages({
+          plugins: allPublishable,
+          manifest: stableManifest,
+          releaseClass,
+          releaseSelector,
+          packageAcceptanceRunId: params?.packageAcceptanceRunId ?? "",
+        })
+      : params?.selectionMode === "all-publishable"
+        ? allPublishable
+        : params?.selection && params.selection.length > 0
+          ? resolveSelectedPublishablePluginPackages({
               plugins: allPublishable,
-              changedExtensionIds,
+              selection: params.selection,
             })
-          : allPublishable;
+          : params?.gitRange
+            ? resolveChangedPublishablePluginPackages({
+                plugins: allPublishable,
+                changedExtensionIds,
+              })
+            : allPublishable;
 
   const explicitPublishSelection =
     params?.selectionMode !== undefined || (params?.selection?.length ?? 0) > 0;
@@ -579,5 +929,12 @@ export function collectPluginReleasePlan(params?: {
     all,
     candidates: all.filter((plugin) => !plugin.alreadyPublished),
     skippedPublished: all.filter((plugin) => plugin.alreadyPublished),
+    packages: all.map((plugin) => `${plugin.packageName}@${plugin.version}`),
+    releaseClass,
+    releaseSelector,
+    selectionMode,
+    stableLine: stableManifest?.stableLine,
+    stablePluginSupportSha256: stableManifest?.sha256,
+    packageAcceptanceRunId: params?.packageAcceptanceRunId,
   };
 }

--- a/scripts/lib/stable-plugin-backport-plan.ts
+++ b/scripts/lib/stable-plugin-backport-plan.ts
@@ -1,0 +1,346 @@
+// Dry-run planner for stable core/plugin backports.
+import {
+  computeStablePluginSupportManifestSha256,
+  parseStablePluginSupportManifest,
+  type StablePluginSupportEntry,
+  type StablePluginSupportManifest,
+} from "../../src/plugins/plugin-version-drift.ts";
+
+export type StablePluginBackportSource = {
+  sourcePr?: string;
+  sourceSha?: string;
+  eligibilityReason: string;
+};
+
+export type StablePluginBackportTarget = {
+  targetType: "core" | "plugin";
+  targetRepository: string;
+  sourceRepository: string;
+  targetBranch: string;
+  expectedBaseSha: null;
+  branchProtectionStatus: "not_checked_dry_run";
+  changeKind: "core_only" | "plugin_only" | "coordinated";
+  packageName: string;
+  pluginId?: string;
+  packageDir?: string;
+  targetVersion?: string;
+  targetNpmSpec?: string;
+  publishOrder: number;
+  validationPlan: StablePluginBackportValidationStep[];
+  rollback: {
+    partialFailureState: string;
+    command: string;
+  };
+  retry: {
+    command: string;
+    requiresProof: string[];
+  };
+};
+
+export type StablePluginBackportValidationStep = {
+  name: string;
+  command: string;
+  required: boolean;
+};
+
+export type StablePluginBackportPlan = {
+  schemaVersion: 1;
+  dryRun: true;
+  stableLine: string;
+  stableBranch: string;
+  source: StablePluginBackportSource & {
+    sourceReviewState: "reviewed_source_required";
+  };
+  manifest: {
+    path?: string;
+    sha256: string;
+    coveredPackageCount: number;
+  };
+  affectedPluginIds: string[];
+  targets: StablePluginBackportTarget[];
+  orderedOperations: {
+    order: number;
+    targetRepository: string;
+    targetBranch: string;
+    packageName: string;
+    operation: string;
+  }[];
+  partialFailureStates: {
+    state: string;
+    recovery: string;
+  }[];
+};
+
+export type StablePluginBackportPlanInput = {
+  sourcePr?: string;
+  sourceSha?: string;
+  stableLine: string;
+  eligibilityReason: string;
+  affectedPluginIds?: readonly string[];
+  manifest: StablePluginSupportManifest;
+  manifestPath?: string;
+  coreRepository?: string;
+  corePackageName?: string;
+};
+
+function normalizeString(value: string | undefined, label: string): string {
+  const normalized = value?.trim();
+  if (!normalized) {
+    throw new Error(`${label} is required.`);
+  }
+  return normalized;
+}
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  return value?.trim() || undefined;
+}
+
+function affectedPluginSet(input: readonly string[] | undefined): Set<string> {
+  return new Set((input ?? []).map((entry) => entry.trim()).filter(Boolean));
+}
+
+function stableBranchFor(input: StablePluginBackportPlanInput): string {
+  return input.manifest.coveredPlugins[0]?.targetBranch ?? `stable/${input.stableLine}`;
+}
+
+function pluginValidationPlan(params: {
+  stableLine: string;
+  packageName: string;
+  targetNpmSpec: string;
+}): StablePluginBackportValidationStep[] {
+  return [
+    {
+      name: "stable-plugin-drift-dry-run",
+      command:
+        `node --import tsx scripts/stable-plugin-drift-report.ts --stable-line ${params.stableLine} ` +
+        "--manifest <stable-plugin-support.json> --registry-proof <registry-proof.json> " +
+        "--package-acceptance <stable-plugin-acceptance.json> --json",
+      required: true,
+    },
+    {
+      name: "package-acceptance-stable-plugin",
+      command:
+        `package-acceptance suite_profile=stable-plugin package=${params.targetNpmSpec} ` +
+        `stable_line=${params.stableLine}`,
+      required: true,
+    },
+    {
+      name: "plugin-publish-proof",
+      command: `npm view ${params.packageName} version dist.integrity dist.tarball time --json`,
+      required: true,
+    },
+  ];
+}
+
+function coreValidationPlan(stableLine: string): StablePluginBackportValidationStep[] {
+  return [
+    {
+      name: "core-stable-branch-tests",
+      command: "node scripts/run-vitest.mjs test/stable-release-closeout.test.ts",
+      required: true,
+    },
+    {
+      name: "stable-plugin-proof-gate",
+      command:
+        `node --import tsx scripts/stable-plugin-drift-report.ts --stable-line ${stableLine} ` +
+        "--manifest <stable-plugin-support.json> --registry-proof <registry-proof.json> " +
+        "--package-acceptance <stable-plugin-acceptance.json> --json",
+      required: true,
+    },
+  ];
+}
+
+function buildPluginTarget(params: {
+  entry: StablePluginSupportEntry;
+  stableLine: string;
+  order: number;
+  coordinated: boolean;
+}): StablePluginBackportTarget {
+  const retryCommand =
+    `node --import tsx scripts/stable-plugin-backport-plan.ts --stable-line ${params.stableLine} ` +
+    `--affected-plugin-ids ${params.entry.pluginId} --source-sha <source-sha> ` +
+    '--eligibility-reason "<reason>" --manifest <stable-plugin-support.json>';
+  return {
+    targetType: "plugin",
+    targetRepository: params.entry.sourceRepository,
+    sourceRepository: params.entry.sourceRepository,
+    targetBranch: params.entry.targetBranch,
+    expectedBaseSha: null,
+    branchProtectionStatus: "not_checked_dry_run",
+    changeKind: params.coordinated ? "coordinated" : "plugin_only",
+    packageName: params.entry.packageName,
+    pluginId: params.entry.pluginId,
+    packageDir: params.entry.packageDir,
+    targetVersion: params.entry.targetVersion,
+    targetNpmSpec: params.entry.targetNpmSpec,
+    publishOrder: params.order,
+    validationPlan: pluginValidationPlan({
+      stableLine: params.stableLine,
+      packageName: params.entry.packageName,
+      targetNpmSpec: params.entry.targetNpmSpec,
+    }),
+    rollback: {
+      partialFailureState: "partial_plugin_publish",
+      command:
+        `block stable activation for ${params.entry.packageName}; verify any existing npm package ` +
+        "identity before retrying or superseding with a higher stable patch",
+    },
+    retry: {
+      command: retryCommand,
+      requiresProof: [
+        "registry identity for already-published package",
+        "stable-plugin package acceptance proof",
+        "stable support manifest digest match",
+      ],
+    },
+  };
+}
+
+function buildCoreTarget(params: {
+  repository: string;
+  packageName: string;
+  stableLine: string;
+  targetBranch: string;
+  order: number;
+  coordinated: boolean;
+}): StablePluginBackportTarget {
+  const retryCommand =
+    `node --import tsx scripts/stable-plugin-backport-plan.ts --stable-line ${params.stableLine} ` +
+    '--source-sha <source-sha> --eligibility-reason "<reason>" --manifest <stable-plugin-support.json>';
+  return {
+    targetType: "core",
+    targetRepository: params.repository,
+    sourceRepository: params.repository,
+    targetBranch: params.targetBranch,
+    expectedBaseSha: null,
+    branchProtectionStatus: "not_checked_dry_run",
+    changeKind: params.coordinated ? "coordinated" : "core_only",
+    packageName: params.packageName,
+    publishOrder: params.order,
+    validationPlan: coreValidationPlan(params.stableLine),
+    rollback: {
+      partialFailureState: params.coordinated
+        ? "core_published_plugin_missing"
+        : "activation_blocked",
+      command:
+        "keep previous stable metadata active; do not move selectors until postpublish and " +
+        "stable-plugin proof are complete",
+    },
+    retry: {
+      command: retryCommand,
+      requiresProof: [
+        "stable branch tests",
+        "core package postpublish evidence",
+        "covered plugin drift report with no blocking drift",
+      ],
+    },
+  };
+}
+
+export function generateStablePluginBackportPlan(
+  input: StablePluginBackportPlanInput,
+): StablePluginBackportPlan {
+  const stableLine = normalizeString(input.stableLine, "stableLine");
+  const eligibilityReason = normalizeString(input.eligibilityReason, "eligibilityReason");
+  const sourcePr = normalizeOptionalString(input.sourcePr);
+  const sourceSha = normalizeOptionalString(input.sourceSha);
+  if (!sourcePr && !sourceSha) {
+    throw new Error("sourcePr or sourceSha is required.");
+  }
+
+  const selectedPluginIds = affectedPluginSet(input.affectedPluginIds);
+  const pluginsById = new Map(
+    input.manifest.coveredPlugins.map((entry) => [entry.pluginId, entry]),
+  );
+  const missingPluginIds = [...selectedPluginIds].filter((pluginId) => !pluginsById.has(pluginId));
+  if (missingPluginIds.length > 0) {
+    throw new Error(
+      `Affected plugin ids are not covered by the stable support manifest: ${missingPluginIds.join(", ")}.`,
+    );
+  }
+
+  const stableBranch = stableBranchFor(input);
+  const pluginEntries = [...selectedPluginIds].map((pluginId) => pluginsById.get(pluginId)!);
+  const targets: StablePluginBackportTarget[] = pluginEntries.map((entry, index) =>
+    buildPluginTarget({
+      entry,
+      stableLine,
+      order: index + 1,
+      coordinated: true,
+    }),
+  );
+  targets.push(
+    buildCoreTarget({
+      repository: input.coreRepository ?? "openclaw/openclaw",
+      packageName: input.corePackageName ?? "openclaw",
+      stableLine,
+      targetBranch: stableBranch,
+      order: targets.length + 1,
+      coordinated: targets.length > 0,
+    }),
+  );
+
+  return {
+    schemaVersion: 1,
+    dryRun: true,
+    stableLine,
+    stableBranch,
+    source: {
+      ...(sourcePr ? { sourcePr } : {}),
+      ...(sourceSha ? { sourceSha } : {}),
+      eligibilityReason,
+      sourceReviewState: "reviewed_source_required",
+    },
+    manifest: {
+      ...(input.manifestPath ? { path: input.manifestPath } : {}),
+      sha256: computeStablePluginSupportManifestSha256(input.manifest),
+      coveredPackageCount: input.manifest.coveredPlugins.length,
+    },
+    affectedPluginIds: [...selectedPluginIds].toSorted(),
+    targets,
+    orderedOperations: targets.map((target) => ({
+      order: target.publishOrder,
+      targetRepository: target.targetRepository,
+      targetBranch: target.targetBranch,
+      packageName: target.packageName,
+      operation:
+        target.targetType === "plugin"
+          ? "backport plugin fix, validate, publish/prove package, then hold core activation"
+          : "backport core fix, publish only after covered plugin proof is available",
+    })),
+    partialFailureStates: [
+      {
+        state: "planned",
+        recovery: "rerun plan after source or evidence fixes; no publish mutation has happened",
+      },
+      {
+        state: "plugin_published_core_pending",
+        recovery: "verify plugin registry identity, then resume core publish or supersede patch",
+      },
+      {
+        state: "core_published_plugin_missing",
+        recovery: "block activation and repair plugin proof before selector movement",
+      },
+      {
+        state: "partial_plugin_publish",
+        recovery: "retry only missing packages after registry proof for succeeded packages",
+      },
+      {
+        state: "activation_blocked",
+        recovery: "keep previous stable active and rerun closeout after evidence repair",
+      },
+    ],
+  };
+}
+
+export function parseAffectedPluginIds(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(/[,\s]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .toSorted();
+}
+
+export function parseStablePluginBackportPlanManifest(raw: unknown): StablePluginSupportManifest {
+  return parseStablePluginSupportManifest(raw);
+}

--- a/scripts/openclaw-npm-release-check.ts
+++ b/scripts/openclaw-npm-release-check.ts
@@ -54,8 +54,8 @@ export type ParsedReleaseTag = {
 
 export type NpmPublishPlan = {
   channel: "stable" | "alpha" | "beta";
-  publishTag: "latest" | "alpha" | "beta";
-  mirrorDistTags: ("latest" | "alpha" | "beta")[];
+  publishTag: "latest" | "stable" | "alpha" | "beta";
+  mirrorDistTags: ("latest" | "stable" | "alpha" | "beta")[];
 };
 
 export type NpmDistTagMirrorAuth = {
@@ -207,21 +207,17 @@ export function compareReleaseVersions(left: string, right: string): number | nu
 export function resolveNpmPublishPlan(
   version: string,
   _currentBetaVersion?: string | null,
-  requestedPublishTag?: "latest" | "alpha" | "beta" | null,
+  requestedPublishTag?: "latest" | "stable" | "alpha" | "beta" | null,
 ): NpmPublishPlan {
   const parsedVersion = parseReleaseVersion(version);
   if (parsedVersion === null) {
     throw new Error(`Unsupported release version "${version}".`);
   }
 
-  const publishTag =
-    requestedPublishTag?.trim() === "latest"
-      ? "latest"
-      : requestedPublishTag?.trim() === "alpha"
-        ? "alpha"
-        : "beta";
+  const requestedTag = requestedPublishTag?.trim();
 
   if (parsedVersion.channel === "alpha") {
+    const publishTag = requestedTag ?? "alpha";
     if (publishTag !== "alpha") {
       throw new Error("Alpha prereleases must publish to the alpha dist-tag.");
     }
@@ -233,6 +229,7 @@ export function resolveNpmPublishPlan(
   }
 
   if (parsedVersion.channel === "beta") {
+    const publishTag = requestedTag ?? "beta";
     if (publishTag !== "beta") {
       throw new Error("Beta prereleases must publish to the beta dist-tag.");
     }
@@ -241,6 +238,11 @@ export function resolveNpmPublishPlan(
       publishTag: "beta",
       mirrorDistTags: [],
     };
+  }
+
+  const publishTag = requestedTag ?? "stable";
+  if (publishTag !== "stable") {
+    throw new Error("Stable releases must publish to the stable dist-tag.");
   }
 
   return {

--- a/scripts/plugin-npm-publish.sh
+++ b/scripts/plugin-npm-publish.sh
@@ -18,6 +18,14 @@ fi
 package_name="$(node -e 'const pkg = require(require("node:path").resolve(process.argv[1], "package.json")); console.log(pkg.name)' "${package_dir}")"
 package_version="$(node -e 'const pkg = require(require("node:path").resolve(process.argv[1], "package.json")); console.log(pkg.version)' "${package_dir}")"
 current_beta_version="$(npm view "${package_name}" dist-tags.beta 2>/dev/null || true)"
+release_selector="${OPENCLAW_PLUGIN_NPM_RELEASE_SELECTOR:-daily}"
+release_class="${OPENCLAW_PLUGIN_NPM_RELEASE_CLASS:-daily}"
+expected_package_name="${OPENCLAW_PLUGIN_NPM_EXPECTED_PACKAGE_NAME:-}"
+expected_package_version="${OPENCLAW_PLUGIN_NPM_EXPECTED_PACKAGE_VERSION:-}"
+expected_npm_tag="${OPENCLAW_PLUGIN_NPM_EXPECTED_NPM_TAG:-}"
+stable_manifest_sha256="${OPENCLAW_PLUGIN_NPM_STABLE_MANIFEST_SHA256:-}"
+stable_line="${OPENCLAW_PLUGIN_NPM_STABLE_LINE:-}"
+package_acceptance_run_id="${OPENCLAW_PLUGIN_NPM_PACKAGE_ACCEPTANCE_RUN_ID:-}"
 log() {
   if [[ "${mode}" == "--pack-dry-run" ]]; then
     printf '%s\n' "$*" >&2
@@ -60,6 +68,51 @@ mirror_auth_source="$(printf '%s\n' "${publish_plan_output}" | sed -n '4p')"
 mirror_auth_requirement="$(printf '%s\n' "${publish_plan_output}" | sed -n '5p')"
 mirror_auth_source="${mirror_auth_source:-none}"
 mirror_auth_requirement="${mirror_auth_requirement:-optional}"
+
+if [[ "${release_selector}" == "stable" ]]; then
+  if [[ "${release_class}" != "stable-base" && "${release_class}" != "stable-patch" ]]; then
+    echo "Stable plugin npm publish requires OPENCLAW_PLUGIN_NPM_RELEASE_CLASS=stable-base or stable-patch." >&2
+    exit 1
+  fi
+  if [[ -z "${stable_line// }" ]]; then
+    echo "Stable plugin npm publish requires OPENCLAW_PLUGIN_NPM_STABLE_LINE." >&2
+    exit 1
+  fi
+  if [[ ! "${stable_manifest_sha256}" =~ ^[a-f0-9]{64}$ ]]; then
+    echo "Stable plugin npm publish requires OPENCLAW_PLUGIN_NPM_STABLE_MANIFEST_SHA256 as a lowercase SHA-256 digest." >&2
+    exit 1
+  fi
+  if [[ -z "${package_acceptance_run_id// }" ]]; then
+    echo "Stable plugin npm publish requires OPENCLAW_PLUGIN_NPM_PACKAGE_ACCEPTANCE_RUN_ID." >&2
+    exit 1
+  fi
+  if [[ "${expected_package_name}" != "${package_name}" ]]; then
+    echo "Stable plugin npm publish package mismatch: expected ${expected_package_name:-<missing>}, got ${package_name}." >&2
+    exit 1
+  fi
+  if [[ "${expected_package_version}" != "${package_version}" ]]; then
+    echo "Stable plugin npm publish version mismatch for ${package_name}: expected ${expected_package_version:-<missing>}, got ${package_version}." >&2
+    exit 1
+  fi
+  if [[ "${expected_npm_tag}" != "stable" ]]; then
+    echo "Stable plugin npm publish requires OPENCLAW_PLUGIN_NPM_EXPECTED_NPM_TAG=stable; refusing ${expected_npm_tag:-<missing>}." >&2
+    exit 1
+  fi
+  if [[ "${publish_tag}" == "latest" || "${publish_tag}" == "daily" ]]; then
+    log "Generic final-version npm plan resolved ${publish_tag}; stable manifest mode overrides it with ${expected_npm_tag}."
+  fi
+  publish_tag="${expected_npm_tag}"
+  mirror_dist_tags_csv=""
+elif [[ "${release_selector}" == "daily" ]]; then
+  if [[ -n "${expected_package_name}${expected_package_version}${expected_npm_tag}${stable_manifest_sha256}${stable_line}${package_acceptance_run_id}" ]]; then
+    echo "Stable plugin npm expectation inputs require OPENCLAW_PLUGIN_NPM_RELEASE_SELECTOR=stable." >&2
+    exit 1
+  fi
+else
+  echo "Unknown OPENCLAW_PLUGIN_NPM_RELEASE_SELECTOR: ${release_selector}. Expected daily or stable." >&2
+  exit 1
+fi
+
 publish_cmd=(npm publish --access public --tag "${publish_tag}")
 if [[ "${OPENCLAW_NPM_PUBLISH_PROVENANCE:-1}" != "0" && "${OPENCLAW_NPM_PUBLISH_PROVENANCE:-1}" != "false" ]]; then
   publish_cmd+=(--provenance)

--- a/scripts/plugin-npm-release-check.ts
+++ b/scripts/plugin-npm-release-check.ts
@@ -4,6 +4,7 @@
 import { pathToFileURL } from "node:url";
 import {
   collectChangedExtensionIdsFromGitRange,
+  collectPluginReleasePlan,
   collectPublishablePluginPackages,
   assertPluginReleaseVersionFloors,
   parsePluginReleaseArgs,
@@ -12,13 +13,40 @@ import {
 } from "./lib/plugin-npm-release.ts";
 
 export function runPluginNpmReleaseCheck(argv: string[]) {
-  const { selection, selectionMode, baseRef, headRef } = parsePluginReleaseArgs(argv);
+  const {
+    selection,
+    selectionMode,
+    baseRef,
+    headRef,
+    releaseClass,
+    releaseSelector,
+    stableLine,
+    stablePluginManifestPath,
+    stablePluginManifestSha256,
+    packageAcceptanceRunId,
+  } = parsePluginReleaseArgs(argv);
   const changedExtensionIds =
     baseRef && headRef
       ? collectChangedExtensionIdsFromGitRange({
           gitRange: { baseRef, headRef },
         })
       : [];
+  if (selectionMode === "stable-manifest") {
+    const plan = collectPluginReleasePlan({
+      selection,
+      selectionMode,
+      releaseClass,
+      releaseSelector,
+      stableLine,
+      stablePluginManifestPath,
+      stablePluginManifestSha256,
+      packageAcceptanceRunId,
+    });
+    console.log(
+      `plugin-npm-release-check: stable manifest ${plan.stablePluginSupportSha256} selects ${plan.packages.join(", ")}.`,
+    );
+    return;
+  }
   const publishable = collectPublishablePluginPackages(".", {
     extensionIds:
       selectionMode === "all-publishable" || !(baseRef && headRef)

--- a/scripts/plugin-npm-release-plan.ts
+++ b/scripts/plugin-npm-release-plan.ts
@@ -5,11 +5,28 @@ import { pathToFileURL } from "node:url";
 import { collectPluginReleasePlan, parsePluginReleaseArgs } from "./lib/plugin-npm-release.ts";
 
 export function collectPluginNpmReleasePlan(argv: string[]) {
-  const { selection, selectionMode, baseRef, headRef } = parsePluginReleaseArgs(argv);
+  const {
+    selection,
+    selectionMode,
+    baseRef,
+    headRef,
+    releaseClass,
+    releaseSelector,
+    stableLine,
+    stablePluginManifestPath,
+    stablePluginManifestSha256,
+    packageAcceptanceRunId,
+  } = parsePluginReleaseArgs(argv);
   return collectPluginReleasePlan({
     selection,
     selectionMode,
     gitRange: baseRef && headRef ? { baseRef, headRef } : undefined,
+    releaseClass,
+    releaseSelector,
+    stableLine,
+    stablePluginManifestPath,
+    stablePluginManifestSha256,
+    packageAcceptanceRunId,
   });
 }
 

--- a/scripts/release-candidate-checklist.mjs
+++ b/scripts/release-candidate-checklist.mjs
@@ -46,9 +46,14 @@ Options:
   --provider <provider>               Full validation provider. Default: ${DEFAULT_PROVIDER}
   --mode <fresh|upgrade|both>         Full validation cross-OS mode. Default: ${DEFAULT_MODE}
   --release-profile <beta|stable|full> Default: beta for prereleases; stable otherwise.
-  --npm-dist-tag <alpha|beta|latest>  Default: ${DEFAULT_NPM_DIST_TAG}
-  --plugin-publish-scope <scope>      selected|all-publishable. Default: ${DEFAULT_PLUGIN_SCOPE}
+  --npm-dist-tag <alpha|beta|stable|latest> Default: beta for prerelease, stable for stable candidates.
+  --plugin-publish-scope <scope>      selected|all-publishable|stable-manifest. Default: ${DEFAULT_PLUGIN_SCOPE}
   --plugins <names>                   Required when plugin scope is selected.
+  --release-class <class>             daily|stable-base|stable-patch. Default: daily for prerelease, stable-base for stable.
+  --stable-line <line>                Stable line month, for example 2026.6.
+  --stable-plugin-manifest-sha256 <sha> Stable plugin support manifest SHA-256 for stable-manifest scope.
+  --stable-plugin-manifest-artifact <name> Stable plugin manifest artifact name for release publish.
+  --package-acceptance-run <id>       Package Acceptance stable-plugin run id.
   --output-dir <dir>                  Evidence output dir. Default: .artifacts/release-candidate/<tag>
 `;
 }
@@ -74,6 +79,11 @@ export function parseArgs(argv) {
     npmDistTag: DEFAULT_NPM_DIST_TAG,
     pluginPublishScope: DEFAULT_PLUGIN_SCOPE,
     plugins: "",
+    releaseClass: "",
+    stableLine: "",
+    stablePluginManifestSha256: "",
+    stablePluginManifestArtifact: "stable-plugin-support",
+    packageAcceptanceRunId: "",
     skipDispatch: false,
     skipLocalGeneratedCheck: false,
     skipParallels: false,
@@ -143,6 +153,21 @@ export function parseArgs(argv) {
       case "--plugins":
         options.plugins = requireValue(args, ++index, arg);
         break;
+      case "--release-class":
+        options.releaseClass = requireValue(args, ++index, arg);
+        break;
+      case "--stable-line":
+        options.stableLine = requireValue(args, ++index, arg);
+        break;
+      case "--stable-plugin-manifest-sha256":
+        options.stablePluginManifestSha256 = requireValue(args, ++index, arg);
+        break;
+      case "--stable-plugin-manifest-artifact":
+        options.stablePluginManifestArtifact = requireValue(args, ++index, arg);
+        break;
+      case "--package-acceptance-run":
+        options.packageAcceptanceRunId = requireValue(args, ++index, arg);
+        break;
       case "--output-dir":
         options.outputDir = requireValue(args, ++index, arg);
         break;
@@ -157,10 +182,24 @@ export function parseArgs(argv) {
   if (!options.tag) {
     throw new Error("--tag is required");
   }
+  const firstStableTag = options.tag === "v2026.6.33";
   options.releaseProfile ||=
-    options.tag.includes("-alpha.") || options.tag.includes("-beta.") ? "beta" : "stable";
+    options.tag.includes("-alpha.") || options.tag.includes("-beta.")
+      ? "beta"
+      : firstStableTag
+        ? "stable"
+        : "full";
+  options.releaseClass ||= firstStableTag ? "stable-base" : "daily";
+  const stableCandidate =
+    options.releaseClass === "stable-base" || options.releaseClass === "stable-patch";
+  if (stableCandidate && options.npmDistTag === DEFAULT_NPM_DIST_TAG) {
+    options.npmDistTag = "stable";
+  }
   if (!["beta", "stable", "full"].includes(options.releaseProfile)) {
     throw new Error("--release-profile must be beta, stable, or full");
+  }
+  if (!["daily", "stable-base", "stable-patch"].includes(options.releaseClass)) {
+    throw new Error("--release-class must be daily, stable-base, or stable-patch");
   }
   if (options.skipDispatch && (!options.fullReleaseRunId || !options.npmPreflightRunId)) {
     throw new Error("--skip-dispatch requires --full-release-run and --npm-preflight-run");
@@ -173,17 +212,57 @@ export function parseArgs(argv) {
       "--plugin-publish-scope selected is only for plugin-only repair publishes; release candidates publish OpenClaw with --plugin-publish-scope all-publishable",
     );
   }
-  if (options.pluginPublishScope === "all-publishable" && options.plugins.trim()) {
+  if (!["selected", "all-publishable", "stable-manifest"].includes(options.pluginPublishScope)) {
+    throw new Error("--plugin-publish-scope must be selected, all-publishable, or stable-manifest");
+  }
+  if (options.pluginPublishScope !== "selected" && options.plugins.trim()) {
     throw new Error("--plugins is only valid with --plugin-publish-scope selected");
+  }
+  if (stableCandidate) {
+    if (options.npmDistTag !== "stable") {
+      throw new Error("stable release candidates require --npm-dist-tag stable");
+    }
+    if (options.pluginPublishScope !== "stable-manifest") {
+      throw new Error("stable release candidates require --plugin-publish-scope stable-manifest");
+    }
+    if (options.releaseClass !== "stable-base" && options.releaseClass !== "stable-patch") {
+      throw new Error(
+        "stable release candidates require --release-class stable-base or stable-patch",
+      );
+    }
+    if (!options.stableLine.trim()) {
+      throw new Error("stable release candidates require --stable-line");
+    }
+    if (!/^(sha256:)?[a-f0-9]{64}$/u.test(options.stablePluginManifestSha256)) {
+      throw new Error(
+        "stable release candidates require --stable-plugin-manifest-sha256 as a lowercase SHA-256 digest",
+      );
+    }
+    if (!options.packageAcceptanceRunId.trim()) {
+      throw new Error("stable release candidates require --package-acceptance-run");
+    }
+  } else {
+    if (options.npmDistTag === "stable") {
+      throw new Error("--npm-dist-tag stable is only valid for stable release candidates");
+    }
+    if (options.pluginPublishScope !== "all-publishable") {
+      throw new Error(
+        "daily/prerelease release candidates require --plugin-publish-scope all-publishable",
+      );
+    }
+    if (
+      options.releaseClass !== "daily" ||
+      options.stableLine.trim() ||
+      options.stablePluginManifestSha256.trim() ||
+      options.packageAcceptanceRunId.trim()
+    ) {
+      throw new Error("stable plugin manifest inputs are only valid for stable release candidates");
+    }
   }
   if (options.windowsNodeTag && !WINDOWS_NODE_TAG_PATTERN.test(options.windowsNodeTag)) {
     throw new Error("--windows-node-tag must be an explicit version tag, not latest");
   }
-  if (
-    !options.tag.includes("-alpha.") &&
-    !options.tag.includes("-beta.") &&
-    !options.windowsNodeTag
-  ) {
+  if (stableCandidate && !options.windowsNodeTag) {
     throw new Error("stable release candidates require --windows-node-tag");
   }
   if (!["mock-openai", "live-frontier"].includes(options.telegramProviderMode)) {
@@ -561,24 +640,56 @@ function sha256(path) {
 }
 
 function pluginPlanArgs(options) {
-  const args = ["--selection-mode", options.pluginPublishScope];
+  const stableManifest = options.pluginPublishScope === "stable-manifest";
+  const args = [
+    "--selection-mode",
+    options.pluginPublishScope,
+    "--release-selector",
+    stableManifest ? "stable" : "daily",
+    "--release-class",
+    options.releaseClass,
+  ];
   if (options.pluginPublishScope === "selected") {
+    args.push("--plugins", options.plugins);
+  }
+  if (stableManifest) {
+    args.push(
+      "--stable-line",
+      options.stableLine,
+      "--stable-plugin-manifest",
+      "release/stable-plugin-support.json",
+      "--stable-plugin-manifest-sha256",
+      options.stablePluginManifestSha256,
+      "--package-acceptance-run-id",
+      options.packageAcceptanceRunId,
+    );
+  }
+  return args;
+}
+
+function clawHubPlanArgs(options) {
+  const scope =
+    options.pluginPublishScope === "stable-manifest"
+      ? "all-publishable"
+      : options.pluginPublishScope;
+  const args = ["--selection-mode", scope];
+  if (scope === "selected") {
     args.push("--plugins", options.plugins);
   }
   return args;
 }
 
-function collectPluginPlan(script, options) {
+function collectPluginPlan(script, options, planArgs = pluginPlanArgs) {
   return JSON.parse(
-    run("node", ["--import", "tsx", script, ...pluginPlanArgs(options)], { capture: true }),
+    run("node", ["--import", "tsx", script, ...planArgs(options)], { capture: true }),
   );
 }
 
-async function collectPluginPlanWithRetry(script, options) {
+async function collectPluginPlanWithRetry(script, options, planArgs = pluginPlanArgs) {
   let lastError;
   for (let attempt = 1; attempt <= 3; attempt += 1) {
     try {
-      return collectPluginPlan(script, options);
+      return collectPluginPlan(script, options, planArgs);
     } catch (error) {
       lastError = error;
       if (attempt === 3) {
@@ -609,6 +720,7 @@ export function buildPublishCommand(options) {
     ["full_release_validation_run_id", options.fullReleaseRunId],
     ["npm_dist_tag", options.npmDistTag],
     ["plugin_publish_scope", options.pluginPublishScope],
+    ["release_class", options.releaseClass],
     ["publish_openclaw_npm", "true"],
     ["release_profile", "from-validation"],
     ["wait_for_clawhub", "false"],
@@ -624,6 +736,17 @@ export function buildPublishCommand(options) {
   }
   if (options.plugins.trim()) {
     fields.push(["plugins", options.plugins]);
+  }
+  if (options.pluginPublishScope === "stable-manifest") {
+    fields.push(
+      ["stable_line", options.stableLine],
+      [
+        "stable_plugin_manifest_sha256",
+        options.stablePluginManifestSha256.replace(/^sha256:/u, ""),
+      ],
+      ["stable_plugin_manifest_artifact", options.stablePluginManifestArtifact],
+      ["package_acceptance_run_id", options.packageAcceptanceRunId],
+    );
   }
   return [
     "gh",
@@ -865,6 +988,7 @@ async function main() {
   const pluginClawHubPlan = await collectPluginPlanWithRetry(
     "scripts/plugin-clawhub-release-plan.ts",
     options,
+    clawHubPlanArgs,
   );
   const publishCommand = buildPublishCommand(options);
   const evidence = {

--- a/scripts/stable-plugin-backport-plan.ts
+++ b/scripts/stable-plugin-backport-plan.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env -S node --import tsx
+// Emits dry-run stable plugin/core backport plans.
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import {
+  generateStablePluginBackportPlan,
+  parseAffectedPluginIds,
+  parseStablePluginBackportPlanManifest,
+} from "./lib/stable-plugin-backport-plan.ts";
+
+type ParsedArgs = {
+  sourcePr?: string;
+  sourceSha?: string;
+  stableLine?: string;
+  eligibilityReason?: string;
+  affectedPluginIds?: string[];
+  manifestPath?: string;
+};
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+export function parseStablePluginBackportPlanArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--source-pr") {
+      parsed.sourcePr = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--source-sha") {
+      parsed.sourceSha = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--stable-line") {
+      parsed.stableLine = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--eligibility-reason") {
+      parsed.eligibilityReason = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--affected-plugin-ids") {
+      parsed.affectedPluginIds = parseAffectedPluginIds(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    if (arg === "--manifest") {
+      parsed.manifestPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--json") {
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return parsed;
+}
+
+export function collectStablePluginBackportPlan(argv: string[]) {
+  const args = parseStablePluginBackportPlanArgs(argv);
+  if (!args.manifestPath) {
+    throw new Error("--manifest is required.");
+  }
+  return generateStablePluginBackportPlan({
+    ...(args.sourcePr ? { sourcePr: args.sourcePr } : {}),
+    ...(args.sourceSha ? { sourceSha: args.sourceSha } : {}),
+    stableLine: args.stableLine ?? "",
+    eligibilityReason: args.eligibilityReason ?? "",
+    affectedPluginIds: args.affectedPluginIds ?? [],
+    manifestPath: args.manifestPath,
+    manifest: parseStablePluginBackportPlanManifest(readJson(args.manifestPath)),
+  });
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  console.log(JSON.stringify(collectStablePluginBackportPlan(process.argv.slice(2)), null, 2));
+}

--- a/scripts/stable-plugin-drift-report.ts
+++ b/scripts/stable-plugin-drift-report.ts
@@ -1,0 +1,293 @@
+#!/usr/bin/env -S node --import tsx
+// Emits stable plugin support drift reports from local JSON evidence inputs.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import {
+  generateStablePluginDriftReport,
+  parseStablePluginSupportManifest,
+  type StablePluginAcceptanceProof,
+  type StablePluginCatalogEntry,
+  type StablePluginInstalledEntry,
+  type StablePluginLineMetadata,
+  type StablePluginRegistryProof,
+} from "../src/plugins/plugin-version-drift.ts";
+
+type ParsedArgs = {
+  stableLine?: string;
+  stableLinesPath?: string;
+  manifestPath?: string;
+  registryProofPath?: string;
+  packageAcceptancePath?: string;
+  catalogPath?: string;
+  installedStatePath?: string;
+  outputPath?: string;
+  issuesOutputPath?: string;
+  updateIssues?: boolean;
+  generatedAt?: string;
+};
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function objectValues(raw: unknown): unknown[] {
+  if (Array.isArray(raw)) {
+    return raw;
+  }
+  if (isRecord(raw)) {
+    if (Array.isArray(raw.entries)) {
+      return raw.entries;
+    }
+    if (Array.isArray(raw.packages)) {
+      return raw.packages;
+    }
+    if (Array.isArray(raw.proofs)) {
+      return raw.proofs;
+    }
+    if (Array.isArray(raw.installedPlugins)) {
+      return raw.installedPlugins;
+    }
+    return Object.values(raw);
+  }
+  return [];
+}
+
+function registryProofs(raw: unknown): StablePluginRegistryProof[] {
+  return objectValues(raw)
+    .filter(isRecord)
+    .map((entry) => {
+      const version = normalizeString(entry.version ?? entry.registryVersion);
+      const targetNpmSpec = normalizeString(entry.targetNpmSpec);
+      const observedAt = normalizeString(entry.observedAt ?? entry.generatedAt);
+      return {
+        packageName: normalizeString(entry.packageName ?? entry.name) ?? "",
+        ...(version ? { version } : {}),
+        ...(targetNpmSpec ? { targetNpmSpec } : {}),
+        exists: entry.exists === undefined ? true : entry.exists === true,
+        ...(observedAt ? { observedAt } : {}),
+      };
+    })
+    .filter((entry) => entry.packageName);
+}
+
+function acceptanceProofs(raw: unknown): StablePluginAcceptanceProof[] {
+  return objectValues(raw)
+    .filter(isRecord)
+    .map((entry) => {
+      const targetVersion = normalizeString(entry.targetVersion ?? entry.version);
+      const targetNpmSpec = normalizeString(entry.targetNpmSpec);
+      const stableLine = normalizeString(entry.stableLine);
+      const stablePluginSupportSha256 = normalizeString(entry.stablePluginSupportSha256);
+      const manifestSha256 = normalizeString(entry.manifestSha256);
+      const result = normalizeString(entry.result) as StablePluginAcceptanceProof["result"];
+      const completedAt = normalizeString(entry.completedAt);
+      const generatedAt = normalizeString(entry.generatedAt);
+      const observedAt = normalizeString(entry.observedAt);
+      return {
+        packageName: normalizeString(entry.packageName ?? entry.name) ?? "",
+        ...(targetVersion ? { targetVersion } : {}),
+        ...(targetNpmSpec ? { targetNpmSpec } : {}),
+        ...(stableLine ? { stableLine } : {}),
+        ...(stablePluginSupportSha256 ? { stablePluginSupportSha256 } : {}),
+        ...(manifestSha256 ? { manifestSha256 } : {}),
+        ...(entry.passed === true ? { passed: true } : {}),
+        ...(result ? { result } : {}),
+        ...(completedAt ? { completedAt } : {}),
+        ...(generatedAt ? { generatedAt } : {}),
+        ...(observedAt ? { observedAt } : {}),
+      };
+    })
+    .filter((entry) => entry.packageName);
+}
+
+function catalogEntries(raw: unknown): StablePluginCatalogEntry[] {
+  return objectValues(raw)
+    .filter(isRecord)
+    .map((entry) => {
+      const openclaw = isRecord(entry.openclaw) ? entry.openclaw : {};
+      const plugin = isRecord(openclaw.plugin) ? openclaw.plugin : {};
+      const kind = normalizeString(entry.kind);
+      const source = normalizeString(entry.source);
+      return {
+        packageName: normalizeString(entry.packageName ?? entry.name) ?? "",
+        pluginId: normalizeString(entry.pluginId ?? plugin.id) ?? "",
+        ...(kind ? { kind } : {}),
+        ...(source ? { source } : {}),
+      };
+    })
+    .filter((entry) => entry.packageName && entry.pluginId);
+}
+
+function installedEntries(raw: unknown): StablePluginInstalledEntry[] {
+  return objectValues(raw)
+    .filter(isRecord)
+    .map((entry) => {
+      const packageName = normalizeString(entry.packageName ?? entry.resolvedName);
+      const installedVersion = normalizeString(entry.installedVersion);
+      const resolvedVersion = normalizeString(entry.resolvedVersion);
+      const version = normalizeString(entry.version);
+      const spec = normalizeString(entry.spec);
+      return {
+        pluginId: normalizeString(entry.pluginId ?? entry.id) ?? "",
+        ...(packageName ? { packageName } : {}),
+        ...(installedVersion ? { installedVersion } : {}),
+        ...(resolvedVersion ? { resolvedVersion } : {}),
+        ...(version ? { version } : {}),
+        ...(spec ? { spec } : {}),
+      };
+    })
+    .filter((entry) => entry.pluginId);
+}
+
+function stableLineMetadata(
+  raw: unknown,
+  requestedLine: string | undefined,
+): StablePluginLineMetadata | undefined {
+  if (!isRecord(raw)) {
+    return requestedLine ? { stableLine: requestedLine } : undefined;
+  }
+  const candidates = objectValues(raw).filter(isRecord);
+  const selected =
+    candidates.find(
+      (entry) => normalizeString(entry.stableLine ?? entry.baseVersion) === requestedLine,
+    ) ??
+    (isRecord(raw.active) ? raw.active : undefined) ??
+    raw;
+  const stableLine = normalizeString(selected.stableLine ?? selected.baseVersion) ?? requestedLine;
+  const baseVersion = normalizeString(selected.baseVersion);
+  const targetBranch = normalizeString(selected.targetBranch ?? selected.branch);
+  const updatedAt = normalizeString(selected.updatedAt ?? selected.lastRefreshed);
+  const manifestSha256 = normalizeString(
+    selected.manifestSha256 ?? selected.stablePluginSupportSha256,
+  );
+  return stableLine
+    ? {
+        stableLine,
+        ...(baseVersion ? { baseVersion } : {}),
+        ...(targetBranch ? { targetBranch } : {}),
+        ...(updatedAt ? { updatedAt } : {}),
+        ...(manifestSha256 ? { manifestSha256 } : {}),
+      }
+    : undefined;
+}
+
+export function parseStablePluginDriftReportArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--stable-line") {
+      parsed.stableLine = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--stable-lines") {
+      parsed.stableLinesPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--manifest") {
+      parsed.manifestPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--registry-proof") {
+      parsed.registryProofPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--package-acceptance") {
+      parsed.packageAcceptancePath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--catalog") {
+      parsed.catalogPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--installed-state") {
+      parsed.installedStatePath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--output") {
+      parsed.outputPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--issues-output") {
+      parsed.issuesOutputPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--update-issues") {
+      parsed.updateIssues = true;
+      continue;
+    }
+    if (arg === "--dry-run-issues") {
+      parsed.updateIssues = false;
+      continue;
+    }
+    if (arg === "--generated-at") {
+      parsed.generatedAt = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--json") {
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return parsed;
+}
+
+export function collectStablePluginDriftReport(argv: string[]) {
+  const args = parseStablePluginDriftReportArgs(argv);
+  if (!args.manifestPath) {
+    throw new Error("--manifest is required.");
+  }
+  const manifest = parseStablePluginSupportManifest(readJson(args.manifestPath));
+  const stableLine = args.stableLinesPath
+    ? stableLineMetadata(readJson(args.stableLinesPath), args.stableLine)
+    : undefined;
+  const requestedStableLine = args.stableLine ? { stableLine: args.stableLine } : undefined;
+  return generateStablePluginDriftReport({
+    manifest,
+    ...((stableLine ?? requestedStableLine)
+      ? { stableLine: stableLine ?? requestedStableLine }
+      : {}),
+    registryProofs: args.registryProofPath ? registryProofs(readJson(args.registryProofPath)) : [],
+    acceptanceProofs: args.packageAcceptancePath
+      ? acceptanceProofs(readJson(args.packageAcceptancePath))
+      : [],
+    catalogEntries: args.catalogPath ? catalogEntries(readJson(args.catalogPath)) : [],
+    installedEntries: args.installedStatePath
+      ? installedEntries(readJson(args.installedStatePath))
+      : [],
+    ...(args.generatedAt ? { generatedAt: args.generatedAt } : {}),
+    updateIssues: args.updateIssues === true,
+  });
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  const args = parseStablePluginDriftReportArgs(process.argv.slice(2));
+  const report = collectStablePluginDriftReport(process.argv.slice(2));
+  const reportJson = JSON.stringify(report, null, 2);
+  if (args.outputPath) {
+    writeFileSync(args.outputPath, `${reportJson}\n`);
+  } else {
+    console.log(reportJson);
+  }
+  if (args.issuesOutputPath) {
+    writeFileSync(args.issuesOutputPath, `${JSON.stringify(report.issues, null, 2)}\n`);
+  }
+}

--- a/src/config/types.installs.ts
+++ b/src/config/types.installs.ts
@@ -1,4 +1,21 @@
 /** Base persisted install record shared by plugin and skill install tracking. */
+export type InstallIntentProvenance =
+  | "explicit_user_pin"
+  | "prior_default_intent_system_pin"
+  | "unknown";
+
+export type InstallIntentProvenanceMigration = {
+  id: "stable-plugin-install-intent-v1";
+  source: "doctor:stable-plugin-install-intent";
+  migratedAt: string;
+  decision: InstallIntentProvenance;
+  evidence?: {
+    spec?: string;
+    resolvedSpec?: string;
+    trustedSourceLinkedOfficialInstall?: boolean;
+  };
+};
+
 export type InstallRecordBase = {
   source: "npm" | "archive" | "path" | "clawhub" | "git";
   spec?: string;
@@ -21,6 +38,8 @@ export type InstallRecordBase = {
   npmIntegrity?: string;
   npmShasum?: string;
   npmTarballName?: string;
+  installIntentProvenance?: InstallIntentProvenance;
+  installIntentProvenanceMigration?: InstallIntentProvenanceMigration;
   clawpackSha256?: string;
   clawpackSpecVersion?: number;
   clawpackManifestSha256?: string;

--- a/src/config/types.plugins.ts
+++ b/src/config/types.plugins.ts
@@ -53,6 +53,8 @@ export type PluginsLoadConfig = {
 
 export type PluginInstallRecord = Omit<InstallRecordBase, "source"> & {
   source: InstallRecordBase["source"] | "marketplace";
+  installIntentProvenance?: InstallRecordBase["installIntentProvenance"];
+  installIntentProvenanceMigration?: InstallRecordBase["installIntentProvenanceMigration"];
   marketplaceName?: string;
   marketplaceSource?: string;
   marketplacePlugin?: string;

--- a/src/config/zod-schema.installs.ts
+++ b/src/config/zod-schema.installs.ts
@@ -10,6 +10,24 @@ const InstallSourceSchema = z.union([
 ]);
 
 const PluginInstallSourceSchema = z.union([InstallSourceSchema, z.literal("marketplace")]);
+const InstallIntentProvenanceSchema = z.union([
+  z.literal("explicit_user_pin"),
+  z.literal("prior_default_intent_system_pin"),
+  z.literal("unknown"),
+]);
+const InstallIntentProvenanceMigrationSchema = z.object({
+  id: z.literal("stable-plugin-install-intent-v1"),
+  source: z.literal("doctor:stable-plugin-install-intent"),
+  migratedAt: z.string(),
+  decision: InstallIntentProvenanceSchema,
+  evidence: z
+    .object({
+      spec: z.string().optional(),
+      resolvedSpec: z.string().optional(),
+      trustedSourceLinkedOfficialInstall: z.boolean().optional(),
+    })
+    .optional(),
+});
 
 /** Zod object shape for persisted generic install records. */
 export const InstallRecordShape = {
@@ -36,6 +54,8 @@ export const InstallRecordShape = {
   npmIntegrity: z.string().optional(),
   npmShasum: z.string().optional(),
   npmTarballName: z.string().optional(),
+  installIntentProvenance: InstallIntentProvenanceSchema.optional(),
+  installIntentProvenanceMigration: InstallIntentProvenanceMigrationSchema.optional(),
   clawpackSha256: z.string().optional(),
   clawpackSpecVersion: z.number().int().nonnegative().optional(),
   clawpackManifestSha256: z.string().optional(),

--- a/src/plugins/install-channel-specs.stable.test.ts
+++ b/src/plugins/install-channel-specs.stable.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import {
+  resolveClawHubInstallSpecsForUpdateChannel,
+  resolveNpmInstallSpecsForUpdateChannel,
+} from "./install-channel-specs.js";
+import type { ValidatedStablePluginSupportManifest } from "./stable-plugin-support.js";
+
+describe("stable plugin install channel specs", () => {
+  it("rewrites covered default official npm specs to exact stable manifest targets", () => {
+    expect(
+      resolveNpmInstallSpecsForUpdateChannel({
+        spec: "@openclaw/slack",
+        updateChannel: "stable",
+      }),
+    ).toMatchObject({
+      installSpec: "@openclaw/slack@2026.6.33",
+      recordSpec: "@openclaw/slack",
+      reason: "covered_stable_target",
+      packageName: "@openclaw/slack",
+      stableLine: "2026.6",
+    });
+  });
+
+  it("keeps covered default official specs on daily selectors", () => {
+    expect(
+      resolveNpmInstallSpecsForUpdateChannel({
+        spec: "@openclaw/slack@latest",
+        updateChannel: "daily",
+      }),
+    ).toMatchObject({
+      installSpec: "@openclaw/slack@latest",
+      recordSpec: "@openclaw/slack@latest",
+      reason: "covered_daily_target",
+      packageName: "@openclaw/slack",
+    });
+  });
+
+  it("fails closed for ambiguous exact covered official records", () => {
+    expect(
+      resolveNpmInstallSpecsForUpdateChannel({
+        spec: "@openclaw/slack@2026.6.8",
+        updateChannel: "stable",
+        record: {
+          source: "npm",
+          spec: "@openclaw/slack@2026.6.8",
+          resolvedSpec: "@openclaw/slack@2026.6.8",
+        },
+      }),
+    ).toMatchObject({
+      installSpec: "@openclaw/slack@2026.6.8",
+      reason: "ambiguous_exact_official_install",
+      classification: "unknown",
+    });
+  });
+
+  it("converges prior default-intent system pins to the active stable target", () => {
+    const record: PluginInstallRecord = {
+      source: "npm",
+      spec: "@openclaw/slack",
+      resolvedSpec: "@openclaw/slack@2026.6.8",
+      installIntentProvenance: "prior_default_intent_system_pin",
+    };
+
+    expect(
+      resolveNpmInstallSpecsForUpdateChannel({
+        spec: record.resolvedSpec ?? record.spec ?? "",
+        updateChannel: "stable",
+        record,
+      }),
+    ).toMatchObject({
+      installSpec: "@openclaw/slack@2026.6.33",
+      recordSpec: "@openclaw/slack",
+      reason: "covered_stable_target",
+      classification: "prior_default_intent_system_pin",
+    });
+  });
+
+  it("infers prior default intent from default npm record specs", () => {
+    const record: PluginInstallRecord = {
+      source: "npm",
+      spec: "@openclaw/slack",
+      resolvedSpec: "@openclaw/slack@2026.6.8",
+    };
+
+    expect(
+      resolveNpmInstallSpecsForUpdateChannel({
+        spec: record.resolvedSpec ?? "",
+        updateChannel: "stable",
+        record,
+      }),
+    ).toMatchObject({
+      installSpec: "@openclaw/slack@2026.6.33",
+      recordSpec: "@openclaw/slack",
+      reason: "covered_stable_target",
+      classification: "prior_default_intent_system_pin",
+    });
+  });
+
+  it("preserves explicit user pins for covered official packages", () => {
+    expect(
+      resolveNpmInstallSpecsForUpdateChannel({
+        spec: "@openclaw/slack@2026.6.8",
+        updateChannel: "stable",
+        record: {
+          source: "npm",
+          spec: "@openclaw/slack@2026.6.8",
+          installIntentProvenance: "explicit_user_pin",
+        },
+      }),
+    ).toMatchObject({
+      installSpec: "@openclaw/slack@2026.6.8",
+      reason: "preserved_exact_pin",
+      classification: "explicit_user_pin",
+    });
+  });
+
+  it("preserves official packages outside the stable manifest contract", () => {
+    expect(
+      resolveNpmInstallSpecsForUpdateChannel({
+        spec: "@openclaw/matrix",
+        updateChannel: "stable",
+      }),
+    ).toMatchObject({
+      installSpec: "@openclaw/matrix",
+      reason: "outside_stable_contract",
+      packageName: "@openclaw/matrix",
+    });
+  });
+
+  it("preserves ClawHub specs for the first stable contract", () => {
+    expect(
+      resolveClawHubInstallSpecsForUpdateChannel({
+        spec: "clawhub:slack",
+        updateChannel: "stable",
+      }),
+    ).toEqual({
+      installSpec: "clawhub:slack",
+      recordSpec: "clawhub:slack",
+      reason: "outside_stable_contract",
+    });
+  });
+
+  it("reports a missing target when a covered package has no manifest target", () => {
+    const stablePluginSupport = {
+      stablePluginSupportSha256: "0".repeat(64),
+      targetsByPackageName: new Map(),
+    } as ValidatedStablePluginSupportManifest;
+
+    expect(
+      resolveNpmInstallSpecsForUpdateChannel({
+        spec: "@openclaw/slack",
+        updateChannel: "stable",
+        stablePluginSupport,
+      }),
+    ).toMatchObject({
+      installSpec: "@openclaw/slack",
+      reason: "missing_stable_target",
+      packageName: "@openclaw/slack",
+    });
+  });
+
+  it("keeps beta default npm behavior unchanged", () => {
+    expect(
+      resolveNpmInstallSpecsForUpdateChannel({
+        spec: "@openclaw/slack",
+        updateChannel: "beta",
+      }),
+    ).toEqual({
+      installSpec: "@openclaw/slack@beta",
+      recordSpec: "@openclaw/slack",
+      fallbackSpec: "@openclaw/slack",
+      fallbackLabel: "@openclaw/slack@beta",
+    });
+  });
+});

--- a/src/plugins/install-channel-specs.ts
+++ b/src/plugins/install-channel-specs.ts
@@ -1,16 +1,51 @@
 // Parses channel-oriented plugin install specs from package inputs.
+import checkedInStablePluginSupportManifest from "../../release/stable-plugin-support.json" with { type: "json" };
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
-import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
+import { parseRegistryNpmSpec, type ParsedRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import type { UpdateChannel } from "../infra/update-channels.js";
+import { getOfficialExternalPluginCatalogEntryForPackage } from "./official-external-plugin-catalog.js";
+import {
+  FIRST_STABLE_PLUGIN_SUPPORT_PACKAGES,
+  validateStablePluginSupportManifest,
+  type StablePluginSupportEntry,
+  type ValidatedStablePluginSupportManifest,
+} from "./stable-plugin-support.js";
+
+type StableAwareUpdateChannel = UpdateChannel | "daily";
+
+export type ChannelInstallConvergenceReason =
+  | "covered_stable_target"
+  | "covered_daily_target"
+  | "preserved_exact_pin"
+  | "outside_stable_contract"
+  | "third_party_preserved"
+  | "disabled_or_blocked_preserved"
+  | "missing_stable_target"
+  | "ambiguous_exact_official_install";
+
+export type StablePluginInstallClassification =
+  | "explicit_user_pin"
+  | "prior_default_intent_system_pin"
+  | "unknown";
 
 export type ChannelInstallSpecs = {
   installSpec: string;
   recordSpec: string;
   fallbackSpec?: string;
   fallbackLabel?: string;
+  reason?: ChannelInstallConvergenceReason;
+  classification?: StablePluginInstallClassification;
+  packageName?: string;
+  stableLine?: string;
+  manifestSha256?: string;
 };
 
-function isDefaultNpmSpecForBetaChannel(spec: string): { name: string } | null {
+const DEFAULT_STABLE_PLUGIN_SUPPORT = validateStablePluginSupportManifest(
+  checkedInStablePluginSupportManifest,
+);
+
+function isDefaultNpmSpecForChannel(spec: string): { name: string } | null {
   const parsed = parseRegistryNpmSpec(spec);
   if (!parsed) {
     return null;
@@ -22,6 +57,51 @@ function isDefaultNpmSpecForBetaChannel(spec: string): { name: string } | null {
     return { name: parsed.name };
   }
   return null;
+}
+
+function isDefaultNpmSpecParsed(parsed: ParsedRegistryNpmSpec): boolean {
+  return (
+    parsed.selectorKind === "none" ||
+    (parsed.selectorKind === "tag" && parsed.selector?.toLowerCase() === "latest")
+  );
+}
+
+function resolveStableManifestTarget(params: {
+  packageName: string;
+  stablePluginSupport?: ValidatedStablePluginSupportManifest;
+}): StablePluginSupportEntry | undefined {
+  const support = params.stablePluginSupport ?? DEFAULT_STABLE_PLUGIN_SUPPORT;
+  return support.targetsByPackageName.get(params.packageName);
+}
+
+function resolveManifestSha256(stablePluginSupport?: ValidatedStablePluginSupportManifest): string {
+  return (stablePluginSupport ?? DEFAULT_STABLE_PLUGIN_SUPPORT).stablePluginSupportSha256;
+}
+
+function isFirstStableCoveredPackageName(packageName: string): boolean {
+  return (FIRST_STABLE_PLUGIN_SUPPORT_PACKAGES as readonly string[]).includes(packageName);
+}
+
+function isOfficialExternalPackage(packageName: string): boolean {
+  return Boolean(getOfficialExternalPluginCatalogEntryForPackage(packageName));
+}
+
+function resolveInstallIntentClassification(
+  record?: PluginInstallRecord,
+): StablePluginInstallClassification {
+  const recorded =
+    record?.installIntentProvenance ?? record?.installIntentProvenanceMigration?.decision;
+  if (recorded) {
+    return recorded;
+  }
+  if (record?.source === "npm" && record.spec && isDefaultNpmSpecForChannel(record.spec)) {
+    return "prior_default_intent_system_pin";
+  }
+  return "unknown";
+}
+
+function isExactCoveredOfficialSpec(parsed: ParsedRegistryNpmSpec): boolean {
+  return parsed.selectorKind === "exact-version" && isFirstStableCoveredPackageName(parsed.name);
 }
 
 function isDefaultClawHubSpecForBetaChannel(spec: string): { name: string } | null {
@@ -37,15 +117,28 @@ function isDefaultClawHubSpecForBetaChannel(spec: string): { name: string } | nu
 
 export function resolveNpmInstallSpecsForUpdateChannel(params: {
   spec: string;
-  updateChannel?: UpdateChannel;
+  updateChannel?: StableAwareUpdateChannel;
+  record?: PluginInstallRecord;
+  stablePluginSupport?: ValidatedStablePluginSupportManifest;
 }): ChannelInstallSpecs {
+  const parsed = parseRegistryNpmSpec(params.spec);
+  if (params.updateChannel === "stable" || params.updateChannel === "daily") {
+    return resolveStableAwareNpmInstallSpecsForUpdateChannel({
+      spec: params.spec,
+      parsed,
+      updateChannel: params.updateChannel,
+      record: params.record,
+      stablePluginSupport: params.stablePluginSupport,
+    });
+  }
+
   if (params.updateChannel !== "beta") {
     return {
       installSpec: params.spec,
       recordSpec: params.spec,
     };
   }
-  const betaTarget = isDefaultNpmSpecForBetaChannel(params.spec);
+  const betaTarget = isDefaultNpmSpecForChannel(params.spec);
   if (!betaTarget) {
     return {
       installSpec: params.spec,
@@ -61,14 +154,217 @@ export function resolveNpmInstallSpecsForUpdateChannel(params: {
   };
 }
 
+function resolveStableAwareNpmInstallSpecsForUpdateChannel(params: {
+  spec: string;
+  parsed: ParsedRegistryNpmSpec | null;
+  updateChannel: "stable" | "daily";
+  record?: PluginInstallRecord;
+  stablePluginSupport?: ValidatedStablePluginSupportManifest;
+}): ChannelInstallSpecs {
+  if (!params.parsed) {
+    return {
+      installSpec: params.spec,
+      recordSpec: params.spec,
+      reason: "third_party_preserved",
+    };
+  }
+
+  const packageName = params.parsed.name;
+  const target = resolveStableManifestTarget({
+    packageName,
+    stablePluginSupport: params.stablePluginSupport,
+  });
+  const isDefaultIntent = isDefaultNpmSpecParsed(params.parsed);
+  const isCoveredPackage = isFirstStableCoveredPackageName(packageName);
+  const isOfficialPackage = isOfficialExternalPackage(packageName);
+
+  if (params.updateChannel === "daily") {
+    if (isDefaultIntent && target) {
+      return {
+        installSpec: params.spec,
+        recordSpec: params.spec,
+        reason: "covered_daily_target",
+        packageName,
+        stableLine: target.stableLine,
+        manifestSha256: resolveManifestSha256(params.stablePluginSupport),
+      };
+    }
+    return preserveStableAwareSpec({
+      spec: params.spec,
+      parsed: params.parsed,
+      target,
+      isOfficialPackage,
+      updateChannel: params.updateChannel,
+      record: params.record,
+      stablePluginSupport: params.stablePluginSupport,
+    });
+  }
+
+  if (isDefaultIntent) {
+    if (target) {
+      return {
+        installSpec: target.targetNpmSpec,
+        recordSpec: params.spec,
+        reason: "covered_stable_target",
+        packageName,
+        stableLine: target.stableLine,
+        manifestSha256: resolveManifestSha256(params.stablePluginSupport),
+      };
+    }
+    return {
+      installSpec: params.spec,
+      recordSpec: params.spec,
+      reason: isCoveredPackage ? "missing_stable_target" : "outside_stable_contract",
+      packageName,
+      ...(isCoveredPackage
+        ? {}
+        : { manifestSha256: resolveManifestSha256(params.stablePluginSupport) }),
+    };
+  }
+
+  if (isExactCoveredOfficialSpec(params.parsed)) {
+    const classification = resolveInstallIntentClassification(params.record);
+    if (classification === "prior_default_intent_system_pin") {
+      if (!target) {
+        return {
+          installSpec: params.spec,
+          recordSpec: params.spec,
+          reason: "missing_stable_target",
+          classification,
+          packageName,
+        };
+      }
+      return {
+        installSpec: target.targetNpmSpec,
+        recordSpec: params.record?.spec ?? packageName,
+        reason: "covered_stable_target",
+        classification,
+        packageName,
+        stableLine: target.stableLine,
+        manifestSha256: resolveManifestSha256(params.stablePluginSupport),
+      };
+    }
+    if (classification === "explicit_user_pin") {
+      return {
+        installSpec: params.spec,
+        recordSpec: params.spec,
+        reason: "preserved_exact_pin",
+        classification,
+        packageName,
+      };
+    }
+    return {
+      installSpec: params.spec,
+      recordSpec: params.spec,
+      reason: "ambiguous_exact_official_install",
+      classification,
+      packageName,
+    };
+  }
+
+  return preserveStableAwareSpec({
+    spec: params.spec,
+    parsed: params.parsed,
+    target,
+    isOfficialPackage,
+    updateChannel: params.updateChannel,
+    record: params.record,
+    stablePluginSupport: params.stablePluginSupport,
+  });
+}
+
+function preserveStableAwareSpec(params: {
+  spec: string;
+  parsed: ParsedRegistryNpmSpec;
+  target?: StablePluginSupportEntry;
+  isOfficialPackage: boolean;
+  updateChannel: "stable" | "daily";
+  record?: PluginInstallRecord;
+  stablePluginSupport?: ValidatedStablePluginSupportManifest;
+}): ChannelInstallSpecs {
+  if (params.parsed.selectorKind === "exact-version") {
+    const classification = resolveInstallIntentClassification(params.record);
+    if (params.target) {
+      if (classification === "explicit_user_pin") {
+        return {
+          installSpec: params.spec,
+          recordSpec: params.spec,
+          reason: "preserved_exact_pin",
+          classification,
+          packageName: params.parsed.name,
+        };
+      }
+      if (
+        classification === "prior_default_intent_system_pin" &&
+        params.updateChannel === "daily"
+      ) {
+        return {
+          installSpec: params.spec,
+          recordSpec: params.record?.spec ?? params.spec,
+          reason: "covered_daily_target",
+          classification,
+          packageName: params.parsed.name,
+          stableLine: params.target.stableLine,
+          manifestSha256: resolveManifestSha256(params.stablePluginSupport),
+        };
+      }
+      return {
+        installSpec: params.spec,
+        recordSpec: params.spec,
+        reason: "ambiguous_exact_official_install",
+        classification,
+        packageName: params.parsed.name,
+      };
+    }
+    if (params.isOfficialPackage) {
+      return {
+        installSpec: params.spec,
+        recordSpec: params.spec,
+        reason: "outside_stable_contract",
+        classification,
+        packageName: params.parsed.name,
+      };
+    }
+    return {
+      installSpec: params.spec,
+      recordSpec: params.spec,
+      reason: "third_party_preserved",
+      classification,
+      packageName: params.parsed.name,
+    };
+  }
+  if (params.target) {
+    return {
+      installSpec: params.spec,
+      recordSpec: params.spec,
+      reason:
+        params.updateChannel === "daily"
+          ? "covered_daily_target"
+          : "ambiguous_exact_official_install",
+      packageName: params.parsed.name,
+      stableLine: params.target.stableLine,
+      manifestSha256: resolveManifestSha256(params.stablePluginSupport),
+    };
+  }
+  return {
+    installSpec: params.spec,
+    recordSpec: params.spec,
+    reason: params.isOfficialPackage ? "outside_stable_contract" : "third_party_preserved",
+    packageName: params.parsed.name,
+  };
+}
+
 export function resolveClawHubInstallSpecsForUpdateChannel(params: {
   spec: string;
-  updateChannel?: UpdateChannel;
+  updateChannel?: StableAwareUpdateChannel;
 }): ChannelInstallSpecs {
   if (params.updateChannel !== "beta") {
     return {
       installSpec: params.spec,
       recordSpec: params.spec,
+      ...(params.updateChannel === "stable" || params.updateChannel === "daily"
+        ? { reason: "outside_stable_contract" as const }
+        : {}),
     };
   }
   const betaTarget = isDefaultClawHubSpecForBetaChannel(params.spec);

--- a/src/plugins/plugin-version-drift.test.ts
+++ b/src/plugins/plugin-version-drift.test.ts
@@ -1,8 +1,16 @@
 /** Tests plugin version drift detection between package, manifest, and install records. */
 import { describe, expect, it } from "vitest";
+import checkedInStablePluginSupportManifest from "../../release/stable-plugin-support.json" with { type: "json" };
 import type { OpenClawConfig } from "../config/types.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
-import { detectPluginVersionDrift } from "./plugin-version-drift.js";
+import {
+  computeStablePluginSupportManifestSha256,
+  detectPluginVersionDrift,
+  generateStablePluginDriftReport,
+  type StablePluginAcceptanceProof,
+  type StablePluginRegistryProof,
+  type StablePluginSupportManifest,
+} from "./plugin-version-drift.js";
 
 function npmRecord(
   version: string,
@@ -316,5 +324,182 @@ describe("detectPluginVersionDrift", () => {
     });
 
     expect(result.drifts.map((d) => d.pluginId)).toEqual(["discord", "matrix", "whatsapp"]);
+  });
+});
+
+const stableManifest = checkedInStablePluginSupportManifest as StablePluginSupportManifest;
+
+function registryProofs(
+  overrides: Partial<Record<string, Partial<StablePluginRegistryProof>>> = {},
+): StablePluginRegistryProof[] {
+  return stableManifest.coveredPlugins.map((entry) => ({
+    packageName: entry.packageName,
+    version: entry.targetVersion,
+    targetNpmSpec: entry.targetNpmSpec,
+    exists: true,
+    observedAt: "2026-06-19T13:00:00.000Z",
+    ...overrides[entry.packageName],
+  }));
+}
+
+function acceptanceProofs(
+  overrides: Partial<Record<string, Partial<StablePluginAcceptanceProof>>> = {},
+): StablePluginAcceptanceProof[] {
+  const manifestSha = computeStablePluginSupportManifestSha256(stableManifest);
+  return stableManifest.coveredPlugins.map((entry) => ({
+    packageName: entry.packageName,
+    targetVersion: entry.targetVersion,
+    targetNpmSpec: entry.targetNpmSpec,
+    stablePluginSupportSha256: manifestSha,
+    passed: true,
+    completedAt: "2026-06-19T13:05:00.000Z",
+    ...overrides[entry.packageName],
+  }));
+}
+
+describe("generateStablePluginDriftReport", () => {
+  it("reports ok for covered plugins with registry, catalog, proof, and installed match", () => {
+    const report = generateStablePluginDriftReport({
+      manifest: stableManifest,
+      stableLine: {
+        stableLine: "2026.6.33",
+        updatedAt: "2026-06-19T12:00:00.000Z",
+      },
+      registryProofs: registryProofs(),
+      acceptanceProofs: acceptanceProofs(),
+      catalogEntries: [
+        { packageName: "@openclaw/codex", pluginId: "codex", kind: "provider" },
+        { packageName: "@openclaw/discord", pluginId: "discord", kind: "channel" },
+        { packageName: "@openclaw/slack", pluginId: "slack", kind: "channel" },
+      ],
+      installedEntries: [
+        {
+          packageName: "@openclaw/slack",
+          pluginId: "slack",
+          installedVersion: "2026.6.33",
+        },
+      ],
+      generatedAt: "2026-06-19T13:10:00.000Z",
+    });
+
+    expect(report.summary.blockingDriftCount).toBe(0);
+    expect(report.rows.map((row) => row.status)).toEqual(["ok", "ok", "ok"]);
+    expect(report.issues.every((issue) => issue.action === "none")).toBe(true);
+  });
+
+  it("reports registry_missing when an exact covered package target is absent", () => {
+    const report = generateStablePluginDriftReport({
+      manifest: stableManifest,
+      registryProofs: registryProofs({
+        "@openclaw/slack": { exists: false },
+      }),
+      acceptanceProofs: acceptanceProofs(),
+    });
+
+    expect(report.rows.find((row) => row.packageName === "@openclaw/slack")?.status).toBe(
+      "registry_missing",
+    );
+  });
+
+  it("reports proof_missing when registry proof exists but package acceptance proof is absent", () => {
+    const report = generateStablePluginDriftReport({
+      manifest: stableManifest,
+      registryProofs: registryProofs(),
+      acceptanceProofs: acceptanceProofs().filter(
+        (proof) => proof.packageName !== "@openclaw/discord",
+      ),
+    });
+
+    expect(report.rows.find((row) => row.packageName === "@openclaw/discord")?.status).toBe(
+      "proof_missing",
+    );
+  });
+
+  it("reports proof_stale when proof references an older manifest digest", () => {
+    const report = generateStablePluginDriftReport({
+      manifest: stableManifest,
+      registryProofs: registryProofs(),
+      acceptanceProofs: acceptanceProofs({
+        "@openclaw/codex": { stablePluginSupportSha256: "old-digest" },
+      }),
+    });
+
+    expect(report.rows.find((row) => row.packageName === "@openclaw/codex")?.status).toBe(
+      "proof_stale",
+    );
+  });
+
+  it("reports installed_drift when inspected local state differs from the stable target", () => {
+    const report = generateStablePluginDriftReport({
+      manifest: stableManifest,
+      registryProofs: registryProofs(),
+      acceptanceProofs: acceptanceProofs(),
+      installedEntries: [
+        {
+          packageName: "@openclaw/slack",
+          pluginId: "slack",
+          installedVersion: "2026.6.32",
+          spec: "@openclaw/slack@2026.6.32",
+        },
+      ],
+    });
+
+    expect(report.rows.find((row) => row.packageName === "@openclaw/slack")?.status).toBe(
+      "installed_drift",
+    );
+  });
+
+  it("reports catalog_drift when official catalog mapping no longer matches manifest", () => {
+    const report = generateStablePluginDriftReport({
+      manifest: stableManifest,
+      registryProofs: registryProofs(),
+      acceptanceProofs: acceptanceProofs(),
+      catalogEntries: [
+        { packageName: "@openclaw/discord", pluginId: "discord-v2", kind: "channel" },
+      ],
+    });
+
+    expect(report.rows.find((row) => row.packageName === "@openclaw/discord")?.status).toBe(
+      "catalog_drift",
+    );
+  });
+
+  it("reports outside_stable_contract and dry-run issue decisions for non-covered installs", () => {
+    const report = generateStablePluginDriftReport({
+      manifest: stableManifest,
+      registryProofs: registryProofs(),
+      acceptanceProofs: acceptanceProofs(),
+      installedEntries: [
+        {
+          packageName: "@openclaw/matrix",
+          pluginId: "matrix",
+          installedVersion: "2026.6.33",
+        },
+      ],
+      updateIssues: false,
+    });
+
+    const outside = report.rows.find((row) => row.packageName === "@openclaw/matrix");
+    expect(outside?.status).toBe("outside_stable_contract");
+    expect(report.summary.outsideStableContractCount).toBe(1);
+    expect(report.issues.find((issue) => issue.packageName === "@openclaw/matrix")?.action).toBe(
+      "warn_only",
+    );
+  });
+
+  it("uses stable idempotency markers for blocking dry-run issue decisions", () => {
+    const report = generateStablePluginDriftReport({
+      manifest: stableManifest,
+      registryProofs: registryProofs({
+        "@openclaw/slack": { exists: false },
+      }),
+      acceptanceProofs: acceptanceProofs(),
+      updateIssues: false,
+    });
+    const issue = report.issues.find((entry) => entry.packageName === "@openclaw/slack");
+
+    expect(issue?.action).toBe("dry_run_create_or_update");
+    expect(issue?.idempotencyKey).toBe("2026.6.33:@openclaw/slack");
+    expect(issue?.marker).toBe("<!-- openclaw:stable-plugin-drift:2026.6.33:@openclaw/slack -->");
   });
 });

--- a/src/plugins/plugin-version-drift.ts
+++ b/src/plugins/plugin-version-drift.ts
@@ -8,6 +8,17 @@ import {
   resolveTrustedSourceLinkedOfficialClawHubInstall,
   resolveTrustedSourceLinkedOfficialNpmSpec,
 } from "./official-external-install-records.js";
+import {
+  computeStablePluginSupportDigest,
+  validateStablePluginSupportManifest,
+  type StablePluginSupportEntry,
+  type StablePluginSupportManifest,
+} from "./stable-plugin-support.js";
+
+export type {
+  StablePluginSupportEntry,
+  StablePluginSupportManifest,
+} from "./stable-plugin-support.js";
 
 export type PluginVersionDriftEntry = {
   pluginId: string;
@@ -23,6 +34,123 @@ export type PluginVersionDriftReport = {
   drifts: PluginVersionDriftEntry[];
 };
 
+export type StablePluginLineMetadata = {
+  stableLine: string;
+  baseVersion?: string;
+  targetBranch?: string;
+  updatedAt?: string;
+  manifestSha256?: string;
+};
+
+export type StablePluginRegistryProof = {
+  packageName: string;
+  version?: string;
+  targetNpmSpec?: string;
+  exists?: boolean;
+  observedAt?: string;
+};
+
+export type StablePluginAcceptanceProof = {
+  packageName: string;
+  targetVersion?: string;
+  targetNpmSpec?: string;
+  stableLine?: string;
+  stablePluginSupportSha256?: string;
+  manifestSha256?: string;
+  passed?: boolean;
+  result?: "ok" | "pass" | "passed" | "success" | "failed" | "failure" | "error";
+  completedAt?: string;
+  generatedAt?: string;
+  observedAt?: string;
+};
+
+export type StablePluginCatalogEntry = {
+  packageName: string;
+  pluginId: string;
+  kind?: string;
+  source?: string;
+};
+
+export type StablePluginInstalledEntry = {
+  pluginId: string;
+  packageName?: string;
+  installedVersion?: string;
+  resolvedVersion?: string;
+  version?: string;
+  spec?: string;
+};
+
+export type StablePluginDriftStatus =
+  | "ok"
+  | "registry_missing"
+  | "proof_missing"
+  | "proof_stale"
+  | "installed_drift"
+  | "catalog_drift"
+  | "outside_stable_contract";
+
+export type StablePluginDriftRow = {
+  status: StablePluginDriftStatus;
+  packageName: string;
+  pluginId?: string;
+  kind?: string;
+  targetVersion?: string;
+  targetNpmSpec?: string;
+  targetBranch?: string;
+  sourceRepository?: string;
+  packageDir?: string;
+  owners?: string[];
+  registry?: {
+    exists: boolean;
+    observedVersion?: string;
+    observedAt?: string;
+  };
+  proof?: {
+    present: boolean;
+    passed?: boolean;
+    completedAt?: string;
+    manifestSha256?: string;
+  };
+  installed?: {
+    version?: string;
+    spec?: string;
+  };
+  catalog?: {
+    pluginId?: string;
+    kind?: string;
+    source?: string;
+    matchesManifest: boolean;
+  };
+  reasons: string[];
+};
+
+export type StablePluginDriftIssueDecision = {
+  idempotencyKey: string;
+  marker: string;
+  packageName: string;
+  pluginId?: string;
+  status: StablePluginDriftStatus;
+  action: "none" | "dry_run_create_or_update" | "create_or_update" | "warn_only";
+  owners: string[];
+  title: string;
+  body: string;
+};
+
+export type StablePluginDriftReport = {
+  schemaVersion: 1;
+  stableLine: string;
+  generatedAt: string;
+  manifestSha256: string;
+  updateIssues: boolean;
+  rows: StablePluginDriftRow[];
+  issues: StablePluginDriftIssueDecision[];
+  summary: {
+    driftCount: number;
+    blockingDriftCount: number;
+    outsideStableContractCount: number;
+  };
+};
+
 /**
  * Strip a trailing build qualifier (e.g. `2026.5.4-1` -> `2026.5.4`) so that
  * a gateway packaged as `2026.5.4-1` is not reported as drifted from a
@@ -30,6 +158,334 @@ export type PluginVersionDriftReport = {
  */
 function normalizeVersion(value: string): string {
   return value.replace(/-\d+$/, "");
+}
+
+export function computeStablePluginSupportManifestSha256(
+  manifest: StablePluginSupportManifest,
+): string {
+  return computeStablePluginSupportDigest(manifest);
+}
+
+export function parseStablePluginSupportManifest(raw: unknown): StablePluginSupportManifest {
+  return validateStablePluginSupportManifest(raw).manifest;
+}
+
+function normalizeRegistryProofs(
+  proofs: readonly StablePluginRegistryProof[],
+): Map<string, StablePluginRegistryProof> {
+  return new Map(proofs.map((proof) => [proof.packageName, proof]));
+}
+
+function normalizeAcceptanceProofs(
+  proofs: readonly StablePluginAcceptanceProof[],
+): Map<string, StablePluginAcceptanceProof> {
+  return new Map(proofs.map((proof) => [proof.packageName, proof]));
+}
+
+function normalizeCatalogEntries(
+  entries: readonly StablePluginCatalogEntry[],
+): Map<string, StablePluginCatalogEntry> {
+  return new Map(entries.map((entry) => [entry.packageName, entry]));
+}
+
+function normalizeInstalledEntries(
+  entries: readonly StablePluginInstalledEntry[],
+): StablePluginInstalledEntry[] {
+  return entries.toSorted((left, right) =>
+    (left.packageName ?? left.pluginId).localeCompare(right.packageName ?? right.pluginId),
+  );
+}
+
+function proofPassed(proof: StablePluginAcceptanceProof | undefined): boolean {
+  if (!proof) {
+    return false;
+  }
+  if (proof.passed === true) {
+    return true;
+  }
+  return (
+    proof.result === "ok" ||
+    proof.result === "pass" ||
+    proof.result === "passed" ||
+    proof.result === "success"
+  );
+}
+
+function proofTimestamp(proof: StablePluginAcceptanceProof): string | undefined {
+  return proof.completedAt ?? proof.generatedAt ?? proof.observedAt;
+}
+
+function proofManifestSha(proof: StablePluginAcceptanceProof): string | undefined {
+  return proof.stablePluginSupportSha256 ?? proof.manifestSha256;
+}
+
+function isProofStale(params: {
+  proof: StablePluginAcceptanceProof;
+  manifestSha256: string;
+  stableLine?: StablePluginLineMetadata;
+  manifestUpdatedAt?: string;
+}): boolean {
+  const proofSha = proofManifestSha(params.proof);
+  if (proofSha && proofSha !== params.manifestSha256) {
+    return true;
+  }
+  const staleAfter = params.manifestUpdatedAt ?? params.stableLine?.updatedAt;
+  const completedAt = proofTimestamp(params.proof);
+  if (!staleAfter || !completedAt) {
+    return false;
+  }
+  return Date.parse(completedAt) < Date.parse(staleAfter);
+}
+
+function installedVersion(entry: StablePluginInstalledEntry | undefined): string | undefined {
+  return entry?.installedVersion ?? entry?.resolvedVersion ?? entry?.version;
+}
+
+function resolveCoveredRowStatus(params: {
+  entry: StablePluginSupportEntry;
+  registryProof?: StablePluginRegistryProof;
+  proof?: StablePluginAcceptanceProof;
+  catalogEntry?: StablePluginCatalogEntry;
+  installedEntry?: StablePluginInstalledEntry;
+  manifestSha256: string;
+  stableLine?: StablePluginLineMetadata;
+  manifestUpdatedAt?: string;
+}): Pick<StablePluginDriftRow, "status" | "reasons"> {
+  const reasons: string[] = [];
+  const registryExists =
+    params.registryProof?.exists === true &&
+    params.registryProof.version === params.entry.targetVersion;
+  if (!registryExists) {
+    reasons.push(`registry target ${params.entry.targetNpmSpec} is missing or mismatched`);
+    return { status: "registry_missing", reasons };
+  }
+
+  if (
+    params.catalogEntry &&
+    (params.catalogEntry.pluginId !== params.entry.pluginId ||
+      params.catalogEntry.kind !== params.entry.kind)
+  ) {
+    reasons.push("official external catalog mapping no longer matches the manifest entry");
+    return { status: "catalog_drift", reasons };
+  }
+
+  const observedInstalledVersion = installedVersion(params.installedEntry);
+  if (
+    observedInstalledVersion &&
+    normalizeVersion(observedInstalledVersion) !== normalizeVersion(params.entry.targetVersion)
+  ) {
+    reasons.push(
+      `installed version ${observedInstalledVersion} does not match ${params.entry.targetVersion}`,
+    );
+    return { status: "installed_drift", reasons };
+  }
+
+  if (!params.proof || !proofPassed(params.proof)) {
+    reasons.push("stable package acceptance proof is missing or failing");
+    return { status: "proof_missing", reasons };
+  }
+
+  if (
+    params.proof.targetVersion &&
+    normalizeVersion(params.proof.targetVersion) !== normalizeVersion(params.entry.targetVersion)
+  ) {
+    reasons.push("stable package acceptance proof targets a different package version");
+    return { status: "proof_stale", reasons };
+  }
+
+  if (
+    isProofStale({
+      proof: params.proof,
+      manifestSha256: params.manifestSha256,
+      stableLine: params.stableLine,
+      manifestUpdatedAt: params.manifestUpdatedAt,
+    })
+  ) {
+    reasons.push("stable package acceptance proof predates active stable metadata or manifest");
+    return { status: "proof_stale", reasons };
+  }
+
+  return { status: "ok", reasons: [] };
+}
+
+function buildIssueDecision(params: {
+  stableLine: string;
+  row: StablePluginDriftRow;
+  updateIssues: boolean;
+}): StablePluginDriftIssueDecision {
+  const idempotencyKey = `${params.stableLine}:${params.row.packageName}`;
+  const marker = `<!-- openclaw:stable-plugin-drift:${params.stableLine}:${params.row.packageName} -->`;
+  const owners = params.row.owners ?? [];
+  const blocking = params.row.status !== "ok" && params.row.status !== "outside_stable_contract";
+  const action = blocking
+    ? params.updateIssues
+      ? "create_or_update"
+      : "dry_run_create_or_update"
+    : params.row.status === "outside_stable_contract"
+      ? "warn_only"
+      : "none";
+  const bodyLines = [
+    marker,
+    "",
+    `Stable line: ${params.stableLine}`,
+    `Package: ${params.row.packageName}`,
+    `Status: ${params.row.status}`,
+    `Target: ${params.row.targetNpmSpec ?? "<outside stable contract>"}`,
+    "",
+    "Reasons:",
+    ...(params.row.reasons.length > 0 ? params.row.reasons : ["none"]).map(
+      (reason) => `- ${reason}`,
+    ),
+  ];
+  return {
+    idempotencyKey,
+    marker,
+    packageName: params.row.packageName,
+    ...(params.row.pluginId ? { pluginId: params.row.pluginId } : {}),
+    status: params.row.status,
+    action,
+    owners,
+    title: `[stable-plugin-drift] ${params.row.packageName} ${params.row.status}`,
+    body: bodyLines.join("\n"),
+  };
+}
+
+export function generateStablePluginDriftReport(params: {
+  manifest: StablePluginSupportManifest;
+  stableLine?: StablePluginLineMetadata;
+  registryProofs?: readonly StablePluginRegistryProof[];
+  acceptanceProofs?: readonly StablePluginAcceptanceProof[];
+  catalogEntries?: readonly StablePluginCatalogEntry[];
+  installedEntries?: readonly StablePluginInstalledEntry[];
+  manifestUpdatedAt?: string;
+  generatedAt?: string;
+  updateIssues?: boolean;
+}): StablePluginDriftReport {
+  const manifestSha256 = computeStablePluginSupportManifestSha256(params.manifest);
+  const stableLine = params.stableLine?.stableLine ?? params.manifest.stableLine.baseVersion;
+  const registryProofs = normalizeRegistryProofs(params.registryProofs ?? []);
+  const acceptanceProofs = normalizeAcceptanceProofs(params.acceptanceProofs ?? []);
+  const catalogEntries = normalizeCatalogEntries(params.catalogEntries ?? []);
+  const installedEntries = normalizeInstalledEntries(params.installedEntries ?? []);
+  const installedByPackage = new Map(
+    installedEntries
+      .filter((entry) => entry.packageName)
+      .map((entry) => [entry.packageName as string, entry]),
+  );
+  const coveredPackageNames = new Set(
+    params.manifest.coveredPlugins.map((entry) => entry.packageName),
+  );
+  const coveredPluginIds = new Set(params.manifest.coveredPlugins.map((entry) => entry.pluginId));
+
+  const rows: StablePluginDriftRow[] = params.manifest.coveredPlugins.map((entry) => {
+    const registryProof = registryProofs.get(entry.packageName);
+    const proof = acceptanceProofs.get(entry.packageName);
+    const catalogEntry = catalogEntries.get(entry.packageName);
+    const installedEntry =
+      installedByPackage.get(entry.packageName) ??
+      installedEntries.find((candidate) => candidate.pluginId === entry.pluginId);
+    const { status, reasons } = resolveCoveredRowStatus({
+      entry,
+      registryProof,
+      proof,
+      catalogEntry,
+      installedEntry,
+      manifestSha256,
+      stableLine: params.stableLine,
+      manifestUpdatedAt: params.manifestUpdatedAt,
+    });
+
+    const proofCompletedAt = proof ? proofTimestamp(proof) : undefined;
+    const proofSha = proof ? proofManifestSha(proof) : undefined;
+    const observedInstalledVersion = installedVersion(installedEntry);
+    return {
+      status,
+      packageName: entry.packageName,
+      pluginId: entry.pluginId,
+      kind: entry.kind,
+      targetVersion: entry.targetVersion,
+      targetNpmSpec: entry.targetNpmSpec,
+      targetBranch: entry.targetBranch,
+      sourceRepository: entry.sourceRepository,
+      packageDir: entry.packageDir,
+      owners: entry.owners ?? [],
+      registry: {
+        exists: registryProof?.exists === true && registryProof.version === entry.targetVersion,
+        ...(registryProof?.version ? { observedVersion: registryProof.version } : {}),
+        ...(registryProof?.observedAt ? { observedAt: registryProof.observedAt } : {}),
+      },
+      proof: {
+        present: Boolean(proof),
+        ...(proof ? { passed: proofPassed(proof) } : {}),
+        ...(proofCompletedAt ? { completedAt: proofCompletedAt } : {}),
+        ...(proofSha ? { manifestSha256: proofSha } : {}),
+      },
+      ...(installedEntry
+        ? {
+            installed: {
+              ...(observedInstalledVersion ? { version: observedInstalledVersion } : {}),
+              ...(installedEntry.spec ? { spec: installedEntry.spec } : {}),
+            },
+          }
+        : {}),
+      ...(catalogEntry
+        ? {
+            catalog: {
+              pluginId: catalogEntry.pluginId,
+              ...(catalogEntry.kind ? { kind: catalogEntry.kind } : {}),
+              ...(catalogEntry.source ? { source: catalogEntry.source } : {}),
+              matchesManifest:
+                catalogEntry.pluginId === entry.pluginId && catalogEntry.kind === entry.kind,
+            },
+          }
+        : {}),
+      reasons,
+    };
+  });
+
+  for (const entry of installedEntries) {
+    const packageName = entry.packageName ?? entry.pluginId;
+    if (coveredPackageNames.has(packageName) || coveredPluginIds.has(entry.pluginId)) {
+      continue;
+    }
+    rows.push({
+      status: "outside_stable_contract",
+      packageName,
+      pluginId: entry.pluginId,
+      installed: {
+        ...(installedVersion(entry) ? { version: installedVersion(entry) } : {}),
+        ...(entry.spec ? { spec: entry.spec } : {}),
+      },
+      reasons: ["installed plugin is not covered by the stable plugin support manifest"],
+    });
+  }
+
+  rows.sort((left, right) => left.packageName.localeCompare(right.packageName));
+
+  const updateIssues = params.updateIssues === true;
+  const issues = rows.map((row) => buildIssueDecision({ stableLine, row, updateIssues }));
+  const driftCount = rows.filter((row) => row.status !== "ok").length;
+  const blockingDriftCount = rows.filter(
+    (row) => row.status !== "ok" && row.status !== "outside_stable_contract",
+  ).length;
+  const outsideStableContractCount = rows.filter(
+    (row) => row.status === "outside_stable_contract",
+  ).length;
+
+  return {
+    schemaVersion: 1,
+    stableLine,
+    generatedAt: params.generatedAt ?? new Date().toISOString(),
+    manifestSha256,
+    updateIssues,
+    rows,
+    issues,
+    summary: {
+      driftCount,
+      blockingDriftCount,
+      outsideStableContractCount,
+    },
+  };
 }
 
 function isPluginEnabled(config: OpenClawConfig | undefined, pluginId: string): boolean {

--- a/src/plugins/stable-plugin-support.test.ts
+++ b/src/plugins/stable-plugin-support.test.ts
@@ -1,0 +1,136 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import checkedInStablePluginSupportManifest from "../../release/stable-plugin-support.json" with { type: "json" };
+import { PluginInstallRecordShape } from "../config/zod-schema.installs.js";
+import {
+  computeStablePluginSupportDigest,
+  type StablePluginSupportManifest,
+  validateStablePluginSupportManifest,
+} from "./stable-plugin-support.js";
+
+type TestManifest = Record<string, unknown> & {
+  coveredPlugins: Record<string, unknown>[];
+};
+
+function cloneManifest(): TestManifest {
+  return JSON.parse(JSON.stringify(checkedInStablePluginSupportManifest)) as TestManifest;
+}
+
+function reverseObjectKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => reverseObjectKeys(entry));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .toReversed()
+        .map(([key, entry]) => [key, reverseObjectKeys(entry)]),
+    );
+  }
+  return value;
+}
+
+describe("stable plugin support manifest", () => {
+  it("validates the first stable covered package set and digest", () => {
+    const result = validateStablePluginSupportManifest(checkedInStablePluginSupportManifest, {
+      repoRoot: path.resolve(__dirname, "../.."),
+    });
+
+    expect(result.coveredPackages).toEqual([
+      "@openclaw/codex",
+      "@openclaw/discord",
+      "@openclaw/slack",
+    ]);
+    expect(result.coveredPackages).not.toContain("@openclaw/telegram");
+    expect(result.coveredPackages).not.toContain("@openclaw/openai-provider");
+    expect(result.stablePluginSupportSha256).toMatch(/^[a-f0-9]{64}$/u);
+    expect(result.targetsByPackageName.get("@openclaw/slack")?.targetNpmSpec).toBe(
+      "@openclaw/slack@2026.6.33",
+    );
+  });
+
+  it("computes a deterministic digest independent of object key order", () => {
+    expect(
+      computeStablePluginSupportDigest(
+        checkedInStablePluginSupportManifest as StablePluginSupportManifest,
+      ),
+    ).toBe(
+      computeStablePluginSupportDigest(
+        reverseObjectKeys(checkedInStablePluginSupportManifest) as StablePluginSupportManifest,
+      ),
+    );
+  });
+
+  it("rejects unsorted or incomplete covered packages", () => {
+    const manifest = cloneManifest();
+    manifest.coveredPlugins = [manifest.coveredPlugins[1], manifest.coveredPlugins[0]];
+
+    expect(() => validateStablePluginSupportManifest(manifest)).toThrow(
+      /coveredPlugins must be exactly/u,
+    );
+  });
+
+  it("rejects support-state proof fields stored in the manifest", () => {
+    const manifest = cloneManifest();
+    manifest.supportState = "ready";
+    const entry = manifest.coveredPlugins[0];
+    entry.requiredProof = ["package-acceptance"];
+
+    expect(() => validateStablePluginSupportManifest(manifest)).toThrow(/supportState/u);
+    expect(() => validateStablePluginSupportManifest(manifest)).toThrow(/requiredProof/u);
+  });
+
+  it("rejects non-exact targets and wrong stable branch", () => {
+    const manifest = cloneManifest();
+    manifest.coveredPlugins[0] = {
+      ...manifest.coveredPlugins[0],
+      targetNpmSpec: "@openclaw/codex@latest",
+      targetBranch: "main",
+    };
+
+    expect(() => validateStablePluginSupportManifest(manifest)).toThrow(/targetNpmSpec/u);
+    expect(() => validateStablePluginSupportManifest(manifest)).toThrow(/targetBranch/u);
+  });
+
+  it("accepts stable patch targets on the first stable line", () => {
+    const manifest = cloneManifest();
+    manifest.coveredPlugins = manifest.coveredPlugins.map((entry) => ({
+      ...entry,
+      targetVersion: "2026.6.34",
+      targetNpmSpec: `${entry.packageName}@2026.6.34`,
+    }));
+
+    expect(validateStablePluginSupportManifest(manifest).coveredPackages).toEqual([
+      "@openclaw/codex",
+      "@openclaw/discord",
+      "@openclaw/slack",
+    ]);
+  });
+
+  it("accepts install intent provenance fields in plugin install records", () => {
+    const schema = z.object(PluginInstallRecordShape);
+
+    expect(
+      schema.parse({
+        source: "npm",
+        spec: "@openclaw/slack",
+        resolvedSpec: "@openclaw/slack@2026.6.33",
+        installIntentProvenance: "prior_default_intent_system_pin",
+        installIntentProvenanceMigration: {
+          id: "stable-plugin-install-intent-v1",
+          source: "doctor:stable-plugin-install-intent",
+          migratedAt: "2026-06-19T00:00:00.000Z",
+          decision: "prior_default_intent_system_pin",
+          evidence: {
+            spec: "@openclaw/slack",
+            resolvedSpec: "@openclaw/slack@2026.6.33",
+            trustedSourceLinkedOfficialInstall: true,
+          },
+        },
+      }),
+    ).toMatchObject({
+      installIntentProvenance: "prior_default_intent_system_pin",
+    });
+  });
+});

--- a/src/plugins/stable-plugin-support.ts
+++ b/src/plugins/stable-plugin-support.ts
@@ -1,0 +1,313 @@
+// Validates the checked-in external plugin support surface for the stable line.
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
+import { isRecord } from "../utils.js";
+import {
+  getOfficialExternalPluginCatalogEntryForPackage,
+  getOfficialExternalPluginCatalogManifest,
+  resolveOfficialExternalPluginId,
+} from "./official-external-plugin-catalog.js";
+
+export const FIRST_STABLE_PLUGIN_SUPPORT_PACKAGES = [
+  "@openclaw/codex",
+  "@openclaw/discord",
+  "@openclaw/slack",
+] as const;
+
+const FIRST_STABLE_LINE_MONTH = "2026.6";
+const FIRST_STABLE_LINE_BASE_VERSION = "2026.6.33";
+const FIRST_STABLE_TARGET_BRANCH = "stable/2026.6.33";
+const STABLE_LINE_VERSION_PATTERN = /^2026\.6\.[1-9][0-9]*$/u;
+const EXCLUDED_EXTERNAL_STABLE_PACKAGES = new Set([
+  "@openclaw/openai-provider",
+  "@openclaw/telegram",
+]);
+const CODEX_REQUIRED_PLATFORM_PACKAGES = [
+  "@openai/codex-linux-x64",
+  "@openai/codex-linux-arm64",
+  "@openai/codex-darwin-x64",
+  "@openai/codex-darwin-arm64",
+  "@openai/codex-win32-x64",
+  "@openai/codex-win32-arm64",
+] as const;
+
+export type StablePluginSupportKind = "channel" | "provider";
+
+export type StablePluginRuntimeHarness = {
+  harnessId: string;
+  runtimePackage: string;
+  installMode: "on_demand_runtime_dependencies";
+  requiredPlatformPackages: string[];
+};
+
+export type StablePluginSupportEntry = {
+  packageName: string;
+  pluginId: string;
+  kind: StablePluginSupportKind;
+  sourceRepository: string;
+  packageDir: string;
+  stableLine: string;
+  targetVersion: string;
+  targetNpmSpec: string;
+  targetBranch: string;
+  runtimeHarness?: StablePluginRuntimeHarness;
+  owners: string[];
+};
+
+export type StablePluginSupportManifest = {
+  schemaVersion: 1;
+  stableLine: {
+    month: string;
+    baseVersion: string;
+  };
+  coveredPlugins: StablePluginSupportEntry[];
+};
+
+export type ValidatedStablePluginSupportManifest = {
+  manifest: StablePluginSupportManifest;
+  stablePluginSupportSha256: string;
+  coveredPackages: string[];
+  targetsByPackageName: Map<string, StablePluginSupportEntry>;
+};
+
+export function computeStablePluginSupportDigest(manifest: StablePluginSupportManifest): string {
+  return createHash("sha256").update(stableJsonStringify(manifest)).digest("hex");
+}
+
+export function validateStablePluginSupportManifest(
+  raw: unknown,
+  options: { repoRoot?: string } = {},
+): ValidatedStablePluginSupportManifest {
+  const errors: string[] = [];
+  const manifest = parseManifest(raw, errors);
+  if (!manifest) {
+    throw new Error(`Invalid stable plugin support manifest: ${errors.join("; ")}`);
+  }
+
+  if (manifest.schemaVersion !== 1) {
+    errors.push("schemaVersion must be 1");
+  }
+  if (manifest.stableLine.month !== FIRST_STABLE_LINE_MONTH) {
+    errors.push(`stableLine.month must be ${FIRST_STABLE_LINE_MONTH}`);
+  }
+  if (manifest.stableLine.baseVersion !== FIRST_STABLE_LINE_BASE_VERSION) {
+    errors.push(`stableLine.baseVersion must be ${FIRST_STABLE_LINE_BASE_VERSION}`);
+  }
+
+  const packages = manifest.coveredPlugins.map((entry) => entry.packageName);
+  const expectedPackages = [...FIRST_STABLE_PLUGIN_SUPPORT_PACKAGES];
+  if (packages.join("\n") !== expectedPackages.join("\n")) {
+    errors.push(`coveredPlugins must be exactly ${expectedPackages.join(", ")} in sorted order`);
+  }
+  if (new Set(packages).size !== packages.length) {
+    errors.push("coveredPlugins packageName values must be unique");
+  }
+
+  for (const entry of manifest.coveredPlugins) {
+    validateStablePluginSupportEntry(entry, errors, options);
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid stable plugin support manifest: ${errors.join("; ")}`);
+  }
+
+  return {
+    manifest,
+    stablePluginSupportSha256: computeStablePluginSupportDigest(manifest),
+    coveredPackages: packages,
+    targetsByPackageName: new Map(
+      manifest.coveredPlugins.map((entry) => [entry.packageName, entry]),
+    ),
+  };
+}
+
+function parseManifest(raw: unknown, errors: string[]): StablePluginSupportManifest | null {
+  if (!isRecord(raw)) {
+    errors.push("manifest must be an object");
+    return null;
+  }
+  rejectUnsupportedProofState(raw, "manifest", errors);
+  if (!isRecord(raw.stableLine)) {
+    errors.push("stableLine must be an object");
+    return null;
+  }
+  if (!Array.isArray(raw.coveredPlugins)) {
+    errors.push("coveredPlugins must be an array");
+    return null;
+  }
+  return {
+    schemaVersion: raw.schemaVersion as 1,
+    stableLine: {
+      month: typeof raw.stableLine.month === "string" ? raw.stableLine.month : "",
+      baseVersion: typeof raw.stableLine.baseVersion === "string" ? raw.stableLine.baseVersion : "",
+    },
+    coveredPlugins: raw.coveredPlugins
+      .filter((entry): entry is Record<string, unknown> => isRecord(entry))
+      .map((entry) => parseEntry(entry, errors)),
+  };
+}
+
+function parseEntry(raw: Record<string, unknown>, errors: string[]): StablePluginSupportEntry {
+  rejectUnsupportedProofState(raw, `entry ${String(raw.packageName ?? "")}`, errors);
+  const runtimeHarness = isRecord(raw.runtimeHarness)
+    ? {
+        harnessId: stringField(raw.runtimeHarness.harnessId),
+        runtimePackage: stringField(raw.runtimeHarness.runtimePackage),
+        installMode: raw.runtimeHarness.installMode as "on_demand_runtime_dependencies",
+        requiredPlatformPackages: stringArrayField(raw.runtimeHarness.requiredPlatformPackages),
+      }
+    : undefined;
+  return {
+    packageName: stringField(raw.packageName),
+    pluginId: stringField(raw.pluginId),
+    kind: raw.kind === "provider" ? "provider" : "channel",
+    sourceRepository: stringField(raw.sourceRepository),
+    packageDir: stringField(raw.packageDir),
+    stableLine: stringField(raw.stableLine),
+    targetVersion: stringField(raw.targetVersion),
+    targetNpmSpec: stringField(raw.targetNpmSpec),
+    targetBranch: stringField(raw.targetBranch),
+    ...(runtimeHarness ? { runtimeHarness } : {}),
+    owners: stringArrayField(raw.owners),
+  };
+}
+
+function validateStablePluginSupportEntry(
+  entry: StablePluginSupportEntry,
+  errors: string[],
+  options: { repoRoot?: string },
+): void {
+  if (EXCLUDED_EXTERNAL_STABLE_PACKAGES.has(entry.packageName)) {
+    errors.push(`${entry.packageName} must not be listed in the external stable support manifest`);
+  }
+  if (entry.stableLine !== FIRST_STABLE_LINE_MONTH) {
+    errors.push(`${entry.packageName} stableLine must be ${FIRST_STABLE_LINE_MONTH}`);
+  }
+  if (!STABLE_LINE_VERSION_PATTERN.test(entry.targetVersion)) {
+    errors.push(
+      `${entry.packageName} targetVersion must be an exact ${FIRST_STABLE_LINE_MONTH}.X version`,
+    );
+  } else {
+    const patch = Number(entry.targetVersion.split(".")[2]);
+    const basePatch = Number(FIRST_STABLE_LINE_BASE_VERSION.split(".")[2]);
+    if (patch < basePatch) {
+      errors.push(
+        `${entry.packageName} targetVersion must be ${FIRST_STABLE_LINE_BASE_VERSION} or a later stable patch on ${FIRST_STABLE_LINE_MONTH}`,
+      );
+    }
+  }
+  if (entry.targetNpmSpec !== `${entry.packageName}@${entry.targetVersion}`) {
+    errors.push(`${entry.packageName} targetNpmSpec must be exact package@targetVersion`);
+  }
+  const parsedTarget = parseRegistryNpmSpec(entry.targetNpmSpec);
+  if (
+    !parsedTarget ||
+    parsedTarget.name !== entry.packageName ||
+    parsedTarget.selectorKind !== "exact-version" ||
+    parsedTarget.selector !== entry.targetVersion
+  ) {
+    errors.push(`${entry.packageName} targetNpmSpec must parse as an exact npm version`);
+  }
+  if (entry.targetBranch !== FIRST_STABLE_TARGET_BRANCH) {
+    errors.push(`${entry.packageName} targetBranch must be ${FIRST_STABLE_TARGET_BRANCH}`);
+  }
+  if (!/^openclaw\/[^/\s]+$/u.test(entry.sourceRepository)) {
+    errors.push(`${entry.packageName} sourceRepository must be under openclaw/*`);
+  }
+  if (entry.sourceRepository === "openclaw/openclaw" && options.repoRoot) {
+    const packageDir = path.join(options.repoRoot, entry.packageDir);
+    if (!fs.existsSync(packageDir)) {
+      errors.push(`${entry.packageName} packageDir does not exist: ${entry.packageDir}`);
+    }
+  }
+  validateCatalogMapping(entry, errors);
+  if (entry.packageName === "@openclaw/codex") {
+    validateCodexRuntimeHarness(entry, errors);
+  } else if (entry.runtimeHarness) {
+    errors.push(`${entry.packageName} must not declare runtimeHarness`);
+  }
+}
+
+function validateCatalogMapping(entry: StablePluginSupportEntry, errors: string[]): void {
+  const catalogEntry = getOfficialExternalPluginCatalogEntryForPackage(entry.packageName);
+  if (!catalogEntry) {
+    errors.push(`${entry.packageName} is not present in the official external catalog`);
+    return;
+  }
+  const catalogPluginId = resolveOfficialExternalPluginId(catalogEntry);
+  if (catalogPluginId !== entry.pluginId) {
+    errors.push(`${entry.packageName} pluginId must match official catalog id ${catalogPluginId}`);
+  }
+  const catalogManifest = getOfficialExternalPluginCatalogManifest(catalogEntry);
+  const catalogKind = catalogManifest?.channel
+    ? "channel"
+    : (catalogManifest?.providers?.length ?? 0) > 0
+      ? "provider"
+      : undefined;
+  if (catalogKind !== entry.kind) {
+    errors.push(`${entry.packageName} kind must match official catalog kind ${catalogKind}`);
+  }
+}
+
+function validateCodexRuntimeHarness(entry: StablePluginSupportEntry, errors: string[]): void {
+  const runtimeHarness = entry.runtimeHarness;
+  if (!runtimeHarness) {
+    errors.push("@openclaw/codex must declare runtimeHarness");
+    return;
+  }
+  if (runtimeHarness.harnessId !== "codex") {
+    errors.push("@openclaw/codex runtimeHarness.harnessId must be codex");
+  }
+  if (runtimeHarness.runtimePackage !== "@openai/codex") {
+    errors.push("@openclaw/codex runtimeHarness.runtimePackage must be @openai/codex");
+  }
+  if (runtimeHarness.installMode !== "on_demand_runtime_dependencies") {
+    errors.push("@openclaw/codex runtimeHarness.installMode is invalid");
+  }
+  const expectedPlatformPackages = [...CODEX_REQUIRED_PLATFORM_PACKAGES];
+  if (runtimeHarness.requiredPlatformPackages.join("\n") !== expectedPlatformPackages.join("\n")) {
+    errors.push(
+      "@openclaw/codex runtimeHarness.requiredPlatformPackages must match Codex manifest",
+    );
+  }
+}
+
+function rejectUnsupportedProofState(
+  value: Record<string, unknown>,
+  label: string,
+  errors: string[],
+): void {
+  if ("supportState" in value) {
+    errors.push(`${label} must not include supportState`);
+  }
+  if ("requiredProof" in value) {
+    errors.push(`${label} must not include requiredProof`);
+  }
+}
+
+function stringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function stringArrayField(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function stableJsonStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableJsonStringify(entry)).join(",")}]`;
+  }
+  if (isRecord(value)) {
+    const entries = Object.entries(value)
+      .filter(([, entry]) => entry !== undefined)
+      .toSorted(([left], [right]) => left.localeCompare(right));
+    return `{${entries
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJsonStringify(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -817,6 +817,93 @@ describe("updateNpmInstalledPlugins", () => {
     });
   });
 
+  it("records prior default intent when stable sync converges a default official npm install", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@openclaw/slack",
+      version: "2026.6.8",
+    });
+    mockNpmViewMetadata({
+      name: "@openclaw/slack",
+      version: "2026.6.33",
+      integrity: "sha512-stable",
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "slack",
+        targetDir: installPath,
+        version: "2026.6.33",
+        npmResolution: {
+          name: "@openclaw/slack",
+          version: "2026.6.33",
+          resolvedSpec: "@openclaw/slack@2026.6.33",
+        },
+      }),
+    );
+
+    const result = await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: "slack",
+        spec: "@openclaw/slack",
+        installPath,
+        resolvedName: "@openclaw/slack",
+        resolvedSpec: "@openclaw/slack@2026.6.8",
+        resolvedVersion: "2026.6.8",
+      }),
+      pluginIds: ["slack"],
+      syncOfficialPluginInstalls: true,
+      updateChannel: "stable",
+    });
+
+    expectNpmUpdateCall({
+      spec: "@openclaw/slack@2026.6.33",
+      expectedPluginId: "slack",
+    });
+    expect(result.config.plugins?.installs?.slack?.spec).toBe("@openclaw/slack@2026.6.33");
+    expect(result.config.plugins?.installs?.slack?.installIntentProvenance).toBe(
+      "prior_default_intent_system_pin",
+    );
+  });
+
+  it("does not repair disabled official npm installs on the stable channel", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@openclaw/slack",
+      version: "2026.6.8",
+    });
+
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          entries: {
+            slack: {
+              enabled: false,
+            },
+          },
+          installs: {
+            slack: {
+              source: "npm",
+              spec: "@openclaw/slack",
+              installPath,
+              resolvedName: "@openclaw/slack",
+              resolvedSpec: "@openclaw/slack@2026.6.8",
+              resolvedVersion: "2026.6.8",
+            },
+          },
+        },
+      },
+      pluginIds: ["slack"],
+      skipDisabledPlugins: true,
+      syncOfficialPluginInstalls: true,
+      updateChannel: "stable",
+    });
+
+    expect(npmInstallCall()).toBeUndefined();
+    expect(result.changed).toBe(false);
+    expect(result.outcomes[0]).toMatchObject({
+      pluginId: "slack",
+      status: "skipped",
+    });
+  });
+
   it("keeps integrity drift checks for exact prerelease-only official pins", async () => {
     const installPath = createInstalledPackageDir({
       name: "@openclaw/voice-call",

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1,6 +1,7 @@
 /** Updates installed plugins across npm, ClawHub, marketplace, Git, and bundled bridge sources. */
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { InstallIntentProvenance } from "../config/types.installs.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
@@ -44,6 +45,8 @@ import { installPluginFromGitSpec } from "./git-install.js";
 import {
   resolveClawHubInstallSpecsForUpdateChannel,
   resolveNpmInstallSpecsForUpdateChannel,
+  type ChannelInstallConvergenceReason,
+  type StablePluginInstallClassification,
 } from "./install-channel-specs.js";
 import {
   installPluginFromNpmSpec,
@@ -936,8 +939,21 @@ function resolveNpmUpdateSpecs(params: {
   recordSpec?: string;
   fallbackSpec?: string;
   fallbackLabel?: string;
+  reason?: ChannelInstallConvergenceReason;
+  classification?: StablePluginInstallClassification;
 } {
-  const recordSpec = params.specOverride ?? params.officialSpecOverride ?? params.record.spec;
+  const exactRecordSpec =
+    params.record.spec && parseRegistryNpmSpec(params.record.spec)?.selectorKind === "exact-version"
+      ? params.record.spec
+      : undefined;
+  const recordSpec =
+    params.specOverride ??
+    (params.updateChannel === "stable"
+      ? (exactRecordSpec ??
+        params.record.resolvedSpec ??
+        params.officialSpecOverride ??
+        params.record.spec)
+      : (params.officialSpecOverride ?? params.record.spec));
   if (!recordSpec) {
     return {};
   }
@@ -950,6 +966,7 @@ function resolveNpmUpdateSpecs(params: {
   return resolveNpmInstallSpecsForUpdateChannel({
     spec: recordSpec,
     updateChannel: params.updateChannel,
+    record: params.record,
   });
 }
 
@@ -972,6 +989,24 @@ function resolveClawHubUpdateSpecs(params: {
     spec: recordSpec,
     updateChannel: params.updateChannel,
   });
+}
+
+function stableInstallIntentForUpdate(params: {
+  updateChannel?: UpdateChannel;
+  reason?: ChannelInstallConvergenceReason;
+  classification?: StablePluginInstallClassification;
+  record: PluginInstallRecord;
+}): InstallIntentProvenance | undefined {
+  if (params.updateChannel !== "stable" || params.reason !== "covered_stable_target") {
+    return params.record.installIntentProvenance;
+  }
+  if (params.classification === "explicit_user_pin") {
+    return "explicit_user_pin";
+  }
+  if (params.classification === "prior_default_intent_system_pin" || params.record.spec) {
+    return "prior_default_intent_system_pin";
+  }
+  return params.record.installIntentProvenance;
 }
 
 function isBridgeAlreadyInstalledFromPreferredSource(params: {
@@ -1322,7 +1357,10 @@ export async function updateNpmInstalledPlugins(params: {
         config: normalizedPluginConfig,
         rootConfig: params.config,
       });
-      if (!enableState.enabled && !officialNpmSpec && !officialClawHubSpec) {
+      if (
+        !enableState.enabled &&
+        (params.updateChannel === "stable" || (!officialNpmSpec && !officialClawHubSpec))
+      ) {
         outcomes.push({
           pluginId,
           status: "skipped",
@@ -1548,6 +1586,12 @@ export async function updateNpmInstalledPlugins(params: {
             });
             if (nextRecordSpec !== record.spec) {
               const resolutionFields = buildNpmResolutionInstallFields(metadataResult.metadata);
+              const installIntentProvenance = stableInstallIntentForUpdate({
+                updateChannel: params.updateChannel,
+                reason: npmSpecs?.reason,
+                classification: npmSpecs?.classification,
+                record,
+              });
               next = {
                 ...next,
                 plugins: {
@@ -1557,6 +1601,7 @@ export async function updateNpmInstalledPlugins(params: {
                     [pluginId]: {
                       ...record,
                       spec: nextRecordSpec,
+                      ...(installIntentProvenance ? { installIntentProvenance } : {}),
                       resolvedName: resolutionFields.resolvedName ?? record.resolvedName,
                       resolvedVersion: resolutionFields.resolvedVersion ?? record.resolvedVersion,
                       resolvedSpec: resolutionFields.resolvedSpec ?? record.resolvedSpec,
@@ -2072,6 +2117,12 @@ export async function updateNpmInstalledPlugins(params: {
         Awaited<ReturnType<typeof installPluginFromNpmSpec>>,
         { ok: true }
       >;
+      const installIntentProvenance = stableInstallIntentForUpdate({
+        updateChannel: params.updateChannel,
+        reason: npmSpecs?.reason,
+        classification: npmSpecs?.classification,
+        record,
+      });
       next = recordPluginInstall(
         usedOfficialNpmFallback ? withoutPluginInstallRecord(next, resolvedPluginId) : next,
         {
@@ -2084,6 +2135,7 @@ export async function updateNpmInstalledPlugins(params: {
               (params.syncOfficialPluginInstalls && trustedSourceLinkedOfficialInstall) ||
               usedOfficialNpmFallback,
           }),
+          ...(installIntentProvenance ? { installIntentProvenance } : {}),
           installPath: result.targetDir,
           version: nextVersion,
           ...buildNpmResolutionInstallFields(npmResult.npmResolution),

--- a/test/npm-publish-plan.test.ts
+++ b/test/npm-publish-plan.test.ts
@@ -39,25 +39,34 @@ describe("shouldRequireNpmDistTagMirrorAuth", () => {
   });
 
   it("requires npm auth for real publishes that mirror dist-tags", () => {
-    const plan = resolveNpmPublishPlan("2026.4.1");
     const auth = resolveNpmDistTagMirrorAuth({});
 
     expect(
       shouldRequireNpmDistTagMirrorAuth({
         mode: "--publish",
-        mirrorDistTags: plan.mirrorDistTags,
+        mirrorDistTags: ["beta"],
         hasAuth: auth.hasAuth,
       }),
     ).toBe(true);
   });
 
-  it("treats stable correction releases as latest publishes with beta mirroring", () => {
+  it("treats daily stable correction releases as latest publishes with beta mirroring", () => {
     const plan = resolveNpmPublishPlan("2026.4.1-1");
 
     expect(plan).toEqual({
       channel: "stable",
       publishTag: "latest",
       mirrorDistTags: ["beta"],
+    });
+  });
+
+  it("treats explicit stable selector releases as stable publishes without mirroring", () => {
+    const plan = resolveNpmPublishPlan("2026.6.33", null, "stable");
+
+    expect(plan).toEqual({
+      channel: "stable",
+      publishTag: "stable",
+      mirrorDistTags: [],
     });
   });
 

--- a/test/openclaw-npm-release-check.test.ts
+++ b/test/openclaw-npm-release-check.test.ts
@@ -167,34 +167,34 @@ describe("resolveNpmPublishPlan", () => {
     });
   });
 
-  it("publishes stable releases to beta first", () => {
+  it("publishes stable releases to stable", () => {
     expect(resolveNpmPublishPlan("2026.3.29")).toEqual({
       channel: "stable",
-      publishTag: "beta",
+      publishTag: "stable",
       mirrorDistTags: [],
     });
   });
 
-  it("publishes stable correction releases to beta first too", () => {
+  it("publishes stable correction releases to stable too", () => {
     expect(resolveNpmPublishPlan("2026.3.29-2")).toEqual({
       channel: "stable",
-      publishTag: "beta",
+      publishTag: "stable",
       mirrorDistTags: [],
     });
   });
 
-  it("can publish stable releases directly to latest when requested", () => {
-    expect(resolveNpmPublishPlan("2026.3.29", undefined, "latest")).toEqual({
+  it("can publish stable releases directly to stable when requested", () => {
+    expect(resolveNpmPublishPlan("2026.3.29", undefined, "stable")).toEqual({
       channel: "stable",
-      publishTag: "latest",
+      publishTag: "stable",
       mirrorDistTags: [],
     });
   });
 
-  it("can publish stable correction releases directly to latest when requested", () => {
-    expect(resolveNpmPublishPlan("2026.3.29-1", undefined, "latest")).toEqual({
+  it("can publish stable correction releases directly to stable when requested", () => {
+    expect(resolveNpmPublishPlan("2026.3.29-1", undefined, "stable")).toEqual({
       channel: "stable",
-      publishTag: "latest",
+      publishTag: "stable",
       mirrorDistTags: [],
     });
   });
@@ -202,9 +202,15 @@ describe("resolveNpmPublishPlan", () => {
   it("ignores current beta dist-tag state for stable publishes", () => {
     expect(resolveNpmPublishPlan("2026.3.29", "2026.4.1-beta.1")).toEqual({
       channel: "stable",
-      publishTag: "beta",
+      publishTag: "stable",
       mirrorDistTags: [],
     });
+  });
+
+  it("rejects publishing stable releases to latest", () => {
+    expect(() => resolveNpmPublishPlan("2026.3.29", undefined, "latest")).toThrow(
+      "Stable releases must publish to the stable dist-tag.",
+    );
   });
 
   it("rejects publishing beta prereleases to latest", () => {
@@ -214,7 +220,7 @@ describe("resolveNpmPublishPlan", () => {
   });
 
   it("rejects publishing alpha prereleases to beta or latest", () => {
-    expect(() => resolveNpmPublishPlan("2026.3.29-alpha.2")).toThrow(
+    expect(() => resolveNpmPublishPlan("2026.3.29-alpha.2", undefined, "beta")).toThrow(
       "Alpha prereleases must publish to the alpha dist-tag.",
     );
     expect(() => resolveNpmPublishPlan("2026.3.29-alpha.2", undefined, "latest")).toThrow(

--- a/test/plugin-npm-release.test.ts
+++ b/test/plugin-npm-release.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { bundledPluginFile, bundledPluginRoot } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it } from "vitest";
+import checkedInStablePluginSupportManifest from "../release/stable-plugin-support.json" with { type: "json" };
 import { collectClawHubPublishablePluginPackages } from "../scripts/lib/plugin-clawhub-release.ts";
 import {
   collectChangedExtensionIdsFromPaths,
@@ -11,12 +12,17 @@ import {
   collectPublishablePluginPackageErrors,
   OPENCLAW_PLUGIN_NPM_REPOSITORY_URL,
   parsePluginReleaseArgs,
+  parsePluginReleaseClass,
   parsePluginReleaseSelection,
   parsePluginReleaseSelectionMode,
+  parsePluginReleaseSelector,
+  resolveStableManifestPublishablePluginPackages,
+  resolveStablePluginSupportManifest,
   resolveChangedPublishablePluginPackages,
   resolveSelectedPublishablePluginPackages,
   type PublishablePluginPackage,
 } from "../scripts/lib/plugin-npm-release.ts";
+import { computeStablePluginSupportDigest } from "../src/plugins/stable-plugin-support.ts";
 import { cleanupTempDirs, makeTempRepoRoot, writeJsonFile } from "./helpers/temp-repo.js";
 
 const tempDirs: string[] = [];
@@ -47,8 +53,16 @@ describe("parsePluginReleaseSelectionMode", () => {
 
   it("rejects unsupported selection modes", () => {
     expect(() => parsePluginReleaseSelectionMode("all")).toThrowError(
-      'Unknown selection mode: all. Expected "selected" or "all-publishable".',
+      'Unknown selection mode: all. Expected "selected", "all-publishable", or "stable-manifest".',
     );
+  });
+});
+
+describe("parsePluginReleaseSelector and parsePluginReleaseClass", () => {
+  it("accepts stable selector inputs", () => {
+    expect(parsePluginReleaseSelector("stable")).toBe("stable");
+    expect(parsePluginReleaseClass("stable-base")).toBe("stable-base");
+    expect(parsePluginReleaseClass("stable-patch")).toBe("stable-patch");
   });
 });
 
@@ -80,9 +94,53 @@ describe("parsePluginReleaseArgs", () => {
     expect(parsePluginReleaseArgs(["--selection-mode", "all-publishable"])).toEqual({
       baseRef: undefined,
       headRef: undefined,
+      packageAcceptanceRunId: undefined,
+      releaseClass: "daily",
+      releaseSelector: "daily",
       selectionMode: "all-publishable",
       selection: [],
+      stableLine: undefined,
+      stablePluginManifestPath: undefined,
+      stablePluginManifestSha256: undefined,
       pluginsFlagProvided: false,
+    });
+  });
+
+  it("requires stable manifest proof inputs for stable selector mode", () => {
+    expect(() =>
+      parsePluginReleaseArgs([
+        "--selection-mode",
+        "stable-manifest",
+        "--release-selector",
+        "stable",
+      ]),
+    ).toThrowError("`--selection-mode stable-manifest` requires `--stable-line`.");
+
+    expect(
+      parsePluginReleaseArgs([
+        "--selection-mode",
+        "stable-manifest",
+        "--release-selector",
+        "stable",
+        "--release-class",
+        "stable-base",
+        "--stable-line",
+        "2026.6",
+        "--stable-plugin-manifest",
+        "release/stable-plugin-support.json",
+        "--stable-plugin-manifest-sha256",
+        "a".repeat(64),
+        "--package-acceptance-run-id",
+        "123",
+      ]),
+    ).toMatchObject({
+      selectionMode: "stable-manifest",
+      releaseSelector: "stable",
+      releaseClass: "stable-base",
+      stableLine: "2026.6",
+      stablePluginManifestPath: "release/stable-plugin-support.json",
+      stablePluginManifestSha256: "a".repeat(64),
+      packageAcceptanceRunId: "123",
     });
   });
 });
@@ -499,6 +557,118 @@ describe("collectPublishablePluginPackages", () => {
         version: "2026.4.10-alpha.1",
       },
     ]);
+  });
+});
+
+describe("stable plugin support manifest release planning", () => {
+  function writeStableManifest(repoDir: string) {
+    const manifestPath = join(repoDir, "stable-plugin-support.json");
+    const manifest = JSON.parse(JSON.stringify(checkedInStablePluginSupportManifest));
+    const text = `${JSON.stringify(manifest, null, 2)}\n`;
+    writeFileSync(manifestPath, text);
+    return {
+      manifestPath,
+      sha256: computeStablePluginSupportDigest(manifest),
+    };
+  }
+
+  it("resolves and validates stable manifest package targets", () => {
+    const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-release-");
+    const { manifestPath, sha256 } = writeStableManifest(repoDir);
+
+    expect(
+      resolveStablePluginSupportManifest({
+        path: manifestPath,
+        expectedSha256: sha256,
+        stableLine: "2026.6",
+      }),
+    ).toEqual({
+      sha256,
+      stableLine: "2026.6",
+      baseVersion: "2026.6.33",
+      packages: [
+        {
+          packageName: "@openclaw/codex",
+          pluginId: "codex",
+          packageDir: "extensions/codex",
+          targetVersion: "2026.6.33",
+          targetNpmSpec: "@openclaw/codex@2026.6.33",
+          targetBranch: "stable/2026.6.33",
+        },
+        {
+          packageName: "@openclaw/discord",
+          pluginId: "discord",
+          packageDir: "extensions/discord",
+          targetVersion: "2026.6.33",
+          targetNpmSpec: "@openclaw/discord@2026.6.33",
+          targetBranch: "stable/2026.6.33",
+        },
+        {
+          packageName: "@openclaw/slack",
+          pluginId: "slack",
+          packageDir: "extensions/slack",
+          targetVersion: "2026.6.33",
+          targetNpmSpec: "@openclaw/slack@2026.6.33",
+          targetBranch: "stable/2026.6.33",
+        },
+      ],
+    });
+  });
+
+  it("rejects a stable manifest digest mismatch", () => {
+    const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-release-");
+    const { manifestPath } = writeStableManifest(repoDir);
+
+    expect(() =>
+      resolveStablePluginSupportManifest({
+        path: manifestPath,
+        expectedSha256: "b".repeat(64),
+        stableLine: "2026.6",
+      }),
+    ).toThrowError("Stable plugin support manifest digest mismatch");
+  });
+
+  it("converts manifest-covered packages to stable npm publish targets", () => {
+    const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-release-");
+    const { manifestPath, sha256 } = writeStableManifest(repoDir);
+    const manifest = resolveStablePluginSupportManifest({
+      path: manifestPath,
+      expectedSha256: sha256,
+      stableLine: "2026.6",
+    });
+
+    expect(
+      resolveStableManifestPublishablePluginPackages({
+        manifest,
+        releaseClass: "stable-base",
+        releaseSelector: "stable",
+        packageAcceptanceRunId: "456",
+        plugins: manifest.packages.map((plugin) => ({
+          extensionId: plugin.pluginId,
+          packageDir: plugin.packageDir,
+          packageName: plugin.packageName,
+          version: plugin.targetVersion,
+          channel: "stable",
+          publishTag: "latest",
+        })),
+      }),
+    ).toEqual(
+      manifest.packages.map((plugin) => ({
+        extensionId: plugin.pluginId,
+        packageDir: plugin.packageDir,
+        packageName: plugin.packageName,
+        version: "2026.6.33",
+        channel: "stable",
+        publishTag: "stable",
+        releaseClass: "stable-base",
+        releaseSelector: "stable",
+        stableLine: "2026.6",
+        stablePluginSupportSha256: sha256,
+        targetBranch: "stable/2026.6.33",
+        targetNpmSpec: plugin.targetNpmSpec,
+        packageAcceptanceRunId: "456",
+      })),
+    );
   });
 });
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -12,6 +12,7 @@ const DOCKER_E2E_PLAN_ACTION = ".github/actions/docker-e2e-plan/action.yml";
 const RELEASE_CHECKS_WORKFLOW = ".github/workflows/openclaw-release-checks.yml";
 const RELEASE_PUBLISH_WORKFLOW = ".github/workflows/openclaw-release-publish.yml";
 const STABLE_MAIN_CLOSEOUT_WORKFLOW = ".github/workflows/openclaw-stable-main-closeout.yml";
+const STABLE_PLUGIN_DRIFT_WORKFLOW = ".github/workflows/stable-plugin-support-drift.yml";
 const WINDOWS_NODE_RELEASE_WORKFLOW = ".github/workflows/windows-node-release.yml";
 const FULL_RELEASE_VALIDATION_WORKFLOW = ".github/workflows/full-release-validation.yml";
 const QA_LIVE_TRANSPORTS_WORKFLOW = ".github/workflows/qa-live-transports-convex.yml";
@@ -1332,9 +1333,8 @@ describe("package artifact reuse", () => {
     const workflow = readFileSync(PACKAGE_ACCEPTANCE_WORKFLOW, "utf8");
 
     expect(workflow).toContain("package_telegram:");
-    expect(workflow).toContain(
-      "needs: [resolve_package, package_integrity, docker_acceptance, package_telegram]",
-    );
+    expect(workflow).toContain("stable_plugin_acceptance_proof,");
+    expect(workflow).toContain("package_telegram,");
     expect(workflow).toContain("PACKAGE_TELEGRAM_RESULT:");
     expect(workflow).toContain("package_telegram=${PACKAGE_TELEGRAM_RESULT}");
     expect(workflow).not.toContain("npm_telegram:");
@@ -1670,6 +1670,8 @@ describe("package artifact reuse", () => {
     expect(npmWorkflow).toContain("full_release_validation_run_id");
     expect(npmWorkflow).toContain("release_publish_run_id");
     expect(npmWorkflow).toContain("Real publish requires full_release_validation_run_id");
+    expect(npmWorkflow).toContain("stable/YYYY.M.PATCH for stable publishes");
+    expect(npmWorkflow).toContain("refs/heads/stable/");
     expect(npmWorkflow).toContain(
       "Workflow-dispatched real publish requires release_publish_run_id",
     );
@@ -1680,6 +1682,128 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain("Unreleased prerelease fallback");
     expect(workflow).not.toContain("gh api --repo");
     expect(workflow).not.toContain("timeout-minutes: 360");
+  });
+
+  it("plumbs stable plugin package acceptance inputs into validation artifacts", () => {
+    const workflow = readFileSync(PACKAGE_ACCEPTANCE_WORKFLOW, "utf8");
+    const dockerWorkflow = readFileSync(LIVE_E2E_WORKFLOW, "utf8");
+
+    expect(workflow).toContain("- stable-plugin");
+    expect(workflow).toContain("stable_plugin_manifest_ref:");
+    expect(workflow).toContain("stable_plugin_targets_json:");
+    expect(workflow).toContain("stable_plugin_package_specs:");
+    expect(workflow).toContain("stable_plugin_package_tarballs_json:");
+    expect(workflow).toContain("stable_plugin_acceptance_artifact_prefix:");
+    expect(workflow).toContain("Validate stable plugin package inputs");
+    expect(workflow).toContain("STABLE_PLUGIN_MANIFEST_REF");
+    expect(workflow).toContain("STABLE_PLUGIN_TARGETS_JSON");
+    expect(workflow).toContain("STABLE_PLUGIN_PACKAGE_SPECS");
+    expect(workflow).toContain("STABLE_PLUGIN_PACKAGE_TARBALLS_JSON");
+    expect(workflow).toContain("STABLE_PLUGIN_ACCEPTANCE_ARTIFACT_PREFIX");
+    expect(workflow).toContain("suite_profile=stable-plugin requires stable_plugin_manifest_ref");
+    expect(workflow).toContain(
+      "suite_profile=stable-plugin requires stable_plugin_package_tarballs_json",
+    );
+    expect(workflow).toContain("stable_plugin_package_specs must exactly match");
+    expect(workflow).toContain("stable-plugin-inputs.json");
+    expect(workflow).toContain("Upload stable plugin acceptance inputs");
+    expect(workflow).toContain(
+      "stable_plugin_targets_json: ${{ inputs.stable_plugin_targets_json }}",
+    );
+    expect(workflow).toContain("Download stable plugin Docker proof");
+    expect(workflow).toContain("stable-plugin-docker-proof.json");
+    expect(workflow).toContain('source == "docker-npm-install"');
+    expect(workflow).toContain('installSource == "tarball"');
+    expect(dockerWorkflow).toContain("tarballSha256");
+    expect(dockerWorkflow).toContain("OPENCLAW_WORKSPACE_IN_CONTAINER");
+    expect(workflow).toContain("Stable plugin acceptance proof");
+    expect(workflow).toContain("stable-plugin-acceptance.json");
+    expect(workflow).toContain("Upload stable plugin acceptance proof");
+    expect(workflow).toContain("stable_plugin_support_sha256");
+  });
+
+  it("guards stable plugin manifest mode in release publish and plugin npm workflows", () => {
+    const releaseWorkflow = readFileSync(RELEASE_PUBLISH_WORKFLOW, "utf8");
+    const pluginNpmWorkflow = readFileSync(".github/workflows/plugin-npm-release.yml", "utf8");
+
+    expect(releaseWorkflow).toContain("- stable-manifest");
+    expect(releaseWorkflow).toContain("release_class:");
+    expect(releaseWorkflow).toContain("stable_line:");
+    expect(releaseWorkflow).toContain("stable_plugin_manifest_sha256:");
+    expect(releaseWorkflow).toContain("package_acceptance_run_id:");
+    expect(releaseWorkflow).toContain(
+      "Stable publish_openclaw_npm=true requires plugin_publish_scope=stable-manifest",
+    );
+    expect(releaseWorkflow).toContain(
+      "Stable releases must publish OpenClaw to npm dist-tag stable",
+    );
+    expect(releaseWorkflow).toContain(
+      "Stable plugin publish must be dispatched from manifest target branch",
+    );
+    expect(releaseWorkflow).toContain("stable/*");
+    expect(releaseWorkflow).toContain(
+      "Daily/prerelease publish_openclaw_npm=true requires plugin_publish_scope=all-publishable",
+    );
+    expect(releaseWorkflow).toContain(
+      "Stable plugin publish requires a successful Package Acceptance run",
+    );
+    expect(releaseWorkflow).toContain(
+      'acceptance_artifact="stable-plugin-acceptance-${manifest_sha}-proof"',
+    );
+    expect(releaseWorkflow).toContain("stable-plugin-acceptance.json");
+    expect(releaseWorkflow).toContain("stable-plugin package acceptance targets do not match");
+    expect(releaseWorkflow).toContain(
+      "stable-plugin package acceptance proof targets do not match",
+    );
+    expect(releaseWorkflow).toContain(
+      "stable-plugin package acceptance proof must come from Docker npm installs of exact target package tarballs",
+    );
+    expect(releaseWorkflow).toContain(
+      "stable-plugin package acceptance package specs do not match",
+    );
+    expect(releaseWorkflow).toContain("Upload stable plugin manifest artifact");
+    expect(releaseWorkflow).toContain("-f release_selector=stable");
+    expect(releaseWorkflow).toContain("-f stable_plugin_manifest_sha256=");
+
+    expect(pluginNpmWorkflow).toContain("- stable-manifest");
+    expect(pluginNpmWorkflow).toContain("release_selector:");
+    expect(pluginNpmWorkflow).toContain("stable_plugin_manifest_sha256:");
+    expect(pluginNpmWorkflow).toContain("Resolve stable plugin manifest");
+    expect(pluginNpmWorkflow).toContain("stable/*");
+    expect(pluginNpmWorkflow).toContain('--selection-mode "${PUBLISH_SCOPE}" --release-selector');
+    expect(pluginNpmWorkflow).toContain("Validate stable manifest plan");
+    expect(pluginNpmWorkflow).toContain(
+      "Stable plugin npm publish must be dispatched from manifest target branch",
+    );
+    expect(pluginNpmWorkflow).toContain("(.skippedPublished | length) == 0");
+    expect(pluginNpmWorkflow).toContain("OPENCLAW_PLUGIN_NPM_RELEASE_SELECTOR");
+    expect(pluginNpmWorkflow).toContain("OPENCLAW_PLUGIN_NPM_STABLE_MANIFEST_SHA256");
+  });
+
+  it("exposes stable plugin drift reporting as an operational workflow and package script", () => {
+    const workflow = readFileSync(STABLE_PLUGIN_DRIFT_WORKFLOW, "utf8");
+    const packageJson = JSON.parse(readFileSync(PACKAGE_JSON, "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.["release:stable-plugin-drift"]).toBe(
+      "node --import tsx scripts/stable-plugin-drift-report.ts",
+    );
+    expect(workflow).toContain("name: Stable Plugin Support Drift");
+    expect(workflow).toContain('cron: "15 17 * * *"');
+    expect(workflow).toContain("actions: read");
+    expect(workflow).toContain("release/stable-plugin-support.json");
+    expect(workflow).toContain("validateStablePluginSupportManifest");
+    expect(workflow).toContain("package_acceptance_run_id:");
+    expect(workflow).toContain('proof_artifact="stable-plugin-acceptance-${support_sha}-proof"');
+    expect(workflow).toContain("stable-plugin-acceptance.json");
+    expect(workflow).toContain("scripts/stable-plugin-drift-report.ts");
+    expect(workflow).toContain(
+      "--registry-proof .artifacts/stable-plugin-drift/registry-proof.json",
+    );
+    expect(workflow).toContain("Apply stable plugin drift issues");
+    expect(workflow).toContain('"issue", "create"');
+    expect(workflow).toContain("stable-plugin-drift-report");
   });
 
   it("keeps OpenClaw npm release pack tarball paths local before preflight upload", () => {

--- a/test/scripts/release-candidate-checklist.test.ts
+++ b/test/scripts/release-candidate-checklist.test.ts
@@ -16,22 +16,59 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), init);
 }
 
+function stablePluginArgs() {
+  return [
+    "--plugin-publish-scope",
+    "stable-manifest",
+    "--stable-line",
+    "2026.6",
+    "--stable-plugin-manifest-sha256",
+    "a".repeat(64),
+    "--package-acceptance-run",
+    "444",
+  ];
+}
+
 describe("release candidate checklist", () => {
   it("infers validation profiles from candidate tags", () => {
     expect(parseArgs(["--tag", "v2026.5.14-beta.3"]).releaseProfile).toBe("beta");
-    expect(parseArgs(["--tag", "v2026.5.14", "--windows-node-tag", "v0.6.3"]).releaseProfile).toBe(
-      "stable",
-    );
+    expect(
+      parseArgs(["--tag", "v2026.6.33", "--windows-node-tag", "v0.6.3", ...stablePluginArgs()])
+        .releaseProfile,
+    ).toBe("stable");
     expect(
       parseArgs([
         "--tag",
-        "v2026.5.14",
+        "v2026.6.33",
         "--windows-node-tag",
         "v0.6.3",
         "--release-profile",
         "full",
+        ...stablePluginArgs(),
       ]).releaseProfile,
     ).toBe("full");
+    expect(parseArgs(["--tag", "v2026.7.1"]).releaseClass).toBe("daily");
+    expect(parseArgs(["--tag", "v2026.7.1"]).pluginPublishScope).toBe("all-publishable");
+    expect(
+      parseArgs(["--tag", "v2026.6.33", "--windows-node-tag", "v0.6.3", ...stablePluginArgs()])
+        .npmDistTag,
+    ).toBe("stable");
+  });
+
+  it("requires stable release candidates to use manifest-limited plugin proof", () => {
+    expect(() => parseArgs(["--tag", "v2026.6.33", "--windows-node-tag", "v0.6.3"])).toThrow(
+      "stable release candidates require --plugin-publish-scope stable-manifest",
+    );
+    expect(() =>
+      parseArgs([
+        "--tag",
+        "v2026.6.33",
+        "--windows-node-tag",
+        "v0.6.3",
+        "--plugin-publish-scope",
+        "stable-manifest",
+      ]),
+    ).toThrow("stable release candidates require --stable-line");
   });
 
   it("runs Parallels against the exact prepared candidate tarball", () => {
@@ -165,21 +202,23 @@ describe("release candidate checklist", () => {
   });
 
   it("requires and carries an exact Windows Node tag for stable release candidates", () => {
-    expect(() => parseArgs(["--tag", "v2026.5.14"])).toThrow(
+    expect(() => parseArgs(["--tag", "v2026.6.33", ...stablePluginArgs()])).toThrow(
       "stable release candidates require --windows-node-tag",
     );
-    expect(() => parseArgs(["--tag", "v2026.5.14", "--windows-node-tag", "latest"])).toThrow(
-      "--windows-node-tag must be an explicit version tag, not latest",
-    );
+    expect(() =>
+      parseArgs(["--tag", "v2026.6.33", "--windows-node-tag", "latest", ...stablePluginArgs()]),
+    ).toThrow("--windows-node-tag must be an explicit version tag, not latest");
 
+    const stableArgs = stablePluginArgs();
     const options = {
       ...parseArgs([
         "--tag",
-        "v2026.5.14",
+        "v2026.6.33",
         "--windows-node-tag",
         "v0.6.3",
         "--workflow-ref",
-        "release/2026.5.14",
+        "release/2026.6.33",
+        ...stableArgs,
       ]),
       workflowRef: "release/2026.5.14",
       windowsNodeInstallerDigests: JSON.stringify({
@@ -189,6 +228,13 @@ describe("release candidate checklist", () => {
     };
 
     expect(buildPublishCommand(options)).toContain("'windows_node_tag=v0.6.3'");
+    expect(buildPublishCommand(options)).toContain("'npm_dist_tag=stable'");
+    expect(buildPublishCommand(options)).toContain("'plugin_publish_scope=stable-manifest'");
+    expect(buildPublishCommand(options)).toContain("'stable_line=2026.6'");
+    expect(buildPublishCommand(options)).toContain(
+      `'stable_plugin_manifest_sha256=${"a".repeat(64)}'`,
+    );
+    expect(buildPublishCommand(options)).toContain("'package_acceptance_run_id=444'");
     expect(buildPublishCommand(options)).toContain(
       `'windows_node_installer_digests={"OpenClawCompanion-Setup-x64.exe":"sha256:${"a".repeat(64)}","OpenClawCompanion-Setup-arm64.exe":"sha256:${"b".repeat(64)}"}'`,
     );

--- a/test/scripts/stable-plugin-backport-plan.test.ts
+++ b/test/scripts/stable-plugin-backport-plan.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import checkedInStablePluginSupportManifest from "../../release/stable-plugin-support.json" with { type: "json" };
+import {
+  generateStablePluginBackportPlan,
+  parseAffectedPluginIds,
+} from "../../scripts/lib/stable-plugin-backport-plan.ts";
+import type { StablePluginSupportManifest } from "../../src/plugins/plugin-version-drift.ts";
+
+const manifest = checkedInStablePluginSupportManifest as StablePluginSupportManifest;
+
+describe("generateStablePluginBackportPlan", () => {
+  it("emits plugin-first coordinated backport targets with validation and recovery fields", () => {
+    const plan = generateStablePluginBackportPlan({
+      sourcePr: "https://github.com/openclaw/openclaw/pull/123",
+      sourceSha: "abc123",
+      stableLine: "2026.6.33",
+      eligibilityReason: "security fix for stable-covered Slack channel",
+      affectedPluginIds: ["slack"],
+      manifest,
+      manifestPath: "release/stable-plugin-support.json",
+    });
+
+    expect(plan.dryRun).toBe(true);
+    expect(plan.stableBranch).toBe("stable/2026.6.33");
+    expect(plan.affectedPluginIds).toEqual(["slack"]);
+    expect(plan.targets.map((target) => target.packageName)).toEqual([
+      "@openclaw/slack",
+      "openclaw",
+    ]);
+    expect(plan.targets.map((target) => target.publishOrder)).toEqual([1, 2]);
+    expect(plan.targets[0]).toMatchObject({
+      targetType: "plugin",
+      targetRepository: "openclaw/openclaw",
+      targetBranch: "stable/2026.6.33",
+      pluginId: "slack",
+      packageDir: "extensions/slack",
+      targetNpmSpec: "@openclaw/slack@2026.6.33",
+      branchProtectionStatus: "not_checked_dry_run",
+      changeKind: "coordinated",
+    });
+    expect(plan.targets[0]?.validationPlan.map((step) => step.name)).toEqual([
+      "stable-plugin-drift-dry-run",
+      "package-acceptance-stable-plugin",
+      "plugin-publish-proof",
+    ]);
+    expect(plan.targets[0]?.rollback.partialFailureState).toBe("partial_plugin_publish");
+    expect(plan.targets[1]?.rollback.partialFailureState).toBe("core_published_plugin_missing");
+    expect(plan.partialFailureStates.map((state) => state.state)).toEqual([
+      "planned",
+      "plugin_published_core_pending",
+      "core_published_plugin_missing",
+      "partial_plugin_publish",
+      "activation_blocked",
+    ]);
+  });
+
+  it("emits a core-only target when no covered plugin ids are affected", () => {
+    const plan = generateStablePluginBackportPlan({
+      sourceSha: "abc123",
+      stableLine: "2026.6.33",
+      eligibilityReason: "reliability fix in core",
+      affectedPluginIds: [],
+      manifest,
+    });
+
+    expect(plan.targets).toHaveLength(1);
+    expect(plan.targets[0]).toMatchObject({
+      targetType: "core",
+      packageName: "openclaw",
+      changeKind: "core_only",
+      publishOrder: 1,
+    });
+  });
+
+  it("rejects affected plugin ids outside the stable support manifest", () => {
+    expect(() =>
+      generateStablePluginBackportPlan({
+        sourceSha: "abc123",
+        stableLine: "2026.6.33",
+        eligibilityReason: "security fix",
+        affectedPluginIds: ["matrix"],
+        manifest,
+      }),
+    ).toThrow("not covered by the stable support manifest");
+  });
+
+  it("parses comma and whitespace separated affected plugin ids", () => {
+    expect(parseAffectedPluginIds("slack,codex discord")).toEqual(["codex", "discord", "slack"]);
+  });
+});


### PR DESCRIPTION
Summary
- Add checked-in stable plugin support manifest and validation for the first stable line covering @openclaw/slack, @openclaw/discord, and @openclaw/codex.
- Implement stable/daily plugin install convergence, exact pin preservation, stable publish planning, package acceptance proof, backport planning, and drift reporting.
- Gate stable plugin/core release workflows on manifest digest, candidate tarball Docker proof, package acceptance proof, stable branch dispatch, and npm dist-tag stable.

Verification
- node scripts/run-vitest.mjs src/plugins/update.test.ts src/plugins/stable-plugin-support.test.ts src/plugins/install-channel-specs.stable.test.ts src/plugins/plugin-version-drift.test.ts test/scripts/stable-plugin-backport-plan.test.ts test/plugin-npm-release.test.ts test/scripts/package-acceptance-workflow.test.ts test/scripts/release-candidate-checklist.test.ts test/npm-publish-plan.test.ts test/openclaw-npm-release-check.test.ts
- node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
- node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
- node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
- node scripts/check-workflows.mjs
- Workflow YAML parse for package acceptance, release publish, plugin npm release, OpenClaw npm release, reusable live/E2E, and stable plugin drift workflows
- Stable plugin backport and drift-report JSON smokes from release/stable-plugin-support.json
- git diff --check
