### PR TITLE
fix(sessions): reset stale per-channel origin fields on channel switch (#95325)

### DIFF
--- a/scripts/repro/issue-95325-channel-switch.mts
+++ b/scripts/repro/issue-95325-channel-switch.mts
@@ -1,0 +1,93 @@
+// Real behavior proof for #95325: drives the production deriveSessionMetaPatch
+// to verify stale per-channel origin fields are reset on a channel switch.
+//
+// Run: node --import tsx scripts/repro/issue-95325-channel-switch.mts
+import { deriveSessionMetaPatch } from "../../src/config/sessions/metadata.ts";
+import type { MsgContext } from "../../src/auto-reply/templating.ts";
+import type { SessionEntry } from "../../src/config/sessions/types.ts";
+
+function slackDmCtx(): MsgContext {
+  return {
+    Provider: "slack",
+    OriginatingChannel: "slack",
+    Surface: "slack",
+    ChatType: "direct",
+    From: "slack-user-id",
+    NativeChannelId: "Dslackdm",
+    NativeDirectUserId: "Uslackuser",
+    AccountId: "slack-account",
+  } as MsgContext;
+}
+
+function telegramDmCtx(): MsgContext {
+  // Telegram DMs carry no nativeChannelId / nativeDirectUserId.
+  return {
+    Provider: "telegram",
+    OriginatingChannel: "telegram",
+    Surface: "telegram",
+    ChatType: "direct",
+    From: "telegram-user-id",
+    AccountId: "telegram-account",
+  } as MsgContext;
+}
+
+function fail(message: string): never {
+  console.error(`FAIL: ${message}`);
+  process.exitCode = 1;
+  throw new Error(message);
+}
+
+let existing: SessionEntry | undefined = undefined;
+
+// Turn 1: Slack DM seeds the shared session with Slack native identity.
+const slackPatch = deriveSessionMetaPatch({
+  ctx: slackDmCtx(),
+  sessionKey: "dm:shared",
+  existing,
+});
+existing = { ...(existing ?? ({} as SessionEntry)), ...(slackPatch ?? {}) } as SessionEntry;
+
+if (existing.origin?.nativeChannelId !== "Dslackdm") {
+  fail(`after Slack turn nativeChannelId should be Dslackdm, got ${existing.origin?.nativeChannelId}`);
+}
+console.log("PASS: Slack turn seeds origin.nativeChannelId = Dslackdm");
+
+// Turn 2: Same user DMs on Telegram. Telegram supplies no nativeChannelId.
+const tgPatch = deriveSessionMetaPatch({
+  ctx: telegramDmCtx(),
+  sessionKey: "dm:shared",
+  existing,
+});
+
+const switchedOrigin = tgPatch?.origin;
+console.log("Telegram-switch origin:", JSON.stringify(switchedOrigin));
+
+if (switchedOrigin?.provider !== "telegram") {
+  fail(`provider should switch to telegram, got ${switchedOrigin?.provider}`);
+}
+if (switchedOrigin?.nativeChannelId !== undefined) {
+  fail(
+    `nativeChannelId should be reset after switch, got stale ${switchedOrigin.nativeChannelId}`,
+  );
+}
+if (switchedOrigin?.nativeDirectUserId !== undefined) {
+  fail(
+    `nativeDirectUserId should be reset after switch, got stale ${switchedOrigin.nativeDirectUserId}`,
+  );
+}
+console.log("PASS: channel switch to telegram reset stale nativeChannelId / nativeDirectUserId");
+
+// Turn 3: Switch back to Slack — new nativeChannelId is adopted.
+const slackBackPatch = deriveSessionMetaPatch({
+  ctx: slackDmCtx(),
+  sessionKey: "dm:shared",
+  existing: { ...(existing as SessionEntry), ...(tgPatch ?? {}) } as SessionEntry,
+});
+if (slackBackPatch?.origin?.nativeChannelId !== "Dslackdm") {
+  fail(
+    `nativeChannelId should re-adopt Slack value on switch back, got ${slackBackPatch?.origin?.nativeChannelId}`,
+  );
+}
+console.log("PASS: switch back to Slack re-adopts nativeChannelId = Dslackdm");
+
+console.log("\nALL CHECKS PASSED — stale per-channel origin fields reset on channel switch.");

--- a/src/config/sessions/metadata.test.ts
+++ b/src/config/sessions/metadata.test.ts
@@ -1,0 +1,116 @@
+// Regression tests for session origin merging across a channel switch (#95325).
+import { describe, expect, it } from "vitest";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import { deriveSessionMetaPatch } from "./metadata.js";
+import type { SessionEntry } from "./types.js";
+
+function ctx(overrides: Partial<MsgContext>): MsgContext {
+  return { ...overrides } as MsgContext;
+}
+
+function sessionWith(origin: SessionEntry["origin"]): SessionEntry {
+  return { origin } as Partial<SessionEntry> as SessionEntry;
+}
+
+describe("deriveSessionMetaPatch origin channel switch (#95325)", () => {
+  it("resets nativeChannelId/nativeDirectUserId/threadId when provider changes", () => {
+    const existing = sessionWith({
+      provider: "slack",
+      surface: "slack",
+      nativeChannelId: "Dslackdm",
+      nativeDirectUserId: "Uslackuser",
+      threadId: "slack-thread",
+      accountId: "slack-account",
+    });
+
+    // Telegram DM carries no nativeChannelId/nativeDirectUserId/threadId.
+    const next = ctx({
+      Provider: "telegram",
+      OriginatingChannel: "telegram",
+      Surface: "telegram",
+      From: "telegram-user",
+      AccountId: "telegram-account",
+    });
+
+    const patch = deriveSessionMetaPatch({
+      ctx: next,
+      sessionKey: "test:key",
+      existing,
+    });
+
+    expect(patch?.origin?.provider).toBe("telegram");
+    expect(patch?.origin?.surface).toBe("telegram");
+    expect(patch?.origin?.nativeChannelId).toBeUndefined();
+    expect(patch?.origin?.nativeDirectUserId).toBeUndefined();
+    expect(patch?.origin?.threadId).toBeUndefined();
+  });
+
+  it("preserves and updates nativeChannelId when the same channel keeps supplying it", () => {
+    const existing = sessionWith({
+      provider: "slack",
+      nativeChannelId: "Dslackdm1",
+    });
+
+    const next = ctx({
+      Provider: "slack",
+      OriginatingChannel: "slack",
+      NativeChannelId: "Dslackdm2",
+    });
+
+    const patch = deriveSessionMetaPatch({
+      ctx: next,
+      sessionKey: "test:key",
+      existing,
+    });
+
+    expect(patch?.origin?.provider).toBe("slack");
+    expect(patch?.origin?.nativeChannelId).toBe("Dslackdm2");
+  });
+
+  it("adopts the new channel's nativeChannelId when switching to a channel that supplies it", () => {
+    const existing = sessionWith({
+      provider: "telegram",
+      nativeDirectUserId: "tg-user",
+    });
+
+    const next = ctx({
+      Provider: "slack",
+      OriginatingChannel: "slack",
+      NativeChannelId: "Dnewslack",
+    });
+
+    const patch = deriveSessionMetaPatch({
+      ctx: next,
+      sessionKey: "test:key",
+      existing,
+    });
+
+    expect(patch?.origin?.provider).toBe("slack");
+    expect(patch?.origin?.nativeChannelId).toBe("Dnewslack");
+    // Stale prior-channel nativeDirectUserId is reset by the channel switch.
+    expect(patch?.origin?.nativeDirectUserId).toBeUndefined();
+  });
+
+  it("resets channel-specific fields when surface changes even if provider matches", () => {
+    const existing = sessionWith({
+      provider: "slack",
+      surface: "slack",
+      nativeChannelId: "Dslackdm",
+    });
+
+    const next = ctx({
+      Provider: "slack",
+      OriginatingChannel: "slack",
+      Surface: "slack-im",
+    });
+
+    const patch = deriveSessionMetaPatch({
+      ctx: next,
+      sessionKey: "test:key",
+      existing,
+    });
+
+    expect(patch?.origin?.surface).toBe("slack-im");
+    expect(patch?.origin?.nativeChannelId).toBeUndefined();
+  });
+});

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -38,6 +38,19 @@ const mergeOrigin = (
   if (next?.to) {
     merged.to = next.to;
   }
+  // A channel switch (provider or surface change) means previously-known native
+  // channel identity no longer applies: DMs on channels like Telegram do not carry
+  // a nativeChannelId, so without resetting the stale prior-channel value (e.g. a
+  // Slack channel id) would persist for the whole new-channel session.
+  const channelChanged =
+    existing !== undefined &&
+    ((next?.provider !== undefined && next.provider !== existing.provider) ||
+      (next?.surface !== undefined && next.surface !== existing.surface));
+  if (channelChanged) {
+    delete merged.nativeChannelId;
+    delete merged.nativeDirectUserId;
+    delete merged.threadId;
+  }
   if (next?.nativeChannelId) {
     merged.nativeChannelId = next.nativeChannelId;
   }


### PR DESCRIPTION
## Summary

With `session.dmScope: "main"`, a user's DMs across channels (Slack, Telegram, webchat) share one session. When the channel switches (e.g. Slack → Telegram), the session origin's per-channel identity fields were not reset.

`mergeOrigin` only overwrites a field when the new inbound supplies it. Telegram DMs do not supply `nativeChannelId` (or `threadId`), so the previous Slack channel id persisted in the now-Telegram session and kept persisting on every subsequent Telegram turn until the user messaged on the original channel again.

## Changes

- `src/config/sessions/metadata.ts`: Detect a `provider` or `surface` change in `mergeOrigin` and reset the channel-specific fields (`nativeChannelId`, `nativeDirectUserId`, `threadId`) before applying the new channel's values. Same-channel turns that keep supplying `nativeChannelId` continue to update it as before.
- `src/config/sessions/metadata.test.ts`: Regression tests covering the channel-switch reset and the preserved-same-channel case.
- `scripts/repro/issue-95325-channel-switch.mts`: Real behavior proof harness driving the production `deriveSessionMetaPatch`.

## Real behavior proof

**Behavior addressed**: Session origin no longer retains the previous channel's `nativeChannelId`/`nativeDirectUserId`/`threadId` after a provider or surface change.

**Real environment tested**: Windows 10 (10.0.17763), Node.js v22.19.2, source tree at commit 0a031e71dc.

**Exact steps or command run after this patch**:
- `node --import tsx scripts/repro/issue-95325-channel-switch.mts`

The harness imports the real production `deriveSessionMetaPatch` and drives a three-turn sequence on a shared `dm:shared` session key (Slack DM → Telegram DM → Slack DM again), reading back the merged `origin` after each turn.

**Evidence after fix**:
```text
PASS: Slack turn seeds origin.nativeChannelId = Dslackdm
Telegram-switch origin: {"label":"telegram-user-id","provider":"telegram","surface":"telegram","chatType":"direct","from":"telegram-user-id","accountId":"telegram-account"}
PASS: channel switch to telegram reset stale nativeChannelId / nativeDirectUserId
PASS: switch back to Slack re-adopts nativeChannelId = Dslackdm

ALL CHECKS PASSED — stale per-channel origin fields reset on channel switch.
```

**Observed result after fix**: After the Slack→Telegram switch, the merged origin carries `provider: "telegram"` and no `nativeChannelId`/`nativeDirectUserId` (the stale Slack `Dslackdm`/`Uslackuser` are gone). Switching back to Slack re-adopts `nativeChannelId: "Dslackdm"`, proving the reset only fires on a real channel change and does not block later same-channel re-adoption.

**What was not tested**: Live Slack↔Telegram round-trip over real channels (requires live credentials). The harness drives the real runtime merge path (`deriveSessionMetaPatch` → `mergeOrigin`), which is the single function the runtime uses to update session origin on each inbound turn.

## Verification

- `node scripts/run-vitest.mjs run src/config/sessions/metadata.test.ts`: 4/4 passing.
- `node --import tsx scripts/repro/issue-95325-channel-switch.mts`: all checks pass (real production function).
- `tsgo -p tsconfig.core.json`: no errors in the modified file.
- `oxlint` on modified files: clean.
- Pre-existing `sessionFile` path tests (2) fail identically on base `origin/main` without this change — unrelated to origin merging.

Fixes #95325
