### PR TITLE
fix #10827: Skill supply-chain security: provenance tracking + permission manifests

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -524,6 +524,12 @@ runs built-in install-time dangerous-code blocking, so it is an empty `ok`
 result. Return additional findings or `{ block: true, blockReason }` to stop the
 install in that process.
 
+For skill installs, `event.skill.permissions` contains the optional audit-only
+`metadata.openclaw.permissions` manifest from the staged `SKILL.md`. Use it to
+compare declared command, tool, filesystem, and network needs with the source
+being installed; the field does not grant permissions or change sandboxing by
+itself.
+
 `block: true` is terminal. `block: false` is treated as no decision.
 Handler failures block the install fail-closed.
 

--- a/docs/tools/creating-skills.md
+++ b/docs/tools/creating-skills.md
@@ -113,7 +113,11 @@ OpenClaw loads skills from several roots in a defined [precedence order](/tools/
 | `homepage`                 | —       | URL shown as "Website" in the macOS Skills UI                                    |
 
 For gating fields (`requires.bins`, `requires.env`, etc.) see
-[Skills — Gating](/tools/skills#gating).
+[Skills — Gating](/tools/skills#gating). For audit-only permission declarations,
+use `metadata.openclaw.permissions` with `exec`, `tools`, `read`, `write`, and
+`network` fields. OpenClaw surfaces these declarations in skill status and install
+policy payloads so operators can compare what a skill says it needs against its
+source and provenance before enabling it.
 
 ### Using `{baseDir}`
 
@@ -144,8 +148,15 @@ metadata: { "openclaw": { "requires": { "bins": ["gemini"] }, "primaryEnv": "GEM
     | `requires.anyBins` | At least one binary must exist on `PATH` |
     | `requires.env` | Each env var must exist in the process or config |
     | `requires.config` | Each `openclaw.json` path must be truthy |
+    | `permissions.exec` | Declare whether the skill expects local command execution |
+    | `permissions.tools` | Tool names or groups the skill expects to use |
+    | `permissions.read` / `permissions.write` | Filesystem scopes the skill expects to read or write |
+    | `permissions.network` | Network domains or hosts the skill expects to contact |
     | `os` | Platform filter: `["darwin"]`, `["linux"]`, `["win32"]` |
     | `always` | Set `true` to skip all gates and always include the skill |
+
+    Permission declarations are informational and policy-facing; they do not grant
+    tools, filesystem access, network access, or sandbox bypasses by themselves.
 
     Full reference: [Skills — Gating](/tools/skills#gating).
 

--- a/docs/tools/skills-config.md
+++ b/docs/tools/skills-config.md
@@ -188,7 +188,10 @@ optional structured `source`, structured `origin`, and `request`. It must write
 one JSON object on stdout: `{ "protocolVersion": 1, "decision": "allow" }` or
 `{ "protocolVersion": 1, "decision": "block", "reason": "..." }`. Non-zero
 exit, timeout, malformed JSON, missing fields, or unsupported protocol versions
-fail closed.
+fail closed. For skills, `skill.permissions` contains the self-declared
+`metadata.openclaw.permissions` manifest when the staged `SKILL.md` provides one.
+The declaration is audit metadata only; policy commands decide whether the
+requested source and provenance are acceptable.
 
 OpenClaw does not execute install policy during normal Gateway startup. Installs
 and updates fail closed when policy is enabled but unavailable. `openclaw doctor`
@@ -226,7 +229,14 @@ Example stdin:
     "requestedSpecifier": "clawhub:weather@1.0.0"
   },
   "skill": {
-    "installId": "clawhub"
+    "installId": "clawhub",
+    "permissions": {
+      "exec": false,
+      "tools": ["web_fetch"],
+      "read": ["MEMORY.md"],
+      "write": ["memory/skills/weather/*"],
+      "network": ["api.weather.gov"]
+    }
   }
 }
 ```

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -214,10 +214,18 @@ publish and sync.
   </Accordion>
   <Accordion title="Operator install policy">
     Configure `security.installPolicy` to run a trusted local policy command
-    before skill installs continue. The policy receives metadata and the staged
-    source path, applies to ClawHub, uploaded, Git, local, update, and
-    dependency-installer paths, and fails closed when the command cannot return
-    a valid decision.
+    before skill installs continue. The policy receives source provenance,
+    origin metadata, declared skill permissions, and the staged source path;
+    it applies to ClawHub, uploaded, Git, local, update, and dependency-installer
+    paths, and fails closed when the command cannot return a valid decision.
+  </Accordion>
+  <Accordion title="Permission manifests">
+    Skills may declare audit-only permission needs under
+    `metadata.openclaw.permissions`: `exec`, `tools`, `read`, `write`, and
+    `network`. These declarations are visible in status and install policy
+    payloads, but they do not grant access by themselves. Use them to make a
+    skill asking to write memory, config, or broad network destinations visible
+    before enabling or updating the skill.
   </Accordion>
   <Accordion title="Secret injection scope">
     `skills.entries.*.env` and `skills.entries.*.apiKey` inject secrets into the

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -10,6 +10,7 @@ import type { ChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { TtsAutoMode } from "../config/types.tts.js";
 import type { DiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
+import type { OpenClawManifestPermissions } from "../shared/frontmatter.js";
 import type {
   PluginHookBeforeAgentStartEvent,
   PluginHookBeforeAgentStartResult,
@@ -1009,6 +1010,7 @@ export type PluginHookBeforeInstallSkillInstallSpec = {
 export type PluginHookBeforeInstallSkill = {
   installId: string;
   installSpec?: PluginHookBeforeInstallSkillInstallSpec;
+  permissions?: OpenClawManifestPermissions;
 };
 
 export type PluginHookBeforeInstallPlugin = {

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -14,6 +14,7 @@ import {
   type InstallPolicySource,
 } from "../security/install-policy.js";
 import { isPathInside } from "../security/scan-paths.js";
+import type { OpenClawManifestPermissions } from "../shared/frontmatter.js";
 import {
   findBlockedManifestDependencies,
   findBlockedNodeModulesDirectory,
@@ -713,6 +714,7 @@ async function runBeforeInstallHook(params: {
   skill?: {
     installId: string;
     installSpec?: SkillInstallSpec;
+    permissions?: OpenClawManifestPermissions;
   };
   plugin?: {
     contentType: "bundle" | "package" | "file";
@@ -863,6 +865,7 @@ async function runOperatorInstallPolicy(params: {
   skill?: {
     installId: string;
     installSpec?: SkillInstallSpec;
+    permissions?: OpenClawManifestPermissions;
   };
   plugin?: {
     contentType: "bundle" | "package" | "file" | "dependency-tree";
@@ -1250,6 +1253,7 @@ export async function evaluateSkillInstallPolicyRuntime(params: {
   config?: OpenClawConfig;
   installId: string;
   installSpec?: SkillInstallSpec;
+  permissions?: OpenClawManifestPermissions;
   logger: InstallScanLogger;
   origin: InstallPolicyOrigin;
   requestedSpecifier?: string;
@@ -1276,6 +1280,7 @@ export async function evaluateSkillInstallPolicyRuntime(params: {
       skill: {
         installId: params.installId,
         ...(params.installSpec ? { installSpec: params.installSpec } : {}),
+        ...(params.permissions ? { permissions: params.permissions } : {}),
       },
     });
   if (shouldBypassOpenClawInstallFriction({ source: params.source })) {
@@ -1300,6 +1305,7 @@ export async function evaluateSkillInstallPolicyRuntime(params: {
     skill: {
       installId: params.installId,
       ...(params.installSpec ? { installSpec: params.installSpec } : {}),
+      ...(params.permissions ? { permissions: params.permissions } : {}),
     },
   });
   return hookResult;

--- a/src/plugins/install-security-scan.ts
+++ b/src/plugins/install-security-scan.ts
@@ -5,6 +5,7 @@ import type {
   InstallPolicyRequestKind,
   InstallPolicySource,
 } from "../security/install-policy.js";
+import type { OpenClawManifestPermissions } from "../shared/frontmatter.js";
 export type { InstallSafetyOverrides } from "./install-security-scan.types.js";
 import type { InstallSafetyOverrides } from "./install-security-scan.types.js";
 
@@ -164,6 +165,7 @@ export async function evaluateSkillInstallPolicy(params: {
   config?: OpenClawConfig;
   installId: string;
   installSpec?: SkillInstallSpecMetadata;
+  permissions?: OpenClawManifestPermissions;
   logger: InstallScanLogger;
   origin: InstallPolicyOrigin;
   requestedSpecifier?: string;

--- a/src/security/install-policy.test.ts
+++ b/src/security/install-policy.test.ts
@@ -154,13 +154,25 @@ describe("runInstallPolicy", () => {
     const cwdPath = path.join(sourceDir, "cwd.txt");
     const response = JSON.stringify({ protocolVersion: 1, decision: "allow" });
 
+    const request = baseRequest(sourceDir);
+    request.skill = {
+      installId: request.skill?.installId ?? "clawhub",
+      permissions: {
+        exec: false,
+        tools: ["web_fetch"],
+        read: ["MEMORY.md"],
+        write: ["memory/skills/weather/*"],
+        network: ["api.weather.gov"],
+      },
+    };
+
     const result = await runInstallPolicy({
       config: configWithPolicy(scriptPath, {
         CWD_FILE: cwdPath,
         OUT_FILE: capturePath,
         POLICY_RESPONSE: response,
       }),
-      request: baseRequest(sourceDir),
+      request,
     });
 
     expect(result).toEqual({});
@@ -182,6 +194,16 @@ describe("runInstallPolicy", () => {
       requestedSpecifier: "clawhub:weather@1.0.0",
     });
     expect(captured.origin).toMatchObject({ type: "clawhub", slug: "weather" });
+    expect(captured.skill).toMatchObject({
+      installId: "clawhub",
+      permissions: {
+        exec: false,
+        tools: ["web_fetch"],
+        read: ["MEMORY.md"],
+        write: ["memory/skills/weather/*"],
+        network: ["api.weather.gov"],
+      },
+    });
   });
 
   it("preserves PATH so env shebang policy scripts can start", async () => {

--- a/src/security/install-policy.ts
+++ b/src/security/install-policy.ts
@@ -9,6 +9,7 @@ import {
   shouldDetachChildForProcessTree,
 } from "../process/child-process-tree.js";
 import { normalizePositiveInt, normalizePositiveTimerMs } from "../secrets/shared.js";
+import type { OpenClawManifestPermissions } from "../shared/frontmatter.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
 import { inspectPathPermissions, safeStat } from "./audit-fs.js";
@@ -94,6 +95,7 @@ export type InstallPolicyRequest = {
   };
   skill?: {
     installId: string;
+    permissions?: OpenClawManifestPermissions;
     installSpec?: {
       id?: string;
       kind: "brew" | "node" | "go" | "uv" | "download";

--- a/src/shared/frontmatter.ts
+++ b/src/shared/frontmatter.ts
@@ -68,6 +68,19 @@ export type OpenClawManifestRequires = {
   config: string[];
 };
 
+export type OpenClawManifestPermissions = {
+  /** Whether the skill declares a need to execute local commands. */
+  exec?: boolean;
+  /** Tool names or groups the skill expects to use. */
+  tools: string[];
+  /** Filesystem read scopes requested by the skill. */
+  read: string[];
+  /** Filesystem write scopes requested by the skill. */
+  write: string[];
+  /** Network domains or hosts the skill expects to contact. */
+  network: string[];
+};
+
 /** Extracts normalized runtime requirement lists from an OpenClaw manifest block. */
 export function resolveOpenClawManifestRequires(
   metadataObj: Record<string, unknown>,
@@ -85,6 +98,40 @@ export function resolveOpenClawManifestRequires(
     env: normalizeStringList(requiresRaw.env),
     config: normalizeStringList(requiresRaw.config),
   };
+}
+
+/** Extracts self-declared skill permission needs from an OpenClaw manifest block. */
+export function resolveOpenClawManifestPermissions(
+  metadataObj: Record<string, unknown>,
+): OpenClawManifestPermissions | undefined {
+  const permissionsRaw =
+    typeof metadataObj.permissions === "object" && metadataObj.permissions !== null
+      ? (metadataObj.permissions as Record<string, unknown>)
+      : undefined;
+  if (!permissionsRaw) {
+    return undefined;
+  }
+
+  const permissions: OpenClawManifestPermissions = {
+    tools: normalizeStringList(permissionsRaw.tools),
+    read: normalizeStringList(permissionsRaw.read),
+    write: normalizeStringList(permissionsRaw.write),
+    network: normalizeStringList(permissionsRaw.network),
+  };
+  if (typeof permissionsRaw.exec === "boolean") {
+    permissions.exec = permissionsRaw.exec;
+  }
+
+  if (
+    permissions.exec === undefined &&
+    permissions.tools.length === 0 &&
+    permissions.read.length === 0 &&
+    permissions.write.length === 0 &&
+    permissions.network.length === 0
+  ) {
+    return undefined;
+  }
+  return permissions;
 }
 
 /** Parses manifest install entries with a caller-owned parser and drops unsupported specs. */

--- a/src/skills/discovery/status.test.ts
+++ b/src/skills/discovery/status.test.ts
@@ -312,6 +312,38 @@ describe("buildWorkspaceSkillStatus", () => {
     ]);
   });
 
+  it("surfaces declared permission manifests in status reports", () => {
+    const entry: SkillEntry = {
+      skill: createCanonicalFixtureSkill({
+        name: "weather",
+        description: "test",
+        filePath: "/tmp/weather/SKILL.md",
+        baseDir: "/tmp/weather",
+        source: "test",
+      }),
+      frontmatter: {},
+      metadata: {
+        permissions: {
+          exec: false,
+          tools: ["web_fetch"],
+          read: ["MEMORY.md"],
+          write: ["memory/skills/weather/*"],
+          network: ["api.weather.gov"],
+        },
+      },
+    };
+
+    const report = buildWorkspaceSkillStatus("/tmp/ws", { entries: [entry] });
+
+    expect(report.skills[0]?.permissions).toEqual({
+      exec: false,
+      tools: ["web_fetch"],
+      read: ["MEMORY.md"],
+      write: ["memory/skills/weather/*"],
+      network: ["api.weather.gov"],
+    });
+  });
+
   it("does not expose raw config values in config checks", () => {
     const secret = "discord-token-secret-abc"; // pragma: allowlist secret
     const entry: SkillEntry = {

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { evaluateEntryRequirementsForCurrentPlatform } from "../../shared/entry-status.js";
+import type { OpenClawManifestPermissions } from "../../shared/frontmatter.js";
 import type { RequirementConfigCheck, Requirements } from "../../shared/requirements.js";
 import { CONFIG_DIR } from "../../utils.js";
 import {
@@ -73,6 +74,7 @@ export type SkillStatusEntry = {
   requirements: Requirements;
   missing: Requirements;
   configChecks: SkillStatusConfigCheck[];
+  permissions?: OpenClawManifestPermissions;
   install: SkillInstallOption[];
   clawhub?: ClawHubSkillStatusLink;
   skillCard?: LocalSkillCardStatus;
@@ -329,6 +331,7 @@ function buildSkillStatus(
     requirements: required,
     missing,
     configChecks,
+    ...(entry.metadata?.permissions ? { permissions: entry.metadata.permissions } : {}),
     install: normalizeInstallOptions(entry, prefs),
     ...(clawhub ? { clawhub } : {}),
     ...(skillCard ? { skillCard } : {}),

--- a/src/skills/lifecycle/archive-install.test.ts
+++ b/src/skills/lifecycle/archive-install.test.ts
@@ -67,8 +67,17 @@ async function expectFlatRootMarkerRejected(params: {
   });
 }
 
-function skillFileContent(name: string): string {
-  return ["---", `name: ${name}`, "description: Test skill", "---", "", "# Test", ""].join("\n");
+function skillFileContent(name: string, metadata?: string[]): string {
+  return [
+    "---",
+    `name: ${name}`,
+    "description: Test skill",
+    ...(metadata ?? []),
+    "---",
+    "",
+    "# Test",
+    "",
+  ].join("\n");
 }
 
 afterEach(async () => {
@@ -135,7 +144,19 @@ describe("skill archive install", () => {
     const workspaceDir = path.join(root, "workspace");
     const extractedRoot = path.join(root, "extracted");
     await fs.mkdir(extractedRoot, { recursive: true });
-    await fs.writeFile(path.join(extractedRoot, "SKILL.md"), skillFileContent("ClawHub Policy"));
+    await fs.writeFile(
+      path.join(extractedRoot, "SKILL.md"),
+      skillFileContent("ClawHub Policy", [
+        "metadata:",
+        "  openclaw:",
+        "    permissions:",
+        "      exec: false",
+        "      tools: [web_fetch]",
+        "      read: [MEMORY.md]",
+        "      write: [memory/skills/weather/*]",
+        "      network: [api.weather.gov]",
+      ]),
+    );
     await fs.writeFile(path.join(extractedRoot, "payload.js"), "eval('danger');\n");
     const handler = vi.fn().mockReturnValue({});
     initializeGlobalHookRunner(createMockPluginRegistry([{ hookName: "before_install", handler }]));
@@ -158,8 +179,18 @@ describe("skill archive install", () => {
     expect(result.ok).toBe(true);
     expect(handler).toHaveBeenCalledTimes(1);
     const payload = handler.mock.calls[0]?.[0] as
-      | { builtinScan?: { status?: string; scannedFiles?: number; findings?: unknown[] } }
+      | {
+          builtinScan?: { status?: string; scannedFiles?: number; findings?: unknown[] };
+          skill?: { permissions?: unknown };
+        }
       | undefined;
+    expect(payload?.skill?.permissions).toEqual({
+      exec: false,
+      tools: ["web_fetch"],
+      read: ["MEMORY.md"],
+      write: ["memory/skills/weather/*"],
+      network: ["api.weather.gov"],
+    });
     expect(payload?.builtinScan).toMatchObject({
       status: "ok",
       scannedFiles: 0,

--- a/src/skills/lifecycle/archive-install.ts
+++ b/src/skills/lifecycle/archive-install.ts
@@ -1,4 +1,5 @@
 // Archive install helpers extract and validate skill archives during installation.
+import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ArchiveLogger } from "../../infra/archive.js";
@@ -12,6 +13,7 @@ import {
   type InstallSecurityScanResult,
 } from "../../plugins/install-security-scan.js";
 import type { InstallPolicyOrigin, InstallPolicySource } from "../../security/install-policy.js";
+import { parseFrontmatter, resolveOpenClawMetadata } from "../loading/frontmatter.js";
 
 const VALID_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i;
 const DEFAULT_SKILL_ARCHIVE_ROOT_MARKERS = ["SKILL.md"] as const;
@@ -96,6 +98,22 @@ async function hasSkillArchiveRoot(
   return false;
 }
 
+async function readSkillArchivePermissions(rootDir: string, rootMarkers: readonly string[]) {
+  for (const candidate of rootMarkers) {
+    const skillFile = path.join(rootDir, candidate);
+    if (!(await pathExists(skillFile))) {
+      continue;
+    }
+    try {
+      const content = await fs.readFile(skillFile, "utf8");
+      return resolveOpenClawMetadata(parseFrontmatter(content))?.permissions;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
 function scanBlockedFailureKind(
   blocked: NonNullable<InstallSecurityScanResult["blocked"]>,
 ): SkillArchiveInstallFailureKind {
@@ -139,12 +157,8 @@ export async function installExtractedSkillRoot(params: {
   rootMarkers?: readonly string[];
 }): Promise<SkillArchiveInstallResult> {
   try {
-    if (
-      !(await hasSkillArchiveRoot(
-        params.extractedRoot,
-        params.rootMarkers ?? DEFAULT_SKILL_ARCHIVE_ROOT_MARKERS,
-      ))
-    ) {
+    const rootMarkers = params.rootMarkers ?? DEFAULT_SKILL_ARCHIVE_ROOT_MARKERS;
+    if (!(await hasSkillArchiveRoot(params.extractedRoot, rootMarkers))) {
       return installFailure("archive is missing SKILL.md", "invalid-request");
     }
     let targetDir: string;
@@ -162,6 +176,7 @@ export async function installExtractedSkillRoot(params: {
       );
     }
 
+    const permissions = await readSkillArchivePermissions(params.extractedRoot, rootMarkers);
     if (params.policy) {
       const scanResult = await evaluateSkillInstallPolicy({
         config: params.policy.config,
@@ -171,6 +186,7 @@ export async function installExtractedSkillRoot(params: {
         requestedSpecifier: params.policy.requestedSpecifier,
         source: params.policy.source,
         mode: effectiveMode,
+        ...(permissions ? { permissions } : {}),
         skillName: params.slug,
         sourceDir: params.extractedRoot,
       });

--- a/src/skills/lifecycle/install.ts
+++ b/src/skills/lifecycle/install.ts
@@ -479,6 +479,7 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
     config: params.config,
     installId: params.installId,
     ...(normalizedSpec ? { installSpec: normalizedSpec } : {}),
+    ...(entry.metadata?.permissions ? { permissions: entry.metadata.permissions } : {}),
     logger: {
       warn: (message) => warnings.push(message),
     },

--- a/src/skills/loading/frontmatter.test.ts
+++ b/src/skills/loading/frontmatter.test.ts
@@ -70,6 +70,21 @@ describe("resolveOpenClawMetadata install validation", () => {
     expect(install).toBeUndefined();
   });
 
+  it("parses permission manifests for skill audit and install policy", () => {
+    const metadata = resolveOpenClawMetadata({
+      metadata:
+        '{"openclaw":{"permissions":{"exec":false,"tools":["web_fetch"],"read":["MEMORY.md","SOUL.md"],"write":["memory/skills/weather/*"],"network":["api.weather.gov"]}}}',
+    });
+
+    expect(metadata?.permissions).toEqual({
+      exec: false,
+      tools: ["web_fetch"],
+      read: ["MEMORY.md", "SOUL.md"],
+      write: ["memory/skills/weather/*"],
+      network: ["api.weather.gov"],
+    });
+  });
+
   it("parses Link-style YAML metadata with node install hints", () => {
     const frontmatter = parseFrontmatter(`---
 name: create-payment-credential

--- a/src/skills/loading/frontmatter.ts
+++ b/src/skills/loading/frontmatter.ts
@@ -11,6 +11,7 @@ import {
   resolveOpenClawManifestBlock,
   resolveOpenClawManifestInstall,
   resolveOpenClawManifestOs,
+  resolveOpenClawManifestPermissions,
   resolveOpenClawManifestRequires,
 } from "../../shared/frontmatter.js";
 import type {
@@ -193,6 +194,7 @@ export function resolveOpenClawMetadata(
     return undefined;
   }
   const requires = resolveOpenClawManifestRequires(metadataObj);
+  const permissions = resolveOpenClawManifestPermissions(metadataObj);
   const install = resolveOpenClawManifestInstall(metadataObj, parseInstallSpec);
   const osRaw = resolveOpenClawManifestOs(metadataObj);
   return {
@@ -203,6 +205,7 @@ export function resolveOpenClawMetadata(
     primaryEnv: readStringValue(metadataObj.primaryEnv),
     os: osRaw.length > 0 ? osRaw : undefined,
     requires,
+    permissions,
     install: install.length > 0 ? install : undefined,
   };
 }

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -1,4 +1,5 @@
 // Skill types expose the shared skill contracts used by discovery, loading, and runtime flows.
+import type { OpenClawManifestPermissions } from "../shared/frontmatter.js";
 import type { Skill } from "./loading/skill-contract.js";
 
 export type SkillInstallSpec = {
@@ -30,6 +31,7 @@ export type OpenClawSkillMetadata = {
     env?: string[];
     config?: string[];
   };
+  permissions?: OpenClawManifestPermissions;
   install?: SkillInstallSpec[];
 };
 


### PR DESCRIPTION
## Summary

- **Behavior or issue addressed:** Adds audit-only skill permission manifests for issue #10827 so skills can declare expected command/tool/filesystem/network needs under `metadata.openclaw.permissions`.
- **Why it matters / User impact:** Operators and users currently see skill provenance/install metadata, but not a structured declaration of what a skill says it needs to touch before install/update. This makes risky skills that request memory/config writes or broad network access easier to inspect in status and policy surfaces.
- **Fix classification:** Minimal canonical root-cause security visibility fix: parse the manifest once, surface it in skill status, and pass it through install policy and `before_install` hook payloads without granting runtime permissions.
- **Conflict-resolution update:** Replayed the PR onto current `origin/main` and resolved the single conflict in `src/plugins/install-security-scan.runtime.ts` by preserving both current main's trusted-source install-friction bypass and this PR's `permissions` propagation into skill install policy / `before_install` payloads.
- **What did NOT change:** This does not change runtime permission granting, sandbox behavior, memory writes, network access, install allow/block defaults, or unrelated skill discovery behavior; enforcement remains out of scope.
- **Architecture / source-of-truth check:** `src/shared/frontmatter.ts` is the parser/normalization source-of-truth for `metadata.openclaw.*`; install policy and hook payloads consume the normalized contract. Related open PR scan for #10827 found no competing open PRs.

## What Problem This Solves

OpenClaw can install skills from ClawHub, uploads, local paths, Git sources, and dependency-installer paths, but staged `SKILL.md` metadata did not expose a structured permission manifest for operator review. This PR adds an audit-only `metadata.openclaw.permissions` contract so a skill can declare expected command, tool, filesystem, and network needs before it is enabled or updated.

## Root Cause

- **Root cause:** Skill metadata parsing already understood OpenClaw `requires` and install hints, but there was no typed `permissions` manifest contract and no path forwarding such declarations to the status or install-policy surfaces that operators can audit.
- **Why this is root-cause fix:** The patch adds a shared parser/type for `metadata.openclaw.permissions` and threads the parsed value through each skill install/audit boundary instead of adding another downstream string scan or UI-only special case.

## Real behavior proof

- **Real environment tested:** Windows Git Bash with Node v22.17.0 and pnpm 11.2.2; repo scripts emit an engine warning because package.json wants Node >=22.19.0.
- **Exact steps or command run after this patch:**
  - `node scripts/run-vitest.mjs src/security/install-policy.test.ts src/skills/discovery/status.test.ts src/skills/lifecycle/archive-install.test.ts src/skills/loading/frontmatter.test.ts`
  - `node scripts/run-oxlint.mjs` on the changed TypeScript files
  - `pnpm tsgo:core`
  - `pnpm check:test-types`
  - `pnpm docs:check-mdx`
  - `pnpm docs:list`
  - `git diff --check`
  - Previous real behavior proof script against the patched source: create a staged weather `SKILL.md`, load workspace skill status, install the staged root through an operator `security.installPolicy` command, and capture the policy stdin.
- **Evidence after fix:** Focused Vitest coverage exercises parsing permission manifests, preserving them in install-policy stdin, surfacing them in skill status, and forwarding archive-staged `SKILL.md` declarations to `before_install`. Type, lint, docs MDX, docs list, and whitespace checks exited 0 after the conflict-resolution rebase.
- **Observed result after fix:** The patched runtime surfaces the same declaration in both skill status and install-policy stdin while remaining informational/audit-only:

  ```json
  {
    "statusSkill": {
      "name": "weather",
      "source": "openclaw-workspace",
      "permissions": {
        "tools": ["web_fetch"],
        "read": ["MEMORY.md"],
        "write": ["memory/skills/weather/*"],
        "network": ["api.weather.gov"],
        "exec": false
      }
    },
    "installPolicySkill": {
      "installId": "clawhub",
      "permissions": {
        "tools": ["web_fetch"],
        "read": ["MEMORY.md"],
        "write": ["memory/skills/weather/*"],
        "network": ["api.weather.gov"],
        "exec": false
      }
    },
    "installResult": { "ok": true }
  }
  ```

  No granting/enforcement behavior is introduced. After the rebase conflict resolution, skill installs from trusted OpenClaw sources still keep current main's install-friction bypass while preserving this PR's `permissions` field in the audit payloads.
- **What was not tested:** No live gateway or ClawHub network install was run. SonarLint/sonar-scanner were not available on PATH, so no Sonar scan was run.

## Evidence

The focused tests verify the real policy/status payload behavior: parsed permission manifests are available in skill status, operator install-policy stdin, and plugin `before_install` events for staged archive installs. Additional type, lint, docs MDX, docs list, and whitespace checks passed after replaying the PR onto current main and resolving the conflict.

## Review findings addressed

- **RF-001:** Public-contract risk is explicitly documented. The new fields are optional, additive, and audit-only; this conflict-resolution update does not broaden the vocabulary or shape beyond the existing PR.
- **RF-002:** The PR body continues to state that #10827 is only partially addressed. Provenance tags, memory namespacing, anomaly flagging, update diffs, and broader user transparency remain separate work.
- **RF-003:** The manifest is still self-declared and audit-only. The PR does not imply sandboxing, enforcement, runtime permission grant, install allow/block defaults, memory write protection, or network/file access policy.
- **RF-004:** Remaining API/security-scope acceptance is a maintainer decision. This update only makes the existing PR mergeable against current main and preserves the maintainer-review scope.

## Regression Test Plan

- **Target test file:** `src/skills/loading/frontmatter.test.ts`, `src/security/install-policy.test.ts`, `src/skills/discovery/status.test.ts`, and `src/skills/lifecycle/archive-install.test.ts`.
- **Scenario locked in:** A weather skill declares `exec: false`, `web_fetch`, memory read/write scopes, and `api.weather.gov`; the parser, status report, operator policy stdin, and archive `before_install` hook all preserve the same manifest.
- **Conflict-resolution guardrail:** `src/plugins/install-security-scan.runtime.ts` now keeps current main's trusted-source bypass and this PR's permission manifest forwarding in the same skill install policy path.
- **Why this is the smallest reliable guardrail:** Unit and lifecycle tests cover each contract boundary where permission metadata could be dropped, without needing broad gateway or network install fixtures for an audit-only manifest field.
- Added parser coverage for JSON frontmatter `metadata.openclaw.permissions`.
- Extended install-policy coverage to assert `skill.permissions` survives policy stdin serialization.
- Added status coverage for permission manifest reporting.
- Extended archive install coverage so a staged `SKILL.md` permission manifest reaches the `before_install` hook even when the built-in scanner allows the install.

## Merge risk

- **Risk labels considered:** security, public contract, plugin hook payload, docs.
- **Risk explanation:** This adds optional typed fields to existing skill metadata/status/policy payloads. The change is additive and leaves existing manifests, installs, policy commands, and hook handlers valid when the field is absent.
- **Why acceptable:** The implementation deliberately does not grant filesystem, tool, command, network, or sandbox access. Docs state the declarations are informational and policy-facing only, so runtime enforcement can be designed separately without silently changing current behavior.
- **Patch quality notes:** Diff is focused on parser/type plumbing, install-policy propagation, focused regression tests, and the relevant docs pages. The parser and archive reader intentionally default to `undefined` when no manifest exists or staged metadata cannot be parsed so legacy skills remain unchanged; this does not mask install failures because the existing archive/root validation and install-policy fail-closed behavior still run. Positive production LOC is limited to the shared parser and optional payload threading needed for a canonical audit surface. The conflict-resolution change only combines current main's trusted-source bypass with this PR's permissions payload; it does not add another policy branch.
- **Maintainer-ready confidence:** High; focused automated coverage and local real behavior proof passed, but no live ClawHub/gateway install proof was run in this Windows environment.

Refs #10827
