### PR TITLE
fix: preserve user text that looks like inbound metadata

### DIFF
--- a/packages/memory-host-sdk/src/host/openclaw-runtime-session.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime-session.ts
@@ -4,6 +4,8 @@ export {
   HEARTBEAT_PROMPT,
   HEARTBEAT_TOKEN,
   SILENT_REPLY_TOKEN,
+  resolveBareUserMessageText,
+  resolveTrustedInboundBareBody,
   hasInterSessionUserProvenance,
   isCompactionCheckpointTranscriptFileName,
   isCronRunSessionKey,

--- a/packages/memory-host-sdk/src/host/openclaw-runtime.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime.ts
@@ -27,7 +27,12 @@ export {
 // Session and reply helpers.
 export { isHeartbeatUserMessage } from "../../../../src/auto-reply/heartbeat-filter.js";
 export { HEARTBEAT_PROMPT } from "../../../../src/auto-reply/heartbeat.js";
-export { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
+export {
+  attachTrustedInboundBareBody,
+  resolveBareUserMessageText,
+  resolveTrustedInboundBareBody,
+  stripInboundMetadata,
+} from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 export {
   HEARTBEAT_TOKEN,
   SILENT_REPLY_TOKEN,

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -280,6 +280,37 @@ describe("buildSessionEntry", () => {
     expect(entry.content).toBe("User: Actual user text");
   });
 
+  it("prefers the trusted bare body over heuristic stripping for user-authored sentinel text", async () => {
+    const quotedDecoration = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"message_id":"msg-100","chat_id":"-100123"}',
+      "```",
+      "Literal quoted metadata from the user",
+    ].join("\n");
+    const jsonlLines = [
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: quotedDecoration,
+          __openclaw: {
+            inboundDecoration: {
+              bareBody: quotedDecoration,
+            },
+          },
+        },
+      }),
+    ];
+    const filePath = path.join(tmpDir, "trusted-bare-session.jsonl");
+    fsSync.writeFileSync(filePath, jsonlLines.join("\n"));
+
+    const entry = requireSessionEntry(await buildSessionEntry(filePath));
+    expect(entry.content).toBe(
+      'User: Conversation info (untrusted metadata): ```json {"message_id":"msg-100","chat_id":"-100123"} ``` Literal quoted metadata from the user',
+    );
+  });
+
   it("skips inter-session user messages", async () => {
     const jsonlLines = [
       JSON.stringify({

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -17,8 +17,8 @@ import {
   isSilentReplyPayloadText,
   isUsageCountedSessionTranscriptFileName,
   parseUsageCountedSessionIdFromFileName,
+  resolveBareUserMessageText,
   resolveSessionTranscriptsDirForAgent,
-  stripInboundMetadata,
   stripInternalRuntimeContext,
 } from "./openclaw-runtime-session.js";
 import { retryTransientMemoryRead } from "./read-retry.js";
@@ -426,11 +426,15 @@ function renderSessionExportLines(label: string, text: string): string[] {
  *
  * See: https://github.com/openclaw/openclaw/issues/63921
  */
-function stripInboundMetadataForUserRole(text: string, role: "user" | "assistant"): string {
+function stripInboundMetadataForUserRole(
+  text: string,
+  role: "user" | "assistant",
+  message?: { role?: unknown; content?: unknown; text?: unknown; __openclaw?: unknown },
+): string {
   if (role !== "user") {
     return text;
   }
-  return stripInboundMetadata(text);
+  return resolveBareUserMessageText(message, text) ?? text;
 }
 
 const GENERATED_SYSTEM_MESSAGE_RE = /^System(?: \(untrusted\))?: \[[^\]]+\]\s*/;
@@ -453,8 +457,12 @@ function isGeneratedHeartbeatPromptMessage(text: string, role: "user" | "assista
   return role === "user" && isHeartbeatUserMessage({ role, content: text }, HEARTBEAT_PROMPT);
 }
 
-function sanitizeSessionText(text: string, role: "user" | "assistant"): string | null {
-  const strippedInbound = stripInboundMetadataForUserRole(text, role);
+function sanitizeSessionText(
+  text: string,
+  role: "user" | "assistant",
+  message?: { role?: unknown; content?: unknown; text?: unknown; __openclaw?: unknown },
+): string | null {
+  const strippedInbound = stripInboundMetadataForUserRole(text, role, message);
   const strippedInternal = stripInternalRuntimeContext(strippedInbound);
   const normalized = normalizeSessionText(strippedInternal);
   if (!normalized) {
@@ -632,7 +640,7 @@ export async function buildSessionEntry(
         lineMap.length = 0;
         messageTimestampsMs.length = 0;
       }
-      const text = sanitizeSessionText(rawText, message.role);
+      const text = sanitizeSessionText(rawText, message.role, message);
       if (!text) {
         // Assistant-side machinery (silent replies, system wrappers) is already
         // dropped by sanitizeSessionText. We deliberately do NOT use the prior

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
@@ -420,6 +420,44 @@ describe("normalizeMessagesForLlmBoundary", () => {
     expect(currentContent).toContain("quoted status body");
   });
 
+  it("prefers the trusted bare body for historical user replay", () => {
+    const trustedBareBody = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"message_id":"msg-1"}',
+      "```",
+      "Literal quoted metadata from the user",
+    ].join("\n");
+    const input = [
+      {
+        role: "user",
+        content: "decorated runtime text that should not be replayed",
+        timestamp: 1,
+        __openclaw: {
+          inboundDecoration: {
+            bareBody: trustedBareBody,
+          },
+        },
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Historical answer" }],
+        timestamp: 2,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Current ask" }],
+        timestamp: 3,
+      },
+    ];
+
+    const output = normalizeMessagesForLlmBoundary(
+      input as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
+    ) as unknown as Array<{ content?: unknown }>;
+
+    expect(output[0]?.content).toBe(trustedBareBody);
+  });
+
   it("strips tool result details before provider conversion", () => {
     const input = [
       {

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
@@ -1,7 +1,10 @@
 /**
  * Installs runtime-context and prompt-transform boundaries before LLM calls.
  */
-import { stripInboundMetadata } from "../../../auto-reply/reply/strip-inbound-meta.js";
+import {
+  resolveTrustedInboundBareBody,
+  stripInboundMetadata,
+} from "../../../auto-reply/reply/strip-inbound-meta.js";
 import { buildTimestampPrefix } from "../../../gateway/server-methods/agent-timestamp.js";
 import { INTER_SESSION_PROMPT_PREFIX_BASE } from "../../../sessions/input-provenance.js";
 import { stripHistoricalRuntimeContextCustomMessages } from "../../internal-runtime-context.js";
@@ -465,6 +468,7 @@ function stripHistoricalInboundMetadataFromUserMessages(
     }
     const content = (message as { content?: unknown }).content;
     const isActive = index === activeUserMessageIndex;
+    const trustedBareBody = !isActive ? resolveTrustedInboundBareBody(message) : undefined;
     const override = options?.currentUserTimestampOverride;
     const runtimeTimestamp = (message as { timestamp?: unknown }).timestamp;
     const useCurrentUserTimestampOverride =
@@ -496,9 +500,9 @@ function stripHistoricalInboundMetadataFromUserMessages(
         const envelope = envelopeMatch ? envelopeMatch[0] : "";
         const body = envelope ? raw.slice(envelope.length) : raw;
         // Strip metadata from the body but re-attach the original envelope.
-        return `${envelope}${stripInboundMetadata(body)}`;
+        return `${envelope}${trustedBareBody ?? stripInboundMetadata(body)}`;
       }
-      const stripped = isActive ? raw : stripInboundMetadata(raw);
+      const stripped = isActive ? raw : (trustedBareBody ?? stripInboundMetadata(raw));
       return stampUserTextWithMessageTimestamp(
         stripped,
         messageTimestamp,
@@ -538,27 +542,39 @@ function stripHistoricalInboundMetadataFromUserMessages(
     // preserved untouched so attachment turns keep their array form.
     let contentChanged = false;
     let processedFirstText = false;
-    const nextContent = content.map((block) => {
-      if (!block || typeof block !== "object") {
-        return block;
-      }
-      const textBlock = block as { type?: unknown; text?: unknown };
-      if (textBlock.type !== "text" || typeof textBlock.text !== "string") {
-        return block;
-      }
-      let nextText: string;
-      if (!processedFirstText) {
-        nextText = transformText(textBlock.text);
-        processedFirstText = true;
-      } else {
-        nextText = isActive ? textBlock.text : stripInboundMetadata(textBlock.text);
-      }
-      if (nextText === textBlock.text) {
-        return block;
-      }
-      contentChanged = true;
-      return Object.assign({}, block, { text: nextText });
-    });
+    const nextContent = content
+      .map((block) => {
+        if (!block || typeof block !== "object") {
+          return block;
+        }
+        const textBlock = block as { type?: unknown; text?: unknown };
+        if (textBlock.type !== "text" || typeof textBlock.text !== "string") {
+          return block;
+        }
+        let nextText: string;
+        if (!processedFirstText) {
+          nextText = transformText(trustedBareBody ?? textBlock.text);
+          processedFirstText = true;
+        } else {
+          nextText = isActive
+            ? textBlock.text
+            : trustedBareBody !== undefined
+              ? ""
+              : stripInboundMetadata(textBlock.text);
+        }
+        if (nextText === textBlock.text) {
+          return block;
+        }
+        contentChanged = true;
+        return Object.assign({}, block, { text: nextText });
+      })
+      .filter((block) => {
+        if (!block || typeof block !== "object") {
+          return true;
+        }
+        const textBlock = block as { type?: unknown; text?: unknown };
+        return textBlock.type !== "text" || textBlock.text !== "";
+      });
     if (!contentChanged) {
       return message;
     }

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -589,6 +589,119 @@ describe("installSessionToolResultGuard", () => {
     });
   });
 
+  it("stores a trusted bare body for plain persisted user messages", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: "plain user text",
+        timestamp: Date.now(),
+      }),
+    );
+
+    const persisted = getPersistedMessages(sm)[0] as Record<string, unknown> | undefined;
+    expect(persisted).toMatchObject({
+      __openclaw: {
+        inboundDecoration: {
+          bareBody: "plain user text",
+        },
+      },
+    });
+  });
+
+  it("does not invent a trusted bare body from sentinel-looking runtime user text", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+    const quotedDecoration = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"message_id":"msg-1"}',
+      "```",
+      "Literal quoted metadata from the user",
+    ].join("\n");
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: quotedDecoration,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const persisted = getPersistedMessages(sm)[0] as Record<string, unknown> | undefined;
+    expect(persisted).not.toHaveProperty("__openclaw.inboundDecoration.bareBody");
+  });
+
+  it("preserves an existing trusted bare body on runtime user messages", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+    const quotedDecoration = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"message_id":"msg-1"}',
+      "```",
+      "Literal quoted metadata from the user",
+    ].join("\n");
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: quotedDecoration,
+        timestamp: Date.now(),
+        __openclaw: {
+          inboundDecoration: {
+            bareBody: quotedDecoration,
+          },
+        },
+      }),
+    );
+
+    const persisted = getPersistedMessages(sm)[0] as Record<string, unknown> | undefined;
+    expect(persisted).toMatchObject({
+      __openclaw: {
+        inboundDecoration: {
+          bareBody: quotedDecoration,
+        },
+      },
+    });
+  });
+
+  it("clears a mismatched trusted bare body on runtime user messages", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+    const originalTrustedBareBody = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"message_id":"msg-1"}',
+      "```",
+      "Literal quoted metadata from the user",
+    ].join("\n");
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: [
+          "Conversation info (untrusted metadata):",
+          "```json",
+          '{"message_id":"msg-2"}',
+          "```",
+          "rewritten sentinel-looking text",
+        ].join("\n"),
+        timestamp: Date.now(),
+        __openclaw: {
+          inboundDecoration: {
+            bareBody: originalTrustedBareBody,
+          },
+        },
+      }),
+    );
+
+    const persisted = getPersistedMessages(sm)[0] as Record<string, unknown> | undefined;
+    expect(persisted).not.toHaveProperty("__openclaw.inboundDecoration.bareBody");
+  });
+
   it("suppresses only the next persisted user message when requested", () => {
     const sm = SessionManager.inMemory();
     installSessionToolResultGuard(sm, {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -5,6 +5,7 @@
  */
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { reconcileTrustedInboundBareBody } from "../auto-reply/reply/strip-inbound-meta.js";
 import {
   boundedJsonUtf8Bytes,
   firstEnumerableOwnKeys,
@@ -64,6 +65,13 @@ type AppendMessageOptions = Parameters<SessionManager["appendMessage"]>[1];
 
 function isUserAgentMessage(message: AgentMessage): message is UserAgentMessage {
   return message.role === "user";
+}
+
+function attachTrustedBareBodyForPersistence(message: AgentMessage): AgentMessage {
+  if (!isUserAgentMessage(message)) {
+    return message;
+  }
+  return reconcileTrustedInboundBareBody(message);
 }
 
 function isExpectedCompactionAppend(entryId: string, appendedText: string): boolean {
@@ -693,16 +701,25 @@ export function installSessionToolResultGuard(
     msg: AgentMessage,
   ): { message: AgentMessage; changed: boolean } | null => {
     if (!beforeWrite) {
-      return { message: msg, changed: false };
+      return {
+        message: attachTrustedBareBodyForPersistence(msg),
+        changed: false,
+      };
     }
     const result = beforeWrite({ message: msg });
     if (result?.block) {
       return null;
     }
     if (result?.message) {
-      return { message: result.message, changed: true };
+      return {
+        message: attachTrustedBareBodyForPersistence(result.message),
+        changed: true,
+      };
     }
-    return { message: msg, changed: false };
+    return {
+      message: attachTrustedBareBodyForPersistence(msg),
+      changed: false,
+    };
   };
 
   const flushPendingToolResults = () => {
@@ -728,7 +745,9 @@ export function installSessionToolResultGuard(
             capToolResultForPersistence(flushed.message, maxToolResultChars, redactionConfig),
             {
               invalidateSerializedPrefixCache:
-                persistedSynthetic !== synthetic || toolResultTransformerMayMutate || flushed.changed,
+                persistedSynthetic !== synthetic ||
+                toolResultTransformerMayMutate ||
+                flushed.changed,
             },
           );
         }

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -4,6 +4,8 @@ import type { TemplateContext } from "../templating.js";
 import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "./delivery-hints.js";
 import { buildInboundUserContextPrefix } from "./inbound-meta.js";
 import {
+  reconcileTrustedInboundBareBody,
+  resolveBareUserMessageText,
   extractInboundSenderLabel,
   stripInboundMetadata,
   stripLeadingInboundMetadata,
@@ -281,5 +283,83 @@ describe("builder compatibility", () => {
     const input = [MESSAGE_TOOL_ONLY_DELIVERY_HINT, "", "Actual user message"].join("\n");
 
     expect(stripInboundMetadata(input)).toBe("Actual user message");
+  });
+});
+
+describe("trusted bare body helpers", () => {
+  it("prefers trusted bare user text over sentinel stripping", () => {
+    const trustedBareBody = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"message_id":"msg-1"}',
+      "```",
+      "Literal quoted metadata from the user",
+    ].join("\n");
+    const message = {
+      role: "user",
+      content: `${CONV_BLOCK}\n\nVisible runtime decoration`,
+      __openclaw: {
+        inboundDecoration: {
+          bareBody: trustedBareBody,
+        },
+      },
+    };
+
+    expect(resolveBareUserMessageText(message, message.content)).toBe(trustedBareBody);
+  });
+
+  it("trusts sentinel-looking text only when the caller opts in", () => {
+    const sentinelLookingText = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"message_id":"msg-1"}',
+      "```",
+      "Literal quoted metadata from the user",
+    ].join("\n");
+    const message = {
+      role: "user",
+      content: sentinelLookingText,
+    };
+
+    expect(reconcileTrustedInboundBareBody(message)).toEqual(message);
+    expect(
+      reconcileTrustedInboundBareBody(message, {
+        allowTrustFromSentinelText: true,
+      }),
+    ).toMatchObject({
+      __openclaw: {
+        inboundDecoration: {
+          bareBody: sentinelLookingText,
+        },
+      },
+    });
+  });
+
+  it("clears a stale trusted bare body when sentinel-looking content changes", () => {
+    const message = {
+      role: "user",
+      content: [
+        "Conversation info (untrusted metadata):",
+        "```json",
+        '{"message_id":"msg-2"}',
+        "```",
+        "rewritten sentinel-looking text",
+      ].join("\n"),
+      __openclaw: {
+        inboundDecoration: {
+          bareBody: [
+            "Conversation info (untrusted metadata):",
+            "```json",
+            '{"message_id":"msg-1"}',
+            "```",
+            "Literal quoted metadata from the user",
+          ].join("\n"),
+        },
+      },
+    };
+
+    expect(reconcileTrustedInboundBareBody(message)).not.toHaveProperty(
+      "__openclaw.inboundDecoration.bareBody",
+    );
   });
 });

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -17,6 +17,12 @@
 import { MESSAGE_TOOL_DELIVERY_HINTS } from "./delivery-hints.js";
 
 const LEADING_TIMESTAMP_PREFIX_RE = /^\[[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]]*\] */;
+const OPENCLAW_INBOUND_DECORATION_KEY = "inboundDecoration";
+const OPENCLAW_INBOUND_BARE_BODY_KEY = "bareBody";
+
+type OpenClawMessageMeta = Record<string, unknown> & {
+  inboundDecoration?: Record<string, unknown>;
+};
 
 /**
  * Sentinel strings that identify the start of an injected metadata block.
@@ -47,6 +53,165 @@ const SENTINEL_FAST_RE = new RegExp(
 /** Fast check for whether text contains any inbound metadata sentinel. */
 export function hasInboundMetadataSentinel(text: string): boolean {
   return Boolean(text && SENTINEL_FAST_RE.test(text));
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function collectUserMessageTextContent(message: unknown): string | undefined {
+  const record = asRecord(message);
+  if (!record) {
+    return undefined;
+  }
+  if (typeof record.content === "string") {
+    return record.content;
+  }
+  if (Array.isArray(record.content)) {
+    const textParts = record.content
+      .map((block) => {
+        const item = asRecord(block);
+        return item?.type === "text" && typeof item.text === "string" ? item.text : undefined;
+      })
+      .filter((value): value is string => typeof value === "string");
+    return textParts.length > 0 ? textParts.join("\n") : undefined;
+  }
+  return typeof record.text === "string" ? record.text : undefined;
+}
+
+/**
+ * Returns the trusted user-visible body stored on newer user transcript rows.
+ * Consumers should prefer this over sentinel stripping when available.
+ */
+export function resolveTrustedInboundBareBody(message: unknown): string | undefined {
+  const record = asRecord(message);
+  const meta = asRecord(record?.["__openclaw"]) as OpenClawMessageMeta | undefined;
+  const inboundDecoration = asRecord(meta?.[OPENCLAW_INBOUND_DECORATION_KEY]);
+  return typeof inboundDecoration?.[OPENCLAW_INBOUND_BARE_BODY_KEY] === "string"
+    ? (inboundDecoration[OPENCLAW_INBOUND_BARE_BODY_KEY] as string)
+    : undefined;
+}
+
+/**
+ * Returns trusted bare user text when available, otherwise falls back to the
+ * legacy sentinel-based stripping path for older rows.
+ */
+export function resolveBareUserMessageText(
+  message: unknown,
+  fallbackText?: string,
+): string | undefined {
+  return (
+    resolveTrustedInboundBareBody(message) ??
+    (fallbackText ? stripInboundMetadata(fallbackText) : fallbackText)
+  );
+}
+
+/**
+ * Attaches the trusted user-visible body contract to a persisted/runtime user
+ * message so downstream consumers do not need to guess from forgeable text.
+ */
+export function attachTrustedInboundBareBody<T>(message: T, bareBody?: string): T {
+  const record = asRecord(message);
+  if (!record || record.role !== "user") {
+    return message;
+  }
+  const nextBareBody = bareBody ?? collectUserMessageTextContent(record);
+  const existingMeta = asRecord(record["__openclaw"]);
+  const nextMeta: OpenClawMessageMeta = existingMeta ? { ...existingMeta } : {};
+  const existingInboundDecoration = asRecord(nextMeta[OPENCLAW_INBOUND_DECORATION_KEY]);
+
+  if (nextBareBody !== undefined) {
+    nextMeta[OPENCLAW_INBOUND_DECORATION_KEY] = {
+      ...(existingInboundDecoration ?? {}),
+      [OPENCLAW_INBOUND_BARE_BODY_KEY]: nextBareBody,
+    };
+  } else if (existingInboundDecoration) {
+    const updatedInboundDecoration = { ...existingInboundDecoration };
+    delete updatedInboundDecoration[OPENCLAW_INBOUND_BARE_BODY_KEY];
+    if (Object.keys(updatedInboundDecoration).length > 0) {
+      nextMeta[OPENCLAW_INBOUND_DECORATION_KEY] = updatedInboundDecoration;
+    } else {
+      delete nextMeta[OPENCLAW_INBOUND_DECORATION_KEY];
+    }
+  }
+
+  const nextRecord = { ...record };
+  if (Object.keys(nextMeta).length > 0) {
+    nextRecord["__openclaw"] = nextMeta;
+  } else {
+    delete nextRecord["__openclaw"];
+  }
+  return nextRecord as T;
+}
+
+export function clearTrustedInboundBareBody<T>(message: T): T {
+  const record = asRecord(message);
+  if (!record || record.role !== "user") {
+    return message;
+  }
+  const existingMeta = asRecord(record["__openclaw"]);
+  const nextMeta: OpenClawMessageMeta = existingMeta ? { ...existingMeta } : {};
+  const existingInboundDecoration = asRecord(nextMeta[OPENCLAW_INBOUND_DECORATION_KEY]);
+  if (!existingInboundDecoration) {
+    return message;
+  }
+
+  const updatedInboundDecoration = { ...existingInboundDecoration };
+  delete updatedInboundDecoration[OPENCLAW_INBOUND_BARE_BODY_KEY];
+  if (Object.keys(updatedInboundDecoration).length > 0) {
+    nextMeta[OPENCLAW_INBOUND_DECORATION_KEY] = updatedInboundDecoration;
+  } else {
+    delete nextMeta[OPENCLAW_INBOUND_DECORATION_KEY];
+  }
+
+  const nextRecord = { ...record };
+  if (Object.keys(nextMeta).length > 0) {
+    nextRecord["__openclaw"] = nextMeta;
+  } else {
+    delete nextRecord["__openclaw"];
+  }
+  return nextRecord as T;
+}
+
+/**
+ * Reconciles the trusted bare-body contract after runtime or hook rewrites.
+ *
+ * - Plain user text always becomes the trusted bare body.
+ * - Sentinel/decorated text keeps an existing trusted body only when that body
+ *   still matches either the full content or the legacy stripped body.
+ * - New sentinel-looking text is trusted only when the caller opts in, such as
+ *   the direct transcript build path where the host already knows the text is
+ *   the canonical user body.
+ */
+export function reconcileTrustedInboundBareBody<T>(
+  message: T,
+  options?: { allowTrustFromSentinelText?: boolean },
+): T {
+  const record = asRecord(message);
+  if (!record || record.role !== "user") {
+    return message;
+  }
+  const contentText = collectUserMessageTextContent(record);
+  if (contentText === undefined) {
+    return message;
+  }
+  if (!hasInboundMetadataSentinel(contentText)) {
+    return attachTrustedInboundBareBody(message, contentText);
+  }
+
+  const trustedBareBody = resolveTrustedInboundBareBody(message);
+  if (trustedBareBody !== undefined) {
+    if (trustedBareBody === contentText || stripInboundMetadata(contentText) === trustedBareBody) {
+      return attachTrustedInboundBareBody(message, trustedBareBody);
+    }
+    return clearTrustedInboundBareBody(message);
+  }
+
+  return options?.allowTrustFromSentinelText === true
+    ? attachTrustedInboundBareBody(message, contentText)
+    : message;
 }
 
 function isMessageToolDeliveryHintLine(line: string): boolean {

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -5,7 +5,7 @@ import {
   normalizeOptionalString,
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
-import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
+import { resolveBareUserMessageText } from "../auto-reply/reply/strip-inbound-meta.js";
 
 const DEDUPE_TIMESTAMP_WINDOW_MS = 5 * 60 * 1000;
 
@@ -40,7 +40,8 @@ function extractComparableText(message: unknown): string | undefined {
   if (!joined) {
     return undefined;
   }
-  const visible = role === "user" ? stripInboundMetadata(joined) : joined;
+  const visible =
+    role === "user" ? (resolveBareUserMessageText(message, joined) ?? joined) : joined;
   const normalized = visible.replace(/\s+/g, " ").trim();
   return normalized || undefined;
 }

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -6,7 +6,7 @@ import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
 import { normalizeUsage } from "../agents/usage.js";
-import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
+import { resolveBareUserMessageText } from "../auto-reply/reply/strip-inbound-meta.js";
 import {
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
@@ -2638,8 +2638,8 @@ export async function loadSessionLogs(params: {
       if (!content) {
         continue;
       }
-      content = stripInboundMetadata(content);
       if (role === "user") {
+        content = resolveBareUserMessageText(message, content) ?? content;
         content = stripMessageIdHints(stripEnvelope(content)).trim();
       }
       if (!content) {

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -293,6 +293,73 @@ describe("user turn transcript persistence", () => {
       ]);
     });
 
+    it("stores a trusted bare body for persisted user turns", async () => {
+      const dir = createTempDir("openclaw-user-turn-trusted-bare-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+
+      const appended = await appendUserTurnTranscriptMessage({
+        transcriptPath,
+        sessionId: "session-1",
+        sessionKey: "main",
+        cwd: dir,
+        input: {
+          text: "Plain user message",
+          timestamp: 123,
+        },
+        updateMode: "none",
+      });
+
+      expect(appended?.message).toMatchObject({
+        __openclaw: {
+          inboundDecoration: {
+            bareBody: "Plain user message",
+          },
+        },
+      });
+      expect(readTranscriptMessages(transcriptPath)).toEqual([
+        expect.objectContaining({
+          __openclaw: {
+            inboundDecoration: {
+              bareBody: "Plain user message",
+            },
+          },
+        }),
+      ]);
+    });
+
+    it("treats sentinel-looking user text as trusted bare body on new transcript rows", async () => {
+      const dir = createTempDir("openclaw-user-turn-sentinel-bare-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+      const quotedDecoration = [
+        "Conversation info (untrusted metadata):",
+        "```json",
+        '{"message_id":"msg-1"}',
+        "```",
+        "Literal quoted metadata from the user",
+      ].join("\n");
+
+      const appended = await appendUserTurnTranscriptMessage({
+        transcriptPath,
+        sessionId: "session-1",
+        sessionKey: "main",
+        cwd: dir,
+        input: {
+          text: quotedDecoration,
+          timestamp: 123,
+        },
+        updateMode: "none",
+      });
+
+      expect(appended?.message).toMatchObject({
+        content: quotedDecoration,
+        __openclaw: {
+          inboundDecoration: {
+            bareBody: quotedDecoration,
+          },
+        },
+      });
+    });
+
     it("uses inline update mode by default", async () => {
       const dir = createTempDir("openclaw-user-turn-append-inline-");
       const transcriptPath = path.join(dir, "session.jsonl");
@@ -418,9 +485,75 @@ describe("user turn transcript persistence", () => {
           content: "[redacted by hook]",
           idempotencyKey: "chat-run-1:user",
           provenance,
+          __openclaw: {
+            inboundDecoration: {
+              bareBody: "[redacted by hook]",
+            },
+          },
         }),
       ]);
       expect(hookCalls).toBe(1);
+    });
+
+    it("updates the trusted bare body after before_message_write rewrites a user turn", async () => {
+      const dir = createTempDir("openclaw-user-turn-redacted-bare-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+
+      const appended = await appendUserTurnTranscriptMessage({
+        transcriptPath,
+        input: {
+          text: "secret prompt",
+          idempotencyKey: "chat-run-2:user",
+        },
+        beforeMessageWrite: ({ message }) =>
+          castAgentMessage({
+            ...(message as Record<string, unknown>),
+            role: "user",
+            content: "[redacted by hook]",
+          }),
+      });
+
+      expect(appended?.message).toMatchObject({
+        role: "user",
+        content: "[redacted by hook]",
+        __openclaw: {
+          inboundDecoration: {
+            bareBody: "[redacted by hook]",
+          },
+        },
+      });
+    });
+
+    it("drops a stale trusted bare body when before_message_write rewrites to different sentinel-looking text", async () => {
+      const dir = createTempDir("openclaw-user-turn-redacted-sentinel-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+      const rewritten = [
+        "Conversation info (untrusted metadata):",
+        "```json",
+        '{"message_id":"rewritten"}',
+        "```",
+        "hook rewrite",
+      ].join("\n");
+
+      const appended = await appendUserTurnTranscriptMessage({
+        transcriptPath,
+        input: {
+          text: "original plain user text",
+          idempotencyKey: "chat-run-3:user",
+        },
+        beforeMessageWrite: ({ message }) =>
+          castAgentMessage({
+            ...(message as Record<string, unknown>),
+            role: "user",
+            content: rewritten,
+          }),
+      });
+
+      expect(appended?.message).toMatchObject({
+        role: "user",
+        content: rewritten,
+      });
+      expect(appended?.message).not.toHaveProperty("__openclaw.inboundDecoration.bareBody");
     });
   });
 

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { mimeTypeFromFilePath } from "@openclaw/media-core/mime";
 import type { AgentMessage } from "../../packages/agent-core/src/types.js";
+import { reconcileTrustedInboundBareBody } from "../auto-reply/reply/strip-inbound-meta.js";
 import { persistSessionTranscriptTurn } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { applyInputProvenanceToUserMessage, normalizeInputProvenance } from "./input-provenance.js";
@@ -245,7 +246,9 @@ function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurn
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
     ...mediaFields,
   } as PersistedUserTurnMessage;
-  return applyInputProvenanceToUserMessage(message, params.provenance) as PersistedUserTurnMessage;
+  return attachTrustedBareUserTurnMessage(
+    applyInputProvenanceToUserMessage(message, params.provenance) as PersistedUserTurnMessage,
+  );
 }
 
 function resolvePersistedUserTurnMessage(
@@ -268,6 +271,14 @@ function isBeforeAgentRunBlockedMessage(message: AgentMessage): boolean {
   const marker = (message as { __openclaw?: { beforeAgentRunBlocked?: unknown } })["__openclaw"]
     ?.beforeAgentRunBlocked;
   return marker !== undefined;
+}
+
+function attachTrustedBareUserTurnMessage(
+  message: PersistedUserTurnMessage,
+): PersistedUserTurnMessage {
+  return reconcileTrustedInboundBareBody(message, {
+    allowTrustFromSentinelText: true,
+  });
 }
 
 // Runtime messages may lack transcript metadata because channel adapters prepare
@@ -317,12 +328,13 @@ export function preparePersistedUserTurnMessageForTranscriptWrite(
   const nextUserMessage = provenance
     ? (applyInputProvenanceToUserMessage(nextMessage, provenance) as PersistedUserTurnMessage)
     : nextMessage;
-  return idempotencyKey
+  const finalUserMessage = idempotencyKey
     ? ({
         ...(nextUserMessage as unknown as Record<string, unknown>),
         idempotencyKey,
       } as unknown as PersistedUserTurnMessage)
     : nextUserMessage;
+  return attachTrustedBareUserTurnMessage(finalUserMessage);
 }
 
 export async function appendUserTurnTranscriptMessage(

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -99,6 +99,38 @@ describe("extractTextCached", () => {
     expect(extractText(message)).toBe("visible ask");
     expect(extractTextCached(message)).toBe("visible ask");
   });
+
+  it("prefers trusted bare user text over sentinel stripping", () => {
+    const message = {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: [
+            "Conversation info (untrusted metadata):",
+            "```json",
+            '{"message_id":"msg-1"}',
+            "```",
+            "Literal quoted metadata from the user",
+          ].join("\n"),
+        },
+      ],
+      __openclaw: {
+        inboundDecoration: {
+          bareBody: [
+            "Conversation info (untrusted metadata):",
+            "```json",
+            '{"message_id":"msg-1"}',
+            "```",
+            "Literal quoted metadata from the user",
+          ].join("\n"),
+        },
+      },
+    };
+
+    expect(extractText(message)).toBe(message.__openclaw.inboundDecoration.bareBody);
+    expect(extractTextCached(message)).toBe(message.__openclaw.inboundDecoration.bareBody);
+  });
 });
 
 describe("extractThinkingCached", () => {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -1,6 +1,6 @@
 // Control UI chat module implements message extract behavior.
 import { stripInternalRuntimeContext } from "../../../../src/agents/internal-runtime-context.js";
-import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
+import { resolveBareUserMessageText } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import { stripEnvelope } from "../../../../src/shared/chat-envelope.js";
 import { extractAssistantVisibleText as extractSharedAssistantVisibleText } from "../../../../src/shared/chat-message-content.js";
 import { normalizeLowercaseStringOrEmpty, normalizeStringEntries } from "../string-coerce.ts";
@@ -10,14 +10,11 @@ const textCache = new WeakMap<object, string | null>();
 const thinkingCache = new WeakMap<object, string | null>();
 
 function processMessageText(text: string, role: string): string {
-  const shouldStripInboundMetadata = normalizeLowercaseStringOrEmpty(role) === "user";
   const withoutInternalContext = stripInternalRuntimeContext(text);
   if (role === "assistant") {
     return stripThinkingTags(withoutInternalContext);
   }
-  return shouldStripInboundMetadata
-    ? stripInboundMetadata(stripEnvelope(withoutInternalContext))
-    : stripEnvelope(withoutInternalContext);
+  return stripEnvelope(withoutInternalContext);
 }
 
 export function extractText(message: unknown): string | null {
@@ -28,7 +25,11 @@ export function extractText(message: unknown): string | null {
   if (!raw) {
     return null;
   }
-  return processMessageText(raw, role);
+  const processed = processMessageText(raw, role);
+  if (normalizeLowercaseStringOrEmpty(role) !== "user") {
+    return processed;
+  }
+  return resolveBareUserMessageText(message, processed) ?? null;
 }
 
 export function extractTextCached(message: unknown): string | null {

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -33,6 +33,27 @@ describe("message-normalizer", () => {
       });
     });
 
+    it("prefers trusted bare user text over forgeable sentinel stripping for string content", () => {
+      const trustedBareBody = [
+        "Conversation info (untrusted metadata):",
+        "```json",
+        '{"message_id":"msg-1"}',
+        "```",
+        "Literal quoted metadata from the user",
+      ].join("\n");
+      const result = normalizeMessage({
+        role: "user",
+        content: `${SENDER_METADATA_BLOCK}\n\nVisible but untrusted wrapper`,
+        __openclaw: {
+          inboundDecoration: {
+            bareBody: trustedBareBody,
+          },
+        },
+      });
+
+      expect(result.content).toEqual([{ type: "text", text: trustedBareBody }]);
+    });
+
     it("strips sender metadata blocks before displaying message text", () => {
       const result = normalizeMessage({
         role: "assistant",
@@ -182,6 +203,49 @@ describe("message-normalizer", () => {
         },
       ]);
       expect(result.audioAsVoice).toBeUndefined();
+    });
+
+    it("preserves non-text user blocks while replacing text with the trusted bare body", () => {
+      const trustedBareBody = [
+        "Conversation info (untrusted metadata):",
+        "```json",
+        '{"message_id":"msg-2"}',
+        "```",
+        "Quoted inbound envelope from the user",
+      ].join("\n");
+      const result = normalizeMessage({
+        role: "user",
+        content: [
+          { type: "text", text: "decorated runtime text that should not display" },
+          {
+            type: "attachment",
+            attachment: {
+              url: "~/Pictures/test image.png",
+              kind: "image",
+              label: "test image.png",
+              mimeType: "image/png",
+            },
+          },
+        ],
+        __openclaw: {
+          inboundDecoration: {
+            bareBody: trustedBareBody,
+          },
+        },
+      });
+
+      expect(result.content).toEqual([
+        { type: "text", text: trustedBareBody },
+        {
+          type: "attachment",
+          attachment: {
+            url: "~/Pictures/test image.png",
+            kind: "image",
+            label: "test image.png",
+            mimeType: "image/png",
+          },
+        },
+      ]);
     });
 
     it("normalizes message with text field (alternative format)", () => {

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -3,7 +3,10 @@
  */
 
 import { mediaKindFromMime } from "@openclaw/media-core/constants";
-import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
+import {
+  resolveBareUserMessageText,
+  stripInboundMetadata,
+} from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import { extractCanvasShortcodes } from "../../../../src/chat/canvas-render.js";
 import {
   isToolCallContentType,
@@ -214,10 +217,16 @@ export function stripMessageDisplayMetadataText(text: string): string {
   return stripInboundMetadata(text);
 }
 
-function stripMessageDisplayMetadata(items: MessageContentItem[]): MessageContentItem[] {
+function stripMessageDisplayMetadata(
+  items: MessageContentItem[],
+  options?: { stripUserText?: boolean },
+): MessageContentItem[] {
   return items
     .map((item) => {
       if (item.type !== "text" || typeof item.text !== "string") {
+        return item;
+      }
+      if (options?.stripUserText === false) {
         return item;
       }
       return { ...item, text: stripMessageDisplayMetadataText(item.text) };
@@ -307,6 +316,8 @@ function expandTextContent(text: string): {
 export function normalizeMessage(message: unknown): NormalizedMessage {
   const m = message as Record<string, unknown>;
   let role = typeof m.role === "string" ? m.role : "unknown";
+  const trustedBareUserText =
+    role === "user" ? resolveBareUserMessageText(message as Record<string, unknown>) : undefined;
 
   // Detect tool messages by common gateway shapes.
   // Some tool events come through as assistant role with tool_* items in the content array.
@@ -340,7 +351,7 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
       audioAsVoice = expanded.audioAsVoice;
       replyTarget = expanded.replyTarget;
     } else {
-      content = [{ type: "text", text: m.content }];
+      content = [{ type: "text", text: trustedBareUserText ?? m.content }];
     }
   } else if (Array.isArray(m.content)) {
     content = m.content.flatMap((item: Record<string, unknown>) => {
@@ -429,6 +440,15 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
         },
       ];
     });
+    if (!isAssistantMessage && trustedBareUserText !== undefined) {
+      const nonTextItems = content.filter((item) => item.type !== "text");
+      content = [
+        ...(trustedBareUserText.trim()
+          ? [{ type: "text" as const, text: trustedBareUserText }]
+          : []),
+        ...nonTextItems,
+      ];
+    }
   } else if (typeof m.text === "string") {
     if (isAssistantMessage) {
       const expanded = expandTextContent(m.text);
@@ -436,7 +456,7 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
       audioAsVoice = expanded.audioAsVoice;
       replyTarget = expanded.replyTarget;
     } else {
-      content = [{ type: "text", text: m.text }];
+      content = [{ type: "text", text: trustedBareUserText ?? m.text }];
     }
   }
 
@@ -445,7 +465,9 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   const senderLabel =
     typeof m.senderLabel === "string" && m.senderLabel.trim() ? m.senderLabel.trim() : null;
 
-  content = stripMessageDisplayMetadata(content);
+  content = stripMessageDisplayMetadata(content, {
+    stripUserText: !(role === "user" && trustedBareUserText !== undefined),
+  });
 
   return {
     role,


### PR DESCRIPTION
Closes #95279

## Summary

- **What did NOT change:** This does not remove legacy sentinel stripping for already-persisted rows, does not migrate transcript files, does not change active-turn model prompt construction, and does not add unrelated provider/channel routing behavior.
- **Why it matters / User impact:** Users who paste or type literal inbound-metadata-looking text should not lose that text from Control UI history, text extraction, memory session export, CLI imported-session dedupe, or historical LLM replay when OpenClaw already knows the canonical bare user body for a decorated inbound turn.
- **Behavior addressed:** user-authored text that looks like OpenClaw inbound metadata could be stripped or deduped incorrectly because downstream consumers inferred the bare body from forgeable sentinel text inside `content`.

## Why This Contract Shape

The accepted source of truth in this PR is a host-owned metadata slot under the existing OpenClaw-owned message bag: `__openclaw.inboundDecoration.bareBody`.

Why this shape instead of top-level `bareBody` / `inboundDecorated` fields:

- **Ownership stays explicit:** this data is OpenClaw-generated transport/runtime metadata, not user content and not a general message-schema field. Keeping it under `__openclaw` matches the repo's existing ownership pattern for OpenClaw-managed per-message metadata.
- **Narrower compatibility surface:** top-level fields would widen the generic message contract across more callers and plugin consumers. Nesting under `__openclaw.inboundDecoration` keeps the new state additive and clearly internal while still serializing it where the affected consumers already read OpenClaw metadata.
- **Room for the same family of trusted decoration data:** the `inboundDecoration` object can carry future trusted decoration facts without minting more one-off top-level keys.
- **Best-fit boundary for this fix:** the bug is not “messages in general need a new public bareBody field”; it is “OpenClaw needs one trusted place to remember the host-authored bare body for inbound-decorated user turns.”

## Real behavior proof

- **Exact steps or command run after this patch:**
  - `node scripts/run-vitest.mjs src/gateway/cli-session-history.test.ts src/sessions/user-turn-transcript.test.ts ui/src/ui/chat/message-extract.test.ts ui/src/ui/chat/message-normalizer.test.ts packages/memory-host-sdk/src/host/session-files.test.ts src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts src/auto-reply/reply/strip-inbound-meta.test.ts`
  - `git diff --check`
  - `node --import tsx <transcript-ui-proof>` using repository runtime code to persist a real transcript row with `appendUserTurnTranscriptMessage(...)`, then feed that persisted row through `normalizeMessage(...)` and `extractTextCached(...)`
  - `node --import tsx <cli-dedupe-proof>` using repository runtime code to call `mergeImportedChatHistoryMessages(...)` with two distinct trusted bare bodies that share decorated model-facing `content`
- **Observed result after fix:** targeted regression tests passed, `git diff --check` passed, the transcript/UI proof preserved literal `Sender (untrusted metadata):` user text when the trusted bare body was present, and the CLI imported-session dedupe proof kept two rows with different trusted bare bodies even though the legacy sentinel-stripped comparable text would have collided.
- **What was not tested:** I did not run an external live channel or packaged app proof in this environment. The real-behavior proof here exercises the repository runtime code locally with synthetic persisted transcript data and CLI merge inputs.
- **Real environment tested:** local source checkout on this branch using repository Vitest lanes and small `tsx` proof harnesses that import the production code paths directly.
- **Evidence after fix:** transcript persistence, Control UI display/extraction, CLI imported-session dedupe, memory-host export/indexing, and historical replay consumers all prefer the trusted bare body when present and fall back to legacy sentinel stripping only for unmarked legacy rows.

Transcript/UI proof output, redacted to synthetic data:

```text
Command shape:
node --import tsx <transcript-ui-proof>

{
  "trusted": {
    "normalizedText": "Sender (untrusted metadata):\n```json\n{\"label\":\"literal user-authored text\"}\n```\n\nPlease preserve this literal block.",
    "extractedText": "Sender (untrusted metadata):\n```json\n{\"label\":\"literal user-authored text\"}\n```\n\nPlease preserve this literal block.",
    "preservedLiteralSenderSentinel": true,
    "usedTrustedBareBodyInsteadOfDecoratedCopy": true
  },
  "legacyFallbackWithoutTrustedField": {
    "normalizedText": "Please preserve this literal block.",
    "extractedText": "Please preserve this literal block.",
    "strippedLiteralSenderSentinel": true
  }
}

Observed result: the same persisted decorated row keeps the literal sentinel-shaped user text when the trusted bare body exists, and the legacy fallback still strips that literal sentinel text when the trusted field is absent.
```

CLI imported-session dedupe proof output, redacted to synthetic data:

```text
Command shape:
node --import tsx <cli-dedupe-proof>

{
  "mergedWithTrustedContract": 2,
  "mergedWithoutTrustedContract": 1,
  "legacyComparableTextCollision": true,
  "preservedDistinctTrustedBareBodies": true
}

Observed result: with the trusted contract, the CLI merge path keeps both rows; without the trusted field, the legacy sentinel-strip comparable text collapses the same two rows into one.
```

## Regression Test Plan

- **Target test files:** `src/gateway/cli-session-history.test.ts`, `src/sessions/user-turn-transcript.test.ts`, `ui/src/ui/chat/message-extract.test.ts`, `ui/src/ui/chat/message-normalizer.test.ts`, `packages/memory-host-sdk/src/host/session-files.test.ts`, `src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts`, and `src/auto-reply/reply/strip-inbound-meta.test.ts`.
- **Scenario locked in:** each consumer test covers a decorated inbound turn whose trusted bare body itself contains sentinel-shaped user text such as `Sender (untrusted metadata):` plus fenced JSON; the expected behavior is that the trusted bare body is preserved literally instead of being reparsed and stripped as metadata. The CLI imported-session test additionally proves two messages with identical decorated `content` but different trusted bare bodies do not dedupe into one row.
- **Why this is the smallest reliable guardrail:** it locks the shared trusted-contract behavior at the persistence, UI, CLI dedupe, memory, and replay boundaries without changing unrelated prompt-construction behavior or removing legacy fallback cleanup for old rows.

## Root Cause

- **Root cause:** the parser/contract boundary was wrong. `buildInboundUserContextPrefix(...)` creates host decoration as plaintext blocks inside user-message `content`, but consumers such as Control UI history, CLI imported-session dedupe, memory-host session export, and historical LLM replay had no trusted way to distinguish host-added decoration from user-authored text in that same channel.
- **Why this is the root-cause fix:** the source-of-truth decision no longer comes from forgeable `content` text. The affected consumers now prefer one shared trusted resolver and only fall back to legacy sentinel stripping for older rows that do not carry the trusted field.
- **Fix classification:** root-cause fix for a public session/transcript contract bug.
- **Maintainer-ready confidence:** high. The change is additive, preserves legacy fallback behavior, and has targeted regression coverage plus local real-behavior proof for the affected consumer paths.
- **Architecture / source-of-truth check:** the canonical contract is the host-owned per-message metadata under `__openclaw.inboundDecoration.bareBody`. Display/history/CLI dedupe/memory/replay consumers use that trusted contract when present; legacy unmarked rows still go through sentinel stripping.

## Scope boundary

In scope: trusted inbound bare-body metadata plumbing for persisted/runtime user turns, transcript persistence/runtime merge preservation, UI display normalization and text extraction, CLI imported-session dedupe, memory-host session export/indexing, historical LLM replay normalization, and targeted regression tests for those paths.

Out of scope: removing legacy sentinel stripping for already-persisted rows, migrating existing transcript files, changing active-turn model prompt construction, or broadening the generic message schema with new top-level public fields.

## Verification

Passed locally:

```text
node scripts/run-vitest.mjs src/gateway/cli-session-history.test.ts src/sessions/user-turn-transcript.test.ts ui/src/ui/chat/message-extract.test.ts ui/src/ui/chat/message-normalizer.test.ts packages/memory-host-sdk/src/host/session-files.test.ts src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts src/auto-reply/reply/strip-inbound-meta.test.ts
```

```text
git diff --check
```

## Merge risk

- Risk labels considered: `compatibility`, `session-state`.
- Risk explanation: this changes display/replay/indexing/dedupe behavior for messages that explicitly opt into the trusted inbound-decoration contract. The new serialized state is additive and only authoritative when present; existing transcripts without the field keep the old heuristic fallback.
- Why acceptable: the fix narrows an unsafe heuristic without removing backward compatibility for legacy rows, and the proof covers the user-visible paths most likely to drop or dedupe real user-authored content.
