### PR TITLE
fix(openrouter): expand short DeepSeek V4 aliases to upstream slug in API normalizer (#95198)

### DIFF
--- a/extensions/openrouter/models.test.ts
+++ b/extensions/openrouter/models.test.ts
@@ -1,0 +1,115 @@
+// Unit tests for the OpenRouter model id normalizers.
+import { describe, expect, it } from "vitest";
+import {
+  isOpenRouterDeepSeekV4ModelId,
+  isOpenRouterMistralModelId,
+  normalizeOpenRouterApiModelId,
+  normalizeOpenRouterModelId,
+} from "./models.js";
+
+describe("normalizeOpenRouterModelId", () => {
+  it("strips the openrouter/ prefix from namespaced refs", () => {
+    expect(normalizeOpenRouterModelId("openrouter/deepseek/deepseek-v4-flash")).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+  });
+
+  it("strips the openrouter/ prefix from short refs", () => {
+    expect(normalizeOpenRouterModelId("openrouter/deepseek-v4-flash")).toBe("deepseek-v4-flash");
+  });
+
+  it("leaves non-openrouter refs unchanged", () => {
+    expect(normalizeOpenRouterModelId("deepseek/deepseek-v4-flash")).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+  });
+
+  it("lowercases input", () => {
+    expect(normalizeOpenRouterModelId("OPENROUTER/Deepseek/Deepseek-V4-Flash")).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+  });
+
+  it("returns undefined for non-string input", () => {
+    expect(normalizeOpenRouterModelId(undefined)).toBeUndefined();
+    expect(normalizeOpenRouterModelId(42)).toBeUndefined();
+  });
+});
+
+describe("normalizeOpenRouterApiModelId", () => {
+  describe("native openrouter/ routes (preserved per #92611/#92627)", () => {
+    it("preserves openrouter/auto as the native upstream slug", () => {
+      expect(normalizeOpenRouterApiModelId("openrouter/auto")).toBe("openrouter/auto");
+    });
+  });
+
+  describe("provider-qualified refs (existing #92627 behavior)", () => {
+    it("strips the openrouter/ qualifier when the remainder is namespaced", () => {
+      expect(normalizeOpenRouterApiModelId("openrouter/deepseek/deepseek-v4-flash")).toBe(
+        "deepseek/deepseek-v4-flash",
+      );
+      expect(normalizeOpenRouterApiModelId("openrouter/moonshotai/kimi-k2.6")).toBe(
+        "moonshotai/kimi-k2.6",
+      );
+    });
+  });
+
+  describe("short aliases (#95198 regression coverage)", () => {
+    it("expands openrouter/deepseek-v4-flash to the namespaced upstream slug", () => {
+      expect(normalizeOpenRouterApiModelId("openrouter/deepseek-v4-flash")).toBe(
+        "deepseek/deepseek-v4-flash",
+      );
+    });
+
+    it("expands openrouter/deepseek-v4-pro to the namespaced upstream slug", () => {
+      expect(normalizeOpenRouterApiModelId("openrouter/deepseek-v4-pro")).toBe(
+        "deepseek/deepseek-v4-pro",
+      );
+    });
+
+    it("expands uppercase short aliases (input is case-normalized first)", () => {
+      expect(normalizeOpenRouterApiModelId("OpenRouter/DeepSeek-V4-Flash")).toBe(
+        "deepseek/deepseek-v4-flash",
+      );
+    });
+  });
+
+  describe("non-openrouter input", () => {
+    it("leaves non-openrouter refs unchanged", () => {
+      expect(normalizeOpenRouterApiModelId("deepseek/deepseek-v4-flash")).toBe(
+        "deepseek/deepseek-v4-flash",
+      );
+      expect(normalizeOpenRouterApiModelId("anthropic/claude-opus-4.7")).toBe(
+        "anthropic/claude-opus-4.7",
+      );
+    });
+
+    it("returns undefined for non-string input", () => {
+      expect(normalizeOpenRouterApiModelId(undefined)).toBeUndefined();
+      expect(normalizeOpenRouterApiModelId(null)).toBeUndefined();
+    });
+  });
+});
+
+describe("isOpenRouterMistralModelId", () => {
+  it("matches namespaced mistral refs", () => {
+    expect(isOpenRouterMistralModelId("openrouter/mistralai/codestral-2508")).toBe(true);
+    expect(isOpenRouterMistralModelId("mistralai/codestral-2508")).toBe(true);
+  });
+
+  it("does not match unrelated providers", () => {
+    expect(isOpenRouterMistralModelId("openrouter/deepseek/deepseek-v4-flash")).toBe(false);
+  });
+});
+
+describe("isOpenRouterDeepSeekV4ModelId", () => {
+  it("matches namespaced DeepSeek V4 refs (both short and qualified inputs)", () => {
+    expect(isOpenRouterDeepSeekV4ModelId("deepseek/deepseek-v4-flash")).toBe(true);
+    expect(isOpenRouterDeepSeekV4ModelId("openrouter/deepseek/deepseek-v4-pro")).toBe(true);
+  });
+
+  it("does not match DeepSeek V3 or unrelated refs", () => {
+    expect(isOpenRouterDeepSeekV4ModelId("deepseek/deepseek-v3.1")).toBe(false);
+    expect(isOpenRouterDeepSeekV4ModelId("openrouter/auto")).toBe(false);
+  });
+});

--- a/extensions/openrouter/models.ts
+++ b/extensions/openrouter/models.ts
@@ -14,6 +14,24 @@ const OPENROUTER_MISTRAL_MODEL_PREFIXES = [
 ] as const;
 const OPENROUTER_MODEL_PREFIX = "openrouter/";
 
+/**
+ * Short, unnamespaced model refs that OpenClaw catalog/config surfaces accept
+ * as `openrouter/<short>`, but which the OpenRouter API exposes under a
+ * namespaced upstream id. Without this expansion, the API normalizer would
+ * see the stripped remainder lack a `/`, treat the original ref as a native
+ * OpenRouter route (like `openrouter/auto`), and send the wrong slug
+ * upstream — yielding `400 model_not_found` (#95198).
+ *
+ * Keep entries narrowly scoped: only short aliases that OpenClaw already
+ * surfaces as `openrouter/<short>` elsewhere. The DeepSeek V4 family is
+ * tracked at this layer because `isOpenRouterDeepSeekV4ModelId` already
+ * recognizes both ids, and the user-reported broken cases were both of them.
+ */
+const OPENROUTER_SHORT_TO_API_MODEL_ID = new Map<string, string>([
+  ["deepseek-v4-flash", "deepseek/deepseek-v4-flash"],
+  ["deepseek-v4-pro", "deepseek/deepseek-v4-pro"],
+]);
+
 export function normalizeOpenRouterModelId(modelId: unknown): string | undefined {
   if (typeof modelId !== "string") {
     return undefined;
@@ -33,6 +51,15 @@ export function normalizeOpenRouterApiModelId(modelId: unknown): string | undefi
     return normalized;
   }
   const unprefixed = normalized.slice(OPENROUTER_MODEL_PREFIX.length);
+  // Known short aliases must expand to their namespaced upstream id even
+  // though the stripped remainder lacks a `/`. Without this, an
+  // `openrouter/deepseek-v4-flash` ref would otherwise fall through to the
+  // legacy native-route branch below and OpenRouter would reject the
+  // unexpanded short id with `400 model_not_found` (#95198).
+  const aliased = OPENROUTER_SHORT_TO_API_MODEL_ID.get(unprefixed);
+  if (aliased) {
+    return aliased;
+  }
   // `openrouter/` is both a provider qualifier and an upstream namespace.
   // Strip it only when the remainder is still a namespaced API model id.
   return unprefixed.includes("/") ? unprefixed : normalized;


### PR DESCRIPTION
Closes #95198

## What Problem This Solves

When OpenRouter users set their model to the catalog-displayed short alias `openrouter/deepseek-v4-flash` (or `openrouter/deepseek-v4-pro`), the gateway sent the literal `openrouter/deepseek-v4-flash` to OpenRouter's API and got back `400 model_not_found`. The upstream slug should have been `deepseek/deepseek-v4-flash`. The user had 13 cron jobs failing with `model_not_found` until they manually rewrote their config to the long form `openrouter/deepseek/deepseek-v4-flash`.

## Why This Change Was Made

`normalizeOpenRouterApiModelId` (added in #92627) strips the `openrouter/` qualifier when the remainder is still namespaced (e.g. `openrouter/deepseek/deepseek-v4-flash` → `deepseek/deepseek-v4-flash`) but otherwise preserves the original ref, on the assumption that single-segment refs like `openrouter/auto` are native OpenRouter routes that must not be stripped. Short DeepSeek V4 aliases fall through the same single-segment branch even though they are not native routes — that is the gap.

This PR adds a narrow `OPENROUTER_SHORT_TO_API_MODEL_ID` map containing the two DeepSeek V4 ids that `isOpenRouterDeepSeekV4ModelId` already recognizes elsewhere in the file. When the stripped remainder hits the map, the normalizer expands it to the namespaced upstream id before the single-segment fallback runs. The map is intentionally minimal — only the short aliases OpenClaw already surfaces — and `openrouter/auto` is preserved unchanged because `auto` is not in the map.

Non-goals (left as follow-up):

- **Catalog cleanup.** Clawsweeper recommended aligning catalog display, config resolution, and API normalization for these refs. This PR only addresses the API normalizer because that is the user-facing 400 error path; the catalog/config-set surfaces work fine today (the user could already type the short form and have it accepted), so the gap was purely on the way out.
- **Generic short-alias resolution.** No attempt to introspect OpenRouter's `/models` endpoint or build a dynamic alias table. The map is deliberately small and hand-maintained alongside the existing DeepSeek V4 family checks.
- **Other providers.** The fix is scoped to OpenRouter's normalizer; no changes to the OpenAI, Anthropic, or other provider paths.

## User Impact

Operators who set `openrouter/deepseek-v4-flash` or `openrouter/deepseek-v4-pro` (the form the catalog and `models list --all` display) stop seeing `400 model_not_found` from OpenRouter. The previously-working `openrouter/deepseek/deepseek-v4-flash` long form continues to work unchanged. Native `openrouter/auto` is unaffected.

## Evidence

**New unit suite (`extensions/openrouter/models.test.ts`) — 16 cases:**

```
$ node scripts/run-vitest.mjs extensions/openrouter/models.test.ts
✓ extensions/openrouter/models.test.ts (16 tests)
  ✓ normalizeOpenRouterModelId
    ✓ strips the openrouter/ prefix from namespaced refs
    ✓ strips the openrouter/ prefix from short refs
    ✓ leaves non-openrouter refs unchanged
    ✓ lowercases input
    ✓ returns undefined for non-string input
  ✓ normalizeOpenRouterApiModelId
    ✓ preserves openrouter/auto as the native upstream slug
    ✓ strips the openrouter/ qualifier when the remainder is namespaced  (#92627 invariant)
    ✓ expands openrouter/deepseek-v4-flash to the namespaced upstream slug   (#95198 fix)
    ✓ expands openrouter/deepseek-v4-pro to the namespaced upstream slug     (#95198 fix)
    ✓ expands uppercase short aliases (input is case-normalized first)
    ✓ leaves non-openrouter refs unchanged
    ✓ returns undefined for non-string input
  ✓ isOpenRouterMistralModelId  (2 cases)
  ✓ isOpenRouterDeepSeekV4ModelId (2 cases)
```

**Broader OpenRouter suite still passes:**

```
$ node scripts/run-vitest.mjs extensions/openrouter/index.test.ts extensions/openrouter/models.test.ts
2 files passed (58 tests)
```

**Typecheck:**

```
$ pnpm tsgo:core         # clean
$ pnpm tsgo:core:test    # clean
```

**Diff:** 2 files, +142/−0. Fix is additive; existing #92627 namespaced-remainder branch and the `openrouter/auto` native-route branch are byte-identical.
