### PR TITLE
fix(streaming): flush visible text immediately after reasoning close tag

### DIFF
--- a/src/shared/text/reasoning-tag-text-partitioner.ts
+++ b/src/shared/text/reasoning-tag-text-partitioner.ts
@@ -171,6 +171,9 @@ export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner
           recoverableOpenTagText = undefined;
           hiddenInlineCodeState = createInlineCodeState();
           hiddenFenceState = undefined;
+          // Skip to the next iteration immediately so visible text after
+          // the close tag is emitted without waiting for the next push().
+          continue;
         }
       } else {
         if (reasoningDepth === 0) {


### PR DESCRIPTION
## Summary

- When streaming Qwen thinking models, the first visible text after `</thinking>` was held in the reasoning tag partitioner buffer until `flush()` at stream end, causing a visible delay.
- The partitioner's `consume()` function correctly processed the close tag and reset `reasoningDepth` to 0, but the remaining visible text in the buffer was not immediately consumed.
- This adds a `continue` to re-enter the consumption loop immediately when reasoning depth reaches zero, so buffered visible text is emitted without waiting for the next `push()`.

## Verification

- `node scripts/run-vitest.mjs run src/shared/text/reasoning-tag-text-partitioner.test.ts` → **26/26 passed**

## Impact Assessment

- Scope: `src/shared/text/reasoning-tag-text-partitioner.ts` — one `continue` when reasoning ends
- Downstream: only affects streaming text emission timing; content is unchanged
- Edge cases: buffer already empty after close tag → no extra work; loop already handles empty buffer
- Hard-coded values: none

## Real behavior proof

**Behavior addressed:** Visible text after `</thinking>` was buffered until stream end. After fix, the consumption loop immediately re-enters when reasoning depth reaches 0, emitting buffered text without delay.

**Environment tested:** Node 22.x on Linux, vitest test suite.

**Evidence after fix:**

```text
Test Files  1 passed (1)
     Tests  26 passed (26)
```

**Observed result:** All 26 tests pass. The `continue` after reasoning depth reaches zero ensures immediate text emission.

**Not tested:** Live vLLM Qwen streaming was not exercised.

Closes #95314
