### PR TITLE
fix(streaming): flush visible text immediately after reasoning close tag

### DIFF
--- a/src/shared/text/reasoning-tag-text-partitioner.test.ts
+++ b/src/shared/text/reasoning-tag-text-partitioner.test.ts
@@ -256,6 +256,35 @@ describe("createReasoningTagTextPartitioner", () => {
     ]);
   });
 
+  it("emits visible text immediately after reasoning close tag without waiting for next push", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    // Enter reasoning mode
+    expect(partitioner.push("<thinking>hidden")).toEqual([
+      { kind: "thinking", text: "hidden" },
+    ]);
+
+    // Close tag + visible text in same chunk should emit visible text immediately
+    expect(partitioner.push("</thinking>\n\nhello")).toEqual([
+      { kind: "text", text: "\n\nhello" },
+    ]);
+
+    // Nothing left in buffer
+    expect(partitioner.hasPending()).toBe(false);
+    expect(partitioner.flush()).toEqual([]);
+  });
+
+  it("emits visible text immediately after nested reasoning close tag", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.push("<thinking>outer <thinking>inner</thinking> between</thinking>\n\nfinal")).toEqual([
+      { kind: "thinking", text: "outer inner between" },
+      { kind: "text", text: "\n\nfinal" },
+    ]);
+    expect(partitioner.hasPending()).toBe(false);
+    expect(partitioner.flush()).toEqual([]);
+  });
+
   it("keeps buffered unclosed reasoning hidden after strict mode is marked", () => {
     const partitioner = createReasoningTagTextPartitioner();
 

--- a/src/shared/text/reasoning-tag-text-partitioner.ts
+++ b/src/shared/text/reasoning-tag-text-partitioner.ts
@@ -171,6 +171,9 @@ export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner
           recoverableOpenTagText = undefined;
           hiddenInlineCodeState = createInlineCodeState();
           hiddenFenceState = undefined;
+          // Re-enter the loop immediately so buffered visible text after the
+          // close tag is emitted without waiting for the next push() or flush().
+          continue;
         }
       } else {
         if (reasoningDepth === 0) {


### PR DESCRIPTION
## Summary

- When streaming Qwen thinking models, the first visible text after `</thinking>` was held in the reasoning tag partitioner buffer until `flush()` at stream end, causing a visible delay.
- The partitioner's `consume()` function correctly processed the close tag and reset `reasoningDepth` to 0, but the remaining visible text in the buffer was not immediately consumed.
- This adds a `continue` to re-enter the consumption loop immediately when reasoning depth reaches zero, so buffered visible text is emitted without waiting for the next `push()`.

## Verification

- `node scripts/run-vitest.mjs run src/shared/text/reasoning-tag-text-partitioner.test.ts` → **28/28 passed**
- Before fix: `push("</thinking>\n\nhello")` emitted `[]`, leaving `\n\nhello` in buffer
- After fix: `push("</thinking>\n\nhello")` emits `[{kind:"text", text:"\n\nhello"}]`, buffer empty

## Impact Assessment

- Scope: `src/shared/text/reasoning-tag-text-partitioner.ts` — one `continue` when reasoning ends
- Downstream: only affects streaming text emission timing; content is unchanged
- Edge cases: buffer already empty after close tag → loop exits naturally; no extra work
- Hard-coded values: none

## Real behavior proof

**Behavior addressed:** Visible text after `</thinking>` was buffered until stream end. After fix, the consumption loop immediately re-enters when reasoning depth reaches 0, emitting buffered text without delay.

**Environment tested:** Node 22.x on Linux, vitest test suite.

**Evidence after fix:**
```text
Test Files  1 passed (1)
     Tests  28 passed (28)
```

**Observed result:** All 28 tests pass including 2 new tests specifically for this fix.

Closes #95314
