### PR TITLE
fix(ui): set payloadKind correctly for cron delivery presets [AI-assisted]

### DIFF
--- a/ui/src/ui/views/cron-quick-create.node.test.ts
+++ b/ui/src/ui/views/cron-quick-create.node.test.ts
@@ -37,5 +37,24 @@ describe("cron quick create", () => {
     expect(patch.sessionTarget).toBe("isolated");
     expect(patch.deliveryMode).toBe("announce");
     expect(patch.wakeMode).toBe("now");
+    expect(patch.payloadKind).toBe("agentTurn");
+  });
+
+  it("sets main session target and systemEvent payload for silent preset", () => {
+    const patch = draftToCronFormPatch(createDraft({ deliveryPreset: "silent" }));
+
+    expect(patch.sessionTarget).toBe("main");
+    expect(patch.deliveryMode).toBe("none");
+    expect(patch.wakeMode).toBe("now");
+    expect(patch.payloadKind).toBe("systemEvent");
+  });
+
+  it("sets isolated session target and agentTurn payload for isolated preset", () => {
+    const patch = draftToCronFormPatch(createDraft({ deliveryPreset: "isolated" }));
+
+    expect(patch.sessionTarget).toBe("isolated");
+    expect(patch.deliveryMode).toBe("none");
+    expect(patch.wakeMode).toBe("now");
+    expect(patch.payloadKind).toBe("agentTurn");
   });
 });

--- a/ui/src/ui/views/cron-quick-create.ts
+++ b/ui/src/ui/views/cron-quick-create.ts
@@ -187,16 +187,19 @@ export function draftToCronFormPatch(draft: CronQuickCreateDraft): Partial<CronF
       patch.sessionTarget = "isolated";
       patch.deliveryMode = "announce";
       patch.wakeMode = "now";
+      patch.payloadKind = "agentTurn";
       break;
     case "silent":
       patch.sessionTarget = "main";
       patch.deliveryMode = "none";
       patch.wakeMode = "now";
+      patch.payloadKind = "systemEvent";
       break;
     case "isolated":
       patch.sessionTarget = "isolated";
       patch.deliveryMode = "none";
       patch.wakeMode = "now";
+      patch.payloadKind = "agentTurn";
       break;
   }
 


### PR DESCRIPTION
Fixes the issue where creating a Cron job with the "Silent" delivery preset in the UI fails to close the dialog or save. 

The "Silent" preset maps the job's `sessionTarget` to `"main"`. However, the backend validation requires that cron jobs targeting the `"main"` session must have `payload.kind = "systemEvent"`. Because the quick-create wizard defaulted to `payloadKind = "agentTurn"`, the API request was rejected with a validation error, leaving the dialog open without any feedback.

We resolved this by setting `payloadKind = "systemEvent"` when the "Silent" preset is selected, and explicitly setting it to `"agentTurn"` for the other presets.

### Real-behavior proof:
`npx vitest run ui/src/ui/views/cron-quick-create.node.test.ts` passes successfully:
```
 ✓  ui  ../../ui/src/ui/views/cron-quick-create.node.test.ts (5 tests) 12ms
 Test Files  1 passed (1)
      Tests  5 passed (5)
```
And the main cron controller tests pass successfully:
```
 ✓  ui  ../../ui/src/ui/controllers/cron.test.ts (40 tests) 54ms
 Test Files  1 passed (1)
      Tests  40 passed (40)
```
