### PR TITLE
fix(discord): bound REST response body to prevent OOM flood

### DIFF
--- a/extensions/discord/src/internal/rest.test.ts
+++ b/extensions/discord/src/internal/rest.test.ts
@@ -692,6 +692,78 @@ describe("RequestClient", () => {
     expect(metrics.invalidRequestCountByStatus).toEqual({ 403: 1 });
   });
 
+  it("bounds oversized REST response bodies instead of buffering them unbounded", async () => {
+    const encoder = new TextEncoder();
+    let pullCount = 0;
+    let cancelCount = 0;
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              pullCount += 1;
+              // Flood far past the cap so an unbounded reader would OOM.
+              controller.enqueue(encoder.encode("x".repeat(4 * 1024 * 1024)));
+            },
+            cancel() {
+              cancelCount += 1;
+            },
+          }),
+          { status: 200 },
+        ),
+    );
+    const client = new RequestClient("test-token", { fetch: fetchSpy, queueRequests: false });
+
+    await expect(client.get("/channels/c1/messages")).rejects.toThrow(
+      /Discord REST response body exceeds 8388608 bytes/,
+    );
+    // The reader was cancelled at the cap rather than draining the whole flood:
+    // only a handful of 4 MiB chunks are pulled before the cap is hit.
+    expect(cancelCount).toBe(1);
+    expect(pullCount).toBeLessThanOrEqual(4);
+  });
+
+  it("aborts stalled REST response bodies after the idle timeout", async () => {
+    const encoder = new TextEncoder();
+    let cancelReason: unknown;
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              // Emit a partial chunk, then stall forever so the idle timeout
+              // (request timeout) must fire and cancel the stream.
+              controller.enqueue(encoder.encode("partial payload"));
+            },
+            cancel(reason) {
+              cancelReason = reason;
+            },
+          }),
+          { status: 200 },
+        ),
+    );
+    const client = new RequestClient("test-token", {
+      fetch: fetchSpy,
+      queueRequests: false,
+      timeout: 50,
+    });
+
+    await expect(client.get("/channels/c1/messages")).rejects.toThrow(
+      "Discord REST response stalled: no data received for 50ms",
+    );
+    expect(cancelReason).toBeInstanceOf(Error);
+    expect((cancelReason as Error).message).toBe(
+      "Discord REST response stalled: no data received for 50ms",
+    );
+  });
+
+  it("still parses normal-sized REST response payloads under the cap", async () => {
+    const fetchSpy = vi.fn(async () => createJsonResponse({ id: "channel", name: "general" }));
+    const client = new RequestClient("test-token", { fetch: fetchSpy, queueRequests: false });
+
+    await expect(client.get("/channels/c1")).resolves.toEqual({ id: "channel", name: "general" });
+  });
+
   it("serializes message multipart uploads with payload_json", () => {
     const headers = new Headers();
     const body = serializeRequestBody(

--- a/extensions/discord/src/internal/rest.ts
+++ b/extensions/discord/src/internal/rest.ts
@@ -6,6 +6,7 @@ import {
   parseFiniteNumber,
   resolveTimerTimeoutMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { serializeRequestBody } from "./rest-body.js";
 import {
   DiscordError,
@@ -88,6 +89,24 @@ const defaultLaneOptions: Record<RestRequestPriority, { staleAfterMs?: number; w
   standard: { weight: 3 },
   background: { staleAfterMs: 20_000, weight: 1 },
 };
+
+// Cap the REST response body well above any legitimate Discord JSON payload
+// (bulk message/member fetches stay in the low hundreds of KB) so a controlled
+// or hijacked endpoint cannot flood the body into an unbounded buffer (OOM).
+const DISCORD_REST_RESPONSE_BODY_MAX_BYTES = 8 * 1024 * 1024;
+
+async function readResponseBodyText(response: Response, idleTimeoutMs: number): Promise<string> {
+  const buffer = await readResponseWithLimit(response, DISCORD_REST_RESPONSE_BODY_MAX_BYTES, {
+    chunkTimeoutMs: idleTimeoutMs,
+    onOverflow: ({ size }) =>
+      new Error(
+        `Discord REST response body exceeds ${DISCORD_REST_RESPONSE_BODY_MAX_BYTES} bytes (received ${size})`,
+      ),
+    onIdleTimeout: ({ chunkTimeoutMs }) =>
+      new Error(`Discord REST response stalled: no data received for ${chunkTimeoutMs}ms`),
+  });
+  return buffer.toString("utf8");
+}
 
 function coerceResponseBody(raw: string): unknown {
   if (!raw) {
@@ -249,7 +268,7 @@ export class RequestClient {
         body: await normalizeFetchBody(body, headers),
         signal,
       });
-      const text = await response.text();
+      const text = await readResponseBodyText(response, this.options.timeout ?? 15_000);
       const parsed = coerceResponseBody(text);
       this.scheduler.recordResponse(routeKey, path, response, parsed);
       if (response.status === 204) {


### PR DESCRIPTION
## What Problem This Solves

This exists to stop Discord REST main responses from buffering attacker-sized bodies into memory before JSON parsing. `RequestClient.executeRequest` previously read the main response with unbounded `await response.text()` (`extensions/discord/src/internal/rest.ts:252`), so a controlled or hijacked REST endpoint, proxy, or gateway redirection path could stream an arbitrary response and turn the Discord extension into an OOM / DoS target.

## Changes

- Bound the Discord REST main-response read with `readResponseWithLimit`, using an 8 MiB cap plus an idle timeout derived from the request timeout.
- Preserved the existing `coerceResponseBody` parsing path for normal JSON, empty responses, rate limits, and errors after the bounded read completes.
- Added regression coverage for oversized stream cancellation, idle-timeout cancellation, and a normal-payload control.

## Evidence

The earlier proof for this PR used an in-process stream fixture, so this proof was upgraded to a real terminal `node:http` check. The scratchpad proof script is local only and is not committed. It starts a real TCP loopback HTTP server, drives the exported `RequestClient` with its normal fetch path, streams a no-`Content-Length` body larger than 16 MiB, verifies bounded throw and socket abort, runs a raw-fetch negative control that consumes the full flood, and verifies a small JSON happy path. No in-process `ReadableStream` fixture is used.

Command: `node --import tsx scratchpad/discord-http-proof.mts`

```text
[proof] real node:http server on http://127.0.0.1:43525, cap=8388608 bytes, would-stream=67108864 bytes
PASS  oversized Discord REST response throws bounded error :: threw=true msg="Discord REST response body exceeds 8388608 bytes (received 8454136)"
PASS  stream cancelled: server saw socket abort before sending full body :: aborted=true bytesSent=9437184 (<67108864) chunks=9
PASS  stream cancelled near 8 MiB cap :: bytesSent=9437184 (<33554432)
PASS  negative control: raw unbounded read buffers the full body past the 8 MiB cap :: buffered=67108864 bytes (> 8388608)
PASS  negative control consumed far more than bounded read :: unbounded buffered=67108864 vs bounded sent≈9437184
PASS  happy path: small JSON response still parsed :: id="channel" name="general" topic="real loopback proof"

[proof] 6 PASS, 0 FAIL
[proof] ALL PASS
```

Focused regression test:

Command: `node scripts/run-vitest.mjs extensions/discord/src/internal/rest.test.ts`

```text
Test Files  1 passed (1)
Tests       34 passed (34)
Result      [test] passed 1 Vitest shard in 14.91s
```

## Symmetry and Remaining Scope

#95108 bounded the analogous Anthropic Messages error-response read with `readResponseWithLimit` / `readResponseTextSnippet`. This PR is the symmetric fix for the Discord REST main-response path, reusing the same `@openclaw/media-core` helper through the `response-limit-runtime` plugin entry rather than introducing a new abstraction.

Sibling read check: `extensions/discord/src/api.ts:194` still has an unbounded `res.text()` on a separate Discord API path and remains appropriate follow-up scope; this PR is scoped to `RequestClient.executeRequest` in `extensions/discord/src/internal/rest.ts`.

**Label**: security

---

AI-assisted: implemented and verified with AI assistance; the proof commands above were run for real against the actual code path.
