### PR TITLE
fix(agents): write unresumable notice to transcript for non-deliverable channels

### DIFF
--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -1319,4 +1319,227 @@ describe("main-session-restart-recovery", () => {
     expect(store["agent:main:demo-channel:room-1"]?.status).toBe("failed");
     expect(store["agent:main:demo-channel:room-1"]?.abortedLastRun).toBe(true);
   });
+
+  it("writes unresumable notice to transcript when session has no deliverable channel (WebChat)", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        lastChannel: "webchat",
+        lastTo: "webchat:user:u1",
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "do the thing" },
+      { role: "assistant", content: "partial answer" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 0, failed: 1, skipped: 0 });
+    // webchat is non-deliverable: gateway must not be called.
+    expect(callGateway).not.toHaveBeenCalled();
+
+    const transcriptPath = path.join(sessionsDir, "main-session.jsonl");
+    const transcriptLines = (await fs.readFile(transcriptPath, "utf8"))
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as { message?: { role?: string; content?: unknown } });
+    const noticeEntry = transcriptLines.find(
+      (l) =>
+        l.message?.role === "assistant" &&
+        Array.isArray(l.message.content) &&
+        (l.message.content as Array<{ type?: string; text?: string }>).some(
+          (c) => c.type === "text" && c.text?.includes("couldn't safely resume"),
+        ),
+    );
+    expect(noticeEntry).toBeDefined();
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(store["agent:main:main"]?.status).toBe("failed");
+  });
+
+  it("writes unresumable notice to <sessionId>.jsonl even when entry.sessionFile is a stale generated path", async () => {
+    const sessionsDir = await makeSessionsDir();
+    // A real generated sessionFile: a UUID filename encoding a different sessionId — stale.
+    const staleFile = "aaaaaaaa-0000-4000-8000-000000000000.jsonl";
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        lastChannel: "webchat",
+        lastTo: "webchat:user:u1",
+        sessionFile: staleFile,
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "do the thing" },
+      { role: "assistant", content: "partial answer" },
+    ]);
+    // staleFile exists so resolveAndPersistSessionFile would follow it without the fix.
+    await fs.writeFile(path.join(sessionsDir, staleFile), "");
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 0, failed: 1, skipped: 0 });
+    expect(callGateway).not.toHaveBeenCalled();
+
+    // Notice lands in canonical <sessionId>.jsonl, not the stale file.
+    const canonicalPath = path.join(sessionsDir, "main-session.jsonl");
+    const canonicalLines = (await fs.readFile(canonicalPath, "utf8"))
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as { message?: { role?: string; content?: unknown } });
+    const noticeInCanonical = canonicalLines.find(
+      (l) =>
+        l.message?.role === "assistant" &&
+        Array.isArray(l.message.content) &&
+        (l.message.content as Array<{ type?: string; text?: string }>).some(
+          (c) => c.type === "text" && c.text?.includes("couldn't safely resume"),
+        ),
+    );
+    expect(noticeInCanonical).toBeDefined();
+
+    const staleContent = await fs.readFile(path.join(sessionsDir, staleFile), "utf8");
+    expect(staleContent).not.toContain("couldn't safely resume");
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(store["agent:main:main"]?.status).toBe("failed");
+  });
+
+  it("writes unresumable notice to non-stale custom sessionFile when session has no deliverable channel", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const customPath = path.join(sessionsDir, "my-custom-transcript.jsonl");
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        lastChannel: "webchat",
+        lastTo: "webchat:user:u1",
+        sessionFile: customPath,
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [{ role: "user", content: "do the thing" }]);
+    await fs.writeFile(customPath, "");
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 0, failed: 1, skipped: 0 });
+    expect(callGateway).not.toHaveBeenCalled();
+
+    const customLines = (await fs.readFile(customPath, "utf8"))
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as { message?: { role?: string; content?: unknown } });
+    const noticeInCustom = customLines.find(
+      (l) =>
+        l.message?.role === "assistant" &&
+        Array.isArray(l.message.content) &&
+        (l.message.content as Array<{ type?: string; text?: string }>).some(
+          (c) => c.type === "text" && c.text?.includes("couldn't safely resume"),
+        ),
+    );
+    expect(noticeInCustom).toBeDefined();
+
+    const canonicalContent = await fs.readFile(
+      path.join(sessionsDir, "main-session.jsonl"),
+      "utf8",
+    );
+    expect(canonicalContent).not.toContain("couldn't safely resume");
+  });
+
+  it("writes unresumable notice to canonical when sessionFile is a relative basename (resolver normalizes)", async () => {
+    const sessionsDir = await makeSessionsDir();
+    // Relative basename: resolveSessionFilePath resolves it inside sessionsDir.
+    const relativeFile = "relative-custom.jsonl";
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        lastChannel: "webchat",
+        lastTo: "webchat:user:u1",
+        sessionFile: relativeFile,
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "do the thing" },
+      { role: "assistant", content: "partial answer" },
+    ]);
+    await fs.writeFile(path.join(sessionsDir, relativeFile), "");
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 0, failed: 1, skipped: 0 });
+    expect(callGateway).not.toHaveBeenCalled();
+
+    // Relative name resolved inside sessionsDir — notice lands there.
+    const resolvedLines = (await fs.readFile(path.join(sessionsDir, relativeFile), "utf8"))
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as { message?: { role?: string; content?: unknown } });
+    expect(
+      resolvedLines.some(
+        (l) =>
+          l.message?.role === "assistant" &&
+          Array.isArray(l.message.content) &&
+          (l.message.content as Array<{ type?: string; text?: string }>).some(
+            (c) => c.type === "text" && c.text?.includes("couldn't safely resume"),
+          ),
+      ),
+    ).toBe(true);
+  });
+
+  it("falls back to canonical when sessionFile metadata is out-of-dir (containment check)", async () => {
+    const sessionsDir = await makeSessionsDir();
+    // An out-of-dir absolute path that resolvePathWithinSessionsDir will reject.
+    const outOfDirFile = path.join(path.dirname(sessionsDir), "escape.jsonl");
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        lastChannel: "webchat",
+        lastTo: "webchat:user:u1",
+        sessionFile: outOfDirFile,
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "do the thing" },
+      { role: "assistant", content: "partial answer" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 0, failed: 1, skipped: 0 });
+    expect(callGateway).not.toHaveBeenCalled();
+
+    // Out-of-dir → resolveSessionFilePath falls back to canonical.
+    const canonicalPath = path.join(sessionsDir, "main-session.jsonl");
+    const canonicalLines = (await fs.readFile(canonicalPath, "utf8"))
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as { message?: { role?: string; content?: unknown } });
+    expect(
+      canonicalLines.some(
+        (l) =>
+          l.message?.role === "assistant" &&
+          Array.isArray(l.message.content) &&
+          (l.message.content as Array<{ type?: string; text?: string }>).some(
+            (c) => c.type === "text" && c.text?.includes("couldn't safely resume"),
+          ),
+      ),
+    ).toBe(true);
+    // Out-of-dir file must not be created.
+    await expect(fs.access(outOfDirFile)).rejects.toThrow();
+  });
 });

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -547,7 +547,7 @@ async function writeUnresumableNoticeToTranscript(params: {
     // Non-stale: route through resolveSessionFilePath so relative/malformed paths get containment
     // checks and fall back to canonical if the stored value is outside the sessions directory.
     const extractedId = extractGeneratedTranscriptSessionId(existingSessionFile);
-    const isStaleGeneratedPath = !!extractedId && extractedId !== params.sessionId;
+    const isStaleGeneratedPath = extractedId !== undefined && extractedId !== params.sessionId;
     const sessionFile =
       existingSessionFile && !isStaleGeneratedPath
         ? resolveSessionFilePath(

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -16,7 +16,12 @@ import {
   resolveSessionFilePath,
   resolveSessionTranscriptPathInDir,
 } from "../config/sessions.js";
+import { extractGeneratedTranscriptSessionId } from "../config/sessions/generated-transcript-session-id.js";
 import { applyRestartRecoveryLifecycle } from "../config/sessions/session-accessor.js";
+import {
+  appendExactAssistantMessageToSessionTranscript,
+  type SessionTranscriptAssistantMessage,
+} from "../config/sessions/transcript.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { readSessionMessagesAsync } from "../gateway/session-transcript-readers.js";
@@ -25,6 +30,7 @@ import {
   getAgentEventLifecycleGeneration,
   listAgentRunsForSession,
 } from "../infra/agent-events.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CommandLane } from "../process/lanes.js";
 import {
@@ -526,6 +532,70 @@ async function sendUnresumableSessionNotice(params: {
   }
 }
 
+async function writeUnresumableNoticeToTranscript(params: {
+  agentId: string | undefined;
+  sessionKey: string;
+  storePath: string;
+  sessionId: string;
+}): Promise<void> {
+  let result: Awaited<ReturnType<typeof appendExactAssistantMessageToSessionTranscript>>;
+  try {
+    const sessionsDir = path.dirname(params.storePath);
+    const store = loadSessionStore(params.storePath, { skipCache: true });
+    const existingSessionFile = store[params.sessionKey]?.sessionFile?.trim() || undefined;
+    // Stale: generated path encodes a different sessionId → use canonical.
+    // Non-stale: route through resolveSessionFilePath so relative/malformed paths get containment
+    // checks and fall back to canonical if the stored value is outside the sessions directory.
+    const extractedId = extractGeneratedTranscriptSessionId(existingSessionFile);
+    const isStaleGeneratedPath = !!extractedId && extractedId !== params.sessionId;
+    const sessionFile =
+      existingSessionFile && !isStaleGeneratedPath
+        ? resolveSessionFilePath(
+            params.sessionId,
+            { sessionFile: existingSessionFile },
+            { sessionsDir },
+          )
+        : resolveSessionTranscriptPathInDir(params.sessionId, sessionsDir);
+    result = await appendExactAssistantMessageToSessionTranscript({
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      sessionFile,
+      idempotencyKey: `main-session-restart-recovery:unresumable-notice:${params.sessionId}`,
+      message: {
+        role: "assistant" as const,
+        content: [{ type: "text", text: UNRESUMABLE_SESSION_NOTICE }],
+        api: "openai-responses",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop" as const,
+        timestamp: Date.now(),
+      } as SessionTranscriptAssistantMessage,
+    });
+  } catch (err) {
+    // Best-effort: transcript write failure must not propagate so markSessionFailed always runs.
+    log.warn(
+      `failed to write unresumable session notice to transcript: ${params.sessionKey} (${formatErrorMessage(err)})`,
+    );
+    return;
+  }
+  if (result.ok) {
+    log.info(`wrote unresumable session notice to transcript: ${params.sessionKey}`);
+  } else {
+    log.warn(
+      `failed to write unresumable session notice to transcript: ${params.sessionKey} (${result.reason})`,
+    );
+  }
+}
+
 function resolveRestartRecoveryDeliveryContext(params: {
   cfg?: OpenClawConfig;
   entry: SessionEntry;
@@ -824,12 +894,31 @@ async function recoverStore(params: {
 
     const resumeBlockReason = resolveMainSessionResumeBlockReason(messages);
     if (resumeBlockReason) {
-      await sendUnresumableSessionNotice({
+      const noticed = await sendUnresumableSessionNotice({
         cfg: params.cfg,
         entry,
         sessionKey,
         reason: resumeBlockReason,
       });
+      if (!noticed) {
+        // Transcript fallback only when there is no outbound channel; deliverable-channel transient failures skip it.
+        const hasDeliveryChannel = Boolean(
+          resolveRestartRecoveryDeliveryContext({
+            cfg: params.cfg,
+            entry,
+            includeSessionDeliveryFallback: true,
+            sessionKey,
+          }),
+        );
+        if (!hasDeliveryChannel) {
+          await writeUnresumableNoticeToTranscript({
+            agentId: resolveAgentIdFromSessionKey(sessionKey),
+            sessionKey,
+            storePath: params.storePath,
+            sessionId: entry.sessionId,
+          });
+        }
+      }
       await markSessionFailed({
         storePath: params.storePath,
         sessionKey,

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -561,6 +561,7 @@ async function writeUnresumableNoticeToTranscript(params: {
       sessionKey: params.sessionKey,
       storePath: params.storePath,
       sessionFile,
+      expectedSessionId: params.sessionId,
       idempotencyKey: `main-session-restart-recovery:unresumable-notice:${params.sessionId}`,
       message: {
         role: "assistant" as const,

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -1026,6 +1026,34 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     ).toBe(false);
   });
 
+  it("rejects after rebound even when an explicit sessionFile is provided", async () => {
+    const explicitFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    fs.writeFileSync(
+      fixture.storePath(),
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "replacement-session",
+          chatType: "direct",
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey,
+      expectedSessionId: sessionId,
+      sessionFile: explicitFile,
+      storePath: fixture.storePath(),
+      message: createExactAssistantMessage({ text: "late output via explicit file" }),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "session-rebound",
+    });
+    expect(fs.existsSync(explicitFile)).toBe(false);
+  });
+
   it("rejects a concurrent session rebind before the assistant append", async () => {
     writeTranscriptStore();
     let releaseReset = () => {};

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -229,6 +229,8 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
   agentId?: string;
   sessionKey: string;
   expectedSessionId?: string;
+  /** Explicit path; skips resolveAndPersistSessionFile so caller controls the write target. */
+  sessionFile?: string;
   message: SessionTranscriptAssistantMessage;
   idempotencyKey?: string;
   storePath?: string;
@@ -361,6 +363,8 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
   let result: SessionTranscriptAppendResult;
   if (params.expectedSessionId) {
     result = await appendToSessionFile(entry);
+  } else if (params.sessionFile?.trim()) {
+    result = await appendToSessionFile(entry, params.sessionFile.trim());
   } else {
     let sessionFile: string;
     try {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -361,9 +361,10 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
   };
 
   let result: SessionTranscriptAppendResult;
-  if (params.expectedSessionId) {
+  if (params.expectedSessionId && !params.sessionFile?.trim()) {
     result = await appendToSessionFile(entry);
   } else if (params.sessionFile?.trim()) {
+    // expectedSessionId (if provided) flows to persistSessionTranscriptTurn for mid-write rebind detection.
     result = await appendToSessionFile(entry, params.sessionFile.trim());
   } else {
     let sessionFile: string;


### PR DESCRIPTION
### Summary

- **Problem**: WebChat (Control UI dashboard) sessions interrupted by a gateway restart show a blank chat on reconnect with no explanation. The session is marked `failed` but no recovery notice appears in the transcript or UI.
- **Root Cause**: `resolveRestartRecoveryDeliveryContext` in `src/agents/main-session-restart-recovery.ts` returns `undefined` for WebChat because `isDeliverableMessageChannel("webchat") === false` (`INTERNAL_MESSAGE_CHANNEL`). `sendUnresumableSessionNotice` returns `false` and the recovery notice is silently discarded. `chat.history` reads the transcript but nothing is ever written there for non-deliverable-channel sessions.
- **Fix**: When `sendUnresumableSessionNotice` returns `false` and there is no outbound delivery channel, write the notice as a `delivery-mirror` assistant row directly to the transcript via `appendExactAssistantMessageToSessionTranscript`. Deliverable-channel sessions (Telegram, Discord, etc.) are excluded — they do not read `chat.history`. Write-target resolution runs through `extractGeneratedTranscriptSessionId` (stale-path detection) and `resolveSessionFilePath` (sessions-directory containment and normalization). All resolution is inside a try/catch so a write failure never skips `markSessionFailed`.
- **What changed**:
  - `src/agents/main-session-restart-recovery.ts` — add `writeUnresumableNoticeToTranscript`; call it from `recoverStore` when `!noticed && !hasDeliveryChannel`; pass `expectedSessionId` to the append call so any session-key rebound between resolution and write is rejected
  - `src/config/sessions/transcript.ts` — add optional `sessionFile?` param to `appendExactAssistantMessageToSessionTranscript`; guard the `sessionFile` branch with `!params.sessionFile?.trim()` so `expectedSessionId` is honoured and flows to `persistSessionTranscriptTurn` even when an explicit file is provided
  - `src/agents/main-session-restart-recovery.test.ts` — 5 new cases covering WebChat delivery and write-target contract
  - `src/config/sessions/transcript.test.ts` — 1 new rebound test: `sessionFile` + mismatching `expectedSessionId` returns `session-rebound` and writes nothing
- **What did NOT change (scope boundary)**:
  - Deliverable-channel notice path unchanged (`hasDeliveryChannel=true` skips transcript write)
  - `chat.history` projection and `shouldHideProjectedHistoryMessage` unchanged; standalone `delivery-mirror` rows already pass through
  - Config surface unchanged
  - Plugin surface unchanged
  - No dependency changes

### Reproduction

1. Start a WebChat session in the Control UI and have a turn in progress.
2. Trigger a gateway restart (e.g. config reload).
3. Reconnect to the same session in the Control UI.
4. **Before this PR**: session is marked `failed`, no notice in transcript, blank chat on reconnect.
5. **After this PR**: transcript gains a `delivery-mirror` assistant row with the unresumable notice; `chat.history` shows it on reconnect.

### Real behavior proof

**Behavior addressed (#95141)**: `recoverRestartAbortedMainSessions` drives the real `sendUnresumableSessionNotice`, `writeUnresumableNoticeToTranscript`, and `appendExactAssistantMessageToSessionTranscript` against `SessionEntry` structs with `lastChannel: "webchat"`. Five new test cases confirm notice delivery and write-target contract; standalone `delivery-mirror` rows are confirmed to pass through `chat.history` unchanged. One new `transcript.test.ts` case confirms `sessionFile` + mismatching `expectedSessionId` returns `session-rebound` without writing.

**Real environment tested (Linux, Node 22 — Vitest against production recovery and transcript implementations)**: `recoverStore` and `writeUnresumableNoticeToTranscript` run against real on-disk session stores and JSONL transcript files in temp directories; no mocks for the production write path.

**Exact steps or command run after this patch**:

```
node scripts/run-vitest.mjs src/agents/main-session-restart-recovery.test.ts
node scripts/run-vitest.mjs src/config/sessions/transcript.test.ts
```

**Evidence after fix (Vitest output)**:

```text
main-session-restart-recovery.test.ts   Tests  38 passed (38)
transcript.test.ts                      Tests  44 passed (44)
```

**Observed result after fix**: All 38 `main-session-restart-recovery` tests pass including the 5 new cases: (1) WebChat no-deliverable-channel writes notice to canonical `<sessionId>.jsonl`; (2) stale generated sessionFile is bypassed in favor of canonical; (3) non-stale absolute custom path receives the notice; (4) relative basename resolved inside sessions dir by `resolveSessionFilePath`; (5) out-of-dir metadata rejected, canonical used — no write outside sessions dir. All 44 transcript tests pass including the new rebound-with-explicit-sessionFile case.

**What was not tested**: live Crabbox WebChat session + managed gateway restart end-to-end; Control UI rendering of the notice on reconnect.

**Repro confirmation**: each of the 5 new `main-session-restart-recovery` test cases fails on `main` before the patch (no `writeUnresumableNoticeToTranscript` exists, transcript stays empty) and passes after, confirming they exercise the production change path.

### Risk / Mitigation

- **Risk**: Existing deliverable-channel path affected. **Mitigation**: transcript write is gated on `!hasDeliveryChannel`; external-channel sessions skip this path entirely.
- **Risk**: Transcript write failure skips `markSessionFailed`. **Mitigation**: resolution and write wrapped in try/catch; failure logs a warning and returns early so `markSessionFailed` always runs.
- **Risk**: sessionFile metadata could write outside sessions directory. **Mitigation**: non-stale paths run through `resolveSessionFilePath` → `resolvePathWithinSessionsDir`, which enforces containment and falls back to canonical on any violation.
- **Risk**: Session key rebounds between path resolution and transcript write. **Mitigation**: `expectedSessionId: params.sessionId` passed to `appendExactAssistantMessageToSessionTranscript`; the early store-read guard rejects mismatched sessionIds before writing.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] agents
- [x] sessions / storage
- [x] tests

### Linked Issue/PR

Fixes #95141