### PR TITLE
fix(sdk): type agent mutation RPC params

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -4,6 +4,9 @@ import { EventHub } from "./event-hub.js";
 import { normalizeGatewayEvent } from "./normalize.js";
 import { GatewayClientTransport, isConnectableTransport } from "./transport.js";
 import type {
+  AgentsCreateParams,
+  AgentsDeleteParams,
+  AgentsUpdateParams,
   AgentRunParams,
   ArtifactQuery,
   ArtifactsDownloadResult,
@@ -715,15 +718,15 @@ export class AgentsNamespace {
     return new Agent(this.client, id);
   }
 
-  async create(params: Record<string, unknown>): Promise<unknown> {
+  async create(params: AgentsCreateParams): Promise<unknown> {
     return await this.client.request("agents.create", params);
   }
 
-  async update(params: Record<string, unknown>): Promise<unknown> {
+  async update(params: AgentsUpdateParams): Promise<unknown> {
     return await this.client.request("agents.update", params);
   }
 
-  async delete(params: Record<string, unknown>): Promise<unknown> {
+  async delete(params: AgentsDeleteParams): Promise<unknown> {
     return await this.client.request("agents.delete", params);
   }
 }

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -446,14 +446,19 @@ describe("OpenClaw SDK websocket e2e", () => {
       const identity = expectJsonObject(await agent.identity({ sessionKey: "sdk-session" }));
       expect(identity.agentId).toBe("main");
       expect(identity.sessionKey).toBe("sdk-session");
-      const createAgent = expectJsonObject(await oc.agents.create({ id: "sdk-agent" }));
+      const createAgent = expectJsonObject(
+        await oc.agents.create({ name: "SDK Agent", workspace: "/tmp/sdk-agent" }),
+      );
       expect(createAgent.method).toBe("agents.create");
+      expect(createAgent.params).toEqual({ name: "SDK Agent", workspace: "/tmp/sdk-agent" });
       const updateAgent = expectJsonObject(
-        await oc.agents.update({ id: "sdk-agent", label: "SDK Agent" }),
+        await oc.agents.update({ agentId: "sdk-agent", name: "Renamed SDK Agent" }),
       );
       expect(updateAgent.method).toBe("agents.update");
-      const deleteAgent = expectJsonObject(await oc.agents.delete({ id: "sdk-agent" }));
+      expect(updateAgent.params).toEqual({ agentId: "sdk-agent", name: "Renamed SDK Agent" });
+      const deleteAgent = expectJsonObject(await oc.agents.delete({ agentId: "sdk-agent" }));
       expect(deleteAgent.method).toBe("agents.delete");
+      expect(deleteAgent.params).toEqual({ agentId: "sdk-agent" });
 
       const sessions = expectJsonObject(await oc.sessions.list());
       expect(sessions.sessions).toEqual([{ key: "sdk-session" }]);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -20,6 +20,9 @@ export { EventHub, isGatewayEvent } from "./event-hub.js";
 export { normalizeGatewayEvent } from "./normalize.js";
 export { GatewayClientTransport, isConnectableTransport } from "./transport.js";
 export type {
+  AgentsCreateParams,
+  AgentsDeleteParams,
+  AgentsUpdateParams,
   AgentRunParams,
   ApprovalMode,
   ArtifactQuery,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -324,3 +324,25 @@ export type SessionTarget = {
 };
 
 export type RunCreateParams = AgentRunParams;
+
+export type AgentsCreateParams = {
+  name: string;
+  workspace: string;
+  model?: string;
+  emoji?: string;
+  avatar?: string;
+};
+
+export type AgentsUpdateParams = {
+  agentId: string;
+  name?: string;
+  workspace?: string;
+  model?: string;
+  emoji?: string;
+  avatar?: string;
+};
+
+export type AgentsDeleteParams = {
+  agentId: string;
+  deleteFiles?: boolean;
+};


### PR DESCRIPTION
## Summary
- align SDK agent mutation helper types with the Gateway `agents.create`, `agents.update`, and `agents.delete` schemas
- update the SDK websocket fake Gateway coverage to send and assert the real RPC field names (`name`, `workspace`, `agentId`)

## Verification
- `git diff --check`
- `node --check packages/sdk/src/client.ts && node --check packages/sdk/src/types.ts && node --check packages/sdk/src/index.ts && node --check packages/sdk/src/index.e2e.test.ts`
- `oxfmt --check packages/sdk/src/client.ts packages/sdk/src/types.ts packages/sdk/src/index.ts packages/sdk/src/index.e2e.test.ts`
- `codex review --base origin/main` (no findings)

Not run:
- `node scripts/run-vitest.mjs packages/sdk/src/index.e2e.test.ts` (blocked: sparse Codex worktree has no `node_modules`)
