### PR TITLE
feat(agent): add session self-compaction action

### DIFF
--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -121,6 +121,10 @@ import {
   replaceWithEffectiveCronCreatorToolAllowlist,
   type CronCreatorToolAllowlistEntry,
 } from "./tools/cron-tool.js";
+import type {
+  SessionStatusSelfCompactRequest,
+  SessionStatusSelfCompactResult,
+} from "./tools/session-status-tool.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
 const MEMORY_FLUSH_ALLOWED_TOOL_NAMES = new Set(["read", "write"]);
@@ -563,6 +567,10 @@ export function createOpenClawCodingTools(options?: {
   authProfileStore?: AuthProfileStore;
   /** Callback invoked when sessions_yield tool is called. */
   onYield?: (message: string) => Promise<void> | void;
+  /** Callback invoked when session_status requests current-session compaction. */
+  onSessionStatusSelfCompact?: (
+    request: SessionStatusSelfCompactRequest,
+  ) => Promise<SessionStatusSelfCompactResult | void> | SessionStatusSelfCompactResult | void;
   /** Optional instrumentation callback for tool preparation stage timing. */
   recordToolPrepStage?: (name: string) => void;
   /** Lower routine policy-removal audits for diagnostic-only tool probes. */
@@ -1097,6 +1105,7 @@ export function createOpenClawCodingTools(options?: {
           inheritedToolAllowlist,
           inheritedToolDenylist,
           onYield: options?.onYield,
+          onSessionStatusSelfCompact: options?.onSessionStatusSelfCompact,
           allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
           recordToolPrepStage: options?.recordToolPrepStage,
         })

--- a/src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts
@@ -86,6 +86,22 @@ describe("runEmbeddedAttempt cwd/workspace split", () => {
     });
   });
 
+  it("passes the session self-compaction callback into runtime tools", async () => {
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey: "agent:main:main",
+      tempPaths,
+      attemptOverrides: {
+        disableTools: false,
+      },
+    });
+
+    const toolsCall = hoisted.createOpenClawCodingToolsMock.mock.calls[0]?.[0] as
+      | { onSessionStatusSelfCompact?: unknown }
+      | undefined;
+    expect(typeof toolsCall?.onSessionStatusSelfCompact).toBe("function");
+  });
+
   it("rejects cwd overrides for sandboxed runs instead of silently ignoring them", async () => {
     // Sandboxed attempts already remap the workspace; accepting an extra cwd
     // override would make tool roots ambiguous.

--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
@@ -16,10 +16,11 @@ function buildSessionsYieldContextMessage(message: string): string {
   return `${message}\n\n[Context: The previous turn ended intentionally via sessions_yield while waiting for a follow-up event.]`;
 }
 
-export async function waitForSessionsYieldAbortSettle(params: {
+export async function waitForRunAbortSettle(params: {
   settlePromise: Promise<void> | null;
   runId: string;
   sessionId: string;
+  label: string;
 }): Promise<void> {
   if (!params.settlePromise) {
     return;
@@ -31,7 +32,7 @@ export async function waitForSessionsYieldAbortSettle(params: {
       .then(() => "settled" as const)
       .catch((err: unknown) => {
         log.warn(
-          `sessions_yield abort settle failed: runId=${params.runId} sessionId=${params.sessionId} err=${String(err)}`,
+          `${params.label} abort settle failed: runId=${params.runId} sessionId=${params.sessionId} err=${String(err)}`,
         );
         return "errored" as const;
       }),
@@ -44,9 +45,17 @@ export async function waitForSessionsYieldAbortSettle(params: {
   }
   if (outcome === "timed_out") {
     log.warn(
-      `sessions_yield abort settle timed out: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${SESSIONS_YIELD_ABORT_SETTLE_TIMEOUT_MS}`,
+      `${params.label} abort settle timed out: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${SESSIONS_YIELD_ABORT_SETTLE_TIMEOUT_MS}`,
     );
   }
+}
+
+export async function waitForSessionsYieldAbortSettle(params: {
+  settlePromise: Promise<void> | null;
+  runId: string;
+  sessionId: string;
+}): Promise<void> {
+  return waitForRunAbortSettle({ ...params, label: "sessions_yield" });
 }
 
 // Return a synthetic aborted response so agent runtime unwinds without a real provider call.
@@ -220,6 +229,69 @@ export function stripSessionsYieldArtifacts(activeSession: {
         entry.customType === SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE;
       return isYieldAbortAssistant || isYieldInterruptMessage;
     },
+    {
+      preserveTrailing: (entry) =>
+        entry.type === "custom" ||
+        entry.type === "label" ||
+        entry.type === "session_info" ||
+        (entry.type === "message" && isTranscriptOnlyOpenClawAssistantMessage(entry.message)),
+    },
+  );
+}
+
+// Remove only the synthetic aborted assistant entry from an intentional run abort.
+export function stripRunAbortArtifacts(activeSession: {
+  messages: AgentMessage[];
+  agent: { state: { messages: AgentMessage[] } };
+  sessionManager?: unknown;
+}) {
+  const strippedMessages = activeSession.messages.slice();
+  while (strippedMessages.length > 0) {
+    const last = strippedMessages.at(-1) as AgentMessage | { role?: string; stopReason?: string };
+    if (last?.role === "assistant" && "stopReason" in last && last.stopReason === "aborted") {
+      strippedMessages.pop();
+      continue;
+    }
+    break;
+  }
+  if (strippedMessages.length !== activeSession.messages.length) {
+    activeSession.agent.state.messages = strippedMessages;
+  }
+
+  const sessionManager = activeSession.sessionManager as
+    | {
+        removeTrailingEntries?: (
+          predicate: (entry: {
+            type?: string;
+            message?: {
+              role?: string;
+              stopReason?: string;
+              provider?: string;
+              model?: string;
+            };
+          }) => boolean,
+          options?: {
+            preserveTrailing?: (entry: {
+              type?: string;
+              message?: {
+                role?: string;
+                provider?: string;
+                model?: string;
+              };
+            }) => boolean;
+          },
+        ) => number;
+      }
+    | undefined;
+  if (typeof sessionManager?.removeTrailingEntries !== "function") {
+    return;
+  }
+
+  sessionManager.removeTrailingEntries(
+    (entry) =>
+      entry.type === "message" &&
+      entry.message?.role === "assistant" &&
+      entry.message?.stopReason === "aborted",
     {
       preserveTrailing: (entry) =>
         entry.type === "custom" ||

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -423,7 +423,9 @@ import {
   createYieldAbortedResponse,
   persistSessionsYieldContextMessage,
   queueSessionsYieldInterruptMessage,
+  stripRunAbortArtifacts,
   stripSessionsYieldArtifacts,
+  waitForRunAbortSettle,
   waitForSessionsYieldAbortSettle,
 } from "./attempt.sessions-yield.js";
 import { wrapStreamFnHandleSensitiveStopReason } from "./attempt.stop-reason-recovery.js";
@@ -543,6 +545,7 @@ export {
 
 const MAX_BTW_SNAPSHOT_MESSAGES = 100;
 const PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER = 4;
+const SESSION_STATUS_SELF_COMPACT_ABORT_REASON = "session_status_compact";
 
 function pluginMetadataSnapshotCoversProvider(
   snapshot: PluginMetadataSnapshot | undefined,
@@ -1359,6 +1362,15 @@ export async function runEmbeddedAttempt(
               runAbortController.abort("sessions_yield");
               abortSessionForYield?.();
             },
+            onSessionStatusSelfCompact: () => {
+              if (selfCompactionRequested) {
+                return { requested: true };
+              }
+              selfCompactionRequested = true;
+              runAbortController.abort(SESSION_STATUS_SELF_COMPACT_ABORT_REASON);
+              abortSessionForSelfCompaction?.();
+              return { requested: true };
+            },
           });
           corePluginToolStages.mark("attempt:create-openclaw-coding-tools");
           const filteredTools = applyEmbeddedAttemptToolsAllow(allTools, effectiveToolsAllow, {
@@ -1509,10 +1521,13 @@ export async function runEmbeddedAttempt(
     // Track sessions_yield tool invocation (callback pattern, like clientToolCallDetected)
     let yieldDetected = false;
     let yieldMessage: string | null = null;
+    let selfCompactionRequested = false;
     // Late-binding reference so onYield can abort the session (declared after tool creation)
     let abortSessionForYield: (() => void) | null = null;
+    let abortSessionForSelfCompaction: (() => void) | null = null;
     let queueYieldInterruptForSession: (() => void) | null = null;
     let yieldAbortSettled: Promise<void> | null = null;
+    let selfCompactionAbortSettled: Promise<void> | null = null;
     const runtimePlanModelContext = {
       workspaceDir: effectiveWorkspace,
       modelApi: params.model.api,
@@ -2616,6 +2631,9 @@ export async function runEmbeddedAttempt(
       abortSessionForYield = () => {
         yieldAbortSettled = abortActiveSession();
       };
+      abortSessionForSelfCompaction = () => {
+        selfCompactionAbortSettled = abortActiveSession();
+      };
       queueYieldInterruptForSession = () => {
         queueSessionsYieldInterruptMessage(activeSession);
       };
@@ -3058,7 +3076,12 @@ export async function runEmbeddedAttempt(
       const innerStreamFn = activeSession.agent.streamFn;
       activeSession.agent.streamFn = (model, context, options) => {
         const signal = runAbortController.signal as AbortSignal & { reason?: unknown };
-        if (yieldDetected && signal.aborted && signal.reason === "sessions_yield") {
+        if (
+          (yieldDetected && signal.aborted && signal.reason === "sessions_yield") ||
+          (selfCompactionRequested &&
+            signal.aborted &&
+            signal.reason === SESSION_STATUS_SELF_COMPACT_ABORT_REASON)
+        ) {
           return createYieldAbortedResponse(model) as unknown as Awaited<
             ReturnType<typeof innerStreamFn>
           >;
@@ -3369,6 +3392,7 @@ export async function runEmbeddedAttempt(
       }
 
       let yieldAborted = false;
+      let selfCompactionAborted = false;
       const abortCompaction = () => {
         if (!activeSession.isCompacting) {
           return;
@@ -4806,7 +4830,12 @@ export async function runEmbeddedAttempt(
             isRunnerAbortError(err) &&
             err instanceof Error &&
             err.cause === "sessions_yield";
-          cleanupYieldAborted = yieldAborted;
+          selfCompactionAborted =
+            selfCompactionRequested &&
+            isRunnerAbortError(err) &&
+            err instanceof Error &&
+            err.cause === SESSION_STATUS_SELF_COMPACT_ABORT_REASON;
+          cleanupYieldAborted = yieldAborted || selfCompactionAborted;
           if (yieldAborted) {
             aborted = false;
             await waitForSessionsYieldAbortSettle({
@@ -4821,6 +4850,22 @@ export async function runEmbeddedAttempt(
               if (yieldMessage) {
                 await persistSessionsYieldContextMessage(activeSession, yieldMessage);
               }
+            });
+          } else if (selfCompactionAborted) {
+            aborted = false;
+            await waitForRunAbortSettle({
+              settlePromise: selfCompactionAbortSettled,
+              runId: params.runId,
+              sessionId: params.sessionId,
+              label: "session_status compact",
+            });
+            await sessionLockController.releaseHeldLockForAbort();
+            await sessionLockController.waitForSessionEvents(activeSession);
+            await withOwnedSessionWriteLock(() => {
+              stripRunAbortArtifacts(activeSession);
+              preflightRecovery = { route: "compact_only", source: "mid-turn" };
+              promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
+              promptErrorSource = "precheck";
             });
           } else if (isMidTurnPrecheckSignal(err)) {
             await sessionLockController.waitForSessionEvents(activeSession);
@@ -4938,20 +4983,21 @@ export async function runEmbeddedAttempt(
             await onBlockReplyFlush();
           }
 
-          // Skip compaction wait when yield aborted the run — the signal is
-          // already tripped and abortable() would immediately reject.
-          const compactionRetryWait = yieldAborted
-            ? { timedOut: false }
-            : await waitForCompactionRetryWithAggregateTimeout({
-                waitForCompactionRetry,
-                abortable,
-                aggregateTimeoutMs: COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS,
-                isCompactionRetryStillActive: () =>
-                  hasActiveCompactionRetryWork({
-                    isCompactionInFlight: isCompactionInFlight(),
-                    isSessionStreaming: activeSession.isStreaming,
-                  }),
-              });
+          // Skip compaction wait when an intentional tool action aborted the run:
+          // the signal is already tripped and abortable() would immediately reject.
+          const compactionRetryWait =
+            yieldAborted || selfCompactionAborted
+              ? { timedOut: false }
+              : await waitForCompactionRetryWithAggregateTimeout({
+                  waitForCompactionRetry,
+                  abortable,
+                  aggregateTimeoutMs: COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS,
+                  isCompactionRetryStillActive: () =>
+                    hasActiveCompactionRetryWork({
+                      isCompactionInFlight: isCompactionInFlight(),
+                      isSessionStreaming: activeSession.isStreaming,
+                    }),
+                });
           if (compactionRetryWait.timedOut) {
             timedOutDuringCompaction = true;
             if (!isProbeSession) {

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -425,14 +425,22 @@ function latestMockCallArg(mock: ReturnType<typeof vi.fn>, argIndex = 0) {
 
 function getSessionStatusTool(
   agentSessionKey = "main",
-  options?: { sandboxed?: boolean; activeModelProvider?: string; activeModelId?: string },
+  options?: {
+    sandboxed?: boolean;
+    activeModelProvider?: string;
+    activeModelId?: string;
+    runSessionKey?: string;
+    onSelfCompact?: NonNullable<Parameters<typeof createSessionStatusTool>[0]>["onSelfCompact"];
+  },
 ) {
   const tool = createSessionStatusTool({
     agentSessionKey,
+    runSessionKey: options?.runSessionKey,
     sandboxed: options?.sandboxed,
     activeModelProvider: options?.activeModelProvider,
     activeModelId: options?.activeModelId,
     config: mockConfig as never,
+    onSelfCompact: options?.onSelfCompact,
   });
   expect(tool.name).toBe("session_status");
   return tool;
@@ -460,6 +468,81 @@ describe("session_status tool", () => {
     expect(details.statusText).toContain("OpenClaw");
     expect(details.statusText).toContain("🧠 Model:");
     expect(details.statusText).not.toContain("OAuth/token status");
+  });
+
+  it("requests self-compaction for the current session", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+      },
+    });
+    const onSelfCompact = vi.fn(async () => ({ requested: true }));
+    const tool = getSessionStatusTool("main", { onSelfCompact });
+
+    const result = await tool.execute("call-compact", { action: "compact" });
+
+    expect(onSelfCompact).toHaveBeenCalledWith({
+      sessionKey: "main",
+      sessionId: "s1",
+      agentId: "main",
+    });
+    const details = result.details as {
+      ok?: boolean;
+      action?: string;
+      compactRequested?: boolean;
+      sessionKey?: string;
+      statusText?: string;
+    };
+    expect(details).toMatchObject({
+      ok: true,
+      action: "compact",
+      compactRequested: true,
+      sessionKey: "main",
+    });
+    expect(details.statusText).toContain("Self-compaction requested");
+    expect(updateSessionStoreMock).not.toHaveBeenCalled();
+  });
+
+  it("requires an active run callback before self-compaction", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+      },
+    });
+    const tool = getSessionStatusTool();
+
+    await expect(tool.execute("call-compact-no-callback", { action: "compact" })).rejects.toThrow(
+      'session_status action "compact" is only available during an active agent run.',
+    );
+  });
+
+  it("blocks self-compaction for non-current sessions", async () => {
+    mockConfig = {
+      ...createMockConfig(),
+      tools: {
+        sessions: { visibility: "all" },
+        agentToAgent: { enabled: false },
+      },
+    };
+    resetSessionStore({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+      },
+      other: {
+        sessionId: "s2",
+        updatedAt: 11,
+      },
+    });
+    const onSelfCompact = vi.fn(async () => ({ requested: true }));
+    const tool = getSessionStatusTool("main", { onSelfCompact });
+
+    await expect(
+      tool.execute("call-compact-other", { action: "compact", sessionKey: "other" }),
+    ).rejects.toThrow('session_status action "compact" can only target the current session.');
+    expect(onSelfCompact).not.toHaveBeenCalled();
   });
 
   it("enables transcript usage fallback for session_status", async () => {

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -470,6 +470,20 @@ describe("session_status tool", () => {
     expect(details.statusText).not.toContain("OAuth/token status");
   });
 
+  it("exposes action as a provider-safe flat enum", () => {
+    const tool = getSessionStatusTool();
+    const parameters = tool.parameters as {
+      properties?: Record<string, { type?: unknown; enum?: unknown; anyOf?: unknown }>;
+    };
+    const action = parameters.properties?.action;
+
+    expect(action).toMatchObject({
+      type: "string",
+      enum: ["status", "compact"],
+    });
+    expect(action?.anyOf).toBeUndefined();
+  });
+
   it("requests self-compaction for the current session", async () => {
     resetSessionStore({
       main: {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -56,7 +56,11 @@ import { createMessageTool } from "./tools/message-tool.js";
 import { createMusicGenerateTool } from "./tools/music-generate-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
 import { createPdfTool } from "./tools/pdf-tool.js";
-import { createSessionStatusTool } from "./tools/session-status-tool.js";
+import {
+  createSessionStatusTool,
+  type SessionStatusSelfCompactRequest,
+  type SessionStatusSelfCompactResult,
+} from "./tools/session-status-tool.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
@@ -182,6 +186,10 @@ export function createOpenClawTools(
     spawnWorkspaceDir?: string;
     /** Callback invoked when sessions_yield tool is called. */
     onYield?: (message: string) => Promise<void> | void;
+    /** Callback invoked when session_status requests current-session compaction. */
+    onSessionStatusSelfCompact?: (
+      request: SessionStatusSelfCompactRequest,
+    ) => Promise<SessionStatusSelfCompactResult | void> | SessionStatusSelfCompactResult | void;
     /** Allow plugin tools for this tool set to late-bind the gateway subagent. */
     allowGatewaySubagentBinding?: boolean;
   } & SpawnedToolContext,
@@ -555,6 +563,7 @@ export function createOpenClawTools(
         accountId: options?.agentAccountId,
         threadId: options?.currentThreadTs ?? options?.agentThreadId,
       },
+      onSelfCompact: options?.onSessionStatusSelfCompact,
     }),
     ...collectPresentOpenClawTools([webSearchTool, webFetchTool, imageTool, pdfTool]),
   ];

--- a/src/agents/prompt-surface.ts
+++ b/src/agents/prompt-surface.ts
@@ -32,7 +32,7 @@ export function buildOpenClawToolFallbackText(params: {
       "- sessions_spawn: spawn an isolated sub-agent session",
       "- sessions_yield: end this turn and wait for sub-agent completion events",
       "- subagents: list active/recent sub-agent runs",
-      '- session_status: show usage/time/model state and answer "what model are we using?"',
+      '- session_status: show usage/time/model state, answer "what model are we using?", or request current-session compaction',
     ].join("\n");
   }
 

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -81,6 +81,7 @@ export function describeSessionStatusTool(): string {
     "Show /status-like card for current/visible session: model, usage, time, cost, tasks.",
     'Use `sessionKey="current"` for current session; UI labels like `openclaw-tui` are not keys.',
     "`model` sets session override; `model=default` resets.",
+    '`action="compact"` requests context compaction for the current session when the context is bloated.',
     "Use for active model/session config questions.",
   ].join(" ");
 }

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -10,8 +10,20 @@ import {
 } from "./tool-mutation.js";
 
 describe("tool mutation helpers", () => {
-  it("treats session_status as mutating only when model override is provided", () => {
+  it("treats session_status compact and model override as mutating", () => {
     expect(isMutatingToolCall("session_status", { sessionKey: "agent:main:main" })).toBe(false);
+    expect(
+      isMutatingToolCall("session_status", {
+        action: "status",
+        sessionKey: "agent:main:main",
+      }),
+    ).toBe(false);
+    expect(
+      isMutatingToolCall("session_status", {
+        action: "compact",
+        sessionKey: "agent:main:main",
+      }),
+    ).toBe(true);
     expect(
       isMutatingToolCall("session_status", {
         sessionKey: "agent:main:main",
@@ -50,7 +62,9 @@ describe("tool mutation helpers", () => {
   ])("treats read-only shell command as non-mutating: %s %s", (toolName, command) => {
     expect(isMutatingToolCall(toolName, { command })).toBe(false);
     expect(buildToolMutationState(toolName, { command }).mutatingAction).toBe(false);
-    expect(buildToolMutationState(toolName, { command }, command).actionFingerprint).toBeUndefined();
+    expect(
+      buildToolMutationState(toolName, { command }, command).actionFingerprint,
+    ).toBeUndefined();
   });
 
   it.each([

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -384,7 +384,10 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
     case "subagents":
       return action === "kill" || action === "steer";
     case "session_status":
-      return typeof record?.model === "string" && record.model.trim().length > 0;
+      return (
+        action === "compact" ||
+        (typeof record?.model === "string" && record.model.trim().length > 0)
+      );
     case "gateway":
       return action == null || !GATEWAY_REPLAY_SAFE_ACTIONS.has(action);
     case "nodes":

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -72,9 +72,23 @@ import {
 } from "./sessions-helpers.js";
 
 const SessionStatusToolSchema = Type.Object({
+  action: Type.Optional(Type.Union([Type.Literal("status"), Type.Literal("compact")])),
   sessionKey: Type.Optional(Type.String()),
   model: Type.Optional(Type.String()),
 });
+
+type SessionStatusAction = "status" | "compact";
+
+export type SessionStatusSelfCompactRequest = {
+  sessionKey: string;
+  sessionId: string;
+  agentId: string;
+};
+
+export type SessionStatusSelfCompactResult = {
+  requested?: boolean;
+  reason?: string;
+};
 
 type CommandsStatusRuntimeModule = {
   buildStatusText: (params: BuildStatusTextParams) => Promise<string>;
@@ -86,6 +100,21 @@ const commandsStatusRuntimeLoader = createLazyImportLoader<CommandsStatusRuntime
 
 function loadCommandsStatusRuntime(): Promise<CommandsStatusRuntimeModule> {
   return commandsStatusRuntimeLoader.load();
+}
+
+function readSessionStatusAction(params: Record<string, unknown>): SessionStatusAction {
+  const raw = params.action;
+  if (raw === undefined) {
+    return "status";
+  }
+  if (typeof raw !== "string") {
+    throw new Error("session_status action must be a string.");
+  }
+  const action = raw.trim().toLowerCase();
+  if (action === "status" || action === "compact") {
+    return action;
+  }
+  throw new Error(`Unsupported session_status action "${raw}". Use "status" or "compact".`);
 }
 
 function resolveSessionEntry(params: {
@@ -499,6 +528,10 @@ export function createSessionStatusTool(opts?: {
   activeModelId?: string;
   /** Active live-run route, kept separate from the persisted/origin delivery route. */
   activeDeliveryContext?: DeliveryContext;
+  /** Request in-run self-compaction for the current session. */
+  onSelfCompact?: (
+    request: SessionStatusSelfCompactRequest,
+  ) => Promise<SessionStatusSelfCompactResult | void> | SessionStatusSelfCompactResult | void;
 }): AnyAgentTool {
   return {
     label: "Session Status",
@@ -508,6 +541,11 @@ export function createSessionStatusTool(opts?: {
     parameters: SessionStatusToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
+      const action = readSessionStatusAction(params);
+      const modelRaw = readStringParam(params, "model");
+      if (action === "compact" && modelRaw !== undefined) {
+        throw new Error('session_status action "compact" cannot be combined with model.');
+      }
       const cfg = opts?.config ?? getRuntimeConfig();
       const { mainKey, alias, effectiveRequesterKey } = resolveSandboxedSessionToolContext({
         cfg,
@@ -764,8 +802,58 @@ export function createSessionStatusTool(opts?: {
         throw new Error(access.error);
       }
 
+      if (action === "compact") {
+        const liveSessionKeysForSelfAction = new Set(
+          [
+            opts?.runSessionKey,
+            opts?.agentSessionKey,
+            storeScopedRequesterKey,
+            effectiveRequesterKey,
+            visibilityRequesterKey,
+          ]
+            .map((value) => value?.trim())
+            .filter((value): value is string => Boolean(value)),
+        );
+        const isSelfCompactionTarget =
+          isSemanticCurrentRequest ||
+          resolvedViaImplicitCurrentFallback ||
+          liveSessionKeysForSelfAction.has(resolved.key.trim());
+        if (!isSelfCompactionTarget) {
+          throw new Error('session_status action "compact" can only target the current session.');
+        }
+        if (!opts?.onSelfCompact) {
+          throw new Error(
+            'session_status action "compact" is only available during an active agent run.',
+          );
+        }
+        const sessionId = resolved.entry.sessionId?.trim();
+        if (!sessionId) {
+          throw new Error('session_status action "compact" requires a live session id.');
+        }
+        const compactResult = await opts.onSelfCompact({
+          sessionKey: resolved.key,
+          sessionId,
+          agentId,
+        });
+        const compactRequested = compactResult?.requested !== false;
+        const reason = compactResult?.reason?.trim();
+        const statusText = compactRequested
+          ? "Self-compaction requested. The current turn will stop, compact context, and resume from the transcript."
+          : `Self-compaction was not requested${reason ? `: ${reason}` : "."}`;
+        return {
+          content: [{ type: "text", text: statusText }],
+          details: {
+            ok: compactRequested,
+            action,
+            sessionKey: resolved.key,
+            compactRequested,
+            ...(reason ? { reason } : {}),
+            statusText,
+          },
+        };
+      }
+
       const configured = resolveDefaultModelForAgent({ cfg, agentId });
-      const modelRaw = readStringParam(params, "model");
       let changedModel = false;
       if (typeof modelRaw === "string") {
         const selection = await resolveModelOverride({

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -53,6 +53,7 @@ import {
   resolveThinkingDefaultWithRuntimeCatalog,
 } from "../model-selection.js";
 import { createModelVisibilityPolicy } from "../model-visibility-policy.js";
+import { optionalStringEnum } from "../schema/string-enum.js";
 import {
   describeSessionStatusTool,
   SESSION_STATUS_TOOL_DISPLAY_SUMMARY,
@@ -71,13 +72,15 @@ import {
   shouldResolveSessionIdInput,
 } from "./sessions-helpers.js";
 
+const SESSION_STATUS_ACTIONS = ["status", "compact"] as const;
+
 const SessionStatusToolSchema = Type.Object({
-  action: Type.Optional(Type.Union([Type.Literal("status"), Type.Literal("compact")])),
+  action: optionalStringEnum(SESSION_STATUS_ACTIONS),
   sessionKey: Type.Optional(Type.String()),
   model: Type.Optional(Type.String()),
 });
 
-type SessionStatusAction = "status" | "compact";
+type SessionStatusAction = (typeof SESSION_STATUS_ACTIONS)[number];
 
 export type SessionStatusSelfCompactRequest = {
   sessionKey: string;


### PR DESCRIPTION
## What Problem This Solves

Fixes #6757.

OpenClaw can compact context automatically or through operator-facing paths, but an agent running inside a turn has no first-class way to request compaction for its own active session when it detects context bloat.

## What Changed

This PR adds the narrow current-session action:

```text
session_status({ action: "compact", sessionKey: "current" })
```

- Exposes the provider-portable flat enum `action: "status" | "compact"` only while an embedded run has installed the live self-compaction callback. Other tool construction contexts keep the existing schema and description unchanged.
- Keeps status as the default action and preserves the existing `session_status` output schema and compact tool hint.
- Rejects compact requests for non-current sessions, stale run/session identities, unsupported execution contexts, or requests combined with `model` or `changesSince`.
- Marks the compact action as mutating for replay/recovery safety.
- Routes the request through a dedicated intentional-handoff abort reason. The tool does not mutate or compact the transcript inline.
- Normalizes the aborted transcript tail, releases the session lock non-terminally, and returns the existing outer recovery signal:

```json
{
  "route": "compact_only",
  "source": "mid-turn",
  "handled": false
}
```

- Reuses one shared handoff primitive for `sessions_yield` and self-compaction while preserving their different after-turn semantics.
- Atomically selects one winner if `sessions_yield` and self-compaction arrive in the same parallel tool batch.
- Preserves completion-required async-task behavior: yield may defer to its wake event, while self-compaction waits for required tasks using the independent attempt cancellation signal before compact-and-retry.

This intentionally does not add arbitrary cross-session compaction, a new scheduler, or the broader continuation framework discussed in #85651.

## Security And Compatibility Boundary

- The action is current/live-session only and is revalidated against both the active session ID and agent ID.
- Explicit unknown or non-current targets never fall back to the current session.
- No host/admin compaction RPC is exposed to the model.
- No hidden host fallback or inline transcript mutation is introduced.
- Existing status reads, model overrides, tool output schema, and contexts without a live callback remain backward-compatible.
- No stored config or data shape changes, so no migration is required.

Maintainer approval is still needed for the model-originated current-session mutation boundary.

## Validation

Mandatory repository autoreview on the final uncommitted bundle:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.86)
```

Focused unit and runner tests:

```text
13 files / 197 tests passed
attempt.spawn-workspace.context-engine.test.ts / 79 tests passed
```

The focused coverage includes:

- dynamic schema exposure and flat enum shape
- unchanged output contract and compact tool hint
- current/stale identity validation
- model and `changesSince` conflict rejection
- mutation classification
- compact-only outer recovery and transcript normalization
- both winner orders for concurrent yield/self-compact requests
- completion-required async-task settlement with external cancellation preserved

Full local fallback:

```text
pnpm check

preflight guards: passed
typecheck (core/ui/extensions/scripts/root tests): passed
lint (core/extensions/scripts): passed
format: 26,441 files passed
policy guards and import-cycle check: passed
```

Additional test typecheck:

```text
pnpm tsgo:core:test
passed
```

`pnpm check:changed` could not start its remote Testbox because the selected crabbox binary failed its basic `--version` / `--help` sanity check. The full trusted local fallback above completed successfully.

## Real OpenClaw Proof

I started a real OpenClaw Gateway with the OpenClaw embedded harness and a local mock OpenAI Responses provider. The first provider response called:

```json
{ "name": "session_status", "arguments": { "action": "compact", "sessionKey": "current" } }
```

OpenClaw intentionally aborted that active turn, made a compaction-summary model call, wrote one transcript compaction entry, and made a third provider call to resume the turn.

Observed redacted proof:

```json
{
  "requestCount": 3,
  "actionSchema": {
    "enum": ["status", "compact"],
    "type": "string"
  },
  "compactCallObserved": true,
  "abortPlaceholderSeenByProvider": true,
  "abortPlaceholderPersisted": true,
  "compactionEntries": 1,
  "finalMarkerSeen": true,
  "rawAbortReasonPersisted": false
}
```

The resumed final assistant text contained:

```text
OPENCLAW_E2E_OK_SELF_COMPACT_RESUMED
```

The provider replay received the runtime-normalized `Aborted` tool placeholder, not the internal `session_status_compact` abort reason. The raw internal reason was absent from the persisted transcript.
