### PR TITLE
[codex] route Telegram poll_answer updates

### DIFF
--- a/extensions/telegram/src/bot-deps.ts
+++ b/extensions/telegram/src/bot-deps.ts
@@ -30,6 +30,7 @@ import { deliverReplies, emitInternalMessageSentHook } from "./bot/delivery.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
 import { resolveTelegramExecApproval } from "./exec-approval-resolver.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
+import { getTelegramPollContext } from "./poll-context-store.js";
 import { editMessageTelegram } from "./send.js";
 import { wasSentByBot } from "./sent-message-cache.js";
 
@@ -54,6 +55,7 @@ export type TelegramBotDeps = {
   listSkillCommandsForAgents: typeof listSkillCommandsForAgents;
   syncTelegramMenuCommands?: typeof syncTelegramMenuCommands;
   wasSentByBot: typeof wasSentByBot;
+  getTelegramPollContext: typeof getTelegramPollContext;
   resolveExecApproval?: typeof resolveTelegramExecApproval;
   createTelegramDraftStream?: typeof createTelegramDraftStream;
   deliverReplies?: typeof deliverReplies;
@@ -124,6 +126,9 @@ export const defaultTelegramBotDeps: TelegramBotDeps = {
   },
   get wasSentByBot() {
     return wasSentByBot;
+  },
+  get getTelegramPollContext() {
+    return getTelegramPollContext;
   },
   get resolveExecApproval() {
     return resolveTelegramExecApproval;

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1910,6 +1910,103 @@ export const registerTelegramHandlers = ({
       throw err;
     }
   });
+
+  bot.on("poll_answer", async (ctx) => {
+    try {
+      const pollAnswer = ctx.pollAnswer;
+      if (!pollAnswer) {
+        return;
+      }
+      if (shouldSkipUpdate(ctx)) {
+        return;
+      }
+
+      const pollId = pollAnswer.poll_id?.trim();
+      if (!pollId) {
+        return;
+      }
+      const pollContext = telegramDeps.getTelegramPollContext(accountId, pollId, cfg);
+      if (!pollContext) {
+        logVerbose(`telegram: skipped poll_answer for unknown poll ${pollId}`);
+        return;
+      }
+
+      const chatId = Number.parseInt(pollContext.chatId, 10);
+      if (!Number.isFinite(chatId)) {
+        logVerbose(`telegram: skipped poll_answer for non-numeric chat ${pollContext.chatId}`);
+        return;
+      }
+
+      const user = pollAnswer.user;
+      if (user?.is_bot) {
+        return;
+      }
+      const senderId = user?.id != null ? String(user.id) : "";
+      const senderUsername = user?.username ?? "";
+      const isGroup = pollContext.chatId.startsWith("-");
+      const isForum = isGroup && pollContext.messageThreadId != null;
+      const eventAuthContext = await resolveTelegramEventAuthorizationContext({
+        chatId,
+        isGroup,
+        isForum,
+        senderId,
+        messageThreadId: pollContext.messageThreadId,
+      });
+      const senderAuthorization = await authorizeTelegramEventSender({
+        chatId,
+        isGroup,
+        senderId,
+        senderUsername,
+        mode: "reaction",
+        context: eventAuthContext,
+      });
+      if (!senderAuthorization) {
+        return;
+      }
+
+      const sessionState = resolveTelegramSessionState({
+        chatId,
+        isGroup,
+        isForum,
+        messageThreadId: pollContext.messageThreadId,
+        senderId,
+      });
+
+      const optionIds = [...new Set((pollAnswer.option_ids ?? []).filter(Number.isInteger))];
+      const selectedOptions = optionIds
+        .map((index) => pollContext.options[index])
+        .filter((option): option is string => typeof option === "string" && option.length > 0);
+      const selectionLabel =
+        selectedOptions.length > 0
+          ? selectedOptions.join(", ")
+          : optionIds.length > 0
+            ? optionIds.map(String).join(", ")
+            : "none";
+
+      const senderName = user && [user.first_name, user.last_name].filter(Boolean).join(" ").trim();
+      const senderUsernameLabel = user?.username ? `@${user.username}` : undefined;
+      let senderLabel = senderName;
+      if (senderName && senderUsernameLabel) {
+        senderLabel = `${senderName} (${senderUsernameLabel})`;
+      } else if (!senderName && senderUsernameLabel) {
+        senderLabel = senderUsernameLabel;
+      }
+      if (!senderLabel && user?.id) {
+        senderLabel = `id:${user.id}`;
+      }
+
+      const text = `Telegram poll answered by ${senderLabel || "unknown"}: ${pollContext.question} -> ${selectionLabel}`;
+      telegramDeps.enqueueSystemEvent(text, {
+        sessionKey: sessionState.sessionKey,
+        contextKey: `telegram:poll_answer:${pollContext.chatId}:${pollId}:${user?.id ?? "anon"}:${optionIds.join(",") || "none"}`,
+      });
+      logVerbose(`telegram: poll answer event enqueued: ${text}`);
+    } catch (err) {
+      runtime.error?.(danger(`telegram poll_answer handler failed: ${String(err)}`));
+      throw err;
+    }
+  });
+
   const processInboundMessage = async (params: {
     ctx: TelegramContext;
     msg: Message;

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -288,6 +288,17 @@ vi.doMock("./sent-message-cache.js", () => ({
   clearSentMessageCache: vi.fn(),
 }));
 
+const pollContextStoreHoisted = vi.hoisted(() => ({
+  getTelegramPollContext: vi.fn(() => undefined),
+}));
+export const getTelegramPollContext = pollContextStoreHoisted.getTelegramPollContext;
+
+vi.doMock("./poll-context-store.js", () => ({
+  getTelegramPollContext: pollContextStoreHoisted.getTelegramPollContext,
+  recordTelegramPollContext: vi.fn(),
+  clearTelegramPollContextCache: vi.fn(),
+}));
+
 // All spy variables used inside vi.mock("grammy", ...) must be created via
 // vi.hoisted() so they are available when the hoisted factory runs, regardless
 // of module evaluation order across different test files.
@@ -465,6 +476,7 @@ export const telegramBotDepsForTest: TelegramBotDeps = {
     listSkillCommandsForAgents as TelegramBotDeps["listSkillCommandsForAgents"],
   syncTelegramMenuCommands: syncTelegramMenuCommands as TelegramBotDeps["syncTelegramMenuCommands"],
   wasSentByBot: wasSentByBot as TelegramBotDeps["wasSentByBot"],
+  getTelegramPollContext: getTelegramPollContext as TelegramBotDeps["getTelegramPollContext"],
   resolveExecApproval: resolveExecApprovalSpy as NonNullable<
     TelegramBotDeps["resolveExecApproval"]
   >,
@@ -629,6 +641,8 @@ beforeEach(() => {
   enqueueSystemEventSpy.mockReset();
   wasSentByBot.mockReset();
   wasSentByBot.mockReturnValue(false);
+  getTelegramPollContext.mockReset();
+  getTelegramPollContext.mockReturnValue(undefined);
   listSkillCommandsForAgents.mockReset();
   listSkillCommandsForAgents.mockReturnValue([]);
   buildModelsProviderData.mockReset();

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -30,6 +30,7 @@ const {
   getLoadConfigMock,
   getLoadWebMediaMock,
   getReadChannelAllowFromStoreMock,
+  getTelegramPollContext,
   getOnHandler,
   listSkillCommandsForAgents,
   onSpy,
@@ -3861,6 +3862,16 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("registers poll_answer handler", () => {
+    onSpy.mockClear();
+    createTelegramBot({ token: "tok" });
+    const pollAnswerHandler = onSpy.mock.calls.find((call) => call[0] === "poll_answer");
+    expect(pollAnswerHandler?.[0]).toBe("poll_answer");
+    if (typeof pollAnswerHandler?.[1] !== "function") {
+      throw new Error("expected poll_answer handler");
+    }
+  });
+
   it("enqueues system event for reaction", async () => {
     onSpy.mockClear();
     enqueueSystemEventSpy.mockClear();
@@ -3893,6 +3904,73 @@ describe("createTelegramBot", () => {
       `Telegram reaction added: ${THUMBS_UP_EMOJI} by Ada (@ada_bot) on msg 42`,
     );
     expect(String(systemEventOptions().contextKey)).toContain("telegram:reaction:add:1234:42:9");
+  });
+
+  it("enqueues system event for poll_answer with stored poll context", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    getTelegramPollContext.mockReturnValue({
+      accountId: "default",
+      chatId: "-1005678",
+      question: "Release now?",
+      options: ["Ship", "Wait"],
+      messageThreadId: 91,
+      updatedAt: Date.now(),
+    });
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("poll_answer") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      update: { update_id: 520 },
+      pollAnswer: {
+        poll_id: "poll-1",
+        user: { id: 10, first_name: "Bob", username: "bob_user" },
+        option_ids: [1],
+      },
+    });
+
+    expect(getTelegramPollContext).toHaveBeenCalledWith("default", "poll-1", expect.anything());
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
+    expect(firstSystemEventArg(0)).toBe(
+      "Telegram poll answered by Bob (@bob_user): Release now? -> Wait",
+    );
+    expect(String(systemEventOptions().sessionKey)).toContain("telegram:group:-1005678:topic:91");
+    expect(String(systemEventOptions().contextKey)).toContain(
+      "telegram:poll_answer:-1005678:poll-1:10:1",
+    );
+  });
+
+  it("skips poll_answer when poll context is missing", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    getTelegramPollContext.mockReturnValue(undefined);
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("poll_answer") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      update: { update_id: 521 },
+      pollAnswer: {
+        poll_id: "missing-poll",
+        user: { id: 10, first_name: "Bob" },
+        option_ids: [0],
+      },
+    });
+
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/extensions/telegram/src/poll-context-store.ts
+++ b/extensions/telegram/src/poll-context-store.ts
@@ -1,0 +1,189 @@
+import fs from "node:fs";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { replaceFileAtomicSync } from "openclaw/plugin-sdk/security-runtime";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+const TELEGRAM_POLL_CONTEXT_STATE_KEY = Symbol.for("openclaw.telegramPollContextState");
+
+export type TelegramPollContext = {
+  accountId: string;
+  chatId: string;
+  question: string;
+  options: string[];
+  messageThreadId?: number;
+  updatedAt: number;
+};
+
+type PollContextStore = Map<string, TelegramPollContext>;
+
+type PollContextBucket = {
+  persistedPath: string;
+  store: PollContextStore;
+};
+
+type PollContextState = {
+  bucketsByPath: Map<string, PollContextBucket>;
+};
+
+function getPollContextState(): PollContextState {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  const existing = globalStore[TELEGRAM_POLL_CONTEXT_STATE_KEY] as PollContextState | undefined;
+  if (existing) {
+    return existing;
+  }
+  const state: PollContextState = {
+    bucketsByPath: new Map(),
+  };
+  globalStore[TELEGRAM_POLL_CONTEXT_STATE_KEY] = state;
+  return state;
+}
+
+function createPollContextStore(): PollContextStore {
+  return new Map<string, TelegramPollContext>();
+}
+
+function resolvePollContextStorePath(cfg?: Pick<OpenClawConfig, "session">): string {
+  return `${resolveStorePath(cfg?.session?.store)}.telegram-poll-context.json`;
+}
+
+function buildContextKey(accountId: string, pollId: string): string {
+  return `${accountId}:${pollId}`;
+}
+
+function cleanupExpired(store: PollContextStore, now: number): void {
+  for (const [key, entry] of store) {
+    if (now - entry.updatedAt > TTL_MS) {
+      store.delete(key);
+    }
+  }
+}
+
+function isTelegramPollContext(value: unknown): value is TelegramPollContext {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const context = value as Partial<TelegramPollContext>;
+  return (
+    typeof context.accountId === "string" &&
+    typeof context.chatId === "string" &&
+    typeof context.question === "string" &&
+    Array.isArray(context.options) &&
+    context.options.every((option) => typeof option === "string") &&
+    typeof context.updatedAt === "number" &&
+    Number.isFinite(context.updatedAt)
+  );
+}
+
+function readPersistedPollContexts(filePath: string): PollContextStore {
+  if (!fs.existsSync(filePath)) {
+    return createPollContextStore();
+  }
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const now = Date.now();
+    const store = createPollContextStore();
+    for (const [key, value] of Object.entries(parsed)) {
+      if (!isTelegramPollContext(value)) {
+        continue;
+      }
+      if (now - value.updatedAt > TTL_MS) {
+        continue;
+      }
+      store.set(key, value);
+    }
+    return store;
+  } catch (error) {
+    logVerbose(`telegram: failed to read poll-context cache: ${String(error)}`);
+    return createPollContextStore();
+  }
+}
+
+function getPollContextBucket(cfg?: Pick<OpenClawConfig, "session">): PollContextBucket {
+  const state = getPollContextState();
+  const persistedPath = resolvePollContextStorePath(cfg);
+  const existing = state.bucketsByPath.get(persistedPath);
+  if (existing) {
+    return existing;
+  }
+  const bucket = {
+    persistedPath,
+    store: readPersistedPollContexts(persistedPath),
+  };
+  state.bucketsByPath.set(persistedPath, bucket);
+  return bucket;
+}
+
+function persistPollContexts(bucket: PollContextBucket): void {
+  const { store, persistedPath } = bucket;
+  cleanupExpired(store, Date.now());
+  if (store.size === 0) {
+    fs.rmSync(persistedPath, { force: true });
+    return;
+  }
+  replaceFileAtomicSync({
+    filePath: persistedPath,
+    content: JSON.stringify(Object.fromEntries(store)),
+    tempPrefix: ".telegram-poll-context",
+  });
+}
+
+export function recordTelegramPollContext(
+  pollId: string,
+  params: {
+    accountId: string;
+    chatId: string | number;
+    question: string;
+    options: string[];
+    messageThreadId?: number;
+  },
+  cfg?: Pick<OpenClawConfig, "session">,
+): void {
+  const normalizedPollId = pollId.trim();
+  if (!normalizedPollId) {
+    return;
+  }
+  const bucket = getPollContextBucket(cfg);
+  bucket.store.set(buildContextKey(params.accountId, normalizedPollId), {
+    accountId: params.accountId,
+    chatId: String(params.chatId),
+    question: params.question,
+    options: [...params.options],
+    ...(params.messageThreadId !== undefined ? { messageThreadId: params.messageThreadId } : {}),
+    updatedAt: Date.now(),
+  });
+  try {
+    persistPollContexts(bucket);
+  } catch (error) {
+    logVerbose(`telegram: failed to persist poll-context cache: ${String(error)}`);
+  }
+}
+
+export function getTelegramPollContext(
+  accountId: string,
+  pollId: string,
+  cfg?: Pick<OpenClawConfig, "session">,
+): TelegramPollContext | undefined {
+  const normalizedPollId = pollId.trim();
+  if (!normalizedPollId) {
+    return undefined;
+  }
+  const bucket = getPollContextBucket(cfg);
+  cleanupExpired(bucket.store, Date.now());
+  return bucket.store.get(buildContextKey(accountId, normalizedPollId));
+}
+
+export function clearTelegramPollContextCache(): void {
+  const state = getPollContextState();
+  for (const bucket of state.bucketsByPath.values()) {
+    bucket.store.clear();
+    fs.rmSync(bucket.persistedPath, { force: true });
+  }
+  state.bucketsByPath.clear();
+}
+
+export function resetTelegramPollContextCacheForTest(): void {
+  getPollContextState().bucketsByPath.clear();
+}

--- a/extensions/telegram/src/poll-context-store.ts
+++ b/extensions/telegram/src/poll-context-store.ts
@@ -1,11 +1,18 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { replaceFileAtomicSync } from "openclaw/plugin-sdk/security-runtime";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { getTelegramRuntime } from "./runtime.js";
 
 const TTL_MS = 24 * 60 * 60 * 1000;
+export const TELEGRAM_POLL_CONTEXT_NAMESPACE = "telegram.poll-context";
+export const TELEGRAM_POLL_CONTEXT_MAX_ENTRIES = 10_000;
 const TELEGRAM_POLL_CONTEXT_STATE_KEY = Symbol.for("openclaw.telegramPollContextState");
+const TELEGRAM_POLL_CONTEXT_STORE_FOR_TEST_KEY = Symbol.for(
+  "openclaw.telegramPollContextStoreForTest",
+);
 
 export type TelegramPollContext = {
   accountId: string;
@@ -16,16 +23,34 @@ export type TelegramPollContext = {
   updatedAt: number;
 };
 
-type PollContextStore = Map<string, TelegramPollContext>;
+type StoredTelegramPollContext = TelegramPollContext & {
+  pollId: string;
+  scopeKey: string;
+};
+
+type PollContextStore = Map<string, StoredTelegramPollContext>;
+type PollContextPersistentStore = PluginStateSyncKeyedStore<StoredTelegramPollContext>;
 
 type PollContextBucket = {
-  persistedPath: string;
+  scopeKey: string;
   store: PollContextStore;
 };
 
 type PollContextState = {
-  bucketsByPath: Map<string, PollContextBucket>;
+  bucketsByScope: Map<string, PollContextBucket>;
 };
+
+let pollContextStoreForTest: PollContextPersistentStore | undefined;
+
+function getPollContextStoreForTest(): PollContextPersistentStore | undefined {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  return (
+    pollContextStoreForTest ??
+    (globalStore[TELEGRAM_POLL_CONTEXT_STORE_FOR_TEST_KEY] as
+      | PollContextPersistentStore
+      | undefined)
+  );
+}
 
 function getPollContextState(): PollContextState {
   const globalStore = globalThis as Record<PropertyKey, unknown>;
@@ -34,22 +59,44 @@ function getPollContextState(): PollContextState {
     return existing;
   }
   const state: PollContextState = {
-    bucketsByPath: new Map(),
+    bucketsByScope: new Map(),
   };
   globalStore[TELEGRAM_POLL_CONTEXT_STATE_KEY] = state;
   return state;
 }
 
 function createPollContextStore(): PollContextStore {
-  return new Map<string, TelegramPollContext>();
+  return new Map<string, StoredTelegramPollContext>();
 }
 
 function resolvePollContextStorePath(cfg?: Pick<OpenClawConfig, "session">): string {
   return `${resolveStorePath(cfg?.session?.store)}.telegram-poll-context.json`;
 }
 
+function resolvePollContextScopeKey(cfg?: Pick<OpenClawConfig, "session">): string {
+  const storePath = resolveStorePath(cfg?.session?.store);
+  return createHash("sha256").update(storePath, "utf8").digest("hex").slice(0, 24);
+}
+
 function buildContextKey(accountId: string, pollId: string): string {
   return `${accountId}:${pollId}`;
+}
+
+function pollContextEntryKey(scopeKey: string, accountId: string, pollId: string): string {
+  return createHash("sha256")
+    .update(`${scopeKey}\0${accountId}\0${pollId}`, "utf8")
+    .digest("hex")
+    .slice(0, 32);
+}
+
+function openPollContextStore(): PollContextPersistentStore {
+  return (
+    getPollContextStoreForTest() ??
+    getTelegramRuntime().state.openSyncKeyedStore<StoredTelegramPollContext>({
+      namespace: TELEGRAM_POLL_CONTEXT_NAMESPACE,
+      maxEntries: TELEGRAM_POLL_CONTEXT_MAX_ENTRIES,
+    })
+  );
 }
 
 function cleanupExpired(store: PollContextStore, now: number): void {
@@ -76,7 +123,7 @@ function isTelegramPollContext(value: unknown): value is TelegramPollContext {
   );
 }
 
-function readPersistedPollContexts(filePath: string): PollContextStore {
+function readLegacyPollContexts(filePath: string): PollContextStore {
   if (!fs.existsSync(filePath)) {
     return createPollContextStore();
   }
@@ -89,45 +136,98 @@ function readPersistedPollContexts(filePath: string): PollContextStore {
       if (!isTelegramPollContext(value)) {
         continue;
       }
-      if (now - value.updatedAt > TTL_MS) {
+      const pollId = key.split(":").slice(1).join(":").trim();
+      if (!pollId || now - value.updatedAt > TTL_MS) {
         continue;
       }
-      store.set(key, value);
+      store.set(key, {
+        ...value,
+        pollId,
+      });
     }
     return store;
   } catch (error) {
-    logVerbose(`telegram: failed to read poll-context cache: ${String(error)}`);
+    logVerbose(`telegram: failed to read legacy poll-context cache: ${String(error)}`);
     return createPollContextStore();
+  }
+}
+
+function readPersistedPollContexts(scopeKey: string): PollContextStore {
+  const now = Date.now();
+  const store = createPollContextStore();
+  try {
+    for (const entry of openPollContextStore().entries()) {
+      if (entry.value.scopeKey !== scopeKey || now - entry.value.updatedAt > TTL_MS) {
+        continue;
+      }
+      store.set(buildContextKey(entry.value.accountId, entry.value.pollId), entry.value);
+    }
+  } catch (error) {
+    logVerbose(`telegram: failed to read poll-context store: ${String(error)}`);
+  }
+  return store;
+}
+
+function persistPollContexts(bucket: PollContextBucket): void {
+  const { store, scopeKey } = bucket;
+  const now = Date.now();
+  cleanupExpired(store, now);
+  for (const entry of store.values()) {
+    const ttlMs = TTL_MS - Math.max(0, now - entry.updatedAt);
+    if (ttlMs <= 0) {
+      continue;
+    }
+    openPollContextStore().register(
+      pollContextEntryKey(scopeKey, entry.accountId, entry.pollId),
+      entry,
+      { ttlMs },
+    );
+  }
+}
+
+function migrateLegacyPollContexts(
+  bucket: PollContextBucket,
+  cfg?: Pick<OpenClawConfig, "session">,
+): void {
+  const legacyPath = resolvePollContextStorePath(cfg);
+  if (!fs.existsSync(legacyPath)) {
+    return;
+  }
+  const legacyStore = readLegacyPollContexts(legacyPath);
+  if (legacyStore.size === 0) {
+    fs.rmSync(legacyPath, { force: true });
+    return;
+  }
+  for (const [key, entry] of legacyStore) {
+    if (!bucket.store.has(key)) {
+      bucket.store.set(key, {
+        ...entry,
+        scopeKey: bucket.scopeKey,
+      });
+    }
+  }
+  try {
+    persistPollContexts(bucket);
+    fs.rmSync(legacyPath, { force: true });
+  } catch (error) {
+    logVerbose(`telegram: failed to migrate legacy poll-context cache: ${String(error)}`);
   }
 }
 
 function getPollContextBucket(cfg?: Pick<OpenClawConfig, "session">): PollContextBucket {
   const state = getPollContextState();
-  const persistedPath = resolvePollContextStorePath(cfg);
-  const existing = state.bucketsByPath.get(persistedPath);
+  const scopeKey = resolvePollContextScopeKey(cfg);
+  const existing = state.bucketsByScope.get(scopeKey);
   if (existing) {
     return existing;
   }
   const bucket = {
-    persistedPath,
-    store: readPersistedPollContexts(persistedPath),
+    scopeKey,
+    store: readPersistedPollContexts(scopeKey),
   };
-  state.bucketsByPath.set(persistedPath, bucket);
+  migrateLegacyPollContexts(bucket, cfg);
+  state.bucketsByScope.set(scopeKey, bucket);
   return bucket;
-}
-
-function persistPollContexts(bucket: PollContextBucket): void {
-  const { store, persistedPath } = bucket;
-  cleanupExpired(store, Date.now());
-  if (store.size === 0) {
-    fs.rmSync(persistedPath, { force: true });
-    return;
-  }
-  replaceFileAtomicSync({
-    filePath: persistedPath,
-    content: JSON.stringify(Object.fromEntries(store)),
-    tempPrefix: ".telegram-poll-context",
-  });
 }
 
 export function recordTelegramPollContext(
@@ -147,6 +247,8 @@ export function recordTelegramPollContext(
   }
   const bucket = getPollContextBucket(cfg);
   bucket.store.set(buildContextKey(params.accountId, normalizedPollId), {
+    scopeKey: bucket.scopeKey,
+    pollId: normalizedPollId,
     accountId: params.accountId,
     chatId: String(params.chatId),
     question: params.question,
@@ -157,7 +259,7 @@ export function recordTelegramPollContext(
   try {
     persistPollContexts(bucket);
   } catch (error) {
-    logVerbose(`telegram: failed to persist poll-context cache: ${String(error)}`);
+    logVerbose(`telegram: failed to persist poll-context store: ${String(error)}`);
   }
 }
 
@@ -172,18 +274,35 @@ export function getTelegramPollContext(
   }
   const bucket = getPollContextBucket(cfg);
   cleanupExpired(bucket.store, Date.now());
-  return bucket.store.get(buildContextKey(accountId, normalizedPollId));
+  const entry = bucket.store.get(buildContextKey(accountId, normalizedPollId));
+  if (!entry) {
+    return undefined;
+  }
+  const { pollId: _pollId, scopeKey: _scopeKey, ...context } = entry;
+  return context;
 }
 
 export function clearTelegramPollContextCache(): void {
   const state = getPollContextState();
-  for (const bucket of state.bucketsByPath.values()) {
+  for (const bucket of state.bucketsByScope.values()) {
     bucket.store.clear();
-    fs.rmSync(bucket.persistedPath, { force: true });
   }
-  state.bucketsByPath.clear();
+  state.bucketsByScope.clear();
+  openPollContextStore().clear();
 }
 
 export function resetTelegramPollContextCacheForTest(): void {
-  getPollContextState().bucketsByPath.clear();
+  getPollContextState().bucketsByScope.clear();
+}
+
+export function setTelegramPollContextStoreForTest(
+  store: PollContextPersistentStore | undefined,
+): void {
+  pollContextStoreForTest = store;
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  if (store) {
+    globalStore[TELEGRAM_POLL_CONTEXT_STORE_FOR_TEST_KEY] = store;
+  } else {
+    delete globalStore[TELEGRAM_POLL_CONTEXT_STORE_FOR_TEST_KEY];
+  }
 }

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -15,6 +15,11 @@ import {
   resolveTelegramMessageCacheScope,
   resetTelegramMessageCacheBucketsForTest,
 } from "./message-cache.js";
+import {
+  clearTelegramPollContextCache,
+  getTelegramPollContext,
+  resetTelegramPollContextCacheForTest,
+} from "./poll-context-store.js";
 import { clearTelegramRuntime, setTelegramRuntime } from "./runtime.js";
 import type { TelegramRuntime } from "./runtime.types.js";
 import type { TelegramApiOverride } from "./send.js";
@@ -319,6 +324,8 @@ afterEach(() => {
   setLoggerOverride(null);
   resetLogger();
   resetTelegramMessageCacheBucketsForTest();
+  clearTelegramPollContextCache();
+  resetTelegramPollContextCacheForTest();
   vi.restoreAllMocks();
 });
 
@@ -3573,6 +3580,33 @@ describe("sendPollTelegram", () => {
     expect(sendPollCall[1]).toBe("Q");
     expect(sendPollCall[2]).toEqual(["A", "B"]);
     expect(requireRecord(sendPollCall[3], "send poll params").open_period).toBe(60);
+  });
+
+  it("records poll context for poll_answer routing", async () => {
+    const api = {
+      sendPoll: vi.fn(async () => ({ message_id: 123, chat: { id: -100555 }, poll: { id: "p1" } })),
+    };
+
+    await sendPollTelegram(
+      "-100555",
+      { question: " Q ", options: [" A ", "B "] },
+      {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "t",
+        api: api as unknown as Bot["api"],
+        accountId: "work",
+        messageThreadId: 77,
+      },
+    );
+
+    expect(getTelegramPollContext("work", "p1", TELEGRAM_TEST_CFG)).toEqual({
+      accountId: "work",
+      chatId: "-100555",
+      question: "Q",
+      options: ["A", "B"],
+      messageThreadId: 77,
+      updatedAt: expect.any(Number),
+    });
   });
 
   it("fails poll sends instead of retrying without message_thread_id", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -19,6 +19,9 @@ import {
   clearTelegramPollContextCache,
   getTelegramPollContext,
   resetTelegramPollContextCacheForTest,
+  setTelegramPollContextStoreForTest,
+  TELEGRAM_POLL_CONTEXT_MAX_ENTRIES,
+  TELEGRAM_POLL_CONTEXT_NAMESPACE,
 } from "./poll-context-store.js";
 import { clearTelegramRuntime, setTelegramRuntime } from "./runtime.js";
 import type { TelegramRuntime } from "./runtime.types.js";
@@ -131,6 +134,7 @@ const sendMessageTelegram: typeof sendMessageTelegramImpl = async (to, text, opt
 
 const TELEGRAM_TEST_CFG = {};
 let sentMessageStore: NonNullable<Parameters<typeof setTelegramSentMessageStoreForTest>[0]>;
+let pollContextStore: NonNullable<Parameters<typeof setTelegramPollContextStoreForTest>[0]>;
 
 function markdownTable(columns: number): string {
   return [
@@ -167,6 +171,12 @@ beforeEach(() => {
   });
   sentMessageStore.clear();
   setTelegramSentMessageStoreForTest(sentMessageStore);
+  pollContextStore = createPluginStateSyncKeyedStoreForTests("telegram", {
+    namespace: TELEGRAM_POLL_CONTEXT_NAMESPACE,
+    maxEntries: TELEGRAM_POLL_CONTEXT_MAX_ENTRIES,
+  });
+  pollContextStore.clear();
+  setTelegramPollContextStoreForTest(pollContextStore);
 });
 
 function installTelegramStateRuntimeForTest(): void {
@@ -317,15 +327,16 @@ function capturedLogText(logFile: string): string {
 }
 
 afterEach(() => {
-  clearTelegramRuntime();
+  clearTelegramPollContextCache();
+  resetTelegramPollContextCacheForTest();
   clearSentMessageCache();
   setTelegramSentMessageStoreForTest(undefined);
+  setTelegramPollContextStoreForTest(undefined);
+  clearTelegramRuntime();
   resetPluginStateStoreForTests();
   setLoggerOverride(null);
   resetLogger();
   resetTelegramMessageCacheBucketsForTest();
-  clearTelegramPollContextCache();
-  resetTelegramPollContextCacheForTest();
   vi.restoreAllMocks();
 });
 
@@ -481,6 +492,104 @@ describe("sent-message-cache", () => {
       cacheA.clearSentMessageCache();
       cacheA.setTelegramSentMessageStoreForTest(undefined);
       cacheB.setTelegramSentMessageStoreForTest(undefined);
+    }
+  });
+});
+
+describe("poll-context-store", () => {
+  it("keeps poll context across restart without writing a sidecar", async () => {
+    const persistedStorePath = `/tmp/openclaw-telegram-send-tests-${process.pid}-poll-restart.json`;
+    const pollContextCfg = { session: { store: persistedStorePath } };
+
+    await sendPollTelegram(
+      "-100555",
+      { question: "Q", options: ["A", "B"] },
+      {
+        cfg: pollContextCfg,
+        token: "t",
+        api: {
+          sendPoll: vi.fn(async () => ({
+            message_id: 123,
+            chat: { id: -100555 },
+            poll: { id: "p1" },
+          })),
+        } as unknown as Bot["api"],
+        accountId: "work",
+        messageThreadId: 77,
+      },
+    );
+
+    expect(getTelegramPollContext("work", "p1", pollContextCfg)).toEqual({
+      accountId: "work",
+      chatId: "-100555",
+      question: "Q",
+      options: ["A", "B"],
+      messageThreadId: 77,
+      updatedAt: expect.any(Number),
+    });
+    expect(fs.existsSync(`${persistedStorePath}.telegram-poll-context.json`)).toBe(false);
+
+    resetTelegramPollContextCacheForTest();
+
+    const restartedStore = await importFreshModule<typeof import("./poll-context-store.js")>(
+      import.meta.url,
+      "./poll-context-store.js?scope=restart",
+    );
+    restartedStore.setTelegramPollContextStoreForTest(pollContextStore);
+
+    try {
+      expect(restartedStore.getTelegramPollContext("work", "p1", pollContextCfg)).toEqual({
+        accountId: "work",
+        chatId: "-100555",
+        question: "Q",
+        options: ["A", "B"],
+        messageThreadId: 77,
+        updatedAt: expect.any(Number),
+      });
+      expect(fs.existsSync(`${persistedStorePath}.telegram-poll-context.json`)).toBe(false);
+    } finally {
+      restartedStore.clearTelegramPollContextCache();
+      restartedStore.setTelegramPollContextStoreForTest(undefined);
+      fs.rmSync(persistedStorePath, { force: true });
+      fs.rmSync(`${persistedStorePath}.telegram-poll-context.json`, { force: true });
+    }
+  });
+
+  it("migrates legacy poll context sidecars into plugin state", () => {
+    const persistedStorePath = `/tmp/openclaw-telegram-send-tests-${process.pid}-poll-legacy.json`;
+    const legacyPath = `${persistedStorePath}.telegram-poll-context.json`;
+    const pollContextCfg = { session: { store: persistedStorePath } };
+    const now = Date.now();
+
+    fs.writeFileSync(
+      legacyPath,
+      JSON.stringify({
+        "work:p1": {
+          accountId: "work",
+          chatId: "-100555",
+          question: "Q",
+          options: ["A", "B"],
+          messageThreadId: 77,
+          updatedAt: now,
+        },
+      }),
+      "utf8",
+    );
+
+    try {
+      expect(getTelegramPollContext("work", "p1", pollContextCfg)).toEqual({
+        accountId: "work",
+        chatId: "-100555",
+        question: "Q",
+        options: ["A", "B"],
+        messageThreadId: 77,
+        updatedAt: now,
+      });
+      expect(fs.existsSync(legacyPath)).toBe(false);
+    } finally {
+      clearTelegramPollContextCache();
+      fs.rmSync(persistedStorePath, { force: true });
+      fs.rmSync(legacyPath, { force: true });
     }
   });
 });

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -35,6 +35,7 @@ import {
   isTelegramServerError,
 } from "./network-errors.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
+import { recordTelegramPollContext } from "./poll-context-store.js";
 import { makeProxyFetch } from "./proxy.js";
 import {
   buildTelegramThreadReplyParams,
@@ -1889,6 +1890,21 @@ export async function sendPollTelegram(
   const resolvedChatId = String(result?.chat?.id ?? chatId);
   const pollId = result?.poll?.id;
   recordSentMessage(chatId, messageId, opts.cfg);
+  if (pollId?.trim()) {
+    recordTelegramPollContext(
+      pollId,
+      {
+        accountId: account.accountId,
+        chatId: resolvedChatId,
+        question: normalizedPoll.question,
+        options: normalizedPoll.options,
+        ...(threadParams.message_thread_id !== undefined
+          ? { messageThreadId: threadParams.message_thread_id }
+          : {}),
+      },
+      opts.cfg,
+    );
+  }
 
   recordChannelActivity({
     channel: "telegram",


### PR DESCRIPTION
## Summary
- route Telegram `poll_answer` updates through agent turns by adding a `poll_id` context cache
- record poll routing context when `sendPollTelegram` sends a poll
- persist poll routing context in Telegram plugin state instead of a session-store JSON sidecar
- add Telegram coverage for poll context persistence, legacy sidecar migration, and `poll_answer` event handling

## Root cause
Telegram `poll_answer` updates do not include `chat_id` or thread routing metadata, so the runtime had no way to resolve the target conversation after a user voted in a poll.

## Impact
Non-anonymous Telegram poll votes can now reach the correct agent session, including forum-topic sessions when the poll was sent in a topic.

## Validation
- `node scripts/run-vitest.mjs extensions/telegram/src/send.test.ts --testNamePattern 'poll'`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts --testNamePattern 'poll_answer|poll answer|poll context'`
- plugin-state migration coverage verifies restart persistence without writing `.telegram-poll-context.json`, and imports existing legacy sidecars into plugin state on first read

## Notes
- This addresses issue #89573.
- Live Telegram proof has been requested separately in the PR thread so the storage-shape fix and behavior proof can land independently.
- A second local rerun on the fresh branch previously hit a missing local `rastermill` dependency in this environment, but the targeted Telegram tests above passed on the current branch.
