### PR TITLE
feat(tasks): persist worker metadata in task ledger

### DIFF
--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -31,6 +31,8 @@ Not every agent run creates a task. Heartbeat turns and normal interactive chat 
 - Completion is push-driven: detached work can notify directly or wake the
   requester session/heartbeat when it finishes, so status polling loops are
   usually the wrong shape.
+- Task status views reconcile against durable task/session truth before
+  reporting active work, so stale `running` rows do not stay active forever.
 - Isolated cron runs and subagent completions best-effort clean up tracked browser tabs/processes for their child session before final cleanup bookkeeping.
 - Isolated cron delivery suppresses stale interim parent replies while descendant subagent work is still draining, and it prefers final descendant output when that arrives before delivery.
 - Completion notifications are delivered directly to a channel or queued for the next heartbeat.
@@ -157,6 +159,11 @@ Agent run completion is authoritative for active task records. A successful deta
   back to the child session. Gateway-backed `openclaw agent` runs also finalize
   from their run result, so completed runs do not sit active until the sweeper
   marks them `lost`.
+
+List, show, status, and audit surfaces use the same reconciliation projection.
+They may show an old active row as terminal when the durable task/session truth
+proves the worker is gone; `openclaw tasks maintenance --apply` persists that
+projection into the ledger and performs cleanup/pruning.
 
 ## Delivery and notifications
 

--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -44,6 +44,9 @@ openclaw tasks list [--runtime <name>] [--status <name>] [--json]
 ```
 
 Lists tracked background tasks newest first.
+The list is reconciled against durable task/session truth before display, so a
+stale active worker row can appear as terminal even before maintenance writes
+the repaired state back to the ledger.
 
 ### `show`
 

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -11,6 +11,7 @@ import {
   recordTaskProgressByRunId,
   resetTaskRegistryForTests,
 } from "../../tasks/runtime-internal.js";
+import { resetTaskRegistryMaintenanceRuntimeForTests } from "../../tasks/task-registry.maintenance.js";
 import type { TaskRecord } from "../../tasks/task-registry.types.js";
 import { tasksHandlers } from "./tasks.js";
 import type { RespondFn } from "./types.js";
@@ -41,6 +42,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   resetTaskRegistryForTests();
+  resetTaskRegistryMaintenanceRuntimeForTests();
   if (ORIGINAL_STATE_DIR === undefined) {
     delete process.env.OPENCLAW_STATE_DIR;
   } else {
@@ -177,6 +179,43 @@ describe("tasks gateway handlers", () => {
 
     expect(payload?.task?.status).toBe("completed");
     expect(payload?.task?.title).toBe("Done task");
+  });
+
+  it("reconciles stale running subagent tasks from session truth before listing", async () => {
+    const staleAt = Date.now() - 10 * 60_000;
+    const task = createTaskRecord({
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: "agent:worker:subagent:missing-session",
+      runId: "run-stale-subagent",
+      task: "Inspect stale worker state",
+      status: "running",
+      deliveryStatus: "pending",
+      createdAt: staleAt,
+      startedAt: staleAt,
+      lastEventAt: staleAt,
+    });
+
+    const runningView = await runTaskHandler("tasks.list", {
+      status: "running",
+      sessionKey: "agent:main:main",
+    });
+    expect(runningView.calls[0]?.[0]).toBe(true);
+    expect(runningView.payload?.tasks ?? []).toEqual([]);
+
+    const failedView = await runTaskHandler("tasks.list", {
+      status: "failed",
+      sessionKey: "agent:main:main",
+    });
+    expect(failedView.payload?.tasks?.map((entry) => entry.taskId)).toEqual([task.taskId]);
+    expect(failedView.payload?.tasks?.[0]?.status).toBe("failed");
+    expect(failedView.payload?.tasks?.[0]?.error).toBe("backing session missing");
+
+    const { payload } = await getTaskPayload(task.taskId);
+    expect(payload?.task?.status).toBe("failed");
+    expect(payload?.task?.endedAt).toBeTypeOf("number");
   });
 
   it("sanitizes task text before exposing SDK summaries", async () => {

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -13,7 +13,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { cancelDetachedTaskRunById } from "../../tasks/detached-task-runtime.js";
-import { getTaskById, listTaskRecords } from "../../tasks/runtime-internal.js";
+import { reconcileInspectableTasks } from "../../tasks/task-registry.reconcile.js";
 import type { TaskRecord, TaskStatus } from "../../tasks/task-registry.types.js";
 import {
   TASK_STATUS_DETAIL_MAX_CHARS,
@@ -171,7 +171,7 @@ export const tasksHandlers: GatewayRequestHandlers = {
     }
     const statusFilter = normalizeTaskStatusFilter(params.status);
     const limit = Math.min(params.limit ?? DEFAULT_TASKS_LIST_LIMIT, MAX_TASKS_LIST_LIMIT);
-    const filtered = listTaskRecords().filter((task) => {
+    const filtered = reconcileInspectableTasks().filter((task) => {
       if (statusFilter && !statusFilter.has(task.status)) {
         return false;
       }
@@ -197,7 +197,7 @@ export const tasksHandlers: GatewayRequestHandlers = {
       return;
     }
     const taskId = params.taskId;
-    const task = getTaskById(taskId);
+    const task = reconcileInspectableTasks().find((entry) => entry.taskId === taskId);
     if (!task) {
       respond(
         false,

--- a/src/tasks/task-owner-access.test.ts
+++ b/src/tasks/task-owner-access.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
+  buildTaskStatusSnapshotForRelatedSessionKeyForOwner,
   findLatestTaskForRelatedSessionKeyForOwner,
   findTaskByRunIdForOwner,
   getTaskByIdForOwner,
@@ -12,6 +13,7 @@ import {
   createTaskRecord as createTaskRecordOrNull,
   resetTaskRegistryForTests,
 } from "./task-registry.js";
+import { resetTaskRegistryMaintenanceRuntimeForTests } from "./task-registry.maintenance.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
 const ORIGINAL_ENV = captureEnv(["OPENCLAW_STATE_DIR"]);
@@ -26,6 +28,7 @@ function createTaskRecord(params: Parameters<typeof createTaskRecordOrNull>[0]):
 
 afterEach(() => {
   resetTaskRegistryForTests({ persist: false });
+  resetTaskRegistryMaintenanceRuntimeForTests();
   ORIGINAL_ENV.restore();
 });
 
@@ -153,6 +156,35 @@ describe("task owner access", () => {
           callerOwnerKey: "agent:main:main",
         }),
       ).toBeUndefined();
+    });
+  });
+
+  it("builds owner status snapshots from reconciled task/session truth", async () => {
+    await withTaskRegistryTempDir(() => {
+      const staleAt = Date.now() - 10 * 60_000;
+      const task = createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:subagent:missing-session",
+        runId: "owner-stale-running-run",
+        task: "Inspect worker state",
+        status: "running",
+        createdAt: staleAt,
+        startedAt: staleAt,
+        lastEventAt: staleAt,
+      });
+
+      const snapshot = buildTaskStatusSnapshotForRelatedSessionKeyForOwner({
+        relatedSessionKey: "agent:main:subagent:missing-session",
+        callerOwnerKey: "agent:main:main",
+      });
+
+      expect(snapshot.activeCount).toBe(0);
+      expect(snapshot.recentFailureCount).toBe(1);
+      expect(snapshot.focus?.taskId).toBe(task.taskId);
+      expect(snapshot.focus?.status).toBe("lost");
+      expect(snapshot.focus?.error).toBe("backing session missing");
     });
   });
 });

--- a/src/tasks/task-owner-access.ts
+++ b/src/tasks/task-owner-access.ts
@@ -1,13 +1,11 @@
 // Normalizes task owner keys and checks requester access to task records.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
-  findTaskByRunId,
   getTaskById,
-  listTasksForRelatedSessionKey,
   markTaskTerminalById as markTaskTerminalRecordById,
-  resolveTaskForLookupToken,
   updateTaskNotifyPolicyById,
 } from "./task-registry.js";
+import { reconcileInspectableTasks, reconcileTaskLookupToken } from "./task-registry.reconcile.js";
 import type { TaskNotifyPolicy, TaskRecord } from "./task-registry.types.js";
 import { buildTaskStatusSnapshot } from "./task-status.js";
 
@@ -22,7 +20,9 @@ export function getTaskByIdForOwner(params: {
   taskId: string;
   callerOwnerKey: string;
 }): TaskRecord | undefined {
-  const task = getTaskById(params.taskId);
+  const task =
+    reconcileInspectableTasks().find((entry) => entry.taskId === params.taskId) ??
+    getTaskById(params.taskId);
   return task && canOwnerAccessTask(task, params.callerOwnerKey) ? task : undefined;
 }
 
@@ -30,8 +30,10 @@ export function findTaskByRunIdForOwner(params: {
   runId: string;
   callerOwnerKey: string;
 }): TaskRecord | undefined {
-  const task = findTaskByRunId(params.runId);
-  return task && canOwnerAccessTask(task, params.callerOwnerKey) ? task : undefined;
+  const task = reconcileTaskLookupToken(params.runId);
+  return task?.runId === params.runId && canOwnerAccessTask(task, params.callerOwnerKey)
+    ? task
+    : undefined;
 }
 
 /** Update an owner-visible task's notification policy. */
@@ -79,8 +81,16 @@ export function listTasksForRelatedSessionKeyForOwner(params: {
   relatedSessionKey: string;
   callerOwnerKey: string;
 }): TaskRecord[] {
-  return listTasksForRelatedSessionKey(params.relatedSessionKey).filter((task) =>
-    canOwnerAccessTask(task, params.callerOwnerKey),
+  const relatedSessionKey = normalizeOptionalString(params.relatedSessionKey);
+  if (!relatedSessionKey) {
+    return [];
+  }
+  return reconcileInspectableTasks().filter(
+    (task) =>
+      canOwnerAccessTask(task, params.callerOwnerKey) &&
+      [task.ownerKey, task.childSessionKey].some(
+        (candidate) => normalizeOptionalString(candidate) === relatedSessionKey,
+      ),
   );
 }
 
@@ -128,6 +138,8 @@ export function resolveTaskForLookupTokenForOwner(params: {
   if (related) {
     return related;
   }
-  const raw = resolveTaskForLookupToken(params.token);
-  return raw && canOwnerAccessTask(raw, params.callerOwnerKey) ? raw : undefined;
+  const reconciled = reconcileTaskLookupToken(params.token);
+  return reconciled && canOwnerAccessTask(reconciled, params.callerOwnerKey)
+    ? reconciled
+    : undefined;
 }

--- a/src/tasks/task-status-access.ts
+++ b/src/tasks/task-status-access.ts
@@ -1,12 +1,17 @@
 // Filters task status visibility by requester, owner, and flow scope.
-import {
-  findTaskByRunId,
-  getTaskById,
-  listTaskRecords,
-  listTasksForAgentId,
-  listTasksForSessionKey,
-} from "./task-registry.js";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { reconcileInspectableTasks, reconcileTaskLookupToken } from "./task-registry.reconcile.js";
 import type { TaskRecord } from "./task-registry.types.js";
+
+function taskMatchesRelatedSessionKey(task: TaskRecord, sessionKey: string): boolean {
+  const normalized = normalizeOptionalString(sessionKey);
+  if (!normalized) {
+    return false;
+  }
+  return [task.requesterSessionKey, task.ownerKey, task.childSessionKey].some(
+    (candidate) => normalizeOptionalString(candidate) === normalized,
+  );
+}
 
 /** Returns only the session lookup fields needed by task status commands. */
 export function getTaskSessionLookupByIdForStatus(
@@ -14,7 +19,7 @@ export function getTaskSessionLookupByIdForStatus(
 ):
   | Pick<TaskRecord, "requesterSessionKey" | "ownerKey" | "runId" | "agentId" | "requesterAgentId">
   | undefined {
-  const task = getTaskById(taskId);
+  const task = reconcileInspectableTasks().find((entry) => entry.taskId === taskId);
   return task
     ? {
         requesterSessionKey: task.requesterSessionKey,
@@ -27,19 +32,22 @@ export function getTaskSessionLookupByIdForStatus(
 }
 
 export function listTasksForSessionKeyForStatus(sessionKey: string): TaskRecord[] {
-  return listTasksForSessionKey(sessionKey);
+  return reconcileInspectableTasks().filter((task) =>
+    taskMatchesRelatedSessionKey(task, sessionKey),
+  );
 }
 
 export function listTasksForOwnerOrRequesterSessionKeyForStatus(sessionKey: string): TaskRecord[] {
-  return listTaskRecords().filter(
+  return reconcileInspectableTasks().filter(
     (task) => task.requesterSessionKey === sessionKey || task.ownerKey === sessionKey,
   );
 }
 
 export function listTasksForAgentIdForStatus(agentId: string): TaskRecord[] {
-  return listTasksForAgentId(agentId);
+  return reconcileInspectableTasks().filter((task) => task.agentId?.trim() === agentId.trim());
 }
 
 export function findTaskByRunIdForStatus(runId: string): TaskRecord | undefined {
-  return findTaskByRunId(runId);
+  const task = reconcileTaskLookupToken(runId);
+  return task?.runId === runId ? task : undefined;
 }


### PR DESCRIPTION
## What Problem This Solves
Task-ledger status views were still partly shaped like a derived worker-state projection: Gateway/task status surfaces could report stale active subagent rows when the backing session was gone, and operational worker facts such as repo, branch, PR URL, owner, next action, and attention-needed state had no durable task-ledger home to query.

This PR makes the SQLite task ledger the durable source for lifecycle plus flat operational metadata. Runtime writes metadata onto `task_runs`, task lifecycle helpers preserve/update it, and Gateway/CLI surfaces expose exact-match metadata filtering from reconciled task records. Worker-state-style files are documented as legacy/import/ephemeral only, not active authority.

## Summary
- keep task/session lifecycle status derived from reconciled task/session truth so stale subagent rows do not continue to report as active
- add flat operational task metadata on the SQLite `task_runs` row, with create/progress/terminal/update helpers for repo, branch, PR URL, owner, next action, and attention-needed flags
- expose metadata through Gateway `tasks.list`/`tasks.get`, exact-match Gateway filters, and `openclaw tasks list --metadata key=value` so orchestrators can query task-ledger state instead of editable worker-state JSON
- document that task metadata belongs in the task ledger and that worker-state-style files should be legacy/import/ephemeral only, not active authority

## Evidence
- `node scripts/run-vitest.mjs src/tasks/task-registry.store.test.ts src/gateway/server-methods/tasks.test.ts packages/gateway-protocol/src/index.test.ts src/cli/program/register.status-health-sessions.test.ts src/state/openclaw-state-db.test.ts`
- `pnpm tsgo:core`
- `pnpm docs:list`
- `git diff --check origin/main...HEAD`

## Notes
- This revises the earlier projection/cache framing: lifecycle and operational worker facts now live on durable SQLite task rows; Gateway/CLI projections are read views over that ledger.
- Fresh autoreview attempted with `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`, but this worker image does not have a `codex` executable, so the helper could not run.
