### PR TITLE
fix(slack): normalize thread participation key to canonical root thread_ts

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -2113,8 +2113,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   // Record thread participation only when we actually delivered a reply and
   // know the thread ts that was used (set by deliverNormally, streaming start,
-  // or draft stream). Falls back to statusThreadTs for edge cases.
-  const participationThreadTs = usedReplyThreadTs ?? statusThreadTs;
+  // or draft stream). For thread replies, prefer the canonical Slack root
+  // thread ts (incomingThreadTs / message.thread_ts) so the participation key
+  // matches what the inbound implicit-mention lookup uses.
+  // Otherwise participation can be recorded under a child message ts, causing
+  // later unmentioned replies in the same thread to be dropped. (#95235)
+  const participationThreadTs =
+    isThreadReply && incomingThreadTs ? incomingThreadTs : (usedReplyThreadTs ?? statusThreadTs);
   if (anyReplyDelivered && participationThreadTs) {
     recordSlackThreadParticipation(account.accountId, message.channel, participationThreadTs, {
       agentId: route.agentId,


### PR DESCRIPTION
Fixes #95235

## Summary

When the bot replies in a Slack thread, thread participation was recorded under the child message `ts` instead of the root `thread_ts`. Later unmentioned replies in the same thread were dropped by the mention gate because the participation lookup (keyed by `thread_ts`) missed.

## Root Cause

`dispatchPreparedSlackMessage` records thread participation using `usedReplyThreadTs` (the delivery's child message ts) as the key. The inbound implicit-mention lookup in `prepare.ts` uses `message.thread_ts` (the root thread ts) as the key. When the delivery child ts differs from the root thread ts, participation is stored under a key that the mention lookup never searches, causing later unmentioned replies to be dropped.

## Changes

- `extensions/slack/src/monitor/message-handler/dispatch.ts`: Prefer `incomingThreadTs` (root `thread_ts`) as the participation key for thread replies.

## Real behavior proof

**Behavior addressed**: Thread participation is now keyed by the canonical root `thread_ts`, so later unmentioned replies in bot-participated threads are correctly recognized.

**Evidence after fix**:

```diff
  const participationThreadTs = usedReplyThreadTs ?? statusThreadTs;
+ const participationThreadTs =
+   isThreadReply && incomingThreadTs ? incomingThreadTs : (usedReplyThreadTs ?? statusThreadTs);
```

The fix normalizes the participation key:
- `isThreadReply=true` with `incomingThreadTs` → uses root `thread_ts` (matches inbound lookup)
- `isThreadReply=false` → uses `usedReplyThreadTs` (unchanged, non-thread messages)

**Tests (104 passed):**

```text
$ node scripts/test-projects.mjs extensions/slack/src/monitor/message-handler/
 ✓ dispatch.preview-fallback.test.ts (78 tests)
 ✓ dispatch.streaming.test.ts (26 tests)
```

**What was not tested**: End-to-end with a live Slack workspace (requires Slack credentials).

## Risk

- [x] Backwards compatible (non-thread replies unchanged)
- [x] Only affects the thread participation cache key for thread replies

Closes: #95235