### PR TITLE
fix(agents): bound provider JSON response reads

### DIFF
--- a/src/agents/provider-http-errors.test.ts
+++ b/src/agents/provider-http-errors.test.ts
@@ -38,6 +38,32 @@ function createStreamingBinaryResponse(params: {
   };
 }
 
+function createStreamingJsonResponse(params: { chunkCount: number; chunkSize: number }): {
+  response: Response;
+  getReadCount: () => number;
+} {
+  // Streaming fixture proves oversized JSON reads stop before buffering everything.
+  let reads = 0;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (reads >= params.chunkCount) {
+        controller.close();
+        return;
+      }
+      reads += 1;
+      controller.enqueue(encoder.encode("a".repeat(params.chunkSize)));
+    },
+  });
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+    getReadCount: () => reads,
+  };
+}
+
 describe("provider error utils", () => {
   it("formats nested provider error details with request ids", async () => {
     const response = new Response(
@@ -209,6 +235,32 @@ describe("provider error utils", () => {
     await expect(readProviderJsonResponse(response, "Provider catalog failed")).rejects.toThrow(
       "Provider catalog failed: malformed JSON response",
     );
+  });
+
+  it("parses well-formed JSON responses under the byte cap", async () => {
+    const response = new Response(JSON.stringify({ models: ["a", "b"] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    await expect(
+      readProviderJsonResponse<{ models: string[] }>(response, "Provider catalog failed"),
+    ).resolves.toEqual({ models: ["a", "b"] });
+  });
+
+  it("caps successful JSON responses instead of buffering oversized bodies", async () => {
+    const streamed = createStreamingJsonResponse({
+      chunkCount: 20,
+      chunkSize: 1024,
+    });
+
+    await expect(
+      readProviderJsonResponse(streamed.response, "Provider catalog failed", {
+        maxBytes: 2048,
+      }),
+    ).rejects.toThrow("Provider catalog failed: JSON response exceeds 2048 bytes");
+
+    expect(streamed.getReadCount()).toBeLessThan(20);
   });
 
   it("caps successful binary responses instead of buffering oversized bodies", async () => {

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -13,6 +13,7 @@ export { normalizeOptionalString as trimToUndefined } from "../../packages/norma
 
 const ERROR_BODY_METADATA_LIMIT = 500;
 const PROVIDER_BINARY_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
+const PROVIDER_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 
 /** Returns a plain object view for provider JSON payloads when one exists. */
 export function asObject(value: unknown): Record<string, unknown> | undefined {
@@ -287,10 +288,24 @@ export async function assertOkOrThrowHttpError(response: Response, label: string
   throw await createProviderHttpError(response, label, { statusPrefix: "HTTP " });
 }
 
-/** Parses a provider JSON response and wraps malformed JSON with the caller's label. */
-export async function readProviderJsonResponse<T>(response: Response, label: string): Promise<T> {
+/**
+ * Parses a provider JSON response under a byte cap and wraps malformed JSON with the caller's label.
+ *
+ * The body is read through the same bounded reader as binary responses so a provider that streams an
+ * unbounded JSON body cannot force the runtime to buffer the whole payload before parsing.
+ */
+export async function readProviderJsonResponse<T>(
+  response: Response,
+  label: string,
+  opts?: { maxBytes?: number },
+): Promise<T> {
+  const maxBytes = opts?.maxBytes ?? PROVIDER_JSON_RESPONSE_MAX_BYTES;
+  const bytes = await readResponseWithLimit(response, maxBytes, {
+    onOverflow: ({ maxBytes: maxBytesLocal }) =>
+      new Error(`${label}: JSON response exceeds ${maxBytesLocal} bytes`),
+  });
   try {
-    return (await response.json()) as T;
+    return JSON.parse(new TextDecoder().decode(bytes)) as T;
   } catch (cause) {
     throw new Error(`${label}: malformed JSON response`, { cause });
   }


### PR DESCRIPTION
## Summary

`readProviderJsonResponse` parsed provider success bodies with an unbounded `await response.json()`. The sibling binary path (`readProviderBinaryResponse`) already caps reads at 16 MiB via `readResponseWithLimit`, and `readResponseTextLimited` bounds error bodies, so the JSON success path was the one remaining unbounded reader in this module — a malicious or malfunctioning provider streaming an endless JSON body could force the runtime to buffer the entire payload before failing. This is the symmetric success-path complement to the error-stream hardening in #95108.

This change reads the JSON body through the same bounded reader (`readResponseWithLimit`) the binary path uses, then `JSON.parse`s the bounded text. Behavior for well-formed and malformed JSON is unchanged; only the unbounded-size case now throws a clear overflow error instead of buffering without limit.

## Changes

- `src/agents/provider-http-errors.ts`: add `PROVIDER_JSON_RESPONSE_MAX_BYTES` (16 MiB, matching the binary cap) and route `readProviderJsonResponse` through `readResponseWithLimit`, with an optional `opts.maxBytes` override and an `onOverflow` that throws `<label>: JSON response exceeds <n> bytes`. Malformed JSON still throws `<label>: malformed JSON response` (now from the bounded text via `JSON.parse`).
- `src/agents/provider-http-errors.test.ts`: add a streaming JSON fixture plus regression tests that (a) still parse well-formed JSON under the cap and (b) cancel and reject oversized streamed JSON bodies before fully buffering them — mirroring the existing binary cap test.

## Real behavior proof

A standalone tsx harness imported and drove the real `readProviderJsonResponse` against a `ReadableStream` that offers a 64 MiB JSON string body, with a 16 MiB cap, instrumenting how many 1 MiB chunks the reader actually pulled.

**Behavior addressed**: Unbounded buffering of provider JSON success responses; an oversized streamed JSON body should be cancelled at the byte cap and rejected, not fully buffered.

**Real environment tested**: Node v22.22.0, tsx 4.22.3, real source imported (no mocks of the function under test); vitest 4.1.7 via `scripts/run-vitest.mjs`.

**Exact steps or command run after this patch**:
- `node --import tsx proof-json-bound.mts` (drives the real `readProviderJsonResponse` with a 64 MiB streamed JSON body, 16 MiB cap)
- `node scripts/run-vitest.mjs src/agents/provider-http-errors.test.ts --run`
- `oxlint src/agents/provider-http-errors.ts src/agents/provider-http-errors.test.ts`

**Evidence after fix**:
```
=== readProviderJsonResponse oversized-body readback ===
total body offered : 64 chunks (64 MiB)
byte cap           : 16777216 bytes (16 MiB)
chunks pulled       : 17
approx bytes read   : 17825792 (~17 MiB)
observed error      : Provider catalog failed: JSON response exceeds 16777216 bytes
parsed string length: (n/a)
RESULT: BOUNDED — stream cancelled before reading the full 64 MiB body.
```
vitest: `Test Files 1 passed (1) / Tests 12 passed (12)`. oxlint: exit 0, no findings.

**Observed result after fix**: The reader pulled only 17 of 64 chunks (~17 MiB, stopping at the 16 MiB cap), cancelled the stream, and threw `Provider catalog failed: JSON response exceeds 16777216 bytes`. Negative control (temporarily reverting the source to `await response.json()` and re-running the same harness) read all 64 chunks (~64 MiB) and fully parsed the body — confirming the unbounded behavior and that the fix is what bounds it.

**What was not tested**: Real network responses from live providers (the harness uses an in-process `ReadableStream` fixture); the idle-timeout dimension (this change only adds the byte cap, matching the existing binary path which also relies on `readResponseWithLimit`'s default behavior).

AI-assisted (human-run real behavior proof included). This is the symmetric success-path complement to the #95108 error-stream hardening for the same module family.
