### PR TITLE
fix(scripts): preserve kitchen sink RPC request errors

### DIFF
--- a/scripts/e2e/kitchen-sink-rpc-walk.mjs
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mjs
@@ -563,7 +563,10 @@ export function parseGatewayCliRequestFailure(error) {
   } catch {
     return null;
   }
-  const requestError = payload?.ok === false ? payload.error : null;
+  return payload?.ok === false ? createGatewayClientRequestError(payload.error) : null;
+}
+
+export function createGatewayClientRequestError(requestError) {
   if (
     requestError?.type !== "gateway_request_error" ||
     !isNonEmptyString(requestError.code) ||
@@ -712,6 +715,10 @@ function hasOwnPayloadField(raw, field) {
 
 export function unwrapRpcPayload(raw) {
   if (raw?.ok === false) {
+    const requestError = createGatewayClientRequestError(raw.error);
+    if (requestError) {
+      throw requestError;
+    }
     throw new Error(`gateway RPC failed: ${boundedJsonPreview(raw.error ?? raw)}`);
   }
   if (

--- a/test/scripts/kitchen-sink-rpc-walk.test.ts
+++ b/test/scripts/kitchen-sink-rpc-walk.test.ts
@@ -860,6 +860,31 @@ describe("kitchen-sink RPC payload unwrapping", () => {
     });
   });
 
+  it("preserves gateway request error metadata from built RPC calls", () => {
+    const error = captureSyncError(() =>
+      unwrapRpcPayload({
+        ok: false,
+        error: {
+          type: "gateway_request_error",
+          code: "INVALID_REQUEST",
+          message: "unauthorized role: operator",
+          details: { method: "skills.bins" },
+          retryable: false,
+          retryAfterMs: 250,
+        },
+      }),
+    );
+
+    expect(error).toMatchObject({
+      name: "GatewayClientRequestError",
+      message: "unauthorized role: operator",
+      gatewayCode: "INVALID_REQUEST",
+      details: { method: "skills.bins" },
+      retryable: false,
+      retryAfterMs: 250,
+    });
+  });
+
   it("bounds failed RPC payload diagnostics", () => {
     const error = captureSyncError(() =>
       unwrapRpcPayload({
@@ -982,6 +1007,19 @@ describe("kitchen-sink RPC command catalog assertions", () => {
           gatewayCode: "INVALID_REQUEST",
         });
       }),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertOperatorRpcDenied({ method: "skills.bins", params: {} }, async () =>
+        unwrapRpcPayload({
+          ok: false,
+          error: {
+            type: "gateway_request_error",
+            code: "INVALID_REQUEST",
+            message: "unauthorized role: operator",
+            retryable: false,
+          },
+        }),
+      ),
     ).resolves.toBeUndefined();
     await expect(
       assertOperatorRpcDenied({ method: "skills.bins", params: {} }, async () => {


### PR DESCRIPTION
Summary:
- Preserve structured `gateway_request_error` metadata when the Kitchen Sink RPC walk uses a built `callGateway` module.
- Cover the packaged-runner auth-denial path so `skills.bins` operator-boundary proof does not false-fail after `unwrapRpcPayload`.

Verification:
- `node --check scripts/e2e/kitchen-sink-rpc-walk.mjs`
- `node --check test/scripts/kitchen-sink-rpc-walk.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 scripts/e2e/kitchen-sink-rpc-walk.mjs test/scripts/kitchen-sink-rpc-walk.test.ts`
- `node scripts/run-vitest.mjs test/scripts/kitchen-sink-rpc-walk.test.ts` (104 tests passed)
- `codex review --base origin/main` (no actionable findings)

Proof gaps:
- Broad `pnpm check:changed` / macOS Crabbox proof not run from this shell because the Crabbox coordinator currently returns 401 for broker/provider readiness. Kept draft until that lane is healthy.
