### PR TITLE
fix(infra): use sw_vers productVersion for macOS release on Darwin 25+

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -5,6 +5,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
+import { resolveRuntimeOsLabel } from "../../infra/os-summary.js";
 import path from "node:path";
 import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import { extensionForMime } from "@openclaw/media-core/mime";
@@ -157,7 +158,7 @@ export function buildCliAgentSystemPrompt(params: {
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
       host: "openclaw",
-      os: `${os.type()} ${os.release()}`,
+      os: resolveRuntimeOsLabel(),
       arch: os.arch(),
       node: process.version,
       model: params.modelDisplay,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -3,6 +3,7 @@
  */
 import fs from "node:fs/promises";
 import os from "node:os";
+import { resolveRuntimeOsLabel } from "../../infra/os-summary.js";
 import { isAcpRuntimeSpawnAvailable } from "../../acp/runtime/availability.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
@@ -1035,7 +1036,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
 
     const runtimeInfo = {
       host: machineName,
-      os: `${os.type()} ${os.release()}`,
+      os: resolveRuntimeOsLabel(),
       arch: os.arch(),
       node: process.version,
       model: `${provider}/${modelId}`,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3,6 +3,7 @@
  */
 import fs from "node:fs/promises";
 import os from "node:os";
+import { resolveRuntimeOsLabel } from "../../../infra/os-summary.js";
 import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -1933,7 +1934,7 @@ export async function runEmbeddedAttempt(
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
         host: machineName,
-        os: `${os.type()} ${os.release()}`,
+        os: resolveRuntimeOsLabel(),
         arch: os.arch(),
         node: process.version,
         model: `${params.provider}/${params.modelId}`,

--- a/src/infra/os-summary.test.ts
+++ b/src/infra/os-summary.test.ts
@@ -11,7 +11,105 @@ vi.mock("node:child_process", async () => {
   );
 });
 
-import { resolveOsSummary } from "./os-summary.js";
+import { resolveOsRelease, resolveOsSummary, resolveRuntimeOsLabel, _resetOsSummaryCaches } from "./os-summary.js";
+
+describe("resolveOsRelease", () => {
+  afterEach(() => {
+    _resetOsSummaryCaches();
+    vi.restoreAllMocks();
+  });
+
+  it("returns sw_vers productVersion on darwin", () => {
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    vi.spyOn(os, "release").mockReturnValue("25.5.0");
+    spawnSyncMock.mockReturnValue({
+      stdout: "26.5.1\n",
+      stderr: "",
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+    });
+    expect(resolveOsRelease()).toBe("26.5.1");
+  });
+
+  it("falls back to os.release on darwin when sw_vers output is blank", () => {
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    vi.spyOn(os, "release").mockReturnValue("25.5.0");
+    spawnSyncMock.mockReturnValue({
+      stdout: "   ",
+      stderr: "",
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+    });
+    expect(resolveOsRelease()).toBe("25.5.0");
+  });
+
+  it("returns os.release unchanged on linux", () => {
+    vi.spyOn(os, "platform").mockReturnValue("linux");
+    vi.spyOn(os, "release").mockReturnValue("6.1.0");
+    expect(resolveOsRelease()).toBe("6.1.0");
+  });
+
+  it("returns os.release unchanged on win32", () => {
+    vi.spyOn(os, "platform").mockReturnValue("win32");
+    vi.spyOn(os, "release").mockReturnValue("10.0.26100");
+    expect(resolveOsRelease()).toBe("10.0.26100");
+  });
+});
+
+describe("resolveRuntimeOsLabel", () => {
+  afterEach(() => {
+    _resetOsSummaryCaches();
+    vi.restoreAllMocks();
+  });
+
+  it("returns macos label with sw_vers productVersion on darwin", () => {
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    vi.spyOn(os, "type").mockReturnValue("Darwin");
+    vi.spyOn(os, "release").mockReturnValue("25.5.0");
+    spawnSyncMock.mockReturnValue({
+      stdout: "26.5.1\n",
+      stderr: "",
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+    });
+    expect(resolveRuntimeOsLabel()).toBe("macos 26.5.1");
+  });
+
+  it("falls back to Darwin kernel version on darwin when sw_vers is blank", () => {
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    vi.spyOn(os, "type").mockReturnValue("Darwin");
+    vi.spyOn(os, "release").mockReturnValue("25.5.0");
+    spawnSyncMock.mockReturnValue({
+      stdout: "   ",
+      stderr: "",
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+    });
+    expect(resolveRuntimeOsLabel()).toBe("macos 25.5.0");
+  });
+
+  it("returns os.type plus os.release on linux", () => {
+    vi.spyOn(os, "platform").mockReturnValue("linux");
+    vi.spyOn(os, "type").mockReturnValue("Linux");
+    vi.spyOn(os, "release").mockReturnValue("6.1.0");
+    expect(resolveRuntimeOsLabel()).toBe("Linux 6.1.0");
+  });
+
+  it("returns os.type plus os.release on win32", () => {
+    vi.spyOn(os, "platform").mockReturnValue("win32");
+    vi.spyOn(os, "type").mockReturnValue("Windows_NT");
+    vi.spyOn(os, "release").mockReturnValue("10.0.26100");
+    expect(resolveRuntimeOsLabel()).toBe("Windows_NT 10.0.26100");
+  });
+});
 
 type OsSummaryCase = {
   name: string;
@@ -24,21 +122,22 @@ type OsSummaryCase = {
 
 describe("resolveOsSummary", () => {
   afterEach(() => {
+    _resetOsSummaryCaches();
     vi.restoreAllMocks();
   });
 
   it.each<OsSummaryCase>([
     {
-      name: "formats darwin labels from sw_vers output",
+      name: "formats darwin labels from sw_vers output and uses productVersion as release",
       platform: "darwin" as const,
-      release: "24.0.0",
+      release: "25.5.0",
       arch: "arm64",
-      swVersStdout: " 15.4 \n",
+      swVersStdout: " 26.5.1 \n",
       expected: {
         platform: "darwin",
         arch: "arm64",
-        release: "24.0.0",
-        label: "macos 15.4 (arm64)",
+        release: "26.5.1",
+        label: "macos 26.5.1 (arm64)",
       },
     },
     {

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -12,10 +12,45 @@ type OsSummary = {
 
 const cachedOsSummaryByKey = new Map<string, OsSummary>();
 
+let cachedMacosVersion: string | undefined;
+
+/** @internal Reset internal caches (for tests only). */
+export function _resetOsSummaryCaches(): void {
+  cachedMacosVersion = undefined;
+  cachedOsSummaryByKey.clear();
+}
+
 function macosVersion(): string {
+  if (cachedMacosVersion !== undefined) {
+    return cachedMacosVersion;
+  }
   const res = spawnSync("sw_vers", ["-productVersion"], { encoding: "utf-8" });
   const out = normalizeOptionalString(res.stdout) ?? "";
-  return out || os.release();
+  cachedMacosVersion = out || os.release();
+  return cachedMacosVersion;
+}
+
+/** Returns the OS release string. On macOS, prefers the marketing version
+ *  from `sw_vers -productVersion` (e.g. "26.5.1") over the Darwin kernel
+ *  version from `os.release()` (e.g. "25.5.0"), which diverged starting
+ *  with macOS 26 (Tahoe / Darwin 25). On other platforms, returns
+ *  `os.release()` unchanged. */
+export function resolveOsRelease(): string {
+  if (os.platform() === "darwin") {
+    return macosVersion();
+  }
+  return os.release();
+}
+
+/** Returns a human-readable runtime OS label. On macOS, uses the marketing
+ *  version from `sw_vers -productVersion` (e.g. "macos 26.5.1") instead of
+ *  the raw Darwin kernel version (e.g. "Darwin 25.5.0"). On other platforms,
+ *  returns `os.type()` plus `os.release()` unchanged. */
+export function resolveRuntimeOsLabel(): string {
+  if (os.platform() === "darwin") {
+    return `macos ${macosVersion()}`;
+  }
+  return `${os.type()} ${os.release()}`;
 }
 
 /** Resolves a compact OS label for diagnostics, logs, and environment summaries. */
@@ -39,7 +74,7 @@ export function resolveOsSummary(): OsSummary {
     }
     return `${platform} ${release} (${arch})`;
   })();
-  const summary = { platform, arch, release, label };
+  const summary = { platform, arch, release: resolveOsRelease(), label };
   cachedOsSummaryByKey.set(cacheKey, summary);
   return summary;
 }


### PR DESCRIPTION
## Summary

- `os.release()` returns the Darwin kernel version (e.g. "25.5.0") which no longer matches the macOS marketing version starting with macOS 26 (Tahoe / Darwin 25). The actual macOS version is "26.5.1" (via `sw_vers -productVersion`).
- Export `resolveOsRelease()` that prefers `sw_vers -productVersion` on Darwin, falling back to `os.release()` if `sw_vers` is unavailable. On other platforms, returns `os.release()` unchanged.
- Export `resolveRuntimeOsLabel()` that returns `"macos <version>"` on Darwin and `os.type() + os.release()` on other platforms.
- Use `resolveOsRelease()` for the `OsSummary.release` field so `openclaw status`, diagnostics, and host detection report the correct macOS version.
- Replace `os.type() + os.release()` in all three runtime prompt paths (`cli-runner/helpers.ts`, `attempt.ts`, `compact.ts`) with `resolveRuntimeOsLabel()` so agent context shows the correct macOS product version instead of raw Darwin kernel version.
- 12 unit tests pass: `resolveOsRelease` (darwin with sw_vers, darwin fallback, linux, win32) + `resolveRuntimeOsLabel` (darwin with sw_vers, darwin fallback, linux, win32) + `resolveOsSummary` (4 cases via it.each)

## Files changed

| File | Change |
|---|---|
| `src/infra/os-summary.ts` | Export `resolveOsRelease()` and `resolveRuntimeOsLabel()`, use `resolveOsRelease()` in `OsSummary.release` |
| `src/agents/cli-runner/helpers.ts` | Replace `` `${os.type()} ${os.release()}` `` with `resolveRuntimeOsLabel()` |
| `src/agents/embedded-agent-runner/run/attempt.ts` | Replace `` `${os.type()} ${os.release()}` `` with `resolveRuntimeOsLabel()` |
| `src/agents/embedded-agent-runner/compact.ts` | Replace `` `${os.type()} ${os.release()}` `` with `resolveRuntimeOsLabel()` |
| `src/infra/os-summary.test.ts` | Add tests for `resolveOsRelease()` and `resolveRuntimeOsLabel()`, update `resolveOsSummary` test data |

## Real behavior proof

**Behavior addressed:** Darwin kernel version 25.x is incorrectly mapped to macOS 15.x instead of macOS 26 (Tahoe). Both the `OsSummary.release` field and the runtime prompt `os` field expose raw Darwin kernel versions instead of the macOS marketing version.

**Environment tested:** Node v24.13.1 on Linux, vitest run with mocked platform/release/sw_vers + `node --import tsx` calling real production functions.

**Steps run after the patch:**

```sh
# Unit tests
node_modules/.bin/vitest run src/infra/os-summary.test.ts

# Production function verification
node --import tsx --no-warnings -e "
import { resolveOsRelease, resolveRuntimeOsLabel, resolveOsSummary } from './src/infra/os-summary.ts';
console.log('resolveOsRelease:', resolveOsRelease());
console.log('resolveRuntimeOsLabel:', resolveRuntimeOsLabel());
console.log('resolveOsSummary:', JSON.stringify(resolveOsSummary()));
"
```

**Evidence after fix:**

Unit test results (12/12 pass):

```text
 ✓ resolveOsRelease > returns sw_vers productVersion on darwin
 ✓ resolveOsRelease > falls back to os.release on darwin when sw_vers output is blank
 ✓ resolveOsRelease > returns os.release unchanged on linux
 ✓ resolveOsRelease > returns os.release unchanged on win32
 ✓ resolveRuntimeOsLabel > returns macos label with sw_vers productVersion on darwin
 ✓ resolveRuntimeOsLabel > falls back to Darwin kernel version on darwin when sw_vers is blank
 ✓ resolveRuntimeOsLabel > returns os.type plus os.release on linux
 ✓ resolveRuntimeOsLabel > returns os.type plus os.release on win32
 ✓ resolveOsSummary > formats darwin labels from sw_vers output and uses productVersion as release
 ✓ resolveOsSummary > falls back to os.release when sw_vers output is blank
 ✓ resolveOsSummary > formats windows labels from os metadata
 ✓ resolveOsSummary > formats non-darwin labels from os metadata

 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Production function output on Linux host:

```text
resolveOsRelease: 4.19.112-2.el8.x86_64
resolveRuntimeOsLabel: Linux 4.19.112-2.el8.x86_64
resolveOsSummary: {"platform":"linux","arch":"x64","release":"4.19.112-2.el8.x86_64","label":"linux 4.19.112-2.el8.x86_64 (x64)"}
```

Expected on macOS 26 Tahoe (Darwin 25.5.0, sw_vers returns 26.5.1):

```text
resolveOsRelease():         "26.5.1" (instead of "25.5.0")
resolveRuntimeOsLabel():    "macos 26.5.1" (instead of "Darwin 25.5.0")
resolveOsSummary().release: "26.5.1" (instead of "25.5.0")
resolveOsSummary().label:   "macos 26.5.1 (arm64)" (unchanged, already correct on main)
```

**What was not tested:** Live macOS 26 Tahoe host (no access). The Darwin path uses the same `sw_vers -productVersion` mechanism already validated by the existing `resolveOsSummary()` label and `system-presence.ts`.

Closes #95145
