### PR TITLE
fix(openai): bound ChatGPT Responses error body reads to prevent OOM

### DIFF
--- a/src/llm/providers/openai-chatgpt-responses.test.ts
+++ b/src/llm/providers/openai-chatgpt-responses.test.ts
@@ -8,6 +8,11 @@ import {
   streamOpenAICodexResponses,
 } from "./openai-chatgpt-responses.js";
 
+// Mirror the (non-exported) bounded-error-body constants in
+// openai-chatgpt-responses.ts so the assertions stay in lockstep with the source.
+const CODEX_ERROR_BODY_TEST_MAX_BYTES = 8 * 1024;
+const CODEX_ERROR_BODY_TEST_IDLE_MS = 10_000;
+
 function createJwt(payload: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
@@ -504,5 +509,103 @@ describe("streamOpenAICodexResponses transport", () => {
     expect(result.stopReason).toBe("error");
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+  });
+
+  it("bounds oversized streamed error responses without buffering the full body", async () => {
+    const encoder = new TextEncoder();
+    const chunk = encoder.encode("E".repeat(64 * 1024));
+    let maxBytesPulledPerResponse = 0;
+    let cancelCount = 0;
+    // Each attempt gets a fresh, oversized stream. The bounded reader caps the
+    // body at 8 KiB and cancels the stream, so a single 64 KiB chunk is pulled
+    // at most once per response instead of being drained to multiple megabytes.
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async () => {
+      let bytesPulled = 0;
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            bytesPulled += chunk.byteLength;
+            maxBytesPulledPerResponse = Math.max(maxBytesPulledPerResponse, bytesPulled);
+            controller.enqueue(chunk);
+          },
+          cancel() {
+            cancelCount += 1;
+          },
+        }),
+        { status: 400, statusText: "Bad Request" },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    // Collapse the short inter-attempt backoff sleeps (<= 4s) without disturbing
+    // the bounded reader's 10s idle-timeout guard, which must keep real timing.
+    const realSetTimeout = globalThis.setTimeout;
+    vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      callback: TimerHandler,
+      delay?: number,
+      ...args: unknown[]
+    ) => {
+      if (typeof callback === "function" && (delay ?? 0) < CODEX_ERROR_BODY_TEST_IDLE_MS) {
+        callback(...args);
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return realSetTimeout(callback, delay, ...(args as []));
+    }) as typeof setTimeout);
+
+    const stream = streamOpenAICodexResponses(model, context, {
+      apiKey: createJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "acct-1",
+        },
+      }),
+      transport: "sse",
+    });
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    // The error message is collapsed to the byte/char cap (8 KiB / 400 chars),
+    // never the full multi-megabyte body that an unbounded read() would buffer.
+    expect(result.errorMessage).toBe(`${"E".repeat(400)}…`);
+    // Each attempt cancels its stream once the cap is hit instead of draining it,
+    // so only a tiny, bounded prefix is ever held in memory per response. A
+    // ReadableStream may pre-pull one extra chunk for backpressure, so allow a
+    // small slack; the body itself is effectively unbounded (chunks keep coming
+    // until cancelled), and without the cap this would balloon without limit.
+    expect(cancelCount).toBeGreaterThanOrEqual(1);
+    expect(maxBytesPulledPerResponse).toBeLessThanOrEqual(
+      CODEX_ERROR_BODY_TEST_MAX_BYTES + chunk.byteLength * 2,
+    );
+  });
+
+  it("still surfaces the friendly message from a normal-sized JSON error body", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "usage_limit_reached",
+            message: "You are out of credits.",
+            plan_type: "Plus",
+          },
+        }),
+        // 400 is non-retryable, so the very first attempt reaches parseErrorResponse.
+        { status: 400, statusText: "Bad Request" },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const stream = streamOpenAICodexResponses(model, context, {
+      apiKey: createJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "acct-1",
+        },
+      }),
+      transport: "sse",
+    });
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.errorMessage).toContain("You have hit your ChatGPT usage limit (plus plan)");
   });
 });

--- a/src/llm/providers/openai-chatgpt-responses.ts
+++ b/src/llm/providers/openai-chatgpt-responses.ts
@@ -21,6 +21,7 @@ if (typeof process !== "undefined" && (process.versions?.node || process.version
   });
 }
 
+import { readResponseTextSnippet } from "@openclaw/media-core/read-response-with-limit";
 import {
   resolveTimerTimeoutMs,
   clampTimerTimeoutMs,
@@ -61,6 +62,9 @@ import { buildBaseOptions } from "./simple-options.js";
 const DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
+const CODEX_ERROR_BODY_MAX_BYTES = 8 * 1024;
+const CODEX_ERROR_BODY_MAX_CHARS = 400;
+const CODEX_ERROR_BODY_READ_IDLE_TIMEOUT_MS = 10_000;
 const RETRY_AFTER_HTTP_DATE_RE =
   /^(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT|(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), \d{2}-(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{2} \d{2}:\d{2}:\d{2} GMT|(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [ \d]\d \d{2}:\d{2}:\d{2} \d{4})$/;
 const CODEX_TOOL_CALL_PROVIDERS = new Set(["openai", "opencode"]);
@@ -338,7 +342,7 @@ export const streamOpenAICodexResponses: StreamFunction<
             break;
           }
 
-          const errorText = await response.text();
+          const errorText = await readCodexErrorBodySnippet(response);
           if (attempt < MAX_RETRIES && isRetryableError(response.status, errorText)) {
             let delayMs = BASE_DELAY_MS * 2 ** attempt;
 
@@ -1519,10 +1523,34 @@ async function processWebSocketStream(
 // Error Handling
 // ============================================================================
 
+async function readCodexErrorBodySnippet(response: Response): Promise<string> {
+  try {
+    return (
+      (await readResponseTextSnippet(response, {
+        maxBytes: CODEX_ERROR_BODY_MAX_BYTES,
+        maxChars: CODEX_ERROR_BODY_MAX_CHARS,
+        chunkTimeoutMs: CODEX_ERROR_BODY_READ_IDLE_TIMEOUT_MS,
+        onIdleTimeout: ({ chunkTimeoutMs }) =>
+          new Error(
+            `ChatGPT Responses error response stalled: no data received for ${chunkTimeoutMs}ms`,
+          ),
+      })) ?? ""
+    );
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      error.message.startsWith("ChatGPT Responses error response stalled:")
+    ) {
+      return error.message;
+    }
+    return "";
+  }
+}
+
 async function parseErrorResponse(
   response: Response,
 ): Promise<{ message: string; friendlyMessage?: string }> {
-  const raw = await response.text();
+  const raw = await readCodexErrorBodySnippet(response);
   let message = raw || response.statusText || "Request failed";
   let friendlyMessage: string | undefined;
 


### PR DESCRIPTION
## Summary

The ChatGPT Responses (Codex) provider reads HTTP error bodies with an unbounded `await response.text()` in two places: the network retry/error path in `streamOpenAICodexResponses` and the canonical `parseErrorResponse` helper. A malicious or misbehaving endpoint that returns an oversized (or never-ending) error response forces the whole body into memory before the error is surfaced — an OOM / DoS vector.

This is the symmetric counterpart to #95108, which hardened the Anthropic Messages error stream with the shared byte-cap reader. The OpenAI/Codex error path was the matching gap: same `response.text()` shape, same unbounded buffering. This PR applies the **same** `readResponseTextSnippet` helper and the same cap/idle-timeout pattern, so both providers now bound diagnostic error bodies identically.

## Changes

- `src/llm/providers/openai-chatgpt-responses.ts`
  - Import the shared bounded reader `readResponseTextSnippet` from `@openclaw/media-core/read-response-with-limit` (the same helper used by the Anthropic sweep in #95108).
  - Add a small `readCodexErrorBodySnippet(response)` wrapper mirroring `readAnthropicMessagesErrorBodySnippet`: 8 KiB byte cap, 400-char snippet cap, 10s idle timeout, with a stall message and graceful `""` fallback on read errors.
  - Replace both unbounded `await response.text()` calls — the network error path (used for retry decisions and the friendly-message parse) and the `parseErrorResponse` body read — with the bounded wrapper. The stream is cancelled once the cap is hit, so only a small prefix is ever buffered.
- `src/llm/providers/openai-chatgpt-responses.test.ts`
  - Regression test: an oversized streamed error response is collapsed to the cap (`400 chars + "…"`), the underlying stream is `cancel()`-ed, and bytes pulled stay a small constant instead of draining the body.
  - Guard test: a normal-sized JSON error body still yields the existing friendly usage-limit message, so the cap does not regress error reporting for real-world payloads.

Normal OpenAI error bodies are far under the 8 KiB cap, so user-facing error messages and the usage-limit friendly text are unchanged.

## Real behavior proof

**Label**: bounded error-body reads for the ChatGPT Responses provider, preventing unbounded memory buffering of oversized/never-ending HTTP error responses (symmetric hardening to #95108).

**Behavior addressed**: oversized/streamed HTTP error responses from the Codex endpoint were buffered in full via `response.text()`; they are now read under an 8 KiB byte cap with stream cancellation and a 10s idle timeout.

**Real environment tested**: Node 22.22.0 on Linux. Two real-runtime executions: (1) the genuine production helper `readResponseTextSnippet` (the function the patched provider now calls) driven against a 10 MiB streamed error body via `node --import tsx`; (2) the full provider path through `streamOpenAICodexResponses` under vitest with a mocked `fetch` returning an oversized `ReadableStream` error body.

**Exact steps or command run after this patch**:
- `node --import tsx --import ./loader.mjs ./proof.mjs` (drives the real `readResponseTextSnippet` with the provider's exact constants: maxBytes 8192, maxChars 400, idle 10000ms)
- `node scripts/run-vitest.mjs src/llm/providers/openai-chatgpt-responses.test.ts --run`
- `npx oxlint src/llm/providers/openai-chatgpt-responses.ts src/llm/providers/openai-chatgpt-responses.test.ts`

**Evidence after fix**:
- tsx proof — AFTER (patched, `readResponseTextSnippet`): `bytes pulled from stream = 524288`, `stream cancel() invoked = true`, `returned snippet length = 401 chars` (400 + "…"). BEFORE (pre-patch, unbounded `response.text()` on the same 10 MiB stream): `bytes pulled from stream = 10485760`, `stream cancel() invoked = false`, `buffered text length = 10485760`. Summary: bounded reader pulled 524288 bytes vs unbounded 10485760 bytes (~20× less buffered). `RESULT: PASS`.
- vitest: `Test Files 1 passed (1)`, `Tests 16 passed (16)`.
- oxlint: exit 0, no diagnostics on the changed files.

**Observed result after fix**: the oversized error body is collapsed to a 400-char snippet, the stream is cancelled after the cap, and only a small bounded prefix is held in memory; the friendly usage-limit message is preserved for normal-sized JSON error bodies.

**Negative control**: reverting both call sites back to `await response.text()` (source fix removed) makes the regression test fail — with a finite oversized body the test reports `errorMessage` equal to the entire multi-hundred-KiB `E…` body instead of the bounded `400 chars + "…"`; with the test's unbounded streaming body, the reverted code hangs draining the never-ending stream (the exact OOM/DoS behavior this PR fixes). Restoring the fix makes all 16 tests pass again.

**What was not tested**: a live network call against the real ChatGPT/Codex backend (the proof uses real `ReadableStream`/`Response` objects and the genuine production reader, not a live remote endpoint). Full-repo `tsgo` type-check was not completed locally (the 20k-file monorepo check exceeded the local time budget); the changed files compile cleanly through the vitest TS pipeline and CI will run the full type-check.

AI-assisted (human-run real behavior proof included).
