### PR TITLE
fix(memory): honor qmd search timeout and bound one-shot CLI cleanup

### DIFF
--- a/extensions/memory-core/src/memory-tool-manager.test-mocks.ts
+++ b/extensions/memory-core/src/memory-tool-manager.test-mocks.ts
@@ -24,7 +24,9 @@ type MemoryBackend = "builtin" | "qmd";
 let backend: MemoryBackend = "builtin";
 let workspaceDir = "/workspace";
 let customStatus: Record<string, unknown> | undefined;
+let searchTimeoutMs: number | undefined;
 let searchImpl: SearchImpl = async () => [];
+let syncImpl: () => Promise<void> = async () => {};
 let getManagerImpl:
   | ((params: { cfg?: unknown; agentId?: string; purpose?: string }) => Promise<{
       manager?: unknown;
@@ -55,9 +57,10 @@ const stubManager = {
     sourceCounts: [{ source: "memory" as const, files: 1, chunks: 1 }],
     custom: customStatus,
   }),
-  sync: vi.fn(),
+  sync: vi.fn(async () => await syncImpl()),
+  getSearchTimeoutMs: vi.fn(() => searchTimeoutMs ?? 15_000),
   probeVectorAvailability: vi.fn(async () => true),
-  close: vi.fn(),
+  close: vi.fn((_timeoutMs?: number) => Promise.resolve()),
 };
 
 const getMemorySearchManagerMock = vi.fn(
@@ -97,6 +100,14 @@ export function setMemorySearchImpl(next: SearchImpl): void {
   searchImpl = next;
 }
 
+export function setMemorySyncImpl(next: () => Promise<void>): void {
+  syncImpl = next;
+}
+
+export function setMemorySearchTimeoutMs(next: number | undefined): void {
+  searchTimeoutMs = next;
+}
+
 export function setMemorySearchManagerImpl(
   next: (params: { cfg?: unknown; agentId?: string; purpose?: string }) => Promise<{
     manager?: unknown;
@@ -120,8 +131,10 @@ export function resetMemoryToolMockState(overrides?: {
   backend = overrides?.backend ?? "builtin";
   workspaceDir = "/workspace";
   customStatus = undefined;
+  searchTimeoutMs = undefined;
   getManagerImpl = undefined;
   searchImpl = overrides?.searchImpl ?? (async () => []);
+  syncImpl = async () => {};
   readFileImpl =
     overrides?.readFileImpl ??
     (async (params: MemoryReadParams) => ({
@@ -143,6 +156,10 @@ export function getMemorySyncMockCalls(): number {
 
 export function getMemoryCloseMockCalls(): number {
   return stubManager.close.mock.calls.length;
+}
+
+export function getMemoryCloseMockArgs(): Array<{ timeoutMs?: number }> {
+  return stubManager.close.mock.calls.map(([timeoutMs]) => ({ timeoutMs }));
 }
 
 export function getMemorySearchManagerMockConfigs(): unknown[] {

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -211,7 +211,11 @@ import {
   resetMemoryCoreDreamingStateForTests,
 } from "../dreaming-state.js";
 import { resolveQmdSessionArtifactIdentity } from "../qmd-session-artifacts.js";
-import { QmdMemoryManager, resolveQmdMcporterSearchProcessTimeoutMs } from "./qmd-manager.js";
+import {
+  QmdMemoryManager,
+  resolveQmdMcporterSearchProcessTimeoutMs,
+  resolveQmdWholeSearchTimeoutMs,
+} from "./qmd-manager.js";
 
 const spawnMock = mockedSpawn as unknown as Mock;
 const originalPath = process.env.PATH;
@@ -292,6 +296,84 @@ describe("QmdMemoryManager", () => {
     expect(mockMessages(mock).join("\n")).not.toContain(text);
   }
 
+  function createClosableQmdManagerForTest(params?: {
+    pendingUpdate?: Promise<void> | null;
+    queuedForcedUpdate?: Promise<void> | null;
+  }): QmdMemoryManager {
+    const manager = Object.create(QmdMemoryManager.prototype) as QmdMemoryManager;
+    const mutable = manager as unknown as {
+      closed: boolean;
+      resolveCloseSignal: () => void;
+      updateTimer: NodeJS.Timeout | null;
+      embedTimer: NodeJS.Timeout | null;
+      watchTimer: NodeJS.Timeout | null;
+      watcher: { close: () => Promise<void> } | null;
+      queuedForcedRuns: number;
+      pendingUpdate: Promise<void> | null;
+      queuedForcedUpdate: Promise<void> | null;
+      db: { close: () => void } | null;
+    };
+    mutable.closed = false;
+    mutable.resolveCloseSignal = vi.fn();
+    mutable.updateTimer = null;
+    mutable.embedTimer = null;
+    mutable.watchTimer = null;
+    mutable.watcher = null;
+    mutable.queuedForcedRuns = 0;
+    mutable.pendingUpdate = params?.pendingUpdate ?? null;
+    mutable.queuedForcedUpdate = params?.queuedForcedUpdate ?? null;
+    mutable.db = null;
+    return manager;
+  }
+
+  it("clears qmd close timeout timers when update waits settle first", async () => {
+    vi.useFakeTimers();
+    try {
+      const manager = createClosableQmdManagerForTest({
+        pendingUpdate: Promise.resolve(),
+        queuedForcedUpdate: Promise.resolve(),
+      });
+
+      await manager.close(5_000);
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expectMockMessageNotContains(logWarnMock, "qmd close timed out");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses one qmd close timeout across pending and queued update waits", async () => {
+    vi.useFakeTimers();
+    try {
+      const manager = createClosableQmdManagerForTest({
+        pendingUpdate: new Promise(() => {}),
+        queuedForcedUpdate: new Promise(() => {}),
+      });
+      let closed = false;
+
+      const closePromise = manager.close(5_000).then(() => {
+        closed = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      await Promise.resolve();
+      expect(closed).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await closePromise;
+
+      expect(closed).toBe(true);
+      expectMockMessageContains(
+        logWarnMock,
+        "qmd close timed out waiting for pending update and queued forced update after 5000ms",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("caps mcporter search process timeout grace", () => {
     expect(resolveQmdMcporterSearchProcessTimeoutMs(1_000)).toBe(5_000);
     expect(resolveQmdMcporterSearchProcessTimeoutMs(10_000)).toBe(12_000);
@@ -302,6 +384,39 @@ describe("QmdMemoryManager", () => {
     expect(resolveQmdMcporterSearchProcessTimeoutMs(MAX_TIMER_TIMEOUT_MS - 100)).toBe(
       MAX_TIMER_TIMEOUT_MS,
     );
+  });
+
+  it("budgets qmd whole-search lifecycles beyond one command timeout", () => {
+    expect(
+      resolveQmdWholeSearchTimeoutMs({
+        timeoutMs: 60_000,
+        updateTimeoutMs: 20_000,
+        embedTimeoutMs: 30_000,
+        searchMode: "vsearch",
+        collectionCount: 3,
+        mcporterEnabled: false,
+        onSearchSync: true,
+      }),
+    ).toBe(782_500);
+  });
+
+  it("keeps qmd memory_search on the old guard unless the qmd search timeout is raised", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          limits: { timeoutMs: 6_000 },
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const { manager } = await createManager();
+
+    expect(manager.getSearchTimeoutMs()).toBe(15_000);
   });
 
   it("reuses persisted collection validation across transient cli managers", async () => {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -119,6 +119,8 @@ function asAbortError(signal: AbortSignal): Error {
 
 const SNIPPET_HEADER_RE = /@@\s*-([0-9]+),([0-9]+)/;
 const SEARCH_PENDING_UPDATE_WAIT_MS = 500;
+const QMD_WHOLE_SEARCH_OVERHEAD_MS = 2_000;
+const MEMORY_SEARCH_DEFAULT_OUTER_TIMEOUT_MS = 15_000;
 const MAX_QMD_OUTPUT_CHARS = 200_000;
 const NUL_MARKER_RE = /(?:\^@|\\0|\\x00|\\u0000|null\s*byte|nul\s*byte)/i;
 const QMD_EMBED_BACKOFF_BASE_MS = 60_000;
@@ -253,6 +255,38 @@ function resolveQmdWriteLockOptions(expectedMs: number, minWaitMs: number) {
 
 export function resolveQmdMcporterSearchProcessTimeoutMs(timeoutMs: number): number {
   return Math.max(addTimerTimeoutGraceMs(timeoutMs, 2_000) ?? 1, 5_000);
+}
+
+export function resolveQmdWholeSearchTimeoutMs(params: {
+  timeoutMs: number;
+  updateTimeoutMs: number;
+  embedTimeoutMs: number;
+  searchMode: ResolvedQmdConfig["searchMode"];
+  collectionCount: number;
+  mcporterEnabled: boolean;
+  onSearchSync: boolean;
+}): number {
+  const qmdCommandTimeoutMs = normalizePositiveInteger(params.timeoutMs, 1);
+  const collectionCount = Math.max(1, Math.floor(params.collectionCount));
+  const searchModeAttempts = params.searchMode === "query" ? 1 : 2;
+  const missingCollectionRepairAttempts = 2;
+  const directMultiCollectionProbeMs =
+    params.mcporterEnabled || collectionCount <= 1 ? 0 : Math.min(qmdCommandTimeoutMs, 5_000);
+  const searchCommandBudgetMs =
+    directMultiCollectionProbeMs +
+    collectionCount * searchModeAttempts * missingCollectionRepairAttempts * qmdCommandTimeoutMs;
+  const dirtySyncBudgetMs = params.onSearchSync
+    ? normalizePositiveInteger(params.updateTimeoutMs, 1) +
+      (qmdUsesVectors(params.searchMode) ? normalizePositiveInteger(params.embedTimeoutMs, 1) : 0)
+    : 0;
+  return (
+    addTimerTimeoutGraceMs(
+      searchCommandBudgetMs +
+        dirtySyncBudgetMs +
+        SEARCH_PENDING_UPDATE_WAIT_MS +
+        QMD_WHOLE_SEARCH_OVERHEAD_MS,
+    ) ?? qmdCommandTimeoutMs
+  );
 }
 
 // Cross-process serialization for qmd embeds (heavy ML work, serialized globally).
@@ -1513,6 +1547,21 @@ export class QmdMemoryManager implements MemorySearchManager {
     return true;
   }
 
+  getSearchTimeoutMs(opts?: { qmdSearchModeOverride?: "query" | "search" | "vsearch" }): number {
+    if (this.qmd.limits.timeoutMs <= MEMORY_SEARCH_DEFAULT_OUTER_TIMEOUT_MS) {
+      return MEMORY_SEARCH_DEFAULT_OUTER_TIMEOUT_MS;
+    }
+    return resolveQmdWholeSearchTimeoutMs({
+      timeoutMs: this.qmd.limits.timeoutMs,
+      updateTimeoutMs: this.qmd.update.updateTimeoutMs,
+      embedTimeoutMs: this.qmd.update.embedTimeoutMs,
+      searchMode: opts?.qmdSearchModeOverride ?? this.qmd.searchMode,
+      collectionCount: this.qmd.collections.length,
+      mcporterEnabled: this.qmd.mcporter.enabled,
+      onSearchSync: this.syncSettings?.onSearch === true,
+    });
+  }
+
   async search(
     query: string,
     opts?: {
@@ -1921,7 +1970,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
   }
 
-  async close(): Promise<void> {
+  async close(timeoutMs?: number): Promise<void> {
     if (this.closed) {
       return;
     }
@@ -1944,8 +1993,46 @@ export class QmdMemoryManager implements MemorySearchManager {
       this.watcher = null;
     }
     this.queuedForcedRuns = 0;
-    await this.pendingUpdate?.catch(() => undefined);
-    await this.queuedForcedUpdate?.catch(() => undefined);
+    const pendingUpdates = [
+      { label: "pending update", promise: this.pendingUpdate },
+      { label: "queued forced update", promise: this.queuedForcedUpdate },
+    ].filter(
+      (update): update is { label: string; promise: Promise<void> } =>
+        update.promise !== null && update.promise !== undefined,
+    );
+    if (pendingUpdates.length > 0) {
+      const cleanupTimeoutMs =
+        typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
+          ? Math.floor(timeoutMs)
+          : undefined;
+      const updatesDone = Promise.all(
+        pendingUpdates.map(async ({ promise }) => await promise.catch(() => undefined)),
+      ).then(() => undefined);
+
+      if (cleanupTimeoutMs === undefined) {
+        await updatesDone;
+      } else {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const labels = pendingUpdates.map(({ label }) => label).join(" and ");
+        const timeoutPromise = new Promise<void>((resolve) => {
+          timer = setTimeout(() => {
+            log.warn(
+              `qmd close timed out waiting for ${labels} after ${cleanupTimeoutMs}ms; proceeding with cleanup`,
+            );
+            resolve();
+          }, cleanupTimeoutMs);
+          timer.unref?.();
+        });
+
+        try {
+          await Promise.race([updatesDone, timeoutPromise]);
+        } finally {
+          if (timer) {
+            clearTimeout(timer);
+          }
+        }
+      }
+    }
     if (this.db) {
       this.db.close();
       this.db = null;

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -332,6 +332,33 @@ describe("getMemorySearchManager caching", () => {
     expect(second.debug?.qmdIdentityHash).toBe(first.debug?.qmdIdentityHash);
   });
 
+  it("forwards timeout mode overrides through cached full qmd manager", async () => {
+    const agentId = "cached-qmd-timeout-opts";
+    const cfg = createQmdCfg(agentId);
+    const getSearchTimeoutMs = vi.fn(
+      (opts?: { qmdSearchModeOverride?: "query" | "search" | "vsearch" }) =>
+        opts?.qmdSearchModeOverride === "vsearch" ? 123_000 : 15_000,
+    );
+    (
+      mockPrimary as typeof mockPrimary & {
+        getSearchTimeoutMs: typeof getSearchTimeoutMs;
+      }
+    ).getSearchTimeoutMs = getSearchTimeoutMs;
+
+    try {
+      const first = await getMemorySearchManager({ cfg, agentId });
+      const second = await getMemorySearchManager({ cfg, agentId });
+      const manager = requireManager(second);
+
+      expect(first.manager).toBe(second.manager);
+      expect(second.debug?.managerCacheState).toBe("cached-full-hit");
+      expect(manager.getSearchTimeoutMs?.({ qmdSearchModeOverride: "vsearch" })).toBe(123_000);
+      expect(getSearchTimeoutMs).toHaveBeenLastCalledWith({ qmdSearchModeOverride: "vsearch" });
+    } finally {
+      delete (mockPrimary as Partial<{ getSearchTimeoutMs: unknown }>).getSearchTimeoutMs;
+    }
+  });
+
   it("keeps the cached QMD manager active when the caller cancels a search", async () => {
     const agentId = "cancelled-search";
     const cfg = createQmdCfg(agentId);
@@ -370,7 +397,13 @@ describe("getMemorySearchManager caching", () => {
     const fallbackResults = await firstManager.search("hello", { signal: controller.signal });
     expect(fallbackResults).toHaveLength(1);
     expect(fallbackResults[0]?.path).toBe("MEMORY.md");
-    expect(fallbackSearch).toHaveBeenCalledWith("hello", { signal: controller.signal });
+    const [, fallbackOpts] = fallbackSearch.mock.calls[0] as unknown as [
+      string,
+      { signal?: AbortSignal },
+    ];
+    expect(fallbackOpts?.signal).toBeInstanceOf(AbortSignal);
+    expect(fallbackOpts?.signal).not.toBe(controller.signal);
+    expect(fallbackOpts?.signal?.aborted).toBe(false);
 
     const second = await getMemorySearchManager({ cfg, agentId: retryAgentId });
     requireManager(second);
@@ -1005,6 +1038,29 @@ describe("getMemorySearchManager caching", () => {
     expect(results).toHaveLength(1);
     expect(results[0]?.path).toBe("MEMORY.md");
     expect(fallbackSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds builtin fallback search after qmd fails", async () => {
+    vi.useFakeTimers();
+    try {
+      const retryAgentId = "retry-agent-fallback-timeout";
+      const { manager: firstManager } = await createFailedQmdSearchHarness({
+        agentId: retryAgentId,
+        errorMessage: "qmd query failed",
+      });
+      fallbackSearch.mockImplementationOnce(async () => await new Promise(() => {}));
+
+      const searchPromise = firstManager.search("hello");
+      const searchExpectation = expect(searchPromise).rejects.toThrow(
+        "memory_search timed out after 15s",
+      );
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      await searchExpectation;
+      expect(fallbackSearch).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps original qmd error when fallback manager initialization fails", async () => {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -50,6 +50,10 @@ type QmdManagerOpenFailure = {
   retryAfterMs: number;
 };
 
+type MemorySearchTimeoutOptions = Parameters<
+  NonNullable<MemorySearchManager["getSearchTimeoutMs"]>
+>[0];
+
 type MemorySearchManagerCacheState =
   | "cached-full-hit"
   | "cached-full-miss"
@@ -75,6 +79,7 @@ type MemorySearchManagerCacheStore = {
 };
 
 const QMD_MANAGER_OPEN_FAILURE_COOLDOWN_MS = 60_000;
+const DEFAULT_MEMORY_MANAGER_SEARCH_TIMEOUT_MS = 15_000;
 
 function createMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
   return {
@@ -117,6 +122,77 @@ const managerRuntimeLoader = createLazyRuntimeModule(() => import("../../manager
 const loadManagerRuntime = managerRuntimeLoader;
 
 const loadQmdManagerModule = createLazyRuntimeModule(() => import("./qmd-manager.js"));
+
+function createMemorySearchTimeoutError(timeoutMs: number): Error {
+  return new Error(`memory_search timed out after ${Math.round(timeoutMs / 1000)}s`);
+}
+
+function resolveAbortError(signal: AbortSignal, fallbackMessage: string): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error(fallbackMessage);
+}
+
+async function runFallbackMemorySearchWithDeadline<T>(params: {
+  timeoutMs: number;
+  signal?: AbortSignal;
+  run: (signal: AbortSignal) => Promise<T>;
+}): Promise<T> {
+  if (params.signal?.aborted) {
+    throw resolveAbortError(params.signal, "memory_search aborted");
+  }
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let removeAbortListener: (() => void) | undefined;
+  const timeoutPromise = new Promise<"timeout">((resolve) => {
+    timer = setTimeout(() => {
+      resolve("timeout");
+      controller.abort(createMemorySearchTimeoutError(params.timeoutMs));
+    }, params.timeoutMs);
+    timer.unref?.();
+  });
+  const parentSignal = params.signal;
+  const abortPromise = parentSignal
+    ? new Promise<"abort">((resolve) => {
+        const onAbort = () => {
+          controller.abort(resolveAbortError(parentSignal, "memory_search aborted"));
+          resolve("abort");
+        };
+        parentSignal.addEventListener("abort", onAbort, { once: true });
+        removeAbortListener = () => parentSignal.removeEventListener("abort", onAbort);
+      })
+    : undefined;
+  const task = params.run(controller.signal);
+  task.catch(() => undefined);
+  try {
+    const result = await Promise.race(
+      abortPromise ? [task, timeoutPromise, abortPromise] : [task, timeoutPromise],
+    );
+    if (result === "timeout") {
+      throw createMemorySearchTimeoutError(params.timeoutMs);
+    }
+    if (result === "abort") {
+      throw resolveAbortError(parentSignal!, "memory_search aborted");
+    }
+    return result as T;
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    removeAbortListener?.();
+  }
+}
+
+function resolveFallbackMemorySearchTimeoutMs(
+  manager: MemorySearchManager,
+  opts?: MemorySearchTimeoutOptions,
+): number {
+  const timeoutMs = manager.getSearchTimeoutMs?.(opts);
+  return Math.min(
+    DEFAULT_MEMORY_MANAGER_SEARCH_TIMEOUT_MS,
+    typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
+      ? Math.floor(timeoutMs)
+      : DEFAULT_MEMORY_MANAGER_SEARCH_TIMEOUT_MS,
+  );
+}
 
 export type MemorySearchManagerResult = {
   manager: Maybe<MemorySearchManager>;
@@ -451,11 +527,17 @@ async function getBuiltinMemorySearchManager(params: {
 
 class BorrowedMemoryManager implements MemorySearchManager {
   readonly probeVectorStoreAvailability?: () => Promise<boolean>;
+  readonly getSearchTimeoutMs?: (opts?: {
+    qmdSearchModeOverride?: "query" | "search" | "vsearch";
+  }) => number;
 
   constructor(private readonly inner: MemorySearchManager) {
     if (inner.probeVectorStoreAvailability) {
       const probeVectorStoreAvailability = inner.probeVectorStoreAvailability.bind(inner);
       this.probeVectorStoreAvailability = async () => await probeVectorStoreAvailability();
+    }
+    if (inner.getSearchTimeoutMs) {
+      this.getSearchTimeoutMs = inner.getSearchTimeoutMs.bind(inner);
     }
   }
 
@@ -595,9 +677,24 @@ class FallbackMemoryManager implements MemorySearchManager {
     }
     const fallback = await this.ensureFallback();
     if (fallback) {
-      return await fallback.search(query, opts);
+      return await runFallbackMemorySearchWithDeadline({
+        timeoutMs: resolveFallbackMemorySearchTimeoutMs(fallback, opts),
+        signal: opts?.signal,
+        run: async (fallbackSignal) =>
+          await fallback.search(query, { ...opts, signal: fallbackSignal }),
+      });
     }
     throw new Error(this.lastError ?? "memory search unavailable");
+  }
+
+  getSearchTimeoutMs(opts?: MemorySearchTimeoutOptions): number {
+    this.ensureOpen();
+    if (!this.primaryFailed) {
+      return (
+        this.deps.primary.getSearchTimeoutMs?.(opts) ?? DEFAULT_MEMORY_MANAGER_SEARCH_TIMEOUT_MS
+      );
+    }
+    return this.fallback?.getSearchTimeoutMs?.(opts) ?? DEFAULT_MEMORY_MANAGER_SEARCH_TIMEOUT_MS;
   }
 
   async readFile(params: { relPath: string; from?: number; lines?: number }) {
@@ -694,13 +791,13 @@ class FallbackMemoryManager implements MemorySearchManager {
     return (await fallback?.probeVectorAvailability()) ?? false;
   }
 
-  async close() {
+  async close(timeoutMs?: number) {
     if (this.closed) {
       return;
     }
     this.closed = true;
-    await this.deps.primary.close?.();
-    await this.fallback?.close?.();
+    await this.deps.primary.close?.(timeoutMs);
+    await this.fallback?.close?.(timeoutMs);
     this.evictCacheEntry();
   }
 

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -2,6 +2,7 @@
 import type { MemorySearchRuntimeDebug } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  getMemoryCloseMockArgs,
   getMemoryCloseMockCalls,
   getMemorySearchManagerMockCalls,
   getMemorySearchManagerMockConfigs,
@@ -12,6 +13,8 @@ import {
   setMemoryCustomStatus,
   setMemorySearchImpl,
   setMemorySearchManagerImpl,
+  setMemorySearchTimeoutMs,
+  setMemorySyncImpl,
 } from "./memory-tool-manager.test-mocks.js";
 import { createMemorySearchTool, testing as memoryToolsTesting } from "./tools.js";
 import {
@@ -190,6 +193,33 @@ describe("memory_search unavailable payloads", () => {
     }
   });
 
+  it("keeps qmd manager setup on the default memory_search deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      setMemoryBackend("qmd");
+      setMemorySearchTimeoutMs(60_000);
+      setMemorySearchManagerImpl(async () => await new Promise(() => {}));
+      const tool = createMemorySearchToolOrThrow({
+        config: {
+          agents: { list: [{ id: "main", default: true }] },
+          memory: { citations: "off", backend: "qmd", qmd: { limits: { timeoutMs: 60_000 } } },
+        },
+      });
+
+      const resultPromise = tool.execute("qmd-manager-timeout", { query: "hello" });
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      const result = await resultPromise;
+      expectUnavailableMemorySearchDetails(result.details, {
+        error: "memory_search timed out after 15s",
+        warning: "Memory search is unavailable due to an embedding/provider error.",
+        action: "Check embedding provider configuration and retry memory_search.",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("returns unavailable metadata when memory search does not settle", async () => {
     vi.useFakeTimers();
     try {
@@ -220,6 +250,190 @@ describe("memory_search unavailable payloads", () => {
         action: "Check embedding provider configuration and retry memory_search.",
       });
       expect(searchCalls).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses the qmd manager whole-search budget for slow memory searches", async () => {
+    vi.useFakeTimers();
+    try {
+      setMemoryBackend("qmd");
+      setMemorySearchTimeoutMs(60_000);
+      setMemorySearchImpl(
+        async () =>
+          await new Promise((resolve) => {
+            setTimeout(
+              () =>
+                resolve([
+                  {
+                    path: "MEMORY.md",
+                    startLine: 1,
+                    endLine: 1,
+                    score: 0.9,
+                    snippet: "QMD slow search survived past fifteen seconds.",
+                    source: "memory" as const,
+                  },
+                ]),
+              16_000,
+            );
+          }),
+      );
+      const tool = createMemorySearchToolOrThrow({
+        config: {
+          agents: { list: [{ id: "main", default: true }] },
+          memory: { citations: "off", backend: "qmd", qmd: { limits: { timeoutMs: 60_000 } } },
+        },
+      });
+
+      const resultPromise = tool.execute("qmd-slow-search", { query: "hello" });
+      await vi.advanceTimersByTimeAsync(15_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      const result = await resultPromise;
+      expect((result.details as { results?: Array<{ path: string }> }).results).toEqual([
+        {
+          corpus: "memory",
+          path: "MEMORY.md",
+          startLine: 1,
+          endLine: 1,
+          score: 0.9,
+          snippet: "QMD slow search survived past fifteen seconds.",
+          source: "memory",
+        },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps builtin forced-sync retry inside the original memory_search deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      let searchCalls = 0;
+      let retrySignal: AbortSignal | undefined;
+      setMemorySearchImpl(async (opts) => {
+        searchCalls += 1;
+        if (searchCalls === 1) {
+          return await new Promise((resolve) => {
+            setTimeout(() => resolve([]), 10_000);
+          });
+        }
+        retrySignal = opts?.signal;
+        return await new Promise(() => {});
+      });
+      const tool = createMemorySearchToolOrThrow();
+
+      const resultPromise = tool.execute("builtin-retry-timeout", { query: "hello" });
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      const result = await resultPromise;
+      expectUnavailableMemorySearchDetails(result.details, {
+        error: "memory_search timed out after 15s",
+        warning: "Memory search is unavailable due to an embedding/provider error.",
+        action: "Check embedding provider configuration and retry memory_search.",
+      });
+      expect(searchCalls).toBe(2);
+      expect(retrySignal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps one-shot qmd zero-hit retry inside one whole-search deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      setMemoryBackend("qmd");
+      setMemorySearchTimeoutMs(60_000);
+      let searchCalls = 0;
+      let retrySignal: AbortSignal | undefined;
+      setMemorySearchImpl(async (opts) => {
+        searchCalls += 1;
+        if (searchCalls === 1) {
+          return await new Promise((resolve) => {
+            setTimeout(() => resolve([]), 10_000);
+          });
+        }
+        retrySignal = opts?.signal;
+        return await new Promise(() => {});
+      });
+      setMemorySyncImpl(
+        async () =>
+          await new Promise((resolve) => {
+            setTimeout(resolve, 10_000);
+          }),
+      );
+      const tool = createMemorySearchToolOrThrow({
+        config: {
+          agents: { list: [{ id: "main", default: true }] },
+          memory: { citations: "off", backend: "qmd", qmd: { limits: { timeoutMs: 60_000 } } },
+        },
+        oneShotCliRun: true,
+      });
+
+      const resultPromise = tool.execute("qmd-zero-hit-retry-timeout", { query: "hello" });
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(40_000);
+
+      const result = await resultPromise;
+      expectUnavailableMemorySearchDetails(result.details, {
+        error: "memory_search timed out after 60s",
+        warning: "Memory search is unavailable due to an embedding/provider error.",
+        action: "Check embedding provider configuration and retry memory_search.",
+      });
+      expect(searchCalls).toBe(2);
+      expect(getMemorySyncMockCalls()).toBe(1);
+      expect(retrySignal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes one-shot CLI qmd manager with timeout when forced sync never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      setMemoryBackend("qmd");
+      setMemorySearchTimeoutMs(60_000);
+      let searchCalls = 0;
+      setMemorySearchImpl(async () => {
+        searchCalls += 1;
+        if (searchCalls === 1) {
+          return await new Promise((resolve) => {
+            setTimeout(() => resolve([]), 10_000);
+          });
+        }
+        return await new Promise(() => {});
+      });
+      setMemorySyncImpl(async () => await new Promise(() => {}));
+      const tool = createMemorySearchToolOrThrow({
+        config: {
+          agents: { list: [{ id: "main", default: true }] },
+          memory: { citations: "off", backend: "qmd", qmd: { limits: { timeoutMs: 60_000 } } },
+        },
+        oneShotCliRun: true,
+      });
+
+      const resultPromise = tool.execute("cli-qmd-forced-sync-timeout", { query: "hello" });
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(40_000);
+
+      const result = await resultPromise;
+      expectUnavailableMemorySearchDetails(result.details, {
+        error: "memory_search timed out after 60s",
+        warning: "Memory search is unavailable due to an embedding/provider error.",
+        action: "Check embedding provider configuration and retry memory_search.",
+      });
+      // The forced sync never settles, so the deadline fires after the first
+      // search + sync attempt. The retry search is never reached because the
+      // sync timeout throws before the second search can run.
+      expect(searchCalls).toBe(1);
+      expect(getMemorySyncMockCalls()).toBe(1);
+      expect(getMemoryCloseMockCalls()).toBe(1);
+      const closeArgs = getMemoryCloseMockArgs();
+      expect(closeArgs[0]?.timeoutMs).toBe(5_000);
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -48,8 +48,12 @@ type MemorySearchToolResult =
 type MemoryManagerContext = Awaited<ReturnType<typeof getMemoryManagerContextWithPurpose>>;
 type ActiveMemoryManagerContext = Extract<MemoryManagerContext, { manager: unknown }>;
 type QmdRuntimeDebug = NonNullable<MemorySearchRuntimeDebug["qmd"]>;
+type MemorySearchDeadline = {
+  timeoutMs: number;
+  startedAtMs: number;
+};
 
-const MEMORY_SEARCH_TOOL_TIMEOUT_MS = 15_000;
+const DEFAULT_MEMORY_SEARCH_TOOL_TIMEOUT_MS = 15_000;
 const MEMORY_SEARCH_TOOL_COOLDOWN_MS = 60_000;
 
 const memorySearchToolCooldowns = new Map<string, { until: number; error: string }>();
@@ -114,12 +118,14 @@ function isActiveMemoryManagerContext(
   return context !== null && "manager" in context;
 }
 
+const QMD_CLOSE_CLEANUP_TIMEOUT_MS = 5_000;
+
 async function closeMemoryManagers(
   managers: Iterable<ActiveMemoryManagerContext["manager"]>,
 ): Promise<void> {
   for (const manager of managers) {
     try {
-      await manager.close?.();
+      await manager.close?.(QMD_CLOSE_CLEANUP_TIMEOUT_MS);
     } catch {
       // Search results should not be hidden by best-effort transient cleanup.
     }
@@ -128,10 +134,13 @@ async function closeMemoryManagers(
 
 async function runMemorySearchToolWithDeadline<T>(params: {
   timeoutMs: number;
+  timeoutMessageMs?: number;
   run: (signal: AbortSignal) => Promise<T>;
 }): Promise<{ status: "ok"; value: T } | { status: "unavailable"; error: string }> {
   const timeoutError = () =>
-    new Error(`memory_search timed out after ${Math.round(params.timeoutMs / 1000)}s`);
+    new Error(
+      `memory_search timed out after ${Math.round((params.timeoutMessageMs ?? params.timeoutMs) / 1000)}s`,
+    );
   // Abort the losing task when the deadline fires so in-flight embedding work
   // is cancelled instead of retrying orphaned for minutes after the tool
   // already returned "timed out" to the agent.
@@ -166,6 +175,53 @@ async function runMemorySearchToolWithDeadline<T>(params: {
       clearTimeout(timer);
     }
   }
+}
+
+async function runMemorySearchTaskWithDeadline<T>(params: {
+  timeoutMs: number;
+  timeoutMessageMs?: number;
+  run: (signal: AbortSignal) => Promise<T>;
+}): Promise<T> {
+  const outcome = await runMemorySearchToolWithDeadline(params);
+  if (outcome.status === "unavailable") {
+    throw new Error(outcome.error);
+  }
+  return outcome.value;
+}
+
+function createMemorySearchDeadline(
+  timeoutMs = DEFAULT_MEMORY_SEARCH_TOOL_TIMEOUT_MS,
+): MemorySearchDeadline {
+  return { timeoutMs, startedAtMs: Date.now() };
+}
+
+function resolveMemorySearchDeadlineRemainingMs(deadline: MemorySearchDeadline): number {
+  return Math.max(1, deadline.timeoutMs - (Date.now() - deadline.startedAtMs));
+}
+
+function resolveMemoryManagerSearchTimeoutMs(
+  manager: ActiveMemoryManagerContext["manager"],
+  opts?: { qmdSearchModeOverride?: "query" | "search" | "vsearch" },
+): number {
+  const timeoutMs = manager.getSearchTimeoutMs?.(opts);
+  return typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? Math.max(DEFAULT_MEMORY_SEARCH_TOOL_TIMEOUT_MS, Math.floor(timeoutMs))
+    : DEFAULT_MEMORY_SEARCH_TOOL_TIMEOUT_MS;
+}
+
+function resolveMemoryManagerSearchPhaseTimeoutMs(deadline: MemorySearchDeadline): number {
+  return resolveMemorySearchDeadlineRemainingMs(deadline);
+}
+
+function createMemoryManagerSearchDeadline(
+  manager: ActiveMemoryManagerContext["manager"],
+  defaultDeadline: MemorySearchDeadline,
+  opts?: { qmdSearchModeOverride?: "query" | "search" | "vsearch" },
+): MemorySearchDeadline {
+  const managerTimeoutMs = resolveMemoryManagerSearchTimeoutMs(manager, opts);
+  return managerTimeoutMs > DEFAULT_MEMORY_SEARCH_TOOL_TIMEOUT_MS
+    ? createMemorySearchDeadline(managerTimeoutMs)
+    : defaultDeadline;
 }
 
 const PAUSED_MEMORY_INDEX_WARNING =
@@ -474,272 +530,315 @@ export function createMemorySearchTool(options: {
           }
         };
 
-        const outcome = await runMemorySearchToolWithDeadline({
-          timeoutMs: MEMORY_SEARCH_TOOL_TIMEOUT_MS,
-          run: async (deadlineSignal) => {
-            const toolStartedAt = Date.now();
-            const { resolveMemoryBackendConfig } = await loadMemoryToolRuntime();
-            const shouldQuerySupplements = requestedCorpus === "wiki" || requestedCorpus === "all";
-            const shouldQueryMemory = requestedCorpus !== "wiki" && !cooldown;
-            if (cooldown && !shouldQuerySupplements) {
-              return jsonResult(buildMemorySearchUnavailableResult(cooldown.error));
+        try {
+          const toolStartedAt = Date.now();
+          const defaultDeadline = createMemorySearchDeadline();
+          const { resolveMemoryBackendConfig } = await runMemorySearchTaskWithDeadline({
+            timeoutMs: resolveMemorySearchDeadlineRemainingMs(defaultDeadline),
+            timeoutMessageMs: DEFAULT_MEMORY_SEARCH_TOOL_TIMEOUT_MS,
+            run: async () => await loadMemoryToolRuntime(),
+          });
+          const shouldQuerySupplements = requestedCorpus === "wiki" || requestedCorpus === "all";
+          const shouldQueryMemory = requestedCorpus !== "wiki" && !cooldown;
+          if (cooldown && !shouldQuerySupplements) {
+            return jsonResult(buildMemorySearchUnavailableResult(cooldown.error));
+          }
+          const memoryManagerPurpose = options.oneShotCliRun ? "cli" : undefined;
+          const memoryManagersToClose = new Set<ActiveMemoryManagerContext["manager"]>();
+          const trackMemoryManager = (context: MemoryManagerContext): MemoryManagerContext => {
+            if (memoryManagerPurpose === "cli" && isActiveMemoryManagerContext(context)) {
+              memoryManagersToClose.add(context.manager);
             }
-            const memoryManagerPurpose = options.oneShotCliRun ? "cli" : undefined;
-            const memoryManagersToClose = new Set<ActiveMemoryManagerContext["manager"]>();
-            const trackMemoryManager = (context: MemoryManagerContext): MemoryManagerContext => {
-              if (memoryManagerPurpose === "cli" && isActiveMemoryManagerContext(context)) {
-                memoryManagersToClose.add(context.manager);
-              }
-              return context;
-            };
-            try {
-              const memory = shouldQueryMemory
-                ? await runUnavailablePhase("memory", async () =>
-                    trackMemoryManager(
-                      await getMemoryManagerContextWithPurpose({
-                        cfg,
-                        agentId,
-                        purpose: memoryManagerPurpose,
-                      }),
-                    ),
-                  )
-                : null;
-              if (shouldQueryMemory && memory && "error" in memory && !shouldQuerySupplements) {
-                recordMemorySearchToolCooldown(
-                  cooldownKey,
-                  memory.error ?? "memory search unavailable",
-                );
-                return jsonResult(buildMemorySearchUnavailableResult(memory.error));
-              }
+            return context;
+          };
+          try {
+            const memory = shouldQueryMemory
+              ? await runUnavailablePhase("memory", async () =>
+                  trackMemoryManager(
+                    await runMemorySearchTaskWithDeadline({
+                      timeoutMs: resolveMemorySearchDeadlineRemainingMs(defaultDeadline),
+                      timeoutMessageMs: DEFAULT_MEMORY_SEARCH_TOOL_TIMEOUT_MS,
+                      run: async () =>
+                        await getMemoryManagerContextWithPurpose({
+                          cfg,
+                          agentId,
+                          purpose: memoryManagerPurpose,
+                        }),
+                    }),
+                  ),
+                )
+              : null;
+            if (shouldQueryMemory && memory && "error" in memory && !shouldQuerySupplements) {
+              recordMemorySearchToolCooldown(
+                cooldownKey,
+                memory.error ?? "memory search unavailable",
+              );
+              return jsonResult(buildMemorySearchUnavailableResult(memory.error));
+            }
 
-              const citationsMode = resolveMemoryCitationsMode(cfg);
-              const includeCitations = shouldIncludeCitations({
-                mode: citationsMode,
-                sessionKey: options.agentSessionKey,
-              });
-              const pluginConfig = resolveMemoryCorePluginConfig(cfg);
-              const dreamingEnabled = resolveMemoryDreamingConfig({
-                pluginConfig,
-                cfg,
-              }).enabled;
-              const dreaming = resolveMemoryDeepDreamingConfig({
-                pluginConfig,
-                cfg,
-              });
-              const searchStartedAt = Date.now();
-              let rawResults: MemorySearchResult[] = [];
-              let surfacedMemoryResults: Array<MemorySearchResult & { corpus: MemorySource }> = [];
-              let provider: string | undefined;
-              let model: string | undefined;
-              let fallback: unknown;
-              let searchMode: string | undefined;
-              let pausedIndexIdentityReason: string | undefined;
-              let managerMs: number | undefined;
-              let managerCacheState: string | undefined;
-              let searchDebug:
-                | {
-                    backend: string;
-                    configuredMode?: string;
-                    effectiveMode?: string;
-                    fallback?: string;
-                    toolMs?: number;
-                    managerMs?: number;
-                    outsideSearchMs?: number;
-                    searchMs: number;
-                    managerCacheState?: string;
-                    qmd?: MemorySearchRuntimeDebug["qmd"];
-                    hits: number;
-                  }
-                | undefined;
-              if (shouldQueryMemory && memory && !("error" in memory)) {
-                await runUnavailablePhase("memory", async () => {
-                  let activeMemory = memory;
-                  const runtimeDebug: MemorySearchRuntimeDebug[] = [];
-                  const qmdSearchModeOverride = resolveActiveMemoryQmdSearchModeOverride(
-                    cfg,
-                    options.agentSessionKey,
-                  );
-                  const searchSources: MemorySource[] | undefined =
-                    requestedCorpus === "sessions"
-                      ? (["sessions"] as MemorySource[])
-                      : requestedCorpus === "memory"
-                        ? (["memory"] as MemorySource[])
-                        : undefined;
-                  const searchOptions = {
-                    maxResults,
-                    minScore,
-                    sessionKey: options.agentSessionKey,
-                    qmdSearchModeOverride,
-                    signal: deadlineSignal,
-                    onDebug: (debug: MemorySearchRuntimeDebug) => {
-                      runtimeDebug.push(debug);
-                    },
-                    ...(searchSources ? { sources: searchSources } : {}),
-                  };
-                  managerMs = memory.debug?.managerMs;
-                  managerCacheState = memory.debug?.managerCacheState;
-                  try {
-                    rawResults = await activeMemory.manager.search(query, searchOptions);
-                  } catch (error) {
-                    if (!isClosedMemoryStoreError(error)) {
-                      throw error;
-                    }
-                    const refreshed = trackMemoryManager(
-                      await getMemoryManagerContextWithPurpose({
-                        cfg,
-                        agentId,
-                        purpose: memoryManagerPurpose,
+            const citationsMode = resolveMemoryCitationsMode(cfg);
+            const includeCitations = shouldIncludeCitations({
+              mode: citationsMode,
+              sessionKey: options.agentSessionKey,
+            });
+            const pluginConfig = resolveMemoryCorePluginConfig(cfg);
+            const dreamingEnabled = resolveMemoryDreamingConfig({
+              pluginConfig,
+              cfg,
+            }).enabled;
+            const dreaming = resolveMemoryDeepDreamingConfig({
+              pluginConfig,
+              cfg,
+            });
+            const searchStartedAt = Date.now();
+            let rawResults: MemorySearchResult[] = [];
+            let surfacedMemoryResults: Array<MemorySearchResult & { corpus: MemorySource }> = [];
+            let provider: string | undefined;
+            let model: string | undefined;
+            let fallback: unknown;
+            let searchMode: string | undefined;
+            let pausedIndexIdentityReason: string | undefined;
+            let managerMs: number | undefined;
+            let managerCacheState: string | undefined;
+            let searchDebug:
+              | {
+                  backend: string;
+                  configuredMode?: string;
+                  effectiveMode?: string;
+                  fallback?: string;
+                  toolMs?: number;
+                  managerMs?: number;
+                  outsideSearchMs?: number;
+                  searchMs: number;
+                  managerCacheState?: string;
+                  qmd?: MemorySearchRuntimeDebug["qmd"];
+                  hits: number;
+                }
+              | undefined;
+            if (shouldQueryMemory && memory && !("error" in memory)) {
+              await runUnavailablePhase("memory", async () => {
+                let activeMemory = memory;
+                const runtimeDebug: MemorySearchRuntimeDebug[] = [];
+                const qmdSearchModeOverride = resolveActiveMemoryQmdSearchModeOverride(
+                  cfg,
+                  options.agentSessionKey,
+                );
+                let activeMemoryDeadline = createMemoryManagerSearchDeadline(
+                  activeMemory.manager,
+                  defaultDeadline,
+                  { qmdSearchModeOverride },
+                );
+                const searchSources: MemorySource[] | undefined =
+                  requestedCorpus === "sessions"
+                    ? (["sessions"] as MemorySource[])
+                    : requestedCorpus === "memory"
+                      ? (["memory"] as MemorySource[])
+                      : undefined;
+                const searchOptions = {
+                  maxResults,
+                  minScore,
+                  sessionKey: options.agentSessionKey,
+                  qmdSearchModeOverride,
+                  onDebug: (debug: MemorySearchRuntimeDebug) => {
+                    runtimeDebug.push(debug);
+                  },
+                  ...(searchSources ? { sources: searchSources } : {}),
+                };
+                managerMs = activeMemory.debug?.managerMs;
+                managerCacheState = activeMemory.debug?.managerCacheState;
+                const runActiveMemorySearch = async (
+                  target: ActiveMemoryManagerContext,
+                  deadline: MemorySearchDeadline,
+                ): Promise<MemorySearchResult[]> => {
+                  const timeoutMs = resolveMemoryManagerSearchPhaseTimeoutMs(deadline);
+                  return await runMemorySearchTaskWithDeadline({
+                    timeoutMs,
+                    timeoutMessageMs: deadline.timeoutMs,
+                    run: async (searchSignal) =>
+                      await target.manager.search(query, {
+                        ...searchOptions,
+                        signal: searchSignal,
                       }),
-                    );
-                    if ("error" in refreshed) {
-                      throw error;
-                    }
-                    managerMs = refreshed.debug?.managerMs;
-                    managerCacheState = refreshed.debug?.managerCacheState;
-                    activeMemory = refreshed;
-                    rawResults = await activeMemory.manager.search(query, searchOptions);
+                  });
+                };
+                try {
+                  rawResults = await runActiveMemorySearch(activeMemory, activeMemoryDeadline);
+                } catch (error) {
+                  if (!isClosedMemoryStoreError(error)) {
+                    throw error;
                   }
-                  const statusBeforeRetry = activeMemory.manager.status();
-                  pausedIndexIdentityReason =
-                    resolvePausedMemoryIndexIdentityReason(statusBeforeRetry);
+                  const refreshed = trackMemoryManager(
+                    await runMemorySearchTaskWithDeadline({
+                      timeoutMs: resolveMemorySearchDeadlineRemainingMs(defaultDeadline),
+                      timeoutMessageMs: DEFAULT_MEMORY_SEARCH_TOOL_TIMEOUT_MS,
+                      run: async () =>
+                        await getMemoryManagerContextWithPurpose({
+                          cfg,
+                          agentId,
+                          purpose: memoryManagerPurpose,
+                        }),
+                    }),
+                  );
+                  if ("error" in refreshed) {
+                    throw error;
+                  }
+                  managerMs = refreshed.debug?.managerMs;
+                  managerCacheState = refreshed.debug?.managerCacheState;
+                  activeMemory = refreshed;
+                  activeMemoryDeadline = createMemoryManagerSearchDeadline(
+                    activeMemory.manager,
+                    defaultDeadline,
+                    { qmdSearchModeOverride },
+                  );
+                  rawResults = await runActiveMemorySearch(activeMemory, activeMemoryDeadline);
+                }
+                const statusBeforeRetry = activeMemory.manager.status();
+                pausedIndexIdentityReason =
+                  resolvePausedMemoryIndexIdentityReason(statusBeforeRetry);
+                if (pausedIndexIdentityReason) {
+                  return;
+                }
+                // One-shot CLI managers have no background lifecycle, so keep their bootstrap
+                // retry. Long-lived QMD managers must not run update work in the tool hot path.
+                if (
+                  rawResults.length === 0 &&
+                  activeMemory.manager.sync &&
+                  (statusBeforeRetry.backend !== "qmd" || options.oneShotCliRun === true)
+                ) {
+                  const timeoutMs = resolveMemoryManagerSearchPhaseTimeoutMs(activeMemoryDeadline);
+                  await runMemorySearchTaskWithDeadline({
+                    timeoutMs,
+                    timeoutMessageMs: activeMemoryDeadline.timeoutMs,
+                    run: async () =>
+                      await activeMemory.manager.sync?.({ reason: "search", force: true }),
+                  });
+                  rawResults = await runActiveMemorySearch(activeMemory, activeMemoryDeadline);
+                  pausedIndexIdentityReason = resolvePausedMemoryIndexIdentityReason(
+                    activeMemory.manager.status(),
+                  );
                   if (pausedIndexIdentityReason) {
                     return;
                   }
-                  // One-shot CLI managers have no background lifecycle, so keep their bootstrap
-                  // retry. Long-lived QMD managers must not run update work in the tool hot path.
-                  if (
-                    rawResults.length === 0 &&
-                    activeMemory.manager.sync &&
-                    (statusBeforeRetry.backend !== "qmd" || options.oneShotCliRun === true)
-                  ) {
-                    await activeMemory.manager.sync({ reason: "search", force: true });
-                    rawResults = await activeMemory.manager.search(query, searchOptions);
-                    pausedIndexIdentityReason = resolvePausedMemoryIndexIdentityReason(
-                      activeMemory.manager.status(),
-                    );
-                    if (pausedIndexIdentityReason) {
-                      return;
-                    }
-                  }
-                  rawResults = await filterMemorySearchHitsBySessionVisibility({
-                    cfg,
-                    agentId,
-                    requesterSessionKey: options.agentSessionKey,
-                    sandboxed: options.sandboxed === true,
-                    hits: rawResults,
-                  });
-                  if (requestedCorpus === "sessions") {
-                    rawResults = rawResults.filter((hit) => hit.source === "sessions");
-                  } else if (requestedCorpus === "memory") {
-                    rawResults = rawResults.filter((hit) => hit.source === "memory");
-                  }
-                  const status = activeMemory.manager.status();
-                  const decorated = decorateCitations(rawResults, includeCitations);
-                  const resolved = resolveMemoryBackendConfig({ cfg, agentId });
-                  const memoryResults =
-                    status.backend === "qmd"
-                      ? clampResultsByInjectedChars(
-                          decorated,
-                          resolved.qmd?.limits.maxInjectedChars,
-                        )
-                      : decorated;
-                  surfacedMemoryResults = memoryResults.map((result) => ({
-                    ...result,
-                    corpus: result.source,
-                  }));
-                  if (dreamingEnabled) {
-                    queueShortTermRecallTracking({
-                      workspaceDir: status.workspaceDir,
-                      query,
-                      rawResults,
-                      surfacedResults: memoryResults,
-                      timezone: dreaming.timezone,
-                    });
-                  }
-                  provider = status.provider;
-                  model = status.model;
-                  fallback = status.fallback;
-                  const latestDebug = runtimeDebug.at(-1);
-                  const qmdDebug = mergeQmdRuntimeDebug(runtimeDebug);
-                  searchMode = latestDebug?.effectiveMode;
-                  const searchMs = Math.max(0, Date.now() - searchStartedAt);
-                  searchDebug = {
-                    backend: status.backend,
-                    configuredMode: latestDebug?.configuredMode,
-                    effectiveMode:
-                      status.backend === "qmd"
-                        ? (latestDebug?.effectiveMode ?? latestDebug?.configuredMode)
-                        : "n/a",
-                    fallback: latestDebug?.fallback,
-                    managerMs,
-                    searchMs,
-                    managerCacheState,
-                    qmd: qmdDebug,
-                    hits: rawResults.length,
-                  };
-                });
-                if (pausedIndexIdentityReason) {
-                  return jsonResult(
-                    buildPausedMemoryIndexUnavailableResult(pausedIndexIdentityReason),
-                  );
                 }
-              }
-              const supplementResults = shouldQuerySupplements
-                ? await runUnavailablePhase(
-                    "supplement",
-                    async () =>
-                      await searchMemoryCorpusSupplements({
-                        query,
-                        maxResults,
-                        agentId,
-                        agentSessionKey: options.agentSessionKey,
-                        sandboxed: options.sandboxed,
-                        corpus: requestedCorpus,
-                      }),
-                  )
-                : [];
-              // Wiki and memory scores use incomparable scales, so corpus=all first
-              // balances candidate selection and then backfills any unused slots.
-              const effectiveMax = Math.max(1, maxResults ?? 10);
-              const results = mergeMemorySearchCorpusResults({
-                memoryResults: surfacedMemoryResults,
-                supplementResults,
-                maxResults: effectiveMax,
-                balanceCorpora: requestedCorpus === "all",
-              });
-              if (searchDebug) {
-                const finalToolMs = Math.max(0, Date.now() - toolStartedAt);
+                rawResults = await filterMemorySearchHitsBySessionVisibility({
+                  cfg,
+                  agentId,
+                  requesterSessionKey: options.agentSessionKey,
+                  sandboxed: options.sandboxed === true,
+                  hits: rawResults,
+                });
+                if (requestedCorpus === "sessions") {
+                  rawResults = rawResults.filter((hit) => hit.source === "sessions");
+                } else if (requestedCorpus === "memory") {
+                  rawResults = rawResults.filter((hit) => hit.source === "memory");
+                }
+                const status = activeMemory.manager.status();
+                const decorated = decorateCitations(rawResults, includeCitations);
+                const resolved = resolveMemoryBackendConfig({ cfg, agentId });
+                const memoryResults =
+                  status.backend === "qmd"
+                    ? clampResultsByInjectedChars(decorated, resolved.qmd?.limits.maxInjectedChars)
+                    : decorated;
+                surfacedMemoryResults = memoryResults.map((result) => ({
+                  ...result,
+                  corpus: result.source,
+                }));
+                if (dreamingEnabled) {
+                  queueShortTermRecallTracking({
+                    workspaceDir: status.workspaceDir,
+                    query,
+                    rawResults,
+                    surfacedResults: memoryResults,
+                    timezone: dreaming.timezone,
+                  });
+                }
+                provider = status.provider;
+                model = status.model;
+                fallback = status.fallback;
+                const latestDebug = runtimeDebug.at(-1);
+                const qmdDebug = mergeQmdRuntimeDebug(runtimeDebug);
+                searchMode = latestDebug?.effectiveMode;
+                const searchMs = Math.max(0, Date.now() - searchStartedAt);
                 searchDebug = {
-                  ...searchDebug,
-                  toolMs: finalToolMs,
-                  outsideSearchMs: Math.max(0, finalToolMs - searchDebug.searchMs),
+                  backend: status.backend,
+                  configuredMode: latestDebug?.configuredMode,
+                  effectiveMode:
+                    status.backend === "qmd"
+                      ? (latestDebug?.effectiveMode ?? latestDebug?.configuredMode)
+                      : "n/a",
+                  fallback: latestDebug?.fallback,
+                  managerMs,
+                  searchMs,
+                  managerCacheState,
+                  qmd: qmdDebug,
+                  hits: rawResults.length,
                 };
-              }
-              return jsonResult({
-                results,
-                provider,
-                model,
-                fallback,
-                citations: citationsMode,
-                mode: searchMode,
-                debug: searchDebug,
               });
-            } finally {
-              await closeMemoryManagers(memoryManagersToClose);
+              if (pausedIndexIdentityReason) {
+                return jsonResult(
+                  buildPausedMemoryIndexUnavailableResult(pausedIndexIdentityReason),
+                );
+              }
             }
-          },
-        });
-        if (outcome.status === "unavailable") {
+            const supplementResults = shouldQuerySupplements
+              ? await runUnavailablePhase(
+                  "supplement",
+                  async () =>
+                    await runMemorySearchTaskWithDeadline({
+                      timeoutMs: resolveMemorySearchDeadlineRemainingMs(defaultDeadline),
+                      timeoutMessageMs: DEFAULT_MEMORY_SEARCH_TOOL_TIMEOUT_MS,
+                      run: async () =>
+                        await searchMemoryCorpusSupplements({
+                          query,
+                          maxResults,
+                          agentId,
+                          agentSessionKey: options.agentSessionKey,
+                          sandboxed: options.sandboxed,
+                          corpus: requestedCorpus,
+                        }),
+                    }),
+                )
+              : [];
+            // Wiki and memory scores use incomparable scales, so corpus=all first
+            // balances candidate selection and then backfills any unused slots.
+            const effectiveMax = Math.max(1, maxResults ?? 10);
+            const results = mergeMemorySearchCorpusResults({
+              memoryResults: surfacedMemoryResults,
+              supplementResults,
+              maxResults: effectiveMax,
+              balanceCorpora: requestedCorpus === "all",
+            });
+            if (searchDebug) {
+              const finalToolMs = Math.max(0, Date.now() - toolStartedAt);
+              searchDebug = {
+                ...searchDebug,
+                toolMs: finalToolMs,
+                outsideSearchMs: Math.max(0, finalToolMs - searchDebug.searchMs),
+              };
+            }
+            return jsonResult({
+              results,
+              provider,
+              model,
+              fallback,
+              citations: citationsMode,
+              mode: searchMode,
+              debug: searchDebug,
+            });
+          } finally {
+            await closeMemoryManagers(memoryManagersToClose);
+          }
+        } catch (error) {
           const unavailablePhase = failedUnavailablePhase ?? activeUnavailablePhase;
+          const errorMessage = formatErrorMessage(error);
           const shouldRecordCooldown =
             requestedCorpus !== "wiki" &&
             (requestedCorpus !== "all" || unavailablePhase === "memory");
           if (shouldRecordCooldown) {
-            recordMemorySearchToolCooldown(cooldownKey, outcome.error);
+            recordMemorySearchToolCooldown(cooldownKey, errorMessage);
           }
-          return jsonResult(buildMemorySearchUnavailableResult(outcome.error));
+          return jsonResult(buildMemorySearchUnavailableResult(errorMessage));
         }
-        return outcome.value;
       },
   });
 }

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -162,5 +162,6 @@ export interface MemorySearchManager {
   probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult>;
   probeVectorStoreAvailability?(): Promise<boolean>;
   probeVectorAvailability(): Promise<boolean>;
-  close?(): Promise<void>;
+  getSearchTimeoutMs?(opts?: { qmdSearchModeOverride?: "query" | "search" | "vsearch" }): number;
+  close?(timeoutMs?: number): Promise<void>;
 }

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -162,6 +162,8 @@ export interface MemorySearchManager {
   probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult>;
   probeVectorStoreAvailability?(): Promise<boolean>;
   probeVectorAvailability(): Promise<boolean>;
+  /** Optional whole-operation budget used by callers instead of a fixed outer search timeout. */
   getSearchTimeoutMs?(opts?: { qmdSearchModeOverride?: "query" | "search" | "vsearch" }): number;
+  /** Optional bounded cleanup wait for managers with pending background work. */
   close?(timeoutMs?: number): Promise<void>;
 }


### PR DESCRIPTION
## What problem this solves

`memory_search` historically imposed a fixed 15 second outer deadline. QMD searches can legitimately require a longer whole-operation budget when `memory.qmd.limits.timeoutMs` is raised, so the wrapper could terminate the tool before the configured QMD operation completed.

Fixes #91947.

## Summary

- Lets a memory manager expose an optional whole-search timeout budget.
- Keeps the historical 15 second guard for builtin memory and default/short QMD configurations.
- Computes a bounded QMD whole-search budget from command, collection, sync, embed, and retry phases.
- Applies one shared deadline to the active QMD search lifecycle.
- Keeps QMD subprocess cancellation through `AbortSignal`.
- Keeps forced-sync retry out of long-lived QMD tool hot paths; one-shot CLI QMD managers may still bootstrap and retry within the same deadline.
- Bounds one-shot QMD cleanup with a 5 second grace period so pending update work cannot hold CLI return indefinitely.
- Preserves the active search-mode override through cached fallback managers.

## User impact

Raised QMD timeout configurations can complete beyond the old 15 second wrapper limit. Builtin memory and short QMD configurations retain the existing fast-failure behavior.

If QMD falls back to builtin search during the same call, the builtin fallback receives its own bounded 15 second deadline rather than inheriting the longer QMD budget.

No storage migration or data-model change is required.

## Real behavior proof

A live QMD-backed harness run used the repository development entrypoint, a temporary QMD workspace, and the real `@tobilu/qmd` CLI. Search-like commands were delayed by 16 seconds, beyond the former fixed outer deadline.

```text
[proof] memory.qmd.limits.timeoutMs=60000
[proof] old memory_search outer deadline=15000ms
[qmd-delay-wrapper] delayed search command by 16000ms
[proof] elapsedMs=28878
[proof] resultCount=1
[proof] first hit path=memory/qmd-proof.md
[proof] PASS elapsedMs=28878 > oldOuterDeadlineMs=15000
```

The proof was captured on proven ancestor `9104253dabcb2d4f4b101f51e672edb81a8e2b15`. The clean current-main rebuild preserves the same timeout implementation and tests while incorporating current memory-search behavior.

## Review findings addressed

- QMD-to-builtin fallback has a separate bounded fallback deadline.
- Cached fallback managers forward `qmdSearchModeOverride` into timeout resolution.
- Pending and queued QMD update waits share one bounded cleanup timeout.
- Cleanup timers are cleared when update work settles first.
- Long-lived QMD searches do not force update work into the tool hot path.
- One-shot QMD bootstrap, sync, and retry remain inside one whole-operation deadline.

## Validation

Current head: `16e2484891d06543da79f2a13a9b99e33c7be836`

The clean current-main repair runner completed successfully before pushing the rebuilt branch:

- 217 focused memory tests passed
- `pnpm tsgo:extensions:test` passed
- formatting, lint, and `git diff --check` passed

The current head adds only contract documentation clarifying the optional whole-search and bounded-cleanup hooks. Fresh full GitHub Actions are running on this exact head.

## Scope and risk

The optional `MemorySearchManager.getSearchTimeoutMs` and bounded `close(timeoutMs)` hooks extend the memory-host contract. Maintainers should explicitly accept that interface direction and the availability tradeoff of allowing intentionally configured QMD searches to run longer than 15 seconds.

QMD subprocess cancellation remains shared behavior from #93394 and is not reimplemented here.

## Tests

AI-assisted: yes.
