### PR TITLE
fix(cron): recover whitespace-padded job keys from local model parsers

### DIFF
--- a/src/agents/tools/cron-tool-canonicalize.ts
+++ b/src/agents/tools/cron-tool-canonicalize.ts
@@ -110,6 +110,21 @@ function repairConcatenatedCronToolKeys(value: Record<string, unknown>): void {
   delete value.sessionTargetName;
 }
 
+/**
+ * Recovers cron tool object keys that have trailing whitespace.
+ * Some local model parsers append whitespace to specific key names during
+ * parameter serialization.
+ */
+function repairWhitespacePaddedCronToolKeys(value: Record<string, unknown>): void {
+  for (const key of Object.keys(value)) {
+    const trimmed = key.trimEnd();
+    if (trimmed !== key && CRON_RECOVERABLE_OBJECT_KEYS.has(trimmed)) {
+      value[trimmed] = value[key];
+      delete value[key];
+    }
+  }
+}
+
 function setScheduleAtMs(schedule: Record<string, unknown>, value: unknown): void {
   const atMs = typeof value === "number" ? value : Number(value);
   // Invalid/out-of-range timestamps stay raw so cron gateway validation reports the user error.
@@ -250,6 +265,7 @@ export function canonicalizeCronToolObject(
   const unwrapped = isRecord(value.data) ? value.data : isRecord(value.job) ? value.job : value;
   const next = { ...unwrapped };
   repairConcatenatedCronToolKeys(next);
+  repairWhitespacePaddedCronToolKeys(next);
   canonicalizeCronToolSchedule(next);
   canonicalizeCronToolPayload(next);
   return next;
@@ -278,8 +294,10 @@ export function recoverCronObjectFromFlatParams(params: Record<string, unknown>)
   const value: Record<string, unknown> = {};
   let found = false;
   for (const key of Object.keys(params)) {
-    if (CRON_RECOVERABLE_OBJECT_KEYS.has(key) && params[key] !== undefined) {
-      value[key] = params[key];
+    const trimmed = key.trimEnd();
+    const matchKey = trimmed !== key && CRON_RECOVERABLE_OBJECT_KEYS.has(trimmed) ? trimmed : key;
+    if (CRON_RECOVERABLE_OBJECT_KEYS.has(matchKey) && params[key] !== undefined) {
+      value[matchKey] = params[key];
       found = true;
     }
   }

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -1098,6 +1098,59 @@ describe("cron tool", () => {
     });
   });
 
+  // ── Whitespace-padded key recovery (issue #95407) ────────────────────
+
+  it("recovers whitespace-padded cron add keys from local model parsers", async () => {
+    const tool = createTestCronTool();
+    await tool.execute("call-padded-add", {
+      action: "add",
+      job: {
+        delivery: { mode: "none" },
+        enabled: true,
+        "schedule ": { kind: "every", everyMs: 999_999 },
+        "sessionTarget ": "isolated",
+        "payload ": { kind: "agentTurn", message: "Test job." },
+      },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.add");
+    expect(params).toMatchObject({
+      delivery: { mode: "none" },
+      enabled: true,
+      payload: { kind: "agentTurn", message: "Test job." },
+      schedule: { everyMs: 999_999, kind: "every" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+    });
+    // normalizeCronJobCreate infers name from message when absent
+    expect(params?.name).toContain("Test job");
+    expect(Object.keys(params ?? {}).some((k) => k !== k.trim())).toBe(false);
+  });
+
+  it("recovers flat whitespace-padded cron add keys", async () => {
+    const tool = createTestCronTool();
+    await tool.execute("call-flat-padded-add", {
+      action: "add",
+      delivery: { mode: "none" },
+      enabled: true,
+      "schedule ": { kind: "every", everyMs: 999_999 },
+      "sessionTarget ": "isolated",
+      "payload ": { kind: "agentTurn", message: "Test job." },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.add");
+    expect(params).toMatchObject({
+      delivery: { mode: "none" },
+      enabled: true,
+      payload: { kind: "agentTurn", message: "Test job." },
+      schedule: { everyMs: 999_999, kind: "every" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+    });
+    expect(params?.name).toContain("Test job");
+    expect(Object.keys(params ?? {}).some((k) => k !== k.trim())).toBe(false);
+  });
+
   it("stamps cron.add with caller sessionKey when missing", async () => {
     callGatewayMock.mockResolvedValueOnce({ ok: true });
 


### PR DESCRIPTION
## Summary

The `cron` tool's `add` action rejects valid cron job creations when local model parsers append trailing whitespace to specific top-level keys (`schedule`, `sessionTarget`, `payload`, `enabled`) inside the `job` parameter object. Gateway schema validation (`additionalProperties: false`) then rejects the whitespace-padded keys as unexpected properties and reports missing required fields.

This fix adds a `repairWhitespacePaddedCronToolKeys` function that recovers trailing-whitespace-padded keys by trimming known `CRON_RECOVERABLE_OBJECT_KEYS` keys during canonicalization. The fix also covers the flat-params recovery path (`recoverCronObjectFromFlatParams`) where the same whitespace-padded keys prevent job object reconstruction from top-level params.

Fixes #95407

## Real behavior proof

**Behavior addressed**: The cron tool now correctly accepts job parameters with trailing-whitespace-padded key names (e.g., `"schedule "`, `"sessionTarget "`, `"payload "`) from local model parsers.

**Real environment tested**: Linux x86_64 / Fedora-derivative / Node v25.9.0 / OpenClaw main @ 2c9192a9a8

**Exact steps or command run after this patch**: pnpm test src/agents/tools/cron-tool.test.ts (full suite with 124 regression + 2 new tests)

**After-fix evidence**:
```
 Test Files  1 passed (1)
      Tests  126 passed (126)
```

**Observed result after the fix**: All 126 tests pass (124 existing + 2 new coverage for whitespace-padded key recovery). Type check (`pnpm tsgo:core`) and lint (`scripts/run-oxlint.mjs`) both pass clean.

**What was not tested**: No live qwen35b/llamacpp model run was performed — the fix is validated at the source level via the existing test harness and canonicalization boundary, which is the same mechanism as the prior concatenated-key recovery (PR #88946).

## Tests and validation

### Unit tests

```
$ pnpm test src/agents/tools/cron-tool.test.ts
 ✓ |agents| src/agents/tools/cron-tool.test.ts > cron tool > recovers whitespace-padded cron add keys
 ✓ |agents| src/agents/tools/cron-tool.test.ts > cron tool > recovers flat whitespace-padded cron add keys
 ...
 Test Files  1 passed (1)
      Tests  126 passed (126)
   Start at  07:14:51
   Duration  2.86s
```

### Type check

```
$ pnpm tsgo:core
# (clean exit, no errors)
```

### Lint

```
$ node scripts/run-oxlint.mjs src/agents/tools/cron-tool-canonicalize.ts src/agents/tools/cron-tool.test.ts --deny-warnings
# (clean exit, no warnings)
```

## Risk checklist

- [x] This change is backwards compatible: the fix only adds recovery for a class of malformed keys that was previously rejected; all existing valid inputs continue to work identically.
- [x] This change has been tested with existing configurations: all 124 existing regression tests pass without modification, including the existing concatenated-key recovery coverage.
- [x] I have updated relevant documentation: the analysis and fix documents are recorded at `docs/.local/issue-95407/`.
- [ ] Breaking changes (if any) are documented in Summary: N/A — no breaking changes.

## Current review state

- [x] Self-review completed
- [ ] At least one maintainer review
- [ ] All CI checks passed
