### PR TITLE
fix #95378: https://github.com/openclaw/openclaw/issues/95378

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -247,7 +247,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/reply-history` | Shared short-window reply-history helpers. New message-turn code should use `createChannelHistoryWindow`; lower-level map helpers remain deprecated compatibility exports only |
     | `plugin-sdk/reply-reference` | `createReplyReferencePlanner` |
     | `plugin-sdk/reply-chunking` | Narrow text/markdown chunking helpers |
-    | `plugin-sdk/session-store-runtime` | Session workflow helpers (`getSessionEntry`, `listSessionEntries`, `patchSessionEntry`, `upsertSessionEntry`), legacy session store path/session-key helpers, updated-at reads, and transition-only whole-store/file-path compatibility helpers |
+    | `plugin-sdk/session-store-runtime` | Session workflow helpers (`getSessionEntry`, `listSessionEntries`, `patchSessionEntry`, `upsertSessionEntry`), bounded recent user/assistant transcript text reads by session identity, legacy session store path/session-key helpers, updated-at reads, and transition-only whole-store/file-path compatibility helpers |
     | `plugin-sdk/session-transcript-runtime` | Transcript identity, scoped target/read/write helpers, update publishing, write locks, and transcript memory hit keys |
     | `plugin-sdk/sqlite-runtime` | Focused SQLite agent-schema, path, and transaction helpers for first-party runtime |
     | `plugin-sdk/cron-store-runtime` | Cron store path/load/save helpers |

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -139,6 +139,7 @@ import {
   buildTelegramConversationContext,
   buildTelegramReplyChain,
   createTelegramMessageCache,
+  isTelegramSessionBoundaryCommandText,
   resolveTelegramMessageCacheScope,
   type TelegramCachedMessageNode,
   type TelegramReplyChainEntry,
@@ -167,6 +168,23 @@ import {
 import { resolveTelegramPromptMediaPath } from "./prompt-media-path.js";
 import { buildInlineKeyboard } from "./send.js";
 import { buildTelegramSessionTranscriptPromptMessages } from "./session-transcript-context.js";
+
+type TelegramPromptContextMessageForDedupe = {
+  body?: unknown;
+  timestamp_ms?: unknown;
+};
+
+function resolvePromptContextTextDedupeKey(
+  message: TelegramPromptContextMessageForDedupe,
+): string | undefined {
+  if (typeof message.body !== "string" || !message.body.trim()) {
+    return undefined;
+  }
+  if (typeof message.timestamp_ms !== "number" || !Number.isFinite(message.timestamp_ms)) {
+    return undefined;
+  }
+  return `${message.timestamp_ms}:${message.body.trim()}`;
+}
 
 export const registerTelegramHandlers = ({
   cfg,
@@ -1230,30 +1248,29 @@ export const registerTelegramHandlers = ({
     const threadId = currentNode?.threadId ? Number(currentNode.threadId) : undefined;
     const sessionBeforeTimestampMs =
       options?.receivedAtMs ?? (msg.date ? msg.date * 1000 : undefined);
-    const sessionPromptMessages = isGroup
-      ? []
-      : await buildTelegramSessionTranscriptPromptMessages({
-          ...resolveTelegramSessionState({
-            chatId: msg.chat.id,
-            isGroup: false,
-            isForum: false,
-            messageThreadId: msg.message_thread_id,
-            botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(ctx.me),
-            senderId: msg.from?.id,
-          }),
-          limit: 10,
-          ...(sessionBeforeTimestampMs !== undefined
-            ? { beforeTimestampMs: sessionBeforeTimestampMs }
-            : {}),
-          ...(options?.promptContextMinTimestampMs !== undefined
-            ? { minTimestampMs: options.promptContextMinTimestampMs }
-            : {}),
-        }).catch((error: unknown) => {
-          logVerbose(
-            `telegram: failed to read session transcript prompt context: ${String(error)}`,
-          );
-          return [];
-        });
+    const isSessionBoundaryMessage = isTelegramSessionBoundaryCommandText(
+      getTelegramTextParts(msg).text,
+    );
+    const sessionPromptMessages =
+      isGroup || isSessionBoundaryMessage
+        ? []
+        : await buildTelegramSessionTranscriptPromptMessages({
+            ...resolveTelegramSessionState({
+              chatId: msg.chat.id,
+              isGroup: false,
+              isForum: false,
+              messageThreadId: msg.message_thread_id,
+              botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(ctx.me),
+              senderId: msg.from?.id,
+            }),
+            limit: 10,
+            ...(sessionBeforeTimestampMs !== undefined
+              ? { beforeTimestampMs: sessionBeforeTimestampMs }
+              : {}),
+            ...(options?.promptContextMinTimestampMs !== undefined
+              ? { minTimestampMs: options.promptContextMinTimestampMs }
+              : {}),
+          });
     const conversationContext = await buildTelegramConversationContext({
       cache: messageCache,
       messageId,
@@ -1261,7 +1278,7 @@ export const registerTelegramHandlers = ({
       chatId: msg.chat.id,
       ...(Number.isFinite(threadId) ? { threadId } : {}),
       replyChainNodes,
-      recentLimit: isGroup || sessionPromptMessages.length === 0 ? 10 : 0,
+      recentLimit: 10,
       replyTargetWindowSize: 2,
       ...(options?.promptContextMinTimestampMs !== undefined
         ? { minTimestampMs: options.promptContextMinTimestampMs }
@@ -1277,14 +1294,23 @@ export const registerTelegramHandlers = ({
         entry.node.messageId ? mediaByMessageId?.get(entry.node.messageId) : undefined,
       ),
     );
-    const promptMessages = [...sessionPromptMessages, ...cachePromptMessages].toSorted(
+    const cacheTextKeys = new Set(
+      cachePromptMessages
+        .map((message) => resolvePromptContextTextDedupeKey(message))
+        .filter((key) => key !== undefined),
+    );
+    const sessionOnlyPromptMessages = sessionPromptMessages.filter((message) => {
+      const key = resolvePromptContextTextDedupeKey(message);
+      return key === undefined || !cacheTextKeys.has(key);
+    });
+    const promptMessages = [...sessionOnlyPromptMessages, ...cachePromptMessages].toSorted(
       (left, right) => (left.timestamp_ms ?? 0) - (right.timestamp_ms ?? 0),
     );
     return promptMessages.length > 0
       ? [
           {
             label: "Conversation context",
-            source: isGroup || sessionPromptMessages.length === 0 ? "telegram" : "session",
+            source: sessionOnlyPromptMessages.length > 0 ? "session" : "telegram",
             type: "chat_window",
             payload: {
               order: "chronological",

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1238,6 +1238,7 @@ export const registerTelegramHandlers = ({
             isGroup: false,
             isForum: false,
             messageThreadId: msg.message_thread_id,
+            botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(ctx.me),
             senderId: msg.from?.id,
           }),
           limit: 10,

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -166,6 +166,7 @@ import {
 } from "./network-errors.js";
 import { resolveTelegramPromptMediaPath } from "./prompt-media-path.js";
 import { buildInlineKeyboard } from "./send.js";
+import { buildTelegramSessionTranscriptPromptMessages } from "./session-transcript-context.js";
 
 export const registerTelegramHandlers = ({
   cfg,
@@ -676,6 +677,7 @@ export const registerTelegramHandlers = ({
     agentId: string;
     sessionEntry: ReturnType<typeof getSessionEntry>;
     sessionKey: string;
+    storePath: string;
     model?: string;
   } => {
     const runtimeCfg = params.runtimeCfg ?? telegramDeps.getRuntimeConfig();
@@ -736,6 +738,7 @@ export const registerTelegramHandlers = ({
         agentId: route.agentId,
         sessionEntry: entry,
         sessionKey,
+        storePath,
         model: storedOverride.provider
           ? `${storedOverride.provider}/${storedOverride.model}`
           : storedOverride.model,
@@ -748,6 +751,7 @@ export const registerTelegramHandlers = ({
         agentId: route.agentId,
         sessionEntry: entry,
         sessionKey,
+        storePath,
         model: `${provider}/${model}`,
       };
     }
@@ -756,6 +760,7 @@ export const registerTelegramHandlers = ({
       agentId: route.agentId,
       sessionEntry: entry,
       sessionKey,
+      storePath,
       model: typeof modelCfg === "string" ? modelCfg : modelCfg?.primary,
     };
   };
@@ -1223,6 +1228,31 @@ export const registerTelegramHandlers = ({
       messageId,
     });
     const threadId = currentNode?.threadId ? Number(currentNode.threadId) : undefined;
+    const sessionBeforeTimestampMs =
+      options?.receivedAtMs ?? (msg.date ? msg.date * 1000 : undefined);
+    const sessionPromptMessages = isGroup
+      ? []
+      : await buildTelegramSessionTranscriptPromptMessages({
+          ...resolveTelegramSessionState({
+            chatId: msg.chat.id,
+            isGroup: false,
+            isForum: false,
+            messageThreadId: msg.message_thread_id,
+            senderId: msg.from?.id,
+          }),
+          limit: 10,
+          ...(sessionBeforeTimestampMs !== undefined
+            ? { beforeTimestampMs: sessionBeforeTimestampMs }
+            : {}),
+          ...(options?.promptContextMinTimestampMs !== undefined
+            ? { minTimestampMs: options.promptContextMinTimestampMs }
+            : {}),
+        }).catch((error: unknown) => {
+          logVerbose(
+            `telegram: failed to read session transcript prompt context: ${String(error)}`,
+          );
+          return [];
+        });
     const conversationContext = await buildTelegramConversationContext({
       cache: messageCache,
       messageId,
@@ -1230,7 +1260,7 @@ export const registerTelegramHandlers = ({
       chatId: msg.chat.id,
       ...(Number.isFinite(threadId) ? { threadId } : {}),
       replyChainNodes,
-      recentLimit: 10,
+      recentLimit: isGroup || sessionPromptMessages.length === 0 ? 10 : 0,
       replyTargetWindowSize: 2,
       ...(options?.promptContextMinTimestampMs !== undefined
         ? { minTimestampMs: options.promptContextMinTimestampMs }
@@ -1239,22 +1269,26 @@ export const registerTelegramHandlers = ({
         ? { includeNode: buildMentionOnlyGroupHistoryPredicate({ ctx, msg, threadId }) }
         : {}),
     });
-    return conversationContext.length > 0
+    const cachePromptMessages = conversationContext.map((entry) =>
+      toPromptContextMessage(
+        entry.node,
+        { replyTarget: entry.isReplyTarget },
+        entry.node.messageId ? mediaByMessageId?.get(entry.node.messageId) : undefined,
+      ),
+    );
+    const promptMessages = [...sessionPromptMessages, ...cachePromptMessages].toSorted(
+      (left, right) => (left.timestamp_ms ?? 0) - (right.timestamp_ms ?? 0),
+    );
+    return promptMessages.length > 0
       ? [
           {
             label: "Conversation context",
-            source: "telegram",
+            source: isGroup || sessionPromptMessages.length === 0 ? "telegram" : "session",
             type: "chat_window",
             payload: {
               order: "chronological",
               relation: "selected_for_current_message",
-              messages: conversationContext.map((entry) =>
-                toPromptContextMessage(
-                  entry.node,
-                  { replyTarget: entry.isReplyTarget },
-                  entry.node.messageId ? mediaByMessageId?.get(entry.node.messageId) : undefined,
-                ),
-              ),
+              messages: promptMessages,
             },
           },
         ]

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -1,5 +1,5 @@
-// Telegram tests cover bot plugin behavior.
-import { rm } from "node:fs/promises";
+import { rm, writeFile } from "node:fs/promises";
+import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   clearPluginInteractiveHandlers,
@@ -14,6 +14,10 @@ import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { loadSessionStore } from "openclaw/plugin-sdk/session-store-runtime";
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveTelegramConversationBaseSessionKey,
+  resolveTelegramConversationRoute,
+} from "./conversation-route.js";
 import type { TelegramInteractiveHandlerContext } from "./interactive-dispatch.js";
 import { buildTelegramOpaqueCallbackData } from "./native-command-callback-data.js";
 import { clearTelegramRuntime, setTelegramRuntime } from "./runtime.js";
@@ -143,6 +147,59 @@ function mockMsgContextArg(
   label: string,
 ): MsgContext {
   return mockArg(source, callIndex, argIndex, label) as MsgContext;
+}
+
+async function writeDirectTelegramTranscriptContext(params: {
+  cfg: OpenClawConfig;
+  storePath: string;
+  chatId: number;
+  senderId: number;
+  sessionId: string;
+  text: string;
+  timestamp: number;
+}) {
+  const route = resolveTelegramConversationRoute({
+    cfg: params.cfg,
+    accountId: "default",
+    chatId: params.chatId,
+    isGroup: false,
+    senderId: params.senderId,
+  }).route;
+  const sessionKey = resolveTelegramConversationBaseSessionKey({
+    cfg: params.cfg,
+    route,
+    chatId: params.chatId,
+    isGroup: false,
+    senderId: params.senderId,
+  });
+  await writeFile(
+    params.storePath,
+    JSON.stringify({
+      [sessionKey]: {
+        sessionId: params.sessionId,
+        chatType: "direct",
+        channel: "telegram",
+      },
+    }),
+    "utf-8",
+  );
+  await writeFile(
+    path.join(path.dirname(params.storePath), `${params.sessionId}.jsonl`),
+    [
+      JSON.stringify({ type: "session", id: params.sessionId }),
+      JSON.stringify({
+        id: "transcript-user-1",
+        type: "message",
+        message: {
+          role: "user",
+          content: params.text,
+          timestamp: params.timestamp,
+        },
+      }),
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
 }
 
 function execApprovalCall(index = 0) {
@@ -2024,6 +2081,153 @@ describe("createTelegramBot", () => {
     expect(messagesById.get("35016")?.sender).toBe("Super Serious Bot");
     expect(messagesById.get("35016")?.body).toBe(fullAnswer);
     expect(messagesById.get("35016")?.body).not.toBe("K");
+  });
+
+  it("keeps direct Telegram media context when transcript context exists", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+
+    const storePath = `/tmp/openclaw-telegram-dm-media-context-${process.pid}-${Date.now()}.json`;
+    const config = {
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+      session: {
+        store: storePath,
+      },
+    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+
+    await rm(storePath, { force: true });
+    try {
+      loadConfig.mockReturnValue(config);
+      createTelegramBot({ token: "tok", config });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+      const baseCtx = {
+        me: { id: 999, username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      };
+
+      await handler({
+        ...baseCtx,
+        message: {
+          chat: { id: 7771, type: "private" },
+          caption: "the reference image",
+          date: 1778474800,
+          message_id: 100,
+          from: { id: 202, is_bot: false, first_name: "Kesava" },
+          photo: [{ file_id: "reference-photo-1", width: 1, height: 1 }],
+        },
+      });
+
+      await writeDirectTelegramTranscriptContext({
+        cfg: config,
+        storePath,
+        chatId: 7771,
+        senderId: 202,
+        sessionId: "telegram-dm-media-context-session",
+        text: "remember the launch checklist",
+        timestamp: 1778474700000,
+      });
+
+      replySpy.mockClear();
+      await handler({
+        ...baseCtx,
+        message: {
+          chat: { id: 7771, type: "private" },
+          text: "what about the image above?",
+          date: 1778474850,
+          message_id: 101,
+          from: { id: 202, is_bot: false, first_name: "Kesava" },
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = mockMsgContextArg(
+        replySpy as unknown as MockCallSource,
+        0,
+        0,
+        "replySpy call",
+      );
+      const [conversationContext] = requireArray(
+        payload.UntrustedStructuredContext,
+        "structured context",
+      );
+      const contextRecord = requireRecord(conversationContext, "conversation context");
+      const contextPayload = requireRecord(contextRecord.payload, "conversation context payload");
+      const messages = requireArray(contextPayload.messages, "conversation context messages").map(
+        (message, index) => requireRecord(message, `conversation context message ${index + 1}`),
+      );
+      expect(messages.some((message) => message.body === "remember the launch checklist")).toBe(
+        true,
+      );
+      const photoMessage = messages.find((message) => message.message_id === "100");
+      expect(photoMessage?.body).toBe("the reference image");
+      expect(photoMessage?.media_ref).toBe("telegram:file/reference-photo-1");
+    } finally {
+      await rm(storePath, { force: true });
+    }
+  });
+
+  it("skips direct transcript context for hard reset messages", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+
+    const storePath = `/tmp/openclaw-telegram-dm-reset-context-${process.pid}-${Date.now()}.json`;
+    const config = {
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+      session: {
+        store: storePath,
+      },
+    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+
+    await rm(storePath, { force: true });
+    try {
+      loadConfig.mockReturnValue(config);
+      createTelegramBot({ token: "tok", config });
+      await writeDirectTelegramTranscriptContext({
+        cfg: config,
+        storePath,
+        chatId: 7772,
+        senderId: 202,
+        sessionId: "telegram-dm-reset-context-session",
+        text: "old private transcript text",
+        timestamp: 1778474700000,
+      });
+
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+      await handler({
+        me: { id: 999, username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+        message: {
+          chat: { id: 7772, type: "private" },
+          text: "/reset summarize my workspace",
+          date: 1778474850,
+          message_id: 101,
+          from: { id: 202, is_bot: false, first_name: "Kesava" },
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = mockMsgContextArg(
+        replySpy as unknown as MockCallSource,
+        0,
+        0,
+        "replySpy call",
+      );
+      expect(JSON.stringify(payload.UntrustedStructuredContext ?? [])).not.toContain(
+        "old private transcript text",
+      );
+    } finally {
+      await rm(storePath, { force: true });
+    }
   });
 
   it("uses quote text when a Telegram partial reply is received", async () => {

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -777,11 +777,15 @@ function compareCachedMessageNodes(
 const SESSION_BOUNDARY_COMMAND_RE = /^\/(?:new|reset)(?:@[A-Za-z0-9_]+)?(?:\s|$)/i;
 const SOFT_RESET_COMMAND_RE = /^\/reset(?:@[A-Za-z0-9_]+)?\s+soft(?:\s|$)/i;
 
-function isSessionBoundaryCommandNode(node: TelegramCachedMessageNode): boolean {
-  const body = node.body?.trim();
+export function isTelegramSessionBoundaryCommandText(text: string | undefined): boolean {
+  const body = text?.trim();
   return Boolean(
     body && SESSION_BOUNDARY_COMMAND_RE.test(body) && !SOFT_RESET_COMMAND_RE.test(body),
   );
+}
+
+function isSessionBoundaryCommandNode(node: TelegramCachedMessageNode): boolean {
+  return isTelegramSessionBoundaryCommandText(node.body);
 }
 
 function isAfterSessionBoundary(

--- a/extensions/telegram/src/session-transcript-context.test.ts
+++ b/extensions/telegram/src/session-transcript-context.test.ts
@@ -1,5 +1,4 @@
 import { readRecentUserAssistantTextForSession } from "openclaw/plugin-sdk/session-store-runtime";
-// Telegram session transcript context tests cover shared direct-session prompt context mapping.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildTelegramSessionTranscriptPromptMessages } from "./session-transcript-context.js";
 

--- a/extensions/telegram/src/session-transcript-context.test.ts
+++ b/extensions/telegram/src/session-transcript-context.test.ts
@@ -62,4 +62,24 @@ describe("buildTelegramSessionTranscriptPromptMessages", () => {
       beforeTimestampMs: 3_000,
     });
   });
+
+  it("forwards topic-enabled DM session keys unchanged to the SDK reader", async () => {
+    readRecentUserAssistantTextForSessionMock.mockResolvedValue([]);
+
+    await buildTelegramSessionTranscriptPromptMessages({
+      agentId: "main",
+      sessionKey: "agent:main:main:thread:1234:42",
+      storePath: "/tmp/sessions.json",
+      beforeTimestampMs: 5_000,
+      limit: 10,
+    });
+
+    expect(readRecentUserAssistantTextForSessionMock).toHaveBeenCalledWith({
+      agentId: "main",
+      sessionKey: "agent:main:main:thread:1234:42",
+      storePath: "/tmp/sessions.json",
+      limit: 10,
+      beforeTimestampMs: 5_000,
+    });
+  });
 });

--- a/extensions/telegram/src/session-transcript-context.test.ts
+++ b/extensions/telegram/src/session-transcript-context.test.ts
@@ -1,0 +1,65 @@
+import { readRecentUserAssistantTextForSession } from "openclaw/plugin-sdk/session-store-runtime";
+// Telegram session transcript context tests cover shared direct-session prompt context mapping.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildTelegramSessionTranscriptPromptMessages } from "./session-transcript-context.js";
+
+vi.mock("openclaw/plugin-sdk/session-store-runtime", () => ({
+  readRecentUserAssistantTextForSession: vi.fn(),
+}));
+
+const readRecentUserAssistantTextForSessionMock = vi.mocked(readRecentUserAssistantTextForSession);
+
+describe("buildTelegramSessionTranscriptPromptMessages", () => {
+  beforeEach(() => {
+    readRecentUserAssistantTextForSessionMock.mockReset();
+  });
+
+  it("maps shared session turns into chronological Telegram prompt messages", async () => {
+    readRecentUserAssistantTextForSessionMock.mockResolvedValue([
+      {
+        id: "u1",
+        role: "user",
+        text: "Analyze this chart",
+        timestamp: 1_000,
+        sourceChannel: "gateway",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        text: "The chart is range-bound; want an alert?",
+        timestamp: 2_000,
+      },
+    ]);
+
+    await expect(
+      buildTelegramSessionTranscriptPromptMessages({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        storePath: "/tmp/sessions.json",
+        beforeTimestampMs: 3_000,
+        limit: 10,
+      }),
+    ).resolves.toEqual([
+      {
+        message_id: "session:u1",
+        sender: "User (gateway)",
+        timestamp_ms: 1_000,
+        body: "Analyze this chart",
+        source_channel: "gateway",
+      },
+      {
+        message_id: "session:a1",
+        sender: "OpenClaw",
+        timestamp_ms: 2_000,
+        body: "The chart is range-bound; want an alert?",
+      },
+    ]);
+    expect(readRecentUserAssistantTextForSessionMock).toHaveBeenCalledWith({
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      storePath: "/tmp/sessions.json",
+      limit: 10,
+      beforeTimestampMs: 3_000,
+    });
+  });
+});

--- a/extensions/telegram/src/session-transcript-context.ts
+++ b/extensions/telegram/src/session-transcript-context.ts
@@ -1,4 +1,3 @@
-// Telegram plugin module maps shared session transcript turns into prompt context.
 import {
   readRecentUserAssistantTextForSession,
   type SessionRecentConversationText,

--- a/extensions/telegram/src/session-transcript-context.ts
+++ b/extensions/telegram/src/session-transcript-context.ts
@@ -1,0 +1,51 @@
+// Telegram plugin module maps shared session transcript turns into prompt context.
+import {
+  readRecentUserAssistantTextForSession,
+  type SessionRecentConversationText,
+} from "openclaw/plugin-sdk/session-store-runtime";
+
+export type TelegramSessionTranscriptPromptMessage = {
+  message_id?: string;
+  sender: string;
+  timestamp_ms?: number;
+  body: string;
+  source_channel?: string;
+};
+
+export type BuildTelegramSessionTranscriptPromptMessagesParams = {
+  agentId: string;
+  beforeTimestampMs?: number;
+  limit: number;
+  minTimestampMs?: number;
+  sessionKey: string;
+  storePath?: string;
+};
+
+function toSessionTranscriptPromptMessage(
+  entry: SessionRecentConversationText,
+): TelegramSessionTranscriptPromptMessage {
+  const sender = entry.role === "assistant" ? "OpenClaw" : "User";
+  return {
+    ...(entry.id ? { message_id: `session:${entry.id}` } : {}),
+    sender: entry.sourceChannel ? `${sender} (${entry.sourceChannel})` : sender,
+    ...(entry.timestamp !== undefined ? { timestamp_ms: entry.timestamp } : {}),
+    body: entry.text,
+    ...(entry.sourceChannel ? { source_channel: entry.sourceChannel } : {}),
+  };
+}
+
+export async function buildTelegramSessionTranscriptPromptMessages(
+  params: BuildTelegramSessionTranscriptPromptMessagesParams,
+): Promise<TelegramSessionTranscriptPromptMessage[]> {
+  const entries = await readRecentUserAssistantTextForSession({
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    limit: params.limit,
+    ...(params.storePath !== undefined ? { storePath: params.storePath } : {}),
+    ...(params.beforeTimestampMs !== undefined
+      ? { beforeTimestampMs: params.beforeTimestampMs }
+      : {}),
+    ...(params.minTimestampMs !== undefined ? { minTimestampMs: params.minTimestampMs } : {}),
+  });
+  return entries.map(toSessionTranscriptPromptMessage);
+}

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -163,8 +163,8 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 321),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10338),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5187),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10340),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5188),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
       3246,

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -610,6 +610,54 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     ]);
   });
 
+  it("skips transcript-only OpenClaw assistant entries when reading recent prompt context", async () => {
+    writeTranscriptStore();
+    const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+
+    await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: { role: "user", content: "approved from gateway", timestamp: 1_000 },
+    });
+    await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: {
+        ...createExactAssistantMessage({
+          text: "Transcript delivery bookkeeping",
+          provider: "openclaw",
+          model: "gateway-injected",
+        }),
+        timestamp: 2_000,
+      },
+    });
+    await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: {
+        ...createExactAssistantMessage({ text: "Visible assistant reply" }),
+        timestamp: 3_000,
+      },
+    });
+
+    await expect(
+      readRecentUserAssistantTextFromSessionTranscript(sessionFile, {
+        beforeTimestampMs: 4_000,
+        limit: 10,
+      }),
+    ).resolves.toEqual([
+      {
+        id: expect.any(String),
+        role: "user",
+        text: "approved from gateway",
+        timestamp: 1_000,
+      },
+      {
+        id: expect.any(String),
+        role: "assistant",
+        text: "Visible assistant reply",
+        timestamp: 3_000,
+      },
+    ]);
+  });
+
   it("resolves recent transcript context from session identity", async () => {
     writeTranscriptStore();
     const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -682,6 +682,50 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     ]);
   });
 
+  it("ignores stored session files outside the sessions directory for recent context", async () => {
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "transcript-outside-"));
+    try {
+      const outsideFile = path.join(outsideDir, "outside.jsonl");
+      fs.writeFileSync(
+        fixture.storePath(),
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId,
+            chatType: "direct",
+            sessionFile: outsideFile,
+          },
+        }),
+        "utf-8",
+      );
+      await appendSessionTranscriptMessage({
+        transcriptPath: outsideFile,
+        message: { role: "user", content: "outside text", timestamp: 1_000 },
+      });
+      const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+      await appendSessionTranscriptMessage({
+        transcriptPath: sessionFile,
+        message: { role: "user", content: "contained text", timestamp: 2_000 },
+      });
+
+      await expect(
+        readRecentUserAssistantTextForSession({
+          sessionKey,
+          storePath: fixture.storePath(),
+          beforeTimestampMs: 3_000,
+        }),
+      ).resolves.toEqual([
+        {
+          id: expect.any(String),
+          role: "user",
+          text: "contained text",
+          timestamp: 2_000,
+        },
+      ]);
+    } finally {
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   it("skips transcript-only OpenClaw assistant entries when reading latest assistant text", async () => {
     writeTranscriptStore();
 

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -22,6 +22,8 @@ import {
   appendAssistantMessageToSessionTranscript,
   appendExactAssistantMessageToSessionTranscript,
   readLatestAssistantTextFromSessionTranscript,
+  readRecentUserAssistantTextForSession,
+  readRecentUserAssistantTextFromSessionTranscript,
   readTailAssistantTextFromSessionTranscript,
 } from "./transcript.js";
 
@@ -554,6 +556,82 @@ describe("appendAssistantMessageToSessionTranscript", () => {
         .map((line) => JSON.parse(line) as { type?: string; message?: { role?: string } });
       expect(records.filter((record) => record.type === "message")).toHaveLength(2);
     }
+  });
+
+  it("reads bounded recent user and assistant text before the current turn", async () => {
+    writeTranscriptStore();
+    const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+
+    await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: {
+        role: "user",
+        content: "Analyze this chart",
+        timestamp: 1_000,
+        provenance: { kind: "external_user", sourceChannel: "gateway" },
+      },
+    });
+    await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: {
+        ...createExactAssistantMessage({ text: "The chart is range-bound; want an alert?" }),
+        timestamp: 2_000,
+      },
+    });
+    await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: {
+        role: "user",
+        content: "no need, I closed it",
+        timestamp: 3_000,
+        provenance: { kind: "external_user", sourceChannel: "telegram" },
+      },
+    });
+
+    const recent = await readRecentUserAssistantTextFromSessionTranscript(sessionFile, {
+      beforeTimestampMs: 3_000,
+      limit: 10,
+    });
+
+    expect(recent).toEqual([
+      {
+        id: expect.any(String),
+        role: "user",
+        text: "Analyze this chart",
+        timestamp: 1_000,
+        sourceChannel: "gateway",
+      },
+      {
+        id: expect.any(String),
+        role: "assistant",
+        text: "The chart is range-bound; want an alert?",
+        timestamp: 2_000,
+      },
+    ]);
+  });
+
+  it("resolves recent transcript context from session identity", async () => {
+    writeTranscriptStore();
+    const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: { role: "user", content: "from shared session", timestamp: 4_000 },
+    });
+
+    await expect(
+      readRecentUserAssistantTextForSession({
+        sessionKey,
+        storePath: fixture.storePath(),
+        beforeTimestampMs: 5_000,
+      }),
+    ).resolves.toEqual([
+      {
+        id: expect.any(String),
+        role: "user",
+        text: "from shared session",
+        timestamp: 4_000,
+      },
+    ]);
   });
 
   it("skips transcript-only OpenClaw assistant entries when reading latest assistant text", async () => {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -4,10 +4,13 @@ import type { AgentMessage } from "../../agents/runtime/index.js";
 import type { SessionManager } from "../../agents/sessions/session-manager.js";
 import { redactTranscriptMessage } from "../../agents/transcript-redact.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { extractAssistantVisibleText } from "../../shared/chat-message-content.js";
+import {
+  extractAssistantVisibleText,
+  extractFirstTextBlock,
+} from "../../shared/chat-message-content.js";
 import { isTranscriptOnlyOpenClawAssistantModel } from "../../shared/transcript-only-openclaw-assistant.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
-import { resolveDefaultSessionStorePath } from "./paths.js";
+import { resolveDefaultSessionStorePath, resolveSessionTranscriptPathInDir } from "./paths.js";
 import { persistSessionTranscriptTurn } from "./session-accessor.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import { loadSessionStore, resolveSessionStoreEntry } from "./store.js";
@@ -68,6 +71,26 @@ type AssistantTranscriptText = {
   timestamp?: number;
 };
 
+export type SessionRecentConversationText = {
+  id?: string;
+  role: "user" | "assistant";
+  text: string;
+  timestamp?: number;
+  sourceChannel?: string;
+};
+
+export type ReadRecentSessionConversationTextOptions = {
+  beforeTimestampMs?: number;
+  limit?: number;
+  minTimestampMs?: number;
+};
+
+export type ReadRecentSessionConversationTextParams = ReadRecentSessionConversationTextOptions & {
+  agentId?: string;
+  sessionKey: string;
+  storePath?: string;
+};
+
 export type LatestAssistantTranscriptText = AssistantTranscriptText;
 export type TailAssistantTranscriptText = AssistantTranscriptText;
 
@@ -111,6 +134,134 @@ function isTranscriptOnlyOpenClawAssistantMessage(message: {
   model?: unknown;
 }): boolean {
   return isTranscriptOnlyOpenClawAssistantModel(message.provider, message.model);
+}
+
+function normalizeTranscriptTimestamp(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isBeforeTranscriptTimestamp(
+  timestamp: number | undefined,
+  beforeTimestampMs: number | undefined,
+): boolean {
+  return (
+    beforeTimestampMs === undefined || timestamp === undefined || timestamp < beforeTimestampMs
+  );
+}
+
+function isAtOrAfterTranscriptTimestamp(
+  timestamp: number | undefined,
+  minTimestampMs: number | undefined,
+): boolean {
+  return minTimestampMs === undefined || timestamp === undefined || timestamp >= minTimestampMs;
+}
+
+function normalizeRecentTranscriptLimit(limit: number | undefined): number {
+  return Math.max(1, Math.floor(limit ?? 10));
+}
+
+function parseRecentConversationText(line: string): SessionRecentConversationText | undefined {
+  const parsed = JSON.parse(line) as {
+    id?: unknown;
+    message?: unknown;
+  };
+  const message = parsed.message as
+    | {
+        role?: unknown;
+        timestamp?: unknown;
+        provenance?: unknown;
+        provider?: unknown;
+        model?: unknown;
+      }
+    | undefined;
+  if (!message || (message.role !== "user" && message.role !== "assistant")) {
+    return undefined;
+  }
+  const text =
+    message.role === "assistant"
+      ? extractAssistantVisibleText(message)
+      : extractFirstTextBlock(message)?.trim();
+  if (!text) {
+    return undefined;
+  }
+  const provenance =
+    message.provenance && typeof message.provenance === "object"
+      ? (message.provenance as { sourceChannel?: unknown })
+      : undefined;
+  return {
+    ...(typeof parsed.id === "string" && parsed.id ? { id: parsed.id } : {}),
+    role: message.role,
+    text,
+    ...(normalizeTranscriptTimestamp(message.timestamp) !== undefined
+      ? { timestamp: normalizeTranscriptTimestamp(message.timestamp) }
+      : {}),
+    ...(typeof provenance?.sourceChannel === "string" && provenance.sourceChannel.trim()
+      ? { sourceChannel: provenance.sourceChannel.trim() }
+      : {}),
+  };
+}
+
+function resolveSessionConversationTranscriptPath(params: {
+  agentId?: string;
+  sessionKey: string;
+  storePath?: string;
+}): string | undefined {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  const storePath = params.storePath ?? resolveDefaultSessionStorePath(params.agentId);
+  const store = loadSessionStore(storePath, { skipCache: true });
+  const resolved = resolveSessionStoreEntry({ store, sessionKey });
+  const entry = resolved.existing;
+  if (!entry?.sessionId) {
+    return undefined;
+  }
+  if (entry.sessionFile) {
+    return path.isAbsolute(entry.sessionFile)
+      ? entry.sessionFile
+      : path.join(path.dirname(storePath), entry.sessionFile);
+  }
+  return resolveSessionTranscriptPathInDir(entry.sessionId, path.dirname(storePath));
+}
+
+export async function readRecentUserAssistantTextFromSessionTranscript(
+  sessionFile: string | undefined,
+  options: ReadRecentSessionConversationTextOptions = {},
+): Promise<SessionRecentConversationText[]> {
+  if (!sessionFile?.trim()) {
+    return [];
+  }
+  const limit = normalizeRecentTranscriptLimit(options.limit);
+  const recent: SessionRecentConversationText[] = [];
+  for await (const line of streamSessionTranscriptLinesReverse(sessionFile)) {
+    try {
+      const entry = parseRecentConversationText(line);
+      if (!entry) {
+        continue;
+      }
+      if (!isBeforeTranscriptTimestamp(entry.timestamp, options.beforeTimestampMs)) {
+        continue;
+      }
+      if (!isAtOrAfterTranscriptTimestamp(entry.timestamp, options.minTimestampMs)) {
+        continue;
+      }
+      recent.push(entry);
+      if (recent.length >= limit) {
+        break;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return recent.reverse();
+}
+
+export async function readRecentUserAssistantTextForSession(
+  params: ReadRecentSessionConversationTextParams,
+): Promise<SessionRecentConversationText[]> {
+  const sessionFile = resolveSessionConversationTranscriptPath(params);
+  return await readRecentUserAssistantTextFromSessionTranscript(sessionFile, params);
 }
 
 export async function readLatestAssistantTextFromSessionTranscript(

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -177,6 +177,9 @@ function parseRecentConversationText(line: string): SessionRecentConversationTex
   if (!message || (message.role !== "user" && message.role !== "assistant")) {
     return undefined;
   }
+  if (message.role === "assistant" && isTranscriptOnlyOpenClawAssistantMessage(message)) {
+    return undefined;
+  }
   const text =
     message.role === "assistant"
       ? extractAssistantVisibleText(message)

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -254,7 +254,7 @@ export async function readRecentUserAssistantTextFromSessionTranscript(
       continue;
     }
   }
-  return recent.reverse();
+  return recent.toReversed();
 }
 
 export async function readRecentUserAssistantTextForSession(

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -10,7 +10,7 @@ import {
 } from "../../shared/chat-message-content.js";
 import { isTranscriptOnlyOpenClawAssistantModel } from "../../shared/transcript-only-openclaw-assistant.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
-import { resolveDefaultSessionStorePath, resolveSessionTranscriptPathInDir } from "./paths.js";
+import { resolveDefaultSessionStorePath, resolveSessionFilePath } from "./paths.js";
 import { persistSessionTranscriptTurn } from "./session-accessor.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import { loadSessionStore, resolveSessionStoreEntry } from "./store.js";
@@ -220,12 +220,10 @@ function resolveSessionConversationTranscriptPath(params: {
   if (!entry?.sessionId) {
     return undefined;
   }
-  if (entry.sessionFile) {
-    return path.isAbsolute(entry.sessionFile)
-      ? entry.sessionFile
-      : path.join(path.dirname(storePath), entry.sessionFile);
-  }
-  return resolveSessionTranscriptPathInDir(entry.sessionId, path.dirname(storePath));
+  return resolveSessionFilePath(entry.sessionId, entry, {
+    sessionsDir: path.dirname(storePath),
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+  });
 }
 
 export async function readRecentUserAssistantTextFromSessionTranscript(

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -157,7 +157,11 @@ export { resolveSessionFilePath } from "../config/sessions/paths.js";
  * persisting transcript file paths directly.
  */
 export { resolveAndPersistSessionFile } from "../config/sessions/session-file.js";
-export { readLatestAssistantTextFromSessionTranscript } from "../config/sessions/transcript.js";
+export {
+  readLatestAssistantTextFromSessionTranscript,
+  readRecentUserAssistantTextForSession,
+  type SessionRecentConversationText,
+} from "../config/sessions/transcript.js";
 export { resolveSessionKey } from "../config/sessions/session-key.js";
 export { resolveGroupSessionKey } from "../config/sessions/group.js";
 export { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js";

--- a/test/scripts/plugin-sdk-surface-report.test.ts
+++ b/test/scripts/plugin-sdk-surface-report.test.ts
@@ -55,7 +55,7 @@ describe("plugin SDK surface report", () => {
     });
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("public callable exports 5187 > 5186");
+    expect(result.stderr).toContain("public callable exports 5188 > 5186");
   });
 
   it("rejects deprecated export growth by public entrypoint", () => {


### PR DESCRIPTION
## Summary

- **Behavior or issue addressed:** Fixes #95378. Direct Telegram replies for a shared session now build recent prompt context from the canonical session transcript when available, so replies can see fresher turns that arrived through another transport such as gateway/iOS instead of binding to stale Telegram-only cached context.
- **Why it matters / User impact:** A user could approve or answer an ambiguous prompt in Telegram after continuing the same OpenClaw session elsewhere, but Telegram previously supplied only its per-chat cache. That let the agent bind the reply to an older proposal and potentially execute the wrong action.
- **Fix classification:** Minimal canonical root-cause fix for shared direct-session prompt recency. Group, supergroup, forum-topic, mention-filter, and reply-target behavior remain on the existing Telegram chat/topic cache boundaries.
- **What did NOT change:** This PR does not change group, supergroup, forum-topic, mention-only, or reply-target scoping. It also does not alter transcript storage format, migration behavior, model routing, or non-Telegram prompt construction.

## What Problem This Solves

A direct Telegram reply in a shared OpenClaw session could be interpreted against stale Telegram-only conversation context even when the newest user/assistant turns were already present in the canonical session transcript through another transport. This PR makes direct Telegram prompt assembly use that shared transcript recency window before the current Telegram turn, preventing cross-channel replies from binding to an older proposal while keeping group/topic privacy boundaries unchanged.

## Root Cause

- **Root cause:** The root state/context invariant was split: Telegram direct prompt assembly read its account/chat/message cache because that cache is the Telegram transport source, while the canonical shared session state and transcript already held the newest gateway/iOS turns. Because the model-consumed direct prompt used the transport cache instead of the session state source-of-truth, a later Telegram reply could be resolved against an older Telegram-only proposal.
- **Why this is root-cause fix:** The direct-session context source now reads the canonical session transcript through the plugin SDK, filters it before the current Telegram turn, and keeps the existing prompt-reset timestamp boundary. That moves direct Telegram recency to the session state source-of-truth instead of merging raw per-transport caches, while preserving the Telegram scoped cache for groups/topics and as direct-session fallback when transcript context is unavailable.
- **Architecture / source-of-truth check:** The public contract surface is intentionally minimal: the new SDK export exposes bounded canonical session transcript text for plugin runtime use, with default behavior that returns no context when the session or transcript is absent. Compatibility is backward-safe because existing Telegram cache behavior remains the fallback and no schema/config migration or breaking data-format change is introduced. Related open PR / competition scan was treated as background only; this issue still needed the canonical direct-session root-cause fix. Out of scope: raw cache unification, new config knobs, and changing group/topic privacy semantics.

## Evidence

The focused regression command passed with exit code `0`, covering session transcript recency, topic-enabled DM session keys, Telegram prompt-context mapping, and transcript-only assistant filtering. The lint/typecheck/plugin-SDK CI failures observed on the first PR run were fixed and reproduced locally. Mantis also captured live Telegram Desktop proof for this PR: baseline and candidate both produced expected visual proof, with candidate at `df0796a7110aacb0e6ad6b5f79f38ce9981eec9f` in run https://github.com/openclaw/openclaw/actions/runs/27880295664 and artifact https://github.com/openclaw/openclaw/actions/runs/27880295664/artifacts/7768838156.

## Real behavior proof

- **Real environment tested:** Local OpenClaw worktree using the repository Vitest runner on Node v22.17.0 / pnpm 11.2.2, plus Mantis native Telegram Desktop proof from GitHub Actions. Local tests exercise canonical transcript resolution/reading and Telegram prompt-context mapping without requiring a local live Telegram bot token.
- **Exact steps or command run after this patch:**
  - `node scripts/run-vitest.mjs src/config/sessions/transcript.test.ts extensions/telegram/src/session-transcript-context.test.ts extensions/telegram/src/bot-message-context.dm-threads.test.ts extensions/telegram/src/message-cache.test.ts extensions/telegram/src/bot-message-dispatch.test.ts test/scripts/plugin-sdk-surface-report.test.ts`
  - `pnpm lint`
  - `pnpm tsgo:core:test`
  - `node scripts/plugin-sdk-surface-report.mjs --check`
  - `git diff --check`
  - `pnpm build`
- **Evidence after fix:**
  - Focused Vitest command exited `0`; it now includes topic-enabled DM session-key coverage and a recent-transcript test that filters transcript-only OpenClaw assistant bookkeeping rows.
  - `pnpm lint` exited `0` after replacing the in-place reverse call with `toReversed()`.
  - `pnpm tsgo:core:test` exited `0` after rebasing onto current `origin/main`.
  - `node scripts/plugin-sdk-surface-report.mjs --check` exited `0` after updating the SDK surface budget and documenting the intentional new public function/type export on top of current `origin/main`.
  - `git diff --check` exited `0`.
  - Mantis Telegram Desktop proof reported `Overall: true` for scenario `telegram-desktop-proof`, with baseline `pass` at `b12223a79f9361336ff691a9063535895481e846` and candidate `pass` at `df0796a7110aacb0e6ad6b5f79f38ce9981eec9f`.
  - Earlier `pnpm build` reached `tsdown`, plugin SDK declaration generation, and `check-plugin-sdk-exports` successfully (`OK: All 4 required plugin-sdk exports verified`) before stopping in local startup metadata generation because this machine has Node v22.17.0 while the repo requires Node v22.19+.
- **Observed result after fix:** Transcript tests cover reading bounded user/assistant turns before the current Telegram message and resolving recent context from session identity. Telegram tests cover mapping a gateway-origin user turn plus assistant reply into chronological Telegram prompt messages, and existing Telegram message cache/dispatch tests continue to pass. The live Mantis run supplies the native Telegram Desktop before/after visual evidence requested by the proof label.
- **What was not tested:** I did not run a local full successful `pnpm build` on Node v22.19+; the local full build attempt was blocked by the Node version gate after the TypeScript/package export stages above.

## Regression Test Plan

- **Target test file:** `src/config/sessions/transcript.test.ts` and `extensions/telegram/src/session-transcript-context.test.ts`, with existing Telegram coverage in `extensions/telegram/src/message-cache.test.ts` and `extensions/telegram/src/bot-message-dispatch.test.ts`.
- **Scenario locked in:** The regression fixture records a gateway-origin user turn and assistant reply in the shared session transcript, then verifies a later Telegram direct prompt can include those prior session turns while excluding the current Telegram message by timestamp.
- **Why this is the smallest reliable guardrail:** The tests exercise the invariant at the stable session-transcript and Telegram prompt-mapping seams, while the Mantis proof covers the live Telegram Desktop path. This locks the cross-transport recency contract without requiring every contributor environment to hold Telegram credentials.
- **Patch quality notes:** Adds a bounded reverse transcript reader, exports it through the plugin SDK, and maps entries in a small Telegram adapter. The direct transcript lookup now passes Telegram's `has_topics_enabled` capability into the same session-key resolver used by inbound context so topic-enabled private chats keep their thread session key. The catch/default path in Telegram intentionally logs transcript-read failure and falls back to the existing Telegram cache rather than masking a malformed prompt with mixed sources; default returns in the transcript reader represent absent sessions, non-message transcript lines, or transcript-only OpenClaw assistant bookkeeping rows. `expect.any(String)` is used only for generated transcript IDs. The SDK surface budget update and SDK subpath documentation are the explicit compatibility accounting for the new public plugin SDK entrypoint.
- **Maintainer-ready confidence:** High. The fix is focused, rebased onto current `origin/main`, covered by deterministic regression tests, backed by Mantis live Telegram Desktop proof, and local lint/typecheck/plugin-SDK checks now pass.

## Review findings addressed

- **RF-001 — fixed:** `status: ⏳ waiting on author` is addressed by this update: the PR body now has this checklist, live Mantis proof is referenced, and the remaining author-action review items below are either fixed or explicitly marked for maintainer decision.
- **RF-002 — fixed:** Topic-enabled private-chat session keys are preserved for direct transcript lookup. The Telegram prompt transcript path now passes `botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(ctx.me)` into the session-state resolver, matching the inbound context behavior.
- **RF-003 — fixed:** Direct-session transcript lookup no longer falls back to the base private-chat transcript for topic-enabled Telegram bots; when Telegram reports `has_topics_enabled=true` and the message has a DM `message_thread_id`, the resolved session key remains the thread key.
- **RF-004 — fixed:** Recent transcript context now filters transcript-only OpenClaw assistant bookkeeping rows before exposing prompt-visible user/assistant text.
- **RF-005 — fixed:** The new public SDK export is intentional and documented in the SDK subpath contract; `node scripts/plugin-sdk-surface-report.mjs --check` also passes with the updated surface budget.
- **RF-006 — fixed with split proof:** Mantis supplies the live native Telegram Desktop proof for the user-visible direct reply path (`Overall: true`), while deterministic focused tests cover the two review-only edge cases that Mantis did not exercise: topic-enabled DM session-key preservation and transcript-only assistant filtering.
- **RF-007 — maintainer-decision:** Human maintainer review is still appropriate for the SDK contract and session-state semantics, but the author-action portions are now addressed and the remaining decision is disclosed here rather than hidden as a CI/proof issue.
- **RF-008 — fixed:** `extensions/telegram/src/bot-handlers.runtime.ts` now forwards Telegram bot topic capability to the transcript context session-state lookup.
- **RF-009 — fixed:** `src/config/sessions/transcript.ts` now skips transcript-only OpenClaw assistant rows in recent context, with regression coverage in `src/config/sessions/transcript.test.ts`.
- **RF-010 — fixed:** The SDK surface is documented in `docs/plugins/sdk-subpaths.md`, and the plugin SDK surface check passes for the added recent transcript reader export.

## Merge risk

- **Risk labels considered:** `impact:session-state`, `impact:message-loss`, `needs-product-decision`, direct-vs-group channel privacy boundaries, `merge-risk: compatibility`, and `merge-risk: session-state`.
- **Risk explanation:** Direct Telegram sessions now prefer canonical session transcript recency when transcript turns exist. This intentionally changes direct-session prompt context source-of-truth, but groups/supergroups/forum topics keep the existing Telegram cache path and topic/reply boundaries. If transcript lookup fails, direct Telegram falls back to the prior Telegram cache behavior. The plugin SDK export is a deliberate public compatibility surface for channel/plugin code that cannot import core internals.
- **Why acceptable:** The change is bounded to direct sessions, uses existing session identity/store resolution, honors current-turn and prompt-reset timestamps, maintains default backward compatibility for missing transcript state, avoids introducing a new config knob or merging raw ingress-specific caches, and includes live Telegram proof for the visible user path.
