### PR TITLE
fix(agents): bound OpenRouter model-scan catalog success body

### DIFF
--- a/src/agents/model-scan.test.ts
+++ b/src/agents/model-scan.test.ts
@@ -113,6 +113,57 @@ describe("scanOpenRouterModels", () => {
     expect(cancel).toHaveBeenCalledOnce();
   });
 
+  it("bounds an oversized catalog success body and cancels the stream", async () => {
+    // The success body is provider-controlled and runtime-fetched. A faulty or
+    // hostile provider can stream an effectively unbounded JSON document; the
+    // read must stop at the byte cap, cancel the upstream stream, and surface a
+    // clear overflow error instead of buffering the whole payload into memory.
+    const cancel = vi.fn(async () => undefined);
+    let pullCount = 0;
+    const chunk = new Uint8Array(64 * 1024).fill(0x20); // 64 KiB of spaces
+    const fetchImpl = withFetchPreconnect(
+      async () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              // Valid JSON array prefix so the body would parse if ever read in full.
+              controller.enqueue(new TextEncoder().encode('{"data":['));
+            },
+            pull(controller) {
+              pullCount += 1;
+              controller.enqueue(chunk);
+            },
+            cancel,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+
+    await expect(scanOpenRouterModels({ fetchImpl, probe: false })).rejects.toThrow(
+      /OpenRouter \/models response too large/,
+    );
+
+    // The reader stopped early instead of draining an unbounded stream, and
+    // cancelled the upstream body once the byte cap was crossed.
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(pullCount).toBeGreaterThan(0);
+    expect(pullCount).toBeLessThan(4 * 1024 * 1024); // nowhere near draining forever
+  });
+
+  it("rejects a malformed catalog success body", async () => {
+    const fetchImpl = withFetchPreconnect(
+      async () =>
+        new Response("not json at all", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    await expect(scanOpenRouterModels({ fetchImpl, probe: false })).rejects.toThrow(
+      /OpenRouter \/models response is malformed JSON/,
+    );
+  });
+
   it("requires an API key when probing", async () => {
     const fetchImpl = createFetchFixture({ data: [] });
     await withEnvAsync({ OPENROUTER_API_KEY: undefined }, async () => {

--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -1,6 +1,7 @@
 /**
  * Scans remote provider model catalogs for configured providers.
  */
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import {
   asDateTimestampMs,
@@ -25,6 +26,11 @@ import { inferParamBFromIdOrName } from "../shared/model-param-b.js";
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const DEFAULT_TIMEOUT_MS = 12_000;
 const DEFAULT_CONCURRENCY = 3;
+// The OpenRouter /models catalog is a provider-controlled, runtime-fetched body
+// (already >100 KB and growing). Read it under a byte cap before JSON.parse so a
+// faulty or hostile provider cannot stream an unbounded document and exhaust
+// process memory. 4 MiB matches the cap used for the same endpoint elsewhere.
+const OPENROUTER_MODELS_BODY_MAX_BYTES = 4 * 1024 * 1024;
 
 const BASE_IMAGE_PNG =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X3mIAAAAASUVORK5CYII=";
@@ -184,6 +190,26 @@ async function withTimeout<T>(
   }
 }
 
+// Reads the OpenRouter /models success body under a byte cap before JSON.parse.
+// The success path was previously buffered with an unbounded res.json(); a faulty
+// or hostile provider could stream an effectively endless document and exhaust
+// memory. readResponseWithLimit caps the read, cancels the stream on overflow,
+// and bounds idle stalls with the call's existing timeout.
+async function readOpenRouterModelsJson(response: Response, timeoutMs: number): Promise<unknown> {
+  const buffer = await readResponseWithLimit(response, OPENROUTER_MODELS_BODY_MAX_BYTES, {
+    chunkTimeoutMs: timeoutMs,
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(`OpenRouter /models response too large: ${size} bytes (limit ${maxBytes} bytes)`),
+    onIdleTimeout: ({ chunkTimeoutMs }) =>
+      new Error(`OpenRouter /models response stalled after ${chunkTimeoutMs}ms`),
+  });
+  try {
+    return JSON.parse(buffer.toString("utf8")) as unknown;
+  } catch (cause) {
+    throw new Error("OpenRouter /models response is malformed JSON", { cause });
+  }
+}
+
 async function fetchOpenRouterModels(
   fetchImpl: typeof fetch,
   timeoutMs: number,
@@ -199,7 +225,7 @@ async function fetchOpenRouterModels(
     if (!res.ok) {
       throw new Error(`OpenRouter /models failed: HTTP ${res.status}`);
     }
-    const payload = (await res.json()) as { data?: unknown };
+    const payload = (await readOpenRouterModelsJson(res, timeoutMs)) as { data?: unknown };
     const entries = Array.isArray(payload.data) ? payload.data : [];
 
     return entries


### PR DESCRIPTION
## Summary

`fetchOpenRouterModels` (the OpenRouter `/v1/models` catalog read behind `scanOpenRouterModels`) hardened only its **error** path — `dbd5689` cancels the unread body when `res.bodyUsed` is false — but the **success** branch still buffered the entire response with an unbounded `await res.json()`. The catalog is a **provider-controlled, runtime-fetched** body, so a faulty or hostile provider can stream an effectively unbounded JSON document and exhaust process memory before the parse completes. The `finally`-block cancel is a no-op on success because `.json()` has already drained the whole body into memory.

This patch reads the success body through the canonical byte-cap reader (`readResponseWithLimit`) before `JSON.parse`, cancelling the stream on overflow and bounding idle stalls with the call's existing `timeoutMs`. It is the symmetric success-path counterpart to the bounded-stream hardening landed for the gateway pricing catalog in #95103 and for Anthropic error streams in #95108 — same vulnerability class, same helper, no new abstraction.

## Changes

- `src/agents/model-scan.ts`
  - Import `readResponseWithLimit` from `@openclaw/media-core/read-response-with-limit` (the same helper used by `model-pricing-cache` in #95103, `provider-http-errors`, `clawhub`, and media fetch).
  - Add `OPENROUTER_MODELS_BODY_MAX_BYTES = 4 * 1024 * 1024` with a comment explaining the untrusted-runtime-body rationale.
  - Add `readOpenRouterModelsJson(response, timeoutMs)` that reads the body under the byte cap (throwing a clear overflow error), bounds idle stalls (reusing the call's existing `timeoutMs` as `chunkTimeoutMs`), then `JSON.parse`s the bounded buffer.
  - Rewire the success branch from `await res.json()` to `await readOpenRouterModelsJson(res, timeoutMs)`. The existing error-path `finally`-cancel is unchanged.
- `src/agents/model-scan.test.ts`
  - Regression: an oversized streamed success body asserts the overflow error fires, the stream is cancelled once, and the reader stops early instead of draining an unbounded stream.
  - Regression: a malformed success body surfaces the clear malformed-JSON error.

**Cap rationale (why 4 MiB):** the OpenRouter live `/models` catalog is already >100 KB and grows; 4 MiB gives generous headroom for the largest known catalog while still bounding memory, and matches the cap used for the same endpoint in the live-catalog read (#95246). An overflow degrades gracefully — `scanOpenRouterModels` surfaces the error to its caller exactly as the prior `HTTP <status>` failure path already did.

## Real behavior proof

**Label**: success-path catalog body bounding

- Behavior addressed: the OpenRouter `/models` catalog success body was read via unbounded `res.json()`; on success the stream was never cancelled, so a provider streaming an unbounded JSON document could exhaust process memory.
- Real environment tested: Node 22 (v22.22.0), `node --expose-gc --import tsx` driving the **real** exported `scanOpenRouterModels` read path (→ real `fetchOpenRouterModels` → `readOpenRouterModelsJson` → `readResponseWithLimit`) against a `Response` wrapping a `ReadableStream` that emits a valid JSON array prefix then a run of 64 KiB padding chunks up to 12 MiB available; the stream is instrumented to count bytes actually pulled and whether `cancel()` fires. Plus `vitest` on the file and `oxlint` / `tsc`.
- Exact steps or commands run:
  1. tsx real-runtime harness driving `scanOpenRouterModels({ fetchImpl, probe: false })` with the oversized instrumented stream.
  2. Negative control: temporarily revert the success-path read back to `await res.json()` and re-run the identical harness.
  3. `node scripts/run-vitest.mjs src/agents/model-scan.test.ts --run`
  4. `npx oxlint src/agents/model-scan.ts src/agents/model-scan.test.ts` and `npx tsc -p tsconfig.json --noEmit`.
- Evidence after fix (tsx readback):
  ```
  threw            : true
  error.message    : OpenRouter /models response too large: 4194313 bytes (limit 4194304 bytes)
  stream.cancelled : true
  bytesPulled      : 4259849 bytes  (~4.06 MiB)
  byteCap          : 4194304 bytes  (~4.00 MiB)
  totalAvailable   : 12582912 bytes (~12.00 MiB an unbounded reader would drain)
  heap delta       : 3.42 MiB
  ```
  Negative control (source reverted to `await res.json()`):
  ```
  threw            : false
  error.message    : (no error thrown)
  stream.cancelled : false
  bytesPulled      : 12582921 bytes (drained the ENTIRE oversized stream — no bound)
  heap delta       : 14.82 MiB      (memory grows with the malicious payload)
  ```
  vitest: `Test Files 1 passed (1) / Tests 9 passed (9)` (7 pre-existing + 2 new). oxlint exit 0; `tsc -p tsconfig.json --noEmit` reports 0 errors project-wide (changed file clean).
- Observed result after fix: the success body is read under a 4 MiB ceiling, the upstream stream is cancelled on overflow, and the call surfaces a clear overflow error that its caller handles exactly like the existing failure path. Idle-stall is bounded by the existing `timeoutMs`.
- What was not tested: a real malicious upstream provider over the network (drove the real read path with an injected fetch instead); the live-probe inference path (unchanged); other providers' catalog projection logic (unchanged — only the byte-read boundary moved).

---

AI-assisted: implemented and verified with AI assistance; the bounded-stream approach mirrors the symmetric success-body hardening in #95103 and the error-stream hardening in #95108, reusing the canonical `readResponseWithLimit` helper rather than introducing a new abstraction.
