### PR TITLE
fix(compaction): count user-message image blocks in cut-point estimator

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import type { ImageContent } from "../../llm.js";
+import type { AgentMessage } from "../../types.js";
+import type { SessionTreeEntry } from "../types.js";
+import { estimateTokens, findCutPoint } from "./compaction.js";
+
+const IMAGE_PAYLOAD = "a".repeat(1_500_000);
+
+function imageBlock(): ImageContent {
+  return { type: "image", data: IMAGE_PAYLOAD, mimeType: "image/png" };
+}
+
+function userImage(timestamp: number): AgentMessage {
+  return { role: "user", content: [imageBlock()], timestamp };
+}
+
+function userText(text: string, timestamp: number): AgentMessage {
+  return { role: "user", content: [{ type: "text", text }], timestamp };
+}
+
+function toolResultImage(timestamp: number): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call-1",
+    toolName: "screenshot",
+    content: [imageBlock()],
+    isError: false,
+    timestamp,
+  };
+}
+
+function assistantText(text: string, timestamp: number): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "claude-fable-5",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp,
+  };
+}
+
+function messageEntry(message: AgentMessage, index: number): SessionTreeEntry {
+  return {
+    type: "message",
+    id: `entry-${index}`,
+    parentId: index === 0 ? null : `entry-${index - 1}`,
+    timestamp: new Date(message.timestamp).toISOString(),
+    message,
+  };
+}
+
+function buildTranscript(recentUserTurns: AgentMessage[]): SessionTreeEntry[] {
+  const messages: AgentMessage[] = [userText("start of the conversation", 1)];
+  let timestamp = 2;
+  for (const turn of recentUserTurns) {
+    messages.push(assistantText("ok", timestamp++));
+    messages.push(turn);
+  }
+  return messages.map((message, index) => messageEntry(message, index));
+}
+
+describe("estimateTokens image accounting", () => {
+  it("charges a user-message image block the same as a tool-result image block", () => {
+    const userTokens = estimateTokens(userImage(1));
+    const toolTokens = estimateTokens(toolResultImage(1));
+
+    expect(userTokens).toBe(toolTokens);
+    expect(userTokens).toBeGreaterThanOrEqual(1200);
+  });
+});
+
+describe("findCutPoint with image-heavy recent turns", () => {
+  it("trims image-dominated user turns instead of keeping the whole transcript", () => {
+    const entries = buildTranscript([userImage(10), userImage(20), userImage(30)]);
+
+    const result = findCutPoint(entries, 0, entries.length, 1500);
+
+    expect(result.firstKeptEntryIndex).toBeGreaterThan(0);
+  });
+
+  it("matches the cut point of an equivalent text-cost control", () => {
+    const equivalentText = "x".repeat(4800);
+    const imageEntries = buildTranscript([userImage(10), userImage(20), userImage(30)]);
+    const textEntries = buildTranscript([
+      userText(equivalentText, 10),
+      userText(equivalentText, 20),
+      userText(equivalentText, 30),
+    ]);
+
+    const imageResult = findCutPoint(imageEntries, 0, imageEntries.length, 1500);
+    const textResult = findCutPoint(textEntries, 0, textEntries.length, 1500);
+
+    expect(textResult.firstKeptEntryIndex).toBeGreaterThan(0);
+    expect(imageResult.firstKeptEntryIndex).toBe(textResult.firstKeptEntryIndex);
+  });
+});

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -244,6 +244,20 @@ export function shouldCompact(
   return contextTokens > contextWindow - settings.reserveTokens;
 }
 
+const IMAGE_BLOCK_CHARS = 4800;
+
+function countContentBlockChars(content: Array<{ type: string; text?: string }>): number {
+  let chars = 0;
+  for (const block of content) {
+    if (block.type === "text" && block.text) {
+      chars += block.text.length;
+    } else if (block.type === "image") {
+      chars += IMAGE_BLOCK_CHARS;
+    }
+  }
+  return chars;
+}
+
 /** Estimate token count for one message using a conservative character heuristic. */
 export function estimateTokens(message: AgentMessage): number {
   let chars = 0;
@@ -257,11 +271,7 @@ export function estimateTokens(message: AgentMessage): number {
       if (typeof content === "string") {
         chars = content.length;
       } else if (Array.isArray(content)) {
-        for (const block of content) {
-          if (block.type === "text" && block.text) {
-            chars += block.text.length;
-          }
-        }
+        chars = countContentBlockChars(content);
       }
       return Math.ceil(chars / 4);
     }
@@ -283,14 +293,7 @@ export function estimateTokens(message: AgentMessage): number {
       if (typeof harnessMessage.content === "string") {
         chars = harnessMessage.content.length;
       } else {
-        for (const block of harnessMessage.content) {
-          if (block.type === "text" && block.text) {
-            chars += block.text.length;
-          }
-          if (block.type === "image") {
-            chars += 4800;
-          }
-        }
+        chars = countContentBlockChars(harnessMessage.content);
       }
       return Math.ceil(chars / 4);
     }


### PR DESCRIPTION
## What Problem This Solves

Sessions that carry recent vision images (a Telegram or Discord photo, a pasted screenshot, an attachment) silently fail to compact. The compaction cut-point estimator charges nothing for image blocks that live in user-message content, so the recent-token accumulator never reaches the keep-recent budget. The cut point stays at the earliest candidate and almost nothing gets summarized. For image-dominated recent turns the trim keeps essentially the entire transcript, the next provider turn re-overflows, and compaction churns without making progress.

## Why This Change Was Made

`estimateTokens` in `packages/agent-core/src/harness/compaction/compaction.ts` is asymmetric about images:

- the `toolResult` / `custom` branch charges `4800` chars per image block,
- the preflight estimator (`src/agents/embedded-agent-runner/run/preemptive-compaction.ts`) charges `IMAGE_BLOCK_TOKENS = 2000`,
- but the `user` branch only sums `block.type === "text"`, so an image block contributes `0`.

Before (`user` branch):

```ts
} else if (Array.isArray(content)) {
  for (const block of content) {
    if (block.type === "text" && block.text) {
      chars += block.text.length;
    }
  }
}
```

Recent user turns persist image blocks directly into user content (`src/agents/sessions/agent-session.ts`). `findCutPoint` (same file) walks backward accumulating `estimateTokens`; with images scored at ~0 it never reaches `keepRecentTokens`, so `cutIndex` stays at `cutPoints[0]` and the trim is a no-op.

This is distinct from the closed issue #39573 ("cache-ttl does not strip image blocks"): that is the pruning mode not stripping image payloads; this is the cut-point estimator under-counting them. No open issue or PR covers it.

## Fix

Count image blocks in the user branch the same way the tool-result branch already does, factored into one shared helper so the two paths cannot drift again:

```ts
const IMAGE_BLOCK_CHARS = 4800;

function countContentBlockChars(content: Array<{ type: string; text?: string }>): number {
  let chars = 0;
  for (const block of content) {
    if (block.type === "text" && block.text) {
      chars += block.text.length;
    } else if (block.type === "image") {
      chars += IMAGE_BLOCK_CHARS;
    }
  }
  return chars;
}
```

Both the `user` and `toolResult` / `custom` branches now call `countContentBlockChars`. This is the right boundary: `estimateTokens` is the single owner of the per-message character heuristic, and the sibling surface (tool results) is folded into the same helper rather than left as a second hand-rolled loop. The preflight estimator keeps its own separate accounting and is unaffected.

## User Impact

Image-heavy sessions now compact correctly: the recent-token accumulator reflects the real cost of recent vision turns, so `findCutPoint` selects a later cut and the summary actually reduces context. This breaks the overflow / futility loop where compaction ran but never reclaimed space.

## Evidence

Regression test `packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts` (3 cases): a 1.5 MB image scores the same as a user turn as it does as a tool result and at least 1200 tokens; and `findCutPoint` trims image-dominated user turns to the same cut point as an equivalent text-cost control instead of keeping the whole transcript.

Local gates (run against an identical copy in a checkout with installed deps):

- `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts` (3/3)
- `node scripts/run-oxlint.mjs <changed files>`
- `oxfmt --check <changed files>`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and the core test tsconfig

### Real behavior proof

Behavior addressed: compaction cut-point estimator under-counts user-message image blocks so image-heavy sessions never trim.
Real environment tested: the real `estimateTokens` and `findCutPoint` from `packages/agent-core/src/harness/compaction/compaction.ts`, driven on pristine `origin/main` and on the patched tree with identical input: a transcript of 7 entries whose 3 recent user turns each carry a 1.5 MB screenshot, with `keepRecentTokens = 1500`. A harness fed this transcript through the real functions and recorded the observed cut-point decision.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs <harness>` reverting only `compaction.ts` between runs; plus the committed regression test `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts`.
Evidence after fix:
```
# BEFORE (pristine main f9f94e7dcd)
scenario: 7 entries, 3 recent user turns each carry a 1.5MB screenshot
keepRecentTokens budget: 1500
estimateTokens(user turn with one image): 0 tokens
total estimated context tokens: 29
findCutPoint.firstKeptEntryIndex: 0
entries summarized (dropped from live context): 0
recent tokens retained after cut: 29
compaction makes progress: NO (no-op / futility loop)

# AFTER (this patch, identical inputs)
scenario: 7 entries, 3 recent user turns each carry a 1.5MB screenshot
keepRecentTokens budget: 1500
estimateTokens(user turn with one image): 1200 tokens
total estimated context tokens: 3629
findCutPoint.firstKeptEntryIndex: 4
entries summarized (dropped from live context): 4
recent tokens retained after cut: 2406
compaction makes progress: YES
```
Runtime planner proof (the live session compaction path, not the estimator in isolation): a vision-heavy session of 11 entries whose 4 recent user turns each carry a 1.5 MB screenshot was fed through the real `prepareCompaction()` in `src/agents/sessions/compaction/compaction.ts` (the same planner the session runtime calls before `compact()`), with `keepRecentTokens = 3000`:
```
# BEFORE (pristine main f9f94e7dcd)
runtime entry point: src/agents/sessions/compaction/compaction.ts prepareCompaction()
settings: keepRecentTokens=3000 reserveTokens=16384
prepareCompaction returned a plan: yes
estimated context tokens before compaction: 0
messages the planner will summarize away: 0
first kept entry id: entry-0
compaction reclaims context: NO (planner summarizes nothing)

# AFTER (this patch, identical session)
runtime entry point: src/agents/sessions/compaction/compaction.ts prepareCompaction()
settings: keepRecentTokens=3000 reserveTokens=16384
prepareCompaction returned a plan: yes
estimated context tokens before compaction: 1200
messages the planner will summarize away: 6
first kept entry id: entry-6
compaction reclaims context: YES
```
The live planner under-counts the vision turns to 0 context tokens on main and therefore plans to summarize nothing (the futility loop); with the patch it values the images, plans to summarize the 6 older messages, and advances the kept boundary to `entry-6`.

Committed regression test (`compaction-image-tokens.test.ts`, 3 cases): 3 failed on pristine main (`expected +0 to be 4`, `expected +0 to be greater than 0`, user image scores 0), 3 passed with the patch.
Observed result after fix: an image-dominated session that previously summarized 0 entries (cut stuck at index 0, context unchanged, re-overflow loop) now scores each image user turn at 1200 tokens, advances the cut to index 4, and summarizes 4 entries so compaction actually reclaims context.
What was not tested: no live LLM summarization round-trip (the `compact()` call after `prepareCompaction`, which needs a model stream) and no end-to-end channel message run (Telegram/Discord image -> overflow -> compaction). The proof drives the real session compaction planner end to end with representative image and transcript inputs, which is the surface this change affects. Full `pnpm build` not run; the change touches no module/packaging boundary.