### PR TITLE
fix(docs): show inline read_when hints in docs:list

### DIFF
--- a/scripts/docs-list.js
+++ b/scripts/docs-list.js
@@ -116,6 +116,11 @@ function extractMetadata(fullPath) {
         } catch {
           // ignore malformed inline arrays
         }
+      } else if (
+        (inline.startsWith('"') && inline.endsWith('"')) ||
+        (inline.startsWith("'") && inline.endsWith("'"))
+      ) {
+        readWhen.push(...compactStrings([inline.slice(1, -1)]));
       }
       continue;
     }

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -1026,6 +1026,7 @@ const TOOLING_SOURCE_TEST_TARGETS = new Map([
     "scripts/deadcode-unused-files.allowlist.mjs",
     ["test/scripts/check-deadcode-unused-files.test.ts"],
   ],
+  ["scripts/docs-list.js", ["test/scripts/docs-list.test.ts"]],
   ["scripts/docs-link-audit.mjs", ["src/scripts/docs-link-audit.test.ts"]],
   ["scripts/lib/arg-utils.mjs", ["test/scripts/arg-utils.test.ts"]],
   [

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -887,6 +887,7 @@ describe("test-projects args", () => {
           "test/scripts/codex-install-assertions.test.ts",
           "test/scripts/config-reload-mutate-metadata.test.ts",
           "test/scripts/control-ui-i18n.test.ts",
+          "test/scripts/docs-list.test.ts",
           "test/scripts/doctor-install-switch-wrapper.test.ts",
           "test/scripts/e2e-text-file-utils.test.ts",
           "test/scripts/fixture-common.test.ts",

--- a/test/scripts/docs-list.test.ts
+++ b/test/scripts/docs-list.test.ts
@@ -1,0 +1,50 @@
+// docs-list tests cover source docs metadata discovery for docs-aware tooling.
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const tempDirs: string[] = [];
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const docsListScriptPath = path.join(repoRoot, "scripts", "docs-list.js");
+
+function makeTempRepoRoot(prefix: string): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function runDocsList(cwd: string): string {
+  return execFileSync(process.execPath, [docsListScriptPath], {
+    cwd,
+    encoding: "utf8",
+  });
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("docs-list", () => {
+  it("prints single-line read_when strings as read hints", () => {
+    const tempRepoRoot = makeTempRepoRoot("openclaw-docs-list-");
+    mkdirSync(path.join(tempRepoRoot, "docs"), { recursive: true });
+    writeFileSync(
+      path.join(tempRepoRoot, "docs", "page.md"),
+      `---
+summary: "Single-line read_when page"
+read_when: "Read this page when the hint is inline."
+---
+`,
+      "utf8",
+    );
+
+    const output = runDocsList(tempRepoRoot);
+
+    expect(output).toContain("page.md - Single-line read_when page");
+    expect(output).toContain("Read when: Read this page when the hint is inline.");
+  });
+});

--- a/test/scripts/docs-list.test.ts
+++ b/test/scripts/docs-list.test.ts
@@ -1,18 +1,16 @@
 // docs-list tests cover source docs metadata discovery for docs-aware tooling.
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
 const tempDirs: string[] = [];
 const repoRoot = path.resolve(import.meta.dirname, "../..");
 const docsListScriptPath = path.join(repoRoot, "scripts", "docs-list.js");
 
 function makeTempRepoRoot(prefix: string): string {
-  const dir = mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
+  return makeTempDir(tempDirs, prefix);
 }
 
 function runDocsList(cwd: string): string {
@@ -23,9 +21,7 @@ function runDocsList(cwd: string): string {
 }
 
 afterEach(() => {
-  for (const dir of tempDirs.splice(0)) {
-    rmSync(dir, { recursive: true, force: true });
-  }
+  cleanupTempDirs(tempDirs);
 });
 
 describe("docs-list", () => {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1389,6 +1389,11 @@ describe("scripts/test-projects changed-target routing", () => {
       targets: ["test/scripts/update-clawtributors.test.ts"],
     });
 
+    expect(resolveChangedTestTargetPlan(["scripts/docs-list.js"])).toEqual({
+      mode: "targets",
+      targets: ["test/scripts/docs-list.test.ts"],
+    });
+
     expect(resolveChangedTestTargetPlan(["scripts/docs-link-audit.mjs"])).toEqual({
       mode: "targets",
       targets: ["src/scripts/docs-link-audit.test.ts"],


### PR DESCRIPTION
## Summary

`pnpm docs:list` was parsing `read_when` lists and inline arrays, but it skipped
the common single-line string form used by source docs pages. That caused real
docs such as `docs/concepts/multi-agent.md`,
`docs/gateway/remote-gateway-readme.md`, and `docs/gateway/sandboxing.md` to
lose their `Read when` hints in docs-aware discovery output.

This patch teaches `scripts/docs-list.js` to accept quoted inline `read_when`
strings, adds a focused regression test for that frontmatter shape, and wires
`scripts/docs-list.js` into changed-test routing.

## Verification

- `node scripts/docs-list.js | rg -n '^concepts/multi-agent\.md|^gateway/remote-gateway-readme\.md|^gateway/sandboxing\.md' -A1`
  - `concepts/multi-agent.md - Multi-agent routing: isolated agents, channel accounts, and bindings`
  - `Read when: You want multiple isolated agents (workspaces + auth) in one gateway process.`
  - `gateway/remote-gateway-readme.md - SSH tunnel setup for OpenClaw.app connecting to a remote gateway`
  - `Read when: Connecting the macOS app to a remote gateway over SSH`
  - `gateway/sandboxing.md - How OpenClaw sandboxing works: modes, scopes, workspace access, and images`
  - `Read when: You want a dedicated explanation of sandboxing or need to tune agents.defaults.sandbox.`
- `node scripts/run-vitest.mjs test/scripts/docs-list.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests  1 passed (1)`
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests  166 passed (166)`

## Real behavior proof

Behavior addressed: `docs:list` now preserves `Read when` hints for docs pages that use single-line quoted `read_when` frontmatter.
Real environment tested: Local checkout on branch `codex/docs-list-read-when-inline`.
Exact steps or command run after this patch:
- `node scripts/docs-list.js | rg -n '^concepts/multi-agent\.md|^gateway/remote-gateway-readme\.md|^gateway/sandboxing\.md' -A1`
- `node scripts/run-vitest.mjs test/scripts/docs-list.test.ts`
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts`
Evidence after fix:
- `concepts/multi-agent.md - Multi-agent routing: isolated agents, channel accounts, and bindings`
- `Read when: You want multiple isolated agents (workspaces + auth) in one gateway process.`
- `gateway/remote-gateway-readme.md - SSH tunnel setup for OpenClaw.app connecting to a remote gateway`
- `Read when: Connecting the macOS app to a remote gateway over SSH`
- `gateway/sandboxing.md - How OpenClaw sandboxing works: modes, scopes, workspace access, and images`
- `Read when: You want a dedicated explanation of sandboxing or need to tune agents.defaults.sandbox.`
- `test/scripts/docs-list.test.ts`: `Test Files  1 passed (1)`, `Tests  1 passed (1)`
- `test/scripts/test-projects.test.ts`: `Test Files  1 passed (1)`, `Tests  166 passed (166)`
Observed result after fix: `docs:list` now surfaces the missing inline `read_when` hints, and both the focused regression test and changed-test routing regression suite pass.
What was not tested: Full repo-wide docs tooling beyond the targeted `docs:list` behavior.