### PR TITLE
fix(agents): return updatedInput instead of behavior:allow for Claude Code 2.1.x PermissionResult schema (fixes #95171)

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1933,14 +1933,13 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; toolUseID?: string };
+        response: { updatedInput?: Record<string, unknown> };
       };
     };
     expect(parsed.type).toBe("control_response");
     expect(parsed.response.subtype).toBe("success");
     expect(parsed.response.request_id).toBe("req-allow");
-    expect(parsed.response.response.behavior).toBe("allow");
-    expect(parsed.response.response.toolUseID).toBe("tool-allow-1");
+    expect(parsed.response.response.updatedInput).toEqual({ command: "ls" });
   });
 
   it("reports Claude live stream progress and keeps native tools fresh while they are running", async () => {
@@ -2303,11 +2302,10 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; toolUseID?: string };
+        response: { updatedInput?: Record<string, unknown> };
       };
     };
-    expect(parsed.response.response.behavior).toBe("allow");
-    expect(parsed.response.response.toolUseID).toBe("tool-default-allow-1");
+    expect(parsed.response.response.updatedInput).toEqual({ command: "echo hi" });
   });
 
   it("answers Claude live control_request can_use_tool with deny when approval defaults are restrictive", async () => {
@@ -2739,11 +2737,10 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; toolUseID?: string };
+        response: { updatedInput?: Record<string, unknown> };
       };
     };
-    expect(parsed.response.response.behavior).toBe("allow");
-    expect(parsed.response.response.toolUseID).toBe("tool-permmode-allow-1");
+    expect(parsed.response.response.updatedInput).toEqual({ command: "ls" });
     const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
     expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("bypassPermissions");
   });

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -867,7 +867,6 @@ function handleClaudeLiveControlRequest(
   if (!requestId) {
     return;
   }
-  const toolUseId = typeof request.tool_use_id === "string" ? request.tool_use_id : undefined;
   const allowed = turn.execPermission.security === "full" && turn.execPermission.ask === "off";
   writeClaudeLiveControlResponse(session, {
     type: "control_response",
@@ -876,8 +875,8 @@ function handleClaudeLiveControlRequest(
       request_id: requestId,
       response: allowed
         ? {
-            behavior: "allow",
-            ...(toolUseId ? { toolUseID: toolUseId } : {}),
+            updatedInput:
+              typeof request.input === "object" && request.input !== null ? request.input : {},
           }
         : {
             behavior: "deny",

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -462,7 +462,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(duplicateApproval.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { updatedInput: expect.any(Object) },
       },
     });
 
@@ -483,7 +483,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(primaryApproval.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { updatedInput: expect.any(Object) },
       },
     });
 
@@ -2473,7 +2473,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(response.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { updatedInput: expect.any(Object) },
       },
     });
     const request = getMockCallArg(approvalRequester, 0, 0, "approval request");
@@ -2633,7 +2633,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(allow.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { updatedInput: expect.any(Object) },
       },
     });
     expect(JSON.parse(deny.stdout)).toEqual({
@@ -2703,13 +2703,13 @@ describe("native hook relay registry", () => {
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { updatedInput: expect.any(Object) },
         },
       },
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { updatedInput: expect.any(Object) },
         },
       },
     ]);
@@ -2883,13 +2883,13 @@ describe("native hook relay registry", () => {
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { updatedInput: expect.any(Object) },
         },
       },
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { updatedInput: expect.any(Object) },
         },
       },
     ]);
@@ -3015,7 +3015,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(firstResponse.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { updatedInput: expect.any(Object) },
       },
     });
   });

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -188,6 +188,7 @@ type NativeHookRelayProviderAdapter = {
   renderPermissionDecisionResponse: (
     decision: NativeHookRelayPermissionDecision,
     message?: string,
+    input?: Record<string, JsonValue>,
   ) => NativeHookRelayProcessResponse;
 };
 
@@ -387,13 +388,13 @@ const nativeHookRelayProviderAdapters: Record<
       stderr: "",
       exitCode: 0,
     }),
-    renderPermissionDecisionResponse: (decision, message) => ({
+    renderPermissionDecisionResponse: (decision, message, input) => ({
       stdout: `${JSON.stringify({
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
           decision:
             decision === "allow"
-              ? { behavior: "allow" }
+              ? { updatedInput: input ?? {} }
               : {
                   behavior: "deny",
                   message: message?.trim() || "Denied by OpenClaw",
@@ -1484,7 +1485,7 @@ async function runNativeHookRelayPermissionRequest(params: {
     request,
   });
   if (hasNativeHookRelayPermissionAllowAlways(allowAlwaysKey)) {
-    return params.adapter.renderPermissionDecisionResponse("allow");
+    return params.adapter.renderPermissionDecisionResponse("allow", undefined, request.toolInput);
   }
   const pendingApproval = pendingPermissionApprovals.get(approvalKey);
   try {
@@ -1495,11 +1496,11 @@ async function runNativeHookRelayPermissionRequest(params: {
         request,
       }));
     if (decision === "allow") {
-      return params.adapter.renderPermissionDecisionResponse("allow");
+      return params.adapter.renderPermissionDecisionResponse("allow", undefined, request.toolInput);
     }
     if (decision === "allow-always") {
       rememberNativeHookRelayPermissionAllowAlways(allowAlwaysKey);
-      return params.adapter.renderPermissionDecisionResponse("allow");
+      return params.adapter.renderPermissionDecisionResponse("allow", undefined, request.toolInput);
     }
     if (decision === "deny") {
       return params.adapter.renderPermissionDecisionResponse("deny", "Denied by user");


### PR DESCRIPTION
## Summary

Claude Code `2.1.x` tightened the `PermissionResult` schema. The new union accepts `{ updatedInput: <record> }` for allow decisions instead of the older `{ behavior: "allow" }` shape. OpenClaw's bridge still returned the old shape, causing every tool call through the permission/approval flow to fail with a `ZodError` on Claude Code ≥ 2.1.

This PR updates both permission response sites to return `{ updatedInput: input }` for allow decisions, matching the new schema. Deny responses (`{ behavior: "deny", message }`) are unchanged.

## Changes

- `src/agents/cli-runner/claude-live-session.ts` — live session `can_use_tool` control response: `{ behavior: "allow" }` → `{ updatedInput: request.input ?? {} }`
- `src/agents/harness/native-hook-relay.ts` — hook relay `PermissionRequest` decision: `{ behavior: "allow" }` → `{ updatedInput: input ?? {} }`; added `input` parameter to `renderPermissionDecisionResponse` signature; updated 3 allow call sites to pass `request.toolInput`
- `src/agents/cli-runner.spawn.test.ts` — updated 3 allow assertions to check `updatedInput` with expected tool input
- `src/agents/harness/native-hook-relay.test.ts` — updated 9 allow assertions to check `updatedInput`

## Real behavior proof

- **Behavior addressed:** `canUseTool` permission response returns `{ updatedInput }` instead of deprecated `{ behavior: "allow" }` for Claude Code 2.1.x compatibility
- **Environment tested:** macOS, Node v24, openclaw upstream/main @ da03996a
- **Steps run after the patch:** Ran the auto-reply verification suite for both changed test files
- **Evidence after fix:**

```
$ grep -n 'updatedInput' src/agents/cli-runner/claude-live-session.ts src/agents/harness/native-hook-relay.ts
src/agents/cli-runner/claude-live-session.ts:878:            updatedInput:
src/agents/harness/native-hook-relay.ts:397:              ? { updatedInput: input ?? {} }

$ node -e "const fs=require('fs'); const s1=fs.readFileSync('src/agents/cli-runner/claude-live-session.ts','utf8'); const s2=fs.readFileSync('src/agents/harness/native-hook-relay.ts','utf8'); console.log('Old behavior:allow removed:', !s1.includes('behavior: \"allow\"') && !s2.includes('behavior: \"allow\"')); console.log('New updatedInput present:', s1.includes('updatedInput') && s2.includes('updatedInput: input'));"
Old behavior:allow removed: true
New updatedInput present: true

$ node scripts/run-vitest.mjs run src/agents/cli-runner.spawn.test.ts
 60 passed (60)

$ node scripts/run-vitest.mjs run src/agents/harness/native-hook-relay.test.ts
 75 passed (75)
```

- **Observed result after fix:** All 135 tests pass. Both source files use `updatedInput` for allow decisions; old `behavior: "allow"` pattern fully removed.
- **What was not tested:** Live Claude Code 2.1.x session (requires real Claude Code CLI installation and runtime)
