### PR TITLE
Honor active steering debounce

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
@@ -2,11 +2,110 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   cancelQueuedSteeringMessage,
+  normalizeQueuedSteeringDebounceMs,
   steerAndWaitForTranscriptCommit,
+  steerActiveSessionWithOptionalDeliveryWait,
   type EmbeddedAgentActiveSessionSteerTarget,
 } from "./attempt.queue-message.js";
 
 describe("embedded OpenClaw queued steering cancellation", () => {
+  it("normalizes queued steering debounce durations", () => {
+    expect(normalizeQueuedSteeringDebounceMs(undefined)).toBe(0);
+    expect(normalizeQueuedSteeringDebounceMs(Number.NaN)).toBe(0);
+    expect(normalizeQueuedSteeringDebounceMs(-5)).toBe(0);
+    expect(normalizeQueuedSteeringDebounceMs(12.8)).toBe(12);
+  });
+
+  it("waits for the configured steering debounce before queueing", async () => {
+    vi.useFakeTimers();
+    try {
+      const steer = vi.fn(async () => {});
+      const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
+        getSteeringMessages: () => [],
+        steer,
+        subscribe: () => () => {},
+      };
+
+      const queued = steerActiveSessionWithOptionalDeliveryWait(activeSession, "delayed steer", {
+        debounceMs: 50,
+      });
+
+      await Promise.resolve();
+      expect(steer).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(49);
+      expect(steer).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(queued).resolves.toBeUndefined();
+      expect(steer).toHaveBeenCalledWith("delayed steer");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits until the active steering debounce window is quiet", async () => {
+    vi.useFakeTimers();
+    try {
+      const steer = vi.fn(async () => {});
+      const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
+        getSteeringMessages: () => [],
+        steer,
+        subscribe: () => () => {},
+      };
+      let lastQueuedAtMs = Date.now();
+      const startQueuedSteer = (text: string) =>
+        steerActiveSessionWithOptionalDeliveryWait(activeSession, text, {
+          debounceMs: 50,
+          getLastDebounceQueuedAtMs: () => lastQueuedAtMs,
+        });
+
+      const first = startQueuedSteer("first steer");
+      await vi.advanceTimersByTimeAsync(30);
+      lastQueuedAtMs = Date.now();
+      const second = startQueuedSteer("second steer");
+
+      await vi.advanceTimersByTimeAsync(49);
+      expect(steer).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+      expect(steer).toHaveBeenCalledTimes(2);
+      expect(steer).toHaveBeenCalledWith("first steer");
+      expect(steer).toHaveBeenCalledWith("second steer");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rechecks active-run acceptance after steering debounce", async () => {
+    vi.useFakeTimers();
+    try {
+      const steer = vi.fn(async () => {});
+      const ensureStillAccepting = vi.fn(() => {
+        throw new Error("active run stopped");
+      });
+      const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
+        getSteeringMessages: () => [],
+        steer,
+        subscribe: () => () => {},
+      };
+
+      const queued = steerActiveSessionWithOptionalDeliveryWait(activeSession, "stale steer", {
+        debounceMs: 50,
+        ensureStillAccepting,
+      });
+      const rejection = expect(queued).rejects.toThrow("active run stopped");
+
+      await vi.advanceTimersByTimeAsync(50);
+      await rejection;
+      expect(ensureStillAccepting).toHaveBeenCalledOnce();
+      expect(steer).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("waits for the queued user message_end transcript boundary", async () => {
     // A queued steer is only durable once the user message_end event lands in
     // the active transcript.

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
@@ -17,6 +17,44 @@ export type EmbeddedAgentActiveSessionSteerTarget = {
 /** Default wait for a steered user message to appear in the active transcript. */
 export const DEFAULT_QUEUE_TRANSCRIPT_COMMIT_TIMEOUT_MS = 120_000;
 
+export type EmbeddedAgentSteerDeliveryOptions = {
+  debounceMs?: number;
+  deliveryTimeoutMs?: number;
+  waitForTranscriptCommit?: boolean;
+  getLastDebounceQueuedAtMs?: () => number;
+  ensureStillAccepting?: () => void;
+};
+
+export function normalizeQueuedSteeringDebounceMs(debounceMs: unknown): number {
+  return typeof debounceMs === "number" && Number.isFinite(debounceMs)
+    ? Math.max(0, Math.floor(debounceMs))
+    : 0;
+}
+
+export async function waitForQueuedSteeringDebounce(
+  debounceMs: unknown,
+  getLastQueuedAtMs?: () => number,
+): Promise<boolean> {
+  const delayMs = normalizeQueuedSteeringDebounceMs(debounceMs);
+  if (delayMs <= 0) {
+    return false;
+  }
+  const fallbackLastQueuedAtMs = Date.now();
+  await new Promise<void>((resolve) => {
+    const check = () => {
+      const sinceLastQueued = Date.now() - (getLastQueuedAtMs?.() ?? fallbackLastQueuedAtMs);
+      if (sinceLastQueued >= delayMs) {
+        resolve();
+        return;
+      }
+      const timer = setTimeout(check, delayMs - sinceLastQueued);
+      timer.unref?.();
+    };
+    check();
+  });
+  return true;
+}
+
 function extractQueuedUserMessageText(message: unknown): string | undefined {
   if (!message || typeof message !== "object") {
     return undefined;
@@ -218,8 +256,10 @@ export async function steerAndWaitForTranscriptCommit(
 export async function steerActiveSessionWithOptionalDeliveryWait(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,
-  options: { deliveryTimeoutMs?: number; waitForTranscriptCommit?: boolean } | undefined,
+  options: EmbeddedAgentSteerDeliveryOptions | undefined,
 ): Promise<void> {
+  await waitForQueuedSteeringDebounce(options?.debounceMs, options?.getLastDebounceQueuedAtMs);
+  options?.ensureStillAccepting?.();
   if (options?.waitForTranscriptCommit !== true) {
     await activeSession.steer(text);
     return;

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3430,16 +3430,33 @@ export async function runEmbeddedAttempt(
         externalAbort = true;
         abortRun();
       };
+      let lastQueuedSteeringAtMs = 0;
       const queueHandle: EmbeddedAgentQueueHandle & {
         kind: "embedded";
         cancel: (reason?: "user_abort" | "restart" | "superseded") => void;
       } = {
         kind: "embedded",
         queueMessage: async (text: string, options) => {
+          lastQueuedSteeringAtMs = Date.now();
           if (options?.steeringMode) {
             activeSession.agent.steeringMode = options.steeringMode;
           }
-          await steerActiveSessionWithOptionalDeliveryWait(activeSession, text, options);
+          await steerActiveSessionWithOptionalDeliveryWait(activeSession, text, {
+            ...options,
+            getLastDebounceQueuedAtMs: () => lastQueuedSteeringAtMs,
+            ensureStillAccepting: () => {
+              if (!activeSession.isStreaming) {
+                throw new Error(
+                  "active session stopped streaming before queued steering could be delivered",
+                );
+              }
+              if (subscription.isCompacting()) {
+                throw new Error(
+                  "active session started compacting before queued steering could be delivered",
+                );
+              }
+            },
+          });
         },
         isStreaming: () => activeSession.isStreaming,
         isCompacting: () => subscription.isCompacting(),


### PR DESCRIPTION
## Summary

- Honor `debounceMs` before delivering active embedded-run steering messages.
- Use a quiet-window timestamp so newer steering messages extend the active steering debounce window.
- Re-check that the active session is still streaming and not compacting before delivering a debounced steer, preventing stale queued messages from leaking into a later turn.

## What Problem This Solves

Active-run steering accepted a `debounceMs` option from auto-reply queue settings, but the embedded-run delivery path did not consume it. That made `steer` mode behave differently from deferred `followup` and `collect` queues: rapid user corrections could be delivered immediately even when the session or channel had configured a debounce window.

This change makes active steering respect the same quiet-window behavior and rejects delivery if the active run stops streaming or starts compacting before the debounce window completes.

## Evidence

Local validation completed on the changed path:

- `node scripts/test-projects.mjs src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts src/agents/embedded-agent-runner/runs.test.ts -- --reporter=verbose`
  - 2 test files passed, 36 tests passed.
- `pnpm exec oxlint src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.queue-message.ts src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts`
  - Passed.
- `pnpm tsgo:test:src`
  - Passed.
- `git diff --check`
  - Passed.

The focused tests cover debounce normalization, waiting before steering delivery, quiet-window extension when another steer arrives, and post-debounce active-run revalidation.

## Validation

- `node scripts/test-projects.mjs src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts src/agents/embedded-agent-runner/runs.test.ts -- --reporter=verbose`
- `pnpm exec oxlint src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.queue-message.ts src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts`
- `pnpm tsgo:test:src`
- `git diff --check`
