### PR TITLE
fix(infra): use macOS product version in os summary diagnostics (related #95145)

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -19,6 +19,7 @@ import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { CliBackendConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveOsSummary } from "../../infra/os-summary.js";
 import { privateFileStore } from "../../infra/private-file-store.js";
 import { tempWorkspace } from "../../infra/private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
@@ -157,7 +158,7 @@ export function buildCliAgentSystemPrompt(params: {
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
       host: "openclaw",
-      os: `${os.type()} ${os.release()}`,
+      os: `${os.type()} ${resolveOsSummary().release}`,
       arch: os.arch(),
       node: process.version,
       model: params.modelDisplay,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -44,6 +44,7 @@ import { isEmbeddedMode } from "../../../infra/embedded-mode.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summary.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
+import { resolveOsSummary } from "../../../infra/os-summary.js";
 import { createCodexNativeWebSearchWrapper } from "../../../llm/providers/stream-wrappers/openai.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../../plugins/command-registry-state.js";
@@ -1933,7 +1934,7 @@ export async function runEmbeddedAttempt(
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
         host: machineName,
-        os: `${os.type()} ${os.release()}`,
+        os: `${os.type()} ${resolveOsSummary().release}`,
         arch: os.arch(),
         node: process.version,
         model: `${params.provider}/${params.modelId}`,

--- a/src/infra/os-summary.test.ts
+++ b/src/infra/os-summary.test.ts
@@ -37,7 +37,9 @@ describe("resolveOsSummary", () => {
       expected: {
         platform: "darwin",
         arch: "arm64",
-        release: "24.0.0",
+        // On darwin, release uses sw_vers -productVersion, not os.release()
+        // (kernel 24.0.0 → macOS 15.4). #95145
+        release: "15.4",
         label: "macos 15.4 (arm64)",
       },
     },

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -21,7 +21,11 @@ function macosVersion(): string {
 /** Resolves a compact OS label for diagnostics, logs, and environment summaries. */
 export function resolveOsSummary(): OsSummary {
   const platform = os.platform();
-  const release = platform === "darwin" ? macosVersion() : os.release();
+  // On darwin, os.release() returns the Darwin kernel version (e.g. "25.5.0"),
+  // not the macOS product version ("26.5.1"). Use macosVersion() which calls
+  // sw_vers -productVersion to get the actual macOS version. (#95145)
+  const darwinProductVersion = platform === "darwin" ? macosVersion() : null;
+  const release = darwinProductVersion ?? os.release();
   const arch = os.arch();
   const cacheKey = `${platform}\0${release}\0${arch}`;
   // Cache by stable os.* facts; darwin's sw_vers lookup is comparatively slow
@@ -32,7 +36,7 @@ export function resolveOsSummary(): OsSummary {
   }
   const label = (() => {
     if (platform === "darwin") {
-      return `macos ${macosVersion()} (${arch})`;
+      return `macos ${darwinProductVersion} (${arch})`;
     }
     if (platform === "win32") {
       return `windows ${release} (${arch})`;

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -21,7 +21,7 @@ function macosVersion(): string {
 /** Resolves a compact OS label for diagnostics, logs, and environment summaries. */
 export function resolveOsSummary(): OsSummary {
   const platform = os.platform();
-  const release = os.release();
+  const release = platform === "darwin" ? macosVersion() : os.release();
   const arch = os.arch();
   const cacheKey = `${platform}\0${release}\0${arch}`;
   // Cache by stable os.* facts; darwin's sw_vers lookup is comparatively slow


### PR DESCRIPTION
### Summary

- **Problem**: On macOS 26 (Tahoe), `resolveOsSummary()` reports the Darwin kernel version (e.g. "25.5.0") as the `release` field instead of the macOS product version ("26.5.1"). Starting with macOS 26, Darwin kernel 25.x no longer maps to the macOS major version using the old convention, causing downstream diagnostics to display incorrect OS versions.
- **Root Cause**: `resolveOsSummary` unconditionally assigned `os.release()` to the `release` field. On macOS, this is the Darwin kernel version. The `macosVersion()` helper (which calls `sw_vers -productVersion`) already existed but was only used for the `label` field.
- **Fix**: Use `macosVersion()` for the `release` field on darwin, cached once per call to avoid double `sw_vers` probe. Route `cli-runner` and `embedded attempt` runtime OS fields through `resolveOsSummary().release` to propagate the product version to agent prompt metadata.
- **Scope**: This PR fixes the status/diagnostics/trajectory metadata and runtime prompt OS fields. This is NOT a complete fix for all `os.release()` consumers — the linked issue may still need additional work for other code paths.
- **What changed**:
  - `src/infra/os-summary.ts` — darwin `release` uses `macosVersion()` (cached)
  - `src/agents/cli-runner/helpers.ts` — runtime OS via `resolveOsSummary().release`
  - `src/agents/embedded-agent-runner/run/attempt.ts` — runtime OS via `resolveOsSummary().release`
  - `src/infra/os-summary.test.ts` — updated darwin expectations
- **What did NOT change**: Linux/Windows — `os.release()` still used on non-darwin

### Real behavior proof

**Behavior or issue addressed (#95145)**: `resolveOsSummary()` returns Darwin kernel version as `release` on macOS, causing incorrect version reporting on macOS 26 where kernel 25 ≠ macOS 15.

**Real environment tested**: Linux, Node v22.22.0, OpenClaw built from source. Non-darwin backward compatibility verified — `release` = `os.release()` on Linux. The darwin code path uses the existing `macosVersion()` helper which calls `sw_vers -productVersion`.

**Exact steps or command run after this patch**: ran `node --import tsx proof.mjs` — confirmed non-darwin path unchanged.

**Evidence after fix**:
```text
Platform: linux
Release:  4.19.112-2.el8.x86_64 (os.release() — unchanged)
RESULT: PASS — non-darwin platforms unchanged
```

**Observed result after fix**: On darwin, `release` now uses `sw_vers -productVersion` instead of `os.release()`. On Linux/Windows, `os.release()` continues to be used.

**What was not tested**: Live `sw_vers` on macOS 26 hardware. The fix is validated by source analysis (reporter confirmed `sw_vers -productVersion` → "26.5.1" vs `uname -r` → "25.5.0"), test updates (4 tests pass), and the non-darwin path remains unchanged.

**Repro confirmation**: `os-summary.test.ts` — darwin expectations updated, all 4 tests pass.

### Change Type

- [x] Bug fix

### Scope

- [x] infra / OS detection

### Regression Test Plan

- `node scripts/run-vitest.mjs src/infra/os-summary.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Related to #95145