### PR TITLE
fix: use macOS product version in runtime prompts

### DIFF
--- a/src/agents/cli-runner/helpers.system-prompt.test.ts
+++ b/src/agents/cli-runner/helpers.system-prompt.test.ts
@@ -7,6 +7,10 @@ vi.mock("../../tts/tts.js", () => ({
   buildTtsSystemPromptHint: vi.fn(() => undefined),
 }));
 
+vi.mock("../../infra/os-summary.js", () => ({
+  resolveOsRuntimeName: vi.fn(() => "macos 26.5.1"),
+}));
+
 describe("buildCliAgentSystemPrompt", () => {
   afterEach(() => {
     clearPluginCommands();
@@ -105,6 +109,17 @@ describe("buildCliAgentSystemPrompt", () => {
     expect(prompt).toContain("agent=main");
     expect(prompt).toContain("session=agent:main:telegram:direct:peer");
     expect(prompt).toContain("sessionId=session-123");
+  });
+
+  it("uses the resolved OS runtime name in prompt metadata", () => {
+    const prompt = buildCliAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      tools: [],
+      modelDisplay: "test/model",
+    });
+
+    expect(prompt).toContain("os=macos 26.5.1");
+    expect(prompt).not.toContain("os=Darwin 25.5.0");
   });
 
   it("includes Telegram rich text guidance for CLI final replies", () => {

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -19,6 +19,7 @@ import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { CliBackendConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveOsRuntimeName } from "../../infra/os-summary.js";
 import { privateFileStore } from "../../infra/private-file-store.js";
 import { tempWorkspace } from "../../infra/private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
@@ -157,7 +158,7 @@ export function buildCliAgentSystemPrompt(params: {
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
       host: "openclaw",
-      os: `${os.type()} ${os.release()}`,
+      os: resolveOsRuntimeName(),
       arch: os.arch(),
       node: process.version,
       model: params.modelDisplay,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -24,6 +24,7 @@ import {
 } from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
+import { resolveOsRuntimeName } from "../../infra/os-summary.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../plugins/command-registry-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
@@ -1035,7 +1036,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
 
     const runtimeInfo = {
       host: machineName,
-      os: `${os.type()} ${os.release()}`,
+      os: resolveOsRuntimeName(),
       arch: os.arch(),
       node: process.version,
       model: `${provider}/${modelId}`,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -44,6 +44,7 @@ import { isEmbeddedMode } from "../../../infra/embedded-mode.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summary.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
+import { resolveOsRuntimeName } from "../../../infra/os-summary.js";
 import { createCodexNativeWebSearchWrapper } from "../../../llm/providers/stream-wrappers/openai.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../../plugins/command-registry-state.js";
@@ -1933,7 +1934,7 @@ export async function runEmbeddedAttempt(
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
         host: machineName,
-        os: `${os.type()} ${os.release()}`,
+        os: resolveOsRuntimeName(),
         arch: os.arch(),
         node: process.version,
         model: `${params.provider}/${params.modelId}`,

--- a/src/infra/os-summary.test.ts
+++ b/src/infra/os-summary.test.ts
@@ -116,10 +116,19 @@ describe("resolveOsRuntimeName", () => {
     expect(resolveOsRuntimeName()).toBe("macos 26.5.1");
   });
 
-  it("keeps non-darwin runtime names on os metadata", () => {
+  it("keeps non-darwin runtime names on os.type metadata", () => {
     vi.spyOn(os, "platform").mockReturnValue("linux");
+    vi.spyOn(os, "type").mockReturnValue("Linux");
     vi.spyOn(os, "release").mockReturnValue("6.8.0");
 
-    expect(resolveOsRuntimeName()).toBe("linux 6.8.0");
+    expect(resolveOsRuntimeName()).toBe("Linux 6.8.0");
+  });
+
+  it("keeps Windows runtime names on os.type metadata", () => {
+    vi.spyOn(os, "platform").mockReturnValue("win32");
+    vi.spyOn(os, "type").mockReturnValue("Windows_NT");
+    vi.spyOn(os, "release").mockReturnValue("10.0.26100");
+
+    expect(resolveOsRuntimeName()).toBe("Windows_NT 10.0.26100");
   });
 });

--- a/src/infra/os-summary.test.ts
+++ b/src/infra/os-summary.test.ts
@@ -11,7 +11,7 @@ vi.mock("node:child_process", async () => {
   );
 });
 
-import { resolveOsSummary } from "./os-summary.js";
+import { resolveOsRuntimeName, resolveOsSummary } from "./os-summary.js";
 
 type OsSummaryCase = {
   name: string;
@@ -93,5 +93,33 @@ describe("resolveOsSummary", () => {
       });
     }
     expect(resolveOsSummary()).toEqual(expected);
+  });
+});
+
+describe("resolveOsRuntimeName", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses the macOS product version instead of the Darwin kernel release", () => {
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    vi.spyOn(os, "release").mockReturnValue("25.5.0");
+    spawnSyncMock.mockReturnValue({
+      stdout: "26.5.1\n",
+      stderr: "",
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+    });
+
+    expect(resolveOsRuntimeName()).toBe("macos 26.5.1");
+  });
+
+  it("keeps non-darwin runtime names on os metadata", () => {
+    vi.spyOn(os, "platform").mockReturnValue("linux");
+    vi.spyOn(os, "release").mockReturnValue("6.8.0");
+
+    expect(resolveOsRuntimeName()).toBe("linux 6.8.0");
   });
 });

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -23,7 +23,8 @@ function macosVersion(): string {
 export function resolveOsRuntimeName(): string {
   const platform = os.platform();
   const release = os.release();
-  const cacheKey = `${platform}\0${release}`;
+  const type = os.type();
+  const cacheKey = `${platform}\0${type}\0${release}`;
   const cached = cachedOsRuntimeNameByKey.get(cacheKey);
   if (cached) {
     return cached;
@@ -32,10 +33,7 @@ export function resolveOsRuntimeName(): string {
     if (platform === "darwin") {
       return `macos ${macosVersion()}`;
     }
-    if (platform === "win32") {
-      return `windows ${release}`;
-    }
-    return `${platform} ${release}`;
+    return `${type} ${release}`;
   })();
   cachedOsRuntimeNameByKey.set(cacheKey, runtimeName);
   return runtimeName;
@@ -53,7 +51,15 @@ export function resolveOsSummary(): OsSummary {
   if (cached) {
     return cached;
   }
-  const label = `${resolveOsRuntimeName()} (${arch})`;
+  const label = (() => {
+    if (platform === "darwin") {
+      return `macos ${macosVersion()} (${arch})`;
+    }
+    if (platform === "win32") {
+      return `windows ${release} (${arch})`;
+    }
+    return `${platform} ${release} (${arch})`;
+  })();
   const summary = { platform, arch, release, label };
   cachedOsSummaryByKey.set(cacheKey, summary);
   return summary;

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -11,11 +11,34 @@ type OsSummary = {
 };
 
 const cachedOsSummaryByKey = new Map<string, OsSummary>();
+const cachedOsRuntimeNameByKey = new Map<string, string>();
 
 function macosVersion(): string {
   const res = spawnSync("sw_vers", ["-productVersion"], { encoding: "utf-8" });
   const out = normalizeOptionalString(res.stdout) ?? "";
   return out || os.release();
+}
+
+/** Resolves the OS name/release text used before a separate architecture field. */
+export function resolveOsRuntimeName(): string {
+  const platform = os.platform();
+  const release = os.release();
+  const cacheKey = `${platform}\0${release}`;
+  const cached = cachedOsRuntimeNameByKey.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  const runtimeName = (() => {
+    if (platform === "darwin") {
+      return `macos ${macosVersion()}`;
+    }
+    if (platform === "win32") {
+      return `windows ${release}`;
+    }
+    return `${platform} ${release}`;
+  })();
+  cachedOsRuntimeNameByKey.set(cacheKey, runtimeName);
+  return runtimeName;
 }
 
 /** Resolves a compact OS label for diagnostics, logs, and environment summaries. */
@@ -30,15 +53,7 @@ export function resolveOsSummary(): OsSummary {
   if (cached) {
     return cached;
   }
-  const label = (() => {
-    if (platform === "darwin") {
-      return `macos ${macosVersion()} (${arch})`;
-    }
-    if (platform === "win32") {
-      return `windows ${release} (${arch})`;
-    }
-    return `${platform} ${release} (${arch})`;
-  })();
+  const label = `${resolveOsRuntimeName()} (${arch})`;
   const summary = { platform, arch, release, label };
   cachedOsSummaryByKey.set(cacheKey, summary);
   return summary;


### PR DESCRIPTION
## Summary

Fixes #95145.

OpenClaw already used `sw_vers -productVersion` for status/presence OS summaries, but agent runtime prompt metadata still used `os.type()` plus `os.release()`. On macOS Tahoe that exposes Darwin `25.x` instead of macOS `26.x`.

This PR adds a shared runtime OS-name helper in `src/infra/os-summary.ts` and uses it in:

- `src/agents/embedded-agent-runner/run/attempt.ts`
- `src/agents/embedded-agent-runner/compact.ts`
- `src/agents/cli-runner/helpers.ts`

The helper intentionally returns OS name/release without architecture so `buildRuntimeLine()` can continue appending the existing separate `arch` field.

## Review feedback addressed

- Preserves previous non-Darwin runtime prompt strings by returning `${os.type()} ${os.release()}` outside Darwin.
- Keeps existing diagnostics/status `resolveOsSummary()` label behavior unchanged for Linux/Windows.
- Adds focused Linux and Windows runtime-name invariant coverage.

## Verification

- `node scripts/run-vitest.mjs src/infra/os-summary.test.ts`
- `node scripts/run-vitest.mjs src/agents/cli-runner/helpers.system-prompt.test.ts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts`
- `git diff --check origin/main...HEAD`

Autoreview attempted with `python .agents\skills\autoreview\scripts\autoreview --mode branch --base origin/main`, but this Windows environment still fails to spawn the Codex reviewer executable with `PermissionError: [WinError 5] Access is denied` from the WindowsApps Codex path.

## Real behavior proof

Behavior addressed: macOS Tahoe runtime prompt metadata no longer exposes the Darwin kernel release as the OS version.

Real environment tested: Windows checkout with mocked Darwin `25.5.0` and mocked `sw_vers` output `26.5.1` in focused unit tests.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/infra/os-summary.test.ts`; `node scripts/run-vitest.mjs src/agents/cli-runner/helpers.system-prompt.test.ts`; `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts`; `git diff --check origin/main...HEAD`.

Evidence after fix: `resolveOsRuntimeName()` returns `macos 26.5.1` for Darwin `25.5.0` when `sw_vers` reports `26.5.1`, CLI prompt metadata includes `os=macos 26.5.1`, and Linux/Windows runtime names preserve the previous `os.type()` shape (`Linux ...`, `Windows_NT ...`).

Observed result after fix: all three focused Vitest files passed after rebasing on latest `origin/main`.

What was not tested: no live macOS 26/Tahoe host was available in this environment, so live Tahoe Runtime-line proof is still missing.
