### PR TITLE
fix(openai-completions): seal native reasoning before the answer under /reasoning on

### DIFF
--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -908,6 +908,7 @@ describe("openai-completions stop-reason tool-call guard", () => {
 
     expect(eventTypes.filter((type) => type === "thinking_start")).toHaveLength(1);
     expect(eventTypes.filter((type) => type === "thinking_end")).toHaveLength(1);
+    expect(eventTypes.indexOf("thinking_end")).toBeLessThan(eventTypes.indexOf("text_start"));
     expect(result.content).toContainEqual({
       type: "thinking",
       thinking: "First thought. Second thought.",

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -799,6 +799,81 @@ describe("openai-completions stop-reason tool-call guard", () => {
     expect(result.content.some((block) => block.type === "thinking")).toBe(false);
   });
 
+  it("seals the native reasoning block before the answer text begins", async () => {
+    // deepseek streams reasoning_content, then switches to content with no
+    // boundary event; thinking_end must precede the answer so channels do not
+    // merge the answer into the reasoning block.
+    mockChunksRef.chunks = [
+      {
+        id: "chatcmpl-test",
+        choices: [{ index: 0, delta: { reasoning_content: "Let me think." } }],
+      },
+      {
+        id: "chatcmpl-test",
+        choices: [{ index: 0, delta: { reasoning_content: " Still thinking." } }],
+      },
+      makeTextChunk("The answer"),
+      makeTextChunk(" is 42."),
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(reasoningModel, context, {
+      apiKey: "sk-test",
+      reasoningEffort: "medium",
+    });
+    const eventTypes: string[] = [];
+    for await (const event of stream as AsyncIterable<{ type: string }>) {
+      eventTypes.push(event.type);
+    }
+    const result = await stream.result();
+
+    const thinkingEndIndex = eventTypes.indexOf("thinking_end");
+    const textStartIndex = eventTypes.indexOf("text_start");
+    const firstTextDeltaIndex = eventTypes.indexOf("text_delta");
+    expect(thinkingEndIndex).toBeGreaterThanOrEqual(0);
+    expect(textStartIndex).toBeGreaterThanOrEqual(0);
+    expect(thinkingEndIndex).toBeLessThan(textStartIndex);
+    expect(thinkingEndIndex).toBeLessThan(firstTextDeltaIndex);
+    // thinking_end is emitted exactly once even though the block is also
+    // visited by the end-of-stream finish loop.
+    expect(eventTypes.filter((type) => type === "thinking_end")).toHaveLength(1);
+
+    expect(result.content).toContainEqual({
+      type: "thinking",
+      thinking: "Let me think. Still thinking.",
+      thinkingSignature: "reasoning_content",
+    });
+    expect(result.content).toContainEqual({ type: "text", text: "The answer is 42." });
+  });
+
+  it("seals the native reasoning block before a following tool call", async () => {
+    mockChunksRef.chunks = [
+      {
+        id: "chatcmpl-test",
+        choices: [{ index: 0, delta: { reasoning_content: "I should call a tool." } }],
+      },
+      makeToolCallChunk("call_1", "bash", '{"cmd":"ls"}'),
+      makeFinishChunk("tool_calls"),
+    ];
+
+    const stream = streamOpenAICompletions(reasoningModel, context, {
+      apiKey: "sk-test",
+      reasoningEffort: "medium",
+    });
+    const eventTypes: string[] = [];
+    for await (const event of stream as AsyncIterable<{ type: string }>) {
+      eventTypes.push(event.type);
+    }
+    await stream.result();
+
+    const thinkingEndIndex = eventTypes.indexOf("thinking_end");
+    const toolCallStartIndex = eventTypes.indexOf("toolcall_start");
+    expect(thinkingEndIndex).toBeGreaterThanOrEqual(0);
+    expect(toolCallStartIndex).toBeGreaterThanOrEqual(0);
+    expect(thinkingEndIndex).toBeLessThan(toolCallStartIndex);
+    expect(eventTypes.filter((type) => type === "thinking_end")).toHaveLength(1);
+  });
+
   it("promotes silent tool_calls with finish_reason stop to toolUse", async () => {
     mockChunksRef.chunks = [
       makeToolCallChunk("call_1", "bash", '{"cmd":"ls"}'),

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -874,6 +874,47 @@ describe("openai-completions stop-reason tool-call guard", () => {
     expect(eventTypes.filter((type) => type === "thinking_end")).toHaveLength(1);
   });
 
+  it("keeps one native reasoning block when content and reasoning co-occur", async () => {
+    mockChunksRef.chunks = [
+      {
+        id: "chatcmpl-test",
+        choices: [{ index: 0, delta: { reasoning_content: "First thought." } }],
+      },
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: "Visible text that shares the reasoning chunk.",
+              reasoning_content: " Second thought.",
+            },
+          },
+        ],
+      },
+      makeTextChunk(" Final answer."),
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(reasoningModel, context, {
+      apiKey: "sk-test",
+      reasoningEffort: "medium",
+    });
+    const eventTypes: string[] = [];
+    for await (const event of stream as AsyncIterable<{ type: string }>) {
+      eventTypes.push(event.type);
+    }
+    const result = await stream.result();
+
+    expect(eventTypes.filter((type) => type === "thinking_start")).toHaveLength(1);
+    expect(eventTypes.filter((type) => type === "thinking_end")).toHaveLength(1);
+    expect(result.content).toContainEqual({
+      type: "thinking",
+      thinking: "First thought. Second thought.",
+      thinkingSignature: "reasoning_content",
+    });
+  });
+
   it("promotes silent tool_calls with finish_reason stop to toolUse", async () => {
     mockChunksRef.chunks = [
       makeToolCallChunk("call_1", "bash", '{"cmd":"ls"}'),

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -265,8 +265,12 @@ export const streamOpenAICompletions: StreamFunction<
           thinkingBlock = null;
         }
       };
-      const appendTextDelta = (delta: string) => {
-        sealNativeReasoningBeforeText();
+      const appendTextDelta = (delta: string, hasNativeReasoning = false) => {
+        // Compatible endpoints can co-emit content and native reasoning in one chunk.
+        // Keep that reasoning block open; a later text-only chunk closes it.
+        if (!hasNativeReasoning) {
+          sealNativeReasoningBeforeText();
+        }
         const block = ensureTextBlock();
         block.text += delta;
         stream.push({
@@ -330,7 +334,7 @@ export const streamOpenAICompletions: StreamFunction<
           : reasoningTagTextPartitioner.pushVisible(text);
         for (const delta of routedDeltas) {
           if (delta.kind === "text") {
-            appendTextDelta(delta.text);
+            appendTextDelta(delta.text, hasMirroredReasoning);
           }
         }
       };

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -265,12 +265,8 @@ export const streamOpenAICompletions: StreamFunction<
           thinkingBlock = null;
         }
       };
-      const appendTextDelta = (delta: string, hasNativeReasoning = false) => {
-        // Compatible endpoints can co-emit content and native reasoning in one chunk.
-        // Keep that reasoning block open; a later text-only chunk closes it.
-        if (!hasNativeReasoning) {
-          sealNativeReasoningBeforeText();
-        }
+      const appendTextDelta = (delta: string) => {
+        sealNativeReasoningBeforeText();
         const block = ensureTextBlock();
         block.text += delta;
         stream.push({
@@ -403,14 +399,6 @@ export const streamOpenAICompletions: StreamFunction<
           if (foundReasoningField) {
             reasoningTagTextPartitioner.markStrict();
           }
-          if (
-            choice.delta.content !== null &&
-            choice.delta.content !== undefined &&
-            choice.delta.content.length > 0
-          ) {
-            appendPartitionedContent(choice.delta.content, Boolean(foundReasoningField));
-          }
-
           if (shouldEmitReasoning && foundReasoningField) {
             const delta = deltaFields[foundReasoningField];
             if (typeof delta === "string" && delta.length > 0) {
@@ -420,6 +408,13 @@ export const streamOpenAICompletions: StreamFunction<
                   : foundReasoningField;
               appendThinkingDelta(thinkingSignature, delta);
             }
+          }
+          if (
+            choice.delta.content !== null &&
+            choice.delta.content !== undefined &&
+            choice.delta.content.length > 0
+          ) {
+            appendPartitionedContent(choice.delta.content, Boolean(foundReasoningField));
           }
 
           if (choice?.delta?.tool_calls) {

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -187,12 +187,17 @@ export const streamOpenAICompletions: StreamFunction<
       const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
       const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
       const blocks = output.content as StreamingBlock[];
+      // A block can be finished mid-stream (native reasoning sealed at the
+      // text-lane transition) and again by the end-of-stream loop; guard so its
+      // *_end event is emitted exactly once.
+      const finishedBlocks = new Set<StreamingBlock>();
       const getContentIndex = (block: StreamingBlock) => blocks.indexOf(block);
       const finishBlock = (block: StreamingBlock) => {
         const contentIndex = getContentIndex(block);
-        if (contentIndex === -1) {
+        if (contentIndex === -1 || finishedBlocks.has(block)) {
           return;
         }
+        finishedBlocks.add(block);
         if (block.type === "text") {
           stream.push({
             type: "text_end",
@@ -249,7 +254,19 @@ export const streamOpenAICompletions: StreamFunction<
         }
         return thinkingBlock;
       };
+      // Native-thinking providers (e.g. deepseek `reasoning_content`) stream the
+      // reasoning lane, then switch to the answer via `content` with no boundary
+      // event. Seal the open thought when visible text begins so `thinking_end`
+      // precedes the answer; tag-based <think> reasoning has no native thinking
+      // block (it is closed by the partitioner), so this is a no-op there.
+      const sealNativeReasoningBeforeText = () => {
+        if (thinkingBlock && !reasoningTagTextPartitioner.isInsideReasoning()) {
+          finishBlock(thinkingBlock);
+          thinkingBlock = null;
+        }
+      };
       const appendTextDelta = (delta: string) => {
+        sealNativeReasoningBeforeText();
         const block = ensureTextBlock();
         block.text += delta;
         stream.push({
@@ -403,6 +420,9 @@ export const streamOpenAICompletions: StreamFunction<
 
           if (choice?.delta?.tool_calls) {
             flushPartitionedContent();
+            // The tool-call lane is also a reasoning boundary; seal the thought
+            // before toolcall_start so thinking_end never trails the action.
+            sealNativeReasoningBeforeText();
             for (const toolCall of choice.delta.tool_calls) {
               const block = ensureToolCallBlock(toolCall);
               if (!block.id && toolCall.id) {

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -330,7 +330,7 @@ export const streamOpenAICompletions: StreamFunction<
           : reasoningTagTextPartitioner.pushVisible(text);
         for (const delta of routedDeltas) {
           if (delta.kind === "text") {
-            appendTextDelta(delta.text, hasMirroredReasoning);
+            appendTextDelta(delta.text);
           }
         }
       };


### PR DESCRIPTION
## What Problem This Solves

Closes #95280.

Under `/reasoning on`, a reasoning model's thought should be sealed as its own block and the answer delivered separately. For deepseek-style providers (api `openai-completions`, `reasoning: true`) the answer is instead appended **into** the last 🧠 reasoning block — thought and answer run together.

Root cause is at the provider boundary. deepseek streams reasoning via `reasoning_content` deltas, then switches to the answer via `content` deltas **with no boundary event** between them. In `src/llm/providers/openai-completions.ts` the native thinking block opened by `appendThinkingDelta` was only closed by the end-of-stream `finishBlock` loop, so the emitted event order was:

```
thinking_start … thinking_delta … text_start … text_delta … [stream end] thinking_end
```

Because the subscribe handler keys `onReasoningEnd` on `thinking_end` (`src/agents/embedded-agent-subscribe.handlers.messages.ts`), the reasoning lane stayed open across the answer text and merged them. Providers that emit a discrete `thinking_end` at the transition (Anthropic, OpenAI-responses, Google, Mistral) live on separate stream functions and are unaffected.

## Why This Change Was Made

The fix belongs at the openai-completions adapter, which owns the `reasoning_content → content` lane switch for every OpenAI-compatible reasoning provider. The text-lane (and tool-call lane) opening **is** the reasoning boundary for native-thinking providers, so the open thought is sealed there:

- `sealNativeReasoningBeforeText()` finishes the open native thinking block when visible text or a tool call begins, emitting `thinking_end` **before** `text_start` / `toolcall_start`.
- It is gated on `!reasoningTagTextPartitioner.isInsideReasoning()`, so tag-based `<think>` reasoning (which has no native thinking block and is closed by the partitioner) is a no-op.
- `finishBlock` is now idempotent (`finishedBlocks` set) so the block sealed mid-stream is never re-emitted by the end-of-stream loop.

## User Impact

Under `/reasoning on` with deepseek-style providers, the thought is now sealed as its own 🧠 block and the answer is delivered as a distinct message/block on every channel with a reasoning lane. No config or behavior change for tag-based reasoning or for providers that already emit a discrete `thinking_end`.

## Evidence

### Live DeepSeek behavior proof (real API, not mocked)

Drove the actual `streamOpenAICompletions` adapter against **`api.deepseek.com`** (`model deepseek-reasoner`, `/reasoning on` → `reasoningEffort: "medium"`) and recorded the real emitted event lanes. Redacted: prompt/answer text omitted, only lane order + character counts shown. Same live code path, fix toggled off vs on:

```text
# BEFORE (fix neutralized) — answer streams INTO the open thought
[live] event lanes: thinking_start → text_start → thinking_end → text_end
[live] thinking_end@143 text_start@91 text_delta@92
[live] reasoningChars=198 answerChars=106 thinking_end count=1
  → text_start(91)/text_delta(92) arrive BEFORE thinking_end(143): the 🧠 block stays open across the answer

# AFTER (this PR) — thought sealed before the answer
[live] event lanes: thinking_start → thinking_end → text_start → text_end
[live] thinking_end@96 text_start@97 text_delta@98
[live] reasoningChars=236 answerChars=107 thinking_end count=1
  → thinking_end(96) precedes text_start(97)/text_delta(98): reasoning closed first, answer is a separate block
```

This is genuine over-the-wire DeepSeek streaming (real `reasoning_content` → `content` transition with no boundary event), confirming the bug on current behavior and the separation after the fix — exactly the user-visible 🧠-then-answer split, captured at the provider boundary that every reasoning channel consumes.

### Deterministic regression test

Provider-boundary test added in `src/llm/providers/openai-completions.test.ts`, asserting `thinking_end` precedes `text_start`/`text_delta` (and `toolcall_start`) and is emitted exactly once.

Before/after on the same test (fix neutralized vs. applied):

```text
# WITHOUT the fix — answer streams inside the open thought
 × seals the native reasoning block before the answer text begins
   AssertionError: expected 7 to be less than 4   (thinking_end at 7, text_start at 4)
 × seals the native reasoning block before a following tool call
   AssertionError: expected 5 to be less than 3   (thinking_end at 5, toolcall_start at 3)

# WITH the fix
 Test Files  1 passed (1)
      Tests  29 passed (29)
```

Run: `node scripts/run-vitest.mjs src/llm/providers/openai-completions.test.ts` → 29 passed.

_AI-assisted._
