### PR TITLE
feat(requesty): add Requesty as a bundled provider plugin

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1457,6 +1457,7 @@
                   "providers/qianfan",
                   "providers/qwen",
                   "providers/qwen-oauth",
+                  "providers/requesty",
                   "providers/runway",
                   "providers/senseaudio",
                   "providers/sglang",

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-72 plugins
+73 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -148,6 +148,8 @@ Each entry lists the package, distribution route, and description.
 - **[openrouter](/plugins/reference/openrouter)** (`@openclaw/openrouter-provider`) - included in OpenClaw. Adds OpenRouter model provider support to OpenClaw.
 
 - **[policy](/plugins/reference/policy)** (`@openclaw/policy`) - included in OpenClaw. Adds policy-backed doctor checks for workspace conformance.
+
+- **[requesty](/plugins/reference/requesty)** (`@openclaw/requesty-provider`) - included in OpenClaw. Adds Requesty model provider support to OpenClaw.
 
 - **[runway](/plugins/reference/runway)** (`@openclaw/runway-provider`) - included in OpenClaw. Adds video generation provider support.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 128
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 129
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/requesty.md
+++ b/docs/plugins/reference/requesty.md
@@ -1,0 +1,19 @@
+---
+summary: "Adds Requesty model provider support to OpenClaw."
+read_when:
+  - You are installing, configuring, or auditing the requesty plugin
+title: "Requesty plugin"
+---
+
+# Requesty plugin
+
+Adds Requesty model provider support to OpenClaw.
+
+## Distribution
+
+- Package: `@openclaw/requesty-provider`
+- Install route: included in OpenClaw
+
+## Surface
+
+providers: requesty

--- a/docs/providers/requesty.md
+++ b/docs/providers/requesty.md
@@ -1,0 +1,99 @@
+---
+summary: "Use Requesty's unified API to access many models in OpenClaw"
+read_when:
+  - You want a single API key for many LLMs
+  - You want to run models via Requesty in OpenClaw
+title: "Requesty"
+---
+
+[Requesty](https://requesty.ai) provides a **unified API** that routes requests to many models
+behind a single endpoint and API key. It is OpenAI-compatible, so most OpenAI SDKs work by
+switching the base URL to `https://router.requesty.ai/v1`.
+
+See the [Requesty docs](https://docs.requesty.ai) for the full provider and model catalog.
+
+## Getting started
+
+<Steps>
+  <Step title="Get your API key">
+    Create an API key at [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys).
+  </Step>
+  <Step title="Run API-key onboarding">
+    ```bash
+    openclaw onboard --auth-choice requesty-api-key
+    ```
+  </Step>
+  <Step title="(Optional) Switch to a specific model">
+    Onboarding defaults to `requesty/openai/gpt-4o`. Pick a concrete model later:
+
+    ```bash
+    openclaw models set requesty/<provider>/<model>
+    ```
+
+  </Step>
+</Steps>
+
+## Config example
+
+```json5
+{
+  env: { REQUESTY_API_KEY: "rqsty-sk-..." },
+  agents: {
+    defaults: {
+      model: { primary: "requesty/openai/gpt-4o" },
+    },
+  },
+}
+```
+
+## Model references
+
+<Note>
+Model refs follow the pattern `requesty/<provider>/<model>`. Browse the available models at
+[app.requesty.ai/router/list](https://app.requesty.ai/router/list) or fetch them from the
+OpenAI-compatible `https://router.requesty.ai/v1/models` endpoint.
+</Note>
+
+Bundled fallback examples:
+
+| Model ref                              | Notes                          |
+| -------------------------------------- | ------------------------------ |
+| `requesty/openai/gpt-4o`               | OpenAI GPT-4o via Requesty     |
+| `requesty/anthropic/claude-sonnet-4-5` | Claude Sonnet 4.5 via Requesty |
+| `requesty/google/gemini-2.5-flash`     | Gemini 2.5 Flash via Requesty  |
+
+Any other `requesty/<provider>/<model>` ref the router accepts also resolves dynamically.
+OpenClaw reads per-model capabilities (reasoning, vision, tool calling, context window) from
+Requesty's `/v1/models` payload when an API key is configured, so reasoning-capable models keep
+their reasoning support.
+
+## Authentication and headers
+
+Requesty uses a Bearer token with your API key. OpenClaw stores it in the `requesty:default`
+API-key auth profile. For an existing install, rotate the stored key without rerunning full
+onboarding:
+
+```bash
+openclaw models auth login --provider requesty --method api-key
+```
+
+## Base URL
+
+The OpenAI-compatible base URL is `https://router.requesty.ai/v1`. OpenClaw canonicalizes the
+bare host (`https://router.requesty.ai`) onto this `/v1` base.
+
+<Warning>
+If you repoint the Requesty provider at some other proxy or base URL, OpenClaw does **not** apply
+the Requesty-specific transport normalization.
+</Warning>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Configuration reference" href="/gateway/configuration-reference" icon="gear">
+    Full config reference for agents, models, and providers.
+  </Card>
+</CardGroup>

--- a/extensions/requesty/index.test.ts
+++ b/extensions/requesty/index.test.ts
@@ -1,0 +1,157 @@
+// Requesty tests cover index plugin behavior.
+import fs from "node:fs";
+import {
+  registerSingleProviderPlugin,
+  resolveProviderPluginChoice,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { expectPassthroughReplayPolicy } from "openclaw/plugin-sdk/provider-test-contracts";
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+import {
+  buildRequestyProvider,
+  normalizeRequestyBaseUrl,
+  projectRequestyModelCapabilities,
+  REQUESTY_BASE_URL,
+  REQUESTY_DEFAULT_MODEL_ID,
+} from "./provider-catalog.js";
+
+type RequestyManifest = {
+  providerAuthChoices?: Array<Record<string, unknown>>;
+};
+
+function readManifest(): RequestyManifest {
+  return JSON.parse(
+    fs.readFileSync(new URL("./openclaw.plugin.json", import.meta.url), "utf8"),
+  ) as RequestyManifest;
+}
+
+async function registerRequestyProvider() {
+  return registerSingleProviderPlugin(plugin);
+}
+
+describe("requesty provider hooks", () => {
+  it("registers the requesty provider with correct metadata", async () => {
+    const provider = await registerRequestyProvider();
+
+    expect(provider.id).toBe("requesty");
+    expect(provider.label).toBe("Requesty");
+    expect(provider.envVars).toEqual(["REQUESTY_API_KEY"]);
+  });
+
+  it("registers API-key auth choice metadata aligned with the manifest", async () => {
+    const provider = await registerRequestyProvider();
+
+    expect(provider.auth?.map((method) => method.id)).toEqual(["api-key"]);
+
+    const choice = resolveProviderPluginChoice({
+      providers: [provider],
+      choice: "requesty-api-key",
+    });
+    expect(choice?.provider.id).toBe("requesty");
+    expect(choice?.method.id).toBe("api-key");
+    expect(readManifest().providerAuthChoices).toStrictEqual([
+      {
+        provider: "requesty",
+        method: "api-key",
+        choiceId: "requesty-api-key",
+        choiceLabel: "Requesty API key",
+        groupId: "requesty",
+        groupLabel: "Requesty",
+        groupHint: "API key",
+        onboardingScopes: ["text-inference"],
+        optionKey: "requestyApiKey",
+        cliFlag: "--requesty-api-key",
+        cliOption: "--requesty-api-key <key>",
+        cliDescription: "Requesty API key",
+      },
+    ]);
+  });
+
+  it("resolves the bare provider choice to the API-key method", async () => {
+    const provider = await registerRequestyProvider();
+
+    const bareChoice = resolveProviderPluginChoice({
+      providers: [provider],
+      choice: "requesty",
+    });
+    expect(bareChoice?.method.id).toBe("api-key");
+  });
+
+  it("exposes a canonical bundled catalog with the default model", () => {
+    const modelIds = buildRequestyProvider().models?.map((model) => model.id) ?? [];
+    expect(modelIds).toContain(REQUESTY_DEFAULT_MODEL_ID);
+    expect(buildRequestyProvider().baseUrl).toBe(REQUESTY_BASE_URL);
+    expect(buildRequestyProvider().api).toBe("openai-completions");
+  });
+
+  it("canonicalizes the bare host and /v1 base urls", () => {
+    expect(normalizeRequestyBaseUrl("https://router.requesty.ai")).toBe(REQUESTY_BASE_URL);
+    expect(normalizeRequestyBaseUrl("https://router.requesty.ai/v1/")).toBe(REQUESTY_BASE_URL);
+    expect(normalizeRequestyBaseUrl("https://example.com/v1")).toBeUndefined();
+  });
+
+  it("projects real per-model capabilities from a /v1/models row", () => {
+    const reasoningModel = projectRequestyModelCapabilities({
+      id: "anthropic/claude-sonnet-4-5",
+      object: "model",
+      supports_reasoning: true,
+      supports_vision: true,
+      supports_tool_calling: true,
+      context_window: 1_000_000,
+      max_output_tokens: 64_000,
+    });
+    expect(reasoningModel).toMatchObject({
+      reasoning: true,
+      input: ["text", "image"],
+      supportsTools: true,
+      contextWindow: 1_000_000,
+      maxTokens: 64_000,
+    });
+
+    const textModel = projectRequestyModelCapabilities({
+      id: "openai/gpt-4o-mini",
+      object: "model",
+      supports_reasoning: false,
+      supports_vision: false,
+      supports_tool_calling: true,
+      context_window: 128_000,
+      max_output_tokens: 16_384,
+    });
+    expect(textModel).toMatchObject({
+      reasoning: false,
+      input: ["text"],
+      supportsTools: true,
+    });
+  });
+
+  it("resolves arbitrary router model ids dynamically against the requesty base url", async () => {
+    const provider = await registerRequestyProvider();
+
+    const resolved = provider.resolveDynamicModel?.({
+      provider: "requesty",
+      modelId: "requesty/openai/gpt-4o-mini",
+      modelRegistry: { find: () => null },
+    } as never);
+
+    expect(resolved).toMatchObject({
+      id: "requesty/openai/gpt-4o-mini",
+      api: "openai-completions",
+      provider: "requesty",
+      baseUrl: REQUESTY_BASE_URL,
+    });
+  });
+
+  it("owns passthrough-gemini replay policy for Gemini-backed routes", async () => {
+    await expectPassthroughReplayPolicy({
+      plugin,
+      providerId: "requesty",
+      modelId: "google/gemini-2.5-pro",
+      sanitizeThoughtSignatures: true,
+    });
+    await expectPassthroughReplayPolicy({
+      plugin,
+      providerId: "requesty",
+      modelId: "openai/gpt-4o",
+    });
+  });
+});

--- a/extensions/requesty/index.ts
+++ b/extensions/requesty/index.ts
@@ -1,0 +1,193 @@
+// Requesty plugin entrypoint registers its OpenClaw integration.
+import {
+  definePluginEntry,
+  type ProviderResolveDynamicModelContext,
+  type ProviderRuntimeModel,
+  type ProviderWrapStreamFnContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import {
+  getCachedLiveProviderModelRows,
+  LiveModelCatalogHttpError,
+} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import {
+  DEFAULT_CONTEXT_TOKENS,
+  PASSTHROUGH_GEMINI_REPLAY_HOOKS,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import { buildProviderStreamFamilyHooks } from "openclaw/plugin-sdk/provider-stream-family";
+import { normalizeRequestyApiModelId } from "./models.js";
+import { applyRequestyConfig, REQUESTY_DEFAULT_MODEL_REF } from "./onboard.js";
+import {
+  buildRequestyProvider,
+  normalizeRequestyBaseUrl,
+  projectRequestyModelCapabilities,
+  REQUESTY_BASE_URL,
+  REQUESTY_FALLBACK_CONTEXT_WINDOW,
+  REQUESTY_FALLBACK_COST,
+  REQUESTY_FALLBACK_MAX_OUTPUT,
+  REQUESTY_MODELS_URL,
+  type RequestyModelCapabilities,
+} from "./provider-catalog.js";
+
+const PROVIDER_ID = "requesty";
+const REQUESTY_MODEL_DISCOVERY_TTL_MS = 60_000;
+
+// Requesty is an OpenAI-compatible router, so the proxy-Gemini replay family and
+// the OpenRouter-style reasoning stream wrapper apply unchanged. Reuse the shared
+// family builders (the same ones the bundled openrouter/kilocode/opencode plugins
+// use) instead of re-implementing provider-local wrappers.
+const REQUESTY_THINKING_STREAM_HOOKS = buildProviderStreamFamilyHooks("openrouter-thinking");
+
+// Per-id capability cache populated by prepareDynamicModel via the live
+// `/v1/models` payload, so resolveDynamicModel can stay synchronous.
+const requestyModelCapabilitiesById = new Map<string, RequestyModelCapabilities>();
+
+function readRequestyModelId(row: unknown): string | undefined {
+  if (!row || typeof row !== "object" || Array.isArray(row)) {
+    return undefined;
+  }
+  const candidate = (row as { id?: unknown }).id;
+  return typeof candidate === "string" && candidate.trim().length > 0
+    ? candidate.trim()
+    : undefined;
+}
+
+async function loadRequestyModelCapabilities(apiModelId: string, apiKey?: string): Promise<void> {
+  if (!apiKey || requestyModelCapabilitiesById.has(apiModelId)) {
+    return;
+  }
+  try {
+    const rows = await getCachedLiveProviderModelRows({
+      providerId: PROVIDER_ID,
+      endpoint: REQUESTY_MODELS_URL,
+      apiKey,
+      ttlMs: REQUESTY_MODEL_DISCOVERY_TTL_MS,
+      auditContext: "requesty-model-discovery",
+    });
+    for (const row of rows) {
+      const rowId = readRequestyModelId(row);
+      const capabilities = projectRequestyModelCapabilities(row);
+      if (rowId && capabilities) {
+        requestyModelCapabilitiesById.set(rowId, capabilities);
+      }
+    }
+  } catch (error) {
+    // Capability discovery is advisory. Fall back to sensible defaults when the
+    // router is unreachable or returns an unexpected body.
+    if (!(error instanceof LiveModelCatalogHttpError)) {
+      throw error;
+    }
+  }
+}
+
+export default definePluginEntry({
+  id: PROVIDER_ID,
+  name: "Requesty Provider",
+  description: "Bundled Requesty provider plugin",
+  register(api) {
+    function buildDynamicRequestyModel(
+      ctx: ProviderResolveDynamicModelContext,
+    ): ProviderRuntimeModel {
+      const apiModelId = normalizeRequestyApiModelId(ctx.modelId) ?? ctx.modelId;
+      const capabilities = requestyModelCapabilitiesById.get(apiModelId);
+      return {
+        id: ctx.modelId,
+        name: capabilities?.name ?? ctx.modelId,
+        api: "openai-completions",
+        provider: PROVIDER_ID,
+        baseUrl: REQUESTY_BASE_URL,
+        reasoning: capabilities?.reasoning ?? false,
+        input: capabilities?.input ?? ["text"],
+        ...(capabilities?.supportsTools !== undefined
+          ? { compat: { supportsTools: capabilities.supportsTools } }
+          : {}),
+        cost: REQUESTY_FALLBACK_COST,
+        contextWindow: capabilities?.contextWindow ?? REQUESTY_FALLBACK_CONTEXT_WINDOW,
+        maxTokens: capabilities?.maxTokens ?? REQUESTY_FALLBACK_MAX_OUTPUT,
+      };
+    }
+
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "Requesty",
+      docsPath: "/providers/models",
+      envVars: ["REQUESTY_API_KEY"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: PROVIDER_ID,
+          methodId: "api-key",
+          label: "Requesty API key",
+          hint: "API key from app.requesty.ai/api-keys",
+          optionKey: "requestyApiKey",
+          flagName: "--requesty-api-key",
+          envVar: "REQUESTY_API_KEY",
+          promptMessage: "Enter Requesty API key",
+          defaultModel: REQUESTY_DEFAULT_MODEL_REF,
+          expectedProviders: [PROVIDER_ID],
+          applyConfig: (cfg) => applyRequestyConfig(cfg),
+          wizard: {
+            choiceId: "requesty-api-key",
+            choiceLabel: "Requesty API key",
+            groupId: "requesty",
+            groupLabel: "Requesty",
+            groupHint: "API key",
+            onboardingScopes: ["text-inference"],
+          },
+        }),
+      ],
+      catalog: {
+        order: "simple",
+        run: async (ctx) => {
+          const apiKey = ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+          if (!apiKey) {
+            return null;
+          }
+          return {
+            provider: {
+              ...buildRequestyProvider(),
+              apiKey,
+            },
+          };
+        },
+      },
+      staticCatalog: {
+        order: "simple",
+        run: async () => ({
+          provider: buildRequestyProvider(),
+        }),
+      },
+      resolveDynamicModel: (ctx) => buildDynamicRequestyModel(ctx),
+      prepareDynamicModel: async (ctx) => {
+        const resolveApiKey = (
+          ctx as {
+            resolveProviderApiKey?: (providerId?: string) => { apiKey: string | undefined };
+          }
+        ).resolveProviderApiKey;
+        const apiKey = resolveApiKey?.(PROVIDER_ID)?.apiKey;
+        await loadRequestyModelCapabilities(
+          normalizeRequestyApiModelId(ctx.modelId) ?? ctx.modelId,
+          apiKey,
+        );
+      },
+      normalizeConfig: ({ providerConfig }) => {
+        const normalizedBaseUrl = normalizeRequestyBaseUrl(providerConfig.baseUrl);
+        return normalizedBaseUrl && normalizedBaseUrl !== providerConfig.baseUrl
+          ? { ...providerConfig, baseUrl: normalizedBaseUrl }
+          : undefined;
+      },
+      normalizeTransport: ({ api: apiLocal, baseUrl }) => {
+        const normalizedBaseUrl = normalizeRequestyBaseUrl(baseUrl);
+        return normalizedBaseUrl && normalizedBaseUrl !== baseUrl
+          ? { api: apiLocal, baseUrl: normalizedBaseUrl }
+          : undefined;
+      },
+      ...PASSTHROUGH_GEMINI_REPLAY_HOOKS,
+      resolveReasoningOutputMode: () => "native",
+      isModernModelRef: () => true,
+      wrapStreamFn: (ctx: ProviderWrapStreamFnContext) =>
+        REQUESTY_THINKING_STREAM_HOOKS.wrapStreamFn?.(ctx) ?? ctx.streamFn,
+    });
+  },
+});
+
+export { DEFAULT_CONTEXT_TOKENS };

--- a/extensions/requesty/models.ts
+++ b/extensions/requesty/models.ts
@@ -1,0 +1,20 @@
+// Requesty plugin module implements model id normalization behavior.
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+const REQUESTY_MODEL_PREFIX = "requesty/";
+
+// Requesty routes to upstream models using the same `provider/model` id shape as
+// the upstream vendors (e.g. `openai/gpt-4o`, `anthropic/claude-sonnet-4-5`). The
+// bare `requesty/` qualifier is the OpenClaw provider prefix; strip it only when
+// the remainder is still a namespaced upstream id, mirroring the OpenRouter rule.
+export function normalizeRequestyApiModelId(modelId: unknown): string | undefined {
+  if (typeof modelId !== "string") {
+    return undefined;
+  }
+  const normalized = normalizeLowercaseStringOrEmpty(modelId);
+  if (!normalized.startsWith(REQUESTY_MODEL_PREFIX)) {
+    return normalized;
+  }
+  const unprefixed = normalized.slice(REQUESTY_MODEL_PREFIX.length);
+  return unprefixed.includes("/") ? unprefixed : normalized;
+}

--- a/extensions/requesty/onboard.test.ts
+++ b/extensions/requesty/onboard.test.ts
@@ -1,0 +1,28 @@
+// Requesty tests cover onboard plugin behavior.
+import {
+  expectProviderOnboardAllowlistAlias,
+  expectProviderOnboardPrimaryAndFallbacks,
+} from "openclaw/plugin-sdk/provider-test-contracts";
+import { describe, it } from "vitest";
+import {
+  applyRequestyConfig,
+  applyRequestyProviderConfig,
+  REQUESTY_DEFAULT_MODEL_REF,
+} from "./onboard.js";
+
+describe("requesty onboard", () => {
+  it("adds allowlist entry and preserves alias", () => {
+    expectProviderOnboardAllowlistAlias({
+      applyProviderConfig: applyRequestyProviderConfig,
+      modelRef: REQUESTY_DEFAULT_MODEL_REF,
+      alias: "Router",
+    });
+  });
+
+  it("sets primary model and preserves existing model fallbacks", () => {
+    expectProviderOnboardPrimaryAndFallbacks({
+      applyConfig: applyRequestyConfig,
+      modelRef: REQUESTY_DEFAULT_MODEL_REF,
+    });
+  });
+});

--- a/extensions/requesty/onboard.ts
+++ b/extensions/requesty/onboard.ts
@@ -1,0 +1,34 @@
+// Requesty setup module handles plugin onboarding behavior.
+import {
+  applyAgentDefaultModelPrimary,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import { REQUESTY_DEFAULT_MODEL_ID } from "./provider-catalog.js";
+
+export const REQUESTY_DEFAULT_MODEL_REF = `requesty/${REQUESTY_DEFAULT_MODEL_ID}`;
+
+export function applyRequestyProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[REQUESTY_DEFAULT_MODEL_REF] = {
+    ...models[REQUESTY_DEFAULT_MODEL_REF],
+    alias: models[REQUESTY_DEFAULT_MODEL_REF]?.alias ?? "Requesty",
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+  };
+}
+
+export function applyRequestyConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(
+    applyRequestyProviderConfig(cfg),
+    REQUESTY_DEFAULT_MODEL_REF,
+  );
+}

--- a/extensions/requesty/openclaw.plugin.json
+++ b/extensions/requesty/openclaw.plugin.json
@@ -1,0 +1,57 @@
+{
+  "id": "requesty",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["requesty"],
+  "modelIdNormalization": {
+    "providers": {
+      "requesty": {
+        "prefixWhenBare": "requesty"
+      }
+    }
+  },
+  "modelPricing": {
+    "providers": {
+      "requesty": {
+        "liteLLM": false
+      }
+    }
+  },
+  "providerEndpoints": [
+    {
+      "endpointClass": "openai-completions",
+      "hostSuffixes": ["requesty.ai"]
+    }
+  ],
+  "setup": {
+    "providers": [
+      {
+        "id": "requesty",
+        "envVars": ["REQUESTY_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "requesty",
+      "method": "api-key",
+      "choiceId": "requesty-api-key",
+      "choiceLabel": "Requesty API key",
+      "groupId": "requesty",
+      "groupLabel": "Requesty",
+      "groupHint": "API key",
+      "onboardingScopes": ["text-inference"],
+      "optionKey": "requestyApiKey",
+      "cliFlag": "--requesty-api-key",
+      "cliOption": "--requesty-api-key <key>",
+      "cliDescription": "Requesty API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/requesty/package.json
+++ b/extensions/requesty/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/requesty-provider",
+  "version": "2026.6.8",
+  "private": true,
+  "description": "OpenClaw Requesty provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/requesty/provider-catalog.ts
+++ b/extensions/requesty/provider-catalog.ts
@@ -1,0 +1,120 @@
+// Requesty provider module implements model/runtime integration.
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+/** Supported input modality for a Requesty-routed model. */
+export type RequestyModelInput = "text" | "image";
+
+export const REQUESTY_BASE_URL = "https://router.requesty.ai/v1";
+export const REQUESTY_MODELS_URL = "https://router.requesty.ai/v1/models";
+export const REQUESTY_DEFAULT_MODEL_ID = "openai/gpt-4o";
+
+export const REQUESTY_FALLBACK_CONTEXT_WINDOW = 128_000;
+export const REQUESTY_FALLBACK_MAX_OUTPUT = 8_192;
+export const REQUESTY_FALLBACK_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+} as const;
+
+function normalizeBaseUrl(baseUrl: string | undefined): string {
+  return (baseUrl ?? "").trim().replace(/\/+$/, "");
+}
+
+// Requesty documents both `/v1` and the bare host as a base. Canonicalize either
+// onto the `/v1` OpenAI-compatible base so transport, config, and runtime
+// metadata stay aligned.
+export function normalizeRequestyBaseUrl(baseUrl: string | undefined): string | undefined {
+  const normalized = normalizeBaseUrl(baseUrl);
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized === REQUESTY_BASE_URL || normalized === "https://router.requesty.ai") {
+    return REQUESTY_BASE_URL;
+  }
+  return undefined;
+}
+
+/** Per-model capability fields projected from the Requesty `/v1/models` payload. */
+export type RequestyModelCapabilities = {
+  name?: string;
+  reasoning: boolean;
+  input: RequestyModelInput[];
+  supportsTools?: boolean;
+  contextWindow?: number;
+  maxTokens?: number;
+};
+
+function readBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+function readPositiveInt(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+// Requesty's `/v1/models` rows expose capability booleans (supports_reasoning,
+// supports_vision, supports_tool_calling) and window sizes (context_window,
+// max_output_tokens). Map the real fields rather than assuming a fixed shape so
+// reasoning-capable upstream models (o-series, Claude extended thinking, etc.)
+// are not silently downgraded to non-reasoning.
+export function projectRequestyModelCapabilities(
+  row: unknown,
+): RequestyModelCapabilities | undefined {
+  if (!row || typeof row !== "object" || Array.isArray(row)) {
+    return undefined;
+  }
+  const record = row as Record<string, unknown>;
+  const input: RequestyModelInput[] = ["text"];
+  if (readBoolean(record.supports_vision)) {
+    input.push("image");
+  }
+  return {
+    name: readString(record.id),
+    reasoning: readBoolean(record.supports_reasoning),
+    input,
+    supportsTools: readBoolean(record.supports_tool_calling),
+    contextWindow: readPositiveInt(record.context_window),
+    maxTokens: readPositiveInt(record.max_output_tokens),
+  };
+}
+
+export function buildRequestyProvider(): ModelProviderConfig {
+  return {
+    baseUrl: REQUESTY_BASE_URL,
+    api: "openai-completions",
+    models: [
+      {
+        id: REQUESTY_DEFAULT_MODEL_ID,
+        name: "OpenAI: GPT-4o",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: REQUESTY_FALLBACK_COST,
+        contextWindow: 128_000,
+        maxTokens: 16_384,
+      },
+      {
+        id: "anthropic/claude-sonnet-4-5",
+        name: "Anthropic: Claude Sonnet 4.5",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: REQUESTY_FALLBACK_COST,
+        contextWindow: 1_000_000,
+        maxTokens: 64_000,
+      },
+      {
+        id: "google/gemini-2.5-flash",
+        name: "Google: Gemini 2.5 Flash",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: REQUESTY_FALLBACK_COST,
+        contextWindow: 1_048_576,
+        maxTokens: 65_536,
+      },
+    ],
+  };
+}

--- a/extensions/requesty/provider.contract.test.ts
+++ b/extensions/requesty/provider.contract.test.ts
@@ -1,0 +1,4 @@
+// Requesty tests cover provider runtime.contract plugin behavior.
+import { describeProviderContracts } from "openclaw/plugin-sdk/provider-test-contracts";
+
+describeProviderContracts("requesty");

--- a/extensions/requesty/requesty.live.test.ts
+++ b/extensions/requesty/requesty.live.test.ts
@@ -1,0 +1,87 @@
+// Requesty tests cover requesty plugin live behavior.
+import OpenAI from "openai";
+import { AuthStorage, ModelRegistry } from "openclaw/plugin-sdk/agent-sessions";
+import {
+  registerProviderPlugin,
+  requireRegisteredProvider,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+import { REQUESTY_BASE_URL } from "./provider-catalog.js";
+
+const REQUESTY_API_KEY = process.env.REQUESTY_API_KEY ?? "";
+const LIVE_MODEL_REF =
+  process.env.OPENCLAW_LIVE_REQUESTY_PLUGIN_MODEL?.trim() || "requesty/openai/gpt-4o-mini";
+const LIVE_MODEL_ID = LIVE_MODEL_REF.startsWith("requesty/")
+  ? LIVE_MODEL_REF
+  : `requesty/${LIVE_MODEL_REF}`;
+const liveEnabled = REQUESTY_API_KEY.trim().length > 0 && process.env.OPENCLAW_LIVE_TEST === "1";
+const describeLive = liveEnabled ? describe : describe.skip;
+const ModelRegistryCtor = ModelRegistry as unknown as {
+  new (authStorage: AuthStorage, modelsJsonPath?: string): ModelRegistry;
+};
+
+async function registerRequestyPlugin() {
+  return registerProviderPlugin({
+    plugin,
+    id: "requesty",
+    name: "Requesty Provider",
+  });
+}
+
+async function expectWeatherToolCall(client: OpenAI, model: string): Promise<void> {
+  const response = await client.chat.completions.create({
+    model,
+    messages: [{ role: "user", content: "Call get_weather for Paris." }],
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "get_weather",
+          description: "Get the weather for a city.",
+          parameters: {
+            type: "object",
+            properties: { city: { type: "string" } },
+            required: ["city"],
+            additionalProperties: false,
+          },
+        },
+      },
+    ],
+    tool_choice: { type: "function", function: { name: "get_weather" } },
+    max_tokens: 64,
+  });
+
+  const toolCall = response.choices[0]?.message?.tool_calls?.find(
+    (call) => call.type === "function",
+  );
+  expect(toolCall?.type).toBe("function");
+  expect(toolCall?.function.name).toBe("get_weather");
+  expect(JSON.parse(toolCall?.function.arguments ?? "{}")).toMatchObject({ city: "Paris" });
+}
+
+describeLive("requesty plugin live", () => {
+  it("resolves a router model and completes a live tool call", async () => {
+    const { providers } = await registerRequestyPlugin();
+    const provider = requireRegisteredProvider(providers, "requesty");
+
+    const resolved = provider.resolveDynamicModel?.({
+      provider: "requesty",
+      modelId: LIVE_MODEL_ID,
+      modelRegistry: new ModelRegistryCtor(AuthStorage.inMemory()),
+    });
+    if (!resolved) {
+      throw new Error(`requesty provider did not resolve ${LIVE_MODEL_ID}`);
+    }
+
+    expect(resolved.provider).toBe("requesty");
+    expect(resolved.api).toBe("openai-completions");
+    expect(resolved.baseUrl).toBe(REQUESTY_BASE_URL);
+
+    const client = new OpenAI({
+      apiKey: REQUESTY_API_KEY,
+      baseURL: resolved.baseUrl,
+    });
+    await expectWeatherToolCall(client, LIVE_MODEL_ID.replace(/^requesty\//, ""));
+  }, 30_000);
+});

--- a/extensions/requesty/tsconfig.json
+++ b/extensions/requesty/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/test/vitest/vitest.extension-provider-paths.mjs
+++ b/test/vitest/vitest.extension-provider-paths.mjs
@@ -26,6 +26,7 @@ export const providerExtensionIds = [
   "ollama",
   "openrouter",
   "qianfan",
+  "requesty",
   "stepfun",
   "together",
   "venice",


### PR DESCRIPTION
## Summary

Adds [Requesty](https://requesty.ai) (`router.requesty.ai`) as a bundled provider plugin under `extensions/requesty/`. Requesty is an OpenAI-compatible LLM router (300+ models behind one key), the same class of bundled provider as the existing `openrouter`, `opencode`, `opencode-go`, and `kilocode` plugins.

This supersedes #54443, which was closed with a request to publish on ClawHub. I'd like to make the case for bundling instead, and I've reworked the implementation to the `extensions/AGENTS.md` bar so it isn't carrying the issues the previous attempt had.

## Why bundled (re: #54443)

Requesty is the same shape as routers OpenClaw already bundles in core (`openrouter`, `opencode`, `opencode-go`, `kilocode`) - a single OpenAI-compatible proxy endpoint with `provider/model` refs. If those belong in `extensions/`, Requesty fits the same boundary. Happy to defer to maintainers if the policy is firm; if so I'll move it to ClawHub instead.

## What changed vs the closed PR

The previous review (greptile) flagged two things; both are fixed here by following the shared-helper rules in `extensions/AGENTS.md`:

1. **No duplicated wrappers.** Instead of copying the OpenRouter stream/replay wrappers, this reuses the shared family helpers - `PASSTHROUGH_GEMINI_REPLAY_HOOKS` and `buildProviderStreamFamilyHooks("openrouter-thinking")` - exactly as `openrouter`/`kilocode`/`opencode` do.
2. **No hardcoded `reasoning: false`.** `resolveDynamicModel` projects real per-model capabilities (reasoning, vision, tool calling, context window, max output) from Requesty's `/v1/models` payload, so reasoning-capable models keep reasoning support.

## Surface

- OpenAI-compatible base `https://router.requesty.ai/v1`, API-key auth (`REQUESTY_API_KEY`, `--requesty-api-key`)
- Bundled fallback catalog (`requesty/openai/gpt-4o`, `requesty/anthropic/claude-sonnet-4-5`, `requesty/google/gemini-2.5-flash`) + dynamic resolution for any `requesty/<provider>/<model>` the router accepts
- Base-URL canonicalization (bare host -> `/v1`)

## Tests

- `index.test.ts` - registration, auth/manifest alignment, capability projection, base-URL normalization, dynamic resolution, passthrough-gemini replay policy
- `onboard.test.ts` - allowlist alias + primary/fallback config
- `provider.contract.test.ts` - generic provider plugin contract
- `requesty.live.test.ts` - gated (`OPENCLAW_LIVE_TEST=1` + `REQUESTY_API_KEY`) live tool-call against the router; verified passing locally
- `bundled-capability-metadata` snapshot + plugin inventory/reference docs regenerated via the repo generators

Lint (oxlint) clean, production typecheck (tsgo) clean, format (oxfmt) applied. No lockfile changes (the workspace `@openclaw/plugin-sdk` link resolves under the existing lockfile; `--frozen-lockfile` passes).

## Docs

Adds `docs/providers/requesty.md` plus the generated `docs/plugins/reference/requesty.md`, inventory, and `docs.json` nav entry.

## Disclosure

I work at Requesty. This is a genuine integration mirroring the existing OpenRouter wiring - happy to adjust scope, naming, or move to ClawHub if that's the preferred path.
