### PR TITLE
feat(telegram): add isolatedIngress config switch

### DIFF
--- a/extensions/telegram/src/config-ui-hints.ts
+++ b/extensions/telegram/src/config-ui-hints.ts
@@ -6,6 +6,10 @@ export const telegramChannelConfigUiHints = {
     label: "Telegram",
     help: "Telegram channel provider configuration including auth tokens, retry behavior, and message rendering controls. Use this section to tune bot behavior for Telegram-specific API semantics.",
   },
+  isolatedIngress: {
+    label: "Telegram Isolated Ingress",
+    help: "When false, disables isolated polling ingress for this account and falls back to legacy main-thread polling. Default: true.",
+  },
   customCommands: {
     label: "Telegram Custom Commands",
     help: "Additional Telegram bot menu commands (merged with native; conflicts ignored).",

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -299,7 +299,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         stallThresholdMs: account.config.pollingStallThresholdMs,
         setStatus: opts.setStatus,
         isolatedIngress: {
-          enabled: opts.isolatedIngress?.enabled ?? true,
+          enabled: account.config.isolatedIngress ?? true,
           apiRoot: account.config.apiRoot,
           timeoutSeconds: account.config.timeoutSeconds,
           proxy: account.config.proxy,

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -109,6 +109,8 @@ export type TelegramAccountConfig = {
   execApprovals?: TelegramExecApprovalConfig;
   /** Markdown formatting overrides (tables). */
   markdown?: MarkdownConfig;
+  /** When false, disables isolated polling ingress and falls back to legacy main-thread polling. Default: true. */
+  isolatedIngress?: boolean;
   /** Override native command registration for Telegram (bool or "auto"). */
   commands?: ProviderCommandsConfig;
   /** Custom commands to register in Telegram's command menu (merged with native). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -263,6 +263,12 @@ export const TelegramAccountSchemaBase = z
     enabled: z.boolean().optional(),
     commands: ProviderCommandsSchema,
     customCommands: z.array(TelegramCustomCommandSchema).optional(),
+    isolatedIngress: z
+      .boolean()
+      .optional()
+      .describe(
+        "When false, disables isolated polling ingress for this account. Falls back to legacy main-thread polling. Default: true.",
+      ),
     configWrites: z.boolean().optional(),
     dmPolicy: DmPolicySchema.optional().default("pairing"),
     botToken: SecretInputSchema.optional().register(sensitive),


### PR DESCRIPTION
Closes #95335

Adds a user-facing config switch to disable the isolated polling ingress for Telegram. When set to false, falls back to legacy main-thread polling.

Changes:
- Config schema accepts `isolatedIngress: boolean` at channel/account level
- Monitor reads config value instead of defaulting to `true`
- Config types and UI hints updated
- Default remains `true` for backward compatibility