### PR TITLE
fix(sdk): tighten approval response params

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -5,6 +5,7 @@ import { normalizeGatewayEvent } from "./normalize.js";
 import { GatewayClientTransport, isConnectableTransport } from "./transport.js";
 import type {
   AgentRunParams,
+  ApprovalDecisionParams,
   ArtifactQuery,
   ArtifactsDownloadResult,
   ArtifactsGetResult,
@@ -906,8 +907,11 @@ export class ApprovalsNamespace {
     return await this.client.request("exec.approval.list", params === undefined ? {} : params);
   }
 
-  async respond(approvalId: string, decision: Record<string, unknown>): Promise<unknown> {
-    return await this.client.request("exec.approval.resolve", { ...decision, id: approvalId });
+  async respond(approvalId: string, params: ApprovalDecisionParams): Promise<unknown> {
+    return await this.client.request("exec.approval.resolve", {
+      id: approvalId,
+      decision: params.decision,
+    });
   }
 }
 

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -768,9 +768,10 @@ describe("OpenClaw SDK", () => {
     const oc = new OpenClaw({ transport });
 
     await expect(oc.approvals.list()).resolves.toEqual({ approvals: [] });
-    await expect(
-      oc.approvals.respond("approval-123", { id: "stale-approval", decision: "allow-once" }),
-    ).resolves.toEqual({ ok: true });
+    const staleDecision = { id: "stale-approval", decision: "allow-once" as const };
+    await expect(oc.approvals.respond("approval-123", staleDecision)).resolves.toEqual({
+      ok: true,
+    });
 
     expect(transport.calls).toEqual([
       {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -21,6 +21,7 @@ export { normalizeGatewayEvent } from "./normalize.js";
 export { GatewayClientTransport, isConnectableTransport } from "./transport.js";
 export type {
   AgentRunParams,
+  ApprovalDecisionParams,
   ApprovalMode,
   ArtifactQuery,
   ArtifactSummary,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -68,6 +68,10 @@ export type WorkspaceSelection = {
 
 export type ApprovalMode = "ask" | "never" | "auto" | "trusted";
 
+export type ApprovalDecisionParams = {
+  decision: "allow-once" | "allow-always" | "deny";
+};
+
 /** Terminal and non-terminal status values returned by Run.wait. */
 export type RunStatus = "accepted" | "completed" | "failed" | "cancelled" | "timed_out";
 


### PR DESCRIPTION
## Summary
- add a public `ApprovalDecisionParams` SDK type for approval resolver decisions
- send the exact `exec.approval.resolve` Gateway payload from `ApprovalsNamespace.respond`
- keep stale caller-provided fields from leaking into the resolve request

## Verification
- `git diff --check`
- `node --check packages/sdk/src/client.ts`
- `node --check packages/sdk/src/types.ts`
- `node --check packages/sdk/src/index.ts`
- `node --check packages/sdk/src/index.test.ts`
- `oxfmt --check --threads=1 packages/sdk/src/client.ts packages/sdk/src/types.ts packages/sdk/src/index.ts packages/sdk/src/index.test.ts`
- `node scripts/run-vitest.mjs packages/sdk/src/index.test.ts` (37 tests passed)
- `codex review --base origin/main` (no findings)

## Known proof gap
- `pnpm check:changed` was attempted via the repo Testbox path, but did not complete because Testbox stayed queued and runner portal sync returned 401 during cleanup. No branch test failure was observed.
