### PR TITLE
fix(channels): prioritize presentation over text in receipt kind resolution

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -444,6 +444,17 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
       accountId,
       payload,
     }),
+  presentationCapabilities: {
+    supported: true,
+    buttons: true,
+    selects: true,
+    context: true,
+    divider: true,
+  },
+  renderPresentation: async ({ payload, presentation, ctx }) => {
+    const { slackOutbound } = await loadSlackOutboundAdapterModule();
+    return slackOutbound.renderPresentation?.({ payload, presentation, ctx }) ?? null;
+  },
   sendPayload: async (ctx) => {
     const { send, threadTsValue, tokenOverride } = await resolveSlackSendContext({
       cfg: ctx.cfg,

--- a/src/channels/message/outbound-bridge.test.ts
+++ b/src/channels/message/outbound-bridge.test.ts
@@ -106,6 +106,28 @@ describe("createChannelMessageAdapterFromOutbound", () => {
     ).resolves.toEqual({ messageId: "legacy-id", receipt });
   });
 
+  it("infers receipt kind as card when both text and presentation are present (#95440)", async () => {
+    const sendPayload = vi.fn(async (_request: ChannelMessageSendPayloadContext) => ({
+      channel: "slack",
+      messageId: "card-2",
+    }));
+    const adapter = createChannelMessageAdapterFromOutbound({
+      capabilities: { payload: true, batch: true },
+      outbound: { sendPayload },
+    });
+
+    const result = await adapter.send?.payload?.({
+      cfg,
+      to: "C0XXXX",
+      text: "test",
+      payload: {
+        presentation: { blocks: [{ type: "text", text: "above" }, { type: "divider" }] },
+      },
+    });
+
+    expect(result?.receipt.parts[0]?.kind).toBe("card");
+  });
+
   it("wraps rich payload sends and infers the receipt part kind", async () => {
     const sendPayload = vi.fn(async (_request: ChannelMessageSendPayloadContext) => ({
       channel: "demo",

--- a/src/channels/message/outbound-bridge.ts
+++ b/src/channels/message/outbound-bridge.ts
@@ -116,11 +116,11 @@ function resolvePayloadReceiptKind(
   if (ctx.mediaUrl || ctx.payload.mediaUrl || ctx.payload.mediaUrls?.length) {
     return "media";
   }
-  if (ctx.payload.text?.trim() || ctx.text.trim()) {
-    return "text";
-  }
   if (ctx.payload.presentation?.blocks?.length || ctx.payload.interactive) {
     return "card";
+  }
+  if (ctx.payload.text?.trim() || ctx.text.trim()) {
+    return "text";
   }
   return "unknown";
 }


### PR DESCRIPTION
## Summary

Two bugs caused Slack presentation payloads to render as plain text instead of Block Kit:

1. **Missing facade bridge** (`extensions/slack/src/channel.ts`): The `slackChannelOutbound` facade did not expose `presentationCapabilities` or `renderPresentation`, even though the delegated `slackOutbound` adapter already implements them. The core delivery pipeline calls `renderPresentationForDelivery`, which checks `handler.renderPresentation` from the channel outbound adapter. Since it was `undefined` on the Slack facade, the pipeline fell back to `renderMessagePresentationFallbackText`, converting the presentation to plain text before send.

2. **Incorrect receipt kind priority** (`src/channels/message/outbound-bridge.ts`): `resolvePayloadReceiptKind` checked `text` before `presentation`, so messages with both text and presentation classified as `"text"` instead of `"card"`.

Fixes #95440

## Changes

- **`extensions/slack/src/channel.ts`**: Bridge `presentationCapabilities` and `renderPresentation` from `slackChannelOutbound` to the existing `slackOutbound` implementation.
- **`src/channels/message/outbound-bridge.ts`**: Move the `presentation`/`interactive` check above the `text` check in `resolvePayloadReceiptKind`.
- **`src/channels/message/outbound-bridge.test.ts`**: Add regression test for text+presentation → kind `"card"`.

## Change Type

- [x] Bug fix

## Scope

- [ ] Gateway / [ ] Skills / [ ] Auth / [ ] Memory / [x] Integrations / [x] API / [ ] UI/UX / [ ] CI

## Real behavior proof

**Behavior addressed:** Slack presentation payload (Block Kit) is delivered as plain text (`kind: "text"`) instead of card (`kind: "card"`) when the message also carries text content. The root cause is the missing `renderPresentation` bridge on `slackChannelOutbound` plus incorrect receipt kind priority.

**Environment tested:** Node.js v24.13.1 on Linux, OpenClaw main branch and PR branch.

**Exact steps run after the patch:** Called `createChannelMessageAdapterFromOutbound` with `sendPayload` handler and sent a payload with both `text: "test"` and `presentation: { blocks: [...] }`, then inspected `receipt.parts[0].kind`. Also verified that `slackChannelOutbound.renderPresentation` is defined and delegates to `slackOutbound.renderPresentation`.

**Evidence before fix (upstream/main — bug present):**

```text
=== #95440 proof ===
Input: text='test' + presentation with blocks
Receipt kind: text
Expected: card
Result: FAIL ❌

Input: text='' + presentation with blocks
Receipt kind: card
Expected: card
Result: PASS ✅

Input: text='hello' only (no presentation)
Receipt kind: text
Expected: text
Result: PASS ✅
```

**Evidence after fix (PR branch — bug fixed):**

```text
=== #95440 proof ===
Input: text='test' + presentation with blocks
Receipt kind: card
Expected: card
Result: PASS ✅

Input: text='' + presentation with blocks
Receipt kind: card
Expected: card
Result: PASS ✅

Input: text='hello' only (no presentation)
Receipt kind: text
Expected: text
Result: PASS ✅
```

**Observed result after the fix:** Messages with both text and presentation now correctly resolve as `"card"`. Messages with presentation only still resolve as `"card"`. Messages with text only still resolve as `"text"`. The Slack facade now exposes `renderPresentation` so the core delivery pipeline can build Block Kit blocks before sending.

**What was not tested:** Live Slack delivery with `openclaw message send --presentation` against a real Slack workspace.