### PR TITLE
fix(cron): don't classify a yielded isolated-cron turn as a fatal error

### DIFF
--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -437,4 +437,34 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.hasFatalErrorPayload).toBe(true);
     expect(result.embeddedRunError).toBe("Exec failed before SYSTEM_RUN_DENIED could be retried");
   });
+
+  it("treats a clean sessions_yield as non-fatal despite an earlier benign tool error", () => {
+    // An isolated cron turn that spawns subagents then yields produces no final
+    // assistant reply. An earlier benign exec (exit 1 used as control flow)
+    // surfaces a ⚠️ 🛠️ tool warning that — absent yield-awareness — is treated
+    // as the fatal terminal payload and suppresses delivery.
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "Staged 2 calendar packet(s)." },
+        { text: "⚠️ 🛠️ list files in briefs/ (agent) failed", isError: true },
+      ],
+      yielded: true,
+    });
+
+    expect(result.hasFatalStructuredErrorPayload).toBe(false);
+    expect(result.hasFatalErrorPayload).toBe(false);
+    // The successful pre-yield work is preserved as the delivery payload.
+    expect(result.deliveryPayloads).toEqual([{ text: "Staged 2 calendar packet(s)." }]);
+  });
+
+  it("still marks a yielded turn fatal when a fatal failureSignal is present", () => {
+    // Yield-awareness must not mask a genuinely fatal run.
+    const result = resolveCronPayloadOutcome({
+      payloads: [{ text: "boom", isError: true }],
+      failureSignal: { fatalForCron: true, message: "run denied" },
+      yielded: true,
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(true);
+  });
 });

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -235,6 +235,7 @@ export function resolveCronPayloadOutcome(params: {
   failureSignal?: CronFailureSignal | undefined;
   finalAssistantVisibleText?: string | undefined;
   preferFinalAssistantVisibleText?: boolean;
+  yielded?: boolean;
 }): CronPayloadOutcome {
   const firstText =
     params.payloads.find((payload) => !isNonTerminalToolErrorWarning(payload))?.text ?? "";
@@ -294,6 +295,13 @@ export function resolveCronPayloadOutcome(params: {
     !hasStructuredDeliveryPayloads &&
     errorPayloads.length > 0 &&
     errorPayloads.every((payload) => isCronToolWarning(payload?.text));
+  // A clean sessions_yield is a deliberate pause (e.g. after spawning
+  // subagents), not a failure. A yielded turn produces no final assistant
+  // reply, so an earlier non-fatal tool error would otherwise remain the
+  // de-facto terminal payload and falsely fail the run. A genuinely fatal
+  // signal (failureSignal/runLevelError) still flips the run fatal below.
+  const hasCleanYieldTerminal =
+    params.yielded === true && !params.runLevelError && params.failureSignal?.fatalForCron !== true;
   // Structured error payloads are fatal unless later successful output or a
   // known non-terminal warning proves the agent recovered.
   const hasFatalStructuredErrorPayload =
@@ -301,7 +309,8 @@ export function resolveCronPayloadOutcome(params: {
     !hasSuccessfulPayloadAfterLastError &&
     !hasPendingPresentationWarning &&
     !hasNonTerminalToolErrorWarning &&
-    !hasRecoveredToolWarning;
+    !hasRecoveredToolWarning &&
+    !hasCleanYieldTerminal;
   // Fatal structured errors own the final delivery payload unless later output
   // proves recovery; otherwise cron would announce stale partial success text.
   // Keep structured/media announce payloads intact. Only collapse purely textual

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1150,6 +1150,7 @@ async function finalizeCronRun(params: {
         deliveryRequested: prepared.deliveryRequested,
       })
     ).preferFinalAssistantVisibleText,
+    yielded: finalRunResult.meta?.yielded === true,
   });
   if (finalRunResult.meta?.aborted === true && !cronPayloadOutcome.hasFatalErrorPayload) {
     const metaErrorMessage = normalizeOptionalString(finalRunResult.meta.error?.message);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an isolated-session scheduled (cron) agent run that ends by yielding — for example, after spawning subagents and pausing for them to complete — is reported as a fatal `error` and its delivery is suppressed, whenever a *non-fatal* tool error occurred earlier in the same turn (e.g. a shell `exec` that exits non-zero as benign control flow, like a `grep` with no match).

The run's actual work succeeds, but the schedule shows `error` / `consecutiveErrors` and no message is delivered.

## Why This Change Was Made

`resolveCronPayloadOutcome` only recognizes recovery from an earlier error via (a) a later successful payload or (b) a final assistant answer. A clean `sessions_yield` produces neither — a yielded turn emits no final assistant reply — so the earlier non-fatal error payload remains the de-facto terminal payload and drives `hasFatalStructuredErrorPayload = true`.

`sessions_yield` was never accounted for in the cron-outcome classifier; yield-awareness had previously been added only for media completions, not the textual/structured-payload path.

The fix threads the runner's existing `meta.yielded` flag into the classifier and treats a clean yield (no `runLevelError`, no fatal `failureSignal`) as a recovering, non-terminal outcome. A genuinely fatal `failureSignal`/`runLevelError` still flips the run fatal — yield-awareness does not mask real failures.

Non-goal: this does not re-deliver a digest assembled *after* spawned subagents finish (that path is a separate, deliberate short-circuit). Scope is strictly the misclassification of the yielded turn itself.

## User Impact

A scheduled isolated-agent run that legitimately yields is now reported as `ok` and its pre-yield output is delivered, instead of being marked failed with delivery suppressed. Operators stop seeing false `error` / `consecutiveErrors` on schedules that are actually working.

## Evidence

Two focused unit tests added to `src/cron/isolated-agent.helpers.test.ts`, written test-first (confirmed RED before the fix, GREEN after):

- `treats a clean sessions_yield as non-fatal despite an earlier benign tool error` — reproduces the bug: a benign `⚠️ 🛠️ … failed` payload before a clean yield no longer forces a fatal classification, and the successful pre-yield payload is preserved for delivery.
- `still marks a yielded turn fatal when a fatal failureSignal is present` — guard proving yield-awareness does not mask a genuinely fatal run.

```
 Test Files  108 passed (108)
      Tests  1144 passed (1144)
```
(full `vitest.cron` suite — no regressions; `oxlint` and `tsgo` core typecheck clean)

---
*Disclosure: prepared with AI assistance (Claude Code); authored and reviewed by the submitter.*
