### PR TITLE
fix(sdk): list helpers work without filters

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -708,7 +708,7 @@ export class AgentsNamespace {
   constructor(private readonly client: OpenClaw) {}
 
   async list(params?: Record<string, unknown>): Promise<unknown> {
-    return await this.client.request("agents.list", params);
+    return await this.client.request("agents.list", params === undefined ? {} : params);
   }
 
   async get(id: string): Promise<Agent> {
@@ -733,7 +733,7 @@ export class SessionsNamespace {
   constructor(private readonly client: OpenClaw) {}
 
   async list(params?: Record<string, unknown>): Promise<unknown> {
-    return await this.client.request("sessions.list", params);
+    return await this.client.request("sessions.list", params === undefined ? {} : params);
   }
 
   async create(params: SessionCreateParams = {}): Promise<Session> {
@@ -817,7 +817,7 @@ export class TasksNamespace extends RpcNamespace {
   }
 
   async list(params?: TasksListParams): Promise<TasksListResult> {
-    return await this.call("list", params);
+    return await this.call("list", params === undefined ? {} : params);
   }
 
   async get(taskId: string): Promise<TasksGetResult> {
@@ -839,7 +839,7 @@ export class ModelsNamespace extends RpcNamespace {
   }
 
   async list(params?: unknown): Promise<unknown> {
-    return await this.call("list", params);
+    return await this.call("list", params === undefined ? {} : params);
   }
 
   async status(params?: unknown): Promise<unknown> {
@@ -854,7 +854,7 @@ export class ToolsNamespace extends RpcNamespace {
   }
 
   async list(params?: unknown): Promise<unknown> {
-    return await this.call("catalog", params);
+    return await this.call("catalog", params === undefined ? {} : params);
   }
 
   async effective(params?: unknown): Promise<unknown> {
@@ -903,7 +903,7 @@ export class ApprovalsNamespace {
   constructor(private readonly client: OpenClaw) {}
 
   async list(params?: unknown): Promise<unknown> {
-    return await this.client.request("exec.approval.list", params);
+    return await this.client.request("exec.approval.list", params === undefined ? {} : params);
   }
 
   async respond(approvalId: string, decision: Record<string, unknown>): Promise<unknown> {
@@ -918,7 +918,7 @@ export class EnvironmentsNamespace extends RpcNamespace {
   }
 
   async list(params?: unknown): Promise<EnvironmentsListResult> {
-    return await this.call("list", params ?? {});
+    return await this.call("list", params === undefined ? {} : params);
   }
 
   async create(params?: unknown): Promise<unknown> {

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -538,6 +538,14 @@ describe("OpenClaw SDK websocket e2e", () => {
         "exec.approval.list",
         "exec.approval.resolve",
       ]);
+      const requestParams = new Map(
+        gateway.requests.map((request) => [request.method, request.params]),
+      );
+      expect(requestParams.get("agents.list")).toEqual({});
+      expect(requestParams.get("sessions.list")).toEqual({});
+      expect(requestParams.get("models.list")).toEqual({});
+      expect(requestParams.get("tools.catalog")).toEqual({});
+      expect(requestParams.get("exec.approval.list")).toEqual({});
     } finally {
       await oc.close();
       await gateway.close();

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -676,6 +676,69 @@ describe("OpenClaw SDK", () => {
     ]);
   });
 
+  it("sends empty params for no-arg Gateway list helpers", async () => {
+    const transport = new FakeTransport({
+      "agents.list": { agents: [] },
+      "sessions.list": { sessions: [] },
+      "tasks.list": { tasks: [] },
+      "models.list": { models: [] },
+      "tools.catalog": { tools: [] },
+      "exec.approval.list": { approvals: [] },
+      "environments.list": { environments: [] },
+    });
+    const oc = new OpenClaw({ transport });
+
+    await expect(oc.agents.list()).resolves.toEqual({ agents: [] });
+    await expect(oc.sessions.list()).resolves.toEqual({ sessions: [] });
+    await expect(oc.tasks.list()).resolves.toEqual({ tasks: [] });
+    await expect(oc.models.list()).resolves.toEqual({ models: [] });
+    await expect(oc.tools.list()).resolves.toEqual({ tools: [] });
+    await expect(oc.approvals.list()).resolves.toEqual({ approvals: [] });
+    await expect(oc.environments.list()).resolves.toEqual({ environments: [] });
+
+    expect(transport.calls).toEqual([
+      { method: "agents.list", params: {}, options: undefined },
+      { method: "sessions.list", params: {}, options: undefined },
+      { method: "tasks.list", params: {}, options: undefined },
+      { method: "models.list", params: {}, options: undefined },
+      { method: "tools.catalog", params: {}, options: undefined },
+      { method: "exec.approval.list", params: {}, options: undefined },
+      { method: "environments.list", params: {}, options: undefined },
+    ]);
+  });
+
+  it("preserves explicit null params for Gateway list validation", async () => {
+    type ListMethod = (this: unknown, params: unknown) => Promise<unknown>;
+    const transport = new FakeTransport({
+      "agents.list": { agents: [] },
+      "sessions.list": { sessions: [] },
+      "tasks.list": { tasks: [] },
+      "models.list": { models: [] },
+      "tools.catalog": { tools: [] },
+      "exec.approval.list": { approvals: [] },
+      "environments.list": { environments: [] },
+    });
+    const oc = new OpenClaw({ transport });
+
+    await (oc.agents.list as unknown as ListMethod).call(oc.agents, null);
+    await (oc.sessions.list as unknown as ListMethod).call(oc.sessions, null);
+    await (oc.tasks.list as unknown as ListMethod).call(oc.tasks, null);
+    await oc.models.list(null);
+    await oc.tools.list(null);
+    await oc.approvals.list(null);
+    await oc.environments.list(null);
+
+    expect(transport.calls).toEqual([
+      { method: "agents.list", params: null, options: undefined },
+      { method: "sessions.list", params: null, options: undefined },
+      { method: "tasks.list", params: null, options: undefined },
+      { method: "models.list", params: null, options: undefined },
+      { method: "tools.catalog", params: null, options: undefined },
+      { method: "exec.approval.list", params: null, options: undefined },
+      { method: "environments.list", params: null, options: undefined },
+    ]);
+  });
+
   it("keeps close terminal when it races a pending connect", async () => {
     const transport = new DelayedConnectTransport({
       "agents.list": { agents: [] },
@@ -713,7 +776,7 @@ describe("OpenClaw SDK", () => {
       {
         method: "exec.approval.list",
         options: undefined,
-        params: undefined,
+        params: {},
       },
       {
         method: "exec.approval.resolve",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where SDK users calling list helpers without filters could send Gateway requests with omitted `params`, causing strict Gateway list validators to reject otherwise valid no-filter calls.

## Why This Change Was Made

SDK list helpers now send `{}` only when params are omitted, matching the Gateway object-param contract without masking explicit malformed values such as `null`. The focused tests cover no-arg helper calls and preserve explicit `null` so Gateway validation still owns invalid input.

## User Impact

Developers can call `oc.agents.list()`, `oc.sessions.list()`, `oc.tasks.list()`, `oc.models.list()`, `oc.tools.list()`, `oc.approvals.list()`, and `oc.environments.list()` without passing empty filter objects manually.

## Evidence

- `git diff --check origin/main...HEAD`
- `node --check packages/sdk/src/client.ts`
- `codex review --base origin/main` accepted one finding about explicit `null` coercion; fixed and reran clean with no introduced correctness issues.
- `node scripts/run-vitest.mjs packages/sdk/src/index.test.ts packages/sdk/src/index.e2e.test.ts` blocked locally because this sparse worktree has no `node_modules` (`OPENCLAW_MISSING_VITEST`).
- Remote proof attempted before PR: Crabbox coordinator returned 401, and a fresh Blacksmith Testbox stayed queued and was stopped. Exact-head GitHub CI will be run on this PR.
