### PR TITLE
fix(anthropic-vertex): upgrade google-auth-library and gaxios to nati…

### DIFF
--- a/extensions/anthropic-vertex/npm-shrinkwrap.json
+++ b/extensions/anthropic-vertex/npm-shrinkwrap.json
@@ -1,20 +1,21 @@
 {
   "name": "@openclaw/anthropic-vertex-provider",
-  "version": "2026.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/anthropic-vertex-provider",
-      "version": "2026.6.8",
       "dependencies": {
-        "@anthropic-ai/vertex-sdk": "0.16.1"
-      }
+        "@anthropic-ai/vertex-sdk": "0.16.1",
+        "gaxios": "7.1.4",
+        "google-auth-library": "10.6.2"
+      },
+      "version": "2026.6.8"
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.100.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
-      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
+      "version": "0.105.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.105.0.tgz",
+      "integrity": "sha512-sDyu+aM9cE6uZE+HgRjjHRb+qqb87GHZOx+8bE0YlWetdL1YcVLxn8h9ltxGOflyChTe6PMEo50kMQV4cw0hfg==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
@@ -101,6 +102,15 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -139,73 +149,93 @@
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/gaxios": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
-      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9",
-        "uuid": "^9.0.1"
+        "node-fetch": "^3.3.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^6.1.1",
-        "google-logging-utils": "^0.0.2",
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.15.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
-      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.1.1",
-        "gcp-metadata": "^6.1.0",
-        "gtoken": "^7.0.0",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/google-logging-utils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
-      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/gtoken": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
-      "license": "MIT",
-      "dependencies": {
-        "gaxios": "^6.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -219,18 +249,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/json-bigint": {
@@ -282,24 +300,42 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/safe-buffer": {
@@ -332,45 +368,19 @@
         "fast-sha256": "^1.3.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+      "engines": {
+        "node": ">= 8"
       }
     }
   }

--- a/extensions/anthropic-vertex/package.json
+++ b/extensions/anthropic-vertex/package.json
@@ -8,7 +8,13 @@
   },
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/vertex-sdk": "0.16.1"
+    "@anthropic-ai/vertex-sdk": "0.16.1",
+    "gaxios": "7.1.4",
+    "google-auth-library": "10.6.2"
+  },
+  "overrides": {
+    "gaxios": "7.1.4",
+    "google-auth-library": "10.6.2"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"


### PR DESCRIPTION
## Summary

Anthropic Vertex OAuth token fetch fails on Node ≥25 with "Premature close" because gaxios 6.x uses node-fetch v2 which is incompatible with Node's globalThis.window removal. Upgrade google-auth-library and gaxios as direct dependencies with overrides so the Vertex SDK's internal GoogleAuth resolves to the native-fetch-based transport.

- Problem: gaxios@6.7.1 → node-fetch@2.7.0 drops connection on oauth2.googleapis.com/token under Node ≥25
- Solution: Add google-auth-library@10.6.2 + gaxios@7.1.4 as direct dependencies with overrides; npm-shrinkwrap now pins native-fetch transport
- What changed: `extensions/anthropic-vertex/package.json` (deps + overrides), `extensions/anthropic-vertex/npm-shrinkwrap.json` (resolved dependency tree)
- What did NOT change: No source code changes (stream-runtime.ts, region.ts, index.ts); existing Vertex SDK internal auth API (GoogleAuth → getClient → getRequestHeaders) is fully compatible with v10

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #95366
- Related #47914 (same fix pattern for googlechat)
- [x] This PR fixes a bug or regression

## Motivation

Users on Node ≥25 (confirmed on Node 26.3.1) cannot use any Anthropic Vertex model. `gcloud auth application-default print-access-token` works fine — the failure is in the provider's OAuth token fetch transport. The googlechat extension already received this fix (PR #47914: google-auth-library@9 → 10, gaxios@6 → 7) but the anthropic-vertex extension was never updated.

The reported workaround — post-install patching of `google-auth-library/build/src/auth/oauth2client.js` — confirms the transport is the root cause.

## Real behavior proof

- Behavior addressed: OAuth token fetch "Premature close" on Node ≥25 for Anthropic Vertex provider
- Real environment tested: Linux, Node 24.13.1, branch `fix/anthropic-vertex-oauth-95366`

- Exact steps or command run after this patch:

```console
$ node scripts/run-vitest.mjs extensions/anthropic-vertex --run

 Test Files  7 passed (7)
      Tests  48 passed (48)

$ node -e "import('google-auth-library').then(g => console.log('GoogleAuth available:', typeof g.GoogleAuth))"
GoogleAuth available: function
```

- Evidence after fix:

```console
$ node -e "
const sw = require('./extensions/anthropic-vertex/npm-shrinkwrap.json');
const pkgs = sw.packages;
console.log('Dependency tree after fix:');
for (const p of ['@anthropic-ai/vertex-sdk','gaxios','google-auth-library','gcp-metadata','node-fetch','google-logging-utils']) {
  const e = pkgs['node_modules/'+p];
  console.log('  ' + p + '@' + (e?.version || '?'));
}
"
Dependency tree after fix:
  @anthropic-ai/vertex-sdk@0.16.1
  gaxios@7.1.4
  google-auth-library@10.6.2
  gcp-metadata@8.1.2
  node-fetch@3.3.2
  google-logging-utils@1.1.3
```

- Observed result after fix:
  1. npm-shrinkwrap.json pins google-auth-library@10.6.2 + gaxios@7.1.4 via overrides
  2. gaxios 7.1.4 no longer depends on node-fetch v2 (uses native fetch / node-fetch v3 ESM)
  3. All 48 existing unit tests pass with no regressions
  4. google-auth-library v10 API (GoogleAuth constructor, getClient, getRequestHeaders) confirmed available
  5. Removed transitive deps: uuid, is-stream, node-fetch@2.7.0, whatwg-url

- What was not tested: Actual OAuth token fetch against oauth2.googleapis.com/token on Node 26 (current dev environment is Node 24, where the bug does not reproduce). However, the same fix pattern (google-auth-library@10.6.2 + gaxios@7.1.4) is already proven in production by the googlechat extension (PR #47914).

**Matrix evidence**:

| Component | Before (v9/gaxios 6) | After (v10/gaxios 7) |
|-----------|---------------------|---------------------|
| Auth transport | gaxios@6.7.1 → node-fetch@2.7.0 | gaxios@7.1.4 → native fetch |
| Node ≥25 compat | ❌ Premature close | ✅ Native fetch |
| googlechat prod | — | ✅ PR #47914, shipped |
| Unit tests | — | 48/48 passed |

## Manual Verification Screenshots

### Terminal Evidence — Dependency Tree After Fix

```console
$ git diff origin/main...HEAD --name-only
extensions/anthropic-vertex/npm-shrinkwrap.json
extensions/anthropic-vertex/package.json

$ node -e "import {GoogleAuth} from 'google-auth-library'; const auth = new GoogleAuth({scopes: 'https://www.googleapis.com/auth/cloud-platform'}); console.log('GoogleAuth@10 created successfully');"
GoogleAuth@10 created successfully
```

### Terminal Evidence — All Tests Pass

```console
$ node scripts/run-vitest.mjs extensions/anthropic-vertex --run

 Test Files  7 passed (7)
      Tests  48 passed (48)
   Duration  9.74s
```

## Root Cause

`@anthropic-ai/vertex-sdk@0.16.1` declares `google-auth-library@^9.4.2`. Google-auth-library v9 depends on `gaxios@^6.1.1`, which uses `node-fetch@^2.6.9` as its HTTP transport. On Node ≥25, node-fetch v2's `globalThis.window` injection pattern throws, causing "Premature close" on any HTTP request (including OAuth2 token fetch).

- **Provenance**: Introduced by the original Vertex SDK dependency choice (google-auth-library@^9.4.2). Not a regression — the incompatibility was created by the Node.js 25 runtime change.
- **Confidence**: Clear

## User-visible / Behavior Changes

Users on Node ≥25 regain working Anthropic Vertex OAuth authentication. No behavior changes for users on Node 22-24.

## Best-fix Verdict

- **Best fix**: Yes. Overrides are the standard npm mechanism to force transitive dependency versions. The same pattern was used by the verified googlechat fix (PR #47914).
- **Refactor needed**: No. This is a pure dependency upgrade with no code changes.
- **Alternative considered**: Post-install vendored patch (reported workaround) — fragile, must re-apply on every reinstall/upgrade. Upgrading the packages is the durable fix.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes — only the HTTP transport is replaced; the auth client API (GoogleAuth → getClient → getRequestHeaders) behaves identically.
- [x] Config/env changes? No
- [x] Migration needed? No

## Human Verification

- Verified scenarios: Dependency resolution correctness (shrinkwrap audit), unit test suite, google-auth-library v10 API compatibility
- Edge cases checked: google-auth-library v10 removed APIs (Transporter, additionalOptions, options.ts, messages.ts) — none used by Vertex SDK

## Risks and Mitigations

**Highest risk area**: google-auth-library v10 has breaking changes (Transporter removal, additionalOptions removal). The Vertex SDK does not use any of the removed APIs — it only calls `new GoogleAuth()`, `GoogleAuth.getClient()`, and `AuthClient.getRequestHeaders()`, all of which are stable in v10.

**Mitigation**: The same google-auth-library@10.6.2 + gaxios@7.1.4 version pair has been running in production for the googlechat extension since PR #47914.

## AI Assistance 🤖

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude Sonnet 4.6 <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Issue #95366 analysis → dependency tree audit → overrides-based fix applied via package.json + npm-shrinkwrap.json regeneration

---

Fixes #95366
