### PR TITLE
fix(lmstudio): canonicalize variant model keys

### DIFF
--- a/extensions/lmstudio/src/models.fetch.ts
+++ b/extensions/lmstudio/src/models.fetch.ts
@@ -27,6 +27,10 @@ type LmstudioLoadResponse = {
   status?: string;
 };
 
+type LmstudioResolvedModelKeyError = {
+  resolvedModelKey: string;
+};
+
 type FetchLmstudioModelsResult = {
   reachable: boolean;
   status?: number;
@@ -77,6 +81,19 @@ function asLmstudioModelWire(value: unknown): LmstudioModelWire {
     throw new Error("LM Studio model list: malformed JSON response");
   }
   return value as LmstudioModelWire;
+}
+
+function withResolvedLmstudioModelKey(
+  error: unknown,
+  resolvedModelKey: string,
+): Error & LmstudioResolvedModelKeyError {
+  if (error instanceof Error) {
+    return Object.assign(error, { resolvedModelKey });
+  }
+  return Object.assign(new Error(String(error)), {
+    cause: error,
+    resolvedModelKey,
+  });
 }
 
 /** Fetches /api/v1/models and reports transport reachability separately from HTTP status. */
@@ -240,42 +257,48 @@ export async function ensureLmstudioModelLoaded(params: {
     return canonicalModelKey;
   }
 
-  const { response, release } = await fetchLmstudioEndpoint({
-    url: `${baseUrl}/api/v1/models/load`,
-    init: {
-      method: "POST",
-      headers: buildLmstudioAuthHeaders({
-        apiKey: params.apiKey,
-        headers: params.headers,
-        json: true,
-      }),
-      body: JSON.stringify({
-        model: canonicalModelKey,
-        // Ask LM Studio to load with our default target, capped to the model's own limit.
-        context_length: contextLengthForLoad,
-      }),
-    },
-    timeoutMs,
-    fetchImpl: params.fetchImpl,
-    ssrfPolicy: params.ssrfPolicy,
-    auditContext: "lmstudio-model-load",
-  });
   try {
-    if (!response.ok) {
-      const body = await readResponseTextLimited(response, LMSTUDIO_ERROR_BODY_LIMIT_BYTES);
-      throw new Error(`LM Studio model load failed (${response.status})${body ? `: ${body}` : ""}`);
-    }
-    let payload: LmstudioLoadResponse;
+    const { response, release } = await fetchLmstudioEndpoint({
+      url: `${baseUrl}/api/v1/models/load`,
+      init: {
+        method: "POST",
+        headers: buildLmstudioAuthHeaders({
+          apiKey: params.apiKey,
+          headers: params.headers,
+          json: true,
+        }),
+        body: JSON.stringify({
+          model: canonicalModelKey,
+          // Ask LM Studio to load with our default target, capped to the model's own limit.
+          context_length: contextLengthForLoad,
+        }),
+      },
+      timeoutMs,
+      fetchImpl: params.fetchImpl,
+      ssrfPolicy: params.ssrfPolicy,
+      auditContext: "lmstudio-model-load",
+    });
     try {
-      payload = (await response.json()) as LmstudioLoadResponse;
-    } catch (cause) {
-      throw new Error("LM Studio model load returned malformed JSON", { cause });
+      if (!response.ok) {
+        const body = await readResponseTextLimited(response, LMSTUDIO_ERROR_BODY_LIMIT_BYTES);
+        throw new Error(
+          `LM Studio model load failed (${response.status})${body ? `: ${body}` : ""}`,
+        );
+      }
+      let payload: LmstudioLoadResponse;
+      try {
+        payload = (await response.json()) as LmstudioLoadResponse;
+      } catch (cause) {
+        throw new Error("LM Studio model load returned malformed JSON", { cause });
+      }
+      if (typeof payload.status === "string" && payload.status.toLowerCase() !== "loaded") {
+        throw new Error(`LM Studio model load returned unexpected status: ${payload.status}`);
+      }
+    } finally {
+      await release();
     }
-    if (typeof payload.status === "string" && payload.status.toLowerCase() !== "loaded") {
-      throw new Error(`LM Studio model load returned unexpected status: ${payload.status}`);
-    }
-  } finally {
-    await release();
+  } catch (error) {
+    throw withResolvedLmstudioModelKey(error, canonicalModelKey);
   }
   return canonicalModelKey;
 }

--- a/extensions/lmstudio/src/models.fetch.ts
+++ b/extensions/lmstudio/src/models.fetch.ts
@@ -13,6 +13,7 @@ import { LMSTUDIO_DEFAULT_LOAD_CONTEXT_LENGTH } from "./defaults.js";
 import {
   buildLmstudioModelName,
   mapLmstudioWireEntry,
+  resolveLmstudioCanonicalModelKey,
   resolveLmstudioServerBase,
   resolveLoadedContextWindow,
   type LmstudioModelWire,
@@ -198,7 +199,7 @@ export async function ensureLmstudioModelLoaded(params: {
   timeoutMs?: number;
   /** Injectable fetch implementation; defaults to the global fetch. */
   fetchImpl?: typeof fetch;
-}): Promise<void> {
+}): Promise<string> {
   const modelKey = params.modelKey.trim();
   if (!modelKey) {
     throw new Error("LM Studio model key is required");
@@ -220,7 +221,11 @@ export async function ensureLmstudioModelLoaded(params: {
   if (preflight.status !== undefined && preflight.status >= 400) {
     throw new Error(`LM Studio model discovery failed (${preflight.status})`);
   }
-  const matchingModel = preflight.models.find((entry) => entry.key?.trim() === modelKey);
+  const canonicalModelKey = resolveLmstudioCanonicalModelKey({
+    modelKey,
+    models: preflight.models,
+  });
+  const matchingModel = preflight.models.find((entry) => entry.key?.trim() === canonicalModelKey);
   const loadedContextWindow = matchingModel ? resolveLoadedContextWindow(matchingModel) : null;
   const advertisedContextLimit = asPositiveSafeInteger(matchingModel?.max_context_length) ?? null;
   const requestedContextLength = asPositiveSafeInteger(params.requestedContextLength) ?? null;
@@ -232,7 +237,7 @@ export async function ensureLmstudioModelLoaded(params: {
           advertisedContextLimit,
         );
   if (loadedContextWindow !== null && loadedContextWindow >= contextLengthForLoad) {
-    return;
+    return canonicalModelKey;
   }
 
   const { response, release } = await fetchLmstudioEndpoint({
@@ -245,7 +250,7 @@ export async function ensureLmstudioModelLoaded(params: {
         json: true,
       }),
       body: JSON.stringify({
-        model: modelKey,
+        model: canonicalModelKey,
         // Ask LM Studio to load with our default target, capped to the model's own limit.
         context_length: contextLengthForLoad,
       }),
@@ -272,4 +277,5 @@ export async function ensureLmstudioModelLoaded(params: {
   } finally {
     await release();
   }
+  return canonicalModelKey;
 }

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -516,6 +516,42 @@ describe("lmstudio-models", () => {
     expectLoadModelKey(fetchMock, canonicalKey);
   });
 
+  it("keeps the canonical model key on load failures after variant discovery", async () => {
+    const canonicalKey = "gemma-4-e4b-it-ultra-uncensored-heretic";
+    const variantKey = `${canonicalKey}@q4_k_m`;
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (String(url).endsWith("/api/v1/models")) {
+        return {
+          ok: true,
+          json: async () => ({
+            models: [
+              {
+                type: "llm",
+                key: canonicalKey,
+                variants: [variantKey],
+                selected_variant: variantKey,
+                loaded_instances: [],
+              },
+            ],
+          }),
+        };
+      }
+      if (String(url).endsWith("/api/v1/models/load")) {
+        return new Response("load failed", { status: 503 });
+      }
+      throw new Error(`Unexpected fetch URL: ${String(url)}`);
+    });
+    vi.stubGlobal("fetch", asFetch(fetchMock));
+
+    const error = await ensureLmstudioModelLoaded({
+      baseUrl: "http://localhost:1234/v1",
+      modelKey: variantKey,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toMatchObject({ resolvedModelKey: canonicalKey });
+  });
+
   it("preserves a suffixed key when LM Studio advertises it as the model key", async () => {
     const suffixedKey = "local/special-model@q4_k_m";
     const fetchMock = createModelLoadFetchMock({

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -66,10 +66,14 @@ describe("lmstudio-models", () => {
     };
   };
   const createModelLoadFetchMock = (params?: {
+    key?: string;
+    variants?: unknown;
+    selectedVariant?: unknown;
     loadedContextLength?: number;
     maxContextLength?: number;
   }) =>
     vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const key = params?.key ?? "qwen3-8b-instruct";
       if (String(url).endsWith("/api/v1/models")) {
         return {
           ok: true,
@@ -77,8 +81,10 @@ describe("lmstudio-models", () => {
             models: [
               {
                 type: "llm",
-                key: "qwen3-8b-instruct",
+                key,
                 max_context_length: params?.maxContextLength,
+                variants: params?.variants,
+                selected_variant: params?.selectedVariant,
                 loaded_instances: params?.loadedContextLength
                   ? [{ id: "inst-1", config: { context_length: params.loadedContextLength } }]
                   : [],
@@ -109,6 +115,18 @@ describe("lmstudio-models", () => {
     const loadInit = loadCall[1] as RequestInit;
     const loadBody = parseJsonRequestBody(loadInit) as { context_length: number };
     expect(loadBody.context_length).toBe(contextLength);
+  };
+  const expectLoadModelKey = (
+    fetchMock: ReturnType<typeof createModelLoadFetchMock>,
+    modelKey: string,
+  ) => {
+    const loadCall = findModelLoadCall(fetchMock);
+    if (!loadCall) {
+      throw new Error("expected LM Studio model load request");
+    }
+    const loadInit = loadCall[1] as RequestInit;
+    const loadBody = parseJsonRequestBody(loadInit) as { model: string };
+    expect(loadBody.model).toBe(modelKey);
   };
 
   afterEach(() => {
@@ -451,7 +469,7 @@ describe("lmstudio-models", () => {
         baseUrl: "http://localhost:1234/v1",
         modelKey: "qwen3-8b-instruct",
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe("qwen3-8b-instruct");
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const calledUrls = fetchMock.mock.calls.map((call) => String(call[0]));
@@ -471,10 +489,51 @@ describe("lmstudio-models", () => {
         modelKey: "qwen3-8b-instruct",
         requestedContextLength: 8192,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe("qwen3-8b-instruct");
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expectLoadContextLength(fetchMock, 8192);
+  });
+
+  it("loads the canonical model key when the requested key is an advertised variant", async () => {
+    const canonicalKey = "gemma-4-e4b-it-ultra-uncensored-heretic";
+    const variantKey = `${canonicalKey}@q4_k_m`;
+    const fetchMock = createModelLoadFetchMock({
+      key: canonicalKey,
+      variants: [variantKey],
+      selectedVariant: variantKey,
+    });
+    vi.stubGlobal("fetch", asFetch(fetchMock));
+
+    await expect(
+      ensureLmstudioModelLoaded({
+        baseUrl: "http://localhost:1234/v1",
+        modelKey: variantKey,
+      }),
+    ).resolves.toBe(canonicalKey);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expectLoadModelKey(fetchMock, canonicalKey);
+  });
+
+  it("preserves a suffixed key when LM Studio advertises it as the model key", async () => {
+    const suffixedKey = "local/special-model@q4_k_m";
+    const fetchMock = createModelLoadFetchMock({
+      key: suffixedKey,
+      variants: ["local/special-model@q8_0"],
+      selectedVariant: "local/special-model@q8_0",
+    });
+    vi.stubGlobal("fetch", asFetch(fetchMock));
+
+    await expect(
+      ensureLmstudioModelLoaded({
+        baseUrl: "http://localhost:1234/v1",
+        modelKey: suffixedKey,
+      }),
+    ).resolves.toBe(suffixedKey);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expectLoadModelKey(fetchMock, suffixedKey);
   });
 
   it("reports malformed model load JSON with an owned error", async () => {
@@ -552,7 +611,7 @@ describe("lmstudio-models", () => {
         baseUrl: "http://localhost:1234/v1",
         modelKey: "qwen3-8b-instruct",
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe("qwen3-8b-instruct");
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expectLoadContextLength(fetchMock, 32768);
@@ -572,7 +631,7 @@ describe("lmstudio-models", () => {
         },
         modelKey: " qwen3-8b-instruct ",
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe("qwen3-8b-instruct");
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const loadCall = findModelLoadCall(fetchMock);
@@ -608,7 +667,7 @@ describe("lmstudio-models", () => {
         modelKey: "qwen3-8b-instruct",
         requestedContextLength: 8192,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe("qwen3-8b-instruct");
 
     expectLoadContextLength(fetchMock, 8192);
   });
@@ -626,7 +685,7 @@ describe("lmstudio-models", () => {
         modelKey: "qwen3-8b-instruct",
         requestedContextLength: 8192.5,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe("qwen3-8b-instruct");
 
     expectLoadContextLength(fetchMock, LMSTUDIO_DEFAULT_LOAD_CONTEXT_LENGTH);
   });

--- a/extensions/lmstudio/src/models.ts
+++ b/extensions/lmstudio/src/models.ts
@@ -17,6 +17,8 @@ export type LmstudioModelWire = {
   display_name?: string;
   max_context_length?: number;
   format?: "gguf" | "mlx" | null;
+  variants?: unknown;
+  selected_variant?: unknown;
   capabilities?: {
     vision?: boolean;
     trained_for_tool_use?: boolean;
@@ -217,6 +219,56 @@ export function resolveLoadedContextWindow(
     contextWindow = contextWindow === null ? normalized : Math.max(contextWindow, normalized);
   }
   return contextWindow;
+}
+
+function normalizeLmstudioVariantIds(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return uniqueStrings(
+    value.flatMap((variant) =>
+      typeof variant === "string" && variant.trim().length > 0 ? variant.trim() : [],
+    ),
+  );
+}
+
+/**
+ * Resolves LM Studio variant ids back to their loadable model key.
+ *
+ * LM Studio exposes quantized variants separately from the canonical `key`, but
+ * `/api/v1/models/load` expects the key. Exact key matches still win so unusual
+ * servers that expose a suffix as the real key are preserved.
+ */
+export function resolveLmstudioCanonicalModelKey(params: {
+  modelKey: string;
+  models: LmstudioModelWire[];
+}): string {
+  const modelKey = params.modelKey.trim();
+  if (!modelKey) {
+    return modelKey;
+  }
+  const normalizedModelKey = modelKey.toLowerCase();
+  for (const entry of params.models) {
+    if (entry.key?.trim() === modelKey) {
+      return modelKey;
+    }
+  }
+  for (const entry of params.models) {
+    const key = entry.key?.trim();
+    if (!key) {
+      continue;
+    }
+    const selectedVariant =
+      typeof entry.selected_variant === "string" ? entry.selected_variant.trim() : "";
+    const variants = normalizeLmstudioVariantIds(entry.variants);
+    if (
+      selectedVariant.toLowerCase() === normalizedModelKey ||
+      variants.some((variant) => variant.toLowerCase() === normalizedModelKey)
+    ) {
+      return key;
+    }
+  }
+  return modelKey;
 }
 
 /**

--- a/extensions/lmstudio/src/stream.test.ts
+++ b/extensions/lmstudio/src/stream.test.ts
@@ -319,6 +319,27 @@ describe("lmstudio stream wrapper", () => {
     expect(baseStream).toHaveBeenCalledTimes(1);
   });
 
+  it("streams with the canonical model key when preload fails after discovery", async () => {
+    ensureLmstudioModelLoadedMock.mockRejectedValueOnce(
+      Object.assign(new Error("load failed"), {
+        resolvedModelKey: "gemma-4-e4b-it-ultra-uncensored-heretic",
+      }),
+    );
+    const baseStream = buildDoneStreamFn();
+    const wrapped = createWrappedLmstudioStream(baseStream);
+    const stream = runWrappedLmstudioStream(wrapped, {
+      id: "lmstudio/gemma-4-e4b-it-ultra-uncensored-heretic@q4_k_m",
+    });
+    const events = await collectEvents(stream);
+
+    expectSingleDoneEvent(events);
+    expect(baseStream).toHaveBeenCalledTimes(1);
+    expectBaseStreamModelFields(baseStream, {
+      provider: "lmstudio",
+      id: "gemma-4-e4b-it-ultra-uncensored-heretic",
+    });
+  });
+
   it("skips native model preload when provider params disable it", async () => {
     const baseStream = buildDoneStreamFn();
     const wrapped = wrapLmstudioInferencePreload({

--- a/extensions/lmstudio/src/stream.test.ts
+++ b/extensions/lmstudio/src/stream.test.ts
@@ -90,6 +90,18 @@ function expectBaseStreamModelFields(baseStream: StreamFn, fields: Record<string
   expect(call[2]).toBeUndefined();
 }
 
+function expectBaseStreamCallModelFields(
+  baseStream: StreamFn,
+  callIndex: number,
+  fields: Record<string, unknown>,
+) {
+  const call = (baseStream as unknown as { mock: { calls: unknown[][] } }).mock.calls[callIndex];
+  if (!call) {
+    throw new Error(`expected base stream call ${callIndex}`);
+  }
+  expectRecordFields(requireRecord(call[0], "base stream model"), fields);
+}
+
 async function collectEvents(stream: ReturnType<StreamFn>): Promise<StreamEvent[]> {
   const resolved = stream instanceof Promise ? await stream : stream;
   const events: StreamEvent[] = [];
@@ -337,6 +349,36 @@ describe("lmstudio stream wrapper", () => {
     expectBaseStreamModelFields(baseStream, {
       provider: "lmstudio",
       id: "gemma-4-e4b-it-ultra-uncensored-heretic",
+    });
+  });
+
+  it("reuses the canonical model key while preload failure cooldown is active", async () => {
+    const canonicalKey = "gemma-4-e4b-it-ultra-uncensored-heretic";
+    const variantModel = {
+      id: `lmstudio/${canonicalKey}@q4_k_m`,
+    };
+    ensureLmstudioModelLoadedMock.mockRejectedValueOnce(
+      Object.assign(new Error("load failed"), {
+        resolvedModelKey: canonicalKey,
+      }),
+    );
+    const baseStream = buildDoneStreamFn();
+    const wrapped = createWrappedLmstudioStream(baseStream);
+
+    const firstEvents = await collectEvents(runWrappedLmstudioStream(wrapped, variantModel));
+    const secondEvents = await collectEvents(runWrappedLmstudioStream(wrapped, variantModel));
+
+    expectSingleDoneEvent(firstEvents);
+    expectSingleDoneEvent(secondEvents);
+    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
+    expect(baseStream).toHaveBeenCalledTimes(2);
+    expectBaseStreamCallModelFields(baseStream, 0, {
+      provider: "lmstudio",
+      id: canonicalKey,
+    });
+    expectBaseStreamCallModelFields(baseStream, 1, {
+      provider: "lmstudio",
+      id: canonicalKey,
     });
   });
 

--- a/extensions/lmstudio/src/stream.test.ts
+++ b/extensions/lmstudio/src/stream.test.ts
@@ -218,6 +218,25 @@ describe("lmstudio stream wrapper", () => {
     });
   });
 
+  it("streams with the canonical model key returned by preload", async () => {
+    ensureLmstudioModelLoadedMock.mockResolvedValueOnce("gemma-4-e4b-it-ultra-uncensored-heretic");
+    const baseStream = buildDoneStreamFn();
+    const wrapped = createWrappedLmstudioStream(baseStream);
+    const variantKey = "gemma-4-e4b-it-ultra-uncensored-heretic@q4_k_m";
+    const stream = runWrappedLmstudioStream(wrapped, { id: `lmstudio/${variantKey}` });
+    const events = await collectEvents(stream);
+
+    expectSingleDoneEvent(events);
+    expectEnsureLoadedFields({
+      modelKey: variantKey,
+      baseUrl: "http://localhost:1234/v1",
+    });
+    expectBaseStreamModelFields(baseStream, {
+      provider: "lmstudio",
+      id: "gemma-4-e4b-it-ultra-uncensored-heretic",
+    });
+  });
+
   it("prefers model contextTokens over contextWindow for preload requests", async () => {
     const baseStream = buildDoneStreamFn();
     const wrapped = createWrappedLmstudioStream(baseStream, {

--- a/extensions/lmstudio/src/stream.ts
+++ b/extensions/lmstudio/src/stream.ts
@@ -37,6 +37,7 @@ const preloadInFlight = new Map<string, Promise<string | undefined>>();
 type PreloadCooldownEntry = {
   untilMs: number;
   consecutiveFailures: number;
+  resolvedModelKey?: string;
 };
 
 const preloadCooldown = new Map<string, PreloadCooldownEntry>();
@@ -54,12 +55,18 @@ function recordPreloadSuccess(preloadKey: string): void {
   preloadCooldown.delete(preloadKey);
 }
 
-function recordPreloadFailure(preloadKey: string, now: number): PreloadCooldownEntry {
+function recordPreloadFailure(
+  preloadKey: string,
+  now: number,
+  resolvedModelKey?: string,
+): PreloadCooldownEntry {
   const existing = preloadCooldown.get(preloadKey);
   const consecutiveFailures = (existing?.consecutiveFailures ?? 0) + 1;
+  const persistedResolvedModelKey = resolvedModelKey ?? existing?.resolvedModelKey;
   const entry: PreloadCooldownEntry = {
     consecutiveFailures,
     untilMs: now + computePreloadBackoffMs(consecutiveFailures),
+    ...(persistedResolvedModelKey ? { resolvedModelKey: persistedResolvedModelKey } : {}),
   };
   preloadCooldown.set(preloadKey, entry);
   return entry;
@@ -259,12 +266,13 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
                   return resolvedModelKey;
                 },
                 (error: unknown) => {
-                  const entry = recordPreloadFailure(preloadKey, Date.now());
+                  const resolvedModelKey = resolveLmstudioModelKeyFromError(error);
+                  const entry = recordPreloadFailure(preloadKey, Date.now(), resolvedModelKey);
                   throw Object.assign(new Error("preload-failed"), {
                     cause: error,
                     consecutiveFailures: entry.consecutiveFailures,
                     cooldownMs: entry.untilMs - Date.now(),
-                    resolvedModelKey: resolveLmstudioModelKeyFromError(error),
+                    resolvedModelKey,
                   });
                 },
               )
@@ -297,6 +305,7 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
           );
         }
       } else if (cooldownEntry) {
+        resolvedModelKey = cooldownEntry.resolvedModelKey;
         log.debug(
           `LM Studio inference preload for "${modelKey}" skipped while backoff active (${cooldownEntry.consecutiveFailures} prior failures)`,
         );

--- a/extensions/lmstudio/src/stream.ts
+++ b/extensions/lmstudio/src/stream.ts
@@ -144,6 +144,22 @@ function withLmstudioResolvedModelKey(
   };
 }
 
+function resolveLmstudioModelKeyFromError(error: unknown): string | undefined {
+  let current = error;
+  const seen = new Set<object>();
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const record = current as { cause?: unknown; resolvedModelKey?: unknown };
+    const resolvedModelKey =
+      typeof record.resolvedModelKey === "string" ? record.resolvedModelKey.trim() : "";
+    if (resolvedModelKey) {
+      return resolvedModelKey;
+    }
+    current = record.cause;
+  }
+  return undefined;
+}
+
 function createPreloadKey(params: {
   baseUrl: string;
   modelKey: string;
@@ -248,6 +264,7 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
                     cause: error,
                     consecutiveFailures: entry.consecutiveFailures,
                     cooldownMs: entry.untilMs - Date.now(),
+                    resolvedModelKey: resolveLmstudioModelKeyFromError(error),
                   });
                 },
               )
@@ -269,6 +286,7 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
             consecutiveFailures?: number;
             cooldownMs?: number;
           };
+          resolvedModelKey = resolveLmstudioModelKeyFromError(error);
           const cause = annotated.cause ?? error;
           const failures = annotated.consecutiveFailures ?? 1;
           const cooldownSec = Math.max(0, Math.round((annotated.cooldownMs ?? 0) / 1000));

--- a/extensions/lmstudio/src/stream.ts
+++ b/extensions/lmstudio/src/stream.ts
@@ -19,7 +19,7 @@ const log = createSubsystemLogger("extensions/lmstudio/stream");
 type StreamOptions = Parameters<StreamFn>[2];
 type StreamModel = Parameters<StreamFn>[0];
 
-const preloadInFlight = new Map<string, Promise<void>>();
+const preloadInFlight = new Map<string, Promise<string | undefined>>();
 
 /**
  * Cooldown state for the LM Studio preload endpoint.
@@ -131,6 +131,19 @@ function withLmstudioUsageCompat(model: StreamModel): StreamModel {
   };
 }
 
+function withLmstudioResolvedModelKey(
+  model: StreamModel,
+  resolvedModelKey: string | undefined,
+): StreamModel {
+  if (!resolvedModelKey || model.id === resolvedModelKey) {
+    return model;
+  }
+  return {
+    ...model,
+    id: resolvedModelKey,
+  };
+}
+
 function createPreloadKey(params: {
   baseUrl: string;
   modelKey: string;
@@ -146,7 +159,7 @@ async function ensureLmstudioModelLoadedBestEffort(params: {
   options: StreamOptions;
   ctx: ProviderWrapStreamFnContext;
   modelHeaders?: Record<string, string>;
-}): Promise<void> {
+}): Promise<string> {
   const providerConfig = params.ctx.config?.models?.providers?.[LMSTUDIO_PROVIDER_ID];
   const providerHeaders = { ...providerConfig?.headers, ...params.modelHeaders };
   const runtimeApiKey =
@@ -166,7 +179,7 @@ async function ensureLmstudioModelLoadedBestEffort(params: {
           headers: providerHeaders,
         });
 
-  await ensureLmstudioModelLoaded({
+  return await ensureLmstudioModelLoaded({
     baseUrl: params.baseUrl,
     apiKey: runtimeApiKey ?? configuredApiKey,
     headers,
@@ -211,7 +224,7 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
 
     const cooldownEntry = isPreloadCoolingDown(preloadKey, Date.now());
     const existing = preloadInFlight.get(preloadKey);
-    const preloadPromise: Promise<void> | undefined =
+    const preloadPromise: Promise<string | undefined> | undefined =
       existing ??
       (cooldownEntry
         ? undefined
@@ -225,8 +238,9 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
               modelHeaders: resolveModelHeaders(model),
             })
               .then(
-                () => {
+                (resolvedModelKey) => {
                   recordPreloadSuccess(preloadKey);
+                  return resolvedModelKey;
                 },
                 (error: unknown) => {
                   const entry = recordPreloadFailure(preloadKey, Date.now());
@@ -245,9 +259,10 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
           })());
 
     return (async () => {
+      let resolvedModelKey: string | undefined;
       if (preloadPromise) {
         try {
-          await preloadPromise;
+          resolvedModelKey = await preloadPromise;
         } catch (error) {
           const annotated = error as {
             cause?: unknown;
@@ -271,7 +286,12 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
       // LM Studio uses OpenAI-compatible streaming usage payloads when requested via
       // `stream_options.include_usage`. Force this compat flag at call time so usage
       // reporting remains enabled even when catalog entries omitted compat metadata.
-      const stream = streamWithThinkingLevel(withLmstudioUsageCompat(model), context, options);
+      const streamModel = withLmstudioResolvedModelKey(model, resolvedModelKey);
+      const stream = streamWithThinkingLevel(
+        withLmstudioUsageCompat(streamModel),
+        context,
+        options,
+      );
       const resolvedStream = stream instanceof Promise ? await stream : stream;
       return resolvedStream;
     })();


### PR DESCRIPTION
## What Problem This Solves

Refs #95394.

LM Studio can expose a canonical model `key` while also advertising quantized variant identifiers such as `...@q4_k_m`. OpenClaw's LM Studio stream path previously trimmed only the `lmstudio/` prefix, then reused the requested model id for both native preload and OpenAI-compatible chat streaming. When the selected id was an advertised variant rather than the canonical key, the assistant turn could carry the variant suffix into `/api/v1/models/load` and the subsequent chat payload, producing a false model error instead of a normal assistant response.

Affected surface: the bundled LM Studio provider preload and assistant stream wrapper in `extensions/lmstudio`.

## Why This Change Was Made

- Adds a provider-local resolver that maps LM Studio `variants` / `selected_variant` values back to the loadable canonical `key` from `/api/v1/models`.
- Preserves exact requested ids when LM Studio advertises the suffixed value as the real model `key`, so this is not a blanket quant-suffix strip.
- Returns the resolved key from `ensureLmstudioModelLoaded()` and passes it into the LM Studio stream wrapper before the OpenAI-compatible request is built.
- Carries the resolved canonical key through load/preload failures, so the existing best-effort continue-without-preload path still streams with the loadable key when discovery already found one.

## User Impact

LM Studio users with multi-variant or quantized local models should no longer get a false assistant-turn error solely because OpenClaw selected a variant-flavored model id. Explicit custom/suffixed model keys still work when the server advertises them as the canonical key.

## Evidence

External contract proof:
- LM Studio documents `/api/v1/models` as returning each model's `key`, the unique model identifier, plus optional `variants` and `selected_variant` fields for multi-variant models: https://lmstudio.ai/docs/developer/rest/list
- LM Studio issue #1462 shows `/api/v1/models/load` rejecting variant keys while accepting base keys, and includes a real `/api/v1/models` response with `key`, `variants`, and `selected_variant`: https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/1462

Local proof:
- `pnpm exec oxfmt --write extensions/lmstudio/src/models.fetch.ts extensions/lmstudio/src/models.test.ts extensions/lmstudio/src/stream.test.ts extensions/lmstudio/src/stream.ts`
- `node scripts/run-vitest.mjs extensions/lmstudio/src/models.test.ts extensions/lmstudio/src/stream.test.ts`
- `node scripts/run-vitest.mjs extensions/lmstudio/src`
- `git diff --check`
- Codex autoreview: clean, no accepted/actionable findings

Regression coverage added:
- Variant id request loads with the canonical model key.
- Load failures after variant discovery retain the canonical model key on the thrown error.
- Exact suffixed server key remains unchanged.
- Stream wrapper calls the underlying OpenAI-compatible stream with the canonical model id returned by preload.
- Stream wrapper also uses the canonical model id when preload/load fails after discovery and streaming continues.

## Real behavior proof

Behavior addressed: A request that starts as `lmstudio/qwen3-0.6b@q4_k_m` must use canonical `qwen3-0.6b` for native load and subsequent chat when `/api/v1/models` reports `key: qwen3-0.6b` with `variants: ["qwen3-0.6b@q4_k_m", "qwen3-0.6b@q8_0"]`, including the continue-after-load-failure path flagged by review.

Real environment tested: macOS arm64, LM Studio headless service installed from `https://lmstudio.ai/install.sh`, `lms` CLI commit `efce996`, local server on `127.0.0.1:1234`, real downloaded GGUF variants `qwen3-0.6b@q4_k_m` (484.22 MB) and `qwen3-0.6b@q8_0` (804.75 MB).

Exact steps or command run after this patch:
```bash
/Users/fallmonkey/.lmstudio/bin/lms daemon up
/Users/fallmonkey/.lmstudio/bin/lms server start --port 1234
/Users/fallmonkey/.lmstudio/bin/lms get https://huggingface.co/lmstudio-community/Qwen3-0.6B-GGUF/blob/main/Qwen3-0.6B-Q4_K_M.gguf --gguf -y
/Users/fallmonkey/.lmstudio/bin/lms get https://huggingface.co/lmstudio-community/Qwen3-0.6B-GGUF --gguf -y
/Users/fallmonkey/.lmstudio/bin/lms load qwen3-0.6b@q4_k_m --identifier qwen3-0.6b --context-length 2048 -y
curl -sS http://127.0.0.1:1234/api/v1/models | jq '{llms: [.models[] | select(.type=="llm") | {key, loaded_instances: [.loaded_instances[].id], quantization: .quantization.name, max_context_length}]}'
# request-logging tsx proof script invoked wrapLmstudioInferencePreload() with streamSimpleOpenAICompletions,
# using a local proxy for redacted request logs and forwarding chat to the live LM Studio server.
```

Evidence after fix:
```json
{
  "liveHeadlessModelInventory": {
    "llms": [
      {
        "key": "qwen3-0.6b@q4_k_m",
        "loaded_instances": ["qwen3-0.6b@q4_k_m", "qwen3-0.6b", "qwen3-0.6b@q4_k_m:2"],
        "quantization": "Q4_K_M",
        "max_context_length": 40960
      },
      {
        "key": "qwen3-0.6b@q8_0",
        "loaded_instances": [],
        "quantization": "Q8_0",
        "max_context_length": 32768
      }
    ]
  },
  "documentedVariantShapeLoadFailureContinuation": {
    "requestedModel": "lmstudio/qwen3-0.6b@q4_k_m",
    "documentedDiscovery": {
      "key": "qwen3-0.6b",
      "loaded_instances": [],
      "variants": ["qwen3-0.6b@q4_k_m", "qwen3-0.6b@q8_0"],
      "selected_variant": "qwen3-0.6b@q4_k_m"
    },
    "requests": [
      {"path": "/api/v1/models", "note": "documented multi-variant shape, unloaded"},
      {"path": "/api/v1/models/load", "model": "qwen3-0.6b", "context_length": 2048, "upstream_status": 503, "note": "forced load failure after canonical discovery"},
      {"path": "/v1/chat/completions", "model": "qwen3-0.6b", "stream": true, "messages": 1, "note": "forwarded to live LM Studio server", "upstream_status": 200}
    ],
    "result": {"stopReason": "length", "model": "qwen3-0.6b"}
  },
  "currentHeadlessSuffixedKeyPreservation": {
    "requestedModel": "lmstudio/qwen3-0.6b@q4_k_m",
    "requests": [
      {"path": "/api/v1/models", "upstream_status": 200},
      {"path": "/v1/chat/completions", "model": "qwen3-0.6b@q4_k_m", "stream": true, "messages": 1, "upstream_status": 200}
    ],
    "result": {"stopReason": "length", "model": "qwen3-0.6b@q4_k_m"}
  }
}
```

Observed result after fix: In the documented multi-variant shape, OpenClaw sent the canonical model key `qwen3-0.6b` to `/api/v1/models/load`; after that load failed, it still sent `qwen3-0.6b` to the live LM Studio `/v1/chat/completions` endpoint and received HTTP 200. In the current headless-server shape, where LM Studio advertises `qwen3-0.6b@q4_k_m` as the actual `key`, OpenClaw preserved the suffixed key and the live chat request also received HTTP 200.

What was not tested: I did not run a GUI recording of LM Studio Desktop `0.4.17-beta+3` in this terminal-only worktree. The Desktop-style `variants` response shape is covered by official LM Studio docs and LM Studio bug-tracker issue #1462, then exercised through a request-logging proxy backed by the live local LM Studio server and real downloaded multi-variant model files.
