### PR TITLE
feat(tasks): persist worker metadata in task ledger

### DIFF
--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -31,6 +31,8 @@ Not every agent run creates a task. Heartbeat turns and normal interactive chat 
 - Completion is push-driven: detached work can notify directly or wake the
   requester session/heartbeat when it finishes, so status polling loops are
   usually the wrong shape.
+- Task status views reconcile against durable task/session truth before
+  reporting active work, so stale `running` rows do not stay active forever.
 - Isolated cron runs and subagent completions best-effort clean up tracked browser tabs/processes for their child session before final cleanup bookkeeping.
 - Isolated cron delivery suppresses stale interim parent replies while descendant subagent work is still draining, and it prefers final descendant output when that arrives before delivery.
 - Completion notifications are delivered directly to a channel or queued for the next heartbeat.
@@ -157,6 +159,11 @@ Agent run completion is authoritative for active task records. A successful deta
   back to the child session. Gateway-backed `openclaw agent` runs also finalize
   from their run result, so completed runs do not sit active until the sweeper
   marks them `lost`.
+
+List, show, status, and audit surfaces use the same reconciliation projection.
+They may show an old active row as terminal when the durable task/session truth
+proves the worker is gone; `openclaw tasks maintenance --apply` persists that
+projection into the ledger and performs cleanup/pruning.
 
 ## Delivery and notifications
 

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -146,6 +146,12 @@ Transitions happen automatically - when the associated agent run ends, the task 
 
 Agent run completion is authoritative for active task records. A successful detached run finalizes as `succeeded`, ordinary run errors finalize as `failed`, and timeout or abort outcomes finalize as `timed_out`. If an operator already cancelled the task, or the runtime already recorded a stronger terminal state such as `failed`, `timed_out`, or `lost`, a later success signal does not downgrade that terminal status.
 
+Task rows also carry flat operational metadata in SQLite. Orchestrators should
+store repo, branch, PR URL, owner, next-action, and attention-needed flags on
+the task record itself instead of maintaining an editable worker-state file.
+`openclaw tasks list --metadata key=value` filters those records by exact
+metadata value.
+
 `lost` is runtime-aware:
 
 - ACP tasks: backing ACP child session metadata disappeared.
@@ -200,10 +206,11 @@ openclaw tasks notify <lookup> state_changes
 <AccordionGroup>
   <Accordion title="tasks list">
     ```bash
-    openclaw tasks list [--runtime <acp|subagent|cron|cli>] [--status <status>] [--json]
+    openclaw tasks list [--runtime <acp|subagent|cron|cli>] [--status <status>] [--metadata <key=value...>] [--json]
     ```
 
     Output columns: Task ID, Kind, Status, Delivery, Run ID, Child Session, Summary.
+    Metadata filters match flat task metadata stored on the SQLite task row.
 
   </Accordion>
   <Accordion title="tasks show">
@@ -211,7 +218,7 @@ openclaw tasks notify <lookup> state_changes
     openclaw tasks show <lookup>
     ```
 
-    The lookup token accepts a task ID, run ID, or session key. Shows the full record including timing, delivery state, error, and terminal summary.
+    The lookup token accepts a task ID, run ID, or session key. Shows the full record including timing, delivery state, metadata, error, and terminal summary.
 
   </Accordion>
   <Accordion title="tasks cancel">

--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -44,6 +44,9 @@ openclaw tasks list [--runtime <name>] [--status <name>] [--json]
 ```
 
 Lists tracked background tasks newest first.
+The list is reconciled against durable task/session truth before display, so a
+stale active worker row can appear as terminal even before maintenance writes
+the repaired state back to the ledger.
 
 ### `show`
 

--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -34,19 +34,21 @@ openclaw tasks flow cancel <lookup>
 - `--json`: output JSON.
 - `--runtime <name>`: filter by kind: `subagent`, `acp`, `cron`, or `cli`.
 - `--status <name>`: filter by status: `queued`, `running`, `succeeded`, `failed`, `timed_out`, `cancelled`, or `lost`.
+- `--metadata <key=value...>`: filter by flat task metadata stored on the SQLite task row. Repeat values after the flag, for example `--metadata repo=openclaw/openclaw khalilAttentionNeeded=true`.
 
 ## Subcommands
 
 ### `list`
 
 ```bash
-openclaw tasks list [--runtime <name>] [--status <name>] [--json]
+openclaw tasks list [--runtime <name>] [--status <name>] [--metadata <key=value...>] [--json]
 ```
 
 Lists tracked background tasks newest first.
 The list is reconciled against durable task/session truth before display, so a
 stale active worker row can appear as terminal even before maintenance writes
 the repaired state back to the ledger.
+Metadata filters exact-match the task row's flat operational metadata.
 
 ### `show`
 
@@ -54,7 +56,7 @@ the repaired state back to the ledger.
 openclaw tasks show <lookup> [--json]
 ```
 
-Shows one task by task ID, run ID, or session key.
+Shows one task by task ID, run ID, or session key, including operational metadata when present.
 
 ### `notify`
 

--- a/packages/gateway-protocol/src/index.test.ts
+++ b/packages/gateway-protocol/src/index.test.ts
@@ -749,6 +749,11 @@ describe("validateTasksListParams", () => {
         status: ["running", "completed"],
         agentId: "main",
         sessionKey: "agent:main:main",
+        metadata: {
+          repo: "openclaw/openclaw",
+          khalilAttentionNeeded: true,
+          priority: 2,
+        },
         limit: 50,
         cursor: "100",
       }),
@@ -757,6 +762,7 @@ describe("validateTasksListParams", () => {
 
   it("rejects internal task statuses and unknown fields", () => {
     expect(validateTasksListParams({ status: "succeeded" })).toBe(false);
+    expect(validateTasksListParams({ metadata: { nested: { nope: true } } })).toBe(false);
     expect(validateTasksCancelParams({ taskId: "task-1", force: true })).toBe(false);
   });
 });

--- a/packages/gateway-protocol/src/schema/tasks.ts
+++ b/packages/gateway-protocol/src/schema/tasks.ts
@@ -19,6 +19,13 @@ export const TaskLedgerStatusSchema = Type.Union([
 ]);
 
 const TimestampSchema = Type.Union([Type.String(), Type.Integer({ minimum: 0 })]);
+const TaskMetadataValueSchema = Type.Union([
+  Type.String(),
+  Type.Number(),
+  Type.Boolean(),
+  Type.Null(),
+]);
+const TaskMetadataSchema = Type.Record(Type.String(), TaskMetadataValueSchema);
 
 /** Public task summary returned by task list/get/cancel responses. */
 export const TaskSummarySchema = Type.Object(
@@ -44,6 +51,7 @@ export const TaskSummarySchema = Type.Object(
     progressSummary: Type.Optional(Type.String()),
     terminalSummary: Type.Optional(Type.String()),
     error: Type.Optional(Type.String()),
+    metadata: Type.Optional(TaskMetadataSchema),
   },
   { additionalProperties: false },
 );
@@ -54,6 +62,7 @@ export const TasksListParamsSchema = Type.Object(
     status: Type.Optional(Type.Union([TaskLedgerStatusSchema, Type.Array(TaskLedgerStatusSchema)])),
     agentId: Type.Optional(NonEmptyString),
     sessionKey: Type.Optional(NonEmptyString),
+    metadata: Type.Optional(TaskMetadataSchema),
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 500 })),
     cursor: Type.Optional(Type.String()),
   },

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -418,12 +418,23 @@ describe("registerStatusHealthSessionsCommands", () => {
   });
 
   it("runs tasks list from the parent command", async () => {
-    await runCli(["tasks", "--json", "--runtime", "acp", "--status", "running"]);
+    await runCli([
+      "tasks",
+      "--json",
+      "--runtime",
+      "acp",
+      "--status",
+      "running",
+      "--metadata",
+      "repo=openclaw/openclaw",
+      "khalilAttentionNeeded=true",
+    ]);
 
     expectCommandOptions(tasksListCommand, {
       json: true,
       runtime: "acp",
       status: "running",
+      metadata: ["repo=openclaw/openclaw", "khalilAttentionNeeded=true"],
     });
   });
 

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -441,6 +441,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
       "--status <name>",
       "Filter by status (queued, running, succeeded, failed, timed_out, cancelled, lost)",
     )
+    .option("--metadata <key=value...>", "Filter by task metadata key/value")
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const { tasksListCommand } = await loadTasksCommands();
@@ -449,6 +450,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
             json: Boolean(opts.json),
             runtime: opts.runtime as string | undefined,
             status: opts.status as string | undefined,
+            metadata: opts.metadata as string[] | undefined,
           },
           defaultRuntime,
         );
@@ -465,12 +467,14 @@ export function registerStatusHealthSessionsCommands(program: Command) {
       "--status <name>",
       "Filter by status (queued, running, succeeded, failed, timed_out, cancelled, lost)",
     )
+    .option("--metadata <key=value...>", "Filter by task metadata key/value")
     .action(async (opts, command) => {
       const parentOpts = command.parent?.opts() as
         | {
             json?: boolean;
             runtime?: string;
             status?: string;
+            metadata?: string[];
           }
         | undefined;
       await runCommandWithRuntime(defaultRuntime, async () => {
@@ -480,6 +484,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
             json: Boolean(opts.json || parentOpts?.json),
             runtime: (opts.runtime as string | undefined) ?? parentOpts?.runtime,
             status: (opts.status as string | undefined) ?? parentOpts?.status,
+            metadata: (opts.metadata as string[] | undefined) ?? parentOpts?.metadata,
           },
           defaultRuntime,
         );

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -44,7 +44,12 @@ import {
   reconcileTaskLookupToken,
 } from "../tasks/task-registry.reconcile.js";
 import { summarizeTaskRecords } from "../tasks/task-registry.summary.js";
-import type { TaskNotifyPolicy, TaskRecord } from "../tasks/task-registry.types.js";
+import type {
+  TaskMetadata,
+  TaskMetadataValue,
+  TaskNotifyPolicy,
+  TaskRecord,
+} from "../tasks/task-registry.types.js";
 import {
   buildTaskSystemAuditFindings,
   type TaskSystemAuditCode,
@@ -72,6 +77,48 @@ function formatTaskLookupMiss(lookup: string): string {
 
 function formatTaskTimestamp(value: number | undefined): string {
   return timestampMsToIsoString(value) ?? "n/a";
+}
+
+function parseTaskMetadataFilterValue(value: string): TaskMetadataValue {
+  const trimmed = value.trim();
+  if (trimmed === "true") {
+    return true;
+  }
+  if (trimmed === "false") {
+    return false;
+  }
+  if (trimmed === "null") {
+    return null;
+  }
+  const numeric = Number(trimmed);
+  return trimmed !== "" && Number.isFinite(numeric) ? numeric : value;
+}
+
+function parseTaskMetadataFilters(filters: readonly string[] | undefined): TaskMetadata {
+  const metadata: TaskMetadata = {};
+  for (const filter of filters ?? []) {
+    const separator = filter.indexOf("=");
+    if (separator <= 0) {
+      throw new Error(`Invalid task metadata filter "${filter}". Use key=value.`);
+    }
+    const key = filter.slice(0, separator).trim();
+    if (!key) {
+      throw new Error(`Invalid task metadata filter "${filter}". Use key=value.`);
+    }
+    metadata[key] = parseTaskMetadataFilterValue(filter.slice(separator + 1));
+  }
+  return metadata;
+}
+
+function taskMatchesMetadata(task: TaskRecord, metadata: TaskMetadata): boolean {
+  const entries = Object.entries(metadata);
+  if (entries.length === 0) {
+    return true;
+  }
+  if (!task.metadata) {
+    return false;
+  }
+  return entries.every(([key, value]) => task.metadata?.[key] === value);
 }
 
 async function loadTaskCancelConfig() {
@@ -401,11 +448,12 @@ function toSystemAuditFindings(params: {
 
 /** Lists background tasks with optional runtime/status filters. */
 export async function tasksListCommand(
-  opts: { json?: boolean; runtime?: string; status?: string },
+  opts: { json?: boolean; runtime?: string; status?: string; metadata?: string[] },
   runtime: RuntimeEnv,
 ) {
   const runtimeFilter = opts.runtime?.trim();
   const statusFilter = opts.status?.trim();
+  const metadataFilter = parseTaskMetadataFilters(opts.metadata);
   const tasks = reconcileInspectableTasks().filter((task) => {
     if (runtimeFilter && task.runtime !== runtimeFilter) {
       return false;
@@ -413,7 +461,7 @@ export async function tasksListCommand(
     if (statusFilter && task.status !== statusFilter) {
       return false;
     }
-    return true;
+    return taskMatchesMetadata(task, metadataFilter);
   });
 
   if (opts.json) {
@@ -423,6 +471,7 @@ export async function tasksListCommand(
           count: tasks.length,
           runtime: runtimeFilter ?? null,
           status: statusFilter ?? null,
+          metadata: Object.keys(metadataFilter).length > 0 ? metadataFilter : null,
           tasks,
         },
         null,
@@ -439,6 +488,15 @@ export async function tasksListCommand(
   }
   if (statusFilter) {
     runtime.log(info(`Status filter: ${statusFilter}`));
+  }
+  if (Object.keys(metadataFilter).length > 0) {
+    runtime.log(
+      info(
+        `Metadata filter: ${Object.entries(metadataFilter)
+          .map(([key, value]) => `${key}=${String(value)}`)
+          .join(", ")}`,
+      ),
+    );
   }
   if (tasks.length === 0) {
     runtime.log(
@@ -493,6 +551,7 @@ export async function tasksShowCommand(
     ...(task.error ? [`error: ${task.error}`] : []),
     ...(task.progressSummary ? [`progressSummary: ${task.progressSummary}`] : []),
     ...(task.terminalSummary ? [`terminalSummary: ${task.terminalSummary}`] : []),
+    ...(task.metadata ? [`metadata: ${JSON.stringify(task.metadata)}`] : []),
   ];
   for (const line of lines) {
     runtime.log(line);

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -11,6 +11,7 @@ import {
   recordTaskProgressByRunId,
   resetTaskRegistryForTests,
 } from "../../tasks/runtime-internal.js";
+import { resetTaskRegistryMaintenanceRuntimeForTests } from "../../tasks/task-registry.maintenance.js";
 import type { TaskRecord } from "../../tasks/task-registry.types.js";
 import { tasksHandlers } from "./tasks.js";
 import type { RespondFn } from "./types.js";
@@ -41,6 +42,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   resetTaskRegistryForTests();
+  resetTaskRegistryMaintenanceRuntimeForTests();
   if (ORIGINAL_STATE_DIR === undefined) {
     delete process.env.OPENCLAW_STATE_DIR;
   } else {
@@ -177,6 +179,43 @@ describe("tasks gateway handlers", () => {
 
     expect(payload?.task?.status).toBe("completed");
     expect(payload?.task?.title).toBe("Done task");
+  });
+
+  it("reconciles stale running subagent tasks from session truth before listing", async () => {
+    const staleAt = Date.now() - 10 * 60_000;
+    const task = createTaskRecord({
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: "agent:worker:subagent:missing-session",
+      runId: "run-stale-subagent",
+      task: "Inspect stale worker state",
+      status: "running",
+      deliveryStatus: "pending",
+      createdAt: staleAt,
+      startedAt: staleAt,
+      lastEventAt: staleAt,
+    });
+
+    const runningView = await runTaskHandler("tasks.list", {
+      status: "running",
+      sessionKey: "agent:main:main",
+    });
+    expect(runningView.calls[0]?.[0]).toBe(true);
+    expect(runningView.payload?.tasks ?? []).toEqual([]);
+
+    const failedView = await runTaskHandler("tasks.list", {
+      status: "failed",
+      sessionKey: "agent:main:main",
+    });
+    expect(failedView.payload?.tasks?.map((entry) => entry.taskId)).toEqual([task.taskId]);
+    expect(failedView.payload?.tasks?.[0]?.status).toBe("failed");
+    expect(failedView.payload?.tasks?.[0]?.error).toBe("backing session missing");
+
+    const { payload } = await getTaskPayload(task.taskId);
+    expect(payload?.task?.status).toBe("failed");
+    expect(payload?.task?.endedAt).toBeTypeOf("number");
   });
 
   it("sanitizes task text before exposing SDK summaries", async () => {

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -182,6 +182,7 @@ describe("tasks gateway handlers", () => {
   });
 
   it("lists and gets tasks by durable task metadata", async () => {
+    const longMetadataValue = "metadata ".repeat(40);
     const task = createTaskRecord({
       runtime: "subagent",
       taskKind: "klaw_worker",
@@ -198,6 +199,7 @@ describe("tasks gateway handlers", () => {
         branch: "klaw/task-ledger-worker-state",
         prUrl: "https://github.com/openclaw/openclaw/pull/95433",
         khalilAttentionNeeded: true,
+        nextAction: longMetadataValue,
       },
     });
     createTaskRecord({
@@ -225,10 +227,14 @@ describe("tasks gateway handlers", () => {
     });
 
     expect(payload?.tasks?.map((entry) => entry.taskId)).toEqual([task.taskId]);
-    expect(payload?.tasks?.[0]?.metadata).toEqual(task.metadata);
+    expect(payload?.tasks?.[0]?.metadata).toEqual({
+      ...task.metadata,
+      nextAction: expect.stringMatching(/^metadata /),
+    });
+    expect(String(payload?.tasks?.[0]?.metadata?.nextAction).length).toBeLessThanOrEqual(120);
 
     const detail = await getTaskPayload(task.taskId);
-    expect(detail.payload?.task?.metadata).toEqual(task.metadata);
+    expect(detail.payload?.task?.metadata).toEqual(payload?.tasks?.[0]?.metadata);
   });
 
   it("reconciles stale running subagent tasks from session truth before listing", async () => {

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -181,6 +181,56 @@ describe("tasks gateway handlers", () => {
     expect(payload?.task?.title).toBe("Done task");
   });
 
+  it("lists and gets tasks by durable task metadata", async () => {
+    const task = createTaskRecord({
+      runtime: "subagent",
+      taskKind: "klaw_worker",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: "agent:worker:subagent:metadata",
+      runId: "run-metadata-filter",
+      task: "Review worker PR",
+      status: "running",
+      deliveryStatus: "pending",
+      metadata: {
+        repo: "openclaw/openclaw",
+        branch: "klaw/task-ledger-worker-state",
+        prUrl: "https://github.com/openclaw/openclaw/pull/95433",
+        khalilAttentionNeeded: true,
+      },
+    });
+    createTaskRecord({
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: "agent:other:subagent:metadata",
+      runId: "run-metadata-filter-other",
+      task: "Review unrelated worker PR",
+      status: "running",
+      deliveryStatus: "pending",
+      metadata: {
+        repo: "openclaw/openclaw",
+        branch: "other",
+        khalilAttentionNeeded: false,
+      },
+    });
+
+    const { payload } = await runTaskHandler("tasks.list", {
+      metadata: {
+        repo: "openclaw/openclaw",
+        khalilAttentionNeeded: true,
+      },
+    });
+
+    expect(payload?.tasks?.map((entry) => entry.taskId)).toEqual([task.taskId]);
+    expect(payload?.tasks?.[0]?.metadata).toEqual(task.metadata);
+
+    const detail = await getTaskPayload(task.taskId);
+    expect(detail.payload?.task?.metadata).toEqual(task.metadata);
+  });
+
   it("reconciles stale running subagent tasks from session truth before listing", async () => {
     const staleAt = Date.now() - 10 * 60_000;
     const task = createTaskRecord({

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -14,7 +14,12 @@ import {
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { cancelDetachedTaskRunById } from "../../tasks/detached-task-runtime.js";
 import { reconcileInspectableTasks } from "../../tasks/task-registry.reconcile.js";
-import type { TaskRecord, TaskStatus } from "../../tasks/task-registry.types.js";
+import type {
+  TaskMetadata,
+  TaskMetadataValue,
+  TaskRecord,
+  TaskStatus,
+} from "../../tasks/task-registry.types.js";
 import {
   TASK_STATUS_DETAIL_MAX_CHARS,
   formatTaskStatusTitle,
@@ -24,6 +29,7 @@ import type { GatewayRequestHandlers } from "./types.js";
 
 const DEFAULT_TASKS_LIST_LIMIT = 100;
 const MAX_TASKS_LIST_LIMIT = 500;
+const TASK_METADATA_KEY_MAX_CHARS = 80;
 
 type TaskLedgerStatus = TaskSummary["status"];
 
@@ -65,10 +71,35 @@ function sanitizeOptionalTaskText(
   return sanitized || undefined;
 }
 
+function sanitizeTaskMetadataValue(value: TaskMetadataValue): TaskMetadataValue | undefined {
+  if (typeof value !== "string") {
+    return value;
+  }
+  return sanitizeOptionalTaskText(value, { errorContext: true });
+}
+
+function sanitizeTaskMetadata(metadata: TaskMetadata | undefined): TaskMetadata | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+  const sanitized: TaskMetadata = {};
+  for (const [rawKey, rawValue] of Object.entries(metadata)) {
+    const key = sanitizeTaskStatusText(rawKey, {
+      maxChars: TASK_METADATA_KEY_MAX_CHARS,
+    });
+    const value = sanitizeTaskMetadataValue(rawValue);
+    if (key && value !== undefined) {
+      sanitized[key] = value;
+    }
+  }
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+}
+
 function mapTaskSummary(task: TaskRecord): TaskSummary {
   const progressSummary = sanitizeOptionalTaskText(task.progressSummary);
   const terminalSummary = sanitizeOptionalTaskText(task.terminalSummary, { errorContext: true });
   const error = sanitizeOptionalTaskText(task.error, { errorContext: true });
+  const metadata = sanitizeTaskMetadata(task.metadata);
   return {
     id: task.taskId,
     taskId: task.taskId,
@@ -91,7 +122,7 @@ function mapTaskSummary(task: TaskRecord): TaskSummary {
     ...(progressSummary ? { progressSummary } : {}),
     ...(terminalSummary ? { terminalSummary } : {}),
     ...(error ? { error } : {}),
-    ...(task.metadata ? { metadata: { ...task.metadata } } : {}),
+    ...(metadata ? { metadata } : {}),
   };
 }
 

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -13,7 +13,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { cancelDetachedTaskRunById } from "../../tasks/detached-task-runtime.js";
-import { getTaskById, listTaskRecords } from "../../tasks/runtime-internal.js";
+import { reconcileInspectableTasks } from "../../tasks/task-registry.reconcile.js";
 import type { TaskRecord, TaskStatus } from "../../tasks/task-registry.types.js";
 import {
   TASK_STATUS_DETAIL_MAX_CHARS,
@@ -171,7 +171,7 @@ export const tasksHandlers: GatewayRequestHandlers = {
     }
     const statusFilter = normalizeTaskStatusFilter(params.status);
     const limit = Math.min(params.limit ?? DEFAULT_TASKS_LIST_LIMIT, MAX_TASKS_LIST_LIMIT);
-    const filtered = listTaskRecords().filter((task) => {
+    const filtered = reconcileInspectableTasks().filter((task) => {
       if (statusFilter && !statusFilter.has(task.status)) {
         return false;
       }
@@ -197,7 +197,7 @@ export const tasksHandlers: GatewayRequestHandlers = {
       return;
     }
     const taskId = params.taskId;
-    const task = getTaskById(taskId);
+    const task = reconcileInspectableTasks().find((entry) => entry.taskId === taskId);
     if (!task) {
       respond(
         false,

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -91,6 +91,7 @@ function mapTaskSummary(task: TaskRecord): TaskSummary {
     ...(progressSummary ? { progressSummary } : {}),
     ...(terminalSummary ? { terminalSummary } : {}),
     ...(error ? { error } : {}),
+    ...(task.metadata ? { metadata: { ...task.metadata } } : {}),
   };
 }
 
@@ -130,6 +131,16 @@ function taskMatchesAgent(task: TaskRecord, agentId: string | undefined): boolea
   return [task.requesterSessionKey, task.childSessionKey, task.ownerKey].some(
     (candidate) => parseAgentSessionKey(candidate)?.agentId === normalized,
   );
+}
+
+function taskMatchesMetadata(task: TaskRecord, metadata: TasksListParams["metadata"]): boolean {
+  if (!metadata || Object.keys(metadata).length === 0) {
+    return true;
+  }
+  if (!task.metadata) {
+    return false;
+  }
+  return Object.entries(metadata).every(([key, value]) => task.metadata?.[key] === value);
 }
 
 // Cursor strings are offsets, not opaque tokens; reject malformed values so a
@@ -175,7 +186,11 @@ export const tasksHandlers: GatewayRequestHandlers = {
       if (statusFilter && !statusFilter.has(task.status)) {
         return false;
       }
-      return taskMatchesAgent(task, params.agentId) && taskMatchesSession(task, params.sessionKey);
+      return (
+        taskMatchesAgent(task, params.agentId) &&
+        taskMatchesSession(task, params.sessionKey) &&
+        taskMatchesMetadata(task, params.metadata)
+      );
     });
     const page = filtered.slice(cursor, cursor + limit);
     const nextOffset = cursor + page.length;

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -844,6 +844,7 @@ export interface TaskRuns {
   error: string | null;
   label: string | null;
   last_event_at: number | null;
+  metadata_json: string | null;
   notify_policy: string;
   owner_key: string;
   parent_flow_id: string | null;

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -176,6 +176,7 @@ describe("openclaw state database", () => {
       name?: string;
     }>;
     expect(columns.some((column) => column.name === "requester_agent_id")).toBe(true);
+    expect(columns.some((column) => column.name === "metadata_json")).toBe(true);
     expect(
       reopened.db
         .prepare(

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -816,6 +816,7 @@ function ensureAdditiveStateColumns(db: DatabaseSync): void {
   ensureColumn(db, "gateway_restart_sentinel", "stats_json TEXT");
   runSqliteImmediateTransactionSync(db, () => {
     const addedTaskRequesterAgentId = ensureColumn(db, "task_runs", "requester_agent_id TEXT");
+    ensureColumn(db, "task_runs", "metadata_json TEXT");
     if (addedTaskRequesterAgentId) {
       repairLegacyTaskAgentAttribution(db);
     }

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -1018,7 +1018,8 @@ CREATE TABLE IF NOT EXISTS task_runs (
   error TEXT,
   progress_summary TEXT,
   terminal_summary TEXT,
-  terminal_outcome TEXT
+  terminal_outcome TEXT,
+  metadata_json TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_task_runs_run_id ON task_runs(run_id);

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1013,7 +1013,8 @@ CREATE TABLE IF NOT EXISTS task_runs (
   error TEXT,
   progress_summary TEXT,
   terminal_summary TEXT,
-  terminal_outcome TEXT
+  terminal_outcome TEXT,
+  metadata_json TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_task_runs_run_id ON task_runs(run_id);

--- a/src/tasks/detached-task-runtime-contract.ts
+++ b/src/tasks/detached-task-runtime-contract.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type {
   TaskDeliveryState,
   TaskDeliveryStatus,
+  TaskMetadata,
   TaskNotifyPolicy,
   TaskRecord,
   TaskRuntime,
@@ -27,6 +28,7 @@ export type DetachedTaskCreateParams = {
   runId?: string;
   label?: string;
   task: string;
+  metadata?: TaskMetadata;
   preferMetadata?: boolean;
   notifyPolicy?: TaskNotifyPolicy;
   deliveryStatus?: TaskDeliveryStatus;
@@ -45,6 +47,7 @@ export type DetachedTaskStartParams = {
   startedAt?: number;
   lastEventAt?: number;
   progressSummary?: string | null;
+  metadata?: TaskMetadata | null;
   eventSummary?: string | null;
 };
 
@@ -54,6 +57,7 @@ export type DetachedTaskProgressParams = {
   sessionKey?: string;
   lastEventAt?: number;
   progressSummary?: string | null;
+  metadata?: TaskMetadata | null;
   eventSummary?: string | null;
 };
 
@@ -66,6 +70,7 @@ export type DetachedTaskCompleteParams = {
   progressSummary?: string | null;
   terminalSummary?: string | null;
   terminalOutcome?: TaskTerminalOutcome | null;
+  metadata?: TaskMetadata | null;
 };
 
 export type DetachedTaskFailParams = {
@@ -78,6 +83,7 @@ export type DetachedTaskFailParams = {
   error?: string;
   progressSummary?: string | null;
   terminalSummary?: string | null;
+  metadata?: TaskMetadata | null;
 };
 
 export type DetachedTaskFinalizeParams = {
@@ -91,6 +97,7 @@ export type DetachedTaskFinalizeParams = {
   progressSummary?: string | null;
   terminalSummary?: string | null;
   terminalOutcome?: TaskTerminalOutcome | null;
+  metadata?: TaskMetadata | null;
 };
 
 export type DetachedTaskDeliveryStatusParams = {

--- a/src/tasks/runtime-internal.ts
+++ b/src/tasks/runtime-internal.ts
@@ -10,6 +10,7 @@ export {
   getTaskById,
   hasActiveTaskForChildSessionKey,
   listFreshTasksForOwnerKey,
+  listTasksByMetadata,
   listTaskRecords,
   listTasksForFlowId,
   listTasksForOwnerKey,
@@ -28,6 +29,8 @@ export {
   setTaskRegistryDeliveryRuntimeForTests,
   setTaskCleanupAfterById,
   setTaskRunDeliveryStatusByRunId,
+  updateTaskMetadataById,
+  updateTaskMetadataByRunId,
   updateTaskNotifyPolicyById,
 } from "./task-registry.js";
-export type { TaskRecord } from "./task-registry.types.js";
+export type { TaskMetadata, TaskRecord } from "./task-registry.types.js";

--- a/src/tasks/task-executor.ts
+++ b/src/tasks/task-executor.ts
@@ -33,6 +33,7 @@ import { summarizeTaskRecords } from "./task-registry.summary.js";
 import type {
   TaskDeliveryState,
   TaskDeliveryStatus,
+  TaskMetadata,
   TaskNotifyPolicy,
   TaskRecord,
   TaskRegistrySummary,
@@ -153,6 +154,7 @@ export function startTaskRunByRunId(params: {
   startedAt?: number;
   lastEventAt?: number;
   progressSummary?: string | null;
+  metadata?: TaskMetadata | null;
   eventSummary?: string | null;
 }) {
   return markTaskRunningByRunId(params);
@@ -164,6 +166,7 @@ export function recordTaskRunProgressByRunId(params: {
   sessionKey?: string;
   lastEventAt?: number;
   progressSummary?: string | null;
+  metadata?: TaskMetadata | null;
   eventSummary?: string | null;
 }) {
   return recordTaskProgressByRunId(params);
@@ -178,6 +181,7 @@ export function completeTaskRunByRunId(params: {
   progressSummary?: string | null;
   terminalSummary?: string | null;
   terminalOutcome?: TaskTerminalOutcome | null;
+  metadata?: TaskMetadata | null;
 }) {
   return finalizeTaskRunByRunId({
     ...params,
@@ -199,6 +203,7 @@ export function failTaskRunByRunId(params: {
   error?: string;
   progressSummary?: string | null;
   terminalSummary?: string | null;
+  metadata?: TaskMetadata | null;
 }) {
   return finalizeTaskRunByRunId({
     ...params,

--- a/src/tasks/task-owner-access.test.ts
+++ b/src/tasks/task-owner-access.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
+  buildTaskStatusSnapshotForRelatedSessionKeyForOwner,
   findLatestTaskForRelatedSessionKeyForOwner,
   findTaskByRunIdForOwner,
   getTaskByIdForOwner,
@@ -12,6 +13,7 @@ import {
   createTaskRecord as createTaskRecordOrNull,
   resetTaskRegistryForTests,
 } from "./task-registry.js";
+import { resetTaskRegistryMaintenanceRuntimeForTests } from "./task-registry.maintenance.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
 const ORIGINAL_ENV = captureEnv(["OPENCLAW_STATE_DIR"]);
@@ -26,6 +28,7 @@ function createTaskRecord(params: Parameters<typeof createTaskRecordOrNull>[0]):
 
 afterEach(() => {
   resetTaskRegistryForTests({ persist: false });
+  resetTaskRegistryMaintenanceRuntimeForTests();
   ORIGINAL_ENV.restore();
 });
 
@@ -153,6 +156,35 @@ describe("task owner access", () => {
           callerOwnerKey: "agent:main:main",
         }),
       ).toBeUndefined();
+    });
+  });
+
+  it("builds owner status snapshots from reconciled task/session truth", async () => {
+    await withTaskRegistryTempDir(() => {
+      const staleAt = Date.now() - 10 * 60_000;
+      const task = createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:subagent:missing-session",
+        runId: "owner-stale-running-run",
+        task: "Inspect worker state",
+        status: "running",
+        createdAt: staleAt,
+        startedAt: staleAt,
+        lastEventAt: staleAt,
+      });
+
+      const snapshot = buildTaskStatusSnapshotForRelatedSessionKeyForOwner({
+        relatedSessionKey: "agent:main:subagent:missing-session",
+        callerOwnerKey: "agent:main:main",
+      });
+
+      expect(snapshot.activeCount).toBe(0);
+      expect(snapshot.recentFailureCount).toBe(1);
+      expect(snapshot.focus?.taskId).toBe(task.taskId);
+      expect(snapshot.focus?.status).toBe("lost");
+      expect(snapshot.focus?.error).toBe("backing session missing");
     });
   });
 });

--- a/src/tasks/task-owner-access.ts
+++ b/src/tasks/task-owner-access.ts
@@ -1,13 +1,11 @@
 // Normalizes task owner keys and checks requester access to task records.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
-  findTaskByRunId,
   getTaskById,
-  listTasksForRelatedSessionKey,
   markTaskTerminalById as markTaskTerminalRecordById,
-  resolveTaskForLookupToken,
   updateTaskNotifyPolicyById,
 } from "./task-registry.js";
+import { reconcileInspectableTasks, reconcileTaskLookupToken } from "./task-registry.reconcile.js";
 import type { TaskNotifyPolicy, TaskRecord } from "./task-registry.types.js";
 import { buildTaskStatusSnapshot } from "./task-status.js";
 
@@ -22,7 +20,9 @@ export function getTaskByIdForOwner(params: {
   taskId: string;
   callerOwnerKey: string;
 }): TaskRecord | undefined {
-  const task = getTaskById(params.taskId);
+  const task =
+    reconcileInspectableTasks().find((entry) => entry.taskId === params.taskId) ??
+    getTaskById(params.taskId);
   return task && canOwnerAccessTask(task, params.callerOwnerKey) ? task : undefined;
 }
 
@@ -30,8 +30,10 @@ export function findTaskByRunIdForOwner(params: {
   runId: string;
   callerOwnerKey: string;
 }): TaskRecord | undefined {
-  const task = findTaskByRunId(params.runId);
-  return task && canOwnerAccessTask(task, params.callerOwnerKey) ? task : undefined;
+  const task = reconcileTaskLookupToken(params.runId);
+  return task?.runId === params.runId && canOwnerAccessTask(task, params.callerOwnerKey)
+    ? task
+    : undefined;
 }
 
 /** Update an owner-visible task's notification policy. */
@@ -79,8 +81,16 @@ export function listTasksForRelatedSessionKeyForOwner(params: {
   relatedSessionKey: string;
   callerOwnerKey: string;
 }): TaskRecord[] {
-  return listTasksForRelatedSessionKey(params.relatedSessionKey).filter((task) =>
-    canOwnerAccessTask(task, params.callerOwnerKey),
+  const relatedSessionKey = normalizeOptionalString(params.relatedSessionKey);
+  if (!relatedSessionKey) {
+    return [];
+  }
+  return reconcileInspectableTasks().filter(
+    (task) =>
+      canOwnerAccessTask(task, params.callerOwnerKey) &&
+      [task.ownerKey, task.childSessionKey].some(
+        (candidate) => normalizeOptionalString(candidate) === relatedSessionKey,
+      ),
   );
 }
 
@@ -128,6 +138,8 @@ export function resolveTaskForLookupTokenForOwner(params: {
   if (related) {
     return related;
   }
-  const raw = resolveTaskForLookupToken(params.token);
-  return raw && canOwnerAccessTask(raw, params.callerOwnerKey) ? raw : undefined;
+  const reconciled = reconcileTaskLookupToken(params.token);
+  return reconciled && canOwnerAccessTask(reconciled, params.callerOwnerKey)
+    ? reconciled
+    : undefined;
 }

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -18,6 +18,8 @@ import {
   parseTaskScopeKind,
   parseTaskStatus,
   type TaskDeliveryState,
+  type TaskMetadata,
+  type TaskMetadataValue,
   type TaskRecord,
 } from "./task-registry.types.js";
 
@@ -73,6 +75,7 @@ const TASK_RUN_SELECT_COLUMNS = [
   "progress_summary",
   "terminal_summary",
   "terminal_outcome",
+  "metadata_json",
 ] as const;
 
 let cachedDatabase: TaskRegistryDatabase | null = null;
@@ -88,6 +91,33 @@ function serializeJson(value: unknown): string | null {
   return value == null ? null : JSON.stringify(value);
 }
 
+function parseTaskMetadataJson(value: string | null): TaskMetadata | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = JSON.parse(value) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Invalid persisted task metadata: expected object");
+  }
+  const metadata: TaskMetadata = {};
+  for (const [key, entry] of Object.entries(parsed)) {
+    if (!key.trim()) {
+      throw new Error("Invalid persisted task metadata: empty key");
+    }
+    if (
+      entry === null ||
+      typeof entry === "string" ||
+      typeof entry === "boolean" ||
+      (typeof entry === "number" && Number.isFinite(entry))
+    ) {
+      metadata[key] = entry as TaskMetadataValue;
+      continue;
+    }
+    throw new Error(`Invalid persisted task metadata value for ${key}`);
+  }
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
 function rowToTaskRecord(row: TaskRegistryRow): TaskRecord {
   const startedAt = normalizeNumber(row.started_at);
   const endedAt = normalizeNumber(row.ended_at);
@@ -95,6 +125,7 @@ function rowToTaskRecord(row: TaskRegistryRow): TaskRecord {
   const cleanupAfter = normalizeNumber(row.cleanup_after);
   const scopeKind = parseTaskScopeKind(row.scope_kind);
   const terminalOutcome = parseOptionalTaskTerminalOutcome(row.terminal_outcome);
+  const metadata = parseTaskMetadataJson(row.metadata_json);
   // System tasks intentionally have no requester session; ownerKey is the lookup anchor.
   const requesterSessionKey =
     scopeKind === "system" ? "" : row.requester_session_key?.trim() || row.owner_key;
@@ -126,6 +157,7 @@ function rowToTaskRecord(row: TaskRegistryRow): TaskRecord {
     ...(row.progress_summary ? { progressSummary: row.progress_summary } : {}),
     ...(row.terminal_summary ? { terminalSummary: row.terminal_summary } : {}),
     ...(terminalOutcome ? { terminalOutcome } : {}),
+    ...(metadata ? { metadata } : {}),
   };
 }
 
@@ -168,6 +200,7 @@ function bindTaskRecordBase(record: TaskRecord): Insertable<TaskRunsTable> {
     progress_summary: record.progressSummary ?? null,
     terminal_summary: record.terminalSummary ?? null,
     terminal_outcome: record.terminalOutcome ?? null,
+    metadata_json: serializeJson(record.metadata),
   };
 }
 
@@ -257,6 +290,7 @@ function upsertTaskRow(db: DatabaseSync, row: Insertable<TaskRunsTable>): void {
           progress_summary: (eb) => eb.ref("excluded.progress_summary"),
           terminal_summary: (eb) => eb.ref("excluded.terminal_summary"),
           terminal_outcome: (eb) => eb.ref("excluded.terminal_outcome"),
+          metadata_json: (eb) => eb.ref("excluded.metadata_json"),
         }),
       ),
   );

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -30,6 +30,7 @@ import {
   markTaskTerminalById,
   maybeDeliverTaskStateChangeUpdate,
   resetTaskRegistryForTests,
+  updateTaskMetadataByRunId,
   updateTaskNotifyPolicyById,
 } from "./task-registry.js";
 import {
@@ -220,6 +221,51 @@ describe("task-registry store runtime", () => {
         );
 
         expect(() => loadTaskRegistryStateFromSqlite()).toThrow("Invalid persisted task status");
+      },
+    );
+  });
+
+  it("persists operational task metadata across sqlite create and updates", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-task-metadata-" },
+      async () => {
+        resetTaskRegistryForTests();
+        const created = createTaskRecord({
+          runtime: "subagent",
+          requesterSessionKey: "agent:main:main",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          childSessionKey: "agent:worker:subagent:metadata",
+          runId: "run-worker-metadata",
+          task: "Inspect worker metadata",
+          status: "running",
+          deliveryStatus: "pending",
+          metadata: {
+            branch: "klaw/task-ledger-worker-state",
+            prUrl: "https://github.com/openclaw/openclaw/pull/95433",
+            khalilAttentionNeeded: true,
+          },
+        });
+
+        updateTaskMetadataByRunId({
+          runId: "run-worker-metadata",
+          metadata: {
+            nextAction: "parent-review",
+            khalilAttentionNeeded: false,
+          },
+        });
+
+        resetTaskRegistryForTests({ persist: false });
+
+        expect(findTaskByRunId("run-worker-metadata")).toMatchObject({
+          taskId: created.taskId,
+          metadata: {
+            branch: "klaw/task-ledger-worker-state",
+            prUrl: "https://github.com/openclaw/openclaw/pull/95433",
+            nextAction: "parent-review",
+            khalilAttentionNeeded: false,
+          },
+        });
       },
     );
   });

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1896,6 +1896,10 @@ describe("task-registry", () => {
         task: "Direct ACP child",
         status: "running",
         deliveryStatus: "pending",
+        metadata: {
+          repo: "openclaw/openclaw",
+          nextAction: "initial",
+        },
       });
 
       const spawnedTask = createTaskRecord({
@@ -1913,6 +1917,10 @@ describe("task-registry", () => {
         preferMetadata: true,
         status: "running",
         deliveryStatus: "pending",
+        metadata: {
+          nextAction: "review PR",
+          khalilAttentionNeeded: true,
+        },
       });
 
       expect(spawnedTask.taskId).toBe(directTask.taskId);
@@ -1920,6 +1928,11 @@ describe("task-registry", () => {
         taskId: directTask.taskId,
         label: "Quant patch",
         task: "Implement the feature and report back",
+        metadata: {
+          repo: "openclaw/openclaw",
+          nextAction: "review PR",
+          khalilAttentionNeeded: true,
+        },
       });
     });
   });

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -539,6 +539,18 @@ function mergeTaskMetadata(
   });
 }
 
+function taskMetadataEqual(
+  left: TaskMetadata | undefined,
+  right: TaskMetadata | undefined,
+): boolean {
+  const leftEntries = Object.entries(left ?? {});
+  const rightEntries = Object.entries(right ?? {});
+  if (leftEntries.length !== rightEntries.length) {
+    return false;
+  }
+  return leftEntries.every(([key, value]) => right?.[key] === value);
+}
+
 function shouldApplyRunScopedStatusUpdate(params: {
   currentStatus: TaskStatus;
   nextStatus: TaskStatus;
@@ -919,6 +931,7 @@ function mergeExistingTaskForCreate(
     label?: string;
     task: string;
     preferMetadata?: boolean;
+    metadata?: TaskMetadata;
     deliveryStatus?: TaskDeliveryStatus;
     notifyPolicy?: TaskNotifyPolicy;
   },
@@ -973,6 +986,12 @@ function mergeExistingTaskForCreate(
   }
   if (params.deliveryStatus === "pending" && existing.deliveryStatus !== "delivered") {
     patch.deliveryStatus = "pending";
+  }
+  if (params.metadata !== undefined) {
+    const metadata = mergeTaskMetadata(existing.metadata, params.metadata);
+    if (!taskMetadataEqual(metadata, existing.metadata)) {
+      patch.metadata = metadata;
+    }
   }
   const notifyPolicy = ensureNotifyPolicy({
     notifyPolicy: params.notifyPolicy,

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -49,6 +49,8 @@ import type {
   TaskDeliveryStatus,
   TaskEventKind,
   TaskEventRecord,
+  TaskMetadata,
+  TaskMetadataValue,
   TaskNotifyPolicy,
   TaskRecord,
   TaskRegistrySummary,
@@ -191,7 +193,10 @@ function assertParentFlowLinkAllowed(params: {
 }
 
 function cloneTaskRecord(record: TaskRecord): TaskRecord {
-  return { ...record };
+  return {
+    ...record,
+    ...(record.metadata ? { metadata: { ...record.metadata } } : {}),
+  };
 }
 
 function normalizeTaskTimestamps(task: TaskRecord): TaskRecord {
@@ -479,6 +484,59 @@ function normalizeTaskTerminalOutcome(
   value: TaskTerminalOutcome | null | undefined,
 ): TaskTerminalOutcome | undefined {
   return value === "succeeded" || value === "blocked" ? value : undefined;
+}
+
+function normalizeTaskMetadataValue(value: unknown): TaskMetadataValue | undefined {
+  if (value === null) {
+    return null;
+  }
+  switch (typeof value) {
+    case "string":
+      return value;
+    case "number":
+      return Number.isFinite(value) ? value : undefined;
+    case "boolean":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function normalizeTaskMetadata(
+  metadata: TaskMetadata | null | undefined,
+): TaskMetadata | undefined {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return undefined;
+  }
+  const normalized: TaskMetadata = {};
+  for (const [rawKey, rawValue] of Object.entries(metadata)) {
+    const key = rawKey.trim();
+    if (!key) {
+      continue;
+    }
+    const value = normalizeTaskMetadataValue(rawValue);
+    if (value !== undefined) {
+      normalized[key] = value;
+    }
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function mergeTaskMetadata(
+  current: TaskMetadata | undefined,
+  patch: TaskMetadata | null | undefined,
+): TaskMetadata | undefined {
+  if (patch === null) {
+    return undefined;
+  }
+  const normalizedPatch = normalizeTaskMetadata(patch);
+  if (!normalizedPatch) {
+    return current ? { ...current } : undefined;
+  }
+  return normalizeTaskMetadata({
+    ...(current ?? {}),
+    ...normalizedPatch,
+  });
 }
 
 function shouldApplyRunScopedStatusUpdate(params: {
@@ -1720,6 +1778,7 @@ export function createTaskRecord(params: {
   progressSummary?: string | null;
   terminalSummary?: string | null;
   terminalOutcome?: TaskTerminalOutcome | null;
+  metadata?: TaskMetadata;
 }): TaskRecord | null {
   ensureTaskRegistryReady();
   const requesterSessionKey = resolveTaskRequesterSessionKey(params);
@@ -1809,6 +1868,7 @@ export function createTaskRecord(params: {
       status,
       terminalOutcome: params.terminalOutcome,
     }),
+    metadata: normalizeTaskMetadata(params.metadata),
   });
   if (isTerminalTaskStatus(record.status) && typeof record.cleanupAfter !== "number") {
     record.cleanupAfter = resolveTaskCleanupAfter(record);
@@ -1854,6 +1914,7 @@ function updateTaskStateByRunId(params: {
   progressSummary?: string | null;
   terminalSummary?: string | null;
   terminalOutcome?: TaskTerminalOutcome | null;
+  metadata?: TaskMetadata | null;
   eventSummary?: string | null;
 }) {
   ensureTaskRegistryReady();
@@ -1901,6 +1962,9 @@ function updateTaskStateByRunId(params: {
         status: nextStatus,
         terminalOutcome: params.terminalOutcome,
       });
+    }
+    if (params.metadata !== undefined) {
+      patch.metadata = mergeTaskMetadata(current.metadata, params.metadata);
     }
     const eventSummary =
       normalizeTaskSummary(params.eventSummary) ??
@@ -1961,6 +2025,7 @@ export function markTaskRunningByRunId(params: {
   startedAt?: number;
   lastEventAt?: number;
   progressSummary?: string | null;
+  metadata?: TaskMetadata | null;
   eventSummary?: string | null;
 }) {
   return updateTaskStateByRunId({
@@ -1971,6 +2036,7 @@ export function markTaskRunningByRunId(params: {
     startedAt: params.startedAt,
     lastEventAt: params.lastEventAt,
     progressSummary: params.progressSummary,
+    metadata: params.metadata,
     eventSummary: params.eventSummary,
   });
 }
@@ -1981,6 +2047,7 @@ export function recordTaskProgressByRunId(params: {
   sessionKey?: string;
   lastEventAt?: number;
   progressSummary?: string | null;
+  metadata?: TaskMetadata | null;
   eventSummary?: string | null;
 }) {
   return updateTaskStateByRunId({
@@ -1989,6 +2056,7 @@ export function recordTaskProgressByRunId(params: {
     sessionKey: params.sessionKey,
     lastEventAt: params.lastEventAt,
     progressSummary: params.progressSummary,
+    metadata: params.metadata,
     eventSummary: params.eventSummary,
   });
 }
@@ -2005,6 +2073,7 @@ export function markTaskTerminalByRunId(params: {
   progressSummary?: string | null;
   terminalSummary?: string | null;
   terminalOutcome?: TaskTerminalOutcome | null;
+  metadata?: TaskMetadata | null;
 }) {
   return finalizeTaskRunByRunId(params);
 }
@@ -2021,6 +2090,7 @@ export function finalizeTaskRunByRunId(params: {
   progressSummary?: string | null;
   terminalSummary?: string | null;
   terminalOutcome?: TaskTerminalOutcome | null;
+  metadata?: TaskMetadata | null;
 }) {
   return updateTaskStateByRunId({
     runId: params.runId,
@@ -2034,7 +2104,40 @@ export function finalizeTaskRunByRunId(params: {
     progressSummary: params.progressSummary,
     terminalSummary: params.terminalSummary,
     terminalOutcome: params.terminalOutcome,
+    metadata: params.metadata,
   });
+}
+
+export function updateTaskMetadataById(params: {
+  taskId: string;
+  metadata: TaskMetadata | null;
+}): TaskRecord | null {
+  ensureTaskRegistryReady();
+  const current = tasks.get(params.taskId.trim());
+  if (!current) {
+    return null;
+  }
+  return updateTask(current.taskId, {
+    metadata: mergeTaskMetadata(current.metadata, params.metadata),
+    lastEventAt: Date.now(),
+  });
+}
+
+export function updateTaskMetadataByRunId(params: {
+  runId: string;
+  runtime?: TaskRuntime;
+  sessionKey?: string;
+  metadata: TaskMetadata | null;
+}): TaskRecord[] {
+  ensureTaskRegistryReady();
+  return getTasksByRunScope(params)
+    .map((task) =>
+      updateTask(task.taskId, {
+        metadata: mergeTaskMetadata(task.metadata, params.metadata),
+        lastEventAt: Date.now(),
+      }),
+    )
+    .filter((task): task is TaskRecord => Boolean(task));
 }
 
 export function setTaskRunDeliveryStatusByRunId(params: {
@@ -2301,6 +2404,17 @@ export function listTasksForAgentId(agentId: string): TaskRecord[] {
   return snapshotTaskRecords(tasks)
     .filter((task) => task.agentId?.trim() === lookup)
     .toSorted(compareTasksNewestFirst);
+}
+
+export function listTasksByMetadata(metadata: TaskMetadata): TaskRecord[] {
+  ensureTaskRegistryReady();
+  const normalized = normalizeTaskMetadata(metadata);
+  if (!normalized) {
+    return listTaskRecords();
+  }
+  return listTaskRecords().filter((task) =>
+    Object.entries(normalized).every(([key, value]) => task.metadata?.[key] === value),
+  );
 }
 
 export function findLatestTaskForOwnerKey(ownerKey: string): TaskRecord | undefined {

--- a/src/tasks/task-registry.types.ts
+++ b/src/tasks/task-registry.types.ts
@@ -26,6 +26,8 @@ export type TaskNotifyPolicy = "done_only" | "state_changes" | "silent";
 /** Semantic success detail for required-completion task outcomes. */
 export type TaskTerminalOutcome = "succeeded" | "blocked";
 export type TaskScopeKind = "session" | "system";
+export type TaskMetadataValue = string | number | boolean | null;
+export type TaskMetadata = Record<string, TaskMetadataValue>;
 
 export type TaskStatusCounts = Record<TaskStatus, number>;
 export type TaskRuntimeCounts = Record<TaskRuntime, number>;
@@ -143,6 +145,7 @@ export type TaskRecord = {
   progressSummary?: string;
   terminalSummary?: string;
   terminalOutcome?: TaskTerminalOutcome;
+  metadata?: TaskMetadata;
 };
 
 export type TaskRegistrySnapshot = {

--- a/src/tasks/task-status-access.ts
+++ b/src/tasks/task-status-access.ts
@@ -1,12 +1,17 @@
 // Filters task status visibility by requester, owner, and flow scope.
-import {
-  findTaskByRunId,
-  getTaskById,
-  listTaskRecords,
-  listTasksForAgentId,
-  listTasksForSessionKey,
-} from "./task-registry.js";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { reconcileInspectableTasks, reconcileTaskLookupToken } from "./task-registry.reconcile.js";
 import type { TaskRecord } from "./task-registry.types.js";
+
+function taskMatchesRelatedSessionKey(task: TaskRecord, sessionKey: string): boolean {
+  const normalized = normalizeOptionalString(sessionKey);
+  if (!normalized) {
+    return false;
+  }
+  return [task.requesterSessionKey, task.ownerKey, task.childSessionKey].some(
+    (candidate) => normalizeOptionalString(candidate) === normalized,
+  );
+}
 
 /** Returns only the session lookup fields needed by task status commands. */
 export function getTaskSessionLookupByIdForStatus(
@@ -14,7 +19,7 @@ export function getTaskSessionLookupByIdForStatus(
 ):
   | Pick<TaskRecord, "requesterSessionKey" | "ownerKey" | "runId" | "agentId" | "requesterAgentId">
   | undefined {
-  const task = getTaskById(taskId);
+  const task = reconcileInspectableTasks().find((entry) => entry.taskId === taskId);
   return task
     ? {
         requesterSessionKey: task.requesterSessionKey,
@@ -27,19 +32,22 @@ export function getTaskSessionLookupByIdForStatus(
 }
 
 export function listTasksForSessionKeyForStatus(sessionKey: string): TaskRecord[] {
-  return listTasksForSessionKey(sessionKey);
+  return reconcileInspectableTasks().filter((task) =>
+    taskMatchesRelatedSessionKey(task, sessionKey),
+  );
 }
 
 export function listTasksForOwnerOrRequesterSessionKeyForStatus(sessionKey: string): TaskRecord[] {
-  return listTaskRecords().filter(
+  return reconcileInspectableTasks().filter(
     (task) => task.requesterSessionKey === sessionKey || task.ownerKey === sessionKey,
   );
 }
 
 export function listTasksForAgentIdForStatus(agentId: string): TaskRecord[] {
-  return listTasksForAgentId(agentId);
+  return reconcileInspectableTasks().filter((task) => task.agentId?.trim() === agentId.trim());
 }
 
 export function findTaskByRunIdForStatus(runId: string): TaskRecord | undefined {
-  return findTaskByRunId(runId);
+  const task = reconcileTaskLookupToken(runId);
+  return task?.runId === runId ? task : undefined;
 }


### PR DESCRIPTION
## What Problem This Solves
Task-ledger status views were still partly shaped like a derived worker-state projection: Gateway/status surfaces could report stale active subagent rows when backing session truth was gone, and operational worker facts such as repo, branch, PR URL, owner, next action, and attention-needed state had no durable task-ledger home to write or query.

This PR makes the SQLite task ledger the durable source for lifecycle plus flat operational metadata. Runtime writes metadata onto `task_runs`, task lifecycle helpers preserve/update it, and Gateway/CLI surfaces expose exact-match metadata filtering from reconciled task records. Worker-state-style files are documented as legacy/import/ephemeral only, not active authority.

## Summary
- keep task/session lifecycle status derived from reconciled task/session truth so stale subagent rows do not continue to report as active
- add flat operational task metadata on the SQLite `task_runs` row, with create/progress/terminal/update helpers for repo, branch, PR URL, owner, next action, and attention-needed flags
- expose metadata through Gateway `tasks.list`/`tasks.get`, exact-match Gateway filters, and `openclaw tasks list --metadata key=value` so orchestrators can query task-ledger state instead of editable worker-state JSON
- bound public Gateway task metadata output with the same status-text sanitization used for adjacent task summaries, and preserve metadata when ACP task creation collapses onto an existing task row
- document that task metadata belongs in the task ledger and that worker-state-style files should be legacy/import/ephemeral only, not active authority

## Evidence
Redacted terminal output from the latest local proof after the ClawSweeper review fixes:

```text
$ node scripts/run-vitest.mjs src/tasks/task-registry.store.test.ts src/gateway/server-methods/tasks.test.ts packages/gateway-protocol/src/index.test.ts src/cli/program/register.status-health-sessions.test.ts src/state/openclaw-state-db.test.ts src/tasks/task-registry.test.ts
[test] starting test/vitest/vitest.unit.config.ts
Test Files  2 passed (2)
Tests  62 passed (62)
[test] starting test/vitest/vitest.gateway.config.ts
Test Files  2 passed (2)
Tests  14 passed (14)
[test] starting test/vitest/vitest.tasks.config.ts
Test Files  2 passed (2)
Tests  105 passed (105)
[test] starting test/vitest/vitest.cli.config.ts
Test Files  1 passed (1)
Tests  26 passed (26)
[test] passed 4 Vitest shards in 36.84s

$ pnpm tsgo:core
$ node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo

$ pnpm docs:list
$ node scripts/docs-list.js
Listing all markdown files in docs folder: ...

$ git diff --check origin/main...HEAD && git diff --check
```

Runtime behavior covered by those tests:
- `tasks.list`/`tasks.get` return reconciled task records and exact-match durable metadata filters.
- Gateway summaries truncate long metadata strings to the bounded public summary size.
- SQLite task rows persist `metadata_json` and reload it through the task registry store.
- ACP create-collapse preserves existing metadata and merges new metadata onto the durable task row.
- Owner/status task views use reconciled task truth so stale backing-session rows stop appearing active.

## Notes
- This supersedes #95433 because GitHub kept that PR's `refs/pull/95433/head` pinned to the old commit even after the source branch ref moved to the revised task-ledger metadata commit.
- Fresh autoreview attempted with `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`, but this worker image does not have a `codex` executable, so the helper could not run.
