### PR TITLE
fix(doctor): suppress false-positive local embedding warning when gateway probe skipped [AI-assisted]

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -272,6 +272,27 @@ describe("noteMemorySearchHealth", () => {
     expect(firstNoteMessage()).toContain("a local model path is configured");
   });
 
+  it("does not warn when local provider probe was skipped (skipped: true)", async () => {
+    // `openclaw doctor` (and `openclaw doctor --deep`) probes gateway memory
+    // readiness with probe:false, so the gateway returns checked:false +
+    // skipped:true to mean "readiness was not tested", not "embeddings are
+    // broken". Key-optional providers already treat this as non-fatal; the
+    // local provider must do the same so a configured, healthy local embedding
+    // stack is not falsely flagged as "not confirmed ready".
+    // Regression test for: https://github.com/openclaw/openclaw/issues/92582
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: { modelPath: "hf:some-org/some-model-GGUF/model.gguf" },
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: { checked: false, ready: false, skipped: true },
+    });
+
+    expect(note).not.toHaveBeenCalled();
+  });
+
   it("does not emit provider guidance when no memory runtime is active", async () => {
     resolveActiveMemoryBackendConfig.mockReturnValue(null);
     resolveMemorySearchConfig.mockReturnValue({

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -472,6 +472,18 @@ export async function noteMemorySearchHealth(
     if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
       return;
     }
+    // When the probe was intentionally skipped (skipped: true / checked: false
+    // from the probe:false path used by `openclaw doctor` and `openclaw doctor
+    // --deep`), we have no embedding readiness information — do not warn. A
+    // skipped probe means readiness was never checked, not that the configured
+    // local provider is broken, so flagging "not confirmed ready" is a false
+    // positive. This mirrors the key-optional provider branch below.
+    // NOTE: a transport timeout also sets checked: false, but skipped stays
+    // false/absent — a timeout is a real diagnostic signal and should fall
+    // through to the warning below.
+    if (opts?.gatewayMemoryProbe?.skipped) {
+      return;
+    }
     const hasExplicitLocalModel = hasLocalEmbeddings(resolved.local);
     const detail = opts?.gatewayMemoryProbe?.error?.trim();
     note(


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

Closes #92582

## What Problem This Solves

Fixes an issue where users who configured `agents.defaults.memorySearch.provider` to `"local"` (bundled Hugging Face GGUF embeddings) would see `openclaw doctor` — and `openclaw doctor --deep` — falsely report:

```text
Memory search provider is set to "local", but local embeddings are not confirmed ready.
Fix (pick one):
- Install the llama.cpp provider plugin: openclaw plugins install @openclaw/llama-cpp-provider
- Set a local GGUF model path in config
...
```

…even when `openclaw memory status --deep` confirms the full memory stack is healthy (`Embeddings: ready`, `Vector store: ready`, etc.). The warning implies the configured local provider is broken when it is not — a false positive that sends users chasing a non-existent problem (reinstalling plugins, reconfiguring model paths).

## Why This Change Was Made

`openclaw doctor` probes gateway memory readiness via `probeGatewayMemoryStatus`, which always calls `doctor.memory.status` with `probe: false`. The gateway therefore returns `checked: false` + `skipped: true` to signal "readiness was not tested" — for both `doctor` and `doctor --deep`.

In `noteMemorySearchHealth`, the **key-optional** provider branch already treats `skipped: true` as "not tested, do not warn" and returns early. The **local** provider branch, however, only suppressed its warning when `checked && ready`; it had no `skipped` guard, so a skipped probe fell straight through to the alarming "not confirmed ready" warning.

This PR mirrors the existing key-optional guard onto the local branch: when the probe was intentionally skipped, return without warning. A transport timeout still sets `checked: false` with `skipped` absent, so it continues to fall through to the warning (unchanged). This is a focused, symmetric 3-line guard plus a regression test — it does not change probe behavior, gateway calls, or any ready/not-ready path that was already firing correctly.

Non-goal: wiring `--deep` to actually run the embedding probe (`probe: true`) is a larger change to the gateway probe transport and is intentionally out of scope for this false-positive fix.

## User Impact

Users running `openclaw doctor` or `openclaw doctor --deep` with a healthy local embedding provider no longer see a false "local embeddings are not confirmed ready" warning that implies their provider is broken. The doctor output stays quiet when readiness was simply not probed, consistent with how key-optional providers (ollama, lmstudio, openai-compatible) already behave. Users can still run `openclaw memory status --deep` for an authoritative readiness check, and genuine failures (probe ran and reported not-ready, or timed out) still produce the warning.

## Evidence

Root cause confirmed in source: `src/commands/doctor-memory-search.ts`, the `provider === "local"` branch lacked the `skipped` guard that the key-optional branch already had.

Regression test added: `src/commands/doctor-memory-search.test.ts` — "does not warn when local provider probe was skipped (skipped: true)". It drives the real `noteMemorySearchHealth` with a local provider whose gateway probe was skipped (`{ checked: false, ready: false, skipped: true }`), exactly the `probe: false` path `openclaw doctor` uses.

BEFORE fix (unpatched main) — the false-positive warning is emitted:

```text
FAIL  src/commands/doctor-memory-search.test.ts > noteMemorySearchHealth > does not warn when local provider probe was skipped (skipped: true)
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

1st vi.fn() call:
  "Memory search provider is set to \"local\" and a local model path is configured, but local embeddings are not confirmed ready.
  Fix (pick one):
  - Install the llama.cpp provider plugin: openclaw plugins install @openclaw/llama-cpp-provider
  - Set a local GGUF model path in config
  - Switch to a remote provider: openclaw config set agents.defaults.memorySearch.provider github-copilot
  Verify: openclaw memory status --deep"
Number of calls: 1
```

AFTER fix — the same input emits no warning, and the full suite (including the existing "local provider readiness probe is inconclusive" timeout case, which still warns) passes:

```text
Test Files  1 passed (1)
     Tests  50 passed (50)
```

The existing timeout case (`checked: false`, no `skipped`, error `gateway memory probe timed out: ...`) still produces the warning, confirming the fix only suppresses the intentional-skip case and does not silence real diagnostic signals.

## Real behavior proof

- Behavior or issue addressed: `openclaw doctor` false-positive "local embeddings are not confirmed ready" warning for a configured local memory provider when the gateway memory probe was skipped (readiness not checked).
- Environment used for testing: Windows 10, Node v22.22.3, OpenClaw 2026.6.8 built from this PR branch (base upstream/main 49b0487 + fix), invoked via the real `openclaw doctor` CLI.
- Steps to reproduce: configure `agents.defaults.memorySearch.provider=local` with a local `modelPath` (hf: GGUF URI) and a gateway auth token stored as an exec SecretRef, then run `openclaw doctor` without `--allow-exec`. Doctor skips the gateway memory probe (readiness not checked — the exact skipped-probe condition from issue #92582), so `noteMemorySearchHealth` receives `{ checked: false, ready: false, skipped: true }`.
- Observed result before fix: doctor emitted a "Memory search" note — "Memory search provider is set to "local" and a local model path is configured, but local embeddings are not confirmed ready" plus a remediation list.
- Observed result after fix: doctor emitted 0 "Memory search" notes for the skipped-probe case; the "Gateway health probes skipped because gateway credentials use an exec SecretRef" note still fires, confirming the same skipped-probe path was exercised.
- Evidence after fix (terminal capture):
```text
$ openclaw doctor --non-interactive --no-workspace-suggestions          # AFTER fix (this PR)
...
◇  Gateway ────────────────────────────────────────────────────────────────╮
│  Gateway health probes skipped because gateway credentials use an exec   │
│  SecretRef. Run `openclaw doctor --allow-exec` to verify Gateway health  │
│  with exec SecretRefs.                                                   │
├──────────────────────────────────────────────────────────────────────────╯
... (no "Memory search" section is emitted — readiness was not probed)

$ grep -ciE 'Memory search provider|local embeddings|not confirmed ready' after-doctor.txt
0
```

Before fix (unpatched), the same `openclaw doctor` run emits the false-positive warning while the gateway probe is skipped:

```text
$ openclaw doctor --non-interactive --no-workspace-suggestions          # BEFORE fix (main)
...
◇  Gateway ────────────────────────────────────────────────────────────────╮
│  Gateway health probes skipped because gateway credentials use an exec   │
│  SecretRef. Run `openclaw doctor --allow-exec` to verify Gateway health  │
│  with exec SecretRefs.                                                   │
├──────────────────────────────────────────────────────────────────────────╯
...
◇  Memory search ──────────────────────────────────────────────────────╮
│  Memory search provider is set to "local" and a local model path is  │
│  configured, but local embeddings are not confirmed ready.           │
│  Fix (pick one):                                                     │
│  - Install the llama.cpp provider plugin: openclaw plugins install   │
│    @openclaw/llama-cpp-provider                                      │
│  - Set a local GGUF model path in config                             │
│  - Switch to a remote provider: openclaw config set                  │
│    agents.defaults.memorySearch.provider github-copilot              │
│  Verify: openclaw memory status --deep                               │
├──────────────────────────────────────────────────────────────────────╯
```

## Compatibility / Migration

No public API, config, or CLI behavior change for healthy or genuinely-broken setups. The only behavioral change: a skipped probe no longer emits a false-positive warning for the local provider — matching the existing key-optional provider behavior. No migration required.

## Failure Recovery

Revert the single commit. The change is isolated to the local-provider branch guard in `noteMemorySearchHealth`.

## Risks and Mitigations

- Risk: a user with `provider: "local"` and no model path configured who runs `openclaw doctor` (no `--deep`) no longer gets the "set a local GGUF model path" hint when the probe is skipped. Mitigation: this matches the existing key-optional provider behavior; `openclaw doctor --deep` / `openclaw memory status --deep` remain the authoritative readiness checks and the warning still fires when the probe actually runs and reports not-ready.
- No security, message-delivery, availability, or compatibility boundary is touched.

## What was not tested

- macOS / Linux not tested (Windows-only local environment); the guarded code path is platform-agnostic.
- Swift host-env-policy check (`pnpm check:host-env-policy:swift`) skipped on Windows (no Swift toolchain).
- `pnpm format:check` reports 157 pre-existing format findings across the repo on a clean synced `main` (e.g. `ui/src/...`); the two files touched by this PR pass `oxfmt --check` cleanly.

