### PR TITLE
fix(agents): forward resolved model to sub-agent gateway agent call

### DIFF
--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -962,8 +962,12 @@ describe("spawnSubagentDirect seam flow", () => {
       if (call.method === "sessions.patch" || call.method === "sessions.delete") {
         // Admin-only methods must be pinned to operator.admin.
         expect(call.scopes).toEqual(["operator.admin"]);
+      } else if (call.method === "agent") {
+        // The agent method receives admin scope when a model override is
+        // present (#91171) so the gateway authorizes the model forwarding.
+        expect(call.scopes).toEqual(["operator.admin"]);
       } else {
-        // Non-admin methods (e.g. "agent") must NOT be forced to admin scope.
+        // Other non-admin methods must NOT be forced to admin scope.
         expect(call.scopes).toBeUndefined();
       }
     }
@@ -1000,6 +1004,42 @@ describe("spawnSubagentDirect seam flow", () => {
     const agentCall = calls.find((call) => call.method === "agent");
     const params = requireRecord(agentCall?.params);
     expect(params.thinking).toBe("high");
+  });
+
+  it("forwards the resolved model and admin scope to the agent run (#91171)", async () => {
+    const calls: Array<{ method?: string; params?: unknown; scopes?: string[] }> = [];
+    hoisted.callGatewayMock.mockImplementation(
+      async (request: { method?: string; params?: unknown; scopes?: string[] }) => {
+        calls.push(request);
+        if (request.method === "agent") {
+          return { runId: "run-model", status: "accepted", acceptedAt: 1000 };
+        }
+        if (request.method?.startsWith("sessions.")) {
+          return { ok: true };
+        }
+        return {};
+      },
+    );
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock);
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "verify model forwarding",
+        model: "openai/gpt-5.4",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const agentCall = calls.find((call) => call.method === "agent");
+    expect(agentCall).toBeDefined();
+    const params = requireRecord(agentCall?.params);
+    expect(params.model).toBe("openai/gpt-5.4");
+    // Admin scope is required so the gateway authorizes the model override.
+    expect(agentCall?.scopes).toEqual(["operator.admin"]);
   });
 
   it("does not forward inherited requester thinking as an explicit agent override", async () => {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1581,6 +1581,7 @@ export async function spawnSubagentDirect(
         cleanupBundleMcpOnRunEnd: spawnMode !== "session",
         extraSystemPrompt: childSystemPrompt,
         thinking: thinkingOverride,
+        model: resolvedModel || undefined,
         timeout: runTimeoutSeconds,
         label: label || undefined,
         ...(bootstrapContextMode
@@ -1591,6 +1592,7 @@ export async function spawnSubagentDirect(
           : {}),
         ...publicSpawnedMetadata,
       },
+      ...(resolvedModel ? { scopes: [ADMIN_SCOPE] } : {}),
       timeoutMs: resolveSubagentAgentGatewayTimeoutMs(runTimeoutSeconds),
     });
     const runId = readGatewayRunId(response);


### PR DESCRIPTION
## Summary

- **Problem:** `sessions_spawn` accepted a `model` parameter and resolved/reported it correctly, but never forwarded it to the child gateway `agent` run. Sub-agents silently fell back to the default model instead of using the explicitly requested one.
- **Root cause:** `spawnSubagentDirect` in `src/agents/subagent-spawn.ts` called `callSubagentGateway({ method: "agent", ... })` without passing `model` in the gateway call params, discarding the `resolvedModel` computed just above.
- **Fix:** Forward `resolvedModel` as `model` in the gateway agent call params and convey admin scope on the call so the gateway authorizes the model override.

Fixes #91171

## Real behavior proof (required for external PRs)

**Behavior addressed**: Sub-agents ignore the `model` parameter from `sessions_spawn` and silently use the agent's default model.

**Real setup tested**:
- **Runtime**: Node 22.19, Linux
- **Code analysis path**: `spawnSubagentDirect` → `callSubagentGateway({ method: "agent" })` → missing `model` in gateway params (see root cause analysis)
- **Test framework**: Vitest

**Exact steps or command run after this patch**:
```bash
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/agents/subagent-spawn.test.ts
```

**After-fix evidence**:
```
✓ |agents| src/agents/subagent-spawn.test.ts (26 tests) 6622ms
  ✓ spawnSubagentDirect seam flow (26)
    ✓ forwards the resolved model and admin scope to the agent run (#91171)
    ✓ pins admin-only methods to operator.admin and preserves least-privilege for others (#59428)
    ✓ forwards normalized thinking to the agent run
    ... (all 26 tests pass)
```

**Observed result after the fix**: The gateway agent call now includes `model: "openai/gpt-5.4"` in its params and `scopes: ["operator.admin"]`. Without the fix, the same call had no `model` field.

**What was not tested**: A live QQ/Qwen/DeepSeek end-to-end reproduction. The source-level path is clear and the regression test verifies the exact params change.

## Tests and validation
| Test Type | Result | Details |
|-----------|--------|---------|
| Unit Tests | ✅ | 26/26 passed in subagent-spawn.test.ts (new regression test included) |
| Type Check | ✅ | No type errors in changed files |
| Lint | ✅ | No lint errors in changed files |

## Risk checklist
**Did user-visible behavior change?** Yes — sub-agents spawned with an explicit `model` parameter now use that model instead of silently falling back to the default.

**Did config, environment, or migration behavior change?** No.

**Did security, auth, secrets, network, or tool execution behavior change?** The sub-agent spawner now requests admin scope for the agent gateway call when a model override is present, which is consistent with the existing plugin-runtime subagent path.

## Current review state
**What is the next action?** Maintainer review requested.
