### PR TITLE
fix(memory): preserve Windows QMD command paths

### DIFF
--- a/packages/memory-host-sdk/src/host/backend-config.test.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.test.ts
@@ -166,6 +166,56 @@ describe("resolveMemoryBackendConfig", () => {
     expect(requireQmdConfig(resolved).command).toBe("/Applications/QMD Tools/qmd");
   });
 
+  it("preserves unquoted Windows absolute qmd command paths", () => {
+    const command = String.raw`C:\Users\penny\AppData\Roaming\npm\node_modules\@tobilu\qmd\dist\cli\qmd.js`;
+    const cfg = {
+      agents: { defaults: { workspace: String.raw`C:\Users\penny\.openclaw\workspace` } },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          command,
+        },
+      },
+    } as OpenClawConfig;
+
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+
+    expect(requireQmdConfig(resolved).command).toBe(command);
+  });
+
+  it("preserves Windows wrapper command paths before extra args", () => {
+    const cfg = {
+      agents: { defaults: { workspace: String.raw`C:\Users\penny\.openclaw\workspace` } },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          command: String.raw`C:\Program Files\qmd\qmd.cmd --json`,
+        },
+      },
+    } as OpenClawConfig;
+
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+
+    expect(requireQmdConfig(resolved).command).toBe(String.raw`C:\Program Files\qmd\qmd.cmd`);
+  });
+
+  it("preserves unquoted UNC qmd command paths", () => {
+    const command = String.raw`\\fileserver\tools\qmd\dist\cli\qmd.js`;
+    const cfg = {
+      agents: { defaults: { workspace: String.raw`C:\Users\penny\.openclaw\workspace` } },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          command,
+        },
+      },
+    } as OpenClawConfig;
+
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+
+    expect(requireQmdConfig(resolved).command).toBe(command);
+  });
+
   it("resolves custom paths relative to workspace", () => {
     const cfg = {
       agents: {

--- a/packages/memory-host-sdk/src/host/backend-config.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.ts
@@ -29,6 +29,34 @@ function escapeQmdExactFilePattern(fileName: string): string {
   return fileName.replace(/[\\*?[\]{}()!+@]/g, "\\$&");
 }
 
+const WINDOWS_COMMAND_EXTENSION_RE =
+  /^((?:[A-Za-z]:[\\/]|\\\\[^\\/]+[\\/][^\\/]+[\\/]).*?\.(?:bat|cmd|cjs|exe|js|mjs|ps1))(?:\s+|$)/i;
+
+function resolveQmdCommand(rawCommand: string): string {
+  const trimmedCommand = rawCommand.trim();
+  const windowsCommand = resolveWindowsAbsoluteCommand(trimmedCommand);
+  if (windowsCommand) {
+    return windowsCommand;
+  }
+
+  const parsedCommand = splitShellArgs(trimmedCommand);
+  return parsedCommand?.[0] || trimmedCommand.split(/\s+/)[0] || "qmd";
+}
+
+function resolveWindowsAbsoluteCommand(rawCommand: string): string | undefined {
+  if (!path.win32.isAbsolute(rawCommand)) {
+    return undefined;
+  }
+
+  const extensionMatch = WINDOWS_COMMAND_EXTENSION_RE.exec(rawCommand);
+  if (extensionMatch) {
+    return extensionMatch[1];
+  }
+
+  const firstWhitespace = rawCommand.search(/\s/);
+  return firstWhitespace === -1 ? rawCommand : rawCommand.slice(0, firstWhitespace);
+}
+
 export type ResolvedMemoryBackendConfig = {
   backend: MemoryBackend;
   citations: MemoryCitationsMode;
@@ -439,8 +467,7 @@ export function resolveMemoryBackendConfig(params: {
   ];
 
   const rawCommand = qmdCfg?.command?.trim() || "qmd";
-  const parsedCommand = splitShellArgs(rawCommand);
-  const command = parsedCommand?.[0] || rawCommand.split(/\s+/)[0] || "qmd";
+  const command = resolveQmdCommand(rawCommand);
   const resolved: ResolvedQmdConfig = {
     command,
     mcporter: resolveMcporterConfig(qmdCfg?.mcporter),


### PR DESCRIPTION
## What Problem This Solves

Fixes #92302.

Windows users can configure `memory.qmd.command` with an absolute QMD command path such as `C:\Users\...\qmd.js`, but the memory backend previously passed that value through POSIX-style shell parsing. For unquoted Windows paths, backslashes were treated as escapes, so the resolved command lost path separators before QMD probing and spawn resolution.

This is a refreshed, focused fix for the same bug line discussed around older stale attempts. The branch is rebased on current `main` and only changes the QMD backend command resolver plus regression coverage.

## Why This Change Was Made

QMD command resolution only needs the executable portion of `memory.qmd.command`. For Windows drive-letter and UNC absolute command paths, preserving the executable path before shell-style parsing is the narrowest safe fix: changing the shared shell parser globally would risk unrelated command parsing, and fixing later in spawn resolution is too late after separators have already been removed.

The patch adds a narrow Windows absolute-command resolver that:

- preserves drive-letter paths such as `C:\Users\penny\...\qmd.js`
- preserves UNC paths such as `\\fileserver\tools\qmd\dist\cli\qmd.js`
- preserves wrapper command paths before extra args, such as `C:\Program Files\qmd\qmd.cmd --json` -> `C:\Program Files\qmd\qmd.cmd`
- keeps the existing shell-arg behavior for non-Windows-style commands

## User Impact

Windows users can point OpenClaw memory/QMD at installed QMD command paths without the command being mangled during config resolution. Non-Windows and bare-command paths continue to use the existing parsing path.

## Evidence

AI-assisted: yes, Codex-assisted patch with manual review of the changed resolver and tests.

Testing degree: tested locally on Windows with focused unit tests plus a live QMD BM25 index/search flow through OpenClaw's QMD host resolver and process runner.

Commands run after this patch:

```text
node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/backend-config.test.ts -- --reporter=verbose
node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/qmd-process.test.ts -- --reporter=verbose
node scripts/run-vitest.mjs extensions/memory-core/src/memory/qmd-manager.test.ts -- -t "resolves bare qmd command to a Windows-compatible spawn invocation" --reporter=verbose
node_modules\.bin\oxfmt.CMD --check --threads=1 packages/memory-host-sdk/src/host/backend-config.ts packages/memory-host-sdk/src/host/backend-config.test.ts
git diff --cached --check
```

All focused checks above passed after rebasing onto current `origin/main`.

Real Windows Node resolver output from this checkout, using the patched `resolveMemoryBackendConfig` path:

```text
{"input":"C:\\Users\\penny\\AppData\\Roaming\\npm\\node_modules\\@tobilu\\qmd\\dist\\cli\\qmd.js","resolved":"C:\\Users\\penny\\AppData\\Roaming\\npm\\node_modules\\@tobilu\\qmd\\dist\\cli\\qmd.js","matchesExpected":true}
{"input":"C:\\Program Files\\qmd\\qmd.cmd --json","resolved":"C:\\Program Files\\qmd\\qmd.cmd","matchesExpected":true}
{"input":"\\\\fileserver\\tools\\qmd\\dist\\cli\\qmd.js","resolved":"\\\\fileserver\\tools\\qmd\\dist\\cli\\qmd.js","matchesExpected":true}
```

Live Windows QMD index/search proof through OpenClaw's QMD host path:

```text
qmd --version
qmd 2.5.3
```

The proof configured `memory.qmd.command` as `D:\pnpm\qmd.CMD --ignored-extra-arg`, then used OpenClaw's patched `resolveMemoryBackendConfig`, `resolveCliSpawnInvocation`, and `runCliCommand` path to spawn QMD and run `collection add`, `update`, and BM25 `search` against a temporary Windows workspace:

```json
{
  "configuredCommand": "D:\\pnpm\\qmd.CMD --ignored-extra-arg",
  "resolvedCommand": "D:\\pnpm\\qmd.CMD",
  "spawnCommand": "F:\\Program Files\\nodejs\\node.exe",
  "spawnArgvHead": [
    "D:\\pnpm\\global\\v11\\28b0-19ee43aaf33\\node_modules\\@tobilu\\qmd\\bin\\qmd",
    "--version"
  ],
  "addStdout": "Creating collection 'proof'...\nCollection: H:\\Temp\\openclaw-qmd-index-proof-1781945961179\\workspace (**/*.md)\n\nIndexed: 1 new, 0 updated, 0 unchanged, 0 removed\n\nRun 'qmd embed' to update embeddings (1 unique hashes need vectors)\n✓ Collection 'proof' created successfully",
  "updateStdout": "Updating 1 collection(s)...\n\n[1/1] proof (**/*.md)\nCollection: H:\\Temp\\openclaw-qmd-index-proof-1781945961179\\workspace (**/*.md)\n\nIndexed: 0 new, 0 updated, 1 unchanged, 0 removed\n\n✓ All collections updated.\n\nRun 'qmd embed' to update embeddings (1 unique hashes need vectors)",
  "searchHitCount": 1,
  "searchFirstHit": {
    "docid": "#e3fbc9",
    "score": 0,
    "file": "qmd://proof/MEMORY.md",
    "line": 3,
    "title": "QMD live proof",
    "snippet": "@@ -2,3 @@ (1 before, 0 after)\n\nneedle-openclaw-qmd-windows-command-proof\n"
  }
}
```

Known verification gap:

- I did not run the full `openclaw memory status --deep` CLI because local `node scripts/run-node.mjs memory status --help` spent the available timeout in the repo's stale build path before reaching the command. The live proof above exercises the changed OpenClaw host resolver and QMD process runner directly.
- Running the full `extensions/memory-core/src/memory/qmd-manager.test.ts` file locally on Windows currently fails in an unrelated fixture that tries to create `Notes #1: blue`; `:` is not valid in Windows file names. The directly relevant QMD manager Windows spawn test passed.

## Real Behavior Proof

- **Behavior addressed:** Windows absolute `memory.qmd.command` values were losing backslashes before QMD spawn resolution.
- **Real environment tested:** Windows local checkout, Node 24.13.1, QMD 2.5.3, current branch rebased on `origin/main`.
- **Exact steps or command run after this patch:** Ran the focused Vitest commands, the Windows Node resolver proof, and a live QMD BM25 index/search proof through OpenClaw's QMD host resolver and process runner.
- **Evidence after fix:** The live proof above shows `D:\pnpm\qmd.CMD --ignored-extra-arg` resolving to `D:\pnpm\qmd.CMD`, materializing to `node.exe` plus the QMD bin entrypoint, indexing one Markdown file, and returning one BM25 search hit from `qmd://proof/MEMORY.md`.
- **Observed result after fix:** `searchHitCount` was `1`, and the first hit contained the expected `needle-openclaw-qmd-windows-command-proof` snippet.
- **What was not tested:** Full `openclaw memory status --deep` CLI startup was not completed because the local source checkout entered the stale build path and timed out before command execution; the changed resolver and process-runner path was tested directly.