### PR TITLE
fix(reply): suppress per-message finals across multi-message block streaming

### DIFF
--- a/src/auto-reply/reply/block-reply-pipeline.multi-message.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.multi-message.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { setReplyPayloadMetadata } from "../reply-payload.js";
+import { createBlockReplyPipeline } from "./block-reply-pipeline.js";
+
+function blockFor(text: string, assistantMessageIndex: number) {
+  return setReplyPayloadMetadata({ text }, { assistantMessageIndex });
+}
+
+describe("block reply pipeline multi-assistant-message suppression", () => {
+  it("recognizes each fully-streamed message across a multi-message turn", async () => {
+    const sent: string[] = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        if (payload.text) {
+          sent.push(payload.text);
+        }
+      },
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue(blockFor("Alpha one.", 0));
+    pipeline.enqueue(blockFor("Alpha two.", 0));
+    pipeline.enqueue(blockFor("Beta one.", 1));
+    pipeline.enqueue(blockFor("Beta two.", 1));
+    await pipeline.flush({ force: true });
+
+    expect(sent).toEqual(["Alpha one.", "Alpha two.", "Beta one.", "Beta two."]);
+    expect(pipeline.hasSentPayload({ text: "Alpha one. Alpha two." })).toBe(true);
+    expect(pipeline.hasSentPayload({ text: "Beta one. Beta two." })).toBe(true);
+  });
+
+  it("does not treat one message as covering another message's text", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue(blockFor("Alpha one.", 0));
+    pipeline.enqueue(blockFor("Alpha two.", 0));
+    pipeline.enqueue(blockFor("Beta one.", 1));
+    pipeline.enqueue(blockFor("Beta two.", 1));
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.hasSentPayload({ text: "Alpha one. Alpha two. Beta one. Beta two." })).toBe(
+      false,
+    );
+  });
+
+  it("suppresses a single message split into multiple blocks", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue(blockFor("Gamma one.", 0));
+    pipeline.enqueue(blockFor("Gamma two.", 0));
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.hasSentPayload({ text: "Gamma one. Gamma two." })).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -120,7 +120,7 @@ export function createBlockReplyPipeline(params: {
   const bufferedKeys = new Set<string>();
   const bufferedPayloadKeys = new Set<string>();
   const bufferedPayloads: ReplyPayload[] = [];
-  const streamedTextFragments: string[] = [];
+  const streamedTextFragmentsByMessage = new Map<number | undefined, string[]>();
   let bufferedAssistantMessageIndex: number | undefined;
   let sendChain: Promise<void> = Promise.resolve();
   let aborted = false;
@@ -186,7 +186,10 @@ export function createBlockReplyPipeline(params: {
           sentMediaUrls.add(mediaUrl);
         }
         if (!isStatusNotice && reply.trimmedText) {
-          streamedTextFragments.push(reply.trimmedText);
+          const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
+          const fragments = streamedTextFragmentsByMessage.get(assistantMessageIndex) ?? [];
+          fragments.push(reply.trimmedText);
+          streamedTextFragmentsByMessage.set(assistantMessageIndex, fragments);
         }
         if (!isStatusNotice) {
           didStream = true;
@@ -328,7 +331,7 @@ export function createBlockReplyPipeline(params: {
       if (sentContentKeys.has(payloadKey)) {
         return true;
       }
-      if (!didStream || streamedTextFragments.length === 0) {
+      if (!didStream) {
         return false;
       }
       const reply = resolveSendableOutboundReplyParts(payload);
@@ -336,7 +339,13 @@ export function createBlockReplyPipeline(params: {
         return false;
       }
       const normalize = (text: string) => text.replace(/\s+/g, "");
-      return normalize(streamedTextFragments.join("")) === normalize(reply.trimmedText);
+      const target = normalize(reply.trimmedText);
+      for (const fragments of streamedTextFragmentsByMessage.values()) {
+        if (fragments.length > 0 && normalize(fragments.join("")) === target) {
+          return true;
+        }
+      }
+      return false;
     },
     getSentMediaUrls: () => Array.from(sentMediaUrls),
   };


### PR DESCRIPTION
## Summary
When an agent turn produces two or more assistant messages (the common text then tool-call then text shape), block streaming re-delivers each fully-streamed assistant message a second time as its final reply. The user sees every message stream live, then receives the same messages again in full: duplicate chat messages on Telegram, Discord, Slack, and other channels.

## Root cause
`createBlockReplyPipeline` tracked every streamed text block in one flat array and suppressed a final payload only when the join of all fragments across all assistant messages equaled that payload.

`src/auto-reply/reply/block-reply-pipeline.ts` (before):
```ts
const streamedTextFragments: string[] = [];
// ...
streamedTextFragments.push(reply.trimmedText);
// ...
return normalize(streamedTextFragments.join("")) === normalize(reply.trimmedText);
```

The end-of-turn payloads are one per assistant message. The join of every fragment across every message ("Alpha one.Alpha two.Beta one.Beta two.") never equals one message's final ("Alpha one. Alpha two."), so `hasSentPayload` returns false and `preserveUnsentMediaAfterBlockSend` (`agent-runner-payloads.ts`) re-delivers it. The sibling direct-send path `hasDirectlySentText` already groups fragments by `assistantMessageIndex`; the pipeline did not.

This is reachable with the coalescer disabled, a real production path: `src/auto-reply/reply/acp-projector.ts` builds the pipeline with `coalescing: undefined` for ACP live delivery, so every streamed block is delivered separately.

## Fix
Group streamed fragments by `assistantMessageIndex` and suppress a final when any single message's fragment join matches it.

`src/auto-reply/reply/block-reply-pipeline.ts` (after):
```ts
const streamedTextFragmentsByMessage = new Map<number | undefined, string[]>();
// ...
const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
const fragments = streamedTextFragmentsByMessage.get(assistantMessageIndex) ?? [];
fragments.push(reply.trimmedText);
streamedTextFragmentsByMessage.set(assistantMessageIndex, fragments);
// ...
for (const fragments of streamedTextFragmentsByMessage.values()) {
  if (fragments.length > 0 && normalize(fragments.join("")) === target) {
    return true;
  }
}
return false;
```
Matching against any one message's join (rather than the final payload's own index) keeps suppression correct even though the per-message finals are stamped from a single `assistantMessageIndex` value.

## Why this is the right boundary
The defect and the fix live entirely in the block-streaming suppression predicate. The change makes it symmetric with the already-correct `hasDirectlySentText` direct-send path in the same module family, so both streamed-delivery paths share one rule. No config or protocol surface changes. Single-message turns (one message split into multiple blocks) stay suppressed, and a payload spanning multiple messages is correctly not suppressed.

## Verification
- node scripts/run-vitest.mjs on the new src/auto-reply/reply/block-reply-pipeline.multi-message.test.ts plus the adjacent block-reply-pipeline and agent-runner-payloads suites: all pass (3 new, 89 adjacent).
- node scripts/run-oxlint.mjs and oxfmt --check on the changed files: clean.
- node scripts/run-tsgo.mjs for tsconfig.core.json and test/tsconfig/tsconfig.core.test.json: clean.
- The new test fails on pristine main and passes with the patch.

## Real behavior proof
Behavior addressed: a two-assistant-message turn re-delivers each fully-streamed message as a duplicate final reply.
Real environment tested: the real production createBlockReplyPipeline from src/auto-reply/reply/block-reply-pipeline.ts driven on pristine main (ba34052a0e) and on the patched tree with identical streamed input; the pipeline, its coalescer-disabled delivery, and the real hasSentPayload suppression predicate that the dispatcher uses all stayed real, nothing mocked.
Exact steps or command run after this patch: stream two assistant messages, each as two blocks (assistantMessageIndex 0 then 1), flush the pipeline, then append every end-of-turn final the suppression predicate does not recognize as already sent, and print the resulting delivered-to-chat sequence.
Evidence after fix:
```
# BEFORE (pristine main ba34052a0e)
messages delivered to chat (6):
  1. Alpha one.
  2. Alpha two.
  3. Beta one.
  4. Beta two.
  5. Alpha one. Alpha two.
  6. Beta one. Beta two.
# AFTER (this patch, identical inputs)
messages delivered to chat (4):
  1. Alpha one.
  2. Alpha two.
  3. Beta one.
  4. Beta two.
```
Observed result after fix: the two fully-streamed messages are no longer appended a second time, so the chat receives four messages instead of six on identical input.
What was not tested: no live channel round trip (Telegram/Discord/Slack delivery transport); the coalescer-enabled path, where the same duplication needs a message longer than the coalescer max chars to flush mid-stream, was not separately driven; full build not run.
