### PR TITLE
Add Codex native hook relay policy

### DIFF
--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -33,6 +33,33 @@ type CodexAppServerAgentHarness = AgentHarness & {
   ): Promise<AgentHarnessCompactResult | undefined>;
 };
 
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function resolveCodexAppServerNativeHookRelay(options?: {
+  pluginConfig?: unknown;
+  resolvePluginConfig?: () => unknown;
+}): { enabled: boolean; hookTimeoutSec?: number } {
+  const pluginConfig = options?.resolvePluginConfig?.() ?? options?.pluginConfig;
+  const appServer = readRecord(readRecord(pluginConfig)?.appServer);
+  const relay = readRecord(appServer?.nativeHookRelay);
+  const mode = typeof relay?.mode === "string" ? relay.mode.trim().toLowerCase() : undefined;
+  const hookTimeoutSec =
+    typeof relay?.hookTimeoutSec === "number" &&
+    Number.isFinite(relay.hookTimeoutSec) &&
+    relay.hookTimeoutSec > 0
+      ? relay.hookTimeoutSec
+      : undefined;
+
+  if (relay?.enabled === false || mode === "disabled") {
+    return { enabled: false };
+  }
+  return hookTimeoutSec === undefined ? { enabled: true } : { enabled: true, hookTimeoutSec };
+}
+
 /**
  * Creates the Codex app-server harness used for attempts, side questions,
  * compaction, reset, and disposal.
@@ -72,14 +99,14 @@ export function createCodexAppServerAgentHarness(options?: {
       const { runCodexAppServerAttempt } = await import("./src/app-server/run-attempt.js");
       return runCodexAppServerAttempt(params, {
         pluginConfig: options?.resolvePluginConfig?.() ?? options?.pluginConfig,
-        nativeHookRelay: { enabled: true },
+        nativeHookRelay: resolveCodexAppServerNativeHookRelay(options),
       });
     },
     runSideQuestion: async (params) => {
       const { runCodexAppServerSideQuestion } = await import("./src/app-server/side-question.js");
       return runCodexAppServerSideQuestion(params, {
         pluginConfig: options?.resolvePluginConfig?.() ?? options?.pluginConfig,
-        nativeHookRelay: { enabled: true },
+        nativeHookRelay: resolveCodexAppServerNativeHookRelay(options),
       });
     },
     compact: async (params) => {

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -166,6 +166,38 @@ describe("codex plugin", () => {
     );
   });
 
+  it("honors disabled native hook relay policy for public Codex app-server attempts", async () => {
+    const harness = createCodexAppServerAgentHarness({
+      pluginConfig: {
+        appServer: {
+          nativeHookRelay: {
+            mode: "disabled",
+            enabled: false,
+          },
+        },
+      },
+    });
+    const result = { success: true };
+    runCodexAppServerAttemptMock.mockResolvedValueOnce(result);
+
+    await expect(harness.runAttempt({ prompt: "hello" } as never)).resolves.toBe(result);
+
+    expect(runCodexAppServerAttemptMock).toHaveBeenCalledWith(
+      { prompt: "hello" },
+      {
+        pluginConfig: {
+          appServer: {
+            nativeHookRelay: {
+              mode: "disabled",
+              enabled: false,
+            },
+          },
+        },
+        nativeHookRelay: { enabled: false },
+      },
+    );
+  });
+
   it("passes live Codex plugin config into public Codex app-server attempts", async () => {
     const registerAgentHarness = vi.fn();
     const liveConfig = {
@@ -224,6 +256,60 @@ describe("codex plugin", () => {
     );
   });
 
+  it("honors disabled live native hook relay policy for public Codex app-server attempts", async () => {
+    const registerAgentHarness = vi.fn();
+    const liveConfig = {
+      plugins: {
+        entries: {
+          codex: {
+            config: {
+              appServer: {
+                nativeHookRelay: {
+                  mode: "disabled",
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    plugin.register(
+      createTestPluginApi({
+        id: "codex",
+        name: "Codex",
+        source: "test",
+        config: {},
+        pluginConfig: { appServer: { nativeHookRelay: { mode: "enabled" } } },
+        runtime: {
+          config: {
+            current: () => liveConfig,
+          },
+        } as never,
+        registerAgentHarness,
+        registerCommand: vi.fn(),
+        registerMediaUnderstandingProvider: vi.fn(),
+        registerMigrationProvider: vi.fn(),
+        registerProvider: vi.fn(),
+        on: vi.fn(),
+      }),
+    );
+    const harness = mockCallArg(registerAgentHarness) as ReturnType<
+      typeof createCodexAppServerAgentHarness
+    >;
+    const result = { success: true };
+    runCodexAppServerAttemptMock.mockResolvedValueOnce(result);
+
+    await expect(harness.runAttempt({ prompt: "linked review" } as never)).resolves.toBe(result);
+
+    expect(runCodexAppServerAttemptMock).toHaveBeenCalledWith(
+      { prompt: "linked review" },
+      {
+        pluginConfig: liveConfig.plugins.entries.codex.config,
+        nativeHookRelay: { enabled: false },
+      },
+    );
+  });
+
   it("enables the native hook relay for public Codex side questions", async () => {
     const harness = createCodexAppServerAgentHarness({ pluginConfig: { appServer: {} } });
     const runSideQuestion = harness["runSideQuestion"];
@@ -240,6 +326,40 @@ describe("codex plugin", () => {
       {
         pluginConfig: { appServer: {} },
         nativeHookRelay: { enabled: true },
+      },
+    );
+  });
+
+  it("honors disabled native hook relay policy for public Codex side questions", async () => {
+    const harness = createCodexAppServerAgentHarness({
+      pluginConfig: {
+        appServer: {
+          nativeHookRelay: {
+            enabled: false,
+          },
+        },
+      },
+    });
+    const runSideQuestion = harness["runSideQuestion"];
+    const result = { text: "ok" };
+    runCodexAppServerSideQuestionMock.mockResolvedValueOnce(result);
+
+    if (!runSideQuestion) {
+      throw new Error("Expected Codex harness to expose side questions");
+    }
+    await expect(runSideQuestion({ question: "btw" } as never)).resolves.toBe(result);
+
+    expect(runCodexAppServerSideQuestionMock).toHaveBeenCalledWith(
+      { question: "btw" },
+      {
+        pluginConfig: {
+          appServer: {
+            nativeHookRelay: {
+              enabled: false,
+            },
+          },
+        },
+        nativeHookRelay: { enabled: false },
       },
     );
   });

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -240,6 +240,25 @@
           "defaultWorkspaceDir": {
             "type": "string"
           },
+          "nativeHookRelay": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": true
+              },
+              "mode": {
+                "type": "string",
+                "enum": ["enabled", "disabled", "serial", "full"],
+                "default": "enabled"
+              },
+              "hookTimeoutSec": {
+                "type": "number",
+                "minimum": 1
+              }
+            }
+          },
           "experimental": {
             "type": "object",
             "additionalProperties": false,
@@ -521,6 +540,11 @@
     "appServer.defaultWorkspaceDir": {
       "label": "Default Workspace",
       "help": "Workspace used by /codex bind when --cwd is omitted.",
+      "advanced": true
+    },
+    "appServer.nativeHookRelay": {
+      "label": "Native Hook Relay",
+      "help": "Controls Codex app-server native hook relay. Use disabled for constrained Telegram linked-review lanes.",
       "advanced": true
     },
     "appServer.experimental": {

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -1073,6 +1073,36 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     ).toEqual({ sandboxExecServer: true });
   });
 
+  it("parses app-server native hook relay policy", () => {
+    expect(
+      readCodexPluginConfig({
+        appServer: {
+          nativeHookRelay: {
+            enabled: false,
+            mode: "disabled",
+            hookTimeoutSec: 15,
+          },
+        },
+      }).appServer?.nativeHookRelay,
+    ).toEqual({
+      enabled: false,
+      mode: "disabled",
+      hookTimeoutSec: 15,
+    });
+  });
+
+  it("rejects invalid app-server native hook relay policy", () => {
+    expect(
+      readCodexPluginConfig({
+        appServer: {
+          nativeHookRelay: {
+            mode: "forklift",
+          },
+        },
+      }),
+    ).toEqual({});
+  });
+
   it("rejects the retired dynamic tool profile key", () => {
     expect(
       readCodexPluginConfig({

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -118,6 +118,14 @@ export type CodexAppServerExperimentalConfig = {
   sandboxExecServer?: boolean;
 };
 
+export type CodexAppServerNativeHookRelayMode = "enabled" | "disabled" | "serial" | "full";
+
+export type CodexAppServerNativeHookRelayConfig = {
+  enabled?: boolean;
+  mode?: CodexAppServerNativeHookRelayMode;
+  hookTimeoutSec?: number;
+};
+
 export type CodexAppServerNetworkProxyDomainPermission = "allow" | "deny";
 export type CodexAppServerNetworkProxyUnixSocketPermission = "allow" | "none";
 export type CodexAppServerNetworkProxyBaseProfile = "read-only" | "workspace";
@@ -230,6 +238,7 @@ export type CodexPluginConfig = {
     serviceTier?: CodexServiceTier | null;
     networkProxy?: CodexAppServerNetworkProxyConfig;
     defaultWorkspaceDir?: string;
+    nativeHookRelay?: CodexAppServerNativeHookRelayConfig;
     experimental?: CodexAppServerExperimentalConfig;
   };
 };
@@ -264,6 +273,7 @@ export const CODEX_APP_SERVER_CONFIG_KEYS = [
   "serviceTier",
   "networkProxy",
   "defaultWorkspaceDir",
+  "nativeHookRelay",
   "experimental",
 ] as const;
 
@@ -322,6 +332,14 @@ const codexAppServerExperimentalSchema = z
     sandboxExecServer: z.boolean().optional(),
   })
   .strict();
+const codexAppServerNativeHookRelayModeSchema = z.enum(["enabled", "disabled", "serial", "full"]);
+const codexAppServerNativeHookRelaySchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    mode: codexAppServerNativeHookRelayModeSchema.optional(),
+    hookTimeoutSec: z.number().positive().optional(),
+  })
+  .strict();
 const codexAppServerRemoteWorkspaceRootSchema = z.string().trim().min(1);
 const codexAppServerNetworkProxyDomainPermissionSchema = z.enum(["allow", "deny"]);
 const codexAppServerNetworkProxyUnixSocketPermissionSchema = z.enum(["allow", "none"]);
@@ -332,7 +350,9 @@ const codexAppServerNetworkProxySchema = z
     baseProfile: z.enum(["read-only", "workspace"]).optional(),
     mode: z.enum(["limited", "full"]).optional(),
     domains: z.record(z.string(), codexAppServerNetworkProxyDomainPermissionSchema).optional(),
-    unixSockets: z.record(z.string(), codexAppServerNetworkProxyUnixSocketPermissionSchema).optional(),
+    unixSockets: z
+      .record(z.string(), codexAppServerNetworkProxyUnixSocketPermissionSchema)
+      .optional(),
     proxyUrl: z.string().trim().min(1).optional(),
     socksUrl: z.string().trim().min(1).optional(),
     enableSocks5: z.boolean().optional(),
@@ -407,6 +427,7 @@ const codexPluginConfigSchema = z
         serviceTier: codexAppServerServiceTierSchema,
         networkProxy: codexAppServerNetworkProxySchema.optional(),
         defaultWorkspaceDir: z.string().optional(),
+        nativeHookRelay: codexAppServerNativeHookRelaySchema.optional(),
         experimental: codexAppServerExperimentalSchema.optional(),
       })
       .strict()


### PR DESCRIPTION
## Summary

Adds first-class Codex app-server native hook relay policy config to the OpenClaw Codex plugin.

The new config surface is:

```json
{
  "plugins": {
    "entries": {
      "codex": {
        "config": {
          "appServer": {
            "nativeHookRelay": {
              "mode": "disabled",
              "enabled": false
            }
          }
        }
      }
    }
  }
}
```

Supported mode values are `enabled`, `disabled`, `serial`, and `full`. The implemented behavior preserves the current default relay behavior unless disabled policy is selected. `serial` is accepted as policy vocabulary for future one-worker relay behavior, but currently maps to enabled relay behavior.

## What Problem This Solves

OC/Telegram linked-review lab work showed that native hook relay/tool pressure can fan out during realistic artifact review. A lab-only private-fixture mitigation completed with `nativeHookRelay` disabled and `agents.defaults.maxConcurrent=1` while the unmitigated fixture stopped on hook fan-out.

This PR promotes the lab-proven policy surface into the actual Codex plugin package path so Telegram/review lanes can configure relay behavior without patching managed package caches.

## Evidence

Source branch checks:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts extensions/codex/index.test.ts extensions/codex/src/app-server/config.test.ts
./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/harness.ts extensions/codex/index.test.ts extensions/codex/src/app-server/config.ts extensions/codex/src/app-server/config.test.ts extensions/codex/openclaw.plugin.json
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
npm run config:schema:check
npm run plugins:inventory:check
./node_modules/.bin/oxlint extensions/codex/harness.ts extensions/codex/index.test.ts extensions/codex/src/app-server/config.ts extensions/codex/src/app-server/config.test.ts
npm_execpath=/Users/yeisonmacbook/.npm/_npx/e32453d063f7b9f9/node_modules/pnpm/bin/pnpm.cjs node scripts/build-all.mjs qaRuntime
```

Lab rebuilt-package proof:

```text
staged runtime: OpenClaw 2026.6.8
staged plugin: @openclaw/codex 2026.6.8 from branch dist
policy: appServer.nativeHookRelay={mode:"disabled",enabled:false}
concurrency: agents.defaults.maxConcurrent=1
result: exit 0, stopReason=stop, real final judgment
watcher: no STOP marker, no sampled openclaw-hooks fan-out, no OOM/restart/app-server closure, no blank final/task_complete failure
```

Lab caveat: the rebuilt-package Docker proof used an explicit existing lab-local Linux Codex app-server command because the staged branch package did not carry its own managed Linux `@openai/codex` binary. That caveat is about the lab package staging path, not the native hook relay policy implementation.

## Production Boundary

This PR does not apply production Sam/Gus mitigation, does not edit managed package caches, and does not restart gateways. Production lane rollout remains a separate approval/proof gate.
