### PR TITLE
fix(agents): correct model-hallucinated document extensions in file tool path params

### DIFF
--- a/src/agents/agent-tools.params.test.ts
+++ b/src/agents/agent-tools.params.test.ts
@@ -1,22 +1,26 @@
 /**
- * Tests required parameter validation for model-facing tools.
- * Covers retry guidance and path-only XML suffix cleanup for file operations.
+ * Tests required parameter validation for model-supplied tools.
+ * Covers retry guidance, XML suffix cleanup, and hallucinated document
+ * extension handling (read correction, write/edit rejection) for file
+ * operations.
  */
 import { describe, expect, it, vi } from "vitest";
 import {
   assertRequiredParams,
-  REQUIRED_PARAM_GROUPS,
+  correctHallucinatedFileExtension,
+  correctHallucinatedFileExtensionFromKeys,
   getToolParamsRecord,
+  hasHallucinatedFileExtension,
+  rejectHallucinatedFileExtensionFromKeys,
+  REQUIRED_PARAM_GROUPS,
   stripMalformedXmlArgValueSuffix,
+  stripMalformedXmlArgValueSuffixFromKeys,
   wrapToolParamValidation,
 } from "./agent-tools.params.js";
 
-describe("assertRequiredParams", () => {
-  it("returns object params unchanged", () => {
-    const params = { path: "test.txt" };
-    expect(getToolParamsRecord(params)).toBe(params);
-  });
+// ── XML suffix cleanup (unchanged) ──────────────────────────────
 
+describe("stripMalformedXmlArgValueSuffix", () => {
   it("strips only the malformed terminal XML arg-value suffix", () => {
     expect(stripMalformedXmlArgValueSuffix("echo test</arg_value>>")).toBe("echo test");
     expect(stripMalformedXmlArgValueSuffix("echo test</arg_value>>>>>")).toBe("echo test");
@@ -25,7 +29,9 @@ describe("assertRequiredParams", () => {
       "echo </arg_value>> test",
     );
   });
+});
 
+describe("stripMalformedXmlArgValueSuffixFromKeys", () => {
   it("strips malformed path suffixes without touching payload text", async () => {
     const execute = vi.fn(async (_id, args) => args);
     const tool = wrapToolParamValidation(
@@ -53,6 +59,174 @@ describe("assertRequiredParams", () => {
       undefined,
       undefined,
     );
+  });
+
+  it("does NOT correct hallucinated extensions (XML-only helper)", () => {
+    const result = stripMalformedXmlArgValueSuffixFromKeys(
+      { path: "report.docodex" },
+      ["path"],
+    );
+    expect(result.path).toBe("report.docodex");
+  });
+
+  it("strips XML suffix but keeps hallucinated extension", () => {
+    const result = stripMalformedXmlArgValueSuffixFromKeys(
+      { path: "report.docodex</arg_value>>" },
+      ["path"],
+    );
+    expect(result.path).toBe("report.docodex");
+  });
+});
+
+// ── Hallucinated extension detection ────────────────────────────
+
+describe("hasHallucinatedFileExtension", () => {
+  it("detects known hallucinated extensions", () => {
+    expect(hasHallucinatedFileExtension("report.docodex")).toBe(true);
+    expect(hasHallucinatedFileExtension("slides.pptcodex")).toBe(true);
+    expect(hasHallucinatedFileExtension("budget.xlscodex")).toBe(true);
+    expect(hasHallucinatedFileExtension("report.docxcodex")).toBe(true);
+    expect(hasHallucinatedFileExtension("slides.pptxcodex")).toBe(true);
+    expect(hasHallucinatedFileExtension("budget.xlstcodex")).toBe(true);
+    expect(hasHallucinatedFileExtension("budget.xltxcodex")).toBe(true);
+    expect(hasHallucinatedFileExtension("budget.xlstxcodex")).toBe(true);
+  });
+
+  it("returns false for real extensions", () => {
+    expect(hasHallucinatedFileExtension("report.docx")).toBe(false);
+    expect(hasHallucinatedFileExtension("slides.pptx")).toBe(false);
+    expect(hasHallucinatedFileExtension("budget.xlsx")).toBe(false);
+    expect(hasHallucinatedFileExtension("notes.txt")).toBe(false);
+    expect(hasHallucinatedFileExtension("README.md")).toBe(false);
+  });
+
+  it("returns false for paths without extensions", () => {
+    expect(hasHallucinatedFileExtension("noext")).toBe(false);
+  });
+});
+
+// ── Hallucinated extension correction (read-only) ──────────────
+
+describe("correctHallucinatedFileExtension", () => {
+  it("corrects known hallucinated extensions", () => {
+    expect(correctHallucinatedFileExtension("report.docodex")).toBe("report.docx");
+    expect(correctHallucinatedFileExtension("slides.pptcodex")).toBe("slides.pptx");
+    expect(correctHallucinatedFileExtension("budget.xlscodex")).toBe("budget.xlsx");
+    expect(correctHallucinatedFileExtension("report.docxcodex")).toBe("report.docx");
+  });
+
+  it("preserves real extensions", () => {
+    expect(correctHallucinatedFileExtension("report.docx")).toBe("report.docx");
+    expect(correctHallucinatedFileExtension("notes.txt")).toBe("notes.txt");
+  });
+
+  it("preserves paths without extensions", () => {
+    expect(correctHallucinatedFileExtension("noext")).toBe("noext");
+  });
+
+  it("corrects paths with directory prefixes", () => {
+    expect(correctHallucinatedFileExtension("path/to/report.docodex")).toBe("path/to/report.docx");
+    expect(correctHallucinatedFileExtension("/abs/path/slides.pptcodex")).toBe(
+      "/abs/path/slides.pptx",
+    );
+  });
+});
+
+describe("correctHallucinatedFileExtensionFromKeys", () => {
+  it("corrects hallucinated extensions on path keys", () => {
+    const result = correctHallucinatedFileExtensionFromKeys(
+      { path: "report.docodex" },
+      ["path"],
+    );
+    expect(result.path).toBe("report.docx");
+  });
+
+  it("does not mutate when no correction is needed", () => {
+    const input = { path: "report.docx" };
+    const result = correctHallucinatedFileExtensionFromKeys(input, ["path"]);
+    expect(result).toBe(input); // same reference, no copy
+  });
+
+  it("does not touch non-path keys", () => {
+    const result = correctHallucinatedFileExtensionFromKeys(
+      { path: "report.docodex", content: "hello.docodex" },
+      ["path"],
+    );
+    expect(result.path).toBe("report.docx");
+    expect(result.content).toBe("hello.docodex");
+  });
+});
+
+// ── Hallucinated extension rejection (write/edit) ──────────────
+
+describe("rejectHallucinatedFileExtensionFromKeys", () => {
+  it("rejects hallucinated extensions on write paths", () => {
+    expect(() =>
+      rejectHallucinatedFileExtensionFromKeys(
+        { path: "report.docodex" },
+        ["path"],
+        "write",
+      ),
+    ).toThrow(/hallucinated file extension/);
+  });
+
+  it("rejects with retry guidance suffix", () => {
+    expect(() =>
+      rejectHallucinatedFileExtensionFromKeys(
+        { path: "budget.xlscodex" },
+        ["path"],
+        "edit",
+      ),
+    ).toThrow(/Supply correct parameters before retrying/);
+  });
+
+  it("suggests the correct extension in the error message", () => {
+    expect(() =>
+      rejectHallucinatedFileExtensionFromKeys(
+        { path: "report.docodex" },
+        ["path"],
+        "write",
+      ),
+    ).toThrow(/\.docx/);
+  });
+
+  it("does not reject real extensions", () => {
+    expect(() =>
+      rejectHallucinatedFileExtensionFromKeys(
+        { path: "report.docx" },
+        ["path"],
+        "write",
+      ),
+    ).not.toThrow();
+  });
+
+  it("does not reject non-path keys", () => {
+    expect(() =>
+      rejectHallucinatedFileExtensionFromKeys(
+        { content: "content with .docodex" },
+        ["path"],
+        "write",
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects after XML suffix stripping", () => {
+    expect(() =>
+      rejectHallucinatedFileExtensionFromKeys(
+        { path: "report.docodex</arg_value>>" },
+        ["path"],
+        "write",
+      ),
+    ).toThrow(/hallucinated file extension/);
+  });
+});
+
+// ── wrapToolParamValidation integration ─────────────────────────
+
+describe("assertRequiredParams", () => {
+  it("returns object params unchanged", () => {
+    const params = { path: "test.txt" };
+    expect(getToolParamsRecord(params)).toBe(params);
   });
 
   it("rejects paths that become empty after malformed XML arg-value suffix stripping", async () => {
@@ -252,5 +426,164 @@ describe("assertRequiredParams", () => {
         "write",
       ),
     ).toBeUndefined();
+  });
+});
+
+// ── wrapToolParamValidation: hallucinated extension integration ──
+
+describe("wrapToolParamValidation: hallucinated extensions", () => {
+  describe("read tools (silent correction)", () => {
+    it("silently corrects hallucinated extensions on read paths", async () => {
+      const execute = vi.fn(async (_id, args) => args);
+      const tool = wrapToolParamValidation(
+        {
+          name: "read",
+          label: "read",
+          description: "read a file",
+          parameters: {},
+          execute,
+        },
+        REQUIRED_PARAM_GROUPS.read,
+      );
+
+      await tool.execute("id", { path: "report.docodex" });
+
+      expect(execute).toHaveBeenCalledWith(
+        "id",
+        { path: "report.docx" },
+        undefined,
+        undefined,
+      );
+    });
+
+    it("corrects hallucinated extensions after XML suffix stripping", async () => {
+      const execute = vi.fn(async (_id, args) => args);
+      const tool = wrapToolParamValidation(
+        {
+          name: "read",
+          label: "read",
+          description: "read a file",
+          parameters: {},
+          execute,
+        },
+        REQUIRED_PARAM_GROUPS.read,
+      );
+
+      await tool.execute("id", { path: "report.docodex</arg_value>>" });
+
+      expect(execute).toHaveBeenCalledWith(
+        "id",
+        { path: "report.docx" },
+        undefined,
+        undefined,
+      );
+    });
+
+    it("does not modify real extensions on read paths", async () => {
+      const execute = vi.fn(async (_id, args) => args);
+      const tool = wrapToolParamValidation(
+        {
+          name: "read",
+          label: "read",
+          description: "read a file",
+          parameters: {},
+          execute,
+        },
+        REQUIRED_PARAM_GROUPS.read,
+      );
+
+      await tool.execute("id", { path: "report.docx" });
+
+      expect(execute).toHaveBeenCalledWith(
+        "id",
+        { path: "report.docx" },
+        undefined,
+        undefined,
+      );
+    });
+  });
+
+  describe("write/edit tools (rejection)", () => {
+    it("rejects hallucinated extensions on write paths", async () => {
+      const execute = vi.fn();
+      const tool = wrapToolParamValidation(
+        {
+          name: "write",
+          label: "write",
+          description: "write a file",
+          parameters: {},
+          execute,
+        },
+        REQUIRED_PARAM_GROUPS.write,
+      );
+
+      await expect(
+        tool.execute("id", { path: "report.docodex", content: "x" }),
+      ).rejects.toThrow(/hallucinated file extension/);
+
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it("rejects hallucinated extensions on edit paths", async () => {
+      const execute = vi.fn();
+      const tool = wrapToolParamValidation(
+        {
+          name: "edit",
+          label: "edit",
+          description: "edit a file",
+          parameters: {},
+          execute,
+        },
+        REQUIRED_PARAM_GROUPS.edit,
+      );
+
+      const edits = [{ oldText: "a", newText: "b" }];
+      await expect(
+        tool.execute("id", { path: "budget.xlscodex", edits }),
+      ).rejects.toThrow(/hallucinated file extension/);
+
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it("accepts real extensions on write paths", async () => {
+      const execute = vi.fn(async (_id, args) => args);
+      const tool = wrapToolParamValidation(
+        {
+          name: "write",
+          label: "write",
+          description: "write a file",
+          parameters: {},
+          execute,
+        },
+        REQUIRED_PARAM_GROUPS.write,
+      );
+
+      await tool.execute("id", { path: "report.docx", content: "x" });
+
+      expect(execute).toHaveBeenCalledWith(
+        "id",
+        { path: "report.docx", content: "x" },
+        undefined,
+        undefined,
+      );
+    });
+
+    it("rejects hallucinated extensions after XML suffix stripping on write paths", async () => {
+      const execute = vi.fn();
+      const tool = wrapToolParamValidation(
+        {
+          name: "write",
+          label: "write",
+          description: "write a file",
+          parameters: {},
+          execute,
+        },
+        REQUIRED_PARAM_GROUPS.write,
+      );
+
+      await expect(
+        tool.execute("id", { path: "report.docodex</arg_value>>", content: "x" }),
+      ).rejects.toThrow(/hallucinated file extension/);
+    });
   });
 });

--- a/src/agents/agent-tools.params.ts
+++ b/src/agents/agent-tools.params.ts
@@ -1,7 +1,8 @@
 /**
  * Shared validation for model-supplied tool parameters.
  * Converts malformed file-tool arguments into retryable errors and fixes the
- * specific XML suffix corruption seen in path arguments.
+ * specific XML suffix corruption and model-hallucinated document extensions
+ * seen in path arguments.
  */
 import type { AnyAgentTool } from "./agent-tools.types.js";
 
@@ -15,6 +16,22 @@ export type RequiredParamGroup = {
 const RETRY_GUIDANCE_SUFFIX = " Supply correct parameters before retrying.";
 const XML_ARG_VALUE_SUFFIX_RE = /<\/arg_value>>+$/;
 const XML_ARG_VALUE_PATH_PARAM_KEYS = new Set(["path"]);
+
+/**
+ * Known model-hallucinated document extensions and their corrections.
+ * Models blending "codex" into office-document extensions produce these
+ * (e.g. GPT-5.4 via Codex runtime: .docx → .docodex, .pptx → .pptcodex).
+ */
+const HALLUCINATED_EXTENSION_MAP: ReadonlyMap<string, string> = new Map([
+  [".docodex", ".docx"],
+  [".docxcodex", ".docx"],
+  [".pptcodex", ".pptx"],
+  [".pptxcodex", ".pptx"],
+  [".xlscodex", ".xlsx"],
+  [".xlstcodex", ".xlsx"],
+  [".xlstxcodex", ".xlsx"],
+  [".xltxcodex", ".xlsx"],
+]);
 
 function parameterValidationError(message: string): Error {
   return new Error(`${message}.${RETRY_GUIDANCE_SUFFIX}`);
@@ -110,7 +127,18 @@ export function stripMalformedXmlArgValueSuffix(value: string): string {
   return value.includes("</arg_value>") ? value.replace(XML_ARG_VALUE_SUFFIX_RE, "") : value;
 }
 
-/** Strip malformed XML suffixes from selected string fields without mutating input. */
+/** Correct model-hallucinated document extensions in a file path (e.g. .docodex → .docx). */
+export function correctHallucinatedFileExtension(value: string): string {
+  const dotIndex = value.lastIndexOf(".");
+  if (dotIndex === -1) {
+    return value;
+  }
+  const ext = value.slice(dotIndex).toLowerCase();
+  const correction = HALLUCINATED_EXTENSION_MAP.get(ext);
+  return correction ? value.slice(0, dotIndex) + correction : value;
+}
+
+/** Normalize path string fields: strip malformed XML suffixes and correct hallucinated document extensions. */
 export function stripMalformedXmlArgValueSuffixFromKeys<T extends Record<string, unknown>>(
   record: T,
   keys: readonly string[],
@@ -121,10 +149,11 @@ export function stripMalformedXmlArgValueSuffixFromKeys<T extends Record<string,
     if (typeof value !== "string") {
       continue;
     }
-    const stripped = stripMalformedXmlArgValueSuffix(value);
-    if (stripped !== value) {
+    let corrected = stripMalformedXmlArgValueSuffix(value);
+    corrected = correctHallucinatedFileExtension(corrected);
+    if (corrected !== value) {
       normalized ??= { ...record };
-      normalized[key as keyof T] = stripped as T[keyof T];
+      normalized[key as keyof T] = corrected as T[keyof T];
     }
   }
   return normalized ?? record;

--- a/src/agents/agent-tools.params.ts
+++ b/src/agents/agent-tools.params.ts
@@ -1,8 +1,11 @@
 /**
  * Shared validation for model-supplied tool parameters.
  * Converts malformed file-tool arguments into retryable errors and fixes the
- * specific XML suffix corruption and model-hallucinated document extensions
- * seen in path arguments.
+ * specific XML suffix corruption seen in path arguments.
+ *
+ * Hallucinated document-extension correction is applied separately at the
+ * file-tool path boundary (not in the shared XML cleanup helper) so that
+ * shell-command and mutation paths are not silently retargeted.
  */
 import type { AnyAgentTool } from "./agent-tools.types.js";
 
@@ -127,7 +130,7 @@ export function stripMalformedXmlArgValueSuffix(value: string): string {
   return value.includes("</arg_value>") ? value.replace(XML_ARG_VALUE_SUFFIX_RE, "") : value;
 }
 
-/** Correct model-hallucinated document extensions in a file path (e.g. .docodex → .docx). */
+/** Correct a model-hallucinated document extension in a file path (e.g. .docodex → .docx). */
 export function correctHallucinatedFileExtension(value: string): string {
   const dotIndex = value.lastIndexOf(".");
   if (dotIndex === -1) {
@@ -138,7 +141,17 @@ export function correctHallucinatedFileExtension(value: string): string {
   return correction ? value.slice(0, dotIndex) + correction : value;
 }
 
-/** Normalize path string fields: strip malformed XML suffixes and correct hallucinated document extensions. */
+/** Detect whether a file path ends with a known hallucinated document extension. */
+export function hasHallucinatedFileExtension(value: string): boolean {
+  const dotIndex = value.lastIndexOf(".");
+  if (dotIndex === -1) {
+    return false;
+  }
+  const ext = value.slice(dotIndex).toLowerCase();
+  return HALLUCINATED_EXTENSION_MAP.has(ext);
+}
+
+/** Strip malformed XML suffixes from selected string fields without mutating input. */
 export function stripMalformedXmlArgValueSuffixFromKeys<T extends Record<string, unknown>>(
   record: T,
   keys: readonly string[],
@@ -149,14 +162,64 @@ export function stripMalformedXmlArgValueSuffixFromKeys<T extends Record<string,
     if (typeof value !== "string") {
       continue;
     }
-    let corrected = stripMalformedXmlArgValueSuffix(value);
-    corrected = correctHallucinatedFileExtension(corrected);
+    const stripped = stripMalformedXmlArgValueSuffix(value);
+    if (stripped !== value) {
+      normalized ??= { ...record };
+      normalized[key as keyof T] = stripped as T[keyof T];
+    }
+  }
+  return normalized ?? record;
+}
+
+/**
+ * Correct hallucinated document extensions on file-tool path keys (read-only).
+ * Only applies to "path" keys — does not touch shell-command or other fields.
+ * Used for read tools where silent correction is safe (no filesystem mutation).
+ */
+export function correctHallucinatedFileExtensionFromKeys<T extends Record<string, unknown>>(
+  record: T,
+  keys: readonly string[],
+): T {
+  let normalized: T | undefined;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value !== "string") {
+      continue;
+    }
+    const corrected = correctHallucinatedFileExtension(value);
     if (corrected !== value) {
       normalized ??= { ...record };
       normalized[key as keyof T] = corrected as T[keyof T];
     }
   }
   return normalized ?? record;
+}
+
+/**
+ * Reject hallucinated document extensions on file-tool path keys (write/edit).
+ * Instead of silently correcting, throws a retryable error so the model
+ * retries with the correct extension — preventing accidental mutation of
+ * a different file than intended.
+ */
+export function rejectHallucinatedFileExtensionFromKeys(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+  toolName: string,
+): void {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value !== "string") {
+      continue;
+    }
+    // Strip XML suffix first so we check the clean extension
+    const cleaned = stripMalformedXmlArgValueSuffix(value);
+    if (hasHallucinatedFileExtension(cleaned)) {
+      const correction = correctHallucinatedFileExtension(cleaned);
+      throw parameterValidationError(
+        `${toolName} parameter "${key}" has a hallucinated file extension "${cleaned.slice(cleaned.lastIndexOf("."))}". Did you mean "${correction.slice(correction.lastIndexOf("."))}"? Path: ${correction}`,
+      );
+    }
+  }
 }
 
 function resolveMalformedXmlArgValuePathKeys(
@@ -171,6 +234,15 @@ function resolveMalformedXmlArgValuePathKeys(
     }
   }
   return [...keys];
+}
+
+/** Return true when the required param groups indicate a read-only tool. */
+function isReadOnlyTool(requiredParamGroups?: readonly RequiredParamGroup[]): boolean {
+  if (!requiredParamGroups || requiredParamGroups.length !== 1) {
+    return false;
+  }
+  const keys = requiredParamGroups[0]!.keys;
+  return keys.length === 1 && keys[0] === "path" && requiredParamGroups[0]!.label === "path";
 }
 
 /** Throw actionable retry guidance when required tool params are missing. */
@@ -225,10 +297,27 @@ export function wrapToolParamValidation(
     execute: async (toolCallId, params, signal, onUpdate) => {
       const record = getToolParamsRecord(params);
       const pathKeys = resolveMalformedXmlArgValuePathKeys(requiredParamGroups);
-      const normalizedParams =
+      // Step 1: Strip malformed XML suffixes (shared cleanup — safe for all tools)
+      let normalizedParams: unknown =
         record && pathKeys.length > 0
           ? stripMalformedXmlArgValueSuffixFromKeys(record, pathKeys)
           : params;
+
+      // Step 2: Handle hallucinated document extensions at the file-tool path boundary
+      if (record && pathKeys.length > 0) {
+        const normalizedRecord = getToolParamsRecord(normalizedParams);
+        if (normalizedRecord) {
+          if (isReadOnlyTool(requiredParamGroups)) {
+            // Read tools: silently correct (safe — no filesystem mutation)
+            normalizedParams = correctHallucinatedFileExtensionFromKeys(normalizedRecord, pathKeys);
+          } else {
+            // Write/edit/memory-flush tools: reject hallucinated extensions
+            // to prevent silent retargeting of mutation paths
+            rejectHallucinatedFileExtensionFromKeys(normalizedRecord, pathKeys, tool.name);
+          }
+        }
+      }
+
       if (requiredParamGroups?.length) {
         assertRequiredParams(getToolParamsRecord(normalizedParams), requiredParamGroups, tool.name);
       }

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -26,7 +26,9 @@ import {
   REQUIRED_PARAM_GROUPS,
   assertRequiredParams,
   correctHallucinatedFileExtension,
+  correctHallucinatedFileExtensionFromKeys,
   getToolParamsRecord,
+  rejectHallucinatedFileExtensionFromKeys,
   stripMalformedXmlArgValueSuffix,
   stripMalformedXmlArgValueSuffixFromKeys,
   wrapToolParamValidation,
@@ -655,6 +657,9 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
       const normalizedRecord = record
         ? stripMalformedXmlArgValueSuffixFromKeys(record, ["path"])
         : undefined;
+      if (normalizedRecord) {
+        rejectHallucinatedFileExtensionFromKeys(normalizedRecord, ["path"], tool.name);
+      }
       assertRequiredParams(normalizedRecord, REQUIRED_PARAM_GROUPS.write, tool.name);
       const filePath =
         typeof normalizedRecord?.path === "string" && normalizedRecord.path.trim()
@@ -886,8 +891,11 @@ export function createOpenClawReadTool(
     ...base,
     execute: async (toolCallId, params, signal) => {
       const record = getToolParamsRecord(params);
-      const normalizedRecord = record
+      const xmlNormalized = record
         ? stripMalformedXmlArgValueSuffixFromKeys(record, ["path"])
+        : undefined;
+      const normalizedRecord = xmlNormalized
+        ? correctHallucinatedFileExtensionFromKeys(xmlNormalized, ["path"])
         : undefined;
       assertRequiredParams(normalizedRecord, REQUIRED_PARAM_GROUPS.read, base.name);
       const result = await executeReadWithAdaptivePaging({

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -25,6 +25,7 @@ import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import {
   REQUIRED_PARAM_GROUPS,
   assertRequiredParams,
+  correctHallucinatedFileExtension,
   getToolParamsRecord,
   stripMalformedXmlArgValueSuffix,
   stripMalformedXmlArgValueSuffixFromKeys,
@@ -770,7 +771,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
         if (typeof rawFilePath !== "string" || !rawFilePath.trim()) {
           continue;
         }
-        const filePath = stripMalformedXmlArgValueSuffix(rawFilePath);
+        const filePath = correctHallucinatedFileExtension(stripMalformedXmlArgValueSuffix(rawFilePath));
         if (!filePath.trim()) {
           throw malformedXmlArgValuePathError(key);
         }

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -25,7 +25,6 @@ import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import {
   REQUIRED_PARAM_GROUPS,
   assertRequiredParams,
-  correctHallucinatedFileExtension,
   correctHallucinatedFileExtensionFromKeys,
   getToolParamsRecord,
   rejectHallucinatedFileExtensionFromKeys,
@@ -776,7 +775,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
         if (typeof rawFilePath !== "string" || !rawFilePath.trim()) {
           continue;
         }
-        const filePath = correctHallucinatedFileExtension(stripMalformedXmlArgValueSuffix(rawFilePath));
+        const filePath = stripMalformedXmlArgValueSuffix(rawFilePath);
         if (!filePath.trim()) {
           throw malformedXmlArgValuePathError(key);
         }


### PR DESCRIPTION
## What Problem This Solves

When models blend "codex" into office-document extensions (e.g. GPT-5.4 via Codex runtime), they produce hallucinated paths like report.docodex instead of report.docx. The existing agent-tool path normalization pipeline only strips malformed XML suffixes — it has no awareness of hallucinated file extensions, so these pass through unchanged and cause file-not-found errors.

Fixes #93326

## Summary

Add hallucinated document extension handling at the file-tool path boundary, with different semantics for read vs mutation tools:

- **Read tools**: silently correct known hallucinated extensions (e.g. .docodex -> .docx) — safe because read operations do not mutate filesystem state
- **Write/edit/memory-flush tools**: reject hallucinated extensions with a retryable error, forcing the model to retry with the correct extension — prevents silent retargeting of mutation paths
- **Exec/bash tools**: no extension correction (the shared XML cleanup helper remains XML-only, used only for malformed XML suffix stripping)

The correction is applied at the wrapToolParamValidation level, NOT in the outer workspace guard (wrapToolWorkspaceRootGuardWithOptions), ensuring mutation rejection cannot be bypassed regardless of wrapper composition order.

**What changed:**
- agent-tools.params.ts: added HALLUCINATED_EXTENSION_MAP, correctHallucinatedFileExtension, hasHallucinatedFileExtension, correctHallucinatedFileExtensionFromKeys (read), rejectHallucinatedFileExtensionFromKeys (write/edit). stripMalformedXmlArgValueSuffixFromKeys restored to XML-only.
- agent-tools.read.ts: createOpenClawReadTool applies correctHallucinatedFileExtensionFromKeys for read paths. wrapToolMemoryFlushAppendOnlyWrite applies rejectHallucinatedFileExtensionFromKeys. wrapToolWorkspaceRootGuardWithOptions stays XML-only.

**What did NOT change (scope boundary):**
- bash-tools.exec.ts: unchanged — only imports stripMalformedXmlArgValueSuffixFromKeys (XML-only)
- No change to the workspace guard extension handling
- No new guard layer, no new files

## Real behavior proof

**Behavior addressed**: Model-supplied paths like report.docodex pass through the current path-normalization pipeline unchanged, causing file-operation failures.

**Environment tested**:
- Runtime: Node 24.13.1, Linux
- Code analysis path: agent-tools.params.ts -> correctHallucinatedFileExtensionFromKeys / rejectHallucinatedFileExtensionFromKeys

**Steps run after the patch**:
node --import tsx -e inline proof script

**Evidence after fix**:

BEFORE (main branch - bug confirmed):
  report.docodex -> report.docodex (unchanged, BUG)
  slides.pptcodex -> slides.pptcodex (unchanged, BUG)

AFTER (fix branch - all paths handled correctly):

1. XML-only helper (shared, used by all tools including exec):
   report.docodex -> report.docodex (no ext correction, PASS)

2. Read pipeline (stripXml + correct):
   report.docodex -> report.docx (silently corrected, PASS)

3. Write pipeline (stripXml + reject):
   report.docodex -> REJECTED (retryable error, PASS)

4. Write real docx (stripXml + reject check):
   report.docx -> accepted (no hallucinated ext, PASS)

5. Exec pipeline (stripXml only):
   cat report.docodex -> cat report.docodex (command untouched, PASS)

**Observed result after the fix**: Read paths are silently corrected, mutation paths are rejected with retry guidance, and exec commands are never retargeted.

**What was not tested**: Live Gateway/agent session with GPT-5.4 producing hallucinated extensions (no Codex runtime environment available). The correction was verified against the production path-normalization functions directly.
