### PR TITLE
fix(workboard): hide archived cards by default in CLI list, add --include-archived flag

### DIFF
--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -87,6 +87,39 @@ describe("registerWorkboardCli", () => {
     delete process.env.OPENCLAW_GATEWAY_URL;
   });
 
+  it("excludes archived cards by default", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const active = await store.create({ title: "Active card", status: "todo" });
+    const archived = await store.create({ title: "Archived card", status: "done" });
+    await store.archive(archived.id);
+    const program = createProgram(store);
+
+    const listOutput = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list", "--json"], { from: "user" });
+    });
+    const parsed = JSON.parse(listOutput);
+
+    expect(parsed.cards).toHaveLength(1);
+    expect(parsed.cards[0].id).toBe(active.id);
+  });
+
+  it("includes archived cards with --include-archived", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    await store.create({ title: "Active card", status: "todo" });
+    const archived = await store.create({ title: "Archived card", status: "done" });
+    await store.archive(archived.id);
+    const program = createProgram(store);
+
+    const listOutput = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list", "--include-archived", "--json"], {
+        from: "user",
+      });
+    });
+    const parsed = JSON.parse(listOutput);
+
+    expect(parsed.cards).toHaveLength(2);
+  });
+
   it("redacts claim tokens from card JSON output", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const card = await store.create({ title: "Claimed worker", status: "running" });

--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -17,6 +17,7 @@ type GatewayOptions = JsonOptions & {
   timeout?: string;
   expectFinal?: boolean;
   board?: string;
+  includeArchived?: boolean;
 };
 
 function writeJson(value: unknown): void {
@@ -130,14 +131,20 @@ export function registerWorkboardCli(params: { program: Command; store: Workboar
     .description("List Workboard cards")
     .option("--board <id>", "Board id")
     .option("--status <status>", "Filter by status")
+    .option("--include-archived", "Include archived cards. Default false.", false)
     .option("--json", "Print JSON", false)
-    .action(async (options: JsonOptions & { board?: string; status?: string }) => {
-      let cards = await params.store.list({ boardId: options.board });
-      if (options.status) {
-        cards = cards.filter((card) => card.status === options.status);
-      }
-      writeCards(cards, options);
-    });
+    .action(
+      async (options: JsonOptions & { board?: string; status?: string; includeArchived?: boolean }) => {
+        let cards = await params.store.list({ boardId: options.board });
+        if (!options.includeArchived) {
+          cards = cards.filter((card) => !card.metadata?.archivedAt);
+        }
+        if (options.status) {
+          cards = cards.filter((card) => card.status === options.status);
+        }
+        writeCards(cards, options);
+      },
+    );
 
   workboard
     .command("create")


### PR DESCRIPTION
## Description

The `openclaw workboard list` CLI command now filters out archived cards by default, matching the existing behavior of the MCP tool (`tools.ts:257`).

## Changes

- **`extensions/workboard/src/cli.ts`** — Added `--include-archived` option flag (default: `false`). Default filter: `!card.metadata?.archivedAt`, matching the pattern in `tools.ts:257`.
- **`extensions/workboard/src/cli.test.ts`** — Added 2 tests:
  1. Excludes archived cards by default (`--json` without flag)
  2. Includes archived cards when `--include-archived` is passed

Closes #95334