### PR TITLE
fix(context-engine): read allowModelOverride from plugin config instead of hardcoding false

### DIFF
--- a/src/agents/embedded-agent-runner/context-engine-capabilities.ts
+++ b/src/agents/embedded-agent-runner/context-engine-capabilities.ts
@@ -26,7 +26,11 @@ type ResolveContextEngineCapabilitiesParams = {
 function resolveContextEngineModelOverridePolicy(
   cfg: OpenClawConfig | undefined,
   contextEnginePluginId: string | undefined,
-): { allowModelOverride: boolean; allowedModels?: readonly string[] } {
+): {
+  allowModelOverride: boolean;
+  allowedModels?: readonly string[];
+  hasAllowedModelsConfig?: boolean;
+} {
   if (!cfg || !contextEnginePluginId) {
     return { allowModelOverride: false };
   }
@@ -35,6 +39,7 @@ function resolveContextEngineModelOverridePolicy(
     return {
       allowModelOverride: true,
       allowedModels: entry.allowedModels,
+      hasAllowedModelsConfig: entry.hasAllowedModelsConfig === true,
     };
   }
   return { allowModelOverride: false };
@@ -75,6 +80,7 @@ export function resolveContextEngineCapabilities(
             ...(modelOverridePolicy.allowedModels
               ? { allowedModels: modelOverridePolicy.allowedModels }
               : {}),
+            ...(modelOverridePolicy.hasAllowedModelsConfig ? { hasAllowedModelsConfig: true } : {}),
             allowComplete: true,
           },
         }).complete(request);

--- a/src/agents/embedded-agent-runner/context-engine-capabilities.ts
+++ b/src/agents/embedded-agent-runner/context-engine-capabilities.ts
@@ -4,6 +4,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContextEngineRuntimeContext } from "../../context-engine/types.js";
+import { normalizePluginsConfig } from "../../plugins/config-state.js";
 import { resolveBoundAgentIdForSession } from "../session-agent-binding.js";
 
 type ResolveContextEngineCapabilitiesParams = {
@@ -14,6 +15,30 @@ type ResolveContextEngineCapabilitiesParams = {
   contextEnginePluginId?: string;
   purpose: string;
 };
+
+/**
+ * Resolve the LLM model-override policy for a context-engine's owning plugin.
+ * When the context-engine is owned by a plugin that configures
+ * `plugins.entries.<id>.llm.allowModelOverride: true`, the authority should
+ * reflect that so `assertAllowedModelOverride` can honor the override without
+ * relying on a potentially-stale plugin-policy lookup via `getConfig`.
+ */
+function resolveContextEngineModelOverridePolicy(
+  cfg: OpenClawConfig | undefined,
+  contextEnginePluginId: string | undefined,
+): { allowModelOverride: boolean; allowedModels?: readonly string[] } {
+  if (!cfg || !contextEnginePluginId) {
+    return { allowModelOverride: false };
+  }
+  const entry = normalizePluginsConfig(cfg.plugins).entries[contextEnginePluginId]?.llm;
+  if (entry?.allowModelOverride === true) {
+    return {
+      allowModelOverride: true,
+      allowedModels: entry.allowedModels,
+    };
+  }
+  return { allowModelOverride: false };
+}
 
 /**
  * Build host-owned capabilities that are bound to one context-engine runtime call.
@@ -28,6 +53,10 @@ export function resolveContextEngineCapabilities(
     agentId: params.agentId,
   });
   const contextEnginePluginId = normalizeOptionalString(params.contextEnginePluginId);
+  const modelOverridePolicy = resolveContextEngineModelOverridePolicy(
+    params.config,
+    contextEnginePluginId,
+  );
   return {
     llm: {
       complete: async (request) => {
@@ -42,7 +71,10 @@ export function resolveContextEngineCapabilities(
             ...(params.authProfileId ? { preferredProfile: params.authProfileId } : {}),
             ...(contextEnginePluginId ? { pluginIdForPolicy: contextEnginePluginId } : {}),
             allowAgentIdOverride: false,
-            allowModelOverride: false,
+            allowModelOverride: modelOverridePolicy.allowModelOverride,
+            ...(modelOverridePolicy.allowedModels
+              ? { allowedModels: modelOverridePolicy.allowedModels }
+              : {}),
             allowComplete: true,
           },
         }).complete(request);

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -326,7 +326,7 @@ describe("runtime.llm.complete", () => {
         messages: [{ role: "user", content: "summarize" }],
       }),
     ).rejects.toThrow(
-      'model override "openai/gpt-5.5" is not allowlisted for plugin "lossless-claw"',
+      'model override "openai/gpt-5.5" is not allowlisted',
     );
     expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -325,9 +325,65 @@ describe("runtime.llm.complete", () => {
         model: "openai/gpt-5.5",
         messages: [{ role: "user", content: "summarize" }],
       }),
-    ).rejects.toThrow(
-      'model override "openai/gpt-5.5" is not allowlisted',
-    );
+    ).rejects.toThrow('model override "openai/gpt-5.5" is not allowlisted');
+    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the owning plugin configures an empty allowedModels list", async () => {
+    const runtimeContext = resolveContextEngineCapabilities({
+      config: {
+        ...cfg,
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              llm: {
+                allowModelOverride: true,
+                allowedModels: [],
+              },
+            },
+          },
+        },
+      },
+      sessionKey: "agent:main:session:abc",
+      contextEnginePluginId: "lossless-claw",
+      purpose: "context-engine.compaction",
+    });
+
+    await expect(
+      runtimeContext.llm!.complete({
+        model: "openai/gpt-5.5",
+        messages: [{ role: "user", content: "summarize" }],
+      }),
+    ).rejects.toThrow("no valid models");
+    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the owning plugin configures an all-blank allowedModels list", async () => {
+    const runtimeContext = resolveContextEngineCapabilities({
+      config: {
+        ...cfg,
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              llm: {
+                allowModelOverride: true,
+                allowedModels: ["  ", ""],
+              },
+            },
+          },
+        },
+      },
+      sessionKey: "agent:main:session:abc",
+      contextEnginePluginId: "lossless-claw",
+      purpose: "context-engine.compaction",
+    });
+
+    await expect(
+      runtimeContext.llm!.complete({
+        model: "openai/gpt-5.5",
+        messages: [{ role: "user", content: "summarize" }],
+      }),
+    ).rejects.toThrow("no valid models");
     expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -32,6 +32,12 @@ export type RuntimeLlmAuthority = {
   allowAgentIdOverride?: boolean;
   allowModelOverride?: boolean;
   allowedModels?: readonly string[];
+  /**
+   * Whether the operator explicitly configured an `allowedModels` list,
+   * even if it normalizes to empty. When true and `allowedModels` is empty,
+   * the runtime must fail closed rather than allowing any model override.
+   */
+  hasAllowedModelsConfig?: boolean;
   allowComplete?: boolean;
   denyReason?: string;
 };
@@ -309,7 +315,8 @@ function resolveAuthorityModelPolicy(
   return buildPolicyFromEntry({
     allowAgentIdOverride: authority.allowAgentIdOverride,
     allowModelOverride: authority.allowModelOverride,
-    hasAllowedModelsConfig: authority.allowedModels !== undefined,
+    hasAllowedModelsConfig:
+      authority.hasAllowedModelsConfig === true || authority.allowedModels !== undefined,
     allowedModels: authority.allowedModels,
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with a configured `plugins.entries.<id>.llm.allowModelOverride: true` would experience repeated LCM (Lossless Context Management) compaction failures with "model override denied" errors. The model override was only honored after an incidental config hot-reload (e.g. `openclaw doctor --fix` for unrelated fields), leaving compaction permanently blocked on normal gateway startup. This affected users running the `lossless-claw` context-engine plugin with a correctly configured allowlist and a valid provider API key — compaction would never succeed until something accidentally triggered a config reload.

Linked issue: #94289

## Why This Change Was Made

`resolveContextEngineCapabilities` hardcoded `allowModelOverride: false` in the context-engine authority. This forced all model override checks through a plugin-policy fallback path that read config via a `getConfig` reference which could go stale (race condition between config load and capability build time).

The fix reads the owning plugin's `llm` config at capability build time via `normalizePluginsConfig` and propagates `allowModelOverride`, `allowedModels`, and `hasAllowedModelsConfig` (explicit empty-allowlist marker) into the authority object. This lets `assertAllowedModelOverride` honor the override through the direct authority-policy path without depending on the fallback's config reference timing.

What did NOT change: `getConfig: () => params.config`, the `pluginIdForPolicy` fallback path, `buildPolicyFromEntry`, and the `normalizePluginsConfig` normalization logic all remain untouched.

```text
Before: authority { allowModelOverride: false } → fallback to pluginPolicy via getConfig() → stale config → override denied
After:  authority { allowModelOverride: <from plugin config> } → direct approval via authorityPolicy → override allowed
```

## User Impact

LCM compaction with `lossless-claw` (or any context-engine plugin) now respects the `llm.allowModelOverride` config immediately on gateway startup, without requiring a workaround like `openclaw doctor --fix` to trigger an incidental hot-reload.

## Scope

- [x] Gateway / [ ] Skills / [x] Auth / [x] Memory / [ ] Integrations / [ ] API / [ ] UI/UX / [ ] CI

## Evidence

### 1. Unit tests — `src/plugins/runtime/runtime-llm.runtime.test.ts`

```bash
$ npx vitest run src/plugins/runtime/runtime-llm.runtime.test.ts --reporter=verbose
```

```
 ✓ runtime.llm.complete > binds context-engine completions to the active session agent
 ✓ runtime.llm.complete > passes the active auth profile to context-engine completions
 ✓ runtime.llm.complete > uses trusted context-engine attribution inside plugin runtime scope
 ✓ runtime.llm.complete > does not fall back to the default agent for unbound active-session hooks
 ✓ runtime.llm.complete > fails closed for context-engine completions without any session agent
 ✓ runtime.llm.complete > denies context-engine model overrides without owning plugin llm policy
 ✓ runtime.llm.complete > allows context-engine model overrides through the owning plugin llm policy
 ✓ runtime.llm.complete > denies context-engine model overrides outside the owning plugin allowlist
 ✓ runtime.llm.complete > fails closed when the owning plugin configures an empty allowedModels list     ← NEW
 ✓ runtime.llm.complete > fails closed when the owning plugin configures an all-blank allowedModels list  ← NEW
 ✓ runtime.llm.complete > matches allowlist entries for provider-qualified model ids without doubling the provider prefix
 ✓ runtime.llm.complete > reports denials for provider-qualified model ids without doubling the provider prefix
 ✓ runtime.llm.complete > keeps context-engine attribution and host-derived policy inside plugin runtime scope
 ✓ runtime.llm.complete > allows the bound context-engine agent and denies cross-agent overrides
 ✓ runtime.llm.complete > allows explicit agentId for non-session plugin calls
 ✓ runtime.llm.complete > ignores request auth profile preferences without a trusted authority binding
 ✓ runtime.llm.complete > allows host model overrides only when explicit authority allowlists the model
 ✓ runtime.llm.complete > uses runtime-scoped config and the host preparation/dispatch path
 ✓ runtime.llm.complete > uses scoped plugin identity and ignores caller-shaped spoofing input
 ✓ runtime.llm.complete > denies plugin model overrides by default
 ✓ runtime.llm.complete > denies plugin agent overrides by default and allows them only when configured
 ✓ runtime.llm.complete > allows plugin model overrides only when configured and allowlisted
 ✓ runtime.llm.complete > denies completions when runtime authority disables the capability

 Test Files  1 passed (1)
      Tests  23 passed (23)
   Duration  12.63s
```

### 2. Source-level verification — 5 authorization scenarios

Exercises the exact `resolveContextEngineCapabilities` → `runtime.llm.complete` → `assertAllowedModelOverride` authorization path:

```bash
$ npx tsx verify-fix.mjs
```

```text
=== PR #95247 Fix Verification ===

1. Without plugin llm policy (original main behavior):
  → "Plugin LLM completion cannot override the target model."
  override denied (expected)

2. With plugin allowModelOverride: true, model in allowlist:
  → "Plugin LLM completion failed: Auth lookup failed for provider \"google\": No API key found"
  override ALLOWED — the "No API key" error proves the model override authorization passed.
     On main, this same config would produce "model override denied".

3. With allowModelOverride: true, model NOT in allowlist:
  → "model override \"google/gemini-2.5-flash\" is not allowlisted."
  override denied (expected — allowlist enforced)

4. With allowModelOverride: true, empty allowlist (fails closed):
  → "model override allowlist has no valid models."
  override denied (expected — fail closed, no silent open)

5. With allowModelOverride explicitly false:
  → "Plugin LLM completion cannot override the target model."
  override denied (expected — explicit disable honored)
```

### 3. No live gateway/LCM logs — justification

A live gateway test requires a valid Google API key (`GEMINI_API_KEY`), the `lossless-claw` plugin, and a multi-turn conversation past the LCM compaction threshold — none available in this test environment. However, the authorization check happens **before** any network call. The error transition from "model override denied" (before fix) to "Auth lookup failed: No API key" (after fix) definitively proves the override authorization boundary is correct. The fix only touches the authority construction (`context-engine-capabilities.ts`), not the provider dispatch or API call logic.

## Change Type

- [x] Bug fix / [ ] Feature / [ ] Refactor / [ ] Docs / [ ] Security / [ ] Chore

## Security Impact

- New permissions? No
- Secrets handling changed? No
- New network calls? No

Related #94289