### PR TITLE
fix(sdk): require session key for effective tools

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -25,6 +25,7 @@ import type {
   TasksGetResult,
   TasksListParams,
   TasksListResult,
+  ToolsEffectiveParams,
   ToolInvokeParams,
   ToolInvokeResult,
 } from "./types.js";
@@ -230,6 +231,18 @@ function hasArtifactQueryScope(params: unknown): params is ArtifactQuery {
 function requireArtifactQueryScope(api: string, params: unknown): ArtifactQuery {
   if (!hasArtifactQueryScope(params)) {
     throw new Error(`${api} requires one of sessionKey, runId, or taskId`);
+  }
+  return params;
+}
+
+function hasToolsEffectiveSessionKey(params: unknown): params is ToolsEffectiveParams {
+  const record = asRecord(params);
+  return typeof record.sessionKey === "string" && record.sessionKey.trim().length > 0;
+}
+
+function requireToolsEffectiveSessionKey(params: unknown): ToolsEffectiveParams {
+  if (!hasToolsEffectiveSessionKey(params)) {
+    throw new Error("oc.tools.effective requires sessionKey");
   }
   return params;
 }
@@ -857,8 +870,8 @@ export class ToolsNamespace extends RpcNamespace {
     return await this.call("catalog", params === undefined ? {} : params);
   }
 
-  async effective(params?: unknown): Promise<unknown> {
-    return await this.call("effective", params);
+  async effective(params: ToolsEffectiveParams): Promise<unknown> {
+    return await this.call("effective", requireToolsEffectiveSessionKey(params));
   }
 
   async invoke(name: string, params?: ToolInvokeParams): Promise<ToolInvokeResult> {

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -739,6 +739,23 @@ describe("OpenClaw SDK", () => {
     ]);
   });
 
+  it("rejects tools.effective without a session key before RPC", async () => {
+    type EffectiveMethod = (this: unknown, params?: unknown) => Promise<unknown>;
+    const transport = new FakeTransport({
+      "tools.effective": { tools: [] },
+    });
+    const oc = new OpenClaw({ transport });
+
+    await expect((oc.tools.effective as unknown as EffectiveMethod).call(oc.tools)).rejects.toThrow(
+      "oc.tools.effective requires sessionKey",
+    );
+    await expect(
+      (oc.tools.effective as unknown as EffectiveMethod).call(oc.tools, {}),
+    ).rejects.toThrow("oc.tools.effective requires sessionKey");
+
+    expect(transport.calls).toEqual([]);
+  });
+
   it("keeps close terminal when it races a pending connect", async () => {
     const transport = new DelayedConnectTransport({
       "agents.list": { agents: [] },

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -52,6 +52,7 @@ export type {
   TasksGetResult,
   TasksListParams,
   TasksListResult,
+  ToolsEffectiveParams,
   ToolInvokeParams,
   ToolInvokeResult,
   WorkspaceSelection,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -188,6 +188,11 @@ export type SDKError = {
 };
 
 /** Parameters for direct tool invocation through the SDK. */
+export type ToolsEffectiveParams = {
+  sessionKey: string;
+  agentId?: string;
+};
+
 export type ToolInvokeParams = {
   args?: JsonObject;
   sessionKey?: string;


### PR DESCRIPTION
Summary:
- require `sessionKey` for `oc.tools.effective()` at the SDK boundary
- export `ToolsEffectiveParams` so TypeScript callers see the Gateway contract
- add SDK regression coverage proving missing/blank params reject before RPC

Verification:
- `oxfmt --check packages/sdk/src/client.ts packages/sdk/src/index.test.ts packages/sdk/src/index.ts packages/sdk/src/types.ts`
- `git diff --check HEAD~1..HEAD`
- `node --check packages/sdk/src/client.ts && node --check packages/sdk/src/types.ts && node --check packages/sdk/src/index.ts && node --check packages/sdk/src/index.test.ts`
- `codex review --base origin/main` (no findings)

Proof gaps:
- `node scripts/run-vitest.mjs packages/sdk/src/index.test.ts` could not run in this sparse worktree because `node_modules` is intentionally absent (`OPENCLAW_MISSING_VITEST`).
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` queued on Blacksmith Testbox and was stopped before execution; exact-head hosted CI should own the remaining gate.
