### PR TITLE
fix(openrouter): expand short DeepSeek V4 aliases in API model normalizer

### DIFF
--- a/extensions/openrouter/models.test.ts
+++ b/extensions/openrouter/models.test.ts
@@ -1,0 +1,123 @@
+// Openrouter models tests cover model ID normalization and alias expansion.
+import { describe, expect, it } from "vitest";
+import {
+  normalizeOpenRouterModelId,
+  normalizeOpenRouterApiModelId,
+  isOpenRouterMistralModelId,
+  isOpenRouterDeepSeekV4ModelId,
+} from "./models.js";
+
+describe("normalizeOpenRouterApiModelId", () => {
+  it("returns undefined for non-string input", () => {
+    expect(normalizeOpenRouterApiModelId(undefined)).toBeUndefined();
+    expect(normalizeOpenRouterApiModelId(null)).toBeUndefined();
+    expect(normalizeOpenRouterApiModelId(42)).toBeUndefined();
+    expect(normalizeOpenRouterApiModelId({})).toBeUndefined();
+  });
+
+  it("passes through non-openrouter model IDs unchanged", () => {
+    expect(normalizeOpenRouterApiModelId("deepseek/deepseek-v4-flash")).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+    expect(normalizeOpenRouterApiModelId("anthropic/claude-opus-4-8")).toBe(
+      "anthropic/claude-opus-4-8",
+    );
+    expect(normalizeOpenRouterApiModelId("unknown-model")).toBe("unknown-model");
+  });
+
+  it("strips openrouter/ prefix when remainder contains a namespace", () => {
+    expect(normalizeOpenRouterApiModelId("openrouter/deepseek/deepseek-v4-flash")).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+    expect(normalizeOpenRouterApiModelId("openrouter/anthropic/claude-opus-4-8")).toBe(
+      "anthropic/claude-opus-4-8",
+    );
+  });
+
+  it("expands known short aliases to full namespaced model IDs", () => {
+    expect(normalizeOpenRouterApiModelId("openrouter/deepseek-v4-flash")).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+    expect(normalizeOpenRouterApiModelId("openrouter/deepseek-v4-pro")).toBe(
+      "deepseek/deepseek-v4-pro",
+    );
+  });
+
+  it("returns the original prefixed form for unknown short aliases", () => {
+    expect(normalizeOpenRouterApiModelId("openrouter/unknown-model")).toBe(
+      "openrouter/unknown-model",
+    );
+    expect(normalizeOpenRouterApiModelId("openrouter/some-other-v1")).toBe(
+      "openrouter/some-other-v1",
+    );
+  });
+
+  it("normalizes case via the lowercase helper", () => {
+    expect(normalizeOpenRouterApiModelId("OPENROUTER/DEEPSEEK-V4-FLASH")).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+    expect(normalizeOpenRouterApiModelId("OpenRouter/DeepSeek-V4-Pro")).toBe(
+      "deepseek/deepseek-v4-pro",
+    );
+  });
+
+  it("is not vulnerable to prototype pollution via plain object lookup", () => {
+    // Plain objects have inherited keys like "constructor", "__proto__", and "toString";
+    // using Map ensures only explicitly defined keys are matched.
+    // Note: normalizeLowercaseStringOrEmpty lowercases the input first.
+    expect(normalizeOpenRouterApiModelId("openrouter/constructor")).toBe("openrouter/constructor");
+    expect(normalizeOpenRouterApiModelId("openrouter/__proto__")).toBe("openrouter/__proto__");
+    expect(normalizeOpenRouterApiModelId("openrouter/tostring")).toBe("openrouter/tostring");
+  });
+});
+
+describe("normalizeOpenRouterModelId", () => {
+  it("returns undefined for non-string input", () => {
+    expect(normalizeOpenRouterModelId(undefined)).toBeUndefined();
+    expect(normalizeOpenRouterModelId(null)).toBeUndefined();
+  });
+
+  it("strips openrouter/ prefix regardless of namespace", () => {
+    expect(normalizeOpenRouterModelId("openrouter/deepseek/deepseek-v4-flash")).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+    expect(normalizeOpenRouterModelId("openrouter/deepseek-v4-flash")).toBe("deepseek-v4-flash");
+  });
+
+  it("passes through non-prefixed model IDs unchanged", () => {
+    expect(normalizeOpenRouterModelId("deepseek/deepseek-v4-flash")).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+  });
+});
+
+describe("isOpenRouterMistralModelId", () => {
+  it("detects known Mistral model prefixes", () => {
+    expect(isOpenRouterMistralModelId("openrouter/mistralai/mixtral-8x7b")).toBe(true);
+    expect(isOpenRouterMistralModelId("mistralai/mixtral-8x7b")).toBe(true);
+    expect(isOpenRouterMistralModelId("mistral/mistral-7b")).toBe(true);
+  });
+
+  it("returns false for non-Mistral models", () => {
+    expect(isOpenRouterMistralModelId("deepseek/deepseek-v4-flash")).toBe(false);
+    expect(isOpenRouterMistralModelId("openrouter/deepseek-v4-flash")).toBe(false);
+  });
+});
+
+describe("isOpenRouterDeepSeekV4ModelId", () => {
+  it("detects DeepSeek V4 flash", () => {
+    expect(isOpenRouterDeepSeekV4ModelId("openrouter/deepseek/deepseek-v4-flash")).toBe(true);
+    expect(isOpenRouterDeepSeekV4ModelId("deepseek/deepseek-v4-flash")).toBe(true);
+  });
+
+  it("detects DeepSeek V4 pro", () => {
+    expect(isOpenRouterDeepSeekV4ModelId("openrouter/deepseek/deepseek-v4-pro")).toBe(true);
+    expect(isOpenRouterDeepSeekV4ModelId("deepseek/deepseek-v4-pro")).toBe(true);
+  });
+
+  it("returns false for non-DeepSeek V4 models", () => {
+    expect(isOpenRouterDeepSeekV4ModelId("openrouter/deepseek/deepseek-v3")).toBe(false);
+    expect(isOpenRouterDeepSeekV4ModelId("openrouter/anthropic/claude-opus-4-8")).toBe(false);
+    expect(isOpenRouterDeepSeekV4ModelId("openrouter/deepseek-v4-flash")).toBe(false);
+  });
+});

--- a/extensions/openrouter/models.ts
+++ b/extensions/openrouter/models.ts
@@ -30,10 +30,10 @@ export function normalizeOpenRouterModelId(modelId: unknown): string | undefined
 // namespace when the unprefixed remainder ("deepseek-v4-flash") contains no "/",
 // and the original prefixed form would be returned — causing downstream code
 // that re-adds the "openrouter/" prefix to produce "openrouter/openrouter/…".
-const SHORT_MODEL_ALIASES: Record<string, string> = {
-  "deepseek-v4-flash": "deepseek/deepseek-v4-flash",
-  "deepseek-v4-pro": "deepseek/deepseek-v4-pro",
-};
+const SHORT_MODEL_ALIASES = new Map<string, string>([
+  ["deepseek-v4-flash", "deepseek/deepseek-v4-flash"],
+  ["deepseek-v4-pro", "deepseek/deepseek-v4-pro"],
+]);
 
 export function normalizeOpenRouterApiModelId(modelId: unknown): string | undefined {
   if (typeof modelId !== "string") {
@@ -49,7 +49,7 @@ export function normalizeOpenRouterApiModelId(modelId: unknown): string | undefi
   }
   // Expand known short aliases (e.g. "deepseek-v4-flash" → "deepseek/deepseek-v4-flash")
   // so downstream code receives a proper namespaced upstream model ID.
-  const expanded = SHORT_MODEL_ALIASES[unprefixed];
+  const expanded = SHORT_MODEL_ALIASES.get(unprefixed);
   if (expanded) {
     return expanded;
   }

--- a/extensions/openrouter/models.ts
+++ b/extensions/openrouter/models.ts
@@ -24,6 +24,17 @@ export function normalizeOpenRouterModelId(modelId: unknown): string | undefined
     : normalized;
 }
 
+// Short model aliases that lack an upstream namespace prefix but still need
+// to be expanded to the full OpenRouter API model id. Without this mapping,
+// a model configured as "openrouter/deepseek-v4-flash" would lose its upstream
+// namespace when the unprefixed remainder ("deepseek-v4-flash") contains no "/",
+// and the original prefixed form would be returned — causing downstream code
+// that re-adds the "openrouter/" prefix to produce "openrouter/openrouter/…".
+const SHORT_MODEL_ALIASES: Record<string, string> = {
+  "deepseek-v4-flash": "deepseek/deepseek-v4-flash",
+  "deepseek-v4-pro": "deepseek/deepseek-v4-pro",
+};
+
 export function normalizeOpenRouterApiModelId(modelId: unknown): string | undefined {
   if (typeof modelId !== "string") {
     return undefined;
@@ -33,9 +44,18 @@ export function normalizeOpenRouterApiModelId(modelId: unknown): string | undefi
     return normalized;
   }
   const unprefixed = normalized.slice(OPENROUTER_MODEL_PREFIX.length);
-  // `openrouter/` is both a provider qualifier and an upstream namespace.
-  // Strip it only when the remainder is still a namespaced API model id.
-  return unprefixed.includes("/") ? unprefixed : normalized;
+  if (unprefixed.includes("/")) {
+    return unprefixed;
+  }
+  // Expand known short aliases (e.g. "deepseek-v4-flash" → "deepseek/deepseek-v4-flash")
+  // so downstream code receives a proper namespaced upstream model ID.
+  const expanded = SHORT_MODEL_ALIASES[unprefixed];
+  if (expanded) {
+    return expanded;
+  }
+  // No known expansion: return the original prefixed form so the caller can
+  // still attempt resolution rather than silently truncating the prefix.
+  return normalized;
 }
 
 export function isOpenRouterMistralModelId(modelId: unknown): boolean {


### PR DESCRIPTION
## What Problem This Solves

When a model is configured as `openrouter/deepseek-v4-flash` (short format, as shown by `models list --all`), `normalizeOpenRouterApiModelId` strips the `"openrouter/"` prefix leaving `"deepseek-v4-flash"`. Since this remainder contains no `"/"`, the function returned the **original prefixed form** — which downstream code then re-prefixed with `"openrouter/"`, producing `"openrouter/openrouter/deepseek-v4-flash"` and causing a `model_not_found` error from OpenRouter.

This fix:
- Adds a `Map`-based short alias lookup (`deepseek-v4-flash` → `deepseek/deepseek-v4-flash`, `deepseek-v4-pro` → `deepseek/deepseek-v4-pro`) — using `Map` instead of a plain `Record` to avoid prototype pollution via inherited keys
- Includes 15 unit tests covering expansion, passthrough, unknown names, Map safety, and DeepSeek V4 detection

Fixes #95198

## Evidence

**Behavior addressed**: Short model IDs like `openrouter/deepseek-v4-flash` now expand to the full upstream model ID `deepseek/deepseek-v4-flash` instead of being returned as-is and later double-prefixed.

**Changes since initial submission (Phase 10)**:
- **Alias lookup safety**: Changed from plain object (`Record`) to `Map` to eliminate prototype pollution vulnerability — inherited keys like `constructor`, `__proto__`, `toString` can no longer bypass the alias check
- **Tests**: Added 15 focused unit tests in a new `models.test.ts` file covering alias expansion, namespaced passthrough, unknown short names, case normalization, Map safety, and DeepSeek V4 detection
- **CI**: All checks passing

**Real setup tested**: Node v24.13.1, Linux x86_64

**Exact steps or command run after this patch**:

```bash
$ npx tsx -e "import { normalizeOpenRouterApiModelId, isOpenRouterDeepSeekV4ModelId } from './extensions/openrouter/models.ts'; ..."
```

**After-fix evidence** (terminal output from production code):

```
=== PR #95214 — OpenRouter short alias expansion proof ===
Runtime: v24.13.1

--- Known short alias expansion ---
  ✅ deepseek-v4-flash → deepseek/deepseek-v4-flash
  ✅ deepseek-v4-pro → deepseek/deepseek-v4-pro

--- Namespaced passthrough ---
  ✅ openrouter/deepseek/deepseek-v4-flash → deepseek/deepseek-v4-flash
  ✅ openrouter/anthropic/claude-opus-4-8 → anthropic/claude-opus-4-8

--- No openrouter/ prefix ---
  ✅ non-prefixed passed through
  ✅ non-openrouter passed through

--- Unknown short names ---
  ✅ unknown short name kept prefixed

--- Map safety (no prototype pollution) ---
  ✅ constructor not treated as alias
  ✅ __proto__ not treated as alias

--- isOpenRouterDeepSeekV4ModelId ---
  ✅ detects deepseek-v4-flash
  ✅ detects deepseek-v4-pro
  ✅ not deepseek-v4 models excluded

Results: 12 passed, 0 failed
```

**Unit test verification**:

```
$ pnpm test -- extensions/openrouter/models.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

**Observed result after the fix**: The `SHORT_MODEL_ALIASES` mapping expands known short model IDs to their full upstream path. `openrouter/deepseek-v4-flash` now correctly resolves to `deepseek/deepseek-v4-flash` instead of being returned as `openrouter/deepseek-v4-flash` (which caused the double-prefix downstream). The `Map`-based lookup ensures inherited `Object.prototype` keys cannot bypass the alias check — fixing the safety issue flagged in review.

**What was not tested**: End-to-end verification with a live OpenRouter API call was not performed — it would require a valid OpenRouter API key. The fix is validated at the model ID normalization level.

## Tests and validation

| Test Type | Result | Details |
|-----------|--------|---------|
| Unit Tests | ✅ | 15/15 passed (new models.test.ts) |
| Map Safety | ✅ | constructor, __proto__, toString not vulnerable |
| Alias Expansion | ✅ | 2 short aliases expand correctly |
| Namespaced Passthrough | ✅ | 2 cases verified |

## Risk checklist

Did user-visible behavior change? (`Yes` / `No`)

**Yes** — users who configured short model IDs like `openrouter/deepseek-v4-flash` will now have them correctly expanded to `deepseek/deepseek-v4-flash`. Users who already used the full format (`openrouter/deepseek/deepseek-v4-flash`) are unaffected. Unknown short model IDs preserve the original prefixed form.

Did config, environment, or migration behavior change? (`Yes` / `No`)

**No**

Did security, auth, secrets, network, or tool execution behavior change? (`Yes` / `No`)

**No**

## Current review state

What is the next action?
- Maintainer review


