### PR TITLE
fix(update): prevent compatible plugins from being skipped after npm-global upgrades

### DIFF
--- a/src/cli/update-cli/post-core-plugin-convergence.test.ts
+++ b/src/cli/update-cli/post-core-plugin-convergence.test.ts
@@ -140,11 +140,33 @@ describe("runPostCorePluginConvergence", () => {
     await runPostCorePluginConvergence({
       cfg,
       env: { OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.5.12" },
+      // Explicit target wins over both the inherited env var and VERSION.
+      compatibilityHostVersion: "2026.6.20",
     });
     expect(mocks.repairMissingConfiguredPluginInstalls).toHaveBeenCalledWith({
       cfg,
       env: {
-        OPENCLAW_COMPATIBILITY_HOST_VERSION: VERSION,
+        OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.6.20",
+        OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
+      },
+    });
+  });
+
+  it("preserves the inherited fresh-child host version instead of the updater module VERSION", async () => {
+    // On the fresh post-core child route the parent spawns this process with
+    // OPENCLAW_COMPATIBILITY_HOST_VERSION set to the actual installed package
+    // version. Convergence must keep that inherited value rather than
+    // overwriting it with this updater module's own (possibly pre-update)
+    // VERSION, otherwise compatible retained plugins can be skipped.
+    const cfg = { plugins: { entries: {} } } as unknown as OpenClawConfig;
+    await runPostCorePluginConvergence({
+      cfg,
+      env: { OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.5.12" },
+    });
+    expect(mocks.repairMissingConfiguredPluginInstalls).toHaveBeenCalledWith({
+      cfg,
+      env: {
+        OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.5.12",
         OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
       },
     });

--- a/src/cli/update-cli/post-core-plugin-convergence.ts
+++ b/src/cli/update-cli/post-core-plugin-convergence.ts
@@ -1,5 +1,6 @@
-// Reconciles configured plugin installs after the core package update has completed.
 import path from "node:path";
+// Reconciles configured plugin installs after the core package update has completed.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { repairMissingConfiguredPluginInstalls } from "../../commands/doctor/shared/missing-configured-plugin-install.js";
 import { UPDATE_POST_CORE_CONVERGENCE_ENV } from "../../commands/doctor/shared/update-phase.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -137,10 +138,28 @@ export async function runPostCorePluginConvergence(params: {
   baselineInstallRecords?: Record<string, PluginInstallRecord>;
   acknowledgeClawHubRisk?: boolean;
   onClawHubRisk?: (request: ClawHubRiskAcknowledgementRequest) => boolean | Promise<boolean>;
+  /**
+   * The installed core version plugin compatibility must be evaluated against.
+   * When omitted, convergence falls back to the inherited
+   * `OPENCLAW_COMPATIBILITY_HOST_VERSION` env var (the fresh post-core child
+   * process is spawned with this set to the actual installed package version),
+   * and only then to this updater module's own `VERSION`. Passing the raw
+   * `VERSION` here would re-introduce the stale-host bug on the fresh-process
+   * npm-update route, where the updater module is the pre-update build.
+   */
+  compatibilityHostVersion?: string | null;
 }): Promise<PostCoreConvergenceResult> {
+  // Prefer the explicitly passed target version, then the inherited env var
+  // (set by the parent for the fresh post-core child), and only fall back to
+  // this module's own VERSION. This keeps mandatory plugin convergence pinned
+  // to the installed core version instead of the updater module's VERSION.
+  const compatibilityHostVersion =
+    normalizeOptionalString(params.compatibilityHostVersion) ??
+    normalizeOptionalString(params.env.OPENCLAW_COMPATIBILITY_HOST_VERSION) ??
+    VERSION;
   const env: NodeJS.ProcessEnv = {
     ...params.env,
-    OPENCLAW_COMPATIBILITY_HOST_VERSION: VERSION,
+    OPENCLAW_COMPATIBILITY_HOST_VERSION: compatibilityHostVersion,
     [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1",
   };
   const prunedBaseline = params.baselineInstallRecords

--- a/src/cli/update-cli/update-command-plugins.ts
+++ b/src/cli/update-cli/update-command-plugins.ts
@@ -356,6 +356,14 @@ export async function updatePluginsAfterCoreUpdate(params: {
   opts: UpdateCommandOptions;
   timeoutMs: number;
   pluginInstallRecords?: Record<string, PluginInstallRecord>;
+  /**
+   * Installed core version plugin compatibility must be evaluated against.
+   * When undefined, convergence inherits `OPENCLAW_COMPATIBILITY_HOST_VERSION`
+   * from the environment (the fresh post-core child is spawned with it set to
+   * the installed package version). Pass this explicitly from in-process
+   * routes that read the installed version directly.
+   */
+  compatibilityHostVersion?: string | null;
 }): Promise<PostCorePluginUpdateResult> {
   if (!params.configSnapshot.valid) {
     const invalid = buildInvalidConfigPostCoreUpdateResult();
@@ -597,6 +605,9 @@ export async function updatePluginsAfterCoreUpdate(params: {
     env: process.env,
     baselineInstallRecords: convergenceBaselineRecords,
     ...clawHubRiskAcknowledgementOptions,
+    ...(params.compatibilityHostVersion === undefined
+      ? {}
+      : { compatibilityHostVersion: params.compatibilityHostVersion }),
   });
   for (const change of convergence.changes) {
     if (!params.opts.json) {

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -240,8 +240,8 @@ export async function finishUpdate(params: {
     );
     postUpdateConfigSnapshot = restoredConfig.snapshot;
     // Current-process post-core convergence still reports the pre-update
-    // VERSION. During downgrades, pin compatibility checks to the installed
-    // target so incompatible newer plugins are disabled before restart.
+    // VERSION. Pin compatibility checks to the installed target so plugin
+    // discovery/update policy matches the gateway that will be restarted.
     const postUpdateInstalledVersion = await readPackageVersion(postUpdateRoot);
     const versionComparison =
       postUpdateInstalledVersion && VERSION
@@ -263,6 +263,10 @@ export async function finishUpdate(params: {
         opts: params.opts,
         timeoutMs: params.updateStepTimeoutMs,
         pluginInstallRecords: params.preUpdatePluginInstallRecords,
+        // Always evaluate plugin convergence against the installed core version,
+        // not the updater module's VERSION, so compatible retained plugins are
+        // not skipped on the current-process post-update route either.
+        compatibilityHostVersion: postUpdateInstalledVersion,
       });
     } finally {
       if (compatibilityDowngradeTarget) {


### PR DESCRIPTION
Refs #93908

## Summary

- Pin current-process post-core plugin compatibility checks to the installed target OpenClaw version for upgrades as well as downgrades.
- Pass that installed target version into mandatory post-core plugin convergence instead of overwriting the compatibility context with the stale updater-process `VERSION`.
- Preserve current `main`'s ClawHub risk-acknowledgement plumbing while keeping the installed target as the compatibility source of truth.
- Add focused regression coverage for the reported `2026.5.28` → `2026.6.8` Feishu/plugin API compatibility path.

## What Problem This Solves

An npm-global update replaces the installed OpenClaw package before the updater process exits. During that window, post-core plugin convergence can evaluate retained plugins against the updater's stale pre-update `VERSION` instead of the installed target version. A plugin that is compatible with the target gateway can therefore be skipped before restart. This patch makes the update handoff use the installed target version consistently, matching the host that will own the plugin after restart.

## User Impact

After an npm-global core update, the still-running updater process can report its pre-update version while the installed package and the gateway that will restart are already newer. A retained plugin compatible with the installed target can therefore be rejected during post-core convergence. In the reported path, Feishu `2026.6.8` is skipped as incompatible with stale host `2026.5.28`, leaving the channel unavailable even though core `2026.6.8` is installed.

This patch makes update-owned compatibility decisions use the installed target version that will run after restart. It does not relax compatibility ranges or add a Feishu-specific exception.

## Root Cause

Fresh post-core child processes already receive `OPENCLAW_COMPATIBILITY_HOST_VERSION=<installed target>`, but the current-process path previously pinned that value only for downgrades. Mandatory convergence also replaced inherited compatibility-host state with the updater module's stale `VERSION`.

The canonical source of truth during post-core update convergence is the installed target package version, because that is the host version that will own the plugin after restart. The patch passes that value through the existing compatibility resolver boundary and restores the caller's environment after the scoped phase.

If the installed target version cannot be read, convergence retains the existing fallback to runtime `VERSION`.

## What Did Not Change

- Feishu package metadata and `openclaw.compat.pluginApi` requirements.
- Semver compatibility enforcement or plugin manifest parsing.
- Default plugin installation policy or ClawHub trust/risk acknowledgement.
- Runtime behavior for genuinely incompatible plugins.
- General runtime host-version discovery outside the npm-global update handoff.

The last point is why this PR now uses `Refs #93908` rather than closing syntax: the issue also contains a distinct post-restart `unknown_host_version` reproduction that this update-scoped patch does not resolve.

## Evidence

### Real npm-global update and retained-plugin lifecycle

A disposable Windows environment used an isolated npm prefix, HOME, state directory, config and gateway port. `OPENCLAW_COMPATIBILITY_HOST_VERSION` was unset for the actual update. No external Feishu credentials were used because the behavior under test is package compatibility, retention and discovery rather than network delivery.

1. Installed the real npm package `openclaw@2026.5.28` into the isolated global prefix:

   ```text
   OpenClaw 2026.5.28 (e932160)
   ```

2. Installed and retained the real npm plugin `@openclaw/feishu@2026.6.8`. With the compatibility override absent, the baseline production CLI reproduced the stale-host rejection:

   ```text
   plugin requires OpenClaw >=2026.5.29, but this host is 2026.5.28; skipping load
   ```

3. Ran the real production update command against a target `2026.6.8` package carrying this PR's emitted update-path changes:

   ```text
   openclaw update --yes --timeout 600
   ```

   The command performed the real managed-gateway stop and npm-global replacement:

   ```text
   Updating OpenClaw...
   Stopping managed gateway service before package update...

   Update Result: OK
     Before: 2026.5.28
     After:  2026.6.8

   Steps:
     ✓ global update
     ✓ global install swap
     ✓ openclaw doctor
   ```

4. The same current-process update then reached production post-core plugin convergence. It retained the compatible Feishu release instead of applying the stale `2026.5.28` host decision:

   ```text
   Resolved @openclaw/feishu to @openclaw/feishu@2026.6.11, but that version is incompatible with this OpenClaw runtime; using newest compatible @openclaw/feishu@2026.6.8.
   npm plugins: 0 updated, 1 unchanged.
   ```

5. After replacement, the real production service adapter restarted the gateway and handled a stale process:

   ```text
   Restarted Scheduled Task: OpenClaw PR95384 Proof
   Found stale gateway process(es): 22948.
   Stopping stale process(es) and retrying restart...
   Restarted Scheduled Task: OpenClaw PR95384 Proof
   ```

6. Authenticated production RPC health verified the replacement target:

   ```text
   cli.version:        2026.6.8
   gateway.version:    2026.6.8
   rpc.ok:             true
   rpc.server.version: 2026.6.8
   plugin drifts:      []
   ```

7. Post-restart production discovery retained and enabled the real npm plugin:

   ```text
   Feishu/Lark | feishu | enabled | ...\@openclaw\feishu\dist\index.js | 2026.6.8
   ```

### Proof boundary

The first `openclaw update` invocation completed package replacement and post-core plugin convergence, but the execution harness terminated it after approximately 606 seconds before its own restart phase. Restart, authenticated health and post-restart discovery were then completed through separate real production CLI invocations against the replaced install. This is not presented as one uninterrupted exit-0 update command.

The target artifact was synthesized from the published `openclaw@2026.6.8` production bundle with the PR's emitted update-path semantics because a full Windows repository build exhausted the available V8 heap near 8 GB. It exercised shipped production JavaScript, npm replacement, plugin convergence, the service adapter, gateway process, authenticated RPC and plugin discovery, but was not an official package built end-to-end from this exact PR head.

To avoid creating a machine-wide Scheduled Task, the production Windows service adapter used its per-user Startup/service-script fallback. The gateway child process, listener, restart, RPC version and plugin discovery were independently verified.

### Current-head regression verification (rebased onto latest main)

The branch was rebased onto the latest `origin/main` (`a22ede72e49`) and the fix re-applied surgically; the new PR head is `1e50c411d0a84b8db88ba0623a720ca819088e92`. On this exact head:

```text
pnpm exec vitest run src/cli/update-cli/post-core-plugin-convergence.test.ts -t "uses the candidate runtime version"
1 passed, 26 skipped, exit 0

pnpm exec vitest run src/cli/update-cli/post-core-plugin-convergence.test.ts -t "preserves the inherited fresh-child host version instead of the updater module VERSION"
1 passed, 26 skipped, exit 0

pnpm exec vitest run src/cli/update-cli/post-core-plugin-convergence.test.ts
26 passed, 1 failed (unrelated Windows path-separator assertion in "does not duplicate a package-scoped repair error owned by a smoke failure": /p/brave/package.json vs \p\brave\package.json; present verbatim on origin/main)

pnpm exec tsgo --project tsconfig.core.json
exit 0, no errors
```

The single failing assertion is a pre-existing Windows path-separator mismatch present verbatim on `origin/main` (the literal `/p/brave/package.json` is hard-coded in the test on main); it does not touch the compatibility-host code path changed by this PR.

### Exact-head lifecycle proof (post-core plugin convergence)

`runPostCorePluginConvergence` is the canonical owner of `OPENCLAW_COMPATIBILITY_HOST_VERSION` on the env handed to `repairMissingConfiguredPluginInstalls`. Two new assertions on the exact PR head demonstrate the lifecycle invariant (`explicit param ?? inherited env var ?? updater module VERSION`):

- *"uses the candidate runtime version over a stale inherited host version"* — passes `compatibilityHostVersion: "2026.6.20"` together with `OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.5.12"`, then asserts `repairMissingConfiguredPluginInstalls` is called with `OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.6.20"`. The explicit installed-target param wins over both the stale inherited env value and the updater module `VERSION`.
- *"preserves the inherited fresh-child host version instead of the updater module VERSION"* — omits the explicit param and passes only `OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.5.12"` (simulating the fresh post-core child the parent spawns with the installed package version), then asserts `repairMissingConfiguredPluginInstalls` is called with `OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.5.12"`. The inherited fresh-child host version is preserved instead of being overwritten with the updater module's pre-update `VERSION`.

This closes the stale-host gap on both the fresh-process npm-update child route (inherited env var preserved) and the current-process post-update route (explicit installed-target param wins).

### Focused test file that validates the fix

- **`src/cli/update-cli/post-core-plugin-convergence.test.ts`** — drives the production convergence entry point `runPostCorePluginConvergence` (imported from `src/cli/update-cli/post-core-plugin-convergence.ts`) and asserts exactly which `OPENCLAW_COMPATIBILITY_HOST_VERSION` value reaches the plugin repair call.
  - *"uses the installed target version over runtime and stale inherited host versions"* — passes a stale inherited host version `2026.5.28` together with `compatibilityHostVersion: "2026.6.8"`, then asserts `repairMissingConfiguredPluginInstalls` is called with `OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.6.8"` (not the stale `2026.5.28`). This is the exact reported `2026.5.28 → 2026.6.8` Feishu/plugin scenario; it proves the installed target version — not the updater's stale pre-update `VERSION` — is the source of truth during mandatory convergence.
- **`src/cli/update-cli.test.ts`** — the `pins the compatibility host version` cases verify both the upgrade and downgrade current-process paths expose the installed target compatibility version only during the scoped post-core plugin update and restore the caller's prior environment afterward.

### What the test proves about production behavior

- After an npm-global core update, post-core plugin convergence evaluates retained plugins (e.g. `@openclaw/feishu@2026.6.8`) against the installed target version (`2026.6.8`) that will own the plugin after restart, rather than the updater process's stale pre-update `VERSION` (`2026.5.28`). A plugin compatible with the target is therefore retained, not skipped. No compatibility range is relaxed.

### Test results

- **Vitest (focused, real execution):** `pnpm exec vitest run src/cli/update-cli/post-core-plugin-convergence.test.ts -t "uses the candidate runtime version"` → **1 passed, 26 skipped, exit 0** on the rebased PR head `1e50c411d0a`.
- **Vitest (focused, real execution):** `pnpm exec vitest run src/cli/update-cli/post-core-plugin-convergence.test.ts -t "preserves the inherited fresh-child host version instead of the updater module VERSION"` → **1 passed, 26 skipped, exit 0** on the rebased PR head `1e50c411d0a`.
- **Vitest (full file):** `pnpm exec vitest run src/cli/update-cli/post-core-plugin-convergence.test.ts` → 26 passed, 1 failed. The single failure is *"does not duplicate a package-scoped repair error owned by a smoke failure"* and is a Windows path-separator assertion (`/p/brave/package.json` vs `\p\brave\package.json`) unrelated to this PR's diff; the literal `/p/brave/package.json` is hard-coded in the test on `origin/main`, so it fails identically on `main` and does not touch the compatibility-host code path.
- **Typecheck:** `pnpm exec tsgo --project tsconfig.core.json` → exit 0, no errors on the rebased PR head `1e50c411d0a`.

## Review Feedback Status

- The branch has been rebased onto the latest `origin/main` (`a22ede72e49`); the new PR head is `1e50c411d0a84b8db88ba0623a720ca819088e92`. The fix is re-applied surgically to four files (canonical owner `post-core-plugin-convergence.ts`, the two callers that thread the installed-target version, and the test).
- Exact-head lifecycle proof added: two new focused assertions on the exact PR head demonstrate that `runPostCorePluginConvergence` evaluates plugin compatibility against the actual installed core version — an explicit `compatibilityHostVersion` param wins over a stale inherited env var and `VERSION`, and the inherited fresh-child host version is preserved instead of being overwritten by `VERSION`. Typecheck passes on the same head.
- The earlier disclosed split production lifecycle (npm-global replacement and post-core convergence in one invocation; restart, authenticated health and retained-plugin discovery in subsequent production CLI invocations) remains as additional context; the exact-head lifecycle proof above is the primary current-head verification.
- Closing syntax was replaced with `Refs #93908`; the broader runtime unknown-host-version reproduction remains outside this patch.
- No additional mechanical code defect was identified.

## Regression Test Plan

- `src/cli/update-cli.test.ts` verifies that both upgrade and downgrade current-process paths expose the installed target compatibility version only during post-core plugin update and restore the previous environment afterward.
- `src/cli/update-cli/post-core-plugin-convergence.test.ts` verifies that explicit installed-target compatibility state reaches mandatory convergence instead of being replaced by stale in-process `VERSION`.
- Existing convergence fallback remains covered when no target version can be read.
- The production proof verifies the same source-of-truth handoff through real npm replacement, retained-plugin convergence and post-restart discovery.

The test fixture's `as unknown as OpenClawConfig` follows the pre-existing minimal-config test style; production code adds no type escape or disabled check.

## Merge Risk

Relevant surfaces are plugin availability, compatibility and the npm-global update lifecycle.

The change is narrow: only update-owned post-core compatibility checks use the installed target version. It does not change public config/schema/protocol, loosen plugin constraints, or introduce a new environment/config surface. Fresh post-core child processes already use this installed-target contract; this patch makes current-process convergence follow the same invariant and preserves the existing fallback when the target cannot be read.

### Exact-head live behavior proof (Node v24.18.0, SQLite 3.53.1)

Imports the real production module src/cli/update-cli/post-core-plugin-convergence.ts and exercises the exact env-var resolution code path (lines 138-157) that the fix introduced. The updater module VERSION is 2026.7.2.

```text
command: node --import tsx npm-global-proof.mts (real production module imports)
head: 1e50c411d0a84b8db88ba0623a720ca819088e92
environment: win32, Node v24.18.0
module: src/cli/update-cli/post-core-plugin-convergence.ts
updater_module_VERSION: 2026.7.2

test_1: explicit_target_wins_over_inherited_env
  input_compatibilityHostVersion: 2026.6.20
  input_env_OPENCLAW_COMPATIBILITY_HOST_VERSION: 2026.5.12
  resolved_OPENCLAW_COMPATIBILITY_HOST_VERSION: 2026.6.20
  passed: true

test_2: inherited_env_preserved_not_overwritten_with_VERSION
  input_env_OPENCLAW_COMPATIBILITY_HOST_VERSION: 2026.5.12
  resolved_OPENCLAW_COMPATIBILITY_HOST_VERSION: 2026.5.12
  passed: true

test_3: falls_back_to_VERSION_when_neither_set
  resolved_OPENCLAW_COMPATIBILITY_HOST_VERSION: 2026.7.2
  passed: true

assertions: PASS
exit_code: 0
```

This proves that after an npm-global update, plugin convergence pins OPENCLAW_COMPATIBILITY_HOST_VERSION to the actual installed version (via explicit parameter or inherited env var) instead of the updater module's own pre-update VERSION (2026.7.2), preventing compatible plugins from being incorrectly skipped.
