### PR TITLE
fix(tasks): match running cron ids to the session-key job segment

### DIFF
--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -568,4 +568,55 @@ describe("tasks commands", () => {
       }
     });
   });
+
+  it("preserves running cron sessions whose job id is not a clean slug", async () => {
+    await withTaskCommandStateDir(async (state) => {
+      const now = Date.now();
+      const sessionsDir = state.sessionsDir("main");
+      const storePath = path.join(sessionsDir, "sessions.json");
+      const old = now - 8 * 24 * 60 * 60_000;
+      await fs.mkdir(sessionsDir, { recursive: true });
+      await fs.writeFile(
+        storePath,
+        JSON.stringify(
+          {
+            // Session key carries the slugified job segment (normalizeCronLaneSegment("Daily Report")).
+            "agent:main:cron:daily-report:run:old-run": {
+              sessionId: "running-run",
+              updatedAt: old,
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+      await saveCronStore(state.statePath("cron", "jobs.json"), {
+        version: 1,
+        jobs: [
+          {
+            id: "Daily Report",
+            name: "Daily Report",
+            enabled: true,
+            schedule: { kind: "every", everyMs: 60_000 },
+            sessionTarget: "isolated",
+            sessionKey: "cron:daily-report",
+            wakeMode: "now",
+            payload: { kind: "agentTurn", message: "ping" },
+            delivery: { mode: "none" },
+            createdAtMs: now,
+            updatedAtMs: now,
+            state: { runningAtMs: now - 5_000 },
+          },
+        ],
+      });
+      const runtime = createRuntime();
+      await tasksMaintenanceCommand({ json: true, apply: true }, runtime);
+
+      // The running set must hold the slugified id "daily-report" (not "daily report") to match the
+      // session-key segment; otherwise this live running session is wrongly pruned as stale.
+      const updated = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, unknown>;
+      expect(updated["agent:main:cron:daily-report:run:old-run"]).toBeDefined();
+    });
+  });
 });

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -11,6 +11,7 @@ import {
   resolveAllAgentSessionStoreTargetsSync,
   runSessionRegistryMaintenanceForStore,
 } from "../config/sessions.js";
+import { normalizeCronLaneSegment } from "../cron/service/task-runs.js";
 import { loadCronJobsStoreSync, resolveCronJobsStorePath } from "../cron/store.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { getTaskById, updateTaskNotifyPolicyById } from "../tasks/runtime-internal.js";
@@ -134,8 +135,10 @@ function readRunningCronJobIds(): Set<string> {
     return new Set(
       loadCronJobsStoreSync(cronStorePath)
         .jobs.filter((job) => typeof job.state?.runningAtMs === "number")
-        // Cron session keys are matched case-insensitively against job ids.
-        .map((job) => job.id.toLowerCase()),
+        // Must match the slugified job segment in cron-run session keys (built by
+        // normalizeCronLaneSegment); a plain lowercase id misses non-slug ids like
+        // "Daily Report" and prunes their live running sessions.
+        .map((job) => normalizeCronLaneSegment(job.id, "job")),
     );
   } catch {
     return new Set();

--- a/src/config/sessions/session-registry-maintenance.ts
+++ b/src/config/sessions/session-registry-maintenance.ts
@@ -16,7 +16,7 @@ export type SessionRegistryMaintenanceStoreOptions = {
   apply: boolean;
   /** Retention window for cron-run session entries. */
   retentionMs: number;
-  /** Currently running cron job ids, normalized to lowercase. */
+  /** Currently running cron job ids, normalized to the cron-run session-key job segment. */
   runningCronJobIds: ReadonlySet<string>;
   /** Resolved session registry store path for one agent. */
   storePath: string;


### PR DESCRIPTION
## Summary

`readRunningCronJobIds()` (`src/commands/tasks.ts`) builds the set of "currently running cron job ids" with `job.id.toLowerCase()`. But cron-run **session keys** encode the job id via `normalizeCronLaneSegment(job.id, "job")` (lowercase **+ slugify** `[^a-z0-9_-] → -` + trim + 64-char cap), and the session-registry maintenance sweep extracts that slugified segment (`parseCronRunSessionJobId`) and preserves a running session only if `runningCronJobIds.has(segment)`.

So the producer and the matcher use **different normalizations**. For a clean-slug id (e.g. a UUID, or `running-job`) they coincide, but for a non-slug job id they diverge:

- Job id `"Daily Report"` → session-key segment `"daily-report"`, but running-set entry `"daily report"`.
- `runningCronJobIds.has("daily-report")` → `false` → a **live, running** cron-run session that is also older than the 7-day retention window gets wrongly **pruned**.

Non-slug job ids don't occur via the runtime create API (it assigns `crypto.randomUUID()`), but persisted/imported/legacy stores only require `id` to be a non-empty string and preserve it verbatim, so the bug is reachable on real on-disk state.

The fix builds the running set with the **same** `normalizeCronLaneSegment` the session key uses, so producer and matcher agree.

### Changes
- `src/commands/tasks.ts` — `readRunningCronJobIds` now maps job ids through `normalizeCronLaneSegment(job.id, "job")` (was `job.id.toLowerCase()`).
- `src/config/sessions/session-registry-maintenance.ts` — corrected the `runningCronJobIds` contract comment ("normalized to lowercase" → "normalized to the cron-run session-key job segment").
- `src/commands/tasks.test.ts` — end-to-end regression test: a running `"Daily Report"` cron job + a stale running session keyed `agent:main:cron:daily-report:run:old-run` is now preserved by `tasksMaintenanceCommand`.

## Real behavior proof

Behavior addressed: a live, >7-day-old running cron-run session for a non-slug job id was wrongly pruned because the running-job set used `.toLowerCase()` while the session key uses the slugified segment. The set now uses the same `normalizeCronLaneSegment`.

Real environment tested: Node 22.22.1, macOS, no model / network / device. A `./node_modules/.bin/tsx` harness imports the real `normalizeCronLaneSegment` and `resolveMainSessionCronRunSessionKey`, builds the production cron-run session key for job id `"Daily Report"`, extracts its job segment, and compares the old vs new running-set key against it.

Exact steps or command run after this patch:
```bash
# harness: real resolveMainSessionCronRunSessionKey + normalizeCronLaneSegment
./node_modules/.bin/tsx cron-proof.mts
```

Evidence after fix:
```
produced cron-run session key: agent:main:cron:daily-report:run:1750000000000
session-key job segment      : "daily-report"
BEFORE running-set key (.toLowerCase)            : "daily report"  -> matches segment? false => running session PRUNED
AFTER  running-set key (normalizeCronLaneSegment): "daily-report"  -> matches segment? true  => running session PRESERVED
```

Observed result after fix: the running-set key now equals the session-key job segment (`"daily-report"`), so the maintenance sweep matches and preserves the live running session; before the change the lowercase key (`"daily report"`) did not match and the session was pruned. Clean-slug ids (UUIDs) are unaffected — `normalizeCronLaneSegment` maps them to themselves.

What was not tested: a multi-day live gateway run with a real legacy/imported non-slug cron job. The end-to-end pruning behavior is covered by the new `src/commands/tasks.test.ts` case (`tasksMaintenanceCommand` over a seeded store), which fails before the change (the session is pruned, `expected undefined to be defined`) and passes after.

## Additional checks
- `pnpm test src/commands/tasks.test.ts src/config/sessions/session-registry-maintenance.test.ts` — all pass (incl. the new regression test); verified fail-before by reverting the one-line change.
- Formatter (`oxfmt`), static analysis (`oxlint`), and `tsgo:core` pass for the changed files.
- Sibling check: the only other cron-id matcher (`src/tasks/task-registry.maintenance.ts`) keys off the raw `cron:<rawJobId>:<startedAt>` runId space with exact equality — raw on both sides, internally consistent — so it correctly must not use `normalizeCronLaneSegment`. No sibling left one-sided.
