### PR TITLE
fix(slack): record canonical sent thread

### DIFF
--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -100,14 +100,42 @@ describe("sendMessageSlack thread participation", () => {
     clearSlackThreadParticipationCache();
     const client = createSlackSendTestClient();
 
-    await sendMessageSlack("channel:C123", "hello thread", {
+    const result = await sendMessageSlack("channel:C123", "hello thread", {
       token: "xoxb-test",
       cfg: SLACK_TEST_CFG,
       client,
       threadTs: "1712345678.123456",
     });
 
+    expect(result.threadTs).toBe("1712345678.123456");
+    expect(result.receipt.threadId).toBe("1712345678.123456");
     expect(hasSlackThreadParticipation("default", "C123", "1712345678.123456")).toBe(true);
+  });
+
+  it("records canonical Slack response thread participation instead of requested child thread", async () => {
+    clearSlackThreadParticipationCache();
+    const client = createSlackSendTestClient();
+    client.chat.postMessage.mockResolvedValueOnce({
+      ts: "1781932190.115869",
+      channel: "C123",
+      message: {
+        ts: "1781932190.115869",
+        thread_ts: "1781803536.235489",
+      },
+    });
+
+    const result = await sendMessageSlack("channel:C123", "hello thread", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      threadTs: "1781932168.648159",
+    });
+
+    expect(postedMessage(client).thread_ts).toBe("1781932168.648159");
+    expect(result.threadTs).toBe("1781803536.235489");
+    expect(result.receipt.threadId).toBe("1781803536.235489");
+    expect(hasSlackThreadParticipation("default", "C123", "1781803536.235489")).toBe(true);
+    expect(hasSlackThreadParticipation("default", "C123", "1781932168.648159")).toBe(false);
   });
 
   it("does not record participation for unthreaded sends", async () => {
@@ -174,6 +202,40 @@ describe("sendMessageSlack chunking", () => {
     ).toStrictEqual([]);
     expect(postedTexts.join("")).toBe(message);
   });
+
+  it("preserves the first canonical response thread across chunked sends", async () => {
+    clearSlackThreadParticipationCache();
+    const client = createSlackSendTestClient();
+    client.chat.postMessage
+      .mockResolvedValueOnce({
+        ts: "1781932190.115869",
+        channel: "C123",
+        message: {
+          ts: "1781932190.115869",
+          thread_ts: "1781803536.235489",
+        },
+      })
+      .mockResolvedValueOnce({
+        ts: "1781932191.000000",
+        channel: "C123",
+      });
+    const message = "a".repeat(8500);
+
+    const result = await sendMessageSlack("channel:C123", message, {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      threadTs: "1781932168.648159",
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    expect(postedMessage(client).thread_ts).toBe("1781932168.648159");
+    expect(postedMessage(client, 1).thread_ts).toBe("1781932168.648159");
+    expect(result.threadTs).toBe("1781803536.235489");
+    expect(result.receipt.threadId).toBe("1781803536.235489");
+    expect(hasSlackThreadParticipation("default", "C123", "1781803536.235489")).toBe(true);
+    expect(hasSlackThreadParticipation("default", "C123", "1781932168.648159")).toBe(false);
+  });
 });
 
 describe("sendMessageSlack blocks", () => {
@@ -200,6 +262,34 @@ describe("sendMessageSlack blocks", () => {
     expect(receiptPart?.kind).toBe("card");
     expect((receiptPart?.raw as Record<string, unknown> | undefined)?.channel).toBe("slack");
     expect((receiptPart?.raw as Record<string, unknown> | undefined)?.channelId).toBe("C123");
+  });
+
+  it("uses canonical Slack response thread for block receipts and participation", async () => {
+    clearSlackThreadParticipationCache();
+    const client = createSlackSendTestClient();
+    client.chat.postMessage.mockResolvedValueOnce({
+      ts: "1781932190.115869",
+      channel: "C123",
+      message: {
+        ts: "1781932190.115869",
+        thread_ts: "1781803536.235489",
+      },
+    });
+
+    const result = await sendMessageSlack("channel:C123", "", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      threadTs: "1781932168.648159",
+      blocks: [{ type: "divider" }],
+    });
+
+    expect(postedMessage(client).thread_ts).toBe("1781932168.648159");
+    expect(result.threadTs).toBe("1781803536.235489");
+    expect(result.receipt.threadId).toBe("1781803536.235489");
+    expect(result.receipt.parts[0]?.kind).toBe("card");
+    expect(hasSlackThreadParticipation("default", "C123", "1781803536.235489")).toBe(true);
+    expect(hasSlackThreadParticipation("default", "C123", "1781932168.648159")).toBe(false);
   });
 
   it("posts user-target block messages directly without conversations.open", async () => {

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -360,10 +360,18 @@ async function postSlackMessageBestEffort(params: {
   }
 }
 
+function resolvePostedMessageThreadTs(response: {
+  message?: { thread_ts?: unknown };
+}): string | undefined {
+  const threadTs = response.message?.thread_ts;
+  return typeof threadTs === "string" ? normalizeSlackThreadTsCandidate(threadTs) : undefined;
+}
+
 export type SlackSendResult = {
   messageId: string;
   channelId: string;
   receipt: MessageReceipt;
+  threadTs?: string;
 };
 
 function createSlackSendReceipt(params: {
@@ -664,7 +672,7 @@ export async function sendMessageSlack(
       blocks,
     }),
   );
-  const threadTs = normalizeSlackThreadTsCandidate(opts.threadTs);
+  const threadTs = result.threadTs ?? normalizeSlackThreadTsCandidate(opts.threadTs);
   if (threadTs && result.channelId && account.accountId) {
     recordSlackThreadParticipation(account.accountId, result.channelId, threadTs);
   }
@@ -737,14 +745,17 @@ async function sendMessageSlackQueuedInner(params: {
     });
     const messageId = response.ts ?? "unknown";
     const deliveredChannelId = resolvePostedMessageChannelId(response, channelId);
+    const deliveredThreadTs =
+      resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
     return {
       messageId,
       channelId: deliveredChannelId,
+      threadTs: deliveredThreadTs,
       receipt: createSlackSendReceipt({
         platformMessageIds: [messageId],
         channelId: deliveredChannelId,
         kind: "card",
-        threadTs: opts.threadTs,
+        threadTs: deliveredThreadTs,
       }),
     };
   }
@@ -774,6 +785,7 @@ async function sendMessageSlackQueuedInner(params: {
   const sentMessageIds: string[] = [];
   let lastMessageId = "";
   let deliveredChannelId = channelId;
+  let canonicalDeliveredThreadTs: string | undefined;
   if (opts.mediaUrl) {
     const [firstChunk, ...rest] = resolvedChunks;
     lastMessageId = await uploadSlackFile({
@@ -803,6 +815,7 @@ async function sendMessageSlackQueuedInner(params: {
       });
       lastMessageId = response.ts ?? lastMessageId;
       deliveredChannelId = resolvePostedMessageChannelId(response, deliveredChannelId);
+      canonicalDeliveredThreadTs ??= resolvePostedMessageThreadTs(response);
       if (response.ts) {
         sentMessageIds.push(response.ts);
       }
@@ -821,6 +834,7 @@ async function sendMessageSlackQueuedInner(params: {
       });
       lastMessageId = response.ts ?? lastMessageId;
       deliveredChannelId = resolvePostedMessageChannelId(response, deliveredChannelId);
+      canonicalDeliveredThreadTs ??= resolvePostedMessageThreadTs(response);
       if (response.ts) {
         sentMessageIds.push(response.ts);
       }
@@ -828,14 +842,17 @@ async function sendMessageSlackQueuedInner(params: {
   }
 
   const messageId = lastMessageId || "unknown";
+  const deliveredThreadTs =
+    canonicalDeliveredThreadTs ?? normalizeSlackThreadTsCandidate(opts.threadTs);
   return {
     messageId,
     channelId: deliveredChannelId,
+    threadTs: deliveredThreadTs,
     receipt: createSlackSendReceipt({
       platformMessageIds: sentMessageIds.length ? sentMessageIds : [messageId],
       channelId: deliveredChannelId,
       kind: opts.mediaUrl ? "media" : "text",
-      threadTs: opts.threadTs,
+      threadTs: deliveredThreadTs,
     }),
   };
 }


### PR DESCRIPTION
## Summary

- Fix Slack generic send receipts and thread-participation state to use Slack's canonical delivered thread timestamp when `chat.postMessage` returns `message.thread_ts`.
- Preserve the requested `threadTs` as the outbound Slack API target, but fall back to it only when Slack does not return a canonical thread.
- Add regression coverage for text sends, chunked text sends, block/card sends, and fallback behavior.

Fixes #95235.

## Root Cause

The Slack message-tool/generic send path recorded participation from the requested `opts.threadTs`. When Slack accepted a child reply timestamp but canonicalized the delivered message into the root thread, OpenClaw persisted the child thread key instead of the canonical root. Later unmentioned replies in the canonical root thread could then be skipped because the participation lookup missed the actual thread.

## Behavior Addressed

For Slack `chat.postMessage` sends, OpenClaw now prefers `response.message.thread_ts` for receipts and participation records. Chunked sends keep the first canonical response thread and do not overwrite it when later chunks omit thread metadata. File upload-only canonicalization is not claimed by this patch because the upload helper currently returns only the file id.

## Verification

Testing level: targeted.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs extensions/slack/src/send.blocks.test.ts extensions/slack/src/send.upload.test.ts extensions/slack/src/message-action-dispatch.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/sent-thread-cache.test.ts
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs extensions/slack/src/send.blocks.test.ts extensions/slack/src/send.upload.test.ts extensions/slack/src/message-action-dispatch.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/sent-thread-cache.test.ts"
git diff --check
```

Observed result after fix:

- Vitest: 5 files passed, 163 tests passed.
- Autoreview: clean, no accepted/actionable findings.
- `git diff --check`: passed.

## Validated with real Slack behavior

Added live behavior proof from an installed OpenClaw instance patched with this PR’s Slack dist changes.

**Private Slack thread test (message content redacted):**

- Root thread ts: `1781936951.138959`
- Initial human root message mentioned the bot.
- Later human replies in the same thread did not mention the bot.
- Bot replied to the unmentioned thread replies, including after a gateway restart.
- Gateway restart occurred at `2026-06-20 02:30:50 -0400`.
- Post-restart human reply `1781937062.706089` received bot reply `1781937081.181599`.

Slack API confirmed every message was in canonical root thread `1781936951.138959`.

**Persistent state after the successful run contains the root participation key only:**
```json
{
  "namespace": "slack.thread-participation",
  "entry_key": "default:<redacted-channel>:1781936951.138959",
  "value_json": "{\"repliedAt\":1781937081261}"
}
```

For the exact generic send regression case, I also sent one live diagnostic message through patched `sendMessageSlack()` with `threadTs` deliberately set to child reply ts `1781937062.706089`.

**Result:**
```json
{
  "requestedChildTs": "1781937062.706089",
  "deliveredMessageTs": "1781937177.361999",
  "resultThreadTs": "1781936951.138959",
  "receiptThreadId": "1781936951.138959",
  "slackDeliveredThreadTs": "1781936951.138959",
  "rootParticipationRecorded": true,
  "childParticipationRecorded": false
}
```

This validates the PR behavior: when Slack canonicalizes a child `thread_ts` request back to the root thread,
OpenClaw now records/receipts the canonical root thread id instead of persisting the child timestamp.

Screenshot:
<img width="754" height="445" alt="Screenshot 2026-06-20 at 2 33 16 AM" src="https://github.com/user-attachments/assets/b801c3d5-d65b-4085-b57e-ae68740b9832" />


## AI Assistance

AI-assisted PR. I understand the code being submitted and validated the changed Slack send path, surrounding call sites, and focused regression tests.
