### PR TITLE
fix(workboard): filter archived cards from CLI list by default

### DIFF
--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -130,14 +130,26 @@ export function registerWorkboardCli(params: { program: Command; store: Workboar
     .description("List Workboard cards")
     .option("--board <id>", "Board id")
     .option("--status <status>", "Filter by status")
+    .option("--include-archived", "Include archived cards (default false)", false)
     .option("--json", "Print JSON", false)
-    .action(async (options: JsonOptions & { board?: string; status?: string }) => {
-      let cards = await params.store.list({ boardId: options.board });
-      if (options.status) {
-        cards = cards.filter((card) => card.status === options.status);
-      }
-      writeCards(cards, options);
-    });
+    .action(
+      async (
+        options: JsonOptions & {
+          board?: string;
+          status?: string;
+          includeArchived?: boolean;
+        },
+      ) => {
+        let cards = await params.store.list({ boardId: options.board });
+        if (!options.includeArchived) {
+          cards = cards.filter((card) => !card.metadata?.archivedAt);
+        }
+        if (options.status) {
+          cards = cards.filter((card) => card.status === options.status);
+        }
+        writeCards(cards, options);
+      },
+    );
 
   workboard
     .command("create")


### PR DESCRIPTION
Closes #94555

## Summary
The `workboard list` CLI omitted the `archivedAt` filter that the `workboard_list` MCP tool already applies. This made archived cards still appear in CLI output, inconsistent with the API.

## Changes
- Added `--include-archived` CLI flag (default false, matching the API tool)
- Default behavior now filters out cards with `metadata.archivedAt` set
- One file: `extensions/workboard/src/cli.ts` (+12, -7)

## Test
```
node scripts/run-vitest.mjs extensions/workboard/src/cli.test.ts
=> 4/4 passed
```