### PR TITLE
docs(hooks): document subagent_ended hook event fields (fixes #95186)

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -146,7 +146,7 @@ observation-only.
 - `subagent_delivery_target` - compatibility hook for completion delivery when no core session binding can project a route.
 - `subagent_spawning` - deprecated compatibility hook. Core now prepares `thread: true` subagent bindings through channel session-binding adapters before `subagent_spawned` fires.
 - `subagent_spawned` includes `resolvedModel` and `resolvedProvider` when OpenClaw has resolved the child session's native model before launch.
-- `subagent_ended` carries `targetSessionKey` (identity — this matches `subagent_spawned.childSessionKey`), `targetKind` (`"subagent"` or `"acp"`), `reason`, optional `outcome` (`"ok"`, `"error"`, `"timeout"`, `"killed"`, `"reset"`, or `"deleted"`), optional `error`, `runId`, `endedAt`, `accountId`, and `sendFarewell`. This hook does **not** include `agentId` or `childSessionKey`; use `targetSessionKey` to correlate with the corresponding `subagent_spawned` event.
+- `subagent_ended` carries `targetSessionKey` (identity — this matches `subagent_spawned.childSessionKey`), `targetKind` (`"subagent"` or `"acp"`), `reason` (`"subagent-complete"`, `"subagent-error"`, or `"subagent-killed"`), optional `outcome` (`"ok"`, `"error"`, `"timeout"`, `"killed"`, `"reset"`, or `"deleted"`), optional `error`, `runId`, `endedAt`, `accountId`, and `sendFarewell`. This hook does **not** include `agentId` or `childSessionKey`; use `targetSessionKey` to correlate with the corresponding `subagent_spawned` event.
 
 **Lifecycle**
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -146,6 +146,16 @@ observation-only.
 - `subagent_delivery_target` - compatibility hook for completion delivery when no core session binding can project a route.
 - `subagent_spawning` - deprecated compatibility hook. Core now prepares `thread: true` subagent bindings through channel session-binding adapters before `subagent_spawned` fires.
 - `subagent_spawned` includes `resolvedModel` and `resolvedProvider` when OpenClaw has resolved the child session's native model before launch.
+- `subagent_ended` fires when a subagent run completes (or is killed/reset). The event includes:
+  - `targetSessionKey` — the session key of the ended subagent.
+  - `targetKind` — `"child"` or `"peer"`, indicating the subagent relationship.
+  - `reason` — why the subagent ended (e.g. `"completed"`, `"killed"`, `"reset"`).
+  - `sendFarewell` — whether a farewell message should be delivered to the subagent's channel.
+  - `accountId` — the account id the subagent ran under.
+  - `runId` — the unique run identifier.
+  - `endedAt` — epoch-ms timestamp of when the subagent ended.
+  - `outcome` — `"ok"`, `"error"`, `"timeout"`, `"killed"`, `"reset"`, or `"deleted"`.
+  - `error` — error message when `outcome` is `"error"`.
 
 **Lifecycle**
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -146,7 +146,7 @@ observation-only.
 - `subagent_delivery_target` - compatibility hook for completion delivery when no core session binding can project a route.
 - `subagent_spawning` - deprecated compatibility hook. Core now prepares `thread: true` subagent bindings through channel session-binding adapters before `subagent_spawned` fires.
 - `subagent_spawned` includes `resolvedModel` and `resolvedProvider` when OpenClaw has resolved the child session's native model before launch.
-- `subagent_ended` carries `targetSessionKey` (identity — this matches `subagent_spawned.childSessionKey`), `targetKind` (`"subagent"` or `"acp"`), `reason` (`"subagent-complete"`, `"subagent-error"`, or `"subagent-killed"`), optional `outcome` (`"ok"`, `"error"`, `"timeout"`, `"killed"`, `"reset"`, or `"deleted"`), optional `error`, `runId`, `endedAt`, `accountId`, and `sendFarewell`. This hook does **not** include `agentId` or `childSessionKey`; use `targetSessionKey` to correlate with the corresponding `subagent_spawned` event.
+- `subagent_ended` carries `targetSessionKey` (identity — this matches `subagent_spawned.childSessionKey`), `targetKind` (`"subagent"` or `"acp"`), `reason` (`"subagent-complete"`, `"subagent-error"`, or `"subagent-killed"`), optional `outcome` (`"ok"`, `"error"`, `"timeout"`, `"killed"`, `"reset"`, or `"deleted"`), optional `error`, and optional `runId`, `endedAt`, `accountId`, `sendFarewell`. This hook does **not** include `agentId` or `childSessionKey`; use `targetSessionKey` to correlate with the corresponding `subagent_spawned` event.
 
 **Lifecycle**
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -146,7 +146,7 @@ observation-only.
 - `subagent_delivery_target` - compatibility hook for completion delivery when no core session binding can project a route.
 - `subagent_spawning` - deprecated compatibility hook. Core now prepares `thread: true` subagent bindings through channel session-binding adapters before `subagent_spawned` fires.
 - `subagent_spawned` includes `resolvedModel` and `resolvedProvider` when OpenClaw has resolved the child session's native model before launch.
-- `subagent_ended` includes `targetSessionKey` (identity — correlates with `subagent_spawned.childSessionKey`), `targetKind` (`"subagent"` or `"acp"`), `reason`, `outcome` (`"ok"`, `"error"`, `"timeout"`, `"killed"`, `"reset"`, or `"deleted"`), `error`, `runId`, `endedAt`, `accountId`, and `sendFarewell`. This hook does **not** include `agentId` or `childSessionKey`; use `targetSessionKey` to correlate with the corresponding `subagent_spawned` event.
+- `subagent_ended` carries `targetSessionKey` (identity — this matches `subagent_spawned.childSessionKey`), `targetKind` (`"subagent"` or `"acp"`), `reason`, optional `outcome` (`"ok"`, `"error"`, `"timeout"`, `"killed"`, `"reset"`, or `"deleted"`), optional `error`, `runId`, `endedAt`, `accountId`, and `sendFarewell`. This hook does **not** include `agentId` or `childSessionKey`; use `targetSessionKey` to correlate with the corresponding `subagent_spawned` event.
 
 **Lifecycle**
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -146,16 +146,7 @@ observation-only.
 - `subagent_delivery_target` - compatibility hook for completion delivery when no core session binding can project a route.
 - `subagent_spawning` - deprecated compatibility hook. Core now prepares `thread: true` subagent bindings through channel session-binding adapters before `subagent_spawned` fires.
 - `subagent_spawned` includes `resolvedModel` and `resolvedProvider` when OpenClaw has resolved the child session's native model before launch.
-- `subagent_ended` fires when a subagent run completes (or is killed/reset). The event includes:
-  - `targetSessionKey` — the session key of the ended subagent.
-  - `targetKind` — `"child"` or `"peer"`, indicating the subagent relationship.
-  - `reason` — why the subagent ended (e.g. `"completed"`, `"killed"`, `"reset"`).
-  - `sendFarewell` — whether a farewell message should be delivered to the subagent's channel.
-  - `accountId` — the account id the subagent ran under.
-  - `runId` — the unique run identifier.
-  - `endedAt` — epoch-ms timestamp of when the subagent ended.
-  - `outcome` — `"ok"`, `"error"`, `"timeout"`, `"killed"`, `"reset"`, or `"deleted"`.
-  - `error` — error message when `outcome` is `"error"`.
+- `subagent_ended` includes `targetSessionKey` (identity — correlates with `subagent_spawned.childSessionKey`), `targetKind` (`"subagent"` or `"acp"`), `reason`, `outcome` (`"ok"`, `"error"`, `"timeout"`, `"killed"`, `"reset"`, or `"deleted"`), `error`, `runId`, `endedAt`, `accountId`, and `sendFarewell`. This hook does **not** include `agentId` or `childSessionKey`; use `targetSessionKey` to correlate with the corresponding `subagent_spawned` event.
 
 **Lifecycle**
 


### PR DESCRIPTION
### Summary

- **Problem**: The plugin-hooks documentation lists `subagent_ended` but does not describe what fields the event carries. Plugin authors building against this hook can assume it exposes the same identity fields as `subagent_spawned` (which includes `agentId` from `PluginHookSubagentSpawnBase`), but `PluginHookSubagentEndedEvent` does not include `agentId` or `childSessionKey`. Without documentation, a handler reaching for `event.agentId` silently gets `undefined`, making correlation with the spawn event difficult.
- **Root Cause**: When `subagent_ended` was added to the type system and runtime emitters, the corresponding field documentation in `docs/plugins/hooks.md` was not updated.
- **Fix**: Add a one-line field summary for `subagent_ended` in the Subagents section, matching the existing `subagent_spawned` compact documentation style. All fields are verified against the authoritative TypeScript types, including `reason` values sourced from `SubagentLifecycleEndedReason`.
- **What changed**:
  - `docs/plugins/hooks.md` — added `subagent_ended` field documentation (+1 line, 9 fields with runtime values)

### Evidence

All documented fields verified against the authoritative source types:

- `PluginHookSubagentEndedEvent` (`src/plugins/hook-types.ts:808-818`): `targetSessionKey`, `targetKind`, `reason`, `sendFarewell?`, `accountId?`, `runId?`, `endedAt?`, `outcome?`, `error?`.
- `PluginHookSubagentTargetKind` (`src/plugins/hook-types.ts:718`): `"subagent" | "acp"`
- `SubagentLifecycleEndedReason` (`src/agents/subagent-lifecycle-events.ts:18-21`): `"subagent-complete" | "subagent-error" | "subagent-killed"`
- Runtime emitter (`src/gateway/session-reset-service.ts:338`): `targetKind = isSubagentSessionKey(key) ? "subagent" : "acp"`
- `PluginHookSubagentSpawnBase` (`src/plugins/hook-types.ts:720-732`): confirms `childSessionKey` and `agentId` are spawn-only — `subagent_ended` uses `targetSessionKey` for identity

### Change Type

- [x] Documentation

### Scope

- [x] docs / plugin hooks reference

### Linked Issue/PR

Fixes #95186