### PR TITLE
fix(feishu): omit replyToMessageId in streaming card for DMs [AI-assisted]

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1565,6 +1565,24 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("omits replyToMessageId in streaming.start() when skipReplyToInMessages is true", async () => {
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+      replyToMessageId: "om_msg",
+      replyInThread: true,
+      skipReplyToInMessages: true,
+    });
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expectStreamingStartOptions(0, {
+      replyToMessageId: undefined,
+      replyInThread: true,
+      header: { title: "agent", template: "blue" },
+      note: "Agent: agent",
+    });
+  });
+
   it("uses streaming cards for thread replies and keeps topic metadata", async () => {
     const { options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -392,7 +392,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         const cardHeader = resolveCardHeader(agentId, identity);
         const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
         await streaming.start(chatId, resolveReceiveIdType(chatId), {
-          replyToMessageId,
+          replyToMessageId: sendReplyToMessageId,
           replyInThread: effectiveReplyInThread,
           rootId,
           header: cardHeader,


### PR DESCRIPTION
Resolves a regression where the built-in Feishu plugin incorrectly sends messages with `replyToMessageId` set in direct messages (1:1 chat), showing a "Reply to [User]" label in the Feishu client.

The issue occurred because the streaming card delivery path (`streaming.start`) always passed the raw `replyToMessageId` instead of the resolved `sendReplyToMessageId` which respects `skipReplyToInMessages` (evaluating to true for direct chats). 

We fixed this by passing `sendReplyToMessageId` to `streaming.start` in `reply-dispatcher.ts`.

### Real-behavior proof:
`npx vitest run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/reply-dispatcher.test.ts` passes successfully:
```
 ✓  extension-feishu  extensions/feishu/src/reply-dispatcher.test.ts (83 tests) 203ms
 Test Files  1 passed (1)
      Tests  83 passed (83)
```
