### PR TITLE
[codex] fix security audit request headers

### DIFF
--- a/src/commands/doctor-security.test.ts
+++ b/src/commands/doctor-security.test.ts
@@ -386,7 +386,7 @@ describe("noteSecurityWarnings gateway exposure", () => {
     expect(message).not.toContain("models.providers.openai.headers.X-Proxy-Region");
   });
 
-  it("keeps request headers aligned with secrets audit plaintext checks", async () => {
+  it("does not warn when non-sensitive model provider request headers are stored as plaintext in config", async () => {
     await noteSecurityWarnings({
       models: {
         providers: {
@@ -402,8 +402,48 @@ describe("noteSecurityWarnings gateway exposure", () => {
     } as unknown as OpenClawConfig);
 
     const message = lastMessage();
+    expect(message).not.toContain("plaintext secret-bearing config fields");
+    expect(message).not.toContain("models.providers.openai.request.headers.X-Proxy-Region");
+  });
+
+  it("warns when sensitive model provider request headers are stored as plaintext in config", async () => {
+    await noteSecurityWarnings({
+      models: {
+        providers: {
+          openai: {
+            request: {
+              headers: {
+                Authorization: "Bearer test-token",
+              },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    const message = lastMessage();
     expect(message).toContain("plaintext secret-bearing config fields");
-    expect(message).toContain("models.providers.openai.request.headers.X-Proxy-Region");
+    expect(message).toContain("models.providers.openai.request.headers.Authorization");
+  });
+
+  it("does not warn when static model provider request headers are stored as plaintext in config", async () => {
+    await noteSecurityWarnings({
+      models: {
+        providers: {
+          "wafer-zdr": {
+            request: {
+              headers: {
+                "Wafer-ZDR": "required",
+              },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    const message = lastMessage();
+    expect(message).not.toContain("plaintext secret-bearing config fields");
+    expect(message).not.toContain("models.providers.wafer-zdr.request.headers.Wafer-ZDR");
   });
 
   it("does not warn when model provider API keys are stored as SecretRefs", async () => {

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -206,6 +206,12 @@ function collectPlaintextConfigSecretWarnings(cfg: OpenClawConfig): string[] {
     ) {
       continue;
     }
+    if (
+      target.entry.id === "models.providers.*.request.headers.*" &&
+      !isLikelySensitiveModelProviderHeaderName(target.pathSegments.at(-1) ?? "")
+    ) {
+      continue;
+    }
     const { ref } = resolveSecretInputRef({
       value: target.value,
       refValue: target.refValue,

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -736,7 +736,7 @@ describe("secrets audit", () => {
     ).toBe(false);
   });
 
-  it("keeps request headers in openclaw config covered by plaintext audit", async () => {
+  it("does not flag non-sensitive request headers in openclaw config as plaintext", async () => {
     await writeJsonFile(fixture.configPath, {
       models: {
         providers: {
@@ -769,6 +769,75 @@ describe("secrets audit", () => {
           entry.file === fixture.configPath &&
           entry.jsonPath === "models.providers.openai.request.headers.X-Proxy-Region",
       ),
+    ).toBe(false);
+  });
+
+  it("flags sensitive request headers in openclaw config as plaintext", async () => {
+    await writeJsonFile(fixture.configPath, {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: { source: "env", provider: "default", id: OPENAI_API_KEY_MARKER },
+            request: {
+              headers: {
+                Authorization: "Bearer test-token",
+              },
+            },
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {},
+    });
+    await fs.writeFile(fixture.envPath, "", "utf8");
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === fixture.configPath &&
+          entry.jsonPath === "models.providers.openai.request.headers.Authorization",
+      ),
     ).toBe(true);
+  });
+
+  it("does not flag static request routing headers in openclaw config as plaintext", async () => {
+    await writeJsonFile(fixture.configPath, {
+      models: {
+        providers: {
+          "wafer-zdr": {
+            request: {
+              headers: {
+                "Wafer-ZDR": "required",
+              },
+            },
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {},
+    });
+    await fs.writeFile(fixture.envPath, "", "utf8");
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === fixture.configPath &&
+          entry.jsonPath === "models.providers.wafer-zdr.request.headers.Wafer-ZDR",
+      ),
+    ).toBe(false);
   });
 });

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -221,6 +221,12 @@ function collectConfigSecrets(params: {
     ) {
       continue;
     }
+    if (
+      target.entry.id === "models.providers.*.request.headers.*" &&
+      !isLikelySensitiveModelProviderHeaderName(target.pathSegments.at(-1) ?? "")
+    ) {
+      continue;
+    }
     if (!hasPlaintext) {
       continue;
     }


### PR DESCRIPTION
## Summary

Align `models.providers.*.request.headers.*` with the shared model-provider header sensitivity policy used by the existing config security audit surfaces.

This fixes the `Wafer-ZDR` false positive from #89664 without creating a Wafer-only carveout, and keeps sensitive request headers such as `Authorization` flagged.

## Changes

- reuse `isLikelySensitiveModelProviderHeaderName(...)` for `models.providers.*.request.headers.*` in both `openclaw doctor` and `openclaw secrets audit`
- keep static routing headers such as `Wafer-ZDR` and `X-Proxy-Region` out of plaintext-secret findings
- keep sensitive request headers such as `Authorization` in plaintext-secret findings
- add regression coverage for both non-sensitive and sensitive request-header cases in doctor and secrets audit
- drop the unrelated DeepSeek replay change and rewrite the branch to a single focused commit

## Validation

- `node scripts/run-vitest.mjs src/commands/doctor-security.test.ts --testNamePattern 'request headers'`
- `node scripts/run-vitest.mjs src/secrets/audit.test.ts --testNamePattern 'request headers'`
- `node scripts/run-node.mjs doctor --lint --only core/doctor/security --json --non-interactive`
  - non-sensitive proof config (`X-Proxy-Region`, `Wafer-ZDR`): `{"ok":true,"checksRun":1,"checksSkipped":21,"findings":[]}`
  - sensitive proof config (`Authorization`): includes `Paths: models.providers.openai.request.headers.Authorization`
- `node scripts/run-node.mjs secrets audit --json`
  - non-sensitive proof config (`X-Proxy-Region`, `Wafer-ZDR`): `"status": "clean"`, `"findings": []`
  - sensitive proof config (`Authorization`): `PLAINTEXT_FOUND` at `models.providers.openai.request.headers.Authorization`

Fixes #89664