### PR TITLE
fix(slack): record thread participation under canonical root thread_ts (fixes #95235)

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -2113,8 +2113,14 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   // Record thread participation only when we actually delivered a reply and
   // know the thread ts that was used (set by deliverNormally, streaming start,
-  // or draft stream). Falls back to statusThreadTs for edge cases.
-  const participationThreadTs = usedReplyThreadTs ?? statusThreadTs;
+  // or draft stream). For thread replies, prefer the canonical Slack root
+  // thread ts (incomingThreadTs / message.thread_ts) so the participation key
+  // matches what the inbound implicit-mention lookup uses in prepare.ts.
+  // Without this normalization, participation can be recorded under a child
+  // message ts, causing later unmentioned replies in the same thread to be
+  // incorrectly dropped as "no-mention".
+  const participationThreadTs =
+    isThreadReply && incomingThreadTs ? incomingThreadTs : (usedReplyThreadTs ?? statusThreadTs);
   if (anyReplyDelivered && participationThreadTs) {
     recordSlackThreadParticipation(account.accountId, message.channel, participationThreadTs, {
       agentId: route.agentId,


### PR DESCRIPTION
## What Problem This Solves

When the bot replies in a Slack thread, the thread participation key is recorded under the child message `ts` instead of the canonical root `thread_ts`. Later unmentioned replies in the same thread fail the participation lookup and get dropped as "no-mention", even though `thread.requireExplicitMention = false`.

## What does this PR do?

Normalizes the participation recording key to use `message.thread_ts` (the canonical Slack root thread timestamp) when the inbound message is a thread reply. This matches the key used by the implicit-mention lookup in `prepare.ts`.

## Related Issue

Fixes #95235

## Type of Change

- [x] Bug fix (non-breaking)
- [x] AI-assisted (Hermes Agent)

## Changes Made

- `extensions/slack/src/monitor/message-handler/dispatch.ts`: Prefer `incomingThreadTs` (canonical root thread ts) over `usedReplyThreadTs` when recording thread participation for thread replies.

## How to Test

1. Configure a Slack channel with `requireMention: true` and `thread.requireExplicitMention: false`
2. Send an explicit @mention reply in a Slack thread → bot responds
3. Send another reply in the same thread without @mention → should be accepted via `bot_thread_participant`
4. Before this fix, step 3 would be dropped as "no-mention"

## Real behavior proof

- **Behavior addressed:** Thread participation recorded under child message ts instead of canonical root thread_ts, causing later unmentioned replies in bot-participated threads to be dropped
- **Environment tested:** macOS, Node.js, OpenClaw upstream/main (93cbd16c)
- **Steps run after the patch:**
```
grep -n "isThreadReply && incomingThreadTs" extensions/slack/src/monitor/message-handler/dispatch.ts
grep -n "threadTs: message.thread_ts" extensions/slack/src/monitor/message-handler/prepare.ts
pnpm test:extension slack
```
- **Evidence after fix:**
```
2123:    isThreadReply && incomingThreadTs

843:              threadTs: message.thread_ts,

 Test Files  101 passed (101)
      Tests  1326 passed (1326)
```
- **Observed result after fix:** Recording side now uses canonical root thread_ts matching the lookup side; all 1326 Slack extension tests pass
- **What was not tested:** Live Slack thread interaction (requires real Slack workspace)
