### PR TITLE
docs(plugins): document subagent_ended hook fields

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -146,6 +146,7 @@ observation-only.
 - `subagent_delivery_target` - compatibility hook for completion delivery when no core session binding can project a route.
 - `subagent_spawning` - deprecated compatibility hook. Core now prepares `thread: true` subagent bindings through channel session-binding adapters before `subagent_spawned` fires.
 - `subagent_spawned` includes `resolvedModel` and `resolvedProvider` when OpenClaw has resolved the child session's native model before launch.
+- `subagent_ended` carries `targetSessionKey` (identity — this matches `subagent_spawned.childSessionKey`), `targetKind` (`"subagent"` or `"acp"`), `reason`, optional `outcome` (`"ok"`, `"error"`, `"timeout"`, `"killed"`, `"reset"`, or `"deleted"`), optional `error`, `runId`, `endedAt`, `accountId`, and `sendFarewell`. It does **not** include `agentId` or `childSessionKey`; use `targetSessionKey` to correlate with the corresponding `subagent_spawned` event.
 
 **Lifecycle**
 


### PR DESCRIPTION
## What Problem This Solves

The plugin-hooks documentation lists `subagent_ended` but does not describe what fields the event carries. Plugin authors building against this hook can reasonably assume it exposes the same identity fields as `subagent_spawned` (which includes `agentId` from `PluginHookSubagentSpawnBase`), but `PluginHookSubagentEndedEvent` does not include `agentId` or `childSessionKey`. Without documentation, a handler reaching for `event.agentId` silently gets `undefined`, making it hard to correlate the ended event with the spawned event.

Closes #95186

## Evidence

I verified the documented fields against the authoritative TypeScript type in `src/plugins/hook-types.ts`:

- `PluginHookSubagentEndedEvent` is defined at lines 808–818 with: `targetSessionKey`, `targetKind`, `reason`, `sendFarewell?`, `accountId?`, `runId?`, `endedAt?`, `outcome?`, `error?`.
- `PluginHookSubagentSpawnBase` at lines 720–732 confirms `childSessionKey` and `agentId` are only present on spawn/spawned events, not on the ended event.

The diff adds one bullet to `docs/plugins/hooks.md` that names `targetSessionKey` as the identity field, lists the other fields, and explicitly notes the absence of `agentId`/`childSessionKey`.
