### PR TITLE
fix(telegram): set ThreadLabel from topicName for forum session display (#7406)

### DIFF
--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -592,6 +592,7 @@ export async function buildTelegramInboundContextPayload(params: {
       ...locationContext,
       IsForum: isForum,
       TopicName: isForum && topicName ? topicName : undefined,
+      ThreadLabel: isForum && topicName ? topicName : undefined,
     },
   } satisfies BuildChannelInboundEventContextAsyncParams);
   if (inboundEventKind === "room_event" && historyKey) {


### PR DESCRIPTION
## Summary

Map the already-captured `topicName` to `ThreadLabel` in the Telegram inbound context so forum topic sessions display human-readable topic names instead of raw numeric IDs in the session picker and TUI dropdown.

Currently, Telegram forum topic sessions show keys like `agent:main:telegram:group:-123456789:topic:42` in the session dropdown. Discord, Slack, and qa-channel extensions already set `ThreadLabel` for threaded sessions — Telegram was the only bundled channel missing it.

## Changes

- `extensions/telegram/src/bot-message-context.session.ts:595` — added `ThreadLabel: isForum && topicName ? topicName : undefined` alongside the existing `TopicName` line

## How to Test

1. Set up a Telegram forum topic session
2. Check the session picker / TUI dropdown — should show the topic name instead of raw numeric ID

## Real behavior proof

- **Behavior addressed:** Telegram forum topic sessions display raw numeric IDs in session picker instead of human-readable topic names
- **Environment tested:** macOS 26.4.1, Node.js, openclaw build from source (commit 4603be95)
- **Steps run after the patch:** Built the project with `pnpm build`, verified the `ThreadLabel` property is present in the source file adjacent to `TopicName`, confirmed the built dist bundle contains the `ThreadLabel` reference
- **Evidence after fix:**

```
$ node -e "const fs=require('fs'); const c=fs.readFileSync('extensions/telegram/src/bot-message-context.session.ts','utf8'); console.log('ThreadLabel present:', c.includes('ThreadLabel: isForum && topicName ? topicName : undefined'));"
ThreadLabel present: true

$ grep -n "ThreadLabel\|TopicName" extensions/telegram/src/bot-message-context.session.ts
594:      TopicName: isForum && topicName ? topicName : undefined,
595:      ThreadLabel: isForum && topicName ? topicName : undefined,

$ grep -rl "ThreadLabel" dist/inbound-context-CZx-NgvC.js
dist/inbound-context-CZx-NgvC.js
```

- **Observed result after fix:** The `ThreadLabel` property is now set from `topicName` for forum sessions, matching the pattern used by Discord (`ThreadLabel: "Discord thread #parent"`) and qa-channel (`ThreadLabel: inbound.threadTitle`). The built dist bundle includes the new property.
- **What was not tested:** Live Telegram forum topic session end-to-end — the fix follows the identical pattern used by 3 other bundled channel extensions and is structurally verified via build + source inspection
