### PR TITLE
feat(work): add Beads-backed work tracking

### DIFF
--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -16,6 +16,8 @@ Background tasks track work that runs **outside your main conversation session**
 
 Tasks do **not** replace sessions, cron jobs, or heartbeats - they are the **activity ledger** that records what detached work happened, when, and whether it succeeded.
 
+For durable multi-step planning, PR ownership, dependency graphs, and next actions, use [Work tracking](/automation/work-tracking). That Beads-backed work graph is the source of truth for long-horizon coordination; task records stay focused on runtime execution and delivery evidence.
+
 <Note>
 Not every agent run creates a task. Heartbeat turns and normal interactive chat do not. All cron executions, ACP spawns, subagent spawns, and CLI agent commands do.
 </Note>

--- a/docs/automation/work-tracking.md
+++ b/docs/automation/work-tracking.md
@@ -1,0 +1,110 @@
+---
+summary: "Durable Beads work graph tracking for long-horizon OpenClaw and Klaw orchestration"
+read_when:
+  - Planning multi-step agent work with dependencies
+  - Replacing worker-state files with a durable work graph
+  - Deciding when to use Beads instead of the OpenClaw task ledger
+title: "Work tracking"
+sidebarTitle: "Work tracking"
+---
+
+OpenClaw uses two different records for two different jobs:
+
+- **Tasks** are the runtime activity ledger. They record detached ACP runs, subagents, cron runs, CLI operations, delivery state, and cleanup.
+- **Work items** are durable coordination records. They live in Beads and describe what should be done, what blocks it, who owns it, and what the next action is.
+
+Use Beads for long-horizon OpenClaw/Klaw coordination. Do not use `worker-state.json` or another editable projection as the source of truth for active work, dependency state, PR ownership, or next actions.
+
+## Why Beads
+
+Beads gives agents a repo-local issue graph:
+
+- issue types, priorities, labels, assignees, metadata, and external refs
+- dependency edges such as `blocks`, `discovered-from`, `parent-child`, and `related`
+- `bd ready --json` for unblocked work
+- `bd list --json`, `bd show --json`, `bd create --json`, `bd update --json`, and `bd close --json` for agent automation
+- repo-local Dolt storage under `.beads`
+
+OpenClaw's `openclaw work` command is a thin bridge over the Beads CLI. It does not copy Beads into OpenClaw SQLite, and it does not make `worker-state.json` authoritative.
+
+## Setup
+
+Install Beads and initialize a workspace:
+
+```bash
+npm install -g @beads/bd@1.0.4
+bd init
+bd status
+```
+
+<Note>
+Beads `1.0.5` is currently marked as a gated upstream release for multi-machine Dolt sync. Pin `@beads/bd@1.0.4` until upstream publishes a cleared `1.0.6` or later.
+</Note>
+
+For an existing shared Beads database, set `BEADS_DIR` before running OpenClaw commands:
+
+```bash
+export BEADS_DIR=/path/to/repo/.beads
+openclaw work status
+```
+
+If Beads is missing or no workspace is initialized, `openclaw work` fails with setup guidance instead of falling back to a local JSON cache.
+
+## Workflow
+
+Create a parent item for a multi-step effort, then create dependent work items for the real units of work:
+
+```bash
+openclaw work create "Replace local worker state with Beads" \
+  --type epic \
+  --priority P1 \
+  --label openclaw \
+  --label klaw \
+  --repo openclaw/openclaw
+
+openclaw work create "Add Beads CLI bridge" \
+  --type task \
+  --priority P1 \
+  --label openclaw \
+  --repo openclaw/openclaw \
+  --branch klaw/beads-work-tracking \
+  --pr-url https://github.com/openclaw/openclaw/pull/123 \
+  --next-action "run focused tests" \
+  --depends-on <parent-bead-id>
+```
+
+Agents should claim from Beads, not from a homegrown projection:
+
+```bash
+openclaw work ready --json --label openclaw --metadata repo=openclaw/openclaw
+openclaw work claim <bead-id>
+openclaw work show <bead-id>
+```
+
+When a PR lands or a task is intentionally abandoned, close the Beads item with the reason:
+
+```bash
+openclaw work close <bead-id> --reason "merged in PR 123"
+```
+
+## Mapping OpenClaw work
+
+Use Beads metadata for operational fields that were previously easy to put in ad hoc worker-state files:
+
+| Field        | Beads location                                   |
+| ------------ | ------------------------------------------------ |
+| Repository   | `metadata.repo`                                  |
+| Branch       | `metadata.branch`                                |
+| Pull request | `metadata.prUrl` or `external_ref`               |
+| Owner        | Beads assignee or `metadata.owner`               |
+| Next action  | `metadata.nextAction` or issue notes             |
+| Blockers     | Beads dependency edges                           |
+| Ready work   | `bd ready --json` / `openclaw work ready --json` |
+
+Keep OpenClaw task ledger records for runtime execution evidence: task IDs, run IDs, session keys, delivery status, terminal outcome, and cleanup. Link those runtime facts from Beads notes or metadata only when they help coordination.
+
+## Related
+
+- [Background tasks](/automation/tasks)
+- [`openclaw work`](/cli/work)
+- [`openclaw tasks`](/cli/tasks)

--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -10,6 +10,7 @@ Inspect durable background tasks and Task Flow state. With no subcommand,
 `openclaw tasks` is equivalent to `openclaw tasks list`.
 
 See [Background Tasks](/automation/tasks) for the lifecycle and delivery model.
+For durable planning and dependency coordination, use [`openclaw work`](/cli/work), which delegates to Beads instead of the task ledger.
 
 ## Usage
 

--- a/docs/cli/work.md
+++ b/docs/cli/work.md
@@ -1,0 +1,122 @@
+---
+summary: "CLI reference for `openclaw work` Beads-backed durable work tracking"
+read_when:
+  - You want to create, claim, list, or close Beads work from OpenClaw
+  - You are coordinating OpenClaw/Klaw work across dependencies and PRs
+title: "`openclaw work`"
+---
+
+Coordinate durable multi-step work with Beads. `openclaw work` delegates to the `bd` CLI with JSON output and keeps Beads as the source of truth for long-horizon planning, dependencies, ownership, and next actions.
+
+Use [`openclaw tasks`](/cli/tasks) for runtime activity records. Use `openclaw work` for the durable work graph.
+
+## Requirements
+
+`openclaw work` requires Beads:
+
+```bash
+npm install -g @beads/bd@1.0.4
+bd init
+```
+
+<Note>
+Beads `1.0.5` is currently marked as a gated upstream release for multi-machine Dolt sync. Pin `@beads/bd@1.0.4` until upstream publishes a cleared `1.0.6` or later.
+</Note>
+
+If the current repository has no `.beads` workspace, set `BEADS_DIR` to an existing Beads directory.
+
+## Usage
+
+```bash
+openclaw work status
+openclaw work ready
+openclaw work list
+openclaw work create <title>
+openclaw work claim <id>
+openclaw work show <id>
+openclaw work close <id>
+```
+
+## Subcommands
+
+### `status`
+
+```bash
+openclaw work status [--json]
+```
+
+Shows whether a Beads workspace is available.
+
+### `ready`
+
+```bash
+openclaw work ready [--label <name>] [--metadata <key=value>] [--limit <n>] [--json]
+```
+
+Shows unblocked Beads issues using Beads ready-work semantics. Repeat `--label` or `--metadata` to narrow the queue.
+
+### `list`
+
+```bash
+openclaw work list [--status <name>] [--all] [--label <name>] [--metadata <key=value>] [--limit <n>] [--json]
+```
+
+Lists Beads work items. `--metadata repo=openclaw/openclaw` maps to Beads metadata filtering, not to an OpenClaw cache.
+
+### `create`
+
+```bash
+openclaw work create "Fix gateway retry" \
+  --type task \
+  --priority P1 \
+  --label openclaw \
+  --repo openclaw/openclaw \
+  --branch fix/gateway-retry \
+  --pr-url https://github.com/openclaw/openclaw/pull/123 \
+  --next-action "wait for CI" \
+  --depends-on <bead-id>
+```
+
+Creates a Beads issue. OpenClaw-specific options are stored as Beads metadata:
+
+- `--repo <name>` -> `metadata.repo`
+- `--branch <name>` -> `metadata.branch`
+- `--pr-url <url>` -> `metadata.prUrl` and default external ref
+- `--owner <name>` -> `metadata.owner`
+- `--next-action <text>` -> `metadata.nextAction`
+- `--metadata <key=value>` -> exact Beads metadata
+
+Dependency options create Beads edges:
+
+- `--depends-on <id>` -> `blocks:<id>`
+- `--discovered-from <id>` -> `discovered-from:<id>`
+
+### `claim`
+
+```bash
+openclaw work claim <id> [--json]
+```
+
+Claims a Beads item for the current Beads actor.
+
+### `show`
+
+```bash
+openclaw work show <id> [--json]
+```
+
+Shows one Beads work item.
+
+### `close`
+
+```bash
+openclaw work close <id> [--reason <text>] [--json]
+```
+
+Closes a Beads item after the durable coordination work is complete or intentionally superseded.
+
+## Related
+
+- [Work tracking](/automation/work-tracking)
+- [Background tasks](/automation/tasks)
+- [`openclaw tasks`](/cli/tasks)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1285,6 +1285,7 @@
                   "automation/index",
                   "automation/cron-jobs",
                   "automation/tasks",
+                  "automation/work-tracking",
                   "automation/taskflow",
                   "automation/standing-orders",
                   "automation/hooks"
@@ -1692,7 +1693,8 @@
                       "cli/models",
                       "cli/sessions",
                       "cli/system",
-                      "cli/tasks"
+                      "cli/tasks",
+                      "cli/work"
                     ]
                   },
                   {

--- a/src/cli/program/command-registry-core.ts
+++ b/src/cli/program/command-registry-core.ts
@@ -138,6 +138,11 @@ const coreEntrySpecs: readonly CommandGroupDescriptorSpec<
         loadModule: () => import("./register.status-health-sessions.js"),
         exportName: "registerStatusHealthSessionsCommands",
       },
+      {
+        commandNames: ["work"],
+        loadModule: () => import("./register.work.js"),
+        exportName: "registerWorkCommands",
+      },
     ]),
   ),
 ];

--- a/src/cli/program/command-registry.test.ts
+++ b/src/cli/program/command-registry.test.ts
@@ -44,6 +44,13 @@ vi.mock("./register.status-health-sessions.js", () => ({
   },
 }));
 
+vi.mock("./register.work.js", () => ({
+  registerWorkCommands: (program: Command) => {
+    const work = program.command("work");
+    work.command("ready");
+  },
+}));
+
 vi.mock("./register.crestodian.js", () => ({
   registerCrestodianCommand: (program: Command) => {
     program.command("crestodian");
@@ -95,6 +102,7 @@ describe("command-registry", () => {
     expect(names).toContain("sessions");
     expect(names).toContain("commitments");
     expect(names).toContain("tasks");
+    expect(names).toContain("work");
     expect(names).not.toContain("agent");
     expect(names).not.toContain("crestodian");
     expect(names).not.toContain("status");
@@ -171,6 +179,7 @@ describe("command-registry", () => {
     expect(names).toContain("sessions");
     expect(names).toContain("commitments");
     expect(names).toContain("tasks");
+    expect(names).toContain("work");
   });
 
   it("can eagerly register the status/session command group repeatedly for completion", async () => {
@@ -185,6 +194,14 @@ describe("command-registry", () => {
       names.reduce((count, name) => count + (name === target ? 1 : 0), 0);
     expect(countName("commitments")).toBe(1);
     expect(countName("tasks")).toBe(1);
+  });
+
+  it("registers the Beads work command group independently", async () => {
+    const program = createProgram();
+    await expect(registerCoreCliByName(program, testProgramContext, "work")).resolves.toBe(true);
+
+    expect(namesOf(program)).toEqual(["work"]);
+    expect(program.commands[0]?.commands.map((command) => command.name())).toEqual(["ready"]);
   });
 
   it("replaces placeholders when loading a grouped entry by secondary command name", async () => {

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -113,6 +113,11 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
     description: "Inspect durable background tasks and flows",
     hasSubcommands: true,
   },
+  {
+    name: "work",
+    description: "Coordinate durable multi-step work with Beads",
+    hasSubcommands: true,
+  },
 ] as const satisfies ReadonlyArray<CoreCliCommandDescriptor>);
 
 /** Static root-command descriptors for the core CLI surface. */

--- a/src/cli/program/register.work.test.ts
+++ b/src/cli/program/register.work.test.ts
@@ -1,0 +1,130 @@
+// Register work command tests cover Beads command option forwarding.
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerWorkCommands } from "./register.work.js";
+
+const mocks = vi.hoisted(() => ({
+  workStatusCommand: vi.fn(),
+  workReadyCommand: vi.fn(),
+  workListCommand: vi.fn(),
+  workCreateCommand: vi.fn(),
+  workClaimCommand: vi.fn(),
+  workShowCommand: vi.fn(),
+  workCloseCommand: vi.fn(),
+  runtime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../../commands/work.js", () => ({
+  workStatusCommand: mocks.workStatusCommand,
+  workReadyCommand: mocks.workReadyCommand,
+  workListCommand: mocks.workListCommand,
+  workCreateCommand: mocks.workCreateCommand,
+  workClaimCommand: mocks.workClaimCommand,
+  workShowCommand: mocks.workShowCommand,
+  workCloseCommand: mocks.workCloseCommand,
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+describe("registerWorkCommands", () => {
+  async function runCli(args: string[]) {
+    const program = new Command();
+    registerWorkCommands(program);
+    await program.parseAsync(args, { from: "user" });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.runtime.exit.mockImplementation(() => {});
+    mocks.workStatusCommand.mockResolvedValue(undefined);
+    mocks.workReadyCommand.mockResolvedValue(undefined);
+    mocks.workListCommand.mockResolvedValue(undefined);
+    mocks.workCreateCommand.mockResolvedValue(undefined);
+    mocks.workClaimCommand.mockResolvedValue(undefined);
+    mocks.workShowCommand.mockResolvedValue(undefined);
+    mocks.workCloseCommand.mockResolvedValue(undefined);
+  });
+
+  it("forwards ready filters to the work command", async () => {
+    await runCli([
+      "work",
+      "ready",
+      "--json",
+      "--limit",
+      "10",
+      "--label",
+      "openclaw",
+      "--metadata",
+      "repo=openclaw/openclaw",
+    ]);
+
+    expect(mocks.workReadyCommand).toHaveBeenCalledWith(
+      {
+        json: true,
+        label: ["openclaw"],
+        limit: 10,
+        metadata: ["repo=openclaw/openclaw"],
+      },
+      mocks.runtime,
+    );
+  });
+
+  it("forwards create options to the work command", async () => {
+    await runCli([
+      "work",
+      "create",
+      "Add Beads work tracking",
+      "--type",
+      "task",
+      "--priority",
+      "P1",
+      "--label",
+      "klaw",
+      "--repo",
+      "openclaw/openclaw",
+      "--branch",
+      "klaw/beads-work-tracking",
+      "--pr-url",
+      "https://github.com/openclaw/openclaw/pull/123",
+      "--depends-on",
+      "bd-parent",
+    ]);
+
+    expect(mocks.workCreateCommand).toHaveBeenCalledWith(
+      {
+        branch: "klaw/beads-work-tracking",
+        dependsOn: ["bd-parent"],
+        description: undefined,
+        discoveredFrom: undefined,
+        externalRef: undefined,
+        json: false,
+        label: ["klaw"],
+        metadata: undefined,
+        nextAction: undefined,
+        owner: undefined,
+        priority: "P1",
+        prUrl: "https://github.com/openclaw/openclaw/pull/123",
+        repo: "openclaw/openclaw",
+        title: "Add Beads work tracking",
+        type: "task",
+      },
+      mocks.runtime,
+    );
+  });
+
+  it("rejects invalid ready limits", async () => {
+    await runCli(["work", "ready", "--limit", "nope"]);
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      "--limit must be a positive integer, for example --limit 25.",
+    );
+    expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.workReadyCommand).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/program/register.work.ts
+++ b/src/cli/program/register.work.ts
@@ -1,0 +1,213 @@
+// Register Beads-backed durable work graph commands.
+import type { Command } from "commander";
+import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
+import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { defaultRuntime } from "../../runtime.js";
+import { runCommandWithRuntime } from "../cli-utils.js";
+import { formatHelpExamples } from "../help-format.js";
+import { parseStrictPositiveIntOrUndefined } from "./helpers.js";
+
+function parseLimit(limit: unknown): number | undefined | null {
+  const parsed = parseStrictPositiveIntOrUndefined(limit);
+  if (limit !== undefined && parsed === undefined) {
+    defaultRuntime.error("--limit must be a positive integer, for example --limit 25.");
+    defaultRuntime.exit(1);
+    return null;
+  }
+  return parsed;
+}
+
+function addCommonListOptions(command: Command): Command {
+  return command
+    .option("--json", "Output JSON", false)
+    .option("--limit <n>", "Limit displayed work items")
+    .option("--label <name>", "Require a label (repeatable)", (value, previous: string[] = []) => [
+      ...previous,
+      value,
+    ])
+    .option(
+      "--metadata <key=value>",
+      "Require an exact metadata match (repeatable)",
+      (value, previous: string[] = []) => [...previous, value],
+    );
+}
+
+/** Register the Beads-backed durable work graph CLI group. */
+export function registerWorkCommands(program: Command): void {
+  const work = program
+    .command("work")
+    .description("Coordinate durable multi-step work with Beads")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw work ready", "Show unblocked work from the Beads graph."],
+          [
+            'openclaw work create "Fix gateway retry" --repo openclaw/openclaw --branch fix/retry --pr-url https://github.com/openclaw/openclaw/pull/123',
+            "Create a durable work item with repo, branch, and PR metadata.",
+          ],
+          ["openclaw work claim bd-a1b2c3", "Claim a ready Beads item."],
+          ["openclaw work close bd-a1b2c3 --reason merged", "Close finished work."],
+        ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/work", "docs.openclaw.ai/cli/work")}\n`,
+    );
+  work.enablePositionalOptions();
+
+  work
+    .command("status")
+    .description("Show Beads workspace status")
+    .option("--json", "Output JSON", false)
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const { workStatusCommand } = await import("../../commands/work.js");
+        await workStatusCommand({ json: Boolean(opts.json) }, defaultRuntime);
+      });
+    });
+
+  addCommonListOptions(work.command("ready").description("Show unblocked Beads work")).action(
+    async (opts) => {
+      const limit = parseLimit(opts.limit);
+      if (limit === null) {
+        return;
+      }
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const { workReadyCommand } = await import("../../commands/work.js");
+        await workReadyCommand(
+          {
+            json: Boolean(opts.json),
+            limit,
+            label: opts.label as string[] | undefined,
+            metadata: opts.metadata as string[] | undefined,
+          },
+          defaultRuntime,
+        );
+      });
+    },
+  );
+
+  addCommonListOptions(work.command("list").description("List Beads work"))
+    .option("--status <name>", "Filter by Beads status")
+    .option("--all", "Include closed work", false)
+    .action(async (opts) => {
+      const limit = parseLimit(opts.limit);
+      if (limit === null) {
+        return;
+      }
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const { workListCommand } = await import("../../commands/work.js");
+        await workListCommand(
+          {
+            json: Boolean(opts.json),
+            limit,
+            label: opts.label as string[] | undefined,
+            metadata: opts.metadata as string[] | undefined,
+            status: opts.status as string | undefined,
+            all: Boolean(opts.all),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  work
+    .command("create")
+    .description("Create a Beads work item")
+    .argument("<title>", "Work item title")
+    .option("--json", "Output JSON", false)
+    .option("--type <name>", "Beads type (task, bug, feature, epic, chore, decision)", "task")
+    .option("--priority <value>", "Beads priority (P0-P4)", "P2")
+    .option("--label <name>", "Add label (repeatable)", (value, previous: string[] = []) => [
+      ...previous,
+      value,
+    ])
+    .option(
+      "--metadata <key=value>",
+      "Set metadata (repeatable)",
+      (value, previous: string[] = []) => [...previous, value],
+    )
+    .option("--repo <name>", "Repository metadata, for example openclaw/openclaw")
+    .option("--branch <name>", "Branch metadata")
+    .option("--pr-url <url>", "Pull request URL metadata and external ref")
+    .option("--owner <name>", "Owner metadata")
+    .option("--next-action <text>", "Next action metadata")
+    .option("--description <text>", "Description")
+    .option("--external-ref <value>", "External reference, for example gh-123")
+    .option(
+      "--depends-on <id>",
+      "Add a blocking dependency (repeatable)",
+      (value, previous: string[] = []) => [...previous, value],
+    )
+    .option(
+      "--discovered-from <id>",
+      "Add a discovered-from dependency (repeatable)",
+      (value, previous: string[] = []) => [...previous, value],
+    )
+    .action(async (title, opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const { workCreateCommand } = await import("../../commands/work.js");
+        await workCreateCommand(
+          {
+            title,
+            json: Boolean(opts.json),
+            type: opts.type as string | undefined,
+            priority: opts.priority as string | undefined,
+            label: opts.label as string[] | undefined,
+            metadata: opts.metadata as string[] | undefined,
+            repo: opts.repo as string | undefined,
+            branch: opts.branch as string | undefined,
+            prUrl: opts.prUrl as string | undefined,
+            owner: opts.owner as string | undefined,
+            nextAction: opts.nextAction as string | undefined,
+            description: opts.description as string | undefined,
+            externalRef: opts.externalRef as string | undefined,
+            dependsOn: opts.dependsOn as string[] | undefined,
+            discoveredFrom: opts.discoveredFrom as string[] | undefined,
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  work
+    .command("claim")
+    .description("Claim a Beads work item")
+    .argument("<id>", "Beads issue id")
+    .option("--json", "Output JSON", false)
+    .action(async (id, opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const { workClaimCommand } = await import("../../commands/work.js");
+        await workClaimCommand({ id, json: Boolean(opts.json) }, defaultRuntime);
+      });
+    });
+
+  work
+    .command("show")
+    .description("Show one Beads work item")
+    .argument("<id>", "Beads issue id")
+    .option("--json", "Output JSON", false)
+    .action(async (id, opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const { workShowCommand } = await import("../../commands/work.js");
+        await workShowCommand({ id, json: Boolean(opts.json) }, defaultRuntime);
+      });
+    });
+
+  work
+    .command("close")
+    .description("Close a Beads work item")
+    .argument("<id>", "Beads issue id")
+    .option("--json", "Output JSON", false)
+    .option("--reason <text>", "Close reason")
+    .action(async (id, opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const { workCloseCommand } = await import("../../commands/work.js");
+        await workCloseCommand(
+          {
+            id,
+            json: Boolean(opts.json),
+            reason: opts.reason as string | undefined,
+          },
+          defaultRuntime,
+        );
+      });
+    });
+}

--- a/src/commands/work.test.ts
+++ b/src/commands/work.test.ts
@@ -1,0 +1,140 @@
+// Work command tests cover the Beads-backed orchestration CLI behavior.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BeadsClient, BeadsIssue } from "../work-tracking/beads.js";
+import {
+  workCloseCommand,
+  workCreateCommand,
+  workListCommand,
+  workReadyCommand,
+  workShowCommand,
+} from "./work.js";
+
+const runtime = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
+  writeStdout: vi.fn(),
+  writeJson: vi.fn(),
+};
+
+const sampleIssue: BeadsIssue = {
+  id: "bd-123",
+  issue_type: "task",
+  metadata: { branch: "klaw/beads-work-tracking", repo: "openclaw/openclaw" },
+  priority: 1,
+  status: "open",
+  title: "Add Beads work tracking",
+};
+
+function createMockClient(): BeadsClient {
+  return {
+    status: vi.fn(async () => ({ ok: true })),
+    ready: vi.fn(async () => [sampleIssue]),
+    list: vi.fn(async () => [sampleIssue]),
+    show: vi.fn(async () => sampleIssue),
+    create: vi.fn(async () => sampleIssue),
+    claim: vi.fn(async () => sampleIssue),
+    close: vi.fn(async () => ({ closed: true })),
+  };
+}
+
+describe("work commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates Beads work with repo, branch, PR, next action, and dependency metadata", async () => {
+    const client = createMockClient();
+
+    await workCreateCommand(
+      {
+        title: "Add Beads work tracking",
+        json: true,
+        type: "task",
+        priority: "P1",
+        label: ["openclaw", "klaw"],
+        metadata: ["source=agent"],
+        repo: "openclaw/openclaw",
+        branch: "klaw/beads-work-tracking",
+        prUrl: "https://github.com/openclaw/openclaw/pull/123",
+        nextAction: "review",
+        dependsOn: ["bd-parent"],
+        discoveredFrom: ["bd-discovery"],
+      },
+      runtime,
+      { client },
+    );
+
+    expect(client.create).toHaveBeenCalledWith({
+      title: "Add Beads work tracking",
+      type: "task",
+      priority: "P1",
+      labels: ["openclaw", "klaw"],
+      metadata: {
+        branch: "klaw/beads-work-tracking",
+        nextAction: "review",
+        prUrl: "https://github.com/openclaw/openclaw/pull/123",
+        repo: "openclaw/openclaw",
+        source: "agent",
+      },
+      description: undefined,
+      externalRef: "https://github.com/openclaw/openclaw/pull/123",
+      dependencies: ["blocks:bd-parent", "discovered-from:bd-discovery"],
+    });
+    expect(runtime.writeJson).toHaveBeenCalledWith({ work: sampleIssue }, 2);
+  });
+
+  it("lists ready work through Beads ready instead of task ledger state", async () => {
+    const client = createMockClient();
+
+    await workReadyCommand(
+      {
+        json: true,
+        limit: 25,
+        label: ["openclaw"],
+        metadata: ["repo=openclaw/openclaw"],
+      },
+      runtime,
+      { client },
+    );
+
+    expect(client.ready).toHaveBeenCalledWith({
+      limit: 25,
+      labels: ["openclaw"],
+      metadata: { repo: "openclaw/openclaw" },
+    });
+    expect(runtime.writeJson).toHaveBeenCalledWith({ count: 1, work: [sampleIssue] }, 2);
+  });
+
+  it("lists Beads work with status and all filters", async () => {
+    const client = createMockClient();
+
+    await workListCommand(
+      {
+        json: true,
+        status: "in_progress",
+        all: true,
+      },
+      runtime,
+      { client },
+    );
+
+    expect(client.list).toHaveBeenCalledWith({
+      all: true,
+      labels: undefined,
+      limit: undefined,
+      metadata: {},
+      status: "in_progress",
+    });
+  });
+
+  it("shows and closes Beads work items", async () => {
+    const client = createMockClient();
+
+    await workShowCommand({ id: "bd-123", json: true }, runtime, { client });
+    await workCloseCommand({ id: "bd-123", reason: "merged", json: true }, runtime, { client });
+
+    expect(client.show).toHaveBeenCalledWith("bd-123");
+    expect(client.close).toHaveBeenCalledWith("bd-123", { reason: "merged" });
+  });
+});

--- a/src/commands/work.ts
+++ b/src/commands/work.ts
@@ -1,0 +1,306 @@
+// Human-facing durable work graph commands backed by Beads.
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import { theme } from "../../packages/terminal-core/src/theme.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import {
+  buildOpenClawWorkMetadata,
+  createBeadsClient,
+  formatMissingBeadsMessage,
+  parseBeadsMetadataFilters,
+  type BeadsClient,
+  type BeadsIssue,
+  type BeadsIssueMetadata,
+} from "../work-tracking/beads.js";
+
+type WorkCommandContext = {
+  client?: BeadsClient;
+};
+
+type WorkCreateOptions = {
+  title: string;
+  json?: boolean;
+  type?: string;
+  priority?: string;
+  label?: string[];
+  metadata?: string[];
+  repo?: string;
+  branch?: string;
+  prUrl?: string;
+  owner?: string;
+  nextAction?: string;
+  description?: string;
+  externalRef?: string;
+  dependsOn?: string[];
+  discoveredFrom?: string[];
+};
+
+type WorkListOptions = {
+  json?: boolean;
+  limit?: number;
+  label?: string[];
+  metadata?: string[];
+  status?: string;
+  all?: boolean;
+};
+
+const info = theme.info;
+
+function safe(value: string): string {
+  return sanitizeTerminalText(value);
+}
+
+function truncate(value: string, maxChars: number): string {
+  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}...`;
+}
+
+function getClient(context: WorkCommandContext | undefined): BeadsClient {
+  return context?.client ?? createBeadsClient();
+}
+
+function parseWorkMetadata(opts: {
+  metadata?: string[];
+  repo?: string;
+  branch?: string;
+  prUrl?: string;
+  owner?: string;
+  nextAction?: string;
+}): BeadsIssueMetadata {
+  return buildOpenClawWorkMetadata({
+    metadata: parseBeadsMetadataFilters(opts.metadata),
+    repo: opts.repo,
+    branch: opts.branch,
+    prUrl: opts.prUrl,
+    owner: opts.owner,
+    nextAction: opts.nextAction,
+  });
+}
+
+function normalizeDependency(type: string, id: string): string {
+  return id.includes(":") ? id : `${type}:${id}`;
+}
+
+function parseDependencies(opts: WorkCreateOptions): string[] {
+  return [
+    ...(opts.dependsOn ?? []).map((id) => normalizeDependency("blocks", id)),
+    ...(opts.discoveredFrom ?? []).map((id) => normalizeDependency("discovered-from", id)),
+  ];
+}
+
+function issueType(issue: BeadsIssue): string {
+  return issue.issue_type ?? issue.type ?? "task";
+}
+
+function issueStatus(issue: BeadsIssue): string {
+  return issue.status ?? "open";
+}
+
+function formatIssueRows(issues: readonly BeadsIssue[]): string[] {
+  const header = ["ID".padEnd(18), "Status".padEnd(12), "Type".padEnd(12), "P", "Title"].join(" ");
+  const lines = [theme.heading(header)];
+  for (const issue of issues) {
+    lines.push(
+      [
+        truncate(safe(issue.id), 18).padEnd(18),
+        truncate(safe(issueStatus(issue)), 12).padEnd(12),
+        truncate(safe(issueType(issue)), 12).padEnd(12),
+        String(issue.priority ?? "").padEnd(1),
+        truncate(safe(issue.title), 90),
+      ].join(" "),
+    );
+  }
+  return lines;
+}
+
+function formatIssueDetail(issue: BeadsIssue): string[] {
+  const metadata = Object.entries(issue.metadata ?? {});
+  return [
+    info(`Bead: ${issue.id}`),
+    `Title: ${safe(issue.title)}`,
+    `Status: ${safe(issueStatus(issue))}`,
+    `Type: ${safe(issueType(issue))}`,
+    `Priority: ${String(issue.priority ?? "n/a")}`,
+    ...(issue.external_ref ? [`External ref: ${safe(issue.external_ref)}`] : []),
+    ...(metadata.length > 0
+      ? ["Metadata:", ...metadata.map(([key, value]) => `  ${safe(key)}=${safe(String(value))}`)]
+      : []),
+  ];
+}
+
+async function runBeadsCommand<T>(
+  runtime: RuntimeEnv,
+  action: () => Promise<T>,
+): Promise<T | null> {
+  try {
+    return await action();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    runtime.error(message || formatMissingBeadsMessage());
+    runtime.exit(1);
+    return null;
+  }
+}
+
+/** Show the Beads workspace status used by OpenClaw work tracking. */
+export async function workStatusCommand(
+  opts: { json?: boolean },
+  runtime: RuntimeEnv,
+  context?: WorkCommandContext,
+): Promise<void> {
+  const result = await runBeadsCommand(runtime, () => getClient(context).status());
+  if (result === null) {
+    return;
+  }
+  if (opts.json) {
+    writeRuntimeJson(runtime, result);
+    return;
+  }
+  runtime.log(info("Beads work graph is available."));
+}
+
+/** List ready Beads work that is not blocked by active dependencies. */
+export async function workReadyCommand(
+  opts: WorkListOptions,
+  runtime: RuntimeEnv,
+  context?: WorkCommandContext,
+): Promise<void> {
+  const metadata = parseBeadsMetadataFilters(opts.metadata);
+  const issues = await runBeadsCommand(runtime, () =>
+    getClient(context).ready({
+      limit: opts.limit,
+      labels: opts.label,
+      metadata,
+    }),
+  );
+  if (!issues) {
+    return;
+  }
+  if (opts.json) {
+    writeRuntimeJson(runtime, { count: issues.length, work: issues });
+    return;
+  }
+  runtime.log(info(`Ready work: ${issues.length}`));
+  for (const line of formatIssueRows(issues)) {
+    runtime.log(line);
+  }
+}
+
+/** List Beads work items for OpenClaw/Klaw orchestration. */
+export async function workListCommand(
+  opts: WorkListOptions,
+  runtime: RuntimeEnv,
+  context?: WorkCommandContext,
+): Promise<void> {
+  const metadata = parseBeadsMetadataFilters(opts.metadata);
+  const issues = await runBeadsCommand(runtime, () =>
+    getClient(context).list({
+      limit: opts.limit,
+      labels: opts.label,
+      metadata,
+      status: opts.status,
+      all: opts.all,
+    }),
+  );
+  if (!issues) {
+    return;
+  }
+  if (opts.json) {
+    writeRuntimeJson(runtime, { count: issues.length, work: issues });
+    return;
+  }
+  runtime.log(info(`Work items: ${issues.length}`));
+  for (const line of formatIssueRows(issues)) {
+    runtime.log(line);
+  }
+}
+
+/** Create a Beads work item with OpenClaw orchestration metadata. */
+export async function workCreateCommand(
+  opts: WorkCreateOptions,
+  runtime: RuntimeEnv,
+  context?: WorkCommandContext,
+): Promise<void> {
+  const metadata = parseWorkMetadata(opts);
+  const issue = await runBeadsCommand(runtime, () =>
+    getClient(context).create({
+      title: opts.title,
+      type: opts.type,
+      priority: opts.priority,
+      labels: opts.label,
+      metadata,
+      description: opts.description,
+      externalRef: opts.externalRef ?? opts.prUrl,
+      dependencies: parseDependencies(opts),
+    }),
+  );
+  if (!issue) {
+    return;
+  }
+  if (opts.json) {
+    writeRuntimeJson(runtime, { work: issue });
+    return;
+  }
+  runtime.log(info(`Created Beads work item: ${issue.id}`));
+  runtime.log(`Next: ${formatCliCommand(`openclaw work claim ${issue.id}`)}`);
+}
+
+/** Claim a Beads work item for the current actor. */
+export async function workClaimCommand(
+  opts: { id: string; json?: boolean },
+  runtime: RuntimeEnv,
+  context?: WorkCommandContext,
+): Promise<void> {
+  const issue = await runBeadsCommand(runtime, () => getClient(context).claim(opts.id));
+  if (!issue) {
+    return;
+  }
+  if (opts.json) {
+    writeRuntimeJson(runtime, { work: issue });
+    return;
+  }
+  runtime.log(info(`Claimed Beads work item: ${issue.id}`));
+}
+
+/** Show one Beads work item. */
+export async function workShowCommand(
+  opts: { id: string; json?: boolean },
+  runtime: RuntimeEnv,
+  context?: WorkCommandContext,
+): Promise<void> {
+  const result = await runBeadsCommand(runtime, () => getClient(context).show(opts.id));
+  if (!result) {
+    return;
+  }
+  if (opts.json) {
+    writeRuntimeJson(runtime, { work: result });
+    return;
+  }
+  const issue = Array.isArray(result) ? result[0] : result;
+  if (!issue) {
+    runtime.error(`Beads work item not found: ${opts.id}`);
+    runtime.exit(1);
+    return;
+  }
+  for (const line of formatIssueDetail(issue)) {
+    runtime.log(line);
+  }
+}
+
+/** Close one Beads work item after the durable coordination work is done. */
+export async function workCloseCommand(
+  opts: { id: string; reason?: string; json?: boolean },
+  runtime: RuntimeEnv,
+  context?: WorkCommandContext,
+): Promise<void> {
+  const result = await runBeadsCommand(runtime, () =>
+    getClient(context).close(opts.id, { reason: opts.reason }),
+  );
+  if (result === null) {
+    return;
+  }
+  if (opts.json) {
+    writeRuntimeJson(runtime, { result });
+    return;
+  }
+  runtime.log(info(`Closed Beads work item: ${opts.id}`));
+}

--- a/src/work-tracking/beads.test.ts
+++ b/src/work-tracking/beads.test.ts
@@ -1,0 +1,110 @@
+// Beads bridge tests cover command construction and metadata parsing.
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildOpenClawWorkMetadata,
+  createBeadsClient,
+  parseBeadsMetadataFilters,
+} from "./beads.js";
+
+describe("Beads work graph client", () => {
+  it("parses exact-match metadata filters", () => {
+    expect(
+      parseBeadsMetadataFilters(["repo=openclaw/openclaw", "priority=2", "active=true"]),
+    ).toEqual({
+      active: true,
+      priority: 2,
+      repo: "openclaw/openclaw",
+    });
+  });
+
+  it("builds OpenClaw orchestration metadata without a custom projection store", () => {
+    expect(
+      buildOpenClawWorkMetadata({
+        metadata: { source: "agent" },
+        repo: "openclaw/openclaw",
+        branch: "klaw/beads-work-tracking",
+        prUrl: "https://github.com/openclaw/openclaw/pull/123",
+        owner: "klaw",
+        nextAction: "review ready work",
+      }),
+    ).toEqual({
+      branch: "klaw/beads-work-tracking",
+      nextAction: "review ready work",
+      owner: "klaw",
+      prUrl: "https://github.com/openclaw/openclaw/pull/123",
+      repo: "openclaw/openclaw",
+      source: "agent",
+    });
+  });
+
+  it("creates Beads work with labels, metadata, external refs, and dependencies", async () => {
+    const runner = vi.fn(async () => ({
+      stderr: "",
+      stdout: JSON.stringify({ id: "bd-123", title: "Ship Beads bridge" }),
+    }));
+    const client = createBeadsClient(runner);
+
+    await client.create({
+      title: "Ship Beads bridge",
+      type: "task",
+      priority: "P1",
+      labels: ["openclaw", "klaw"],
+      metadata: {
+        repo: "openclaw/openclaw",
+        prUrl: "https://github.com/openclaw/openclaw/pull/123",
+      },
+      externalRef: "gh-123",
+      dependencies: ["blocks:bd-parent", "discovered-from:bd-source"],
+    });
+
+    expect(runner).toHaveBeenCalledWith([
+      "create",
+      "Ship Beads bridge",
+      "--type",
+      "task",
+      "--priority",
+      "P1",
+      "--labels",
+      "openclaw",
+      "--labels",
+      "klaw",
+      "--external-ref",
+      "gh-123",
+      "--deps",
+      "blocks:bd-parent,discovered-from:bd-source",
+      "--metadata",
+      JSON.stringify({
+        repo: "openclaw/openclaw",
+        prUrl: "https://github.com/openclaw/openclaw/pull/123",
+      }),
+      "--json",
+    ]);
+  });
+
+  it("asks Beads for ready work using dependency-aware filters", async () => {
+    const runner = vi.fn(async () => ({
+      stderr: "",
+      stdout: JSON.stringify([{ id: "bd-ready", title: "Ready item" }]),
+    }));
+    const client = createBeadsClient(runner);
+
+    await expect(
+      client.ready({
+        limit: 10,
+        labels: ["openclaw"],
+        metadata: { repo: "openclaw/openclaw" },
+      }),
+    ).resolves.toEqual([{ id: "bd-ready", title: "Ready item" }]);
+
+    expect(runner).toHaveBeenCalledWith([
+      "ready",
+      "--limit",
+      "10",
+      "--label",
+      "openclaw",
+      "--metadata-field",
+      "repo=openclaw/openclaw",
+      "--json",
+    ]);
+  });
+});

--- a/src/work-tracking/beads.ts
+++ b/src/work-tracking/beads.ts
@@ -1,0 +1,248 @@
+// Optional Beads CLI bridge for durable orchestration work graphs.
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type BeadsIssueMetadataValue = string | number | boolean | null;
+export type BeadsIssueMetadata = Record<string, BeadsIssueMetadataValue>;
+
+export type BeadsIssue = {
+  id: string;
+  title: string;
+  status?: string;
+  issue_type?: string;
+  type?: string;
+  priority?: number | string;
+  assignee?: string;
+  owner?: string;
+  external_ref?: string;
+  labels?: string[];
+  metadata?: BeadsIssueMetadata;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export type BeadsCommandResult = {
+  stdout: string;
+  stderr: string;
+};
+
+export type BeadsCommandRunner = (args: readonly string[]) => Promise<BeadsCommandResult>;
+
+export type BeadsClient = {
+  status: () => Promise<unknown>;
+  ready: (params?: {
+    limit?: number;
+    labels?: readonly string[];
+    metadata?: BeadsIssueMetadata;
+  }) => Promise<BeadsIssue[]>;
+  list: (params?: {
+    limit?: number;
+    labels?: readonly string[];
+    metadata?: BeadsIssueMetadata;
+    status?: string;
+    all?: boolean;
+  }) => Promise<BeadsIssue[]>;
+  show: (id: string) => Promise<BeadsIssue | BeadsIssue[]>;
+  create: (params: {
+    title: string;
+    type?: string;
+    priority?: string;
+    labels?: readonly string[];
+    metadata?: BeadsIssueMetadata;
+    description?: string;
+    externalRef?: string;
+    dependencies?: readonly string[];
+  }) => Promise<BeadsIssue>;
+  claim: (id: string) => Promise<BeadsIssue>;
+  close: (id: string, params?: { reason?: string }) => Promise<unknown>;
+};
+
+export class BeadsUnavailableError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "BeadsUnavailableError";
+  }
+}
+
+export function parseBeadsMetadataFilterValue(value: string): BeadsIssueMetadataValue {
+  const trimmed = value.trim();
+  if (trimmed === "true") {
+    return true;
+  }
+  if (trimmed === "false") {
+    return false;
+  }
+  if (trimmed === "null") {
+    return null;
+  }
+  const numeric = Number(trimmed);
+  return trimmed !== "" && Number.isFinite(numeric) ? numeric : value;
+}
+
+export function parseBeadsMetadataFilters(
+  filters: readonly string[] | undefined,
+): BeadsIssueMetadata {
+  const metadata: BeadsIssueMetadata = {};
+  for (const filter of filters ?? []) {
+    const separator = filter.indexOf("=");
+    if (separator <= 0) {
+      throw new Error(`Invalid Beads metadata filter "${filter}". Use key=value.`);
+    }
+    const key = filter.slice(0, separator).trim();
+    if (!key) {
+      throw new Error(`Invalid Beads metadata filter "${filter}". Use key=value.`);
+    }
+    metadata[key] = parseBeadsMetadataFilterValue(filter.slice(separator + 1));
+  }
+  return metadata;
+}
+
+export function formatMissingBeadsMessage(): string {
+  return [
+    "No Beads workspace is available.",
+    "Install Beads (`npm install -g @beads/bd@1.0.4`) and run `bd init` in this repository, or set BEADS_DIR to an existing .beads directory.",
+  ].join(" ");
+}
+
+function parseJsonOutput<T>(result: BeadsCommandResult): T {
+  const text = result.stdout.trim();
+  if (!text) {
+    return null as T;
+  }
+  return JSON.parse(text) as T;
+}
+
+function appendRepeated(args: string[], flag: string, values: readonly string[] | undefined): void {
+  for (const value of values ?? []) {
+    args.push(flag, value);
+  }
+}
+
+function appendMetadataFilters(args: string[], metadata: BeadsIssueMetadata | undefined): void {
+  for (const [key, value] of Object.entries(metadata ?? {})) {
+    args.push("--metadata-field", `${key}=${String(value)}`);
+  }
+}
+
+function buildMetadata(params: {
+  metadata?: BeadsIssueMetadata;
+  repo?: string;
+  branch?: string;
+  prUrl?: string;
+  owner?: string;
+  nextAction?: string;
+}): BeadsIssueMetadata {
+  return {
+    ...(params.metadata ?? {}),
+    ...(params.repo ? { repo: params.repo } : {}),
+    ...(params.branch ? { branch: params.branch } : {}),
+    ...(params.prUrl ? { prUrl: params.prUrl } : {}),
+    ...(params.owner ? { owner: params.owner } : {}),
+    ...(params.nextAction ? { nextAction: params.nextAction } : {}),
+  };
+}
+
+export function buildOpenClawWorkMetadata(params: {
+  metadata?: BeadsIssueMetadata;
+  repo?: string;
+  branch?: string;
+  prUrl?: string;
+  owner?: string;
+  nextAction?: string;
+}): BeadsIssueMetadata {
+  return buildMetadata(params);
+}
+
+async function runBdProcess(args: readonly string[]): Promise<BeadsCommandResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync("bd", [...args], {
+      maxBuffer: 1024 * 1024 * 16,
+    });
+    return {
+      stdout: String(stdout),
+      stderr: String(stderr),
+    };
+  } catch (err) {
+    const code = (err as { code?: unknown })?.code;
+    if (code === "ENOENT") {
+      throw new BeadsUnavailableError(formatMissingBeadsMessage(), { cause: err });
+    }
+    const stderr = String((err as { stderr?: unknown })?.stderr ?? "").trim();
+    if (/no beads database found|No active beads workspace found/iu.test(stderr)) {
+      throw new BeadsUnavailableError(formatMissingBeadsMessage(), { cause: err });
+    }
+    throw err;
+  }
+}
+
+function normalizeIssueList(value: unknown): BeadsIssue[] {
+  if (Array.isArray(value)) {
+    return value as BeadsIssue[];
+  }
+  if (value && typeof value === "object" && Array.isArray((value as { issues?: unknown }).issues)) {
+    return (value as { issues: BeadsIssue[] }).issues;
+  }
+  return [];
+}
+
+export function createBeadsClient(runner: BeadsCommandRunner = runBdProcess): BeadsClient {
+  const runJson = async <T>(args: readonly string[]): Promise<T> =>
+    parseJsonOutput<T>(await runner([...args, "--json"]));
+
+  return {
+    status: () => runJson<unknown>(["status"]),
+    async ready(params = {}) {
+      const args = ["ready", "--limit", String(params.limit ?? 100)];
+      appendRepeated(args, "--label", params.labels);
+      appendMetadataFilters(args, params.metadata);
+      return normalizeIssueList(await runJson<unknown>(args));
+    },
+    async list(params = {}) {
+      const args = ["list", "--limit", String(params.limit ?? 50)];
+      if (params.all) {
+        args.push("--all");
+      }
+      if (params.status) {
+        args.push("--status", params.status);
+      }
+      appendRepeated(args, "--label", params.labels);
+      appendMetadataFilters(args, params.metadata);
+      return normalizeIssueList(await runJson<unknown>(args));
+    },
+    show: (id) => runJson<BeadsIssue | BeadsIssue[]>(["show", id]),
+    create(params) {
+      const args = [
+        "create",
+        params.title,
+        "--type",
+        params.type ?? "task",
+        "--priority",
+        params.priority ?? "P2",
+      ];
+      appendRepeated(args, "--labels", params.labels);
+      if (params.description) {
+        args.push("--description", params.description);
+      }
+      if (params.externalRef) {
+        args.push("--external-ref", params.externalRef);
+      }
+      if (params.dependencies && params.dependencies.length > 0) {
+        args.push("--deps", params.dependencies.join(","));
+      }
+      if (params.metadata && Object.keys(params.metadata).length > 0) {
+        args.push("--metadata", JSON.stringify(params.metadata));
+      }
+      return runJson<BeadsIssue>(args);
+    },
+    claim: (id) => runJson<BeadsIssue>(["update", id, "--claim"]),
+    close(id, params = {}) {
+      const args = ["close", id];
+      if (params.reason) {
+        args.push("--reason", params.reason);
+      }
+      return runJson<unknown>(args);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add `openclaw work`, a Beads-backed CLI surface for durable multi-step work coordination (`status`, `ready`, `list`, `create`, `claim`, `show`, `close`)
- add a small optional `bd --json` bridge that keeps Beads as the source of truth for work graph state instead of `worker-state.json`, OpenClaw SQLite, or another projection cache
- document the split between `openclaw tasks` runtime/activity records and Beads-backed `openclaw work` planning/dependency records
- pin setup guidance to `@beads/bd@1.0.4` because upstream marks `1.0.5` as gated for multi-machine Dolt sync

Supersedes the task-ledger metadata direction in #95433 and #95438. Those PRs are closed and should remain closed unless maintainers explicitly want the old SQLite metadata approach.

## Verification
- `node scripts/run-vitest.mjs src/work-tracking/beads.test.ts src/commands/work.test.ts src/cli/program/register.work.test.ts src/cli/program/command-registry.test.ts`
- `pnpm tsgo:core`
- `pnpm docs:list`
- `git diff --check`
- Temp Beads workspace smoke with `BEADS_DIR=$(mktemp -d)/.beads`: `bd init --quiet --stealth`, `pnpm openclaw work status --json`, `pnpm openclaw work create ... --json`, `pnpm openclaw work ready --json --metadata repo=openclaw/openclaw`, and `pnpm openclaw work show <id> --json`

Autoreview attempted with `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; it could not run in this worker because the `codex` executable is not installed (`executable not found: codex`).

## Real behavior proof
Behavior addressed: `openclaw work` uses Beads issues and dependency-aware ready queries as the durable work graph for OpenClaw/Klaw coordination, instead of extending task-ledger metadata or relying on worker-state-style JSON.

Real environment tested: Local OpenClaw checkout with installed `bd version 1.0.4`, using a temporary Beads workspace through `BEADS_DIR`.

Exact steps or command run after this patch: Initialized a temp Beads workspace, ran `pnpm openclaw work status --json`, created a Beads item with repo/branch/PR/next-action metadata via `pnpm openclaw work create ... --json`, queried it via `pnpm openclaw work ready --json --metadata repo=openclaw/openclaw`, and showed it via `pnpm openclaw work show <id> --json`.

Evidence after fix: `work create` returned a Beads issue with `metadata.repo`, `metadata.branch`, `metadata.prUrl`, and `metadata.nextAction`; `work ready --metadata repo=openclaw/openclaw` returned that same issue from Beads; `work show <id> --json` returned the Beads issue details.

Observed result after fix: OpenClaw created and queried durable coordination work through Beads JSON commands. No OpenClaw task-ledger row or custom JSON projection was created for the planning state.

What was not tested: A committed/shared `.beads` database in the upstream OpenClaw repo, multi-machine Dolt push/pull, full CI completion, and autoreview beyond the failed helper attempt noted above.
