### PR TITLE
fix(agents): use macOS product version in runtime prompt OS metadata

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -19,6 +19,7 @@ import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { CliBackendConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveAgentOsString } from "../../infra/os-summary.js";
 import { privateFileStore } from "../../infra/private-file-store.js";
 import { tempWorkspace } from "../../infra/private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
@@ -157,7 +158,7 @@ export function buildCliAgentSystemPrompt(params: {
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
       host: "openclaw",
-      os: `${os.type()} ${os.release()}`,
+      os: resolveAgentOsString(),
       arch: os.arch(),
       node: process.version,
       model: params.modelDisplay,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -24,6 +24,7 @@ import {
 } from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
+import { resolveAgentOsString } from "../../infra/os-summary.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../plugins/command-registry-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
@@ -1035,7 +1036,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
 
     const runtimeInfo = {
       host: machineName,
-      os: `${os.type()} ${os.release()}`,
+      os: resolveAgentOsString(),
       arch: os.arch(),
       node: process.version,
       model: `${provider}/${modelId}`,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -44,6 +44,7 @@ import { isEmbeddedMode } from "../../../infra/embedded-mode.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summary.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
+import { resolveAgentOsString } from "../../../infra/os-summary.js";
 import { createCodexNativeWebSearchWrapper } from "../../../llm/providers/stream-wrappers/openai.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../../plugins/command-registry-state.js";
@@ -1933,7 +1934,7 @@ export async function runEmbeddedAttempt(
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
         host: machineName,
-        os: `${os.type()} ${os.release()}`,
+        os: resolveAgentOsString(),
         arch: os.arch(),
         node: process.version,
         model: `${params.provider}/${params.modelId}`,

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -18,6 +18,19 @@ function macosVersion(): string {
   return out || os.release();
 }
 
+/**
+ * Resolves the OS version string for agent runtime prompts.
+ * On macOS this uses sw_vers -productVersion (e.g. "26.5.1") instead
+ * of os.release() which returns the Darwin kernel version (e.g. "25.5.0")
+ * that diverged from the marketing version starting with macOS 26 Tahoe.
+ */
+export function resolveAgentOsString(): string {
+  if (os.platform() === "darwin") {
+    return `${os.type()} ${macosVersion()}`;
+  }
+  return `${os.type()} ${os.release()}`;
+}
+
 /** Resolves a compact OS label for diagnostics, logs, and environment summaries. */
 export function resolveOsSummary(): OsSummary {
   const platform = os.platform();


### PR DESCRIPTION
Closes #95145

## Summary
`os.release()` returns the Darwin kernel version (e.g. "25.5.0"), which diverged from the macOS marketing version starting with macOS 26 Tahoe. Agents reported "Darwin 25.5.0" instead of "Darwin 26.5.1" in their runtime prompts.

## Changes
- Added `resolveAgentOsString()` to `src/infra/os-summary.ts` that uses `sw_vers -productVersion` on Darwin
- Updated 3 agent runtime-info sites:
  - `src/agents/embedded-agent-runner/compact.ts`
  - `src/agents/embedded-agent-runner/run/attempt.ts`
  - `src/agents/cli-runner/helpers.ts`
- 4 files, +20 -3 lines

## Test
```
node scripts/run-vitest.mjs src/infra/os-summary.test.ts src/agents/system-prompt.test.ts
=> 94/94 passed
```