### PR TITLE
fix(doctor): suppress local memory embedding warning when probe was skipped

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -272,6 +272,23 @@ describe("noteMemorySearchHealth", () => {
     expect(firstNoteMessage()).toContain("a local model path is configured");
   });
 
+  it("does not warn when local provider probe was skipped (skipped: true)", async () => {
+    // When gateway probe is skipped (checked: false, skipped: true), the
+    // local provider should not produce a false warning — it just means the
+    // probe was not run, not that embeddings are broken.
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: { checked: false, ready: false, skipped: true },
+    });
+
+    expect(note).not.toHaveBeenCalled();
+  });
+
   it("does not emit provider guidance when no memory runtime is active", async () => {
     resolveActiveMemoryBackendConfig.mockReturnValue(null);
     resolveMemorySearchConfig.mockReturnValue({

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -472,6 +472,13 @@ export async function noteMemorySearchHealth(
     if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
       return;
     }
+    // When the probe was intentionally skipped (skipped: true / checked: false
+    // due to probe:false path), we have no embedding status information — do
+    // not warn. A skipped probe means the user ran `openclaw doctor` without
+    // --deep; it does not mean embeddings are unavailable.
+    if (opts?.gatewayMemoryProbe?.skipped) {
+      return;
+    }
     const hasExplicitLocalModel = hasLocalEmbeddings(resolved.local);
     const detail = opts?.gatewayMemoryProbe?.error?.trim();
     note(

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -473,9 +473,9 @@ export async function noteMemorySearchHealth(
       return;
     }
     // When the probe was intentionally skipped (skipped: true / checked: false
-    // due to probe:false path), we have no embedding status information — do
-    // not warn. A skipped probe means the user ran `openclaw doctor` without
-    // --deep; it does not mean embeddings are unavailable.
+    // due to probe:false path, e.g. when the gateway sends probe:false even
+    // during --deep), we have no embedding status information — do not warn.
+    // A skipped probe does not mean embeddings are unavailable.
     if (opts?.gatewayMemoryProbe?.skipped) {
       return;
     }


### PR DESCRIPTION
Closes #92582

## Summary
`openclaw doctor` warns "local embeddings are not confirmed ready" even when `openclaw memory status --deep` confirms healthy memory, because the local provider branch lacks the skipped-probe guard that other providers already have.

## Changes
- Added `skipped` probe guard to the `provider === "local"` branch in `noteMemorySearchHealth`
- Matches the existing behavior of `isKeyOptionalMemoryProvider` (line ~535) which silently returns when `opts.gatewayMemoryProbe.skipped === true`
- Source: +7 lines in `src/commands/doctor-memory-search.ts`

## Test
```
node scripts/run-vitest.mjs src/commands/doctor-memory-search.test.ts
=> 49/49 passed
```

## Drift proof
Source-only fix: the `skipped` guard is a pure source-level invariant. The same pattern already exists in the key-optional provider path at the same scope. Added 1 block (7 lines with comment) directly above the existing warning `note()` call.