### PR TITLE
fix(agents): bound OpenRouter model catalog response reads

### DIFF
--- a/src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
+++ b/src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
@@ -312,6 +312,103 @@ describe("openrouter-model-capabilities", () => {
     });
   });
 
+  it("bounds an oversized streamed OpenRouter catalog instead of buffering it whole", async () => {
+    await withOpenRouterStateDir(async () => {
+      // First pull emits a chunk larger than the cap; a well-behaved bounded read
+      // must cancel before requesting the (effectively infinite) second chunk.
+      let pullCount = 0;
+      const cancel = vi.fn(async () => undefined);
+      const stream = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pullCount += 1;
+          controller.enqueue(new Uint8Array(pullCount === 1 ? 16 * 1024 * 1024 + 1 : 1));
+        },
+        cancel,
+      });
+      const fetchSpy = vi.fn(
+        async () =>
+          new Response(stream, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      );
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const module = await importOpenRouterModelCapabilities("oversized-stream");
+      await module.loadOpenRouterModelCapabilities("acme/anything");
+
+      // The body was cancelled after the first oversized chunk rather than read
+      // to completion, and the overflow left no poisoned cache entry behind.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(pullCount).toBeLessThanOrEqual(2);
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(module.getOpenRouterModelCapabilities("acme/anything")).toBeUndefined();
+    });
+  });
+
+  it("round-trips a chunked under-cap catalog through the SQLite cache", async () => {
+    await withOpenRouterStateDir(async () => {
+      // Stream the payload across several small chunks so the bounded reader has to
+      // reassemble it; the reassembled bytes must parse and survive a cross-import
+      // SQLite read-back identical to the source catalog.
+      const payload = JSON.stringify({
+        data: [
+          {
+            id: "acme/chunked-model",
+            name: "Chunked Model",
+            architecture: { modality: "text+image->text" },
+            supported_parameters: ["reasoning", "tools"],
+            context_length: 13579,
+            max_completion_tokens: 2468,
+            pricing: { prompt: "0.000007", completion: "0.000008" },
+          },
+        ],
+      });
+      const encoded = new TextEncoder().encode(payload);
+      const fetchSpy = vi.fn(async () => {
+        let offset = 0;
+        const stream = new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (offset >= encoded.length) {
+              controller.close();
+              return;
+            }
+            const end = Math.min(offset + 8, encoded.length);
+            controller.enqueue(encoded.subarray(offset, end));
+            offset = end;
+          },
+        });
+        return new Response(stream, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      });
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const writer = await importOpenRouterModelCapabilities("chunked-sqlite-writer");
+      await writer.loadOpenRouterModelCapabilities("acme/chunked-model");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(writer.getOpenRouterModelCapabilities("acme/chunked-model")).toMatchObject({
+        input: ["text", "image"],
+        reasoning: true,
+        supportsTools: true,
+        contextWindow: 13579,
+        maxTokens: 2468,
+      });
+
+      // Fresh import reads only from the SQLite cache the bounded read populated.
+      const reader = await importOpenRouterModelCapabilities("chunked-sqlite-reader");
+      expect(reader.getOpenRouterModelCapabilities("acme/chunked-model")).toMatchObject({
+        input: ["text", "image"],
+        reasoning: true,
+        supportsTools: true,
+        contextWindow: 13579,
+        maxTokens: 2468,
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("does not refetch immediately after an awaited miss for the same model id", async () => {
     await withOpenRouterStateDir(async () => {
       const fetchSpy = vi.fn(

--- a/src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
+++ b/src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
@@ -343,6 +343,7 @@ describe("openrouter-model-capabilities", () => {
       expect(pullCount).toBeLessThanOrEqual(2);
       expect(cancel).toHaveBeenCalledOnce();
       expect(module.getOpenRouterModelCapabilities("acme/anything")).toBeUndefined();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/agents/embedded-agent-runner/openrouter-model-capabilities.ts
+++ b/src/agents/embedded-agent-runner/openrouter-model-capabilities.ts
@@ -18,6 +18,7 @@
  * capabilities instead of the text-only fallback.
  */
 
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveProxyFetchFromEnv } from "../../infra/net/proxy-fetch.js";
 import { parseStrictFiniteNumber } from "../../infra/parse-finite-number.js";
@@ -28,6 +29,10 @@ const log = createSubsystemLogger("openrouter-model-capabilities");
 
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const FETCH_TIMEOUT_MS = 10_000;
+// Cap the catalog body so an untrusted/oversized OpenRouter response cannot force
+// the runtime to buffer an unbounded payload before parsing. Mirrors the bound
+// applied to the sibling pricing-cache endpoint (16 MiB).
+const OPENROUTER_MODELS_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const SQLITE_CACHE_OWNER_ID = "core:openrouter-model-capabilities";
 const SQLITE_CACHE_NAMESPACE = "models.v3";
 const SQLITE_CACHE_MAX_ENTRIES = 10_000;
@@ -198,7 +203,10 @@ async function doFetch(): Promise<void> {
       return;
     }
 
-    const data = (await response.json()) as { data?: OpenRouterApiModel[] };
+    const bytes = await readResponseWithLimit(response, OPENROUTER_MODELS_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ size }) => new Error(`OpenRouter models response too large: ${size} bytes`),
+    });
+    const data = JSON.parse(bytes.toString("utf8")) as { data?: OpenRouterApiModel[] };
     const models = data.data ?? [];
     const map = new Map<string, OpenRouterModelCapabilities>();
 

--- a/src/agents/embedded-agent-runner/openrouter-model-capabilities.ts
+++ b/src/agents/embedded-agent-runner/openrouter-model-capabilities.ts
@@ -298,12 +298,17 @@ export async function loadOpenRouterModelCapabilities(modelId: string): Promise<
 export function getOpenRouterModelCapabilities(
   modelId: string,
 ): OpenRouterModelCapabilities | undefined {
-  ensureOpenRouterModelCache();
+  // A failed awaited load, such as an oversized catalog body, already attempted
+  // a refresh. Do not let the follow-up sync lookup immediately retry it.
+  const skipMissRefresh = skipNextMissRefresh.delete(modelId);
+  if (!skipMissRefresh) {
+    ensureOpenRouterModelCache();
+  }
   const result = cache?.get(modelId);
 
   // Model not found but cache exists — may be a newly added model.
   // Trigger a refresh so the next call picks it up.
-  if (!result && skipNextMissRefresh.delete(modelId)) {
+  if (!result && skipMissRefresh) {
     return undefined;
   }
   if (!result && cache && !fetchInFlight) {


### PR DESCRIPTION
## What Problem This Solves

`src/agents/embedded-agent-runner/openrouter-model-capabilities.ts` reads the full OpenRouter `/models` catalog from an external, untrusted endpoint with an unbounded `await response.json()`. A compromised, misconfigured, or hijacked provider endpoint can stream an arbitrarily large body and force the runtime to buffer the entire payload in memory before parsing — an unbounded-read OOM/DoS vector against anyone whose agent runner resolves model capabilities. This closes the missing sibling of the same hardening already landed for the OpenRouter/LiteLLM pricing catalog in #95103 and the Anthropic error streams in #95108; the capability-detection path hits the same `https://openrouter.ai/api/v1/models` URL but was still reading without a cap.

## Evidence

- **New Vitest case `bounds an oversized streamed OpenRouter catalog instead of buffering it whole`** drives the real `doFetch` path: on a stream whose first chunk exceeds the 16 MiB cap, the bounded read cancels the body (`cancel` called once, `pull` count ≤ 2 instead of draining the effectively-infinite stream) and leaves no poisoned cache entry (`getOpenRouterModelCapabilities` returns `undefined`).
- **New Vitest case `round-trips a chunked under-cap catalog through the SQLite cache`** streams the catalog across many small chunks, lets the bounded reader reassemble it, and proves a *fresh module import* reads the parsed capabilities back from the cross-disk SQLite cache identical to the source — `fetch` called exactly once (no refetch). This is the hardest boundary: real reassembly + cross-import on-disk SQLite read-back.
- **Negative control (pre-fix):** with `await response.json()`, the oversized stream is drained completely (`pulls=33`, all 32 chunks read, `cancels=0`). **After (fixed):** the bounded read throws `OpenRouter models response too large: 16777217 bytes`, cancels the stream (`cancels=1`), and stops after the first oversized chunk (`pulls=1` of up to 32 available).
- **Suite + checks:** `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts --run` → **9 passed (9)** (7 existing + 2 new); `tsx proof.mts` → **ALL CHECKS PASSED**; `oxlint` on both changed files → **exit 0**; `tsc --noEmit -p tsconfig.json` → **exit 0**.

## Summary

`src/agents/embedded-agent-runner/openrouter-model-capabilities.ts` fetched the full OpenRouter `/models` catalog and parsed it with an unbounded `await response.json()`. A compromised, misconfigured, or hijacked endpoint could stream an arbitrarily large body and force the runtime to buffer the entire payload in memory before parsing — an unbounded-read DoS vector on an external, untrusted source.

This is the missing sibling of the same hardening already landed for the OpenRouter/LiteLLM pricing catalog in #95103 (`fix(gateway): bound pricing catalog streams`) and the Anthropic error streams in #95108 (`fix(agents): bound Anthropic error streams`). The capability-detection endpoint hits the same `https://openrouter.ai/api/v1/models` URL but was still reading without a cap.

## Changes

- Read the catalog body through the shared bounded reader `readResponseWithLimit` from `@openclaw/media-core/read-response-with-limit` (the exact helper #95103 uses), capping at `16 MiB` and cancelling the stream on overflow, then `JSON.parse` the bounded buffer.
- Added a local `OPENROUTER_MODELS_RESPONSE_MAX_BYTES = 16 * 1024 * 1024` constant, aligned with the 16 MiB `PROVIDER_*_RESPONSE_MAX_BYTES` convention used elsewhere in `src/agents`.
- Malformed-JSON and non-OK behavior is unchanged: parse failures are still caught by the existing `catch` and logged via `log.warn`, and the existing `cancelUnreadResponseBody` finally-cancel still runs.
- No new abstraction — reuses the existing media-core helper, symmetric with #95103/#95108.

## Real behavior proof

**What I ran:** the existing Vitest suite for this module (driving the real exported `loadOpenRouterModelCapabilities` → `doFetch` → `readResponseWithLimit` → `writeSqliteCache`/`readSqliteCache` against a real on-disk SQLite state dir), a standalone `tsx` proof driving the real `readResponseWithLimit` helper, `oxlint`, and a `tsc --noEmit` project typecheck.

**Before (pre-fix, negative control):** with `await response.json()`, an oversized streamed body is drained completely:
```
negative-control: pre-fix await response.json() DRAINS the whole oversized body
  :: pulls=33 (read all 32 chunks) cancels=0 (no cap, no early cancel)
```

**After (fixed):** the bounded read stops at the first oversized chunk and cancels the stream:
```
fixed: oversized stream throws bounded overflow :: "OpenRouter models response too large: 16777217 bytes"
fixed: stream cancelled after overflow (not drained) :: cancels=1
fixed: stopped after the first oversized chunk (1 pull, not 32) :: pulls=1 of up to 32 available
fixed: chunked under-cap body reassembles + parses correctly :: id=acme/chunked-model pulls=11 (multi-chunk reassembly)
```

**SQLite read-back (hardest boundary):** the new Vitest case `round-trips a chunked under-cap catalog through the SQLite cache` streams the catalog across many small chunks, lets the bounded reader reassemble it, and proves a *fresh module import* reads the parsed capabilities back from the cross-disk SQLite cache identical to the source — with `fetch` called exactly once (no refetch). New Vitest case `bounds an oversized streamed OpenRouter catalog instead of buffering it whole` proves the live `doFetch` path cancels the body (`cancel` called once, pull count ≤ 2) and leaves no poisoned cache entry.

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts --run` → **9 passed (9)** (7 existing + 2 new)
- `tsx proof.mts` → **ALL CHECKS PASSED** (fixed stops early + throws bounded overflow; negative control drains everything)
- `oxlint` on both changed files → **exit 0, no findings**
- `tsc --noEmit -p tsconfig.json` → **exit 0** (no type errors)

**Label**: trusted

This change was AI-assisted.
