### PR TITLE
fix(openrouter): expand short canonical model IDs to upstream API slugs (fixes #95198)

### DIFF
--- a/extensions/openrouter/models.test.ts
+++ b/extensions/openrouter/models.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  isOpenRouterDeepSeekV4ModelId,
+  isOpenRouterMistralModelId,
+  normalizeOpenRouterApiModelId,
+  normalizeOpenRouterModelId,
+} from "./models.js";
+
+describe("normalizeOpenRouterModelId", () => {
+  it("strips the openrouter/ provider qualifier", () => {
+    expect(normalizeOpenRouterModelId("openrouter/deepseek/deepseek-v4-flash")).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+  });
+
+  it("leaves non-openrouter refs unchanged", () => {
+    expect(normalizeOpenRouterModelId("deepseek/deepseek-v4-flash")).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+  });
+
+  it("returns undefined for non-strings", () => {
+    expect(normalizeOpenRouterModelId(null)).toBeUndefined();
+  });
+});
+
+describe("normalizeOpenRouterApiModelId", () => {
+  it.each([
+    ["openrouter/deepseek-v4-flash", "deepseek/deepseek-v4-flash"],
+    ["openrouter/deepseek-v4-pro", "deepseek/deepseek-v4-pro"],
+    ["openrouter/DEEPSEEK-V4-FLASH", "deepseek/deepseek-v4-flash"],
+  ])("expands short OpenRouter ref %s to %s", (input, expected) => {
+    expect(normalizeOpenRouterApiModelId(input)).toBe(expected);
+  });
+
+  it("strips provider prefix from already-namespaced refs", () => {
+    expect(normalizeOpenRouterApiModelId("openrouter/deepseek/deepseek-v4-flash")).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+  });
+
+  it.each([
+    ["openrouter/auto", "openrouter/auto"],
+    ["openrouter/auto:free", "openrouter/auto:free"],
+    ["openrouter/free", "openrouter/free"],
+  ])("preserves native OpenRouter route %s", (input, expected) => {
+    expect(normalizeOpenRouterApiModelId(input)).toBe(expected);
+  });
+
+  it("passes through refs without the openrouter prefix", () => {
+    expect(normalizeOpenRouterApiModelId("deepseek/deepseek-v4-flash")).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+  });
+});
+
+describe("isOpenRouterDeepSeekV4ModelId", () => {
+  it("matches namespaced DeepSeek V4 refs", () => {
+    expect(isOpenRouterDeepSeekV4ModelId("openrouter/deepseek/deepseek-v4-flash")).toBe(true);
+    expect(isOpenRouterDeepSeekV4ModelId("openrouter/deepseek/deepseek-v4-pro")).toBe(true);
+    expect(isOpenRouterDeepSeekV4ModelId("openrouter/anthropic/claude-sonnet-4-6")).toBe(false);
+  });
+});
+
+describe("isOpenRouterMistralModelId", () => {
+  it("matches Mistral-prefixed refs", () => {
+    expect(isOpenRouterMistralModelId("openrouter/mistral/ministral-8b")).toBe(true);
+    expect(isOpenRouterMistralModelId("openrouter/codestral-22b")).toBe(true);
+  });
+});

--- a/extensions/openrouter/models.ts
+++ b/extensions/openrouter/models.ts
@@ -14,6 +14,13 @@ const OPENROUTER_MISTRAL_MODEL_PREFIXES = [
 ] as const;
 const OPENROUTER_MODEL_PREFIX = "openrouter/";
 
+// Short OpenRouter model refs surfaced by OpenClaw (e.g. `models list`) that are
+// not native OpenRouter routes. The upstream API expects the namespaced slug.
+const OPENROUTER_SHORT_TO_API_MODEL_ID = new Map([
+  ["deepseek-v4-flash", "deepseek/deepseek-v4-flash"],
+  ["deepseek-v4-pro", "deepseek/deepseek-v4-pro"],
+]);
+
 export function normalizeOpenRouterModelId(modelId: unknown): string | undefined {
   if (typeof modelId !== "string") {
     return undefined;
@@ -33,6 +40,10 @@ export function normalizeOpenRouterApiModelId(modelId: unknown): string | undefi
     return normalized;
   }
   const unprefixed = normalized.slice(OPENROUTER_MODEL_PREFIX.length);
+  const shortExpanded = OPENROUTER_SHORT_TO_API_MODEL_ID.get(unprefixed);
+  if (shortExpanded) {
+    return shortExpanded;
+  }
   // `openrouter/` is both a provider qualifier and an upstream namespace.
   // Strip it only when the remainder is still a namespaced API model id.
   return unprefixed.includes("/") ? unprefixed : normalized;

--- a/scripts/repro/issue-95198-openrouter-short-model.mts
+++ b/scripts/repro/issue-95198-openrouter-short-model.mts
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Live repro for issue #95198: OpenRouter short model IDs get double-prefixed.
+ *
+ * Verifies that `openrouter/deepseek-v4-flash` resolves to the upstream API
+ * model ID `deepseek/deepseek-v4-flash` instead of the broken
+ * `openrouter/openrouter/deepseek-v4-flash`.
+ */
+import { normalizeOpenRouterApiModelId } from "../../extensions/openrouter/models.js";
+
+const cases = [
+  { input: "openrouter/deepseek-v4-flash", expected: "deepseek/deepseek-v4-flash" },
+  { input: "openrouter/deepseek-v4-pro", expected: "deepseek/deepseek-v4-pro" },
+  { input: "openrouter/deepseek/deepseek-v4-flash", expected: "deepseek/deepseek-v4-flash" },
+  { input: "openrouter/auto", expected: "openrouter/auto" },
+  { input: "openrouter/free", expected: "openrouter/free" },
+  { input: "deepseek/deepseek-v4-flash", expected: "deepseek/deepseek-v4-flash" },
+];
+
+let failed = false;
+console.log("=== Reproduction for issue #95198 ===");
+for (const { input, expected } of cases) {
+  const actual = normalizeOpenRouterApiModelId(input);
+  const pass = actual === expected;
+  console.log(`${pass ? "PASS" : "FAIL"}: ${input} -> ${actual} (expected ${expected})`);
+  if (!pass) {
+    failed = true;
+  }
+}
+
+if (failed) {
+  console.error("\nFAIL: one or more OpenRouter model ID normalizations are incorrect.");
+  process.exitCode = 1;
+} else {
+  console.log("\nPASS: short OpenRouter model IDs resolve to the correct upstream slugs.");
+}


### PR DESCRIPTION
## What Problem This Solves

OpenClaw surfaces `openrouter/deepseek-v4-flash` and `openrouter/deepseek-v4-pro` as valid short model refs, but the OpenRouter API rejects them with `400 model_not_found` because it expects the upstream namespaced slug `deepseek/deepseek-v4-*`. The gateway currently passes the short ref through unchanged, and downstream code ends up sending `openrouter/openrouter/deepseek-v4-flash` to the API.

Closes #95198.

## Why This Change Was Made

`normalizeOpenRouterApiModelId` only strips the `openrouter/` qualifier when the remainder still contains a `/`. Short refs like `deepseek-v4-flash` fall through and are returned with the provider prefix intact, which is not a valid OpenRouter API model ID.

This change adds a minimal, hand-maintained map of the two short DeepSeek V4 refs that OpenClaw already recognizes elsewhere in the plugin. The normalizer expands them to the upstream slug before the existing namespaced strip logic runs. Native OpenRouter routes such as `openrouter/auto`, `openrouter/free`, etc. continue to be preserved unchanged.

## Changes

- `extensions/openrouter/models.ts`: add `OPENROUTER_SHORT_TO_API_MODEL_ID` map and expand short refs in `normalizeOpenRouterApiModelId`.
- `extensions/openrouter/models.test.ts`: new unit tests covering short refs, long refs, native routes, and pass-through behavior.
- `scripts/repro/issue-95198-openrouter-short-model.mts`: standalone reproduction script that verifies the normalization matrix.

## Real behavior proof

**Behavior addressed**: short OpenRouter model IDs like `openrouter/deepseek-v4-flash` now resolve to the upstream API slug `deepseek/deepseek-v4-flash`.

**Environment tested**: Linux x64, Node.js v22.x, OpenClaw main branch.

**Exact steps or command run after this patch**:

```bash
node --import tsx scripts/repro/issue-95198-openrouter-short-model.mts
```

**Evidence after fix**:

```text
=== Reproduction for issue #95198 ===
PASS: openrouter/deepseek-v4-flash -> deepseek/deepseek-v4-flash (expected deepseek/deepseek-v4-flash)
PASS: openrouter/deepseek-v4-pro -> deepseek/deepseek-v4-pro (expected deepseek/deepseek-v4-pro)
PASS: openrouter/deepseek/deepseek-v4-flash -> deepseek/deepseek-v4-flash (expected deepseek/deepseek-v4-flash)
PASS: openrouter/auto -> openrouter/auto (expected openrouter/auto)
PASS: openrouter/free -> openrouter/free (expected openrouter/free)
PASS: deepseek/deepseek-v4-flash -> deepseek/deepseek-v4-flash (expected deepseek/deepseek-v4-flash)

PASS: short OpenRouter model IDs resolve to the correct upstream slugs.
```

Unit tests:

```text
pnpm test extensions/openrouter/models.test.ts --run
Test Files  1 passed (1)
Tests       13 passed (13)
```

## Verification

- `node --import tsx scripts/repro/issue-95198-openrouter-short-model.mts` → PASS
- `pnpm test extensions/openrouter/models.test.ts --run` → 13 passed
- `npx oxlint --import-plugin --config .oxlintrc.json extensions/openrouter/models.ts extensions/openrouter/models.test.ts scripts/repro/issue-95198-openrouter-short-model.mts` → clean
- `pnpm format:check extensions/openrouter/models.ts extensions/openrouter/models.test.ts scripts/repro/issue-95198-openrouter-short-model.mts` → clean
- `pnpm build` → success

## What was not tested

No live OpenRouter API request was made; reproduction and tests exercise the normalizer locally.
