### PR TITLE
fix(ui): show workspace context in dashboard header

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -219,9 +219,20 @@
   white-space: nowrap;
 }
 
+.topnav-shell .dashboard-header__breadcrumb-context--workspace {
+  max-width: min(32ch, 28vw);
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 500;
+}
+
 @media (max-width: 720px) {
   .topnav-shell .dashboard-header__breadcrumb-context {
     max-width: 10ch;
+  }
+
+  .topnav-shell .dashboard-header__breadcrumb-context--workspace {
+    max-width: 12ch;
   }
 }
 

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -537,6 +537,107 @@ describe("resolveDashboardHeaderContext", () => {
       } as unknown as AppViewState),
     ).toEqual({ agentLabel: "beta" });
   });
+
+  it("uses the active session workspace root when workspace context is enabled", () => {
+    expect(
+      resolveDashboardHeaderContext(
+        {
+          sessionKey: "agent:deep-chat:main",
+          agentsList: {
+            defaultId: "deep-chat",
+            mainKey: "main",
+            scope: "user",
+            agents: [
+              {
+                id: "deep-chat",
+                identity: { name: "Deep Chat" },
+                workspace: "/Users/marko/projects/default-workspace",
+              },
+            ],
+          },
+        } as unknown as AppViewState,
+        {
+          includeWorkspace: true,
+          workspaceRoot: "/Users/marko/projects/live-workspace",
+        },
+      ),
+    ).toEqual({
+      agentLabel: "Deep Chat",
+      workspaceLabel: "/Users/marko/projects/live-workspace",
+      workspaceTitle: "/Users/marko/projects/live-workspace",
+    });
+  });
+
+  it("falls back to the active agent workspace before session files load", () => {
+    expect(
+      resolveDashboardHeaderContext(
+        {
+          sessionKey: "agent:deep-chat:main",
+          agentsList: {
+            defaultId: "deep-chat",
+            mainKey: "main",
+            scope: "user",
+            agents: [
+              {
+                id: "deep-chat",
+                identity: { name: "Deep Chat" },
+                workspace: "/Users/marko/projects/default-workspace",
+              },
+            ],
+          },
+        } as unknown as AppViewState,
+        { includeWorkspace: true },
+      ),
+    ).toEqual({
+      agentLabel: "Deep Chat",
+      workspaceLabel: "/Users/marko/projects/default-workspace",
+      workspaceTitle: "/Users/marko/projects/default-workspace",
+    });
+  });
+
+  it("uses the selected agent workspace for global-session context", () => {
+    expect(
+      resolveDashboardHeaderContext(
+        {
+          sessionKey: "global",
+          agentsList: {
+            defaultId: "main",
+            mainKey: "main",
+            scope: "user",
+            agents: [
+              { id: "main", name: "Main", workspace: "/Users/marko/projects/main-workspace" },
+              { id: "codex", name: "Codex", workspace: "/Users/marko/projects/codex-workspace" },
+            ],
+          },
+        } as unknown as AppViewState,
+        { agentId: "codex", includeWorkspace: true },
+      ),
+    ).toEqual({
+      agentLabel: "Codex",
+      workspaceLabel: "/Users/marko/projects/codex-workspace",
+      workspaceTitle: "/Users/marko/projects/codex-workspace",
+    });
+  });
+
+  it("omits workspace context unless explicitly enabled", () => {
+    expect(
+      resolveDashboardHeaderContext({
+        sessionKey: "agent:deep-chat:main",
+        agentsList: {
+          defaultId: "deep-chat",
+          mainKey: "main",
+          scope: "user",
+          agents: [
+            {
+              id: "deep-chat",
+              identity: { name: "Deep Chat" },
+              workspace: "/Users/marko/projects/default-workspace",
+            },
+          ],
+        },
+      } as unknown as AppViewState),
+    ).toEqual({ agentLabel: "Deep Chat" });
+  });
 });
 
 describe("isCronSessionKey", () => {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -95,8 +95,11 @@ export function resolveAssistantAttachmentAuthToken(
 
 export function resolveDashboardHeaderContext(
   state: Pick<AppViewState, "agentsList" | "sessionKey">,
-): { agentLabel: string } {
-  const agentId = resolveAgentIdFromSessionKey(state.sessionKey);
+  opts?: { agentId?: string | null; includeWorkspace?: boolean; workspaceRoot?: string | null },
+): { agentLabel: string; workspaceLabel?: string; workspaceTitle?: string } {
+  const agentId = opts?.agentId
+    ? normalizeAgentId(opts.agentId)
+    : resolveAgentIdFromSessionKey(state.sessionKey);
   const agent = state.agentsList?.agents.find(
     (entry) => normalizeLowercaseStringOrEmpty(entry.id) === agentId,
   );
@@ -104,7 +107,14 @@ export function resolveDashboardHeaderContext(
     normalizeOptionalString(agent?.identity?.name) ??
     normalizeOptionalString(agent?.name) ??
     agentId;
-  return { agentLabel };
+  if (!opts?.includeWorkspace) {
+    return { agentLabel };
+  }
+  const workspaceRoot =
+    normalizeOptionalString(opts.workspaceRoot) ?? normalizeOptionalString(agent?.workspace);
+  return workspaceRoot
+    ? { agentLabel, workspaceLabel: workspaceRoot, workspaceTitle: workspaceRoot }
+    : { agentLabel };
 }
 
 function resolveSidebarChatSessionKey(state: AppViewState): string {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1402,7 +1402,6 @@ export function renderApp(state: AppViewState) {
   const chatHeaderHidden = isChat && (state.onboarding || state.chatHeaderControlsHidden);
   const navDrawerOpen = state.navDrawerOpen && !state.onboarding;
   const navCollapsed = state.settings.navCollapsed && !navDrawerOpen;
-  const dashboardHeaderContext = resolveDashboardHeaderContext(state);
   const showThinking = state.onboarding ? false : state.settings.chatShowThinking;
   const showToolCalls = state.onboarding ? true : state.settings.chatShowToolCalls;
   const activeAssistantAgentId = resolveSidebarSelectedAgentId(state);
@@ -1595,6 +1594,14 @@ export function renderApp(state: AppViewState) {
     state.sessionKey,
     chatWorkspaceAgentId,
   );
+  const showDashboardWorkspaceContext = isChat && (state.agentsList?.agents?.length ?? 0) > 1;
+  const activeSessionWorkspaceRoot =
+    chatWorkspaceFiles.list?.sessionKey === state.sessionKey ? chatWorkspaceFiles.list.root : null;
+  const dashboardHeaderContext = resolveDashboardHeaderContext(state, {
+    agentId: chatWorkspaceAgentId,
+    includeWorkspace: showDashboardWorkspaceContext,
+    workspaceRoot: activeSessionWorkspaceRoot,
+  });
   const currentChatWorkspaceFilesState = () =>
     getChatWorkspaceFilesState(state, state.sessionKey, resolveChatWorkspaceAgentId());
   const currentSessionWorkspaceKey = () => state.sessionKey;
@@ -2506,6 +2513,8 @@ export function renderApp(state: AppViewState) {
               .tab=${state.tab}
               .basePath=${state.basePath}
               .agentLabel=${dashboardHeaderContext.agentLabel}
+              .workspaceLabel=${dashboardHeaderContext.workspaceLabel ?? ""}
+              .workspaceTitle=${dashboardHeaderContext.workspaceTitle ?? ""}
               @navigate=${(event: CustomEvent<Tab>) => {
                 state.setTab(event.detail);
               }}

--- a/ui/src/ui/components/dashboard-header.ts
+++ b/ui/src/ui/components/dashboard-header.ts
@@ -11,6 +11,8 @@ export class DashboardHeader extends LitElement {
   @property() tab: Tab = "overview";
   @property() basePath = "";
   @property() agentLabel = "";
+  @property() workspaceLabel = "";
+  @property() workspaceTitle = "";
 
   private readonly handleOverviewClick = (event: MouseEvent) => {
     if (
@@ -32,6 +34,8 @@ export class DashboardHeader extends LitElement {
   override render() {
     const label = titleForTab(this.tab);
     const agentLabel = this.agentLabel.trim();
+    const workspaceLabel = this.workspaceLabel.trim();
+    const workspaceTitle = this.workspaceTitle.trim() || workspaceLabel;
 
     return html`
       <div class="dashboard-header">
@@ -49,6 +53,19 @@ export class DashboardHeader extends LitElement {
                   <span class="dashboard-header__breadcrumb-sep">›</span>
                   <span class="dashboard-header__breadcrumb-context" title=${agentLabel}>
                     ${agentLabel}
+                  </span>
+                </span>
+              `
+            : nothing}
+          ${workspaceLabel
+            ? html`
+                <span class="dashboard-header__breadcrumb-segment">
+                  <span class="dashboard-header__breadcrumb-sep">›</span>
+                  <span
+                    class="dashboard-header__breadcrumb-context dashboard-header__breadcrumb-context--workspace"
+                    title=${workspaceTitle}
+                  >
+                    ${workspaceLabel}
                   </span>
                 </span>
               `

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -105,6 +105,45 @@ describe("control UI routing", () => {
     expect(breadcrumb.getAttribute("href")).toBe("/ui/overview");
   });
 
+  it("renders workspace context in the chat dashboard header without preloading the rail", async () => {
+    const app = mountApp("/chat?session=agent%3Acodex%3Amain");
+    app.tab = "chat";
+    app.sessionKey = "agent:codex:main";
+    app.agentsList = {
+      defaultId: "main",
+      mainKey: "main",
+      scope: "user",
+      agents: [
+        { id: "main", name: "Main", workspace: "/workspace/main" },
+        { id: "codex", identity: { name: "Codex" }, workspace: "/workspace/configured" },
+      ],
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.files.list") {
+        return { sessionKey: "agent:codex:main", root: "/workspace/live", files: [] };
+      }
+      if (method === "artifacts.list") {
+        return { artifacts: [] };
+      }
+      return null;
+    });
+    app.client = {
+      request,
+      stop: vi.fn(),
+    } as unknown as NonNullable<typeof app.client>;
+
+    await app.updateComplete;
+
+    const workspace = expectElement(
+      app,
+      ".dashboard-header__breadcrumb-context--workspace",
+      HTMLElement,
+    );
+    expect(workspace.textContent?.trim()).toBe("/workspace/configured");
+    expect(workspace.getAttribute("title")).toBe("/workspace/configured");
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it("renders the dreaming view on the /dreaming route", async () => {
     const app = mountApp("/dreaming");
     app.dreamingStatus = {


### PR DESCRIPTION
Closes #30861

This PR was prepared with AI assistance.

## What Problem This Solves

Fixes an issue where users working across multiple agents could see the active agent in the Dashboard header but not the workspace/cwd context tied to that agent, making it easier to confuse which workspace a chat session is operating against.

## Why This Change Was Made

The Dashboard header now shows a workspace breadcrumb for multi-agent chat contexts. It uses the active session workspace root when the workspace rail has already loaded, otherwise it falls back to the selected agent's configured workspace, and it keeps the workspace rail collapsed without triggering hidden `sessions.files.list` or artifact loads.

Single-agent contexts keep the existing compact header.

## User Impact

Multi-agent users can keep the active agent and workspace visible while moving around the chat Dashboard, including before opening the workspace rail. The indicator stays aligned with the selected chat agent instead of silently falling back to the default agent for global-session context.

## Evidence

Real behavior proof from headless Chromium using the existing Control UI E2E Vite/mock-gateway harness (`ui/src/test-helpers/control-ui-e2e.ts`) on PR head `07d42157a03d3a6443577b9b522fb3f4f655f2ec`:

```text
OpenClaw #95346 browser proof (PR head 07d42157a03d3a6443577b9b522fb3f4f655f2ec)
page=http://127.0.0.1:51727/chat?session=agent%3Acodex%3Amain
viewport=1280x900 locale=en-US chromium=/Users/m.milosevic/Library/Caches/ms-playwright/chromium-1223/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing
visible header text="OpenClaw › Codex › /redacted/project-alpha › Chat"
active agent label="Codex"
workspace breadcrumb text="/redacted/project-alpha"
workspace breadcrumb title="/redacted/project-alpha"
workspace rail collapsed=true
sessions.files.list calls before opening rail=0
artifacts.list calls before opening rail=0
```

Validation:

- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs ui/src/ui/app-render.helpers.node.test.ts ui/src/ui/navigation.browser.test.ts` - 2 files / 94 tests passed
- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts` - 1 file / 110 tests passed
- `pnpm ui:build` passed; only the existing large-chunk/plugin timing warning was emitted
- `pnpm test:changed` passed earlier on this final diff before commit (116 UI files / 1665 tests plus the unit-UI shard); a later rerun under concurrent validation load hit a local Vitest worker-start timeout, and an isolated rerun hung in `scripts/test-projects.mjs` before launching Vitest, so I covered the affected shards explicitly above
- `codex review --base origin/main` initially found two issues; both were fixed. A second review found no discrete actionable regressions.
- Local `pnpm check:changed` is blocked by missing Blacksmith Testbox auth: `not authenticated — run 'blacksmith auth login' first`.
