### PR TITLE
fix(cron): recover whitespace-padded tool keys before validation

### DIFF
--- a/src/agents/tools/cron-tool-canonicalize.ts
+++ b/src/agents/tools/cron-tool-canonicalize.ts
@@ -110,6 +110,26 @@ function repairConcatenatedCronToolKeys(value: Record<string, unknown>): void {
   delete value.sessionTargetName;
 }
 
+function repairWhitespacePaddedCronToolKeys(value: Record<string, unknown>): void {
+  // Some small/local tool-call serializers emit valid JSON where specific cron
+  // keys carry leading/trailing whitespace (e.g. `"schedule "`, `"enabled "`).
+  // Trim back onto the canonical key before strict gateway validation rejects
+  // the padded property names. Only recover known cron keys, and skip when the
+  // canonical key already exists so a genuine duplicate is left for validation
+  // instead of being silently merged.
+  for (const key of Object.keys(value)) {
+    const trimmed = key.trim();
+    if (trimmed === key || !CRON_RECOVERABLE_OBJECT_KEYS.has(trimmed)) {
+      continue;
+    }
+    if (value[trimmed] !== undefined) {
+      continue;
+    }
+    value[trimmed] = value[key];
+    delete value[key];
+  }
+}
+
 function setScheduleAtMs(schedule: Record<string, unknown>, value: unknown): void {
   const atMs = typeof value === "number" ? value : Number(value);
   // Invalid/out-of-range timestamps stay raw so cron gateway validation reports the user error.
@@ -249,6 +269,7 @@ export function canonicalizeCronToolObject(
 ): Record<string, unknown> {
   const unwrapped = isRecord(value.data) ? value.data : isRecord(value.job) ? value.job : value;
   const next = { ...unwrapped };
+  repairWhitespacePaddedCronToolKeys(next);
   repairConcatenatedCronToolKeys(next);
   canonicalizeCronToolSchedule(next);
   canonicalizeCronToolPayload(next);

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -1098,6 +1098,52 @@ describe("cron tool", () => {
     });
   });
 
+  it("recovers whitespace-padded cron add keys from local tool-call parsers", async () => {
+    const tool = createTestCronTool();
+    await tool.execute("call-padded-add", {
+      action: "add",
+      job: {
+        name: "Holiday Check-in",
+        description: "Casual check-in while on holiday, 2x per day",
+        "schedule ": { kind: "cron", expr: "30 10,20 * * *", tz: "Europe/Madrid" },
+        "sessionTarget ": "isolated",
+        "payload ": { kind: "agentTurn", message: "Holiday check-in." },
+        "enabled ": true,
+      },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.add") as Record<string, unknown>;
+    expect(Object.keys(params).every((key) => key === key.trim())).toBe(true);
+    expect(params).toMatchObject({
+      name: "Holiday Check-in",
+      description: "Casual check-in while on holiday, 2x per day",
+      schedule: { kind: "cron", expr: "30 10,20 * * *", tz: "Europe/Madrid" },
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "Holiday check-in." },
+      enabled: true,
+    });
+  });
+
+  it("keeps a padded duplicate key when the canonical cron key already exists", async () => {
+    const tool = createTestCronTool();
+    await tool.execute("call-padded-duplicate-add", {
+      action: "add",
+      job: {
+        name: "dup",
+        schedule: { kind: "cron", expr: "0 9 * * *" },
+        "enabled ": true,
+        enabled: false,
+        payload: { kind: "agentTurn", message: "dup test" },
+      },
+    });
+
+    // Genuine duplicates are not silently merged: the padded key survives so
+    // strict gateway validation surfaces the conflict instead of guessing.
+    const params = expectSingleGatewayCallMethod("cron.add") as Record<string, unknown>;
+    expect(params.enabled).toBe(false);
+    expect(params["enabled "]).toBe(true);
+  });
+
   it("stamps cron.add with caller sessionKey when missing", async () => {
     callGatewayMock.mockResolvedValueOnce({ ok: true });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #95407. Some small/local model tool-call serializers emit valid JSON for the `cron` tool's `add` action where specific top-level keys in the `job` object carry trailing whitespace — `"schedule "`, `"sessionTarget "`, `"payload "`, `"enabled "` — while keys like `name`/`description` and nested keys stay intact. The gateway `cron.add` schema is strict (`additionalProperties: false`), so these padded keys make the call fail validation with "must have required properties schedule, sessionTarget, payload", and the job is never created.

## Why This Change Was Made

The cron tool already canonicalizes model-friendly/malformed shorthands before strict gateway validation in `src/agents/tools/cron-tool-canonicalize.ts` — including a sibling `repairConcatenatedCronToolKeys` recovery for an earlier local-model key-corruption shape (concatenated keys). The trailing-space variant is the same class of defect at the same boundary, so the narrowest, consistent fix is a sibling recovery step in that canonicalizer rather than loosening the gateway schema or touching shared cross-provider JSON parsing.

`repairWhitespacePaddedCronToolKeys` trims each top-level key and, only when the trimmed name is a known cron key, renames it onto the canonical key. It deliberately skips renaming when the canonical key already exists, so a genuine duplicate (e.g. both `enabled` and `"enabled "`) is left for strict validation to reject instead of being silently merged.

## User Impact

Local/non-frontier models that pad cron `job` keys with whitespace can now successfully create scheduled jobs through the `cron` tool. Gateway validation stays strict; no config, schema, or migration changes. Frontier models that already emit clean keys are unaffected (the trim loop is a no-op when no padded known keys are present).

## Evidence

Real-behavior proof: drove the actual production `canonicalizeCronToolObject` plus the real strict gateway validator `validateCronAddParams` (`@openclaw/gateway-protocol`) on the reporter's exact mangled payload. The mangled (trailing-space) input is rejected before the fix path and the recovered output is accepted after:

```
valid input accepted by strict schema:   true
mangled input accepted by strict schema: false
  first schema error: "must have required properties schedule, sessionTarget, payload"
mangled keys: ["name","schedule ","sessionTarget ","wakeMode","payload ","enabled "]
recovered keys: ["name","wakeMode","schedule","sessionTarget","payload","enabled"]
recovered input accepted by strict schema: true
```

Added regression tests through the full `cron` tool execute path in `src/agents/tools/cron-tool.test.ts`:
- recovers whitespace-padded cron add keys from local tool-call parsers (asserts the gateway receives canonical keys and no padded key leaks);
- keeps a padded duplicate key when the canonical cron key already exists (asserts no silent merge).

Test run (worktree-safe runner, full cron-tool suite):

```
node scripts/run-vitest.mjs src/agents/tools/cron-tool.test.ts
 Test Files  1 passed (1)
      Tests  126 passed (126)
```

Formatting (`oxfmt --check`) and lint (`oxlint`) pass on both touched files.

AI-assisted.
