### PR TITLE
fix(agents): forward resolved sub-agent model to gateway call (#91171)

### DIFF
--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -963,8 +963,9 @@ describe("spawnSubagentDirect seam flow", () => {
         // Admin-only methods must be pinned to operator.admin.
         expect(call.scopes).toEqual(["operator.admin"]);
       } else {
-        // Non-admin methods (e.g. "agent") must NOT be forced to admin scope.
-        expect(call.scopes).toBeUndefined();
+        // "agent" must escalate to operator.admin when a resolved model is
+        // forwarded as an explicit override (#91171).
+        expect(call.scopes).toEqual(["operator.admin"]);
       }
     }
   });
@@ -1107,5 +1108,27 @@ describe("spawnSubagentDirect seam flow", () => {
         (call) => (call[0] as { method?: string }).method === "agent",
       ),
     ).toBe(false);
+  });
+
+  // ── Regression: #91171 sub-agent model routing ─────────────────
+  it("forwards resolved model + provider to the sub-agent gateway agent call", async () => {
+    const result = await spawnSubagentDirect(
+      {
+        task: "spawn sub-agent with explicit qwen model",
+        model: "qwen/qwen3.6-plus",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "qq",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const agentRequest = gatewayRequest("agent");
+    const agentParams = requireRecord(agentRequest.params);
+    // Regression: resolved model must be forwarded to the child gateway call
+    // so the sub-agent actually runs on the requested provider/model.
+    expect(agentParams.model).toBe("qwen3.6-plus");
+    expect(agentParams.provider).toBe("qwen");
   });
 });

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -239,7 +239,7 @@ async function updateSubagentSessionStore(
 }
 
 async function callSubagentGateway(
-  params: Parameters<typeof callGateway>[0],
+  params: Parameters<typeof callGateway>[0] & { allowModelOverride?: boolean },
 ): Promise<Awaited<ReturnType<typeof callGateway>>> {
   // Subagent lifecycle requires methods spanning multiple scope tiers
   // (sessions.patch / sessions.delete → admin, agent → write).  When each call
@@ -250,7 +250,19 @@ async function callSubagentGateway(
   //
   // Only admin-only methods are pinned to ADMIN_SCOPE; other methods (e.g.
   // "agent" -> write) keep their least-privilege scope.
-  const scopes = params.scopes ?? (isAdminOnlyMethod(params.method) ? [ADMIN_SCOPE] : undefined);
+  const allowModelOverride = params.allowModelOverride === true;
+  const baseScopes =
+    params.scopes ?? (isAdminOnlyMethod(params.method) ? [ADMIN_SCOPE] : undefined);
+  // When a resolved model is forwarded as an explicit override, escalate to
+  // admin scope so the gateway authorizes it. ADMIN_SCOPE is required for
+  // both dispatch paths: out-of-process callGateway (no synthetic client
+  // seam) and in-process dispatchGatewayMethodInProcess (synthetic client
+  // gains allowModelOverride from the broader scope set) (#91171).
+  const scopes = (() => {
+    if (!allowModelOverride) return baseScopes;
+    if (baseScopes == null) return [ADMIN_SCOPE];
+    return baseScopes.includes(ADMIN_SCOPE) ? baseScopes : [...baseScopes, ADMIN_SCOPE];
+  })();
   const request = {
     ...params,
     ...(scopes != null ? { scopes } : {}),
@@ -271,6 +283,7 @@ async function callSubagentGateway(
         ...(scopes != null ? { forceSyntheticClient: true } : {}),
         timeoutMs: request.timeoutMs,
         ...(scopes != null ? { syntheticScopes: scopes } : {}),
+        ...(allowModelOverride ? { allowSyntheticModelOverride: true } : {}),
       },
     );
   }
@@ -1562,6 +1575,13 @@ export async function spawnSubagentDirect(
       workspaceDir: _workspaceDir,
       ...publicSpawnedMetadata
     } = spawnedMetadata;
+    // Forward the resolved sub-agent model to the child gateway call so the
+    // spawned run actually uses the requested provider/model instead of
+    // silently falling back to the agent default (#91171). The gateway
+    // requires explicit override authorization, hence allowModelOverride.
+    const resolvedModelRef = resolvedModel?.trim();
+    const { provider: resolvedProvider, model: resolvedModelId } = splitModelRef(resolvedModelRef);
+    const hasResolvedModelOverride = Boolean(resolvedProvider && resolvedModelId);
     const response = await callSubagentGateway({
       method: "agent",
       params: {
@@ -1583,6 +1603,7 @@ export async function spawnSubagentDirect(
         thinking: thinkingOverride,
         timeout: runTimeoutSeconds,
         label: label || undefined,
+        ...(hasResolvedModelOverride ? { model: resolvedModelId, provider: resolvedProvider } : {}),
         ...(bootstrapContextMode
           ? {
               bootstrapContextMode,
@@ -1592,6 +1613,7 @@ export async function spawnSubagentDirect(
         ...publicSpawnedMetadata,
       },
       timeoutMs: resolveSubagentAgentGatewayTimeoutMs(runTimeoutSeconds),
+      ...(hasResolvedModelOverride ? { allowModelOverride: true } : {}),
     });
     const runId = readGatewayRunId(response);
     if (runId) {


### PR DESCRIPTION
Closes #91171

## Summary

Forwards the resolved sub-agent model and provider to the child gateway `agent` call so spawned runs honor `sessions_spawn({ model })` instead of silently falling back to the agent default. Authorized via `ADMIN_SCOPE` / `allowSyntheticModelOverride`. Regression test added in `src/agents/subagent-spawn.test.ts`.

## What Problem This Solves

Fixes an issue where users who configured `sessions_spawn({ model: "qwen/qwen3.6-plus" })` (or any explicit provider/model) would see the spawn response report `resolvedModel` and `modelApplied: true`, but the child sub-agent would silently run on the default provider/model (e.g. `deepseek/deepseek-v4-pro`). Affected: 5/5 spawned sub-agents in the reporter's QQ/Qwen scenario fell back to DeepSeek, forcing image recognition to OCR.

The sub-agent spawn seam resolved the explicit model and persisted it to the child session, but the child gateway `agent` launch call did not forward the resolved provider/model, so the gateway fell back to the agent default.

### What does this PR do?

- Forwards the resolved `provider` and `model` into the gateway `agent` call in `spawnSubagentDirect`.
- Authorizes the override via `ADMIN_SCOPE` for the WebSocket path and `allowSyntheticModelOverride: true` for the in-process dispatch path so the gateway accepts the forwarded fields.
- Only adds the override when a resolved model is actually set, so existing default-model spawns are unchanged.
- Adds a regression test in `src/agents/subagent-spawn.test.ts` asserting the gateway `agent` request now includes `params.model` and `params.provider` from the resolved sub-agent model.

### Intentionally out of scope

- Plugin subagent override authorization (`src/gateway/server-plugins.ts:144`) is unchanged; the fix is in the direct sub-agent spawn path.
- Default model precedence policy is unchanged.
- `CHANGELOG.md` is left to the maintainer (CONTRIBUTING rule for contributors).

## Evidence

### Real behavior proof

- **Behavior or issue addressed:** Sub-agent gateway `agent` call now receives the resolved `provider` and `model` so the child run honors `sessions_spawn({ model })`.
- **Source proof:** `src/agents/subagent-spawn.ts:1577-1580` (forwarding) and `src/agents/subagent-spawn.ts:253-265` (authorization) on `b3968f69c910` era.
- **Test seam:** `callGatewayMock` in `src/agents/subagent-spawn.test-helpers.ts` records `{ method, params, ... }` for assertions; existing `gatewayRequest("agent")` helper inspects the recorded call.
- **Real environment tested:** Local checkout (Windows 11, Node 24) with `subagent-spawn` vitest seam.
- **Exact steps or command run after this patch:**

```bash
# RED before fix (failing test on pre-fix code)
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
  -t "forwards resolved model"
# -> FAIL: AssertionError: expected undefined to be 'qwen3.6-plus'

# GREEN after fix (same test on post-fix code)
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
  -t "forwards resolved model"
# -> PASS: forwards resolved model + provider to the sub-agent gateway agent call (1ms)
```

- **Before evidence:**
  - RED test run: `AssertionError: expected undefined to be 'qwen3.6-plus'`
  - Call shape before fix: `{ method: "agent", params: { message, sessionKey, ..., timeout, label, ... } }` — no `model` or `provider`.
- **After evidence:**
  - GREEN test run: `✓ forwards resolved model + provider to the sub-agent gateway agent call 1ms`
  - Call shape after fix: `{ method: "agent", params: { message, sessionKey, ..., timeout, label, model: "qwen3.6-plus", provider: "qwen", ... } }`
  - In-process dispatch also receives `allowSyntheticModelOverride: true`.
- **Observed result after fix:** Spawned sub-agent gateway `agent` request now contains the resolved `provider` and `model` from the explicit `sessions_spawn({ model: "qwen/qwen3.6-plus" })` call, so the child run honors the requested provider/model instead of silently falling back to the agent default.
- **Both dispatch paths covered:** the fix escalates the `agent` call to `operator.admin` whenever a resolved model is forwarded, so the gateway's `resolveAllowModelOverrideFromClient` returns `true` on both the out-of-process `callGateway` path and the in-process `dispatchGatewayMethodInProcess` path. The pre-fix `pins admin-only methods to operator.admin` test was updated to assert the new admin-scope requirement for the `agent` call.
- **What was not tested:**
  - No live QQ/Qwen/DeepSeek runtime was exercised from this checkout. Verification is bounded to source + test seam (L2). The fix is mechanical — forwarding two fields plus an authorization flag — and the test seam covers the full call shape via the existing `callGatewayMock`.
  - The synthetic-client `allowSyntheticModelOverride` path in `src/gateway/server-plugins.ts:417` is exercised indirectly by the in-process dispatch test seam but not by a dedicated live dispatch test.
  - ClawSweeper review noted that v2026.6.1 already wrote `modelOverride` and `providerOverride` via `buildDirectChildSessionPatch`; the new path does not regress that, it only adds the launch-time forwarding.

### Reproduction (source-level)

The reporter's runtime (OpenClaw 2026.6.1, QQ channel) used `sessions_spawn({ model: "qwen/qwen3.6-plus" })`. The spawn response reported `resolvedModel: "qwen/qwen3.6-plus"` and `modelApplied: true`, but the child gateway `agent` call at `src/agents/subagent-spawn.ts:1565` (review commit `b3968f69c910`) did not include `model` or `provider` in its `params`. Result: child run used `deepseek/deepseek-v4-pro`.

### Tests and validation

```text
# RED before fix
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
  -t "forwards resolved model"
# -> FAIL: expected undefined to be 'qwen3.6-plus'
```

```text
# GREEN after fix
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
  -t "forwards resolved model"
# -> PASS: forwards resolved model + provider to the sub-agent gateway agent call
```

```text
# Full subagent-spawn file
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
  src/agents/subagent-spawn.test.ts
# -> 25 passed (1 pre-existing Windows path failure unrelated to this fix)
```

```text
# Format
node_modules/.bin/oxfmt --check src/agents/subagent-spawn.ts \
  src/agents/subagent-spawn.test.ts spec-91171.md
# -> All matched files use the correct format.
```

```text
# Whitespace
git diff --check
# -> clean
```

## Why this change was made

The sub-agent spawn path is the canonical place to forward an explicit model override into the child gateway call. Two reasons the previous path silently dropped it:

1. `spawnSubagentDirect` resolved the model via `resolveSubagentModelAndThinkingPlan`, but the call to `callSubagentGateway({ method: "agent", params: {...} })` at `src/agents/subagent-spawn.ts:1565` did not include `model` or `provider` fields.
2. The gateway `agent` handler (`src/gateway/server-methods/agent.ts:1131`) treats request `provider` / `model` as explicit overrides and rejects them unless the caller is authorized. The sub-agent spawn uses `WRITE_SCOPE` for `agent`, not `ADMIN_SCOPE`, so even if the fields had been forwarded, the gateway would have rejected them.

This change forwards the resolved `provider` and `model` into the gateway call and authorizes the override:

- For the in-process dispatch path, sets `allowSyntheticModelOverride: true` on `dispatchGatewayMethodInProcess`, which marks the synthetic client with `internal.allowModelOverride = true` so the gateway accepts the forwarded model.
- For the WebSocket path, escalates the call to `ADMIN_SCOPE` (in addition to any scopes the caller already declared) so the gateway's `resolveAllowModelOverrideFromClient` returns true.

The override is only added when a resolved model is actually set, so existing default-model spawns are unchanged.

## User Impact

Users who explicitly pass `model` to `sessions_spawn` (or rely on the inherited `modelOverride` from the requester session) will see the spawned sub-agent actually use that model. The 5/5 fall-back-to-DeepSeek scenario becomes a 5/5 honored-Qwen scenario. Existing default-model spawns are unchanged because the override fields are only added when a resolved model is set. Image-recognition flows on Qwen stop silently degrading to OCR.

## Risk checklist

- [x] No `CHANGELOG.md` edit (CONTRIBUTING)
- [x] No `--no-maintainer-edit` (CONTRIBUTING)
- [x] No parallel open PR for #91171 (closed unmerged predecessors #91190, #91206, #95210, #95217, #95286 excluded)
- [x] AI-assisted: yes (Hermes Agent) — clearly marked in PR body
- [x] No live runtime proof (L2 only) — `What was not tested` section above
- [x] Diff is bounded: 2 files, 22 lines added (42 lines including test), 2 lines modified
- [x] No new config surface, no new env var, no new compat layer
- [x] Owner-boundary respected: only direct sub-agent spawn path touched
- [x] Format: `oxfmt --check` passes on all changed files
- [x] Whitespace: `git diff --check` clean
- [x] Vitest: 25/26 pass (1 pre-existing Windows path failure unrelated to this fix)

## Current review state

This is a fresh PR. No prior review. No bot reviews yet.

ClawSweeper review on #91171 (per `[clawsweeper-review item=91171]`, reviewed 2026-06-20 against `b3968f69c910`): "keep open for maintainer follow-up". The same review notes that v2026.6.1 already wrote `modelOverride` and `providerOverride` via `buildDirectChildSessionPatch`; the remaining current-main gap was the direct child run launch path — exactly what this PR fixes.

### Related

- #91171 (canonical report — also covers #73444 same_root_cause).
- Closed unmerged predecessors: #91190, #91206, #95210, #95217, #95286. Those PRs proposed similar forwarding but were closed without merge. This PR takes the narrow source-side forwarding path without policy changes.
