### PR TITLE
fix(auto-reply): keep drain/restart-abort reply paths silent

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.post-compaction-duplicate-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.post-compaction-duplicate-prompt.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
+import { afterEach, describe, expect, it } from "vitest";
+import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
+import { rotateTranscriptAfterCompaction } from "./compaction-successor-transcript.js";
+import { readTranscriptFileState } from "./transcript-file-state.js";
+
+let tmpDir: string | undefined;
+afterEach(async () => {
+  if (tmpDir) {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+    tmpDir = undefined;
+  }
+});
+
+function makeAssistant(text: string, timestamp: number) {
+  return makeAgentAssistantMessage({ content: [{ type: "text", text }], timestamp });
+}
+
+function readUserTexts(entries: { type: string; message?: unknown }[]): string[] {
+  return entries
+    .filter(
+      (entry) =>
+        entry.type === "message" &&
+        (entry.message as { role?: unknown } | undefined)?.role === "user",
+    )
+    .map((entry) => {
+      const content = (entry.message as { content?: unknown } | undefined)?.content;
+      if (typeof content === "string") {
+        return content;
+      }
+      if (Array.isArray(content)) {
+        return content.map((block) => (block as { text?: string })?.text ?? "").join("");
+      }
+      return "";
+    });
+}
+
+const PROMPT = "Run the deployment script for staging now";
+
+describe("rotateTranscriptAfterCompaction post-compaction duplicate", () => {
+  it("keeps a real post-compaction user turn that repeats a kept-tail prompt", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "successor-dup-post-"));
+    const manager = SessionManager.create(tmpDir, tmpDir);
+
+    manager.appendMessage({ role: "user", content: "set up the project", timestamp: 1000 });
+    manager.appendMessage(makeAssistant("Project ready.", 1001));
+
+    const firstKeptId = manager.appendMessage({
+      role: "user",
+      content: PROMPT,
+      timestamp: 2000,
+    });
+    manager.appendMessage(makeAssistant("Deploying to staging.", 2001));
+    manager.appendCompaction("Summary of project setup.", firstKeptId, 2050);
+
+    manager.appendMessage({ role: "user", content: PROMPT, timestamp: 2080 });
+    manager.appendMessage(makeAssistant("Redeploying to staging (second run).", 2081));
+
+    const sessionFile = manager.getSessionFile();
+    if (!sessionFile) {
+      throw new Error("no session file");
+    }
+
+    const result = await rotateTranscriptAfterCompaction({ sessionManager: manager, sessionFile });
+    expect(result.rotated).toBe(true);
+    const successorFile = result.sessionFile;
+    if (!successorFile) {
+      throw new Error("no successor file");
+    }
+
+    const successor = await readTranscriptFileState(successorFile);
+    const userPromptTexts = readUserTexts(
+      successor.getEntries() as { type: string; message?: unknown }[],
+    );
+
+    const occurrences = userPromptTexts.filter((text) => text.includes(PROMPT)).length;
+    expect(occurrences).toBe(2);
+  });
+});

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -143,9 +143,14 @@ function buildSuccessorEntries(params: {
   }
 
   const removedIds = new Set<string>();
-  const keptBranchEntries = branch.filter((entry) => !summarizedBranchIds.has(entry.id));
-  const duplicateUserMessageIds =
-    collectDuplicateUserMessageEntryIdsForCompaction(keptBranchEntries);
+  const keptPreCompactionEntries = branch
+    .slice(0, latestCompactionIndex)
+    .filter((entry) => !summarizedBranchIds.has(entry.id));
+  const postCompactionEntries = branch.slice(latestCompactionIndex + 1);
+  const duplicateUserMessageIds = new Set<string>([
+    ...collectDuplicateUserMessageEntryIdsForCompaction(keptPreCompactionEntries),
+    ...collectDuplicateUserMessageEntryIdsForCompaction(postCompactionEntries),
+  ]);
   for (const entry of allEntries) {
     if (
       (summarizedBranchIds.has(entry.id) && entry.type === "message") ||

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -5890,7 +5890,7 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
-  it("stays silent (NO_REPLY) when fallback exhaustion wraps a drain error, keeping fail bookkeeping", async () => {
+  it("surfaces restart text when fallback exhaustion wraps a drain error, keeping fail bookkeeping", async () => {
     const { replyOperation, failMock } = createMockReplyOperation();
     state.runWithModelFallbackMock.mockRejectedValueOnce(
       Object.assign(new Error("fallback exhausted"), {
@@ -5930,19 +5930,20 @@ describe("runAgentTurnWithFallback", () => {
       sessionKey: "main",
       getActiveSessionEntry: () => undefined,
       resolvedVerboseLevel: "off",
-      isRestartRecoveryArmed: () => true,
     });
 
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
-      expect(result.payload.text).toBe(SILENT_REPLY_TOKEN);
+      expect(result.payload.text).toBe(
+        "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
+      );
     }
     const failCall = requireMockCall(failMock, 0, "reply operation fail");
     expect(failCall[0]).toBe("gateway_draining");
     expect(failCall[1]).toBeInstanceOf(GatewayDrainingError);
   });
 
-  it("stays silent (NO_REPLY) when fallback exhaustion wraps a cleared lane error, keeping fail bookkeeping", async () => {
+  it("surfaces restart text when fallback exhaustion wraps a cleared lane error, keeping fail bookkeeping", async () => {
     const { replyOperation, failMock } = createMockReplyOperation();
     state.runWithModelFallbackMock.mockRejectedValueOnce(
       Object.assign(new Error("fallback exhausted"), {
@@ -5982,12 +5983,13 @@ describe("runAgentTurnWithFallback", () => {
       sessionKey: "main",
       getActiveSessionEntry: () => undefined,
       resolvedVerboseLevel: "off",
-      isRestartRecoveryArmed: () => true,
     });
 
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
-      expect(result.payload.text).toBe(SILENT_REPLY_TOKEN);
+      expect(result.payload.text).toBe(
+        "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
+      );
     }
     const failCall = requireMockCall(failMock, 0, "reply operation fail");
     expect(failCall[0]).toBe("command_lane_cleared");

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -5890,7 +5890,7 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
-  it("surfaces gateway restart text when fallback exhaustion wraps a drain error", async () => {
+  it("stays silent (NO_REPLY) when fallback exhaustion wraps a drain error, keeping fail bookkeeping", async () => {
     const { replyOperation, failMock } = createMockReplyOperation();
     state.runWithModelFallbackMock.mockRejectedValueOnce(
       Object.assign(new Error("fallback exhausted"), {
@@ -5934,16 +5934,14 @@ describe("runAgentTurnWithFallback", () => {
 
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
-      expect(result.payload.text).toBe(
-        "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
-      );
+      expect(result.payload.text).toBe(SILENT_REPLY_TOKEN);
     }
     const failCall = requireMockCall(failMock, 0, "reply operation fail");
     expect(failCall[0]).toBe("gateway_draining");
     expect(failCall[1]).toBeInstanceOf(GatewayDrainingError);
   });
 
-  it("surfaces gateway restart text when fallback exhaustion wraps a cleared lane error", async () => {
+  it("stays silent (NO_REPLY) when fallback exhaustion wraps a cleared lane error, keeping fail bookkeeping", async () => {
     const { replyOperation, failMock } = createMockReplyOperation();
     state.runWithModelFallbackMock.mockRejectedValueOnce(
       Object.assign(new Error("fallback exhausted"), {
@@ -5987,16 +5985,14 @@ describe("runAgentTurnWithFallback", () => {
 
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
-      expect(result.payload.text).toBe(
-        "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
-      );
+      expect(result.payload.text).toBe(SILENT_REPLY_TOKEN);
     }
     const failCall = requireMockCall(failMock, 0, "reply operation fail");
     expect(failCall[0]).toBe("command_lane_cleared");
     expect(failCall[1]).toBeInstanceOf(CommandLaneClearedError);
   });
 
-  it("surfaces gateway restart text when the reply operation was aborted for restart", async () => {
+  it("stays silent (NO_REPLY) when the reply operation was aborted for restart", async () => {
     const agentEvents = await import("../../infra/agent-events.js");
     const emitAgentEvent = vi.mocked(agentEvents.emitAgentEvent);
     const { replyOperation, failMock } = createMockReplyOperation();
@@ -6035,9 +6031,7 @@ describe("runAgentTurnWithFallback", () => {
 
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
-      expect(result.payload.text).toBe(
-        "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
-      );
+      expect(result.payload.text).toBe(SILENT_REPLY_TOKEN);
     }
     expect(failMock).not.toHaveBeenCalled();
     expect(
@@ -6092,7 +6086,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result).toEqual({
       kind: "final",
       payload: expect.objectContaining({
-        text: "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
+        text: SILENT_REPLY_TOKEN,
       }),
     });
     expect(

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -5930,6 +5930,7 @@ describe("runAgentTurnWithFallback", () => {
       sessionKey: "main",
       getActiveSessionEntry: () => undefined,
       resolvedVerboseLevel: "off",
+      isRestartRecoveryArmed: () => true,
     });
 
     expect(result.kind).toBe("final");
@@ -5981,6 +5982,7 @@ describe("runAgentTurnWithFallback", () => {
       sessionKey: "main",
       getActiveSessionEntry: () => undefined,
       resolvedVerboseLevel: "off",
+      isRestartRecoveryArmed: () => true,
     });
 
     expect(result.kind).toBe("final");

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -6031,6 +6031,7 @@ describe("runAgentTurnWithFallback", () => {
       sessionKey: "main",
       getActiveSessionEntry: () => undefined,
       resolvedVerboseLevel: "off",
+      isRestartRecoveryArmed: () => true,
     });
 
     expect(result.kind).toBe("final");
@@ -6085,6 +6086,7 @@ describe("runAgentTurnWithFallback", () => {
       sessionKey: "main",
       getActiveSessionEntry: () => undefined,
       resolvedVerboseLevel: "off",
+      isRestartRecoveryArmed: () => true,
     });
 
     expect(result).toEqual({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1405,6 +1405,10 @@ export function buildContextOverflowRecoveryText(params: {
   return prefix + (heartbeatBleedHint ?? buildContextOverflowResetHint(primaryContextWindow));
 }
 
+function buildRestartLifecycleReplyText(): string {
+  return "⚠️ Gateway is restarting. Please wait a few seconds and try again.";
+}
+
 function resolveRestartLifecycleError(
   err: unknown,
 ): GatewayDrainingError | CommandLaneClearedError | undefined {
@@ -1590,6 +1594,7 @@ export async function runAgentTurnWithFallback(params: {
   toolProgressDetail?: "explain" | "raw";
   replyMediaContext?: ReplyMediaContext;
   onCompactionNoticePayload?: (payload: ReplyPayload) => Promise<void> | void;
+  isRestartRecoveryArmed?: () => boolean;
 }): Promise<AgentRunLoopResult> {
   const TRANSIENT_HTTP_RETRY_DELAY_MS = 2_500;
   let didLogHeartbeatStrip = false;
@@ -3137,6 +3142,14 @@ export async function runAgentTurnWithFallback(params: {
       if (restartLifecycleError instanceof GatewayDrainingError) {
         takePendingLifecycleTerminal()?.emit("error", restartLifecycleError);
         params.replyOperation?.fail("gateway_draining", restartLifecycleError);
+        if (params.isRestartRecoveryArmed?.() !== true) {
+          return {
+            kind: "final",
+            payload: markAgentRunFailureReplyPayload({
+              text: buildRestartLifecycleReplyText(),
+            }),
+          };
+        }
         return {
           kind: "final",
           payload: {
@@ -3148,6 +3161,14 @@ export async function runAgentTurnWithFallback(params: {
       if (restartLifecycleError instanceof CommandLaneClearedError) {
         takePendingLifecycleTerminal()?.emit("error", restartLifecycleError);
         params.replyOperation?.fail("command_lane_cleared", restartLifecycleError);
+        if (params.isRestartRecoveryArmed?.() !== true) {
+          return {
+            kind: "final",
+            payload: markAgentRunFailureReplyPayload({
+              text: buildRestartLifecycleReplyText(),
+            }),
+          };
+        }
         return {
           kind: "final",
           payload: {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1594,6 +1594,7 @@ export async function runAgentTurnWithFallback(params: {
   toolProgressDetail?: "explain" | "raw";
   replyMediaContext?: ReplyMediaContext;
   onCompactionNoticePayload?: (payload: ReplyPayload) => Promise<void> | void;
+  isRestartRecoveryArmed?: () => boolean;
 }): Promise<AgentRunLoopResult> {
   const TRANSIENT_HTTP_RETRY_DELAY_MS = 2_500;
   let didLogHeartbeatStrip = false;
@@ -3119,6 +3120,14 @@ export async function runAgentTurnWithFallback(params: {
       // bookkeeping for drain/lane-cleared is still recorded.
       if (isReplyOperationRestartAbort(params.replyOperation)) {
         takePendingLifecycleTerminal()?.emit("end", err);
+        if (params.isRestartRecoveryArmed?.() !== true) {
+          return {
+            kind: "final",
+            payload: markAgentRunFailureReplyPayload({
+              text: buildRestartLifecycleReplyText(),
+            }),
+          };
+        }
         return {
           kind: "final",
           payload: {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1405,10 +1405,6 @@ export function buildContextOverflowRecoveryText(params: {
   return prefix + (heartbeatBleedHint ?? buildContextOverflowResetHint(primaryContextWindow));
 }
 
-function buildRestartLifecycleReplyText(): string {
-  return "⚠️ Gateway is restarting. Please wait a few seconds and try again.";
-}
-
 function resolveRestartLifecycleError(
   err: unknown,
 ): GatewayDrainingError | CommandLaneClearedError | undefined {
@@ -3111,13 +3107,19 @@ export async function runAgentTurnWithFallback(params: {
         !isBilling && !shouldSurfaceToControlUi ? classifyProviderRequestError(err) : undefined;
       const isTransientHttp = isTransientHttpError(message);
 
+      // Drain/restart aborts stay silent and defer to post-restart
+      // main-session recovery, which resumes the interrupted turn (or emits its
+      // own genuine non-resumable notice). A generic "try again" here is a
+      // false terminal that invites a duplicate manual retry. Restart abort is
+      // treated exactly like user abort for visible output; the fail()
+      // bookkeeping for drain/lane-cleared is still recorded.
       if (isReplyOperationRestartAbort(params.replyOperation)) {
         takePendingLifecycleTerminal()?.emit("end", err);
         return {
           kind: "final",
-          payload: markAgentRunFailureReplyPayload({
-            text: buildRestartLifecycleReplyText(),
-          }),
+          payload: {
+            text: SILENT_REPLY_TOKEN,
+          },
         };
       }
 
@@ -3137,9 +3139,9 @@ export async function runAgentTurnWithFallback(params: {
         params.replyOperation?.fail("gateway_draining", restartLifecycleError);
         return {
           kind: "final",
-          payload: markAgentRunFailureReplyPayload({
-            text: buildRestartLifecycleReplyText(),
-          }),
+          payload: {
+            text: SILENT_REPLY_TOKEN,
+          },
         };
       }
 
@@ -3148,9 +3150,9 @@ export async function runAgentTurnWithFallback(params: {
         params.replyOperation?.fail("command_lane_cleared", restartLifecycleError);
         return {
           kind: "final",
-          payload: markAgentRunFailureReplyPayload({
-            text: buildRestartLifecycleReplyText(),
-          }),
+          payload: {
+            text: SILENT_REPLY_TOKEN,
+          },
         };
       }
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1594,7 +1594,6 @@ export async function runAgentTurnWithFallback(params: {
   toolProgressDetail?: "explain" | "raw";
   replyMediaContext?: ReplyMediaContext;
   onCompactionNoticePayload?: (payload: ReplyPayload) => Promise<void> | void;
-  isRestartRecoveryArmed?: () => boolean;
 }): Promise<AgentRunLoopResult> {
   const TRANSIENT_HTTP_RETRY_DELAY_MS = 2_500;
   let didLogHeartbeatStrip = false;
@@ -3142,38 +3141,22 @@ export async function runAgentTurnWithFallback(params: {
       if (restartLifecycleError instanceof GatewayDrainingError) {
         takePendingLifecycleTerminal()?.emit("error", restartLifecycleError);
         params.replyOperation?.fail("gateway_draining", restartLifecycleError);
-        if (params.isRestartRecoveryArmed?.() !== true) {
-          return {
-            kind: "final",
-            payload: markAgentRunFailureReplyPayload({
-              text: buildRestartLifecycleReplyText(),
-            }),
-          };
-        }
         return {
           kind: "final",
-          payload: {
-            text: SILENT_REPLY_TOKEN,
-          },
+          payload: markAgentRunFailureReplyPayload({
+            text: buildRestartLifecycleReplyText(),
+          }),
         };
       }
 
       if (restartLifecycleError instanceof CommandLaneClearedError) {
         takePendingLifecycleTerminal()?.emit("error", restartLifecycleError);
         params.replyOperation?.fail("command_lane_cleared", restartLifecycleError);
-        if (params.isRestartRecoveryArmed?.() !== true) {
-          return {
-            kind: "final",
-            payload: markAgentRunFailureReplyPayload({
-              text: buildRestartLifecycleReplyText(),
-            }),
-          };
-        }
         return {
           kind: "final",
-          payload: {
-            text: SILENT_REPLY_TOKEN,
-          },
+          payload: markAgentRunFailureReplyPayload({
+            text: buildRestartLifecycleReplyText(),
+          }),
         };
       }
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -25,6 +25,7 @@ import {
   registerMemoryCapability,
   type MemoryFlushPlanResolver,
 } from "../../plugins/memory-state.js";
+import { GatewayDrainingError } from "../../process/command-queue.js";
 import type { TemplateContext } from "../templating.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 import { scheduleFollowupDrain } from "./queue.js";
@@ -443,6 +444,50 @@ describe("runReplyAgent auto-compaction token update", () => {
     // totalTokens should use lastCallUsage (55k), not accumulated (75k)
     expect(stored[sessionKey].totalTokens).toBe(55_000);
   }, 180_000);
+
+  it("keeps an unarmed preflight drain visible instead of dropping the reply", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-preflight-drain-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 200_000,
+    };
+    await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+    compactState.compactEmbeddedAgentSessionMock.mockRejectedValueOnce(new GatewayDrainingError());
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath,
+      sessionEntry,
+    });
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expectReplyText(result, "⚠️ Gateway is restarting. Please wait a few seconds and try again.");
+  });
 
   it("starts queued followup drain only after clearing the active reply operation", async () => {
     const sessionKey = "main";

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1742,6 +1742,7 @@ export async function runReplyAgent(params: {
         resolvedVerboseLevel,
         toolProgressDetail,
         replyMediaContext,
+        isRestartRecoveryArmed: () => trackedRestartRecoveryDeliveryContext,
       }),
     );
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1568,6 +1568,18 @@ export async function runReplyAgent(params: {
       }
     }
   };
+  const isRestartRecoveryArmed = (): boolean => {
+    if (!trackedRestartRecoveryDeliveryContext || !sessionKey || !storePath) {
+      return false;
+    }
+    const persisted = loadSessionEntry({
+      sessionKey,
+      storePath,
+      clone: false,
+      hydrateSkillPromptRefs: false,
+    });
+    return persisted?.abortedLastRun === true || activeSessionEntry?.abortedLastRun === true;
+  };
   const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
   let preflightCompactionApplied;
 
@@ -1742,6 +1754,7 @@ export async function runReplyAgent(params: {
         resolvedVerboseLevel,
         toolProgressDetail,
         replyMediaContext,
+        isRestartRecoveryArmed,
       }),
     );
 
@@ -2596,8 +2609,24 @@ export async function runReplyAgent(params: {
     // terminal: it looks like the owed work was abandoned and invites a
     // duplicate manual retry. `aborted_for_restart` is an "aborted" result, so
     // it falls through to the shared abort branch below.
-    if (replyOperation.result?.kind === "aborted") {
+    if (
+      replyOperation.result?.kind === "aborted" &&
+      replyOperation.result.code === "aborted_by_user"
+    ) {
       return returnWithQueuedFollowupDrain({ text: SILENT_REPLY_TOKEN });
+    }
+    if (
+      replyOperation.result?.kind === "aborted" &&
+      replyOperation.result.code === "aborted_for_restart"
+    ) {
+      if (isRestartRecoveryArmed()) {
+        return returnWithQueuedFollowupDrain({ text: SILENT_REPLY_TOKEN });
+      }
+      return returnWithQueuedFollowupDrain(
+        markReplyPayloadForSourceSuppressionDelivery({
+          text: RESTART_LIFECYCLE_REPLY_TEXT,
+        }),
+      );
     }
     if (error instanceof GatewayDrainingError) {
       replyOperation.fail("gateway_draining", error);

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -134,6 +134,8 @@ import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
+const RESTART_LIFECYCLE_REPLY_TEXT =
+  "⚠️ Gateway is restarting. Please wait a few seconds and try again.";
 
 function scheduleFollowupDrainAfterReplyOperationClear(params: {
   operation: ReplyOperation;
@@ -2599,10 +2601,24 @@ export async function runReplyAgent(params: {
     }
     if (error instanceof GatewayDrainingError) {
       replyOperation.fail("gateway_draining", error);
+      if (!trackedRestartRecoveryDeliveryContext) {
+        return returnWithQueuedFollowupDrain(
+          markReplyPayloadForSourceSuppressionDelivery({
+            text: RESTART_LIFECYCLE_REPLY_TEXT,
+          }),
+        );
+      }
       return returnWithQueuedFollowupDrain({ text: SILENT_REPLY_TOKEN });
     }
     if (error instanceof CommandLaneClearedError) {
       replyOperation.fail("command_lane_cleared", error);
+      if (!trackedRestartRecoveryDeliveryContext) {
+        return returnWithQueuedFollowupDrain(
+          markReplyPayloadForSourceSuppressionDelivery({
+            text: RESTART_LIFECYCLE_REPLY_TEXT,
+          }),
+        );
+      }
       return returnWithQueuedFollowupDrain({ text: SILENT_REPLY_TOKEN });
     }
     const knownFailurePayload = buildKnownAgentRunFailureReplyPayload({

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2588,34 +2588,22 @@ export async function runReplyAgent(params: {
 
     return result;
   } catch (error) {
-    if (
-      replyOperation.result?.kind === "aborted" &&
-      replyOperation.result.code === "aborted_for_restart"
-    ) {
-      return returnWithQueuedFollowupDrain(
-        markReplyPayloadForSourceSuppressionDelivery({
-          text: "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
-        }),
-      );
-    }
+    // Drain/restart aborts stay silent and defer to post-restart main-session
+    // recovery, which resumes the interrupted turn (or emits its own genuine
+    // non-resumable notice). Surfacing a generic "try again" here is a false
+    // terminal: it looks like the owed work was abandoned and invites a
+    // duplicate manual retry. `aborted_for_restart` is an "aborted" result, so
+    // it falls through to the shared abort branch below.
     if (replyOperation.result?.kind === "aborted") {
       return returnWithQueuedFollowupDrain({ text: SILENT_REPLY_TOKEN });
     }
     if (error instanceof GatewayDrainingError) {
       replyOperation.fail("gateway_draining", error);
-      return returnWithQueuedFollowupDrain(
-        markReplyPayloadForSourceSuppressionDelivery({
-          text: "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
-        }),
-      );
+      return returnWithQueuedFollowupDrain({ text: SILENT_REPLY_TOKEN });
     }
     if (error instanceof CommandLaneClearedError) {
       replyOperation.fail("command_lane_cleared", error);
-      return returnWithQueuedFollowupDrain(
-        markReplyPayloadForSourceSuppressionDelivery({
-          text: "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
-        }),
-      );
+      return returnWithQueuedFollowupDrain({ text: SILENT_REPLY_TOKEN });
     }
     const knownFailurePayload = buildKnownAgentRunFailureReplyPayload({
       err: error,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1742,7 +1742,6 @@ export async function runReplyAgent(params: {
         resolvedVerboseLevel,
         toolProgressDetail,
         replyMediaContext,
-        isRestartRecoveryArmed: () => trackedRestartRecoveryDeliveryContext,
       }),
     );
 
@@ -2602,25 +2601,19 @@ export async function runReplyAgent(params: {
     }
     if (error instanceof GatewayDrainingError) {
       replyOperation.fail("gateway_draining", error);
-      if (!trackedRestartRecoveryDeliveryContext) {
-        return returnWithQueuedFollowupDrain(
-          markReplyPayloadForSourceSuppressionDelivery({
-            text: RESTART_LIFECYCLE_REPLY_TEXT,
-          }),
-        );
-      }
-      return returnWithQueuedFollowupDrain({ text: SILENT_REPLY_TOKEN });
+      return returnWithQueuedFollowupDrain(
+        markReplyPayloadForSourceSuppressionDelivery({
+          text: RESTART_LIFECYCLE_REPLY_TEXT,
+        }),
+      );
     }
     if (error instanceof CommandLaneClearedError) {
       replyOperation.fail("command_lane_cleared", error);
-      if (!trackedRestartRecoveryDeliveryContext) {
-        return returnWithQueuedFollowupDrain(
-          markReplyPayloadForSourceSuppressionDelivery({
-            text: RESTART_LIFECYCLE_REPLY_TEXT,
-          }),
-        );
-      }
-      return returnWithQueuedFollowupDrain({ text: SILENT_REPLY_TOKEN });
+      return returnWithQueuedFollowupDrain(
+        markReplyPayloadForSourceSuppressionDelivery({
+          text: RESTART_LIFECYCLE_REPLY_TEXT,
+        }),
+      );
     }
     const knownFailurePayload = buildKnownAgentRunFailureReplyPayload({
       err: error,

--- a/src/auto-reply/reply/block-reply-pipeline.multi-message.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.multi-message.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { setReplyPayloadMetadata } from "../reply-payload.js";
+import { createBlockReplyPipeline } from "./block-reply-pipeline.js";
+
+function blockFor(text: string, assistantMessageIndex: number) {
+  return setReplyPayloadMetadata({ text }, { assistantMessageIndex });
+}
+
+describe("block reply pipeline multi-assistant-message suppression", () => {
+  it("recognizes each fully-streamed message across a multi-message turn", async () => {
+    const sent: string[] = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        if (payload.text) {
+          sent.push(payload.text);
+        }
+      },
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue(blockFor("Alpha one.", 0));
+    pipeline.enqueue(blockFor("Alpha two.", 0));
+    pipeline.enqueue(blockFor("Beta one.", 1));
+    pipeline.enqueue(blockFor("Beta two.", 1));
+    await pipeline.flush({ force: true });
+
+    expect(sent).toEqual(["Alpha one.", "Alpha two.", "Beta one.", "Beta two."]);
+    expect(pipeline.hasSentPayload({ text: "Alpha one. Alpha two." })).toBe(true);
+    expect(pipeline.hasSentPayload({ text: "Beta one. Beta two." })).toBe(true);
+  });
+
+  it("does not treat one message as covering another message's text", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue(blockFor("Alpha one.", 0));
+    pipeline.enqueue(blockFor("Alpha two.", 0));
+    pipeline.enqueue(blockFor("Beta one.", 1));
+    pipeline.enqueue(blockFor("Beta two.", 1));
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.hasSentPayload({ text: "Alpha one. Alpha two. Beta one. Beta two." })).toBe(
+      false,
+    );
+  });
+
+  it("suppresses a single message split into multiple blocks", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue(blockFor("Gamma one.", 0));
+    pipeline.enqueue(blockFor("Gamma two.", 0));
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.hasSentPayload({ text: "Gamma one. Gamma two." })).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -120,7 +120,7 @@ export function createBlockReplyPipeline(params: {
   const bufferedKeys = new Set<string>();
   const bufferedPayloadKeys = new Set<string>();
   const bufferedPayloads: ReplyPayload[] = [];
-  const streamedTextFragments: string[] = [];
+  const streamedTextFragmentsByMessage = new Map<number | undefined, string[]>();
   let bufferedAssistantMessageIndex: number | undefined;
   let sendChain: Promise<void> = Promise.resolve();
   let aborted = false;
@@ -186,7 +186,10 @@ export function createBlockReplyPipeline(params: {
           sentMediaUrls.add(mediaUrl);
         }
         if (!isStatusNotice && reply.trimmedText) {
-          streamedTextFragments.push(reply.trimmedText);
+          const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
+          const fragments = streamedTextFragmentsByMessage.get(assistantMessageIndex) ?? [];
+          fragments.push(reply.trimmedText);
+          streamedTextFragmentsByMessage.set(assistantMessageIndex, fragments);
         }
         if (!isStatusNotice) {
           didStream = true;
@@ -328,7 +331,7 @@ export function createBlockReplyPipeline(params: {
       if (sentContentKeys.has(payloadKey)) {
         return true;
       }
-      if (!didStream || streamedTextFragments.length === 0) {
+      if (!didStream) {
         return false;
       }
       const reply = resolveSendableOutboundReplyParts(payload);
@@ -336,7 +339,13 @@ export function createBlockReplyPipeline(params: {
         return false;
       }
       const normalize = (text: string) => text.replace(/\s+/g, "");
-      return normalize(streamedTextFragments.join("")) === normalize(reply.trimmedText);
+      const target = normalize(reply.trimmedText);
+      for (const fragments of streamedTextFragmentsByMessage.values()) {
+        if (fragments.length > 0 && normalize(fragments.join("")) === target) {
+          return true;
+        }
+      }
+      return false;
     },
     getSentMediaUrls: () => Array.from(sentMediaUrls),
   };


### PR DESCRIPTION
## What Problem This Solves

During a gateway drain/restart, in-flight agent reply runs can be aborted with `aborted_for_restart`, `GatewayDrainingError`, or `CommandLaneClearedError`.

Before this change, two pre-exit reply paths force-delivered a generic visible notice:

> ⚠️ Gateway is restarting. Please wait a few seconds and try again.

That message fires before post-restart main-session recovery. Recovery then resumes the interrupted turn, or emits its own distinct non-resumable notice if it cannot safely resume. The generic pre-exit notice is therefore a false terminal: it makes the user think the owed work was abandoned and invites duplicate manual retries.

This PR makes drain/restart-abort reply paths silent and lets restart recovery own the user-visible outcome.

## Summary

- `runAgentTurnWithFallback` (`agent-runner-execution.ts`): restart-abort plus `gateway_draining` / `command_lane_cleared` branches now return `{ text: SILENT_REPLY_TOKEN }`.
- `runReplyAgent` (`agent-runner.ts`): the redundant `aborted_for_restart` special case is removed so it falls through to the existing shared `aborted` → silent branch; `gateway_draining` / `command_lane_cleared` branches return the silent token.
- `replyOperation.fail("gateway_draining" | "command_lane_cleared", …)` bookkeeping is preserved.
- Ordinary non-restart failures still surface their notices.
- Removed the now-unused `buildRestartLifecycleReplyText` helper.

## Evidence

- Updated the four existing regression tests in `agent-runner-execution.test.ts` that asserted the old generic notice to assert silent `NO_REPLY`, while preserving `fail()` bookkeeping assertions.
- Targeted restart-drain tests: `6/6` passed.
- Adjacent suites: `vitest run agent-runner-execution.test.ts agent-runner.misc.runreplyagent.test.ts` → `251/251` passed.
- `oxlint` clean on changed files.
- Live local hotfix verification before this source PR: installed-runtime verifier passed `7/7` after gateway restart, proving the same behaviour against the compiled runtime.

## Notes

The `runReplyAgent` outer catch is a defensive secondary net. `GatewayDrainingError` raised during a reply run is intercepted by the inner `runAgentTurnWithFallback` catch first, so the primary behavioural coverage lives there. The outer-catch change consolidates onto the already-tested shared `aborted` → silent branch.
