### PR TITLE
fix(sessions): keep bound channel identity across non-delivery turns

### DIFF
--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -7,7 +7,11 @@ import type { MsgContext } from "../../auto-reply/templating.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveConversationLabel } from "../../channels/conversation-label.js";
 import { getLoadedChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
-import { normalizeMessageChannel } from "../../utils/message-channel.js";
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  isInternalNonDeliveryChannel,
+  normalizeMessageChannel,
+} from "../../utils/message-channel.js";
 import { buildGroupDisplayName, resolveGroupSessionKey } from "./group.js";
 import type { GroupKeyResolution, SessionEntry, SessionOrigin } from "./types.js";
 
@@ -24,9 +28,15 @@ const mergeOrigin = (
   // moving Slack -> Telegram, or between Slack accounts). Channel-keyed fields belong to the prior
   // channel; drop them so an inbound that omits them does not keep reactions, native threading, and
   // status reads pointed at the previous channel.
+  const nextProvider = next?.provider;
+  const nextIsDeliverableChannel =
+    nextProvider != null &&
+    nextProvider !== INTERNAL_MESSAGE_CHANNEL &&
+    !isInternalNonDeliveryChannel(nextProvider);
   const channelChanged =
     existing != null &&
-    ((existing.provider != null && next?.provider != null && next.provider !== existing.provider) ||
+    nextIsDeliverableChannel &&
+    ((existing.provider != null && nextProvider !== existing.provider) ||
       (existing.surface != null && next?.surface != null && next.surface !== existing.surface) ||
       (existing.accountId != null &&
         next?.accountId != null &&

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -15,6 +15,10 @@ import {
 import { buildGroupDisplayName, resolveGroupSessionKey } from "./group.js";
 import type { GroupKeyResolution, SessionEntry, SessionOrigin } from "./types.js";
 
+function isSystemEventProvider(provider?: string): boolean {
+  return provider === "heartbeat" || provider === "cron-event" || provider === "exec-event";
+}
+
 // Origin updates merge sparse channel metadata without deleting previously known fields.
 const mergeOrigin = (
   existing: SessionOrigin | undefined,
@@ -32,7 +36,8 @@ const mergeOrigin = (
   const nextIsDeliverableChannel =
     nextProvider != null &&
     nextProvider !== INTERNAL_MESSAGE_CHANNEL &&
-    !isInternalNonDeliveryChannel(nextProvider);
+    !isInternalNonDeliveryChannel(nextProvider) &&
+    !isSystemEventProvider(nextProvider);
   const channelChanged =
     existing != null &&
     nextIsDeliverableChannel &&
@@ -85,9 +90,7 @@ export function deriveSessionOrigin(
   ctx: MsgContext,
   opts?: { skipSystemEventOrigin?: boolean },
 ): SessionOrigin | undefined {
-  const isSystemEventProvider =
-    ctx.Provider === "heartbeat" || ctx.Provider === "cron-event" || ctx.Provider === "exec-event";
-  if (opts?.skipSystemEventOrigin && isSystemEventProvider) {
+  if (opts?.skipSystemEventOrigin && isSystemEventProvider(ctx.Provider)) {
     return undefined;
   }
   const label = normalizeOptionalString(resolveConversationLabel(ctx));

--- a/src/config/sessions/origin-channel-switch.test.ts
+++ b/src/config/sessions/origin-channel-switch.test.ts
@@ -252,6 +252,34 @@ describe("session origin across a non-delivery turn", () => {
     expect(afterHeartbeat.origin?.threadId).toBe("1700000000.000100");
   });
 
+  it("keeps the bound channel identity across a cron-event turn that omits the channel", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const afterCron = applyOrigin(afterSlack, {
+      Provider: "cron-event",
+      ChatType: "direct",
+      From: "cron:job_REDACTED",
+      To: "cron:job_REDACTED",
+    } satisfies Partial<MsgContext>);
+
+    expect(afterCron.origin?.nativeChannelId).toBe("D111SLACK");
+    expect(afterCron.origin?.nativeDirectUserId).toBe("U0001");
+    expect(afterCron.origin?.accountId).toBe("slack-team-1");
+    expect(afterCron.origin?.threadId).toBe("1700000000.000100");
+  });
+
+  it("keeps the bound channel identity across an exec-event turn that omits the channel", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const afterExec = applyOrigin(afterSlack, {
+      Provider: "exec-event",
+      ChatType: "direct",
+      From: "exec:run_REDACTED",
+      To: "exec:run_REDACTED",
+    } satisfies Partial<MsgContext>);
+
+    expect(afterExec.origin?.nativeChannelId).toBe("D111SLACK");
+    expect(afterExec.origin?.threadId).toBe("1700000000.000100");
+  });
+
   it("still adopts a real channel after an intervening non-delivery turn", () => {
     const afterSlack = applyOrigin(undefined, slackTurn);
     const afterWebchat = applyOrigin(afterSlack, webchatTurn);

--- a/src/config/sessions/origin-channel-switch.test.ts
+++ b/src/config/sessions/origin-channel-switch.test.ts
@@ -220,3 +220,45 @@ describe("session origin across a channel switch (real inbound-event context bui
     expect(afterTelegram.origin?.nativeChannelId).toBeUndefined();
   });
 });
+
+describe("session origin across a non-delivery turn", () => {
+  const webchatTurn = {
+    Provider: "webchat",
+    Surface: "webchat",
+    OriginatingChannel: "webchat",
+    ChatType: "direct",
+  } satisfies Partial<MsgContext>;
+
+  it("keeps the bound Slack channel identity across a non-deliver gateway webchat turn", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const afterWebchat = applyOrigin(afterSlack, webchatTurn);
+
+    expect(afterWebchat.origin?.nativeChannelId).toBe("D111SLACK");
+    expect(afterWebchat.origin?.nativeDirectUserId).toBe("U0001");
+    expect(afterWebchat.origin?.accountId).toBe("slack-team-1");
+    expect(afterWebchat.origin?.threadId).toBe("1700000000.000100");
+  });
+
+  it("keeps the bound channel identity across a heartbeat tick", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const afterHeartbeat = applyOrigin(afterSlack, {
+      Provider: "heartbeat",
+      Surface: "heartbeat",
+      OriginatingChannel: "heartbeat",
+      ChatType: "direct",
+    } satisfies Partial<MsgContext>);
+
+    expect(afterHeartbeat.origin?.nativeChannelId).toBe("D111SLACK");
+    expect(afterHeartbeat.origin?.threadId).toBe("1700000000.000100");
+  });
+
+  it("still adopts a real channel after an intervening non-delivery turn", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const afterWebchat = applyOrigin(afterSlack, webchatTurn);
+    const afterTelegram = applyOrigin(afterWebchat, telegramTurn);
+
+    expect(afterTelegram.origin?.provider).toBe("telegram");
+    expect(afterTelegram.origin?.nativeChannelId).toBeUndefined();
+    expect(afterTelegram.origin?.threadId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

A `dmScope:"main"` session keeps one durable origin record (`origin.nativeChannelId`, `origin.nativeDirectUserId`, `origin.accountId`, `origin.threadId`) so reactions, native threading, and status reads stay pointed at the channel the session is bound to.

`mergeOrigin` in `src/config/sessions/metadata.ts` now drops those channel-keyed fields whenever the new turn's `provider`/`surface`/`accountId` differs from the stored origin (added to reset stale fields on a real Slack -> Telegram switch). But the check fires for **non-delivery turns too**. A non-deliver gateway `chat.send` builds its context with `Provider = Surface = OriginatingChannel = INTERNAL_MESSAGE_CHANNEL` ("webchat") (`src/gateway/server-methods/chat.ts`), and `deriveSessionOrigin` derives `origin.provider = "webchat"`. For a session bound to a real channel (e.g. Slack), `"webchat" !== "slack"` is treated as a channel switch, so the live Slack `nativeChannelId`/`nativeDirectUserId`/`accountId`/`threadId` are deleted even though the session never left Slack.

The same wipe happens for any internal non-delivery provider (`heartbeat`, `cron`, `webhook`, `voice`, `sessions_send`) that reaches `mergeOrigin` through `recordSessionMetaFromInbound` / `updateLastRoute`, which call `deriveSessionMetaPatch` without `skipSystemEventOrigin`.

## Why This Change Was Made

An internal/non-delivery turn has no channel identity of its own, so it is not a channel switch and must not overwrite or erase the session's bound channel. The fix gates the reset on the new turn being a real, deliverable channel:

```ts
const nextProvider = next?.provider;
const nextIsDeliverableChannel =
  nextProvider != null &&
  nextProvider !== INTERNAL_MESSAGE_CHANNEL &&
  !isInternalNonDeliveryChannel(nextProvider);
const channelChanged = existing != null && nextIsDeliverableChannel && (/* provider/surface/account differs */);
```

A genuine Slack -> Telegram switch still resets the stale fields (Telegram is deliverable); a webchat send or heartbeat tick preserves them. This restores the pre-regression behavior for internal turns while keeping the intended cross-channel reset.

## User Impact

Before: after an operator/webchat message or a heartbeat/cron tick lands in a channel-bound `dmScope:"main"` session, the agent's next threaded reply, reaction, or status read has no channel/thread target (origin wiped), so it posts to the wrong place or fails to route until the next real inbound on that channel re-populates the fields. P1, reachable on current `main`.

After: the bound channel identity survives non-delivery turns; cross-channel switches still reset correctly.

## Evidence

Regression source: PR #95328 (`fix(sessions): reset stale per-channel origin fields on channel switch`), commit `73c988a9c8`.

Before/after, driving the real `deriveSessionMetaPatch` (`src/config/sessions/origin-channel-switch.test.ts`):

- On unpatched `main`: the two new non-delivery tests FAIL — a Slack origin's `nativeChannelId`/`threadId`/`accountId` become `undefined` after a webchat send and after a heartbeat tick (`2 failed | 10 passed`).
- With the fix: `12 passed (12)` — the bound Slack identity is preserved across a webchat send and a heartbeat tick, a real Slack -> Telegram switch still resets, and all 9 original PR #95328 cases stay green.
- The gate also excludes the system-event providers `heartbeat`/`cron-event`/`exec-event` (reusing `isSystemEventProvider`, which now de-dupes the same check in `deriveSessionOrigin`); without that clause the new cron-event/exec-event tests fail (the bound `nativeChannelId` is wiped to `undefined`). 14/14 pass with it.

oxlint (core, type-aware) and tsgo core/test typecheck clean on the changed files.

### Real behavior proof (live runtime, head `60a482119b`)

Driving the real persistence path `recordSessionMetaFromInbound` (load `sessions.json` -> `deriveSessionMetaPatch`/`mergeOrigin` -> persist) against a temp store, identical inputs on both trees: a Slack DM turn, then a non-deliver gateway webchat turn on the same `dmScope:"main"` session key. Output redacted (no real ids/endpoints/tokens).

Pristine `main` (before):
```
[1] Slack DM persisted origin   : {"label":"slack:U_REDACTED","provider":"slack","surface":"slack","chatType":"direct","from":"slack:U_REDACTED","to":"slack:D_REDACTED","nativeChannelId":"D_REDACTED","nativeDirectUserId":"U_REDACTED","accountId":"team_REDACTED","threadId":"1700000000.000100"}
[2] after non-deliver webchat   : {"label":"webchat:operator_REDACTED","provider":"webchat","surface":"webchat","chatType":"direct","from":"webchat:operator_REDACTED","to":"webchat:agent"}
    nativeChannelId retained? false
    nativeDirectUserId retained? false
    accountId retained? false
    threadId retained? false
```

Patched tree (after):
```
[1] Slack DM persisted origin   : {"label":"slack:U_REDACTED","provider":"slack","surface":"slack","chatType":"direct","from":"slack:U_REDACTED","to":"slack:D_REDACTED","nativeChannelId":"D_REDACTED","nativeDirectUserId":"U_REDACTED","accountId":"team_REDACTED","threadId":"1700000000.000100"}
[2] after non-deliver webchat   : {"label":"webchat:operator_REDACTED","provider":"webchat","surface":"webchat","chatType":"direct","from":"webchat:operator_REDACTED","to":"webchat:agent","nativeChannelId":"D_REDACTED","nativeDirectUserId":"U_REDACTED","accountId":"team_REDACTED","threadId":"1700000000.000100"}
    nativeChannelId retained? true
    nativeDirectUserId retained? true
    accountId retained? true
    threadId retained? true
```

On `main` the non-deliver webchat turn erases the persisted Slack `nativeChannelId`/`nativeDirectUserId`/`accountId`/`threadId` (so the next threaded reply/reaction/status read has no target); with the fix they survive while the webchat turn still updates `provider`/`surface`. Both runs `1 passed`.
