### PR TITLE
fix #94943: [BUG] gog skill.md in OpenClaw bundle is significantly out of date vs the official gogcli

### DIFF
--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gog
-description: "Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs."
+description: "Google Workspace and Google API CLI for Gmail, Calendar, Drive, Docs, Sheets, Chat, Classroom, Maps, YouTube, and more."
 homepage: https://gogcli.sh
 metadata:
   {
@@ -24,13 +24,25 @@ metadata:
 
 # gog
 
-Use `gog` for Gmail/Calendar/Drive/Contacts/Sheets/Docs. Requires OAuth setup.
+Use `gog` for Google Workspace and Google API tasks. Requires OAuth setup.
+
+This bundled skill is a quick-start reference, not the authoritative command index. `gogcli` changes faster than OpenClaw releases, so before using a command that is not shown here, check the live CLI help or generated docs:
+
+- `gog --help`
+- `gog <command> --help`
+- `gog schema` for machine-readable command/flag metadata
+- https://gogcli.sh/ and https://github.com/openclaw/gogcli/tree/main/docs/commands for the generated command reference
 
 Setup (once)
 
 - `gog auth credentials /path/to/client_secret.json`
 - `gog auth add you@gmail.com --services gmail,calendar,drive,contacts,docs,sheets`
 - `gog auth list`
+- Use `gog auth services` to list available service groups and scopes before requesting access for newer command families.
+
+Command surface
+
+`gog` includes commands for Gmail, Calendar, Drive, Contacts/People, Sheets, Docs, Slides, Chat, Classroom, Forms, Meet, Apps Script, Analytics, Search Console, Workspace Admin/Groups, Keep, Tasks, YouTube, Maps, Photos, Sites, backups, and a typed MCP server.
 
 Common commands
 
@@ -43,13 +55,16 @@ Common commands
 - Gmail draft: `gog gmail drafts create --to a@b.com --subject "Hi" --body-file ./message.txt`
 - Gmail send draft: `gog gmail drafts send <draftId>`
 - Gmail reply: `gog gmail send --to a@b.com --subject "Re: Hi" --body "Reply" --reply-to-message-id <msgId>`
+- Gmail filters export: `gog gmail settings filters export --account you@example.com --out filters.xml`
 - Calendar list events: `gog calendar events <calendarId> --from <iso> --to <iso>`
 - Calendar create event: `gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso>`
 - Calendar create with color: `gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso> --event-color 7`
 - Calendar update event: `gog calendar update <calendarId> <eventId> --summary "New Title" --event-color 4`
 - Calendar show colors: `gog calendar colors`
 - Drive search: `gog drive search "query" --max 10`
+- Drive raw API JSON: `gog drive raw <fileId> --json`
 - Contacts: `gog contacts list --max 20`
+- People profile: `gog people me --json`
 - Sheets get: `gog sheets get <sheetId> "Tab!A1:D10" --json`
 - Sheets update: `gog sheets update <sheetId> "Tab!A1:B2" --values-json '[["A","B"],["1","2"]]' --input USER_ENTERED`
 - Sheets append: `gog sheets append <sheetId> "Tab!A:C" --values-json '[["x","y","z"]]' --insert INSERT_ROWS`
@@ -57,6 +72,10 @@ Common commands
 - Sheets metadata: `gog sheets metadata <sheetId> --json`
 - Docs export: `gog docs export <docId> --format txt --out /tmp/doc.txt`
 - Docs cat: `gog docs cat <docId>`
+- Forms: `gog forms --help`
+- Maps/Places: `gog maps --help`
+- YouTube: `gog youtube --help`
+- MCP server: `gog mcp --help`
 
 Calendar Colors
 


### PR DESCRIPTION
Fixes #94943

## Summary

Refresh the bundled `gog` skill so it no longer presents the compact OpenClaw quick reference as the full gogcli command surface. The skill now points agents to live `gog` help, `gog schema`, and upstream generated command docs, and it summarizes the broader command families currently exposed by gogcli.

- Fix classification: Root-cause documentation/skill metadata fix for a stale model-consumed skill contract.
- Maintainer-ready confidence: High for the bounded bundled-skill update; upstream command examples were checked against generated gogcli docs and no runtime code changed.
- Patch quality notes: Small one-file Markdown skill change; no guard/catch/default fallback behavior, no dependencies, no lockfiles, no unrelated formatting.

## What Problem This Solves

- Behavior or issue addressed: The bundled `skills/gog/SKILL.md` described gogcli as a Gmail/Calendar/Drive/Contacts/Sheets/Docs helper and only showed that older compact command set, so agents reading the bundled skill could miss newer gogcli capabilities after an OpenClaw update restored the baseline skill file.

## Root Cause

- Root cause: The bundled `skills/gog/SKILL.md` was written as a static quick reference for an older subset of gogcli, but the model-consumed skill text did not state that upstream gogcli help/generated docs are the source of truth. Because OpenClaw ships this static skill, updates can restore the old compact wording and make agents treat the bundled examples as the available command contract.
- Why this is root-cause fix: The change fixes the source of the bad agent guidance by updating the bundled skill contract itself: it broadens the description, names the authoritative upstream help/schema/docs path, and adds current command-family awareness instead of adding a downstream workaround or only documenting the issue elsewhere.
- Architecture / source-of-truth check: The authoritative command schema remains in gogcli (`gog schema --json` and generated docs). OpenClaw core keeps only a quick-start bundled skill, preserving the source-of-truth boundary instead of vendoring the full generated gogcli command index.

## User Impact

- Why it matters / User impact: Agents using the bundled OpenClaw `gog` skill will know that gogcli covers more than Gmail/Calendar/Drive/Contacts/Sheets/Docs and will be directed to current help before using newer command families.
- Observed result after fix: The skill now advertises the broader Google Workspace/API surface and tells agents to use `gog --help`, `gog <command> --help`, `gog schema`, and upstream generated docs for commands not shown in the local quick reference.
- Compatibility: Existing common examples are preserved; no CLI behavior, config defaults, schema files, package metadata, or install behavior changed.

## Real behavior proof

- Real environment tested: Local OpenClaw source checkout on Windows Git Bash with Node `v22.17.0` and pnpm `11.2.2`; no live Google OAuth/API environment was used because the patch only changes bundled Markdown skill content.
- Evidence after fix: The committed diff changes only `skills/gog/SKILL.md`, preserving existing common examples while adding the live-help/generated-docs source-of-truth guidance and broader command-family summary.

## Evidence

- Compared the bundled skill with upstream generated gogcli docs using `gh api -H 'Accept: application/vnd.github.raw' repos/openclaw/gogcli/contents/docs/commands/README.md`.
- Confirmed the upstream command index is generated from `gog schema --json` / the live CLI schema and lists a broader top-level surface including `admin`, `analytics`, `appscript`, `backup`, `batch`, `chat`, `classroom`, `forms`, `groups`, `keep`, `maps`, `mcp`, `meet`, `people`, `photos`, `searchconsole`, `sites`, `slides`, `tasks`, `youtube`, and `zoom`.
- Spot-checked added examples against generated upstream command docs for `gog drive raw <fileId>`, `gog gmail settings filters export`, and `gog people me`.
- Ran `git diff --check` successfully after refreshing onto current `origin/main`.
- Ran `pnpm docs:list`; it completed, with the existing local environment warning that Node is `v22.17.0` while the repo requests `>=22.19.0`.
- SonarLint was not available in this shell (`sonarlint` / `sonarlint-language-server` not found); the only changed tracked file is Markdown skill content.

## Regression Test Plan

- Exact steps or command run after this patch: Compared the bundled skill with upstream generated gogcli docs; spot-checked added examples against generated docs for `gog-drive-raw.md`, `gog-gmail-settings-filters-export.md`, and `gog-people-me.md`; ran `git diff --check`; ran `pnpm docs:list`; checked for SonarLint availability.
- Target test file: No regression test added; this is Markdown skill content rather than source code. The regression guard is the reviewed skill diff plus upstream generated command-doc spot checks.
- Scenario locked in: A user/agent reading the bundled `gog` skill after an OpenClaw update sees that gogcli has broader current command families and sees the commands/docs to query before assuming a command is unsupported.
- Why this is the smallest reliable guardrail: A full generated command reference would be large and drift unless OpenClaw also owned regeneration automation; the smallest reliable guardrail is to keep the quick reference but explicitly route unknown/new commands to the live CLI schema/help source of truth.
- What was not tested: No live Google OAuth/API calls were run; the patch does not change gogcli runtime behavior. SonarLint was not available in this shell (`sonarlint` / `sonarlint-language-server` not found), and the changed tracked file is Markdown skill content only.

## Merge risk

- What did NOT change: Out of scope: vendoring the full gogcli generated docs, adding CI regeneration automation, changing ClawHub publication, changing OAuth scopes, changing gogcli itself, changing OpenClaw runtime code, or changing package/dependency/lockfile state.
- Related open PR scan: The daily-fix public-contract scan reported no related open PRs for this issue before implementation.
- Risk labels considered: Public-config/schema wording risk because the skill mentions `gog schema` and is model-consumed content.
- Risk explanation: The compatibility risk is low: this changes guidance text only, preserves existing examples, and keeps the canonical gogcli schema/docs outside OpenClaw core.
- Why acceptable: The issue is specifically that the bundled skill content is stale; updating that content while naming the upstream source of truth gives maintainers a bounded core change without taking ownership of the full generated command index.
