### PR TITLE
fix(sessions): add slash name clear support

### DIFF
--- a/src/auto-reply/reply/commands-name.test.ts
+++ b/src/auto-reply/reply/commands-name.test.ts
@@ -113,6 +113,32 @@ describe("name command", () => {
     ]);
   });
 
+  it("clears the current session label", async () => {
+    const storePath = await createStorePath();
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "sess-main",
+        updatedAt: 1,
+        totalTokens: 0,
+        totalTokensFresh: true,
+        label: "Billing rework",
+      },
+    });
+
+    const params = buildNameParams("/name --clear", storePath);
+    const result = await handleNameCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Session name cleared");
+    expect(getSessionEntry({ storePath, sessionKey })?.label).toBeUndefined();
+    expect(params.sessionEntry?.label).toBeUndefined();
+    expect(takeCommandSessionMetadataChanges(params.ctx)).toEqual([
+      { sessionKey, reason: "command-metadata" },
+    ]);
+  });
+
   it("suggests a name without mutating when no argument is given", async () => {
     const storePath = await createStorePath();
     await upsertSessionEntry({

--- a/src/auto-reply/reply/commands-name.ts
+++ b/src/auto-reply/reply/commands-name.ts
@@ -19,6 +19,7 @@ import type {
 } from "./commands-types.js";
 
 const NAME_COMMAND_PREFIX = "/name";
+const NAME_CLEAR_FLAG = "--clear";
 
 export function parseNameCommand(raw: string): { title: string } | null {
   const trimmed = raw.trim();
@@ -50,10 +51,11 @@ function syncNameSessionEntry(params: HandleCommandsParams): void {
 type NameWriteResult =
   | {
       ok: true;
-      label: string;
+      label: string | undefined;
       sessionKey: string;
       entry: SessionEntry;
       hadLegacyAliases: boolean;
+      cleared: boolean;
     }
   | { ok: false; error: string };
 
@@ -91,12 +93,13 @@ export const handleNameCommand: CommandHandler = async (params, allowTextCommand
     if (suggestion && suggestion !== current) {
       lines.push(`Suggested name: ${suggestion}`);
     }
-    lines.push("Use /name <title> to set a name (mirrors the session manager).");
+    lines.push("Use /name <title> to set a name, or /name --clear to remove it.");
     return nameReply(lines.join("\n"));
   }
 
   const storePath = params.storePath;
   const sessionKey = params.sessionKey;
+  const shouldClear = title === NAME_CLEAR_FLAG;
   // Reuse the canonical label validation (`parseSessionLabel`) and the same
   // cross-store uniqueness rule enforced by the web/admin `sessions.patch`
   // path so chat naming behaves identically to the session manager. Resolve the
@@ -114,17 +117,21 @@ export const handleNameCommand: CommandHandler = async (params, allowTextCommand
       if (!entry) {
         return { ok: false, error: "no active session to name" };
       }
-      const validated = parseSessionLabel(title);
-      if (!validated.ok) {
-        return { ok: false, error: validated.error };
-      }
       const aliasKeys = new Set<string>([resolved.normalizedKey, ...resolved.legacyKeys]);
-      for (const [key, other] of Object.entries(store)) {
-        if (!aliasKeys.has(key) && other?.label === validated.label) {
-          return { ok: false, error: `label already in use: ${validated.label}` };
+      if (shouldClear) {
+        delete entry.label;
+      } else {
+        const validated = parseSessionLabel(title);
+        if (!validated.ok) {
+          return { ok: false, error: validated.error };
         }
+        for (const [key, other] of Object.entries(store)) {
+          if (!aliasKeys.has(key) && other?.label === validated.label) {
+            return { ok: false, error: `label already in use: ${validated.label}` };
+          }
+        }
+        entry.label = validated.label;
       }
-      entry.label = validated.label;
       entry.updatedAt = Math.max(entry.updatedAt ?? 0, Date.now());
       // Persist through the canonical key and drop any legacy/case-folded
       // aliases, mirroring `persistResolvedSessionEntry`.
@@ -134,10 +141,11 @@ export const handleNameCommand: CommandHandler = async (params, allowTextCommand
       }
       return {
         ok: true,
-        label: validated.label,
+        label: entry.label,
         sessionKey: resolved.normalizedKey,
         entry,
         hadLegacyAliases: resolved.legacyKeys.length > 0,
+        cleared: shouldClear,
       };
     },
     {
@@ -154,5 +162,8 @@ export const handleNameCommand: CommandHandler = async (params, allowTextCommand
   }
   syncNameSessionEntry(params);
   markCommandSessionMetadataChanged(params);
+  if (result.cleared) {
+    return nameReply("Session name cleared.");
+  }
   return nameReply(`✅ Session renamed to “${result.label}”.`);
 };


### PR DESCRIPTION
## Summary

- Keeps session naming on the existing persisted `label` contract.
- Adds `/name --clear` to remove a custom session label through the same slash-command surface that sets it.
- Keeps `/name` duplicate detection aligned with `sessions.patch` by using the existing exact-label rule.
- Adds focused coverage for clearing a session label.

## Scope

This intentionally avoids changes to `SessionEntry`, gateway protocol schemas, `sessions.patch`, `sessions.resolve`, gateway row projection, UI display, or transcript `session_info.name`.

A full `label` versus `title` naming-contract migration should be handled separately if maintainers decide to change the persisted/public session naming model.

Supersedes the closed draft PR #95159, which was reduced after review from a partial title migration into this label-only change.

## Real behavior proof

Behavior or issue addressed: users can set a session label with `/name <title>` and now clear that same persisted label with `/name --clear`; no second persisted naming field is introduced.

Real environment tested: Not run locally from this ChatGPT session. GitHub edits were made through the connector.

Exact steps or command run after this patch:

```bash
# Not run in this environment
node scripts/run-vitest.mjs run src/auto-reply/reply/commands-name.test.ts
```

Observed result after fix: Not locally verified here. The branch contains focused test coverage for `/name --clear`.

What was not tested: Full OpenClaw runtime behavior, browser UI, TUI refresh, and Gateway API behavior beyond preserving the existing label contract in source.

## Risk checklist

Did user-visible behavior change? Yes. `/name --clear` now clears the current session label.

Did config, environment, or migration behavior change? No.

Did security, auth, secrets, network, or tool execution behavior change? No.

What is the highest-risk area? Accidental drift between slash-command naming and Gateway label APIs.

How is that risk mitigated? The change keeps `/name` on `parseSessionLabel`, exact `entry.label` duplicate matching, and the existing `label` field only.

AI-assisted changes: Yes, generated with ChatGPT.