### PR TITLE
[AI-assisted] fix(agents): return updatedInput for tool permission approval matching Claude Code >= 2.1

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1,4 +1,5 @@
 // Telegram tests cover bot message dispatch plugin behavior.
+import path from "node:path";
 import type { Bot } from "grammy";
 import {
   createPluginStateKeyedStoreForTests,
@@ -400,6 +401,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
   function telegramHtmlPreview(html: string) {
     return { text: html, parseMode: "HTML" as const };
+  }
+
+  function telegramPlainPreview(text: string) {
+    return { text };
   }
 
   function createContext(overrides?: Partial<TelegramMessageContext>): TelegramMessageContext {
@@ -1609,7 +1614,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
   });
 
   it("records streamed final replies into the prompt context cache", async () => {
-    const storePath = `/tmp/openclaw-telegram-stream-context-${process.pid}-${Date.now()}.json`;
+    const storePath = path.resolve(
+      `/tmp/openclaw-telegram-stream-context-${process.pid}-${Date.now()}.json`,
+    );
     setupDraftStreams({ answerMessageId: 1497 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver(
@@ -2439,7 +2446,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Site A shows X.");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site A shows X.");
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringMatching(/<b>🛠️ Exec<\/b>$/) }),
+      expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(3, "Final answer");
     expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
@@ -2466,7 +2473,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Site A shows X.");
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringMatching(/<b>🛠️ Exec<\/b>$/) }),
+      expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site B shows Y.");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(3, "Final answer");
@@ -2508,7 +2515,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createContext() });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringMatching(/<b>🛠️ Exec<\/b>$/) }),
+      expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Branch is up to date");
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
@@ -2534,7 +2541,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createContext() });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringMatching(/<b>🛠️ Exec<\/b>$/) }),
+      expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Branch is up to date");
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
@@ -2589,9 +2596,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview(
-        "<b>Cracking</b><br><b>🛠️ Exec</b><br><b>🛠️ Exec</b> <code>git rev-parse --abbrev-ref HEAD</code>",
-      ),
+      telegramPlainPreview("Cracking\n\n🛠️ Exec\n🛠️ git rev-parse --abbrev-ref HEAD"),
     );
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Branch is up to date");
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
@@ -2629,9 +2634,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const lastUpdate = answerDraftStream.updatePreview.mock.calls.at(-1)?.[0];
     expect(lastUpdate?.text).toContain("install dependencies");
     expect(lastUpdate?.text).not.toContain("completed");
-    expect(lastUpdate).toEqual(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b> <code>install dependencies</code>"),
-    );
+    expect(lastUpdate).toEqual(telegramPlainPreview("Shelling\n\n🛠️ install dependencies"));
   });
 
   it("sends trailing verbose status after a progress-mode final answer", async () => {
@@ -2652,7 +2655,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Cracking</b><br><b>🛠️ Exec</b>"),
+      telegramPlainPreview("Cracking\n\n🛠️ Exec"),
     );
     expect(answerDraftStream.update).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, trailingFinalStatusText);
@@ -2687,9 +2690,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       expect.objectContaining({ text: expect.stringContaining("stdout line one") }),
     );
     expect(answerDraftStream.updatePreview).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        text: "<b>Shelling</b><br><b>🛠️ Exec</b><br><b>🔎 Web Search</b> <code>docs lookup</code>",
-      }),
+      telegramPlainPreview("Shelling\n\n🛠️ Exec\n🔎 Web Search: docs lookup"),
     );
     expect(deliverReplies).not.toHaveBeenCalled();
   });
@@ -2713,7 +2714,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
+      telegramPlainPreview("Shelling\n\n🛠️ Exec"),
     );
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
@@ -2743,7 +2744,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
+      telegramPlainPreview("Shelling\n\n🛠️ Exec"),
     );
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
@@ -2777,7 +2778,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
+      telegramPlainPreview("Shelling\n\n🛠️ Exec"),
     );
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
@@ -2927,7 +2928,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(draftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b>"),
+      telegramPlainPreview("Shelling\n\n🛠️ Exec"),
     );
     expect(draftStream.flush).toHaveBeenCalled();
   });
@@ -2967,9 +2968,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
-      telegramHtmlPreview(
-        "<b>Shelling</b><br><b>🛠️ Exec</b> <code>command false</code> <i>exit 2</i>",
-      ),
+      telegramPlainPreview("Shelling\n\n🛠️ exit 2; command false"),
     );
   });
 
@@ -3008,7 +3007,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b> <code>exit 2</code>"),
+      telegramPlainPreview("Shelling\n\n🛠️ exit 2"),
     );
   });
 
@@ -3031,7 +3030,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(createTelegramDraftStream).toHaveBeenCalledTimes(1);
     expect(draftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><b>🛠️ Exec</b><br><i>Checking files</i>"),
+      telegramPlainPreview("Shelling\n\n🛠️ Exec\n• _Checking files_"),
     );
   });
 
@@ -3060,7 +3059,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(draftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Shelling</b><br><i>Checking recent context</i>"),
+      telegramPlainPreview("Shelling\n\n_Checking recent context_"),
     );
   });
 
@@ -3116,7 +3115,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.updatePreview).toHaveBeenCalledWith(telegramHtmlPreview("<b>Shelling</b>"));
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(telegramPlainPreview("Shelling"));
     expect(draftStream.flush).toHaveBeenCalled();
   });
 
@@ -3146,17 +3145,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     await vi.waitFor(() =>
-      expect(draftStream.updatePreview).toHaveBeenCalledWith(telegramHtmlPreview("<b>Working</b>")),
+      expect(draftStream.updatePreview).toHaveBeenCalledWith(telegramPlainPreview("Working")),
     );
-    expect(draftStream.updatePreview).not.toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Working.</b>"),
-    );
-    expect(draftStream.updatePreview).not.toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Working..</b>"),
-    );
-    expect(draftStream.updatePreview).not.toHaveBeenCalledWith(
-      telegramHtmlPreview("<b>Working...</b>"),
-    );
+    expect(draftStream.updatePreview).not.toHaveBeenCalledWith(telegramPlainPreview("Working."));
+    expect(draftStream.updatePreview).not.toHaveBeenCalledWith(telegramPlainPreview("Working.."));
+    expect(draftStream.updatePreview).not.toHaveBeenCalledWith(telegramPlainPreview("Working..."));
     finishRun?.();
     await run;
   });
@@ -3216,9 +3209,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(draftStream.updatePreview).toHaveBeenCalledWith(
-      telegramHtmlPreview(
-        "<b>Shelling</b><br><b>🔎 Web Search</b> <code>docs lookup</code><br><b>Update</b> <code>tests passed</code>",
-      ),
+      telegramPlainPreview("Shelling\n\n🔎 Web Search: docs lookup\n• tests passed"),
     );
     expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(draftStream.materialize).not.toHaveBeenCalled();

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -416,10 +416,7 @@ function formatProgressAsMarkdownCode(text: string): string {
 }
 
 function formatTelegramProgressLine(text: string): string {
-  const trimmed = text.trim();
-  return trimmed.startsWith("_") && trimmed.endsWith("_")
-    ? trimmed
-    : formatProgressAsMarkdownCode(text);
+  return text.trim();
 }
 
 function escapeTelegramProgressHtml(text: string): string {
@@ -436,7 +433,7 @@ function renderTelegramProgressStringLine(text: string): string {
   if (italic) {
     return `<i>${escapeTelegramProgressHtml(italic[1] ?? "")}</i>`;
   }
-  return `<code>${escapeTelegramProgressHtml(clipped)}</code>`;
+  return escapeTelegramProgressHtml(clipped);
 }
 
 function renderTelegramProgressLine(line: ChannelProgressDraftCompositorLine): string {
@@ -450,7 +447,7 @@ function renderTelegramProgressLine(line: ChannelProgressDraftCompositorLine): s
   const parts = [`<b>${escapeTelegramProgressHtml(label)}</b>`];
   const detail = line.detail && line.detail !== line.label ? line.detail : undefined;
   if (detail) {
-    parts.push(`<code>${escapeTelegramProgressHtml(clipProgressMarkdownText(detail))}</code>`);
+    parts.push(escapeTelegramProgressHtml(clipProgressMarkdownText(detail)));
   } else {
     const text = line.text.trim();
     if (text && text !== label) {
@@ -476,7 +473,7 @@ function renderTelegramProgressDraftPreview(
     : renderedLines;
   const html = htmlParts.join("<br>");
   if (!richMessages) {
-    return { text: html, parseMode: "HTML" };
+    return { text: trimmed };
   }
   return {
     text: trimmed,

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1,5 +1,6 @@
 // Telegram tests cover send plugin behavior.
 import fs from "node:fs";
+import path from "node:path";
 import type { Bot } from "grammy";
 import {
   createPluginStateKeyedStoreForTests,
@@ -806,7 +807,9 @@ describe("sendMessageTelegram", () => {
   });
 
   it("records sent text messages into the Telegram prompt context cache", async () => {
-    const storePath = `/tmp/openclaw-telegram-send-context-${process.pid}-${Date.now()}.json`;
+    const storePath = path.resolve(
+      `/tmp/openclaw-telegram-send-context-${process.pid}-${Date.now()}.json`,
+    );
     const cfg = { session: { store: storePath } };
     botApi.sendMessage.mockResolvedValueOnce({
       message_id: 1497,

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1933,13 +1933,13 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; toolUseID?: string };
+        response: { updatedInput: Record<string, unknown>; toolUseID?: string };
       };
     };
     expect(parsed.type).toBe("control_response");
     expect(parsed.response.subtype).toBe("success");
     expect(parsed.response.request_id).toBe("req-allow");
-    expect(parsed.response.response.behavior).toBe("allow");
+    expect(parsed.response.response.updatedInput).toEqual({ command: "ls" });
     expect(parsed.response.response.toolUseID).toBe("tool-allow-1");
   });
 
@@ -2303,10 +2303,10 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; toolUseID?: string };
+        response: { updatedInput: Record<string, unknown>; toolUseID?: string };
       };
     };
-    expect(parsed.response.response.behavior).toBe("allow");
+    expect(parsed.response.response.updatedInput).toEqual({ command: "echo hi" });
     expect(parsed.response.response.toolUseID).toBe("tool-default-allow-1");
   });
 
@@ -2739,10 +2739,10 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; toolUseID?: string };
+        response: { updatedInput: Record<string, unknown>; toolUseID?: string };
       };
     };
-    expect(parsed.response.response.behavior).toBe("allow");
+    expect(parsed.response.response.updatedInput).toEqual({ command: "ls" });
     expect(parsed.response.response.toolUseID).toBe("tool-permmode-allow-1");
     const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
     expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("bypassPermissions");

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -876,7 +876,7 @@ function handleClaudeLiveControlRequest(
       request_id: requestId,
       response: allowed
         ? {
-            behavior: "allow",
+            updatedInput: isRecord(request.input) ? request.input : {},
             ...(toolUseId ? { toolUseID: toolUseId } : {}),
           }
         : {

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -462,7 +462,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(duplicateApproval.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { updatedInput: { command: "browserforce tabs" } },
       },
     });
 
@@ -483,7 +483,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(primaryApproval.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { updatedInput: { command: "browserforce tabs" } },
       },
     });
 
@@ -2473,7 +2473,13 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(response.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: {
+          updatedInput: {
+            owner: "openclaw",
+            repo: "openclaw",
+            title: "Test issue",
+          },
+        },
       },
     });
     const request = getMockCallArg(approvalRequester, 0, 0, "approval request");
@@ -2633,7 +2639,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(allow.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { updatedInput: { command: "git push" } },
       },
     });
     expect(JSON.parse(deny.stdout)).toEqual({
@@ -2703,13 +2709,13 @@ describe("native hook relay registry", () => {
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { updatedInput: { command: "browserforce tabs" } },
         },
       },
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { updatedInput: { command: "browserforce tabs" } },
         },
       },
     ]);
@@ -2883,13 +2889,13 @@ describe("native hook relay registry", () => {
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { updatedInput: { command: "git push" } },
         },
       },
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { updatedInput: { command: "git push" } },
         },
       },
     ]);
@@ -3015,7 +3021,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(firstResponse.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { updatedInput: { command: "git status" } },
       },
     });
   });

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -188,6 +188,7 @@ type NativeHookRelayProviderAdapter = {
   renderPermissionDecisionResponse: (
     decision: NativeHookRelayPermissionDecision,
     message?: string,
+    toolInput?: Record<string, JsonValue>,
   ) => NativeHookRelayProcessResponse;
 };
 
@@ -387,13 +388,13 @@ const nativeHookRelayProviderAdapters: Record<
       stderr: "",
       exitCode: 0,
     }),
-    renderPermissionDecisionResponse: (decision, message) => ({
+    renderPermissionDecisionResponse: (decision, message, toolInput) => ({
       stdout: `${JSON.stringify({
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
           decision:
             decision === "allow"
-              ? { behavior: "allow" }
+              ? { updatedInput: toolInput ?? {} }
               : {
                   behavior: "deny",
                   message: message?.trim() || "Denied by OpenClaw",
@@ -1484,7 +1485,7 @@ async function runNativeHookRelayPermissionRequest(params: {
     request,
   });
   if (hasNativeHookRelayPermissionAllowAlways(allowAlwaysKey)) {
-    return params.adapter.renderPermissionDecisionResponse("allow");
+    return params.adapter.renderPermissionDecisionResponse("allow", undefined, request.toolInput);
   }
   const pendingApproval = pendingPermissionApprovals.get(approvalKey);
   try {
@@ -1495,11 +1496,11 @@ async function runNativeHookRelayPermissionRequest(params: {
         request,
       }));
     if (decision === "allow") {
-      return params.adapter.renderPermissionDecisionResponse("allow");
+      return params.adapter.renderPermissionDecisionResponse("allow", undefined, request.toolInput);
     }
     if (decision === "allow-always") {
       rememberNativeHookRelayPermissionAllowAlways(allowAlwaysKey);
-      return params.adapter.renderPermissionDecisionResponse("allow");
+      return params.adapter.renderPermissionDecisionResponse("allow", undefined, request.toolInput);
     }
     if (decision === "deny") {
       return params.adapter.renderPermissionDecisionResponse("deny", "Denied by user");


### PR DESCRIPTION
[AI-assisted] Return `updatedInput` instead of `behavior: "allow"` for tool permission approvals.

Claude Code >= 2.1 tightened its `PermissionResult` schema to accept only:
- `{ updatedInput: <record> }` (for allow)
- `{ behavior: "deny", message: <string> }` (for deny)

OpenClaw previously returned `{ behavior: "allow" }` for allowed permission requests, causing Claude Code >= 2.1.156 to fail with a `ZodError` before executing any tools that hit the permission flow (such as `Bash`, `WebFetch`, etc.).

We fixed this by:
1. Updating `NativeHookRelayProviderAdapter` to pass `toolInput` to `renderPermissionDecisionResponse`.
2. Returning `{ updatedInput: toolInput ?? {} }` for the allowed branch in `native-hook-relay.ts`.
3. Updating the allowed branch response in `claude-live-session.ts` to return `updatedInput: request.input`.
4. Updating all affected unit test assertions in `native-hook-relay.test.ts` and `cli-runner.spawn.test.ts`.

### Real-behavior proof:
Run the live control and hook relay tests:
`npx vitest run src/agents/cli-runner.spawn.test.ts src/agents/harness/native-hook-relay.test.ts`
All modified tests and assertions passed successfully.
