### PR TITLE
fix(infra): use macOS product version in agent runtime OS context

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -19,6 +19,7 @@ import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { CliBackendConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { macosVersion } from "../../infra/os-summary.js";
 import { privateFileStore } from "../../infra/private-file-store.js";
 import { tempWorkspace } from "../../infra/private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
@@ -157,7 +158,8 @@ export function buildCliAgentSystemPrompt(params: {
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
       host: "openclaw",
-      os: `${os.type()} ${os.release()}`,
+      os:
+        process.platform === "darwin" ? `macos ${macosVersion()}` : `${os.type()} ${os.release()}`,
       arch: os.arch(),
       node: process.version,
       model: params.modelDisplay,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -24,6 +24,7 @@ import {
 } from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
+import { macosVersion } from "../../infra/os-summary.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../plugins/command-registry-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
@@ -1035,7 +1036,8 @@ async function compactEmbeddedAgentSessionDirectOnce(
 
     const runtimeInfo = {
       host: machineName,
-      os: `${os.type()} ${os.release()}`,
+      os:
+        process.platform === "darwin" ? `macos ${macosVersion()}` : `${os.type()} ${os.release()}`,
       arch: os.arch(),
       node: process.version,
       model: `${provider}/${modelId}`,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -44,6 +44,7 @@ import { isEmbeddedMode } from "../../../infra/embedded-mode.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summary.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
+import { macosVersion } from "../../../infra/os-summary.js";
 import { createCodexNativeWebSearchWrapper } from "../../../llm/providers/stream-wrappers/openai.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../../plugins/command-registry-state.js";
@@ -1933,7 +1934,10 @@ export async function runEmbeddedAttempt(
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
         host: machineName,
-        os: `${os.type()} ${os.release()}`,
+        os:
+          process.platform === "darwin"
+            ? `macos ${macosVersion()}`
+            : `${os.type()} ${os.release()}`,
         arch: os.arch(),
         node: process.version,
         model: `${params.provider}/${params.modelId}`,

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -12,7 +12,8 @@ type OsSummary = {
 
 const cachedOsSummaryByKey = new Map<string, OsSummary>();
 
-function macosVersion(): string {
+/** Resolve the macOS product version (e.g. "26.5.1") via sw_vers, falling back to kernel release. */
+export function macosVersion(): string {
   const res = spawnSync("sw_vers", ["-productVersion"], { encoding: "utf-8" });
   const out = normalizeOptionalString(res.stdout) ?? "";
   return out || os.release();


### PR DESCRIPTION
## Summary

On Darwin, `os.release()` returns the Darwin kernel version (e.g. `25.5.0`), which no longer maps 1:1 to the macOS marketing version. macOS 26 "Tahoe" still ships Darwin kernel 25.x, so agent runtime context reported `Darwin 25.5.0` instead of `macos 26.5.1`.

Fix: export `macosVersion()` from `src/infra/os-summary.ts` (uses `sw_vers -productVersion`) and replace `os.type() + " " + os.release()` in all three runtime OS context paths — embedded attempt, CLI runner, and compaction. The existing diagnostics/status surfaces already used this approach; only the runtime prompt paths were stale.

Non-Darwin platforms are unaffected.

Fixes #95145

## Real behavior proof (required for external PRs)

**Behavior addressed**: Agent runtime OS context now uses the macOS product version (`macos 26.5.1`) on Darwin instead of the kernel version (`Darwin 25.5.0`).

**Real setup tested**:
- **Runtime**: Linux (WSL2 Ubuntu), Node v22.22.2 (non-Darwin — confirms no regression on other platforms)

**Exact steps or command run after fix**:

```bash
$ pnpm test -- src/infra/os-summary.test.ts
$ pnpm test -- src/agents/system-prompt.test.ts
$ pnpm test -- src/agents/embedded-agent-runner/run/attempt.test.ts
$ pnpm test -- src/agents/cli-runner/helpers.system-prompt.test.ts
$ pnpm test -- src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
```

**After-fix evidence**:

```
Test Files  1 passed (1)   — os-summary.test.ts
     Tests  4 passed (4)

Test Files  1 passed (1)   — system-prompt.test.ts
     Tests  90 passed (90)

Test Files  1 passed (1)   — attempt.test.ts
     Tests  122 passed (122)

Test Files  1 passed (1)   — helpers.system-prompt.test.ts
     Tests  7 passed (7)

Test Files  1 passed (1)   — compaction-runtime-context.test.ts
     Tests  24 passed (24)
```

**Observed result after the fix**: On Darwin hosts, `runtime.os` will now emit `macos 26.5.1` instead of `Darwin 25.5.0`. The fallback `sw_vers` call degrades gracefully to `os.release()` if `sw_vers` is unavailable.

**What was not tested**: Live macOS 26 (Tahoe) host — tested on Linux with the non-Darwin code path. The Darwin code path correctness depends on `sw_vers -productVersion` (already used and tested in `os-summary.ts`).

## Tests and validation

247 tests across 5 test files — all pass:

| Test file | Tests | Result |
|-----------|-------|--------|
| os-summary.test.ts | 4 | ✅ |
| system-prompt.test.ts | 90 | ✅ |
| attempt.test.ts | 122 | ✅ |
| helpers.system-prompt.test.ts | 7 | ✅ |
| compaction-runtime-context.test.ts | 24 | ✅ |

## Risk checklist

Did user-visible behavior change? (`Yes` / `No`)

**Yes** — agent runtime context on Darwin/macOS will report the macOS product version (`macos 26.5.1`) instead of the Darwin kernel version (`Darwin 25.5.0`). This is the intended fix.

Did config, environment, or migration behavior change? (`Yes` / `No`)

**No** — no config or env changes.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes` / `No`)

**No** — `macosVersion()` already exists in `os-summary.ts` and is an existing synchronous `sw_vers` spawn. No new process execution or network calls.

What is the highest-risk area?
- A corrupted or missing `sw_vers` binary on Darwin would product empty output. But the existing fallback to `os.release()` handles this case.

How is that risk mitigated?
- `macosVersion()` already has `os.release()` as fallback. This is the same pattern already used by `resolveOsSummary()` for diagnostics.

## Current review state

What is the next action?
- Maintainer review
