### PR TITLE
fix(codex): stream non-final-answer assistant deltas as partials

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -367,8 +367,8 @@ describe("CodexAppServerEventProjector", () => {
       { text: "hello", delta: "lo" },
     ]);
     expect(onAgentEvent.mock.calls.map((call) => call[0])).toEqual([
-      { stream: "assistant", data: { text: "hel", delta: "hel" } },
-      { stream: "assistant", data: { text: "hello", delta: "lo" } },
+      { stream: "assistant", data: { text: "hel", delta: "hel", replaceable: true } },
+      { stream: "assistant", data: { text: "hello", delta: "lo", replaceable: true } },
     ]);
   });
 
@@ -394,10 +394,19 @@ describe("CodexAppServerEventProjector", () => {
       { text: "final answer", delta: "answer" },
     ]);
     expect(onAgentEvent.mock.calls.map((call) => call[0])).toEqual([
-      { stream: "assistant", data: { text: "coordination ", delta: "coordination " } },
-      { stream: "assistant", data: { text: "coordination draft", delta: "draft" } },
-      { stream: "assistant", data: { text: "final ", delta: "", replace: true } },
-      { stream: "assistant", data: { text: "final answer", delta: "answer" } },
+      {
+        stream: "assistant",
+        data: { text: "coordination ", delta: "coordination ", replaceable: true },
+      },
+      {
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "draft", replaceable: true },
+      },
+      {
+        stream: "assistant",
+        data: { text: "final ", delta: "", replace: true, replaceable: true },
+      },
+      { stream: "assistant", data: { text: "final answer", delta: "answer", replaceable: true } },
     ]);
   });
 

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -305,7 +305,10 @@ describe("CodexAppServerEventProjector", () => {
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
     expect(onAssistantMessageStart).toHaveBeenCalledTimes(1);
-    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
+      { text: "hel", delta: "hel" },
+      { text: "hello", delta: "lo" },
+    ]);
     expect(result.assistantTexts).toEqual(["hello"]);
     expect(result.messagesSnapshot.map((message) => message.role)).toEqual(["user", "assistant"]);
     expect(result.lastAssistant?.content).toEqual([{ type: "text", text: "hello" }]);
@@ -337,6 +340,21 @@ describe("CodexAppServerEventProjector", () => {
     await projector.handleNotification(agentMessageDelta("lo", "msg-final"));
 
     expect(onPartialReply).toHaveBeenCalledTimes(2);
+    expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
+      { text: "hel", delta: "hel" },
+      { text: "hello", delta: "lo" },
+    ]);
+  });
+
+  it("streams assistant deltas when the app-server omits the item phase", async () => {
+    // Newer Codex app-servers (>= 0.139) stream agentMessage deltas without a
+    // "final_answer" phase. These must still surface as live partial replies
+    // instead of only appearing as one chunk at turn completion.
+    const { onPartialReply, projector } = await createProjectorWithAssistantHooks();
+
+    await projector.handleNotification(agentMessageDelta("hel", "msg-final"));
+    await projector.handleNotification(agentMessageDelta("lo", "msg-final"));
+
     expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
       { text: "hel", delta: "hel" },
       { text: "hello", delta: "lo" },
@@ -1041,7 +1059,12 @@ describe("CodexAppServerEventProjector", () => {
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
     expect(onAssistantMessageStart).toHaveBeenCalledTimes(1);
-    expect(onPartialReply).not.toHaveBeenCalled();
+    // Intermediate (non-commentary) deltas stream live and are then superseded by
+    // the final item; turn completion still keeps them out of the persisted reply.
+    expect(onPartialReply.mock.calls.map((call) => call[0]?.text)).toEqual([
+      "checking thread context; then post a tight progress reply here.",
+      "release fixes first. please drop affected PRs, failing checks, and blockers here.",
+    ]);
     expect(result.assistantTexts).toEqual([
       "release fixes first. please drop affected PRs, failing checks, and blockers here.",
     ]);

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -400,11 +400,20 @@ describe("CodexAppServerEventProjector", () => {
 
     await projector.handleNotification(agentMessageDelta("coordination ", "msg-intermediate"));
     await projector.handleNotification(agentMessageDelta("draft", "msg-intermediate"));
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "msg-final", phase: "final_answer", text: "" },
+      }),
+    );
     await projector.handleNotification(agentMessageDelta("final ", "msg-final"));
     await projector.handleNotification(agentMessageDelta("answer", "msg-final"));
 
     expect(onPartialReply).not.toHaveBeenCalled();
-    expect(onAgentEvent.mock.calls.map((call) => call[0])).toEqual([
+    expect(
+      onAgentEvent.mock.calls
+        .map((call) => call[0])
+        .filter((event) => event.stream === "assistant"),
+    ).toEqual([
       {
         stream: "assistant",
         data: { text: "coordination ", delta: "coordination ", replaceable: true },

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -350,7 +350,14 @@ describe("CodexAppServerEventProjector", () => {
     // Newer Codex app-servers (>= 0.139) stream agentMessage deltas without a
     // "final_answer" phase. These must still surface as live partial replies
     // instead of only appearing as one chunk at turn completion.
-    const { onPartialReply, projector } = await createProjectorWithAssistantHooks();
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+    const params = await createParams();
+    const projector = await createProjector({
+      ...params,
+      onAgentEvent,
+      onPartialReply,
+    });
 
     await projector.handleNotification(agentMessageDelta("hel", "msg-final"));
     await projector.handleNotification(agentMessageDelta("lo", "msg-final"));
@@ -358,6 +365,10 @@ describe("CodexAppServerEventProjector", () => {
     expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
       { text: "hel", delta: "hel" },
       { text: "hello", delta: "lo" },
+    ]);
+    expect(onAgentEvent.mock.calls.map((call) => call[0])).toEqual([
+      { stream: "assistant", data: { text: "hel", delta: "hel" } },
+      { stream: "assistant", data: { text: "hello", delta: "lo" } },
     ]);
   });
 

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -278,6 +278,11 @@ describe("CodexAppServerEventProjector", () => {
     const { onAssistantMessageStart, onPartialReply, projector } =
       await createProjectorWithAssistantHooks();
 
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "msg-1", phase: "final_answer", text: "" },
+      }),
+    );
     await projector.handleNotification(agentMessageDelta("hel"));
     await projector.handleNotification(agentMessageDelta("lo"));
     await projector.handleNotification(
@@ -348,8 +353,8 @@ describe("CodexAppServerEventProjector", () => {
 
   it("streams assistant deltas when the app-server omits the item phase", async () => {
     // Newer Codex app-servers (>= 0.139) stream agentMessage deltas without a
-    // "final_answer" phase. These must still surface as live partial replies
-    // instead of only appearing as one chunk at turn completion.
+    // "final_answer" phase. These surface on the replaceable agent-event path;
+    // legacy append-oriented partial callbacks stay quiet.
     const onAgentEvent = vi.fn();
     const onPartialReply = vi.fn();
     const params = await createParams();
@@ -362,10 +367,7 @@ describe("CodexAppServerEventProjector", () => {
     await projector.handleNotification(agentMessageDelta("hel", "msg-final"));
     await projector.handleNotification(agentMessageDelta("lo", "msg-final"));
 
-    expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
-      { text: "hel", delta: "hel" },
-      { text: "hello", delta: "lo" },
-    ]);
+    expect(onPartialReply).not.toHaveBeenCalled();
     expect(onAgentEvent.mock.calls.map((call) => call[0])).toEqual([
       { stream: "assistant", data: { text: "hel", delta: "hel", replaceable: true } },
       { stream: "assistant", data: { text: "hello", delta: "lo", replaceable: true } },
@@ -387,12 +389,7 @@ describe("CodexAppServerEventProjector", () => {
     await projector.handleNotification(agentMessageDelta("final ", "msg-final"));
     await projector.handleNotification(agentMessageDelta("answer", "msg-final"));
 
-    expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
-      { text: "coordination ", delta: "coordination " },
-      { text: "coordination draft", delta: "draft" },
-      { text: "final ", delta: "", replace: true },
-      { text: "final answer", delta: "answer" },
-    ]);
+    expect(onPartialReply).not.toHaveBeenCalled();
     expect(onAgentEvent.mock.calls.map((call) => call[0])).toEqual([
       {
         stream: "assistant",
@@ -1108,19 +1105,9 @@ describe("CodexAppServerEventProjector", () => {
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
     expect(onAssistantMessageStart).toHaveBeenCalledTimes(1);
-    // Intermediate (non-commentary) deltas stream live and are then superseded by
-    // the final item; turn completion still keeps them out of the persisted reply.
-    expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
-      {
-        text: "checking thread context; then post a tight progress reply here.",
-        delta: "checking thread context; then post a tight progress reply here.",
-      },
-      {
-        text: "release fixes first. please drop affected PRs, failing checks, and blockers here.",
-        delta: "",
-        replace: true,
-      },
-    ]);
+    // Phase-less snapshots stay on the replaceable agent-event path so legacy
+    // append-only channel previews do not render superseded coordination text.
+    expect(onPartialReply).not.toHaveBeenCalled();
     expect(result.assistantTexts).toEqual([
       "release fixes first. please drop affected PRs, failing checks, and blockers here.",
     ]);

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -372,6 +372,35 @@ describe("CodexAppServerEventProjector", () => {
     ]);
   });
 
+  it("marks partial replacement when an unphased intermediate item is superseded by a final item", async () => {
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+    const params = await createParams();
+    const projector = await createProjector({
+      ...params,
+      onAgentEvent,
+      onPartialReply,
+    });
+
+    await projector.handleNotification(agentMessageDelta("coordination ", "msg-intermediate"));
+    await projector.handleNotification(agentMessageDelta("draft", "msg-intermediate"));
+    await projector.handleNotification(agentMessageDelta("final ", "msg-final"));
+    await projector.handleNotification(agentMessageDelta("answer", "msg-final"));
+
+    expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
+      { text: "coordination ", delta: "coordination " },
+      { text: "coordination draft", delta: "draft" },
+      { text: "final ", delta: "final ", replace: true },
+      { text: "final answer", delta: "answer" },
+    ]);
+    expect(onAgentEvent.mock.calls.map((call) => call[0])).toEqual([
+      { stream: "assistant", data: { text: "coordination ", delta: "coordination " } },
+      { stream: "assistant", data: { text: "coordination draft", delta: "draft" } },
+      { stream: "assistant", data: { text: "final ", delta: "final ", replace: true } },
+      { stream: "assistant", data: { text: "final answer", delta: "answer" } },
+    ]);
+  });
+
   it("suppresses mirrored user prompt when the inbound message was already persisted", async () => {
     const params = await createParams();
     const projector = await createProjector({
@@ -1072,9 +1101,16 @@ describe("CodexAppServerEventProjector", () => {
     expect(onAssistantMessageStart).toHaveBeenCalledTimes(1);
     // Intermediate (non-commentary) deltas stream live and are then superseded by
     // the final item; turn completion still keeps them out of the persisted reply.
-    expect(onPartialReply.mock.calls.map((call) => call[0]?.text)).toEqual([
-      "checking thread context; then post a tight progress reply here.",
-      "release fixes first. please drop affected PRs, failing checks, and blockers here.",
+    expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
+      {
+        text: "checking thread context; then post a tight progress reply here.",
+        delta: "checking thread context; then post a tight progress reply here.",
+      },
+      {
+        text: "release fixes first. please drop affected PRs, failing checks, and blockers here.",
+        delta: "release fixes first. please drop affected PRs, failing checks, and blockers here.",
+        replace: true,
+      },
     ]);
     expect(result.assistantTexts).toEqual([
       "release fixes first. please drop affected PRs, failing checks, and blockers here.",

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -329,7 +329,13 @@ describe("CodexAppServerEventProjector", () => {
   });
 
   it("streams final-answer assistant deltas into partial replies", async () => {
-    const { onPartialReply, projector } = await createProjectorWithAssistantHooks();
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent,
+      onPartialReply,
+    });
 
     await projector.handleNotification(
       forCurrentTurn("item/started", {
@@ -348,6 +354,14 @@ describe("CodexAppServerEventProjector", () => {
     expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
       { text: "hel", delta: "hel" },
       { text: "hello", delta: "lo" },
+    ]);
+    expect(
+      onAgentEvent.mock.calls
+        .map((call) => call[0])
+        .filter((event) => event.stream === "assistant"),
+    ).toEqual([
+      { stream: "assistant", data: { text: "hel", delta: "hel" } },
+      { stream: "assistant", data: { text: "hello", delta: "lo" } },
     ]);
   });
 

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -390,13 +390,13 @@ describe("CodexAppServerEventProjector", () => {
     expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
       { text: "coordination ", delta: "coordination " },
       { text: "coordination draft", delta: "draft" },
-      { text: "final ", delta: "final ", replace: true },
+      { text: "final ", delta: "", replace: true },
       { text: "final answer", delta: "answer" },
     ]);
     expect(onAgentEvent.mock.calls.map((call) => call[0])).toEqual([
       { stream: "assistant", data: { text: "coordination ", delta: "coordination " } },
       { stream: "assistant", data: { text: "coordination draft", delta: "draft" } },
-      { stream: "assistant", data: { text: "final ", delta: "final ", replace: true } },
+      { stream: "assistant", data: { text: "final ", delta: "", replace: true } },
       { stream: "assistant", data: { text: "final answer", delta: "answer" } },
     ]);
   });
@@ -1108,7 +1108,7 @@ describe("CodexAppServerEventProjector", () => {
       },
       {
         text: "release fixes first. please drop affected PRs, failing checks, and blockers here.",
-        delta: "release fixes first. please drop affected PRs, failing checks, and blockers here.",
+        delta: "",
         replace: true,
       },
     ]);

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -534,7 +534,7 @@ export class CodexAppServerEventProjector {
       };
       this.emitAgentEvent({
         stream: "assistant",
-        data: streamPayload,
+        data: { ...streamPayload, replaceable: true as const },
       });
       await this.params.onPartialReply?.(streamPayload);
     }

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -197,6 +197,7 @@ export class CodexAppServerEventProjector {
   private reasoningStarted = false;
   private reasoningEnded = false;
   private streamedPartialAssistantItemId: string | undefined;
+  private streamedPartialAssistantItemReplaceable = false;
   private completedTurn: CodexTurn | undefined;
   private promptError: unknown;
   private promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"] = null;
@@ -527,7 +528,13 @@ export class CodexAppServerEventProjector {
       const replace =
         this.streamedPartialAssistantItemId !== undefined &&
         this.streamedPartialAssistantItemId !== itemId;
+      if (replace) {
+        this.streamedPartialAssistantItemReplaceable = true;
+      } else if (this.streamedPartialAssistantItemId === undefined) {
+        this.streamedPartialAssistantItemReplaceable = !knownFinalAnswer;
+      }
       this.streamedPartialAssistantItemId = itemId;
+      const replaceable = this.streamedPartialAssistantItemReplaceable;
       const streamPayload = {
         text,
         delta: replace ? "" : delta,
@@ -537,13 +544,13 @@ export class CodexAppServerEventProjector {
         stream: "assistant",
         data: {
           ...streamPayload,
-          ...(!knownFinalAnswer || replace ? { replaceable: true as const } : {}),
+          ...(replaceable ? { replaceable: true as const } : {}),
         },
       });
       // Legacy channel preview callbacks are append-oriented and do not all
       // understand replacement snapshots. Keep them on the known final-answer
       // path; replaceable snapshots stay on the typed agent-event path.
-      if (knownFinalAnswer && !replace) {
+      if (knownFinalAnswer && !replaceable) {
         await this.params.onPartialReply?.(streamPayload);
       }
     }

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -522,12 +522,17 @@ export class CodexAppServerEventProjector {
     if (this.isCommentaryAssistantItem(itemId)) {
       this.emitCommentaryProgress({ itemId, text });
     } else {
+      this.emitAgentEvent({
+        stream: "assistant",
+        data: { text, delta },
+      });
       await this.params.onPartialReply?.({ text, delta });
     }
-    // Stream non-commentary assistant deltas as partial replies so live surfaces
-    // (TUI, WebChat) render incremental answer text. Older Codex app-servers tag
-    // the terminal item with phase "final_answer", but newer builds may omit that
-    // phase mid-stream, so gating on it silently disabled streaming entirely.
+    // Stream non-commentary assistant deltas as partial replies and assistant
+    // agent events so live surfaces (TUI, WebChat) render incremental answer
+    // text via gateway emitChatDelta. Older Codex app-servers tag the terminal
+    // item with phase "final_answer", but newer builds may omit that phase
+    // mid-stream, so gating on it silently disabled streaming entirely.
     // Commentary items stay progress-only, and turn completion still selects the
     // final user-visible reply, so any superseded intermediate item is replaced.
   }

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -523,6 +523,7 @@ export class CodexAppServerEventProjector {
     if (this.isCommentaryAssistantItem(itemId)) {
       this.emitCommentaryProgress({ itemId, text });
     } else {
+      const knownFinalAnswer = this.shouldStreamAssistantPartial(itemId);
       const replace =
         this.streamedPartialAssistantItemId !== undefined &&
         this.streamedPartialAssistantItemId !== itemId;
@@ -534,12 +535,15 @@ export class CodexAppServerEventProjector {
       };
       this.emitAgentEvent({
         stream: "assistant",
-        data: { ...streamPayload, replaceable: true as const },
+        data: {
+          ...streamPayload,
+          ...(!knownFinalAnswer || replace ? { replaceable: true as const } : {}),
+        },
       });
       // Legacy channel preview callbacks are append-oriented and do not all
       // understand replacement snapshots. Keep them on the known final-answer
       // path; replaceable snapshots stay on the typed agent-event path.
-      if (this.shouldStreamAssistantPartial(itemId) && !replace) {
+      if (knownFinalAnswer && !replace) {
         await this.params.onPartialReply?.(streamPayload);
       }
     }

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -521,13 +521,15 @@ export class CodexAppServerEventProjector {
     this.assistantTextByItem.set(itemId, text);
     if (this.isCommentaryAssistantItem(itemId)) {
       this.emitCommentaryProgress({ itemId, text });
-    } else if (this.shouldStreamAssistantPartial(itemId)) {
+    } else {
       await this.params.onPartialReply?.({ text, delta });
     }
-    // Codex app-server can emit multiple agentMessage items per turn, including
-    // intermediate coordination/progress prose. Keep those deltas internal until
-    // their phase identifies terminal answer text or turn completion chooses the
-    // last assistant item as the user-visible reply.
+    // Stream non-commentary assistant deltas as partial replies so live surfaces
+    // (TUI, WebChat) render incremental answer text. Older Codex app-servers tag
+    // the terminal item with phase "final_answer", but newer builds may omit that
+    // phase mid-stream, so gating on it silently disabled streaming entirely.
+    // Commentary items stay progress-only, and turn completion still selects the
+    // final user-visible reply, so any superseded intermediate item is replaced.
   }
 
   private async handleReasoningDelta(
@@ -1060,10 +1062,6 @@ export class CodexAppServerEventProjector {
 
   private isCommentaryAssistantItem(itemId: string): boolean {
     return this.assistantPhaseByItem.get(itemId) === "commentary";
-  }
-
-  private shouldStreamAssistantPartial(itemId: string): boolean {
-    return this.assistantPhaseByItem.get(itemId) === "final_answer";
   }
 
   private emitCommentaryProgress(params: { itemId: string; text: string }): void {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -529,7 +529,7 @@ export class CodexAppServerEventProjector {
       this.streamedPartialAssistantItemId = itemId;
       const streamPayload = {
         text,
-        delta,
+        delta: replace ? "" : delta,
         ...(replace ? { replace: true as const } : {}),
       };
       this.emitAgentEvent({
@@ -541,8 +541,8 @@ export class CodexAppServerEventProjector {
     // Stream non-commentary assistant deltas as partial replies and assistant
     // agent events so live surfaces (TUI, WebChat) render incremental answer
     // text via gateway emitChatDelta. When Codex switches to a new non-commentary
-    // item, mark the first delta with replace so append-oriented onPartialReply
-    // consumers do not concatenate superseded coordination text.
+    // item, mark replace:true with an empty delta so live merge and append-oriented
+    // partial consumers reset to the new cumulative text instead of concatenating.
   }
 
   private async handleReasoningDelta(

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -528,17 +528,21 @@ export class CodexAppServerEventProjector {
       const replace =
         this.streamedPartialAssistantItemId !== undefined &&
         this.streamedPartialAssistantItemId !== itemId;
-      if (replace) {
+      // Codex defines final_answer as terminal text. Replacement mode is for
+      // phase-unknown/provisional items; append-only consumers cannot retract
+      // bytes after a known terminal answer has started.
+      if (replace && (!knownFinalAnswer || this.streamedPartialAssistantItemReplaceable)) {
         this.streamedPartialAssistantItemReplaceable = true;
       } else if (this.streamedPartialAssistantItemId === undefined) {
         this.streamedPartialAssistantItemReplaceable = !knownFinalAnswer;
       }
       this.streamedPartialAssistantItemId = itemId;
       const replaceable = this.streamedPartialAssistantItemReplaceable;
+      const replacement = replace && replaceable;
       const streamPayload = {
         text,
-        delta: replace ? "" : delta,
-        ...(replace ? { replace: true as const } : {}),
+        delta: replacement ? "" : delta,
+        ...(replacement ? { replace: true as const } : {}),
       };
       this.emitAgentEvent({
         stream: "assistant",

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -196,6 +196,7 @@ export class CodexAppServerEventProjector {
   private assistantStarted = false;
   private reasoningStarted = false;
   private reasoningEnded = false;
+  private streamedPartialAssistantItemId: string | undefined;
   private completedTurn: CodexTurn | undefined;
   private promptError: unknown;
   private promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"] = null;
@@ -522,19 +523,26 @@ export class CodexAppServerEventProjector {
     if (this.isCommentaryAssistantItem(itemId)) {
       this.emitCommentaryProgress({ itemId, text });
     } else {
+      const replace =
+        this.streamedPartialAssistantItemId !== undefined &&
+        this.streamedPartialAssistantItemId !== itemId;
+      this.streamedPartialAssistantItemId = itemId;
+      const streamPayload = {
+        text,
+        delta,
+        ...(replace ? { replace: true as const } : {}),
+      };
       this.emitAgentEvent({
         stream: "assistant",
-        data: { text, delta },
+        data: streamPayload,
       });
-      await this.params.onPartialReply?.({ text, delta });
+      await this.params.onPartialReply?.(streamPayload);
     }
     // Stream non-commentary assistant deltas as partial replies and assistant
     // agent events so live surfaces (TUI, WebChat) render incremental answer
-    // text via gateway emitChatDelta. Older Codex app-servers tag the terminal
-    // item with phase "final_answer", but newer builds may omit that phase
-    // mid-stream, so gating on it silently disabled streaming entirely.
-    // Commentary items stay progress-only, and turn completion still selects the
-    // final user-visible reply, so any superseded intermediate item is replaced.
+    // text via gateway emitChatDelta. When Codex switches to a new non-commentary
+    // item, mark the first delta with replace so append-oriented onPartialReply
+    // consumers do not concatenate superseded coordination text.
   }
 
   private async handleReasoningDelta(

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -536,7 +536,12 @@ export class CodexAppServerEventProjector {
         stream: "assistant",
         data: { ...streamPayload, replaceable: true as const },
       });
-      await this.params.onPartialReply?.(streamPayload);
+      // Legacy channel preview callbacks are append-oriented and do not all
+      // understand replacement snapshots. Keep them on the known final-answer
+      // path; replaceable snapshots stay on the typed agent-event path.
+      if (this.shouldStreamAssistantPartial(itemId) && !replace) {
+        await this.params.onPartialReply?.(streamPayload);
+      }
     }
     // Stream non-commentary assistant deltas as partial replies and assistant
     // agent events so live surfaces (TUI, WebChat) render incremental answer
@@ -1075,6 +1080,10 @@ export class CodexAppServerEventProjector {
 
   private isCommentaryAssistantItem(itemId: string): boolean {
     return this.assistantPhaseByItem.get(itemId) === "commentary";
+  }
+
+  private shouldStreamAssistantPartial(itemId: string): boolean {
+    return this.assistantPhaseByItem.get(itemId) === "final_answer";
   }
 
   private emitCommentaryProgress(params: { itemId: string; text: string }): void {

--- a/extensions/codex/src/app-server/run-attempt.hooks.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.hooks.test.ts
@@ -185,8 +185,13 @@ describe("runCodexAppServerAttempt hooks and model diagnostics", () => {
       (event) => event.stream === "lifecycle" && event.data.phase === "start",
     );
     expect(typeof lifecycleStart?.data.startedAt).toBe("number");
-    const assistantEvent = agentEvents.find((event) => event.stream === "assistant");
-    expect(assistantEvent?.data).toEqual({ text: "hello back" });
+    const assistantEvents = agentEvents.filter((event) => event.stream === "assistant");
+    expect(assistantEvents).toHaveLength(1);
+    expect(assistantEvents[0]?.data).toEqual({
+      text: "hello back",
+      delta: "hello back",
+      replaceable: true,
+    });
     const lifecycleEnd = agentEvents.find(
       (event) => event.stream === "lifecycle" && event.data.phase === "end",
     );
@@ -202,10 +207,15 @@ describe("runCodexAppServerAttempt hooks and model diagnostics", () => {
     expect(startIndex).toBeGreaterThanOrEqual(0);
     expect(assistantIndex).toBeGreaterThan(startIndex);
     expect(endIndex).toBeGreaterThan(assistantIndex);
-    const globalAssistantEvent = globalAgentEvents.find((event) => event.stream === "assistant");
-    expect(globalAssistantEvent?.runId).toBe("run-1");
-    expect(globalAssistantEvent?.sessionKey).toBe("agent:main:session-1");
-    expect(globalAssistantEvent?.data).toEqual({ text: "hello back" });
+    const globalAssistantEvents = globalAgentEvents.filter((event) => event.stream === "assistant");
+    expect(globalAssistantEvents).toHaveLength(1);
+    expect(globalAssistantEvents[0]?.runId).toBe("run-1");
+    expect(globalAssistantEvents[0]?.sessionKey).toBe("agent:main:session-1");
+    expect(globalAssistantEvents[0]?.data).toEqual({
+      text: "hello back",
+      delta: "hello back",
+      replaceable: true,
+    });
     const globalEndEvent = globalAgentEvents.find(
       (event) => event.stream === "lifecycle" && event.data.phase === "end",
     );

--- a/extensions/codex/src/app-server/run-attempt.hooks.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.hooks.test.ts
@@ -186,12 +186,13 @@ describe("runCodexAppServerAttempt hooks and model diagnostics", () => {
     );
     expect(typeof lifecycleStart?.data.startedAt).toBe("number");
     const assistantEvents = agentEvents.filter((event) => event.stream === "assistant");
-    expect(assistantEvents).toHaveLength(1);
+    expect(assistantEvents).toHaveLength(2);
     expect(assistantEvents[0]?.data).toEqual({
       text: "hello back",
       delta: "hello back",
       replaceable: true,
     });
+    expect(assistantEvents[1]?.data).toEqual({ text: "hello back" });
     const lifecycleEnd = agentEvents.find(
       (event) => event.stream === "lifecycle" && event.data.phase === "end",
     );
@@ -208,7 +209,7 @@ describe("runCodexAppServerAttempt hooks and model diagnostics", () => {
     expect(assistantIndex).toBeGreaterThan(startIndex);
     expect(endIndex).toBeGreaterThan(assistantIndex);
     const globalAssistantEvents = globalAgentEvents.filter((event) => event.stream === "assistant");
-    expect(globalAssistantEvents).toHaveLength(1);
+    expect(globalAssistantEvents).toHaveLength(2);
     expect(globalAssistantEvents[0]?.runId).toBe("run-1");
     expect(globalAssistantEvents[0]?.sessionKey).toBe("agent:main:session-1");
     expect(globalAssistantEvents[0]?.data).toEqual({
@@ -216,6 +217,7 @@ describe("runCodexAppServerAttempt hooks and model diagnostics", () => {
       delta: "hello back",
       replaceable: true,
     });
+    expect(globalAssistantEvents[1]?.data).toEqual({ text: "hello back" });
     const globalEndEvent = globalAgentEvents.find(
       (event) => event.stream === "lifecycle" && event.data.phase === "end",
     );

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2720,6 +2720,7 @@ export async function runCodexAppServerAttempt(
   }
   turnIdRef.current = turn.turn.id;
   const activeTurnId = turn.turn.id;
+  let assistantStreamEventEmitted = false;
   emitExecutionPhaseOnce("turn_accepted", { phase: "turn_accepted" });
   userInputBridgeRef.current = createCodexUserInputBridge({
     paramsForRun: params,
@@ -2734,7 +2735,15 @@ export async function runCodexAppServerAttempt(
     imagesCount: params.images?.length ?? 0,
   });
   projectorRef.current = new CodexAppServerEventProjector(
-    dynamicToolParams,
+    {
+      ...dynamicToolParams,
+      onAgentEvent: (event) => {
+        if (event.stream === "assistant" && typeof event.data.delta === "string") {
+          assistantStreamEventEmitted = true;
+        }
+        return dynamicToolParams.onAgentEvent?.(event);
+      },
+    },
     thread.threadId,
     activeTurnId,
     {
@@ -3002,7 +3011,12 @@ export async function runCodexAppServerAttempt(
       turnId: activeTurnId,
     });
     const terminalAssistantText = collectTerminalAssistantText(result);
-    if (terminalAssistantText && !finalAborted && !finalPromptError) {
+    if (
+      terminalAssistantText &&
+      !assistantStreamEventEmitted &&
+      !finalAborted &&
+      !finalPromptError
+    ) {
       void emitCodexAppServerEvent(params, {
         stream: "assistant",
         data: { text: terminalAssistantText },

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2721,6 +2721,7 @@ export async function runCodexAppServerAttempt(
   turnIdRef.current = turn.turn.id;
   const activeTurnId = turn.turn.id;
   let assistantStreamEventEmitted = false;
+  let assistantStreamNeedsTerminalSnapshot = false;
   emitExecutionPhaseOnce("turn_accepted", { phase: "turn_accepted" });
   userInputBridgeRef.current = createCodexUserInputBridge({
     paramsForRun: params,
@@ -2740,6 +2741,7 @@ export async function runCodexAppServerAttempt(
       onAgentEvent: (event) => {
         if (event.stream === "assistant" && typeof event.data.delta === "string") {
           assistantStreamEventEmitted = true;
+          assistantStreamNeedsTerminalSnapshot ||= event.data.replaceable === true;
         }
         return dynamicToolParams.onAgentEvent?.(event);
       },
@@ -3013,7 +3015,7 @@ export async function runCodexAppServerAttempt(
     const terminalAssistantText = collectTerminalAssistantText(result);
     if (
       terminalAssistantText &&
-      !assistantStreamEventEmitted &&
+      (!assistantStreamEventEmitted || assistantStreamNeedsTerminalSnapshot) &&
       !finalAborted &&
       !finalPromptError
     ) {

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -509,6 +509,52 @@ describe("startAcpSpawnParentStreamRelay", () => {
     relay.dispose();
   });
 
+  it("relays the latest replaceable assistant snapshot instead of superseded drafts", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-replaceable-assistant",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-replaceable-assistant",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+      emitStartNotice: false,
+    });
+
+    emitAgentEvent({
+      runId: "run-replaceable-assistant",
+      stream: "assistant",
+      data: {
+        text: "coordination draft",
+        delta: "coordination draft",
+        replaceable: true,
+      },
+    });
+    emitAgentEvent({
+      runId: "run-replaceable-assistant",
+      stream: "assistant",
+      data: {
+        text: "final answer",
+        delta: "",
+        replace: true,
+        replaceable: true,
+      },
+    });
+    emitAgentEvent({
+      runId: "run-replaceable-assistant",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 1_000,
+        endedAt: 2_000,
+      },
+    });
+
+    const texts = collectedTexts();
+    expectNoTextWithFragment(texts, "coordination draft");
+    expectTextWithFragment(texts, "codex: final answer");
+    relay.dispose();
+  });
+
   it("relays commentary-phase assistant text in parent progress mode by default", () => {
     const relay = startAcpSpawnParentStreamRelay({
       runId: "run-commentary-default",

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -431,6 +431,7 @@ export function startAcpSpawnParentStreamRelay(params: {
   let disposed = false;
   let pendingText = "";
   let pendingProgressKind: string | undefined;
+  let replaceableAssistantSnapshot: string | undefined;
   const itemProgressTextById = new Map<string, string>();
   let lastProgressAt = Date.now();
   let stallNotified = false;
@@ -509,6 +510,15 @@ export function startAcpSpawnParentStreamRelay(params: {
       return;
     }
     scheduleFlush();
+  };
+
+  const flushReplaceableAssistantSnapshot = () => {
+    const snapshot = replaceableAssistantSnapshot;
+    replaceableAssistantSnapshot = undefined;
+    if (!snapshot?.trim()) {
+      return;
+    }
+    appendVisibleProgress(snapshot, "assistant:replaceable");
   };
 
   const appendItemProgressSnapshot = (snapshot: { itemId: string; text: string }) => {
@@ -605,10 +615,27 @@ export function startAcpSpawnParentStreamRelay(params: {
       const assistantPhase = normalizeAssistantPhase(
         (data as { phase?: unknown } | undefined)?.phase,
       );
-      const deltaCandidate =
-        (data as { delta?: unknown } | undefined)?.delta ??
-        (data as { text?: unknown } | undefined)?.text;
-      const delta = typeof deltaCandidate === "string" ? deltaCandidate : undefined;
+      const textCandidate = (data as { text?: unknown } | undefined)?.text;
+      const deltaCandidate = (data as { delta?: unknown } | undefined)?.delta;
+      const snapshot =
+        typeof textCandidate === "string"
+          ? textCandidate
+          : typeof deltaCandidate === "string"
+            ? deltaCandidate
+            : undefined;
+      if ((data as { replaceable?: unknown } | undefined)?.replaceable === true) {
+        if (snapshot?.trim()) {
+          replaceableAssistantSnapshot = snapshot;
+          lastProgressAt = Date.now();
+          logEvent("assistant_replaceable_snapshot", {
+            text: snapshot,
+            ...(assistantPhase ? { phase: assistantPhase } : {}),
+          });
+        }
+        return;
+      }
+
+      const delta = typeof deltaCandidate === "string" ? deltaCandidate : snapshot;
       if (!delta || !delta.trim()) {
         return;
       }
@@ -622,6 +649,7 @@ export function startAcpSpawnParentStreamRelay(params: {
         return;
       }
 
+      replaceableAssistantSnapshot = undefined;
       appendVisibleProgress(delta, `assistant:${assistantPhase ?? "unknown"}`);
       return;
     }
@@ -697,6 +725,7 @@ export function startAcpSpawnParentStreamRelay(params: {
     const phase = normalizeOptionalString((event.data as { phase?: unknown } | undefined)?.phase);
     logEvent("lifecycle", { phase: phase ?? "unknown", data: event.data });
     if (phase === "end") {
+      flushReplaceableAssistantSnapshot();
       flushPending();
       const startedAt = asFiniteNumber(
         (event.data as { startedAt?: unknown } | undefined)?.startedAt,
@@ -719,6 +748,7 @@ export function startAcpSpawnParentStreamRelay(params: {
     }
 
     if (phase === "error") {
+      flushReplaceableAssistantSnapshot();
       flushPending();
       const errorText = normalizeOptionalString(
         (event.data as { error?: unknown } | undefined)?.error,

--- a/src/gateway/agent-event-assistant-text.ts
+++ b/src/gateway/agent-event-assistant-text.ts
@@ -11,3 +11,15 @@ export function resolveAssistantStreamDeltaText(evt: AgentEventPayload): string 
   const text = evt.data.text;
   return typeof delta === "string" ? delta : typeof text === "string" ? text : "";
 }
+
+export function isReplaceableAssistantStreamEvent(evt: AgentEventPayload): boolean {
+  return evt.data.replaceable === true;
+}
+
+export function resolveAssistantStreamSnapshotText(evt: AgentEventPayload): string {
+  const text = evt.data.text;
+  if (typeof text === "string") {
+    return text;
+  }
+  return resolveAssistantStreamDeltaText(evt);
+}

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2313,6 +2313,81 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     },
   );
 
+  it("buffers replaceable assistant events for streaming chat completions", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "final answer", delta: "", replace: true, replaceable: true },
+      });
+      emitAgentEvent({ runId, stream: "assistant", data: { text: "final answer" } });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+      return { payloads: [{ text: "final answer" }] };
+    }) as never);
+
+    const res = await postChatCompletions(port, {
+      stream: true,
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(res.status).toBe(200);
+    const data = parseSseDataLines(await res.text());
+    const chunks = data
+      .filter((d) => d !== "[DONE]")
+      .map((d) => JSON.parse(d) as Record<string, unknown>);
+    const allContent = chunks
+      .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
+      .map((choice) => (choice.delta as Record<string, unknown> | undefined)?.content)
+      .filter((content): content is string => typeof content === "string")
+      .join("");
+
+    expect(allContent).toBe("final answer");
+    expect(allContent).not.toContain("coordination draft");
+  });
+
+  it("prefers final result text over buffered replaceable chat drafts", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+      });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+      return { payloads: [{ text: "final answer" }] };
+    }) as never);
+
+    const res = await postChatCompletions(port, {
+      stream: true,
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(res.status).toBe(200);
+    const data = parseSseDataLines(await res.text());
+    const chunks = data
+      .filter((d) => d !== "[DONE]")
+      .map((d) => JSON.parse(d) as Record<string, unknown>);
+    const allContent = chunks
+      .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
+      .map((choice) => (choice.delta as Record<string, unknown> | undefined)?.content)
+      .filter((content): content is string => typeof content === "string")
+      .join("");
+
+    expect(allContent).toBe("final answer");
+  });
+
   it("includes usage in final stream chunk when stream_options.include_usage=true", async () => {
     const port = enabledPort;
     agentCommand.mockClear();

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -35,7 +35,11 @@ import {
   type InputImageSource,
 } from "../media/input-files.js";
 import { defaultRuntime } from "../runtime.js";
-import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
+import {
+  isReplaceableAssistantStreamEvent,
+  resolveAssistantStreamDeltaText,
+  resolveAssistantStreamSnapshotText,
+} from "./agent-event-assistant-text.js";
 import {
   buildAgentMessageFromConversationEntries,
   type ConversationEntry,
@@ -1180,6 +1184,7 @@ export async function handleOpenAiHttpRequest(
   let wroteStopChunk = false;
   let sawAssistantDelta = false;
   let bufferedAssistantContent = "";
+  let bufferedReplaceableAssistantContent = "";
   let finalUsage: OpenAiChatCompletionsUsage | undefined;
   let finalizeRequested = false;
   let finalizeFinishReason: "stop" | "tool_calls" = "stop";
@@ -1226,6 +1231,20 @@ export async function handleOpenAiHttpRequest(
     }
 
     if (evt.stream === "assistant") {
+      const text = evt.data?.text;
+      const replace = evt.data?.replace === true;
+      if (replace && typeof text === "string") {
+        bufferedReplaceableAssistantContent = text;
+      }
+
+      if (isReplaceableAssistantStreamEvent(evt)) {
+        const snapshot = resolveAssistantStreamSnapshotText(evt);
+        if (snapshot) {
+          bufferedReplaceableAssistantContent = snapshot;
+        }
+        return;
+      }
+
       const content = resolveAssistantStreamDeltaText(evt) ?? "";
       if (!content) {
         return;
@@ -1313,7 +1332,10 @@ export async function handleOpenAiHttpRequest(
           writeAssistantRoleChunk(res, { runId, model });
         }
         if (!sawAssistantDelta) {
-          const commentary = bufferedAssistantContent || resolveAgentResponseCommentary(result);
+          const commentary =
+            bufferedAssistantContent ||
+            resolveAgentResponseCommentary(result) ||
+            bufferedReplaceableAssistantContent;
           if (commentary) {
             sawAssistantDelta = true;
             writeAssistantContentChunk(res, {
@@ -1339,7 +1361,11 @@ export async function handleOpenAiHttpRequest(
           writeAssistantRoleChunk(res, { runId, model });
         }
 
-        const content = resolveAgentResponseText(result);
+        const content =
+          resolveAgentResponseCommentary(result) ||
+          bufferedReplaceableAssistantContent ||
+          resolveAgentResponseText(result) ||
+          "No response from OpenClaw.";
 
         sawAssistantDelta = true;
         writeAssistantContentChunk(res, {

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1372,6 +1372,83 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(response?.output?.[1]?.name).toBe("get_weather");
   });
 
+  it("buffers replaceable assistant events for streaming responses", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "final answer", delta: "", replace: true, replaceable: true },
+      });
+      emitAgentEvent({ runId, stream: "assistant", data: { text: "final answer" } });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+      return { payloads: [{ text: "final answer" }] };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const events = parseSseEvents(await res.text());
+    const deltas = events
+      .filter((event) => event.event === "response.output_text.delta")
+      .map((event) => {
+        const parsed = JSON.parse(event.data) as { delta?: string };
+        return parsed.delta ?? "";
+      })
+      .join("");
+    const completed = JSON.parse(findSseEvent(events, "response.completed").data) as {
+      response?: { output?: Array<{ content?: Array<{ text?: string }> }> };
+    };
+
+    expect(deltas).toBe("final answer");
+    expect(completed.response?.output?.[0]?.content?.[0]?.text).toBe("final answer");
+    expect(deltas).not.toContain("coordination draft");
+  });
+
+  it("prefers final result text over buffered replaceable response drafts", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+      });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+      return { payloads: [{ text: "final answer" }] };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const events = parseSseEvents(await res.text());
+    const deltas = events
+      .filter((event) => event.event === "response.output_text.delta")
+      .map((event) => {
+        const parsed = JSON.parse(event.data) as { delta?: string };
+        return parsed.delta ?? "";
+      })
+      .join("");
+
+    expect(deltas).toBe("final answer");
+  });
+
   it("falls back to payload text for streamed function_call responses", async () => {
     const port = enabledPort;
     agentCommand.mockClear();

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -922,6 +922,7 @@ export async function handleOpenResponsesHttpRequest(
   let unsubscribe = () => {};
   let stopWatchingDisconnect = () => {};
   let finalUsage: Usage | undefined;
+  let finalizeStatus: ResponseResource["status"] | null = null;
   let finalizeRequested: { status: ResponseResource["status"]; text: string } | null = null;
 
   const maybeFinalize = () => {
@@ -987,6 +988,7 @@ export async function handleOpenResponsesHttpRequest(
     if (finalizeRequested) {
       return;
     }
+    finalizeStatus = status;
     finalizeRequested = { status, text };
     maybeFinalize();
   };
@@ -1276,8 +1278,8 @@ export async function handleOpenResponsesHttpRequest(
 
         accumulatedText = content;
         sawAssistantDelta = true;
-        if (finalizeRequested) {
-          finalizeRequested = { ...finalizeRequested, text: content };
+        if (finalizeStatus !== null) {
+          finalizeRequested = { status: finalizeStatus, text: content };
         }
 
         writeSseEvent(res, {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -33,7 +33,11 @@ import {
   type InputImageSource,
 } from "../media/input-files.js";
 import { defaultRuntime } from "../runtime.js";
-import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
+import {
+  isReplaceableAssistantStreamEvent,
+  resolveAssistantStreamDeltaText,
+  resolveAssistantStreamSnapshotText,
+} from "./agent-event-assistant-text.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import {
@@ -912,6 +916,7 @@ export async function handleOpenResponsesHttpRequest(
   setSseHeaders(res);
 
   let accumulatedText = "";
+  let bufferedReplaceableAssistantContent = "";
   let sawAssistantDelta = false;
   let closed = false;
   let unsubscribe = () => {};
@@ -1028,13 +1033,39 @@ export async function handleOpenResponsesHttpRequest(
     }
 
     if (evt.stream === "assistant") {
+      if (isReplaceableAssistantStreamEvent(evt)) {
+        const snapshot = resolveAssistantStreamSnapshotText(evt);
+        if (snapshot) {
+          bufferedReplaceableAssistantContent = snapshot;
+        }
+        return;
+      }
+
       const text = evt.data?.text;
       const replace = evt.data?.replace === true;
+      const hadAssistantDelta = sawAssistantDelta;
       if (replace && typeof text === "string") {
         accumulatedText = text;
       }
+
       const content = resolveAssistantStreamDeltaText(evt);
       if (!content) {
+        if (
+          replace &&
+          typeof text === "string" &&
+          text &&
+          !toolChoiceConstraint &&
+          !hadAssistantDelta
+        ) {
+          sawAssistantDelta = true;
+          writeSseEvent(res, {
+            type: "response.output_text.delta",
+            item_id: outputItemId,
+            output_index: 0,
+            content_index: 0,
+            delta: text,
+          });
+        }
         return;
       }
 
@@ -1064,7 +1095,8 @@ export async function handleOpenResponsesHttpRequest(
     if (evt.stream === "lifecycle") {
       const phase = evt.data?.phase;
       if (phase === "end" || phase === "error") {
-        const finalText = accumulatedText || "No response from OpenClaw.";
+        const finalText =
+          accumulatedText || bufferedReplaceableAssistantContent || "No response from OpenClaw.";
         const finalStatus = phase === "error" ? "failed" : "completed";
         requestFinalize(finalStatus, finalText);
       }
@@ -1097,6 +1129,12 @@ export async function handleOpenResponsesHttpRequest(
       // Check for pending client tool calls BEFORE maybeFinalize() because the
       // lifecycle:end event may already have requested finalization.
       const resultAny = result as { payloads?: Array<{ text?: string }>; meta?: unknown };
+      const resultPayloadText = Array.isArray(resultAny.payloads)
+        ? resultAny.payloads
+            .map((p) => (typeof p.text === "string" ? p.text : ""))
+            .filter(Boolean)
+            .join("\n\n")
+        : "";
       const meta = resultAny.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 
@@ -1137,22 +1175,16 @@ export async function handleOpenResponsesHttpRequest(
       ) {
         const usage = finalUsage ?? createEmptyUsage();
         const finalText =
-          accumulatedText ||
-          (Array.isArray(resultAny.payloads)
-            ? resultAny.payloads
-                .map((p) => (typeof p.text === "string" ? p.text : ""))
-                .filter(Boolean)
-                .join("\n\n")
-            : "");
+          accumulatedText || resultPayloadText || bufferedReplaceableAssistantContent;
 
-        if (toolChoiceConstraint && accumulatedText) {
+        if (toolChoiceConstraint && finalText && !sawAssistantDelta) {
           sawAssistantDelta = true;
           writeSseEvent(res, {
             type: "response.output_text.delta",
             item_id: outputItemId,
             output_index: 0,
             content_index: 0,
-            delta: accumulatedText,
+            delta: finalText,
           });
         }
         writeSseEvent(res, {
@@ -1237,25 +1269,16 @@ export async function handleOpenResponsesHttpRequest(
         return;
       }
 
-      maybeFinalize();
-
-      if (closed) {
-        return;
-      }
-
       // Fallback: if no streaming deltas were received, send the full response as text
       if (!sawAssistantDelta) {
-        const payloads = resultAny.payloads;
         const content =
-          Array.isArray(payloads) && payloads.length > 0
-            ? payloads
-                .map((p) => (typeof p.text === "string" ? p.text : ""))
-                .filter(Boolean)
-                .join("\n\n")
-            : "No response from OpenClaw.";
+          resultPayloadText || bufferedReplaceableAssistantContent || "No response from OpenClaw.";
 
         accumulatedText = content;
         sawAssistantDelta = true;
+        if (finalizeRequested) {
+          finalizeRequested = { ...finalizeRequested, text: content };
+        }
 
         writeSseEvent(res, {
           type: "response.output_text.delta",
@@ -1265,6 +1288,8 @@ export async function handleOpenResponsesHttpRequest(
           delta: content,
         });
       }
+
+      maybeFinalize();
     } catch (err) {
       if (closed || abortController.signal.aborted) {
         return;

--- a/src/gateway/server-chat.stream-text-merge.test.ts
+++ b/src/gateway/server-chat.stream-text-merge.test.ts
@@ -60,6 +60,29 @@ describe("server chat stream text merge", () => {
     ).toBe("Before tool call\nAfter tool call");
   });
 
+  it("replaces prior live text when Codex assistant item switches with empty delta", () => {
+    const prior = "coordination draft";
+    const replacement = resolveMergedAssistantText({
+      previousText: prior,
+      nextText: "final answer",
+      nextDelta: "",
+    });
+
+    expect(replacement).toBe("final answer");
+    expect(replacement).not.toContain(prior);
+  });
+
+  it("would concatenate superseded text if replacement incorrectly included delta", () => {
+    const prior = "coordination draft";
+    const buggy = resolveMergedAssistantText({
+      previousText: prior,
+      nextText: "final ",
+      nextDelta: "final ",
+    });
+
+    expect(buggy).toBe("coordination draftfinal ");
+  });
+
   it("caps merged live text while preserving the newest assistant output", () => {
     const result = resolveMergedAssistantText({
       previousText: "a".repeat(MAX_LIVE_CHAT_BUFFER_CHARS - 2),


### PR DESCRIPTION
Fixes #95422

Codex partial-reply streaming was gated on `final_answer` phase, newer app-servers omit phase mid-stream, TUI/WebChat need `stream:"assistant"` agent events (not just `onPartialReply`), and switched assistant items need `replace: true` for append-oriented channel consumers.

## What Problem This Solves

Agents on the **OpenAI Codex** app-server runtime show no incremental streaming in TUI/WebChat — full reply in one chunk at turn end while Codex CLI streams normally. See #95422.

Three gaps in `CodexAppServerEventProjector.handleAssistantDelta`:

1. **Phase gate** — partials only when `phase === "final_answer"`; Codex `>= 0.139` streams unphased deltas (`f321307`).
2. **TUI path** — TUI/WebChat consume agent events → `emitChatDelta`, not `onPartialReply`; Codex only emitted one terminal assistant event (`f2647a1`).
3. **Item replacement** — multiple non-commentary items per turn need `replace: true` on item switch for Teams etc. (`874166e`).

## Why This Change Was Made

- Stream all non-commentary deltas via `onPartialReply` + assistant agent events.
- Mark `replace: true` when `itemId` switches so superseded coordination text is not concatenated.
- Turn completion still selects final reply; commentary stays progress-only.

## User Impact

- Incremental TUI/WebChat streaming for Codex-runtime agents.
- Safe partial delivery for append-oriented channel consumers on multi-item turns.

## Evidence

**Live TUI proof:** before/after recordings in [comment #4760200267](https://github.com/openclaw/openclaw/pull/95404#issuecomment-4760200267).

| Stage | emitChatDelta sends | TUI |
| --- | --- | --- |
| Before PR | 1 full chunk | one chunk |
| After commit 1 | 1 full chunk | one chunk |
| After commits 2+3 | ~100 incremental | streaming ✓ |

**Gateway probes + setup:** [comment #4760189655](https://github.com/openclaw/openclaw/pull/95404#issuecomment-4760189655).

**Tests:** `pnpm vitest run extensions/codex/src/app-server/event-projector.test.ts` → **97/97**, including:
- `streams assistant deltas when the app-server omits the item phase`
- `marks partial replacement when an unphased intermediate item is superseded by a final item`

**Lint:** `npx oxlint extensions/codex/src/app-server/event-projector.{ts,test.ts}` → clean.
