### PR TITLE
fix(ui): show cron job model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.
 - **Control UI Talk controls:** keep voice, model, and sensitivity in the composer while moving provider, transport, VAD timing, and reasoning defaults to Settings → Communications → Talk.
+- **Cron model selection:** choose an agent-turn model in Control UI Quick Create and show configured or default models in cron job rows and details. (#95341) Thanks @ly85206559.
 - **Control UI GitHub previews:** show issue and pull request state, title, author, activity, comments, and change statistics in hover and keyboard-focus cards. (#100434)
 - **Logbook work journal:** add a disabled-by-default bundled plugin that turns paired-node screen snapshots into a private timeline, daily standup, and timeline-grounded Q&A in a plugin-contributed Control UI tab. (#99930)
 - **Control UI message context:** reveal per-message token, context, and model details from the timestamp on hover or activation instead of showing a separate Context button.

--- a/ui/src/e2e/cron-filters.e2e.test.ts
+++ b/ui/src/e2e/cron-filters.e2e.test.ts
@@ -228,4 +228,72 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
       await context.close();
     }
   });
+
+  it("saves and displays agent-turn model overrides", async () => {
+    const configuredModel = "openai/gpt-5.2";
+    const existingJob = {
+      ...cronJob("model-job", "Model-specific job", { kind: "every", everyMs: 60_000 }),
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "Use the configured model", model: configuredModel },
+    };
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "cron.add": { id: "quick-created-model-job" },
+        "cron.list": cronListResponse([existingJob]),
+        "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
+        "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}cron`);
+      await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
+      const existingCard = page.locator(".cron-job", { hasText: existingJob.name });
+      expect(await existingCard.locator(".cron-job-chips").textContent()).toContain(
+        `Model: ${configuredModel}`,
+      );
+      const details = await existingCard
+        .locator(".cron-job-detail-section")
+        .evaluateAll((sections) =>
+          sections.map((section) => ({
+            label: section.querySelector(".cron-job-detail-label")?.textContent?.trim(),
+            value: section.querySelector(".cron-job-detail-value")?.textContent?.trim(),
+          })),
+        );
+      expect(details).toContainEqual({ label: "Model", value: configuredModel });
+
+      await page.getByRole("button", { name: "New Job" }).click();
+      await page.locator(".cqc-textarea").fill("Run with a selected model");
+      await page.locator(".cqc-actions .btn.primary").click();
+      await page.locator(".cqc-actions .btn.primary").click();
+
+      const modelInput = page.locator("#cron-quick-create-model");
+      await modelInput.fill("openai/gpt-5.5");
+      expect(await modelInput.getAttribute("list")).toBe("cron-quick-create-model-suggestions");
+      expect(
+        await page
+          .locator("#cron-quick-create-model-suggestions option")
+          .evaluateAll((options) => options.map((option) => option.getAttribute("value"))),
+      ).toContain(configuredModel);
+
+      await page.locator(".cqc-actions .btn.primary").click();
+      const addRequest = await gateway.waitForRequest("cron.add");
+      expect(requestParams(addRequest)).toMatchObject({
+        payload: {
+          kind: "agentTurn",
+          message: "Run with a selected model",
+          model: "openai/gpt-5.5",
+        },
+      });
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -303,6 +303,7 @@ export class CronPage extends LitElement {
             open: this.quickCreateOpen,
             step: this.quickCreateStep,
             draft: this.quickCreateDraft ?? createDefaultDraft(),
+            modelSuggestions: suggestions.modelSuggestions,
             onCancel: () => this.closeQuickCreate(),
             onStepChange: (step) => (this.quickCreateStep = step),
             onDraftChange: (patch) => {

--- a/ui/src/pages/cron/quick-create.node.test.ts
+++ b/ui/src/pages/cron/quick-create.node.test.ts
@@ -6,6 +6,7 @@ function createDraft(overrides: Partial<CronQuickCreateDraft> = {}): CronQuickCr
   return {
     prompt: "Check inbox",
     name: "Inbox check",
+    model: "",
     schedulePreset: "every-morning",
     deliveryPreset: "notify",
     ...overrides,
@@ -46,5 +47,11 @@ describe("cron quick create", () => {
     expect(patch.payloadKind).toBe("systemEvent");
     expect(patch.deliveryMode).toBe("none");
     expect(patch.wakeMode).toBe("now");
+  });
+
+  it("maps a selected model into the cron payload model override", () => {
+    const patch = draftToCronFormPatch(createDraft({ model: " openai/gpt-5.2 " }));
+
+    expect(patch.payloadModel).toBe("openai/gpt-5.2");
   });
 });

--- a/ui/src/pages/cron/quick-create.node.test.ts
+++ b/ui/src/pages/cron/quick-create.node.test.ts
@@ -54,4 +54,13 @@ describe("cron quick create", () => {
 
     expect(patch.payloadModel).toBe("openai/gpt-5.2");
   });
+
+  it("does not map a model for silent systemEvent presets", () => {
+    const patch = draftToCronFormPatch(
+      createDraft({ deliveryPreset: "silent", model: "openai/gpt-5.2" }),
+    );
+
+    expect(patch.payloadKind).toBe("systemEvent");
+    expect(patch.payloadModel).toBeUndefined();
+  });
 });

--- a/ui/src/pages/cron/quick-create.ts
+++ b/ui/src/pages/cron/quick-create.ts
@@ -17,6 +17,7 @@ export type CronQuickCreateProps = {
   open: boolean;
   step: CronQuickCreateStep;
   draft: CronQuickCreateDraft;
+  modelSuggestions?: readonly string[];
   onDraftChange: (patch: Partial<CronQuickCreateDraft>) => void;
   onStepChange: (step: CronQuickCreateStep) => void;
   onCreate: () => void;
@@ -29,6 +30,7 @@ export type CronQuickCreateStep = "what" | "when" | "how";
 export type CronQuickCreateDraft = {
   prompt: string;
   name: string;
+  model: string;
   schedulePreset: SchedulePresetId | "custom";
   deliveryPreset: DeliveryPresetId;
 };
@@ -121,6 +123,7 @@ export function createDefaultDraft(): CronQuickCreateDraft {
   return {
     prompt: "",
     name: "",
+    model: "",
     schedulePreset: "every-morning",
     deliveryPreset: "notify",
   };
@@ -148,6 +151,11 @@ export function draftToCronFormPatch(draft: CronQuickCreateDraft): Partial<CronF
     payloadText: draft.prompt,
     enabled: true,
   };
+
+  const model = draft.model.trim();
+  if (model) {
+    patch.payloadModel = model;
+  }
 
   // Schedule
   switch (draft.schedulePreset) {
@@ -326,6 +334,22 @@ function renderHowStep(props: CronQuickCreateProps) {
     <div class="cqc-body">
       <h3 class="cqc-body__heading">${t("cron.quickCreate.howHeading")}</h3>
       <p class="cqc-body__hint muted">${t("cron.quickCreate.howHint")}</p>
+      <div class="cqc-field">
+        <label class="cqc-field__label" for="cron-quick-create-model">
+          ${t("cron.form.model")}
+        </label>
+        <input
+          id="cron-quick-create-model"
+          class="cqc-input"
+          type="text"
+          list="cron-quick-create-model-suggestions"
+          placeholder=${t("cron.form.modelPlaceholder")}
+          .value=${props.draft.model}
+          @input=${(e: Event) =>
+            props.onDraftChange({ model: (e.target as HTMLInputElement).value })}
+        />
+        <div class="cron-help">${t("cron.form.modelHelp")}</div>
+      </div>
       <div class="cqc-delivery-options">
         ${DELIVERY_PRESETS.map(
           (preset) => html`
@@ -396,6 +420,17 @@ export function renderCronQuickCreate(props: CronQuickCreateProps) {
             ? renderWhenStep(props)
             : renderHowStep(props)}
       </section>
+      ${renderQuickCreateModelSuggestions(props.modelSuggestions)}
     </div>
   `;
+}
+
+function renderQuickCreateModelSuggestions(options: readonly string[] | undefined) {
+  const clean = Array.from(new Set((options ?? []).map((value) => value.trim()).filter(Boolean)));
+  if (clean.length === 0) {
+    return nothing;
+  }
+  return html`<datalist id="cron-quick-create-model-suggestions">
+    ${clean.map((value) => html`<option value=${value}></option>`)}
+  </datalist>`;
 }

--- a/ui/src/pages/cron/quick-create.ts
+++ b/ui/src/pages/cron/quick-create.ts
@@ -152,11 +152,6 @@ export function draftToCronFormPatch(draft: CronQuickCreateDraft): Partial<CronF
     enabled: true,
   };
 
-  const model = draft.model.trim();
-  if (model) {
-    patch.payloadModel = model;
-  }
-
   // Schedule
   switch (draft.schedulePreset) {
     case "every-morning":
@@ -207,6 +202,11 @@ export function draftToCronFormPatch(draft: CronQuickCreateDraft): Partial<CronF
       patch.deliveryMode = "none";
       patch.wakeMode = "now";
       break;
+  }
+
+  const model = draft.model.trim();
+  if (patch.payloadKind === "agentTurn" && model) {
+    patch.payloadModel = model;
   }
 
   return patch;
@@ -330,26 +330,12 @@ function renderWhenStep(props: CronQuickCreateProps) {
 }
 
 function renderHowStep(props: CronQuickCreateProps) {
+  const supportsModelOverride = draftSupportsModelOverride(props.draft);
   return html`
     <div class="cqc-body">
       <h3 class="cqc-body__heading">${t("cron.quickCreate.howHeading")}</h3>
       <p class="cqc-body__hint muted">${t("cron.quickCreate.howHint")}</p>
-      <div class="cqc-field">
-        <label class="cqc-field__label" for="cron-quick-create-model">
-          ${t("cron.form.model")}
-        </label>
-        <input
-          id="cron-quick-create-model"
-          class="cqc-input"
-          type="text"
-          list="cron-quick-create-model-suggestions"
-          placeholder=${t("cron.form.modelPlaceholder")}
-          .value=${props.draft.model}
-          @input=${(e: Event) =>
-            props.onDraftChange({ model: (e.target as HTMLInputElement).value })}
-        />
-        <div class="cron-help">${t("cron.form.modelHelp")}</div>
-      </div>
+      ${supportsModelOverride ? renderQuickCreateModelField(props) : nothing}
       <div class="cqc-delivery-options">
         ${DELIVERY_PRESETS.map(
           (preset) => html`
@@ -384,6 +370,30 @@ function renderHowStep(props: CronQuickCreateProps) {
 }
 
 // ── Main render ──
+
+function draftSupportsModelOverride(draft: CronQuickCreateDraft) {
+  return draft.deliveryPreset !== "silent";
+}
+
+function renderQuickCreateModelField(props: CronQuickCreateProps) {
+  return html`
+    <div class="cqc-field">
+      <label class="cqc-field__label" for="cron-quick-create-model">
+        ${t("cron.form.model")}
+      </label>
+      <input
+        id="cron-quick-create-model"
+        class="cqc-input"
+        type="text"
+        list="cron-quick-create-model-suggestions"
+        placeholder=${t("cron.form.modelPlaceholder")}
+        .value=${props.draft.model}
+        @input=${(e: Event) => props.onDraftChange({ model: (e.target as HTMLInputElement).value })}
+      />
+      <div class="cron-help">${t("cron.form.modelHelp")}</div>
+    </div>
+  `;
+}
 
 export function renderCronQuickCreate(props: CronQuickCreateProps) {
   if (!props.open) {

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -446,6 +446,30 @@ describe("cron view", () => {
     expect(onDraftChange).toHaveBeenCalledWith({ model: "openai/gpt-5.5" });
   });
 
+  it("hides quick-create model selection for silent systemEvent presets", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderCronQuickCreate({
+        open: true,
+        step: "how",
+        draft: {
+          ...createDefaultDraft(),
+          deliveryPreset: "silent",
+          model: "openai/gpt-5.2",
+        },
+        modelSuggestions: ["openai/gpt-5.2"],
+        onDraftChange: () => undefined,
+        onStepChange: () => undefined,
+        onCreate: () => undefined,
+        onCancel: () => undefined,
+      }),
+      container,
+    );
+
+    expect(container.querySelector("#cron-quick-create-model")).toBeNull();
+  });
+
   it("shows webhook delivery details for jobs", () => {
     const container = document.createElement("div");
     const job = {

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -413,6 +413,39 @@ describe("cron view", () => {
     expect(onCancelEdit).toHaveBeenCalledTimes(1);
   });
 
+  it("wires quick-create model selection into the draft", () => {
+    const container = document.createElement("div");
+    const onDraftChange = vi.fn();
+
+    render(
+      renderCronQuickCreate({
+        open: true,
+        step: "how",
+        draft: { ...createDefaultDraft(), model: "openai/gpt-5.2" },
+        modelSuggestions: ["openai/gpt-5.2", "anthropic/claude-sonnet-4.6"],
+        onDraftChange,
+        onStepChange: () => undefined,
+        onCreate: () => undefined,
+        onCancel: () => undefined,
+      }),
+      container,
+    );
+
+    const model = getElement(container, "#cron-quick-create-model", HTMLInputElement);
+    expect(model.value).toBe("openai/gpt-5.2");
+    expect(model.getAttribute("list")).toBe("cron-quick-create-model-suggestions");
+    expect(
+      Array.from(container.querySelectorAll("#cron-quick-create-model-suggestions option")).map(
+        (option) => option.getAttribute("value"),
+      ),
+    ).toEqual(["openai/gpt-5.2", "anthropic/claude-sonnet-4.6"]);
+
+    model.value = "openai/gpt-5.5";
+    model.dispatchEvent(new Event("input", { bubbles: true }));
+
+    expect(onDraftChange).toHaveBeenCalledWith({ model: "openai/gpt-5.5" });
+  });
+
   it("shows webhook delivery details for jobs", () => {
     const container = document.createElement("div");
     const job = {
@@ -438,8 +471,38 @@ describe("cron view", () => {
     );
     expect(details).toEqual([
       { label: "Prompt", value: "do it" },
+      { label: "Model", value: "Default" },
       { label: "Delivery", value: "webhook (https://example.invalid/cron)" },
     ]);
+    expect(
+      Array.from(container.querySelectorAll(".cron-job-chips .chip")).map((chip) =>
+        chip.textContent?.trim(),
+      ),
+    ).toContain("Model: Default");
+  });
+
+  it("shows configured cron job models in job details", () => {
+    const container = document.createElement("div");
+    const job = {
+      ...createJob("job-model"),
+      sessionTarget: "isolated" as const,
+      payload: { kind: "agentTurn" as const, message: "do it", model: "openai/gpt-5.2" },
+    };
+
+    render(renderCron(createProps({ jobs: [job] })), container);
+
+    const details = Array.from(container.querySelectorAll(".cron-job-detail-section")).map(
+      (section) => ({
+        label: section.querySelector(".cron-job-detail-label")?.textContent?.trim(),
+        value: section.querySelector(".cron-job-detail-value")?.textContent?.trim(),
+      }),
+    );
+    expect(details).toContainEqual({ label: "Model", value: "openai/gpt-5.2" });
+    expect(
+      Array.from(container.querySelectorAll(".cron-job-chips .chip")).map((chip) =>
+        chip.textContent?.trim(),
+      ),
+    ).toContain("Model: openai/gpt-5.2");
   });
 
   it("renders a stale cron job with no payload", () => {

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -1610,6 +1610,7 @@ function renderFieldError(message?: string, id?: string) {
 function renderJob(job: CronJob, props: CronProps) {
   const isSelected = props.runsJobId === job.id;
   const itemClass = `list-item list-item-clickable cron-job${isSelected ? " list-item-selected" : ""}`;
+  const modelLabel = getCronJobModelLabel(job);
   const selectAnd = (action: () => void) => {
     props.onLoadRuns(job.id);
     action();
@@ -1636,6 +1637,9 @@ function renderJob(job: CronJob, props: CronProps) {
           </span>
           <span class="chip">${job.sessionTarget}</span>
           <span class="chip">${job.wakeMode}</span>
+          ${modelLabel
+            ? html`<span class="chip">${t("cron.form.model")}: ${modelLabel}</span>`
+            : nothing}
         </div>
         <div class="row cron-job-actions">
           <button
@@ -1723,6 +1727,14 @@ function renderJob(job: CronJob, props: CronProps) {
   `;
 }
 
+function getCronJobModelLabel(job: CronJob) {
+  const payload = getCronJobPayload(job);
+  if (payload?.kind !== "agentTurn") {
+    return null;
+  }
+  return payload.model?.trim() || t("agents.default");
+}
+
 function renderJobPayload(job: CronJob) {
   const payload = getCronJobPayload(job);
   if (!payload) {
@@ -1775,6 +1787,10 @@ function renderJobPayload(job: CronJob) {
         <div class="muted cron-job-detail-value chat-text" @click=${stopPropagationForInteractive}>
           ${unsafeHTML(toSanitizedMarkdownHtml(payload.message))}
         </div>
+      </div>
+      <div class="cron-job-detail-section">
+        <span class="cron-job-detail-label">${t("cron.form.model")}</span>
+        <span class="muted cron-job-detail-value">${getCronJobModelLabel(job)}</span>
       </div>
       ${delivery
         ? html`<div class="cron-job-detail-section">


### PR DESCRIPTION
Related: #93507

## What Problem This Solves

Control UI Quick Create could not choose a model for an agent-turn cron job, and scheduled jobs did not clearly show whether they used a configured model or the default.

## Why This Change Was Made

The implementation reuses the existing `payload.model` / `payloadModel` contract instead of adding a runtime, schema, or config surface. Quick Create offers the existing model suggestions only for agent-turn jobs, trims the selected value into the existing form patch, and shows configured/default model state in the row and details. Silent system-event jobs neither render nor persist an inapplicable model override.

## User Impact

Users can choose a model in the guided cron flow and audit the effective choice from list and detail views. Silent jobs no longer offer a setting the Gateway would ignore.

## Evidence

- Focused tests cover model trimming/persistence, silent system-event omission, configured model display, and explicit default display.
- Real-Chromium Control UI E2E opens Quick Create, selects `openai/gpt-5.5`, captures the real `cron.add` request, and verifies configured model visibility.
- Exact-head sanitized AWS Crabbox run `run_5e49afbe4816` passed all 24 focused unit assertions and both `cron-filters.e2e.test.ts` browser scenarios on `2009dceacb577b760a0f6780cd96b63c65a38831`.
- Contributor live-Gateway proof also persisted and reloaded an override through the running Gateway with no page errors: https://gist.github.com/ly85206559/b1a14621d6086d6cb0c31548d8bb28b3
- Fresh autoreview found no accepted/actionable defects.

