### PR TITLE
fix(telegram): materialize streaming progress placeholders

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -336,7 +336,8 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     Requirement:
 
     - `channels.telegram.streaming` is `off | partial | block | progress` (default: `partial`)
-    - `progress` keeps one editable status draft for tool progress, clears it at completion, and sends the final answer as a normal message
+    - short initial answer previews are debounced, then materialized after a bounded delay if the run is still active
+    - `progress` keeps one editable status draft for tool progress, shows the stable status label when answer activity arrives before tool progress, clears it at completion, and sends the final answer as a normal message
     - `streaming.preview.toolProgress` controls whether tool/progress updates reuse the same edited preview message (default: `true` when preview streaming is active)
     - `streaming.preview.commandText` controls command/exec detail inside those tool-progress lines: `raw` (default, preserves released behavior) or `status` (tool label only)
     - `streaming.progress.commentary` (default: `false`) opts into assistant commentary/preamble text in the temporary progress draft

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -160,9 +160,10 @@ Legacy key migration:
 Telegram:
 
 - Uses `sendMessage` + `editMessageText` preview updates across DMs and group/topics.
+- Short initial previews are still debounced for push-notification UX, but Telegram now materializes them after a bounded delay so active runs do not stay visually silent.
 - Final text edits the active preview in place; long finals reuse that message for the first chunk and send only the remaining chunks.
 - `block` mode rotates the preview into a new message at `streaming.preview.chunk.maxChars` (default 800, capped at Telegram's 4096 edit limit); other modes grow one preview up to 4096 characters.
-- `progress` mode keeps tool progress in an editable status draft, clears that draft at completion, and sends the final answer through normal delivery.
+- `progress` mode keeps tool progress in an editable status draft, materializes the status label when answer streaming is active but no tool line is available yet, clears that draft at completion, and sends the final answer through normal delivery.
 - If the final edit fails before the completed text is confirmed, OpenClaw uses normal final delivery and cleans up the stale preview.
 - Preview streaming is skipped when Telegram block streaming is explicitly enabled (to avoid double-streaming).
 - `/reasoning stream` can write reasoning to a transient preview that is deleted after final delivery.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -637,6 +637,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       chatId: 123,
       thread: { id: 777, scope: "dm" },
       minInitialChars: 30,
+      minInitialDelayMs: 5000,
     });
     expect(draftStream.update).toHaveBeenCalledWith("Hello");
     const delivery = expectDeliverRepliesParams({ thread: { id: 777, scope: "dm" } });
@@ -2598,6 +2599,27 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
     expectDeliveredReply(0, { text: "Branch is up to date" });
     expect(editMessageTelegram).not.toHaveBeenCalled();
+  });
+
+  it("shows a stable progress placeholder for progress-mode answer activity", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onPartialReply?.({ text: "Short" });
+      await replyOptions?.onPartialReply?.({ text: "Short answer" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+    });
+
+    expect(answerDraftStream.update).not.toHaveBeenCalledWith("Short");
+    expect(answerDraftStream.update).not.toHaveBeenCalledWith("Short answer");
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+      telegramHtmlPreview("<b>Shelling</b>"),
+    );
   });
 
   it("replaces Telegram command progress items with matching command output", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -152,6 +152,7 @@ const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-d
 
 /** Minimum chars before sending first streaming message (improves push notification UX) */
 const DRAFT_MIN_INITIAL_CHARS = 30;
+const DRAFT_MIN_INITIAL_DELAY_MS = 5_000;
 
 type DraftPartialTextUpdate = {
   text: string;
@@ -1005,6 +1006,7 @@ export const dispatchTelegramMessage = async ({
           replyToMessageId: draftReplyToMessageId,
           richMessages: telegramCfg.richMessages,
           minInitialChars: draftMinInitialChars,
+          minInitialDelayMs: draftMinInitialChars > 0 ? DRAFT_MIN_INITIAL_DELAY_MS : undefined,
           renderText: renderStreamText,
           onSupersededPreview: (superseded) => {
             if (superseded.retain) {
@@ -1364,7 +1366,7 @@ export const dispatchTelegramMessage = async ({
       recomputeQueuedAnswerBlockRotations();
     }
   };
-  const updateDraftFromPartial = (lane: DraftLaneState, update: DraftPartialTextUpdate) => {
+  const updateDraftFromPartial = async (lane: DraftLaneState, update: DraftPartialTextUpdate) => {
     const laneStream = lane.stream;
     if (!laneStream || !update.text) {
       return;
@@ -1376,6 +1378,7 @@ export const dispatchTelegramMessage = async ({
     }
     if (lane === answerLane) {
       if (streamMode === "progress") {
+        await progressDraft.noteActivity();
         return;
       }
       resetAnswerToolProgressDraft();
@@ -1402,7 +1405,7 @@ export const dispatchTelegramMessage = async ({
         reasoningStepState.noteReasoningHint();
         reasoningStepState.noteReasoningDelivered();
       }
-      updateDraftFromPartial(lanes[segment.lane], segment.update);
+      await updateDraftFromPartial(lanes[segment.lane], segment.update);
     }
   };
   const flushDraftLane = async (lane: DraftLaneState) => {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -934,6 +934,23 @@ describe("draft stream initial message debounce", () => {
       expectPreviewSend(api, "Processing");
     });
 
+    it("cancels a delayed first message when clear() removes the draft", async () => {
+      const api = createMockApi();
+      const stream = createDebouncedStream(api, 30, 5000);
+
+      stream.update("Processing");
+      await stream.flush();
+      expect(api.sendMessage).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(1);
+
+      await stream.clear();
+      expect(vi.getTimerCount()).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(api.sendMessage).not.toHaveBeenCalled();
+      expect(api.editMessageText).not.toHaveBeenCalled();
+    });
+
     it("works with longer text above threshold", async () => {
       const api = createMockApi();
       const stream = createDebouncedStream(api);

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -843,11 +843,16 @@ describe("createTelegramDraftStream", () => {
 describe("draft stream initial message debounce", () => {
   const createMockApi = () => createMockDraftApi(async () => ({ message_id: 42 }));
 
-  function createDebouncedStream(api: ReturnType<typeof createMockApi>, minInitialChars = 30) {
+  function createDebouncedStream(
+    api: ReturnType<typeof createMockApi>,
+    minInitialChars = 30,
+    minInitialDelayMs?: number,
+  ) {
     return createTelegramDraftStream({
       api: api as unknown as Bot["api"],
       chatId: 123,
       minInitialChars,
+      minInitialDelayMs,
     });
   }
 
@@ -914,6 +919,19 @@ describe("draft stream initial message debounce", () => {
       await stream.flush();
 
       expect(api.sendMessage).toHaveBeenCalled();
+    });
+
+    it("materializes a short first message after the initial delay", async () => {
+      const api = createMockApi();
+      const stream = createDebouncedStream(api, 30, 5000);
+
+      stream.update("Processing");
+      await stream.flush();
+      expect(api.sendMessage).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expectPreviewSend(api, "Processing");
     });
 
     it("works with longer text above threshold", async () => {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -229,7 +229,6 @@ export function createTelegramDraftStream(params: {
   let lastRequestedPreview: TelegramDraftPreview | undefined;
   let firstShortPreviewSeenMs: number | undefined;
   let initialPreviewTimer: ReturnType<typeof setTimeout> | undefined;
-  let flushInitialPreview: (() => Promise<void>) | undefined;
   let previewRevision = 0;
   let generation = 0;
   let deliveredTextOffset = 0;
@@ -509,7 +508,7 @@ export function createTelegramDraftStream(params: {
     state: streamState,
     sendOrEditStreamMessage,
   });
-  flushInitialPreview = loop.flush;
+  const flushInitialPreview = loop.flush;
 
   const requestDraftUpdate = (text: string, preview?: TelegramDraftPreview) => {
     if (streamState.stopped || streamState.final) {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -331,13 +331,13 @@ export function createTelegramDraftStream(params: {
     }
   };
   const scheduleInitialPreviewFlush = (delayMs: number) => {
-    if (initialPreviewTimer || !flushInitialPreview) {
+    if (initialPreviewTimer) {
       return;
     }
     initialPreviewTimer = setTimeout(
       () => {
         initialPreviewTimer = undefined;
-        void flushInitialPreview?.().catch((err: unknown) => {
+        void flushInitialPreview().catch((err: unknown) => {
           params.warn?.(`telegram stream preview delayed send failed: ${formatErrorMessage(err)}`);
         });
       },

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -570,6 +570,7 @@ export function createTelegramDraftStream(params: {
   };
 
   const clear = async () => {
+    clearInitialPreviewTimer();
     const messageId = await takeMessageIdAfterStop({
       stopForClear,
       readMessageId: () => streamMessageId,

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -178,6 +178,8 @@ export function createTelegramDraftStream(params: {
   throttleMs?: number;
   /** Minimum chars before sending first message (debounce for push notifications) */
   minInitialChars?: number;
+  /** Maximum time to hold a short first preview before materializing it anyway. */
+  minInitialDelayMs?: number;
   /** Optional preview renderer (e.g. markdown -> HTML + parse mode). */
   renderText?: (text: string) => TelegramDraftPreview;
   /** Called when a late send resolves after forceNewMessage() switched generations. */
@@ -190,6 +192,7 @@ export function createTelegramDraftStream(params: {
   const maxChars = Math.min(params.maxChars ?? transportLimit, transportLimit);
   const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
   const minInitialChars = params.minInitialChars;
+  const minInitialDelayMs = params.minInitialDelayMs;
   const chatId = params.chatId;
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyToMessageId = normalizeTelegramReplyToMessageId(params.replyToMessageId);
@@ -224,6 +227,9 @@ export function createTelegramDraftStream(params: {
   let lastDeliveredText = "";
   let lastRequestedText = "";
   let lastRequestedPreview: TelegramDraftPreview | undefined;
+  let firstShortPreviewSeenMs: number | undefined;
+  let initialPreviewTimer: ReturnType<typeof setTimeout> | undefined;
+  let flushInitialPreview: (() => Promise<void>) | undefined;
   let previewRevision = 0;
   let generation = 0;
   let deliveredTextOffset = 0;
@@ -319,6 +325,26 @@ export function createTelegramDraftStream(params: {
     streamVisibleSinceMs = visibleSinceMs;
     return true;
   };
+  const clearInitialPreviewTimer = () => {
+    if (initialPreviewTimer) {
+      clearTimeout(initialPreviewTimer);
+      initialPreviewTimer = undefined;
+    }
+  };
+  const scheduleInitialPreviewFlush = (delayMs: number) => {
+    if (initialPreviewTimer || !flushInitialPreview) {
+      return;
+    }
+    initialPreviewTimer = setTimeout(
+      () => {
+        initialPreviewTimer = undefined;
+        void flushInitialPreview?.().catch((err: unknown) => {
+          params.warn?.(`telegram stream preview delayed send failed: ${formatErrorMessage(err)}`);
+        });
+      },
+      Math.max(0, delayMs),
+    );
+  };
   const stopOversizedPreview = (payloadLength: number): false => {
     streamState.stopped = true;
     params.warn?.(`telegram stream preview stopped (text length ${payloadLength} > ${maxChars})`);
@@ -405,8 +431,24 @@ export function createTelegramDraftStream(params: {
 
     if (typeof streamMessageId !== "number" && minInitialChars != null && !streamState.final) {
       if (renderedText.length < minInitialChars) {
-        return false;
+        if (minInitialDelayMs == null) {
+          return false;
+        }
+        const now = Date.now();
+        firstShortPreviewSeenMs ??= now;
+        const remainingDelayMs = minInitialDelayMs - (now - firstShortPreviewSeenMs);
+        if (remainingDelayMs > 0) {
+          scheduleInitialPreviewFlush(remainingDelayMs);
+          return false;
+        }
+        clearInitialPreviewTimer();
+      } else {
+        firstShortPreviewSeenMs = undefined;
+        clearInitialPreviewTimer();
       }
+    } else {
+      firstShortPreviewSeenMs = undefined;
+      clearInitialPreviewTimer();
     }
 
     const previousSentPreviewKey = lastSentPreviewKey;
@@ -467,6 +509,7 @@ export function createTelegramDraftStream(params: {
     state: streamState,
     sendOrEditStreamMessage,
   });
+  flushInitialPreview = loop.flush;
 
   const requestDraftUpdate = (text: string, preview?: TelegramDraftPreview) => {
     if (streamState.stopped || streamState.final) {
@@ -513,6 +556,8 @@ export function createTelegramDraftStream(params: {
     messageSendAttempted = false;
     streamMessageId = undefined;
     streamVisibleSinceMs = undefined;
+    firstShortPreviewSeenMs = undefined;
+    clearInitialPreviewTimer();
     lastSentPreviewKey = "";
     if (options?.resetOffset !== false) {
       deliveredTextOffset = 0;
@@ -544,6 +589,7 @@ export function createTelegramDraftStream(params: {
   };
 
   const discard = async () => {
+    clearInitialPreviewTimer();
     await stopForClear();
   };
 

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -44,6 +44,31 @@ describe("createChannelProgressDraftCompositor", () => {
     }
   });
 
+  it("does not materialize delayed answer activity after final delivery starts or lands", async () => {
+    vi.useFakeTimers();
+    try {
+      for (const markFinal of ["markFinalReplyStarted", "markFinalReplyDelivered"] as const) {
+        const update = vi.fn();
+        const progress = createChannelProgressDraftCompositor({
+          entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+          mode: "progress",
+          active: true,
+          seed: "test",
+          update,
+        });
+
+        await progress.noteActivity();
+        progress[markFinal]();
+        await vi.advanceTimersByTimeAsync(DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS);
+
+        expect(update).not.toHaveBeenCalled();
+        expect(progress.hasStarted).toBe(false);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("starts a label-only progress draft on repeated upstream answer activity", async () => {
     const update = vi.fn();
     const progress = createChannelProgressDraftCompositor({

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -21,6 +21,45 @@ describe("createChannelProgressDraftCompositor", () => {
     expect(update).toHaveBeenCalledWith("Shelling", { flush: true, lines: [] });
   });
 
+  it("materializes a label-only progress draft after upstream answer activity", async () => {
+    vi.useFakeTimers();
+    try {
+      const update = vi.fn();
+      const progress = createChannelProgressDraftCompositor({
+        entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+        mode: "progress",
+        active: true,
+        seed: "test",
+        update,
+      });
+
+      await progress.noteActivity();
+      expect(update).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS);
+
+      expect(update).toHaveBeenCalledWith("Shelling", { flush: true, lines: [] });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("starts a label-only progress draft on repeated upstream answer activity", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      update,
+    });
+
+    await progress.noteActivity();
+    await progress.noteActivity();
+
+    expect(update).toHaveBeenCalledWith("Shelling", { flush: true, lines: [] });
+  });
+
   it("passes structured progress lines to draft updates", async () => {
     const update = vi.fn();
     const progress = createChannelProgressDraftCompositor({

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -81,7 +81,7 @@ export function createChannelProgressDraftCompositor(params: {
   };
 
   const render = async (options?: { flush?: boolean }): Promise<boolean> => {
-    if (!params.active || params.mode !== "progress") {
+    if (!params.active || params.mode !== "progress" || finalReplyStarted || finalReplyDelivered) {
       return false;
     }
     const text = formatDraftText();
@@ -197,9 +197,11 @@ export function createChannelProgressDraftCompositor(params: {
     },
     markFinalReplyStarted() {
       finalReplyStarted = true;
+      gate.cancel();
     },
     markFinalReplyDelivered() {
       finalReplyDelivered = true;
+      gate.cancel();
     },
     reset() {
       clearProgressState(false);

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -216,6 +216,27 @@ export function createChannelProgressDraftCompositor(params: {
     start() {
       return gate.startNow();
     },
+    async noteActivity(options?: { startImmediately?: boolean }) {
+      if (
+        !params.active ||
+        params.mode !== "progress" ||
+        progressSuppressed ||
+        finalReplyStarted ||
+        finalReplyDelivered
+      ) {
+        return false;
+      }
+      if (options?.startImmediately) {
+        await gate.startNow();
+        return gate.hasStarted ? await render({ flush: true }) : false;
+      }
+      const alreadyStarted = gate.hasStarted;
+      const progressActive = await gate.noteWork();
+      if ((alreadyStarted || progressActive) && gate.hasStarted) {
+        return await render();
+      }
+      return false;
+    },
     pushToolProgress: noteProgress,
     async pushReasoningProgress(text?: string, options?: { snapshot?: boolean }) {
       if (


### PR DESCRIPTION
## What Problem This Solves

Fixes #95004.

Telegram preview streaming had two source-proven silent paths that made Telegram feel stuck even while upstream/Web draft state existed:

- short first previews below `minInitialChars` could remain unsent for the whole active turn;
- `progress` mode dropped answer-lane partial activity when no tool/progress row existed yet, so Telegram could stay silent while Web had upstream draft/progress state.

This PR keeps Telegram's existing one-preview/no-spam policy, but makes the silence bounded and predictable.


## Related Work / Scope Boundary

Related: #82303 (`feat(telegram): add progress assistant preview lane`).

This PR and #82303 both address Telegram feeling silent while upstream answer activity exists in `progress`-style streaming, but they intentionally choose different product shapes:

- #82303 adds an **opt-in** `streaming.progress.assistantPreview` path that keeps the existing progress/tool draft and streams assistant partials on a separate transient assistant preview lane.
- This PR keeps the existing default Telegram `progress` semantics narrower: it only materializes a stable label-only progress placeholder when answer activity would otherwise be invisible, and it does **not** stream assistant answer text into the progress draft.
- This PR also separately bounds short first-preview silence for non-progress answer previews via `minInitialDelayMs`.

So #95183 is not a duplicate of #82303. It can coexist as the lower-risk default-silence fix, while #82303 remains the fuller opt-in two-lane assistant-preview feature if maintainers want that product behavior.

## Summary

- Add `minInitialDelayMs` to Telegram draft streams:
  - short first previews still respect the initial debounce;
  - if the turn remains active past the bounded delay, the same preview materializes instead of staying invisible forever;
  - finals and threshold-reaching previews clear the delayed timer normally.
- Add a shared progress-draft `noteActivity()` hook:
  - `progress` mode can show the stable status label when upstream answer activity exists but no tool/progress row is available yet;
  - answer text is still not leaked into the progress draft in `progress` mode.
- Wire Telegram dispatch to use a 5s delayed materialization window for non-progress answer previews.
- Update Telegram/streaming docs to describe the bounded short-preview behavior and progress-label placeholder.

## Product decision encoded

Issue #95004 was tagged for maintainer/product choice because the existing first-preview debounce is intentional. This PR chooses the least noisy fix shape:

- keep the debounce for push-notification UX;
- keep one visible Telegram preview message;
- avoid token/delta spam;
- only materialize a stable placeholder/preview when upstream activity remains active long enough to otherwise look stuck.

## Latest timer cleanup fix evidence

Latest head: `1ab0ba3ae113761e8875f75eb5c644da1ce73adf`.

This update addresses the ClawSweeper P2 finding that `createTelegramDraftStream.clear()` did not cancel a delayed first-preview timer. The fix calls `clearInitialPreviewTimer()` in `clear()` before stopping/removing the draft, and adds a fake-timer regression covering: below-threshold pending preview → `clear()` → timer count drops to zero → advancing the old delay does not send or edit a Telegram draft.

Validation run on the updated head:

```bash
git diff --check origin/main...HEAD
node scripts/run-vitest.mjs \
  extensions/telegram/src/draft-stream.test.ts \
  extensions/telegram/src/bot-message-dispatch.test.ts \
  src/channels/progress-draft-compositor.test.ts
```

Result: 193 targeted tests passed (`draft-stream` 48, `bot-message-dispatch` 130, `progress-draft-compositor` 15).

## Live Telegram Bot API timer cleanup proof

A real Telegram Bot API proof was run with the configured test bot token against a private proof chat. Token and chat identifiers are redacted in the captured evidence.

Scenario:

1. Create a Telegram draft stream with `minInitialChars: 80` and `minInitialDelayMs: 1200`.
2. Send a below-threshold first preview (`Proof <label>`), then flush once so the delayed first-preview timer is scheduled.
3. Call `clear()` before the delay elapses.
4. Wait beyond the original delay window and record Bot API calls plus runtime timer events.

Before/after evidence:

```text
#95183 before fix (70c0948...)
- after flush: active delayed timers = 1
- after clear(): active delayed timers = 1
- after 1200ms: timer fired after clear = true
- Telegram send/edit/delete calls after clear: 0/0/0

#95183 after fix (1ab0ba3...)
- after flush: active delayed timers = 1
- clear() called clearTimeout(timerId=1)
- after clear(): active delayed timers = 0
- after 1200ms: timer fired after clear = false
- Telegram send/edit/delete calls after clear: 0/0/0

#95522 before fix (3296107...)
- after flush: active delayed timers = 1
- after clear(): active delayed timers = 1
- after 1200ms: timer fired after clear = true
- Telegram send/edit/delete calls after clear: 0/0/0

#95522 after fix (ae1b0bd...)
- after flush: active delayed timers = 1
- clear() called clearTimeout(timerId=1)
- after clear(): active delayed timers = 0
- after 1200ms: timer fired after clear = false
- Telegram send/edit/delete calls after clear: 0/0/0
```

Observed result: before the fix, `clear()` removed the visible draft state but left the delayed first-preview timer alive until it fired after cleanup. After the fix, `clear()` cancels the pending timer immediately, so no delayed flush runs after draft cleanup. The live Bot API run also confirms that the cleanup scenario does not leave a stray Telegram message after the fix.

## Evidence

Local verification on this branch:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts telegram/src/draft-stream.test.ts telegram/src/bot-message-dispatch.test.ts
# 177 passed

node scripts/run-vitest.mjs run src/channels/progress-draft-compositor.test.ts
# 15 passed

pnpm docs:list
# passed

pnpm tsgo:extensions
# passed

pnpm tsgo:core
# passed

git diff --check
# passed
```

Targeted source-level proof added:

- `draft-stream.test.ts` now proves a short first preview is initially held, then materialized after the configured delay.
- `progress-draft-compositor.test.ts` now proves upstream activity can materialize a label-only progress draft after the delay or repeated activity.
- `progress-draft-compositor.test.ts` also proves pending delayed answer activity is cancelled when final delivery starts or lands, preventing stale progress placeholders after final delivery.
- `bot-message-dispatch.test.ts` now proves Telegram `progress` mode shows a stable status placeholder for answer activity without streaming answer text into that draft.

Follow-up verification after addressing ClawSweeper's delayed-final guard finding at `d2687eaed7`:

```bash
node scripts/run-vitest.mjs src/channels/progress-draft-compositor.test.ts
# 15 passed

node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts
# 130 passed

git diff --check
# passed
```

CI status after initial PR creation:

- Some repository workflows started and reported unrelated GitHub API installation rate-limit failures while listing PR files or comparing refs (`x-ratelimit-remaining: 0`). These are infrastructure/rate-limit failures, not code/test failures from this PR.
- The `Real behavior proof` workflow initially failed because external PRs require explicit authored `What Problem This Solves` and `Evidence` sections. This body now includes those sections.

## Native Telegram Bot API proof

A dedicated Telegram test bot was used for native Bot API proof. Sensitive values are intentionally not included: the bot token is omitted and the private test chat id is redacted.

- Dedicated test bot: `@snowzlmOpenClawtestBot` (`8602965171`)
- Chat: redacted private test chat
- Token: not included
- Generated at: `2026-06-20T06:22:49.182Z`

Scenarios verified:

1. PR #95007 — progress draft rows are visible as readable Telegram text.
   - Operation: `sendMessage` + `editMessageText` with Telegram HTML parse mode.
   - Message id: `4`
   - Before: `Shelling`
   - After: `Shelling` plus compact `exec running ...` and `exec passed ...` rows.
   - Checks: Bot API accepted the HTML payload; no `[object Object]` or raw object dump; rows are readable as plain text in the Telegram message.

2. PR #95183 — short first preview is bounded, not indefinitely silent.
   - Operation: delayed `sendMessage` after an intentional initial quiet window.
   - Message id: `5`
   - `minInitialChars`: `30`
   - Proof delay: `1201ms`
   - Text: `Short`
   - Checks: initially quiet; then materialized despite being below threshold.

3. PR #95183 — progress mode can show a stable label placeholder before final delivery.
   - Operation: placeholder `sendMessage`, followed by normal final `sendMessage`.
   - Placeholder message id: `6`
   - Final message id: `7`
   - Checks: placeholder visible as `Shelling`; final delivery is separate and normal; answer text is not leaked into the placeholder.

Local sanitized artifact retained in the maintenance workspace: `projects/openclaw-pr-maintenance/proofs/telegram-real/telegram-proof-1781936573613.public.md`.
### Telegram draft lifecycle proof

Additional native Bot API lifecycle proof was captured to address draft-message count and cleanup behavior:

- Dedicated test bot: `@snowzlmOpenClawtestBot` (`8602965171`)
- Chat/token: redacted
- Local sanitized artifact: `projects/openclaw-pr-maintenance/proofs/telegram-real/telegram-proof-draft-lifecycle-1781937832925.public.md`

Verified scenarios:

1. Progress draft lifecycle, covering #95007 and #95183:
   - Operations: `sendMessage(draft)` → `editMessageText(same draft id)` → `editMessageText(same draft id)` → `sendMessage(final)` → `deleteMessage(draft)`.
   - Checks: both draft edits reused the initial draft message id; the final answer was delivered as a separate normal message; `deleteMessage` for the draft returned success.

2. Short-preview lifecycle, covering #95183:
   - Operations: `sendMessage(short preview)` → `editMessageText(same id update)` → `editMessageText(same id final)`.
   - Checks: the short preview, later update, and final text all used the same Telegram message id, so the bounded short preview does not create multiple default draft messages.



