### PR TITLE
fix docs-list-mdx-pages

### DIFF
--- a/scripts/docs-list.js
+++ b/scripts/docs-list.js
@@ -65,7 +65,7 @@ function walkMarkdownFiles(dir, base = dir) {
         continue;
       }
       files.push(...walkMarkdownFiles(fullPath, base));
-    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+    } else if (entry.isFile() && /\.(md|mdx)$/i.test(entry.name)) {
       files.push(relative(base, fullPath));
     }
   }


### PR DESCRIPTION
## Summary

`pnpm docs:list` was omitting `.mdx` source pages because `scripts/docs-list.js`
only collected `.md` files. That hid real docs pages from the repo's required
docs-discovery workflow, including `docs/install/northflank.mdx`,
`docs/install/railway.mdx`, and `docs/install/render.mdx`.

This patch updates the docs-list walker to include both `.md` and `.mdx` files,
adds a focused regression test for mixed Markdown/MDX discovery, and wires
`scripts/docs-list.js` into changed-test routing.

## Verification

- `node scripts/docs-list.js | rg 'render\.mdx|northflank\.mdx|railway\.mdx'`
  - `install/northflank.mdx - Deploy OpenClaw on Northflank with one-click template`
  - `install/railway.mdx - Deploy OpenClaw on Railway with one-click template`
  - `install/render.mdx - Deploy OpenClaw on Render with Infrastructure-as-Code`
- `node scripts/run-vitest.mjs test/scripts/docs-list.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests  1 passed (1)`
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests  166 passed (166)`

## Real behavior proof

Behavior addressed: `docs:list` now includes real `.mdx` source docs pages instead of silently omitting them.
Real environment tested: Local checkout on branch `codex/docs-list-mdx-pages`.
Exact steps or command run after this patch:
- `node scripts/docs-list.js | rg 'render\.mdx|northflank\.mdx|railway\.mdx'`
- `node scripts/run-vitest.mjs test/scripts/docs-list.test.ts`
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts`
Evidence after fix:
- `install/northflank.mdx - Deploy OpenClaw on Northflank with one-click template`
- `install/railway.mdx - Deploy OpenClaw on Railway with one-click template`
- `install/render.mdx - Deploy OpenClaw on Render with Infrastructure-as-Code`
- `test/scripts/docs-list.test.ts`: `Test Files  1 passed (1)`, `Tests  1 passed (1)`
- `test/scripts/test-projects.test.ts`: `Test Files  1 passed (1)`, `Tests  166 passed (166)`
Observed result after fix: The docs discovery output now surfaces the missing `.mdx` pages, and both the focused regression test and changed-test routing regression suite pass.
What was not tested: Full repo-wide docs checks beyond the targeted `docs:list` behavior.