### PR TITLE
fix(doctor): skip false-positive local embedding warning when probe is skipped

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -207,6 +207,20 @@ describe("noteMemorySearchHealth", () => {
     expect(message).toContain("openclaw plugins install @openclaw/llama-cpp-provider");
   });
 
+  it("does not warn when local provider probe was skipped", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: { checked: false, ready: false, skipped: true },
+    });
+
+    expect(note).not.toHaveBeenCalled();
+  });
+
   it("warns when local provider with default model but gateway probe reports not ready", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "local",

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -472,6 +472,13 @@ export async function noteMemorySearchHealth(
     if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
       return;
     }
+    // When the probe was intentionally skipped (probe: false path per
+    // probeGatewayMemoryStatus), the gateway made no readiness
+    // determination — do not warn. A skipped probe does not mean local
+    // embeddings are unavailable.
+    if (opts?.gatewayMemoryProbe?.skipped) {
+      return;
+    }
     const hasExplicitLocalModel = hasLocalEmbeddings(resolved.local);
     const detail = opts?.gatewayMemoryProbe?.error?.trim();
     note(


### PR DESCRIPTION
## Summary

`openclaw doctor` displays a false-positive warning for the `local` memory embedding provider when the gateway memory probe is intentionally skipped (`probe: false` path, e.g. running `openclaw doctor` without `--deep`). The local-provider branch warns unconditionally when `checked: false`, while sibling key-optional providers (ollama, lmstudio, openai-compatible) correctly suppress warnings for skipped probes via the `skipped` flag. The authoritative `openclaw memory status --deep` confirms the full memory stack is healthy.

This change adds the same `skipped`-probe guard to the local provider branch, matching the existing pattern in the `isKeyOptionalMemoryProvider` branch. Transport timeouts and genuine failures (where `skipped` is `false` or absent) continue to produce warnings as before.

Fixes #92582

## Real behavior proof

**Behavior addressed**: `openclaw doctor` no longer falsely warns "local embeddings are not confirmed ready" when the gateway memory probe was intentionally skipped.

**Real environment tested**: Linux x86_64, OpenClaw `ad5d2cbc1b` (upstream/main)

**Exact steps or command run after this patch**: Run the test suite to validate the fix
```bash
node scripts/run-vitest.mjs src/commands/doctor-memory-search.test.ts
```

**After-fix evidence**:
```
 RUN  v4.1.8 /home/lizeyu/workspace/issues-killer/openclaw/.worktrees/issue-92582

 Test Files  1 passed (1)
      Tests  50 passed (50)
   Start at  01:11:04
   Duration  1.28s (transform 561ms, setup 207ms, import 643ms, tests 288ms, environment 0ms)
```

**Observed result after the fix**: All 50 tests pass (49 existing + 1 new regression test). The new test asserts that a `{checked: false, ready: false, skipped: true}` probe does NOT trigger a warning for the local provider, matching the behavior of sibling key-optional providers.

**What was not tested**: A live `openclaw doctor` run with a configured local GGUF embedding provider. The fix is purely a renderer-side skip guard that mirrors the established pattern in the `isKeyOptionalMemoryProvider` branch — the existing tests for the `checked: false` with `error` path and `checked: false` no-opts path confirm that unskipped probes still warn correctly.

## Tests and validation

### Unit tests

```
$ node scripts/run-vitest.mjs src/commands/doctor-memory-search.test.ts

 Test Files  1 passed (1)
      Tests  50 passed (50)
```

New test: `"does not warn when local provider probe was skipped"` — asserts `note` is not called when `gatewayMemoryProbe` has `skipped: true`.

### Test coverage matrix

| Scenario | Probe input | Expected | Status |
|----------|------------|----------|--------|
| No probe (empty opts) | `{}` | Warn (no probe info) | ✅ existing |
| Probe checked + ready | `{checked:true, ready:true}` | Silent | ✅ existing |
| Probe checked + not ready | `{checked:true, ready:false, error:"not installed"}` | Warn | ✅ existing |
| Probe timeout | `{checked:false, ready:false, error:"timeout"}` | Warn (skipped absent) | ✅ existing |
| **Probe skipped** | `{checked:false, ready:false, skipped:true}` | **Silent** | ✅ new |

## Risk checklist

- [x] This change is backwards compatible — no API, config, or data changes
- [x] This change has been tested with existing configurations — all 49 existing tests pass unchanged
- [ ] I have updated relevant documentation — not needed (doctor output change only)
- [ ] Breaking changes (if any) are documented in Summary — N/A

## Current review state

- [x] Self-review completed
- [ ] At least one maintainer review
- [ ] All CI checks passed
