### PR TITLE
fix(scripts): guard reused testbox keys

### DIFF
--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -679,6 +679,56 @@ function pathExists(path) {
   }
 }
 
+function crabboxConfigDir() {
+  if (process.platform === "darwin") {
+    return resolve(homedir(), "Library", "Application Support", "crabbox");
+  }
+  if (process.platform === "win32") {
+    return resolve(process.env.APPDATA || resolve(homedir(), "AppData", "Roaming"), "crabbox");
+  }
+  return resolve(process.env.XDG_CONFIG_HOME || resolve(homedir(), ".config"), "crabbox");
+}
+
+function userDisplayPath(path) {
+  const home = homedir();
+  const rel = relative(home, path);
+  if (rel && !rel.startsWith("..") && !isAbsolute(rel)) {
+    return `~/${rel}`;
+  }
+  return path;
+}
+
+function blacksmithTestboxPrivateKeyPath(id) {
+  return resolve(crabboxConfigDir(), "testboxes", id, "id_ed25519");
+}
+
+function enforceCrabboxOwnedBlacksmithLease(commandArgs) {
+  if (commandArgs[0] !== "run") {
+    return;
+  }
+  const id = optionValue(commandArgs, "--id");
+  if (!id) {
+    return;
+  }
+  if (!id.startsWith("tbx_")) {
+    return;
+  }
+
+  const keyPath = blacksmithTestboxPrivateKeyPath(id);
+  if (pathExists(keyPath)) {
+    return;
+  }
+
+  console.error(
+    [
+      `[crabbox] provider=blacksmith-testbox --id ${id} has no Crabbox SSH key at ${userDisplayPath(keyPath)}.`,
+      "[crabbox] create reusable Testboxes through Crabbox before reusing them: node scripts/crabbox-wrapper.mjs warmup --provider blacksmith-testbox --idle-timeout 90m",
+      "[crabbox] direct `blacksmith testbox warmup` leases can be used with `blacksmith testbox run`, but Crabbox cannot sync or run them by id.",
+    ].join("\n"),
+  );
+  process.exit(2);
+}
+
 function preserveTemporaryCrabboxRuns() {
   if (childCwd === repoRoot) {
     return;
@@ -2393,6 +2443,7 @@ if (canonicalProvider === "blacksmith-testbox") {
   console.error(
     `[crabbox] provider=blacksmith-testbox ${source}; if Testbox is queued or down, ${fallback}`,
   );
+  enforceCrabboxOwnedBlacksmithLease(normalizedArgs);
 }
 
 let childCwd = repoRoot;

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -355,6 +355,25 @@ function normalizeShellLineEndings(value: string): string {
   return value.replace(/\r\n/g, "\n");
 }
 
+function testCrabboxConfigDir(home: string): string {
+  if (process.platform === "darwin") {
+    return path.join(home, "Library", "Application Support", "crabbox");
+  }
+  if (process.platform === "win32") {
+    return path.join(home, "AppData", "Roaming", "crabbox");
+  }
+  return path.join(home, ".config", "crabbox");
+}
+
+function testHomeEnv(home: string): Record<string, string> {
+  return {
+    APPDATA: path.join(home, "AppData", "Roaming"),
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: path.join(home, ".config"),
+  };
+}
+
 function expectGroupedShellCommand(remoteCommand: string, command: string): void {
   expect(remoteCommand).toContain(`&& { ${command}`);
   if (process.platform !== "win32") {
@@ -488,6 +507,70 @@ describe.concurrent("scripts/crabbox-wrapper", () => {
 
     expect(result.status).toBe(0);
     expect(parseFakeCrabboxOutput(result).args).toContain("blacksmith-testbox");
+  });
+
+  it("rejects reused Blacksmith Testboxes that were not created by Crabbox", () => {
+    const home = mkdtempSync(path.join(tmpdir(), "openclaw-crabbox-home-"));
+    tempDirs.push(home);
+
+    const result = runWrapper(
+      "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
+      ["run", "--provider", "blacksmith-testbox", "--id", "tbx_direct", "--", "echo ok"],
+      { env: testHomeEnv(home) },
+    );
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("provider=blacksmith-testbox --id tbx_direct");
+    expect(result.stderr).toContain("has no Crabbox SSH key");
+    expect(result.stderr).toContain("direct `blacksmith testbox warmup` leases");
+  });
+
+  it("allows reused Blacksmith Testboxes when the Crabbox SSH key exists", () => {
+    const home = mkdtempSync(path.join(tmpdir(), "openclaw-crabbox-home-"));
+    tempDirs.push(home);
+    const keyPath = path.join(testCrabboxConfigDir(home), "testboxes", "tbx_owned", "id_ed25519");
+    mkdirSync(path.dirname(keyPath), { recursive: true });
+    writeFileSync(keyPath, "fake test key\n", "utf8");
+
+    const result = runWrapper(
+      "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
+      ["run", "--provider", "blacksmith-testbox", "--id", "tbx_owned", "--", "echo ok"],
+      { env: testHomeEnv(home) },
+    );
+
+    expect(result.status).toBe(0);
+    expect(parseFakeCrabboxOutput(result).args).toEqual([
+      "run",
+      "--provider",
+      "blacksmith-testbox",
+      "--id",
+      "tbx_owned",
+      "--",
+      "echo ok",
+    ]);
+  });
+
+  it("lets Crabbox resolve reusable Testbox slugs", () => {
+    const home = mkdtempSync(path.join(tmpdir(), "openclaw-crabbox-home-"));
+    tempDirs.push(home);
+
+    const result = runWrapper(
+      "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
+      ["run", "--provider", "blacksmith-testbox", "--id", "blue-hermit", "--", "echo ok"],
+      { env: testHomeEnv(home) },
+    );
+
+    expect(result.status).toBe(0);
+    expect(parseFakeCrabboxOutput(result).args).toEqual([
+      "run",
+      "--provider",
+      "blacksmith-testbox",
+      "--id",
+      "blue-hermit",
+      "--",
+      "echo ok",
+    ]);
   });
 
   it("only forces the short local-container Docker work root on Linux", () => {


### PR DESCRIPTION
Summary:
- fail fast when `crabbox-wrapper` is asked to reuse a Blacksmith Testbox `tbx_...` id that has no Crabbox-owned SSH key
- keep Crabbox slug reuse delegated to Crabbox so `--id <slug>` still works
- cover missing-key, existing-key, and slug reuse behavior in the wrapper tests

Verification:
- `node --check scripts/crabbox-wrapper.mjs`
- `node --check test/scripts/crabbox-wrapper.test.ts`
- `oxfmt --check --threads=1 scripts/crabbox-wrapper.mjs test/scripts/crabbox-wrapper.test.ts`
- `node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts`
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --id tbx_fake_direct -- echo ok` exits 2 with the new actionable message
- `codex review --base origin/main` clean after rebase

Known proof gap:
- Broad `check:changed` could not complete because Blacksmith Testbox remained queued during live proof. A Crabbox-owned warmup did create a reusable Testbox id and got past the new key guard, but the run did not leave the Blacksmith queue; the created Testbox was stopped and `blacksmith testbox list` showed no active boxes afterward.
