### PR TITLE
fix(anthropic): retry on UND_ERR_SOCKET keep-alive failures (#87407)

### DIFF
--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1720,3 +1720,32 @@ describe("buildGuardedModelFetch", () => {
     });
   });
 });
+
+import { isUndiciSocketError } from "./provider-transport-fetch.js";
+
+describe("isUndiciSocketError", () => {
+  it("detects direct UND_ERR_SOCKET code", () => {
+    const err = Object.assign(new Error("socket hang up"), { code: "UND_ERR_SOCKET" });
+    expect(isUndiciSocketError(err)).toBe(true);
+  });
+
+  it("detects nested UND_ERR_SOCKET in cause", () => {
+    const cause = Object.assign(new Error("socket hang up"), { code: "UND_ERR_SOCKET" });
+    const err = new TypeError("fetch failed", { cause });
+    expect(isUndiciSocketError(err)).toBe(true);
+  });
+
+  it("returns false for non-socket errors", () => {
+    expect(isUndiciSocketError(new Error("generic"))).toBe(false);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(isUndiciSocketError(null)).toBe(false);
+    expect(isUndiciSocketError(undefined)).toBe(false);
+  });
+
+  it("returns false for errors with different codes", () => {
+    const err = Object.assign(new Error("timeout"), { code: "ETIMEDOUT" });
+    expect(isUndiciSocketError(err)).toBe(false);
+  });
+});

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -841,16 +841,21 @@ export function buildGuardedModelFetch(
             `${summarizeError(error)}`,
         );
         localServiceLease?.release();
-        localServiceLease = await ensureModelProviderLocalService(
-          model,
-          baseInit?.headers,
-          localServiceSignal,
-        );
-        result = await fetchWithSsrFGuard(
-          useEnvProxy
-            ? withTrustedEnvProxyGuardedFetchMode(guardedFetchOptions)
-            : guardedFetchOptions,
-        );
+        try {
+          localServiceLease = await ensureModelProviderLocalService(
+            model,
+            baseInit?.headers,
+            localServiceSignal,
+          );
+          result = await fetchWithSsrFGuard(
+            useEnvProxy
+              ? withTrustedEnvProxyGuardedFetchMode(guardedFetchOptions)
+              : guardedFetchOptions,
+          );
+        } catch (retryError) {
+          localServiceLease?.release();
+          throw retryError;
+        }
       } else {
         log.warn(
           `[model-fetch] error provider=${model.provider} api=${model.api} model=${model.id} ` +

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -738,6 +738,22 @@ export function buildGuardedModelFetch(
       `message=${error instanceof Error ? error.message : read(record.message)}`,
     ].join(" ");
   };
+
+  /** True when the error is an undici keep-alive socket reuse failure. */
+  const isUndiciSocketError = (error: unknown): boolean => {
+    if (!error || typeof error !== "object") {
+      return false;
+    }
+    const record = error as Record<string, unknown>;
+    if (record.code === "UND_ERR_SOCKET") {
+      return true;
+    }
+    const cause =
+      record.cause && typeof record.cause === "object"
+        ? (record.cause as Record<string, unknown>)
+        : undefined;
+    return cause?.code === "UND_ERR_SOCKET";
+  };
   return async (input, init) => {
     let localServiceLease: ProviderLocalServiceLease | undefined;
     const request = input instanceof Request ? new Request(input, init) : undefined;
@@ -815,12 +831,34 @@ export function buildGuardedModelFetch(
           : guardedFetchOptions,
       );
     } catch (error) {
-      log.warn(
-        `[model-fetch] error provider=${model.provider} api=${model.api} model=${model.id} ` +
-          `elapsedMs=${Date.now() - fetchStartedAt} ${summarizeError(error)}`,
-      );
-      localServiceLease?.release();
-      throw error;
+      // Retry once on undici keep-alive socket reuse failure (UND_ERR_SOCKET).
+      // A stale pooled socket can fail on first use; a fresh connection almost
+      // always succeeds. Only retry once to avoid infinite loops.
+      if (isUndiciSocketError(error)) {
+        log.warn(
+          `[model-fetch] undici socket error, retrying once provider=${model.provider} ` +
+            `api=${model.api} model=${model.id} elapsedMs=${Date.now() - fetchStartedAt} ` +
+            `${summarizeError(error)}`,
+        );
+        localServiceLease?.release();
+        localServiceLease = await ensureModelProviderLocalService(
+          model,
+          baseInit?.headers,
+          localServiceSignal,
+        );
+        result = await fetchWithSsrFGuard(
+          useEnvProxy
+            ? withTrustedEnvProxyGuardedFetchMode(guardedFetchOptions)
+            : guardedFetchOptions,
+        );
+      } else {
+        log.warn(
+          `[model-fetch] error provider=${model.provider} api=${model.api} model=${model.id} ` +
+            `elapsedMs=${Date.now() - fetchStartedAt} ${summarizeError(error)}`,
+        );
+        localServiceLease?.release();
+        throw error;
+      }
     }
     let response = result.response;
     emitModelTransportDebug(

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -591,6 +591,22 @@ function resolveModelRequestPolicy(model: Model) {
   });
 }
 
+/** True when the error is an undici keep-alive socket reuse failure. */
+export function isUndiciSocketError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const record = error as Record<string, unknown>;
+  if (record.code === "UND_ERR_SOCKET") {
+    return true;
+  }
+  const cause =
+    record.cause && typeof record.cause === "object"
+      ? (record.cause as Record<string, unknown>)
+      : undefined;
+  return cause?.code === "UND_ERR_SOCKET";
+}
+
 export function resolveModelRequestTimeoutMs(
   model: Model,
   timeoutMs: number | undefined,
@@ -739,21 +755,6 @@ export function buildGuardedModelFetch(
     ].join(" ");
   };
 
-  /** True when the error is an undici keep-alive socket reuse failure. */
-  const isUndiciSocketError = (error: unknown): boolean => {
-    if (!error || typeof error !== "object") {
-      return false;
-    }
-    const record = error as Record<string, unknown>;
-    if (record.code === "UND_ERR_SOCKET") {
-      return true;
-    }
-    const cause =
-      record.cause && typeof record.cause === "object"
-        ? (record.cause as Record<string, unknown>)
-        : undefined;
-    return cause?.code === "UND_ERR_SOCKET";
-  };
   return async (input, init) => {
     let localServiceLease: ProviderLocalServiceLease | undefined;
     const request = input instanceof Request ? new Request(input, init) : undefined;


### PR DESCRIPTION
## Description

Node.js undici can return a stale pooled keep-alive socket that fails on first use with `UND_ERR_SOCKET` (either top-level or nested as a `TypeError` cause). This triggers silent mid-turn fallback from Anthropic to OpenAI/Codex.

## Changes
- **`src/agents/provider-transport-fetch.ts`**: Add `isUndiciSocketError` helper that checks both top-level `err.code` and nested `err.cause.code === "UND_ERR_SOCKET"`. Add single retry in `buildGuardedModelFetch` when the error is a socket reuse failure. Retry path properly releases local-service lease on both success and failure.

## Related Issue
Fixes #87407

## AI Assistance
This PR was created with assistance from AI (Claude Code).

## Real behavior proof

**Behavior or issue addressed:** Node.js undici connection pool reuses a stale keep-alive socket that fails with UND_ERR_SOCKET, causing spurious mid-turn model fallback.

**Real environment tested:** Code review of the guarded model transport layer in provider-transport-fetch.ts, which is the path used by all gateway Anthropic requests.

**Exact steps or command run after the patch:**
Added `isUndiciSocketError` helper and single retry in `buildGuardedModelFetch` catch block. When fetch fails with UND_ERR_SOCKET (top-level or nested cause), releases the old lease, acquires a fresh one, and retries once. If the retry also fails, the new lease is properly released.

**After-fix evidence:**
```typescript
const isUndiciSocketError = (error: unknown): boolean => {
  // checks both err.code === "UND_ERR_SOCKET"
  // and err.cause?.code === "UND_ERR_SOCKET" (TypeError wrapping)
};
// In the retry path:
try {
  localServiceLease = await ensureModelProviderLocalService(model, ...);
  result = await fetchWithSsrFGuard(...);
} catch (retryError) {
  localServiceLease?.release();  // NEW: release on retry failure
  throw retryError;
}
```

**Observed result after fix:**
- UND_ERR_SOCKET triggers a single retry with a fresh connection
- Both direct `err.code` and nested `cause.code` are handled
- Local-service lease is released on original failure, retry failure, and retry success
- Non-socket errors are rethrown immediately
- Single retry limit prevents infinite loops

**What was not tested:** Full integration test with actual UND_ERR_SOCKET in a real gateway run (requires specific network conditions).