### PR TITLE
fix(macos): create DMG output directories

### DIFF
--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -62,6 +62,8 @@ to_applescript_pair() {
 if [[ -z "$OUT_PATH" ]]; then
   OUT_PATH="$BUILD_DIR/$DMG_NAME"
 fi
+OUT_DIR="$(dirname "$OUT_PATH")"
+mkdir -p "$OUT_DIR"
 
 echo "Creating DMG: $OUT_PATH"
 

--- a/test/scripts/create-dmg.test.ts
+++ b/test/scripts/create-dmg.test.ts
@@ -1,6 +1,14 @@
 // Create Dmg tests cover create dmg script behavior.
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -213,6 +221,23 @@ describe.runIf(process.platform === "darwin")("create-dmg ownership boundaries",
     expect(log).toContain(`${outputDir}${path.sep}.openclaw-dmg.`);
     expect(log).not.toContain("/Volumes/");
     expect(log).not.toContain(sibling);
+  });
+
+  it("creates a caller-provided output directory before finalizing the DMG", () => {
+    const app = makeValidApp();
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-create-dmg-output-"));
+    tempDirs.push(root);
+    const outputDir = path.join(root, "nested", "artifacts");
+    const output = path.join(outputDir, "OpenClaw.dmg");
+    const tools = makeFakeDmgTools();
+
+    const result = runScript([app, output], tools.env);
+
+    expect(result.status).toBe(0);
+    expect(existsSync(outputDir)).toBe(true);
+    expect(readFileSync(output, "utf8")).toBe("converted");
+    const log = readFileSync(tools.hdiutilLog, "utf8");
+    expect(log).toContain(`${outputDir}${path.sep}.openclaw-dmg.`);
   });
 
   it("preserves an existing output when image creation fails", () => {


### PR DESCRIPTION
## Summary

- create the caller-provided DMG output directory before building the image
- cover nested artifact output paths with the existing fake-hdiutil DMG test harness

## Verification

- `bash -n scripts/create-dmg.sh`
- `git diff HEAD^..HEAD --check`
- `shellcheck -x scripts/create-dmg.sh`
- direct fake-hdiutil shell probe: nested output dir was created, final DMG content was written, and temp output stayed under the caller output directory
- autoreview: no actionable findings

Blocked locally:

- `node scripts/run-vitest.mjs test/scripts/create-dmg.test.ts` cannot run in this sparse worktree because `node_modules` / Vitest is missing (`OPENCLAW_MISSING_VITEST`).
