### PR TITLE
test(docker): stabilize build signal probe

### DIFF
--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -549,9 +549,10 @@ printf '%s\\n' "$count" >"$TMPDIR/docker-count"
 printf '%s\\n' "$$" >"$TMPDIR/docker.pid"
 printf 'rpc error: code = Unavailable\\n'
 trap 'printf "term\\n" >"$TMPDIR/docker.term"; exit 0' TERM
+mkfifo "$TMPDIR/docker.block"
 printf 'ready\\n' >"$TMPDIR/docker.ready"
 while true; do
-  /bin/sleep 1
+  read -r -t 1 _ <> "$TMPDIR/docker.block" || true
 done
 `,
       );
@@ -600,6 +601,7 @@ docker_build_run e2e-build -t demo-image .
         rmSync(join(workDir, "docker.pid"), { force: true });
         rmSync(join(workDir, "docker.term"), { force: true });
         rmSync(join(workDir, "docker.ready"), { force: true });
+        rmSync(join(workDir, "docker.block"), { force: true });
         rmSync(join(workDir, "docker-count"), { force: true });
         const runner = spawn(join(workDir, "runner.sh"), {
           env: { ...process.env, TMPDIR: workDir },


### PR DESCRIPTION
## Summary

- keep the fake Docker process in the signal-interruption test blocked in Bash instead of inside an external `/bin/sleep` child
- use a private FIFO so the fixture does not busy-loop when spawned with ignored stdin

## Verification

- `git diff HEAD^..HEAD --check`
- direct signal probe x20: SIGTERM and SIGINT both wrote `docker.term`, exited with expected codes, avoided retries, and killed the tracked fake Docker process
- direct FIFO loop probe: no busy-loop (`fifo-loop-count=1` over the sample)

Context:

- Exact-head CI gate https://github.com/openclaw/openclaw/actions/runs/27853796914 attempt 1 failed in `checks-node-core-tooling-docker` because `test/scripts/docker-build-helper.test.ts` did not observe `docker.term`; attempt 2 passed.

Blocked locally:

- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts` cannot run in this sparse worktree because `node_modules` / Vitest is missing (`OPENCLAW_MISSING_VITEST`).
