### PR TITLE
fix(telegram): exclude EADDRNOTAVAIL from transport fallback to avoid misleading logs and dead-code retries

### DIFF
--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -113,6 +113,7 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
 let resolveTelegramFetch: typeof import("./fetch.js").resolveTelegramFetch;
 let resolveTelegramApiBase: typeof import("./fetch.js").resolveTelegramApiBase;
 let resolveTelegramTransport: typeof import("./fetch.js").resolveTelegramTransport;
+let shouldRetryTelegramTransportFallback: typeof import("./fetch.js").shouldRetryTelegramTransportFallback;
 const tempDirs: string[] = [];
 
 type TelegramDispatcherPolicy = NonNullable<
@@ -125,8 +126,12 @@ type ExplicitProxyTelegramDispatcherPolicy = Extract<
 >;
 
 beforeAll(async () => {
-  ({ resolveTelegramApiBase, resolveTelegramFetch, resolveTelegramTransport } =
-    await import("./fetch.js"));
+  ({
+    resolveTelegramApiBase,
+    resolveTelegramFetch,
+    resolveTelegramTransport,
+    shouldRetryTelegramTransportFallback,
+  } = await import("./fetch.js"));
 });
 
 beforeEach(() => {
@@ -1325,6 +1330,26 @@ describe("resolveTelegramFetch", () => {
       instance.destroy.mockRejectedValueOnce(new Error("already destroyed"));
 
       await expect(transport.close()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("shouldRetryTelegramTransportFallback", () => {
+    it("returns false for EADDRNOTAVAIL code string", () => {
+      const err = buildFetchFallbackError("EADDRNOTAVAIL");
+      expect(shouldRetryTelegramTransportFallback(err)).toBe(false);
+    });
+
+    it("returns false for EADDRNOTAVAIL numeric errno", () => {
+      const connectErr = Object.assign(new Error("connect EADDRNOTAVAIL api.telegram.org:443"), {
+        errno: 99,
+      });
+      const err = Object.assign(new TypeError("fetch failed"), { cause: connectErr });
+      expect(shouldRetryTelegramTransportFallback(err)).toBe(false);
+    });
+
+    it("returns true for other network errors", () => {
+      const err = buildFetchFallbackError("ENETUNREACH");
+      expect(shouldRetryTelegramTransportFallback(err)).toBe(true);
     });
   });
 });

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -431,6 +431,10 @@ function collectErrorCodes(err: unknown): Set<string> {
       if (typeof code === "string" && code.trim()) {
         codes.add(code.trim().toUpperCase());
       }
+      const errno = (current as { errno?: unknown }).errno;
+      if (typeof errno === "number") {
+        codes.add(String(errno));
+      }
       const cause = (current as { cause?: unknown }).cause;
       if (cause && !seen.has(cause)) {
         queue.push(cause);
@@ -473,6 +477,10 @@ function shouldUseTelegramTransportFallback(err: unknown): boolean {
         : "",
     codes: collectErrorCodes(err),
   };
+  // EADDRNOTAVAIL 是本地 socket 分配失败，换远程 IP 无效
+  if (ctx.codes.has("EADDRNOTAVAIL") || ctx.codes.has("99")) {
+    return false;
+  }
   const hasFetchFailedEnvelope = ctx.message.includes("fetch failed");
   const hasKnownNetworkCode = FALLBACK_RETRY_ERROR_CODES.some((code) => ctx.codes.has(code));
   return hasKnownNetworkCode || (hasFetchFailedEnvelope && ctx.codes.size === 0);


### PR DESCRIPTION
## Summary

当系统临时端口耗尽（EADDRNOTAVAIL）时，Telegram 传输层误判为"DNS 解析的 IP 不可达"，触发 fallback 切换远程 IP——这对本地 socket 分配失败毫无意义。

## Root Cause

`collectErrorCodes()` 只收集 `.code` 字符串，忽略了 `.errno`（数值 99）。`ctx.codes` 为空时触发 `codes.size === 0` 的兜底回退。

## Fix

1. `collectErrorCodes()`: 增加数值 `errno` 提取
2. `shouldUseTelegramTransportFallback()`: 遇到 `EADDRNOTAVAIL`（code 或 errno）时直接返回 false

## Test plan

- [x] 45 tests passed（包括 3 个新测试）

| 测试 | 验证内容 |
|------|---------|
| EADDRNOTAVAIL(code) 不回退 | `buildFetchFallbackError("EADDRNOTAVAIL")` → false |
| EADDRNOTAVAIL(errno) 不回退 | 手动构造 `{ errno: 99 }` 的 cause → false |
| 其他网络错误仍回退 | `buildFetchFallbackError("ENETUNREACH")` → true |

Fixes #94620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Real behavior proof

**Behavior addressed**: EADDRNOTAVAIL（临时端口耗尽）不再误触发 Telegram fallback

**Real environment tested**: Linux 4.19.112, Node v22.18.0

**Before-fix evidence**:
`collectErrorCodes()` 只检查 `.code` 字符串，EADDRNOTAVAIL 的 `.code` 和 `.errno` 均未捕获 → `ctx.codes` 为空 → 触发 `codes.size === 0` 兜底回退，日志误导性显示 "DNS-resolved IP unreachable"。

**Exact steps or command run after this patch**:
```bash
npx vitest run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/fetch.test.ts
```

**After-fix evidence**:
45 tests passed，新增 3 个 EADDRNOTAVAIL 测试全部通过：
```
✓ shouldRetryTelegramTransportFallback > returns false for EADDRNOTAVAIL code string
✓ shouldRetryTelegramTransportFallback > returns false for EADDRNOTAVAIL numeric errno
✓ shouldRetryTelegramTransportFallback > returns true for other network errors
```

**Observed result after the fix**: `shouldUseTelegramTransportFallback()` 在包含 `"EADDRNOTAVAIL"` 或 `"99"` 时返回 `false`，避免无意义 IP 切换。其他网络错误（如 `ENETUNREACH`）仍正常回退。

**What was not tested**: 未在实际 Telegram API 环境中验证（缺少 Telegram bot token）。单元测试覆盖了关键代码路径和边界条件。