### PR TITLE
fix(agents): forward resolved model in subagent gateway agent call

### DIFF
--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -315,6 +315,9 @@ describe("spawnSubagentDirect seam flow", () => {
     const agentParams = requireRecord(agentRequest.params);
     expect(agentParams.sessionKey).toBe(childSessionKey);
     expect(agentParams.cleanupBundleMcpOnRunEnd).toBe(true);
+    // Model override must be forwarded to the gateway agent call so the child
+    // run uses the requested model instead of falling back to the default (#91171).
+    expect(agentParams.model).toBe("openai/gpt-5.4");
   });
 
   it("dispatches spawned agent runs in process when a gateway context is available", async () => {
@@ -347,6 +350,40 @@ describe("spawnSubagentDirect seam flow", () => {
       }),
       expect.objectContaining({
         timeoutMs: expect.any(Number),
+      }),
+    );
+  });
+
+  it("enables allowSyntheticModelOverride when subagent spawn requests a specific model (regression #91171)", async () => {
+    hoisted.hasInProcessGatewayContextMock.mockReturnValue(true);
+    hoisted.callGatewayMock.mockRejectedValue(new Error("unexpected websocket gateway call"));
+    hoisted.dispatchGatewayMethodInProcessMock.mockImplementation(async (method: string) => {
+      if (method === "agent") {
+        return { runId: "run-in-process-model-override" };
+      }
+      return { ok: true };
+    });
+
+    await spawnSubagentDirect(
+      {
+        task: "use specific model",
+        model: "openai/gpt-5.4",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    // The in-process dispatch must authorize model overrides on the synthetic
+    // client when model is requested, or the gateway agent handler will silently
+    // discard it.
+    expect(hoisted.dispatchGatewayMethodInProcessMock).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        model: "openai/gpt-5.4",
+      }),
+      expect.objectContaining({
+        allowSyntheticModelOverride: true,
       }),
     );
   });

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -263,6 +263,12 @@ async function callSubagentGateway(
   ) {
     // Spawn is already running in the gateway process for channel/tool calls.
     // Direct dispatch avoids self-connecting over WS while the same event loop is busy.
+    // Subagent calls that set model/provider need model-override authorization on
+    // the synthetic client; otherwise the gateway agent handler silently discards
+    // the override and the child run falls back to the default model (#91171).
+    const hasModelOverride =
+      (request.params as Record<string, unknown>).model != null ||
+      (request.params as Record<string, unknown>).provider != null;
     return await subagentSpawnDeps.dispatchGatewayMethodInProcess(
       request.method,
       request.params as Record<string, unknown>,
@@ -271,6 +277,7 @@ async function callSubagentGateway(
         ...(scopes != null ? { forceSyntheticClient: true } : {}),
         timeoutMs: request.timeoutMs,
         ...(scopes != null ? { syntheticScopes: scopes } : {}),
+        ...(hasModelOverride ? { allowSyntheticModelOverride: true } : {}),
       },
     );
   }
@@ -1581,6 +1588,7 @@ export async function spawnSubagentDirect(
         cleanupBundleMcpOnRunEnd: spawnMode !== "session",
         extraSystemPrompt: childSystemPrompt,
         thinking: thinkingOverride,
+        ...(resolvedModel ? { model: resolvedModel } : {}),
         timeout: runTimeoutSeconds,
         label: label || undefined,
         ...(bootstrapContextMode


### PR DESCRIPTION
## Summary

When `sessions_spawn` is called with an explicit `model` parameter, `spawnSubagentDirect` correctly resolves the model and persists it to the session store via `persistInitialChildSessionRuntimeModel`, but the gateway `agent` call that launches the child run omits the `model` field from its request params. The child run thus falls back to the default model instead of using the requested one.

This fix:

1. **Forwards `model` in the gateway agent params**: Adds `...(resolvedModel ? { model: resolvedModel } : {})` to the `callSubagentGateway` params in `spawnSubagentDirect`.

2. **Authorizes model overrides on the in-process dispatch**: When the agent params contain `model` or `provider`, `callSubagentGateway` now sets `allowSyntheticModelOverride: true` so the gateway agent handler's `resolveAllowModelOverrideFromClient` check passes for the synthetic client.

Fixes #91171

## Real behavior proof (required for external PRs)

**Behavior addressed**: Sub-agents spawned via `sessions_spawn` with an explicit `model` parameter were silently routed to the default model instead of the requested one. The spawn response reported `modelApplied: true` and `resolvedModel: "qwen/qwen3.6-plus"`, but the child agent actually ran as `deepseek/deepseek-v4-pro`.

**Real setup tested**:
- **Runtime**: Node v22.19.0, Linux x86_64
- **Code analysis path**: `spawnSubagentDirect` → `callSubagentGateway` → `dispatchGatewayMethodInProcess` → `dispatchGatewayMethodInProcessRaw` → gateway `agent` handler
- **Test framework**: Vitest v4.1.8

**Exact steps or command run after this patch**:
```bash
node scripts/run-vitest.mjs src/agents/subagent-spawn.test.ts
```

**After-fix evidence**:
```
 RUN  v4.1.8
 Test Files  1 passed (1)
      Tests  26 passed (26)
   Start at  11:53:34
   Duration  15.79s
```

**Observed result after the fix**:
1. `resolvedModel` is now forwarded as `model` in the gateway agent request params.
2. The in-process dispatch sets `allowSyntheticModelOverride: true` when model/provider is present, so the gateway agent handler authorizes the override on its synthetic client.
3. The child agent run now uses the explicitly requested model instead of falling back to the default.

**What was not tested**: Live QQ/Qwen/DeepSeek end-to-end subagent spawn. The fix is verified at the unit level: the existing test suite (26 tests) is augmented with model-param forwarding and `allowSyntheticModelOverride` assertions.

## Tests and validation

| Test Type | Result | Details |
|-----------|--------|---------|
| Unit Tests | ✅ | 26/26 passed (subagent-spawn.test.ts) |
| Type Check | ✅ | `pnpm tsgo:core` clean |
| Lint | ✅ | oxlint clean on changed files |

**New regression test**: `"enables allowSyntheticModelOverride when subagent spawn requests a specific model (regression #91171)"` — verifies both the model param forwarding and the `allowSyntheticModelOverride` flag.

## Risk checklist

**Did user-visible behavior change?** `Yes` — sub-agents spawned with an explicit model parameter now actually use the requested model instead of silently ignoring it.

**Did config, environment, or migration behavior change?** `No`

**Did security, auth, secrets, network, or tool execution behavior change?** `Yes` — the synthetic client created for in-process subagent dispatch now has `allowModelOverride: true` when model/provider is requested. This is scoped to subagent spawn calls only and mirrors the same authorization pattern already used in `plugin-runtime` subagent launches (`createGatewaySubagentRuntime`).

**What is the highest-risk area?**
- The `allowSyntheticModelOverride` flag broadens the synthetic client's capabilities during in-process subagent dispatch.

**How is that risk mitigated?**
- The flag is only set when the params actually contain `model` or `provider` (narrow conditional).
- The synthetic client is already scoped to `[WRITE_SCOPE]` and only exists for the duration of the in-process call.
- This mirrors the existing pattern in `createGatewaySubagentRuntime` which also enables `allowSyntheticModelOverride` for plugin-initiated subagent runs.

## Current review state

**What is the next action?** Maintainer review requested
