### PR TITLE
fix(agents): seal deepseek reasoning before the answer (no discrete thinking_end)

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -23,6 +23,7 @@ function createMessageUpdateContext(
   params: {
     onAgentEvent?: ReturnType<typeof vi.fn>;
     onPartialReply?: ReturnType<typeof vi.fn>;
+    onReasoningEnd?: ReturnType<typeof vi.fn>;
     flushBlockReplyBuffer?: ReturnType<typeof vi.fn>;
     resetAssistantMessageState?: ReturnType<typeof vi.fn>;
     debug?: ReturnType<typeof vi.fn>;
@@ -43,11 +44,13 @@ function createMessageUpdateContext(
       session: { id: "session-1" },
       ...(params.onAgentEvent ? { onAgentEvent: params.onAgentEvent } : {}),
       ...(params.onPartialReply ? { onPartialReply: params.onPartialReply } : {}),
+      ...(params.onReasoningEnd ? { onReasoningEnd: params.onReasoningEnd } : {}),
     },
     state: {
       deterministicApprovalPromptPending: false,
       deterministicApprovalPromptSent: false,
       reasoningStreamOpen: false,
+      reasoningSealedByTextBoundary: false,
       streamReasoning: false,
       deltaBuffer: "",
       blockBuffer: "",
@@ -251,6 +254,125 @@ describe("pending assistant reply directives", () => {
       isReasoning: true,
     });
     expect(state.pendingAssistantReplyDirectives?.mediaUrls).toEqual(["/tmp/reply.png"]);
+  });
+});
+
+describe("handleMessageUpdate native reasoning boundary", () => {
+  const createThinkingEvent = (content: string) =>
+    ({
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: { type: "thinking_delta", delta: content, content },
+    }) as never;
+  const createTextEvent = (text: string, delta: string) =>
+    ({
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta,
+        partial: {
+          role: "assistant",
+          content: [{ type: "text", text }],
+          stopReason: "stop",
+          provider: "test",
+          model: "local",
+          usage: {},
+          timestamp: 0,
+        },
+      },
+    }) as never;
+
+  it("closes the reasoning stream when text begins without a thinking_end (deepseek)", () => {
+    // deepseek streams reasoning via thinking_* events but switches to the answer
+    // without a discrete thinking_end. The text lane opening must close the
+    // thought so the channel does not merge the answer into the last 🧠 block.
+    const onReasoningEnd = vi.fn();
+    const context = createMessageUpdateContext({ onReasoningEnd });
+
+    handleMessageUpdate(context, createThinkingEvent("Planning the answer"));
+    expect(onReasoningEnd).not.toHaveBeenCalled();
+    expect(context.state.reasoningStreamOpen).toBe(true);
+
+    handleMessageUpdate(context, createTextEvent("Done.", "Done."));
+
+    expect(onReasoningEnd).toHaveBeenCalledTimes(1);
+    expect(context.state.reasoningStreamOpen).toBe(false);
+  });
+
+  it("does not re-fire the boundary when a thinking_end already closed it", () => {
+    // Providers with a clean thinking_end close on that event; the text lane must
+    // not double-fire the boundary.
+    const onReasoningEnd = vi.fn();
+    const context = createMessageUpdateContext({ onReasoningEnd });
+
+    handleMessageUpdate(context, createThinkingEvent("Planning the answer"));
+    handleMessageUpdate(context, {
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: { type: "thinking_end", content: "Planning the answer" },
+    } as never);
+    expect(onReasoningEnd).toHaveBeenCalledTimes(1);
+
+    handleMessageUpdate(context, createTextEvent("Done.", "Done."));
+
+    expect(onReasoningEnd).toHaveBeenCalledTimes(1);
+    expect(context.state.reasoningStreamOpen).toBe(false);
+  });
+
+  it("absorbs a late end-of-stream thinking_end after the text boundary sealed it (deepseek)", () => {
+    // deepseek/openai-compatible providers finalize blocks at end of stream, so a
+    // thinking_end arrives for the segment AFTER the answer text already closed it
+    // via the text-lane boundary. It must not reopen the stream and fire a second
+    // onReasoningEnd.
+    const onReasoningEnd = vi.fn();
+    const context = createMessageUpdateContext({ onReasoningEnd });
+
+    handleMessageUpdate(context, createThinkingEvent("Planning the answer"));
+    handleMessageUpdate(context, createTextEvent("Done.", "Done."));
+    expect(onReasoningEnd).toHaveBeenCalledTimes(1);
+    expect(context.state.reasoningStreamOpen).toBe(false);
+
+    handleMessageUpdate(context, {
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: { type: "thinking_end", content: "Planning the answer" },
+    } as never);
+
+    expect(onReasoningEnd).toHaveBeenCalledTimes(1);
+    expect(context.state.reasoningStreamOpen).toBe(false);
+  });
+
+  it("fires once per segment across multiple text-sealed segments, absorbing trailing late ends", () => {
+    // thinking -> text -> thinking -> text: each text boundary seals its own
+    // segment; the seal flag resets when the second reasoning opens, so the
+    // second segment fires its own onReasoningEnd, and trailing end-of-stream
+    // thinking_end events for both blocks are absorbed (total = 2, not 4).
+    const thinkingEndEvent = {
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: { type: "thinking_end", content: "" },
+    } as never;
+    const onReasoningEnd = vi.fn();
+    const context = createMessageUpdateContext({ onReasoningEnd });
+
+    handleMessageUpdate(context, createThinkingEvent("Segment one"));
+    expect(context.state.reasoningSealedByTextBoundary).toBe(false);
+    handleMessageUpdate(context, createTextEvent("Answer one. ", "Answer one. "));
+    expect(onReasoningEnd).toHaveBeenCalledTimes(1);
+    expect(context.state.reasoningSealedByTextBoundary).toBe(true);
+
+    handleMessageUpdate(context, createThinkingEvent("Segment two"));
+    expect(context.state.reasoningSealedByTextBoundary).toBe(false);
+    expect(context.state.reasoningStreamOpen).toBe(true);
+    handleMessageUpdate(context, createTextEvent("Answer one. Answer two.", "Answer two."));
+    expect(onReasoningEnd).toHaveBeenCalledTimes(2);
+
+    // Late end-of-stream finalization for both thinking blocks: absorbed.
+    handleMessageUpdate(context, thinkingEndEvent);
+    handleMessageUpdate(context, thinkingEndEvent);
+    expect(onReasoningEnd).toHaveBeenCalledTimes(2);
+    expect(context.state.reasoningStreamOpen).toBe(false);
   });
 });
 

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -612,6 +612,9 @@ export function handleMessageUpdate(
       (evtType === "thinking_start" || evtType === "thinking_delta")
     ) {
       openReasoningStream(ctx);
+      // Genuinely new reasoning: clear any prior text-boundary seal so this
+      // segment's own thinking_end is handled normally.
+      ctx.state.reasoningSealedByTextBoundary = false;
     }
     const thinkingDelta = typeof assistantRecord?.delta === "string" ? assistantRecord.delta : "";
     const thinkingContent =
@@ -631,16 +634,41 @@ export function handleMessageUpdate(
       ctx.emitReasoningStream(partialThinking || thinkingContent || thinkingDelta);
     }
     if (!suppressMessageToolOnlySourceReplyOutput && evtType === "thinking_end") {
-      if (!ctx.state.reasoningStreamOpen) {
-        openReasoningStream(ctx);
+      // deepseek/openai-compatible providers finalize all blocks at end of
+      // stream, so a late thinking_end can arrive for a segment the text-lane
+      // boundary already sealed. Absorb it (stays absorbed until new reasoning
+      // opens) instead of reopening + firing onReasoningEnd a second time.
+      const alreadySealedByTextBoundary =
+        ctx.state.reasoningSealedByTextBoundary && !ctx.state.reasoningStreamOpen;
+      if (!alreadySealedByTextBoundary) {
+        if (!ctx.state.reasoningStreamOpen) {
+          openReasoningStream(ctx);
+        }
+        emitReasoningEnd(ctx);
       }
-      emitReasoningEnd(ctx);
     }
     return;
   }
 
   if (evtType !== "text_delta" && evtType !== "text_start" && evtType !== "text_end") {
     return;
+  }
+
+  // Native-thinking providers (e.g. deepseek) stream reasoning via thinking_*
+  // events but may switch to the answer without a discrete thinking_end; the
+  // text lane opening is itself the reasoning boundary. Close the stream here so
+  // the channel seals the thought before the final instead of merging the answer
+  // into the last 🧠 block. Tag-based <think> reasoning lives inside text deltas
+  // (partialBlockState.thinking), so skip it there — its end is detected below.
+  if (
+    !suppressMessageToolOnlySourceReplyOutput &&
+    ctx.state.reasoningStreamOpen &&
+    !ctx.state.partialBlockState.thinking
+  ) {
+    emitReasoningEnd(ctx);
+    // Mark the segment sealed so a later end-of-stream thinking_end for it is
+    // absorbed rather than reopening the stream (see thinking_end handling).
+    ctx.state.reasoningSealedByTextBoundary = true;
   }
 
   const delta = typeof assistantRecord?.delta === "string" ? assistantRecord.delta : "";
@@ -977,6 +1005,7 @@ export function handleMessageEnd(
     ctx.state.lastStreamedAssistant = undefined;
     ctx.state.lastStreamedAssistantCleaned = undefined;
     ctx.state.reasoningStreamOpen = false;
+    ctx.state.reasoningSealedByTextBoundary = false;
   };
 
   const previousStreamedText = ctx.state.lastStreamedAssistantCleaned ?? "";

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -130,6 +130,11 @@ export type EmbeddedAgentSubscribeState = {
   deferredAssistantEvents: AssistantStreamDelivery[];
   toolExecutionSinceLastBlockReply: boolean;
   reasoningStreamOpen: boolean;
+  // True once the text-lane boundary has closed a native reasoning segment that
+  // never emitted a discrete thinking_end (deepseek). A late end-of-stream
+  // thinking_end for that segment is then absorbed instead of firing
+  // onReasoningEnd twice. Cleared when genuinely new reasoning opens.
+  reasoningSealedByTextBoundary: boolean;
   assistantMessageIndex: number;
   lastAssistantStreamItemId?: string;
   lastAssistantTextMessageIndex: number;

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -200,6 +200,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     deferredAssistantEvents: [],
     toolExecutionSinceLastBlockReply: false,
     reasoningStreamOpen: false,
+    reasoningSealedByTextBoundary: false,
     assistantMessageIndex: 0,
     lastAssistantStreamItemId: undefined,
     lastAssistantTextMessageIndex: -1,
@@ -425,6 +426,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.lastStreamedReasoning = undefined;
     state.lastReasoningSent = undefined;
     state.reasoningStreamOpen = false;
+    state.reasoningSealedByTextBoundary = false;
     state.suppressBlockChunks = false;
     state.pendingAssistantUsage = undefined;
     state.assistantUsageCommitted = false;


### PR DESCRIPTION
Fixes #95280.

## Summary
deepseek streams reasoning via `thinking_*` events but switches to the answer **without a discrete `thinking_end`**; neither the native `thinking_end` nor the tag-based `</think>` boundary fires at the transition, so `onReasoningEnd` runs too late and the channel merges the final answer into the last reasoning block.

This treats the **text-lane opening as the reasoning boundary** for native-thinking providers (skipping tag-based `<think>`, whose end is detected during content parsing), and absorbs the late end-of-stream `thinking_end` so the boundary is not fired twice.

Now that #95029 delivers deepseek reasoning to Discord, this content-merge is visible on `main`: the thought and the answer render together under `/reasoning on`.

## Root cause
In `src/llm/providers/openai-completions.ts`, `thinking_end` is emitted only by `finishBlock`, which runs once at end-of-stream (`for (const block of blocks) finishBlock(block)`) — never at the `reasoning_content`→`content` transition. So the subscribe handler sees `thinking_delta … text_delta … [stream end] thinking_end`, and the `thinking_end`-keyed close fires after the answer already streamed. Providers that emit a discrete `thinking_end` at the transition (Anthropic, OpenAI-responses, Google, Mistral) are unaffected.

## Change
`src/agents/embedded-agent-subscribe.handlers.messages.ts`:
- On the first text delta, if `reasoningStreamOpen && !partialBlockState.thinking`, emit `onReasoningEnd` to seal the thought before the answer.
- Track `reasoningSealedByTextBoundary` so a late end-of-stream `thinking_end` for the already-sealed segment is absorbed (not reopened + re-fired); the flag resets when genuinely new reasoning opens, so multi-segment turns still fire once per segment.

State field added in `…handlers.types.ts`; initialised + reset alongside `reasoningStreamOpen` in `…subscribe.ts` and the per-message reset.

## Verification
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` → 0.
- `vitest run embedded-agent-subscribe.handlers.messages.test.ts -t "native reasoning boundary"` → 8 passed (4 scenarios × 2 project lanes).
- Deterministic regression proof: with the source hunk reverted (test kept), `closes the reasoning stream when text begins without a thinking_end (deepseek)` fails (`onReasoningEnd` called 0 times → answer merges); with the fix, passes.
- Reviewed with a Codex red-team pass, which caught a double-fire (late `thinking_end` reopening the sealed stream); fixed via the seal flag and covered by `absorbs a late end-of-stream thinking_end…` and `fires once per segment across multiple text-sealed segments…`.

### Real behavior proof
- **Behavior addressed:** deepseek final answer merging into the last 🧠 reasoning block under `/reasoning on`.
- **Real environment tested:** local — OpenClaw 2026.6.9-beta.1, macOS; `tsgo` + `vitest` lanes above.
- **Exact steps or command run after this patch:** the two commands under Verification; plus the seal-removed deterministic comparison.
- **Evidence after fix:** tsgo 0; 8/8 boundary tests pass; seal-removed run fails the deepseek boundary test (`expected "vi.fn()" to be called 1 times, but got 0 times`).
- **Observed result after fix:** reasoning stream closes at the text-lane boundary; exactly one `onReasoningEnd` per reasoning segment; late `thinking_end` absorbed.
- **What was not tested:** live visible before/after capture on Discord/Telegram (deferred; the fix is provider-side and exercised by the unit tests above).

## AI assistance
Prepared with AI assistance (Claude Opus 4.8); behavior verified locally on OpenClaw 2026.6.9-beta.1.

cc @Peetiegonzalez for review.
