### PR TITLE
fix(doctor): keep narrowed open-DM allowlists from being widened to a wildcard

### DIFF
--- a/src/channels/plugins/dm-access.ts
+++ b/src/channels/plugins/dm-access.ts
@@ -301,10 +301,6 @@ export function normalizeLegacyDmAliases(params: {
   return { entry: updated, changed };
 }
 
-function hasWildcard(list?: Array<string | number>) {
-  return list?.some((value) => String(value).trim() === "*") ?? false;
-}
-
 /**
  * Ensures `dmPolicy="open"` has the wildcard allowlist required by access gates.
  */
@@ -344,29 +340,26 @@ export function ensureOpenDmPolicyAllowFromWildcard(params: {
       ? (legacyAllowFrom as Array<string | number>)
       : undefined;
 
-  if (hasWildcard(sourceAllowFrom)) {
-    if (canonicalAllowFrom === undefined && sourceAllowFrom) {
+  if (sourceAllowFrom !== undefined && sourceAllowFrom.length > 0) {
+    if (canonicalAllowFrom === undefined) {
       setCanonicalDmAllowFrom({
         entry: params.entry,
         mode: params.mode,
         allowFrom: sourceAllowFrom,
         pathPrefix: params.pathPrefix,
         changes: params.changes,
-        reason: `moved wildcard allowlist from ${formatPath(params.pathPrefix, allowPaths.legacyPath)}`,
+        reason: `moved allowlist from ${formatPath(params.pathPrefix, allowPaths.legacyPath)}`,
       });
     }
     return;
   }
 
-  const nextAllowFrom = [...(sourceAllowFrom ?? []), "*"];
   setCanonicalDmAllowFrom({
     entry: params.entry,
     mode: params.mode,
-    allowFrom: nextAllowFrom,
+    allowFrom: ["*"],
     pathPrefix: params.pathPrefix,
     changes: params.changes,
-    reason: Array.isArray(sourceAllowFrom)
-      ? 'added "*" (required by dmPolicy="open")'
-      : 'set to ["*"] (required by dmPolicy="open")',
+    reason: 'set to ["*"] (required by dmPolicy="open")',
   });
 }

--- a/src/commands/doctor/shared/open-policy-allowfrom.test.ts
+++ b/src/commands/doctor/shared/open-policy-allowfrom.test.ts
@@ -66,7 +66,7 @@ describe("doctor open-policy allowFrom repair", () => {
     expect(result.config.channels?.matrix?.dm?.allowFrom).toEqual(["*"]);
   });
 
-  it("appends wildcard to discord nested dm allowFrom when top-level is absent", () => {
+  it("moves a discord nested narrowed dm allowFrom to canonical without widening it", () => {
     const result = maybeRepairOpenPolicyAllowFrom({
       channels: {
         discord: {
@@ -81,13 +81,13 @@ describe("doctor open-policy allowFrom repair", () => {
     expect(result.changes).toEqual([
       '- channels.discord.dmPolicy: set to "open" (migrated from channels.discord.dm.policy)',
       "- channels.discord.dm.allowFrom: removed after moving allowlist to channels.discord.allowFrom",
-      '- channels.discord.allowFrom: added "*" (required by dmPolicy="open")',
+      "- channels.discord.allowFrom: moved allowlist from channels.discord.dm.allowFrom",
     ]);
-    expect(result.config.channels?.discord?.allowFrom).toEqual(["123", "*"]);
+    expect(result.config.channels?.discord?.allowFrom).toEqual(["123"]);
     expect(result.config.channels?.discord?.dm).toBeUndefined();
   });
 
-  it("appends wildcard to existing top-level allowFrom", () => {
+  it("preserves an existing top-level narrowed allowFrom", () => {
     const result = maybeRepairOpenPolicyAllowFrom({
       channels: {
         slack: {
@@ -97,7 +97,8 @@ describe("doctor open-policy allowFrom repair", () => {
       },
     });
 
-    expect(result.config.channels?.slack?.allowFrom).toEqual(["U123", "*"]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.config.channels?.slack?.allowFrom).toEqual(["U123"]);
   });
 
   it("skips top-level allowFrom that already includes a wildcard", () => {
@@ -112,6 +113,24 @@ describe("doctor open-policy allowFrom repair", () => {
 
     expect(result.changes).toStrictEqual([]);
     expect(result.config.channels?.discord?.allowFrom).toEqual(["*"]);
+  });
+
+  it("preserves a per-account narrowed allowFrom", () => {
+    const result = maybeRepairOpenPolicyAllowFrom({
+      channels: {
+        discord: {
+          accounts: {
+            work: {
+              dmPolicy: "open",
+              allowFrom: ["u_alpha"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.config.channels?.discord?.accounts?.work?.allowFrom).toEqual(["u_alpha"]);
   });
 
   it("repairs per-account open dmPolicy without allowFrom", () => {


### PR DESCRIPTION
## Summary
With `dmPolicy: "open"` and a non-empty `allowFrom` (for example `["u_alpha"]`), the DM access gate admits only `u_alpha` and blocks every other sender. Running `openclaw doctor --fix` rewrites that allowlist to `["u_alpha", "*"]`, which the gate reads as admit everyone. A previously blocked stranger can then DM the bot or agent, and the change is written back to `openclaw.json` silently. Any account or channel a user deliberately narrowed under open DM policy is opened to the public by a routine repair.

## Root cause
The open-policy repair only skips when the allowlist already contains a wildcard, then unconditionally appends `"*"` to whatever is there.

`src/channels/plugins/dm-access.ts` (before):
```ts
if (hasWildcard(sourceAllowFrom)) {
  if (canonicalAllowFrom === undefined && sourceAllowFrom) {
    setCanonicalDmAllowFrom({ ... });
  }
  return;
}

const nextAllowFrom = [...(sourceAllowFrom ?? []), "*"];
setCanonicalDmAllowFrom({ ...nextAllowFrom... });
```

This contradicts the runtime contract in `src/channels/message-access/sender-gates.ts`, whose own comment states the narrowing is intentional:
```ts
if (params.policy.dmPolicy === "open") {
  // Open DM policy still requires either wildcard or an explicit normalized entry so
  // configured allowlists keep their narrowing effect.
  if (dm.hasWildcard) {
    return allow("dm_policy_open");
  }
  if (dm.match.matched) {
    return allow("dm_policy_allowlisted");
  }
  return block("dm_policy_not_allowlisted");
}
```
So open plus a non-wildcard list is a valid narrowing (matched senders allowed, others blocked). Appending `"*"` defeats it. The repair runs during `doctor --fix` (`src/commands/doctor/repair-sequencing.ts:158`) and in the warning preview (`src/commands/doctor/shared/preview-warnings.ts`).

## Fix
Only inject `"*"` when the open-policy allowlist is absent or empty, which is the genuinely broken state where open would otherwise block everyone. A non-empty configured allowlist (wildcard or narrowing) keeps its meaning and is only moved to canonical config, never widened.

`src/channels/plugins/dm-access.ts` (after):
```ts
if (sourceAllowFrom !== undefined && sourceAllowFrom.length > 0) {
  if (canonicalAllowFrom === undefined) {
    setCanonicalDmAllowFrom({
      ...
      allowFrom: sourceAllowFrom,
      reason: `moved allowlist from ${formatPath(params.pathPrefix, allowPaths.legacyPath)}`,
    });
  }
  return;
}

setCanonicalDmAllowFrom({
  ...
  allowFrom: ["*"],
  reason: 'set to ["*"] (required by dmPolicy="open")',
});
```

## Why this is the right boundary
The defect is in the doctor repair, and the runtime gate is the authoritative contract for what open plus an allowlist means. The fix aligns the repair with that gate: empty or absent allowlist under open still gets the wildcard it needs, while a configured list is preserved and only migrated from any legacy nested path to canonical. The existing tests that asserted the old append-wildcard behavior were updated to assert preservation, and tests for the empty and already-wildcard cases stay green. This is a stricter, access-preserving change with no new config surface.

## Verification
- node scripts/run-vitest.mjs on src/commands/doctor/shared/open-policy-allowfrom.test.ts (9 pass, including two updated cases and two new narrowed-list regressions), plus the adjacent src/commands/doctor/repair-sequencing.test.ts (8) and src/channels/message-access/message-access.test.ts (14).
- node scripts/run-oxlint.mjs and oxfmt --check on the changed files: clean.
- node scripts/run-tsgo.mjs for tsconfig.core.json and test/tsconfig/tsconfig.core.test.json: clean.
- The updated and new tests fail on pristine main and pass with the patch.

## Real behavior proof
Behavior addressed: openclaw doctor --fix appends a wildcard to a deliberately narrowed open-DM allowlist, which the access gate then reads as admit everyone.
Real environment tested: the real doctor open-policy repair maybeRepairOpenPolicyAllowFrom from src/commands/doctor/shared/open-policy-allowfrom.ts (the function openclaw doctor --fix applies at src/commands/doctor/repair-sequencing.ts) driven on pristine main ba34052a0e and on the patched tree with the same input config; the repair ran for real with nothing stubbed. The widened list matters because the DM gate at src/channels/message-access/sender-gates.ts treats a wildcard entry as admit all while a non-wildcard list admits only matched senders.
Exact steps or command run after this patch: start from channels.slack.dmPolicy=open with allowFrom ["u_alpha"], apply the doctor open-policy repair to that config, and print the resulting allowFrom plus the change lines the repair reported.
Evidence after fix:
```
# BEFORE (pristine main ba34052a0e)
input: channels.slack.dmPolicy=open
input: channels.slack.allowFrom=["u_alpha"]
doctor open-policy repair output allowFrom=["u_alpha","*"]
doctor change lines: ["- channels.slack.allowFrom: added \"*\" (required by dmPolicy=\"open\")"]
# AFTER (this patch, identical input)
input: channels.slack.dmPolicy=open
input: channels.slack.allowFrom=["u_alpha"]
doctor open-policy repair output allowFrom=["u_alpha"]
doctor change lines: []
```
Observed result after fix: the repair leaves the narrowed allowlist exactly as authored and reports no change, instead of adding a wildcard that would open the account to every sender.
What was not tested: no live Slack or Telegram delivery round trip; the open plus empty allowlist case still receives the wildcard it needs and is covered separately; full build not run.
