### PR TITLE
fix(agents): bound Google prompt cache response reads

### DIFF
--- a/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
@@ -68,6 +68,30 @@ function createCacheFetchMock(params: { name: string; expireTime: string }) {
   );
 }
 
+// Builds a 200-OK response whose body streams more than 1 MiB with no
+// Content-Length, mirroring a buggy/hostile Google cachedContents endpoint.
+// The shared byte-cap reader must cancel the body before fully buffering it.
+function createOversizedJsonResponse(): { response: Response; cancel: ReturnType<typeof vi.fn> } {
+  const cancel = vi.fn(async () => undefined);
+  let pullCount = 0;
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        // First chunk already exceeds the 1 MiB cap so the reader truncates
+        // and cancels instead of waiting for the (never-ending) rest.
+        controller.enqueue(new Uint8Array(pullCount === 1 ? 1024 * 1024 + 1 : 1));
+      },
+      cancel,
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    },
+  );
+  return { response, cancel };
+}
+
 function createCapturingStreamFn(result = "stream") {
   // The wrapper mutates payloads through onPayload before calling the real
   // stream; capture that final payload instead of mocking Google responses.
@@ -551,5 +575,92 @@ describe("google prompt cache", () => {
 
     expect(wrapped).toBeUndefined();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("bounds an oversized cache-creation response body instead of buffering it", async () => {
+    const now = 4_000_000;
+    const { response, cancel } = createOversizedJsonResponse();
+    const fetchMock = vi.fn(async () => response);
+    const sessionManager = makeSessionManager();
+    const innerStreamFn = vi.fn(() => "stream" as never);
+
+    const wrapped = await preparePromptCacheStream({
+      fetchMock,
+      now,
+      sessionManager,
+      streamFn: innerStreamFn,
+    });
+
+    await expect(
+      Promise.resolve(
+        wrapped?.(
+          makeGoogleModel(),
+          { systemPrompt: "Follow policy.", messages: [] } as never,
+          {} as never,
+        ),
+      ),
+    ).rejects.toThrow(/Google prompt cache response too large: \d+ bytes/);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(callArg(fetchMock, 0, 0)).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/cachedContents",
+    );
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("bounds an oversized cache-refresh response body instead of buffering it", async () => {
+    const now = 4_500_000;
+    const expireSoon = new Date(now + 60_000).toISOString();
+    const systemPromptDigest = crypto.createHash("sha256").update("Follow policy.").digest("hex");
+    const sessionManager = makeSessionManager([
+      {
+        id: "entry-1",
+        parentId: null,
+        timestamp: new Date(now - 5_000).toISOString(),
+        type: "custom",
+        customType: "openclaw.google-prompt-cache",
+        data: {
+          status: "ready",
+          timestamp: now - 5_000,
+          provider: "google",
+          modelId: "gemini-3.1-pro-preview",
+          modelApi: "google-generative-ai",
+          baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+          systemPromptDigest,
+          cacheRetention: "long",
+          cachedContent: "cachedContents/system-cache-overflow",
+          expireTime: expireSoon,
+        },
+      },
+    ]);
+    const { response, cancel } = createOversizedJsonResponse();
+    const fetchMock = vi.fn(async () => response);
+    const { streamFn: innerStreamFn, getCapturedPayload } = createCapturingStreamFn();
+
+    const wrapped = await preparePromptCacheStream({
+      fetchMock,
+      now,
+      sessionManager,
+      streamFn: innerStreamFn,
+    });
+
+    // The TTL-refresh read swallows errors (.catch(() => null)) and falls back
+    // to the still-valid cached content, so the oversized body must be cancelled
+    // by the byte cap rather than fully buffered.
+    await Promise.resolve(
+      wrapped?.(
+        makeGoogleModel(),
+        { systemPrompt: "Follow policy.", messages: [] } as never,
+        {} as never,
+      ),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchUrl(fetchMock)).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/cachedContents/system-cache-overflow?updateMask=ttl",
+    );
+    expect(fetchInit(fetchMock).method).toBe("PATCH");
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(getCapturedPayload()?.cachedContent).toBe("cachedContents/system-cache-overflow");
   });
 });

--- a/src/agents/embedded-agent-runner/google-prompt-cache.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.ts
@@ -2,6 +2,7 @@
  * Prepares Google prompt-cache payloads for embedded-agent stream calls.
  */
 import crypto from "node:crypto";
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import {
   asDateTimestampMs,
   isFutureDateTimestampMs,
@@ -23,6 +24,9 @@ import { isGooglePromptCacheEligible, resolveCacheRetention } from "./prompt-cac
 import { EmbeddedAttemptSessionTakeoverError } from "./run/attempt.session-lock.js";
 
 const GOOGLE_PROMPT_CACHE_CUSTOM_TYPE = "openclaw.google-prompt-cache";
+// CachedContent metadata responses are tiny (name + expireTime); cap the read so
+// a buggy/hostile Google endpoint cannot stream an unbounded body into memory.
+const GOOGLE_PROMPT_CACHE_RESPONSE_MAX_BYTES = 1024 * 1024;
 const GOOGLE_PROMPT_CACHE_RETRY_BACKOFF_MS = 10 * 60_000;
 const GOOGLE_PROMPT_CACHE_SHORT_REFRESH_WINDOW_MS = 30_000;
 const GOOGLE_PROMPT_CACHE_LONG_REFRESH_WINDOW_MS = 5 * 60_000;
@@ -278,6 +282,19 @@ async function cancelUnreadResponseBody(response: Response | undefined): Promise
   }
 }
 
+/**
+ * Reads a Google cachedContents JSON body under a byte cap and parses it.
+ * Streams through the shared limiter so an oversized response is cancelled
+ * mid-flight instead of being fully buffered by `response.json()`.
+ */
+async function readGooglePromptCacheJson<T>(response: Response): Promise<T> {
+  const buffer = await readResponseWithLimit(response, GOOGLE_PROMPT_CACHE_RESPONSE_MAX_BYTES, {
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(`Google prompt cache response too large: ${size} bytes (limit: ${maxBytes} bytes)`),
+  });
+  return JSON.parse(buffer.toString("utf8")) as T;
+}
+
 async function updateGooglePromptCacheTtl(params: {
   apiKey: string;
   baseUrl: string;
@@ -300,7 +317,7 @@ async function updateGooglePromptCacheTtl(params: {
     if (!response.ok) {
       return null;
     }
-    const json = (await response.json()) as { expireTime?: string };
+    const json = await readGooglePromptCacheJson<{ expireTime?: string }>(response);
     return json;
   } finally {
     await cancelUnreadResponseBody(response);
@@ -338,7 +355,7 @@ async function createGooglePromptCache(params: {
     if (!response.ok) {
       return null;
     }
-    const json = (await response.json()) as { name?: string; expireTime?: string };
+    const json = await readGooglePromptCacheJson<{ name?: string; expireTime?: string }>(response);
     const cachedContent = normalizeOptionalString(json.name) ?? "";
     return cachedContent ? { cachedContent, expireTime: json.expireTime } : null;
   } finally {


### PR DESCRIPTION
## What Problem This Solves

The Google embedded-agent prompt-cache helpers parsed `cachedContents` metadata with an unbounded `await response.json()` in **both** `createGooglePromptCache` and `updateGooglePromptCacheTtl` — two reads from the external Google Generative Language endpoint, which is an untrusted source from openclaw's perspective. A buggy or hostile endpoint returning `200 OK` with a large or never-ending body (especially with no `Content-Length`) was fully buffered into memory before parsing, so the existing `cancelUnreadResponseBody` guard fired too late. That is an out-of-memory / DoS vector that affects any embedded-agent run using Google prompt caching. This is the Google-endpoint counterpart to the recently merged bound-stream work in #95108 (Anthropic error streams) and #95103 (gateway pricing catalog), closing the same symmetric unbounded-read class on the Google path.

## Evidence

- **Test**: `google-prompt-cache.test.ts` exercises the real create and TTL-refresh paths against a streamed `Response` whose first chunk exceeds the 1 MiB cap and whose body never ends. Command: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/google-prompt-cache.test.ts --run` → `Test Files 1 passed (1) / Tests 10 passed (10)` in ~2.2s.
- **Before (negative control, fix reverted to `await response.json()`)**: the unbounded read fully buffers the never-ending body and the Vitest worker crashes with `ERR_WORKER_OUT_OF_MEMORY` ("Worker terminated due to reaching memory limit: JS heap out of memory") after hanging 90s+ with no output — reproducing the vulnerability.
- **After (fix applied)**: tests pass; the create path rejects with `Google prompt cache response too large: <n> bytes` and the refresh path swallows the error (`.catch(() => null)`) and falls back to the still-valid cached content. In both cases the body's `cancel()` is asserted called once (not buffered).
- **Direct read-path control (tsx)**: `node --import tsx` driving `readResponseWithLimit` exactly as `readGooglePromptCacheJson` does → `threw: Google prompt cache response too large: 1048577 bytes (limit: 1048576 bytes)`, `body_cancelled: true`, `pulls_before_cancel: 1` — cap engaged, stream cancelled, no unbounded buffering.
- **Static checks**: `npx oxlint` exit 0; `node --check --experimental-strip-types` clean; `git diff --check` clean.

---

## Summary
- The Google embedded-agent prompt-cache helpers parsed `cachedContents` metadata with an unbounded `await response.json()` in **both** `createGooglePromptCache` (`google-prompt-cache.ts:341`) and `updateGooglePromptCacheTtl` (`google-prompt-cache.ts:303`). This is a symmetric pair on the Google Generative Language endpoint.
- A buggy or hostile endpoint returning `200 OK` with a large or never-ending body (especially with no `Content-Length`) was fully buffered into memory before parsing. The existing `cancelUnreadResponseBody` guard fired too late, since `response.json()` had already drained the whole body.
- Both reads now go through the shared streaming byte-cap reader `readResponseWithLimit` under a 1 MiB cap, cancelling the stream on overflow instead of buffering it, then `JSON.parse` the bounded buffer.

## Changes
- `src/agents/embedded-agent-runner/google-prompt-cache.ts`: add `GOOGLE_PROMPT_CACHE_RESPONSE_MAX_BYTES` (1 MiB) + a small `readGooglePromptCacheJson<T>` helper that wraps `readResponseWithLimit({ onOverflow })` + `JSON.parse`; route both call sites through it.
- `src/agents/embedded-agent-runner/google-prompt-cache.test.ts`: regressions that stream an oversized, no-`Content-Length` body through the real create and TTL-refresh paths and assert the body is cancelled (not buffered).

This is the Google-endpoint counterpart to the recently merged bound-stream work in #95108 (Anthropic error streams) and #95103 (gateway pricing catalog), reusing the same `readResponseWithLimit` helper rather than introducing a new abstraction.

## Real behavior proof

**What was tested**: the real `prepareGooglePromptCacheStreamFn` wrapper driving the real `createGooglePromptCache` and `updateGooglePromptCacheTtl` against a streamed `Response` whose first chunk exceeds the cap and whose body never ends.

**Command**: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/google-prompt-cache.test.ts --run`

**Before (negative control, fix reverted to `await response.json()`)**: the unbounded read fully buffers the never-ending body and the Vitest worker crashes:
```
Caused by: Error: Worker terminated due to reaching memory limit: JS heap out of memory
Serialized Error: { code: 'ERR_WORKER_OUT_OF_MEMORY' }
```
(The run hung 90s+ with no output before the OOM, reproducing the unbounded-buffering vulnerability.)

**After (fix applied)**: `Test Files 1 passed (1) / Tests 10 passed (10)` in ~2.2s. The new tests assert the create path rejects with `Google prompt cache response too large: <n> bytes` and the refresh path swallows the error (`.catch(() => null)`) and falls back to the still-valid cached content — and in both cases the body's `cancel()` is called once.

**Also (tsx, real read path)**: `node --import tsx` driving `readResponseWithLimit` exactly as `readGooglePromptCacheJson` does:
```
threw: Google prompt cache response too large: 1048577 bytes (limit: 1048576 bytes)
body_cancelled: true
pulls_before_cancel: 1
PROOF OK: cap engaged, stream cancelled, no unbounded buffering
```

**Other checks**: `npx oxlint <both files>` exit 0; `node --check --experimental-strip-types <both files>` clean; `git diff --check` clean.

**Label**: proof-sufficient

---
🤖 AI-assisted (human-reviewed). Symmetric Google-endpoint follow-up to #95108 / #95103 bound-stream reads.
