### PR TITLE
fix(doctor): stop scaffolding empty safeBinProfiles that override built-in defaults

### DIFF
--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -118,7 +118,7 @@ Configuration location:
 - `safeBinProfiles` comes from config (`tools.exec.safeBinProfiles` or per-agent `agents.list[].tools.exec.safeBinProfiles`). Per-agent profile keys override global keys.
 - allowlist entries live in the host-local approvals file under `agents.<id>.allowlist` (or via Control UI / `openclaw approvals allowlist ...`).
 - `openclaw security audit` warns with `tools.exec.safe_bins_interpreter_unprofiled` when interpreter/runtime bins appear in `safeBins` without explicit profiles.
-- `openclaw doctor --fix` can scaffold missing custom `safeBinProfiles.<bin>` entries as `{}` (review and tighten afterward). Interpreter/runtime bins are not auto-scaffolded.
+- `openclaw doctor --fix` scaffolds missing custom `safeBinProfiles.<bin>` entries as `{ maxPositional: 0 }` (a stdin-only default; review and adjust flags/positionals afterward). Built-in bins (`cut`, `grep`, `head`, `jq`, `sort`, `tail`, `tr`, `uniq`, `wc`) are not scaffolded because their profile already applies, and an empty `{}` override of a built-in is removed so the shipped profile is restored. Interpreter/runtime bins are not auto-scaffolded.
 
 Custom profile example:
 

--- a/src/commands/doctor-config-flow.safe-bins.test.ts
+++ b/src/commands/doctor-config-flow.safe-bins.test.ts
@@ -51,10 +51,10 @@ describe("doctor config flow safe bins", () => {
         }>;
       };
     };
-    expect(cfg.tools?.exec?.safeBinProfiles?.myfilter).toStrictEqual({});
+    expect(cfg.tools?.exec?.safeBinProfiles?.myfilter).toStrictEqual({ maxPositional: 0 });
     expect(cfg.tools?.exec?.safeBinProfiles?.python3).toBeUndefined();
     const ops = cfg.agents?.list?.find((entry) => entry.id === "ops");
-    expect(ops?.tools?.exec?.safeBinProfiles?.mytool).toStrictEqual({});
+    expect(ops?.tools?.exec?.safeBinProfiles?.mytool).toStrictEqual({ maxPositional: 0 });
     expect(ops?.tools?.exec?.safeBinProfiles?.node).toBeUndefined();
   });
 

--- a/src/commands/doctor/shared/exec-safe-bins.test.ts
+++ b/src/commands/doctor/shared/exec-safe-bins.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
+import { resolveSafeBinProfiles } from "../../../infra/exec-safe-bin-policy.js";
 import {
+  collectExecSafeBinCoverageInfoNotes,
   collectExecSafeBinCoverageWarnings,
   collectExecSafeBinTrustedDirHintWarnings,
   maybeRepairExecSafeBinProfiles,
@@ -38,6 +40,7 @@ describe("doctor exec safe bin helpers", () => {
         warning:
           "jq supports broad jq programs and builtins (for example `env`), so prefer explicit allowlist entries or approval-gated runs instead of safeBins.",
       },
+      { scopePath: "tools.exec", bin: "jq", kind: "emptyBuiltinOverride" },
     ]);
   });
 
@@ -59,7 +62,6 @@ describe("doctor exec safe bin helpers", () => {
     expect(warnings).toEqual([
       "- tools.exec.safeBins includes interpreter/runtime 'node' without profile.",
       "- agents.list.runner.tools.exec.safeBins includes 'jq': jq supports broad jq programs and builtins (for example `env`), so prefer explicit allowlist entries or approval-gated runs instead of safeBins.",
-      '- Run "openclaw doctor --fix" to scaffold missing custom safeBinProfiles entries.',
     ]);
   });
 
@@ -67,19 +69,18 @@ describe("doctor exec safe bin helpers", () => {
     const result = maybeRepairExecSafeBinProfiles({
       tools: {
         exec: {
-          safeBins: ["node", "jq"],
+          safeBins: ["node", "myfilter"],
         },
       },
     } as OpenClawConfig);
 
     expect(result.changes).toEqual([
-      "- tools.exec.safeBinProfiles.jq: added scaffold profile {} (review and tighten flags/positionals).",
+      "- tools.exec.safeBinProfiles.myfilter: added scaffold profile { maxPositional: 0 } (stdin-only default; review and adjust flags/positionals).",
     ]);
     expect(result.warnings).toEqual([
-      "- tools.exec.safeBins includes 'jq': jq supports broad jq programs and builtins (for example `env`), so prefer explicit allowlist entries or approval-gated runs instead of safeBins.",
       "- tools.exec.safeBins includes interpreter/runtime 'node' without profile; remove it from safeBins or use explicit allowlist entries.",
     ]);
-    expect(result.config.tools?.exec?.safeBinProfiles).toEqual({ jq: {} });
+    expect(result.config.tools?.exec?.safeBinProfiles).toEqual({ myfilter: { maxPositional: 0 } });
   });
 
   it("warns on awk-family safeBins instead of scaffolding them", () => {
@@ -98,7 +99,7 @@ describe("doctor exec safe bin helpers", () => {
       "- tools.exec.safeBins includes interpreter/runtime 'awk' without profile; remove it from safeBins or use explicit allowlist entries.",
       "- tools.exec.safeBins includes interpreter/runtime 'sed' without profile; remove it from safeBins or use explicit allowlist entries.",
     ]);
-    expect(result.config.tools?.exec?.safeBinProfiles).toStrictEqual({});
+    expect(result.config.tools?.exec?.safeBinProfiles).toBeUndefined();
   });
 
   it("warns on busybox/toybox safeBins instead of scaffolding them", () => {
@@ -115,7 +116,7 @@ describe("doctor exec safe bin helpers", () => {
       "- tools.exec.safeBins includes interpreter/runtime 'busybox' without profile; remove it from safeBins or use explicit allowlist entries.",
       "- tools.exec.safeBins includes interpreter/runtime 'toybox' without profile; remove it from safeBins or use explicit allowlist entries.",
     ]);
-    expect(result.config.tools?.exec?.safeBinProfiles).toStrictEqual({});
+    expect(result.config.tools?.exec?.safeBinProfiles).toBeUndefined();
   });
 
   it("flags safeBins that resolve outside trusted directories", () => {
@@ -153,5 +154,126 @@ describe("doctor exec safe bin helpers", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("doctor exec safe bin built-in profile handling", () => {
+  it("reports built-in bins without overrides as info, not missing profiles", () => {
+    const cfg = { tools: { exec: { safeBins: ["grep"] } } } as OpenClawConfig;
+
+    const hits = scanExecSafeBinCoverage(cfg);
+    expect(hits).toEqual([{ scopePath: "tools.exec", bin: "grep", kind: "builtinProfile" }]);
+    expect(collectExecSafeBinCoverageInfoNotes({ hits })).toEqual([
+      "- tools.exec.safeBins entry 'grep' uses built-in profile (no custom override needed).",
+    ]);
+    expect(
+      collectExecSafeBinCoverageWarnings({ hits, doctorFixCommand: "openclaw doctor --fix" }),
+    ).toStrictEqual([]);
+
+    const repair = maybeRepairExecSafeBinProfiles(cfg);
+    expect(repair.changes).toStrictEqual([]);
+    expect(repair.config.tools?.exec?.safeBinProfiles).toBeUndefined();
+  });
+
+  it("scaffolds a stdin-only default profile for custom bins", () => {
+    const repair = maybeRepairExecSafeBinProfiles({
+      tools: { exec: { safeBins: ["myfilter"] } },
+    } as OpenClawConfig);
+
+    expect(repair.changes).toEqual([
+      "- tools.exec.safeBinProfiles.myfilter: added scaffold profile { maxPositional: 0 } (stdin-only default; review and adjust flags/positionals).",
+    ]);
+    expect(repair.config.tools?.exec?.safeBinProfiles).toStrictEqual({
+      myfilter: { maxPositional: 0 },
+    });
+  });
+
+  it("warns and removes an empty override that disables a built-in profile", () => {
+    const cfg = {
+      tools: { exec: { safeBins: ["grep"], safeBinProfiles: { grep: {} } } },
+    } as OpenClawConfig;
+
+    const hits = scanExecSafeBinCoverage(cfg);
+    expect(hits).toEqual([{ scopePath: "tools.exec", bin: "grep", kind: "emptyBuiltinOverride" }]);
+    expect(
+      collectExecSafeBinCoverageWarnings({ hits, doctorFixCommand: "openclaw doctor --fix" }),
+    ).toEqual([
+      "- tools.exec.safeBinProfiles.grep: empty profile overrides built-in defaults (positional limits, allowedValueFlags, and deniedFlags are lost). Remove this entry to restore built-in protection, or provide explicit constraints.",
+    ]);
+
+    const repair = maybeRepairExecSafeBinProfiles(cfg);
+    expect(repair.changes).toEqual([
+      "- tools.exec.safeBinProfiles.grep: removed empty override that disabled the built-in profile (restored built-in positional limits, allowedValueFlags, and deniedFlags).",
+    ]);
+    expect(repair.config.tools?.exec?.safeBinProfiles).toBeUndefined();
+  });
+
+  it("detects and removes a built-in override that disables profiles via global safeBins fallback", () => {
+    // The agent inherits the global safeBins list at runtime, so its empty grep override silently
+    // disables the built-in profile even though the agent declares no safeBins of its own.
+    const cfg = {
+      tools: { exec: { safeBins: ["grep"] } },
+      agents: {
+        list: [{ id: "ops", tools: { exec: { safeBinProfiles: { grep: {} } } } }],
+      },
+    } as OpenClawConfig;
+
+    expect(scanExecSafeBinCoverage(cfg)).toEqual([
+      { scopePath: "tools.exec", bin: "grep", kind: "builtinProfile" },
+      { scopePath: "agents.list.ops.tools.exec", bin: "grep", kind: "emptyBuiltinOverride" },
+    ]);
+
+    const repair = maybeRepairExecSafeBinProfiles(cfg);
+    expect(repair.changes).toEqual([
+      "- agents.list.ops.tools.exec.safeBinProfiles.grep: removed empty override that disabled the built-in profile (restored built-in positional limits, allowedValueFlags, and deniedFlags).",
+    ]);
+    const ops = repair.config.agents?.list?.find((entry) => entry.id === "ops");
+    expect(ops?.tools?.exec?.safeBinProfiles).toBeUndefined();
+  });
+
+  it("flags an empty built-in override even when safeBins is not explicitly configured", () => {
+    // head is in DEFAULT_SAFE_BINS, so it is an active safeBin at runtime even without an explicit
+    // safeBins list; a stale empty override therefore disables its built-in profile.
+    const cfg = { tools: { exec: { safeBinProfiles: { head: {} } } } } as OpenClawConfig;
+
+    expect(scanExecSafeBinCoverage(cfg)).toEqual([
+      { scopePath: "tools.exec", bin: "head", kind: "emptyBuiltinOverride" },
+    ]);
+
+    const repair = maybeRepairExecSafeBinProfiles(cfg);
+    expect(repair.changes).toEqual([
+      "- tools.exec.safeBinProfiles.head: removed empty override that disabled the built-in profile (restored built-in positional limits, allowedValueFlags, and deniedFlags).",
+    ]);
+    expect(repair.config.tools?.exec?.safeBinProfiles).toBeUndefined();
+  });
+
+  it("keeps an explicit non-empty override of a built-in bin", () => {
+    const cfg = {
+      tools: {
+        exec: {
+          safeBins: ["grep"],
+          safeBinProfiles: { grep: { maxPositional: 0, allowedValueFlags: ["-e"] } },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(scanExecSafeBinCoverage(cfg)).toStrictEqual([]);
+
+    const repair = maybeRepairExecSafeBinProfiles(cfg);
+    expect(repair.changes).toStrictEqual([]);
+    expect(repair.config.tools?.exec?.safeBinProfiles).toStrictEqual({
+      grep: { maxPositional: 0, allowedValueFlags: ["-e"] },
+    });
+  });
+
+  it("leaves built-in profiles intact through resolveSafeBinProfiles after repair", () => {
+    const repair = maybeRepairExecSafeBinProfiles({
+      tools: { exec: { safeBins: ["grep"] } },
+    } as OpenClawConfig);
+
+    const resolved = resolveSafeBinProfiles(repair.config.tools?.exec?.safeBinProfiles);
+    expect(resolved.grep?.maxPositional).toBe(0);
+    expect(resolved.grep?.deniedFlags?.size ?? 0).toBeGreaterThan(0);
+    expect(resolved.grep?.allowedValueFlags?.size ?? 0).toBeGreaterThan(0);
   });
 });

--- a/src/commands/doctor/shared/exec-safe-bins.ts
+++ b/src/commands/doctor/shared/exec-safe-bins.ts
@@ -4,6 +4,11 @@ import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { resolveCommandResolutionFromArgv } from "../../../infra/exec-command-resolution.js";
 import {
+  isBuiltinSafeBinProfile,
+  normalizeSafeBinProfileFixtures,
+  type SafeBinProfileFixture,
+} from "../../../infra/exec-safe-bin-policy.js";
+import {
   listInterpreterLikeSafeBins,
   resolveMergedSafeBinProfileFixtures,
 } from "../../../infra/exec-safe-bin-runtime-policy.js";
@@ -20,8 +25,14 @@ export type ExecSafeBinCoverageHit = {
   scopePath: string;
   /** Normalized binary name from safeBins. */
   bin: string;
-  /** Missing profile coverage or unsafe semantic shape detected by doctor. */
-  kind: "missingProfile" | "riskySemantics";
+  /**
+   * Coverage classification:
+   * - `missingProfile`: a custom or interpreter bin in safeBins with no profile.
+   * - `builtinProfile`: a built-in bin relying on its shipped profile (info only, no scaffold).
+   * - `emptyBuiltinOverride`: an explicit empty `{}` override that wipes a built-in profile.
+   * - `riskySemantics`: a bin whose semantics are too broad for the safeBins fast path.
+   */
+  kind: "missingProfile" | "builtinProfile" | "emptyBuiltinOverride" | "riskySemantics";
   /** True when the missing profile belongs to an interpreter/runtime binary. */
   isInterpreter?: boolean;
   /** Risk explanation for risky semantic hits. */
@@ -32,9 +43,39 @@ type ExecSafeBinScopeRef = {
   scopePath: string;
   safeBins: string[];
   exec: Record<string, unknown>;
-  mergedProfiles: Record<string, unknown>;
+  mergedProfiles: Record<string, SafeBinProfileFixture>;
   trustedSafeBinDirs: ReadonlySet<string>;
 };
+
+/** A normalized fixture carries no constraints when every positional limit and flag set is empty. */
+function isEmptySafeBinProfileFixture(fixture: SafeBinProfileFixture): boolean {
+  return (
+    fixture.minPositional === undefined &&
+    fixture.maxPositional === undefined &&
+    (fixture.allowedValueFlags?.length ?? 0) === 0 &&
+    (fixture.deniedFlags?.length ?? 0) === 0
+  );
+}
+
+/** True when a raw user safeBinProfiles value normalizes to a no-op (empty) override. */
+function isEmptyRawSafeBinProfile(value: unknown): boolean {
+  // Reuse the runtime normalizer so empty flag arrays collapse to undefined exactly as at runtime.
+  const normalized = normalizeSafeBinProfileFixtures({
+    probe: value as SafeBinProfileFixture,
+  }).probe;
+  return normalized === undefined || isEmptySafeBinProfileFixture(normalized);
+}
+
+/** Lists built-in bins whose explicit override is an empty `{}` that wipes the shipped profile. */
+function listEmptyBuiltinOverrides(exec: Record<string, unknown>): string[] {
+  const ownProfiles = asObjectRecord(exec.safeBinProfiles);
+  if (!ownProfiles) {
+    return [];
+  }
+  return Object.keys(ownProfiles)
+    .toSorted()
+    .filter((bin) => isBuiltinSafeBinProfile(bin) && isEmptyRawSafeBinProfile(ownProfiles[bin]));
+}
 
 export type ExecSafeBinTrustedDirHintHit = {
   /** Config scope that owns the safeBins entry. */
@@ -121,6 +162,34 @@ function collectExecSafeBinScopes(cfg: OpenClawConfig): ExecSafeBinScopeRef[] {
   return scopes;
 }
 
+/**
+ * Lists every config scope that carries a `safeBinProfiles` object, regardless of `safeBins`.
+ * Empty `{}` overrides of built-in bins must be found here, not via the safeBins-gated scopes:
+ * a global override reaches agents through profile inheritance, and an agent override applies even
+ * when the agent inherits the global `safeBins` list (resolveExecSafeBinRuntimePolicy falls back to
+ * global safeBins). Either way the empty override silently disables the built-in profile at runtime.
+ */
+function collectSafeBinProfileScopes(
+  cfg: OpenClawConfig,
+): Array<{ scopePath: string; exec: Record<string, unknown> }> {
+  const scopes: Array<{ scopePath: string; exec: Record<string, unknown> }> = [];
+  const globalExec = asObjectRecord(cfg.tools?.exec);
+  if (globalExec && asObjectRecord(globalExec.safeBinProfiles)) {
+    scopes.push({ scopePath: "tools.exec", exec: globalExec });
+  }
+  const agents = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
+  for (const agent of agents) {
+    if (!agent || typeof agent !== "object" || typeof agent.id !== "string") {
+      continue;
+    }
+    const agentExec = asObjectRecord(agent.tools?.exec);
+    if (agentExec && asObjectRecord(agentExec.safeBinProfiles)) {
+      scopes.push({ scopePath: `agents.list.${agent.id}.tools.exec`, exec: agentExec });
+    }
+  }
+  return scopes;
+}
+
 /** Scan configured safeBins for missing profiles and risky low-friction entries. */
 export function scanExecSafeBinCoverage(cfg: OpenClawConfig): ExecSafeBinCoverageHit[] {
   const hits: ExecSafeBinCoverageHit[] = [];
@@ -128,14 +197,19 @@ export function scanExecSafeBinCoverage(cfg: OpenClawConfig): ExecSafeBinCoverag
     const interpreterBins = new Set(listInterpreterLikeSafeBins(scope.safeBins));
     for (const bin of scope.safeBins) {
       if (scope.mergedProfiles[bin]) {
+        // Has a user profile (covered); empty overrides are flagged from safeBinProfiles below.
         continue;
       }
-      hits.push({
-        scopePath: scope.scopePath,
-        bin,
-        kind: "missingProfile",
-        isInterpreter: interpreterBins.has(bin),
-      });
+      if (interpreterBins.has(bin)) {
+        hits.push({ scopePath: scope.scopePath, bin, kind: "missingProfile", isInterpreter: true });
+        continue;
+      }
+      if (isBuiltinSafeBinProfile(bin)) {
+        // Built-in profile is already active at runtime, so this is informational, never scaffolded.
+        hits.push({ scopePath: scope.scopePath, bin, kind: "builtinProfile" });
+        continue;
+      }
+      hits.push({ scopePath: scope.scopePath, bin, kind: "missingProfile", isInterpreter: false });
     }
     for (const hit of listRiskyConfiguredSafeBins(scope.safeBins)) {
       hits.push({
@@ -144,6 +218,13 @@ export function scanExecSafeBinCoverage(cfg: OpenClawConfig): ExecSafeBinCoverag
         kind: "riskySemantics",
         warning: hit.warning,
       });
+    }
+  }
+  // Empty built-in overrides are scanned across all profile scopes, not the safeBins-gated ones,
+  // so inherited/fallback overrides that disable a built-in at runtime are still surfaced.
+  for (const { scopePath, exec } of collectSafeBinProfileScopes(cfg)) {
+    for (const bin of listEmptyBuiltinOverrides(exec)) {
+      hits.push({ scopePath, bin, kind: "emptyBuiltinOverride" });
     }
   }
   return hits;
@@ -192,6 +273,7 @@ export function collectExecSafeBinCoverageWarnings(params: {
   const customHits = params.hits.filter(
     (hit) => hit.kind === "missingProfile" && !hit.isInterpreter,
   );
+  const emptyOverrideHits = params.hits.filter((hit) => hit.kind === "emptyBuiltinOverride");
   const riskyHits = params.hits.filter((hit) => hit.kind === "riskySemantics");
   const lines: string[] = [];
   if (interpreterHits.length > 0) {
@@ -216,6 +298,18 @@ export function collectExecSafeBinCoverageWarnings(params: {
       lines.push(`- ${customHits.length - 5} more custom safeBins entries are missing profiles.`);
     }
   }
+  if (emptyOverrideHits.length > 0) {
+    for (const hit of emptyOverrideHits.slice(0, 5)) {
+      lines.push(
+        `- ${sanitizeForLog(hit.scopePath)}.safeBinProfiles.${sanitizeForLog(hit.bin)}: empty profile overrides built-in defaults (positional limits, allowedValueFlags, and deniedFlags are lost). Remove this entry to restore built-in protection, or provide explicit constraints.`,
+      );
+    }
+    if (emptyOverrideHits.length > 5) {
+      lines.push(
+        `- ${emptyOverrideHits.length - 5} more safeBinProfiles entries override built-in defaults with empty profiles.`,
+      );
+    }
+  }
   if (riskyHits.length > 0) {
     for (const hit of riskyHits.slice(0, 5)) {
       lines.push(
@@ -228,9 +322,32 @@ export function collectExecSafeBinCoverageWarnings(params: {
       );
     }
   }
-  lines.push(
-    `- Run "${params.doctorFixCommand}" to scaffold missing custom safeBinProfiles entries.`,
-  );
+  // Only suggest --fix scaffolding when there are custom bins to scaffold; built-in bins are not.
+  if (customHits.length > 0) {
+    lines.push(
+      `- Run "${params.doctorFixCommand}" to scaffold missing custom safeBinProfiles entries.`,
+    );
+  }
+  return lines;
+}
+
+/** Format informational doctor notes for safeBins that rely on their shipped built-in profile. */
+export function collectExecSafeBinCoverageInfoNotes(params: {
+  hits: ExecSafeBinCoverageHit[];
+}): string[] {
+  const builtinHits = params.hits.filter((hit) => hit.kind === "builtinProfile");
+  if (builtinHits.length === 0) {
+    return [];
+  }
+  const lines = builtinHits
+    .slice(0, 5)
+    .map(
+      (hit) =>
+        `- ${sanitizeForLog(hit.scopePath)}.safeBins entry '${sanitizeForLog(hit.bin)}' uses built-in profile (no custom override needed).`,
+    );
+  if (builtinHits.length > 5) {
+    lines.push(`- ${builtinHits.length - 5} more safeBins entries use built-in profiles.`);
+  }
   return lines;
 }
 
@@ -271,26 +388,51 @@ export function maybeRepairExecSafeBinProfiles(cfg: OpenClawConfig): {
     for (const hit of listRiskyConfiguredSafeBins(scope.safeBins)) {
       warnings.push(`- ${scope.scopePath}.safeBins includes '${hit.bin}': ${hit.warning}`);
     }
-    const missingBins = scope.safeBins.filter((bin) => !scope.mergedProfiles[bin]);
-    if (missingBins.length === 0) {
-      continue;
-    }
-    const profileHolder =
-      asObjectRecord(scope.exec.safeBinProfiles) ?? (scope.exec.safeBinProfiles = {});
-    for (const bin of missingBins) {
+    // Scaffold a stdin-only default only for custom bins. Built-in profiles are already active at
+    // runtime (scaffolding them would clobber the shipped constraints), and interpreters are too
+    // broad to constrain via a profile. Create the profiles holder lazily so we never leave an
+    // empty `{}` safeBinProfiles object behind when nothing is scaffolded.
+    for (const bin of scope.safeBins) {
+      if (scope.mergedProfiles[bin]) {
+        continue;
+      }
       if (interpreterBins.has(bin)) {
         warnings.push(
           `- ${scope.scopePath}.safeBins includes interpreter/runtime '${bin}' without profile; remove it from safeBins or use explicit allowlist entries.`,
         );
         continue;
       }
+      if (isBuiltinSafeBinProfile(bin)) {
+        continue;
+      }
+      const profileHolder =
+        asObjectRecord(scope.exec.safeBinProfiles) ?? (scope.exec.safeBinProfiles = {});
       if (profileHolder[bin] !== undefined) {
         continue;
       }
-      profileHolder[bin] = {};
+      profileHolder[bin] = { maxPositional: 0 };
       changes.push(
-        `- ${scope.scopePath}.safeBinProfiles.${bin}: added scaffold profile {} (review and tighten flags/positionals).`,
+        `- ${scope.scopePath}.safeBinProfiles.${bin}: added scaffold profile { maxPositional: 0 } (stdin-only default; review and adjust flags/positionals).`,
       );
+    }
+  }
+
+  // Remove empty `{}` overrides of built-in bins across all profile scopes (including inherited and
+  // safeBins-fallback cases): they silently wipe the shipped profile via the key-spread in
+  // resolveSafeBinProfiles, so deleting them restores built-in protection.
+  for (const { scopePath, exec } of collectSafeBinProfileScopes(next)) {
+    const profileHolder = asObjectRecord(exec.safeBinProfiles);
+    if (!profileHolder) {
+      continue;
+    }
+    for (const bin of listEmptyBuiltinOverrides(exec)) {
+      delete profileHolder[bin];
+      changes.push(
+        `- ${scopePath}.safeBinProfiles.${bin}: removed empty override that disabled the built-in profile (restored built-in positional limits, allowedValueFlags, and deniedFlags).`,
+      );
+    }
+    if (Object.keys(profileHolder).length === 0) {
+      delete exec.safeBinProfiles;
     }
   }
 

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -488,6 +488,19 @@ describe("doctor preview warnings", () => {
     expect(warning).toContain("Move the affected model/provider defaults manually");
   });
 
+  it("warns about an empty built-in safeBin override even without an explicit safeBins list", async () => {
+    const warnings = await collectDoctorPreviewWarnings({
+      cfg: {
+        tools: { exec: { safeBinProfiles: { head: {} } } },
+      } as OpenClawConfig,
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(warnings.join("\n")).toContain(
+      "tools.exec.safeBinProfiles.head: empty profile overrides built-in defaults (positional limits, allowedValueFlags, and deniedFlags are lost).",
+    );
+  });
+
   it("sanitizes empty-allowlist warning paths before returning preview output", async () => {
     const warnings = await collectDoctorPreviewWarnings({
       cfg: {

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -90,6 +90,25 @@ function hasConfiguredSafeBins(cfg: OpenClawConfig): boolean {
   });
 }
 
+function hasConfiguredSafeBinProfiles(cfg: OpenClawConfig): boolean {
+  const globalExec = cfg.tools?.exec;
+  if (
+    hasRecord(globalExec) &&
+    hasRecord(globalExec.safeBinProfiles) &&
+    Object.keys(globalExec.safeBinProfiles).length > 0
+  ) {
+    return true;
+  }
+  return listAgentRecords(cfg).some((agent) => {
+    const agentExec = hasRecord(agent) && hasRecord(agent.tools) ? agent.tools.exec : undefined;
+    return (
+      hasRecord(agentExec) &&
+      hasRecord(agentExec.safeBinProfiles) &&
+      Object.keys(agentExec.safeBinProfiles).length > 0
+    );
+  });
+}
+
 type VisibleReplyPolicyProvenance = "default" | "global-explicit" | "group-explicit";
 type ToolPolicyConfig = {
   allow?: string[];
@@ -943,8 +962,11 @@ export async function collectDoctorPreviewNotes(params: {
     }
   }
 
-  if (hasConfiguredSafeBins(params.cfg)) {
+  // Also run when only safeBinProfiles are configured: default safeBins are active at runtime, so a
+  // stale empty `{}` override of a built-in still disables it even without an explicit safeBins list.
+  if (hasConfiguredSafeBins(params.cfg) || hasConfiguredSafeBinProfiles(params.cfg)) {
     const {
+      collectExecSafeBinCoverageInfoNotes,
       collectExecSafeBinCoverageWarnings,
       collectExecSafeBinTrustedDirHintWarnings,
       scanExecSafeBinCoverage,
@@ -952,12 +974,17 @@ export async function collectDoctorPreviewNotes(params: {
     } = await import("./exec-safe-bins.js");
     const safeBinCoverage = scanExecSafeBinCoverage(params.cfg);
     if (safeBinCoverage.length > 0) {
-      warnings.push(
-        collectExecSafeBinCoverageWarnings({
-          hits: safeBinCoverage,
-          doctorFixCommand: params.doctorFixCommand,
-        }).join("\n"),
-      );
+      const coverageWarnings = collectExecSafeBinCoverageWarnings({
+        hits: safeBinCoverage,
+        doctorFixCommand: params.doctorFixCommand,
+      });
+      if (coverageWarnings.length > 0) {
+        warnings.push(coverageWarnings.join("\n"));
+      }
+      const coverageInfoNotes = collectExecSafeBinCoverageInfoNotes({ hits: safeBinCoverage });
+      if (coverageInfoNotes.length > 0) {
+        infoNotes.push(coverageInfoNotes.join("\n"));
+      }
     }
 
     const safeBinTrustedDirHints = scanExecSafeBinTrustedDirHints(params.cfg);

--- a/src/infra/exec-safe-bin-policy-profiles.ts
+++ b/src/infra/exec-safe-bin-policy-profiles.ts
@@ -230,6 +230,18 @@ function normalizeSafeBinProfileName(raw: string): string | null {
   return name.length > 0 ? name : null;
 }
 
+const BUILTIN_SAFE_BIN_NAMES: ReadonlySet<string> = new Set(Object.keys(SAFE_BIN_PROFILE_FIXTURES));
+
+/**
+ * True when a safeBin name ships a built-in profile. These bins are constrained at runtime even
+ * with no user override, so doctor must not scaffold `{}` for them (an empty override would wipe
+ * the built-in maxPositional/allowedValueFlags/deniedFlags via the key-spread in resolveSafeBinProfiles).
+ */
+export function isBuiltinSafeBinProfile(name: string): boolean {
+  const normalized = normalizeSafeBinProfileName(name);
+  return normalized !== null && BUILTIN_SAFE_BIN_NAMES.has(normalized);
+}
+
 function normalizeFixtureLimit(raw: number | undefined): number | undefined {
   if (typeof raw !== "number" || !Number.isFinite(raw)) {
     return undefined;

--- a/src/infra/exec-safe-bin-policy.ts
+++ b/src/infra/exec-safe-bin-policy.ts
@@ -6,6 +6,7 @@ export {
   SAFE_BIN_PROFILES,
   buildLongFlagPrefixMap,
   collectKnownLongFlags,
+  isBuiltinSafeBinProfile,
   normalizeSafeBinProfileFixtures,
   renderDefaultSafeBinsDocText,
   renderSafeBinDeniedFlagsDocBullets,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw doctor --fix` silently weakened exec safe-bin security for anyone who added a built-in stdin-only helper (`cut`, `uniq`, `head`, `tail`, `tr`, `wc`, `grep`, `sort`, `jq`) to `tools.exec.safeBins`. Doctor scaffolded an empty `{}` profile for these bins, and because `resolveSafeBinProfiles` merges user profiles over the built-ins by key (not a deep merge), the empty `{}` wiped the built-in `maxPositional`, `allowedValueFlags`, and `deniedFlags`. The result was the worst of both worlds: the safe stdin-only form was rejected (e.g. `grep -e "pattern"`) while unsafe forms were allowed (e.g. `grep pattern file.txt`, `grep -r /`). The same empty-override hazard also lived in already-saved configs and was never repaired.

## Why This Change Was Made

doctor now distinguishes built-in bins from custom bins:

- Built-in bins are never scaffolded — their profile already applies at runtime. Plain `doctor` shows an informational note ("uses built-in profile (no custom override needed)") instead of a warning, and they are dropped from the `--fix` scaffold suggestion.
- Custom bins scaffold `{ maxPositional: 0 }` (a stdin-only default) instead of `{}`, matching the documented purpose of safeBins.
- The `safeBinProfiles` holder is created lazily, so doctor no longer leaves an empty `{}` object behind when nothing is scaffolded.
- An empty `{}` override of a built-in is flagged by plain `doctor` and **removed** by `doctor --fix` to restore the shipped profile. Detection is inheritance/fallback aware: it covers global scope, per-agent scope, agents that inherit the global `safeBins` list, and configs relying on the default safeBins set with no explicit `safeBins` key.

No config-shape, schema, or API change; no migration required (the runtime already reads the canonical shape — this only stops doctor from writing a harmful one and repairs existing harmful ones).

## User Impact

- Adding a built-in helper to `safeBins` keeps its built-in protections: the safe `-e`/stdin form works and unsafe file/recursive forms stay blocked.
- `doctor --fix` self-heals existing broken configs that contain an empty `{}` override of a built-in.
- Custom safeBins get a conservative stdin-only default scaffold instead of an unconstrained `{}`.

## Evidence

Tests (new + updated):

- `src/commands/doctor/shared/exec-safe-bins.test.ts`: built-in info note + no scaffold; custom `{ maxPositional: 0 }` scaffold; empty-override warn + `--fix` removal; explicit non-empty override preserved; global-`safeBins`-fallback (agent with no own safeBins) removal; default-safeBins (no `safeBins` key) detection; and a regression asserting `resolveSafeBinProfiles` returns the intact built-in `grep` profile after `--fix`.
- `src/commands/doctor/shared/preview-warnings.test.ts`: plain `doctor` warns about an empty built-in override even with no explicit `safeBins`.

Local validation (macOS):

- ~298 tests green across exec-safe-bins, preview-warnings, doctor-config-flow, repair-sequencing, security audit, exec-safe-bin policy/runtime, and agent-tools safe-bins.
- `pnpm tsgo:core` clean; `pnpm tsgo:core:test` clean for changed files (one unrelated pre-existing `packages/sdk/src/package.e2e.test.ts` error already on `main`).
- `oxfmt --check` and `oxlint` clean on all changed files.

Review: the fix plan and the implementation were independently reviewed by Codex across three passes; all findings (inheritance/fallback detection gaps, message wording, and the plain-`doctor` preview gate for default-active safeBins) were addressed and confirmed resolved.

Notes: branched off latest `main`; independent of (and non-overlapping with) the other open PR on this fork.
