### PR TITLE
fix(telegram): honor ingest before media skip

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -14,6 +14,7 @@ import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
 } from "openclaw/plugin-sdk/channel-inbound-debounce";
+import { resolveChannelGroupPolicy } from "openclaw/plugin-sdk/channel-policy";
 import { resolveStoredModelOverride } from "openclaw/plugin-sdk/command-auth-native";
 import { hasControlCommand } from "openclaw/plugin-sdk/command-detection";
 import { isAbortRequestText } from "openclaw/plugin-sdk/command-primitives-runtime";
@@ -824,6 +825,20 @@ export const registerTelegramHandlers = ({
       resolveGroupRequireMention(chatId),
     );
     if (!requireMention) {
+      return false;
+    }
+
+    const telegramGroupPolicy = resolveChannelGroupPolicy({
+      cfg: runtimeCfg,
+      channel: "telegram",
+      groupId: String(chatId),
+      accountId,
+    });
+    const ingestEnabled =
+      topicConfig?.ingest ??
+      telegramGroupPolicy.groupConfig?.ingest ??
+      telegramGroupPolicy.defaultConfig?.ingest;
+    if (ingestEnabled === true) {
       return false;
     }
 

--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -488,6 +488,43 @@ describe("createTelegramBot channel_post media", () => {
     }
   });
 
+  it("downloads unmentioned requireMention group media when ingest is enabled (#92067)", async () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: { "*": { requireMention: true, ingest: true } },
+        },
+      },
+    });
+    const getFile = vi.fn(async () => ({ file_path: "photos/p1.jpg" }));
+    const fetchSpy = createImageFetchSpy();
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+      await handler({
+        message: {
+          chat: { id: -100456, type: "supergroup", title: "Ops Chat" },
+          message_id: 92067,
+          date: 1736380800,
+          photo: [{ file_id: "p1" }],
+          from: { id: 55, is_bot: false, first_name: "u" },
+        },
+        me: { id: 999, username: "openclaw_bot" },
+        getFile,
+      });
+
+      await waitForMockCalls(getFile, 1);
+
+      expect(getFile).toHaveBeenCalledTimes(1);
+      expect(sendMessageSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("notifies mentioned requireMention groups when media download fails", async () => {
     loadConfig.mockReturnValue({
       channels: {


### PR DESCRIPTION
## Summary

Honor Telegram ingest configuration before the unaddressed requireMention media skip so configured ingest hooks still receive group media.

## Changes

- resolve Telegram group policy before the requireMention media early return
- bypass the skip when topic/group/default ingest is explicitly enabled
- add a regression test covering unmentioned group media with `ingest: true`

## Testing

- `./node_modules/.bin/vitest run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts --reporter=dot`

Fixes openclaw/openclaw#92067