### PR TITLE
fix(slack): allow name-allowlisted reads by channel id

### DIFF
--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -994,6 +994,24 @@ describe("handleSlackAction", () => {
     expect(requireMockArg(readSlackMessages, "readSlackMessages", 0, 0)).toBe("C_ALLOWED");
   });
 
+  it("reads from name-allowlisted Slack target channels when the context has the channel name", async () => {
+    readSlackMessages.mockResolvedValueOnce({ messages: [], hasMore: false });
+
+    const cfg = slackConfig({
+      groupPolicy: "allowlist",
+      dangerouslyAllowNameMatching: true,
+      channels: {
+        "#allowed-channel": { enabled: true },
+      },
+    });
+    await handleSlackAction({ action: "readMessages", channelId: "C0123456789" }, cfg, {
+      currentChannelId: "C0123456789",
+      currentChannelName: "allowed-channel",
+    });
+
+    expect(requireMockArg(readSlackMessages, "readSlackMessages", 0, 0)).toBe("C0123456789");
+  });
+
   it("rejects Slack reads for non-allowlisted target channels", async () => {
     const cfg = slackConfig({
       groupPolicy: "allowlist",

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -5,6 +5,7 @@ import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import type { ResolvedSlackAccount } from "./accounts.js";
 import { parseSlackBlocksInput } from "./blocks-input.js";
+import { resolveSlackConversationInfo } from "./channel-type.js";
 import { resolveSlackChannelConfig } from "./monitor/channel-config.js";
 import { isSlackChannelAllowedByPolicy } from "./monitor/policy.js";
 import {
@@ -78,6 +79,8 @@ export const slackActionRuntime = {
 export type SlackActionContext = {
   /** Current channel ID for auto-threading. */
   currentChannelId?: string;
+  /** Current channel name, when available from the inbound transport context. */
+  currentChannelName?: string;
   /** Routable target for the current conversation when it differs from the channel ID. */
   currentMessagingTarget?: string;
   /** Current thread timestamp for auto-threading. */
@@ -152,15 +155,24 @@ function isImageContentType(value: string | undefined): boolean {
   return value?.trim().toLowerCase().startsWith("image/") === true;
 }
 
-function assertSlackReadTargetAllowed(params: {
+type SlackReadTargetAllowance = {
+  allowed: boolean;
+  explicitlyDenied: boolean;
+  groupPolicy: "open" | "disabled" | "allowlist";
+  channelAllowlistConfigured: boolean;
+};
+
+function resolveSlackReadTargetAllowance(params: {
   account: ResolvedSlackAccount;
   cfg: OpenClawConfig;
   channelId: string;
-}) {
+  channelName?: string;
+}): SlackReadTargetAllowance {
   const channels = params.account.config.channels;
   const channelKeys = Object.keys(channels ?? {});
   const channelConfig = resolveSlackChannelConfig({
     channelId: params.channelId,
+    channelName: params.channelName,
     channels,
     channelKeys,
     allowNameMatching: params.account.config.dangerouslyAllowNameMatching,
@@ -172,20 +184,67 @@ function assertSlackReadTargetAllowed(params: {
     groupPolicy: params.account.config.groupPolicy,
     defaultGroupPolicy: params.cfg.channels?.defaults?.groupPolicy,
   });
+  const policyAllowed = isSlackChannelAllowedByPolicy({
+    groupPolicy,
+    channelAllowlistConfigured: channelKeys.length > 0,
+    channelAllowed,
+  });
+  return {
+    allowed:
+      groupPolicy !== "disabled" &&
+      policyAllowed &&
+      (channelAllowed || (groupPolicy === "open" && !channelConfig?.matchSource)),
+    explicitlyDenied:
+      !channelAllowed && (groupPolicy !== "open" || Boolean(channelConfig?.matchSource)),
+    groupPolicy,
+    channelAllowlistConfigured: channelKeys.length > 0,
+  };
+}
+
+async function assertSlackReadTargetAllowed(params: {
+  account: ResolvedSlackAccount;
+  cfg: OpenClawConfig;
+  channelId: string;
+  channelName?: string;
+}) {
+  const direct = resolveSlackReadTargetAllowance(params);
+  if (direct.allowed) {
+    return;
+  }
+  if (direct.explicitlyDenied || direct.groupPolicy === "disabled") {
+    throw new Error("Slack read target channel is not allowed.");
+  }
+
+  // Action tools often receive only a Slack channel ID from permalinks. In
+  // allowlist mode, operators commonly configure human-readable channel names
+  // (for example "#allowed-channel"). If name matching is enabled, resolve the
+  // channel name lazily and re-check before failing closed.
   if (
-    groupPolicy === "disabled" ||
-    (groupPolicy === "allowlist" &&
-      !isSlackChannelAllowedByPolicy({
-        groupPolicy,
-        channelAllowlistConfigured: channelKeys.length > 0,
-        channelAllowed,
-      }))
+    direct.groupPolicy === "allowlist" &&
+    direct.channelAllowlistConfigured &&
+    params.account.config.dangerouslyAllowNameMatching === true &&
+    !params.channelName
   ) {
-    throw new Error("Slack read target channel is not allowed.");
+    const conversationInfo = await resolveSlackConversationInfo({
+      cfg: params.cfg,
+      accountId: params.account.accountId,
+      channelId: params.channelId,
+    });
+    if (conversationInfo.name) {
+      const named = resolveSlackReadTargetAllowance({
+        ...params,
+        channelName: conversationInfo.name,
+      });
+      if (named.allowed) {
+        return;
+      }
+      if (named.explicitlyDenied || named.groupPolicy === "disabled") {
+        throw new Error("Slack read target channel is not allowed.");
+      }
+    }
   }
-  if (!channelAllowed && (groupPolicy !== "open" || channelConfig?.matchSource)) {
-    throw new Error("Slack read target channel is not allowed.");
-  }
+
+  throw new Error("Slack read target channel is not allowed.");
 }
 
 export async function handleSlackAction(
@@ -264,7 +323,12 @@ export async function handleSlackAction(
       }
       return jsonResult({ ok: true, added: emoji });
     }
-    assertSlackReadTargetAllowed({ account, cfg, channelId });
+    await assertSlackReadTargetAllowed({
+      account,
+      cfg,
+      channelId,
+      channelName: context?.currentChannelName,
+    });
     const reactions = readOpts
       ? await slackActionRuntime.listSlackReactions(channelId, messageId, readOpts)
       : await slackActionRuntime.listSlackReactions(channelId, messageId);
@@ -413,7 +477,12 @@ export async function handleSlackAction(
       }
       case "readMessages": {
         const channelId = resolveChannelId();
-        assertSlackReadTargetAllowed({ account, cfg, channelId });
+        await assertSlackReadTargetAllowed({
+          account,
+          cfg,
+          channelId,
+          channelName: context?.currentChannelName,
+        });
         const limit = readPositiveIntegerParam(params, "limit", {
           message: "limit must be a positive integer.",
         });
@@ -449,7 +518,12 @@ export async function handleSlackAction(
           );
         }
         const channelId = resolveSlackChannelId(channelTarget);
-        assertSlackReadTargetAllowed({ account, cfg, channelId });
+        await assertSlackReadTargetAllowed({
+          account,
+          cfg,
+          channelId,
+          channelName: context?.currentChannelName,
+        });
         const threadId = readStringParam(params, "threadId") ?? readStringParam(params, "replyTo");
         const maxBytes = account.config?.mediaMaxMb
           ? account.config.mediaMaxMb * 1024 * 1024
@@ -526,7 +600,12 @@ export async function handleSlackAction(
       }
       return jsonResult({ ok: true });
     }
-    assertSlackReadTargetAllowed({ account, cfg, channelId });
+    await assertSlackReadTargetAllowed({
+      account,
+      cfg,
+      channelId,
+      channelName: context?.currentChannelName,
+    });
     const pins = writeOpts
       ? await slackActionRuntime.listSlackPins(channelId, readOpts)
       : await slackActionRuntime.listSlackPins(channelId);

--- a/extensions/slack/src/channel-type.test.ts
+++ b/extensions/slack/src/channel-type.test.ts
@@ -178,6 +178,31 @@ describe("resolveSlackChannelType", () => {
     expect(conversationsInfoMock).not.toHaveBeenCalled();
   });
 
+  it("returns Slack channel names from conversations.info", async () => {
+    conversationsInfoMock.mockResolvedValueOnce({
+      channel: {
+        id: "C0123456789",
+        name: "allowed-channel",
+      },
+    });
+
+    await expect(
+      resolveSlackConversationInfo({
+        cfg: {
+          channels: {
+            slack: {
+              botToken: "xoxb-test",
+            },
+          },
+        } as never,
+        channelId: "C0123456789",
+      }),
+    ).resolves.toEqual({
+      type: "channel",
+      name: "allowed-channel",
+    });
+  });
+
   it("preserves the channel-type wrapper contract", async () => {
     conversationsInfoMock.mockResolvedValueOnce({
       channel: {

--- a/extensions/slack/src/channel-type.ts
+++ b/extensions/slack/src/channel-type.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "./runtime-api.js";
 
 export type SlackConversationInfo = {
   type: "channel" | "group" | "dm" | "unknown";
+  name?: string;
   user?: string;
 };
 
@@ -94,9 +95,12 @@ export async function resolveSlackConversationInfo(params: {
       return result;
     }
     const info = await client.conversations.info({ channel: channelId });
-    const channel = info.channel as { is_im?: boolean; is_mpim?: boolean } | undefined;
+    const channel = info.channel as
+      | { is_im?: boolean; is_mpim?: boolean; name?: unknown }
+      | undefined;
     const type = channel?.is_im ? "dm" : channel?.is_mpim ? "group" : "channel";
-    const result = { type } as const;
+    const name = normalizeOptionalString(channel?.name);
+    const result: SlackConversationInfo = { type, ...(name ? { name } : {}) };
     SLACK_CONVERSATION_INFO_CACHE.set(cacheKey, result);
     return result;
   } catch {

--- a/extensions/slack/src/threading-tool-context.ts
+++ b/extensions/slack/src/threading-tool-context.ts
@@ -36,8 +36,10 @@ export function buildSlackThreadingToolContext(params: {
   const currentChannelId = currentMessagingTarget?.startsWith("channel:")
     ? currentMessagingTarget.slice("channel:".length)
     : (normalizeOptionalString(params.context.NativeChannelId) ?? currentMessagingTarget);
+  const currentChannelName = normalizeOptionalString(params.context.Channel)?.replace(/^#/, "");
   return {
     currentChannelId,
+    currentChannelName,
     currentMessagingTarget,
     currentThreadTs,
     replyToMode: effectiveReplyToMode,

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -468,6 +468,8 @@ export type ChannelThreadingContext = {
 
 export type ChannelThreadingToolContext = {
   currentChannelId?: string;
+  /** Human-readable channel name, when the transport provides one. */
+  currentChannelName?: string;
   /** Routable messaging target when it differs from the platform-native channel id. */
   currentMessagingTarget?: string;
   currentGraphChannelId?: string;


### PR DESCRIPTION
## Summary
- allow Slack read/list/pin/reaction actions to authorize channel-ID targets against name-based allowlists when Slack name matching is enabled
- propagate current Slack channel names into tool context for same-thread actions
- cache/return Slack conversation names from `conversations.info` and cover the behavior with Slack action/channel-type tests

## Tests
- `pnpm test:extension slack` (99 files, 1297 tests passed)
- `git diff --check`

## Notes
- `pnpm tsgo:extensions` currently fails on pre-existing unrelated Telegram code: `extensions/telegram/src/rich-message.ts(300,3): error TS6133: 'markdown' is declared but its value is never read.`
