### PR TITLE
fix #95407: [Bug]: `cron` tool `add` action mangles certain key names in `job` parameter

### DIFF
--- a/src/agents/tools/cron-tool-canonicalize.ts
+++ b/src/agents/tools/cron-tool-canonicalize.ts
@@ -85,6 +85,30 @@ function moveDefinedField(params: {
   return true;
 }
 
+function recoverCronToolKey(key: string): string | undefined {
+  if (CRON_RECOVERABLE_OBJECT_KEYS.has(key)) {
+    return key;
+  }
+  const trimmed = key.trim();
+  return trimmed !== key && CRON_RECOVERABLE_OBJECT_KEYS.has(trimmed) ? trimmed : undefined;
+}
+
+function repairWhitespacePaddedCronToolKeys(value: Record<string, unknown>): void {
+  // Some local tool-call parsers preserve schema-shaped JSON but pad property
+  // names. Recover only known cron fields so strict validation still rejects
+  // genuinely unknown keys after canonicalization.
+  for (const key of Object.keys(value)) {
+    const recoveredKey = recoverCronToolKey(key);
+    if (recoveredKey === undefined || recoveredKey === key) {
+      continue;
+    }
+    if (value[recoveredKey] === undefined) {
+      value[recoveredKey] = value[key];
+    }
+    delete value[key];
+  }
+}
+
 function repairConcatenatedCronToolKeys(value: Record<string, unknown>): void {
   // Some small/local tool-call parsers can return valid JSON with adjacent cron
   // key names merged. Recover only the observed schema-specific pairs before
@@ -249,6 +273,7 @@ export function canonicalizeCronToolObject(
 ): Record<string, unknown> {
   const unwrapped = isRecord(value.data) ? value.data : isRecord(value.job) ? value.job : value;
   const next = { ...unwrapped };
+  repairWhitespacePaddedCronToolKeys(next);
   repairConcatenatedCronToolKeys(next);
   canonicalizeCronToolSchedule(next);
   canonicalizeCronToolPayload(next);
@@ -278,8 +303,11 @@ export function recoverCronObjectFromFlatParams(params: Record<string, unknown>)
   const value: Record<string, unknown> = {};
   let found = false;
   for (const key of Object.keys(params)) {
-    if (CRON_RECOVERABLE_OBJECT_KEYS.has(key) && params[key] !== undefined) {
-      value[key] = params[key];
+    const recoveredKey = recoverCronToolKey(key);
+    if (recoveredKey !== undefined && params[key] !== undefined) {
+      if (key === recoveredKey || value[recoveredKey] === undefined) {
+        value[recoveredKey] = params[key];
+      }
       found = true;
     }
   }

--- a/src/agents/tools/cron-tool-canonicalize.ts
+++ b/src/agents/tools/cron-tool-canonicalize.ts
@@ -104,8 +104,8 @@ function repairWhitespacePaddedCronToolKeys(value: Record<string, unknown>): voi
     }
     if (value[recoveredKey] === undefined) {
       value[recoveredKey] = value[key];
+      delete value[key];
     }
-    delete value[key];
   }
 }
 
@@ -305,8 +305,11 @@ export function recoverCronObjectFromFlatParams(params: Record<string, unknown>)
   for (const key of Object.keys(params)) {
     const recoveredKey = recoverCronToolKey(key);
     if (recoveredKey !== undefined && params[key] !== undefined) {
-      if (key === recoveredKey || value[recoveredKey] === undefined) {
+      const hasCanonicalParam = Object.prototype.hasOwnProperty.call(params, recoveredKey);
+      if (key === recoveredKey || !hasCanonicalParam) {
         value[recoveredKey] = params[key];
+      } else {
+        value[key] = params[key];
       }
       found = true;
     }

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -1075,6 +1075,64 @@ describe("cron tool", () => {
     });
   });
 
+  it.each([
+    {
+      callId: "call-whitespace-padded-add",
+      input: {
+        action: "add",
+        job: {
+          name: "Holiday Check-in",
+          description: "Casual check-in while on holiday, 2x per day",
+          "schedule ": { expr: "30 10,20 * * *", kind: "cron", tz: "Europe/Madrid" },
+          "sessionTarget ": "isolated",
+          "payload ": {
+            kind: "agentTurn",
+            message: "Holiday check-in: how's everything going?",
+          },
+          "enabled ": true,
+        },
+      },
+      label: "job",
+    },
+    {
+      callId: "call-flat-whitespace-padded-add",
+      input: {
+        action: "add",
+        name: "Holiday Check-in",
+        description: "Casual check-in while on holiday, 2x per day",
+        "schedule ": { expr: "30 10,20 * * *", kind: "cron", tz: "Europe/Madrid" },
+        "sessionTarget ": "isolated",
+        "payload ": {
+          kind: "agentTurn",
+          message: "Holiday check-in: how's everything going?",
+        },
+        "enabled ": true,
+      },
+      label: "flat",
+    },
+  ])(
+    "recovers whitespace-padded cron add $label keys from local tool-call parsers",
+    async ({ callId, input }) => {
+      const tool = createTestCronTool();
+      await tool.execute(callId, input);
+
+      const params = expectSingleGatewayCallMethod("cron.add");
+      expect(params).toEqual({
+        delivery: { mode: "announce" },
+        description: "Casual check-in while on holiday, 2x per day",
+        enabled: true,
+        name: "Holiday Check-in",
+        payload: {
+          kind: "agentTurn",
+          message: "Holiday check-in: how's everything going?",
+        },
+        schedule: { expr: "30 10,20 * * *", kind: "cron", tz: "Europe/Madrid" },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+      });
+    },
+  );
+
   it("recovers flat concatenated cron add keys from local tool-call parsers", async () => {
     const tool = createTestCronTool();
     await tool.execute("call-flat-concatenated-add", {

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -1,5 +1,6 @@
 // Cron tool tests cover schedule guidance, scoped job operations, delivery
 // context inheritance, session routing, and agent id ownership.
+import { Value } from "typebox/value";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { callGatewayMock, extractDeliveryInfoMock } = vi.hoisted(() => ({
@@ -19,6 +20,7 @@ vi.mock("../../config/sessions/delivery-info.js", () => ({
   extractDeliveryInfo: extractDeliveryInfoMock,
 }));
 
+import { CronAddParamsSchema } from "../../../packages/gateway-protocol/src/schema/cron.js";
 import { GatewayClientRequestError } from "../../gateway/client.js";
 import { buildAgentPeerSessionKey } from "../../routing/session-key.js";
 import { createCronTool } from "./cron-tool.js";
@@ -1130,6 +1132,62 @@ describe("cron tool", () => {
         sessionTarget: "isolated",
         wakeMode: "now",
       });
+    },
+  );
+
+  it.each([
+    {
+      callId: "call-duplicate-padded-add",
+      input: {
+        action: "add",
+        job: {
+          name: "Holiday Check-in",
+          schedule: { expr: "30 10,20 * * *", kind: "cron", tz: "Europe/Madrid" },
+          sessionTarget: "isolated",
+          payload: {
+            kind: "agentTurn",
+            message: "Holiday check-in: how's everything going?",
+          },
+          enabled: false,
+          "enabled ": true,
+        },
+      },
+      label: "job",
+    },
+    {
+      callId: "call-flat-duplicate-padded-add",
+      input: {
+        action: "add",
+        name: "Holiday Check-in",
+        schedule: { expr: "30 10,20 * * *", kind: "cron", tz: "Europe/Madrid" },
+        sessionTarget: "isolated",
+        payload: {
+          kind: "agentTurn",
+          message: "Holiday check-in: how's everything going?",
+        },
+        enabled: false,
+        "enabled ": true,
+      },
+      label: "flat",
+    },
+  ])(
+    "preserves duplicate whitespace-padded cron add $label keys for strict validation",
+    async ({ callId, input }) => {
+      const tool = createTestCronTool();
+      await tool.execute(callId, input);
+
+      const params = expectSingleGatewayCallMethod("cron.add") as Record<string, unknown>;
+      expect(params.enabled).toBe(false);
+      expect(params["enabled "]).toBe(true);
+      expect(Value.Check(CronAddParamsSchema, params)).toBe(false);
+      expect(Array.from(Value.Errors(CronAddParamsSchema, params))).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            keyword: "additionalProperties",
+            params: { additionalProperties: ["enabled "] },
+          }),
+        ]),
+      );
     },
   );
 

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -1137,6 +1137,7 @@ describe("cron tool", () => {
 
   it.each([
     {
+      additionalProperty: "enabled ",
       callId: "call-duplicate-padded-add",
       input: {
         action: "add",
@@ -1153,8 +1154,13 @@ describe("cron tool", () => {
         },
       },
       label: "job",
+      verify: (params: Record<string, unknown>) => {
+        expect(params.enabled).toBe(false);
+        expect(params["enabled "]).toBe(true);
+      },
     },
     {
+      additionalProperty: "enabled ",
       callId: "call-flat-duplicate-padded-add",
       input: {
         action: "add",
@@ -1169,22 +1175,60 @@ describe("cron tool", () => {
         "enabled ": true,
       },
       label: "flat",
+      verify: (params: Record<string, unknown>) => {
+        expect(params.enabled).toBe(false);
+        expect(params["enabled "]).toBe(true);
+      },
+    },
+    {
+      additionalProperty: "cron ",
+      callId: "call-flat-duplicate-padded-cron-add",
+      input: {
+        action: "add",
+        name: "Holiday Check-in",
+        cron: "30 10,20 * * *",
+        "cron ": "*/5 * * * *",
+        sessionTarget: "isolated",
+        message: "Holiday check-in: how's everything going?",
+      },
+      label: "flat schedule shorthand",
+      verify: (params: Record<string, unknown>) => {
+        expect(params.schedule).toMatchObject({ expr: "30 10,20 * * *", kind: "cron" });
+        expect(params["cron "]).toBe("*/5 * * * *");
+      },
+    },
+    {
+      additionalProperty: "allowUnsafeExternalContent ",
+      callId: "call-flat-duplicate-padded-payload-add",
+      input: {
+        action: "add",
+        name: "Holiday Check-in",
+        schedule: { expr: "30 10,20 * * *", kind: "cron", tz: "Europe/Madrid" },
+        sessionTarget: "isolated",
+        message: "Holiday check-in: how's everything going?",
+        allowUnsafeExternalContent: false,
+        "allowUnsafeExternalContent ": true,
+      },
+      label: "flat payload shorthand",
+      verify: (params: Record<string, unknown>) => {
+        expect(params.payload).toMatchObject({ allowUnsafeExternalContent: false });
+        expect(params["allowUnsafeExternalContent "]).toBe(true);
+      },
     },
   ])(
     "preserves duplicate whitespace-padded cron add $label keys for strict validation",
-    async ({ callId, input }) => {
+    async ({ additionalProperty, callId, input, verify }) => {
       const tool = createTestCronTool();
       await tool.execute(callId, input);
 
       const params = expectSingleGatewayCallMethod("cron.add") as Record<string, unknown>;
-      expect(params.enabled).toBe(false);
-      expect(params["enabled "]).toBe(true);
+      verify(params);
       expect(Value.Check(CronAddParamsSchema, params)).toBe(false);
       expect(Array.from(Value.Errors(CronAddParamsSchema, params))).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             keyword: "additionalProperties",
-            params: { additionalProperties: ["enabled "] },
+            params: { additionalProperties: [additionalProperty] },
           }),
         ]),
       );

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -921,6 +921,7 @@ Use jobId canonical; id accepted compat. contextMessages (0-10) adds previous me
           // them inside `job`. When `params.job` is missing or empty, reconstruct
           // a synthetic job object from any recognised top-level job fields.
           // See: https://github.com/openclaw/openclaw/issues/11310
+          let recoveredFlatJob = false;
           if (isMissingOrEmptyObject(params.job)) {
             const synthetic = recoverCronObjectFromFlatParams(params);
             // Only use the synthetic job if at least one meaningful field is present
@@ -928,13 +929,16 @@ Use jobId canonical; id accepted compat. contextMessages (0-10) adds previous me
             // LLM intended to create a job).
             if (synthetic.found && hasCronCreateSignal(synthetic.value)) {
               params.job = synthetic.value;
+              recoveredFlatJob = true;
             }
           }
 
           if (!params.job || typeof params.job !== "object") {
             throw new Error("job required");
           }
-          const canonicalJob = canonicalizeCronToolObject(params.job as Record<string, unknown>);
+          const canonicalJob = recoveredFlatJob
+            ? (params.job as Record<string, unknown>)
+            : canonicalizeCronToolObject(params.job as Record<string, unknown>);
           assertNoCronCommandPayload(canonicalJob);
           assertCronDeliveryInputNonBlankFields(canonicalJob.delivery);
           const job =
@@ -1051,9 +1055,9 @@ Use jobId canonical; id accepted compat. contextMessages (0-10) adds previous me
           if (!params.patch || typeof params.patch !== "object") {
             throw new Error("patch required");
           }
-          const canonicalPatch = canonicalizeCronToolObject(
-            params.patch as Record<string, unknown>,
-          );
+          const canonicalPatch = recoveredFlatPatch
+            ? (params.patch as Record<string, unknown>)
+            : canonicalizeCronToolObject(params.patch as Record<string, unknown>);
           assertNoCronCommandPayload(canonicalPatch);
           assertCronDeliveryInputNonBlankFields(canonicalPatch.delivery);
           const patch = normalizeCronJobPatch(canonicalPatch) ?? canonicalPatch;


### PR DESCRIPTION
## What Problem This Solves

Fixes #95407.

- Behavior or issue addressed: `cron.add` rejected local parser outputs where recognized top-level job keys had trailing spaces, such as `schedule `, `sessionTarget `, `payload `, and `enabled `.
- Why it matters / User impact: affected local-model users could not create cron jobs through the function-call interface even though the generated job shape was otherwise valid.

## Summary

Recover whitespace-padded top-level cron job keys before `cron.add` gateway validation. This keeps the gateway schema strict while allowing the cron tool's existing model-friendly canonicalization seam to repair a concrete parser corruption shape.

The update also preserves ambiguous duplicate input when both a canonical key and its whitespace-padded duplicate are present. In that case the padded duplicate remains on the normalized object so strict `CronAddParamsSchema` validation rejects the extra property instead of silently choosing one value.

For flat `cron.add` inputs, recovered synthetic jobs/patches are not canonicalized a second time. This keeps moved flat shorthand conflicts such as `cron` + `cron ` and `allowUnsafeExternalContent` + `allowUnsafeExternalContent ` visible to final strict validation instead of re-recovering the padded shorthand and overwriting nested `schedule` or `payload` values.

## Root Cause

- Root cause: `canonicalizeCronToolObject` only recovered the earlier concatenated-key corruption shape (`namePayload`, `scheduleKind`, `sessionTargetName`). It copied whitespace-padded keys as-is, so strict gateway validation saw missing canonical fields plus unexpected padded fields.
- Follow-up root cause from review: the first recovery pass deleted a whitespace-padded key even when the canonical key already existed, which could hide ambiguous/conflicting input from strict gateway validation.
- Second follow-up root cause from review: flat synthetic job recovery was already canonicalized once, but the `cron.add` path canonicalized the synthetic job again. For flat shorthands moved into `schedule` or `payload`, that second pass could recover the remaining padded shorthand and overwrite the nested canonical value before strict validation saw the duplicate.
- Why this is root-cause fix: the cron tool canonicalizer is the existing boundary that normalizes model/parser-shaped cron arguments immediately before gateway dispatch. Normalizing only known cron field names there repairs the corrupted parser output before validation without widening the gateway protocol contract; preserving duplicate conflicts and avoiding double canonicalization for recovered flat objects keeps the gateway schema as the final source-of-truth rejector for ambiguous input.

## Why This Change Was Made

The gateway schema is the source of truth and should continue rejecting unknown fields. This patch trims only property names whose trimmed form is already a known cron job/patch/recovery field; unsupported fields remain unsupported. Flat cron parameter recovery uses the same known-key normalization so flat and nested job inputs handle this whitespace-padded key shape consistently. If a parser supplies both `enabled` and `enabled `, or both a flat shorthand such as `cron` and `cron ` / `allowUnsafeExternalContent` and `allowUnsafeExternalContent `, the padded duplicate is not discarded or re-applied; strict validation rejects the extra property.

## Real behavior proof

- Real environment tested: local source checkout on Windows Git Bash; Node v22.17.0; pnpm 11.2.2. pnpm emitted the repo engine warning because the repo requests Node >=22.19.0.
- Exact steps or command run after this patch:
  - `pnpm exec oxfmt --check --threads=1 src/agents/tools/cron-tool.ts src/agents/tools/cron-tool-canonicalize.ts src/agents/tools/cron-tool.test.ts`
  - `node scripts/run-vitest.mjs src/agents/tools/cron-tool.test.ts src/agents/tools/cron-tool.flat-params.test.ts`
  - `pnpm test src/agents/tools/cron-tool.test.ts src/agents/tools/cron-tool.flat-params.test.ts`
  - `git diff --check`
  - `pnpm exec tsx --input-type=module` with production `canonicalizeCronToolObject`, `recoverCronObjectFromFlatParams`, `normalizeCronJobCreate`, `createCronTool`, and gateway protocol `CronAddParamsSchema` against padded-only, duplicate/conflicting padded-key, and flat shorthand duplicate cron add shapes.
- Evidence after fix: the focused regression tests exercise both `job` and flat `cron.add` inputs with padded top-level cron keys; nested and flat duplicate `enabled` inputs; a flat schedule shorthand duplicate (`cron` + `cron `); and a flat security-sensitive payload shorthand duplicate (`allowUnsafeExternalContent` + `allowUnsafeExternalContent `). The strict schema proof produced canonical keys and `schema.accepted: true` for padded-only input. For duplicate nested and flat inputs it preserved the canonical value, kept the padded duplicate as an additional top-level property, and `CronAddParamsSchema` rejected the payload with the expected `additionalProperties` entry.
- Observed result after fix: reported padded-only keys are canonicalized before strict cron add validation, while conflicting canonical+padded duplicates remain visible to strict validation and are rejected. Flat shorthand conflicts no longer get re-recovered on a second canonicalization pass.
- What was not tested: I did not run a live qwen35b/llamacpp provider route; proof is source-level regression coverage plus production canonicalizer/normalizer/cron-tool/schema-validator output.

## Evidence

- Formatting check passed for all touched files.
- `node scripts/run-vitest.mjs src/agents/tools/cron-tool.test.ts src/agents/tools/cron-tool.flat-params.test.ts` passed.
- `pnpm test src/agents/tools/cron-tool.test.ts src/agents/tools/cron-tool.flat-params.test.ts` passed: 136 tests passed across 2 files.
- Strict schema-validator proof passed outside Vitest mocks for the accepted padded-only path and the rejected duplicate nested/flat paths, including flat schedule shorthand and flat security-sensitive payload shorthand conflicts captured through `createCronTool` dispatch.
- `git diff --check` passed.

## Regression Test Plan

- Target test file: `src/agents/tools/cron-tool.test.ts`.
- The new tests cover `cron.add` with a `job` object whose top-level `schedule `, `sessionTarget `, `payload `, and `enabled ` keys have trailing spaces.
- The same table also covers flat `cron.add` input with those whitespace-padded fields recovered into a job before dispatch.
- Duplicate/conflict regression coverage checks both nested `job` and flat `cron.add` inputs containing `enabled` plus `enabled `, and asserts strict `CronAddParamsSchema` rejects the outgoing `cron.add` params because the padded duplicate remains an additional property.
- Flat shorthand duplicate coverage checks `cron` plus `cron ` and `allowUnsafeExternalContent` plus `allowUnsafeExternalContent ` so moved schedule and payload fields cannot be overwritten by a second canonicalization pass.

## Review findings addressed

- RF-001 (`status: ⏳ waiting on author`): addressed by this update; the PR body documents the author-side flat-shorthand fix, regression coverage, and verification results.
- RF-002 (schedule and payload/security-sensitive shorthand regression coverage): fixed. `src/agents/tools/cron-tool.test.ts` covers `cron` plus `cron ` and `allowUnsafeExternalContent` plus `allowUnsafeExternalContent `.
- RF-003 (flat canonical-plus-padded shorthand conflicts can be re-recovered): fixed. Recovered flat synthetic jobs/patches now skip the second canonicalization pass in the add/update dispatch path, preserving padded shorthand duplicates through final gateway params.
- RF-004 (`allowUnsafeExternalContent` security-sensitive overwrite): fixed and covered. Regression and production-path proof preserve `payload.allowUnsafeExternalContent: false` while keeping top-level `allowUnsafeExternalContent : true` as an additional property rejected by strict validation.
- RF-005 (multiple sibling PRs / canonical landing path): maintainer decision. This patch keeps this PR narrowly focused and does not choose among sibling PRs beyond making this branch maintainer-ready.
- RF-006 (mechanical repair for padded flat shorthand duplicates): fixed via the flat synthetic-job dispatch repair plus focused regression tests; maintainer selection among sibling PRs remains separate.
- RF-007 (`src/agents/tools/cron-tool-canonicalize.ts:309-312` / keep flat shorthand duplicates rejectable): fixed by avoiding duplicate canonicalization of already-recovered flat cron objects before gateway submission.
- RF-008 (`node scripts/run-vitest.mjs src/agents/tools/cron-tool.test.ts src/agents/tools/cron-tool.flat-params.test.ts`): passed.
- RF-009 (`pnpm exec oxfmt --check --threads=1 src/agents/tools/cron-tool-canonicalize.ts src/agents/tools/cron-tool.test.ts`): passed. I also checked `src/agents/tools/cron-tool.ts`, which is touched by the final dispatch fix.
- RF-010 (`git diff --check`): passed.

## Merge risk

- Risk labels considered: `merge-risk:low` / no compatibility-expanding protocol change.
- Risk explanation: the change touches model-facing cron argument canonicalization and flat add/update dispatch, but it does not change the gateway schema, persisted cron data, public protocol fields, or defaults.
- Why acceptable: recovery is limited to known cron fields. If a parser supplies an actually unknown field, strict validation still rejects it. If a parser supplies conflicting canonical and padded keys, the conflict is preserved for strict validation instead of being silently resolved or re-applied.
- Fix classification: minimal canonical root-cause fix at the cron tool canonicalization boundary and the flat synthetic-job dispatch seam that previously caused a second canonicalization pass.
- Maintainer-ready confidence: high for source-level reproduction, strict schema-validator proof, duplicate-conflict regression coverage including flat schedule/payload shorthands, and unchanged gateway schema behavior; live provider proof intentionally not claimed.
- Patch quality notes: production changes are confined to cron key canonicalization and avoiding duplicate canonicalization of already-recovered flat cron objects, paired with targeted regression tests.
