### PR TITLE
fix(sdk): send exec approval resolve id

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -907,7 +907,7 @@ export class ApprovalsNamespace {
   }
 
   async respond(approvalId: string, decision: Record<string, unknown>): Promise<unknown> {
-    return await this.client.request("exec.approval.resolve", { approvalId, ...decision });
+    return await this.client.request("exec.approval.resolve", { ...decision, id: approvalId });
   }
 }
 

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -332,6 +332,7 @@ async function createFakeGateway(port = 0): Promise<FakeGateway> {
       }
 
       if (frame.method === "exec.approval.resolve") {
+        expect(frame.params).toMatchObject({ id: "approval-1", decision: "allow-once" });
         reply({ ok: true, params: frame.params as JsonObject | undefined });
         return;
       }
@@ -508,7 +509,7 @@ describe("OpenClaw SDK websocket e2e", () => {
       const approvals = expectJsonObject(await oc.approvals.list());
       expect(approvals.approvals).toEqual([]);
       const approvalResult = expectJsonObject(
-        await oc.approvals.respond("approval-1", { decision: "approve" }),
+        await oc.approvals.respond("approval-1", { decision: "allow-once" }),
       );
       expect(approvalResult.ok).toBe(true);
 

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -697,6 +697,32 @@ describe("OpenClaw SDK", () => {
     expect(transport.calls).toEqual([]);
   });
 
+  it("calls exec approval Gateway RPCs with protocol params", async () => {
+    const transport = new FakeTransport({
+      "exec.approval.list": { approvals: [] },
+      "exec.approval.resolve": { ok: true },
+    });
+    const oc = new OpenClaw({ transport });
+
+    await expect(oc.approvals.list()).resolves.toEqual({ approvals: [] });
+    await expect(
+      oc.approvals.respond("approval-123", { id: "stale-approval", decision: "allow-once" }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(transport.calls).toEqual([
+      {
+        method: "exec.approval.list",
+        options: undefined,
+        params: undefined,
+      },
+      {
+        method: "exec.approval.resolve",
+        options: undefined,
+        params: { id: "approval-123", decision: "allow-once" },
+      },
+    ]);
+  });
+
   it("does not request after close races event pump startup", async () => {
     const transport = new ClosingEventPumpTransport({
       "agents.list": { agents: [] },


### PR DESCRIPTION
## Summary
- send `id` instead of stale `approvalId` from `oc.approvals.respond()` to `exec.approval.resolve`
- add SDK unit coverage for the gateway protocol params, including a conflicting stale `id`
- tighten the websocket SDK e2e fixture to use the real exec approval decision value `allow-once`

## Verification
- `git diff HEAD^..HEAD --check`
- `node --check packages/sdk/src/client.ts`
- autoreview: prior test-fidelity finding fixed; no remaining findings

Blocked locally:
- `node scripts/run-vitest.mjs packages/sdk/src/index.test.ts packages/sdk/src/index.e2e.test.ts` could not run in this sparse GWT because `node_modules` is absent (`OPENCLAW_MISSING_VITEST`). Hosted exact-head validation will cover the test run.
