### PR TITLE
fix(exec): stop forcing approval for safe commands with harmless redirections

### DIFF
--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -75,8 +75,14 @@ explicitly to `tools.exec.safeBinTrustedDirs`.
 ### Shell chaining, wrappers, and multiplexers
 
 Shell chaining (`&&`, `||`, `;`) is allowed when every top-level segment
-satisfies the allowlist (including safe bins or skill auto-allow). Redirections
-remain unsupported in allowlist mode. Command substitution (`$()` / backticks) is
+satisfies the allowlist (including safe bins or skill auto-allow). Stream-only
+redirections that touch no filesystem are allowlist-analyzable: stdout/stderr to
+`/dev/null` (`>/dev/null`, `1>/dev/null`, `2>/dev/null`) and standard-stream
+duplication (`2>&1`, `1>&2`) are auto-allowed when every command segment also
+passes the allowlist or safe-bin check; every other redirection still requires
+approval (file writes and appends, file reads, stderr-to-file, the `&>`
+shorthand, descriptor close `>&-`, and any target other than `/dev/null` or
+descriptors 1/2). Command substitution (`$()` / backticks) is
 rejected during allowlist parsing, including inside double quotes; use single
 quotes if you need literal `$()` text.
 

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -202,10 +202,17 @@ Manual allowlist enforcement matches resolved binary path globs and bare command
 globs. Bare names match only commands invoked through PATH, so `rg` can match
 `/opt/homebrew/bin/rg` when the command is `rg`, but not `./rg` or `/tmp/rg`.
 When `security=allowlist`, shell commands are auto-allowed only if every pipeline
-segment is allowlisted or a safe bin. Chaining (`;`, `&&`, `||`) and redirections
-are rejected in allowlist mode unless every top-level segment satisfies the
-allowlist (including safe bins). Redirections remain unsupported.
-Durable `allow-always` trust does not bypass that rule: a chained command still requires every
+segment is allowlisted or a safe bin. Chaining (`;`, `&&`, `||`) still requires every
+top-level segment to satisfy the allowlist (including safe bins).
+
+Stream-only redirections that touch no filesystem are allowlist-analyzable: discarding
+stdout or stderr to `/dev/null` (`>/dev/null`, `1>/dev/null`, `2>/dev/null`) and
+duplicating between the standard streams (`2>&1`, `1>&2`) are auto-allowed when every
+command segment also passes the allowlist or safe-bin check. Every other redirection
+still requires approval, including file writes and appends (`> file`, `>> file`), file
+reads (`< file`), stderr-to-file (`2> err.log`), the `&>` shorthand, descriptor close
+(`>&-`), and any target other than `/dev/null` or descriptors 1/2.
+Durable `allow-always` trust does not bypass these rules: a chained command still requires every
 top-level segment to match.
 
 `autoAllowSkills` is a separate convenience path in exec approvals. It is not the same as

--- a/src/infra/exec-authorization-allowlist.test.ts
+++ b/src/infra/exec-authorization-allowlist.test.ts
@@ -3,6 +3,7 @@ import { detectPolicyInlineEval } from "./command-analysis/policy.js";
 import { makeExecutable, makePathEnv, makeTempDir } from "./exec-approvals-test-helpers.js";
 import {
   evaluateShellAllowlistWithAuthorization,
+  requiresExecApproval,
   resolveAllowAlwaysPersistenceDecision,
   resolveExecApprovalAllowedDecisions,
 } from "./exec-approvals.js";
@@ -189,5 +190,76 @@ describe("authorization-backed exec allowlist", () => {
       "allow-once",
       "deny",
     ]);
+  });
+
+  it("does not require approval for an allowlisted command with a harmless redirect", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const dir = makeTempDir();
+    const headPath = makeExecutable(dir, "head");
+    const env = makePathEnv(dir);
+
+    const result = await evaluateShellAllowlistWithAuthorization({
+      command: "head -n 1 2>/dev/null",
+      allowlist: [{ pattern: headPath }],
+      safeBins: new Set(),
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+
+    expect(result.analysisOk).toBe(true);
+    expect(result.allowlistSatisfied).toBe(true);
+    // The redirect leaves argv untouched, so allowlist matching still applies.
+    expect(result.segments.map((segment) => segment.argv)).toEqual([["head", "-n", "1"]]);
+    expect(
+      requiresExecApproval({
+        ask: "on-miss",
+        security: "allowlist",
+        analysisOk: result.analysisOk,
+        allowlistSatisfied: result.allowlistSatisfied,
+      }),
+    ).toBe(false);
+  });
+
+  it("still requires approval when a harmless redirect rides a chained unsafe command", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const dir = makeTempDir();
+    const headPath = makeExecutable(dir, "head");
+    const env = makePathEnv(dir);
+
+    // `head` is allowlisted and the redirect is harmless, but the chained `rm`
+    // is not allowlisted: the command must still fall to the approval flow.
+    const result = await evaluateShellAllowlistWithAuthorization({
+      command: "head -n 1 2>/dev/null; rm -rf /tmp/x",
+      allowlist: [{ pattern: headPath }],
+      safeBins: new Set(),
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+
+    // analysisOk proves the harmless redirect did NOT block planning (otherwise
+    // this would be false); both segments parse, and the block is attributable to
+    // the unallowlisted `rm`, not to the redirect.
+    expect(result.analysisOk).toBe(true);
+    expect(result.segments.map((segment) => segment.argv)).toEqual([
+      ["head", "-n", "1"],
+      ["rm", "-rf", "/tmp/x"],
+    ]);
+    expect(result.allowlistSatisfied).toBe(false);
+    expect(
+      requiresExecApproval({
+        ask: "on-miss",
+        security: "allowlist",
+        analysisOk: result.analysisOk,
+        allowlistSatisfied: result.allowlistSatisfied,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/infra/exec-authorization-plan.test.ts
+++ b/src/infra/exec-authorization-plan.test.ts
@@ -303,7 +303,7 @@ describe("exec authorization planner", () => {
   });
 
   it("does not promote positional shell carriers with outer shell substitutions", async () => {
-    await expectSingleShellCandidate("sh -c '$0 \"$@\"' touch \"$(id)\"", {
+    await expectSingleShellCandidate('sh -c \'$0 "$@"\' touch "$(id)"', {
       sourceSegment: expect.objectContaining({
         argv: ["sh", "-c", '$0 "$@"', "touch", "$(id)"],
       }),
@@ -348,5 +348,87 @@ describe("exec authorization planner", () => {
         reason: "non-POSIX command wrapper",
       }),
     );
+  });
+});
+
+describe("harmless redirection authorization", () => {
+  // Spec-listed harmless forms + multi-redirect + redirect-before-executable.
+  const allow = [
+    "ls 2>/dev/null",
+    "ls >/dev/null",
+    "ls 1>/dev/null",
+    "cat 2>&1",
+    "cat 1>&2",
+    "ls 2>/dev/null 1>/dev/null",
+    ">/dev/null ls",
+    "ls 2> /dev/null", // whitespace between operator and target is normalized away
+  ];
+  // Out-of-spec or file-touching forms — every one stays blocked (default-deny).
+  const block = [
+    "ls > out.txt",
+    "ls 2>error.log",
+    "cat < input.txt",
+    "ls >>/dev/null",
+    "ls &>/dev/null",
+    "ls >&-",
+    "ls >/dev/null2",
+  ];
+
+  it.each(allow)("plans %s without a redirect block", async (command) => {
+    const plan = await planShellAuthorization({ command });
+    expect(plan.ok).toBe(true);
+  });
+
+  it("normalizes tab-separated harmless redirects", async () => {
+    const plan = await planShellAuthorization({ command: "ls 2>\t/dev/null" });
+    expect(plan.ok).toBe(true);
+  });
+
+  it.each(block)("keeps %s blocked", async (command) => {
+    const plan = await planShellAuthorization({ command });
+    expect(plan.ok).toBe(false);
+  });
+
+  it("auto-allows a safe pipeline carrying a harmless redirect", async () => {
+    const plan = await planShellAuthorization({
+      command: 'echo test 2>/dev/null | grep -e "test" | head -1',
+    });
+    expect(plan.ok).toBe(true);
+  });
+
+  it("blocks when a harmless redirect is mixed with a file write", async () => {
+    const plan = await planShellAuthorization({
+      command: 'grep -e "pattern" 2>/dev/null > /tmp/results.txt',
+    });
+    expect(plan).toEqual(expect.objectContaining({ ok: false, reason: "redirect" }));
+  });
+
+  it("does not let a harmless redirect lift a command-substitution block", async () => {
+    // command-substitution stays unanalyzable; the redirect exemption applies
+    // only to redirect risks, never to a sibling risk on the same command.
+    const plan = await planShellAuthorization({ command: "$(whoami) 2>/dev/null" });
+    expect(plan.ok).toBe(false);
+  });
+});
+
+describe("adversarial redirection bypass attempts", () => {
+  // Disguised file-touching or fd-escaping redirects that must NOT be classified
+  // as harmless. Each stays blocked; this is the change's security evidence.
+  const attacks = [
+    "head >/dev/null/../../../etc/crontab", // path traversal off the /dev/null prefix
+    "head >/dev/nullx", // extra char defeats the exact-match anchor
+    "head > /dev/null/subpath", // path segment after /dev/null
+    "head 2>&3", // merge into an arbitrary fd that may be bound to a file
+    "head 3>/dev/null", // fd > 2 is not in the harmless allowlist
+    "head 9>/dev/null", // fd > 2 is not in the harmless allowlist
+    "head >| /dev/null", // noclobber-override operator is not allowlisted
+    "head >&2-", // fd duplicate-and-close variant is not allowlisted
+    'head >"/dev/null"', // quoted target — classifier does not normalize quotes
+    "head >$(echo /tmp/evil).log", // command-substitution in the redirect target
+  ];
+
+  it.each(attacks)("keeps %s blocked at plan time", async (command) => {
+    const plan = await planShellAuthorization({ command });
+    expect(plan.ok).toBe(false);
   });
 });

--- a/src/infra/exec-authorization-plan.ts
+++ b/src/infra/exec-authorization-plan.ts
@@ -107,6 +107,34 @@ const UNANALYZABLE_RISKS = new Set<CommandRisk["kind"]>([
   "function-definition",
 ]);
 
+// Stream-only redirections touch no filesystem: discarding stdout/stderr to
+// /dev/null or merging one std fd into another (2>&1, 1>&2) is safe to treat as
+// analyzable, so a command using only these falls through to normal per-segment
+// allowlist/safeBins evaluation instead of forcing approval. The patterns match
+// the parser's raw `file_redirect` text (e.g. "2>/dev/null", "> out.txt") after
+// whitespace removal. Anything writing/reading a real file, appending (`>>`),
+// `&>`, fd-close (`>&-`), or targeting an fd other than 1/2 is excluded and stays
+// blocking. The leading fd is optional (bare `>` = stdout) and limited to 1/2.
+const HARMLESS_REDIRECT_PATTERNS: readonly RegExp[] = [/^[12]?>\/dev\/null$/, /^[12]?>&[12]$/];
+
+function isHarmlessRedirect(text: string): boolean {
+  const normalized = text.replace(/\s+/g, "");
+  return HARMLESS_REDIRECT_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+// A risk only blocks planning when it is genuinely unanalyzable. Harmless
+// stream-only redirects are the one exception: they leave argv untouched, so the
+// command can still be authorized segment by segment.
+function isUnanalyzableRisk(risk: CommandRisk): boolean {
+  if (!UNANALYZABLE_RISKS.has(risk.kind)) {
+    return false;
+  }
+  if (risk.kind === "redirect" && isHarmlessRedirect(risk.text)) {
+    return false;
+  }
+  return true;
+}
+
 const POWERSHELL_NAMES = new Set(["powershell", "pwsh"]);
 const WINDOWS_CMD_NAMES = new Set(["cmd", "cmd.exe"]);
 export const POSITIONAL_CARRIER_BLOCKED_EXECUTABLES = new Set(["find", "xargs"]);
@@ -231,7 +259,7 @@ function riskInsidePromptOnlyStep(risk: CommandRisk, explanation: CommandExplana
 }
 
 function findUnanalyzableRisk(explanation: CommandExplanation): CommandRisk | null {
-  return explanation.risks.find((entry) => UNANALYZABLE_RISKS.has(entry.kind)) ?? null;
+  return explanation.risks.find(isUnanalyzableRisk) ?? null;
 }
 
 function hasBlockingRisk(
@@ -262,9 +290,7 @@ function shellWrapperPreludeReasons(params: {
   risks: readonly CommandRisk[];
 }): string[] {
   const reasons = params.risks
-    .filter(
-      (risk) => UNANALYZABLE_RISKS.has(risk.kind) && riskBeforeStepExecutable(risk, params.step),
-    )
+    .filter((risk) => isUnanalyzableRisk(risk) && riskBeforeStepExecutable(risk, params.step))
     .map((risk) => risk.kind);
   return [...new Set(reasons)];
 }


### PR DESCRIPTION
## What Problem This Solves

In `security: "allowlist"` mode, OpenClaw treats any command containing a shell redirection as an allowlist miss and forces a manual approval prompt — even when every command segment is already allowlisted/safe and the redirection only discards or merges a standard stream. Routine safe commands like `ls 2>/dev/null` or `grep … 2>&1 | head` interrupt the operator with an approval prompt despite touching no filesystem.

## Why This Change Was Made

Stream-only redirections — `>/dev/null`, `1>/dev/null`, `2>/dev/null`, `2>&1`, `1>&2` — are now classified as harmless and excluded from the unanalyzable-risk set in the POSIX authorization planner (`src/infra/exec-authorization-plan.ts`), so a command whose redirections are all harmless falls through to the existing per-segment allowlist/safeBins evaluation. Redirections never alter the parsed argv, so the same program-safety check still applies. Anything that writes or reads a real file (`> file`, `>> file`, `2> err.log`, `< in`), uses `&>`, closes/duplicates to an arbitrary fd (`>&-`, `2>&3`), or targets anything other than `/dev/null` or fd 1/2 still blocks. Non-goals: no change to which programs are considered safe, and no new config surface.

## User Impact

Operators running in allowlist mode no longer get approval prompts for safe commands that only redirect to `/dev/null` or merge stdout/stderr. The security posture is unchanged for any redirection that touches the filesystem — those still require approval exactly as before.

## Evidence

Developed AI-assisted (Claude Code) and gated by a Codex review pass on **both the implementation plan and the final diff**; all Codex findings were addressed (regex narrowed to fd 1/2; the end-to-end test made non-vacuous via `analysisOk`; adversarial bypass cases added).

**Scope:** 5 files — the classifier in `src/infra/exec-authorization-plan.ts`, its two colocated test files, and two public docs pages (`docs/tools/exec.md`, `docs/tools/exec-approvals-advanced.md`) updated to match the new behavior. No config, no `CHANGELOG`.

**Unit + integration tests** (`src/infra/exec-authorization-plan.test.ts` = plan-layer classification incl. an `adversarial redirection bypass attempts` block; `src/infra/exec-authorization-allowlist.test.ts` = end-to-end through `evaluateShellAllowlistWithAuthorization` + `requiresExecApproval`):

```
$ pnpm test src/infra/exec-authorization-plan.test.ts src/infra/exec-authorization-allowlist.test.ts
 Test Files  1 passed (1)
      Tests  61 passed (61)
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

Adjacent suites, no regressions (`exec-approvals-policy`, `exec-allow-always-persistence`, `exec-approvals-allow-always`, `exec-approvals-safe-bins`, `exec-approvals-parity`, `command-explainer/extract`): **228 passed**.

**Security + behavioral proof against the compiled `dist` bundle.** This harness imports the *bundled* `planShellAuthorization` / `evaluateShellAllowlistWithAuthorization` from `dist/` (production build, not the test transform) and runs the real commands. The `plan.ok=false` rows are disguised redirects that **stay blocked**; the end-to-end rows show the real approval decision (`head` is a default safe bin):

```
== plan-layer (compiled dist) ==
PASS  plan.ok=true  exp=true   ls 2>/dev/null
PASS  plan.ok=true  exp=true   ls >/dev/null
PASS  plan.ok=true  exp=true   ls 1>/dev/null
PASS  plan.ok=true  exp=true   cat 2>&1
PASS  plan.ok=true  exp=true   cat 1>&2
PASS  plan.ok=true  exp=true   ls 2>/dev/null 1>/dev/null
PASS  plan.ok=true  exp=true   ls 2> /dev/null
PASS  plan.ok=true  exp=true   echo test 2>/dev/null | grep -e "test" | head -1
PASS  plan.ok=false exp=false  ls > out.txt
PASS  plan.ok=false exp=false  ls 2>error.log
PASS  plan.ok=false exp=false  cat < input.txt
PASS  plan.ok=false exp=false  grep -e "pattern" 2>/dev/null > /tmp/results.txt
PASS  plan.ok=false exp=false  ls >>/dev/null
PASS  plan.ok=false exp=false  ls &>/dev/null
PASS  plan.ok=false exp=false  head >/dev/null/../../../etc/crontab
PASS  plan.ok=false exp=false  head 2>&3
PASS  plan.ok=false exp=false  head 3>/dev/null
PASS  plan.ok=false exp=false  head >| /dev/null
PASS  plan.ok=false exp=false  head >"/dev/null"
PASS  plan.ok=false exp=false  $(whoami) 2>/dev/null

== end-to-end approval (compiled dist), head is a default safe bin ==
PASS  prompt=false exp=false (analysisOk=true, allowlistSatisfied=true)  head -n 1 2>/dev/null
PASS  prompt=true  exp=true  (analysisOk=false, allowlistSatisfied=false)  head -n 1 > /tmp/x
PASS  prompt=true  exp=true  (analysisOk=true, allowlistSatisfied=false)  head -n 1 2>/dev/null; rm -rf /tmp/x

RESULT: 23 passed, 0 failed
```

**Other gates:** `pnpm build` green; `pnpm tsgo` + `pnpm check:test-types` clean; `oxfmt` and `oxlint` clean. The full repo-wide suite runs in CI on this PR.

### AI-assisted PR checklist
- [x] Marked as AI-assisted (Claude Code; Codex review gate on plan + diff)
- [x] Concise Evidence section with verbatim validation output
- [x] Author understands what the code does
- [x] Codex review run and findings addressed before opening
- [x] Will resolve/reply to bot review conversations as they arrive
