### PR TITLE
fix config-chmod-warning

### DIFF
--- a/src/config/io.observe-recovery.test.ts
+++ b/src/config/io.observe-recovery.test.ts
@@ -272,6 +272,48 @@ describe("config observe recovery", () => {
     };
   }
 
+  function withAsyncChmodFailure(
+    deps: ObserveRecoveryDeps,
+    targetPath: string,
+    error = Object.assign(new Error("EPERM: chmod denied"), { code: "EPERM" }),
+  ): ObserveRecoveryDeps {
+    const chmod = deps.fs.promises.chmod?.bind(deps.fs.promises);
+    return {
+      ...deps,
+      fs: {
+        ...deps.fs,
+        promises: {
+          ...deps.fs.promises,
+          chmod: async (filePath, mode) => {
+            if (filePath === targetPath) {
+              throw error;
+            }
+            return await chmod?.(filePath, mode);
+          },
+        },
+      },
+    };
+  }
+
+  function withSyncChmodFailure(
+    deps: ObserveRecoveryDeps,
+    targetPath: string,
+    error = Object.assign(new Error("EPERM: chmod denied"), { code: "EPERM" }),
+  ): ObserveRecoveryDeps {
+    const chmodSync = deps.fs.chmodSync?.bind(deps.fs);
+    return {
+      ...deps,
+      fs: {
+        ...deps.fs,
+        chmodSync: (filePath, mode) => {
+          if (filePath === targetPath) {
+            throw error;
+          }
+          return chmodSync?.(filePath, mode);
+        },
+      },
+    };
+  }
   it("auto-restores suspicious update-channel-only roots from backup", async () => {
     await withSuiteHome(async (home) => {
       const { deps, configPath, auditPath, warn } = makeDeps(home);
@@ -348,6 +390,28 @@ describe("config observe recovery", () => {
       await recoverClobberedUpdateChannel({ deps, configPath });
 
       expect((await fsp.stat(configPath)).mode & 0o777).toBe(0o600);
+    });
+  });
+
+  it("warns when async backup restore cannot tighten config permissions", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath, warn } = makeDeps(home);
+      await seedConfigBackup(configPath, recoverableTelegramConfig);
+      const clobbered = await writeClobberedUpdateChannel(configPath);
+
+      const recovered = await maybeRecoverSuspiciousConfigRead({
+        deps: withAsyncChmodFailure(deps, configPath),
+        configPath,
+        raw: clobbered.raw,
+        parsed: clobbered.parsed,
+      });
+
+      expect((recovered.parsed as { gateway?: { mode?: string } }).gateway?.mode).toBe("local");
+      expectWarnContaining(
+        warn,
+        `Config permission hardening failed (backup restore): ${configPath}: EPERM: chmod denied`,
+      );
+      expectWarnContaining(warn, `Config auto-restored from backup: ${configPath}`);
     });
   });
 
@@ -941,7 +1005,26 @@ describe("config observe recovery", () => {
     });
   });
 
-  it("writes async health state to SQLite", async () => {
+  it("warns when sync backup restore cannot tighten config permissions", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath, warn } = makeDeps(home);
+      await seedConfigBackup(configPath, recoverableTelegramConfig);
+      await writeClobberedUpdateChannel(configPath);
+
+      recoverClobberedUpdateChannelSync({
+        deps: withSyncChmodFailure(deps, configPath),
+        configPath,
+      });
+
+      expectWarnContaining(
+        warn,
+        `Config permission hardening failed (backup restore): ${configPath}: EPERM: chmod denied`,
+      );
+      expectWarnContaining(warn, `Config auto-restored from backup: ${configPath}`);
+    });
+  });
+
+  it("logs async health-state write failures", async () => {
     await withSuiteHome(async (home) => {
       const { deps, configPath, warn } = makeDeps(home);
       const snapshot = await makeSnapshot(configPath, recoverableTelegramConfig);
@@ -1016,6 +1099,62 @@ describe("config observe recovery", () => {
       const observe = await readLastObserveEvent(auditPath);
       expect(observe?.restoredFromBackup).toBe(true);
       expect(observe?.restoredBackupPath).toBe(resolveLastKnownGoodConfigPath(configPath));
+    });
+  });
+
+  it("warns when last-known-good promotion cannot tighten snapshot permissions", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath, warn } = makeDeps(home);
+      const snapshot = await makeSnapshot(configPath, recoverableTelegramConfig);
+      const lastGoodPath = resolveLastKnownGoodConfigPath(configPath);
+
+      await expect(
+        promoteConfigSnapshotToLastKnownGood({
+          deps: withAsyncChmodFailure(deps, lastGoodPath),
+          snapshot,
+          logger: deps.logger,
+        }),
+      ).resolves.toBe(true);
+
+      expectWarnContaining(
+        warn,
+        `Config permission hardening failed (last-known-good promotion): ${lastGoodPath}: EPERM: chmod denied`,
+      );
+    });
+  });
+
+  it("warns when last-known-good recovery cannot tighten restored config permissions", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath, warn } = makeDeps(home);
+      const snapshot = await makeSnapshot(configPath, {
+        gateway: { mode: "local", auth: { mode: "token", token: "secret-token" } },
+        channels: { discord: { enabled: true, dmPolicy: "pairing" } },
+      });
+      await expect(
+        promoteConfigSnapshotToLastKnownGood({ deps, snapshot, logger: deps.logger }),
+      ).resolves.toBe(true);
+
+      const brokenRaw = "{ gateway: { mode: 123 } }\n";
+      await fsp.writeFile(configPath, brokenRaw, "utf-8");
+      await expect(
+        recoverConfigFromLastKnownGood({
+          deps: withAsyncChmodFailure(deps, configPath),
+          snapshot: {
+            ...snapshot,
+            raw: brokenRaw,
+            parsed: { gateway: { mode: 123 } },
+            valid: false,
+            issues: [{ path: "gateway.mode", message: "Expected string" }],
+          },
+          reason: "test-invalid-config",
+        }),
+      ).resolves.toBe(true);
+
+      expectWarnContaining(
+        warn,
+        `Config permission hardening failed (last-known-good recovery): ${configPath}: EPERM: chmod denied`,
+      );
+      expectWarnContaining(warn, "Config auto-restored from last-known-good:");
     });
   });
 

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -108,6 +108,50 @@ type ConfigStatMetadataSource =
     } & Record<string, unknown>)
   | null;
 
+function formatConfigPermissionHardeningWarning(params: {
+  configPath: string;
+  context: string;
+  error: unknown;
+}): string {
+  const detail = params.error instanceof Error ? params.error.message : String(params.error);
+  return `Config permission hardening failed (${params.context}): ${params.configPath}: ${detail}`;
+}
+
+async function chmodConfigBestEffort(params: {
+  deps: ObserveRecoveryDeps;
+  configPath: string;
+  context: string;
+}): Promise<void> {
+  try {
+    await params.deps.fs.promises.chmod?.(params.configPath, 0o600);
+  } catch (error) {
+    params.deps.logger.warn(
+      formatConfigPermissionHardeningWarning({
+        configPath: params.configPath,
+        context: params.context,
+        error,
+      }),
+    );
+  }
+}
+
+function chmodConfigBestEffortSync(params: {
+  deps: ObserveRecoveryDeps;
+  configPath: string;
+  context: string;
+}): void {
+  try {
+    params.deps.fs.chmodSync?.(params.configPath, 0o600);
+  } catch (error) {
+    params.deps.logger.warn(
+      formatConfigPermissionHardeningWarning({
+        configPath: params.configPath,
+        context: params.context,
+        error,
+      }),
+    );
+  }
+}
 type ConfigReadRecoveryParams = {
   deps: ObserveRecoveryDeps;
   configPath: string;
@@ -635,7 +679,11 @@ export async function maybeRecoverSuspiciousConfigRead(
       encoding: "utf-8",
       mode: 0o600,
     });
-    await params.deps.fs.promises.chmod?.(params.configPath, 0o600).catch(() => {});
+    await chmodConfigBestEffort({
+      deps: params.deps,
+      configPath: params.configPath,
+      context: "backup restore",
+    });
     restoredFromBackup = true;
   } catch (error) {
     restoreError = error;
@@ -745,9 +793,11 @@ export function maybeRecoverSuspiciousConfigReadSync(
       encoding: "utf-8",
       mode: 0o600,
     });
-    try {
-      params.deps.fs.chmodSync?.(params.configPath, 0o600);
-    } catch {}
+    chmodConfigBestEffortSync({
+      deps: params.deps,
+      configPath: params.configPath,
+      context: "backup restore",
+    });
     restoredFromBackup = true;
   } catch (error) {
     restoreError = error;
@@ -823,7 +873,11 @@ export async function promoteConfigSnapshotToLastKnownGood(params: {
     encoding: "utf-8",
     mode: 0o600,
   });
-  await deps.fs.promises.chmod?.(lastGoodPath, 0o600).catch(() => {});
+  await chmodConfigBestEffort({
+    deps,
+    configPath: lastGoodPath,
+    context: "last-known-good promotion",
+  });
   const healthState = await readConfigHealthState(deps);
   const entry = getConfigHealthEntry(healthState, snapshot.path);
   await writeConfigHealthState(
@@ -899,7 +953,11 @@ export async function recoverConfigFromLastKnownGood(params: {
     encoding: "utf-8",
     mode: 0o600,
   });
-  await deps.fs.promises.chmod?.(snapshot.path, 0o600).catch(() => {});
+  await chmodConfigBestEffort({
+    deps,
+    configPath: snapshot.path,
+    context: "last-known-good recovery",
+  });
   const issueSummary = formatConfigIssueSummary([...snapshot.issues, ...snapshot.legacyIssues]);
   deps.logger.warn(
     `Config auto-restored from last-known-good: ${snapshot.path} (${params.reason})${issueSummary ? `; Rejected validation details: ${issueSummary}.` : ""}`,

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1054,6 +1054,18 @@ function findJsonRootSuffix(
   return null;
 }
 
+function warnOnConfigPermissionHardeningFailure(params: {
+  deps: Required<ConfigIoDeps>;
+  configPath: string;
+  context: string;
+  error: unknown;
+}): void {
+  const detail = params.error instanceof Error ? params.error.message : String(params.error);
+  params.deps.logger.warn(
+    `Config permission hardening failed (${params.context}): ${params.configPath}: ${detail}`,
+  );
+}
+
 async function persistPrefixedConfigRecovery(params: {
   deps: Required<ConfigIoDeps>;
   configPath: string;
@@ -1071,7 +1083,14 @@ async function persistPrefixedConfigRecovery(params: {
     encoding: "utf-8",
     mode: 0o600,
   });
-  await params.deps.fs.promises.chmod?.(params.configPath, 0o600).catch(() => {});
+  await params.deps.fs.promises.chmod?.(params.configPath, 0o600).catch((error: unknown) => {
+    warnOnConfigPermissionHardeningFailure({
+      deps: params.deps,
+      configPath: params.configPath,
+      context: "prefix recovery",
+      error,
+    });
+  });
   params.deps.logger.warn(
     `Config auto-stripped non-JSON prefix: ${params.configPath}` +
       (clobberedPath ? ` (original saved as ${clobberedPath})` : ""),

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -183,6 +183,13 @@ describe("config io write", () => {
     expect(persistedHash).not.toBe("");
   };
 
+  const warnMessages = (warn: ReturnType<typeof vi.fn>): string[] =>
+    warn.mock.calls.map(([message]) => String(message));
+
+  const expectWarnContaining = (warn: ReturnType<typeof vi.fn>, expected: string) => {
+    expect(warnMessages(warn).join("\n")).toContain(expected);
+  };
+
   const createFastConfigIO = (home: string) =>
     createConfigIO({
       env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
@@ -935,6 +942,49 @@ describe("config io write", () => {
           )})`,
         ],
       ]);
+    });
+  });
+
+  it("warns when prefix recovery cannot tighten config permissions", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const cleanConfig = {
+        gateway: { mode: "local" },
+        agents: { list: [{ id: "main", default: true }, { id: "discord-dm" }] },
+      } satisfies ConfigFileSnapshot["config"];
+      const cleanRaw = `${JSON.stringify(cleanConfig, null, 2)}\n`;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, `Found and updated: False\n${cleanRaw}`, "utf-8");
+      const chmodError = Object.assign(new Error("EPERM: chmod denied"), { code: "EPERM" });
+      const warn = vi.fn();
+      const chmod = fsNode.promises.chmod.bind(fsNode.promises);
+      const io = createConfigIO({
+        fs: {
+          ...fsNode,
+          promises: {
+            ...fsNode.promises,
+            chmod: async (target, mode) => {
+              if (target === configPath) {
+                throw chmodError;
+              }
+              return await chmod(target, mode);
+            },
+          },
+        },
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: { warn, error: vi.fn() },
+      });
+
+      const initialSnapshot = await io.readConfigFileSnapshot();
+      expect(initialSnapshot.valid).toBe(false);
+
+      await expect(io.recoverConfigFromJsonRootSuffix(initialSnapshot)).resolves.toBe(true);
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(cleanRaw);
+      expect(warnMessages(warn)).toContain(
+        `Config permission hardening failed (prefix recovery): ${configPath}: EPERM: chmod denied`,
+      );
+      expectWarnContaining(warn, `Config auto-stripped non-JSON prefix: ${configPath}`);
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Config recovery already rewrites recovered config files with `mode: 0o600`, but a follow-up `chmod(0o600)` failure was silently ignored.

That made recovery appear successful while hiding that permission hardening failed on the final config file. This patch keeps recovery best-effort and emits an explicit warning with the file path and recovery context.

## Evidence

### Live terminal proof

```text
$ node --import tsx -e "import fsNode from 'node:fs'; import fs from 'node:fs/promises'; import os from 'node:os'; import path from 'node:path'; import { createConfigIO } from './src/config/io.ts'; const home = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-config-proof-')); const configPath = path.join(home, '.openclaw', 'openclaw.json'); await fs.mkdir(path.dirname(configPath), { recursive: true }); const cleanRaw = `${JSON.stringify({ gateway: { mode: 'local' }, agents: { list: [{ id: 'main', default: true }] } }, null, 2)}\n`; await fs.writeFile(configPath, `Found and updated: False\n${cleanRaw}`, 'utf-8'); const io = createConfigIO({ fs: { ...fsNode, promises: { ...fsNode.promises, chmod: async (target, mode) => { if (target === configPath) throw Object.assign(new Error('EPERM: chmod denied'), { code: 'EPERM' }); return await fsNode.promises.chmod(target, mode); } } }, env: { VITEST: 'true' }, homedir: () => home, logger: { warn: (message) => console.log(`WARN: ${String(message)}`), error: () => {} } }); const before = await io.readConfigFileSnapshot(); console.log(`BEFORE_VALID=${before.valid}`); await io.recoverConfigFromJsonRootSuffix(before); console.log(`AFTER_VALID=${(await io.readConfigFileSnapshot()).valid}`);"
BEFORE_VALID=false
WARN: Config permission hardening failed (prefix recovery): ... EPERM: chmod denied
WARN: Config auto-stripped non-JSON prefix: ...
AFTER_VALID=true
```

### Focused tests

- `node scripts/run-vitest.mjs src/config/io.observe-recovery.test.ts`
  - `Tests  37 passed (37)`
- `node scripts/run-vitest.mjs src/config/io.write-config.test.ts`
  - `Tests  67 passed (67)`
- `git diff --check`
  - no output

## Real behavior proof

- `Behavior addressed:`
  Config recovery no longer silently ignores `chmod(0o600)` failures; it now keeps the recovered config and emits an explicit warning.

- `Real environment tested:`
  Local OpenClaw checkout on macOS with a live `createConfigIO` recovery run and targeted Vitest coverage.

- `Exact steps or command run after this patch:`
  `node --import tsx -e "<inline createConfigIO recovery script above>"`
  `node scripts/run-vitest.mjs src/config/io.observe-recovery.test.ts`
  `node scripts/run-vitest.mjs src/config/io.write-config.test.ts`

- `Evidence after fix:`
  Live output showed `BEFORE_VALID=false`, the new `Config permission hardening failed (prefix recovery)` warning, and `AFTER_VALID=true`.

- `Observed result after fix:`
  Recovery still succeeds, the config becomes valid again, and the chmod failure is surfaced instead of being silently swallowed.

- `What was not tested:`
  I did not reproduce this on a filesystem that natively rejects `chmod`, and I did not run a Windows-specific scenario.

- `Proof limitations or environment constraints:`
  This path is hard to prove with a naturally failing local filesystem on demand, so the live proof uses the real recovery code path with an injected `chmod` failure at the filesystem boundary instead of a mocked unit-test assertion alone.