### PR TITLE
fix(agents): return updatedInput instead of deprecated behavior:allow in canUseTool response

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1933,13 +1933,14 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; toolUseID?: string };
+        response: { behavior: string; updatedInput: Record<string, unknown>; toolUseID?: string };
       };
     };
     expect(parsed.type).toBe("control_response");
     expect(parsed.response.subtype).toBe("success");
     expect(parsed.response.request_id).toBe("req-allow");
     expect(parsed.response.response.behavior).toBe("allow");
+    expect(parsed.response.response.updatedInput).toEqual({ command: "ls" });
     expect(parsed.response.response.toolUseID).toBe("tool-allow-1");
   });
 
@@ -2303,10 +2304,11 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; toolUseID?: string };
+        response: { behavior: string; updatedInput: Record<string, unknown>; toolUseID?: string };
       };
     };
     expect(parsed.response.response.behavior).toBe("allow");
+    expect(parsed.response.response.updatedInput).toEqual({ command: "echo hi" });
     expect(parsed.response.response.toolUseID).toBe("tool-default-allow-1");
   });
 
@@ -2739,10 +2741,11 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; toolUseID?: string };
+        response: { behavior: string; updatedInput: Record<string, unknown>; toolUseID?: string };
       };
     };
     expect(parsed.response.response.behavior).toBe("allow");
+    expect(parsed.response.response.updatedInput).toEqual({ command: "ls" });
     expect(parsed.response.response.toolUseID).toBe("tool-permmode-allow-1");
     const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
     expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("bypassPermissions");

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -868,6 +868,7 @@ function handleClaudeLiveControlRequest(
     return;
   }
   const toolUseId = typeof request.tool_use_id === "string" ? request.tool_use_id : undefined;
+  const toolInput = isRecord(request.input) ? request.input : {};
   const allowed = turn.execPermission.security === "full" && turn.execPermission.ask === "off";
   writeClaudeLiveControlResponse(session, {
     type: "control_response",
@@ -877,6 +878,7 @@ function handleClaudeLiveControlRequest(
       response: allowed
         ? {
             behavior: "allow",
+            updatedInput: toolInput,
             ...(toolUseId ? { toolUseID: toolUseId } : {}),
           }
         : {


### PR DESCRIPTION
Fixes #95171
## What Problem This Solves

`handleClaudeLiveControlRequest` replies `{ behavior: "allow" }` without `updatedInput` when Claude Code >= 2.1 requires both fields, causing ZodError on every tool call through the approval flow.


## Summary
- **Problem:** `handleClaudeLiveControlRequest` replies `{ behavior: "allow" }` without `updatedInput` when Claude Code >= 2.1 requires both fields, causing ZodError on every tool call through the approval flow
- **Why now:** Claude Code 2.1 tightened the PermissionResult schema to require `behavior: "allow"` + `updatedInput`
- **What changed:** Extract `request.input` from the `can_use_tool` control_request and add it as `updatedInput` alongside the existing `behavior: "allow"` discriminator (1 line source, 3 test assertions)
- **What did NOT change:** Deny path unchanged (`{ behavior: "deny", message, decisionClassification }`); no other response shapes modified
- **Outcome:** Tool calls through the approval flow succeed with the correct dual-field allow response
- **Reviewer focus:** `claude-live-session.ts:879-881` — the allow response shape

## Verification

```bash
cd /mnt/g/code/openclaw-worktrees/issue-95171
node scripts/run-vitest.mjs src/agents/cli-runner.spawn.test.ts
```

```
✓ agents src/agents/cli-runner.spawn.test.ts (60 tests) 1429ms
Test Files 1 passed (1)
Tests 60 passed (60)
```

## Evidence

**Behavior addressed:** Claude Code >= 2.1 `can_use_tool` approval flow requires both `behavior: "allow"` and `updatedInput` in the allow response; the old shape missing `updatedInput` causes ZodError.

**Environment tested:** Node.js v22.14.0, Linux 6.18.33.1-microsoft-standard-WSL2

**Steps run after the patch:**

```bash
cd /mnt/g/code/openclaw-worktrees/issue-95171 && node --input-type=module -e "
import { readFileSync } from 'node:fs';
const code = readFileSync('./src/agents/cli-runner/claude-live-session.ts', 'utf8');
const hasBehaviorAllow = code.includes('behavior: \"allow\"');
const hasUpdatedInput = code.includes('updatedInput: toolInput');
const hasToolInput = code.includes('const toolInput = isRecord(request.input)');
const testCode = readFileSync('./src/agents/cli-runner.spawn.test.ts', 'utf8');
const hasBothAssertions = testCode.includes('behavior).toBe(\"allow\")') && testCode.includes('updatedInput).toEqual');
console.log('behavior:allow preserved:', hasBehaviorAllow);
console.log('updatedInput added:', hasUpdatedInput);
console.log('toolInput from request.input:', hasToolInput);
console.log('tests assert both fields:', hasBothAssertions);
"
```

**Evidence after fix (console output):**

```text
behavior:allow preserved: true
updatedInput added: true
toolInput from request.input: true
tests assert both fields: true
```

**Observed result:** Allow response now contains both `behavior: "allow"` and `updatedInput: toolInput`, matching the Claude Code 2.1.x PermissionResult schema. All 3 allow-path test cases updated to assert both fields.

**Not tested:** End-to-end with actual Claude Code 2.1 binary (requires live Claude CLI session); deny path behavior unchanged (existing deny tests still pass).

