### PR TITLE
fix(config): allow Nix-mode doctor --fix for non-config writes

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -216,7 +216,7 @@ envelope with a `plugin.index_unavailable` error finding.
 
 Notes:
 
-- In Nix mode (`OPENCLAW_NIX_MODE=1`), read-only doctor checks still work, but `doctor --fix`, `doctor --repair`, `doctor --yes`, and `doctor --generate-gateway-token` are disabled because `openclaw.json` is immutable. Edit the Nix source for this install instead; for nix-openclaw, use the agent-first [Quick Start](https://github.com/openclaw/nix-openclaw#quick-start).
+- In Nix mode (`OPENCLAW_NIX_MODE=1`), read-only doctor checks still work. `doctor --generate-gateway-token` is disabled because it necessarily mutates `openclaw.json`. `doctor --fix`, `doctor --repair`, and `doctor --yes` run non-config repairs such as session/legacy state migrations and permission fixes, but still fail at the point of any actual `openclaw.json` mutation. Edit the Nix source for this install instead; for nix-openclaw, use the agent-first [Quick Start](https://github.com/openclaw/nix-openclaw#quick-start).
 - Interactive prompts (like keychain/OAuth fixes) only run when stdin is a TTY and `--non-interactive` is **not** set. Headless runs (cron, Telegram, no terminal) will skip prompts.
 - Performance: non-interactive `doctor` runs skip eager plugin loading so headless health checks stay fast. Interactive doctor sessions still load the plugin surfaces needed by the legacy health and repair flow.
 - `--lint` is stricter than `--non-interactive`: it is always read-only, never prompts, and never applies safe migrations. Run `doctor --fix` or `doctor --repair` when you want doctor to make changes.

--- a/docs/install/nix.md
+++ b/docs/install/nix.md
@@ -67,7 +67,7 @@ defaults write ai.openclaw.mac openclaw.nixMode -bool true
 ### What changes in Nix mode
 
 - Auto-install and self-mutation flows are disabled
-- `openclaw.json` is treated as immutable. Startup-derived defaults stay runtime-only, and config writers such as setup, onboarding, mutating `openclaw update`, plugin install/update/uninstall/enable, `doctor --fix`, `doctor --generate-gateway-token`, and `openclaw config set` refuse to edit the file.
+- `openclaw.json` is treated as immutable. Startup-derived defaults stay runtime-only, and config writers such as setup, onboarding, mutating `openclaw update`, plugin install/update/uninstall/enable, `doctor --generate-gateway-token`, and `openclaw config set` refuse to edit the file. `doctor --fix`, `doctor --repair`, and `doctor --yes` still run non-config repairs (for example session/legacy state migrations and permission fixes) but fail at the point of any actual `openclaw.json` mutation.
 - Agents should edit the Nix source instead. For nix-openclaw, use the agent-first [Quick Start](https://github.com/openclaw/nix-openclaw#quick-start) and set config under `programs.openclaw.config` or `instances.<name>.config`.
 - Missing dependencies surface Nix-specific remediation messages
 - UI surfaces a read-only Nix mode banner

--- a/src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts
+++ b/src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts
@@ -93,14 +93,14 @@ describe("doctor command", () => {
     expect(writeConfigFile).not.toHaveBeenCalled();
   });
 
-  it("allows doctor gateway token generation in Nix before config writes", async () => {
+  it("refuses doctor gateway token generation in Nix before config writes", async () => {
     const previous = process.env.OPENCLAW_NIX_MODE;
     process.env.OPENCLAW_NIX_MODE = "1";
     try {
       mockDoctorConfigSnapshot();
       await expect(
         doctorCommand(createDoctorRuntime(), { generateGatewayToken: true }),
-      ).resolves.toBeUndefined();
+      ).rejects.toThrow("OPENCLAW_NIX_MODE=1");
     } finally {
       if (previous === undefined) {
         delete process.env.OPENCLAW_NIX_MODE;

--- a/src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts
+++ b/src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts
@@ -76,14 +76,12 @@ describe("doctor command", () => {
     expect(confirm).not.toHaveBeenCalled();
   }, 30_000);
 
-  it("refuses doctor repair mode in Nix before repair side effects", async () => {
+  it("allows doctor repair mode in Nix when no config mutation is required", async () => {
     const previous = process.env.OPENCLAW_NIX_MODE;
     process.env.OPENCLAW_NIX_MODE = "1";
     try {
       mockDoctorConfigSnapshot();
-      await expect(doctorCommand(createDoctorRuntime(), { repair: true })).rejects.toThrow(
-        "OPENCLAW_NIX_MODE=1",
-      );
+      await expect(doctorCommand(createDoctorRuntime(), { repair: true })).resolves.toBeUndefined();
     } finally {
       if (previous === undefined) {
         delete process.env.OPENCLAW_NIX_MODE;
@@ -95,14 +93,14 @@ describe("doctor command", () => {
     expect(writeConfigFile).not.toHaveBeenCalled();
   });
 
-  it("refuses doctor gateway token generation in Nix before config writes", async () => {
+  it("allows doctor gateway token generation in Nix before config writes", async () => {
     const previous = process.env.OPENCLAW_NIX_MODE;
     process.env.OPENCLAW_NIX_MODE = "1";
     try {
       mockDoctorConfigSnapshot();
       await expect(
         doctorCommand(createDoctorRuntime(), { generateGatewayToken: true }),
-      ).rejects.toThrow("OPENCLAW_NIX_MODE=1");
+      ).resolves.toBeUndefined();
     } finally {
       if (previous === undefined) {
         delete process.env.OPENCLAW_NIX_MODE;

--- a/src/config/nix-mode-write-guard.test.ts
+++ b/src/config/nix-mode-write-guard.test.ts
@@ -6,31 +6,11 @@ import {
 } from "./nix-mode-write-guard.js";
 
 describe("nix-mode-write-guard", () => {
-  it("throws NixModeConfigMutationError when NIX_MODE=1 and no skip flag", () => {
+  it("throws NixModeConfigMutationError when NIX_MODE=1", () => {
     expect(() =>
       assertConfigWriteAllowedInCurrentMode({
         env: { OPENCLAW_NIX_MODE: "1" },
-        operation: "doctor --fix",
-      }),
-    ).toThrow(NixModeConfigMutationError);
-  });
-
-  it("does not throw when skipIfNoConfigMutation is true in Nix mode", () => {
-    expect(() =>
-      assertConfigWriteAllowedInCurrentMode({
-        env: { OPENCLAW_NIX_MODE: "1" },
-        operation: "models auth login",
-        skipIfNoConfigMutation: true,
-      }),
-    ).not.toThrow();
-  });
-
-  it("still throws in Nix mode when skipIfNoConfigMutation is false", () => {
-    expect(() =>
-      assertConfigWriteAllowedInCurrentMode({
-        env: { OPENCLAW_NIX_MODE: "1" },
-        operation: "config set",
-        skipIfNoConfigMutation: false,
+        operation: "doctor --generate-gateway-token",
       }),
     ).toThrow(NixModeConfigMutationError);
   });
@@ -49,5 +29,13 @@ describe("nix-mode-write-guard", () => {
       operation: "config set",
     });
     expect(message).toContain("Operation: config set");
+  });
+
+  it("does not tell users to avoid non-config doctor repairs", () => {
+    const message = formatNixModeConfigMutationMessage({
+      operation: "doctor --fix",
+    });
+    expect(message).not.toContain("doctor repair/token-generation");
+    expect(message).toContain("doctor --fix/--repair/--yes may still run non-config repairs");
   });
 });

--- a/src/config/nix-mode-write-guard.test.ts
+++ b/src/config/nix-mode-write-guard.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertConfigWriteAllowedInCurrentMode,
+  formatNixModeConfigMutationMessage,
+  NixModeConfigMutationError,
+} from "./nix-mode-write-guard.js";
+
+describe("nix-mode-write-guard", () => {
+  it("throws NixModeConfigMutationError when NIX_MODE=1 and no skip flag", () => {
+    expect(() =>
+      assertConfigWriteAllowedInCurrentMode({
+        env: { OPENCLAW_NIX_MODE: "1" },
+        operation: "doctor --fix",
+      }),
+    ).toThrow(NixModeConfigMutationError);
+  });
+
+  it("does not throw when skipIfNoConfigMutation is true in Nix mode", () => {
+    expect(() =>
+      assertConfigWriteAllowedInCurrentMode({
+        env: { OPENCLAW_NIX_MODE: "1" },
+        operation: "models auth login",
+        skipIfNoConfigMutation: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("still throws in Nix mode when skipIfNoConfigMutation is false", () => {
+    expect(() =>
+      assertConfigWriteAllowedInCurrentMode({
+        env: { OPENCLAW_NIX_MODE: "1" },
+        operation: "config set",
+        skipIfNoConfigMutation: false,
+      }),
+    ).toThrow(NixModeConfigMutationError);
+  });
+
+  it("is a no-op when OPENCLAW_NIX_MODE is not set", () => {
+    expect(() =>
+      assertConfigWriteAllowedInCurrentMode({
+        env: {},
+        operation: "config set",
+      }),
+    ).not.toThrow();
+  });
+
+  it("includes the operation name in the error message", () => {
+    const message = formatNixModeConfigMutationMessage({
+      operation: "config set",
+    });
+    expect(message).toContain("Operation: config set");
+  });
+});

--- a/src/config/nix-mode-write-guard.ts
+++ b/src/config/nix-mode-write-guard.ts
@@ -29,7 +29,8 @@ export function formatNixModeConfigMutationMessage(
     "This usually means nix-openclaw, the first-party Nix distribution, or another Nix-managed package set this mode.",
     ...(params.configPath ? [`Config path: ${params.configPath}`] : []),
     ...(operationHint ? [operationHint] : []),
-    "Do not run setup, onboarding, openclaw update, plugin install/update/uninstall/enable, doctor repair/token-generation, or config set against this file.",
+    "Do not run config-mutating operations such as setup, onboarding, openclaw update, plugin install/update/uninstall/enable, doctor --generate-gateway-token, or config set against this file.",
+    "In Nix mode, doctor --fix/--repair/--yes may still run non-config repairs (for example session/legacy state migrations or permission fixes), but any step that tries to modify this file will fail.",
     "Edit the Nix source for this install instead. For nix-openclaw, edit `programs.openclaw.config` or `instances.<name>.config`, then rebuild with Home Manager or NixOS.",
     `Agent-first Nix setup: ${NIX_OPENCLAW_AGENT_FIRST_URL}`,
     `OpenClaw Nix overview: ${OPENCLAW_NIX_OVERVIEW_URL}`,
@@ -42,25 +43,20 @@ export function formatNixModeConfigMutationMessage(
  * @param params.configPath - The config file path being mutated (if known)
  * @param params.env - Environment variables to check for OPENCLAW_NIX_MODE
  * @param params.operation - Description of the operation being performed (for better error messages)
- * @param params.skipIfNoConfigMutation - When true, only throw if the operation would actually modify openclaw.json
  */
 export function assertConfigWriteAllowedInCurrentMode(
   params: {
     configPath?: string;
     env?: NodeJS.ProcessEnv;
     operation?: string;
-    skipIfNoConfigMutation?: boolean;
   } = {},
 ): void {
   if (!resolveIsNixMode(params.env)) {
     return;
   }
   // In Nix mode, all writes must happen in the declarative source and then rebuild.
-  // However, some operations (like auth-profile writes or session state repairs) don't
-  // touch openclaw.json and should be allowed.
-  if (params.skipIfNoConfigMutation) {
-    return;
-  }
+  // The caller is responsible for only invoking this guard at actual openclaw.json write points;
+  // non-config repairs (session/legacy state, permission fixes) do not call it.
   throw new NixModeConfigMutationError({
     configPath: params.configPath,
     operation: params.operation,

--- a/src/config/nix-mode-write-guard.ts
+++ b/src/config/nix-mode-write-guard.ts
@@ -10,18 +10,25 @@ export const OPENCLAW_NIX_OVERVIEW_URL = "https://docs.openclaw.ai/install/nix";
 export class NixModeConfigMutationError extends Error {
   readonly code = "OPENCLAW_NIX_MODE_CONFIG_IMMUTABLE";
 
-  constructor(params: { configPath?: string } = {}) {
+  constructor(params: { configPath?: string; operation?: string } = {}) {
     super(formatNixModeConfigMutationMessage(params));
     this.name = "NixModeConfigMutationError";
   }
 }
 
 /** Build the operator-facing immutable-config message for Nix-managed installs. */
-export function formatNixModeConfigMutationMessage(params: { configPath?: string } = {}): string {
+export function formatNixModeConfigMutationMessage(
+  params: {
+    configPath?: string;
+    operation?: string;
+  } = {},
+): string {
+  const operationHint = params.operation ? `Operation: ${params.operation}` : "";
   return [
     "Config is managed by Nix (`OPENCLAW_NIX_MODE=1`), so OpenClaw treats openclaw.json as immutable.",
     "This usually means nix-openclaw, the first-party Nix distribution, or another Nix-managed package set this mode.",
     ...(params.configPath ? [`Config path: ${params.configPath}`] : []),
+    ...(operationHint ? [operationHint] : []),
     "Do not run setup, onboarding, openclaw update, plugin install/update/uninstall/enable, doctor repair/token-generation, or config set against this file.",
     "Edit the Nix source for this install instead. For nix-openclaw, edit `programs.openclaw.config` or `instances.<name>.config`, then rebuild with Home Manager or NixOS.",
     `Agent-first Nix setup: ${NIX_OPENCLAW_AGENT_FIRST_URL}`,
@@ -29,16 +36,33 @@ export function formatNixModeConfigMutationMessage(params: { configPath?: string
   ].join("\n");
 }
 
-/** Throw when the current environment marks OpenClaw config as Nix-managed and immutable. */
+/**
+ * Throw when the current environment marks OpenClaw config as Nix-managed and immutable.
+ *
+ * @param params.configPath - The config file path being mutated (if known)
+ * @param params.env - Environment variables to check for OPENCLAW_NIX_MODE
+ * @param params.operation - Description of the operation being performed (for better error messages)
+ * @param params.skipIfNoConfigMutation - When true, only throw if the operation would actually modify openclaw.json
+ */
 export function assertConfigWriteAllowedInCurrentMode(
   params: {
     configPath?: string;
     env?: NodeJS.ProcessEnv;
+    operation?: string;
+    skipIfNoConfigMutation?: boolean;
   } = {},
 ): void {
   if (!resolveIsNixMode(params.env)) {
     return;
   }
   // In Nix mode, all writes must happen in the declarative source and then rebuild.
-  throw new NixModeConfigMutationError({ configPath: params.configPath });
+  // However, some operations (like auth-profile writes or session state repairs) don't
+  // touch openclaw.json and should be allowed.
+  if (params.skipIfNoConfigMutation) {
+    return;
+  }
+  throw new NixModeConfigMutationError({
+    configPath: params.configPath,
+    operation: params.operation,
+  });
 }

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -20,10 +20,14 @@ function loadConfigModule(): Promise<ConfigModule> {
 /** Runs the full interactive doctor flow against the provided or default runtime. */
 export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions = {}) {
   const effectiveRuntime = runtime ?? (await import("../runtime.js")).defaultRuntime;
-  // Nix-mode write guard is now handled at the point of actual config mutation.
-  // Doctor repairs may include operations that don't touch openclaw.json (e.g. session
-  // state repairs, legacy state migrations), so we can't block the entire flow upfront.
-  // The individual repair operations that mutate openclaw.json will check Nix mode.
+  // Nix-mode write guard is handled at the point of actual config mutation for most
+  // doctor repairs, because some repairs (session/legacy state migrations, permission
+  // fixes) do not touch openclaw.json. However, --generate-gateway-token necessarily
+  // prepares a config mutation, so it stays fail-fast in Nix mode.
+  if (options.generateGatewayToken === true) {
+    const { assertConfigWriteAllowedInCurrentMode } = await loadConfigModule();
+    assertConfigWriteAllowedInCurrentMode({ operation: "doctor --generate-gateway-token" });
+  }
 
   const { createDoctorPrompter } = await import("../commands/doctor-prompter.js");
   const { printWizardHeader } = await import("../commands/onboard-helpers.js");

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -20,10 +20,10 @@ function loadConfigModule(): Promise<ConfigModule> {
 /** Runs the full interactive doctor flow against the provided or default runtime. */
 export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions = {}) {
   const effectiveRuntime = runtime ?? (await import("../runtime.js")).defaultRuntime;
-  if (options.repair === true || options.yes === true || options.generateGatewayToken === true) {
-    const { assertConfigWriteAllowedInCurrentMode } = await loadConfigModule();
-    assertConfigWriteAllowedInCurrentMode();
-  }
+  // Nix-mode write guard is now handled at the point of actual config mutation.
+  // Doctor repairs may include operations that don't touch openclaw.json (e.g. session
+  // state repairs, legacy state migrations), so we can't block the entire flow upfront.
+  // The individual repair operations that mutate openclaw.json will check Nix mode.
 
   const { createDoctorPrompter } = await import("../commands/doctor-prompter.js");
   const { printWizardHeader } = await import("../commands/onboard-helpers.js");


### PR DESCRIPTION
## Summary

Fix Nix-mode write guard blocking `openclaw doctor --fix` / `--repair` / `--yes` when the repair work does not modify `openclaw.json`, while keeping `--generate-gateway-token` fail-fast because it necessarily mutates config.

## What Problem This Solves

When `OPENCLAW_NIX_MODE=1`, `assertConfigWriteAllowedInCurrentMode()` was invoked unconditionally at the start of the doctor flow for `--fix`, `--repair`, `--yes`, and `--generate-gateway-token`. That blocked repairs that do not actually modify `openclaw.json`:

1. **`openclaw doctor --fix` / `--repair` / `--yes`** - Refused to run even when the only pending repairs were session state fixes, legacy state migrations, or permission fixes (none of which touch `openclaw.json`).

## Why This Change Was Made

The Nix-mode write guard should only block operations that actually mutate `openclaw.json`. Doctor repairs that write to other stores (session state, auth profile store, etc.) should be allowed to run. `--generate-gateway-token` is an explicit config-mutating operation, so it remains fail-fast.

## Changes

1. **`src/config/nix-mode-write-guard.ts`**:
   - Add `operation` parameter for clearer error messages.
   - Align the error message with the new contract: it no longer tells users to avoid `doctor --fix`/`--repair`/`--yes`, and instead explains that those commands may run non-config repairs but will fail at any `openclaw.json` mutation.

2. **`src/flows/doctor-health.ts`**:
   - Remove the unconditional `assertConfigWriteAllowedInCurrentMode()` check from `doctorCommand` for `--fix` / `--repair` / `--yes`.
   - Restore the fail-fast guard for `--generate-gateway-token`.
   - The guard is now enforced at the point of actual config mutation (e.g. `writeConfigFile`), so non-config repairs can proceed in Nix mode.

3. **`docs/cli/doctor.md` and `docs/install/nix.md`**:
   - Document that `--generate-gateway-token` is disabled in Nix mode.
   - Document that `--fix` / `--repair` / `--yes` run non-config repairs and fail only at actual `openclaw.json` mutations.

4. **`src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts`**:
   - Expect doctor repair to proceed in Nix mode when no config mutation is required.
   - Expect doctor gateway token generation to be refused in Nix mode before config writes.

5. **`src/config/nix-mode-write-guard.test.ts`**:
   - Cover the Nix-mode throw/no-op behavior and the new error-message copy.

## Impact

- Nix users can now run `openclaw doctor --fix` for session state repairs, legacy state migrations, and permission fixes.
- `openclaw doctor --generate-gateway-token` remains blocked in Nix mode because it necessarily mutates `openclaw.json`.
- Operations that modify `openclaw.json` still properly check Nix mode and throw `NixModeConfigMutationError` at the point of write.

Fixes #95135

---

## Evidence

### Problem Statement
Nix-mode (`OPENCLAW_NIX_MODE=1`) incorrectly blocked `openclaw doctor --fix` up front, even for repairs that never touch `openclaw.json`.

### Validation Evidence

#### 1. Focused unit test for the guard
New test file `src/config/nix-mode-write-guard.test.ts` verifies the Nix-mode throw/no-op behavior and the updated error message:

```
$ pnpm test src/config/nix-mode-write-guard.test.ts
 RUN  v4.1.8 /home/0668001525/PR解决/openclaw
 ✓ |runtime-config| src/config/nix-mode-write-guard.test.ts (4 tests) 6ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

#### 2. Doctor e2e tests updated for the new behavior
`src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts` was updated to match the scoped Nix behavior:

```
$ pnpm test src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts
 RUN  v4.1.8 /home/0668001525/PR解决/openclaw
 ✓ src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts (6 tests)
     ✓ allows doctor repair mode in Nix when no config mutation is required
     ✓ refuses doctor gateway token generation in Nix before config writes
     ...
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

#### 3. Real CLI behavior: `openclaw doctor --repair` in Nix mode
Built from this branch and ran against an isolated `OPENCLAW_HOME` with pre-existing legacy session state:

```
$ OPENCLAW_HOME=/tmp/openclaw-nix-test OPENCLAW_STATE_DIR=/tmp/openclaw-nix-test \
  OPENCLAW_NIX_MODE=1 ./openclaw.mjs doctor --repair --yes --non-interactive
...
◇  Legacy state detected ─────────────────────────╮
│  - Sessions: /tmp/openclaw-nix-test/sessions →  │
│    /tmp/openclaw-nix-test/agents/main/sessions  │
├─────────────────────────────────────────────────╯
◇  Doctor changes ────────────────────────────────────────────╮
│  Merged sessions store →                                    │
│  /tmp/openclaw-nix-test/agents/main/sessions/sessions.json  │
├─────────────────────────────────────────────────────────────╯
...
NixModeConfigMutationError: Config is managed by Nix (`OPENCLAW_NIX_MODE=1`), so OpenClaw treats openclaw.json as immutable.
Config path: /tmp/openclaw-nix-test/openclaw.json
...
```

The command no longer aborts at the start; it performs the non-config session migration and is only blocked when a later repair tries to write `openclaw.json`.

#### 4. Real CLI behavior: `openclaw doctor --generate-gateway-token` in Nix mode

```
$ OPENCLAW_HOME=/tmp/openclaw-nix-test OPENCLAW_STATE_DIR=/tmp/openclaw-nix-test \
  OPENCLAW_NIX_MODE=1 ./openclaw.mjs doctor --generate-gateway-token --yes --non-interactive
NixModeConfigMutationError: Config is managed by Nix (`OPENCLAW_NIX_MODE=1`), so OpenClaw treats openclaw.json as immutable.
Operation: doctor --generate-gateway-token
...
```

`--generate-gateway-token` is refused before any doctor side effects because it necessarily prepares an `openclaw.json` mutation.
