### PR TITLE
fix(ci): increase timeouts in flaky process-group signal test

### DIFF
--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -1370,7 +1370,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
           cwd: process.cwd(),
           env: {
             ...process.env,
-            OPENCLAW_CROSS_OS_PROCESS_TREE_KILL_AFTER_MS: "25",
+            OPENCLAW_CROSS_OS_PROCESS_TREE_KILL_AFTER_MS: "200",
             OPENCLAW_TEST_CHILD_PID: childPidPath,
           },
           stdio: ["ignore", "ignore", "pipe"],
@@ -1384,7 +1384,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       const result = await waitForExit(runner, 5_000);
 
       expect(result).toEqual({ signal: null, status: 143 });
-      await waitForDead(childPid, 2_000);
+      await waitForDead(childPid, 10_000);
     } finally {
       if (runnerPid !== undefined && isProcessAlive(runnerPid)) {
         process.kill(runnerPid, "SIGKILL");


### PR DESCRIPTION
## What Problem This Solves

The `checks-node-core-tooling` CI job fails intermittently due to a flaky test:

`test/scripts/openclaw-cross-os-release-checks.test.ts` > "forwards external termination to command process groups"

The test fails with `Error: process still alive: <pid>` because the child process doesn't die within the 2s `waitForDead` timeout. This is a timing-sensitive process-group signal forwarding test that fails on heavily loaded CI runners.

## What Changed

- Increase `OPENCLAW_CROSS_OS_PROCESS_TREE_KILL_AFTER_MS` from 25ms to 200ms (more reliable signal delivery)
- Increase `waitForDead` timeout from 2000ms to 10000ms (more tolerant of slow CI)

Only two test timeout literals changed. No production code changes.

## Evidence

### After-fix: touched test passes on PR head

Command:

`node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts -t "forwards external termination to command process groups"`

Observed terminal output:

```
✓  tooling  test/scripts/openclaw-cross-os-release-checks.test.ts (89 tests | 88 skipped) 444ms
     ✓ forwards external termination to command process groups  439ms
 Test Files  1 passed | 237 skipped (238)
      Tests  1 passed | 3567 skipped (3568)
```

### Before-fix: CI failure on PR #95400

```
FAIL   tooling  test/scripts/openclaw-cross-os-release-checks.test.ts > scripts/openclaw-cross-os-release-checks > forwards external termination to command process groups
Error: process still alive: 9031
  ❯ waitForDead test/scripts/openclaw-cross-os-release-checks.test.ts:130:9
```

The child process (PID 9031) survived past the 2s `waitForDead` timeout on the CI runner.
