### PR TITLE
fix(config): allow stdio transport in mcp server schema [AI-assisted]

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -215,6 +215,22 @@ describe("config schema", () => {
     ).toThrow();
   });
 
+  it("allows stdio transport on command-bearing MCP servers", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        mcp: {
+          servers: {
+            demo: {
+              command: "npx",
+              args: ["-y", "@modelcontextprotocol/server-memory"],
+              transport: "stdio",
+            },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
   it("validates MCP OAuth client metadata URLs against the SDK contract", () => {
     expect(() =>
       OpenClawSchema.parse({

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -392,7 +392,9 @@ const McpServerSchema = z
     cwd: z.string().optional(),
     workingDirectory: z.string().optional(),
     url: HttpUrlSchema.optional(),
-    transport: z.union([z.literal("sse"), z.literal("streamable-http")]).optional(),
+    transport: z
+      .union([z.literal("stdio"), z.literal("sse"), z.literal("streamable-http")])
+      .optional(),
     headers: z
       .record(
         z.string(),


### PR DESCRIPTION
Allows `transport: "stdio"` in MCP server schema config validation. The runtime already supports command-bearing servers with this transport setting, but `config validate` was rejecting it.

### Real-behavior proof:
`npx vitest run src/config/schema.test.ts` passes successfully:
```
 ✓  runtime-config  ../../src/config/schema.test.ts (52 tests) 3757ms
 Test Files  1 passed (1)
      Tests  52 passed (52)
```
