### PR TITLE
refactor(dispatch): gate reasoning delivery on a channel capability (follow-up to #95051)

### DIFF
--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -170,6 +170,7 @@ export function createTelegramPluginBase(params: {
       polls: true,
       nativeCommands: true,
       blockStreaming: true,
+      reasoningPayloads: true,
     },
     commands: {
       nativeCommandsAutoEnabled: true,

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -989,7 +989,14 @@ describe("dispatchReplyFromConfig", () => {
       "mattermost",
       "imessage",
     ].map((id) => {
-      const plugin = createChannelTestPluginBase({ id });
+      // Telegram advertises a reasoning lane; core dispatch gates durable
+      // reasoning delivery on that capability (channelSupportsReasoningPayloads).
+      const plugin = createChannelTestPluginBase({
+        id,
+        ...(id === "telegram"
+          ? { capabilities: { chatTypes: ["direct"], reasoningPayloads: true } }
+          : {}),
+      });
       return {
         pluginId: id,
         source: "test" as const,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -42,6 +42,7 @@ import {
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { shouldSuppressLocalExecApprovalPrompt } from "../../channels/plugins/exec-approval-local.js";
+import { channelSupportsReasoningPayloads } from "../../channels/plugins/reasoning-capabilities.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
 import { normalizeExplicitSessionKey } from "../../config/sessions/explicit-session-key-normalization.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
@@ -2867,8 +2868,12 @@ export async function dispatchReplyFromConfig(
       params.configOverride ? (applyMergePatch(cfg, params.configOverride) as OpenClawConfig) : cfg,
     );
     recordAgentDispatchStarted();
+    // Deliver durable reasoning to channels that advertise a reasoning lane;
+    // suppress it for the rest (WhatsApp/web have no lane). Capability-driven so
+    // new reasoning-capable channels opt in by declaring it, not by being named.
+    const deliveryChannelRendersReasoning = channelSupportsReasoningPayloads(deliveryChannel);
     const shouldSuppressReasoningPayloadForDelivery = (payload: ReplyPayload) =>
-      payload.isReasoning === true && deliveryChannel !== "telegram";
+      payload.isReasoning === true && !deliveryChannelRendersReasoning;
 
     const replyResult = await runWithDispatchAbortSignal(getDispatchAbortSignal(), () =>
       traceReplyPhase("reply.run_reply_resolver", () =>
@@ -3104,8 +3109,9 @@ export async function dispatchReplyFromConfig(
                 if (suppressDelivery) {
                   return;
                 }
-                // Telegram owns a durable reasoning lane and strips the marker
-                // before outbound normalization; generic channels keep suppression.
+                // Channels advertising a reasoning lane render the marker and
+                // strip it before outbound normalization; generic channels keep
+                // suppression (see deliveryChannelRendersReasoning).
                 if (shouldSuppressReasoningPayloadForDelivery(payload)) {
                   return;
                 }
@@ -3276,8 +3282,9 @@ export async function dispatchReplyFromConfig(
       (ctx.InboundEventKind !== "room_event" || explicitCommandTurnCtx);
     for (const [replyIndex, reply] of replies.entries()) {
       throwIfDispatchOperationAborted();
-      // Telegram owns a durable reasoning lane and strips the marker before
-      // outbound normalization; generic channels keep suppression.
+      // Channels advertising a reasoning lane render the marker and strip it
+      // before outbound normalization; generic channels keep suppression
+      // (see deliveryChannelRendersReasoning).
       if (shouldSuppressReasoningPayloadForDelivery(reply)) {
         continue;
       }

--- a/src/channels/plugins/reasoning-capabilities.test.ts
+++ b/src/channels/plugins/reasoning-capabilities.test.ts
@@ -1,0 +1,50 @@
+// Reasoning capability tests cover channel plugin reasoning-lane detection.
+import { afterEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { channelSupportsReasoningPayloads } from "./reasoning-capabilities.js";
+import type { ChannelPlugin } from "./types.js";
+
+function createChannelPlugin(id: string, capabilities: ChannelPlugin["capabilities"]): ChannelPlugin {
+  return createChannelTestPluginBase({
+    id,
+    label: id,
+    capabilities,
+    config: {
+      listAccountIds: () => ["default"],
+    },
+  });
+}
+
+describe("channelSupportsReasoningPayloads", () => {
+  afterEach(() => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("reads the reasoning-lane capability from channel plugins", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: createChannelPlugin("telegram", {
+            chatTypes: ["direct"],
+            reasoningPayloads: true,
+          }),
+        },
+        {
+          pluginId: "whatsapp",
+          source: "test",
+          plugin: createChannelPlugin("whatsapp", { chatTypes: ["direct"] }),
+        },
+      ]),
+    );
+    expect(channelSupportsReasoningPayloads("telegram")).toBe(true);
+    // No declared capability → not a reasoning-lane channel.
+    expect(channelSupportsReasoningPayloads("whatsapp")).toBe(false);
+    // Unregistered channel → false (not undefined-throws).
+    expect(channelSupportsReasoningPayloads("slack")).toBe(false);
+    expect(channelSupportsReasoningPayloads(undefined)).toBe(false);
+  });
+});

--- a/src/channels/plugins/reasoning-capabilities.ts
+++ b/src/channels/plugins/reasoning-capabilities.ts
@@ -1,0 +1,19 @@
+/**
+ * Channel reasoning-lane capability resolver.
+ *
+ * Reads whether a channel advertises a dedicated reasoning (thinking) lane so
+ * core reply dispatch can deliver durable `isReasoning` payloads to it and keep
+ * suppressing them for channels without a lane.
+ */
+import { getLoadedChannelPlugin, normalizeChannelId } from "./registry.js";
+
+export function channelSupportsReasoningPayloads(channel: string | undefined): boolean {
+  const channelId = normalizeChannelId(channel);
+  if (!channelId) {
+    return false;
+  }
+  // Runs on every reply dispatch, so read only already-loaded plugins — never
+  // fall through to bundled-runtime cold-load (getChannelPlugin). The delivery
+  // target is loaded at delivery time; an unloaded channel fails closed.
+  return getLoadedChannelPlugin(channelId)?.capabilities.reasoningPayloads === true;
+}

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -316,6 +316,10 @@ export type ChannelCapabilities = {
   };
   nativeCommands?: boolean;
   blockStreaming?: boolean;
+  // Channel renders reasoning (`isReasoning`) payloads on a dedicated thinking
+  // lane. Core's reply dispatch delivers durable reasoning to channels that
+  // declare this and suppresses it for the rest (WhatsApp/web have no lane).
+  reasoningPayloads?: boolean;
 };
 
 export type ChannelSecurityDmPolicy = {


### PR DESCRIPTION
Small follow-up on top of this PR's branch (`qa-sre-telegram-reasoning-delivery-20260619`) — feel free to squash/cherry-pick into #95051 or ignore.

## Summary
#95051 gates reasoning-payload suppression on `deliveryChannel !== "telegram"`. This swaps that hardcoded channel name for a declared **`reasoningPayloads` channel capability**, mirroring the existing `resolveChannelTtsVoiceDelivery` precedent (`getChannelPlugin(id)?.capabilities.tts?.voice`). Channels with a reasoning lane opt in by declaring the capability instead of being named in core dispatch, so the next reasoning-capable channel (Slack, Matrix, …) needs no core edit.

- `ChannelCapabilities` gains `reasoningPayloads?: boolean` (next to `blockStreaming`).
- New `channelSupportsReasoningPayloads()` resolver — uses `getLoadedChannelPlugin` (loaded-only, no bundled cold-load) since it runs on every dispatch; fails closed for unloaded/unknown channels.
- Telegram declares `reasoningPayloads: true`; the suppression gate becomes `!channelSupportsReasoningPayloads(deliveryChannel)`.

**Behaviour-preserving:** Telegram still delivers durable reasoning, generic channels (WhatsApp/web) still suppress — the existing dispatch tests assert both, unchanged.

## Verification
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` → 0
- `vitest run dispatch-from-config.test.ts -t "isReasoning"` + the new `reasoning-capabilities.test.ts` → green (telegram delivers via capability; generic suppressed)
- Reviewed with a Codex red-team pass (no blocking findings; verified the `getLoadedChannelPlugin` choice avoids a hot-path cold-load).

## AI assistance
Prepared with AI assistance (Claude). Behaviour verified locally on OpenClaw 2026.6.9-beta.1.

cc @Peetiegonzalez
