### PR TITLE
fix(tavily): allow env fallback for unresolved apiKey refs

### DIFF
--- a/extensions/tavily/src/config.ts
+++ b/extensions/tavily/src/config.ts
@@ -1,10 +1,7 @@
 // Tavily helper module supports config behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolvePositiveTimeoutSeconds } from "openclaw/plugin-sdk/provider-web-search";
-import {
-  normalizeResolvedSecretInputString,
-  normalizeSecretInput,
-} from "openclaw/plugin-sdk/secret-input";
+import { normalizeSecretInput, resolveSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 export const DEFAULT_TAVILY_BASE_URL = "https://api.tavily.com";
@@ -35,12 +32,12 @@ export function resolveTavilySearchConfig(cfg?: OpenClawConfig): TavilySearchCon
 }
 
 function normalizeConfiguredSecret(value: unknown, path: string): string | undefined {
-  return normalizeSecretInput(
-    normalizeResolvedSecretInputString({
-      value,
-      path,
-    }),
-  );
+  const resolved = resolveSecretInputString({
+    value,
+    path,
+    mode: "configured_unavailable",
+  });
+  return resolved.status === "available" ? normalizeSecretInput(resolved.value) : undefined;
 }
 
 export function resolveTavilyApiKey(cfg?: OpenClawConfig): string | undefined {

--- a/extensions/tavily/src/tavily-tools.test.ts
+++ b/extensions/tavily/src/tavily-tools.test.ts
@@ -427,6 +427,30 @@ describe("tavily tools", () => {
     expect(resolveTavilyExtractTimeoutSeconds()).toBe(DEFAULT_TAVILY_EXTRACT_TIMEOUT_SECONDS);
   });
 
+  it("falls back to process.env when the configured apiKey is an unresolved SecretRef", () => {
+    vi.stubEnv("TAVILY_API_KEY", "env-key");
+
+    const cfg = {
+      plugins: {
+        entries: {
+          tavily: {
+            config: {
+              webSearch: {
+                apiKey: {
+                  source: "env",
+                  provider: "default",
+                  id: "TAVILY_API_KEY",
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveTavilyApiKey(cfg)).toBe("env-key");
+  });
+
   it("accepts positive numeric timeout overrides and floors them", () => {
     expect(resolveTavilySearchTimeoutSeconds(19.9)).toBe(19);
     expect(resolveTavilyExtractTimeoutSeconds(42.7)).toBe(42);


### PR DESCRIPTION
## Summary
- avoid throwing when Tavily config still contains an unresolved SecretRef
- keep using the configured literal value when available
- fall back to `process.env.TAVILY_API_KEY` when the runtime snapshot has not inlined the ref yet

## Testing
- pnpm vitest run extensions/tavily/src/tavily-tools.test.ts

Closes #95109