### PR TITLE
fix #92582: Bug: doctor falsely warns local memory embeddings are not ready

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -237,6 +237,26 @@ describe("noteMemorySearchHealth", () => {
     expect(note).not.toHaveBeenCalled();
   });
 
+  it("does not warn when local provider readiness probe was intentionally skipped", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: { modelPath: "hf:some-org/some-model-GGUF/model.gguf" },
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: {
+        checked: false,
+        ready: false,
+        error:
+          "memory embedding readiness not checked; run `openclaw memory status --deep` to probe",
+        skipped: true,
+      },
+    });
+
+    expect(note).not.toHaveBeenCalled();
+  });
+
   it("warns when local provider readiness probe is inconclusive", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "local",

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -257,6 +257,27 @@ describe("noteMemorySearchHealth", () => {
     expect(note).not.toHaveBeenCalled();
   });
 
+  it("warns when local provider skipped readiness but configured local model is missing", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: { modelPath: "/definitely/missing/openclaw-memory-model.gguf" },
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: {
+        checked: false,
+        ready: false,
+        error:
+          "memory embedding readiness not checked; run `openclaw memory status --deep` to probe",
+        skipped: true,
+      },
+    });
+
+    expect(note).toHaveBeenCalledTimes(1);
+    expect(firstNoteMessage()).toContain('Memory search provider is set to "local"');
+  });
+
   it("warns when local provider readiness probe is inconclusive", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "local",

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -472,10 +472,12 @@ export async function noteMemorySearchHealth(
     if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
       return;
     }
-    if (opts?.gatewayMemoryProbe?.skipped) {
+    const hasExplicitLocalModel = hasLocalEmbeddings(resolved.local);
+    const hasUnavailableConfiguredLocalModel =
+      Boolean(normalizeOptionalString(resolved.local.modelPath)) && !hasExplicitLocalModel;
+    if (opts?.gatewayMemoryProbe?.skipped && !hasUnavailableConfiguredLocalModel) {
       return;
     }
-    const hasExplicitLocalModel = hasLocalEmbeddings(resolved.local);
     const detail = opts?.gatewayMemoryProbe?.error?.trim();
     note(
       [

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -472,6 +472,9 @@ export async function noteMemorySearchHealth(
     if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
       return;
     }
+    if (opts?.gatewayMemoryProbe?.skipped) {
+      return;
+    }
     const hasExplicitLocalModel = hasLocalEmbeddings(resolved.local);
     const detail = opts?.gatewayMemoryProbe?.error?.trim();
     note(


### PR DESCRIPTION
Fixes #92582

## Summary

`openclaw doctor` can warn that local memory embeddings are "not confirmed ready" even when the configured local memory stack is healthy. This PR makes the local-provider doctor renderer honor the gateway's explicit skipped-probe state, matching the existing key-optional provider behavior.

## What Problem This Solves

- **Behavior or issue addressed:** Doctor rendered a fix-required local embeddings warning when the gateway intentionally skipped the embedding readiness probe (`probe: false`).
- **Why it matters / User impact:** Users with working local GGUF embeddings could see a misleading warning even after `openclaw memory status --deep` confirmed embeddings, vector store, semantic vectors, and FTS were ready.

## Fix classification

- **Fix classification:** Minimal root-cause diagnostic fix. It fixes the renderer invariant for one provider branch so intentionally skipped probes do not become warnings.
- **Maintainer-ready confidence:** High for the source-level diagnostic path. The changed branch is small, the existing timeout warning remains covered, and the new regression exercises the exact skipped-probe shape returned by the gateway helper.

## Root Cause

- **Root cause:** `probeGatewayMemoryStatus()` already returns `checked: false` and `skipped: true` when the gateway intentionally skips the embedding readiness probe. The key-optional provider renderer returns early for that state, but the local-provider renderer only returned for `checked && ready`, so skipped local probes fell through to the "local embeddings are not confirmed ready" warning.
- **Why this is root-cause fix:** The source-of-truth diagnostic contract is the structured `gatewayMemoryProbe` state. Honoring `skipped` in the local provider branch restores that contract without changing gateway probing or suppressing checked failures.

## Changes

- Return early from the local-provider doctor branch when `gatewayMemoryProbe.skipped` is true.
- Add regression coverage for a configured local GGUF model with a skipped gateway embedding probe.
- Keep the existing timeout/inconclusive-probe warning path unchanged.

## Scope boundary

This PR only changes doctor diagnostic rendering in `src/commands/doctor-memory-search.ts` and its focused regression test. It does not change gateway probe RPC parameters, `openclaw memory status --deep`, embedding model loading, vector-store readiness, or local provider runtime behavior.

## Source-of-truth boundary

The existing `gatewayMemoryProbe` object is the source of truth: `skipped: true` means the gateway intentionally did not perform an embedding readiness probe. This PR consumes that existing contract in the local provider branch; it does not add a new config option or redefine gateway memory status payloads.

## Real behavior proof

- **Real environment tested:** `openclaw doctor --non-interactive --no-color` from the issue worktree on Windows Git Bash with an isolated `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_HOME`. The temporary config set `agents.defaults.memorySearch.provider=local` and an explicit `agents.defaults.memorySearch.local.modelPath=hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf`. Gateway auth used an exec SecretRef and the command intentionally omitted `--allow-exec`, which makes doctor skip gateway health probes instead of running the exec credential.
- **Exact steps or command run after this patch:** `OPENCLAW_CONFIG_PATH=<tmp>/openclaw.json OPENCLAW_STATE_DIR=<tmp>/state OPENCLAW_HOME=<tmp>/home NO_COLOR=1 NODE_OPTIONS="--require <tmp>/node-version-shim.cjs" pnpm -s openclaw doctor --non-interactive --no-color`
- **Evidence after fix:** The doctor command exited 0. Its output included the expected skipped-probe diagnostic and did not include either local embedding false-positive string.

```text
Gateway health probes skipped because gateway credentials use an exec
SecretRef. Run `openclaw doctor --allow-exec` to verify Gateway health
with exec SecretRefs.
...
Doctor complete.
exit=0
probe summary:
Gateway health probes skipped: True
Memory search provider is set to "local": False
local embeddings are not confirmed ready: False
```

- **Observed result after fix:** With local memory search configured and the gateway memory probe intentionally skipped, `openclaw doctor` completed without rendering `Memory search provider is set to "local"` or `local embeddings are not confirmed ready`.
- **What was not tested:** No live local GGUF model download/inference was performed, and no real gateway health probe was run. This proof specifically covers the reported skipped-probe doctor path, which is the path that produced the false warning.

## Review findings addressed

- **RF-001:** Added redacted terminal output from a patched `openclaw doctor` run with local memory search configured, showing the false warning strings were absent.
- **RF-002:** Updated this PR body with after-fix configured local-provider doctor output and the exact sanitized command shape.
- **RF-003:** The previous source-only proof gap is addressed by the CLI doctor output above. Live GGUF inference and a real gateway health probe remain intentionally untested and are disclosed in the proof boundary.
- **RF-004:** Several open PRs target the same linked issue. This PR keeps its diff XS and focused; choosing the canonical overlapping branch is a maintainer decision.
- **RF-005:** No additional narrow automated code repair is left on this branch beyond the proof/body update; maintainers still need to choose the canonical overlapping PR.

## Verification

- `OPENCLAW_CONFIG_PATH=<tmp>/openclaw.json OPENCLAW_STATE_DIR=<tmp>/state OPENCLAW_HOME=<tmp>/home NO_COLOR=1 NODE_OPTIONS="--require <tmp>/node-version-shim.cjs" pnpm -s openclaw doctor --non-interactive --no-color`  
  Observed: exited 0; output showed gateway probes skipped and no local embeddings warning.
- `node scripts/run-vitest.mjs src/commands/doctor-memory-search.test.ts src/commands/doctor-gateway-health.test.ts src/flows/doctor-health-contributions.test.ts`  
  Observed: exited 0.
- `node scripts/run-oxlint.mjs src/commands/doctor-memory-search.ts src/commands/doctor-memory-search.test.ts`  
  Observed: exited 0.
- `git diff --check HEAD~1 HEAD`  
  Observed: exited 0.

## Regression Test Plan

- **Target test file:** `src/commands/doctor-memory-search.test.ts`
- **Regression scenario:** The new test configures provider `local` with an explicit `hf:` model path and passes the gateway skipped-probe shape: `checked: false`, `ready: false`, `skipped: true`.
- **Test guardrail rationale:** The regression targets the renderer boundary where the bug lives. The neighboring timeout test still uses `checked: false`, `ready: false`, `skipped: false` and expects the warning, preventing the fix from masking real gateway failures.

## Additional Check

- `pnpm check:test-types` was attempted after the commit. It did not pass in this checkout because of an existing unrelated type error outside this diff:

```text
[WARN] Unsupported engine: wanted: {"node":">=22.19.0"} (current: {"node":"v22.17.0","pnpm":"11.2.2"})
packages/sdk/src/package.e2e.test.ts(127,5): error TS2322: Type 'string | URL' is not assignable to type 'string'.
  Type 'URL' is not assignable to type 'string'.
```

## Patch quality notes

- **Patch quality notes:** XS diff: one production branch check and one regression test. It avoids broad doctor behavior changes, does not auto-run deep probes, and does not downgrade transport failures or checked not-ready states.

## Merge risk

- **Risk labels considered:** `merge-risk: session-state` signal because doctor memory diagnostics touch memory/session-adjacent health reporting.
- **Risk explanation:** The change affects only doctor output for the explicit skipped-probe state. It does not mutate memory/session state, gateway probing, or embedding readiness.
- **Why acceptable:** Checked not-ready probes and transport timeouts still warn. The only newly neutral state is the gateway's explicit "probe intentionally skipped" discriminator.

## Risk / Scope

Low risk, diagnostic-only. The failure mode of this change is bounded to doctor output for local memory search.
