### PR TITLE
fix(cron): preserve startup catch-up overflow deferral across read RPCs and timer maintenance (#93935)

### DIFF
--- a/src/cron/service.startup-overflow-clobber.test.ts
+++ b/src/cron/service.startup-overflow-clobber.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { setupCronServiceSuite } from "./service.test-harness.js";
-import { start } from "./service/ops.js";
+import { list, remove, start, status } from "./service/ops.js";
 import { createCronServiceState } from "./service/state.js";
 import { saveCronStore } from "./store.js";
 import type { CronJob } from "./types.js";
@@ -106,6 +106,93 @@ describe("CronService startup catch-up repair scoping", () => {
 
     expect(repaired?.state.nextRunAtMs).toBe(naturalSlot);
     expect(repaired?.state.nextRunAtMs).not.toBe(staleFutureSlot);
+
+    state.stopped = true;
+    await store.cleanup();
+  });
+
+  it("keeps the overflow daily-cron deferral after read RPCs (cron list/status) run post-start (#93935)", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+    const stagger = 5_000;
+    const deferredSlot = startNow + stagger;
+    const tomorrowNaturalSlot = Date.parse("2025-12-14T09:00:00.000Z");
+
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [
+        createHourlyCronJob("hourly-0", Date.parse("2025-12-13T03:00:00.000Z")),
+        createHourlyCronJob("hourly-1", Date.parse("2025-12-13T04:00:00.000Z")),
+        createHourlyCronJob("hourly-2", Date.parse("2025-12-13T05:00:00.000Z")),
+        createHourlyCronJob("hourly-3", Date.parse("2025-12-13T06:00:00.000Z")),
+        createHourlyCronJob("hourly-4", Date.parse("2025-12-13T07:00:00.000Z")),
+        createDailyCronJob("daily-overflow", Date.parse("2025-12-13T09:00:00.000Z")),
+      ],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => startNow,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await start(state);
+
+    // Sanity check: start() preserves the deferral (this is the #93810 invariant).
+    const afterStart = state.store?.jobs.find((job) => job.id === "daily-overflow");
+    expect(afterStart?.state.nextRunAtMs).toBe(deferredSlot);
+    expect(state.pendingCatchupDeferralJobIds.has("daily-overflow")).toBe(true);
+
+    // Simulate any caller that issues a plain read RPC before the staggered
+    // catch-up tick fires (Mac app poll, control UI refresh, `cron list`).
+    await status(state);
+    await list(state);
+
+    const afterRead = state.store?.jobs.find((job) => job.id === "daily-overflow");
+    expect(afterRead?.state.nextRunAtMs).toBe(deferredSlot);
+    expect(afterRead?.state.nextRunAtMs).not.toBe(tomorrowNaturalSlot);
+
+    state.stopped = true;
+    await store.cleanup();
+  });
+
+  it("clears the deferral when the deferred job is removed so the id cannot leak (#93935)", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [
+        createHourlyCronJob("hourly-0", Date.parse("2025-12-13T03:00:00.000Z")),
+        createHourlyCronJob("hourly-1", Date.parse("2025-12-13T04:00:00.000Z")),
+        createHourlyCronJob("hourly-2", Date.parse("2025-12-13T05:00:00.000Z")),
+        createHourlyCronJob("hourly-3", Date.parse("2025-12-13T06:00:00.000Z")),
+        createHourlyCronJob("hourly-4", Date.parse("2025-12-13T07:00:00.000Z")),
+        createDailyCronJob("daily-overflow", Date.parse("2025-12-13T09:00:00.000Z")),
+      ],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => startNow,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await start(state);
+
+    expect(state.pendingCatchupDeferralJobIds.has("daily-overflow")).toBe(true);
+
+    const removed = await remove(state, "daily-overflow");
+    expect(removed).toEqual({ ok: true, removed: true });
+    expect(state.pendingCatchupDeferralJobIds.has("daily-overflow")).toBe(false);
 
     state.stopped = true;
     await store.cleanup();

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -244,6 +244,7 @@ export function createMockCronStateForJobs(params: {
     warnedInvalidPersistedJobKeys: new Set<string>(),
     pendingQuarantineConfigJobs: [],
     lastQuarantineFailureWarnKey: null,
+    pendingCatchupDeferralJobIds: new Set<string>(),
     deps: {
       storePath: "/mock/path",
       cronEnabled: true,

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -678,7 +678,13 @@ export function recomputeNextRunsForMaintenance(
 ): boolean {
   const recomputeExpired = opts?.recomputeExpired ?? false;
   const repairFutureCronNextRunAtMs = opts?.repairFutureCronNextRunAtMs ?? true;
-  const skipFutureRepairJobIds = opts?.skipFutureRepairJobIds;
+  // Callers that pass an explicit skip set get exactly that set (used by
+  // start()'s post-catchup pass which already knows its deferral ids). All
+  // other callers (read RPCs via ensureLoadedForRead, empty-due timer ticks,
+  // post-finalization recompute) fall back to the canonical service-state
+  // set populated during runMissedJobs. This preserves overflow catch-up
+  // deferrals across every maintenance recompute path (#93935).
+  const skipFutureRepairJobIds = opts?.skipFutureRepairJobIds ?? state.pendingCatchupDeferralJobIds;
   return walkSchedulableJobs(
     state,
     ({ job, nowMs: now }) => {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -186,6 +186,7 @@ function mergeManualRunSnapshotAfterReload(params: {
   }
   if (params.removed) {
     params.state.store.jobs = params.state.store.jobs.filter((job) => job.id !== params.jobId);
+    params.state.pendingCatchupDeferralJobIds.delete(params.jobId);
     return;
   }
   if (!params.snapshot) {
@@ -591,6 +592,7 @@ export async function remove(state: CronServiceState, id: string) {
     }
     const removedJob = state.store.jobs.find((j) => j.id === id);
     state.store.jobs = state.store.jobs.filter((j) => j.id !== id);
+    state.pendingCatchupDeferralJobIds.delete(id);
     const removed = (state.store.jobs.length ?? 0) !== before;
     await persist(state);
     armTimer(state);
@@ -681,6 +683,7 @@ async function skipInvalidPersistedManualRun(params: {
 
   if (shouldDelete && params.state.store) {
     params.state.store.jobs = params.state.store.jobs.filter((entry) => entry.id !== params.job.id);
+    params.state.pendingCatchupDeferralJobIds.delete(params.job.id);
     emit(params.state, { jobId: params.job.id, action: "removed" });
   }
 
@@ -977,6 +980,7 @@ async function finishPreparedManualRun(
 
       if (shouldDelete && state.store) {
         state.store.jobs = state.store.jobs.filter((entry) => entry.id !== job.id);
+        state.pendingCatchupDeferralJobIds.delete(job.id);
         emit(state, { jobId: job.id, action: "removed", job });
       }
 

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -257,6 +257,9 @@ export async function start(state: CronServiceState) {
     skipJobIds: interruptedJobIds.size > 0 ? interruptedJobIds : undefined,
     deferAgentTurnJobs: true,
   });
+  for (const jobId of deferredCatchupJobIds) {
+    state.pendingCatchupDeferralJobIds.add(jobId);
+  }
 
   await locked(state, async () => {
     // Startup catch-up already persisted the latest in-memory store state, and

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -209,6 +209,16 @@ export type CronServiceState = {
   pendingQuarantineConfigJobs: QuarantinedCronConfigJob[];
   lastQuarantineFailureWarnKey: string | null;
   storeLoadedAtMs: number | null;
+  /**
+   * Job ids whose `nextRunAtMs` was deferred during startup catch-up overflow
+   * staggering (or by other catch-up scaffolding) and which must be preserved
+   * by every maintenance recompute caller, not just `start()`'s post-catchup
+   * pass. Ids are removed when the deferred slot is reserved for execution,
+   * the job finishes, or the job is removed.
+   *
+   * See `recomputeNextRunsForMaintenance` (jobs.ts) and #93935.
+   */
+  pendingCatchupDeferralJobIds: Set<string>;
 };
 
 /** Creates mutable cron service state with a concrete clock dependency. */
@@ -228,6 +238,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     pendingQuarantineConfigJobs: [],
     lastQuarantineFailureWarnKey: null,
     storeLoadedAtMs: null,
+    pendingCatchupDeferralJobIds: new Set<string>(),
   };
 }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1196,6 +1196,10 @@ export async function onTimer(state: CronServiceState) {
       const now = state.deps.nowMs();
       for (const job of due) {
         job.state.runningAtMs = now;
+        // The deferral has now been honored — once the job is reserved for
+        // execution, ordinary future-slot repair must apply again so the
+        // post-run recompute can advance to the next natural slot (#93935).
+        state.pendingCatchupDeferralJobIds.delete(job.id);
       }
       await persist(state);
       if (state.stopped) {


### PR DESCRIPTION
Closes #93935

## What Problem This Solves

Resolves a problem where a missed cron job that was deferred by startup catch-up overflow staggering would be silently dropped for an entire period after restart. On the reporter's setup (5 hourly `0 * * * *` jobs plus 1 daily `0 9 * * *` job overdue at start), the daily job correctly stagger-deferred to `startNow + 5000`, but the very next `cron list`, `cron status`, Mac-app poll, or empty-due timer tick would advance its `nextRunAtMs` to the natural tomorrow 09:00 slot and the missed run would never execute.

## Why This Change Was Made

#93810 fixed this in `start()`'s post-catchup pass with a local `skipFutureRepairJobIds` set, but the exemption was only threaded into that single call site. Every other caller of `recomputeNextRunsForMaintenance` — `ensureLoadedForRead` (used by `status`/`list`/`readJob`/`listPage`), `finalizeCompletedResults`, and the empty-due maintenance pass — ran with the default `repairFutureCronNextRunAtMs: true` and no skip set, so they clobbered the deferral.

This PR makes the deferral canonical:

1. **`CronServiceState.pendingCatchupDeferralJobIds: Set<string>`** — a single in-memory source of truth populated when `runMissedJobs` returns deferred ids during startup.
2. **`recomputeNextRunsForMaintenance` consults the state set as a fallback** when callers do not pass an explicit `skipFutureRepairJobIds`. `start()`'s existing explicit override still wins, so the previously-fixed path is byte-identical.
3. **Clears** happen exactly where the deferral has been consumed or invalidated: timer-tick reservation (so the post-run recompute can advance normally), public `remove()`, the in-memory file/store reconciliation paths, and inline single-shot cleanup after a finalized run.

Non-goals:
- No on-disk persistence of the deferral. The set is rebuilt on every restart by `runMissedJobs`, which is the only path that can produce a deferral.
- No change to disable/enable cycles. The deferral persists across an `enabled: false` flip because the next slot will recompute correctly either way.
- No change to non-catchup future-slot repair. Jobs that were never in the deferral set still get the existing stale-future-slot repair behavior.

## User Impact

Operators on hosts where the gateway was down long enough to overflow `maxMissedJobsPerRestart` (default 5) now reliably see the deferred-to-later missed jobs actually execute. Without the fix, any agent, control surface, or Mac app reading cron state during the stagger window silently caused a full-period drop. After the fix the deferred slot survives until the timer reservation fires.

## Evidence

**New regression test cases (extending `src/cron/service.startup-overflow-clobber.test.ts`):**

```
$ node scripts/run-vitest.mjs src/cron/service.startup-overflow-clobber.test.ts
✓ keeps the overflow daily-cron catch-up deferral after start()'s maintenance pass     (#93810 invariant)
✓ still repairs a stale future cron slot on start() when no jobs were deferred         (#93810 invariant)
✓ keeps the overflow daily-cron deferral after read RPCs (cron list/status) run        (#93935 new)
✓ clears the deferral when the deferred job is removed so the id cannot leak           (#93935 new)
4 passed
```

The new "read RPCs" test is the exact repro from the issue: it builds the same 5 hourly + 1 daily setup, calls `start()`, then calls `status()` and `list()`, and asserts the daily job's `nextRunAtMs` is still `startNow + 5000` rather than the natural tomorrow 09:00 slot. Without the fix this case fails on the assertion `expect(afterRead?.state.nextRunAtMs).toBe(deferredSlot)` because `ensureLoadedForRead` runs maintenance recompute with no skip set.

**Broader cron suites pass unchanged:**

```
$ node scripts/run-vitest.mjs \
    src/cron/service.startup-overflow-clobber.test.ts \
    src/cron/service.restart-catchup.test.ts \
    src/cron/service/ops.regression.test.ts \
    src/cron/service/timer.test.ts
4 files passed (34 tests)
```

**Typecheck:**

```
$ pnpm tsgo:core         # clean
$ pnpm tsgo:core:test    # clean
```

**Diff size:** 6 files, +118/−2. The fix is entirely additive on the existing `skipFutureRepairJobIds` mechanism — no behavior change for callers that already pass an explicit skip set.
