### PR TITLE
fix(mattermost): bound null-body error response reads

### DIFF
--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -15,6 +15,7 @@ import {
   createMattermostClient,
   createMattermostPost,
   normalizeMattermostBaseUrl,
+  readMattermostError,
   updateMattermostPost,
 } from "./client.js";
 
@@ -155,6 +156,38 @@ describe("normalizeMattermostBaseUrl", () => {
   });
 });
 
+// ── readMattermostError ───────────────────────────────────────────────
+
+describe("readMattermostError", () => {
+  it("bounds null-body JSON errors without response.json/text", async () => {
+    const response = new Response(null, {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+    const jsonSpy = vi.spyOn(response, "json").mockRejectedValue(new Error("unbounded"));
+    const textSpy = vi.spyOn(response, "text").mockRejectedValue(new Error("unbounded"));
+
+    await expect(readMattermostError(response)).resolves.toBe("");
+
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(textSpy).not.toHaveBeenCalled();
+  });
+
+  it("parses bounded JSON error messages from response bodies", async () => {
+    const response = new Response(JSON.stringify({ message: "invalid token", id: "app.error" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+    const jsonSpy = vi.spyOn(response, "json").mockRejectedValue(new Error("unbounded"));
+    const textSpy = vi.spyOn(response, "text").mockRejectedValue(new Error("unbounded"));
+
+    await expect(readMattermostError(response)).resolves.toBe("invalid token");
+
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(textSpy).not.toHaveBeenCalled();
+  });
+});
+
 // ── createMattermostClient ───────────────────────────────────────────
 
 describe("createMattermostClient", () => {
@@ -170,6 +203,29 @@ describe("createMattermostClient", () => {
     await expect(client.request("/users/me")).resolves.toEqual({ id: "u1" });
 
     expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads guarded null-body Mattermost errors without response.json/text", async () => {
+    const release = vi.fn(async () => {});
+    const response = new Response(null, {
+      status: 503,
+      statusText: "Service Unavailable",
+      headers: { "content-type": "application/json" },
+    });
+    const jsonSpy = vi.spyOn(response, "json").mockRejectedValue(new Error("unbounded"));
+    const textSpy = vi.spyOn(response, "text").mockRejectedValue(new Error("unbounded"));
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({ response, release });
+    const client = createMattermostClient({
+      baseUrl: "https://chat.example.com",
+      botToken: "test-token",
+    });
+
+    await expect(client.request("/users/me")).rejects.toThrow(
+      "Mattermost API 503 Service Unavailable: unknown error",
+    );
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(textSpy).not.toHaveBeenCalled();
     expect(release).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -105,16 +105,6 @@ async function readMattermostSuccessText(res: Response, path: string): Promise<s
 
 export async function readMattermostError(res: Response): Promise<string> {
   const contentType = res.headers.get("content-type") ?? "";
-  if (!res.body) {
-    if (contentType.includes("application/json")) {
-      const data = (await res.json()) as { message?: string } | undefined;
-      if (data?.message) {
-        return data.message;
-      }
-      return JSON.stringify(data);
-    }
-    return await res.text();
-  }
   const text = await readResponseTextLimited(res, MATTERMOST_ERROR_BODY_LIMIT_BYTES);
   if (contentType.includes("application/json")) {
     try {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Mattermost API error handling could still call unbounded `response.json()` / `response.text()` when `readMattermostError()` saw a response with no readable body stream. That left a narrow follow-up hole after #96033 bounded the successful REST read path.

## Why This Change Was Made

`readMattermostError()` already bounded error bodies when `res.body` was present, but the `!res.body` branch fell back to native `json()` / `text()`. The helper now always uses `readResponseTextLimited` (8 KiB) and parses JSON from that bounded text, matching the existing error-path contract without a second buffering strategy.

## User Impact

Operators and agents talking to self-hosted or misbehaving Mattermost servers still get the same API error messages on failures, without the plugin buffering arbitrarily large error bodies through the null-body fallback.

## Evidence

```bash
node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/client.test.ts
```

```text
Test Files  1 passed (1)
     Tests  27 passed (27)
```

Added regression tests that:
- prove null-body JSON errors never call `response.json()` / `response.text()`
- keep parsing bounded JSON `message` fields from normal response bodies
- cover guarded null-body failures through `createMattermostClient().request()`

AI-assisted: implementation and tests were drafted with Cursor agent assistance; validation was run locally with the command above.