### PR TITLE
fix(slack): bridge presentation capabilities and renderPresentation through channel outbound facade

### DIFF
--- a/extensions/slack/src/blocks-render.ts
+++ b/extensions/slack/src/blocks-render.ts
@@ -12,16 +12,23 @@ import type {
   MessagePresentationSelectBlock,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { SLACK_REPLY_BUTTON_ACTION_ID, SLACK_REPLY_SELECT_ACTION_ID } from "./reply-action-ids.js";
+import {
+  SLACK_ACTION_BLOCK_ELEMENTS_MAX,
+  SLACK_ACTION_LABEL_MAX,
+  SLACK_BUTTON_VALUE_MAX,
+  SLACK_HEADER_TEXT_MAX,
+  SLACK_OPTION_VALUE_MAX,
+  SLACK_SECTION_TEXT_MAX,
+  SLACK_STATIC_SELECT_OPTIONS_MAX,
+} from "./presentation.js";
+import {
+  SLACK_REPLY_BUTTON_ACTION_ID,
+  SLACK_REPLY_LINK_ACTION_ID,
+  SLACK_REPLY_SELECT_ACTION_ID,
+} from "./reply-action-ids.js";
 import { truncateSlackText } from "./truncate.js";
 
-const SLACK_SECTION_TEXT_MAX = 3000;
-const SLACK_PLAIN_TEXT_MAX = 75;
-const SLACK_OPTION_VALUE_MAX = 150;
-const SLACK_BUTTON_VALUE_MAX = 2000;
 const SLACK_BUTTON_URL_MAX = 3000;
-const SLACK_STATIC_SELECT_OPTIONS_MAX = 100;
-const SLACK_ACTION_BLOCK_ELEMENTS_MAX = 25;
 
 export type SlackBlock = Block | KnownBlock;
 
@@ -32,6 +39,10 @@ type SlackInteractiveBlockRenderOptions = {
 
 function buildSlackReplyButtonActionId(buttonIndex: number, choiceIndex: number): string {
   return `${SLACK_REPLY_BUTTON_ACTION_ID}:${String(buttonIndex)}:${String(choiceIndex + 1)}`;
+}
+
+function buildSlackReplyLinkActionId(buttonIndex: number, choiceIndex: number): string {
+  return `${SLACK_REPLY_LINK_ACTION_ID}:${String(buttonIndex)}:${String(choiceIndex + 1)}`;
 }
 
 function buildSlackReplySelectActionId(selectIndex: number): string {
@@ -154,18 +165,21 @@ export function buildSlackInteractiveBlocks(
           if (!value && !url) {
             return [];
           }
+          const target = url ? { url } : { value };
           const style = resolveSlackButtonStyle(button.style);
           return [
             {
               type: "button" as const,
-              action_id: buildSlackReplyButtonActionId(state.buttonIndex + 1, choiceIndex),
+              // Slack emits block_actions even for URL buttons; link-only actions must be ignored.
+              action_id: url
+                ? buildSlackReplyLinkActionId(state.buttonIndex + 1, choiceIndex)
+                : buildSlackReplyButtonActionId(state.buttonIndex + 1, choiceIndex),
               text: {
                 type: "plain_text" as const,
-                text: truncateSlackText(button.label, SLACK_PLAIN_TEXT_MAX),
+                text: truncateSlackText(button.label, SLACK_ACTION_LABEL_MAX),
                 emoji: true,
               },
-              ...(value ? { value } : {}),
-              ...(url ? { url } : {}),
+              ...target,
               ...(style ? { style } : {}),
             },
           ];
@@ -202,14 +216,14 @@ export function buildSlackInteractiveBlocks(
             type: "plain_text",
             text: truncateSlackText(
               normalizeOptionalString(block.placeholder) ?? "Choose an option",
-              SLACK_PLAIN_TEXT_MAX,
+              SLACK_ACTION_LABEL_MAX,
             ),
             emoji: true,
           },
           options: optionsLocal.map((option, _choiceIndex) => ({
             text: {
               type: "plain_text",
-              text: truncateSlackText(option.label, SLACK_PLAIN_TEXT_MAX),
+              text: truncateSlackText(option.label, SLACK_ACTION_LABEL_MAX),
               emoji: true,
             },
             value: option.value,
@@ -235,11 +249,13 @@ export function buildSlackPresentationBlocks(
       type: "header",
       text: {
         type: "plain_text",
-        text: truncateSlackText(presentation.title, 150),
+        text: truncateSlackText(presentation.title, SLACK_HEADER_TEXT_MAX),
         emoji: true,
       },
     });
   }
+  let buttonIndex = options.buttonIndexOffset ?? 0;
+  let selectIndex = options.selectIndexOffset ?? 0;
   for (const block of presentation.blocks) {
     if (block.type === "text" || block.type === "context") {
       const text = block.text.trim();
@@ -261,11 +277,8 @@ export function buildSlackPresentationBlocks(
     }
     if (block.type === "divider") {
       blocks.push({ type: "divider" });
+      continue;
     }
-  }
-  let buttonIndex = options.buttonIndexOffset ?? 0;
-  let selectIndex = options.selectIndexOffset ?? 0;
-  for (const block of presentation.blocks) {
     if (block.type === "buttons") {
       const rendered = buildSlackPresentationButtonBlock(block, buttonIndex + 1);
       if (rendered) {
@@ -291,28 +304,24 @@ function buildSlackPresentationButtonBlock(
 ): SlackBlock | undefined {
   const elements = block.buttons
     .flatMap((button, choiceIndex) => {
-      const callbackData = resolveSlackControlValue(button);
-      const value =
-        callbackData && isWithinSlackLimit(callbackData, SLACK_BUTTON_VALUE_MAX)
-          ? callbackData
-          : undefined;
-      const url =
-        button.url && isWithinSlackLimit(button.url, SLACK_BUTTON_URL_MAX) ? button.url : undefined;
-      if (!value && !url) {
+      const target = resolveSlackPresentationButtonTarget(button);
+      if (!target) {
         return [];
       }
       const style = resolveSlackButtonStyle(button.style);
       return [
         {
           type: "button" as const,
-          action_id: buildSlackReplyButtonActionId(buttonIndex, choiceIndex),
+          // Slack emits block_actions even for URL buttons; link-only actions must be ignored.
+          action_id: target.url
+            ? buildSlackReplyLinkActionId(buttonIndex, choiceIndex)
+            : buildSlackReplyButtonActionId(buttonIndex, choiceIndex),
           text: {
             type: "plain_text" as const,
-            text: truncateSlackText(button.label, SLACK_PLAIN_TEXT_MAX),
+            text: truncateSlackText(button.label, SLACK_ACTION_LABEL_MAX),
             emoji: true,
           },
-          ...(value ? { value } : {}),
-          ...(url ? { url } : {}),
+          ...target,
           ...(style ? { style } : {}),
         },
       ];
@@ -325,6 +334,49 @@ function buildSlackPresentationButtonBlock(
         elements,
       }
     : undefined;
+}
+
+function resolveSlackPresentationButtonTarget(
+  button: MessagePresentationButtonsBlock["buttons"][number],
+): { value?: string; url?: string } | undefined {
+  const callbackData = resolveSlackControlValue(button);
+  const value =
+    callbackData && isWithinSlackLimit(callbackData, SLACK_BUTTON_VALUE_MAX)
+      ? callbackData
+      : undefined;
+  const rawUrl = button.url ?? button.webApp?.url ?? button.web_app?.url;
+  const url = rawUrl && isWithinSlackLimit(rawUrl, SLACK_BUTTON_URL_MAX) ? rawUrl : undefined;
+  return url ? { url } : value ? { value } : undefined;
+}
+
+/** True when native Slack rendering preserves every portable control. */
+export function canRenderSlackPresentation(presentation: MessagePresentation): boolean {
+  if (presentation.title && !isWithinSlackLimit(presentation.title.trim(), SLACK_HEADER_TEXT_MAX)) {
+    return false;
+  }
+  return presentation.blocks.every((block) => {
+    if (block.type === "text" || block.type === "context") {
+      return isWithinSlackLimit(block.text.trim(), SLACK_SECTION_TEXT_MAX);
+    }
+    if (block.type === "buttons") {
+      return (
+        block.buttons.length <= SLACK_ACTION_BLOCK_ELEMENTS_MAX &&
+        block.buttons.every((button) => resolveSlackPresentationButtonTarget(button) !== undefined)
+      );
+    }
+    if (block.type === "select") {
+      return (
+        block.options.length <= SLACK_STATIC_SELECT_OPTIONS_MAX &&
+        block.options.every((option) =>
+          isRenderableSlackOption({
+            label: option.label,
+            value: resolveSlackControlValue(option),
+          }),
+        )
+      );
+    }
+    return true;
+  });
 }
 
 function buildSlackPresentationSelectBlock(
@@ -350,14 +402,14 @@ function buildSlackPresentationSelectBlock(
               type: "plain_text",
               text: truncateSlackText(
                 normalizeOptionalString(block.placeholder) ?? "Choose an option",
-                SLACK_PLAIN_TEXT_MAX,
+                SLACK_ACTION_LABEL_MAX,
               ),
               emoji: true,
             },
             options: options.map((option) => ({
               text: {
                 type: "plain_text",
-                text: truncateSlackText(option.label, SLACK_PLAIN_TEXT_MAX),
+                text: truncateSlackText(option.label, SLACK_ACTION_LABEL_MAX),
                 emoji: true,
               },
               value: option.value,

--- a/extensions/slack/src/channel.message-adapter.test.ts
+++ b/extensions/slack/src/channel.message-adapter.test.ts
@@ -6,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { slackPlugin } from "./channel.js";
+import { SLACK_PRESENTATION_CAPABILITIES } from "./presentation.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 
 const cfg = {
@@ -185,6 +186,56 @@ describe("slack channel message adapter", () => {
         },
       },
     });
+  });
+
+  it("renders portable presentations through the facade as card receipts (#95440)", async () => {
+    const outbound = slackPlugin.outbound;
+    const renderPresentation = outbound?.renderPresentation;
+    if (!renderPresentation) {
+      throw new Error("Expected Slack presentation renderer");
+    }
+    expect(outbound.presentationCapabilities).toBe(SLACK_PRESENTATION_CAPABILITIES);
+
+    const presentation = {
+      title: "Status",
+      blocks: [{ type: "divider" as const }],
+    };
+    const payload = { text: "Fallback", presentation };
+    const rendered = await renderPresentation({
+      payload,
+      presentation,
+      ctx: { cfg, to: "C123", text: payload.text, payload },
+    });
+    if (!rendered) {
+      throw new Error("Expected rendered Slack presentation payload");
+    }
+    // Core consumes the portable presentation before handing the native payload to the adapter.
+    const { presentation: _presentation, ...deliveryPayload } = rendered;
+
+    const result = await requirePayloadSender(requireSlackMessageAdapter())({
+      cfg,
+      to: "C123",
+      text: deliveryPayload.text ?? "",
+      payload: deliveryPayload,
+      accountId: "default",
+      deps: { sendSlack },
+    });
+
+    const [to, text, options] = expectLastSendSlackCall();
+    expect(to).toBe("C123");
+    expect(text).toBe("Fallback");
+    expect(options.blocks).toEqual([
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "Fallback" },
+      },
+      {
+        type: "header",
+        text: { type: "plain_text", text: "Status", emoji: true },
+      },
+      { type: "divider" },
+    ]);
+    expect(result.receipt.parts[0]?.kind).toBe("card");
   });
 
   it("backs declared live preview finalizer capabilities with adapter proofs", async () => {

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -1077,6 +1077,13 @@ describe("slackPlugin outbound", () => {
         type: "section",
         text: {
           type: "mrkdwn",
+          text: "hello",
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
           text: "Block body",
         },
       },

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -9,8 +9,11 @@ import {
   buildThreadAwareOutboundSessionRoute,
   createChatChannelPlugin,
 } from "openclaw/plugin-sdk/channel-core";
-import { createChannelMessageAdapterFromOutbound } from "openclaw/plugin-sdk/channel-outbound";
-import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  createChannelMessageAdapterFromOutbound,
+  createRuntimeOutboundDelegates,
+  resolveOutboundSendDep,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import {
   attachChannelToResult,
@@ -61,6 +64,7 @@ import {
   isSlackInteractiveRepliesEnabled,
 } from "./interactive-replies.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
+import { SLACK_PRESENTATION_CAPABILITIES } from "./presentation.js";
 import type { SlackProbe } from "./probe.js";
 import { resolveSlackReplyBlocks } from "./reply-blocks.js";
 import { getOptionalSlackRuntime } from "./runtime.js";
@@ -426,6 +430,14 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
       accountId,
       payload,
     }),
+  presentationCapabilities: SLACK_PRESENTATION_CAPABILITIES,
+  ...createRuntimeOutboundDelegates({
+    getRuntime: loadSlackOutboundAdapterModule,
+    renderPresentation: {
+      resolve: ({ slackOutbound }) => slackOutbound.renderPresentation,
+      unavailableMessage: "Slack outbound presentation rendering is unavailable",
+    },
+  }),
   sendPayload: async (ctx) => {
     const { send, threadTsValue, tokenOverride } = await resolveSlackSendContext({
       cfg: ctx.cfg,

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -19,6 +19,7 @@ import { isSlackExecApprovalAuthorizedSender } from "../../exec-approvals.js";
 import { dispatchSlackPluginInteractiveHandler } from "../../interactive-dispatch.js";
 import {
   SLACK_REPLY_BUTTON_ACTION_ID,
+  SLACK_REPLY_LINK_ACTION_ID,
   SLACK_REPLY_SELECT_ACTION_ID,
 } from "../../reply-action-ids.js";
 import { truncateSlackText } from "../../truncate.js";
@@ -377,6 +378,17 @@ function isSlackReplyActionId(actionId: string): boolean {
     actionId.startsWith(`${SLACK_REPLY_BUTTON_ACTION_ID}:`) ||
     actionId.startsWith(`${SLACK_REPLY_SELECT_ACTION_ID}:`)
   );
+}
+
+function isSlackReplyLinkAction(parsed: ParsedSlackBlockAction): boolean {
+  if (
+    parsed.actionId === SLACK_REPLY_LINK_ACTION_ID ||
+    parsed.actionId.startsWith(`${SLACK_REPLY_LINK_ACTION_ID}:`)
+  ) {
+    return true;
+  }
+  const legacyUrl = normalizeOptionalString((parsed.typedAction as { url?: unknown }).url);
+  return Boolean(legacyUrl && isSlackReplyActionId(parsed.actionId));
 }
 
 function buildSlackPluginInteractionId(params: {
@@ -902,6 +914,10 @@ async function handleSlackBlockAction(params: {
     log: params.ctx.runtime.log,
   });
   if (!parsed) {
+    return;
+  }
+  // Slack reports URL-button clicks too; navigation must not enqueue an agent interaction.
+  if (isSlackReplyLinkAction(parsed)) {
     return;
   }
   params.trackEvent?.();

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -1397,6 +1397,53 @@ describe("registerSlackInteractionEvents", () => {
     });
   });
 
+  it.each([
+    { name: "current", actionId: "openclaw:reply_link:1:1", value: undefined },
+    {
+      name: "legacy",
+      actionId: "openclaw:reply_button:1:1",
+      value: "/approve req-1 allow-once",
+    },
+  ])("ignores $name Slack callbacks emitted for link-only reply buttons", async (testCase) => {
+    const { ctx, app, getHandler } = createContext();
+    registerSlackInteractionEvents({ ctx: ctx as never });
+
+    const ack = vi.fn().mockResolvedValue(undefined);
+    await getHandler()({
+      ack,
+      body: {
+        user: { id: "U123" },
+        channel: { id: "C1" },
+        container: { channel_id: "C1", message_ts: "100.200" },
+        message: {
+          ts: "100.200",
+          text: "fallback",
+          blocks: [
+            {
+              type: "actions",
+              block_id: "reply_actions",
+              elements: [{ type: "button", action_id: testCase.actionId }],
+            },
+          ],
+        },
+      },
+      action: {
+        type: "button",
+        action_id: testCase.actionId,
+        block_id: "reply_actions",
+        url: "https://example.com/app",
+        ...(testCase.value ? { value: testCase.value } : {}),
+        text: { type: "plain_text", text: "Launch" },
+      },
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect(dispatchPluginInteractiveHandlerMock).not.toHaveBeenCalled();
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatMock).not.toHaveBeenCalled();
+    expect(app.client.chat.update).not.toHaveBeenCalled();
+  });
+
   it("keeps exec approval buttons when gateway resolution fails", async () => {
     resolveApprovalOverGatewayMock.mockRejectedValueOnce(new Error("gateway down"));
     const { ctx, app, getHandler } = createContext();

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -75,6 +75,10 @@ describe("slackOutbound", () => {
       blocks: [
         {
           type: "section",
+          text: { type: "mrkdwn", text: "final text" },
+        },
+        {
+          type: "section",
           text: { type: "mrkdwn", text: "Block body" },
         },
       ],

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/channel-send-result";
 import {
   resolveInteractiveTextFallback,
+  renderMessagePresentationFallbackText,
   type InteractiveReply,
   type MessagePresentation,
 } from "openclaw/plugin-sdk/interactive-runtime";
@@ -17,21 +18,33 @@ import {
   sendPayloadMediaSequenceAndFinalize,
   sendTextMediaPayload,
 } from "openclaw/plugin-sdk/reply-payload";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { parseSlackBlocksInput } from "./blocks-input.js";
+import { parseSlackBlocksInput, SLACK_MAX_BLOCKS } from "./blocks-input.js";
 import {
   buildSlackInteractiveBlocks,
   buildSlackPresentationBlocks,
+  canRenderSlackPresentation,
   resolveSlackInteractiveBlockOffsets,
   type SlackBlock,
 } from "./blocks-render.js";
-import { compileSlackInteractiveReplies } from "./interactive-replies.js";
+import { markdownToSlackMrkdwnChunks } from "./format.js";
+import {
+  compileSlackInteractiveReplies,
+  isSlackInteractiveRepliesEnabled,
+} from "./interactive-replies.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
+import { SLACK_PRESENTATION_CAPABILITIES, SLACK_SECTION_TEXT_MAX } from "./presentation.js";
 import type { SlackSendIdentity } from "./send.js";
 import { resolveSlackThreadTsValue } from "./thread-ts.js";
 
-const SLACK_MAX_BLOCKS = 50;
 type SlackSendFn = typeof import("./send.runtime.js").sendMessageSlack;
+
+type SlackOutboundChannelData = Record<string, unknown> & {
+  blocks?: unknown;
+  presentationBlocks?: SlackBlock[];
+  presentationFallbackText?: string;
+};
 
 const loadSlackSendRuntime = createLazyRuntimeModule(() => import("./send.runtime.js"));
 
@@ -61,6 +74,82 @@ function resolveSlackSendIdentity(identity?: OutboundIdentity): SlackSendIdentit
     return undefined;
   }
   return { username, iconUrl, iconEmoji };
+}
+
+function buildSlackTextSectionBlocks(text: string): SlackBlock[] {
+  return markdownToSlackMrkdwnChunks(text.trim(), SLACK_SECTION_TEXT_MAX).map(
+    (chunk): SlackBlock => ({
+      type: "section",
+      text: { type: "mrkdwn", text: chunk },
+    }),
+  );
+}
+
+function normalizeComparableSlackText(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+function isPayloadTextRepresentedInInteractive(
+  text: string,
+  interactive?: InteractiveReply,
+): boolean {
+  const target = normalizeComparableSlackText(text);
+  const fragments =
+    interactive?.blocks.flatMap((block) =>
+      block.type === "text" ? [normalizeComparableSlackText(block.text)] : [],
+    ) ?? [];
+  // Legacy inline controls split surrounding text into multiple interactive text blocks.
+  for (let start = 0; start < fragments.length; start += 1) {
+    let combined = "";
+    for (let end = start; end < fragments.length; end += 1) {
+      combined = normalizeComparableSlackText(`${combined} ${fragments[end]}`);
+      if (combined === target) {
+        return true;
+      }
+      if (combined.length > target.length) {
+        break;
+      }
+    }
+  }
+  return false;
+}
+
+function buildSlackVisiblePayloadTextBlocks(payload: ReplyPayload): SlackBlock[] {
+  const text = normalizeOptionalString(payload.text);
+  if (!text || isPayloadTextRepresentedInInteractive(text, payload.interactive)) {
+    return [];
+  }
+  return buildSlackTextSectionBlocks(text);
+}
+
+function buildSlackPresentationFallback(presentation: MessagePresentation): {
+  blocks: SlackBlock[];
+  text: string;
+} {
+  const text = renderMessagePresentationFallbackText({ presentation }).trim();
+  return { blocks: buildSlackTextSectionBlocks(text), text };
+}
+
+function withSlackPresentationData(
+  payload: ReplyPayload,
+  slackData: SlackOutboundChannelData | undefined,
+  presentationData: Pick<
+    SlackOutboundChannelData,
+    "presentationBlocks" | "presentationFallbackText"
+  >,
+): ReplyPayload {
+  const {
+    presentationBlocks: _presentationBlocks,
+    presentationFallbackText: _presentationFallbackText,
+    ...rest
+  } = slackData ?? {};
+  return {
+    ...payload,
+    channelData: {
+      ...payload.channelData,
+      slack: { ...rest, ...presentationData },
+    },
+  };
 }
 
 async function sendSlackOutboundMessage(params: {
@@ -119,17 +208,21 @@ function resolveSlackBlocks(payload: {
   channelData?: Record<string, unknown>;
   interactive?: InteractiveReply;
   presentation?: MessagePresentation;
+  text?: string;
 }) {
-  const slackData = payload.channelData?.slack as
-    | { blocks?: unknown; presentationBlocks?: SlackBlock[] }
-    | undefined;
+  const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
   const nativeBlocks = parseSlackBlocksInput(slackData?.blocks) as SlackBlock[] | undefined;
   const renderedPresentation =
     slackData?.presentationBlocks ??
-    buildSlackPresentationBlocks(
-      payload.presentation,
-      resolveSlackInteractiveBlockOffsets(nativeBlocks),
-    );
+    (payload.presentation
+      ? [
+          ...buildSlackVisiblePayloadTextBlocks(payload),
+          ...buildSlackPresentationBlocks(
+            payload.presentation,
+            resolveSlackInteractiveBlockOffsets(nativeBlocks),
+          ),
+        ]
+      : []);
   const previousBlocks = [...(nativeBlocks ?? []), ...renderedPresentation];
   const renderedInteractive = resolveRenderedInteractiveBlocks(payload.interactive, previousBlocks);
   const mergedBlocks = [...previousBlocks, ...(renderedInteractive ?? [])];
@@ -148,53 +241,84 @@ export const slackOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: null,
   textChunkLimit: SLACK_TEXT_LIMIT,
-  normalizePayload: ({ payload }) => compileSlackInteractiveReplies(payload),
-  presentationCapabilities: {
-    supported: true,
-    buttons: true,
-    selects: true,
-    context: true,
-    divider: true,
-    limits: {
-      actions: {
-        maxActionsPerRow: 25,
-        maxLabelLength: 75,
-        maxValueBytes: 2000,
-        supportsStyles: true,
-      },
-      selects: {
-        maxOptions: 100,
-        maxLabelLength: 75,
-        maxValueBytes: 150,
-      },
-      text: {
-        maxLength: SLACK_TEXT_LIMIT,
-        encoding: "characters",
-        markdownDialect: "slack-mrkdwn",
-        supportsEdit: true,
-      },
-    },
-  },
-  renderPresentation: ({ payload, presentation }) => {
-    const slackData = payload.channelData?.slack as Record<string, unknown> | undefined;
+  normalizePayload: ({ payload, cfg, accountId }) =>
+    isSlackInteractiveRepliesEnabled({ cfg, accountId })
+      ? compileSlackInteractiveReplies(payload)
+      : payload,
+  presentationCapabilities: SLACK_PRESENTATION_CAPABILITIES,
+  renderPresentation: ({ payload, presentation, ctx }) => {
+    const payloadForBudget = isSlackInteractiveRepliesEnabled({
+      cfg: ctx.cfg,
+      accountId: ctx.accountId,
+    })
+      ? compileSlackInteractiveReplies(payload)
+      : payload;
+    const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
     const nativeBlocks = parseSlackBlocksInput(slackData?.blocks) as SlackBlock[] | undefined;
-    const presentationBlocks = buildSlackPresentationBlocks(
-      presentation,
-      resolveSlackInteractiveBlockOffsets(nativeBlocks),
+    const payloadTextBlocks = buildSlackVisiblePayloadTextBlocks(payloadForBudget);
+    if (canRenderSlackPresentation(presentation)) {
+      const presentationBlocks = [
+        ...payloadTextBlocks,
+        ...buildSlackPresentationBlocks(
+          presentation,
+          resolveSlackInteractiveBlockOffsets(nativeBlocks),
+        ),
+      ];
+      const previousBlocks = [...(nativeBlocks ?? []), ...presentationBlocks];
+      const interactiveBlocks = resolveRenderedInteractiveBlocks(
+        payloadForBudget.interactive,
+        previousBlocks,
+      );
+      if (
+        presentationBlocks.length > 0 &&
+        previousBlocks.length + (interactiveBlocks?.length ?? 0) <= SLACK_MAX_BLOCKS
+      ) {
+        return withSlackPresentationData(payloadForBudget, slackData, { presentationBlocks });
+      }
+    }
+
+    const baseInteractiveBlocks = resolveRenderedInteractiveBlocks(
+      payloadForBudget.interactive,
+      nativeBlocks,
     );
-    if (presentationBlocks.length === 0) {
+    if ((nativeBlocks?.length ?? 0) + (baseInteractiveBlocks?.length ?? 0) === 0) {
       return null;
     }
-    return {
-      ...payload,
-      channelData: {
-        ...payload.channelData,
-        slack: {
-          ...slackData,
-          presentationBlocks,
-        },
-      },
+    const fallback = buildSlackPresentationFallback(presentation);
+    const fallbackBlocks = [...payloadTextBlocks, ...fallback.blocks];
+    if (fallbackBlocks.length === 0) {
+      return null;
+    }
+    const fallbackPayload = {
+      ...payloadForBudget,
+      text: renderMessagePresentationFallbackText({
+        text: payloadForBudget.text,
+        presentation,
+      }),
     };
+    const fallbackPreviousBlocks = [...(nativeBlocks ?? []), ...fallbackBlocks];
+    const fallbackInteractiveBlocks = resolveRenderedInteractiveBlocks(
+      payloadForBudget.interactive,
+      fallbackPreviousBlocks,
+    );
+    if (
+      fallbackPreviousBlocks.length + (fallbackInteractiveBlocks?.length ?? 0) <=
+      SLACK_MAX_BLOCKS
+    ) {
+      return withSlackPresentationData(fallbackPayload, slackData, {
+        presentationBlocks: fallbackBlocks,
+      });
+    }
+
+    const separateFallbackText = renderMessagePresentationFallbackText({
+      text: payloadTextBlocks.length > 0 ? payloadForBudget.text : undefined,
+      presentation,
+    });
+    const separateFallbackPayload =
+      payloadTextBlocks.length > 0 ? { ...payloadForBudget, text: undefined } : payloadForBudget;
+    return withSlackPresentationData(separateFallbackPayload, slackData, {
+      presentationFallbackText: separateFallbackText,
+    });
   },
   sendPayload: async (ctx) => {
     const payload = {
@@ -205,13 +329,22 @@ export const slackOutbound: ChannelOutboundAdapter = {
           interactive: ctx.payload.interactive,
         }) ?? "",
     };
+    const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
+    const presentationFallbackText = normalizeOptionalString(slackData?.presentationFallbackText);
     const blocks = resolveSlackBlocks(payload);
     if (!blocks) {
       return await sendTextMediaPayload({
         channel: "slack",
         ctx: {
           ...ctx,
-          payload,
+          payload: presentationFallbackText
+            ? {
+                ...payload,
+                text: [normalizeOptionalString(payload.text), presentationFallbackText]
+                  .filter((part): part is string => Boolean(part))
+                  .join("\n\n"),
+              }
+            : payload,
         },
         adapter: slackOutbound,
       });
@@ -238,8 +371,8 @@ export const slackOutbound: ChannelOutboundAdapter = {
             identity: ctx.identity,
             onDeliveryResult: ctx.onDeliveryResult,
           }),
-        finalize: async () =>
-          await sendSlackOutboundMessage({
+        finalize: async () => {
+          const blockResult = await sendSlackOutboundMessage({
             cfg: ctx.cfg,
             to: ctx.to,
             text: payload.text ?? "",
@@ -253,7 +386,25 @@ export const slackOutbound: ChannelOutboundAdapter = {
             threadId: ctx.threadId,
             identity: ctx.identity,
             onDeliveryResult: ctx.onDeliveryResult,
-          }),
+          });
+          if (!presentationFallbackText) {
+            return blockResult;
+          }
+          return await sendSlackOutboundMessage({
+            cfg: ctx.cfg,
+            to: ctx.to,
+            text: presentationFallbackText,
+            mediaAccess: ctx.mediaAccess,
+            mediaLocalRoots: ctx.mediaLocalRoots,
+            mediaReadFile: ctx.mediaReadFile,
+            accountId: ctx.accountId,
+            deps: ctx.deps,
+            replyToId: ctx.replyToId,
+            threadId: ctx.threadId,
+            identity: ctx.identity,
+            onDeliveryResult: ctx.onDeliveryResult,
+          });
+        },
       }),
     );
   },

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -60,18 +60,24 @@ describe("slackOutbound sendPayload", () => {
     const call = sendCall(sendMock, 0);
     expect(call[0]).toBe(to);
     expect(call[1]).toBe("Fallback summary");
-    expect(sendOptions(call).blocks).toEqual([{ type: "divider" }]);
+    expect(sendOptions(call).blocks).toEqual([
+      { type: "section", text: { type: "mrkdwn", text: "Fallback summary" } },
+      { type: "divider" },
+    ]);
     expect(result.channel).toBe("slack");
     expect(result.messageId).toBe("sl-1");
   });
 
-  it("keeps the portable fallback when presentation renders no Slack blocks", async () => {
+  it("keeps the full portable fallback when any control cannot render natively", async () => {
     const payload: ReplyPayload = {
+      text: "Fallback",
       presentation: {
+        title: "Actions",
         blocks: [
+          { type: "text", text: "Choose an action" },
           {
             type: "buttons",
-            buttons: [{ label: "Launch", webApp: { url: "https://example.com/app" } }],
+            buttons: [{ label: "Status", action: { type: "command", command: "/status" } }],
           },
         ],
       },
@@ -89,6 +95,245 @@ describe("slackOutbound sendPayload", () => {
     });
 
     expect(rendered).toBeNull();
+  });
+
+  it("renders the portable fallback visibly when native Slack blocks survive", async () => {
+    const payload: ReplyPayload = {
+      channelData: { slack: { blocks: [{ type: "divider" }] } },
+      presentation: {
+        title: "Actions",
+        blocks: [
+          { type: "text", text: "Choose an action" },
+          {
+            type: "buttons",
+            buttons: [{ label: "Status", action: { type: "command", command: "/status" } }],
+          },
+        ],
+      },
+    };
+
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation!,
+      ctx: { cfg: {}, to: "C12345", text: "", payload },
+    });
+
+    expect(rendered?.channelData?.slack).toEqual({
+      blocks: [{ type: "divider" }],
+      presentationBlocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "Actions\n\nChoose an action\n\n• Status: `/status`",
+          },
+        },
+      ],
+    });
+    expect(rendered?.text).toBe("Actions\n\nChoose an action\n\n- Status: `/status`");
+  });
+
+  it("renders web-app buttons as native Slack links", async () => {
+    const payload: ReplyPayload = {
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Launch",
+                value: "approve",
+                webApp: { url: "https://example.com/app" },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation!,
+      ctx: { cfg: {}, to: "C12345", text: "", payload },
+    });
+
+    expect(rendered?.channelData?.slack).toEqual({
+      presentationBlocks: [
+        expect.objectContaining({
+          type: "actions",
+          elements: [
+            expect.objectContaining({
+              type: "button",
+              action_id: "openclaw:reply_link:1:1",
+              url: "https://example.com/app",
+            }),
+          ],
+        }),
+      ],
+    });
+    const linkButton = (
+      rendered?.channelData?.slack as {
+        presentationBlocks?: Array<{ elements?: Array<Record<string, unknown>> }>;
+      }
+    )?.presentationBlocks?.[0]?.elements?.[0];
+    expect(linkButton).not.toHaveProperty("value");
+  });
+
+  it.each([
+    {
+      name: "title",
+      presentation: { title: "x".repeat(151), blocks: [] },
+    },
+    {
+      name: "text block",
+      presentation: { blocks: [{ type: "text", text: "x".repeat(3001) }] },
+    },
+    {
+      name: "context block",
+      presentation: { blocks: [{ type: "context", text: "x".repeat(3001) }] },
+    },
+  ] satisfies Array<{
+    name: string;
+    presentation: NonNullable<ReplyPayload["presentation"]>;
+  }>)("keeps the portable fallback for an oversized $name", async ({ presentation }) => {
+    const payload: ReplyPayload = { presentation };
+
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation,
+      ctx: { cfg: {}, to: "C12345", text: "", payload },
+    });
+
+    expect(rendered).toBeNull();
+  });
+
+  it("marks a separate visible fallback when presentation cannot fit Slack's block limit", async () => {
+    const payload: ReplyPayload = {
+      channelData: {
+        slack: {
+          blocks: Array.from({ length: 49 }, () => ({ type: "divider" })),
+        },
+      },
+      presentation: { title: "Deploy status", blocks: [{ type: "divider" }] },
+      interactive: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Allow", value: "pluginbind:approval-123:o" }],
+          },
+        ],
+      },
+    };
+
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation!,
+      ctx: { cfg: {}, to: "C12345", text: "", payload },
+    });
+
+    expect(rendered?.channelData?.slack).toEqual({
+      blocks: Array.from({ length: 49 }, () => ({ type: "divider" })),
+      presentationFallbackText: "Deploy status",
+    });
+    expect(rendered?.text).toBeUndefined();
+  });
+
+  it("counts legacy interactive blocks compiled after presentation rendering", async () => {
+    const payload: ReplyPayload = {
+      text: "Question [[slack_buttons: OK:ok]]",
+      channelData: {
+        slack: {
+          blocks: Array.from({ length: 48 }, () => ({ type: "divider" })),
+        },
+      },
+      presentation: { title: "Deploy status", blocks: [{ type: "divider" }] },
+    };
+
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation!,
+      ctx: {
+        cfg: {
+          channels: {
+            slack: {
+              botToken: "xoxb-test",
+              appToken: "xapp-test",
+              capabilities: { interactiveReplies: true },
+            },
+          },
+        },
+        accountId: "default",
+        to: "C12345",
+        text: payload.text ?? "",
+        payload,
+      },
+    });
+
+    expect(rendered?.channelData?.slack).toEqual({
+      blocks: Array.from({ length: 48 }, () => ({ type: "divider" })),
+      presentationFallbackText: "Deploy status",
+    });
+  });
+
+  it("does not duplicate text compiled around inline legacy controls", async () => {
+    const payload: ReplyPayload = {
+      text: "Before [[slack_buttons: OK:ok]] after",
+      presentation: { blocks: [{ type: "divider" }] },
+    };
+
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation!,
+      ctx: {
+        cfg: {
+          channels: {
+            slack: {
+              botToken: "xoxb-test",
+              appToken: "xapp-test",
+              capabilities: { interactiveReplies: true },
+            },
+          },
+        },
+        accountId: "default",
+        to: "C12345",
+        text: payload.text ?? "",
+        payload,
+      },
+    });
+
+    expect(rendered?.channelData?.slack).toEqual({
+      presentationBlocks: [{ type: "divider" }],
+    });
+    expect(rendered?.interactive?.blocks).toEqual([
+      { type: "text", text: "Before" },
+      { type: "buttons", buttons: [{ label: "OK", value: "ok" }] },
+      { type: "text", text: "after" },
+    ]);
+  });
+
+  it("sends a block-budget fallback as a separate visible message", async () => {
+    const { run, sendMock, to } = createHarness({
+      payload: {
+        text: "Notification fallback",
+        channelData: {
+          slack: {
+            blocks: [{ type: "divider" }],
+            presentationFallbackText: "Visible presentation fallback",
+          },
+        },
+      },
+      sendResults: [{ messageId: "sl-blocks" }, { messageId: "sl-fallback" }],
+    });
+
+    const result = await run();
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendCall(sendMock, 0)[0]).toBe(to);
+    expect(sendOptions(sendCall(sendMock, 0)).blocks).toEqual([{ type: "divider" }]);
+    expect(sendCall(sendMock, 1)[0]).toBe(to);
+    expect(sendCall(sendMock, 1)[1]).toBe("Visible presentation fallback");
+    expect(sendCall(sendMock, 1)[2]).not.toHaveProperty("blocks");
+    expect(result.messageId).toBe("sl-fallback");
   });
 
   it("sends media before a separate interactive blocks message", async () => {
@@ -185,10 +430,11 @@ describe("slackOutbound sendPayload", () => {
     expect(call[1]).toBe("Deploy?");
     const blocks = sendOptions(call).blocks;
     expect(blocks?.[0]?.block_id).toBe("openclaw_reply_buttons_1");
-    expect(blocks?.[1]?.block_id).toBe("openclaw_reply_buttons_2");
-    expect(blocks?.[1]?.elements?.[0]?.action_id).toBe("openclaw:reply_button:2:1");
-    expect(blocks?.[2]?.block_id).toBe("openclaw_reply_buttons_3");
-    expect(blocks?.[2]?.elements?.[0]?.action_id).toBe("openclaw:reply_button:3:1");
+    expect(blocks?.[1]?.type).toBe("section");
+    expect(blocks?.[2]?.block_id).toBe("openclaw_reply_buttons_2");
+    expect(blocks?.[2]?.elements?.[0]?.action_id).toBe("openclaw:reply_button:2:1");
+    expect(blocks?.[3]?.block_id).toBe("openclaw_reply_buttons_3");
+    expect(blocks?.[3]?.elements?.[0]?.action_id).toBe("openclaw:reply_button:3:1");
   });
 });
 

--- a/extensions/slack/src/presentation.ts
+++ b/extensions/slack/src/presentation.ts
@@ -1,0 +1,36 @@
+// Slack presentation limits shared by the hot channel facade and lazy renderer.
+import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
+
+export const SLACK_ACTION_BLOCK_ELEMENTS_MAX = 25;
+export const SLACK_ACTION_LABEL_MAX = 75;
+export const SLACK_BUTTON_VALUE_MAX = 2000;
+export const SLACK_HEADER_TEXT_MAX = 150;
+export const SLACK_OPTION_VALUE_MAX = 150;
+export const SLACK_SECTION_TEXT_MAX = 3000;
+export const SLACK_STATIC_SELECT_OPTIONS_MAX = 100;
+
+export const SLACK_PRESENTATION_CAPABILITIES = {
+  supported: true,
+  buttons: true,
+  selects: true,
+  context: true,
+  divider: true,
+  limits: {
+    actions: {
+      maxActionsPerRow: SLACK_ACTION_BLOCK_ELEMENTS_MAX,
+      maxLabelLength: SLACK_ACTION_LABEL_MAX,
+      maxValueBytes: SLACK_BUTTON_VALUE_MAX,
+      supportsStyles: true,
+    },
+    selects: {
+      maxOptions: SLACK_STATIC_SELECT_OPTIONS_MAX,
+      maxLabelLength: SLACK_ACTION_LABEL_MAX,
+      maxValueBytes: SLACK_OPTION_VALUE_MAX,
+    },
+    text: {
+      encoding: "characters",
+      markdownDialect: "slack-mrkdwn",
+      supportsEdit: true,
+    },
+  },
+} satisfies ChannelOutboundAdapter["presentationCapabilities"];

--- a/extensions/slack/src/reply-action-ids.ts
+++ b/extensions/slack/src/reply-action-ids.ts
@@ -1,3 +1,4 @@
 // Slack plugin module implements reply action ids behavior.
 export const SLACK_REPLY_BUTTON_ACTION_ID = "openclaw:reply_button";
+export const SLACK_REPLY_LINK_ACTION_ID = "openclaw:reply_link";
 export const SLACK_REPLY_SELECT_ACTION_ID = "openclaw:reply_select";

--- a/extensions/slack/src/shared-interactive.test.ts
+++ b/extensions/slack/src/shared-interactive.test.ts
@@ -198,7 +198,7 @@ describe("buildSlackInteractiveBlocks", () => {
     expect(buttonBlock.elements?.[0]?.value).toBe("a".repeat(2000));
     expect(buttonBlock.elements?.[1]).toEqual({
       type: "button",
-      action_id: "openclaw:reply_button:1:3",
+      action_id: "openclaw:reply_link:1:3",
       text: {
         type: "plain_text",
         text: "Docs",
@@ -273,7 +273,7 @@ describe("buildSlackInteractiveBlocks", () => {
 
     expect(buttonBlock.elements?.[0]).toEqual({
       type: "button",
-      action_id: "openclaw:reply_button:1:1",
+      action_id: "openclaw:reply_link:1:1",
       text: {
         type: "plain_text",
         text: "Docs",
@@ -310,6 +310,29 @@ describe("buildSlackInteractiveBlocks", () => {
 });
 
 describe("buildSlackPresentationBlocks", () => {
+  it("renders presentation blocks in authored order", () => {
+    const blocks = buildSlackPresentationBlocks({
+      blocks: [
+        { type: "text", text: "First" },
+        { type: "buttons", buttons: [{ label: "Approve", value: "approve" }] },
+        { type: "context", text: "After buttons" },
+        { type: "divider" },
+        {
+          type: "select",
+          options: [{ label: "One", value: "one" }],
+        },
+      ],
+    });
+
+    expect(blocks.map((block) => block.type)).toEqual([
+      "section",
+      "actions",
+      "context",
+      "divider",
+      "actions",
+    ]);
+  });
+
   it("renders presentation controls without requiring legacy interactive payloads", () => {
     const blocks = buildSlackPresentationBlocks({
       blocks: [

--- a/src/channels/message/outbound-bridge.test.ts
+++ b/src/channels/message/outbound-bridge.test.ts
@@ -138,6 +138,68 @@ describe("createChannelMessageAdapterFromOutbound", () => {
     ).resolves.toEqual({ messageId: "legacy-id", receipt });
   });
 
+  it.each([
+    {
+      name: "portable presentation with fallback text",
+      payload: {
+        text: "Fallback",
+        presentation: { blocks: [{ type: "divider" }] },
+      },
+      expected: "card",
+    },
+    {
+      name: "title-only presentation",
+      payload: {
+        text: "Fallback",
+        presentation: { title: "Heading", blocks: [] },
+      },
+      expected: "card",
+    },
+    {
+      name: "rendered presentation blocks",
+      payload: {
+        text: "Fallback",
+        channelData: { slack: { presentationBlocks: [{ type: "divider" }] } },
+      },
+      expected: "card",
+    },
+    {
+      name: "empty rendered presentation blocks",
+      payload: {
+        text: "Fallback",
+        channelData: { slack: { presentationBlocks: [] } },
+      },
+      expected: "text",
+    },
+    {
+      name: "unrelated channel metadata",
+      payload: {
+        text: "Fallback",
+        channelData: { slack: { unfurl: false } },
+      },
+      expected: "text",
+    },
+  ] satisfies Array<{
+    name: string;
+    payload: ChannelMessageSendPayloadContext["payload"];
+    expected: "card" | "text";
+  }>)("classifies $name payloads as $expected", async ({ payload, expected }) => {
+    const adapter = createChannelMessageAdapterFromOutbound({
+      outbound: {
+        sendPayload: vi.fn(async () => ({ channel: "demo", messageId: "msg-1" })),
+      },
+    });
+
+    const result = await adapter.send?.payload?.({
+      cfg,
+      to: "room-1",
+      text: payload.text ?? "",
+      payload,
+    });
+
+    expect(result?.receipt.parts[0]?.kind).toBe(expected);
+  });
+
   it("wraps rich payload sends and infers the receipt part kind", async () => {
     const sendPayload = vi.fn(async (_request: ChannelMessageSendPayloadContext) => ({
       channel: "demo",

--- a/src/channels/message/outbound-bridge.ts
+++ b/src/channels/message/outbound-bridge.ts
@@ -131,6 +131,16 @@ function adaptOutboundBridgeContext<
   };
 }
 
+function hasRenderedPresentationBlocks(channelData: Record<string, unknown> | undefined): boolean {
+  return Object.values(channelData ?? {}).some((value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return false;
+    }
+    const blocks = (value as Record<string, unknown>).presentationBlocks;
+    return Array.isArray(blocks) && blocks.length > 0;
+  });
+}
+
 function resolvePayloadReceiptKind(
   ctx: ChannelMessageSendPayloadContext<unknown>,
 ): MessageReceiptPartKind {
@@ -143,11 +153,17 @@ function resolvePayloadReceiptKind(
   if (ctx.mediaUrl || ctx.payload.mediaUrl || ctx.payload.mediaUrls?.length) {
     return "media";
   }
+  const hasPortablePresentation = Boolean(
+    ctx.payload.presentation?.title || ctx.payload.presentation?.blocks?.length,
+  );
+  if (hasPortablePresentation || hasRenderedPresentationBlocks(ctx.payload.channelData)) {
+    return "card";
+  }
+  if (ctx.payload.interactive) {
+    return "card";
+  }
   if (ctx.payload.text?.trim() || ctx.text.trim()) {
     return "text";
-  }
-  if (ctx.payload.presentation?.blocks?.length || ctx.payload.interactive) {
-    return "card";
   }
   return "unknown";
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack users sending portable presentations would receive only plain-text fallback content because the Slack channel facade did not expose its native presentation renderer. This affected Block Kit text, dividers, buttons, selects, card receipts, and callback delivery.

Closes #95440

## Why This Change Was Made

The Slack facade now advertises one shared capability contract and lazily delegates native rendering to the Slack outbound adapter. The adapter preserves authored block order and visible payload text, enforces Slack's text/action/option/message limits, falls back without dropping content, and ignores callbacks generated by URL-only buttons (including already-posted legacy buttons). Core receipt classification now recognizes semantic presentations and non-empty rendered presentation blocks before plain text.

## User Impact

Slack presentation payloads now render as native Block Kit cards with working controls and `card` receipts. Unsupported or oversized content remains visible as a complete fallback; ordinary non-presentation media and interactive sends retain their existing behavior.

## Evidence

- Existing live Slack proof in this PR and #95440: native Block Kit screenshots, a `receipt.parts[0].kind = "card"` CLI result, and independent production confirmation that bridging this facade path restores buttons and callbacks.
- Focused rebased proof: `node scripts/run-vitest.mjs ...` across nine core/Slack files — 176 tests passed.
- Fresh autoreview after all fixes: clean; no accepted/actionable findings.
- Full changed gate: Testbox `tbx_01kwpqw5dfdsykccvz0923dy0d`, [Actions run 28708979405](https://github.com/openclaw/openclaw/actions/runs/28708979405), exit 0.
- Full changed gate plus production build: Testbox `tbx_01kwpr3ayn81x3n7wrt6yymxwd`, [Actions run 28709080389](https://github.com/openclaw/openclaw/actions/runs/28709080389), exit 0.
- Slack contracts checked against official Block Kit documentation: [blocks](https://docs.slack.dev/reference/block-kit/blocks/), [actions blocks](https://docs.slack.dev/reference/block-kit/blocks/actions-block/), [buttons](https://docs.slack.dev/reference/block-kit/block-elements/button-element/), [select menus](https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/), and [chat.postMessage accessibility behavior](https://docs.slack.dev/reference/methods/chat.postMessage/).
