### PR TITLE
Show Telegram progress placeholder when progress-mode answer drafts are suppressed

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2600,6 +2600,30 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
+  it("shows a progress placeholder when progress mode suppresses answer partial text", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onPartialReply?.({ text: "Short draft" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: {
+          mode: "progress",
+          progress: { label: "Working", toolProgress: false },
+        },
+      },
+    });
+
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(telegramHtmlPreview("<b>Working</b>"));
+    expect(draftStream.update).not.toHaveBeenCalledWith("Short draft");
+    expect(draftStream.flush).toHaveBeenCalled();
+  });
+
   it("replaces Telegram command progress items with matching command output", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1364,7 +1364,7 @@ export const dispatchTelegramMessage = async ({
       recomputeQueuedAnswerBlockRotations();
     }
   };
-  const updateDraftFromPartial = (lane: DraftLaneState, update: DraftPartialTextUpdate) => {
+  const updateDraftFromPartial = async (lane: DraftLaneState, update: DraftPartialTextUpdate) => {
     const laneStream = lane.stream;
     if (!laneStream || !update.text) {
       return;
@@ -1376,6 +1376,7 @@ export const dispatchTelegramMessage = async ({
     }
     if (lane === answerLane) {
       if (streamMode === "progress") {
+        await progressDraft.start();
         return;
       }
       resetAnswerToolProgressDraft();
@@ -1402,7 +1403,7 @@ export const dispatchTelegramMessage = async ({
         reasoningStepState.noteReasoningHint();
         reasoningStepState.noteReasoningDelivered();
       }
-      updateDraftFromPartial(lanes[segment.lane], segment.update);
+      await updateDraftFromPartial(lanes[segment.lane], segment.update);
     }
   };
   const flushDraftLane = async (lane: DraftLaneState) => {


### PR DESCRIPTION
## What Problem This Solves

Telegram progress-mode streaming can receive answer partials but show no visible draft, because progress mode intentionally suppresses answer-lane partial text when there are no tool/progress rows to render. This makes Telegram appear stuck even though upstream draft state exists.

This PR starts the existing Telegram progress placeholder when progress-mode answer partials are suppressed, while keeping the partial answer text itself suppressed until final delivery.

Addresses one concrete silent-preview path from #95004. The broader issue also discusses non-progress short first previews; this PR intentionally keeps that debounce behavior unchanged.

## Summary

- start the existing Telegram progress draft placeholder when progress mode suppresses answer-lane partial text
- keep the answer partial itself suppressed in progress mode, preserving the existing final-delivery behavior
- add a regression test for the no-visible-draft case

## Evidence

- Added a regression test proving a progress-mode answer partial renders the configured progress placeholder and does not stream the suppressed answer text.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts`
  - 123 files passed, 2163 tests passed
- `pnpm test:changed`
  - Telegram shard passed, 130 tests passed
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts`
  - passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts`
  - passed
- `git diff --check`
  - passed

Note: `pnpm check:changed` was not used as final evidence because the local crabbox binary fails its basic `--version`/`--help` sanity check before running repo checks.
