### PR TITLE
fix(os): use sw_vers for macOS version on Darwin instead of os.release()

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -19,7 +19,7 @@ import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { CliBackendConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveOsProductLabel } from "../../infra/os-summary.js";
+import { resolveRuntimeOsLabel } from "../../infra/os-summary.js";
 import { privateFileStore } from "../../infra/private-file-store.js";
 import { tempWorkspace } from "../../infra/private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
@@ -158,7 +158,7 @@ export function buildCliAgentSystemPrompt(params: {
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
       host: "openclaw",
-      os: resolveOsProductLabel(),
+      os: resolveRuntimeOsLabel(),
       arch: os.arch(),
       node: process.version,
       model: params.modelDisplay,

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -19,6 +19,7 @@ import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { CliBackendConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveOsProductLabel } from "../../infra/os-summary.js";
 import { privateFileStore } from "../../infra/private-file-store.js";
 import { tempWorkspace } from "../../infra/private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
@@ -157,7 +158,7 @@ export function buildCliAgentSystemPrompt(params: {
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
       host: "openclaw",
-      os: `${os.type()} ${os.release()}`,
+      os: resolveOsProductLabel(),
       arch: os.arch(),
       node: process.version,
       model: params.modelDisplay,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -24,7 +24,7 @@ import {
 } from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
-import { resolveOsProductLabel } from "../../infra/os-summary.js";
+import { resolveRuntimeOsLabel } from "../../infra/os-summary.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../plugins/command-registry-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
@@ -1036,7 +1036,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
 
     const runtimeInfo = {
       host: machineName,
-      os: resolveOsProductLabel(),
+      os: resolveRuntimeOsLabel(),
       arch: os.arch(),
       node: process.version,
       model: `${provider}/${modelId}`,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -24,6 +24,7 @@ import {
 } from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
+import { resolveOsProductLabel } from "../../infra/os-summary.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../plugins/command-registry-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
@@ -1035,7 +1036,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
 
     const runtimeInfo = {
       host: machineName,
-      os: `${os.type()} ${os.release()}`,
+      os: resolveOsProductLabel(),
       arch: os.arch(),
       node: process.version,
       model: `${provider}/${modelId}`,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -44,6 +44,7 @@ import { isEmbeddedMode } from "../../../infra/embedded-mode.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summary.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
+import { resolveOsProductLabel } from "../../../infra/os-summary.js";
 import { createCodexNativeWebSearchWrapper } from "../../../llm/providers/stream-wrappers/openai.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../../plugins/command-registry-state.js";
@@ -1933,7 +1934,7 @@ export async function runEmbeddedAttempt(
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
         host: machineName,
-        os: `${os.type()} ${os.release()}`,
+        os: resolveOsProductLabel(),
         arch: os.arch(),
         node: process.version,
         model: `${params.provider}/${params.modelId}`,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -44,7 +44,7 @@ import { isEmbeddedMode } from "../../../infra/embedded-mode.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summary.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
-import { resolveOsProductLabel } from "../../../infra/os-summary.js";
+import { resolveRuntimeOsLabel } from "../../../infra/os-summary.js";
 import { createCodexNativeWebSearchWrapper } from "../../../llm/providers/stream-wrappers/openai.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../../plugins/command-registry-state.js";
@@ -1934,7 +1934,7 @@ export async function runEmbeddedAttempt(
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
         host: machineName,
-        os: resolveOsProductLabel(),
+        os: resolveRuntimeOsLabel(),
         arch: os.arch(),
         node: process.version,
         model: `${params.provider}/${params.modelId}`,

--- a/src/infra/os-summary.test.ts
+++ b/src/infra/os-summary.test.ts
@@ -11,7 +11,7 @@ vi.mock("node:child_process", async () => {
   );
 });
 
-import { resolveOsSummary } from "./os-summary.js";
+import { _resetCachedDarwinProductVersion, resolveOsSummary } from "./os-summary.js";
 
 type OsSummaryCase = {
   name: string;
@@ -25,6 +25,7 @@ type OsSummaryCase = {
 describe("resolveOsSummary", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    _resetCachedDarwinProductVersion();
   });
 
   it.each<OsSummaryCase>([

--- a/src/infra/os-summary.test.ts
+++ b/src/infra/os-summary.test.ts
@@ -11,7 +11,7 @@ vi.mock("node:child_process", async () => {
   );
 });
 
-import { _resetCachedDarwinProductVersion, resolveOsSummary } from "./os-summary.js";
+import { resolveOsSummary, resolveRuntimeOsLabel } from "./os-summary.js";
 
 type OsSummaryCase = {
   name: string;
@@ -25,7 +25,7 @@ type OsSummaryCase = {
 describe("resolveOsSummary", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    _resetCachedDarwinProductVersion();
+    spawnSyncMock.mockReset();
   });
 
   it.each<OsSummaryCase>([
@@ -94,5 +94,83 @@ describe("resolveOsSummary", () => {
       });
     }
     expect(resolveOsSummary()).toEqual(expected);
+  });
+});
+
+describe("resolveRuntimeOsLabel", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    spawnSyncMock.mockReset();
+  });
+
+  it("reports the macOS product version without an architecture suffix on tahoe", () => {
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    vi.spyOn(os, "type").mockReturnValue("Darwin");
+    vi.spyOn(os, "release").mockReturnValue("25.6.0");
+    vi.spyOn(os, "arch").mockReturnValue("arm64");
+    spawnSyncMock.mockReturnValue({
+      stdout: "26.6.0\n",
+      stderr: "",
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+    });
+
+    expect(resolveRuntimeOsLabel()).toBe("macOS 26.6.0");
+  });
+
+  it("falls back to the Darwin release when sw_vers output is blank", () => {
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    vi.spyOn(os, "type").mockReturnValue("Darwin");
+    vi.spyOn(os, "release").mockReturnValue("25.7.0");
+    vi.spyOn(os, "arch").mockReturnValue("arm64");
+    spawnSyncMock.mockReturnValue({
+      stdout: "   ",
+      stderr: "",
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+    });
+
+    expect(resolveRuntimeOsLabel()).toBe("macOS 25.7.0");
+  });
+
+  it("preserves the old Windows os.type/os.release shape", () => {
+    vi.spyOn(os, "platform").mockReturnValue("win32");
+    vi.spyOn(os, "type").mockReturnValue("Windows_NT");
+    vi.spyOn(os, "release").mockReturnValue("10.0.26100");
+    vi.spyOn(os, "arch").mockReturnValue("x64");
+
+    expect(resolveRuntimeOsLabel()).toBe("Windows_NT 10.0.26100");
+  });
+
+  it("preserves the old Linux os.type/os.release shape", () => {
+    vi.spyOn(os, "platform").mockReturnValue("linux");
+    vi.spyOn(os, "type").mockReturnValue("Linux");
+    vi.spyOn(os, "release").mockReturnValue("6.8.0-generic");
+    vi.spyOn(os, "arch").mockReturnValue("x64");
+
+    expect(resolveRuntimeOsLabel()).toBe("Linux 6.8.0-generic");
+  });
+
+  it("caches the Darwin product version for repeated runtime prompt lookups", () => {
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    vi.spyOn(os, "type").mockReturnValue("Darwin");
+    vi.spyOn(os, "release").mockReturnValue("25.8.0");
+    vi.spyOn(os, "arch").mockReturnValue("arm64");
+    spawnSyncMock.mockReturnValue({
+      stdout: "26.8.0\n",
+      stderr: "",
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+    });
+
+    expect(resolveRuntimeOsLabel()).toBe("macOS 26.8.0");
+    expect(resolveRuntimeOsLabel()).toBe("macOS 26.8.0");
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -12,6 +12,13 @@ type OsSummary = {
 
 const cachedOsSummaryByKey = new Map<string, OsSummary>();
 
+let _cachedDarwinProductVersion: string | undefined;
+
+/** Reset module-level cache (for tests). */
+export function _resetCachedDarwinProductVersion(): void {
+  _cachedDarwinProductVersion = undefined;
+}
+
 /**
  * Resolve Darwin product version via sw_vers.
  *
@@ -19,11 +26,19 @@ const cachedOsSummaryByKey = new Map<string, OsSummary>();
  * with macOS 26 (Tahoe), where Darwin 25.x maps to macOS 26.x instead of the
  * historical Darwin N → macOS N+9 formula. Prefer sw_vers over os.release() on
  * macOS to avoid stale mappings.
+ *
+ * Result is cached for the process lifetime — sw_vers output is stable within
+ * a single OS boot. Called on the agent prompt hot path, so caching avoids a
+ * synchronous subprocess spawn on every prompt build.
  */
 export function resolveDarwinProductVersion(): string {
+  if (_cachedDarwinProductVersion !== undefined) {
+    return _cachedDarwinProductVersion;
+  }
   const res = spawnSync("sw_vers", ["-productVersion"], { encoding: "utf-8" });
   const out = normalizeOptionalString(res.stdout) ?? "";
-  return out || os.release();
+  _cachedDarwinProductVersion = out || os.release();
+  return _cachedDarwinProductVersion;
 }
 
 /**
@@ -54,10 +69,11 @@ export function resolveOsSummary(): OsSummary {
   if (cached) {
     return cached;
   }
-  const release = platform === "darwin" ? resolveDarwinProductVersion() : rawRelease;
+  const release = rawRelease;
   const label = (() => {
     if (platform === "darwin") {
-      return `macos ${release} (${arch})`;
+      const productVersion = resolveDarwinProductVersion();
+      return `macos ${productVersion} (${arch})`;
     }
     if (platform === "win32") {
       return `windows ${release} (${arch})`;

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -11,13 +11,7 @@ type OsSummary = {
 };
 
 const cachedOsSummaryByKey = new Map<string, OsSummary>();
-
-let _cachedDarwinProductVersion: string | undefined;
-
-/** Reset module-level cache (for tests). */
-export function _resetCachedDarwinProductVersion(): void {
-  _cachedDarwinProductVersion = undefined;
-}
+const cachedRuntimeOsLabelByKey = new Map<string, string>();
 
 /**
  * Resolve Darwin product version via sw_vers.
@@ -26,35 +20,31 @@ export function _resetCachedDarwinProductVersion(): void {
  * with macOS 26 (Tahoe), where Darwin 25.x maps to macOS 26.x instead of the
  * historical Darwin N → macOS N+9 formula. Prefer sw_vers over os.release() on
  * macOS to avoid stale mappings.
- *
- * Result is cached for the process lifetime — sw_vers output is stable within
- * a single OS boot. Called on the agent prompt hot path, so caching avoids a
- * synchronous subprocess spawn on every prompt build.
  */
-export function resolveDarwinProductVersion(): string {
-  if (_cachedDarwinProductVersion !== undefined) {
-    return _cachedDarwinProductVersion;
-  }
+function resolveDarwinProductVersion(): string {
   const res = spawnSync("sw_vers", ["-productVersion"], { encoding: "utf-8" });
   const out = normalizeOptionalString(res.stdout) ?? "";
-  _cachedDarwinProductVersion = out || os.release();
-  return _cachedDarwinProductVersion;
+  return out || os.release();
 }
 
 /**
- * Canonical OS product label for system prompts, diagnostics, and user-facing
- * display. Uses sw_vers on macOS to get the real product version instead of the
- * Darwin kernel version that diverged in Tahoe.
+ * Resolves the OS string used in agent runtime prompt metadata, without the
+ * architecture suffix. The prompt renderer appends `arch` separately. Off
+ * Darwin this preserves the historical `${os.type()} ${os.release()}` shape.
  */
-export function resolveOsProductLabel(): string {
+export function resolveRuntimeOsLabel(): string {
   const platform = os.platform();
-  if (platform === "darwin") {
-    return `macOS ${resolveDarwinProductVersion()}`;
+  const release = os.release();
+  const arch = os.arch();
+  const cacheKey = `${platform}\0${release}\0${arch}`;
+  const cached = cachedRuntimeOsLabelByKey.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
   }
-  if (platform === "win32") {
-    return `Windows ${os.release()}`;
-  }
-  return `${os.type()} ${os.release()}`;
+  const label =
+    platform === "darwin" ? `macOS ${resolveDarwinProductVersion()}` : `${os.type()} ${release}`;
+  cachedRuntimeOsLabelByKey.set(cacheKey, label);
+  return label;
 }
 
 /** Resolves a compact OS label for diagnostics, logs, and environment summaries. */

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -12,27 +12,52 @@ type OsSummary = {
 
 const cachedOsSummaryByKey = new Map<string, OsSummary>();
 
-function macosVersion(): string {
+/**
+ * Resolve Darwin product version via sw_vers.
+ *
+ * Darwin kernel version and macOS product version are no longer in sync starting
+ * with macOS 26 (Tahoe), where Darwin 25.x maps to macOS 26.x instead of the
+ * historical Darwin N → macOS N+9 formula. Prefer sw_vers over os.release() on
+ * macOS to avoid stale mappings.
+ */
+export function resolveDarwinProductVersion(): string {
   const res = spawnSync("sw_vers", ["-productVersion"], { encoding: "utf-8" });
   const out = normalizeOptionalString(res.stdout) ?? "";
   return out || os.release();
 }
 
+/**
+ * Canonical OS product label for system prompts, diagnostics, and user-facing
+ * display. Uses sw_vers on macOS to get the real product version instead of the
+ * Darwin kernel version that diverged in Tahoe.
+ */
+export function resolveOsProductLabel(): string {
+  const platform = os.platform();
+  if (platform === "darwin") {
+    return `macOS ${resolveDarwinProductVersion()}`;
+  }
+  if (platform === "win32") {
+    return `Windows ${os.release()}`;
+  }
+  return `${os.type()} ${os.release()}`;
+}
+
 /** Resolves a compact OS label for diagnostics, logs, and environment summaries. */
 export function resolveOsSummary(): OsSummary {
   const platform = os.platform();
-  const release = os.release();
+  const rawRelease = os.release();
   const arch = os.arch();
-  const cacheKey = `${platform}\0${release}\0${arch}`;
-  // Cache by stable os.* facts; darwin's sw_vers lookup is comparatively slow
-  // and only needed once per observed platform/release/arch tuple.
+  // Cache key uses raw os.release() (stable per kernel) so sw_vers drift across
+  // minor macOS updates does not invalidate the cache.
+  const cacheKey = `${platform}\0${rawRelease}\0${arch}`;
   const cached = cachedOsSummaryByKey.get(cacheKey);
   if (cached) {
     return cached;
   }
+  const release = platform === "darwin" ? resolveDarwinProductVersion() : rawRelease;
   const label = (() => {
     if (platform === "darwin") {
-      return `macos ${macosVersion()} (${arch})`;
+      return `macos ${release} (${arch})`;
     }
     if (platform === "win32") {
       return `windows ${release} (${arch})`;


### PR DESCRIPTION
Fixes #95145

## What Problem This Solves

Fixes an issue where agents running on macOS 26 (Tahoe) could receive Darwin kernel metadata in their runtime prompt instead of the macOS product version, causing prompt context such as `Darwin 25.x` to describe the host incorrectly.

## Why This Change Was Made

The runtime prompt OS helper now uses `sw_vers -productVersion` only on Darwin and keeps the historical `${os.type()} ${os.release()}` shape on Linux and Windows. The Darwin runtime label is cached by the raw OS tuple, and `resolveOsSummary().release` remains the raw kernel release for status JSON and trajectory compatibility.

## User Impact

macOS 26 users now get runtime prompt context like `os=macOS 26.4 (arm64)` instead of `os=Darwin 25.4.0 (arm64)`, while Linux and Windows prompt labels stay unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/infra/os-summary.test.ts` - 9 tests passed. Covers Darwin `sw_vers` product version, blank `sw_vers` fallback, Windows/Linux legacy output, raw `resolveOsSummary().release`, and cached Darwin runtime prompt lookup.
- `node scripts/run-vitest.mjs src/agents/system-prompt.test.ts src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts` - 94 tests passed across the prompt renderer and embedded attempt prompt surface.
- `node scripts/run-oxlint.mjs src/infra/os-summary.ts src/infra/os-summary.test.ts src/agents/cli-runner/helpers.ts src/agents/embedded-agent-runner/compact.ts src/agents/embedded-agent-runner/run/attempt.ts` - passed.
- `git diff --check` - passed.

Live macOS proof from this branch's implementation:

```text
uname -r: 25.4.0
sw_vers -productVersion: 26.4
node: v26.0.0
os.type/os.release/os.arch: Darwin 25.4.0 arm64
resolveRuntimeOsLabel(): macOS 26.4
resolveOsSummary(): {"platform":"darwin","arch":"arm64","release":"25.4.0","label":"macos 26.4 (arm64)"}
runtime line: Runtime: session=redacted | sessionId=redacted | host=redacted-host | os=macOS 26.4 (arm64) | node=v26.0.0 | model=redacted/provider | thinking=off
```

Observed result: on a real macOS 26.4 / Darwin 25.4.0 host, the runtime prompt renders `os=macOS 26.4 (arm64)` while `resolveOsSummary().release` remains the raw kernel release. Non-Darwin runtime labels preserve the previous `${os.type()} ${os.release()}` shape, including `Windows_NT ...`.

AI-assisted: built with Codex