### PR TITLE
fix(plugins): pin HTTP route registry during gateway bootstrap

### DIFF
--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -8,6 +8,7 @@ import type { PluginRegistryParams } from "../plugins/registry-types.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import {
   pinActivePluginChannelRegistry,
+  pinActivePluginHttpRouteRegistry,
   pinActivePluginSessionExtensionRegistry,
 } from "../plugins/runtime.js";
 import {
@@ -63,6 +64,7 @@ function installGatewayPluginRuntimeEnvironment(cfg: OpenClawConfig) {
 
 function pinGatewayPluginRuntimeRegistries(pluginRegistry: PluginRegistry): void {
   pinActivePluginChannelRegistry(pluginRegistry);
+  pinActivePluginHttpRouteRegistry(pluginRegistry);
   pinActivePluginSessionExtensionRegistry(pluginRegistry);
 }
 

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -6,6 +6,7 @@ import { WebSocketServer } from "ws";
 import type { CliDeps } from "../cli/deps.types.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginRegistry } from "../plugins/registry.js";
+import { getPluginRegistryState } from "../plugins/runtime-state.js";
 import {
   pinActivePluginChannelRegistry,
   pinActivePluginHttpRouteRegistry,
@@ -134,8 +135,19 @@ export async function createGatewayRuntimeState(params: {
     releasePinnedPluginChannelRegistry();
   }
   try {
-    const resolvePluginRouteRegistry = () =>
-      params.getPluginRouteRegistry?.() ?? params.pluginRegistry;
+    const resolvePluginRouteRegistry = () => {
+      const base = params.getPluginRouteRegistry?.() ?? params.pluginRegistry;
+      // Runtime-loaded workspace plugins register HTTP routes into the active
+      // plugin registry (setActivePluginRegistry). The gateway's pluginRegistry
+      // only covers startup/reload paths; merge active registry routes so
+      // deferred-loaded plugin routes are also discoverable. (#94572)
+      const activeHttpRoutes = getPluginRegistryState()?.activeRegistry?.httpRoutes;
+      if (!activeHttpRoutes || activeHttpRoutes.length === 0) return base;
+      return {
+        ...base,
+        httpRoutes: [...(base.httpRoutes ?? []), ...activeHttpRoutes],
+      };
+    };
     const clients = new Set<GatewayWsClient>();
     const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
 

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -6,7 +6,6 @@ import { WebSocketServer } from "ws";
 import type { CliDeps } from "../cli/deps.types.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginRegistry } from "../plugins/registry.js";
-import { getPluginRegistryState } from "../plugins/runtime-state.js";
 import {
   pinActivePluginChannelRegistry,
   pinActivePluginHttpRouteRegistry,
@@ -135,19 +134,11 @@ export async function createGatewayRuntimeState(params: {
     releasePinnedPluginChannelRegistry();
   }
   try {
-    const resolvePluginRouteRegistry = () => {
-      const base = params.getPluginRouteRegistry?.() ?? params.pluginRegistry;
-      // Runtime-loaded workspace plugins register HTTP routes into the active
-      // plugin registry (setActivePluginRegistry). The gateway's pluginRegistry
-      // only covers startup/reload paths; merge active registry routes so
-      // deferred-loaded plugin routes are also discoverable. (#94572)
-      const activeHttpRoutes = getPluginRegistryState()?.activeRegistry?.httpRoutes;
-      if (!activeHttpRoutes || activeHttpRoutes.length === 0) return base;
-      return {
-        ...base,
-        httpRoutes: [...(base.httpRoutes ?? []), ...activeHttpRoutes],
-      };
-    };
+    // resolvePluginRouteRegistry returns the gateway's pluginRegistry.
+    // Runtime-loaded plugins' HTTP routes are made discoverable by the
+    // getPluginRouteRegistry callback in server.impl.ts. (#94572)
+    const resolvePluginRouteRegistry = () =>
+      params.getPluginRouteRegistry?.() ?? params.pluginRegistry;
     const clients = new Set<GatewayWsClient>();
     const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -925,13 +925,8 @@ export async function startGatewayServer(
       hooksConfig: () => runtimeState?.hooksConfig ?? initialHooksConfig,
       getHookClientIpConfig: () => runtimeState?.hookClientIpConfig ?? initialHookClientIpConfig,
       pluginRegistry,
-      getPluginRouteRegistry: () => {
-        // Merge HTTP routes from the active plugin registry so deferred
-        // runtime-loaded workspace plugins are discoverable. (#94572)
-        const active = getPluginRegistryState()?.activeRegistry;
-        if (!active?.httpRoutes?.length) return pluginRegistry;
-        return { ...pluginRegistry, httpRoutes: [...(pluginRegistry.httpRoutes ?? []), ...active.httpRoutes] };
-      },
+      getPluginRouteRegistry: () =>
+        getPluginRegistryState()?.activeRegistry ?? pluginRegistry,
       getGatewayRequestContext: () => currentPluginRegistryGatewayContext,
       pinChannelRegistry: !minimalTestGateway,
       deps,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -45,6 +45,7 @@ import { withDiagnosticPhase } from "../logging/diagnostic-phase.js";
 import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/diagnostic.js";
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { getPluginRegistryState } from "../plugins/runtime-state.js";
 import type { PluginHookGatewayCronService } from "../plugins/hook-types.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import {
@@ -924,7 +925,13 @@ export async function startGatewayServer(
       hooksConfig: () => runtimeState?.hooksConfig ?? initialHooksConfig,
       getHookClientIpConfig: () => runtimeState?.hookClientIpConfig ?? initialHookClientIpConfig,
       pluginRegistry,
-      getPluginRouteRegistry: () => pluginRegistry,
+      getPluginRouteRegistry: () => {
+        // Merge HTTP routes from the active plugin registry so deferred
+        // runtime-loaded workspace plugins are discoverable. (#94572)
+        const active = getPluginRegistryState()?.activeRegistry;
+        if (!active?.httpRoutes?.length) return pluginRegistry;
+        return { ...pluginRegistry, httpRoutes: [...(pluginRegistry.httpRoutes ?? []), ...active.httpRoutes] };
+      },
       getGatewayRequestContext: () => currentPluginRegistryGatewayContext,
       pinChannelRegistry: !minimalTestGateway,
       deps,

--- a/src/plugins/runtime/standalone-runtime-registry-loader.ts
+++ b/src/plugins/runtime/standalone-runtime-registry-loader.ts
@@ -39,6 +39,8 @@ function installStandaloneRegistry(
   setActivePluginRegistry(registry, cacheKey, mode, params.loadOptions.workspaceDir);
   switch (params.surface) {
     case "active":
+      // Runtime-loaded plugins can register HTTP routes; pin them (#94572)
+      pinActivePluginHttpRouteRegistry(registry);
       break;
     case "channel":
       pinActivePluginChannelRegistry(registry);


### PR DESCRIPTION
Closes #94572

## What Problem This Solves

Plugin HTTP routes registered during bootstrap were invisible to the gateway because no active HTTP route registry was pinned. Routes went to a detached context that `getPluginRouteRegistry()` couldn't find.

## Why This Change Was Made

Added `pinActivePluginHttpRouteRegistry()` at bootstrap and runtime loader points. Routes now land in the registry visible to gateway lookup.

## Evidence

```text
$ npx tsx -e ...

=== Before pinActivePluginHttpRouteRegistry ===
  getActivePluginHttpRouteRegistry(): null (no active registry)
  → Routes registered via registerPluginHttpRoute() go to a detached context

=== After pinActivePluginHttpRouteRegistry ===
  requireActivePluginHttpRouteRegistry(): registry with 0 routes
  After registerPluginHttpRoute():
  registry.httpRoutes: 1 route(s)
  route[0].path: /api/test-route
  → Routes are visible to the gateway lookup
```

**Not tested:** End-to-end with a running gateway serving real HTTP requests.