### PR TITLE
fix(telegram): parse direct thread session keys

### DIFF
--- a/extensions/telegram/session-key-api.ts
+++ b/extensions/telegram/session-key-api.ts
@@ -1,2 +1,6 @@
 // Telegram API module exposes the plugin public contract.
-export { resolveTelegramSessionConversation as resolveSessionConversation } from "./src/session-conversation.js";
+export {
+  parseTelegramDirectSessionKey,
+  resolveTelegramSessionConversation as resolveSessionConversation,
+  type ParsedTelegramDirectSessionKey,
+} from "./src/session-conversation.js";

--- a/extensions/telegram/src/session-conversation.test.ts
+++ b/extensions/telegram/src/session-conversation.test.ts
@@ -1,6 +1,7 @@
 // Telegram tests cover session conversation plugin behavior.
 import { describe, expect, it } from "vitest";
 import {
+  parseTelegramDirectSessionKey,
   resolveTelegramSessionConversation,
   resolveTelegramSessionTarget,
 } from "./session-conversation.js";
@@ -35,6 +36,48 @@ describe("resolveTelegramSessionConversation", () => {
         rawId: "-1001",
       }),
     ).toBeNull();
+  });
+});
+
+describe("parseTelegramDirectSessionKey", () => {
+  it("parses direct sessions with optional DM topic suffixes", () => {
+    expect(parseTelegramDirectSessionKey("agent:31:telegram:direct:172724380")).toEqual({
+      agentId: "31",
+      baseSessionKey: "agent:31:telegram:direct:172724380",
+      chatId: "172724380",
+    });
+    expect(
+      parseTelegramDirectSessionKey("agent:31:telegram:direct:172724380:thread:172724380:440162"),
+    ).toEqual({
+      agentId: "31",
+      baseSessionKey: "agent:31:telegram:direct:172724380",
+      chatId: "172724380",
+      messageThreadId: 440162,
+      threadId: "172724380:440162",
+    });
+  });
+
+  it("parses account-scoped direct sessions and raw parsed rest values", () => {
+    expect(
+      parseTelegramDirectSessionKey("agent:31:telegram:personal:direct:172724380:thread:440162"),
+    ).toEqual({
+      accountId: "personal",
+      agentId: "31",
+      baseSessionKey: "agent:31:telegram:personal:direct:172724380",
+      chatId: "172724380",
+      messageThreadId: 440162,
+      threadId: "440162",
+    });
+    expect(parseTelegramDirectSessionKey("telegram:direct:172724380:thread:440162")).toEqual({
+      baseSessionKey: "telegram:direct:172724380",
+      chatId: "172724380",
+      messageThreadId: 440162,
+      threadId: "440162",
+    });
+  });
+
+  it("rejects non-direct Telegram sessions", () => {
+    expect(parseTelegramDirectSessionKey("agent:31:telegram:group:-1001:topic:7")).toBeNull();
   });
 });
 

--- a/extensions/telegram/src/session-conversation.ts
+++ b/extensions/telegram/src/session-conversation.ts
@@ -1,6 +1,20 @@
 // Telegram plugin module implements session conversation behavior.
+import { parseAgentSessionKey, parseThreadSessionSuffix } from "openclaw/plugin-sdk/routing";
+import { parseTelegramThreadId } from "./outbound-params.js";
 import { normalizeTelegramChatId, normalizeTelegramLookupTarget } from "./targets.js";
 import { parseTelegramTopicConversation } from "./topic-conversation.js";
+
+export type ParsedTelegramDirectSessionKey = {
+  agentId?: string;
+  accountId?: string;
+  baseSessionKey: string;
+  chatId: string;
+  messageThreadId?: number;
+  threadId?: string;
+};
+
+const TELEGRAM_DIRECT_SESSION_RE =
+  /^telegram:(?:(?<accountId>[a-z0-9][a-z0-9_-]{0,63}):)?direct:(?<chatId>-?\d+)$/i;
 
 export function resolveTelegramSessionConversation(params: {
   kind: "group" | "channel";
@@ -15,6 +29,32 @@ export function resolveTelegramSessionConversation(params: {
     threadId: parsed.topicId,
     baseConversationId: parsed.chatId,
     parentConversationCandidates: [parsed.chatId],
+  };
+}
+
+export function parseTelegramDirectSessionKey(
+  sessionKey: string | undefined | null,
+): ParsedTelegramDirectSessionKey | null {
+  const parsedAgent = parseAgentSessionKey(sessionKey);
+  const rest = parsedAgent?.rest ?? sessionKey?.trim();
+  if (!rest) {
+    return null;
+  }
+  const thread = parseThreadSessionSuffix(rest);
+  const baseRest = thread.baseSessionKey ?? rest;
+  const match = TELEGRAM_DIRECT_SESSION_RE.exec(baseRest);
+  const chatId = match?.groups?.chatId;
+  if (!chatId) {
+    return null;
+  }
+  const messageThreadId = thread.threadId ? parseTelegramThreadId(thread.threadId) : undefined;
+  return {
+    ...(parsedAgent ? { agentId: parsedAgent.agentId } : {}),
+    ...(match.groups?.accountId ? { accountId: match.groups.accountId } : {}),
+    baseSessionKey: parsedAgent ? `agent:${parsedAgent.agentId}:${baseRest}` : baseRest,
+    chatId,
+    ...(thread.threadId ? { threadId: thread.threadId } : {}),
+    ...(messageThreadId !== undefined ? { messageThreadId } : {}),
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Telegram DM topic session keys include a generic thread suffix, e.g. `agent:31:telegram:direct:172724380:thread:172724380:440162`. Plugin hooks that need the Telegram direct peer currently have to hand-roll parsing; exact matches for `telegram:direct:<chatId>` miss DM-topic sessions and can route replies to the wrong agent/session.

## Why This Change Was Made

Adds a Telegram-owned `parseTelegramDirectSessionKey` helper on the existing `session-key-api` public artifact. This keeps Telegram-specific direct/account/thread parsing out of generic session-key code and reuses the existing agent-session and thread-suffix helpers instead of expanding broad core parsing.

## User Impact

Downstream Telegram hooks can parse both normal direct sessions and DM-topic direct sessions with the same helper, preserving per-user/per-topic routing without one-off regexes.

## Evidence

- `pnpm test extensions/telegram/src/bot-message-context.dm-threads.test.ts extensions/telegram/src/conversation-route.base-session-key.test.ts extensions/telegram/src/session-conversation.test.ts`
- `pnpm format:check extensions/telegram/session-key-api.ts extensions/telegram/src/session-conversation.ts extensions/telegram/src/session-conversation.test.ts`
- `pnpm build`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review this small Telegram public session-key parser change. Context: private reply_dispatch hooks were matching parseAgentSessionKey(...).rest against ^telegram:direct:<chatId>$ and missed DM-topic keys like agent:31:telegram:direct:172724380:thread:172724380:440162. Check whether adding parseTelegramDirectSessionKey to the Telegram session-key public API is the right upstream seam versus changing generic direct/thread parsing."` — clean, no accepted/actionable findings.
