### PR TITLE
fix(sdk): classify failed/blocked tool events as tool.call.failed

### DIFF
--- a/packages/sdk/src/normalize.test.ts
+++ b/packages/sdk/src/normalize.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { normalizeGatewayEvent } from "./normalize.js";
+
+// Terminal tool/item events are emitted with phase:"end" plus the real status
+// (running|completed|failed|blocked), so failed/blocked must not collapse to completed.
+function agentItemEvent(data: Record<string, unknown>) {
+  return { event: "agent", payload: { runId: "r1", stream: "item", data } };
+}
+
+describe("normalizeGatewayEvent terminal tool item status", () => {
+  it("classifies a failed terminal tool item as tool.call.failed", () => {
+    expect(normalizeGatewayEvent(agentItemEvent({ phase: "end", status: "failed" })).type).toBe(
+      "tool.call.failed",
+    );
+  });
+
+  it("classifies a blocked terminal tool item as tool.call.failed", () => {
+    expect(normalizeGatewayEvent(agentItemEvent({ phase: "end", status: "blocked" })).type).toBe(
+      "tool.call.failed",
+    );
+  });
+
+  it("still classifies a completed terminal tool item as tool.call.completed", () => {
+    expect(normalizeGatewayEvent(agentItemEvent({ phase: "end", status: "completed" })).type).toBe(
+      "tool.call.completed",
+    );
+  });
+
+  it("still classifies a phase:end tool item without status as tool.call.completed", () => {
+    expect(normalizeGatewayEvent(agentItemEvent({ phase: "end" })).type).toBe(
+      "tool.call.completed",
+    );
+  });
+});

--- a/packages/sdk/src/normalize.ts
+++ b/packages/sdk/src/normalize.ts
@@ -112,11 +112,14 @@ function normalizeAgentEventType(payload: JsonObject): OpenClawEventType {
     if (phase === "delta" || phase === "update") {
       return "tool.call.delta";
     }
-    if (phase === "end" || status === "completed") {
-      return "tool.call.completed";
-    }
+    // Terminal tool/item events carry phase:"end" together with the real status, so a failed or
+    // blocked tool must be classified before the end/completed branch — otherwise phase:"end" wins
+    // and failures are reported as tool.call.completed.
     if (status === "failed" || status === "blocked") {
       return "tool.call.failed";
+    }
+    if (phase === "end" || status === "completed") {
+      return "tool.call.completed";
     }
     return "tool.call.delta";
   }


### PR DESCRIPTION
## Summary

The SDK's `normalizeAgentEventType` (`packages/sdk/src/normalize.ts`) maps raw gateway agent events into the public `OpenClawEventType`. For the `tool` / `item` / `command_output` streams the terminal branches were ordered:

```ts
if (phase === "end" || status === "completed") return "tool.call.completed";
if (status === "failed" || status === "blocked") return "tool.call.failed";
```

But terminal tool/item events are emitted with **`phase: "end"` together with the real status** — the producer (`src/agents/embedded-agent-subscribe.handlers.tools.ts`) emits `{ phase: "end", status: isToolError ? "failed" : "completed" }` and `{ phase: "end", status: "blocked" }`, and `AgentItemEventStatus` (`src/infra/agent-events.ts:26`) is `running | completed | failed | blocked`. So for a **failed or blocked** tool the `phase === "end"` check won first and returned `tool.call.completed` — the `tool.call.failed` branch was effectively dead for the item stream. SDK consumers filtering on `tool.call.failed` (a documented public event type, `types.ts:257`) never saw tool failures; **failures looked like successes.**

This reorders the two branches so failed/blocked is classified before end/completed. Pure logic — no type, schema, protocol, or config change. `normalize.ts` is the only classifier of these event types (grep of `src/`/`packages/`/`ui/`), so this is the single consumer boundary.

### Changes
- `packages/sdk/src/normalize.ts` — check `failed`/`blocked` before the `end`/`completed` branch (+ comment).
- `packages/sdk/src/normalize.test.ts` — new regression test for terminal tool item status classification.

## Real behavior proof

Behavior addressed: terminal tool/item events with `phase:"end"` + `status:"failed"|"blocked"` were normalized to `tool.call.completed`, hiding tool failures from SDK consumers. They now normalize to `tool.call.failed`; `completed` and unstatused-end events are unchanged.

Real environment tested: Node 22.22.1, macOS, no model / network / device. A `./node_modules/.bin/tsx` harness imports the real exported `normalizeGatewayEvent` and feeds it the producer's exact terminal event shapes (`{ event:"agent", payload:{ stream:"item", data:{ phase:"end", status } } }`). BEFORE is `origin/main`'s `normalize.ts` (cp-swapped in for the run).

Exact steps or command run after this patch:
```bash
# harness calls the real normalizeGatewayEvent for status=failed|blocked|completed
./node_modules/.bin/tsx norm-proof.mts
```

Evidence after fix:
```
BEFORE (origin/main):
  item phase=end status=failed    -> tool.call.completed
  item phase=end status=blocked   -> tool.call.completed
  item phase=end status=completed -> tool.call.completed
AFTER (this branch):
  item phase=end status=failed    -> tool.call.failed
  item phase=end status=blocked   -> tool.call.failed
  item phase=end status=completed -> tool.call.completed
```

Observed result after fix: failed and blocked terminal tool items now normalize to `tool.call.failed`; before the change all three collapsed to `tool.call.completed`. Completed (and `phase:"end"` with no status) remain `tool.call.completed`.

What was not tested: a full live gateway→SDK round-trip with a real failing tool (no model/gateway run was performed). The end-to-end normalization is covered by the new `packages/sdk/src/normalize.test.ts` (failed→failed, blocked→failed, completed→completed, end-without-status→completed), which fails before the change and passes after.

## Additional checks
- `pnpm test packages/sdk/src/normalize.test.ts packages/sdk/src/index.test.ts packages/sdk/src/transport.test.ts` — 46 pass, no regressions. Verified fail-before by cp-swapping `origin/main`'s `normalize.ts` → the new test fails (failed/blocked classified as completed).
- Formatter (`oxfmt`), static analysis (`oxlint`), and `tsgo:core` pass for the changed files.
- Sibling check: `normalize.ts` is the only producer of `tool.call.completed`/`tool.call.failed` (the gateway emits raw `{stream,data}`; the SDK normalizes), so the fix is not one-sided.


## Compatibility / release note

This corrects a public SDK event type, so it is an intentional, release-note-worthy behavior change: SDK consumers that previously observed **failed or blocked** terminal tool/item events as `tool.call.completed` will now correctly receive `tool.call.failed`. Both are existing members of the public `OpenClawEventType` union (`packages/sdk/src/types.ts`), so consumers already handling `tool.call.failed` need no change; consumers that only branched on `tool.call.completed` were previously treating failures as completions and can now distinguish them. `tool.call.completed` (and a `phase:"end"` event with no status) are unchanged. No type/schema/protocol change accompanies this.
