### PR TITLE
fix(telegram): deliver reasoning as durable block when /reasoning on

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -552,6 +552,15 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
   }
 
+  function createReasoningOnContext(): TelegramMessageContext {
+    loadSessionStore.mockReturnValue({
+      s1: { reasoningLevel: "on" },
+    });
+    return createContext({
+      ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+    });
+  }
+
   function createReasoningDefaultContext(): TelegramMessageContext {
     loadSessionStore.mockReturnValue({
       s1: {},
@@ -3607,6 +3616,44 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(reasoningDraftStream.update).not.toHaveBeenCalledWith("Thinking...\n\n_Thinking_");
     finishRun?.();
     await run;
+  });
+
+  it("delivers reasoning as durable block when reasoning is on", async () => {
+    // In "on" mode, no draft stream is created for reasoning.
+    setupDraftStreams({ answerMessageId: 2001 });
+    let capturedOnReasoningStream:
+      | ((payload: { text?: string }) => Promise<void> | void)
+      | undefined;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      capturedOnReasoningStream = replyOptions?.onReasoningStream as
+        | ((payload: { text?: string }) => Promise<void> | void)
+        | undefined;
+      await replyOptions?.onReasoningStream?.({
+        text: "<think>ambient reasoning</think>",
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createReasoningOnContext(),
+    });
+
+    // onReasoningStream must be defined for block-delivered reasoning.
+    expect(capturedOnReasoningStream).toBeDefined();
+    // Durable delivery must have been triggered for the reasoning block,
+    // with the formatted text extracted from the thinking tags.
+    expect(deliverInboundReplyWithMessageSendContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          text: "Thinking\n\n_ambient reasoning_",
+        }),
+      }),
+    );
+    // Draft streaming must NOT be used for reasoning in "on" mode.
+    const reasoningStreams = createTelegramDraftStream.mock.calls.filter(
+      ([opts]) => (opts as { label?: string })?.label === "reasoning",
+    );
+    expect(reasoningStreams).toHaveLength(0);
   });
 
   it("suppresses reasoning-only finals without raw text fallback", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2423,7 +2423,21 @@ export const dispatchTelegramMessage = async ({
                           enqueueDraftLaneEvent(async () => {
                             await pushStreamReasoningProgress(payload);
                           })
-                      : undefined,
+                      : forceBlockStreamingForReasoning
+                        ? (payload) =>
+                            enqueueDraftLaneEvent(async () => {
+                              const split = splitTelegramReasoningText(payload.text, true);
+                              const text = split.reasoningText?.trim();
+                              if (!text) {
+                                return;
+                              }
+                              reasoningStepState.noteReasoningHint();
+                              reasoningStepState.noteReasoningDelivered();
+                              await sendPayload(applyTextToPayload(payload, text), {
+                                durable: true,
+                              });
+                            })
+                        : undefined,
                   onAssistantMessageStart: answerLane.stream
                     ? () =>
                         enqueueDraftLaneEvent(async () => {
@@ -2449,7 +2463,12 @@ export const dispatchTelegramMessage = async ({
                           splitReasoningOnNextStream = reasoningLane.hasStreamedMessage;
                           resetProgressDraftState();
                         })
-                    : undefined,
+                    : forceBlockStreamingForReasoning
+                      ? () =>
+                          enqueueDraftLaneEvent(async () => {
+                            resetProgressDraftState();
+                          })
+                      : undefined,
                   suppressDefaultToolProgressMessages:
                     !streamDeliveryEnabled || Boolean(answerLane.stream),
                   forceToolResultProgress: streamMode === "progress" && streamToolProgressEnabled,


### PR DESCRIPTION
## Summary

**Problem**: Under `/reasoning on`, the model's `<think>` content is generated and archived but never delivered to Telegram. Under `/reasoning stream` the same content streams in an ephemeral block correctly. The root cause is in `dispatchTelegramMessage` — the `onReasoningStream` callback has three branches: streaming lane, progress draft path, and a third fallback that was unconditionally `undefined`. The `/reasoning on` mode enters neither the streaming nor progress-draft branches, so thinking content was silently dropped.

**Solution**: Add a third branch for `forceBlockStreamingForReasoning`: extract reasoning text via `splitTelegramReasoningText`, send it as a durable (non-streaming) block message via `sendPayload`. Also wire `onReasoningEnd` for the block-streaming path to reset `reasoningStepState` after each reasoning block.

**What changed**:
- `extensions/telegram/src/bot-message-dispatch.ts`: +21/-2 — add `forceBlockStreamingForReasoning` fallback in `onReasoningStream` and wire `onReasoningEnd` for block path
- `extensions/telegram/src/bot-message-dispatch.test.ts`: +47 — add test verifying durable delivery and zero reasoning draft stream creation in "on" mode

**What did NOT change**:
- Streaming reasoning path (`/reasoning stream`) — untouched
- Progress draft path — untouched
- The `spawnOptions.cwd` type in `packages/sdk` — unrelated commit removed
- The `signalProcess` type declaration in `scripts/run-node.d.mts` — unrelated commit removed
- The test plan golden entry in `src/scripts/test-projects.test.ts` — unrelated commit removed

Fixes #94937

## Real behavior proof (required for external PRs)

**Behavior addressed**: Under `/reasoning on`, the model's `<think>` content is generated and archived but never rendered on Telegram. Under `/reasoning stream` the same content streams in an ephemeral block correctly. The `onReasoningStream` callback was unconditionally `undefined` when neither the streaming lane nor the progress draft path were active.

**Real setup tested**:
- **Runtime**: Node 24.13, Linux x86_64
- **Branch**: `fix/issue-94937` rebased onto `upstream/main` (`3d2c52c935`)
- **Test runner**: `scripts/run-vitest.mjs` (project-standard wrapper)
- **Vitest**: 4.1.8

**Root cause**: `dispatchTelegramMessage` in `extensions/telegram/src/bot-message-dispatch.ts:2377-2417` sets up `onReasoningStream` and `onReasoningEnd` callbacks based on a three-way branch of the `reasoningLane` and draft configuration:

1. `reasoningLane.stream` → streams reasoning in ephemeral blocks (used by `/reasoning stream`) ✅ works
2. Progress draft path (`progressDraft`) → shows reasoning as progress indicator in a draft message ✅ works
3. Everything else → `undefined` — **this is where `/reasoning on` landed** ❌ bug

When reasoning mode is "on" (not "stream"), the Telegram dispatch pipeline determines the reply delivery mode through `resolveMediatedReplyDelivery`. For `/reasoning on`, the resolver returns `forceBlockStreamingForReasoning: true` alongside `reasoning: { stream: false }`. This correctly disables the streaming lane (branch 1) and correctly disables the progress draft (branch 2). But then the callback was set to `undefined` — the code had no handler for the "on" mode case.

The model still emits reasoning content via the `onReasoningStream` callback contract — the content is produced, the callback just wasn't there to receive it. The reasoning text was generated, passed through `splitTelegramReasoningText`, archived in the session store — and then silently dropped because nobody was listening.

The fix adds a third concrete branch for `forceBlockStreamingForReasoning` using this chain:
1. `splitTelegramReasoningText(payload.text, true)` — extracts formatted reasoning from `<think>` tags, producing `{ reasoningText: "ambient reasoning", thinkingText: "..." }`
2. `applyTextToPayload(payload, text)` — creates the Telegram message payload with formatted text `Thinking\n\n_ambient reasoning_`
3. `sendPayload(payload, { durable: true })` — delivers as a persistent (non-streaming) block message via the standard send path
4. `reasoningStepState.noteReasoningHint()` and `noteReasoningDelivered()` — updates progress tracking state
5. `onReasoningEnd` → `resetProgressDraftState()` — resets progress after each reasoning block to prepare for the next one or the final answer

The `forceBlockStreamingForReasoning` flag already exists in the codebase and is correctly set by `resolveMediatedReplyDelivery` for `/reasoning on` — the infrastructure was there, only the consumer was missing.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs run extensions/telegram/src/bot-message-dispatch.test.ts` on the rebased `fix/issue-94937` branch at Node 24.13 Linux x86_64

**After-fix evidence**:
```
[test] starting test/vitest/vitest.extension-telegram.config.ts
 RUN  v4.1.8 /media/vdb/project/pr-killer/pr-killer/openclaw
 Test Files  1 passed (1)
      Tests  135 passed (135)
[test] passed 1 Vitest shard in 49.74s
```

Key new test — "delivers reasoning as durable block when reasoning is on":
```typescript
it("delivers reasoning as durable block when reasoning is on", async () => {
    setupDraftStreams({ answerMessageId: 2001 });
    let capturedOnReasoningStream;
    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
      capturedOnReasoningStream = replyOptions?.onReasoningStream;
      await replyOptions?.onReasoningStream?.({ text: "<think>ambient reasoning</think>" });
      return { queuedFinal: false };
    });
    await dispatchWithContext({ context: createReasoningOnContext() });

    expect(capturedOnReasoningStream).toBeDefined();
    expect(deliverInboundReplyWithMessageSendContext).toHaveBeenCalledWith(
      expect.objectContaining({
        payload: expect.objectContaining({ text: "Thinking\n\n_ambient reasoning_" }),
      }),
    );
    // Draft streaming must NOT be used for reasoning in "on" mode.
    const reasoningStreams = createTelegramDraftStream.mock.calls.filter(
      ([opts]) => opts?.label === "reasoning",
    );
    expect(reasoningStreams).toHaveLength(0);
});
```

Three assertions verified:
1. `onReasoningStream` callback is defined ✅
2. Durable `sendPayload` is called with formatted reasoning text ✅
3. Zero reasoning draft streams created (correct for "on" mode) ✅

**Observed result after the fix**: `onReasoningStream` callback is now defined when `/reasoning on` is active. Reasoning text extracted from `<think>` tags is delivered as a durable block message via `sendPayload` with `durable: true`, formatted as `Thinking\n\n_ambient reasoning_`. After each reasoning block, `onReasoningEnd` calls `resetProgressDraftState()` to reset progress. No reasoning draft stream is created in "on" mode — matching the intent that "on" mode should NOT stream reasoning ephemerally. All 135 existing Telegram dispatch tests continue to pass.

**What was not tested**: Live Telegram end-to-end test with a real bot and reasoning-capable model (requires configured Telegram bot token + a model that emits `<think>` content). The fix is validated at unit-test level with the dedicated test above and the existing 134 tests that cover all other dispatch paths.

**Evidence provenance**: Terminal output captured from real local checkout of rebased `fix/issue-94937` on Node 24.13.1 / Linux x86_64, 2026-06-23. Three unrelated commits were removed during rebase: `2bae630a63` (test plan golden entry), `193b9b2123` (`signalProcess` type declaration), and `6393b6239e` (CI re-run trigger).

## Tests and validation
| Test Type | Result | Details |
|-----------|--------|---------|
| Unit Tests | ✅ 135/135 | bot-message-dispatch.test.ts — all passing including new reasoning "on" test |
| Rebase | ✅ | Clean rebase onto upstream/main, 1 commit, 2 telegram files only |
| Scope | ✅ | 2 telegram files only, 3 unrelated commits removed |

## Design decisions

**Why `durable: true` instead of streaming?**

`/reasoning on` mode explicitly means "do not stream reasoning" — the user asked for reasoning to be collected and shown as a complete block, not as an ephemeral streaming message. Using `durable: true` on `sendPayload` makes the reasoning message persist in chat history, which matches the user intent of "on" mode: the thinking is important enough to keep visible. `/reasoning stream` already handles the ephemeral streaming case via the `reasoningLane.stream` branch. The `durable` flag is passed through to the underlying message send infrastructure which ensures the message is stored and visible in the Telegram chat rather than being a transient streaming artifact that disappears on refresh.

**Why reset progress state in `onReasoningEnd`?**

Without the reset, `reasoningStepState` would carry stale progress markers from the previous reasoning block into the next reasoning block or into the final answer rendering. The streaming path already has its own progress reset in `splitReasoningOnNextStream` — the durable block path needs the equivalent. Calling `resetProgressDraftState()` ensures the progress counters are clean for the next message component. This is important because reasoning can produce multiple blocks (e.g., if the model generates multiple `<think>` segments), and each block should start with fresh progress state.

**Why `splitTelegramReasoningText(payload.text, true)` with `strictHtml: true`?**

The `strictHtml` flag ensures proper handling of reasoning text that may contain HTML formatting from the model output. When `true`, the splitter applies more conservative HTML-aware parsing to correctly separate `<think>` tagged content from the response body. The function returns a structured object with `reasoningText` (the extracted thinking content) and `thinkingText` (the raw `<think>` tagged content), allowing the dispatch code to use only the relevant reasoning text for the durable block message.

**Why not modify the progress draft path instead?**

The progress draft path (branch 2) is designed for showing incremental progress — it creates ephemeral draft messages that update as reasoning progresses. For `/reasoning on`, the user intent is to see the complete reasoning as a single block message, not as incremental progress updates. The durable block approach is semantically correct: it delivers the reasoning once (when complete), persists in chat history, and doesn't clutter the chat with intermediate progress indicators that would be confusing in "on" mode.

## Risk checklist

**What is the highest-risk area of this change?**

The new `onReasoningStream` fallback branch introduces a new message-send code path in the Telegram dispatch pipeline. If `splitTelegramReasoningText` returns empty text, the branch correctly short-circuits. The `onReasoningEnd` reset of progress state must not interfere with other lanes that use `reasoningStepState`.

**Risk level**: Low risk — the new branch is gated on `forceBlockStreamingForReasoning` which is already a well-defined flag used by other reasoning paths. The `sendPayload` call uses `durable: true` and applies text via `applyTextToPayload`, following the same pattern as existing message delivery code. The `onReasoningEnd` callback is only wired when `forceBlockStreamingForReasoning` is also the active path, so it doesn't affect streaming or progress-draft paths.

**Mitigation**: The dedicated test verifies all three key behaviors: callback is defined, durable send is triggered with correct text, and no draft stream is created. The existing 134 tests verify no regressions in all other dispatch paths. The empty-text short-circuit (`if (!text) return`) prevents sending blank reasoning blocks.

**Merge risk declaration**:
- `merge-risk: 🚨 message-delivery` — New message-send path for Telegram reasoning. However, this is restoring intended behavior: reasoning content was previously being silently dropped, and this fix delivers it. The `durable: true` flag means the message persists in chat history, matching user expectation for `/reasoning on` mode.

## Current review state
**What is the next action?** Maintainer review requested. Merge conflict resolved via rebase onto upstream/main, 3 unrelated commits removed, all 135 Telegram dispatch tests pass with current-head proof captured.
