### PR TITLE
fix: bound agents load their own inbound workspace context

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -301,6 +301,7 @@ export function resolveSessionAgentIds(params: {
   sessionKey?: string;
   config?: OpenClawConfig;
   agentId?: string;
+  fallbackAgentId?: string;
 }): {
   defaultAgentId: string;
   sessionAgentId: string;
@@ -308,11 +309,14 @@ export function resolveSessionAgentIds(params: {
   const defaultAgentId = resolveDefaultAgentId(params.config ?? {});
   const explicitAgentIdRaw = normalizeLowercaseStringOrEmpty(params.agentId);
   const explicitAgentId = explicitAgentIdRaw ? normalizeAgentId(explicitAgentIdRaw) : null;
+  const fallbackAgentIdRaw = normalizeLowercaseStringOrEmpty(params.fallbackAgentId);
+  const fallbackAgentId = fallbackAgentIdRaw ? normalizeAgentId(fallbackAgentIdRaw) : null;
   const sessionKey = params.sessionKey?.trim();
   const normalizedSessionKey = sessionKey ? normalizeLowercaseStringOrEmpty(sessionKey) : undefined;
   const parsed = normalizedSessionKey ? parseAgentSessionKey(normalizedSessionKey) : null;
   const sessionAgentId =
-    explicitAgentId ?? (parsed?.agentId ? normalizeAgentId(parsed.agentId) : defaultAgentId);
+    explicitAgentId ??
+    (parsed?.agentId ? normalizeAgentId(parsed.agentId) : (fallbackAgentId ?? defaultAgentId));
   return { defaultAgentId, sessionAgentId };
 }
 
@@ -320,6 +324,7 @@ export function resolveSessionAgentId(params: {
   sessionKey?: string;
   config?: OpenClawConfig;
   agentId?: string;
+  fallbackAgentId?: string;
 }): string {
   return resolveSessionAgentIds(params).sessionAgentId;
 }

--- a/src/agents/embedded-agent-runner.resolvesessionagentids.test.ts
+++ b/src/agents/embedded-agent-runner.resolvesessionagentids.test.ts
@@ -68,4 +68,32 @@ describe("resolveSessionAgentIds", () => {
     });
     expect(sessionAgentId).toBe("main");
   });
+
+  it("uses fallbackAgentId for unscoped channel session keys", () => {
+    const { sessionAgentId } = resolveSessionAgentIds({
+      sessionKey: "feishu:direct:ou_user1",
+      fallbackAgentId: "main",
+      config: cfg,
+    });
+    expect(sessionAgentId).toBe("main");
+  });
+
+  it("prefers session-key agent over fallbackAgentId", () => {
+    const { sessionAgentId } = resolveSessionAgentIds({
+      sessionKey: "agent:beta:feishu:direct:ou_user1",
+      fallbackAgentId: "main",
+      config: cfg,
+    });
+    expect(sessionAgentId).toBe("beta");
+  });
+
+  it("prefers explicit agentId over fallbackAgentId", () => {
+    const { sessionAgentId } = resolveSessionAgentIds({
+      sessionKey: "feishu:direct:ou_user1",
+      agentId: "beta",
+      fallbackAgentId: "main",
+      config: cfg,
+    });
+    expect(sessionAgentId).toBe("beta");
+  });
 });

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -393,7 +393,7 @@ const resolveSessionStoreLookup = (
   if (!sessionKey) {
     return {};
   }
-  const agentId = resolveSessionAgentId({ sessionKey, config: cfg, agentId: ctx.AgentId });
+  const agentId = resolveSessionAgentId({ sessionKey, config: cfg, fallbackAgentId: ctx.AgentId });
   const storePath = resolveStorePath(cfg.session?.store, { agentId });
   try {
     const store = loadSessionStore(storePath);
@@ -1266,7 +1266,7 @@ export async function dispatchReplyFromConfig(
   const sessionAgentId = resolveSessionAgentId({
     sessionKey: acpDispatchSessionKey,
     config: cfg,
-    agentId: ctx.AgentId,
+    fallbackAgentId: ctx.AgentId,
   });
   const sessionAgentCfg = resolveAgentConfig(cfg, sessionAgentId);
   const verboseProgress = createShouldEmitVerboseProgress({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -284,7 +284,7 @@ export async function getReplyFromConfig(
         agentId: resolveSessionAgentId({
           sessionKey: resolvedAgentSessionKey,
           config: cfg,
-          agentId: finalized.AgentId,
+          fallbackAgentId: finalized.AgentId,
         }),
       };
     },

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -265,6 +265,7 @@ export async function initSessionState(params: {
   const agentId = resolveSessionAgentId({
     sessionKey: sessionCtxForState.SessionKey,
     config: cfg,
+    fallbackAgentId: sessionCtxForState.AgentId,
   });
   const groupResolution = resolveGroupSessionKey(sessionCtxForState) ?? undefined;
   const resetTriggers = sessionCfg?.resetTriggers?.length

--- a/src/channels/inbound-event/context.test.ts
+++ b/src/channels/inbound-event/context.test.ts
@@ -137,6 +137,7 @@ describe("buildChannelInboundEventContext", () => {
       From: "test:user:u1",
       To: "test:room:room-1",
       SessionKey: "agent:main:test:group:room-1",
+      AgentId: "main",
       AccountId: "acct",
       ParentSessionKey: "agent:main:test:group",
       ModelParentSessionKey: "agent:main:test:model",
@@ -209,6 +210,20 @@ describe("buildChannelInboundEventContext", () => {
     );
 
     expect(ctx.CommandAuthorized).toBe(false);
+  });
+
+  it("carries the routed agent for unscoped session keys", async () => {
+    const ctx = buildChannelInboundEventContext(
+      createBaseContextParams({
+        route: {
+          agentId: "bound-agent",
+          routeSessionKey: "feishu:direct:ou_user1",
+        },
+      }),
+    );
+
+    expect(ctx.AgentId).toBe("bound-agent");
+    expect(ctx.SessionKey).toBe("feishu:direct:ou_user1");
   });
 
   it("carries room event semantics into the finalized context", async () => {

--- a/src/channels/inbound-event/context.ts
+++ b/src/channels/inbound-event/context.ts
@@ -484,6 +484,7 @@ export function buildChannelInboundEventContext(
     From: params.from,
     To: params.reply.to,
     SessionKey: params.route.dispatchSessionKey ?? params.route.routeSessionKey,
+    AgentId: params.route.agentId,
     AccountId: params.route.accountId ?? params.accountId,
     ParentSessionKey: params.route.parentSessionKey,
     ModelParentSessionKey: params.route.modelParentSessionKey,


### PR DESCRIPTION
Closes #92903

## What Problem This Solves

Fixes an issue where users with multiple agents bound to channel conversations could see the default agent workspace injected into Project Context when a non-default bound agent received an inbound turn whose routed session key did not encode an agent id.

## Why This Change Was Made

The route already resolves the bound agent, but the shared inbound context builder was not carrying that agent into the finalized context. This change threads the routed agent as a fallback agent id for unscoped session keys, while preserving the existing precedence where explicit agent ids and agent-scoped session keys still win.

Session store lookup, reply workspace resolution, and ACP dispatch now use the same fallback semantics. This intentionally does not add a runtime fallback to old default-agent session records that were previously mis-associated.

## User Impact

Bound multi-agent channel sessions now load the bound agent's own workspace bootstrap files, including SOUL.md, AGENTS.md, USER.md, and IDENTITY.md, instead of falling back to the default agent workspace. Existing affected unscoped conversations that were previously stored under the default agent may start fresh under the correct bound-agent store.

## Evidence

Real behavior proof:

Behavior addressed: inbound channel turns for a bound non-default agent resolve the bound agent's own workspace/bootstrap when the routed session key is unscoped, instead of falling back to the default agent workspace.

Real environment tested: local equivalent multi-agent Feishu direct-message setup using production OpenClaw code paths: `buildChannelInboundEventContext`, `resolveSessionAgentId`, `resolveAgentWorkspaceDir`, and `resolveBootstrapContextForRun`. This uses two real temporary workspaces with distinct AGENTS.md/SOUL.md markers and a Feishu-shaped unscoped direct-message route. No live Feishu tenant credentials were used.

Exact steps or command run after this patch:

```bash
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs src/agents/embedded-agent-runner.resolvesessionagentids.test.ts src/channels/inbound-event/context.test.ts
node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts
pnpm exec oxfmt --check --threads=1 src/agents/agent-scope.ts src/agents/embedded-agent-runner.resolvesessionagentids.test.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/get-reply.ts src/auto-reply/reply/session.ts src/channels/inbound-event/context.ts src/channels/inbound-event/context.test.ts
pnpm exec oxlint --config .oxlintrc.json src/agents/agent-scope.ts src/agents/embedded-agent-runner.resolvesessionagentids.test.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/get-reply.ts src/auto-reply/reply/session.ts src/channels/inbound-event/context.ts src/channels/inbound-event/context.test.ts
.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review the local fix for OpenClaw issue #92903. Scope is a narrow multi-agent inbound route-agent fallback: route AgentId must fix unscoped bound channel session keys without overriding agent-scoped session keys or explicit agentId."
node --import tsx --input-type=module < local-equivalent-multi-agent-feishu-proof-script
```

Evidence after fix:

- Resolver/context test run passed: resolver suite 10/10 and channel inbound-context suite 20/20.
- Session suite passed: 114/114.
- Formatting check passed on all 7 changed files.
- Direct oxlint passed on all 7 changed files.
- Autoreview result: `autoreview clean: no accepted/actionable findings reported`.
- Local equivalent Feishu multi-agent proof passed with this redacted output:

```json
{
  "scenario": "local equivalent multi-agent Feishu direct-message turn using production channel/context/bootstrap code",
  "routeAgentId": "feishu-a1",
  "unscopedRouteSessionKey": "feishu:direct:ou_redacted",
  "controlWithoutRouteFallbackAgentId": "main",
  "resolvedAgentId": "feishu-a1",
  "resolvedWorkspace": "<tmp>/workspace-feishu-a1",
  "injectedContainsBoundMarker": true,
  "injectedContainsDefaultMarker": false,
  "injectedFiles": [
    "AGENTS.md @ <tmp>/workspace-feishu-a1/AGENTS.md",
    "SOUL.md @ <tmp>/workspace-feishu-a1/SOUL.md",
    "TOOLS.md @ <tmp>/workspace-feishu-a1/TOOLS.md",
    "IDENTITY.md @ <tmp>/workspace-feishu-a1/IDENTITY.md",
    "USER.md @ <tmp>/workspace-feishu-a1/USER.md",
    "HEARTBEAT.md @ <tmp>/workspace-feishu-a1/HEARTBEAT.md",
    "BOOTSTRAP.md @ <tmp>/workspace-feishu-a1/BOOTSTRAP.md"
  ]
}
```

Observed result after fix: the production shared channel context carries `route.agentId` as `ctx.AgentId`; the unscoped Feishu-shaped route resolves to `feishu-a1`; bootstrap resolution loads files from `<tmp>/workspace-feishu-a1`; the bound workspace marker is present and the default workspace marker is absent. The control value shows the same unscoped session key would resolve to `main` without the route fallback.

What was not tested: no live Feishu tenant deployment. The added real behavior proof uses an equivalent local multi-agent Feishu-shaped channel turn through the production channel/context/bootstrap code paths with real temporary workspaces.
