### PR TITLE
fix(agents): forward resolved model to subagent gateway agent call

### DIFF
--- a/src/agents/subagent-spawn.model-session.test.ts
+++ b/src/agents/subagent-spawn.model-session.test.ts
@@ -147,4 +147,58 @@ describe("spawnSubagentDirect runtime model persistence", () => {
     expect(persistedEntry?.modelOverrideFallbackOriginProvider).toBe("openai");
     expect(persistedEntry?.modelOverrideFallbackOriginModel).toBe("gpt-5.4");
   });
+
+  it("forwards resolved model to the agent gateway call so the child run uses the correct model (#91171)", async () => {
+    // In-process spawn must include the resolved model in the agent gateway
+    // params so the agent handler authorizes and applies the override.
+    // Without this, the child run silently falls back to the default model.
+    const agentCallParams: Array<Record<string, unknown>> = [];
+    const dispatchedMethods: string[] = [];
+    const forwardDispatchMock = vi.fn(async (...args: unknown[]) => {
+      const method = args[0] as string;
+      const params = args[1] as Record<string, unknown>;
+      dispatchedMethods.push(method);
+      if (method === "agent") {
+        agentCallParams.push(params);
+      }
+      if (method === "sessions.patch" || method === "sessions.delete") {
+        return { ok: true };
+      }
+      return { runId: "run-forward", status: "accepted", acceptedAt: Date.now() };
+    });
+    const forwardPruneMock = vi.fn();
+    const forwardUpdateSessionStoreMock = vi.fn();
+    installSessionStoreCaptureMock(forwardUpdateSessionStoreMock);
+    const {
+      resetSubagentRegistryForTests: resetForForwardTest,
+      spawnSubagentDirect: spawnForForward,
+    } = await loadSubagentSpawnModuleForTest({
+      callGatewayMock,
+      dispatchGatewayMethodInProcessMock: forwardDispatchMock,
+      hasInProcessGatewayContextMock: () => true,
+      getRuntimeConfig: () => createSubagentSpawnTestConfig(os.tmpdir()),
+      updateSessionStoreMock: forwardUpdateSessionStoreMock,
+      pruneLegacyStoreKeysMock: forwardPruneMock,
+      workspaceDir: os.tmpdir(),
+    });
+    resetForForwardTest();
+
+    const result = await spawnForForward(
+      {
+        task: "verify model forwarding",
+        model: "qwen/qwen3.6-plus",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "guildchat",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.resolvedModel).toBe("qwen/qwen3.6-plus");
+    expect(dispatchedMethods).toContain("agent");
+    const agentParams = agentCallParams[0];
+    expect(agentParams).toBeDefined();
+    expect(agentParams.model).toBe("qwen/qwen3.6-plus");
+  });
 });

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -263,14 +263,20 @@ async function callSubagentGateway(
   ) {
     // Spawn is already running in the gateway process for channel/tool calls.
     // Direct dispatch avoids self-connecting over WS while the same event loop is busy.
+    // Subagent agent calls that forward a model need model-override authorization
+    // on the synthetic client; otherwise the gateway agent handler silently drops
+    // the override and the child run falls back to the default model (#91171).
+    const hasModelOverride =
+      request.method === "agent" && (request.params as Record<string, unknown>).model != null;
     return await subagentSpawnDeps.dispatchGatewayMethodInProcess(
       request.method,
       request.params as Record<string, unknown>,
       {
         expectFinal: request.expectFinal,
-        ...(scopes != null ? { forceSyntheticClient: true } : {}),
+        ...(scopes != null || hasModelOverride ? { forceSyntheticClient: true } : {}),
         timeoutMs: request.timeoutMs,
         ...(scopes != null ? { syntheticScopes: scopes } : {}),
+        ...(hasModelOverride ? { allowSyntheticModelOverride: true } : {}),
       },
     );
   }
@@ -1562,6 +1568,14 @@ export async function spawnSubagentDirect(
       workspaceDir: _workspaceDir,
       ...publicSpawnedMetadata
     } = spawnedMetadata;
+    // Forward the resolved model to the child agent run so the gateway agent
+    // handler sees the override and uses the explicitly-requested model instead
+    // of falling back to the session/agent default (#91171).
+    // The model is also persisted in the session store so restarted runs and
+    // cross-process dispatches can still resolve it; the agent call param is
+    // authoritative for the in-process path used by channel/tool spawns.
+    const agentModelOverride =
+      subagentSpawnDeps.hasInProcessGatewayContext() && resolvedModel ? resolvedModel : undefined;
     const response = await callSubagentGateway({
       method: "agent",
       params: {
@@ -1581,6 +1595,7 @@ export async function spawnSubagentDirect(
         cleanupBundleMcpOnRunEnd: spawnMode !== "session",
         extraSystemPrompt: childSystemPrompt,
         thinking: thinkingOverride,
+        ...(agentModelOverride ? { model: agentModelOverride } : {}),
         timeout: runTimeoutSeconds,
         label: label || undefined,
         ...(bootstrapContextMode


### PR DESCRIPTION
## Summary
Fix sub-agent model routing silently ignoring the `sessions_spawn` `model` parameter. When a sub-agent was spawned with an explicit model override (e.g. `model: "qwen/qwen3.6-plus"`), the spawn response correctly reported `resolvedModel` and `modelApplied: true`, but the actual agent run fell back to the default model. The `resolvedModel` was correctly stored in the session store, but was never forwarded to the gateway `agent` RPC call params, so the gateway agent handler used the session/agent default model.

Fixes #91171

## Real behavior proof (required for external PRs)

**Behavior addressed**: Sub-agent model routing ignoring explicit `sessions_spawn` model parameter

**Real setup tested**:
- **Runtime**: Node 22.19, Linux 4.19.112
- **Code analysis path**: `spawnSubagentDirect` (`src/agents/subagent-spawn.ts:1572`) → `callSubagentGateway` → `dispatchGatewayMethodInProcess` → `agent` handler (`src/gateway/server-methods/agent.ts:1131-1163`). The `agent` handler only uses `request.model` when `allowModelOverride` is true; without explicit model forwarding + authorization, the resolved model was silently dropped.
- **Test framework**: Vitest

**Exact steps or command run after this patch**:
```bash
pnpm test src/agents/subagent-spawn.test.ts src/agents/subagent-spawn.model-session.test.ts --run
```

**After-fix evidence**:
```
 Test Files  2 passed (2)
      Tests  28 passed (28)
   Start at  11:20:23
   Duration  6.32s
```

**Observed result after the fix**: All 28 tests pass, including a new test that verifies the resolved model is forwarded in the agent gateway call params during in-process dispatch.

**What was not tested**: Cross-process (remote gateway) dispatch path — this is extremely rare for subagent spawns and the model is already persisted in the session store for that case.

## Tests and validation
| Test Type | Result | Details |
|-----------|--------|---------|
| Unit Tests | ✅ | 28/28 passed (incl. new #91171 test) |
| Type Check | ✅ | `pnpm tsgo:core` clean |
| Lint | ✅ | oxlint clean |

## Risk checklist
**Did user-visible behavior change?** **Yes** — sub-agents now correctly use the `model` specified in `sessions_spawn` instead of silently falling back to the default model.
**Did config, environment, or migration behavior change?** **No**
**Did security, auth, secrets, network, or tool execution behavior change?** **No** — model override authorization uses the existing `allowSyntheticModelOverride` mechanism for in-process dispatch, which is the same mechanism used by plugin subagent runs.

## Current review state
**What is the next action?** Maintainer review requested
