### PR TITLE
fix(cli): expose --count on infer image edit, matching image generate

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -1685,6 +1685,35 @@ describe("capability cli", () => {
     expect(inputImages[0]?.fileName).toBe(path.basename(inputPath));
   });
 
+  it("forwards --count through to the image edit runtime", async () => {
+    mocks.generateImage.mockResolvedValue({
+      provider: "openai",
+      model: "gpt-image-1.5",
+      attempts: [],
+      images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png", fileName: "edit.png" }],
+    });
+    const inputPath = path.join(os.tmpdir(), `openclaw-image-edit-count-${Date.now()}.png`);
+    await fs.writeFile(inputPath, Buffer.from("png-input"));
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "image",
+        "edit",
+        "--file",
+        inputPath,
+        "--prompt",
+        "make three variants",
+        "--count",
+        "3",
+        "--json",
+      ],
+    });
+
+    expect(firstImageGenerationCall()?.count).toBe(3);
+  });
+
   it("rejects unsupported image output format and background hints", async () => {
     await expect(
       runRegisteredCli({
@@ -1854,6 +1883,7 @@ describe("capability cli", () => {
       "--file",
       "--prompt",
       "--model",
+      "--count",
       "--size",
       "--aspect-ratio",
       "--resolution",

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -218,6 +218,7 @@ const CAPABILITY_METADATA: CapabilityMetadata[] = [
       "--file",
       "--prompt",
       "--model",
+      "--count",
       "--size",
       "--aspect-ratio",
       "--resolution",
@@ -2297,6 +2298,7 @@ export function registerCapabilityCli(program: Command) {
     .requiredOption("--file <path>", "Input file", collectOption, [])
     .requiredOption("--prompt <text>", "Prompt text")
     .option("--model <provider/model>", "Model override")
+    .option("--count <n>", "Number of images")
     .option("--size <size>", "Size hint like 1024x1024")
     .option("--aspect-ratio <ratio>", "Aspect ratio hint like 16:9")
     .option("--resolution <value>", "Resolution hint: 1K, 2K, or 4K")
@@ -2315,6 +2317,7 @@ export function registerCapabilityCli(program: Command) {
           capability: "image.edit",
           prompt: String(opts.prompt),
           model: opts.model as string | undefined,
+          count: parseOptionalPositiveInteger(opts.count, "--count"),
           size: opts.size as string | undefined,
           aspectRatio: opts.aspectRatio as string | undefined,
           resolution: opts.resolution as "1K" | "2K" | "4K" | undefined,


### PR DESCRIPTION
## Summary

`openclaw infer image edit` (the `capability image edit` command) could not request multiple edited images, while the sibling `image generate` could — even though multi-output edit is supported end-to-end:

- The shared action `runImageGenerate` accepts `count` for **both** `image.generate` and `image.edit` and threads it unconditionally (`src/cli/capability-cli.ts:1019`), and `generateImage` forwards it to the provider with no capability gating (`src/image-generation/runtime.ts`).
- Providers honor edit-mode count: xai `n: Math.min(count, 4)` and litellm `n: count` in their `buildEditRequest`, with `edit.maxCount: 4` advertised (xai/litellm/openai).
- The agent image tool already supports edit count (shared `count` param; edit/generate decided by input-image presence).

So the CLI `image edit` surface was the lone outlier. Provenance: PR #94156 added `--quality`/`--openai-moderation` to **both** `image generate` and `image edit` to close parity gaps, but left `--count` off `edit` only — an oversight, not a documented restriction.

This adds `--count` to the `image edit` command registration, its action, and `CAPABILITY_METADATA`, mirroring `image generate` exactly. With no flag, behavior is unchanged (`count` → `undefined` → provider default 1).

### Changes
- `src/cli/capability-cli.ts` (+3): `--count <n>` option on the `image edit` command, `count: parseOptionalPositiveInteger(opts.count, "--count")` in its action, and `"--count"` in the `image.edit` `CAPABILITY_METADATA` flags (all mirroring `image generate`).
- `src/cli/capability-cli.test.ts`: updated the locked `image.edit` flags assertion + a new test asserting `image edit --count 3` reaches the runtime as `count: 3`.

## Real behavior proof

Behavior addressed: `infer image edit` could not pass `--count` to request multiple edited images, unlike `image generate`, despite the shared action and providers supporting edit-mode count. `--count` is now accepted and threaded.

Real environment tested: Node 22.22.1, macOS, no model / network / device. A `./node_modules/.bin/tsx` harness imports the real `registerCapabilityCli`, builds a fresh commander program, and parses `capability image edit --file <tmp.png> --prompt p --count 3`. BEFORE is the same harness with the production change reverted (`git stash`).

Exact steps or command run after this patch:
```bash
# harness: registerCapabilityCli into a commander program, parse `image edit ... --count 3`
./node_modules/.bin/tsx ie-count-proof.mts
```

Evidence after fix:
```
AFTER  (this branch): --count accepted; the command proceeds past parse to provider
                      resolution and fails only with "No image-generation model configured."
                      (i.e. the flag is accepted; not an unknown-option error)
BEFORE (origin/main): RESULT: REJECTED at parse -> CommanderError: error: unknown option '--count'
```

Observed result after fix: before the change, `image edit --count 3` is rejected at parse as an unknown option; after, it is accepted and the command reaches provider resolution (the only remaining failure is the absent provider config, which is unrelated to the flag). The value flow (`count: 3` reaching the image runtime) is asserted by the colocated test.

What was not tested: an actual multi-image edit against a live provider — no provider API key was used. The end-to-end count threading is covered by `capability-cli.test.ts` (`forwards --count through to the image edit runtime`, asserting `firstImageGenerationCall()?.count === 3`), and the provider edit paths (xai/litellm/openai) already honor `count` in their `buildEditRequest`.

## Additional checks
- `pnpm test src/cli/capability-cli.test.ts` — 98 pass (incl. the new edit-count test + the updated locked `image.edit` flags assertion).
- Formatter (`oxfmt`), static analysis (`oxlint`), and `tsgo:core` pass for the changed files.
- Parity check: the agent image tool already supports edit count and no RPC/gateway-protocol surface exposes image-edit count, so the CLI was the only one-sided surface — now resolved.
