### PR TITLE
fix(cron): persist failure alert delivery status

### DIFF
--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -62,6 +62,17 @@ function buildFailureDestinationOnlyJob(name: string): CronAddInput {
   };
 }
 
+function buildFailureAlertOnlyJob(name: string): CronAddInput {
+  return {
+    ...buildIsolatedAgentTurnJob(name),
+    failureAlert: {
+      after: 1,
+      channel: "forum",
+      to: "123",
+    },
+  };
+}
+
 function buildBestEffortFailureDestinationOnlyJob(name: string): CronAddInput {
   return {
     ...buildFailureDestinationOnlyJob(name),
@@ -92,6 +103,7 @@ function createIsolatedCronWithFinishedBarrier(params: {
   status?: "ok" | "error";
   delivered?: boolean;
   error?: string;
+  sendCronFailureAlert?: ConstructorParameters<typeof CronService>[0]["sendCronFailureAlert"];
   onFinished?: (evt: {
     jobId: string;
     delivered?: boolean;
@@ -116,6 +128,9 @@ function createIsolatedCronWithFinishedBarrier(params: {
       ...(params.error === undefined ? {} : { error: params.error }),
       ...(params.delivered === undefined ? {} : { delivered: params.delivered }),
     })),
+    ...(params.sendCronFailureAlert === undefined
+      ? {}
+      : { sendCronFailureAlert: params.sendCronFailureAlert }),
     onEvent: (evt) => {
       if (evt.action === "finished") {
         params.onFinished?.({
@@ -190,6 +205,7 @@ async function runIsolatedJobAndReadState(params: {
   status?: "ok" | "error";
   delivered?: boolean;
   error?: string;
+  sendCronFailureAlert?: ConstructorParameters<typeof CronService>[0]["sendCronFailureAlert"];
   onFinished?: (evt: {
     jobId: string;
     delivered?: boolean;
@@ -208,6 +224,9 @@ async function runIsolatedJobAndReadState(params: {
     ...(params.status !== undefined ? { status: params.status } : {}),
     ...(params.delivered !== undefined ? { delivered: params.delivered } : {}),
     ...(params.error !== undefined ? { error: params.error } : {}),
+    ...(params.sendCronFailureAlert !== undefined
+      ? { sendCronFailureAlert: params.sendCronFailureAlert }
+      : {}),
     onFinished: (evt) => {
       params.onFinished?.(evt);
       finishedEvents.get(evt.jobId)?.(evt);
@@ -324,6 +343,102 @@ describe("CronService persists delivered status", () => {
     expect(capturedEvent?.delivered).toBeUndefined();
     expect(capturedEvent?.deliveryStatus).toBe("not-requested");
     expect(capturedEvent?.failureNotificationDelivery).toEqual({ status: "unknown" });
+  });
+
+  it("persists delivered status for requested per-job failureAlert", async () => {
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    let capturedEvent:
+      | {
+          delivered?: boolean;
+          deliveryStatus?: string;
+          failureNotificationDelivery?: {
+            delivered?: boolean;
+            status: string;
+            error?: string;
+          };
+        }
+      | undefined;
+    const updated = await runIsolatedJobAndReadState({
+      job: buildFailureAlertOnlyJob("failure-alert-only"),
+      status: "error",
+      error: "Agent couldn't generate a response.",
+      sendCronFailureAlert,
+      onFinished: (evt) => {
+        capturedEvent = evt;
+      },
+    });
+
+    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+    expect(updated?.state.lastRunStatus).toBe("error");
+    expect(updated?.state.lastDeliveryStatus).toBe("not-requested");
+    expect(updated?.state.lastFailureNotificationDelivered).toBe(true);
+    expect(updated?.state.lastFailureNotificationDeliveryStatus).toBe("delivered");
+    expect(updated?.state.lastFailureNotificationDeliveryError).toBeUndefined();
+    expect(capturedEvent?.deliveryStatus).toBe("not-requested");
+    expect(capturedEvent?.failureNotificationDelivery).toEqual({
+      delivered: true,
+      status: "delivered",
+    });
+  });
+
+  it("persists not-delivered status when per-job failureAlert send fails", async () => {
+    const sendCronFailureAlert = vi.fn(async () => {
+      throw new Error("channel offline");
+    });
+    let capturedEvent:
+      | {
+          failureNotificationDelivery?: {
+            delivered?: boolean;
+            status: string;
+            error?: string;
+          };
+        }
+      | undefined;
+    const updated = await runIsolatedJobAndReadState({
+      job: buildFailureAlertOnlyJob("failure-alert-send-fails"),
+      status: "error",
+      error: "Agent couldn't generate a response.",
+      sendCronFailureAlert,
+      onFinished: (evt) => {
+        capturedEvent = evt;
+      },
+    });
+
+    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+    expect(updated?.state.lastRunStatus).toBe("error");
+    expect(updated?.state.lastDeliveryStatus).toBe("not-requested");
+    expect(updated?.state.lastFailureNotificationDelivered).toBe(false);
+    expect(updated?.state.lastFailureNotificationDeliveryStatus).toBe("not-delivered");
+    expect(updated?.state.lastFailureNotificationDeliveryError).toBe("Error: channel offline");
+    expect(capturedEvent?.failureNotificationDelivery).toEqual({
+      delivered: false,
+      status: "not-delivered",
+      error: "Error: channel offline",
+    });
+  });
+
+  it("persists unknown status when per-job failureAlert send times out", async () => {
+    const sendCronFailureAlert = vi.fn(() => new Promise<never>(() => {}));
+    const updatedPromise = runIsolatedJobAndReadState({
+      job: buildFailureAlertOnlyJob("failure-alert-send-times-out"),
+      status: "error",
+      error: "Agent couldn't generate a response.",
+      sendCronFailureAlert,
+    });
+
+    await vi.runOnlyPendingTimersAsync();
+    await vi.waitFor(() => expect(sendCronFailureAlert).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    const updated = await updatedPromise;
+    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+    expect(updated?.state.lastRunStatus).toBe("error");
+    expect(updated?.state.lastDeliveryStatus).toBe("not-requested");
+    expect(updated?.state.lastFailureNotificationDelivered).toBeUndefined();
+    expect(updated?.state.lastFailureNotificationDeliveryStatus).toBe("unknown");
+    expect(updated?.state.lastFailureNotificationDeliveryError).toBe(
+      "failure alert delivery timed out after 10000ms",
+    );
   });
 
   it("does not treat primary error delivery as alternate failure-destination delivery", async () => {

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -6,6 +6,7 @@ import type { CronServiceState } from "./state.js";
 
 const DEFAULT_FAILURE_ALERT_AFTER = 2;
 const DEFAULT_FAILURE_ALERT_COOLDOWN_MS = 60 * 60_000; // 1 hour
+const FAILURE_ALERT_DELIVERY_TIMEOUT_MS = 10_000;
 
 type ResolvedFailureAlert = {
   after: number;
@@ -98,7 +99,16 @@ export function resolveFailureAlert(
   };
 }
 
-function emitFailureAlert(
+function setFailureNotificationDelivery(
+  job: CronJob,
+  delivery: CronFailureNotificationDelivery,
+): void {
+  job.state.lastFailureNotificationDelivered = delivery.delivered;
+  job.state.lastFailureNotificationDeliveryStatus = delivery.status;
+  job.state.lastFailureNotificationDeliveryError = delivery.error;
+}
+
+async function emitFailureAlert(
   state: CronServiceState,
   params: {
     job: CronJob;
@@ -111,7 +121,7 @@ function emitFailureAlert(
     status: "error" | "skipped";
     provider?: string;
   },
-) {
+): Promise<CronFailureNotificationDelivery> {
   const safeJobName = params.job.name || params.job.id;
   const truncatedError = (params.error?.trim() || "unknown reason").slice(0, 200);
   const errorReason =
@@ -129,22 +139,48 @@ function emitFailureAlert(
   ].join("\n");
 
   if (state.deps.sendCronFailureAlert) {
-    void state.deps
-      .sendCronFailureAlert({
-        job: params.job,
-        text,
-        channel: params.channel,
-        to: params.to,
-        mode: params.mode,
-        accountId: params.accountId,
-      })
-      .catch((err: unknown) => {
-        state.deps.log.warn(
-          { jobId: params.job.id, err: String(err) },
-          "cron: failure alert delivery failed",
-        );
-      });
-    return;
+    const deliveryPromise = state.deps.sendCronFailureAlert({
+      job: params.job,
+      text,
+      channel: params.channel,
+      to: params.to,
+      mode: params.mode,
+      accountId: params.accountId,
+    });
+    const timeoutToken = Symbol("failure-alert-timeout");
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const delivery = await Promise.race([
+        deliveryPromise,
+        new Promise<typeof timeoutToken>((resolve) => {
+          timeout = setTimeout(() => resolve(timeoutToken), FAILURE_ALERT_DELIVERY_TIMEOUT_MS);
+        }),
+      ]);
+      if (delivery === timeoutToken) {
+        void deliveryPromise.catch((err: unknown) => {
+          state.deps.log.warn(
+            { jobId: params.job.id, err: String(err) },
+            "cron: failure alert delivery failed after timeout",
+          );
+        });
+        return {
+          status: "unknown",
+          error: `failure alert delivery timed out after ${FAILURE_ALERT_DELIVERY_TIMEOUT_MS}ms`,
+        };
+      }
+      return delivery ?? { delivered: true, status: "delivered" };
+    } catch (err: unknown) {
+      const error = String(err);
+      state.deps.log.warn(
+        { jobId: params.job.id, err: error },
+        "cron: failure alert delivery failed",
+      );
+      return { delivered: false, status: "not-delivered", error };
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
   }
 
   state.deps.enqueueSystemEvent(text, { agentId: params.job.agentId });
@@ -155,10 +191,11 @@ function emitFailureAlert(
       reason: `cron:${params.job.id}:failure-alert`,
     });
   }
+  return { status: "unknown" };
 }
 
 /** Emits a failure alert when threshold, best-effort, and cooldown policy allow it. */
-export function maybeEmitFailureAlert(
+export async function maybeEmitFailureAlert(
   state: CronServiceState,
   params: {
     job: CronJob;
@@ -168,7 +205,7 @@ export function maybeEmitFailureAlert(
     provider?: string;
     consecutiveCount: number;
   },
-) {
+): Promise<void> {
   if (!params.alertConfig || params.consecutiveCount < params.alertConfig.after) {
     return;
   }
@@ -185,7 +222,8 @@ export function maybeEmitFailureAlert(
   if (inCooldown) {
     return;
   }
-  emitFailureAlert(state, {
+  params.job.state.lastFailureAlertAtMs = now;
+  const delivery = await emitFailureAlert(state, {
     job: params.job,
     error: params.error,
     consecutiveErrors: params.consecutiveCount,
@@ -196,5 +234,5 @@ export function maybeEmitFailureAlert(
     status: params.status,
     provider: params.provider,
   });
-  params.job.state.lastFailureAlertAtMs = now;
+  setFailureNotificationDelivery(params.job, delivery);
 }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -53,6 +53,7 @@ import {
   armTimer,
   emit,
   executeJobCoreWithTimeout,
+  maybeEmitPostRunFailureAlert,
   type IsolatedAgentSetupTimeoutSignal,
   maybeNotifyIsolatedAgentSetupTimeout,
   runMissedJobs,
@@ -661,6 +662,10 @@ async function skipInvalidPersistedManualRun(params: {
     },
     { preserveSchedule: params.mode === "force" },
   );
+  await maybeEmitPostRunFailureAlert(params.state, params.job, {
+    status: "skipped",
+    error: errorText,
+  });
 
   emit(params.state, {
     jobId: params.job.id,
@@ -947,6 +952,7 @@ async function finishPreparedManualRun(
         },
         { preserveSchedule: mode === "force" },
       );
+      await maybeEmitPostRunFailureAlert(state, job, coreResult);
 
       emit(state, {
         jobId: job.id,

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -179,7 +179,7 @@ export type CronServiceDeps = {
     to?: string;
     mode?: "announce" | "webhook";
     accountId?: string;
-  }) => Promise<void>;
+  }) => Promise<CronFailureNotificationDelivery | void>;
   onEvent?: (evt: CronEvent) => void;
 };
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -721,31 +721,13 @@ export function applyJobResult(
   // Track consecutive errors for backoff / auto-disable; skipped runs use a
   // separate counter so opt-in skip alerts do not affect retry behavior.
   const previousConsecutiveErrors = job.state.consecutiveErrors ?? 0;
-  const alertConfig = resolveFailureAlert(state, job);
   if (result.status === "error") {
     job.state.consecutiveErrors = (job.state.consecutiveErrors ?? 0) + 1;
     job.state.consecutiveSkipped = 0;
-    maybeEmitFailureAlert(state, {
-      job,
-      alertConfig,
-      status: "error",
-      error: result.error,
-      provider: result.provider,
-      consecutiveCount: job.state.consecutiveErrors,
-    });
   } else if (result.status === "skipped") {
     job.state.consecutiveErrors = 0;
     job.state.consecutiveSkipped = (job.state.consecutiveSkipped ?? 0) + 1;
-    if (alertConfig?.includeSkipped) {
-      maybeEmitFailureAlert(state, {
-        job,
-        alertConfig,
-        status: "skipped",
-        error: result.error,
-        provider: result.provider,
-        consecutiveCount: job.state.consecutiveSkipped,
-      });
-    } else {
+    if (!resolveFailureAlert(state, job)?.includeSkipped) {
       job.state.lastFailureAlertAtMs = undefined;
     }
   } else {
@@ -960,7 +942,43 @@ export function applyJobResult(
   return shouldDelete;
 }
 
-function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOutcome): void {
+export async function maybeEmitPostRunFailureAlert(
+  state: CronServiceState,
+  job: CronJob,
+  result: {
+    status: CronRunStatus;
+    error?: string;
+    provider?: string;
+  },
+): Promise<void> {
+  const alertConfig = resolveFailureAlert(state, job);
+  if (result.status === "error") {
+    await maybeEmitFailureAlert(state, {
+      job,
+      alertConfig,
+      status: "error",
+      error: result.error,
+      provider: result.provider,
+      consecutiveCount: job.state.consecutiveErrors ?? 0,
+    });
+    return;
+  }
+  if (result.status === "skipped" && alertConfig?.includeSkipped) {
+    await maybeEmitFailureAlert(state, {
+      job,
+      alertConfig,
+      status: "skipped",
+      error: result.error,
+      provider: result.provider,
+      consecutiveCount: job.state.consecutiveSkipped ?? 0,
+    });
+  }
+}
+
+async function applyOutcomeToStoredJob(
+  state: CronServiceState,
+  result: TimedCronRunOutcome,
+): Promise<void> {
   tryFinishCronTaskRun(state, result);
   const store = state.store;
   if (!store) {
@@ -981,6 +999,7 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
         startedAt: result.startedAt,
         endedAt: result.endedAt,
       });
+      await maybeEmitPostRunFailureAlert(state, result.job, result);
       emitJobFinished(state, result.job, result, result.startedAt);
       state.deps.log.info(
         { jobId: result.jobId },
@@ -1004,6 +1023,7 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
     startedAt: result.startedAt,
     endedAt: result.endedAt,
   });
+  await maybeEmitPostRunFailureAlert(state, job, result);
 
   emitJobFinished(state, job, result, result.startedAt);
 
@@ -1286,7 +1306,7 @@ export async function onTimer(state: CronServiceState) {
           finalizedResults = filterCurrentCronRunOutcomes(currentResults);
           finishRetiredCronTaskRuns(state, completedResults, finalizedResults);
           for (const result of finalizedResults) {
-            applyOutcomeToStoredJob(state, result);
+            await applyOutcomeToStoredJob(state, result);
           }
           if (finalizedResults.length === 0) {
             return;
@@ -1824,7 +1844,7 @@ async function applyStartupCatchupOutcomes(
         outcomes,
       );
       for (const result of finalizedOutcomes) {
-        applyOutcomeToStoredJob(state, result);
+        await applyOutcomeToStoredJob(state, result);
       }
       if (finalizedOutcomes.length === 0 && plan.deferredJobs.length === 0) {
         if (releasedReservations) {
@@ -2204,6 +2224,7 @@ export async function executeJob(
     startedAt,
     endedAt,
   });
+  await maybeEmitPostRunFailureAlert(state, job, coreResult);
 
   emitJobFinished(state, job, coreResult, startedAt);
 

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -3,7 +3,17 @@
 import { describe, expect, it, vi } from "vitest";
 import type { CliDeps } from "../cli/deps.types.js";
 import type { CronJob } from "../cron/types.js";
-import { dispatchGatewayCronFinishedNotifications } from "./server-cron-notifications.js";
+import {
+  dispatchGatewayCronFinishedNotifications,
+  sendGatewayCronFailureAlert,
+} from "./server-cron-notifications.js";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+  SsrFBlockedError: class SsrFBlockedError extends Error {},
+}));
 
 describe("dispatchGatewayCronFinishedNotifications", () => {
   it("redacts invalid completion webhook targets in warnings", () => {
@@ -44,6 +54,57 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
         deliveryTo: "ftp://example.invalid/hook",
       },
       "cron: skipped completion webhook delivery, delivery.completionDestination.to must be a valid http(s) URL",
+    );
+  });
+
+  it("marks failure alert webhook HTTP failures not delivered", async () => {
+    const logger = {
+      warn: vi.fn(),
+    };
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response("failed", { status: 500, statusText: "Server Error" }),
+      finalUrl: "https://example.invalid/hook",
+      release,
+    });
+    const job = {
+      id: "cron-failure-webhook",
+      name: "failure webhook",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      state: {},
+    } satisfies CronJob;
+
+    const result = await sendGatewayCronFailureAlert({
+      deps: {} as CliDeps,
+      logger,
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+      job,
+      text: "failed",
+      channel: "telegram",
+      mode: "webhook",
+      to: "https://example.invalid/hook",
+    });
+
+    expect(result).toEqual({
+      delivered: false,
+      status: "not-delivered",
+      error: "failure alert webhook returned HTTP 500 Server Error",
+    });
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      {
+        jobId: "cron-failure-webhook",
+        status: 500,
+        statusText: "Server Error",
+        webhookUrl: "https://example.invalid/hook",
+      },
+      "cron: failure alert webhook failed",
     );
   });
 });

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -15,7 +15,11 @@ import {
 } from "../cron/delivery.js";
 import type { CronEvent } from "../cron/service.js";
 import { resolveCronDeliverySessionKey } from "../cron/session-target.js";
-import type { CronJob, CronMessageChannel } from "../cron/types.js";
+import type {
+  CronFailureNotificationDelivery,
+  CronJob,
+  CronMessageChannel,
+} from "../cron/types.js";
 import { normalizeHttpWebhookUrl } from "../cron/webhook-url.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
@@ -100,7 +104,7 @@ async function postCronWebhook(params: {
   blockedLog: string;
   failedLog: string;
   logger: CronLogger;
-}): Promise<void> {
+}): Promise<CronFailureNotificationDelivery> {
   const abortController = new AbortController();
   const timeout = setTimeout(() => {
     abortController.abort();
@@ -116,13 +120,32 @@ async function postCronWebhook(params: {
         signal: abortController.signal,
       },
     });
+    const { response } = result;
+    const statusText = response.statusText.trim();
     await result.release();
+    if (!response.ok) {
+      const error = `failure alert webhook returned HTTP ${response.status}${
+        statusText ? ` ${statusText}` : ""
+      }`;
+      params.logger.warn(
+        {
+          ...params.logContext,
+          status: response.status,
+          ...(statusText ? { statusText } : {}),
+          webhookUrl: redactWebhookUrl(params.webhookUrl),
+        },
+        params.failedLog,
+      );
+      return { delivered: false, status: "not-delivered", error };
+    }
+    return { delivered: true, status: "delivered" };
   } catch (err) {
+    const error = formatErrorMessage(err);
     if (err instanceof SsrFBlockedError) {
       params.logger.warn(
         {
           ...params.logContext,
-          reason: formatErrorMessage(err),
+          reason: error,
           webhookUrl: redactWebhookUrl(params.webhookUrl),
         },
         params.blockedLog,
@@ -131,12 +154,13 @@ async function postCronWebhook(params: {
       params.logger.warn(
         {
           ...params.logContext,
-          err: formatErrorMessage(err),
+          err: error,
           webhookUrl: redactWebhookUrl(params.webhookUrl),
         },
         params.failedLog,
       );
     }
+    return { delivered: false, status: "not-delivered", error };
   } finally {
     clearTimeout(timeout);
   }
@@ -154,22 +178,23 @@ export async function sendGatewayCronFailureAlert(params: {
   to?: string;
   mode?: "announce" | "webhook";
   accountId?: string;
-}): Promise<void> {
+}): Promise<CronFailureNotificationDelivery> {
   const { agentId, cfg: runtimeConfig } = params.resolveCronAgent(params.job.agentId);
   const webhookToken = normalizeOptionalString(params.webhookToken);
 
   if (params.mode === "webhook" && !params.to) {
+    const error = "failure alert webhook mode requires URL";
     params.logger.warn(
       { jobId: params.job.id },
       "cron: failure alert webhook mode requires URL, skipping",
     );
-    return;
+    return { delivered: false, status: "not-delivered", error };
   }
 
   if (params.mode === "webhook" && params.to) {
     const webhookUrl = normalizeHttpWebhookUrl(params.to);
     if (webhookUrl) {
-      await postCronWebhook({
+      return await postCronWebhook({
         webhookUrl,
         webhookToken,
         payload: {
@@ -182,33 +207,38 @@ export async function sendGatewayCronFailureAlert(params: {
         failedLog: "cron: failure alert webhook failed",
         logger: params.logger,
       });
-    } else {
-      params.logger.warn(
-        {
-          jobId: params.job.id,
-          webhookUrl: redactWebhookUrl(params.to),
-        },
-        "cron: failure alert webhook URL is invalid, skipping",
-      );
     }
-    return;
+    const error = "failure alert webhook URL is invalid";
+    params.logger.warn(
+      {
+        jobId: params.job.id,
+        webhookUrl: redactWebhookUrl(params.to),
+      },
+      "cron: failure alert webhook URL is invalid, skipping",
+    );
+    return { delivered: false, status: "not-delivered", error };
   }
 
   const abortController = new AbortController();
-  await sendCronAnnouncePayloadStrict({
-    deps: params.deps,
-    cfg: runtimeConfig,
-    agentId,
-    jobId: params.job.id,
-    target: {
-      channel: params.channel,
-      to: params.to,
-      accountId: params.accountId,
-      sessionKey: resolveCronDeliverySessionKey(params.job),
-    },
-    message: params.text,
-    abortSignal: abortController.signal,
-  });
+  try {
+    await sendCronAnnouncePayloadStrict({
+      deps: params.deps,
+      cfg: runtimeConfig,
+      agentId,
+      jobId: params.job.id,
+      target: {
+        channel: params.channel,
+        to: params.to,
+        accountId: params.accountId,
+        sessionKey: resolveCronDeliverySessionKey(params.job),
+      },
+      message: params.text,
+      abortSignal: abortController.signal,
+    });
+    return { delivered: true, status: "delivered" };
+  } catch (err) {
+    return { delivered: false, status: "not-delivered", error: formatErrorMessage(err) };
+  }
 }
 
 /** Dispatches completion and failure-destination notifications after a cron run finishes. */


### PR DESCRIPTION
## Summary
- Persist per-job `failureAlert` delivery status from the actual alert request before emitting the cron `finished` event/run log.
- Record alert send success as `delivered`, send failure as `not-delivered`, and bounded send timeout as `unknown` instead of leaving errored runs at `not-requested`.
- Return accurate webhook failure-alert results for HTTP non-2xx responses instead of treating every completed fetch as delivered.

Fixes #92058.

## Verification
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cron/service.persists-delivered-status.test.ts src/cron/service/failure-alerts.ts src/cron/service/ops.ts src/cron/service/state.ts src/cron/service/timer.ts src/gateway/server-cron-notifications.ts src/gateway/server-cron-notifications.test.ts --type-aware --report-unused-disable-directives-severity error --threads=1`
- `git diff --check upstream/main..HEAD`
- `node scripts/run-vitest.mjs src/cron/service.persists-delivered-status.test.ts src/cron/service.failure-alert.test.ts src/cron/service/timer.regression.test.ts src/gateway/server-cron-notifications.test.ts packages/gateway-protocol/src/cron-validators.test.ts src/cli/cron-cli.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` (`autoreview clean: no accepted/actionable findings reported`)

## Real behavior proof
Behavior addressed: Errored cron runs with configured `failureAlert.after = 1` no longer persist the failure-notification status as `not-requested` when the alert path is actually requested.

Real environment tested: Local OpenClaw source checkout on macOS with an isolated `OPENCLAW_STATE_DIR`; the proof used `CronService.run(job.id, "force")`, the real `runCronCommandJob` child-process command runner, the production `sendGatewayCronFailureAlert` gateway webhook path, `fetchWithSsrFGuard`, cron store persistence, and SQLite cron run-log readback.

Exact steps or command run after this patch: `OPENCLAW_STATE_DIR="$(mktemp -d /tmp/openclaw-95129-state.XXXXXX)" node --import tsx --input-type=module <proof script>` plus the focused test command listed above.

Evidence after fix: Real proof output from the `CronService.run(force)` command-failure run. Temp paths are redacted; the raw command result shows the actual child process exited with code 7, and the finished event/job state/run log show the resulting failure-alert delivery status persisted as `not-delivered`.

```json
{
  "scenario": "CronService.run(force) real command failure with per-job failureAlert.after=1",
  "head": "40dd4c72e73a12372f30157d863e0253f9d100f0",
  "stateDir": "<isolated-temp-state>",
  "storePath": "<isolated-temp-store>/cron/jobs.json",
  "job": {
    "name": "issue-92058-real-command-failure-alert-proof",
    "payloadKind": "command",
    "command": [
      "/bin/sh",
      "-lc",
      "printf proof-command-started; exit 7"
    ],
    "delivery": {
      "mode": "none"
    },
    "failureAlert": {
      "after": 1,
      "mode": "webhook",
      "channel": "telegram",
      "to": "http://127.0.0.1:9/openclaw-cron-proof",
      "cooldownMs": 0
    }
  },
  "rawCommandResult": {
    "status": "error",
    "error": "command exited with code 7",
    "summary": "proof-command-started",
    "diagnosticSummary": "proof-command-started",
    "exitCode": 7
  },
  "runResult": {
    "ok": true,
    "ran": true
  },
  "finishedEvent": {
    "action": "finished",
    "status": "error",
    "deliveryStatus": "not-requested",
    "failureNotificationDelivery": {
      "delivered": false,
      "status": "not-delivered",
      "error": "Blocked hostname or private/internal/special-use IP address"
    }
  },
  "persistedJobState": {
    "lastRunStatus": "error",
    "lastStatus": "error",
    "consecutiveErrors": 1,
    "lastDeliveryStatus": "not-requested",
    "lastFailureNotificationDelivered": false,
    "lastFailureNotificationDeliveryStatus": "not-delivered",
    "lastFailureNotificationDeliveryError": "Blocked hostname or private/internal/special-use IP address",
    "lastFailureAlertAtMsType": "number"
  },
  "persistedRunLog": {
    "action": "finished",
    "status": "error",
    "deliveryStatus": "not-requested",
    "failureNotificationDelivery": {
      "status": "not-delivered",
      "delivered": false,
      "error": "Blocked hostname or private/internal/special-use IP address"
    },
    "runId": "cron:<job-id>:<timestamp>"
  },
  "warningMessages": [
    "cron: job run returned error status",
    "cron: failure alert webhook blocked by SSRF guard"
  ]
}
```

Observed result after fix: For a failed job with `failureAlert.after = 1` and no primary delivery, the job state/event/run log keep primary `lastDeliveryStatus` as `not-requested` while `lastFailureNotificationDeliveryStatus` records the actual alert path result. In the real guarded-webhook proof above, the persisted result is `not-delivered`; the regression tests also cover `delivered` on success and `unknown` on bounded timeout.

What was not tested: No packaged/Docker E2E lane or live external messaging channel was run. The live proof used a real local cron command failure and the production guarded webhook path from source, and channel delivery remains covered by the focused cron/gateway tests.
