### PR TITLE
fix(cron): stop read RPCs from dropping a deferred startup catch-up run

### DIFF
--- a/src/cron/service.read-rpc-overflow-clobber.test.ts
+++ b/src/cron/service.read-rpc-overflow-clobber.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import { setupCronServiceSuite } from "./service.test-harness.js";
+import { list, readJob, start, status } from "./service/ops.js";
+import { createCronServiceState } from "./service/state.js";
+import { saveCronStore } from "./store.js";
+import type { CronJob } from "./types.js";
+
+const { logger: noopLogger, makeStorePath } = setupCronServiceSuite({
+  prefix: "openclaw-cron-read-overflow-",
+  baseTimeIso: "2025-12-13T17:00:00.000Z",
+});
+
+describe("CronService read-RPC overflow deferral clobber", () => {
+  function createHourlyCronJob(id: string, nextRunAtMs: number): CronJob {
+    return {
+      id,
+      name: `job-${id}`,
+      enabled: true,
+      createdAtMs: nextRunAtMs - 60_000,
+      updatedAtMs: nextRunAtMs - 60_000,
+      schedule: { kind: "cron", expr: "0 * * * *", tz: "UTC" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: `tick-${id}` },
+      state: { nextRunAtMs },
+    };
+  }
+
+  function createDailyCronJob(id: string, nextRunAtMs: number): CronJob {
+    return {
+      id,
+      name: `job-${id}`,
+      enabled: true,
+      createdAtMs: nextRunAtMs - 60_000,
+      updatedAtMs: nextRunAtMs - 60_000,
+      schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: `tick-${id}` },
+      state: { nextRunAtMs },
+    };
+  }
+
+  function buildState(storePath: string, startNow: number) {
+    return createCronServiceState({
+      cronEnabled: true,
+      storePath,
+      log: noopLogger,
+      nowMs: () => startNow,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+  }
+
+  it("preserves the overflow daily-cron catch-up deferral across a read RPC after start()", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+    const tomorrowNaturalSlot = Date.parse("2025-12-14T09:00:00.000Z");
+
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [
+        createHourlyCronJob("hourly-0", Date.parse("2025-12-13T03:00:00.000Z")),
+        createHourlyCronJob("hourly-1", Date.parse("2025-12-13T04:00:00.000Z")),
+        createHourlyCronJob("hourly-2", Date.parse("2025-12-13T05:00:00.000Z")),
+        createHourlyCronJob("hourly-3", Date.parse("2025-12-13T06:00:00.000Z")),
+        createHourlyCronJob("hourly-4", Date.parse("2025-12-13T07:00:00.000Z")),
+        createDailyCronJob("daily-overflow", Date.parse("2025-12-13T09:00:00.000Z")),
+      ],
+    });
+
+    const state = buildState(store.storePath, startNow);
+
+    await start(state);
+
+    const afterStart = state.store?.jobs.find((j) => j.id === "daily-overflow");
+    expect(afterStart?.state.nextRunAtMs).toBe(startNow + 5_000);
+
+    await list(state);
+
+    const afterList = state.store?.jobs.find((j) => j.id === "daily-overflow");
+    expect(afterList?.state.nextRunAtMs).toBe(startNow + 5_000);
+    expect(afterList?.state.nextRunAtMs).not.toBe(tomorrowNaturalSlot);
+
+    state.stopped = true;
+    await store.cleanup();
+  });
+
+  it("also preserves the deferral across status() and readJob()", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [
+        createHourlyCronJob("hourly-0", Date.parse("2025-12-13T03:00:00.000Z")),
+        createHourlyCronJob("hourly-1", Date.parse("2025-12-13T04:00:00.000Z")),
+        createHourlyCronJob("hourly-2", Date.parse("2025-12-13T05:00:00.000Z")),
+        createHourlyCronJob("hourly-3", Date.parse("2025-12-13T06:00:00.000Z")),
+        createHourlyCronJob("hourly-4", Date.parse("2025-12-13T07:00:00.000Z")),
+        createDailyCronJob("daily-overflow", Date.parse("2025-12-13T09:00:00.000Z")),
+      ],
+    });
+
+    const state = buildState(store.storePath, startNow);
+    await start(state);
+
+    await status(state);
+    await readJob(state, "daily-overflow");
+
+    const after = state.store?.jobs.find((j) => j.id === "daily-overflow");
+    expect(after?.state.nextRunAtMs).toBe(startNow + 5_000);
+
+    state.stopped = true;
+    await store.cleanup();
+  });
+});

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -207,7 +207,9 @@ async function ensureLoadedForRead(state: CronServiceState) {
   }
   // Use the maintenance-only version so that read-only operations never
   // advance a past-due nextRunAtMs without executing the job (#16156).
-  const changed = recomputeNextRunsForMaintenance(state);
+  const changed = recomputeNextRunsForMaintenance(state, {
+    repairFutureCronNextRunAtMs: false,
+  });
   if (changed) {
     await persist(state);
   }


### PR DESCRIPTION
## What Problem This Solves

When the gateway restarts after downtime that spanned more than `maxMissedJobsPerRestart` (default 5) missed cron slots, startup catch-up runs the first few immediately and **defers the overflow**: each deferred job is parked at a near-future timestamp (`now + 5s`, `now + 10s`, ... staggered by `missedJobStaggerMs`) so its missed run still fires shortly after boot. `start()` protects these parked slots by passing `skipFutureRepairJobIds`/`repairFutureCronNextRunAtMs: false` to its recompute (`src/cron/service/ops.ts` and `src/cron/service/timer.ts`).

The read path does not. `ensureLoadedForRead` (`src/cron/service/ops.ts`) calls `recomputeNextRunsForMaintenance(state)` with default options, so `repairFutureCronNextRunAtMs` is `true`. Any read RPC that runs inside the deferral window, `list()` / `status()` / `readJob()` / `listPage()` (the CLI `openclaw cron list/status` and routine UI polling), treats a deferred slot as an out-of-place future slot and "repairs" it to the natural next slot, **silently dropping the missed catch-up run** and persisting the advance.

## Why This Change Was Made

Reads must never advance a schedule slot. The deferral mechanism is owned by the timer/startup paths that carry the deferral context; the read path has no such context and was the one surface that still ran future-cron repair. Passing `repairFutureCronNextRunAtMs: false` aligns the read path with the invariant the sibling `start()` and post-deferral `runMissedJobs` recompute already enforce. Past-due slots are still left untouched on reads (`recomputeExpired` stays off), so the existing `#16156` behavior (reads never advance a past-due slot without executing it) is unchanged.

## User Impact

Before: after a restart that overflowed the missed-job limit, a single `openclaw cron list`/`status` (or a UI poll) during the few-second deferral window advances a deferred job to its next natural slot, so that missed run never fires (e.g. a daily 09:00 job silently jumps to tomorrow). Silent missed-run / scheduler data loss, P1.

After: deferred catch-up slots survive read RPCs and fire as scheduled.

This is the read-path sibling of the startup-path fix in PR #93810 (which guarded `start()` only).

## Evidence

Before/after, driving the real `start()` + `list()`/`status()`/`readJob()` over a store with 6 missed jobs (5 hourly + 1 overflow daily), mocked clock, no network (`src/cron/service.read-rpc-overflow-clobber.test.ts`):

- On unpatched `main`: both cases FAIL: after `start()` the overflow daily slot is correctly parked at `startNow + 5s`, but a single `list()`/`status()`/`readJob()` advances it to the next natural `09:00` slot (`expected 1765702800000 to be 1765645205000`).
- With the fix: both pass; the deferred slot stays at `startNow + 5s` across the read RPCs.

oxlint and oxfmt clean on the changed files.
