### PR TITLE
test(scripts): add check-package-dist-imports to golden test plan

### DIFF
--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -880,6 +880,7 @@ describe("test-projects args", () => {
           "test/helpers/temp-dir.test.ts",
           "test/scripts/android-pin-version.test.ts",
           "test/scripts/bench-cli-startup.test.ts",
+          "test/scripts/check-package-dist-imports.test.ts",
           "test/scripts/control-ui-i18n.test.ts",
           "test/scripts/ios-configure-signing.test.ts",
           "test/scripts/ios-pin-version.test.ts",


### PR DESCRIPTION
## What Problem This Solves

The golden test `routes top-level test helpers to importing repo tests` in `src/scripts/test-projects.test.ts` fails on `main` because `test/scripts/check-package-dist-imports.test.ts` imports `test/helpers/temp-dir.ts` but is not listed in the expected golden output. This causes `checks-node-core-tooling` CI failures for all PRs.

## Why This Change Was Made

`test/scripts/check-package-dist-imports.test.ts` was added to the repository and imports `../helpers/temp-dir.js`. The `buildVitestRunPlans` function correctly includes it in the tooling config shard, but the golden test expectation was not updated to match.

## User Impact

Fixes `checks-node-core-tooling` CI failures across all open PRs.

## Evidence

- **Before**: `pnpm test -- src/scripts/test-projects.test.ts` → 1 failure
- **After**: `pnpm test -- src/scripts/test-projects.test.ts` → 83 passed

```
 Test Files  1 passed (1)
      Tests  83 passed (83)
```

## Real behavior proof

**Behavior addressed**: `buildVitestRunPlans` golden test fails because the expected file list is missing `test/scripts/check-package-dist-imports.test.ts`.

**Real setup tested**: Node 22.19, Linux, latest `main`

**Exact steps or command run after this patch**:
```bash
pnpm test -- src/scripts/test-projects.test.ts --reporter=verbose
```

**After-fix evidence**: All 83 tests pass.

**Observed result after the fix**: Golden test matches actual file import graph.

**What was not tested**: Full CI suite (this is a test-expectation-only change).