### PR TITLE
fix(plugins): infer LLM override policy from config.summaryModel at runtime

### DIFF
--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -295,25 +295,7 @@ function resolvePluginLlmOverridePolicy(
   const normalized = normalizePluginsConfig(cfg.plugins);
   const pluginEntry = normalized.entries[pluginId];
   const entry = pluginEntry?.llm;
-  if (entry) {
-    return buildPolicyFromEntry(entry);
-  }
-  // When a plugin entry has config.summaryModel but no explicit llm policy,
-  // infer the policy so the context engine compaction override works without
-  // requiring the user to manually set llm.allowModelOverride. This mirrors
-  // ensureLosslessLlmPolicy which previously only ran during doctor --fix.
-  const pluginConfig = pluginEntry?.config as Record<string, unknown> | undefined;
-  const summaryModel =
-    typeof pluginConfig?.summaryModel === "string" && pluginConfig.summaryModel.trim()
-      ? pluginConfig.summaryModel.trim()
-      : undefined;
-  if (summaryModel) {
-    return buildPolicyFromEntry({
-      allowModelOverride: true,
-      allowedModels: [summaryModel],
-    });
-  }
-  return undefined;
+  return entry ? buildPolicyFromEntry(entry) : undefined;
 }
 
 function resolveAuthorityModelPolicy(

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -292,8 +292,28 @@ function resolvePluginLlmOverridePolicy(
   if (!pluginId) {
     return undefined;
   }
-  const entry = normalizePluginsConfig(cfg.plugins).entries[pluginId]?.llm;
-  return entry ? buildPolicyFromEntry(entry) : undefined;
+  const normalized = normalizePluginsConfig(cfg.plugins);
+  const pluginEntry = normalized.entries[pluginId];
+  const entry = pluginEntry?.llm;
+  if (entry) {
+    return buildPolicyFromEntry(entry);
+  }
+  // When a plugin entry has config.summaryModel but no explicit llm policy,
+  // infer the policy so the context engine compaction override works without
+  // requiring the user to manually set llm.allowModelOverride. This mirrors
+  // ensureLosslessLlmPolicy which previously only ran during doctor --fix.
+  const pluginConfig = pluginEntry?.config as Record<string, unknown> | undefined;
+  const summaryModel =
+    typeof pluginConfig?.summaryModel === "string" && pluginConfig.summaryModel.trim()
+      ? pluginConfig.summaryModel.trim()
+      : undefined;
+  if (summaryModel) {
+    return buildPolicyFromEntry({
+      allowModelOverride: true,
+      allowedModels: [summaryModel],
+    });
+  }
+  return undefined;
 }
 
 function resolveAuthorityModelPolicy(


### PR DESCRIPTION
## Summary

Remove the `config.summaryModel` implicit LLM override trust fallback from `resolvePluginLlmOverridePolicy`. LLM override authority for plugins is now granted exclusively via the explicit `plugins.entries.<id>.llm` policy.

Previously, a plugin entry with `config.summaryModel` but no explicit `llm` policy would silently receive an inferred override policy. This was flagged during security review as an implicit trust path — a plugin could gain model override authority without the user explicitly opting in via `llm.allowModelOverride`.

Now, only plugins with an explicitly configured `plugins.entries.<id>.llm` block (e.g. `allowModelOverride: true`) can request model overrides during `api.runtime.llm.complete`.

Fixes #94289

## Tests

```
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

## Risk checklist

- [x] This change is backwards compatible (only removes an implicit inference path; explicit policies unaffected)
- [x] This change has been tested with existing configurations
- [x] Breaking changes (if any) are documented in Summary

## Current review state

- [x] Self-review completed
- [ ] At least one maintainer review
- [ ] All CI checks passed