### PR TITLE
 fix(workboard): filter archived cards from CLI list output

### DIFF
--- a/docs/cli/workboard.md
+++ b/docs/cli/workboard.md
@@ -53,12 +53,12 @@ restore the full listing.
 
 Flags:
 
-| Flag                    | Purpose                                    |
-| ----------------------- | ------------------------------------------ |
-| `--board <id>`          | Limit results to one board namespace       |
-| `--status <status>`     | Limit results to one Workboard status      |
-| `--include-archived`    | Include archived cards in text output      |
-| `--json`                | Print the full card list as machine JSON   |
+| Flag                 | Purpose                                  |
+| -------------------- | ---------------------------------------- |
+| `--board <id>`       | Limit results to one board namespace     |
+| `--status <status>`  | Limit results to one Workboard status    |
+| `--include-archived` | Include archived cards in text output    |
+| `--json`             | Print the full card list as machine JSON |
 
 `--json` output always returns all cards regardless of archive state, preserving
 backward compatibility for scripts and automation that consume the machine JSON

--- a/docs/cli/workboard.md
+++ b/docs/cli/workboard.md
@@ -22,7 +22,7 @@ openclaw gateway restart
 ## Usage
 
 ```bash
-openclaw workboard list [--board <id>] [--status <status>] [--json]
+openclaw workboard list [--board <id>] [--status <status>] [--include-archived] [--json]
 openclaw workboard create <title...> [--notes <text>] [--status <status>] [--priority <priority>] [--agent <id>] [--board <id>] [--labels <items>] [--json]
 openclaw workboard show <id> [--json]
 openclaw workboard dispatch [--url <url>] [--token <token>] [--timeout <ms>] [--json]
@@ -48,13 +48,21 @@ Text output is compact:
 
 Columns are id prefix, status, priority, board id, optional agent id, and title.
 
+Archived cards are hidden from text output by default. Use `--include-archived` to
+restore the full listing.
+
 Flags:
 
-| Flag                | Purpose                                  |
-| ------------------- | ---------------------------------------- |
-| `--board <id>`      | Limit results to one board namespace     |
-| `--status <status>` | Limit results to one Workboard status    |
-| `--json`            | Print the full card list as machine JSON |
+| Flag                    | Purpose                                    |
+| ----------------------- | ------------------------------------------ |
+| `--board <id>`          | Limit results to one board namespace       |
+| `--status <status>`     | Limit results to one Workboard status      |
+| `--include-archived`    | Include archived cards in text output      |
+| `--json`                | Print the full card list as machine JSON   |
+
+`--json` output always returns all cards regardless of archive state, preserving
+backward compatibility for scripts and automation that consume the machine JSON
+contract.
 
 ## `create`
 

--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -155,7 +155,7 @@ describe("registerWorkboardCli", () => {
 
   it("hides archived cards from workboard list by default", async () => {
     const store = new WorkboardStore(createMemoryStore());
-    const active = await store.create({ title: "active-card" });
+    const _active = await store.create({ title: "active-card" });
     const archived = await store.create({ title: "archived-card" });
     await store.update(archived.id, { metadata: { archivedAt: Date.now() } });
     const program = createProgram(store);
@@ -170,7 +170,7 @@ describe("registerWorkboardCli", () => {
 
   it("shows archived cards with --include-archived flag", async () => {
     const store = new WorkboardStore(createMemoryStore());
-    const active = await store.create({ title: "active-card" });
+    const _active = await store.create({ title: "active-card" });
     const archived = await store.create({ title: "archived-card" });
     await store.update(archived.id, { metadata: { archivedAt: Date.now() } });
     const program = createProgram(store);
@@ -206,7 +206,9 @@ describe("registerWorkboardCli", () => {
     const program = createProgram(store);
 
     const output = await captureStdout(async () => {
-      await program.parseAsync(["workboard", "list", "--json", "--include-archived"], { from: "user" });
+      await program.parseAsync(["workboard", "list", "--json", "--include-archived"], {
+        from: "user",
+      });
     });
 
     expect(output).toContain("active-card");

--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -155,7 +155,7 @@ describe("registerWorkboardCli", () => {
 
   it("hides archived cards from workboard list by default", async () => {
     const store = new WorkboardStore(createMemoryStore());
-    const _active = await store.create({ title: "active-card" });
+    await store.create({ title: "active-card" });
     const archived = await store.create({ title: "archived-card" });
     await store.update(archived.id, { metadata: { archivedAt: Date.now() } });
     const program = createProgram(store);
@@ -170,7 +170,7 @@ describe("registerWorkboardCli", () => {
 
   it("shows archived cards with --include-archived flag", async () => {
     const store = new WorkboardStore(createMemoryStore());
-    const _active = await store.create({ title: "active-card" });
+    await store.create({ title: "active-card" });
     const archived = await store.create({ title: "archived-card" });
     await store.update(archived.id, { metadata: { archivedAt: Date.now() } });
     const program = createProgram(store);

--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -183,7 +183,7 @@ describe("registerWorkboardCli", () => {
     expect(output).toContain("archived-card");
   });
 
-  it("hides archived cards from JSON output by default", async () => {
+  it("preserves archived cards in JSON output by default", async () => {
     const store = new WorkboardStore(createMemoryStore());
     await store.create({ title: "active-card" });
     const archived = await store.create({ title: "archived-card" });
@@ -195,7 +195,7 @@ describe("registerWorkboardCli", () => {
     });
 
     expect(output).toContain("active-card");
-    expect(output).not.toContain("archived-card");
+    expect(output).toContain("archived-card");
   });
 
   it("shows archived cards in JSON output with --include-archived", async () => {

--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -152,4 +152,64 @@ describe("registerWorkboardCli", () => {
       program.parseAsync(["workboard", "show", prefix], { from: "user" }),
     ).rejects.toThrow("Ambiguous card id prefix");
   });
+
+  it("hides archived cards from workboard list by default", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const active = await store.create({ title: "active-card" });
+    const archived = await store.create({ title: "archived-card" });
+    await store.update(archived.id, { metadata: { archivedAt: Date.now() } });
+    const program = createProgram(store);
+
+    const output = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list"], { from: "user" });
+    });
+
+    expect(output).toContain("active-card");
+    expect(output).not.toContain("archived-card");
+  });
+
+  it("shows archived cards with --include-archived flag", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const active = await store.create({ title: "active-card" });
+    const archived = await store.create({ title: "archived-card" });
+    await store.update(archived.id, { metadata: { archivedAt: Date.now() } });
+    const program = createProgram(store);
+
+    const output = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list", "--include-archived"], { from: "user" });
+    });
+
+    expect(output).toContain("active-card");
+    expect(output).toContain("archived-card");
+  });
+
+  it("hides archived cards from JSON output by default", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    await store.create({ title: "active-card" });
+    const archived = await store.create({ title: "archived-card" });
+    await store.update(archived.id, { metadata: { archivedAt: Date.now() } });
+    const program = createProgram(store);
+
+    const output = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list", "--json"], { from: "user" });
+    });
+
+    expect(output).toContain("active-card");
+    expect(output).not.toContain("archived-card");
+  });
+
+  it("shows archived cards in JSON output with --include-archived", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    await store.create({ title: "active-card" });
+    const archived = await store.create({ title: "archived-card" });
+    await store.update(archived.id, { metadata: { archivedAt: Date.now() } });
+    const program = createProgram(store);
+
+    const output = await captureStdout(async () => {
+      await program.parseAsync(["workboard", "list", "--json", "--include-archived"], { from: "user" });
+    });
+
+    expect(output).toContain("active-card");
+    expect(output).toContain("archived-card");
+  });
 });

--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -137,11 +137,13 @@ export function registerWorkboardCli(params: { program: Command; store: Workboar
         options: JsonOptions & { board?: string; status?: string; includeArchived?: boolean },
       ) => {
         let cards = await params.store.list({ boardId: options.board });
-        if (!options.includeArchived) {
-          cards = cards.filter((card) => !card.metadata?.archivedAt);
-        }
         if (options.status) {
           cards = cards.filter((card) => card.status === options.status);
+        }
+        // Only filter archived cards from human-readable output; JSON is a
+        // backward-compatible machine contract that must keep returning all cards.
+        if (!options.json && !options.includeArchived) {
+          cards = cards.filter((card) => !card.metadata?.archivedAt);
         }
         writeCards(cards, options);
       },

--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -130,14 +130,22 @@ export function registerWorkboardCli(params: { program: Command; store: Workboar
     .description("List Workboard cards")
     .option("--board <id>", "Board id")
     .option("--status <status>", "Filter by status")
+    .option("--include-archived", "Include archived cards (default false)", false)
     .option("--json", "Print JSON", false)
-    .action(async (options: JsonOptions & { board?: string; status?: string }) => {
-      let cards = await params.store.list({ boardId: options.board });
-      if (options.status) {
-        cards = cards.filter((card) => card.status === options.status);
-      }
-      writeCards(cards, options);
-    });
+    .action(
+      async (
+        options: JsonOptions & { board?: string; status?: string; includeArchived?: boolean },
+      ) => {
+        let cards = await params.store.list({ boardId: options.board });
+        if (!options.includeArchived) {
+          cards = cards.filter((card) => !card.metadata?.archivedAt);
+        }
+        if (options.status) {
+          cards = cards.filter((card) => card.status === options.status);
+        }
+        writeCards(cards, options);
+      },
+    );
 
   workboard
     .command("create")


### PR DESCRIPTION
## Summary

The `openclaw workboard list` CLI command shows archived (soft-deleted) cards by default, inconsistent with the `workboard_list` agent tool and `/workboard list` slash command which both hide them. This change filters archived cards from human-readable text output while preserving full-card JSON output for backward compatibility.

- Problem: CLI `list` defaults to showing archived cards while other entry points hide them
- Solution: Add `--include-archived` flag; filter `archivedAt` cards only in text mode; keep JSON output unchanged (machine contract backward compat)
- What changed: `extensions/workboard/src/cli.ts` (list handler + filter logic + inline comment), `extensions/workboard/src/cli.test.ts` (4 new tests), `docs/cli/workboard.md` (document --include-archived flag and JSON backward compat)
- What did NOT change: store layer (`WorkboardStore.list`), slash command (`command.ts`), MCP tool (`tools.ts`), default JSON output behavior

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related to #94555
- [x] This PR fixes a bug or regression

## Motivation

The Workboard plugin has three entry points for listing cards: CLI (`workboard list`), slash command (`/workboard list`), and MCP agent tool (`workboard_list`). The CLI was added after the other two and missed the `archivedAt` filter that both existing entry points apply by default. This inconsistency causes confusion: users see archived/"deleted" cards in CLI output without opting in.

## Real behavior proof

**Behavior addressed**: CLI `workboard list` shows archived cards by default; fix hides them in text output while preserving JSON backward compat.

**Real environment tested**: Linux, Node.js v24.13.1, branch `fix/workboard-archive-filter-94555` from latest `origin/main` (commit 7daba184b5)

**Exact steps or command run after this patch**:

```bash
# 1. Real CLI proof: list cards with --board filter
pnpm openclaw workboard list --board cli-proof
pnpm openclaw workboard list --board cli-proof --include-archived
pnpm openclaw workboard list --board cli-proof --json

# 2. Unit test proof
node scripts/run-vitest.mjs extensions/workboard/src/cli.test.ts --run --reporter=verbose
```

**Evidence after fix**:

```console
$ pnpm openclaw workboard list --board cli-proof
866f0f06  todo      normal  cli-proof  Active test card

$ pnpm openclaw workboard list --board cli-proof --include-archived
866f0f06  todo      normal  cli-proof  Active test card
20ae476c  todo      normal  cli-proof  Archived proof card

$ pnpm openclaw workboard list --board cli-proof --json | grep -E "title|archivedAt"
      "title": "Active test card",
      "title": "Archived proof card",
        "archivedAt": 1782010944377,
```

The three commands above show:
1. Default `list` hides the archived card (only "Active test card" visible)
2. `--include-archived` shows both cards ("Archived proof card" restored)
3. `--json` preserves full card set including `archivedAt` (backward compatible)

Unit test proof:

```console
$ node scripts/run-vitest.mjs extensions/workboard/src/cli.test.ts --run --reporter=verbose
[test] starting test/vitest/vitest.extensions.config.ts

 RUN  v4.1.8 /home/0668000787/project/open-claw-github/openclaw

 ✓ |extensions| extensions/workboard/src/cli.test.ts > registerWorkboardCli > redacts claim tokens from card JSON output
 ✓ |extensions| extensions/workboard/src/cli.test.ts > registerWorkboardCli > does not fall back to local dispatch for explicit gateway targets
 ✓ |extensions| extensions/workboard/src/cli.test.ts > registerWorkboardCli > does not fall back to local dispatch for configured remote gateways
 ✓ |extensions| extensions/workboard/src/cli.test.ts > registerWorkboardCli > rejects ambiguous card id prefixes
 ✓ |extensions| extensions/workboard/src/cli.test.ts > registerWorkboardCli > hides archived cards from workboard list by default
 ✓ |extensions| extensions/workboard/src/cli.test.ts > registerWorkboardCli > shows archived cards with --include-archived flag
 ✓ |extensions| extensions/workboard/src/cli.test.ts > registerWorkboardCli > preserves archived cards in JSON output by default
 ✓ |extensions| extensions/workboard/src/cli.test.ts > registerWorkboardCli > shows archived cards in JSON output with --include-archived

 Test Files  1 passed (1)
      Tests  8 passed (8)
```

**Behavior matrix (before vs after):**

| Command | Before (unfixed) | After (this PR) |
|---------|-----------------|-----------------|
| `workboard list` | shows archived cards | hides archived cards |
| `workboard list --include-archived` | N/A (no flag) | shows archived cards |
| `workboard list --json` | shows archived cards | shows archived cards (unchanged) |
| `workboard list --json --include-archived` | N/A (no flag) | shows archived cards |

**Observed result after fix**:
1. Default `workboard list` text output filters out cards where `metadata.archivedAt` is set
2. `--include-archived` flag restores full listing including archived cards
3. `--json` output preserves all cards by default (backward compatible — key differentiator from 8 closed competitor PRs)
4. `--json --include-archived` also works as expected
5. All 4 existing tests continue to pass

**What was not tested**: Gateway dispatch scenario (not applicable — list is a read-only local command); `openclaw workboard list` via a remote gateway connection

## Root Cause

`extensions/workboard/src/cli.ts:135` — The CLI `list` handler was added without the `archivedAt` filter that already existed in `command.ts:97` (`/workboard list` slash command) and `tools.ts:257` (`workboard_list` MCP tool). The `WorkboardStore.list()` intentionally returns all cards unfiltered; each consumer is responsible for its own filtering.

| File | Filter present? | Added |
|------|---------------|-------|
| `tools.ts:257` (`workboard_list` MCP tool) | Yes | 2026-05-29 (`61031d1b1c`) |
| `command.ts:97` (`/workboard list` slash) | Yes | Initial implementation |
| `cli.ts:135` (`workboard list` CLI) | **No** (before this PR) | 2026-05-31 (`ed46e62bcc`) — added 2 days later, missed the filter |

Made visible by: initial CLI implementation at `commands.ts` → `cli.ts` migration.

## Regression Test Plan

- **Target**: `extensions/workboard/src/cli.test.ts`
- **Coverage**: 4 new test cases:
  - Text default hides archived cards
  - `--include-archived` shows archived cards
  - JSON preserves archived cards by default (backward compat)
  - JSON + `--include-archived` shows archived cards
- **Rationale**: Minimal proof surface — the fix is a single filter predicate in one handler, using the same pattern and same `archivedAt` field already proven in `command.ts` and `tools.ts`

## User-visible / Behavior Changes

- Default `workboard list` text output no longer shows archived cards
- New `--include-archived` flag available to show archived cards in text mode
- `--json` output unchanged (always returns all cards)
- `docs/cli/workboard.md` updated to document `--include-archived` flag and JSON backward compatibility

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Human Verification

- **Verified scenarios**: Text default hide, `--include-archived` show, JSON backward compat, JSON + `--include-archived`, docs build and flag table
- **Edge cases checked**: Only text output is filtered (JSON preserved); filter applied after status filter (correct ordering)

## Compatibility / Migration

- [x] Backward compatible? Yes — JSON output unchanged, `--include-archived` flag is additive
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — aligns CLI with the same filter pattern and field already proven in `command.ts` and `tools.ts`. JSON backward compat avoids breaking existing machine consumers. The `if (!options.json && !options.includeArchived)` guard is the same architectural boundary used by the canonical fix #94562.
- **Refactor needed**: No — this is a bounded one-predicate addition to a single handler
- **Alternative considered**: Filtering in `writeCards` directly — rejected because it would affect all card output paths, not just `list`

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude Sonnet 4.6 <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Internal conversation transcript available

## Risks and Mitigations

**Highest risk area**: Users or scripts that expect archived cards in default text output may be surprised by the change.

**Mitigation**:
- The `--include-archived` flag provides an explicit escape hatch
- JSON output is preserved for existing automation
- This change mirrors the already-shipped behavior in the slash command and MCP tool, making the three entry points consistent
- Note: 8 previous competitor PRs were closed for changing default JSON output — this PR explicitly preserves it

**Compatibility**: Additive change (`--include-archived` flag), no existing users broken unless they relied on (undocumented) behavior of archived cards appearing in default text output.

---

Related to #94555
