### PR TITLE
fix(memory): align session file counter denominator with indexer filter (fixes #77338)

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -10,6 +10,7 @@ import {
   resolveMemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
+import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import {
   colorize,
@@ -538,7 +539,7 @@ async function scanSessionFiles(agentId: string): Promise<SourceScan> {
   try {
     const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
     const totalFiles = entries.filter(
-      (entry) => entry.isFile() && entry.name.endsWith(".jsonl"),
+      (entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name),
     ).length;
     return { source: "sessions", totalFiles, issues };
   } catch (err) {


### PR DESCRIPTION
## What Problem This Solves

`openclaw memory status` reports `sessions · N/M` where N can exceed M because the denominator scanner used a simpler `.endsWith(".jsonl")` filter while the indexer uses the canonical `isUsageCountedSessionTranscriptFileName()` function. The scanner therefore missed usage-counted reset/deleted archives that the indexer includes, while backup/checkpoint/trajectory artifacts should remain excluded.

## What does this PR do?

Aligns the `scanSessionFiles` denominator filter in `extensions/memory-core/src/cli.runtime.ts` with the indexer by using the canonical `isUsageCountedSessionTranscriptFileName()` helper from the plugin SDK.

## Related Issue

Fixes #77338

## Type of Change

- [x] Bug fix (non-breaking)
- [x] AI-assisted (Hermes Agent)

## Changes Made

- `extensions/memory-core/src/cli.runtime.ts`: import `isUsageCountedSessionTranscriptFileName` from `openclaw/plugin-sdk/memory-core-host-engine-qmd`
- `extensions/memory-core/src/cli.runtime.ts`: use the canonical helper for `scanSessionFiles` instead of `.endsWith(".jsonl")`

## How to Test

1. Build the source checkout or run through `node scripts/run-node.mjs`.
2. Create an isolated `OPENCLAW_STATE_DIR` with session transcript artifacts:
   - `primary.jsonl`
   - `primary.jsonl.reset.2026-02-16T22-26-33.000Z`
   - `primary.jsonl.deleted.2026-02-16T22-27-33.000Z`
   - `primary.jsonl.bak.2026-02-16T22-28-33.000Z`
   - `primary.checkpoint.11111111-1111-4111-8111-111111111111.jsonl`
   - `primary.trajectory.jsonl`
3. Run `openclaw memory status --agent main --no-color` with `memorySearch.sources=["memory","sessions"]` and `experimental.sessionMemory=true`.
4. Confirm the session denominator is 3: primary + reset + deleted are counted; backup + checkpoint + trajectory are excluded.

## Evidence

- **Behavior addressed:** session status denominator now uses the same usage-counted session transcript predicate as the memory indexer.
- **Environment tested:** macOS local source checkout, Node v22.22.3, pnpm v11.2.2, isolated `OPENCLAW_STATE_DIR` under `/tmp`.
- **Steps run after the patch:**

```bash
$ find "$OPENCLAW_STATE_DIR/agents/main/sessions" -maxdepth 1 -type f -exec basename {} \; | sort
primary.checkpoint.11111111-1111-4111-8111-111111111111.jsonl
primary.jsonl
primary.jsonl.bak.2026-02-16T22-28-33.000Z
primary.jsonl.deleted.2026-02-16T22-27-33.000Z
primary.jsonl.reset.2026-02-16T22-26-33.000Z
primary.trajectory.jsonl
```

```bash
$ OPENCLAW_STATE_DIR="$state_dir" \
  OPENCLAW_CONFIG_PATH="$state_dir/openclaw.json" \
  OPENCLAW_HOME="$home_dir" \
  OPENCLAW_DISABLE_AUTO_UPDATE=1 \
  node scripts/run-node.mjs memory status --agent main --no-color
Memory Search (main)
Provider: openai (requested: openai)
Model: openai
Sources: memory, sessions
Indexed: 0/5 files · 0 chunks
Dirty: yes
Store: /tmp/openclaw-memory-status-proof.<redacted>/state/agents/main/agent/openclaw-agent.sqlite
Workspace: /tmp/openclaw-memory-status-proof.<redacted>/state/workspace
Dreaming: off
By source:
  memory · 0/2 files · 0 chunks
  sessions · 0/3 files · 0 chunks
Vector store: disabled
FTS: ready
```

- **Observed result after fix:** The session source reports `sessions · 0/3 files` for six on-disk artifacts. The denominator includes `primary.jsonl`, `.jsonl.reset.*`, and `.jsonl.deleted.*`, and excludes `.jsonl.bak.*`, `.checkpoint.*.jsonl`, and `.trajectory.jsonl`.
- **What was not tested:** A production container was not touched; the proof uses an isolated local state directory with the same session artifact filename classes.

## Real behavior proof

- **Behavior:** `openclaw memory status --agent main --no-color` was run against an isolated state directory containing primary, reset/deleted, backup, checkpoint, and trajectory session artifacts.
- **Environment:** macOS local source checkout, Node v22.22.3, pnpm v11.2.2, `OPENCLAW_STATE_DIR=/tmp/openclaw-memory-status-proof.<redacted>/state`.
- **Evidence:** command output above shows `Sources: memory, sessions` and `By source: sessions · 0/3 files` with all six artifact filenames present on disk.
- **Observed result:** reset/deleted archives are included in the denominator, while backup/checkpoint/trajectory artifacts are excluded.
- **Not tested:** no production state or user data was accessed.
