### PR TITLE
fix(package): ignore stale packed tarballs

### DIFF
--- a/scripts/package-openclaw-for-docker.mjs
+++ b/scripts/package-openclaw-for-docker.mjs
@@ -357,6 +357,30 @@ async function newestOpenClawTarball(outputDir, packOutput) {
   return path.join(outputDir, packed);
 }
 
+async function cleanPackedOpenClawTarballs(outputDir) {
+  let entries;
+  try {
+    entries = await fs.readdir(outputDir);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      entries = [];
+    } else {
+      throw error;
+    }
+  }
+  await Promise.all(
+    entries
+      .filter((entry) => {
+        try {
+          return resolvePackedOpenClawFileName(entry) === entry;
+        } catch {
+          return false;
+        }
+      })
+      .map((entry) => fs.rm(path.join(outputDir, entry), { force: true })),
+  );
+}
+
 export async function packOpenClawPackageForDocker(sourceDir, outputDir, options = {}) {
   const runCaptureImpl = options.runCaptureImpl ?? runCapture;
   const prepareChangelog = options.prepareChangelog ?? preparePackageChangelog;
@@ -365,6 +389,7 @@ export async function packOpenClawPackageForDocker(sourceDir, outputDir, options
   await prepareChangelog(sourceDir);
   let packOutput;
   try {
+    await cleanPackedOpenClawTarballs(outputDir);
     packOutput = await runCaptureImpl(
       "npm",
       ["pack", "--silent", "--ignore-scripts", "--pack-destination", outputDir],

--- a/scripts/resolve-openclaw-package-candidate.mjs
+++ b/scripts/resolve-openclaw-package-candidate.mjs
@@ -570,6 +570,32 @@ async function moveNewestPackedTarball(outputDir, packOutput, outputName) {
 
 export const moveNewestPackedTarballForTest = moveNewestPackedTarball;
 
+async function cleanPackedOpenClawTarballs(outputDir) {
+  let entries;
+  try {
+    entries = await fs.readdir(outputDir);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      entries = [];
+    } else {
+      throw error;
+    }
+  }
+  await Promise.all(
+    entries
+      .filter((entry) => {
+        try {
+          return resolvePackedOpenClawTarballFilename(entry) === entry;
+        } catch {
+          return false;
+        }
+      })
+      .map((entry) => fs.rm(path.join(outputDir, entry), { force: true })),
+  );
+}
+
+export const cleanPackedOpenClawTarballsForTest = cleanPackedOpenClawTarballs;
+
 function normalizeUrlHostname(hostname) {
   return hostname.replace(/^\[/u, "").replace(/\]$/u, "").replace(/\.+$/u, "").toLowerCase();
 }
@@ -1307,6 +1333,7 @@ async function resolveCandidate(options) {
       const npmPackRunner = resolveNpmPackageCandidatePackRunner(options.packageSpec, outputDir, {
         env: process.env,
       });
+      await cleanPackedOpenClawTarballs(outputDir);
       const packOutput = await run(npmPackRunner.command, npmPackRunner.args, {
         capture: true,
         env: npmPackRunner.env,

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -253,14 +253,41 @@ describe("package-openclaw-for-docker", () => {
         }),
       ).rejects.toThrow("missing packed OpenClaw tarball");
 
-      fs.writeFileSync(path.join(outputDir, "openclaw-2026.6.17.tgz"), "");
       await expect(
         packOpenClawPackageForDocker("/repo", outputDir, {
           prepareChangelog: async () => {},
           restoreChangelog: async () => {},
-          runCaptureImpl: async () => "npm notice\n",
+          runCaptureImpl: async () => {
+            fs.writeFileSync(path.join(outputDir, "openclaw-2026.6.17.tgz"), "");
+            return "npm notice\n";
+          },
         }),
       ).resolves.toBe(path.join(outputDir, "openclaw-2026.6.17.tgz"));
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores stale package tarballs before fallback scanning npm output", async () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docker-pack-stale-"));
+    try {
+      fs.writeFileSync(path.join(outputDir, "openclaw-9999.1.1.tgz"), "stale");
+
+      await expect(
+        packOpenClawPackageForDocker("/repo", outputDir, {
+          prepareChangelog: async () => {},
+          restoreChangelog: async () => {},
+          runCaptureImpl: async () => {
+            fs.writeFileSync(path.join(outputDir, "openclaw-2026.6.17.tgz"), "current");
+            return "npm notice\n";
+          },
+        }),
+      ).resolves.toBe(path.join(outputDir, "openclaw-2026.6.17.tgz"));
+
+      expect(fs.existsSync(path.join(outputDir, "openclaw-9999.1.1.tgz"))).toBe(false);
+      expect(fs.readFileSync(path.join(outputDir, "openclaw-2026.6.17.tgz"), "utf8")).toBe(
+        "current",
+      );
     } finally {
       fs.rmSync(outputDir, { recursive: true, force: true });
     }

--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   ARTIFACT_TARBALL_SCAN_MAX_ENTRIES,
   cleanupPackageSourceWorktreeForTest,
+  cleanPackedOpenClawTarballsForTest,
   downloadUrl,
   findSingleTarballForTest,
   loadTrustedPackageSource,
@@ -261,6 +262,25 @@ describe("resolve-openclaw-package-candidate", () => {
         ),
       ).rejects.toThrow("npm pack reported unsafe OpenClaw tarball filename");
     }
+  });
+
+  it("cleans stale package tarballs before npm fallback scanning", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "openclaw-package-npm-pack-stale-"));
+    tempDirs.push(dir);
+    await writeFile(path.join(dir, "openclaw-9999.1.1.tgz"), "stale");
+    await writeFile(path.join(dir, "openclaw-C:evil.tgz"), "unsafe");
+
+    await cleanPackedOpenClawTarballsForTest(dir);
+    await writeFile(path.join(dir, "openclaw-2026.6.17.tgz"), "current");
+
+    await expect(
+      moveNewestPackedTarballForTest(dir, "npm notice\n", "openclaw-current.tgz"),
+    ).resolves.toBe(path.join(dir, "openclaw-current.tgz"));
+    await expect(missing(path.join(dir, "openclaw-9999.1.1.tgz"))).resolves.toBe(true);
+    await expect(readFile(path.join(dir, "openclaw-C:evil.tgz"), "utf8")).resolves.toBe("unsafe");
+    await expect(readFile(path.join(dir, "openclaw-current.tgz"), "utf8")).resolves.toBe(
+      "current",
+    );
   });
 
   it("bounds captured command stderr tails on failures", async () => {


### PR DESCRIPTION
## Summary
- remove stale safe `openclaw-*.tgz` files from package output directories before `npm pack` fallback scanning
- cover both package-artifact builders so noisy `npm pack` output cannot select an older tarball already present in `.artifacts/docker-e2e-package`

## Verification
- `node --check scripts/package-openclaw-for-docker.mjs`
- `node --check scripts/resolve-openclaw-package-candidate.mjs`
- `git diff --check`
- direct Node probe for `packOpenClawPackageForDocker` stale-tarball cleanup and fallback selection
- direct Node probe for `cleanPackedOpenClawTarballsForTest` + `moveNewestPackedTarballForTest` stale-tarball cleanup and fallback selection
- attempted `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts test/scripts/resolve-openclaw-package-candidate.test.ts`; blocked locally by missing `node_modules` in sparse GWT (`OPENCLAW_MISSING_VITEST`)
- attempted Testbox changed gate `tbx_01kvh37jk0ws5z7m7853afqt3b`; queue did not clear, stopped the task-owned box before switching to hosted CI
