### PR TITLE
fix: prevent Claude ACP sessions from failing on primitive adapter frames

### DIFF
--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -246,7 +246,7 @@ describe("prepareAcpxCodexAuthConfig", () => {
       /child\.on\("exit", \(code, signal\) => \{\s*if \(parentWatcher\) \{\s*clearInterval\(parentWatcher\);\s*\}\s*if \(orphanCleanupStarted\) \{\s*return;\s*\}/s,
     );
     expect(wrapper).toMatch(
-      /child\.on\("close", \(\) => \{\s*finishStderrLog\(\);\s*process\.exit\(childExitCode\);/s,
+      /child\.on\("close", \(\) => \{\s*finishStdout\(\);\s*finishStderrLog\(\);\s*process\.exitCode = childExitCode;/s,
     );
     expect(wrapper).not.toMatch(
       /forceKillTimer = setTimeout\(\(\) => killChildTree\("SIGKILL"\), 1_500\);\s*forceKillTimer\.unref\?\.\(\);\s*process\.exit\(1\);/s,
@@ -458,6 +458,87 @@ describe("prepareAcpxCodexAuthConfig", () => {
     const launched = JSON.parse(stdout.trim()) as { argv?: unknown; codexHome?: unknown };
     expect(launched.argv).toEqual(["--permission-mode", "bypass"]);
     expect(launched.codexHome).toBeNull();
+  });
+
+  it("drops primitive ACP JSON stdout frames before acpx reads them", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const generated = generatedClaudePaths(stateDir);
+    const installedBinPath = path.join(root, "claude-agent-acp-bin.js");
+    const validMessage = {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: { ok: true },
+    };
+    await fs.writeFile(
+      installedBinPath,
+      [
+        'process.stdout.write("1\\n");',
+        'process.stdout.write("\\"bad\\"\\n");',
+        'process.stdout.write("null\\n");',
+        'process.stdout.write("[{}]\\n");',
+        'process.stdout.write("{not json}\\n");',
+        `process.stdout.write(${JSON.stringify(JSON.stringify(validMessage) + "\n")});`,
+      ].join("\n"),
+      "utf8",
+    );
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+      resolveInstalledClaudeAcpBinPath: async () => installedBinPath,
+    });
+
+    const { stdout } = await execFileAsync(process.execPath, [generated.wrapperPath], {
+      cwd: root,
+    });
+
+    expect(stdout.trimEnd().split("\n")).toEqual(["{not json}", JSON.stringify(validMessage)]);
+  });
+
+  it("preserves ACP stdout when UTF-8 JSON text spans chunks", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const generated = generatedClaudePaths(stateDir);
+    const installedBinPath = path.join(root, "claude-agent-acp-bin.js");
+    const validMessage = {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: { text: "雪" },
+    };
+    await fs.writeFile(
+      installedBinPath,
+      [
+        'const prefix = Buffer.from(\'{"jsonrpc":"2.0","method":"session/update","params":{"text":"\');',
+        'const character = Buffer.from("雪");',
+        "const suffix = Buffer.from('\"}}\\n');",
+        "process.stdout.write(Buffer.concat([prefix, character.subarray(0, 1)]));",
+        "setTimeout(() => {",
+        "  process.stdout.write(Buffer.concat([character.subarray(1), suffix]));",
+        "}, 10);",
+      ].join("\n"),
+      "utf8",
+    );
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+      resolveInstalledClaudeAcpBinPath: async () => installedBinPath,
+    });
+
+    const { stdout } = await execFileAsync(process.execPath, [generated.wrapperPath], {
+      cwd: root,
+    });
+
+    expect(JSON.parse(stdout.trim())).toEqual(validMessage);
   });
 
   it("does not copy source Codex auth", async () => {
@@ -749,9 +830,10 @@ describe("prepareAcpxCodexAuthConfig", () => {
     await expectPathMissing(path.join(stateDir, "acpx", "codex-acp-wrapper.stderr.log"));
   });
 
-  it("leaves a custom Claude agent command alone", async () => {
+  it("wraps a custom Claude agent command", async () => {
     const root = await makeTempDir();
     const stateDir = path.join(root, "state");
+    const generated = generatedClaudePaths(stateDir);
     const pluginConfig = resolveAcpxPluginConfig({
       rawConfig: {
         agents: {
@@ -769,12 +851,16 @@ describe("prepareAcpxCodexAuthConfig", () => {
       resolveInstalledClaudeAcpBinPath: async () => path.join(root, "claude-agent-acp.js"),
     });
 
-    expect(resolved.agents.claude).toBe("node ./custom-claude-wrapper.mjs --flag");
+    expectClaudeWrapperCommand(resolved.agents.claude, generated.wrapperPath);
+    expect(resolved.agents.claude).toContain("--openclaw-run-configured");
+    expect(resolved.agents.claude).toContain("custom-claude-wrapper.mjs");
+    expect(resolved.agents.claude).toContain("--flag");
   });
 
-  it("does not normalize custom Claude commands that only mention the package name", async () => {
+  it("wraps custom Claude commands that only mention the package name", async () => {
     const root = await makeTempDir();
     const stateDir = path.join(root, "state");
+    const generated = generatedClaudePaths(stateDir);
     const command =
       "node ./custom-claude-wrapper.mjs @agentclientprotocol/claude-agent-acp@0.31.4 --flag";
     const pluginConfig = resolveAcpxPluginConfig({
@@ -794,6 +880,37 @@ describe("prepareAcpxCodexAuthConfig", () => {
       resolveInstalledClaudeAcpBinPath: async () => path.join(root, "claude-agent-acp.js"),
     });
 
-    expect(resolved.agents.claude).toBe(command);
+    expectClaudeWrapperCommand(resolved.agents.claude, generated.wrapperPath);
+    expect(resolved.agents.claude).toContain("--openclaw-run-configured");
+    expect(resolved.agents.claude).toContain("custom-claude-wrapper.mjs");
+    expect(resolved.agents.claude).toContain("@agentclientprotocol/claude-agent-acp@0.31.4");
+    expect(resolved.agents.claude).toContain("--flag");
+  });
+
+  it("wraps custom non-Claude agent commands", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const generated = generatedClaudePaths(stateDir);
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {
+        agents: {
+          hermes: {
+            command: "node ./hermes-acp.mjs --flag",
+          },
+        },
+      },
+      workspaceDir: root,
+    });
+
+    const resolved = await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+      resolveInstalledClaudeAcpBinPath: async () => path.join(root, "claude-agent-acp.js"),
+    });
+
+    expectClaudeWrapperCommand(resolved.agents.hermes, generated.wrapperPath);
+    expect(resolved.agents.hermes).toContain("--openclaw-run-configured");
+    expect(resolved.agents.hermes).toContain("hermes-acp.mjs");
+    expect(resolved.agents.hermes).toContain("--flag");
   });
 });

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -235,6 +235,7 @@ function buildAdapterWrapperScript(params: {
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
 import { fileURLToPath } from "node:url";
 
 ${params.envSetup}
@@ -379,6 +380,55 @@ function stripOpenClawWrapperArgs(args) {
   return stripped;
 }
 
+let pendingStdoutText = "";
+const stdoutDecoder = new StringDecoder("utf8");
+
+function shouldForwardAcpJsonValue(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function forwardStdoutLine(line, hasLineBreak) {
+  const trimmedLine = line.trim();
+  if (trimmedLine) {
+    try {
+      const parsed = JSON.parse(trimmedLine);
+      if (!shouldForwardAcpJsonValue(parsed)) {
+        return;
+      }
+    } catch {
+      // Keep non-JSON stdout behavior unchanged; acpx owns diagnostics for it.
+    }
+  }
+  process.stdout.write(line + (hasLineBreak ? "\\n" : ""));
+}
+
+function appendStdoutText(text) {
+  pendingStdoutText += text;
+  while (true) {
+    const lineBreak = pendingStdoutText.indexOf("\\n");
+    if (lineBreak === -1) {
+      return;
+    }
+    const line = pendingStdoutText.slice(0, lineBreak);
+    pendingStdoutText = pendingStdoutText.slice(lineBreak + 1);
+    forwardStdoutLine(line, true);
+  }
+}
+
+function appendStdout(chunk) {
+  appendStdoutText(typeof chunk === "string" ? chunk : stdoutDecoder.write(chunk));
+}
+
+function finishStdout() {
+  appendStdoutText(stdoutDecoder.end());
+  if (!pendingStdoutText) {
+    return;
+  }
+  const finalLine = pendingStdoutText;
+  pendingStdoutText = "";
+  forwardStdoutLine(finalLine, false);
+}
+
 const rawConfiguredArgs = process.argv.slice(2);
 const stderrLogPath = resolveStderrLogPath(rawConfiguredArgs);
 
@@ -434,8 +484,12 @@ if (!command) {
 const child = spawn(command, args, {
   detached: process.platform !== "win32",
   env,
-  stdio: ["inherit", "inherit", "pipe"],
+  stdio: ["inherit", "pipe", "pipe"],
   windowsHide: true,
+});
+
+child.stdout?.on("data", (chunk) => {
+  appendStdout(chunk);
 });
 
 child.stderr?.on("data", (chunk) => {
@@ -518,8 +572,9 @@ child.on("exit", (code, signal) => {
 });
 
 child.on("close", () => {
+  finishStdout();
   finishStderrLog();
-  process.exit(childExitCode);
+  process.exitCode = childExitCode;
 });
 `;
 }
@@ -725,7 +780,36 @@ function buildClaudeAcpWrapperCommand(wrapperPath: string, configuredCommand?: s
   if (configuredAdapterArgs) {
     return buildWrapperCommand(wrapperPath, configuredAdapterArgs);
   }
-  return configuredCommand?.trim() || buildWrapperCommand(wrapperPath);
+  return buildWrapperCommand(wrapperPath, [
+    RUN_CONFIGURED_COMMAND_SENTINEL,
+    ...splitCommandParts(configuredCommand?.trim() ?? ""),
+  ]);
+}
+
+function buildConfiguredAcpWrapperCommand(
+  wrapperPath: string,
+  configuredCommand: string | undefined,
+): string | undefined {
+  const normalized = configuredCommand?.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return buildWrapperCommand(wrapperPath, [
+    RUN_CONFIGURED_COMMAND_SENTINEL,
+    ...splitCommandParts(normalized),
+  ]);
+}
+
+function buildWrappedConfiguredAgentCommands(
+  agents: Record<string, string>,
+  wrapperPath: string,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(agents).flatMap(([agentName, command]) => {
+      const wrappedCommand = buildConfiguredAcpWrapperCommand(wrapperPath, command);
+      return wrappedCommand ? [[agentName, wrappedCommand]] : [];
+    }),
+  );
 }
 
 /** Prepare ACPX agent commands and isolated auth homes for Codex/Claude adapters. */
@@ -756,7 +840,7 @@ export async function prepareAcpxCodexAuthConfig(params: {
   return {
     ...params.pluginConfig,
     agents: {
-      ...params.pluginConfig.agents,
+      ...buildWrappedConfiguredAgentCommands(params.pluginConfig.agents, claudeWrapperPath),
       codex: buildCodexAcpWrapperCommand(wrapperPath, configuredCodexCommand),
       claude: buildClaudeAcpWrapperCommand(claudeWrapperPath, configuredClaudeCommand),
     },


### PR DESCRIPTION
Closes #90404

## What Problem This Solves

Fixes an issue where users spawning Claude through the ACPX runtime could get an empty ACP session when the adapter wrote a primitive JSON frame such as `1` to stdout.

## Why This Change Was Made

OpenClaw's generated ACP adapter wrappers now own a small stdout boundary before `acpx` reads adapter output. The wrapper forwards object-shaped ACP JSON-RPC messages and existing non-JSON diagnostics, but drops top-level JSON primitives, `null`, and arrays so they cannot reach the pinned ACP SDK dispatcher path that applies `"method" in message`.

The filter uses `StringDecoder` so split UTF-8 chunks are preserved, and wrapper shutdown now sets `process.exitCode` after flushing pending stdout instead of calling `process.exit()` immediately. Configured custom ACP agent commands are also launched through the generated wrapper, so custom agents such as `hermes` get the same stdout boundary as Codex and Claude.

## User Impact

Claude ACP sessions launched through OpenClaw's generated ACPX wrapper no longer fail just because the adapter emits a primitive JSON stdout frame. Valid ACP message objects and non-JSON diagnostic output keep their existing behavior.

## Evidence

- `node scripts/run-vitest.mjs extensions/acpx/src/codex-auth-bridge.test.ts extensions/acpx/src/claude-agent-acp-completion.test.ts extensions/acpx/src/runtime.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 extensions/acpx/src/codex-auth-bridge.ts extensions/acpx/src/codex-auth-bridge.test.ts`
- `corepack pnpm exec oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/acpx/src/codex-auth-bridge.ts extensions/acpx/src/codex-auth-bridge.test.ts`
- `git diff --check HEAD~1..HEAD`
- `node scripts/check-package-patches.mjs`
- `node scripts/check-dependency-pins.mjs`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`
- Standalone generated-wrapper smoke with `corepack pnpm exec tsx`: generated `claude-agent-acp-wrapper.mjs`, ran it against a local fake Claude ACP adapter that emitted `1`, `null`, `[{}]`, and a valid split-UTF-8 ACP JSON object.
- Standalone custom-Claude generated-wrapper smoke with `corepack pnpm exec tsx`: configured `agents.claude.command` to a local custom command, verified the resolved command uses `claude-agent-acp-wrapper.mjs --openclaw-run-configured`, and verified the same primitive filtering behavior.
- Standalone custom-agent generated-wrapper smoke with `corepack pnpm exec tsx`: configured `agents.hermes.command` to a local custom command, verified the resolved command uses `claude-agent-acp-wrapper.mjs --openclaw-run-configured`, and verified the same primitive filtering behavior.
- Codex sibling protocol/source check: inspected `../codex/codex-rs/app-server-transport/src/transport/stdio.rs:83` and `../codex/codex-rs/app-server-protocol/src/jsonrpc_lite.rs:34`; Codex app-server stdio emits newline-delimited JSON-RPC object messages, so dropping top-level JSON primitives/arrays does not suppress valid Codex JSON-RPC frames.

Standalone smoke output:

```text
PASS standalone generated-wrapper primitive stdout smoke
forwarded: {"jsonrpc":"2.0","method":"session/update","params":{"ok":true,"text":"雪"}}
filtered: 1, null, [{}]
PASS standalone custom-Claude generated-wrapper primitive stdout smoke
resolved command uses wrapper: true
forwarded: {"jsonrpc":"2.0","method":"session/update","params":{"ok":true,"text":"雪"}}
filtered: 1, null, [{}]
PASS standalone custom-agent generated-wrapper primitive stdout smoke
resolved hermes uses wrapper: true
forwarded: {"jsonrpc":"2.0","method":"session/update","params":{"ok":true,"agent":"hermes","text":"雪"}}
filtered: 1, null, [{}]
```

Real behavior proof:

Behavior addressed: generated ACPX adapter wrappers drop primitive JSON stdout frames before the ACP SDK dispatcher can see them, while valid object-shaped messages still pass through. Configured custom ACP agent commands are now launched through the generated wrapper so they get the same stdout boundary.

Real environment tested: local OpenClaw source checkout on macOS using the repo ACPX Vitest config.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/acpx/src/codex-auth-bridge.test.ts extensions/acpx/src/claude-agent-acp-completion.test.ts extensions/acpx/src/runtime.test.ts`; standalone generated-wrapper smoke with `corepack pnpm exec tsx`; standalone custom-Claude generated-wrapper smoke with `corepack pnpm exec tsx`; standalone custom-agent generated-wrapper smoke with `corepack pnpm exec tsx`.

Evidence after fix: 3 test files passed; 70 tests passed, including regression coverage for primitive/null/array stdout frames, split UTF-8 JSON text, and custom non-Claude agent wrapping. The standalone generated-wrapper smokes forwarded one valid ACP JSON object containing `雪`, filtered `1`, `null`, and `[{}]`, and confirmed custom configured Claude and `hermes` commands resolve through the generated wrapper.

Observed result after fix: the generated wrapper drops `1`, string, `null`, and array JSON lines, preserves valid ACP JSON objects, preserves multibyte JSON text split across stdout chunks, and also wraps configured custom ACP agent commands.

What was not tested: live Claude ACP `sessions_spawn(runtime="acp", agentId="claude")` smoke was not run because no Claude ACP credentials/session were available in this local validation pass.
