### PR TITLE
fix(gateway): accept --port for health and probe

### DIFF
--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
     ok: true,
   })),
   gatewayStatusCommand: vi.fn(async (_opts: unknown, _runtime: unknown) => {}),
+  readBestEffortConfig: vi.fn(async () => ({})),
   defaultRuntime: {
     log: vi.fn(),
     error: vi.fn(),
@@ -47,6 +48,7 @@ vi.mock("./call.js", () => ({
   gatewayCallOpts: (cmd: Command) =>
     cmd
       .option("--url <url>", "Gateway WebSocket URL")
+      .option("--port <port>", "Gateway port")
       .option("--token <token>", "Gateway token")
       .option("--password <password>", "Gateway password")
       .option("--timeout <ms>", "Timeout in ms", "10000")
@@ -72,7 +74,7 @@ vi.mock("../../commands/health.js", () => ({
 }));
 
 vi.mock("../../config/read-best-effort-config.runtime.js", () => ({
-  readBestEffortConfig: async () => ({}),
+  readBestEffortConfig: () => mocks.readBestEffortConfig(),
   readSourceConfigBestEffort: async () => ({}),
 }));
 
@@ -147,9 +149,29 @@ describe("gateway register option collisions", () => {
     defaultRuntime.writeStdout.mockClear();
     defaultRuntime.writeJson.mockClear();
     defaultRuntime.exit.mockClear();
+    mocks.readBestEffortConfig.mockClear();
+    mocks.readBestEffortConfig.mockResolvedValue({});
   });
 
   it.each([
+    {
+      name: "registers gateway health --port so the flag is no longer rejected",
+      argv: ["gateway", "health", "--json"],
+      assert: () => {
+        const gateway = sharedProgram.commands.find((command) => command.name() === "gateway");
+        const health = gateway?.commands.find((command) => command.name() === "health");
+        expect(health?.options.some((option) => option.long === "--port")).toBe(true);
+      },
+    },
+    {
+      name: "accepts gateway probe --port and forwards it to status probing",
+      argv: ["gateway", "probe", "--port", "19001", "--json"],
+      assert: () => {
+        expect(gatewayStatusCommand).toHaveBeenCalledTimes(1);
+        const [opts] = firstGatewayStatusCall();
+        expect((opts as { port?: string } | undefined)?.port).toBe("19001");
+      },
+    },
     {
       name: "forwards --token to gateway call when parent and child option names collide",
       argv: ["gateway", "call", "health", "--token", "tok_call", "--json"],

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -19,6 +19,7 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { addGatewayServiceCommands } from "../daemon-cli/register-service-commands.js";
 import { formatHelpExamples } from "../help-format.js";
+import { parsePort } from "../shared/parse-port.js";
 import type { GatewayRpcOpts } from "./call.js";
 import type { GatewayDiscoverOpts } from "./discover.js";
 import { addGatewayRunCommand } from "./run-command.js";
@@ -91,6 +92,7 @@ function loadDaemonStatusGatherModule() {
 function gatewayCallOpts(cmd: Command): Command {
   return cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
+    .option("--port <port>", "Gateway port for local loopback targeting")
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (password auth)")
     .option("--timeout <ms>", "Timeout in ms", "10000")
@@ -165,6 +167,30 @@ function resolveGatewayRpcOptions<T extends { token?: string; password?: string 
     ...opts,
     token: opts.token ?? parentToken,
     password: opts.password ?? parentPassword,
+  };
+}
+
+async function applyGatewayPortConfigOverride<T extends GatewayRpcOpts & { port?: unknown }>(
+  opts: T,
+): Promise<T> {
+  if (opts.port === undefined) {
+    return opts;
+  }
+  const port = parsePort(opts.port);
+  if (port === null) {
+    throw new Error(`Invalid --port value: ${String(opts.port)}`);
+  }
+  const { readBestEffortConfig } = await loadConfigModule();
+  const cfg = await readBestEffortConfig();
+  return {
+    ...opts,
+    config: {
+      ...cfg,
+      gateway: {
+        ...cfg.gateway,
+        port,
+      },
+    },
   };
 }
 
@@ -556,7 +582,9 @@ export function registerGatewayCli(program: Command) {
       .action(async (opts, command) => {
         await runGatewayCommand(
           async () => {
-            const rpcOpts = resolveGatewayRpcOptions(opts, command);
+            const rpcOpts = await applyGatewayPortConfigOverride(
+              resolveGatewayRpcOptions(opts, command),
+            );
             const [
               { emitReachableGatewayAuthDiagnostic, formatHealthChannelLines },
               { styleHealthChannelLine },
@@ -728,6 +756,7 @@ export function registerGatewayCli(program: Command) {
       "Show gateway reachability, auth capability, and read-probe summary (local + remote)",
     )
     .option("--url <url>", "Explicit Gateway WebSocket URL (still probes localhost)")
+    .option("--port <port>", "Gateway port for local loopback and remote probes")
     .option("--ssh <target>", "SSH target for remote gateway tunnel (user@host or user@host:port)")
     .option("--ssh-identity <path>", "SSH identity file path")
     .option("--ssh-auto", "Try to derive an SSH target from Bonjour discovery", false)

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -1,6 +1,7 @@
 /** CLI entrypoint for `openclaw gateway status`. */
 import { isRich } from "../../packages/terminal-core/src/theme.js";
 import { withProgress } from "../cli/progress.js";
+import { parsePort } from "../cli/shared/parse-port.js";
 import { readBestEffortConfig, resolveGatewayPort } from "../config/config.js";
 import { resolveWideAreaDiscoveryDomain } from "../infra/widearea-dns.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -40,6 +41,7 @@ function loadGatewayTlsModule() {
 export async function gatewayStatusCommand(
   opts: {
     url?: string;
+    port?: unknown;
     token?: string;
     password?: string;
     timeout?: unknown;
@@ -52,15 +54,19 @@ export async function gatewayStatusCommand(
 ) {
   const startedAt = Date.now();
   const cfg = await readBestEffortConfig();
+  const portOverride = parsePort(opts.port);
+  if (opts.port !== undefined && portOverride === null) {
+    throw new Error(`Invalid --port value: ${String(opts.port)}`);
+  }
   const rich = isRich() && opts.json !== true;
   const defaultTimeoutMs = Math.max(3000, cfg.gateway?.handshakeTimeoutMs ?? 0);
   const overallTimeoutMs = parseTimeoutMs(opts.timeout, defaultTimeoutMs);
   const wideAreaDomain = resolveWideAreaDiscoveryDomain({
     configDomain: cfg.discovery?.wideArea?.domain,
   });
-  const baseTargets = resolveTargets(cfg, opts.url);
+  const baseTargets = resolveTargets(cfg, opts.url, portOverride ?? undefined);
   const network = buildNetworkHints(cfg);
-  const remotePort = resolveGatewayPort(cfg);
+  const remotePort = portOverride ?? resolveGatewayPort(cfg);
   const discoveryTimeoutMs = Math.min(1200, overallTimeoutMs);
 
   let sshTarget = sanitizeSshTarget(opts.ssh) ?? sanitizeSshTarget(cfg.gateway?.remote?.sshTarget);

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -87,7 +87,11 @@ function normalizeWsUrl(value: string): string | null {
 }
 
 /** Builds the deduplicated ordered gateway probe targets from CLI input and config. */
-export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): GatewayStatusTarget[] {
+export function resolveTargets(
+  cfg: OpenClawConfig,
+  explicitUrl?: string,
+  portOverride?: number,
+): GatewayStatusTarget[] {
   const targets: GatewayStatusTarget[] = [];
   const add = (t: GatewayStatusTarget) => {
     if (!targets.some((x) => x.url === t.url)) {
@@ -111,7 +115,7 @@ export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): Gatew
     });
   }
 
-  const port = resolveGatewayPort(cfg);
+  const port = portOverride ?? resolveGatewayPort(cfg);
   const localScheme = cfg.gateway?.tls?.enabled === true ? "wss" : "ws";
   add({
     id: "localLoopback",


### PR DESCRIPTION
## Summary

Allow `gateway health` and `gateway probe` to accept the same `--port` override already supported by `gateway run`, so loopback checks can target non-default gateway ports.

## Changes

- add `--port` support to `gateway health` command registration
- thread the parsed port override through `gateway probe` target resolution and remote port inference
- extend CLI coverage for the new flag on health/probe paths

## Testing

- `./node_modules/.bin/vitest run --config test/vitest/vitest.cli.config.ts src/cli/gateway-cli/register.option-collisions.test.ts --reporter=dot`

Fixes openclaw/openclaw#79100