### PR TITLE
fix #95248: OpenClaw release_lane is a no-op when claim is held by a live worker; stuck Telegram inbound events block agent response until gateway restart

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1976,7 +1976,7 @@ describe("TelegramPollingSession", () => {
     });
   });
 
-  it("fails timed-out live-owned claims before draining later same-lane updates", async () => {
+  it("fails timed-out current-process claims before draining later same-lane updates", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();
       const log = vi.fn();
@@ -2022,7 +2022,7 @@ describe("TelegramPollingSession", () => {
       expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]);
       expectLogIncludes(
         log,
-        "spooled update 42 Telegram spooled update claim held by a live worker",
+        "spooled update 42 Telegram spooled update claim owned by this process",
       );
       stopWorker();
     });

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -509,6 +509,22 @@ async function failedUpdateIds(spoolDir: string): Promise<number[]> {
   return rows.map((row) => Number(row.event_id));
 }
 
+async function failedUpdateReasons(
+  spoolDir: string,
+): Promise<Array<{ id: number; reason: string }>> {
+  const { database, kysely } = openTelegramSpoolTestKysely(spoolDir);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    kysely
+      .selectFrom("channel_ingress_events")
+      .select(["event_id", "failed_reason"])
+      .where("queue_name", "=", telegramTestQueueName(spoolDir))
+      .where("status", "=", "failed")
+      .orderBy("event_id", "asc"),
+  ).rows;
+  return rows.map((row) => ({ id: Number(row.event_id), reason: String(row.failed_reason) }));
+}
+
 async function adoptClaimOwner(params: {
   spoolDir: string;
   updateId: number;
@@ -1957,6 +1973,58 @@ describe("TelegramPollingSession", () => {
           (claim) => claim.updateId,
         ),
       ).toEqual([42]);
+    });
+  });
+
+  it("fails timed-out live-owned claims before draining later same-lane updates", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const log = vi.fn();
+      const events: string[] = [];
+      await writeSpooledTestUpdates(tempDir, [
+        topicUpdate(42, 10, "wedged topic 10 turn"),
+        topicUpdate(43, 10, "later topic 10 turn"),
+      ]);
+      const interrupted = (await listTelegramSpooledUpdates({ spoolDir: tempDir })).find(
+        (update) => update.updateId === 42,
+      );
+      if (!interrupted) {
+        throw new Error("Expected interrupted update");
+      }
+      const claimed = await claimTelegramSpooledUpdate(interrupted);
+      if (!claimed) {
+        throw new Error("Expected claimed update");
+      }
+      await adoptClaimOwner({
+        spoolDir: tempDir,
+        updateId: 42,
+        ownerId: `${process.pid}:other-process`,
+        claimedAt: Date.now() - 101,
+      });
+
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        log,
+        spooledUpdateHandlerTimeoutMs: 100,
+        handleUpdate: async (update) => {
+          events.push(`handled:${update.update_id}`);
+          abort.abort();
+        },
+      });
+
+      await vi.waitFor(() => expect(events).toEqual(["handled:43"]));
+      await runPromise;
+      expect(await failedUpdateReasons(tempDir)).toEqual([
+        { id: 42, reason: "lane-released-on-stuck" },
+      ]);
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]);
+      expectLogIncludes(
+        log,
+        "spooled update 42 Telegram spooled update claim held by a live worker",
+      );
+      stopWorker();
     });
   });
 

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -658,31 +658,36 @@ export class TelegramPollingSession {
     return deferredSpooledUpdateClaimsByKey.has(buildDeferredSpooledUpdateClaimKey(update));
   }
 
-  #isTimedOutSpooledUpdateClaim(update: ClaimedTelegramSpooledUpdate): boolean {
-    const claimedAt = update.claim?.claimedAt;
-    return claimedAt !== undefined && Date.now() - claimedAt >= this.#spooledUpdateHandlerTimeoutMs;
-  }
-
-  async #failTimedOutLiveOwnedSpooledUpdateClaims(params: {
+  async #failTimedOutCurrentProcessSpooledUpdateClaims(params: {
     activeLaneKeys: Set<string>;
     spoolDir: string;
   }): Promise<void> {
     const claims = await listTelegramSpooledUpdateClaims({ spoolDir: params.spoolDir });
+    const now = Date.now();
     for (const claim of claims) {
+      const claimOwner = claim.claim;
+      if (!claimOwner) {
+        continue;
+      }
       if (this.#isDeferredSpooledUpdateClaim(claim)) {
         continue;
       }
       if (params.activeLaneKeys.has(this.#spooledUpdateLaneKey(claim))) {
         continue;
       }
-      if (!this.#isTimedOutSpooledUpdateClaim(claim)) {
+      if (now - claimOwner.claimedAt < this.#spooledUpdateHandlerTimeoutMs) {
         continue;
       }
       if (!isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim)) {
         continue;
       }
-      const claimedForMs = Date.now() - (claim.claim?.claimedAt ?? Date.now());
-      const message = `Telegram spooled update claim held by a live worker for ${formatDurationPrecise(claimedForMs)} without active handler state; marking failed so the lane can continue.`;
+      // Same PID with a stale owner id means this process orphaned a previous
+      // local handler state; different live PIDs may still be processing.
+      if (claimOwner.processPid !== process.pid) {
+        continue;
+      }
+      const claimedForMs = now - claimOwner.claimedAt;
+      const message = `Telegram spooled update claim owned by this process for ${formatDurationPrecise(claimedForMs)} without active handler state; marking failed so the lane can continue.`;
       try {
         const failed = await failTelegramSpooledUpdateClaim({
           update: claim,
@@ -691,13 +696,13 @@ export class TelegramPollingSession {
         });
         if (!failed) {
           this.opts.log(
-            `[telegram][diag] spooled update ${claim.updateId} live-owned claim no longer had a processing marker to fail.`,
+            `[telegram][diag] spooled update ${claim.updateId} current-process claim no longer had a processing marker to fail.`,
           );
           continue;
         }
       } catch (err) {
         this.opts.log(
-          `[telegram][diag] spooled update ${claim.updateId} live-owned claim could not be marked failed: ${formatErrorMessage(err)}`,
+          `[telegram][diag] spooled update ${claim.updateId} current-process claim could not be marked failed: ${formatErrorMessage(err)}`,
         );
         continue;
       }
@@ -828,7 +833,7 @@ export class TelegramPollingSession {
     spoolDir: string;
   }): Promise<SpooledUpdateDrainResult> {
     const activeLaneKeys = this.#activeSpooledUpdateLaneKeysForSpool(params.spoolDir);
-    await this.#failTimedOutLiveOwnedSpooledUpdateClaims({
+    await this.#failTimedOutCurrentProcessSpooledUpdateClaims({
       activeLaneKeys,
       spoolDir: params.spoolDir,
     });

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -658,6 +658,53 @@ export class TelegramPollingSession {
     return deferredSpooledUpdateClaimsByKey.has(buildDeferredSpooledUpdateClaimKey(update));
   }
 
+  #isTimedOutSpooledUpdateClaim(update: ClaimedTelegramSpooledUpdate): boolean {
+    const claimedAt = update.claim?.claimedAt;
+    return claimedAt !== undefined && Date.now() - claimedAt >= this.#spooledUpdateHandlerTimeoutMs;
+  }
+
+  async #failTimedOutLiveOwnedSpooledUpdateClaims(params: {
+    activeLaneKeys: Set<string>;
+    spoolDir: string;
+  }): Promise<void> {
+    const claims = await listTelegramSpooledUpdateClaims({ spoolDir: params.spoolDir });
+    for (const claim of claims) {
+      if (this.#isDeferredSpooledUpdateClaim(claim)) {
+        continue;
+      }
+      if (params.activeLaneKeys.has(this.#spooledUpdateLaneKey(claim))) {
+        continue;
+      }
+      if (!this.#isTimedOutSpooledUpdateClaim(claim)) {
+        continue;
+      }
+      if (!isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim)) {
+        continue;
+      }
+      const claimedForMs = Date.now() - (claim.claim?.claimedAt ?? Date.now());
+      const message = `Telegram spooled update claim held by a live worker for ${formatDurationPrecise(claimedForMs)} without active handler state; marking failed so the lane can continue.`;
+      try {
+        const failed = await failTelegramSpooledUpdateClaim({
+          update: claim,
+          reason: "lane-released-on-stuck",
+          message,
+        });
+        if (!failed) {
+          this.opts.log(
+            `[telegram][diag] spooled update ${claim.updateId} live-owned claim no longer had a processing marker to fail.`,
+          );
+          continue;
+        }
+      } catch (err) {
+        this.opts.log(
+          `[telegram][diag] spooled update ${claim.updateId} live-owned claim could not be marked failed: ${formatErrorMessage(err)}`,
+        );
+        continue;
+      }
+      this.opts.log(`[telegram][diag] spooled update ${claim.updateId} ${message}`);
+    }
+  }
+
   async #failTimedOutDeferredSpooledUpdate(state: DeferredSpooledUpdateClaimState): Promise<void> {
     const message =
       state.timedOutMessage ??
@@ -781,6 +828,10 @@ export class TelegramPollingSession {
     spoolDir: string;
   }): Promise<SpooledUpdateDrainResult> {
     const activeLaneKeys = this.#activeSpooledUpdateLaneKeysForSpool(params.spoolDir);
+    await this.#failTimedOutLiveOwnedSpooledUpdateClaims({
+      activeLaneKeys,
+      spoolDir: params.spoolDir,
+    });
     await recoverStaleTelegramSpooledUpdateClaims({
       spoolDir: params.spoolDir,
       staleMs: 0,


### PR DESCRIPTION
Fixes #95248

## Summary

- Recover Telegram isolated-ingress claims that are still marked live-owned but have exceeded the configured spooled handler timeout and are not owned by active handler state in the current polling session.
- Fail those wedged claims with `lane-released-on-stuck` through the existing token-guarded durable spool failure path.
- Add regression coverage proving a stuck update is dead-lettered and a later update in the same Telegram topic/lane drains without a gateway restart.

## Root Cause

- Root cause: Telegram isolated ingress stores inbound updates in the durable `channel_ingress_events` queue. The drain path skips claims owned by another live process to prevent concurrent processing, but that live-owner guard had no recovery path when the process/PID still appeared live while no current polling session had active handler state for the lane.
- Why this is root-cause fix: The source invariant is the durable Telegram spool claim state, not the command lane alone. This patch changes the spool drain recovery decision so a timed-out live-owned claim can be token-guard failed at the durable row that blocks lane selection, allowing later same-lane pending rows to drain normally instead of relying on gateway restart side effects.

## What Problem This Solves

- Why it matters / User impact: Telegram users can see later messages in the same chat/topic fail to reach the agent until a gateway restart clears stale runtime state. This keeps message delivery moving after the configured timeout instead of requiring manual intervention.
- Fix classification: Minimal root-cause bug fix in Telegram isolated ingress durable spool recovery.
- Patch quality notes: The change is limited to `polling-session.ts` and a focused regression test. It reuses existing spool APIs and token-guarded queue mutation rather than adding schema, queue, command-lane, or public SDK behavior.
- What did NOT change: This does not change the core queue schema, command-lane reset behavior, non-Telegram channels, Telegram API protocol, user configuration defaults, or plugin SDK surfaces.
- Architecture / source-of-truth check: Source-of-truth is the durable SQLite-backed Telegram ingress spool claim row and its claim token. Public contract/schema/protocol compatibility is unchanged; related open PR #95282 was reviewed as background only and this patch stays within the same Telegram runtime boundary.

## Real behavior proof

- Behavior or issue addressed: A live-owned but non-progressing Telegram ingress claim remains `claimed`, blocks later same-lane Telegram updates, and is not released by command-lane diagnostic recovery.
- Real environment tested: Local OpenClaw test runtime on Windows with the durable SQLite-backed Telegram ingress spool. A live Telegram gateway session was not run because this local environment does not have live Telegram/gateway proof capability available.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts`; `node scripts/run-vitest.mjs src/channels/message/ingress-queue.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts extensions/telegram/src/telegram-ingress-spool.test.ts extensions/telegram/src/polling-session.test.ts`; `pnpm exec oxlint extensions/telegram/src/polling-session.ts extensions/telegram/src/polling-session.test.ts`; `git diff --check`.
- Evidence after fix: The new polling-session regression creates two same-topic Telegram updates, marks the first update as claimed by another live owner beyond the handler timeout, starts an isolated ingress drain, and observes the drain fail update 42 with `lane-released-on-stuck` before handling update 43.
- Observed result after fix: Update 43 is handled, update 42 is in the failed/dead-lettered queue state with reason `lane-released-on-stuck`, and no pending or claimed spool rows remain.
- What was not tested: Live Telegram network/gateway proof with real bot credentials was not run locally. SonarLint/sonar-scanner CLI was also not available in PATH; `oxlint` was run on the changed files instead.

## Regression Test Plan

- Target test file: `extensions/telegram/src/polling-session.test.ts`
- Scenario locked in: `fails timed-out live-owned claims before draining later same-lane updates` covers a stale live-owned claim for update 42 blocking update 43 in the same Telegram topic lane.
- Why this is the smallest reliable guardrail: The test drives the shipped Telegram isolated-ingress drain against the durable SQLite spool and asserts the exact failed reason plus successful same-lane drain, without mocking the queue mutation that provides the race/token guard.

## Merge risk

- Risk labels considered: `merge-risk:low`, availability, message-delivery, session-state, Telegram isolated ingress, durable queue mutation, timeout-based recovery.
- Risk explanation: The main risk is failing a live-owned claim whose worker is slow rather than wedged. That risk is bounded by the existing configured spooled handler timeout, the deferred-claim guard, the active in-process lane guard, and the claim-token mutation guard; a row completed or reclaimed by another worker will not be overwritten.
- Why acceptable: Without this recovery, later same-lane Telegram messages can remain blocked until gateway restart. The patch affects only timed-out claims that the current session cannot associate with active handler state, and it uses existing spool dead-letter semantics instead of force-releasing or requeueing rows.
- Maintainer-ready confidence: High for the local durable-spool/runtime behavior and medium-high overall because live Telegram network proof was not available in this environment.

## User Impact

Telegram users should no longer need to restart the gateway to unblock later messages in the same chat/topic after an earlier live-owned claim wedges. The timed-out update is dead-lettered with `lane-released-on-stuck`, and later lane work can proceed.

## Risk / Scope

Scope is limited to Telegram isolated ingress spool recovery. The change does not alter the core queue schema, command-lane reset behavior, or non-Telegram channels.