### PR TITLE
fix(feishu): replace Type.Any() with explicit AnyJsonValue schema for Bedrock compatibility

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -488,6 +488,18 @@ async function updateRecord(
   };
 }
 
+// Non-empty schema accepting any JSON value (strict validators like Bedrock reject {} from Type.Any())
+const AnyJsonValue = Type.Unsafe<any>({
+  anyOf: [
+    { type: "string" },
+    { type: "number" },
+    { type: "boolean" },
+    { type: "null" },
+    { type: "array" },
+    { type: "object" },
+  ],
+});
+
 // ============ Schemas ============
 
 const GetMetaSchema = Type.Object({
@@ -530,7 +542,7 @@ const CreateRecordSchema = Type.Object({
     description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
-  fields: Type.Record(Type.String(), Type.Any(), {
+  fields: Type.Record(Type.String(), AnyJsonValue, {
     description:
       "Field values keyed by field name. Format by type: Text='string', Number=123, SingleSelect='Option', MultiSelect=['A','B'], DateTime=timestamp_ms, User=[{id:'ou_xxx'}], URL={text:'Display',link:'https://...'}",
   }),
@@ -560,7 +572,7 @@ const CreateFieldSchema = Type.Object({
     minimum: 1,
   }),
   property: Type.Optional(
-    Type.Record(Type.String(), Type.Any(), {
+    Type.Record(Type.String(), AnyJsonValue, {
       description: "Field-specific properties (e.g., options for SingleSelect, format for Number)",
     }),
   ),
@@ -572,7 +584,7 @@ const UpdateRecordSchema = Type.Object({
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
   record_id: Type.String({ description: "Record ID to update" }),
-  fields: Type.Record(Type.String(), Type.Any(), {
+  fields: Type.Record(Type.String(), AnyJsonValue, {
     description: "Field values to update (same format as create_record)",
   }),
 });


### PR DESCRIPTION
## Summary

Fix three bitable write tools that use `Type.Record(Type.String(), Type.Any())` which serializes to empty `{}` sub-schema, rejected by AWS Bedrock strict draft 2020-12 validation.

## Changes

- Add `AnyJsonValue` schema (`Type.Unsafe<any>({ anyOf: [string, number, boolean, null, array, object] })`)
- Replace `Type.Any()` in `CreateRecordSchema.fields`, `CreateFieldSchema.property`, `UpdateRecordSchema.fields`

## Related issue

Closes #94547

## Real behavior proof

**Behavior addressed**: Type.Any() 序列化为空 `{}` 被 AWS Bedrock strict draft 2020-12 拒绝

**Real environment tested**: Linux 4.19.112, Node v22.18.0, typebox

**Before-fix evidence**:
```
{ "type": "object", "patternProperties": { "^.*$": {} } }
```
空 `{}` patternProperties 子 schema 不满足 draft 2020-12 的 anyOf/type 约束。

**Exact steps or command run after this patch**:
```bash
node -e "const {Type}=require('typebox'); \
  const V=Type.Unsafe({anyOf:[{type:'string'},{type:'number'},{type:'boolean'},{type:'null'},{type:'array'},{type:'object'}]}); \
  console.log(JSON.stringify(Type.Record(Type.String(),V),null,2))"
```

**After-fix evidence**:
```
{
  "type": "object",
  "patternProperties": {
    "^.*$": {
      "anyOf": [
        { "type": "string" }, { "type": "number" }, { "type": "boolean" },
        { "type": "null" }, { "type": "array" }, { "type": "object" }
      ]
    }
  }
}
```
patternProperties 子 schema 包含明确的 anyOf，符合 strict draft 2020-12。

**Observed result after the fix**: 三处 Type.Any()（CreateRecordSchema.fields、CreateFieldSchema.property、UpdateRecordSchema.fields）全部替换为 AnyJsonValue，工具 schema 不再被 AWS Bedrock 拒绝。

**What was not tested**: 未在包含 AWS Bedrock 的实际环境中验证（缺少 Bedrock 凭证）。schema 序列化对比确认了修复效果。