### PR TITLE
docs(plugins): document subagent_ended hook payload fields

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -146,6 +146,7 @@ observation-only.
 - `subagent_delivery_target` - compatibility hook for completion delivery when no core session binding can project a route.
 - `subagent_spawning` - deprecated compatibility hook. Core now prepares `thread: true` subagent bindings through channel session-binding adapters before `subagent_spawned` fires.
 - `subagent_spawned` includes `resolvedModel` and `resolvedProvider` when OpenClaw has resolved the child session's native model before launch.
+- `subagent_ended` identifies the subagent by `targetSessionKey` (there is no `agentId` or `subagentId` on this event) and includes `outcome`, `reason`, and optional `error` and `runId`.
 
 **Lifecycle**
 


### PR DESCRIPTION
The Subagents section of `docs/plugins/hooks.md` lists `subagent_ended` but only documents `subagent_spawned`'s fields, so it's not obvious what payload an `subagent_ended` handler receives. Because `subagent_spawned` extends a base with `agentId`, it's easy to assume `subagent_ended` carries one too — it doesn't.

This adds a one-line note, parallel to the existing `subagent_spawned` one, naming `targetSessionKey` as the identity field (no `agentId`/`subagentId`) plus `outcome`, `reason`, and optional `error`/`runId`.

**Evidence:** Fields verified against `PluginHookSubagentEndedEvent` in `src/plugins/hook-types.ts`. Docs-only change.

AI-assisted.

Closes #95186

Happy to adjust the wording or placement.
