### PR TITLE
fix(doctor): add OAuth re-auth hint to openai-codex provider migration

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1301,7 +1301,7 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS: LegacyConfigMigrationSpec[
       {
         path: ["models", "providers"],
         message:
-          'models.providers.openai-codex is legacy; run "openclaw doctor --fix" to move it to models.providers.openai.',
+          'models.providers.openai-codex is legacy; run "openclaw doctor --fix" to move it to models.providers.openai. After migration, re-establish OAuth credentials with "openclaw models auth login --provider openai".',
         match: (value) => hasAutoFixableLegacyOpenAICodexProvider(value),
       },
       {


### PR DESCRIPTION
## Summary

- When OpenClaw 2026.6.x removed `openai-codex` as a registered provider, the `doctor` migration correctly recommended renaming model refs to `openai/*`, but OAuth credentials stored under the old provider id were silently orphaned.
- This adds a hint to the migration message: re-establish OAuth credentials with `openclaw models auth login --provider openai` after migration.
- This resolves the discoverability gap reported in #95136.

## Verification

- `node scripts/run-vitest.mjs run src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts` → **10/10 passed**

## Impact Assessment

- Scope: one-line string change to an existing doctor migration message
- Downstream: no functional changes; purely an informational hint for users
- Edge cases: none
- Hard-coded values: none

## Real behavior proof

**Behavior addressed:** Users following doctor's openai-codex→openai migration were unaware that OAuth re-authentication was needed, resulting in 401 errors. After the fix, the migration message includes the re-auth step.

**Environment tested:** Node 22.x on Linux, vitest test suite.

**Evidence after fix:**



**Observed result:** All migration tests pass. The updated message reads: `models.providers.openai-codex is legacy; run "openclaw doctor --fix" to move it to models.providers.openai. After migration, re-establish OAuth credentials with "openclaw models auth login --provider openai".`

**Not tested:** Full doctor migration cycle with OAuth credential migration was not exercised.

Closes #95136
