### PR TITLE
fix(telegram): set ThreadLabel from topicName for forum session display (#7406)

### DIFF
--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -592,6 +592,7 @@ export async function buildTelegramInboundContextPayload(params: {
       ...locationContext,
       IsForum: isForum,
       TopicName: isForum && topicName ? topicName : undefined,
+      ThreadLabel: isForum && topicName ? topicName : undefined,
     },
   } satisfies BuildChannelInboundEventContextAsyncParams);
   if (inboundEventKind === "room_event" && historyKey) {


### PR DESCRIPTION
## What does this PR do?

Adds `ThreadLabel` to the Telegram inbound context payload for forum topics, so session dropdowns display human-readable topic names (e.g. "TopicName") instead of raw session keys (e.g. "agent:main:telegram:group:-123456789:topic:42").

## Related Issue

Fixes #7406

## Type of Change

- [x] New feature (non-breaking)

## Changes Made

- `extensions/telegram/src/bot-message-context.session.ts`: Add `ThreadLabel` field populated from `topicName` when the chat is a forum topic. This follows the existing `TopicName` pattern on the adjacent line.

## How to Test

1. Connect OpenClaw to a Telegram group with forum topics enabled
2. Send a message in a forum topic
3. Check the session dropdown — the session should display the topic name instead of a raw numeric key

## Real behavior proof

- **Behavior addressed:** Telegram forum topic sessions displayed raw keys like `agent:main:telegram:group:-123456789:topic:42` in the session dropdown instead of the human-readable topic name.
- **Environment tested:** macOS 26.4.1, Node v24.3.0, pnpm build of openclaw/openclaw at commit 50b5238b
- **Steps run after the patch:**
```bash
cd /Users/liuhao/.hermes/workdir/openclaw
pnpm build
node -e "const fs=require('fs'); const c=fs.readFileSync('extensions/telegram/src/bot-message-context.session.ts','utf8'); const lines=c.split('\n'); const idx=lines.findIndex(l=>l.includes('ThreadLabel')); console.log('Line '+(idx+1)+': '+lines[idx].trim());"
grep -n 'ThreadLabel' extensions/telegram/src/bot-message-context.session.ts
```
- **Evidence after fix:**
```
Line 595: ThreadLabel: isForum && topicName ? topicName : undefined,
595:      ThreadLabel: isForum && topicName ? topicName : undefined,
```
- **Observed result after fix:** The `ThreadLabel` field is now set from `topicName` for forum topics, matching the existing `TopicName` pattern. The session label resolver will use this to display human-readable topic names in the session dropdown.
- **What was not tested:** Live Telegram forum topic interaction (requires a Telegram bot connected to a forum-enabled group). The change follows the identical pattern of the adjacent `TopicName` field which is already proven in production.
