### PR TITLE
fix(channels): avoid copying process.env in ingress queue hot path (fixes #94571)

### DIFF
--- a/scripts/repro/issue-94571-ingress-queue-env-overlay.mts
+++ b/scripts/repro/issue-94571-ingress-queue-env-overlay.mts
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Live repro for issue #94571: Telegram isolated ingress copies large process.env
+ * in the queue hot path.
+ *
+ * Verifies that createChannelIngressQueue with a custom stateDir does not
+ * enumerate and copy the full process environment on every queue operation.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createChannelIngressQueue } from "../../src/channels/message/ingress-queue.js";
+
+let readCount = 0;
+const originalEnv = process.env;
+// Proxy every env read so we can detect enumeration/copies.
+const instrumentedEnv = new Proxy(originalEnv, {
+  get(target, prop) {
+    if (typeof prop === "string") {
+      readCount++;
+    }
+    return Reflect.get(target, prop);
+  },
+});
+
+process.env = instrumentedEnv;
+
+async function main() {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-repro-94571-"));
+  const calls = 1000;
+
+  const queue = createChannelIngressQueue<{ index: number }>({
+    channelId: "telegram",
+    accountId: "default",
+    stateDir,
+    now: () => Date.now(),
+  });
+
+  readCount = 0;
+  for (let i = 0; i < calls; i++) {
+    await queue.listPending();
+  }
+
+  await fs.rm(stateDir, { recursive: true, force: true });
+
+  console.log("=== Reproduction for issue #94571 ===");
+  console.log(`Queue operations: ${calls}`);
+  console.log(`Total env reads: ${readCount}`);
+  console.log(`Reads per operation: ${(readCount / calls).toFixed(2)}`);
+
+  // With the old `{ ...process.env }` implementation each operation copied every
+  // key. With the overlay implementation only the handful of keys used for path
+  // resolution are read.
+  if (readCount > calls * 5) {
+    console.error("FAIL: the queue appears to copy or enumerate process.env on each call.");
+    process.exitCode = 1;
+  } else {
+    console.log("PASS: queue operations do not enumerate the full process environment.");
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -187,9 +187,16 @@ function normalizePart(value: string | undefined, fallback: string): string {
 }
 
 function openStateDatabase(stateDir?: string) {
-  return openOpenClawStateDatabase({
-    env: stateDir ? { ...process.env, OPENCLAW_STATE_DIR: stateDir } : process.env,
-  });
+  // Avoid `{ ...process.env }` in the hot path: Kubernetes pods can inherit
+  // thousands of service env vars, and this function is called on every queue
+  // operation. An overlay object preserves inherited lookups while only adding
+  // the state-dir override.
+  const env = stateDir
+    ? Object.assign(Object.create(process.env) as NodeJS.ProcessEnv, {
+        OPENCLAW_STATE_DIR: stateDir,
+      })
+    : process.env;
+  return openOpenClawStateDatabase({ env });
 }
 
 function getChannelIngressKysely(db: DatabaseSync) {


### PR DESCRIPTION
## What Problem This Solves

In Kubernetes pods with `enableServiceLinks` enabled, `process.env` can contain thousands of service environment variables. The Telegram isolated polling ingress queue calls `openStateDatabase` every ~500ms, and the old implementation used `{ ...process.env, OPENCLAW_STATE_DIR: stateDir }`, copying every env var on each call. This saturates the gateway event loop and delays replies on other channels.

Closes #94571.

## Why This Change Was Made

`openStateDatabase` in `src/channels/message/ingress-queue.ts` is on the hot path for every durable channel ingress queue operation when a custom `stateDir` is configured. The state DB path resolution only needs `OPENCLAW_STATE_DIR` (plus inherited env lookups like `HOME`/`OPENCLAW_HOME` if ever referenced), so copying the entire environment is unnecessary.

The fix uses `Object.assign(Object.create(process.env), { OPENCLAW_STATE_DIR: stateDir })` to create an overlay object. This preserves inherited property lookups without enumerating or copying the host environment.

## Changes

- `src/channels/message/ingress-queue.ts`: replace `{ ...process.env, OPENCLAW_STATE_DIR: stateDir }` with a prototype overlay object.
- `scripts/repro/issue-94571-ingress-queue-env-overlay.mts`: standalone reproduction script that instruments `process.env` reads and verifies queue operations do not enumerate the full environment.

## Real behavior proof

**Behavior addressed**: opening a channel ingress queue with a custom `stateDir` no longer copies the full `process.env` on each operation.

**Environment tested**: Linux x64, Node.js v22.x, OpenClaw main branch.

**Exact steps or command run after this patch**:

```bash
node --import tsx scripts/repro/issue-94571-ingress-queue-env-overlay.mts
```

**Evidence after fix**:

```text
=== Reproduction for issue #94571 ===
Queue operations: 1000
Total env reads: 2
Reads per operation: 0.00
PASS: queue operations do not enumerate the full process environment.
```

## Verification

- `node --import tsx scripts/repro/issue-94571-ingress-queue-env-overlay.mts` → PASS
- `pnpm test src/channels/message/ingress-queue.test.ts --run` → 8 passed
- `npx oxlint --import-plugin --config .oxlintrc.json src/channels/message/ingress-queue.ts scripts/repro/issue-94571-ingress-queue-env-overlay.mts` → clean
- `pnpm format:check src/channels/message/ingress-queue.ts scripts/repro/issue-94571-ingress-queue-env-overlay.mts` → clean
- `pnpm build` → success

## What was not tested

No live Kubernetes pod or Telegram bot polling was exercised; the reproduction uses an instrumented local process environment and the actual queue implementation.
