### PR TITLE
[codex] fix Telegram live-owned stuck ingress claims

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1762,6 +1762,50 @@ describe("TelegramPollingSession", () => {
     });
   });
 
+  it("fails timed-out live-owned claims before draining later same-lane updates", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const events: string[] = [];
+      await writeSpooledTestUpdates(tempDir, [
+        topicUpdate(42, 10, "wedged topic 10 turn"),
+        topicUpdate(43, 10, "later topic 10 turn"),
+      ]);
+      const interrupted = (await listTelegramSpooledUpdates({ spoolDir: tempDir })).find(
+        (update) => update.updateId === 42,
+      );
+      if (!interrupted) {
+        throw new Error("Expected interrupted update");
+      }
+      const claimed = await claimTelegramSpooledUpdate(interrupted);
+      if (!claimed) {
+        throw new Error("Expected claimed update");
+      }
+      await adoptClaimOwner({
+        spoolDir: tempDir,
+        updateId: 42,
+        ownerId: `${process.pid}:other-process`,
+        claimedAt: Date.now() - 101,
+      });
+
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        spooledUpdateHandlerTimeoutMs: 100,
+        handleUpdate: async (update) => {
+          events.push(`handled:${update.update_id}`);
+          abort.abort();
+        },
+      });
+
+      await runPromise;
+      expect(events).toEqual(["handled:43"]);
+      expect(await failedUpdateIds(tempDir)).toEqual([42]);
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]);
+      stopWorker();
+    });
+  });
+
   it("scans past active-lane backlogs to start unrelated lanes", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -765,11 +765,52 @@ export class TelegramPollingSession {
     return laneKeys;
   }
 
+  #isTimedOutSpooledUpdateClaim(claim: ClaimedTelegramSpooledUpdate): boolean {
+    const claimedAt = claim.claim?.claimedAt;
+    return claimedAt !== undefined && Date.now() - claimedAt >= this.#spooledUpdateHandlerTimeoutMs;
+  }
+
+  async #failTimedOutLiveOwnedSpooledUpdateClaims(params: {
+    activeLaneKeys: Set<string>;
+    spoolDir: string;
+  }): Promise<void> {
+    const claims = await listTelegramSpooledUpdateClaims({ spoolDir: params.spoolDir });
+    for (const claim of claims) {
+      if (this.#isDeferredSpooledUpdateClaim(claim)) {
+        continue;
+      }
+      if (params.activeLaneKeys.has(this.#spooledUpdateLaneKey(claim))) {
+        continue;
+      }
+      if (!this.#isTimedOutSpooledUpdateClaim(claim)) {
+        continue;
+      }
+      if (!isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim)) {
+        continue;
+      }
+      const claimedForMs = Date.now() - (claim.claim?.claimedAt ?? Date.now());
+      const failed = await failTelegramSpooledUpdateClaim({
+        update: claim,
+        reason: "lane-released-on-stuck",
+        message: `Telegram spooled update claim held by a live worker for ${formatDurationPrecise(claimedForMs)} without active handler state.`,
+      });
+      if (failed) {
+        this.opts.log(
+          `[telegram][diag] spooled update ${claim.updateId} claim held by live worker for ${formatDurationPrecise(claimedForMs)}; marking failed so lane can continue`,
+        );
+      }
+    }
+  }
+
   async #drainSpooledUpdates(params: {
     bot: TelegramBot;
     spoolDir: string;
   }): Promise<SpooledUpdateDrainResult> {
     const activeLaneKeys = this.#activeSpooledUpdateLaneKeysForSpool(params.spoolDir);
+    await this.#failTimedOutLiveOwnedSpooledUpdateClaims({
+      activeLaneKeys,
+      spoolDir: params.spoolDir,
+    });
     await recoverStaleTelegramSpooledUpdateClaims({
       spoolDir: params.spoolDir,
       staleMs: 0,


### PR DESCRIPTION
Summary

- Fail timed-out Telegram spooled ingress claims that are still owned by a live process but no longer have active handler state in this gateway.
- Keep deferred claims and active in-memory lanes guarded so truly active work is not released.
- Add regression coverage proving a wedged live-owned same-lane claim is failed and the later update drains without replaying the stuck update.

Root cause

The Telegram isolated ingress drain recovered dead or unowned durable claims, but it skipped any claim held by a live process. If that live worker stopped making progress without leaving active handler state behind, the durable `channel_ingress_events` row stayed claimed and later same-lane updates remained blocked until gateway restart or manual SQL cleanup.

Validation

- `node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts`
- `node scripts/run-vitest.mjs src/channels/message/ingress-queue.test.ts extensions/telegram/src/polling-session.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/polling-session.ts extensions/telegram/src/polling-session.test.ts`
- `git diff --check`

Fixes #95248
