### PR TITLE
fix(update): warn about stale gateway when version changes

### DIFF
--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -262,6 +262,25 @@ export function printResult(result: UpdateRunResult, opts: PrintResultOptions): 
     }
   }
 
+  // Warn about potentially stale gateway after a version-changing update.
+  // The running gateway process still references the old package files on disk
+  // and may use stale module import paths until restarted.
+  if (
+    result.status === "ok" &&
+    result.before?.version &&
+    result.after?.version &&
+    result.before.version !== result.after.version
+  ) {
+    defaultRuntime.log("");
+    defaultRuntime.log(
+      theme.warn(
+        "Gateway restart may be required. If the gateway was running before the update, " +
+          "restart it to pick up the new package files: " +
+          theme.command("openclaw gateway restart"),
+      ),
+    );
+  }
+
   defaultRuntime.log("");
   defaultRuntime.log(`Total time: ${theme.muted(formatDurationPrecise(result.durationMs))}`);
 }


### PR DESCRIPTION
## What Problem This Solves

After a version-changing update, the running gateway process still references old package files on disk. Users see stale module import paths and unexpected behavior until they manually restart the gateway. There is currently no indication that a restart is needed.

## Why This Change Was Made

The updater replaces package files on disk but has no mechanism to notify the user that the in-memory gateway process is now running against stale files. Adding a post-update warning closes this gap.

## Changes

- **`src/cli/update-cli/progress.ts`** — add a warning after successful version-changing updates telling users to run `openclaw gateway restart`

## Evidence

- Warning only appears when `result.status === "ok"` AND version actually changed
- No warning when: status is not ok, or version unchanged, or before/after version info is missing
- The change is a simple conditional log statement in the existing `printResult()` function with no side effects
- Users who update to a new version see: "Gateway restart may be required. If the gateway was running before the update, restart it to pick up the new package files: openclaw gateway restart"

## Related

Closes #92241