### PR TITLE
fix(claude-cli): update PermissionResult to match Claude Code 2.1.x schema

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1939,7 +1939,8 @@ ${JSON.stringify({
     expect(parsed.type).toBe("control_response");
     expect(parsed.response.subtype).toBe("success");
     expect(parsed.response.request_id).toBe("req-allow");
-    expect(parsed.response.response.behavior).toBe("allow");
+    expect(parsed.response.response).toHaveProperty("updatedInput");
+    expect(parsed.response.response.behavior).toBeUndefined();
     expect(parsed.response.response.toolUseID).toBe("tool-allow-1");
   });
 
@@ -2306,7 +2307,8 @@ ${JSON.stringify({
         response: { behavior: string; toolUseID?: string };
       };
     };
-    expect(parsed.response.response.behavior).toBe("allow");
+    expect(parsed.response.response).toHaveProperty("updatedInput");
+    expect(parsed.response.response.behavior).toBeUndefined();
     expect(parsed.response.response.toolUseID).toBe("tool-default-allow-1");
   });
 
@@ -2742,7 +2744,8 @@ ${JSON.stringify({
         response: { behavior: string; toolUseID?: string };
       };
     };
-    expect(parsed.response.response.behavior).toBe("allow");
+    expect(parsed.response.response).toHaveProperty("updatedInput");
+    expect(parsed.response.response.behavior).toBeUndefined();
     expect(parsed.response.response.toolUseID).toBe("tool-permmode-allow-1");
     const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
     expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("bypassPermissions");

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -876,7 +876,10 @@ function handleClaudeLiveControlRequest(
       request_id: requestId,
       response: allowed
         ? {
-            behavior: "allow",
+            updatedInput:
+              request.input && typeof request.input === "object"
+                ? (request.input as Record<string, unknown>)
+                : {},
             ...(toolUseId ? { toolUseID: toolUseId } : {}),
           }
         : {

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -462,7 +462,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(duplicateApproval.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { updatedInput: {} },
       },
     });
 
@@ -483,7 +483,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(primaryApproval.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { updatedInput: {} },
       },
     });
 
@@ -2473,7 +2473,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(response.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { updatedInput: {} },
       },
     });
     const request = getMockCallArg(approvalRequester, 0, 0, "approval request");
@@ -2633,7 +2633,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(allow.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { updatedInput: {} },
       },
     });
     expect(JSON.parse(deny.stdout)).toEqual({
@@ -2703,13 +2703,13 @@ describe("native hook relay registry", () => {
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { updatedInput: {} },
         },
       },
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { updatedInput: {} },
         },
       },
     ]);
@@ -2883,13 +2883,13 @@ describe("native hook relay registry", () => {
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { updatedInput: {} },
         },
       },
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { updatedInput: {} },
         },
       },
     ]);
@@ -3015,7 +3015,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(firstResponse.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { updatedInput: {} },
       },
     });
   });

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -393,7 +393,7 @@ const nativeHookRelayProviderAdapters: Record<
           hookEventName: "PermissionRequest",
           decision:
             decision === "allow"
-              ? { behavior: "allow" }
+              ? { updatedInput: {} }
               : {
                   behavior: "deny",
                   message: message?.trim() || "Denied by OpenClaw",


### PR DESCRIPTION
## What Problem This Solves

Claude Code 2.1.156 tightened the `PermissionResult` schema. OpenClaw returned `{ behavior: "allow" }` which validates against neither branch of the new union, causing `ZodError` on every tool call.

Pinning Claude Code to 2.0.77 confirms the regression is on the OpenClaw bridge side.

## Why This Change Was Made

Two locations returned the deprecated `{ behavior: "allow" }` shape:
- `src/agents/cli-runner/claude-live-session.ts:879`
- `src/agents/harness/native-hook-relay.ts:396`

Both need to return `{ updatedInput }` instead, matching the Claude Code 2.1.x PermissionResult union shape.

## Changes

- **`src/agents/cli-runner/claude-live-session.ts`** — return `{ updatedInput: request.input }` instead of `{ behavior: "allow" }` for the allow path
- **`src/agents/harness/native-hook-relay.ts`** — return `{ updatedInput: {} }` instead of `{ behavior: "allow" }`; deny path unchanged

## Evidence

- Verified against Claude Code 2.1.156: tool calls no longer throw ZodError
- Verified against Claude Code 2.0.77: backward-compatible (old CLI accepts updatedInput)
- Both allow-path call sites now return `{ updatedInput }` matching the current Claude Code PermissionResult schema; deny paths are unchanged

## Related

Closes #95171