### PR TITLE
fix(volcengine): bound TTS success response text reads

### DIFF
--- a/extensions/volcengine/tts.ts
+++ b/extensions/volcengine/tts.ts
@@ -1,6 +1,9 @@
 // Volcengine plugin module implements tts behavior.
 import * as crypto from "node:crypto";
+import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+
+const VOLCENGINE_TTS_BODY_LIMIT_BYTES = 16 * 1024 * 1024;
 
 export type VolcengineTtsEncoding = "ogg_opus" | "mp3" | "pcm" | "wav";
 
@@ -158,7 +161,9 @@ async function seedSpeechTTS(params: VolcengineTTSParams & { apiKey: string }): 
   });
 
   try {
-    const frames = parseSeedTtsFrames(await response.text());
+    const frames = parseSeedTtsFrames(
+      await readResponseTextLimited(response, VOLCENGINE_TTS_BODY_LIMIT_BYTES),
+    );
     const chunks: Buffer[] = [];
     for (const frame of frames) {
       if (frame.code === 0) {
@@ -240,7 +245,9 @@ async function legacyVolcengineTTS(
   });
 
   try {
-    const body = parseLegacyTtsResponse(await response.text());
+    const body = parseLegacyTtsResponse(
+      await readResponseTextLimited(response, VOLCENGINE_TTS_BODY_LIMIT_BYTES),
+    );
     if (!response.ok || body.code !== 3000 || !body.data) {
       throw new Error(
         `Volcengine TTS error ${body.code ?? response.status}: ${body.message ?? "unknown"}`,


### PR DESCRIPTION
## What Problem This Solves

`extensions/volcengine/tts.ts` reads its TTS success response bodies with
unbounded `await response.text()` on two paths:

* `seedSpeechTTS` — BytePlus Seed Speech: reads line-delimited JSON frames
  where each frame carries a `data` field with base64-encoded audio.
* `legacyVolcengineTTS` — legacy Volcengine TTS: reads a single JSON body
  carrying the full base64-encoded audio payload.

Both bodies carry base64-encoded PCM/MP3/OGG audio data, which can legitimately
reach several MiB per request. Neither path has any size cap today. A
misbehaving or hostile Volcengine/BytePlus TTS endpoint (including a
self-hosted `baseUrl` override) can stream an arbitrarily large body into memory
before parsing, causing OOM.

This closes the same unbounded-body OOM class targeted by the
`#95103`/`#95108`/`#95218` response-limit campaign, now applied to the
Volcengine TTS success paths.

## Changes

* `extensions/volcengine/tts.ts`:
  - Adds `import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http"`.
  - Adds constant `VOLCENGINE_TTS_BODY_LIMIT_BYTES = 16 * 1024 * 1024` (16 MiB —
    same default cap used for JSON responses by `readProviderJsonResponse`).
  - Replaces `await response.text()` in `seedSpeechTTS` with
    `readResponseTextLimited(response, VOLCENGINE_TTS_BODY_LIMIT_BYTES)`.
  - Replaces `await response.text()` in `legacyVolcengineTTS` with
    `readResponseTextLimited(response, VOLCENGINE_TTS_BODY_LIMIT_BYTES)`.
  - No test file exists for these functions; no test changes needed.

## Real behavior proof

* **Behavior addressed:** A misbehaving Volcengine/BytePlus TTS endpoint can no
  longer stream an arbitrarily large body into memory; both TTS success-body
  reads are now capped at 16 MiB, and the stream is cancelled on overflow.
* **Real environment tested:** A real `node:http` `createServer` bound to
  `127.0.0.1`, streaming a 24 MiB body in 64 KiB chunks with **no
  Content-Length** header, driving the real exported `readResponseTextLimited`
  helper (the same function added to `tts.ts`) on Node v22.22.0.
* **Exact steps:**
  1. Boot server; `GET /huge` streams 24 MiB with no `Content-Length`;
     `GET /small` returns a valid single TTS JSON frame
     (`{"code":0,"data":"<base64>"}`).
  2. Drive `readResponseTextLimited(response, 16 MiB)` against `/huge` and
     assert the returned text length ≤ 16 MiB and bytes-on-wire stayed near cap.
  3. **Negative control**: run the OLD `await response.text()` against `/huge`
     and measure total bytes pushed by server.
  4. Drive against `/small` and assert the frame is returned intact.
* **Evidence after fix:**
  * Bounded case: returned text length **16,777,216 bytes** (exactly 16 MiB cap);
    server sent **17,694,720 bytes** — near the cap, not the full 24 MiB body.
  * Negative control: the unbounded `response.text()` forced the server to push
    the **full 25,165,824 bytes** (~1.5× the bounded read), proving the cap is
    load-bearing.
  * Small case: frame text returned intact with `"code":0` present — no loss.
* **Observed result:** `ALL PROOF ASSERTIONS PASSED`. Bounded-reader enforcement
  is covered by the existing `readResponseTextLimited` unit tests in
  `packages/media-core`.
* **What was not tested:** Live Volcengine/BytePlus TTS API calls. The proof
  instead measures bytes-on-wire and text truncation, which is the load-bearing
  signal.

## Evidence

```
[case 1] oversized TTS body, cap=16 MiB, NO content-length
  ok: readResponseTextLimited truncated at cap (got 16777216 bytes) — true
  ok: bytes on wire stayed near cap, not full body (sent 17694720) — true

[negative control] OLD unbounded response.text()
  ok: unbounded read pulled the FULL ~24 MiB body (sent 25165824) — true

[case 3] small valid TTS frame reads intact
  ok: small frame text returned — true
  ok: small frame content intact — true

ALL PROOF ASSERTIONS PASSED
```

Proof script: `scripts/proof-volcengine-tts-bound.mjs`
Node version: v22.22.0

**Label**: security

AI-assisted.
