### PR TITLE
fix #94919: [Bug]: Z.AI Coding-Plan: ECONNRESET triggers model fallback — fallback notice is invisible to the user in async contexts (cron jobs, sub-agents, isolated runs)

### DIFF
--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -295,6 +295,49 @@ describe("startAcpSpawnParentStreamRelay", () => {
     relay.dispose();
   });
 
+  it("does not announce transient fallback_step handoffs before a candidate succeeds", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-fallback-step-multihop",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-fallback-step-multihop",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-fallback-step-multihop",
+      stream: "lifecycle",
+      data: {
+        phase: "fallback_step",
+        fallbackStepType: "fallback_step",
+        fallbackStepFromModel: "proof-fail/fail-model",
+        fallbackStepToModel: "proof-mid/mid-model",
+        fallbackStepFromFailureReason: "timeout",
+        fallbackStepFinalOutcome: "next_fallback",
+      },
+    });
+    emitAgentEvent({
+      runId: "run-fallback-step-multihop",
+      stream: "lifecycle",
+      data: {
+        phase: "fallback_step",
+        fallbackStepType: "fallback_step",
+        fallbackStepFromModel: "proof-mid/mid-model",
+        fallbackStepToModel: "proof-ok/ok-model",
+        fallbackStepFromFailureReason: "overloaded",
+        fallbackStepFinalOutcome: "succeeded",
+      },
+    });
+
+    const fallbackNotices = collectedTexts().filter((text) => text.includes("Model Fallback:"));
+    expect(fallbackNotices).toEqual([
+      "codex: ↪️ Model Fallback: proof-ok/ok-model (selected proof-mid/mid-model; overloaded)",
+    ]);
+    expect(requestHeartbeatMock).toHaveBeenCalledTimes(2);
+    relay.dispose();
+  });
+
   it("remaps cron-run parent session keys while relaying stream events", () => {
     const relay = startAcpSpawnParentStreamRelay({
       runId: "run-cron",

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -252,6 +252,49 @@ describe("startAcpSpawnParentStreamRelay", () => {
     relay.dispose();
   });
 
+  it("relays production fallback_step lifecycle notices to the parent session", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-fallback-step",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-fallback-step",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-fallback-step",
+      stream: "lifecycle",
+      data: {
+        phase: "fallback_step",
+        fallbackStepType: "fallback_step",
+        fallbackStepFromModel: "zai/glm-5-turbo",
+        fallbackStepToModel: "minimax/MiniMax-M3",
+        fallbackStepFromFailureReason: "timeout",
+        fallbackStepFinalOutcome: "succeeded",
+      },
+    });
+    emitAgentEvent({
+      runId: "run-fallback-step",
+      stream: "lifecycle",
+      data: {
+        phase: "fallback",
+        selectedProvider: "zai",
+        selectedModel: "glm-5-turbo",
+        activeProvider: "minimax",
+        activeModel: "MiniMax-M3",
+        reasonSummary: "timeout",
+      },
+    });
+
+    const fallbackNotices = collectedTexts().filter((text) => text.includes("Model Fallback:"));
+    expect(fallbackNotices).toEqual([
+      "codex: ↪️ Model Fallback: minimax/MiniMax-M3 (selected zai/glm-5-turbo; timeout)",
+    ]);
+    expect(requestHeartbeatMock).toHaveBeenCalled();
+    relay.dispose();
+  });
+
   it("remaps cron-run parent session keys while relaying stream events", () => {
     const relay = startAcpSpawnParentStreamRelay({
       runId: "run-cron",

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -222,6 +222,36 @@ describe("startAcpSpawnParentStreamRelay", () => {
     relay.dispose();
   });
 
+  it("relays model fallback lifecycle notices to the parent session", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-fallback",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-fallback",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-fallback",
+      stream: "lifecycle",
+      data: {
+        phase: "fallback",
+        selectedProvider: "zai",
+        selectedModel: "glm-5-turbo",
+        activeProvider: "minimax",
+        activeModel: "MiniMax-M3",
+        reasonSummary: "timeout",
+      },
+    });
+
+    expect(collectedTexts()).toContain(
+      "codex: ↪️ Model Fallback: minimax/MiniMax-M3 (selected zai/glm-5-turbo; timeout)",
+    );
+    expect(requestHeartbeatMock).toHaveBeenCalled();
+    relay.dispose();
+  });
+
   it("remaps cron-run parent session keys while relaying stream events", () => {
     const relay = startAcpSpawnParentStreamRelay({
       runId: "run-cron",

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -314,6 +314,7 @@ describe("startAcpSpawnParentStreamRelay", () => {
         fallbackStepFromModel: "proof-fail/fail-model",
         fallbackStepToModel: "proof-mid/mid-model",
         fallbackStepFromFailureReason: "timeout",
+        fallbackStepChainPosition: 1,
         fallbackStepFinalOutcome: "next_fallback",
       },
     });
@@ -326,13 +327,26 @@ describe("startAcpSpawnParentStreamRelay", () => {
         fallbackStepFromModel: "proof-mid/mid-model",
         fallbackStepToModel: "proof-ok/ok-model",
         fallbackStepFromFailureReason: "overloaded",
+        fallbackStepChainPosition: 2,
         fallbackStepFinalOutcome: "succeeded",
+      },
+    });
+    emitAgentEvent({
+      runId: "run-fallback-step-multihop",
+      stream: "lifecycle",
+      data: {
+        phase: "fallback",
+        selectedProvider: "proof-fail",
+        selectedModel: "fail-model",
+        activeProvider: "proof-ok",
+        activeModel: "ok-model",
+        reasonSummary: "timeout (+1 more attempts)",
       },
     });
 
     const fallbackNotices = collectedTexts().filter((text) => text.includes("Model Fallback:"));
     expect(fallbackNotices).toEqual([
-      "codex: ↪️ Model Fallback: proof-ok/ok-model (selected proof-mid/mid-model; overloaded)",
+      "codex: ↪️ Model Fallback: proof-ok/ok-model (selected proof-fail/fail-model; timeout (+1 more attempts))",
     ]);
     expect(requestHeartbeatMock).toHaveBeenCalledTimes(2);
     relay.dispose();

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -86,6 +86,38 @@ function buildLifecycleFallbackNotice(
   return `↪️ Model Fallback: ${active} (selected ${selected}; ${reasonSummary ?? "selected model unavailable"})`;
 }
 
+function formatLifecycleFallbackStepModelRef(value: unknown): string | undefined {
+  const modelRef = normalizeOptionalString(value);
+  if (!modelRef) {
+    return undefined;
+  }
+  const separator = modelRef.indexOf("/");
+  if (separator <= 0 || separator >= modelRef.length - 1) {
+    return undefined;
+  }
+  return formatProviderModelRef(modelRef.slice(0, separator), modelRef.slice(separator + 1));
+}
+
+function formatLifecycleFallbackStepReason(value: unknown): string | undefined {
+  return normalizeOptionalString(value)?.replace(/_/g, " ");
+}
+
+function buildLifecycleFallbackStepNotice(
+  data: Record<string, unknown> | undefined,
+): string | undefined {
+  const outcome = normalizeOptionalString(data?.fallbackStepFinalOutcome);
+  if (outcome === "chain_exhausted") {
+    return undefined;
+  }
+  const selected = formatLifecycleFallbackStepModelRef(data?.fallbackStepFromModel);
+  const active = formatLifecycleFallbackStepModelRef(data?.fallbackStepToModel);
+  if (!selected || !active) {
+    return undefined;
+  }
+  const reasonSummary = formatLifecycleFallbackStepReason(data?.fallbackStepFromFailureReason);
+  return `↪️ Model Fallback: ${active} (selected ${selected}; ${reasonSummary ?? "selected model unavailable"})`;
+}
+
 function buildLifecycleFallbackClearedNotice(
   data: Record<string, unknown> | undefined,
 ): string | undefined {
@@ -414,6 +446,7 @@ export function startAcpSpawnParentStreamRelay(params: {
     mainKey: params.mainKey,
     sessionScope: params.sessionScope,
   };
+  let lastFallbackNoticeText: string | undefined;
   const wake = () => {
     if (!shouldSurfaceUpdates) {
       return;
@@ -445,6 +478,13 @@ export function startAcpSpawnParentStreamRelay(params: {
       deliveryContext: params.deliveryContext,
     });
     wake();
+  };
+  const emitFallbackNotice = (notice: string, contextKey: string) => {
+    if (notice === lastFallbackNoticeText) {
+      return;
+    }
+    lastFallbackNoticeText = notice;
+    emit(`${relayLabel}: ${notice}`, contextKey);
   };
   const emitStartNotice = () => {
     recordTaskRunProgressByRunId({
@@ -757,11 +797,14 @@ export function startAcpSpawnParentStreamRelay(params: {
     const lifecycleData = asObjectRecord(event.data);
     const phase = normalizeOptionalString(lifecycleData?.phase);
     logEvent("lifecycle", { phase: phase ?? "unknown", data: event.data });
-    if (phase === "fallback") {
+    if (phase === "fallback" || phase === "fallback_step") {
       flushPending();
-      const notice = buildLifecycleFallbackNotice(lifecycleData);
+      const notice =
+        phase === "fallback_step"
+          ? buildLifecycleFallbackStepNotice(lifecycleData)
+          : buildLifecycleFallbackNotice(lifecycleData);
       if (notice) {
-        emit(`${relayLabel}: ${notice}`, `${contextPrefix}:fallback`);
+        emitFallbackNotice(notice, `${contextPrefix}:fallback`);
       }
       return;
     }

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -106,7 +106,7 @@ function buildLifecycleFallbackStepNotice(
   data: Record<string, unknown> | undefined,
 ): string | undefined {
   const outcome = normalizeOptionalString(data?.fallbackStepFinalOutcome);
-  if (outcome === "chain_exhausted") {
+  if (outcome !== "succeeded") {
     return undefined;
   }
   const selected = formatLifecycleFallbackStepModelRef(data?.fallbackStepFromModel);

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
+import { formatProviderModelRef } from "../auto-reply/model-runtime.js";
 import {
   isAcpTagVisible,
   resolveAcpProjectionSettings,
@@ -67,6 +68,37 @@ function formatProxyEnvSummary(keys: string[]): string {
     return "proxy env: none";
   }
   return `proxy env: ${keys.join(", ")}`;
+}
+
+function buildLifecycleFallbackNotice(
+  data: Record<string, unknown> | undefined,
+): string | undefined {
+  const selectedProvider = normalizeOptionalString(data?.selectedProvider);
+  const selectedModel = normalizeOptionalString(data?.selectedModel);
+  const activeProvider = normalizeOptionalString(data?.activeProvider);
+  const activeModel = normalizeOptionalString(data?.activeModel);
+  const reasonSummary = normalizeOptionalString(data?.reasonSummary);
+  if (!selectedModel || !activeModel) {
+    return undefined;
+  }
+  const selected = formatProviderModelRef(selectedProvider ?? "", selectedModel);
+  const active = formatProviderModelRef(activeProvider ?? "", activeModel);
+  return `↪️ Model Fallback: ${active} (selected ${selected}; ${reasonSummary ?? "selected model unavailable"})`;
+}
+
+function buildLifecycleFallbackClearedNotice(
+  data: Record<string, unknown> | undefined,
+): string | undefined {
+  const selectedProvider = normalizeOptionalString(data?.selectedProvider);
+  const selectedModel = normalizeOptionalString(data?.selectedModel);
+  if (!selectedModel) {
+    return undefined;
+  }
+  const selected = formatProviderModelRef(selectedProvider ?? "", selectedModel);
+  const previous = normalizeOptionalString(data?.previousActiveModel);
+  return previous && previous !== selected
+    ? `↪️ Model Fallback cleared: ${selected} (was ${previous})`
+    : `↪️ Model Fallback cleared: ${selected}`;
 }
 
 function asObjectRecord(value: unknown): Record<string, unknown> | undefined {
@@ -722,8 +754,25 @@ export function startAcpSpawnParentStreamRelay(params: {
       return;
     }
 
-    const phase = normalizeOptionalString((event.data as { phase?: unknown } | undefined)?.phase);
+    const lifecycleData = asObjectRecord(event.data);
+    const phase = normalizeOptionalString(lifecycleData?.phase);
     logEvent("lifecycle", { phase: phase ?? "unknown", data: event.data });
+    if (phase === "fallback") {
+      flushPending();
+      const notice = buildLifecycleFallbackNotice(lifecycleData);
+      if (notice) {
+        emit(`${relayLabel}: ${notice}`, `${contextPrefix}:fallback`);
+      }
+      return;
+    }
+    if (phase === "fallback_cleared") {
+      flushPending();
+      const notice = buildLifecycleFallbackClearedNotice(lifecycleData);
+      if (notice) {
+        emit(`${relayLabel}: ${notice}`, `${contextPrefix}:fallback-cleared`);
+      }
+      return;
+    }
     if (phase === "end") {
       flushReplaceableAssistantSnapshot();
       flushPending();

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -102,19 +102,44 @@ function formatLifecycleFallbackStepReason(value: unknown): string | undefined {
   return normalizeOptionalString(value)?.replace(/_/g, " ");
 }
 
+function buildFallbackNoticeDedupeKey(
+  selected: string | undefined,
+  active: string | undefined,
+): string | undefined {
+  return selected && active ? `${selected}\0${active}` : undefined;
+}
+
+function buildLifecycleFallbackNoticeDedupeKey(
+  data: Record<string, unknown> | undefined,
+): string | undefined {
+  const selectedProvider = normalizeOptionalString(data?.selectedProvider);
+  const selectedModel = normalizeOptionalString(data?.selectedModel);
+  const activeProvider = normalizeOptionalString(data?.activeProvider);
+  const activeModel = normalizeOptionalString(data?.activeModel);
+  if (!selectedModel || !activeModel) {
+    return undefined;
+  }
+  return buildFallbackNoticeDedupeKey(
+    formatProviderModelRef(selectedProvider ?? "", selectedModel),
+    formatProviderModelRef(activeProvider ?? "", activeModel),
+  );
+}
+
 function buildLifecycleFallbackStepNotice(
   data: Record<string, unknown> | undefined,
+  originalSelectedModel: string | undefined,
+  reasonSummary: string | undefined,
 ): string | undefined {
   const outcome = normalizeOptionalString(data?.fallbackStepFinalOutcome);
   if (outcome !== "succeeded") {
     return undefined;
   }
-  const selected = formatLifecycleFallbackStepModelRef(data?.fallbackStepFromModel);
+  const selected =
+    originalSelectedModel ?? formatLifecycleFallbackStepModelRef(data?.fallbackStepFromModel);
   const active = formatLifecycleFallbackStepModelRef(data?.fallbackStepToModel);
   if (!selected || !active) {
     return undefined;
   }
-  const reasonSummary = formatLifecycleFallbackStepReason(data?.fallbackStepFromFailureReason);
   return `↪️ Model Fallback: ${active} (selected ${selected}; ${reasonSummary ?? "selected model unavailable"})`;
 }
 
@@ -447,6 +472,10 @@ export function startAcpSpawnParentStreamRelay(params: {
     sessionScope: params.sessionScope,
   };
   let lastFallbackNoticeText: string | undefined;
+  let lastFallbackNoticeKey: string | undefined;
+  let fallbackStepOriginalSelectedModel: string | undefined;
+  let fallbackStepFirstFailureReason: string | undefined;
+  const fallbackStepFailedModels = new Set<string>();
   const wake = () => {
     if (!shouldSurfaceUpdates) {
       return;
@@ -479,11 +508,16 @@ export function startAcpSpawnParentStreamRelay(params: {
     });
     wake();
   };
-  const emitFallbackNotice = (notice: string, contextKey: string) => {
-    if (notice === lastFallbackNoticeText) {
+  const emitFallbackNotice = (
+    notice: string,
+    contextKey: string,
+    dedupeKey: string | undefined = notice,
+  ) => {
+    if (notice === lastFallbackNoticeText || dedupeKey === lastFallbackNoticeKey) {
       return;
     }
     lastFallbackNoticeText = notice;
+    lastFallbackNoticeKey = dedupeKey;
     emit(`${relayLabel}: ${notice}`, contextKey);
   };
   const emitStartNotice = () => {
@@ -799,17 +833,69 @@ export function startAcpSpawnParentStreamRelay(params: {
     logEvent("lifecycle", { phase: phase ?? "unknown", data: event.data });
     if (phase === "fallback" || phase === "fallback_step") {
       flushPending();
-      const notice =
-        phase === "fallback_step"
-          ? buildLifecycleFallbackStepNotice(lifecycleData)
-          : buildLifecycleFallbackNotice(lifecycleData);
-      if (notice) {
-        emitFallbackNotice(notice, `${contextPrefix}:fallback`);
+      if (phase === "fallback_step") {
+        const stepFromModel = formatLifecycleFallbackStepModelRef(
+          lifecycleData?.fallbackStepFromModel,
+        );
+        const stepToModel = formatLifecycleFallbackStepModelRef(lifecycleData?.fallbackStepToModel);
+        const stepReason = formatLifecycleFallbackStepReason(
+          lifecycleData?.fallbackStepFromFailureReason,
+        );
+        const stepChainPosition = asFiniteNumber(lifecycleData?.fallbackStepChainPosition);
+        if (stepChainPosition != null && stepChainPosition <= 1) {
+          fallbackStepOriginalSelectedModel = stepFromModel;
+          fallbackStepFirstFailureReason = undefined;
+          fallbackStepFailedModels.clear();
+        } else {
+          fallbackStepOriginalSelectedModel ??= stepFromModel;
+        }
+        if (stepFromModel) {
+          if (!fallbackStepFailedModels.has(stepFromModel)) {
+            fallbackStepFailedModels.add(stepFromModel);
+            fallbackStepFirstFailureReason ??= stepReason;
+          }
+          fallbackStepOriginalSelectedModel ??= stepFromModel;
+        }
+        fallbackStepFirstFailureReason ??= stepReason;
+        const failedAttemptCount = fallbackStepFailedModels.size;
+        const stepReasonSummary = fallbackStepFirstFailureReason
+          ? failedAttemptCount > 1
+            ? `${fallbackStepFirstFailureReason} (+${failedAttemptCount - 1} more attempts)`
+            : fallbackStepFirstFailureReason
+          : undefined;
+        const notice = buildLifecycleFallbackStepNotice(
+          lifecycleData,
+          fallbackStepOriginalSelectedModel,
+          stepReasonSummary,
+        );
+        if (notice) {
+          emitFallbackNotice(
+            notice,
+            `${contextPrefix}:fallback`,
+            buildFallbackNoticeDedupeKey(fallbackStepOriginalSelectedModel, stepToModel),
+          );
+        }
+        return;
       }
+      const notice = buildLifecycleFallbackNotice(lifecycleData);
+      if (notice) {
+        emitFallbackNotice(
+          notice,
+          `${contextPrefix}:fallback`,
+          buildLifecycleFallbackNoticeDedupeKey(lifecycleData),
+        );
+      }
+      fallbackStepOriginalSelectedModel = undefined;
+      fallbackStepFirstFailureReason = undefined;
+      fallbackStepFailedModels.clear();
       return;
     }
     if (phase === "fallback_cleared") {
       flushPending();
+      fallbackStepOriginalSelectedModel = undefined;
+      fallbackStepFirstFailureReason = undefined;
+      fallbackStepFailedModels.clear();
+      lastFallbackNoticeKey = undefined;
       const notice = buildLifecycleFallbackClearedNotice(lifecycleData);
       if (notice) {
         emit(`${relayLabel}: ${notice}`, `${contextPrefix}:fallback-cleared`);

--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -288,6 +288,31 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.deliveryPayload).toEqual({ text: "section 2" });
   });
 
+  it("keeps leading fallback notices when finalAssistantVisibleText replaces text payloads", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        {
+          text: "↪️ Model Fallback: minimax/MiniMax-M3 (selected zai/glm-5-turbo; timeout)",
+          isFallbackNotice: true,
+        },
+        { text: "partial streamed reply" },
+        { text: "final answer" },
+      ],
+      finalAssistantVisibleText: "final answer",
+      preferFinalAssistantVisibleText: true,
+    });
+
+    expect(result.deliveryPayloads).toEqual([
+      {
+        text: "↪️ Model Fallback: minimax/MiniMax-M3 (selected zai/glm-5-turbo; timeout)",
+        isFallbackNotice: true,
+      },
+      { text: "final answer" },
+    ]);
+    expect(result.outputText).toBe("final answer");
+    expect(result.synthesizedText).toBe("final answer");
+  });
+
   it("keeps structured-content detection scoped to the last delivery payload", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [{ mediaUrl: "https://example.com/report.png" }, { text: "final text" }],

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -9,7 +9,16 @@ import { shouldSkipHeartbeatOnlyDelivery } from "../heartbeat-policy.js";
 
 type DeliveryPayload = Pick<
   ReplyPayload,
-  "text" | "mediaUrl" | "mediaUrls" | "presentation" | "interactive" | "channelData" | "isError"
+  | "text"
+  | "mediaUrl"
+  | "mediaUrls"
+  | "presentation"
+  | "interactive"
+  | "channelData"
+  | "isError"
+  | "isCompactionNotice"
+  | "isFallbackNotice"
+  | "isStatusNotice"
 >;
 
 /** Normalized cron run payload state used for summaries, delivery, and failure classification. */
@@ -228,6 +237,19 @@ function isSuccessfulCronPayload(payload: DeliveryPayload | undefined): boolean 
   );
 }
 
+function pickLeadingFallbackNoticePayloads(payloads: DeliveryPayload[]): DeliveryPayload[] {
+  const notices: DeliveryPayload[] = [];
+  for (const payload of payloads) {
+    if (payload.isError === true || payload.isFallbackNotice !== true) {
+      break;
+    }
+    if (normalizeOptionalString(payload.text)) {
+      notices.push(payload);
+    }
+  }
+  return notices;
+}
+
 /** Resolves summary, output text, delivery payloads, and fatal-error state from cron run output. */
 export function resolveCronPayloadOutcome(params: {
   payloads: DeliveryPayload[];
@@ -320,8 +342,11 @@ export function resolveCronPayloadOutcome(params: {
     ? normalizedFinalAssistantVisibleText
     : fallbackOutputText;
   const synthesizedText = normalizeOptionalString(outputText) ?? normalizeOptionalString(summary);
+  const finalAssistantFallbackNotices = shouldUseFinalAssistantVisibleText
+    ? pickLeadingFallbackNoticePayloads(params.payloads)
+    : [];
   const resolvedDeliveryPayloads = shouldUseFinalAssistantVisibleText
-    ? [{ text: normalizedFinalAssistantVisibleText }]
+    ? [...finalAssistantFallbackNotices, { text: normalizedFinalAssistantVisibleText }]
     : selectedDeliveryPayloads.length > 0
       ? selectedDeliveryPayloads
       : synthesizedText


### PR DESCRIPTION
## Summary

- Problem: OpenClaw already authors `↪️ Model Fallback: ...` notices when a run falls back from the selected model, but async users can miss the notice when the fallback happens inside child/async execution.
- Solution: preserve and project the existing fallback notice at the async-visible boundaries instead of changing provider fallback decisions or transport behavior.
- What changed:
  - ACP child-to-parent relay now handles the production `lifecycle.phase === "fallback_step"` event shape emitted by the model fallback runner, formats a parent-visible fallback notice only when `fallbackStepFinalOutcome === "succeeded"`, preserves the original selected model across multi-hop fallback chains, and de-dupes the later final `fallback` notice for the same selected/active transition.
  - Transient `fallback_step` outcomes such as `next_fallback` and `chain_exhausted` are not announced as successful fallback notices, and intermediate failed fallback candidates are not reported as the originally selected model.
  - Existing ACP `fallback` / `fallback_cleared` lifecycle handling remains intact.
  - Cron/isolated payload normalization preserves leading `isFallbackNotice` payloads when final assistant-visible text replaces ordinary streamed text.
- What did **not** change: no Z.AI endpoint handling, provider fallback selection, retry/backoff behavior, provider transport/dispatcher defaults, public provider schema/config, or new `fetchOptions` contract.
- Refs #94919. This is intentionally a partial fix for async fallback-notice propagation only; the broader provider connection/transport-policy portion remains out of scope.

## What Problem This Solves

When fallback from the selected model to a configured runtime fallback already happened, the fallback notice was authored by the runner but could be lost at async delivery boundaries. The fix keeps the source-of-truth fallback decision in the runner and projects the existing notice metadata through the async-visible boundaries that were dropping it: ACP child lifecycle events to parent stream, and cron/isolated final-output normalization.

## User impact

A user who starts an ACP/sub-agent, cron, or isolated async run can now see the model-swap notice in the async-visible parent/result path instead of discovering the fallback only from changed model behavior, style, or logs.

## Root Cause

- **Root cause:** The fallback decision path was not the broken source of truth. The runner can produce fallback lifecycle metadata and user-facing fallback notices, but async delivery boundaries did not reliably carry that status to the user who triggered the async work.
- **Why this is root-cause fix:** The patch fixes the source async projection owners directly: ACP child lifecycle metadata is projected into the parent stream, and cron/isolated final-output normalization preserves the existing fallback notice payload before final delivery. It does not add Z.AI-specific handling, downstream string scraping, or provider transport changes.

Details:

- ACP parent relays only handled the legacy/final `fallback` lifecycle event and missed the production `fallback_step` events emitted as the fallback chain transitions.
- `fallback_step` consumers must distinguish candidate handoffs from success: `next_fallback` only means another candidate is about to be tried, while `succeeded` confirms the active fallback model served the turn. The relay therefore announces only `succeeded` fallback steps, and it carries the original selected model/first failure summary through the chain so a multi-hop fallback does not present an intermediate failed candidate as the user-selected model.
- Cron/isolated final-output normalization could replace streamed text with `finalAssistantVisibleText` and drop a leading fallback notice payload.

## Evidence

## Real behavior proof

- **Behavior or issue addressed:** A configured model fallback inside an ACP/sub-agent async run now reaches the triggering parent session as the existing `↪️ Model Fallback: ...` notice.
- **Real environment tested:** PR worktree after sync with current `origin/main`; Node v22.19.0 via `npx -y node@22.19.0`; production `runWithModelFallback`, `startAcpSpawnParentStreamRelay`, `emitAgentEvent`, and system-event queue modules from this checkout; deterministic local proof candidates `proof-fail/fail-model` and `proof-ok/ok-model`.
- **Exact steps or command run after this patch:**
  ```sh
  cd <pr-worktree>
  npx -y node@22.19.0 --import tsx <ACP fallback-step proof>
  ```
- **Evidence after fix:** The proof recorded primary attempt `proof-fail/fail-model`, fallback attempt `proof-ok/ok-model`, real `fallback_step` fields from the fallback runner, and a parent-visible system event containing `codex: ↪️ Model Fallback: proof-ok/ok-model (selected proof-fail/fail-model; timeout)`.
- **Observed result after fix:** The fallback runner completed on `proof-ok/ok-model`. It emitted both `next_fallback` and `succeeded` step outcomes, but the ACP parent session received exactly one fallback notice from the `succeeded` step; the transient `next_fallback` handoff did not produce a success-looking parent notice. The multi-hop regression additionally proves A -> B `next_fallback`, B -> C `succeeded`, and a later final A -> C `fallback` event produce exactly one notice that preserves selected A rather than intermediate B.
- **What was not tested:** No hosted cron/gateway deployment proof and no live credentialed Z.AI outage reproduction were run in this contributor environment. Provider transport/fetch-options policy was not changed or tested.
- **Why it matters / User impact:** Users who trigger async child work can see that OpenClaw switched away from their selected model instead of only seeing a final answer with different model behavior and no visible fallback explanation.
- **Patch quality notes:** The proof and tests use fallback/timeout strings because those are the actual status lifecycle terms and expected user-visible notice text; they are not new retry logic, broad fallback masking, or a downstream text-scraping workaround. The relay treats `fallback_step` as structured lifecycle data and only projects confirmed success outcomes to the parent.

The strongest proof run after this patch exercises the production fallback-step source and the ACP parent relay together:

```sh
cd <pr-worktree>
npx -y node@22.19.0 --import tsx <ACP fallback-step proof>
```

The proof uses `runWithModelFallback` from this checkout with deterministic local candidates:

- selected model: `proof-fail/fail-model`
- fallback model: `proof-ok/ok-model`
- the selected model throws a structured timeout failover error
- the fallback model completes successfully
- `onFallbackStep` forwards the real runner step fields as `stream: "lifecycle"`, `phase: "fallback_step"` into `startAcpSpawnParentStreamRelay`
- the parent session system-event queue is drained and asserted

Key result excerpts:

```json
"attempts": ["proof-fail/fail-model", "proof-ok/ok-model"],
"result": {
  "outcome": "completed",
  "provider": "proof-ok",
  "model": "ok-model",
  "result": "winner=proof-ok/ok-model"
},
"steps": [
  {
    "fallbackStepType": "fallback_step",
    "fallbackStepFromModel": "proof-fail/fail-model",
    "fallbackStepToModel": "proof-ok/ok-model",
    "fallbackStepFromFailureReason": "timeout",
    "fallbackStepFinalOutcome": "next_fallback"
  },
  {
    "fallbackStepType": "fallback_step",
    "fallbackStepFromModel": "proof-fail/fail-model",
    "fallbackStepToModel": "proof-ok/ok-model",
    "fallbackStepFromFailureReason": "timeout",
    "fallbackStepFinalOutcome": "succeeded"
  }
],
"events": [
  {
    "text": "Started codex session agent:codex:acp:child-proof-95370. Streaming progress updates to parent session."
  },
  {
    "text": "codex: ↪️ Model Fallback: proof-ok/ok-model (selected proof-fail/fail-model; timeout)",
    "contextKey": "acp-spawn:live-proof-acp-19024:fallback"
  }
]
```

The proof ended with:

```text
ACP_FALLBACK_STEP_LIVE_PROOF_OK
```

The model fallback decision log for the same proof showed the primary failure and fallback success:

```text
model fallback decision: decision=candidate_failed requested=proof-fail/fail-model candidate=proof-fail/fail-model reason=timeout next=proof-ok/ok-model detail=Connection error.
model fallback decision: decision=candidate_succeeded requested=proof-fail/fail-model candidate=proof-ok/ok-model reason=unknown next=none
```

This proves the previously missing async path: a production fallback runner step becomes a parent-visible ACP/sub-agent notice for the triggering session only after the fallback destination is confirmed successful.

## Validation

All validation commands were run from the PR worktree after syncing with current `origin/main` and applying the repair.

```sh
node scripts/run-vitest.mjs src/agents/acp-spawn-parent-stream.test.ts src/cron/isolated-agent.helpers.test.ts
```

Result: passed.

```sh
node scripts/run-oxlint.mjs src/agents/acp-spawn-parent-stream.ts src/agents/acp-spawn-parent-stream.test.ts src/cron/isolated-agent/helpers.ts src/cron/isolated-agent.helpers.test.ts
```

Result: passed.

```sh
pnpm check:test-types
```

Result: passed. The only notable output was the existing local Node engine warning (`wanted >=22.19.0`, local shell had `v22.17.0`) before both test typecheck projects completed.

```sh
pnpm tsgo:core
```

Result: passed with the same local Node engine warning only.

```sh
git diff --check
```

Result: passed.

## Review findings addressed

- **RF-001:** The current `status: ⏳ waiting on author` label is addressed by the code/test updates and refreshed PR body evidence below; no manual label mutation was performed.
- **RF-002 / RF-003 / RF-004 / RF-007:** Multi-hop fallback-step notices now preserve the original selected model and first-failure summary across the chain, and de-dupe the later final fallback lifecycle event by selected/active transition. The regression includes A -> B `next_fallback`, B -> C `succeeded`, and the later final A -> C `fallback` lifecycle event, and asserts the parent receives one notice for C selected from A rather than an intermediate B notice or a duplicate final notice.
- **RF-005 / RF-006:** The fallback notice audience policy remains a maintainer/product decision. This implementation only surfaces the already-authored fallback status at the async parent/result boundary, avoids adding any new external provider transport policy or schema, and keeps the broader audience decision visible for maintainer review.
- **RF-008:** `node scripts/run-vitest.mjs src/agents/acp-spawn-parent-stream.test.ts src/cron/isolated-agent.helpers.test.ts` passed after the latest repair.
- **RF-009:** `node scripts/run-oxlint.mjs src/agents/acp-spawn-parent-stream.ts src/agents/acp-spawn-parent-stream.test.ts src/cron/isolated-agent/helpers.ts src/cron/isolated-agent.helpers.test.ts` passed after the latest repair.
- **RF-010:** `git diff --check` passed after the latest repair.
- **Original async-proof findings:** Added production-shape async proof. The proof uses `runWithModelFallback` to emit real `fallback_step` fields, forwards them through the ACP child-to-parent relay, and confirms the triggering parent session receives `codex: ↪️ Model Fallback: proof-ok/ok-model (selected proof-fail/fail-model; timeout)`.
- **Original scope finding:** Replaced closing issue language with a non-closing reference and explicitly scoped this PR to fallback-notice propagation only. This PR does not claim to complete the broader provider connection/transport-policy request in #94919.

## Regression Test Plan

- **Target test file:** `src/agents/acp-spawn-parent-stream.test.ts` covers ACP child-to-parent stream relay; `src/cron/isolated-agent.helpers.test.ts` covers cron/isolated payload normalization.
- **Scenario locked in:** A production `phase: "fallback_step"` lifecycle event with `fallbackStepFromModel`, `fallbackStepToModel`, `fallbackStepFromFailureReason`, and `fallbackStepFinalOutcome: "succeeded"` emits the formatted fallback notice to the parent session; a later same-transition final `fallback` lifecycle event is not duplicated. A multi-hop regression emits A -> B `next_fallback`, B -> C `succeeded`, and then final A -> C `fallback`, and asserts only the successful C destination notice is visible with selected A preserved. A leading `isFallbackNotice` payload remains in cron/isolated `deliveryPayloads` when `finalAssistantVisibleText` replaces ordinary text payloads.
- **Why this is the smallest reliable guardrail:** The regressions exercise the exact async boundary functions that dropped visibility, without requiring flaky external provider failures or live credentials. They fail if future code again treats fallback notices as child-local text during ACP parent stream relay, treats transient fallback handoffs as successful active-model notices, reports an intermediate failed fallback candidate as the original selected model, duplicates the final fallback lifecycle notice, or drops cron fallback notices during output selection.

## Scope boundary and source of truth

- **Fix classification:** Root cause fix.
- **Maintainer-ready confidence:** High for fallback notice propagation; medium for the broader #94919 issue because provider connection/transport policy is intentionally not implemented here.
- **Scope boundary:** This PR is limited to async notice projection/delivery. It does not change provider fallback decisions, auth, retry/backoff, endpoint selection, dispatcher defaults, config schema, public provider config, or any provider `fetchOptions` contract.
- **Architecture / source-of-truth check:** Source of truth for fallback decisions remains in the model fallback runner and fallback state code. ACP relay now projects runner lifecycle metadata to the parent session only after a fallback step confirms success, while carrying the chain's original selected model/first failure summary so the notice matches the final fallback transition rather than an intermediate candidate. Cron payload outcome now preserves existing fallback-notice payload metadata before final delivery. No downstream text scraping or provider-specific special casing was added.
- **Related open PR scan / public contract boundary:** The issue discussion also mentions guarded provider connection/transport policy. That is a separate public config/schema/transport contract question and remains out of scope for this PR; this patch does not overlap those schema/API decisions.

## Patch quality notes

- The added `fallback` and `timeout` strings are regression fixtures and expected user-visible status text, not new retry/default/fallback masking.
- The new `undefined` returns only skip malformed lifecycle payloads or non-success fallback-step outcomes that should not be formatted as successful fallback notices; they do not hide provider failures or alter fallback selection.
- The parent-visible fallback-step notice uses the structured fallback reason (`timeout`, `rate limit`, etc.) and does not expose arbitrary provider error detail text in the system event.
- Duplicate suppression is scoped to identical fallback notice text in one ACP relay, so a later lifecycle event cannot spam the same parent notice while distinct fallback transitions can still be surfaced.
- The multi-hop regression protects against the exact review concerns: a candidate that is merely about to be tried is not announced as the active fallback model, an intermediate failed fallback candidate is not presented as the user's selected model, and the later final fallback lifecycle event does not duplicate the parent notice for the same selected/active transition.

## Merge risk

- **Risk labels considered:** message-delivery, session-state, compatibility, security-boundary.
- **Risk explanation:** Message-delivery/session-state risk is real because this intentionally adds parent-visible status events and preserves fallback notice payloads in async delivery results. Compatibility risk is limited to surfacing a notice OpenClaw already generates, and only for confirmed fallback-success lifecycle steps. Security-boundary risk was reviewed because the issue also suggests provider transport config, but this PR does not add config/schema/dispatcher behavior or change SSRF/pinned dispatcher code.
- **Why acceptable:** The diff is focused to async projection/delivery boundaries and adds no new provider API surface. It only moves an already-authored internal status notice to the user-visible async surface, with tests and production-shape proof showing the notice is preserved, formatted, gated to successful fallback destinations, and de-duplicated against the final fallback lifecycle event.

## Not tested / out of scope

- I did not run a hosted cron/gateway deployment proof or a live credentialed Z.AI outage reproduction in this contributor environment.
- I did not change or validate any public provider transport/fetch-options contract.
- The deterministic proof avoids external network flakiness while still exercising the production fallback runner step generation and ACP parent relay delivery path that this PR changes.
