### PR TITLE
test(tui): lock dunder markdown rendering

### DIFF
--- a/apps/ios/Sources/Design/OpenClawProComponents.swift
+++ b/apps/ios/Sources/Design/OpenClawProComponents.swift
@@ -1,3 +1,4 @@
+import OpenClawChatUI
 import SwiftUI
 
 enum OpenClawProMetric {

--- a/apps/macos/Sources/OpenClaw/AboutSettings.swift
+++ b/apps/macos/Sources/OpenClaw/AboutSettings.swift
@@ -1,3 +1,4 @@
+import OpenClawChatUI
 import SwiftUI
 
 struct AboutSettings: View {
@@ -8,20 +9,18 @@ struct AboutSettings: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            let appIcon = NSApplication.shared.applicationIconImage ?? CritterIconRenderer.makeIcon(blink: 0)
             Button {
                 if let url = URL(string: "https://github.com/openclaw/openclaw") {
                     NSWorkspace.shared.open(url)
                 }
             } label: {
-                Image(nsImage: appIcon)
-                    .resizable()
+                OpenClawMascotView()
                     .frame(width: 160, height: 160)
-                    .cornerRadius(24)
                     .shadow(color: self.iconHover ? .accentColor.opacity(0.25) : .clear, radius: 10)
                     .scaleEffect(self.iconHover ? 1.05 : 1.0)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("OpenClaw on GitHub")
             .focusable(false)
             .pointingHandCursor()
             .onHover { hover in

--- a/apps/macos/Sources/OpenClaw/OnboardingWidgets.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingWidgets.swift
@@ -1,8 +1,9 @@
-import AppKit
+import OpenClawChatUI
 import SwiftUI
 
 struct GlowingOpenClawIcon: View {
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let size: CGFloat
     let glowIntensity: Double
@@ -35,12 +36,10 @@ struct GlowingOpenClawIcon: View {
                 .scaleEffect(self.breathe ? 1.08 : 0.96)
                 .opacity(0.84)
 
-            Image(nsImage: NSApp.applicationIconImage)
-                .resizable()
+            // Mascot animates itself (and goes still under reduce motion), so no breathe scale here.
+            OpenClawMascotView()
                 .frame(width: self.size, height: self.size)
-                .clipShape(RoundedRectangle(cornerRadius: self.size * 0.22, style: .continuous))
                 .shadow(color: .black.opacity(0.18), radius: 14, y: 6)
-                .scaleEffect(self.breathe ? 1.02 : 1.0)
         }
         .frame(
             width: glowCanvasSize + (glowBlurRadius * 2),
@@ -53,7 +52,7 @@ struct GlowingOpenClawIcon: View {
     }
 
     private func updateBreatheAnimation() {
-        guard self.enableFloating, self.scenePhase == .active else {
+        guard self.enableFloating, !self.reduceMotion, self.scenePhase == .active else {
             self.breathe = false
             return
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotView.swift
@@ -3,10 +3,12 @@ import SwiftUI
 /// Animated OpenClaw mascot. Redraws the canonical 120x120 vector from
 /// `ui/public/favicon.svg` so individual parts (claws, antennae, eyes) can
 /// animate like the openclaw.ai hero mark; the bundled PNG asset cannot.
-struct OpenClawMascotView: View {
+public struct OpenClawMascotView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    var body: some View {
+    public init() {}
+
+    public var body: some View {
         if self.reduceMotion {
             OpenClawMascotCanvas(pose: .still)
         } else {
@@ -31,11 +33,11 @@ struct OpenClawMascotPose: Equatable {
 
     static func at(time: TimeInterval) -> OpenClawMascotPose {
         OpenClawMascotPose(
-            floatOffset: -2.5 * (1 - cos(2 * .pi * cyclePhase(time, period: 4))),
-            antennaDegrees: -3 * sin(2 * .pi * cyclePhase(time, period: 2)),
-            leftClawDegrees: clawSnapDegrees(phase: cyclePhase(time, period: 4)),
-            rightClawDegrees: clawSnapDegrees(phase: cyclePhase(time - 0.2, period: 4)),
-            eyeGlowOpacity: blinkOpacity(phase: cyclePhase(time, period: 3)))
+            floatOffset: -2.5 * (1 - cos(2 * .pi * self.cyclePhase(time, period: 4))),
+            antennaDegrees: -3 * sin(2 * .pi * self.cyclePhase(time, period: 2)),
+            leftClawDegrees: self.clawSnapDegrees(phase: self.cyclePhase(time, period: 4)),
+            rightClawDegrees: self.clawSnapDegrees(phase: self.cyclePhase(time - 0.2, period: 4)),
+            eyeGlowOpacity: self.blinkOpacity(phase: self.cyclePhase(time, period: 3)))
     }
 
     private static func cyclePhase(_ time: TimeInterval, period: TimeInterval) -> CGFloat {
@@ -49,9 +51,9 @@ struct OpenClawMascotPose: Equatable {
             return 0
         }
         if phase < 0.9 {
-            return -8 * easeInOut((phase - 0.85) / 0.05)
+            return -8 * self.easeInOut((phase - 0.85) / 0.05)
         }
-        return -8 * (1 - easeInOut((phase - 0.9) / 0.05))
+        return -8 * (1 - self.easeInOut((phase - 0.9) / 0.05))
     }
 
     private static func blinkOpacity(phase: CGFloat) -> CGFloat {
@@ -59,7 +61,7 @@ struct OpenClawMascotPose: Equatable {
         if phase < 0.9 {
             return 1
         }
-        let dip = phase < 0.95 ? easeInOut((phase - 0.9) / 0.05) : 1 - easeInOut((phase - 0.95) / 0.05)
+        let dip = phase < 0.95 ? self.easeInOut((phase - 0.9) / 0.05) : 1 - self.easeInOut((phase - 0.95) / 0.05)
         return 1 - 0.7 * dip
     }
 
@@ -148,40 +150,44 @@ private struct OpenClawMascotCanvas: View {
         context.translateBy(x: 0, y: pose.floatOffset)
 
         let bodyShading = GraphicsContext.Shading.linearGradient(
-            Gradient(colors: [bodyColorTop, bodyColorBottom]),
+            Gradient(colors: [self.bodyColorTop, self.bodyColorBottom]),
             startPoint: .zero,
             endPoint: CGPoint(x: 120, y: 120))
         let antennaStroke = StrokeStyle(lineWidth: 3, lineCap: .round)
 
         // Same paint order as favicon.svg: body, claws, antennae, eyes.
-        context.fill(bodyPath, with: bodyShading)
-        drawRotated(context: context, degrees: pose.leftClawDegrees, pivot: leftClawPivot) {
-            $0.fill(leftClawPath, with: bodyShading)
+        context.fill(self.bodyPath, with: bodyShading)
+        self.drawRotated(context: context, degrees: pose.leftClawDegrees, pivot: self.leftClawPivot) {
+            $0.fill(self.leftClawPath, with: bodyShading)
         }
-        drawRotated(context: context, degrees: pose.rightClawDegrees, pivot: rightClawPivot) {
-            $0.fill(rightClawPath, with: bodyShading)
+        self.drawRotated(context: context, degrees: pose.rightClawDegrees, pivot: self.rightClawPivot) {
+            $0.fill(self.rightClawPath, with: bodyShading)
         }
-        drawRotated(context: context, degrees: pose.antennaDegrees, pivot: leftAntennaPivot) {
-            $0.stroke(leftAntennaPath, with: .color(bodyColorTop), style: antennaStroke)
+        self.drawRotated(context: context, degrees: pose.antennaDegrees, pivot: self.leftAntennaPivot) {
+            $0.stroke(self.leftAntennaPath, with: .color(self.bodyColorTop), style: antennaStroke)
         }
-        drawRotated(context: context, degrees: pose.antennaDegrees, pivot: rightAntennaPivot) {
-            $0.stroke(rightAntennaPath, with: .color(bodyColorTop), style: antennaStroke)
+        self.drawRotated(context: context, degrees: pose.antennaDegrees, pivot: self.rightAntennaPivot) {
+            $0.stroke(self.rightAntennaPath, with: .color(self.bodyColorTop), style: antennaStroke)
         }
 
-        context.fill(Path(ellipseIn: CGRect(x: 39, y: 29, width: 12, height: 12)), with: .color(eyeColor))
-        context.fill(Path(ellipseIn: CGRect(x: 69, y: 29, width: 12, height: 12)), with: .color(eyeColor))
+        context.fill(Path(ellipseIn: CGRect(x: 39, y: 29, width: 12, height: 12)), with: .color(self.eyeColor))
+        context.fill(Path(ellipseIn: CGRect(x: 69, y: 29, width: 12, height: 12)), with: .color(self.eyeColor))
         var glowContext = context
         glowContext.opacity = pose.eyeGlowOpacity
-        glowContext.fill(Path(ellipseIn: CGRect(x: 43.5, y: 31.5, width: 5, height: 5)), with: .color(eyeGlowColor))
-        glowContext.fill(Path(ellipseIn: CGRect(x: 73.5, y: 31.5, width: 5, height: 5)), with: .color(eyeGlowColor))
+        glowContext.fill(
+            Path(ellipseIn: CGRect(x: 43.5, y: 31.5, width: 5, height: 5)),
+            with: .color(self.eyeGlowColor))
+        glowContext.fill(
+            Path(ellipseIn: CGRect(x: 73.5, y: 31.5, width: 5, height: 5)),
+            with: .color(self.eyeGlowColor))
     }
 
     private static func drawRotated(
         context: GraphicsContext,
         degrees: CGFloat,
         pivot: CGPoint,
-        draw: (inout GraphicsContext) -> Void
-    ) {
+        draw: (inout GraphicsContext) -> Void)
+    {
         var rotated = context
         rotated.translateBy(x: pivot.x, y: pivot.y)
         rotated.rotate(by: .degrees(degrees))

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -893,6 +893,7 @@ Scenario catalog (`extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.
   sticker, and reaction events through the driver.
 - Direct Gateway contract probes: `whatsapp-outbound-media-matrix`,
   `whatsapp-outbound-document-preserves-filename`, `whatsapp-outbound-poll`,
+  `whatsapp-outbound-send-serialization`,
   `whatsapp-group-outbound-media`, `whatsapp-group-outbound-poll`,
   `whatsapp-message-actions`, `whatsapp-reply-context-isolation`,
   `whatsapp-reply-delivery-shape`. These bypass model prompting on purpose
@@ -908,7 +909,7 @@ Scenario catalog (`extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.
 - Status reactions: `whatsapp-status-reactions`,
   `whatsapp-status-reaction-lifecycle`.
 
-The catalog currently contains 51 scenarios. The `live-frontier` default lane
+The catalog currently contains 52 scenarios. The `live-frontier` default lane
 is kept small at 10 scenarios for fast smoke coverage. The `mock-openai`
 default lane runs 45 scenarios deterministically through the real WhatsApp
 transport while mocking only model output; approval scenarios and a few

--- a/extensions/google-meet/src/calendar.ts
+++ b/extensions/google-meet/src/calendar.ts
@@ -1,3 +1,4 @@
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 // Google Meet plugin module implements calendar behavior.
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { googleApiError } from "./google-api-errors.js";
@@ -197,7 +198,10 @@ async function fetchGoogleCalendarEvents(params: {
         scopes: [GOOGLE_CALENDAR_EVENTS_SCOPE],
       });
     }
-    const payload = (await response.json()) as { items?: unknown };
+    const payload = await readProviderJsonResponse<{ items?: unknown }>(
+      response,
+      "Google Calendar events.list",
+    );
     if (payload.items !== undefined && !Array.isArray(payload.items)) {
       throw new Error("Google Calendar events.list response had non-array items");
     }

--- a/extensions/google-meet/src/meet.ts
+++ b/extensions/google-meet/src/meet.ts
@@ -1,3 +1,4 @@
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 // Google Meet plugin module implements meet behavior.
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -289,7 +290,7 @@ async function fetchGoogleMeetJson<T>(params: {
         scopes: [GOOGLE_MEET_MEDIA_SCOPE],
       });
     }
-    return (await response.json()) as T;
+    return await readProviderJsonResponse<T>(response, params.errorPrefix);
   } finally {
     await release();
   }
@@ -354,7 +355,10 @@ export async function fetchGoogleMeetSpace(params: {
         scopes: [GOOGLE_MEET_SPACE_SCOPE],
       });
     }
-    const payload = (await response.json()) as GoogleMeetSpace;
+    const payload = await readProviderJsonResponse<GoogleMeetSpace>(
+      response,
+      "Google Meet spaces.get",
+    );
     if (!payload.name?.trim()) {
       throw new Error("Google Meet spaces.get response was missing name");
     }
@@ -397,7 +401,10 @@ export async function createGoogleMeetSpace(params: {
             : [GOOGLE_MEET_SPACE_CREATED_SCOPE],
       });
     }
-    const payload = (await response.json()) as GoogleMeetSpace;
+    const payload = await readProviderJsonResponse<GoogleMeetSpace>(
+      response,
+      "Google Meet spaces.create",
+    );
     if (!payload.name?.trim()) {
       throw new Error("Google Meet spaces.create response was missing name");
     }

--- a/extensions/google-meet/src/oauth.test.ts
+++ b/extensions/google-meet/src/oauth.test.ts
@@ -102,6 +102,26 @@ describe("Google Meet OAuth", () => {
     expect(params.get("refresh_token")).toBe("refresh-token");
   });
 
+  it("rejects oversized OAuth token responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(new Uint8Array(300 * 1024), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
+
+    await expect(
+      refreshGoogleMeetAccessToken({
+        clientId: "client-id",
+        refreshToken: "refresh-token",
+      }),
+    ).rejects.toThrow("Google OAuth token: JSON response exceeds 262144 bytes");
+  });
+
   it("refreshes cached access tokens with Date-invalid expiries", async () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
       return new Response(

--- a/extensions/google-meet/src/oauth.ts
+++ b/extensions/google-meet/src/oauth.ts
@@ -10,6 +10,7 @@ import {
   parseOAuthCallbackInput,
   waitForLocalOAuthCallback,
 } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { readGoogleApiErrorDetail } from "./google-api-errors.js";
 
@@ -18,6 +19,7 @@ const GOOGLE_MEET_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_MEET_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_MEET_TOKEN_HOST = "oauth2.googleapis.com";
 const GOOGLE_MEET_DEFAULT_TOKEN_LIFETIME_SECONDS = 3600;
+const GOOGLE_OAUTH_TOKEN_JSON_MAX_BYTES = 256 * 1024;
 const GOOGLE_MEET_SCOPES = [
   "https://www.googleapis.com/auth/meetings.space.created",
   "https://www.googleapis.com/auth/meetings.space.readonly",
@@ -89,13 +91,13 @@ async function executeGoogleTokenRequest(body: URLSearchParams): Promise<GoogleM
       const detail = await readGoogleApiErrorDetail(response);
       throw new Error(`Google OAuth token request failed (${response.status}): ${detail}`);
     }
-    const payload = (await response.json()) as {
+    const payload = await readProviderJsonResponse<{
       access_token?: string;
       expires_in?: number;
       refresh_token?: string;
       scope?: string;
       token_type?: string;
-    };
+    }>(response, "Google OAuth token", { maxBytes: GOOGLE_OAUTH_TOKEN_JSON_MAX_BYTES });
     const accessToken = payload.access_token?.trim();
     if (!accessToken) {
       throw new Error("Google OAuth token response was missing access_token");

--- a/extensions/google-meet/src/response-body-boundary.test.ts
+++ b/extensions/google-meet/src/response-body-boundary.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
+    "openclaw/plugin-sdk/ssrf-runtime",
+  );
+  return {
+    ...actual,
+    fetchWithSsrFGuard: async (params: {
+      url: string;
+      init?: RequestInit;
+      signal?: AbortSignal;
+    }) => ({
+      response: await fetch(params.url, { ...params.init, signal: params.signal }),
+      finalUrl: params.url,
+      release: async () => {},
+    }),
+  };
+});
+
+const SEVENTEEN_MIB = 17 * 1024 * 1024;
+
+describe("google-meet response body boundary", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects an oversized spaces.get success response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array(SEVENTEEN_MIB), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const { fetchGoogleMeetSpace } = await import("./meet.js");
+    await expect(
+      fetchGoogleMeetSpace({
+        accessToken: "fake-token",
+        meeting: "abc-defg-hij",
+      }),
+    ).rejects.toThrow("Google Meet spaces.get: JSON response exceeds");
+  });
+});

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
@@ -139,6 +139,7 @@ const DIRECT_GATEWAY_SCENARIO_IDS = [
   "whatsapp-outbound-media-matrix",
   "whatsapp-outbound-document-preserves-filename",
   "whatsapp-outbound-poll",
+  "whatsapp-outbound-send-serialization",
   "whatsapp-message-actions",
   "whatsapp-group-outbound-media",
   "whatsapp-group-outbound-audio",

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
@@ -18,6 +18,7 @@ import { z } from "zod";
 import { createQaArtifactRunId } from "../../artifact-run-id.js";
 import { QA_EVIDENCE_FILENAME, buildLiveTransportEvidenceSummary } from "../../evidence-summary.js";
 import { startQaGatewayChild } from "../../gateway-child.js";
+import { startQaGatewayRpcClient } from "../../gateway-rpc-client.js";
 import { isTruthyOptIn } from "../../mantis-options.runtime.js";
 import { DEFAULT_QA_LIVE_PROVIDER_MODE } from "../../providers/index.js";
 import { fingerprintQaCredentialId } from "../../qa-credentials-fingerprint.runtime.js";
@@ -93,6 +94,7 @@ type WhatsAppQaScenarioId =
   | "whatsapp-outbound-document-preserves-filename"
   | "whatsapp-outbound-media-matrix"
   | "whatsapp-outbound-poll"
+  | "whatsapp-outbound-send-serialization"
   | "whatsapp-pairing-block"
   | "whatsapp-mention-gating"
   | "whatsapp-reply-delivery-shape"
@@ -158,6 +160,7 @@ const WHATSAPP_QA_SCENARIO_POSTURES = {
   "whatsapp-outbound-document-preserves-filename": "direct-gateway",
   "whatsapp-outbound-media-matrix": "direct-gateway",
   "whatsapp-outbound-poll": "direct-gateway",
+  "whatsapp-outbound-send-serialization": "direct-gateway",
   "whatsapp-pairing-block": "user-path",
   "whatsapp-reply-context-isolation": "direct-gateway",
   "whatsapp-reply-delivery-shape": "direct-gateway",
@@ -186,7 +189,8 @@ type WhatsAppQaMessageSendMode =
     };
 
 type WhatsAppQaGateway = Awaited<ReturnType<typeof startQaGatewayChild>>;
-type WhatsAppQaGatewayRuntime = Pick<WhatsAppQaGateway, "call" | "restart" | "workspaceDir">;
+type WhatsAppQaGatewayRuntime = Pick<WhatsAppQaGateway, "call" | "restart" | "workspaceDir"> &
+  Partial<Pick<WhatsAppQaGateway, "logs" | "token" | "wsUrl">>;
 type WhatsAppQaGatewayCallContext = {
   gateway: Pick<WhatsAppQaGatewayRuntime, "call">;
   gatewayTarget: string;
@@ -1525,6 +1529,43 @@ const WHATSAPP_QA_SCENARIOS: WhatsAppQaScenarioDefinition[] = [
         configMode: "allowlist",
         expectReply: true,
         input: `Reply with only this exact marker before document filename check: ${token}`,
+        matchText: token,
+        target: "dm",
+      };
+    },
+  },
+  {
+    id: "whatsapp-outbound-send-serialization",
+    title: "WhatsApp parallel Gateway sends deliver every outbound message",
+    defaultEnabled: false,
+    defaultProviderModes: ["mock-openai"],
+    timeoutMs: 90_000,
+    buildRun: () => {
+      const token = `WHATSAPP_QA_SERIAL_SEND_${randomUUID().slice(0, 8).toUpperCase()}`;
+      const markers = Array.from({ length: 5 }, (_, index) => `${token}_${index + 1}`);
+      return {
+        afterReply: async (_reply, context) => {
+          const sendsStartedAt = new Date();
+          await callWhatsAppGatewaySendConcurrently(
+            context,
+            markers.map((marker, index) => ({
+              label: `parallel-${index + 1}`,
+              message: marker,
+            })),
+          );
+          await Promise.all(
+            markers.map((marker) =>
+              waitForScenarioObservedMessage(context, {
+                observedAfter: sendsStartedAt,
+                match: (message) => message.kind === "text" && message.text.includes(marker),
+              }),
+            ),
+          );
+          return `gateway parallel send delivered ${markers.length}/${markers.length} messages`;
+        },
+        configMode: "allowlist",
+        expectReply: true,
+        input: `Reply with only this exact marker before parallel send checks: ${token}`,
         matchText: token,
         target: "dm",
       };
@@ -2878,6 +2919,16 @@ function buildWhatsAppQaIdempotencyKey(scenarioId: WhatsAppQaScenarioId, label: 
   return `${scenarioId}:${label}:${randomUUID()}`;
 }
 
+type WhatsAppQaGatewaySendParams = {
+  asVoice?: boolean;
+  forceDocument?: boolean;
+  label: string;
+  mediaUrl?: string;
+  mediaUrls?: string[];
+  message?: string;
+  replyToId?: string;
+};
+
 async function writeWhatsAppQaWorkspaceFixture(
   context: WhatsAppQaMessageScenarioContext,
   params: {
@@ -2894,33 +2945,70 @@ async function writeWhatsAppQaWorkspaceFixture(
 
 async function callWhatsAppGatewaySend(
   context: WhatsAppQaGatewayCallContext,
-  params: {
-    asVoice?: boolean;
-    forceDocument?: boolean;
-    label: string;
-    mediaUrl?: string;
-    mediaUrls?: string[];
-    message?: string;
-    replyToId?: string;
-  },
+  params: WhatsAppQaGatewaySendParams,
 ) {
-  return await context.gateway.call(
-    "send",
-    {
-      accountId: context.sutAccountId,
-      agentId: "main",
-      channel: "whatsapp",
-      idempotencyKey: buildWhatsAppQaIdempotencyKey(context.scenarioId, params.label),
-      to: context.gatewayTarget,
-      ...(params.message !== undefined ? { message: params.message } : {}),
-      ...(params.mediaUrl ? { mediaUrl: params.mediaUrl } : {}),
-      ...(params.mediaUrls ? { mediaUrls: params.mediaUrls } : {}),
-      ...(params.asVoice !== undefined ? { asVoice: params.asVoice } : {}),
-      ...(params.forceDocument !== undefined ? { forceDocument: params.forceDocument } : {}),
-      ...(params.replyToId ? { replyToId: params.replyToId } : {}),
-    },
-    { timeoutMs: 60_000 },
+  return await context.gateway.call("send", buildWhatsAppGatewaySendRequest(context, params), {
+    timeoutMs: 60_000,
+  });
+}
+
+function buildWhatsAppGatewaySendRequest(
+  context: WhatsAppQaGatewayCallContext,
+  params: WhatsAppQaGatewaySendParams,
+) {
+  return {
+    accountId: context.sutAccountId,
+    agentId: "main",
+    channel: "whatsapp",
+    idempotencyKey: buildWhatsAppQaIdempotencyKey(context.scenarioId, params.label),
+    to: context.gatewayTarget,
+    ...(params.message !== undefined ? { message: params.message } : {}),
+    ...(params.mediaUrl ? { mediaUrl: params.mediaUrl } : {}),
+    ...(params.mediaUrls ? { mediaUrls: params.mediaUrls } : {}),
+    ...(params.asVoice !== undefined ? { asVoice: params.asVoice } : {}),
+    ...(params.forceDocument !== undefined ? { forceDocument: params.forceDocument } : {}),
+    ...(params.replyToId ? { replyToId: params.replyToId } : {}),
+  };
+}
+
+async function callWhatsAppGatewaySendConcurrently(
+  context: WhatsAppQaMessageScenarioContext,
+  sends: WhatsAppQaGatewaySendParams[],
+) {
+  // Each QA RPC client serializes its own requests. Separate clients preserve
+  // real Gateway overlap so this probe reaches the shared WhatsApp socket concurrently.
+  const connection = resolveWhatsAppGatewayRpcConnection(context.gateway);
+  const clients = await Promise.all(
+    sends.map(() =>
+      startQaGatewayRpcClient({
+        logs: connection.logs,
+        token: connection.token,
+        wsUrl: connection.wsUrl,
+      }),
+    ),
   );
+  try {
+    await Promise.all(
+      clients.map((client, index) =>
+        client.request("send", buildWhatsAppGatewaySendRequest(context, sends[index]), {
+          timeoutMs: 60_000,
+        }),
+      ),
+    );
+  } finally {
+    await Promise.all(clients.map((client) => client.stop()));
+  }
+}
+
+function resolveWhatsAppGatewayRpcConnection(gateway: WhatsAppQaGatewayRuntime) {
+  if (!gateway.logs || !gateway.token || !gateway.wsUrl) {
+    throw new Error("WhatsApp concurrent Gateway probe requires a live RPC connection.");
+  }
+  return {
+    logs: gateway.logs,
+    token: gateway.token,
+    wsUrl: gateway.wsUrl,
+  };
 }
 
 async function callWhatsAppGatewayPoll(

--- a/extensions/whatsapp/src/socket-timing.test.ts
+++ b/extensions/whatsapp/src/socket-timing.test.ts
@@ -1,9 +1,11 @@
-import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 // Whatsapp tests cover socket timing plugin behavior.
+import type { AnyMessageContent, WAMessage } from "baileys";
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_WHATSAPP_SOCKET_TIMING,
   WhatsAppSocketOperationTimeoutError,
+  createWhatsAppSocketOperationTimeoutAdapter,
   isWhatsAppSocketOperationTimeoutError,
   resolveWhatsAppSocketOperationTimeoutMs,
   resolveWhatsAppSocketTiming,
@@ -112,6 +114,88 @@ describe("withWhatsAppSocketOperationTimeout", () => {
       DEFAULT_WHATSAPP_SOCKET_TIMING.defaultQueryTimeoutMs,
     );
     await expect(bounded).resolves.toBe("read");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe("createWhatsAppSocketOperationTimeoutAdapter", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("serializes sendMessage calls across adapter instances for the same socket", async () => {
+    const started: string[] = [];
+    const resolves: Array<(value: WAMessage) => void> = [];
+    const sock = {
+      sendMessage: vi.fn(
+        async (jid: string, content: AnyMessageContent): Promise<WAMessage | undefined> =>
+          await new Promise((resolve) => {
+            const text =
+              typeof content === "object" && content && "text" in content ? content.text : "";
+            started.push(`${jid}:${text}`);
+            resolves.push(resolve);
+          }),
+      ),
+      sendPresenceUpdate: vi.fn(async () => undefined),
+    };
+
+    const first = createWhatsAppSocketOperationTimeoutAdapter(sock, 30_000).sendMessage(
+      "111@s.whatsapp.net",
+      { text: "first" },
+    );
+    await vi.waitFor(() => expect(started).toEqual(["111@s.whatsapp.net:first"]));
+
+    const second = createWhatsAppSocketOperationTimeoutAdapter(sock, 30_000).sendMessage(
+      "222@s.whatsapp.net",
+      { text: "second" },
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started).toEqual(["111@s.whatsapp.net:first"]);
+
+    resolves[0]?.({ key: { id: "msg-1" } } as WAMessage);
+    await expect(first).resolves.toMatchObject({ key: { id: "msg-1" } });
+    await vi.waitFor(() =>
+      expect(started).toEqual(["111@s.whatsapp.net:first", "222@s.whatsapp.net:second"]),
+    );
+
+    resolves[1]?.({ key: { id: "msg-2" } } as WAMessage);
+    await expect(second).resolves.toMatchObject({ key: { id: "msg-2" } });
+  });
+
+  it("releases the send queue after a socket operation timeout", async () => {
+    vi.useFakeTimers();
+    const sendMessage = vi
+      .fn<(jid: string, content: AnyMessageContent) => Promise<WAMessage | undefined>>()
+      .mockImplementationOnce(async () => await new Promise(() => {}))
+      .mockResolvedValueOnce({ key: { id: "msg-2" } } as WAMessage);
+    const sock = {
+      sendMessage,
+      sendPresenceUpdate: vi.fn(async () => undefined),
+    };
+
+    const first = createWhatsAppSocketOperationTimeoutAdapter(sock, 1_000).sendMessage(
+      "111@s.whatsapp.net",
+      { text: "first" },
+    );
+    const firstRejection = expect(first).rejects.toMatchObject({
+      name: "WhatsAppSocketOperationTimeoutError",
+      operation: "sendMessage",
+    });
+    await Promise.resolve();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    const second = createWhatsAppSocketOperationTimeoutAdapter(sock, 1_000).sendMessage(
+      "222@s.whatsapp.net",
+      { text: "second" },
+    );
+    await Promise.resolve();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await firstRejection;
+    await expect(second).resolves.toMatchObject({ key: { id: "msg-2" } });
+    expect(sendMessage).toHaveBeenCalledTimes(2);
     expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/extensions/whatsapp/src/socket-timing.ts
+++ b/extensions/whatsapp/src/socket-timing.ts
@@ -27,6 +27,8 @@ type WhatsAppSocketOperationTimeoutHooks = {
   onSendMessageTimeout?: (params: { jid: string; promise: Promise<WAMessage | undefined> }) => void;
 };
 
+const socketSendMessageQueueTails = new WeakMap<WhatsAppSocketOperationAdapter, Promise<void>>();
+
 export const DEFAULT_WHATSAPP_SOCKET_TIMING: Required<WhatsAppSocketTimingOptions> = {
   keepAliveIntervalMs: 25_000,
   connectTimeoutMs: 60_000,
@@ -80,6 +82,27 @@ export function resolveWhatsAppSocketOperationTimeoutMs(timeoutMs: number): numb
   return resolveTimerTimeoutMs(timeoutMs, DEFAULT_WHATSAPP_SOCKET_TIMING.defaultQueryTimeoutMs);
 }
 
+async function runSerializedSocketSendMessage<T>(
+  sock: WhatsAppSocketOperationAdapter,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = socketSendMessageQueueTails.get(sock) ?? Promise.resolve();
+  // Adapter instances are short-lived, so key the FIFO by the raw socket. A
+  // bounded send releases the queue after timeout to avoid wedging later work.
+  const result = previous.then(run);
+  const tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  socketSendMessageQueueTails.set(sock, tail);
+  void tail.then(() => {
+    if (socketSendMessageQueueTails.get(sock) === tail) {
+      socketSendMessageQueueTails.delete(sock);
+    }
+  });
+  return await result;
+}
+
 export async function withWhatsAppSocketOperationTimeout<T>(
   operation: string,
   promise: Promise<T>,
@@ -114,17 +137,19 @@ export function createWhatsAppSocketOperationTimeoutAdapter(
   const operationTimeoutMs = resolveWhatsAppSocketOperationTimeoutMs(timeoutMs);
   return {
     sendMessage: (jid, content, options) => {
-      const send = options
-        ? sock.sendMessage(jid, content, options)
-        : sock.sendMessage(jid, content);
-      return withWhatsAppSocketOperationTimeout(
-        "sendMessage",
-        send,
-        operationTimeoutMs,
-        hooks?.onSendMessageTimeout
-          ? () => hooks.onSendMessageTimeout?.({ jid, promise: send })
-          : undefined,
-      );
+      return runSerializedSocketSendMessage(sock, () => {
+        const send = options
+          ? sock.sendMessage(jid, content, options)
+          : sock.sendMessage(jid, content);
+        return withWhatsAppSocketOperationTimeout(
+          "sendMessage",
+          send,
+          operationTimeoutMs,
+          hooks?.onSendMessageTimeout
+            ? () => hooks.onSendMessageTimeout?.({ jid, promise: send })
+            : undefined,
+        );
+      });
     },
     sendPresenceUpdate: (presence, jid) => {
       const send =

--- a/scripts/ios-write-swift-filelist.mjs
+++ b/scripts/ios-write-swift-filelist.mjs
@@ -28,6 +28,7 @@ const sharedSwiftFiles = [
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift",
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
+  "../shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotView.swift",
   "../shared/OpenClawKit/Sources/OpenClawKit/AnyCodable.swift",
   "../shared/OpenClawKit/Sources/OpenClawKit/BonjourEscapes.swift",
   "../shared/OpenClawKit/Sources/OpenClawKit/BonjourTypes.swift",

--- a/src/tui/components/hyperlink-markdown.test.ts
+++ b/src/tui/components/hyperlink-markdown.test.ts
@@ -1,0 +1,37 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { normalizeTestText } from "../../../test/helpers/normalize-text.js";
+import { markdownTheme } from "../theme/theme.js";
+import { HyperlinkMarkdown } from "./hyperlink-markdown.js";
+
+describe("HyperlinkMarkdown", () => {
+  it("moves dunder identifiers intact across fenced code wrap boundaries", () => {
+    const markdown = new HyperlinkMarkdown(
+      ["```python", 'if __name__ == "__main__":', "```"].join("\n"),
+      0,
+      0,
+      markdownTheme,
+    );
+
+    const rendered = markdown.render(12);
+    const normalized = rendered.map((line) => normalizeTestText(line));
+
+    expect(rendered.every((line) => visibleWidth(line) <= 12)).toBe(true);
+    expect(normalized.some((line) => line.includes("__name__ =="))).toBe(true);
+    expect(normalized.some((line) => line.includes('"__main__":'))).toBe(true);
+  });
+
+  it("preserves underscores in fenced and inline code", () => {
+    const markdown = new HyperlinkMarkdown(
+      ["```python", "is_palindrome", "```", "", "Call `__init__`."].join("\n"),
+      0,
+      0,
+      markdownTheme,
+    );
+
+    const normalized = markdown.render(16).map((line) => normalizeTestText(line));
+
+    expect(normalized.some((line) => line.includes("is_palindrome"))).toBe(true);
+    expect(normalized.some((line) => line.includes("__init__"))).toBe(true);
+  });
+});

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { html, LitElement } from "lit";
+import { html, LitElement, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { FastMode } from "../../api/types.ts";
 import type { RouteId } from "../../app-route-paths.ts";
@@ -574,7 +574,6 @@ export class ConfigPage extends LitElement {
       excludeSections,
       includeVirtualSections: this.pageId === "communications" || this.pageId === "appearance",
       settingsLayout: this.pageId === "config" ? "accordion" : undefined,
-      onBackToQuick: this.pageId === "config" ? () => (this.settingsMode = "quick") : undefined,
       webPush: this.context.webPush.snapshot,
       onWebPushSubscribe: () => void this.context.webPush.enable(),
       onWebPushUnsubscribe: () => void this.context.webPush.disable(),
@@ -656,6 +655,10 @@ export class ConfigPage extends LitElement {
       version:
         appConfig.serverVersion ?? this.context.gateway.snapshot.hello?.server?.version ?? "",
       configObject,
+      savedConfigObject:
+        asConfigRecord(
+          runtimeConfig.state.configFormOriginal ?? runtimeConfig.state.configSnapshot?.config,
+        ) ?? {},
       configDirty: runtimeConfig.state.configFormDirty,
       configSaving: runtimeConfig.state.configSaving,
       configApplying: runtimeConfig.state.configApplying,
@@ -669,9 +672,6 @@ export class ConfigPage extends LitElement {
       onResetConfig: () => runtimeConfig.resetDraft(),
       onSaveConfig: () => void runtimeConfig.save(),
       onApplyConfig: () => void runtimeConfig.apply(),
-      onAdvancedSettings: () => {
-        this.settingsMode = "advanced";
-      },
       onThinkingChange: (level) =>
         runtimeConfig.patchForm(["agents", "defaults", "thinkingLevel"], level),
       onFastModeChange: (mode: FastMode) =>
@@ -703,6 +703,34 @@ export class ConfigPage extends LitElement {
     });
   }
 
+  private renderSettingsModeToggle() {
+    if (this.pageId !== "config") {
+      return nothing;
+    }
+    const modes = [
+      ["quick", "Simple"],
+      ["advanced", "Advanced"],
+    ] as const;
+    return html`
+      <div class="config-view-toggle qs-segmented" role="tablist" aria-label="Settings view">
+        ${modes.map(
+          ([mode, label]) => html`
+            <button
+              class="qs-segmented__btn ${this.settingsMode === mode
+                ? "qs-segmented__btn--active"
+                : ""}"
+              role="tab"
+              aria-selected=${this.settingsMode === mode}
+              @click=${() => (this.settingsMode = mode)}
+            >
+              ${label}
+            </button>
+          `,
+        )}
+      </div>
+    `;
+  }
+
   override render() {
     const configState = this.context.runtimeConfig.state;
     const configObject =
@@ -717,7 +745,11 @@ export class ConfigPage extends LitElement {
           <div class="page-title">${configPageTitle(this.pageId)}</div>
           <div class="page-sub">${configPageSubtitle(this.pageId)}</div>
         </div>
+        ${this.renderSettingsModeToggle()}
       </section>
+      ${this.pageId === "config"
+        ? html`<div class="config-view-toggle-row">${this.renderSettingsModeToggle()}</div>`
+        : nothing}
       ${renderSettingsWorkspace(
         this.context.basePath,
         body,

--- a/ui/src/pages/config/presets.ts
+++ b/ui/src/pages/config/presets.ts
@@ -19,8 +19,6 @@ export type ConfigPreset = {
   id: ConfigPresetId;
   label: string;
   description: string;
-  detail: string;
-  impact: string;
   icon: string;
   patch: ConfigPresetPatch;
 };
@@ -30,8 +28,6 @@ export const CONFIG_PRESETS: ConfigPreset[] = [
     id: "personal",
     label: "Personal Assistant",
     description: "Balanced default for daily use.",
-    detail: "Good fit for chat, docs, and light edits without a large coding budget.",
-    impact: "Injects bootstrap context every turn with a moderate prompt budget.",
     icon: "✨",
     patch: {
       agents: {
@@ -47,8 +43,6 @@ export const CONFIG_PRESETS: ConfigPreset[] = [
     id: "codeAgent",
     label: "Code Agent",
     description: "Highest context budget for repo work.",
-    detail: "Best for multi-file changes, long bootstrap docs, and code-heavy sessions.",
-    impact: "Uses the largest prompt budget and reinjects context every turn.",
     icon: "🛠️",
     patch: {
       agents: {
@@ -64,9 +58,6 @@ export const CONFIG_PRESETS: ConfigPreset[] = [
     id: "teamBot",
     label: "Team Bot",
     description: "Lean follow-ups for shared bots.",
-    detail:
-      "Best for multi-channel workflows where continuity matters more than large bootstrap payloads.",
-    impact: "Keeps follow-up turns smaller by skipping safe continuation reinjection.",
     icon: "👥",
     patch: {
       agents: {
@@ -82,8 +73,6 @@ export const CONFIG_PRESETS: ConfigPreset[] = [
     id: "minimal",
     label: "Minimal",
     description: "Smallest context budget and lowest cost.",
-    detail: "Best for quick utility turns, automations, and cost-sensitive workflows.",
-    impact: "Uses the smallest bootstrap budget and the leanest follow-up behavior.",
     icon: "⚡",
     patch: {
       agents: {

--- a/ui/src/pages/config/quick.test.ts
+++ b/ui/src/pages/config/quick.test.ts
@@ -76,7 +76,6 @@ function createProps(overrides: Partial<QuickSettingsProps> = {}): QuickSettings
     onUserAvatarChange: vi.fn(),
     configObject: {},
     onSelectPreset: vi.fn(),
-    onAdvancedSettings: vi.fn(),
     connected: true,
     gatewayUrl: "ws://localhost:18789",
     assistantName: "OpenClaw",
@@ -127,11 +126,10 @@ describe("renderQuickSettings", () => {
       "qs-card--model",
       "qs-card--channels",
       "qs-card--security",
-      "qs-card--personal",
       "qs-card--appearance",
+      "qs-card--personal",
       "qs-card--automations",
     ]);
-    expect(container.querySelectorAll(".qs-side-stack .qs-card")).toHaveLength(2);
     expect(container.querySelectorAll(".qs-card--span-all")).toHaveLength(1);
   });
 
@@ -140,13 +138,9 @@ describe("renderQuickSettings", () => {
 
     render(renderQuickSettings(createProps({ configObject: {} })), container);
 
-    const stat = Array.from(container.querySelectorAll<HTMLElement>(".qs-profile-stat")).find(
-      (candidate) =>
-        candidate.querySelector(".qs-profile-stat__label")?.textContent?.trim() ===
-        "Bootstrap Per File",
-    );
-    expect(stat?.querySelector(".qs-profile-stat__value")?.textContent?.trim()).toBe(
-      "20,000 chars",
+    const summary = container.querySelector(".qs-profiles__summary-values");
+    expect(summary?.textContent?.replace(/\s+/g, " ").trim()).toBe(
+      "20,000 chars per file · 60,000 chars total · Every turn",
     );
   });
 

--- a/ui/src/pages/config/quick.ts
+++ b/ui/src/pages/config/quick.ts
@@ -105,9 +105,6 @@ export type QuickSettingsProps = {
   onSaveConfig?: () => void;
   onApplyConfig?: () => void;
 
-  // Navigation
-  onAdvancedSettings?: () => void;
-
   // Connection
   connected: boolean;
   gatewayUrl: string;
@@ -366,33 +363,6 @@ function formatContextInjectionLabel(mode: ProfileSettings["contextInjection"]):
   return mode === "always" ? "Every turn" : "Skip safe follow-ups";
 }
 
-function describeContextInjection(mode: ProfileSettings["contextInjection"]): string {
-  return mode === "always"
-    ? "Reinject workspace bootstrap context on every turn."
-    : "Skip bootstrap reinjection after a completed safe follow-up.";
-}
-
-function renderProfileStat(params: {
-  label: string;
-  value: string;
-  previousValue: string;
-  note: string;
-}) {
-  const changed = params.value !== params.previousValue;
-  return html`
-    <div class="qs-profile-stat ${changed ? "qs-profile-stat--changed" : ""}">
-      <div class="qs-profile-stat__header">
-        <span class="qs-profile-stat__label">${params.label}</span>
-        <span class="qs-profile-stat__value">${params.value}</span>
-      </div>
-      <div class="qs-profile-stat__sub">
-        ${changed ? `Was ${params.previousValue}` : "Matches current default"}
-      </div>
-      <div class="qs-profile-stat__note muted">${params.note}</div>
-    </div>
-  `;
-}
-
 // ── Card renderers ──
 
 function renderCardHeader(icon: TemplateResult, title: string, action?: TemplateResult) {
@@ -578,7 +548,7 @@ function renderSecurityCard(props: QuickSettingsProps) {
             <span class="qs-toggle__hint muted">${browserEnabled ? "Enabled" : "Disabled"}</span>
           </label>
         </div>
-        <div class="qs-row qs-row--tool-profile">
+        <div class="qs-row qs-row--stacked">
           <span class="qs-row__label">${t("quickSettings.security.toolProfile")}</span>
           <div class="qs-segmented">
             ${toolProfiles.map(
@@ -631,8 +601,8 @@ function renderAppearanceCard(props: QuickSettingsProps) {
   return html`
     <div class="qs-card qs-card--appearance">
       ${renderCardHeader(icons.spark, "Appearance")}
-      <div class="qs-card__body">
-        <div class="qs-row">
+      <div class="qs-card__body qs-appearance">
+        <div class="qs-row qs-row--stacked">
           <span class="qs-row__label">Theme</span>
           <div class="qs-segmented">
             ${themeOptions.map(
@@ -659,7 +629,7 @@ function renderAppearanceCard(props: QuickSettingsProps) {
             )}
           </div>
         </div>
-        <div class="qs-row">
+        <div class="qs-row qs-row--stacked">
           <span class="qs-row__label">Mode</span>
           <div class="qs-segmented">
             ${(["light", "dark", "system"] as ThemeMode[]).map(
@@ -682,14 +652,13 @@ function renderAppearanceCard(props: QuickSettingsProps) {
             )}
           </div>
         </div>
-        <div class="qs-row">
+        <div class="qs-row qs-row--stacked">
           <span class="qs-row__label">Roundness</span>
           <div class="qs-segmented">
             ${BORDER_RADIUS_STOPS.map(
               (stop) => html`
                 <button
-                  class="qs-segmented__btn qs-segmented__btn--compact ${stop.value ===
-                  props.borderRadius
+                  class="qs-segmented__btn ${stop.value === props.borderRadius
                     ? "qs-segmented__btn--active"
                     : ""}"
                   @click=${() => props.setBorderRadius(stop.value)}
@@ -700,14 +669,13 @@ function renderAppearanceCard(props: QuickSettingsProps) {
             )}
           </div>
         </div>
-        <div class="qs-row">
+        <div class="qs-row qs-row--stacked">
           <span class="qs-row__label">Text size</span>
           <div class="qs-segmented">
             ${TEXT_SCALE_OPTIONS.map(
               (stop) => html`
                 <button
-                  class="qs-segmented__btn qs-segmented__btn--compact ${stop.value ===
-                  props.textScale
+                  class="qs-segmented__btn ${stop.value === props.textScale
                     ? "qs-segmented__btn--active"
                     : ""}"
                   title=${`${stop.value}%`}
@@ -765,7 +733,6 @@ function renderPersonalCard(props: QuickSettingsProps) {
             <div class="qs-identity-card__copy">
               <div class="qs-identity-card__eyebrow">User</div>
               <div class="qs-identity-card__title">${LOCAL_USER_LABEL}</div>
-              <div class="qs-identity-card__sub">Avatar is browser-local</div>
               <div class="qs-identity-card__repair">
                 <label class="qs-field">
                   <span class="qs-row__label">Avatar text / emoji</span>
@@ -897,55 +864,9 @@ function renderPresetsCard(props: QuickSettingsProps) {
     props.configReady === true &&
     props.configSaving !== true &&
     props.configApplying !== true;
-  const stateBanner = hasPendingProfileChange
-    ? html`
-        <div class="qs-profile-state qs-profile-state--pending" aria-live="polite">
-          <span class="qs-status-dot"></span>
-          <div class="qs-profile-state__text">
-            <span class="qs-profile-state__title"
-              >${selectedPreset?.label ?? "Custom"} is selected but not saved yet.</span
-            >
-            <span class="qs-profile-state__copy"
-              >Save Profile writes it as the default. Apply Now writes it and reloads the current
-              session.</span
-            >
-          </div>
-        </div>
-      `
-    : savedPreset
-      ? html`
-          <div class="qs-profile-state qs-profile-state--ok" aria-live="polite">
-            <span class="qs-status-dot qs-status-dot--ok"></span>
-            <div class="qs-profile-state__text">
-              <span class="qs-profile-state__title"
-                >${savedPreset.label} is your current default.</span
-              >
-              <span class="qs-profile-state__copy"
-                >Profiles only change bootstrap size and follow-up reinjection behavior.</span
-              >
-            </div>
-          </div>
-        `
-      : html`
-          <div class="qs-profile-state" aria-live="polite">
-            <span class="qs-status-dot"></span>
-            <div class="qs-profile-state__text">
-              <span class="qs-profile-state__title">Custom bootstrap settings are active.</span>
-              <span class="qs-profile-state__copy"
-                >Choose a built-in profile to replace the current custom values.</span
-              >
-            </div>
-          </div>
-        `;
-  const panelTitle = selectedPreset?.label ?? "Custom Configuration";
-  const panelDescription =
-    selectedPreset?.detail ?? "This config does not currently match one of the built-in profiles.";
-  const panelImpact =
-    selectedPreset?.impact ??
-    "Pick a profile to stage a focused change to bootstrap size and follow-up behavior.";
-  const commitCopy = hasPendingProfileChange
-    ? "Save Profile writes this as the default. Apply Now writes it and reloads the current session."
-    : "Other staged config edits are pending. Saving here will commit all staged config changes.";
+  const commitHint = hasPendingProfileChange
+    ? "Save writes this profile as the default. Apply Now also reloads the current session."
+    : "Staged config edits are pending. Saving commits all staged changes.";
 
   return html`
     <div class="qs-card qs-card--span-all">
@@ -959,131 +880,96 @@ function renderPresetsCard(props: QuickSettingsProps) {
             : html`<span class="qs-badge">Custom</span>`,
       )}
       <div class="qs-card__body qs-profiles">
-        <div class="qs-profiles__copy">
-          <div class="qs-profiles__eyebrow">Bootstrap Context</div>
-          <p class="qs-profiles__intro">
-            Choose how much workspace context OpenClaw injects into each run. These profiles do not
-            change your model, tools, channels, or theme.
-          </p>
-          ${stateBanner}
-          <div class="qs-presets-grid">
-            ${CONFIG_PRESETS.map((preset) => {
-              const presetDefaults = ((preset.patch.agents as Record<string, unknown> | undefined)
-                ?.defaults ?? {}) as Record<string, unknown>;
-              const presetContext =
-                presetDefaults.contextInjection === "continuation-skip"
-                  ? "continuation-skip"
-                  : "always";
-              return html`
-                <button
-                  type="button"
-                  class="qs-preset ${preset.id === selectedPresetId ? "qs-preset--active" : ""}"
-                  aria-pressed=${preset.id === selectedPresetId}
-                  @click=${() => props.onSelectPreset?.(preset.id)}
-                >
-                  <div class="qs-preset__head">
-                    <div class="qs-preset__identity">
-                      <span class="qs-preset__icon">${preset.icon}</span>
-                      <div class="qs-preset__identity-copy">
-                        <span class="qs-preset__label">${preset.label}</span>
-                        <span class="qs-preset__desc muted">${preset.description}</span>
-                      </div>
-                    </div>
-                    <div class="qs-preset__badges">
-                      ${preset.id === savedPresetId
-                        ? html`<span class="qs-badge qs-badge--ok">Current</span>`
-                        : nothing}
-                      ${hasPendingProfileChange && preset.id === selectedPresetId
-                        ? html`<span class="qs-badge qs-badge--warn">Selected</span>`
-                        : nothing}
+        <p class="qs-profiles__intro">
+          Choose how much workspace context OpenClaw injects into each run. Profiles only change
+          bootstrap size and follow-up reinjection — never your model, tools, channels, or theme.
+        </p>
+        <div class="qs-presets-grid">
+          ${CONFIG_PRESETS.map((preset) => {
+            const presetDefaults = ((preset.patch.agents as Record<string, unknown> | undefined)
+              ?.defaults ?? {}) as Record<string, unknown>;
+            const presetContext =
+              presetDefaults.contextInjection === "continuation-skip"
+                ? "continuation-skip"
+                : "always";
+            return html`
+              <button
+                type="button"
+                class="qs-preset ${preset.id === selectedPresetId ? "qs-preset--active" : ""}"
+                aria-pressed=${preset.id === selectedPresetId}
+                @click=${() => props.onSelectPreset?.(preset.id)}
+              >
+                <div class="qs-preset__head">
+                  <div class="qs-preset__identity">
+                    <span class="qs-preset__icon">${preset.icon}</span>
+                    <div class="qs-preset__identity-copy">
+                      <span class="qs-preset__label">${preset.label}</span>
+                      <span class="qs-preset__desc muted">${preset.description}</span>
                     </div>
                   </div>
-                  <div class="qs-preset__meta">
-                    <span
-                      >${formatCharBudget(Number(presetDefaults.bootstrapMaxChars ?? 0))} per
-                      file</span
-                    >
-                    <span
-                      >${formatCharBudget(Number(presetDefaults.bootstrapTotalMaxChars ?? 0))}
-                      total</span
-                    >
-                    <span>${formatContextInjectionLabel(presetContext)}</span>
+                  <div class="qs-preset__badges">
+                    ${preset.id === savedPresetId
+                      ? html`<span class="qs-badge qs-badge--ok">Current</span>`
+                      : nothing}
+                    ${hasPendingProfileChange && preset.id === selectedPresetId
+                      ? html`<span class="qs-badge qs-badge--warn">Selected</span>`
+                      : nothing}
                   </div>
-                </button>
-              `;
-            })}
-          </div>
+                </div>
+                <div class="qs-preset__meta">
+                  <span
+                    >${formatCharBudget(Number(presetDefaults.bootstrapMaxChars ?? 0))} per
+                    file</span
+                  >
+                  <span
+                    >${formatCharBudget(Number(presetDefaults.bootstrapTotalMaxChars ?? 0))}
+                    total</span
+                  >
+                  <span>${formatContextInjectionLabel(presetContext)}</span>
+                </div>
+              </button>
+            `;
+          })}
         </div>
-
-        <div class="qs-profile-panel">
-          <div class="qs-profile-panel__eyebrow">
-            ${selectedPreset ? "Selected Profile" : "Current Values"}
+        <div class="qs-profiles__footer" aria-live="polite">
+          <div class="qs-profiles__summary">
+            <span class="qs-profiles__summary-label"
+              >${selectedPreset?.label ?? "Custom values"}</span
+            >
+            <span class="qs-profiles__summary-values"
+              >${formatCharBudget(draftSettings.bootstrapMaxChars)} per file ·
+              ${formatCharBudget(draftSettings.bootstrapTotalMaxChars)} total ·
+              ${formatContextInjectionLabel(draftSettings.contextInjection)}</span
+            >
           </div>
-          <h4 class="qs-profile-panel__title">${panelTitle}</h4>
-          <p class="qs-profile-panel__copy">${panelDescription}</p>
-          <div class="qs-profile-panel__impact">${panelImpact}</div>
-
-          <div class="qs-profile-panel__stats">
-            ${renderProfileStat({
-              label: "Bootstrap Per File",
-              value: formatCharBudget(draftSettings.bootstrapMaxChars),
-              previousValue: formatCharBudget(savedSettings.bootstrapMaxChars),
-              note: "Maximum context injected from any single bootstrap file.",
-            })}
-            ${renderProfileStat({
-              label: "Bootstrap Total",
-              value: formatCharBudget(draftSettings.bootstrapTotalMaxChars),
-              previousValue: formatCharBudget(savedSettings.bootstrapTotalMaxChars),
-              note: "Total combined context allowed across all bootstrap files.",
-            })}
-            ${renderProfileStat({
-              label: "Follow-up Turns",
-              value: formatContextInjectionLabel(draftSettings.contextInjection),
-              previousValue: formatContextInjectionLabel(savedSettings.contextInjection),
-              note: describeContextInjection(draftSettings.contextInjection),
-            })}
-          </div>
-
           ${hasPendingConfigChange
             ? html`
-                <div class="qs-profile-panel__actions">
-                  <div class="qs-profile-panel__actions-copy muted">${commitCopy}</div>
-                  <div class="qs-profile-panel__actions-row">
-                    <button
-                      class="btn btn--sm"
-                      ?disabled=${props.configSaving === true || props.configApplying === true}
-                      @click=${props.onResetConfig}
-                    >
-                      Discard
-                    </button>
-                    <button
-                      class="btn btn--sm primary"
-                      ?disabled=${!canCommit}
-                      @click=${props.onSaveConfig}
-                    >
-                      ${props.configSaving === true
-                        ? "Saving…"
-                        : hasPendingProfileChange
-                          ? "Save Profile"
-                          : "Save Changes"}
-                    </button>
-                    <button
-                      class="btn btn--sm"
-                      ?disabled=${!canCommit}
-                      @click=${props.onApplyConfig}
-                    >
-                      ${props.configApplying === true ? "Applying…" : "Apply Now"}
-                    </button>
-                  </div>
+                <div class="qs-profiles__actions">
+                  <span class="qs-profiles__hint muted">${commitHint}</span>
+                  <button
+                    class="btn btn--sm"
+                    ?disabled=${props.configSaving === true || props.configApplying === true}
+                    @click=${props.onResetConfig}
+                  >
+                    Discard
+                  </button>
+                  <button
+                    class="btn btn--sm primary"
+                    ?disabled=${!canCommit}
+                    @click=${props.onSaveConfig}
+                  >
+                    ${props.configSaving === true
+                      ? "Saving…"
+                      : hasPendingProfileChange
+                        ? "Save Profile"
+                        : "Save Changes"}
+                  </button>
+                  <button class="btn btn--sm" ?disabled=${!canCommit} @click=${props.onApplyConfig}>
+                    ${props.configApplying === true ? "Applying…" : "Apply Now"}
+                  </button>
                 </div>
               `
-            : html`
-                <div class="qs-profile-panel__footer muted" aria-live="polite">
-                  ${savedPreset
-                    ? "Saved and ready. Choose another profile to stage a change."
-                    : "Current values are custom. Choose a profile to stage a change."}
-                </div>
-              `}
+            : nothing}
         </div>
       </div>
     </div>
@@ -1108,19 +994,9 @@ function renderConnectionFooter(props: QuickSettingsProps) {
 export function renderQuickSettings(props: QuickSettingsProps) {
   return html`
     <div class="qs-container">
-      <div class="qs-header">
-        <h2 class="qs-header__title">${icons.settings} Quick Settings</h2>
-        <button class="btn btn--sm" @click=${props.onAdvancedSettings}>
-          Advanced ${icons.chevronRight}
-        </button>
-      </div>
-
       <div class="qs-grid">
         ${renderModelCard(props)} ${renderChannelsCard(props)} ${renderSecurityCard(props)}
-        ${renderPersonalCard(props)}
-        <div class="qs-side-stack">
-          ${renderAppearanceCard(props)} ${renderAutomationsCard(props)}
-        </div>
+        ${renderAppearanceCard(props)} ${renderPersonalCard(props)} ${renderAutomationsCard(props)}
         ${renderPresetsCard(props)}
       </div>
 

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -162,8 +162,6 @@ export type ConfigProps = {
   includeVirtualSections?: boolean;
   /** Layout mode: "tabs" (default flat scroll) or "accordion" (grouped collapsible). */
   settingsLayout?: "tabs" | "accordion";
-  /** Callback to navigate back to Quick Settings. Shown in accordion mode. */
-  onBackToQuick?: () => void;
   webPush?: WebPushUiState;
   onWebPushSubscribe?: () => void;
   onWebPushUnsubscribe?: () => void;
@@ -1390,23 +1388,6 @@ export function renderConfig(props: ConfigProps) {
   function renderAccordionNav() {
     return html`
       <div class="config-accordion-nav">
-        ${props.onBackToQuick
-          ? html`
-              <button class="config-accordion-nav__back" @click=${props.onBackToQuick}>
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  width="14"
-                  height="14"
-                >
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                Quick Settings
-              </button>
-            `
-          : nothing}
         ${allCategories.map(
           (cat) => html`
             <div class="config-accordion-group">

--- a/ui/src/styles/config-quick.css
+++ b/ui/src/styles/config-quick.css
@@ -8,7 +8,8 @@
   width: 100%;
 }
 
-.content-header + .settings-workspace {
+.content-header + .settings-workspace,
+.config-view-toggle-row + .settings-workspace {
   margin-top: 20px;
 }
 
@@ -148,37 +149,29 @@ openclaw-logs-page {
   padding: 32px 16px 56px;
 }
 
-.qs-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 24px;
+/* Persistent Simple/Advanced switch in the page header; keeps the way back
+   from advanced settings visible at all times. */
+.config-view-toggle {
+  flex: 0 0 auto;
+  align-self: center;
 }
 
-.qs-header__title {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 1.35rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  margin: 0;
-  color: var(--text-strong);
+/* Mobile fallback: layout.mobile.css hides .content-header at small widths,
+   which would strand users in advanced mode with no way back. Mirror the
+   switch in an in-body row that only shows when the header is hidden. */
+.config-view-toggle-row {
+  display: none;
 }
 
-.qs-header__title svg {
-  width: 22px;
-  height: 22px;
-  opacity: 0.5;
-  color: currentColor;
-  stroke: currentColor;
-  fill: none;
-}
-
-.qs-header__title svg * {
-  stroke: currentColor;
-  fill: none;
+@media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
+  .config-view-toggle-row {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
+    max-width: 1520px;
+    margin: 0 auto;
+    padding: 12px 16px 0;
+  }
 }
 
 /* ── Grid ── */
@@ -188,15 +181,6 @@ openclaw-logs-page {
   grid-template-columns: repeat(12, minmax(0, 1fr));
   align-items: stretch;
   gap: 14px;
-}
-
-.qs-side-stack {
-  display: grid;
-  grid-column: span 3;
-  grid-template-rows: auto 1fr;
-  align-self: stretch;
-  gap: 14px;
-  min-width: 0;
 }
 
 /* ── Card ── */
@@ -223,12 +207,17 @@ openclaw-logs-page {
 
 .qs-card--model,
 .qs-card--channels,
-.qs-card--security {
+.qs-card--security,
+.qs-card--automations {
   grid-column: span 4;
 }
 
+.qs-card--appearance {
+  grid-column: 1 / -1;
+}
+
 .qs-card--personal {
-  grid-column: span 9;
+  grid-column: span 8;
 }
 
 .qs-card--personal .qs-identity-grid {
@@ -372,21 +361,43 @@ openclaw-logs-page {
   color: var(--accent);
 }
 
-.qs-row--tool-profile {
+/* Stacked row: label above a full-width, equal-segment control. Used where a
+   side-by-side row would wrap unpredictably (Appearance, tool profile). */
+.qs-row--stacked {
   align-items: stretch;
   flex-direction: column;
   gap: 8px;
   padding-block: 10px;
 }
 
-.qs-row--tool-profile .qs-row__label {
+.qs-row--stacked .qs-row__label {
   flex: 0 0 auto;
   width: 100%;
 }
 
-.qs-row--tool-profile .qs-segmented {
+.qs-row--stacked .qs-segmented {
   align-self: stretch;
   justify-content: flex-start;
+}
+
+.qs-row--stacked .qs-segmented__btn {
+  flex: 1 1 0;
+  padding-inline: 6px;
+  text-align: center;
+}
+
+/* ── Appearance card ── */
+
+.qs-appearance {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(240px, 100%), 1fr));
+  gap: 0 24px;
+  padding: 2px 16px 8px;
+}
+
+.qs-appearance .qs-row {
+  border-top: none;
+  padding-inline: 0;
 }
 
 .qs-field {
@@ -429,12 +440,6 @@ openclaw-logs-page {
   border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--bg-elevated) 42%, var(--card) 58%);
-  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--accent) 42%, transparent);
-}
-
-.qs-identity-card--assistant {
-  background: color-mix(in srgb, var(--bg-elevated) 50%, var(--card) 50%);
-  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--border-strong) 70%, transparent);
 }
 
 .qs-identity-card__copy {
@@ -554,7 +559,7 @@ openclaw-logs-page {
   flex: 0 0 auto;
   border-radius: calc(var(--radius-md) + 2px);
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.16);
+  box-shadow: var(--shadow-sm);
   object-fit: cover;
   object-position: center;
 }
@@ -804,29 +809,6 @@ openclaw-logs-page {
   margin-bottom: 20px;
 }
 
-.config-accordion-nav__back {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: var(--accent);
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 8px 12px;
-  margin-bottom: 8px;
-  border-radius: var(--radius-md);
-  transition:
-    opacity var(--duration-fast) var(--ease-out),
-    background var(--duration-fast) var(--ease-out);
-}
-
-.config-accordion-nav__back:hover {
-  opacity: 0.85;
-  background: var(--accent-subtle);
-}
-
 .config-accordion-group {
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   border-radius: var(--radius-md);
@@ -931,91 +913,68 @@ openclaw-logs-page {
 
 /* ── Presets Grid ── */
 
-.qs-presets-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-  padding: 0;
-}
-
 .qs-profiles {
   display: grid;
-  grid-template-columns: minmax(0, 1.3fr) minmax(280px, 0.9fr);
-  gap: 18px;
-  padding: 18px 16px 16px;
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--accent-subtle) 18%, transparent) 0%,
-    transparent 36%
-  );
-}
-
-.qs-profiles__copy {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
   gap: 14px;
-}
-
-.qs-profiles__eyebrow {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--accent) 68%, var(--muted) 32%);
+  padding: 14px 16px 16px;
 }
 
 .qs-profiles__intro {
   margin: 0;
-  max-width: 62ch;
+  max-width: 78ch;
   font-size: 0.8125rem;
   line-height: 1.55;
   color: var(--muted);
   text-wrap: pretty;
 }
 
-.qs-profile-state {
-  display: flex;
-  align-items: flex-start;
+.qs-presets-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(230px, 100%), 1fr));
   gap: 10px;
-  padding: 12px 14px;
-  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--bg-elevated) 72%, var(--card) 28%);
 }
 
-.qs-profile-state--pending {
-  border-color: color-mix(in srgb, var(--accent) 28%, var(--border) 72%);
-  background: color-mix(in srgb, var(--accent-subtle) 42%, var(--card) 58%);
-}
-
-.qs-profile-state--pending .qs-status-dot {
-  background: var(--accent);
-  box-shadow: 0 0 10px color-mix(in srgb, var(--accent) 24%, transparent);
-}
-
-.qs-profile-state--ok {
-  border-color: color-mix(in srgb, var(--ok) 24%, var(--border) 76%);
-  background: color-mix(in srgb, var(--ok-subtle) 58%, var(--card) 42%);
-}
-
-.qs-profile-state__text {
-  min-width: 0;
+.qs-profiles__footer {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px 16px;
+  padding-top: 12px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
 }
 
-.qs-profile-state__title {
+.qs-profiles__summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 10px;
+  min-width: 0;
+}
+
+.qs-profiles__summary-label {
   font-size: 0.8125rem;
   font-weight: 650;
   color: var(--text-strong);
 }
 
-.qs-profile-state__copy {
+.qs-profiles__summary-values {
   font-size: 0.75rem;
-  line-height: 1.45;
   color: var(--muted);
+}
+
+.qs-profiles__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.qs-profiles__hint {
+  font-size: 0.75rem;
+  line-height: 1.4;
+  max-width: 46ch;
 }
 
 .qs-preset {
@@ -1039,25 +998,18 @@ openclaw-logs-page {
 .qs-preset:hover {
   border-color: color-mix(in srgb, var(--accent) 40%, var(--border) 60%);
   background: color-mix(in srgb, var(--accent-subtle) 40%, var(--card) 60%);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.16);
-  transform: translateY(-1px);
 }
 
 .qs-preset:focus-visible {
   outline: none;
   border-color: color-mix(in srgb, var(--accent) 55%, var(--border) 45%);
-  box-shadow:
-    0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent),
-    0 8px 24px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 .qs-preset--active {
   border-color: color-mix(in srgb, var(--accent) 50%, var(--border) 50%);
   background: color-mix(in srgb, var(--accent-subtle) 60%, var(--card) 40%);
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--accent) 15%, transparent),
-    0 12px 28px rgba(0, 0, 0, 0.2);
-  transform: translateY(-1px);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 15%, transparent);
 }
 
 .qs-preset--active:hover {
@@ -1128,180 +1080,20 @@ openclaw-logs-page {
   background: color-mix(in srgb, var(--bg-elevated) 84%, transparent);
 }
 
-.qs-profile-panel {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 16px;
-  border-radius: var(--radius-lg);
-  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  background: color-mix(in srgb, var(--bg-elevated) 76%, var(--card) 24%);
-}
-
-.qs-profile-panel__eyebrow {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--accent) 68%, var(--muted) 32%);
-}
-
-.qs-profile-panel__title {
-  margin: 0;
-  font-size: 1.08rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  color: var(--text-strong);
-  text-wrap: balance;
-}
-
-.qs-profile-panel__copy {
-  margin: 0;
-  font-size: 0.8125rem;
-  line-height: 1.55;
-  color: var(--text);
-}
-
-.qs-profile-panel__impact {
-  font-size: 0.75rem;
-  line-height: 1.5;
-  color: var(--muted);
-}
-
-.qs-profile-panel__stats {
-  display: grid;
-  gap: 10px;
-}
-
-.qs-profile-stat {
-  display: grid;
-  gap: 4px;
-  padding: 12px;
-  border: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--card) 84%, transparent);
-}
-
-.qs-profile-stat--changed {
-  border-color: color-mix(in srgb, var(--accent) 32%, var(--border) 68%);
-  background: color-mix(in srgb, var(--accent-subtle) 44%, var(--card) 56%);
-}
-
-.qs-profile-stat__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.qs-profile-stat__label {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-
-.qs-profile-stat__value {
-  font-size: 0.875rem;
-  font-weight: 650;
-  color: var(--text-strong);
-  text-align: right;
-}
-
-.qs-profile-stat__sub {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--muted);
-}
-
-.qs-profile-stat--changed .qs-profile-stat__sub {
-  color: var(--accent);
-}
-
-.qs-profile-stat__note {
-  font-size: 0.75rem;
-  line-height: 1.45;
-}
-
-.qs-profile-panel__actions {
-  display: grid;
-  gap: 10px;
-  padding-top: 4px;
-  border-top: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
-}
-
-.qs-profile-panel__actions-copy,
-.qs-profile-panel__footer {
-  font-size: 0.75rem;
-  line-height: 1.5;
-}
-
-.qs-profile-panel__actions-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.qs-profile-panel__footer {
-  padding-top: 4px;
-  border-top: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
-}
-
 @media (max-width: 1100px) {
   .qs-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     align-items: stretch;
   }
 
-  .qs-side-stack {
-    display: contents;
-  }
-
-  .qs-card,
-  .qs-card--span-all,
-  .qs-card--personal,
-  .qs-card--model,
-  .qs-card--channels,
-  .qs-card--security,
-  .qs-card--appearance,
-  .qs-card--automations {
+  .qs-card {
     grid-column: span 1;
   }
 
+  .qs-card--appearance,
   .qs-card--personal,
   .qs-card--span-all {
     grid-column: 1 / -1;
-  }
-
-  .qs-card--model {
-    order: 1;
-  }
-
-  .qs-card--channels {
-    order: 2;
-  }
-
-  .qs-card--security {
-    order: 3;
-  }
-
-  .qs-card--appearance {
-    order: 5;
-  }
-
-  .qs-card--personal {
-    order: 4;
-  }
-
-  .qs-card--automations {
-    grid-column: 1 / -1;
-    order: 6;
-  }
-
-  .qs-card--span-all {
-    order: 7;
   }
 }
 
@@ -1312,6 +1104,17 @@ openclaw-logs-page {
 
   .qs-card--personal .qs-identity-grid {
     grid-template-columns: 1fr;
+  }
+
+  .qs-profiles__footer,
+  .qs-profiles__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .qs-profiles__actions .btn {
+    width: 100%;
+    justify-content: center;
   }
 }
 
@@ -1331,34 +1134,5 @@ openclaw-logs-page {
 
   .qs-identity-grid {
     grid-template-columns: 1fr;
-  }
-
-  .qs-header {
-    align-items: flex-start;
-  }
-
-  .qs-header__title {
-    font-size: 1.15rem;
-  }
-}
-
-@media (max-width: 920px) {
-  .qs-profiles {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 720px) {
-  .qs-presets-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .qs-profile-panel__actions-row {
-    flex-direction: column;
-  }
-
-  .qs-profile-panel__actions-row .btn {
-    width: 100%;
-    justify-content: center;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Closes #90769. Prevents regressions where narrow TUI Markdown wrapping splits Python dunder and underscore identifiers inside fenced or inline code.

## Why This Change Was Made

Current `main` upgraded `@earendil-works/pi-tui` from 0.78.0 to 0.80.3 in #99949. Direct dependency inspection and current-main rendering now show that upstream keeps `__name__`, `__main__`, `is_palindrome`, and `__init__` intact while respecting the terminal width.

The original PR's 135-line production patch wrapped pi-tui's private `Markdown.renderToken` method. That is no longer the best fix: it duplicates the current upstream renderer and creates a private dependency seam. This rewrite removes the monkey patch entirely and keeps only focused regression coverage against the public `HyperlinkMarkdown` behavior.

## User Impact

No new runtime path. The corrected behavior already exists on current `main`; this PR locks it in so future dependency or wrapper changes cannot silently corrupt displayed code identifiers.

Contributor credit is preserved for @zhangguiping-xydt, whose report, proof, and original PR supplied the regression cases.

## Evidence

- Current-main render at width 12 moves `__name__` and `__main__` to fitting lines without splitting either identifier; fenced `is_palindrome` and inline `__init__` also remain intact.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/tui/components/hyperlink-markdown.test.ts src/tui/components/chat-log.test.ts src/tui/tui-formatters.test.ts src/tui/theme/theme.test.ts` — 4 files, 98 tests passed.
- `git diff --cached --check` — passed before commit.
- Fresh autoreview found one test-boundary gap; the test was tightened to force the dunder token across a real width boundary. Second autoreview: clean, no accepted/actionable findings (0.98 confidence).

## Scope

Test-only. No config, protocol, provider, auth, persistence, or tool-execution behavior changed. No changelog entry required.

## AI Assistance

AI-assisted maintainer rewrite and review.
