### PR TITLE
fix(ui): show child-spawned subagent sessions in sidebar global view

### DIFF
--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -880,6 +880,7 @@ describe("test-projects args", () => {
           "test/helpers/temp-dir.test.ts",
           "test/scripts/android-pin-version.test.ts",
           "test/scripts/bench-cli-startup.test.ts",
+          "test/scripts/check-package-dist-imports.test.ts",
           "test/scripts/control-ui-i18n.test.ts",
           "test/scripts/ios-configure-signing.test.ts",
           "test/scripts/ios-pin-version.test.ts",

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSidebarRecentSessions } from "./app-render.ts";
 const {
   refreshChatMock,
   refreshChatAvatarMock,
@@ -1596,5 +1597,68 @@ describe("dismissRealtimeTalkError", () => {
     expect(state.realtimeTalkStatus).toBe("idle");
     expect(state.realtimeTalkDetail).toBeNull();
     expect(state.realtimeTalkTranscript).toBeNull();
+  });
+});
+
+describe("resolveSidebarRecentSessions", () => {
+  function sidebarRow(
+    key: string,
+    overrides?: Partial<{ kind: string; spawnedBy: string | null; updatedAt: number }>,
+  ) {
+    return {
+      key,
+      name: key,
+      kind: (overrides?.kind ?? "direct") as SessionRow["kind"],
+      spawnedBy: overrides?.spawnedBy ?? null,
+      updatedAt: overrides?.updatedAt ?? 0,
+      archived: false,
+      label: key,
+    } as SessionRow;
+  }
+
+  it("includes subagent and spawned sessions when sessionKey is unknown (global view)", () => {
+    const state = {
+      sessionKey: "unknown",
+      sessionsResult: {
+        sessions: [
+          sidebarRow("agent:main:main", { updatedAt: 100 }),
+          sidebarRow("agent:main:subagent:child-1", { updatedAt: 90 }),
+          sidebarRow("agent:orch:main", { updatedAt: 80, spawnedBy: "agent:main:main" }),
+          sidebarRow("agent:reviewer:main", { updatedAt: 70 }),
+          sidebarRow("agent:main:subagent:child-2", { updatedAt: 60 }),
+        ],
+      },
+    } as unknown as Parameters<typeof resolveSidebarRecentSessions>[0];
+
+    const result = resolveSidebarRecentSessions(state);
+    const keys = result.map((r) => r.key);
+
+    // In global view, subagent and spawned sessions should be visible
+    expect(keys).toContain("agent:main:subagent:child-1");
+    expect(keys).toContain("agent:orch:main");
+    expect(keys).toContain("agent:main:subagent:child-2");
+  });
+
+  it("hides subagent and spawned sessions when scoped to a specific agent", () => {
+    const state = {
+      sessionKey: "agent:main:main",
+      sessionsResult: {
+        sessions: [
+          sidebarRow("agent:main:main", { updatedAt: 100 }),
+          sidebarRow("agent:main:subagent:child-1", { updatedAt: 90 }),
+          sidebarRow("agent:orch:main", { updatedAt: 80, spawnedBy: "agent:main:main" }),
+        ],
+      },
+      agentsList: { defaultId: "main" },
+      hello: { snapshot: { sessionDefaults: { defaultAgentId: "main" } } },
+    } as unknown as Parameters<typeof resolveSidebarRecentSessions>[0];
+
+    const result = resolveSidebarRecentSessions(state);
+    const keys = result.map((r) => r.key);
+
+    // In agent-scoped view, subagent and spawned sessions are hidden
+    expect(keys).toContain("agent:main:main");
+    expect(keys).not.toContain("agent:main:subagent:child-1");
+    expect(keys).not.toContain("agent:orch:main");
   });
 });

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -528,7 +528,7 @@ function isSidebarSessionForSelectedAgent(
   return isSessionKeyTiedToAgent(row.key, selectedAgentId, resolveSidebarDefaultAgentId(state));
 }
 
-function resolveSidebarRecentSessions(state: AppViewState): GatewaySessionRow[] {
+export function resolveSidebarRecentSessions(state: AppViewState): GatewaySessionRow[] {
   const selectedAgentId = resolveSidebarSelectedAgentId(state);
   const shouldFilterByAgent =
     normalizeOptionalString(state.sessionKey)?.toLowerCase() !== "unknown";
@@ -540,8 +540,8 @@ function resolveSidebarRecentSessions(state: AppViewState): GatewaySessionRow[] 
         row.kind !== "unknown" &&
         row.kind !== "cron" &&
         !isCronSessionKey(row.key) &&
-        !isSubagentSessionKey(row.key) &&
-        !row.spawnedBy &&
+        (!shouldFilterByAgent || !isSubagentSessionKey(row.key)) &&
+        (!shouldFilterByAgent || !row.spawnedBy) &&
         (!shouldFilterByAgent || isSidebarSessionForSelectedAgent(state, row, selectedAgentId)),
     )
     .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))


### PR DESCRIPTION
## Summary
Fix the Web UI sidebar to show child-spawned subagent sessions in the global (dashboard) view. Previously, `resolveSidebarRecentSessions` unconditionally filtered out `isSubagentSessionKey` and `spawnedBy` rows, hiding cross-agent subagent sessions even when no specific agent was selected. This change makes the subagent/spawnedBy filters conditional on `shouldFilterByAgent`, so they only apply when scoped to a specific agent. In the global/dashboard view (`sessionKey === "unknown"`), all sessions including subagent and spawned ones are now visible.

Fixes #95295

## Real behavior proof (required for external PRs)

**Behavior addressed**: Web UI "Recent Sessions" sidebar hides child-spawned subagent sessions across agent scopes even in the global dashboard view, making it impossible to discover or navigate to subagent sessions from other agents.

**Real setup tested**:
- **Runtime**: Node 24.13.1, Linux 4.19.112-2.el8.x86_64
- **Code analysis path**: See root cause analysis below
- **Test framework**: Vitest 4.1.8

**Exact steps or command run after this patch**:
```bash
pnpm test ui/src/ui/app-render.helpers.node.test.ts
pnpm test ui/src/ui/controllers/sessions.test.ts
pnpm test ui/src/ui/views/chat.test.ts
```

**After-fix evidence**:
```
Test Files  3 passed (3)
     Tests  265 passed (265)
  Duration  14.87s
```

**Observed result after the fix**: All existing tests pass, and 2 new tests confirm:
1. In global view (`sessionKey: "unknown"`), subagent and spawned sessions are included in sidebar
2. In agent-scoped view (`sessionKey: "agent:main:main"`), subagent and spawned sessions remain hidden

**What was not tested**: Live browser session with multi-agent setup and real `sessions_spawn()` calls. The fix was verified at source/unit-test level only.

## Tests and validation
| Test Type | Result | Details |
|-----------|--------|---------|
| Unit Tests | ✅ | 265 tests passed (original 263 + 2 new for sidebar behavior) |
| Type Check | ✅ | tsgo:core passed; tsgo:all timed out (unrelated, pre-existing) |
| Lint | ✅ | oxfmt check passed on changed files |

## Risk checklist
**Did user-visible behavior change?** `Yes` - Subagent and spawned sessions are now visible in the sidebar when in global/dashboard view (`sessionKey: "unknown"`). Previously they were always hidden.
**Did config, environment, or migration behavior change?** `No`
**Did security, auth, secrets, network, or tool execution behavior change?** `No` - The change only affects UI rendering. Agent-scoped views still hide internal sessions. The "unknown" session key is the dashboard view that already shows sessions across all agents.

## Current review state
**What is the next action?** Maintainer review requested

## Root cause analysis

**File**: `ui/src/ui/app-render.ts:531-549`

`resolveSidebarRecentSessions` unconditionally filtered `isSubagentSessionKey(row.key)` and `row.spawnedBy` rows regardless of whether the user was in a global view or scoped to a specific agent. The `shouldFilterByAgent` flag (derived from whether `sessionKey === "unknown"`) only controlled the agent-id matching filter, not the subagent/spawnedBy filters.

**Fix**: Changed lines 543-544 from unconditional filters to conditional filters that only apply when `shouldFilterByAgent` is true (agent-scoped view). In global view (`shouldFilterByAgent = false`), all sessions are shown.

```diff
-        !isSubagentSessionKey(row.key) &&
-        !row.spawnedBy &&
-        (!shouldFilterByAgent || isSidebarSessionForSelectedAgent(state, row, selectedAgentId)),
+        (!shouldFilterByAgent || !isSubagentSessionKey(row.key)) &&
+        (!shouldFilterByAgent || !row.spawnedBy) &&
+        (!shouldFilterByAgent || isSidebarSessionForSelectedAgent(state, row, selectedAgentId)),
```
