### PR TITLE
fix(test): stream QA Lab stdout artifacts

### DIFF
--- a/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
@@ -3,7 +3,7 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, open, rm, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { Socket } from "node:net";
 import { tmpdir } from "node:os";
@@ -1075,12 +1075,35 @@ async function appendGatewayStdoutArtifactLogs(params: {
     "gateway.stdout.log",
   );
   try {
-    params.capture.append(await readFile(gatewayStdoutPath, "utf8"));
+    params.capture.append(
+      await readUtf8FileTail(gatewayStdoutPath, MAX_STDOUT_DIAGNOSTIC_LINE_BYTES),
+    );
     params.capture.flush();
   } catch (error) {
     if (!isErrnoCode(error, "ENOENT")) {
       throw error;
     }
+  }
+}
+
+async function readUtf8FileTail(filePath: string, maxBytes: number): Promise<string> {
+  const file = await open(filePath, "r");
+  try {
+    const stats = await file.stat();
+    const bytesToRead = Math.min(stats.size, Math.max(1, maxBytes));
+    const buffer = Buffer.alloc(bytesToRead);
+    const start = stats.size - bytesToRead;
+    let offset = 0;
+    while (offset < bytesToRead) {
+      const { bytesRead } = await file.read(buffer, offset, bytesToRead - offset, start + offset);
+      if (bytesRead === 0) {
+        break;
+      }
+      offset += bytesRead;
+    }
+    return buffer.subarray(0, offset).toString("utf8");
+  } finally {
+    await file.close();
   }
 }
 
@@ -1882,6 +1905,7 @@ async function main() {
 }
 
 export const testing = {
+  appendGatewayStdoutArtifactLogs,
   appendCapturedBodyText,
   assertSmoke,
   createBoundedTextAccumulator,
@@ -1890,6 +1914,7 @@ export const testing = {
   parseStdoutDiagnosticLogLine,
   readPositiveIntegerEnv,
   readRequestBody,
+  readUtf8FileTail,
   startLocalOtlpReceiver,
   startDockerOtelCollector,
   terminateChildTree,

--- a/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
@@ -158,6 +158,7 @@ const MAX_STDOUT_DIAGNOSTIC_LINE_BYTES = readPositiveIntegerEnv(
   "OPENCLAW_QA_OTEL_MAX_STDOUT_DIAGNOSTIC_LINE_BYTES",
   512 * 1024,
 );
+const GATEWAY_STDOUT_ARTIFACT_READ_CHUNK_BYTES = 64 * 1024;
 
 function readPositiveIntegerEnv(
   name: string,
@@ -1075,8 +1076,10 @@ async function appendGatewayStdoutArtifactLogs(params: {
     "gateway.stdout.log",
   );
   try {
-    params.capture.append(
-      await readUtf8FileTail(gatewayStdoutPath, MAX_STDOUT_DIAGNOSTIC_LINE_BYTES),
+    await appendUtf8FileToStdoutDiagnosticCapture(
+      gatewayStdoutPath,
+      params.capture,
+      GATEWAY_STDOUT_ARTIFACT_READ_CHUNK_BYTES,
     );
     params.capture.flush();
   } catch (error) {
@@ -1086,22 +1089,21 @@ async function appendGatewayStdoutArtifactLogs(params: {
   }
 }
 
-async function readUtf8FileTail(filePath: string, maxBytes: number): Promise<string> {
+async function appendUtf8FileToStdoutDiagnosticCapture(
+  filePath: string,
+  capture: ReturnType<typeof createStdoutDiagnosticLogCapture>,
+  chunkBytes = GATEWAY_STDOUT_ARTIFACT_READ_CHUNK_BYTES,
+): Promise<void> {
   const file = await open(filePath, "r");
   try {
-    const stats = await file.stat();
-    const bytesToRead = Math.min(stats.size, Math.max(1, maxBytes));
-    const buffer = Buffer.alloc(bytesToRead);
-    const start = stats.size - bytesToRead;
-    let offset = 0;
-    while (offset < bytesToRead) {
-      const { bytesRead } = await file.read(buffer, offset, bytesToRead - offset, start + offset);
+    const buffer = Buffer.alloc(Math.max(1, chunkBytes));
+    for (;;) {
+      const { bytesRead } = await file.read(buffer, 0, buffer.length);
       if (bytesRead === 0) {
         break;
       }
-      offset += bytesRead;
+      capture.append(buffer.subarray(0, bytesRead));
     }
-    return buffer.subarray(0, offset).toString("utf8");
   } finally {
     await file.close();
   }
@@ -1909,12 +1911,13 @@ export const testing = {
   appendCapturedBodyText,
   assertSmoke,
   createBoundedTextAccumulator,
+  createStdoutDiagnosticLogCapture,
   decodeRequestBody,
   parseArgs,
   parseStdoutDiagnosticLogLine,
   readPositiveIntegerEnv,
   readRequestBody,
-  readUtf8FileTail,
+  appendUtf8FileToStdoutDiagnosticCapture,
   startLocalOtlpReceiver,
   startDockerOtelCollector,
   terminateChildTree,

--- a/test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
@@ -501,19 +501,30 @@ describe("qa-otel-smoke receiver bounds", () => {
     expect(output.text()).not.toContain("DO_NOT_RETAIN_COLLECTOR_PREFIX");
   });
 
-  it("reads only a bounded tail from gateway stdout artifacts", async () => {
-    const tempRoot = mkdtempSync(path.join(os.tmpdir(), "openclaw-qa-otel-stdout-tail-"));
+  it("streams gateway stdout artifact records without requiring them in the tail", async () => {
+    const tempRoot = mkdtempSync(path.join(os.tmpdir(), "openclaw-qa-otel-stdout-stream-"));
     const logPath = path.join(tempRoot, "gateway.stdout.log");
+    const capture = testing.createStdoutDiagnosticLogCapture();
+    const record = {
+      signal: "openclaw.diagnostic.log",
+      ts: "2026-06-18T00:00:00.000Z",
+      "service.name": "openclaw-qa-lab-otel-smoke",
+      severityText: "INFO",
+      severityNumber: 9,
+      body: "early log",
+      attributes: {},
+    };
     try {
       writeFileSync(
         logPath,
-        `DO_NOT_RETAIN_GATEWAY_STDOUT_PREFIX\n${"x".repeat(2048)}\nGATEWAY_STDOUT_TAIL\n`,
+        `${JSON.stringify(record)}\n${"x".repeat(256 * 1024)}\nGATEWAY_STDOUT_TAIL\n`,
       );
 
-      const text = await testing.readUtf8FileTail(logPath, 64);
+      await testing.appendUtf8FileToStdoutDiagnosticCapture(logPath, capture);
+      capture.flush();
 
-      expect(text).toContain("GATEWAY_STDOUT_TAIL");
-      expect(text).not.toContain("DO_NOT_RETAIN_GATEWAY_STDOUT_PREFIX");
+      expect(capture.records).toEqual([record]);
+      expect(capture.lines).toHaveLength(1);
     } finally {
       rmSync(tempRoot, { force: true, recursive: true });
     }
@@ -536,14 +547,14 @@ describe("qa-otel-smoke receiver bounds", () => {
       mkdirSync(artifactDir, { recursive: true });
       writeFileSync(
         path.join(artifactDir, "gateway.stdout.log"),
-        `DO_NOT_RETAIN_GATEWAY_STDOUT_PREFIX\n${"x".repeat(2048)}\n${JSON.stringify(record)}\n`,
+        `${JSON.stringify(record)}\n${"x".repeat(256 * 1024)}\n`,
       );
       const capture = testing.createStdoutDiagnosticLogCapture();
 
       await testing.appendGatewayStdoutArtifactLogs({ capture, outputDir });
 
       expect(capture.records).toEqual([record]);
-      expect(capture.lines.join("\n")).not.toContain("DO_NOT_RETAIN_GATEWAY_STDOUT_PREFIX");
+      expect(capture.lines).toHaveLength(1);
     } finally {
       rmSync(tempRoot, { force: true, recursive: true });
     }

--- a/test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
@@ -1,7 +1,7 @@
 // QA OTEL Smoke tests cover QA Lab telemetry evidence.
 import { spawn, spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { createConnection as createNetConnection } from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -499,6 +499,54 @@ describe("qa-otel-smoke receiver bounds", () => {
     expect(output.text()).toContain("COLLECTOR_TAIL_MARKER");
     expect(output.text()).toContain("...");
     expect(output.text()).not.toContain("DO_NOT_RETAIN_COLLECTOR_PREFIX");
+  });
+
+  it("reads only a bounded tail from gateway stdout artifacts", async () => {
+    const tempRoot = mkdtempSync(path.join(os.tmpdir(), "openclaw-qa-otel-stdout-tail-"));
+    const logPath = path.join(tempRoot, "gateway.stdout.log");
+    try {
+      writeFileSync(
+        logPath,
+        `DO_NOT_RETAIN_GATEWAY_STDOUT_PREFIX\n${"x".repeat(2048)}\nGATEWAY_STDOUT_TAIL\n`,
+      );
+
+      const text = await testing.readUtf8FileTail(logPath, 64);
+
+      expect(text).toContain("GATEWAY_STDOUT_TAIL");
+      expect(text).not.toContain("DO_NOT_RETAIN_GATEWAY_STDOUT_PREFIX");
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("keeps gateway stdout artifact fallback parsing bounded", async () => {
+    const tempRoot = mkdtempSync(path.join(os.tmpdir(), "openclaw-qa-otel-stdout-artifact-"));
+    const outputDir = path.join(tempRoot, "output");
+    const artifactDir = path.join(outputDir, "artifacts", "gateway-runtime");
+    const record = {
+      signal: "openclaw.diagnostic.log",
+      ts: "2026-06-18T00:00:00.000Z",
+      "service.name": "openclaw-qa-lab-otel-smoke",
+      severityText: "INFO",
+      severityNumber: 9,
+      body: "tail log",
+      attributes: {},
+    };
+    try {
+      mkdirSync(artifactDir, { recursive: true });
+      writeFileSync(
+        path.join(artifactDir, "gateway.stdout.log"),
+        `DO_NOT_RETAIN_GATEWAY_STDOUT_PREFIX\n${"x".repeat(2048)}\n${JSON.stringify(record)}\n`,
+      );
+      const capture = testing.createStdoutDiagnosticLogCapture();
+
+      await testing.appendGatewayStdoutArtifactLogs({ capture, outputDir });
+
+      expect(capture.records).toEqual([record]);
+      expect(capture.lines.join("\n")).not.toContain("DO_NOT_RETAIN_GATEWAY_STDOUT_PREFIX");
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
   });
 
   it("times out and kills a wedged QA suite child with a detached gateway", async () => {


### PR DESCRIPTION
## Summary

- stream fallback `gateway.stdout.log` parsing through the bounded stdout diagnostic capture instead of reading the whole artifact into memory
- keep stdout diagnostic records discoverable anywhere in the artifact, including before large trailing gateway output
- add focused QA OTEL smoke coverage for direct artifact streaming and the real fallback path

## Verification

- `node --check --experimental-strip-types test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts`
- `node --check --experimental-strip-types test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts`
- direct Node import probe for an early diagnostic JSON line followed by a 256 KiB tail
- `git diff --check`
- Fresh autoreview: no actionable findings

`node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts` was not run locally because this Codex worktree has no `node_modules` and exits with `OPENCLAW_MISSING_VITEST`; dependencies were intentionally not installed in the Codex worktree.
