### PR TITLE
fix(cron): trim whitespace from object keys to handle malformed model outputs

### DIFF
--- a/src/agents/tools/cron-tool-canonicalize.ts
+++ b/src/agents/tools/cron-tool-canonicalize.ts
@@ -86,17 +86,24 @@ function moveDefinedField(params: {
 }
 
 /**
- * Trims whitespace from object keys to handle malformed model outputs.
+ * Trims whitespace from known cron keys to handle malformed model outputs.
  * Some small/local models (e.g. qwen35b via llamacpp) emit JSON with trailing
  * whitespace in object keys (e.g. `"schedule "` instead of `"schedule"`).
- * See: https://github.com/openclaw/openclaw/issues/95407
+ * Only trims recognized cron keys to avoid silent field overwrites or
+ * prototype-sensitive assignments. See: https://github.com/openclaw/openclaw/issues/95407
  */
-function trimObjectKeys(value: Record<string, unknown>): Record<string, unknown> {
+function trimKnownCronKeys(value: Record<string, unknown>): Record<string, unknown> {
   const trimmed: Record<string, unknown> = {};
-  for (const key of Object.keys(value)) {
-    const clean = key.trim();
-    if (clean.length > 0) {
-      trimmed[clean] = value[key];
+  for (const [key, entry] of Object.entries(value)) {
+    if (CRON_RECOVERABLE_OBJECT_KEYS.has(key)) {
+      trimmed[key] = entry;
+      continue;
+    }
+    const cleanKey = key.trim();
+    if (CRON_RECOVERABLE_OBJECT_KEYS.has(cleanKey)) {
+      trimmed[cleanKey] = entry;
+    } else {
+      trimmed[key] = entry;
     }
   }
   return trimmed;
@@ -264,15 +271,10 @@ function canonicalizeCronToolPayload(value: Record<string, unknown>): void {
 export function canonicalizeCronToolObject(
   value: Record<string, unknown>,
 ): Record<string, unknown> {
-  // Trim whitespace from keys to handle malformed model outputs
-  // Some small/local models emit keys with trailing spaces (e.g. "schedule ")
-  const trimmedValue = trimObjectKeys(value);
-  const unwrapped = isRecord(trimmedValue.data)
-    ? trimmedValue.data
-    : isRecord(trimmedValue.job)
-      ? trimmedValue.job
-      : trimmedValue;
-  const next = { ...unwrapped };
+  // Unwrap data/job wrappers first, then trim whitespace from known keys
+  // to handle malformed model outputs (e.g. "schedule " instead of "schedule")
+  const unwrapped = isRecord(value.data) ? value.data : isRecord(value.job) ? value.job : value;
+  const next = trimKnownCronKeys({ ...unwrapped });
   repairConcatenatedCronToolKeys(next);
   canonicalizeCronToolSchedule(next);
   canonicalizeCronToolPayload(next);
@@ -299,9 +301,9 @@ export function recoverCronObjectFromFlatParams(params: Record<string, unknown>)
   found: boolean;
   value: Record<string, unknown>;
 } {
-  // Trim whitespace from keys to handle malformed model outputs
+  // Trim whitespace from known keys to handle malformed model outputs
   // Some small/local models emit keys with trailing spaces (e.g. "schedule ")
-  const trimmedParams = trimObjectKeys(params);
+  const trimmedParams = trimKnownCronKeys(params);
   const value: Record<string, unknown> = {};
   let found = false;
   for (const key of Object.keys(trimmedParams)) {

--- a/src/agents/tools/cron-tool-canonicalize.ts
+++ b/src/agents/tools/cron-tool-canonicalize.ts
@@ -85,6 +85,23 @@ function moveDefinedField(params: {
   return true;
 }
 
+/**
+ * Trims whitespace from object keys to handle malformed model outputs.
+ * Some small/local models (e.g. qwen35b via llamacpp) emit JSON with trailing
+ * whitespace in object keys (e.g. `"schedule "` instead of `"schedule"`).
+ * See: https://github.com/openclaw/openclaw/issues/95407
+ */
+function trimObjectKeys(value: Record<string, unknown>): Record<string, unknown> {
+  const trimmed: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    const clean = key.trim();
+    if (clean.length > 0) {
+      trimmed[clean] = value[key];
+    }
+  }
+  return trimmed;
+}
+
 function repairConcatenatedCronToolKeys(value: Record<string, unknown>): void {
   // Some small/local tool-call parsers can return valid JSON with adjacent cron
   // key names merged. Recover only the observed schema-specific pairs before
@@ -247,7 +264,14 @@ function canonicalizeCronToolPayload(value: Record<string, unknown>): void {
 export function canonicalizeCronToolObject(
   value: Record<string, unknown>,
 ): Record<string, unknown> {
-  const unwrapped = isRecord(value.data) ? value.data : isRecord(value.job) ? value.job : value;
+  // Trim whitespace from keys to handle malformed model outputs
+  // Some small/local models emit keys with trailing spaces (e.g. "schedule ")
+  const trimmedValue = trimObjectKeys(value);
+  const unwrapped = isRecord(trimmedValue.data)
+    ? trimmedValue.data
+    : isRecord(trimmedValue.job)
+      ? trimmedValue.job
+      : trimmedValue;
   const next = { ...unwrapped };
   repairConcatenatedCronToolKeys(next);
   canonicalizeCronToolSchedule(next);
@@ -275,11 +299,14 @@ export function recoverCronObjectFromFlatParams(params: Record<string, unknown>)
   found: boolean;
   value: Record<string, unknown>;
 } {
+  // Trim whitespace from keys to handle malformed model outputs
+  // Some small/local models emit keys with trailing spaces (e.g. "schedule ")
+  const trimmedParams = trimObjectKeys(params);
   const value: Record<string, unknown> = {};
   let found = false;
-  for (const key of Object.keys(params)) {
-    if (CRON_RECOVERABLE_OBJECT_KEYS.has(key) && params[key] !== undefined) {
-      value[key] = params[key];
+  for (const key of Object.keys(trimmedParams)) {
+    if (CRON_RECOVERABLE_OBJECT_KEYS.has(key) && trimmedParams[key] !== undefined) {
+      value[key] = trimmedParams[key];
       found = true;
     }
   }

--- a/src/agents/tools/cron-tool.flat-params.test.ts
+++ b/src/agents/tools/cron-tool.flat-params.test.ts
@@ -181,4 +181,85 @@ describe("cron tool flat-params", () => {
       staggerMs: 30_000,
     });
   });
+
+  it("trims trailing whitespace from object keys in job (Issue #95407)", async () => {
+    // Some small/local models (e.g. qwen35b via llamacpp) emit JSON with
+    // trailing whitespace in object keys. The cron tool should trim these
+    // keys before processing to avoid validation errors.
+    const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
+
+    await tool.execute("call-trailing-space-keys", {
+      action: "add",
+      job: {
+        name: "test job",
+        "schedule ": {
+          kind: "cron",
+          expr: "0 * * * *",
+          tz: "UTC",
+        },
+        "sessionTarget ": "isolated",
+        "payload ": {
+          kind: "agentTurn",
+          message: "test message",
+        },
+        "enabled ": true,
+      },
+    });
+
+    const [method, _gatewayOpts, params] = firstGatewayToolCall<{
+      job?: {
+        name?: string;
+        schedule?: unknown;
+        sessionTarget?: string;
+        payload?: unknown;
+        enabled?: boolean;
+      };
+    }>();
+    expect(method).toBe("cron.add");
+    expect(params.job?.name).toBe("test job");
+    expect(params.job?.schedule).toEqual({
+      kind: "cron",
+      expr: "0 * * * *",
+      tz: "UTC",
+    });
+    expect(params.job?.sessionTarget).toBe("isolated");
+    expect(params.job?.payload).toEqual({
+      kind: "agentTurn",
+      message: "test message",
+    });
+    expect(params.job?.enabled).toBe(true);
+  });
+
+  it("trims trailing whitespace from flat params (Issue #95407)", async () => {
+    // Flat params recovery should also trim whitespace from keys
+    const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
+
+    await tool.execute("call-trailing-space-flat", {
+      action: "add",
+      "name ": "flat job",
+      "schedule ": {
+        kind: "cron",
+        expr: "0 12 * * *",
+        tz: "UTC",
+      },
+      "message ": "flat message",
+    });
+
+    const [method, _gatewayOpts, params] = firstGatewayToolCall<{
+      name?: string;
+      schedule?: unknown;
+      payload?: unknown;
+    }>();
+    expect(method).toBe("cron.add");
+    expect(params.name).toBe("flat job");
+    expect(params.schedule).toEqual({
+      kind: "cron",
+      expr: "0 12 * * *",
+      tz: "UTC",
+    });
+    expect(params.payload).toEqual({
+      kind: "agentTurn",
+      message: "flat message",
+    });
+  });
 });

--- a/src/agents/tools/cron-tool.flat-params.test.ts
+++ b/src/agents/tools/cron-tool.flat-params.test.ts
@@ -207,27 +207,26 @@ describe("cron tool flat-params", () => {
     });
 
     const [method, _gatewayOpts, params] = firstGatewayToolCall<{
-      job?: {
-        name?: string;
-        schedule?: unknown;
-        sessionTarget?: string;
-        payload?: unknown;
-        enabled?: boolean;
-      };
+      name?: string;
+      schedule?: unknown;
+      sessionTarget?: string;
+      payload?: unknown;
+      enabled?: boolean;
     }>();
     expect(method).toBe("cron.add");
-    expect(params.job?.name).toBe("test job");
-    expect(params.job?.schedule).toEqual({
+    expect(params.name).toBe("test job");
+    expect(params.schedule).toEqual({
       kind: "cron",
       expr: "0 * * * *",
       tz: "UTC",
+      staggerMs: 300000,
     });
-    expect(params.job?.sessionTarget).toBe("isolated");
-    expect(params.job?.payload).toEqual({
+    expect(params.sessionTarget).toBe("isolated");
+    expect(params.payload).toEqual({
       kind: "agentTurn",
       message: "test message",
     });
-    expect(params.job?.enabled).toBe(true);
+    expect(params.enabled).toBe(true);
   });
 
   it("trims trailing whitespace from flat params (Issue #95407)", async () => {


### PR DESCRIPTION
## Summary

Some small/local models (e.g. qwen35b via llamacpp) emit JSON with trailing whitespace in object keys (e.g. `"schedule "` instead of `"schedule"`). This causes cron tool validation to fail because the trimmed key names don't match the expected schema properties.

## Changes

- Added `trimObjectKeys` helper function that normalizes keys by trimming leading/trailing whitespace
- Applied trimming in `canonicalizeCronToolObject` to handle structured job objects
- Applied trimming in `recoverCronObjectFromFlatParams` to handle flat parameter recovery
- Added test cases to verify trailing whitespace is properly handled

## Testing

- Added two new test cases in `cron-tool.flat-params.test.ts`:
  - `trims trailing whitespace from job keys (Issue #95407)` - tests structured job object with trailing spaces
  - `trims trailing whitespace from flat params (Issue #95407)` - tests flat parameter recovery with trailing spaces
- Existing tests continue to pass

Fixes #95407