### PR TITLE
fix(sdk): narrow SpawnOptions cwd type for tsgo compatibility

### DIFF
--- a/packages/sdk/src/package.e2e.test.ts
+++ b/packages/sdk/src/package.e2e.test.ts
@@ -5,8 +5,8 @@ import fs from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { createPnpmRunnerSpawnSpec } from "../../../scripts/pnpm-runner.mjs";
 import { afterEach, describe, expect, it } from "vitest";
+import { createPnpmRunnerSpawnSpec } from "../../../scripts/pnpm-runner.mjs";
 import { createNodeEvalArgs } from "../../../src/test-utils/node-process.js";
 
 type CommandResult = {
@@ -124,7 +124,7 @@ function runPnpmCommand(
     stdio: ["ignore", "pipe", "pipe"],
   });
   return runCommand(spec.command, spec.args, {
-    cwd: spec.options.cwd ?? options.cwd,
+    cwd: (spec.options.cwd as string) ?? options.cwd,
     env: spec.options.env,
     shell: spec.options.shell,
     timeoutMs: options.timeoutMs,


### PR DESCRIPTION
## What Problem This Solves

`check-test-types` CI lane fails on all recent PRs because `packages/sdk/src/package.e2e.test.ts:127` passes `spec.options.cwd` (typed as `string | URL` from `SpawnOptions`) to `runCommand` which expects `cwd: string`.

Error: `error TS2322: Type 'string | URL' is not assignable to type 'string'.`

## Why This Change Was Made

The one-line fix adds a type assertion `(spec.options.cwd as string)` to narrow the type before the `??` fallback. This is safe because `spec.options.cwd` is set from `options.cwd` which is already `string` in the only call site (`runPnpmCommand`).

## User Impact

Fixes CI for all open PRs. No runtime behavior change.

## Evidence

- Before: `pnpm tsgo:test:packages` exits with code 2
- After: `pnpm tsgo:test:packages` passes cleanly