### PR TITLE
fix(runtime-prompt): use macOS product version on Darwin (#95145)

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -19,6 +19,7 @@ import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { CliBackendConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveRuntimePromptOs } from "../../infra/os-summary.js";
 import { privateFileStore } from "../../infra/private-file-store.js";
 import { tempWorkspace } from "../../infra/private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
@@ -157,7 +158,7 @@ export function buildCliAgentSystemPrompt(params: {
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
       host: "openclaw",
-      os: `${os.type()} ${os.release()}`,
+      os: resolveRuntimePromptOs(),
       arch: os.arch(),
       node: process.version,
       model: params.modelDisplay,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -24,6 +24,7 @@ import {
 } from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
+import { resolveRuntimePromptOs } from "../../infra/os-summary.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../plugins/command-registry-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
@@ -1035,7 +1036,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
 
     const runtimeInfo = {
       host: machineName,
-      os: `${os.type()} ${os.release()}`,
+      os: resolveRuntimePromptOs(),
       arch: os.arch(),
       node: process.version,
       model: `${provider}/${modelId}`,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -44,6 +44,7 @@ import { isEmbeddedMode } from "../../../infra/embedded-mode.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summary.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
+import { resolveRuntimePromptOs } from "../../../infra/os-summary.js";
 import { createCodexNativeWebSearchWrapper } from "../../../llm/providers/stream-wrappers/openai.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../../plugins/command-registry-state.js";
@@ -1933,7 +1934,7 @@ export async function runEmbeddedAttempt(
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
         host: machineName,
-        os: `${os.type()} ${os.release()}`,
+        os: resolveRuntimePromptOs(),
         arch: os.arch(),
         node: process.version,
         model: `${params.provider}/${params.modelId}`,

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1303,6 +1303,29 @@ describe("buildAgentSystemPrompt", () => {
     expect(line).toContain("thinking=low");
   });
 
+  it("renders darwin runtime line with macOS marketing version and no duplicated arch (#95145)", () => {
+    // Simulates what the runtime callers now pass after using
+    // resolveRuntimePromptOs(): `macOS <productVersion>` plus a separate
+    // `arch` field, instead of the legacy `${os.type()} ${os.release()}`
+    // (e.g. "Darwin 25.5.0") that maps incorrectly to macOS 15 on Tahoe.
+    const line = buildRuntimeLine(
+      {
+        host: "host",
+        os: "macOS 26.5.1",
+        arch: "arm64",
+        node: "v20",
+      },
+      "telegram",
+      ["inlineButtons"],
+    );
+
+    expect(line).toContain("os=macOS 26.5.1 (arm64)");
+    // Guard: arch must not appear twice when both `os` and `arch` are set.
+    expect(line).not.toContain("(arm64) (arm64)");
+    // Guard: the legacy Darwin kernel release must not leak through.
+    expect(line).not.toContain("Darwin 25");
+  });
+
   it("renders extra system prompt exactly once", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/infra/os-summary.test.ts
+++ b/src/infra/os-summary.test.ts
@@ -1,6 +1,6 @@
 // Tests operating system summary collection and normalization.
 import os from "node:os";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const spawnSyncMock = vi.hoisted(() => vi.fn());
 
@@ -11,7 +11,11 @@ vi.mock("node:child_process", async () => {
   );
 });
 
-import { resolveOsSummary, resolveRuntimePromptOs } from "./os-summary.js";
+import {
+  __resetOsSummaryCachesForTests,
+  resolveOsSummary,
+  resolveRuntimePromptOs,
+} from "./os-summary.js";
 
 type OsSummaryCase = {
   name: string;
@@ -23,6 +27,9 @@ type OsSummaryCase = {
 };
 
 describe("resolveOsSummary", () => {
+  beforeEach(() => {
+    __resetOsSummaryCachesForTests();
+  });
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -106,6 +113,9 @@ type RuntimePromptOsCase = {
 };
 
 describe("resolveRuntimePromptOs", () => {
+  beforeEach(() => {
+    __resetOsSummaryCachesForTests();
+  });
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -164,5 +174,74 @@ describe("resolveRuntimePromptOs", () => {
       });
     }
     expect(resolveRuntimePromptOs()).toBe(expected);
+  });
+});
+
+describe("resolveRuntimePromptOs caching", () => {
+  beforeEach(() => {
+    __resetOsSummaryCachesForTests();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reuses cached macOS product version across repeated calls (PR #95189 reviewer P1)", () => {
+    // Use a kernel release no other test case in this file uses, so the
+    // module-level cache miss is exclusively this test's responsibility.
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    vi.spyOn(os, "release").mockReturnValue("25.7.0");
+    spawnSyncMock.mockReturnValue({
+      stdout: "26.7.0\n",
+      stderr: "",
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+    });
+
+    const callsBefore = spawnSyncMock.mock.calls.length;
+    const first = resolveRuntimePromptOs();
+    const callsAfterFirst = spawnSyncMock.mock.calls.length;
+    const second = resolveRuntimePromptOs();
+    const third = resolveRuntimePromptOs();
+    const callsAfterThird = spawnSyncMock.mock.calls.length;
+
+    expect(first).toBe("macOS 26.7.0");
+    expect(second).toBe("macOS 26.7.0");
+    expect(third).toBe("macOS 26.7.0");
+    // First call must spawn sw_vers exactly once; subsequent calls must reuse
+    // the cached product version and not re-spawn the subprocess.
+    expect(callsAfterFirst - callsBefore).toBe(1);
+    expect(callsAfterThird - callsAfterFirst).toBe(0);
+  });
+
+  it("runtime-prompt and os-summary share the cached Darwin product version", () => {
+    // Same kernel release across both call paths: the second path must not
+    // spawn sw_vers again, because the cache is keyed by os.release().
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    vi.spyOn(os, "release").mockReturnValue("25.8.0");
+    vi.spyOn(os, "arch").mockReturnValue("arm64");
+    spawnSyncMock.mockReturnValue({
+      stdout: "26.8.0\n",
+      stderr: "",
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+    });
+
+    const callsBefore = spawnSyncMock.mock.calls.length;
+    const summaryLabel = resolveOsSummary().label;
+    const callsAfterSummary = spawnSyncMock.mock.calls.length;
+    const runtimeLabel = resolveRuntimePromptOs();
+    const callsAfterRuntime = spawnSyncMock.mock.calls.length;
+
+    expect(summaryLabel).toBe("macos 26.8.0 (arm64)");
+    expect(runtimeLabel).toBe("macOS 26.8.0");
+    expect(callsAfterSummary - callsBefore).toBe(1);
+    // resolveRuntimePromptOs called after resolveOsSummary for the same
+    // kernel release must not re-spawn sw_vers — the two helpers share the
+    // module-level cachedMacosProductVersionByRelease map.
+    expect(callsAfterRuntime - callsAfterSummary).toBe(0);
   });
 });

--- a/src/infra/os-summary.test.ts
+++ b/src/infra/os-summary.test.ts
@@ -11,7 +11,7 @@ vi.mock("node:child_process", async () => {
   );
 });
 
-import { resolveOsSummary } from "./os-summary.js";
+import { resolveOsSummary, resolveRuntimePromptOs } from "./os-summary.js";
 
 type OsSummaryCase = {
   name: string;
@@ -93,5 +93,76 @@ describe("resolveOsSummary", () => {
       });
     }
     expect(resolveOsSummary()).toEqual(expected);
+  });
+});
+
+type RuntimePromptOsCase = {
+  name: string;
+  platform: ReturnType<typeof os.platform>;
+  type: string;
+  release: string;
+  swVersStdout?: string;
+  expected: string;
+};
+
+describe("resolveRuntimePromptOs", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each<RuntimePromptOsCase>([
+    {
+      name: "renders macOS marketing version on darwin (Tahoe / Darwin 25.x)",
+      platform: "darwin" as const,
+      type: "Darwin",
+      release: "25.5.0",
+      swVersStdout: "26.5.1\n",
+      expected: "macOS 26.5.1",
+    },
+    {
+      name: "renders macOS marketing version on darwin (Sequoia / Darwin 24.x)",
+      platform: "darwin" as const,
+      type: "Darwin",
+      release: "24.5.0",
+      swVersStdout: "15.6\n",
+      expected: "macOS 15.6",
+    },
+    {
+      name: "falls back to os.release on darwin when sw_vers returns blank",
+      platform: "darwin" as const,
+      type: "Darwin",
+      release: "25.5.0",
+      swVersStdout: "   ",
+      expected: "macOS 25.5.0",
+    },
+    {
+      name: "keeps os.type/os.release shape on linux",
+      platform: "linux" as const,
+      type: "Linux",
+      release: "6.10.0-amd64",
+      expected: "Linux 6.10.0-amd64",
+    },
+    {
+      name: "keeps os.type/os.release shape on win32",
+      platform: "win32" as const,
+      type: "Windows_NT",
+      release: "10.0.26100",
+      expected: "Windows_NT 10.0.26100",
+    },
+  ])("$name", ({ platform, type, release, swVersStdout, expected }) => {
+    vi.spyOn(os, "platform").mockReturnValue(platform);
+    vi.spyOn(os, "type").mockReturnValue(type);
+    vi.spyOn(os, "release").mockReturnValue(release);
+    if (platform === "darwin") {
+      spawnSyncMock.mockReturnValue({
+        stdout: swVersStdout ?? "",
+        stderr: "",
+        pid: 1,
+        output: [],
+        status: 0,
+        signal: null,
+      });
+    }
+    expect(resolveRuntimePromptOs()).toBe(expected);
   });
 });

--- a/src/infra/os-summary.test.ts
+++ b/src/infra/os-summary.test.ts
@@ -12,7 +12,7 @@ vi.mock("node:child_process", async () => {
 });
 
 import {
-  __resetOsSummaryCachesForTests,
+  resetOsSummaryCachesForTests,
   resolveOsSummary,
   resolveRuntimePromptOs,
 } from "./os-summary.js";
@@ -28,7 +28,7 @@ type OsSummaryCase = {
 
 describe("resolveOsSummary", () => {
   beforeEach(() => {
-    __resetOsSummaryCachesForTests();
+    resetOsSummaryCachesForTests();
   });
   afterEach(() => {
     vi.restoreAllMocks();
@@ -114,7 +114,7 @@ type RuntimePromptOsCase = {
 
 describe("resolveRuntimePromptOs", () => {
   beforeEach(() => {
-    __resetOsSummaryCachesForTests();
+    resetOsSummaryCachesForTests();
   });
   afterEach(() => {
     vi.restoreAllMocks();
@@ -179,7 +179,7 @@ describe("resolveRuntimePromptOs", () => {
 
 describe("resolveRuntimePromptOs caching", () => {
   beforeEach(() => {
-    __resetOsSummaryCachesForTests();
+    resetOsSummaryCachesForTests();
   });
   afterEach(() => {
     vi.restoreAllMocks();

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -12,10 +12,39 @@ type OsSummary = {
 
 const cachedOsSummaryByKey = new Map<string, OsSummary>();
 
+/**
+ * Cache for the slow Darwin `sw_vers -productVersion` lookup, keyed by
+ * `os.release()` (the kernel release a given binary is observing). Once
+ * resolved for a given kernel release, the macOS marketing product version
+ * is stable for the lifetime of the process — there is no scenario where
+ * macOS changes its product version without the kernel release changing
+ * too — so re-spawning `sw_vers` per call only burns latency on every
+ * runtime prompt build (#95145 review feedback on PR #95189).
+ */
+const cachedMacosProductVersionByRelease = new Map<string, string>();
+
 function macosProductVersion(): string {
+  const release = os.release();
+  const cached = cachedMacosProductVersionByRelease.get(release);
+  if (cached !== undefined) {
+    return cached;
+  }
   const res = spawnSync("sw_vers", ["-productVersion"], { encoding: "utf-8" });
   const out = normalizeOptionalString(res.stdout) ?? "";
-  return out || os.release();
+  const resolved = out || release;
+  cachedMacosProductVersionByRelease.set(release, resolved);
+  return resolved;
+}
+
+/**
+ * Test-only: clear both module-level caches so each test case can mock a
+ * different `os.release()` without leaking the previous case's resolved
+ * Darwin marketing version. Not part of the public API — prefer keying tests
+ * by unique kernel releases when possible.
+ */
+export function __resetOsSummaryCachesForTests(): void {
+  cachedOsSummaryByKey.clear();
+  cachedMacosProductVersionByRelease.clear();
 }
 
 /** Resolves a compact OS label for diagnostics, logs, and environment summaries. */

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -12,7 +12,7 @@ type OsSummary = {
 
 const cachedOsSummaryByKey = new Map<string, OsSummary>();
 
-function macosVersion(): string {
+function macosProductVersion(): string {
   const res = spawnSync("sw_vers", ["-productVersion"], { encoding: "utf-8" });
   const out = normalizeOptionalString(res.stdout) ?? "";
   return out || os.release();
@@ -32,7 +32,7 @@ export function resolveOsSummary(): OsSummary {
   }
   const label = (() => {
     if (platform === "darwin") {
-      return `macos ${macosVersion()} (${arch})`;
+      return `macos ${macosProductVersion()} (${arch})`;
     }
     if (platform === "win32") {
       return `windows ${release} (${arch})`;
@@ -42,4 +42,24 @@ export function resolveOsSummary(): OsSummary {
   const summary = { platform, arch, release, label };
   cachedOsSummaryByKey.set(cacheKey, summary);
   return summary;
+}
+
+/**
+ * Resolves the OS display string used in the agent runtime prompt line.
+ *
+ * The returned value intentionally omits the architecture; the runtime prompt
+ * renderer (`buildRuntimeLine`) appends `arch` separately. On Darwin the
+ * marketing product version (e.g. `macOS 26.5.1`) is preferred over the
+ * kernel release reported by `os.release()`, since the Darwin major version
+ * no longer tracks the macOS major version starting with macOS 26 (Tahoe):
+ * Darwin 25.x ships with macOS 26 (Tahoe), not macOS 15 (Sequoia).
+ */
+export function resolveRuntimePromptOs(): string {
+  const platform = os.platform();
+  if (platform === "darwin") {
+    return `macOS ${macosProductVersion()}`;
+  }
+  // Non-darwin platforms keep the original Node-reported os.type()/os.release()
+  // pair that agent prompts have rendered historically.
+  return `${os.type()} ${os.release()}`;
 }

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -42,7 +42,7 @@ function macosProductVersion(): string {
  * Darwin marketing version. Not part of the public API — prefer keying tests
  * by unique kernel releases when possible.
  */
-export function __resetOsSummaryCachesForTests(): void {
+export function resetOsSummaryCachesForTests(): void {
   cachedOsSummaryByKey.clear();
   cachedMacosProductVersionByRelease.clear();
 }


### PR DESCRIPTION
Closes #95145

## What Problem This Solves

Fixes an issue where agents running on macOS 26 (Tahoe) saw the wrong OS in their runtime prompt — `os=Darwin 25.5.0 (arm64)` instead of `os=macOS 26.5.1 (arm64)`. Agents reading "Darwin 25" mapped it to macOS 15 (Sequoia), because the Darwin kernel major version stopped tracking the macOS marketing major version starting with macOS 26.

The OS line is rendered by `buildRuntimeLine()` from the `runtimeInfo.os` field that three callers populate: the embedded agent runner attempt path, embedded-agent compaction, and the CLI runner. All three were building that field with `` `${os.type()} ${os.release()}` `` instead of reusing the existing `sw_vers`-backed helper. `src/infra/os-summary.ts` and `src/infra/system-presence.ts` already had the right pattern for status/presence surfaces; this PR brings the runtime prompt onto the same path.

## Why This Change Was Made

Adds `resolveRuntimePromptOs()` next to the existing `resolveOsSummary()` and routes the three runtime callers through it. The new helper returns `macOS <productVersion>` on Darwin and the legacy `${os.type()} ${os.release()}` on every other platform, so non-Darwin prompt output is byte-identical. Architecture is deliberately not appended — the renderer already adds `arch` separately, and folding it into `os` would have produced `os=macOS 26.5.1 (arm64) (arm64)`.

Non-goals (left untouched):
- `os-summary.label` (`macos 15.4 (arm64)` style) — still used by status/diagnostics, not the prompt line.
- `openai-chatgpt-responses.ts` User-Agent string — that surface is sent to OpenAI, not into agent context.
- Caching of `sw_vers` for the prompt helper — runtime prompt callers fire once per attempt, and `resolveOsSummary()` already caches when called from status surfaces.

## User Impact

Agent runtime prompts on macOS 26 (Tahoe) hosts now correctly report the macOS marketing version, fixing the `os=` token that downstream prompts and behavior keyed off of. Any agent logic that branched on macOS version (skill availability, command syntax hints, OS-specific guidance) now sees the correct major. No behavior change on Linux, Windows, or pre-Tahoe macOS — the rendered prompt line is byte-identical there.

## Evidence

**Live host probe (this PR was developed on a macOS 26.5 / Darwin 25.5.0 host):**

```
$ uname -r
25.5.0
$ sw_vers -productVersion
26.5
$ node -e '... probe of the new branch ...'
BEFORE: Darwin 25.5.0
AFTER:  macOS 26.5
RENDERED LINE FRAGMENT: os=macOS 26.5 (arm64)
```

**Vitest — the three suites called out in the issue triage all pass:**

```
$ node scripts/run-vitest.mjs src/infra/os-summary.test.ts \
    src/agents/system-prompt.test.ts \
    src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
✓ infra/os-summary.test.ts                 (9 tests)
✓ agents/system-prompt.test.ts             (91 tests)
✓ agents/embedded-agent-runner/run/attempt-system-prompt.test.ts  (4 tests)
3 passed (104 tests)
```

**Typecheck:**

```
$ pnpm tsgo:core         # clean
$ pnpm tsgo:core:test    # clean
```

**New tests added:**
- `resolveRuntimePromptOs` cases for Tahoe (Darwin 25.x), Sequoia (Darwin 24.x), blank `sw_vers` fallback, Linux, and Windows.
- `buildRuntimeLine` regression that asserts `os=macOS 26.5.1 (arm64)` is rendered exactly once and that the legacy `Darwin 25` substring does not leak through.
