### PR TITLE
fix(workboard): hide archived cards in cli list by default

### DIFF
--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -106,6 +106,32 @@ describe("registerWorkboardCli", () => {
     expect(showOutput).toContain("[redacted]");
   });
 
+  it("hides archived cards by default and shows them with --include-archived", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const active = await store.create({ title: "Visible card" });
+    const archived = await store.create({ title: "Archived card" });
+    await store.update(archived.id, {
+      metadata: {
+        archivedAt: Date.now(),
+      },
+    });
+    const program = createProgram(store);
+
+    const defaultOutput = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list", "--json"], { from: "user" });
+    });
+    const includeArchivedOutput = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list", "--json", "--include-archived"], {
+        from: "user",
+      });
+    });
+
+    expect(defaultOutput).toContain(active.id);
+    expect(defaultOutput).not.toContain(archived.id);
+    expect(includeArchivedOutput).toContain(active.id);
+    expect(includeArchivedOutput).toContain(archived.id);
+  });
+
   it("does not fall back to local dispatch for explicit gateway targets", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const card = await store.create({ title: "Remote target", status: "ready" });

--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -11,6 +11,12 @@ type JsonOptions = {
   json?: boolean;
 };
 
+type ListOptions = JsonOptions & {
+  board?: string;
+  status?: string;
+  includeArchived?: boolean;
+};
+
 type GatewayOptions = JsonOptions & {
   url?: string;
   token?: string;
@@ -130,9 +136,13 @@ export function registerWorkboardCli(params: { program: Command; store: Workboar
     .description("List Workboard cards")
     .option("--board <id>", "Board id")
     .option("--status <status>", "Filter by status")
+    .option("--include-archived", "Include archived cards", false)
     .option("--json", "Print JSON", false)
-    .action(async (options: JsonOptions & { board?: string; status?: string }) => {
+    .action(async (options: ListOptions) => {
       let cards = await params.store.list({ boardId: options.board });
+      if (!options.includeArchived) {
+        cards = cards.filter((card) => !card.metadata?.archivedAt);
+      }
       if (options.status) {
         cards = cards.filter((card) => card.status === options.status);
       }


### PR DESCRIPTION
## Summary
- filter archived workboard cards out of `openclaw workboard list` by default
- add an explicit `--include-archived` escape hatch for callers that want the old full listing
- align CLI list behavior with the chat command and tool defaults

## Testing
- pnpm vitest run extensions/workboard/src/cli.test.ts

Closes #94555