### PR TITLE
test(gateway): harden watch regression diagnostics

### DIFF
--- a/scripts/check-gateway-watch-regression.mjs
+++ b/scripts/check-gateway-watch-regression.mjs
@@ -50,9 +50,14 @@ const WATCH_GATEWAY_SKIP_ENV = {
  * Maximum retained stdout/stderr text for gateway watch diagnostics.
  */
 export const WATCH_LOG_CAPTURE_MAX_CHARS = 2 * 1024 * 1024;
+export const WATCH_LOG_FAILURE_TAIL_CHARS = 12_000;
 const WATCH_BUILD_DETECTION_MAX_CHARS = 4096;
 const NON_NEGATIVE_INTEGER_PATTERN = /^(0|[1-9]\d*)$/u;
 const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, "g");
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
 
 /**
  * Appends watch output while preserving only the diagnostic tail.
@@ -69,6 +74,28 @@ function formatCapturedWatchLog(text, truncated) {
   return truncated
     ? `[openclaw] log truncated to last ${WATCH_LOG_CAPTURE_MAX_CHARS} chars\n${text}`
     : text;
+}
+
+function formatWatchExit(exit) {
+  if (!exit) {
+    return "unknown exit";
+  }
+  const parts = [];
+  if (exit.code !== undefined) {
+    parts.push(`code ${exit.code === null ? "null" : exit.code}`);
+  }
+  if (exit.signal !== undefined) {
+    parts.push(`signal ${exit.signal === null ? "null" : exit.signal}`);
+  }
+  if (exit.error) {
+    parts.push(`error ${exit.error}`);
+  }
+  return parts.length > 0 ? parts.join(", ") : "unknown exit";
+}
+
+function readTextTail(filePath, maxChars = WATCH_LOG_FAILURE_TAIL_CHARS) {
+  const text = fs.readFileSync(filePath, "utf8");
+  return text.length <= maxChars ? text : text.slice(-maxChars);
 }
 
 /**
@@ -449,21 +476,43 @@ async function allocateLoopbackPort() {
   });
 }
 
-function buildTimedWatchCommand(pidFilePath, timeFilePath, isolatedHomeDir, port) {
+export function resolveTimedWatchShell(deps = {}) {
+  const existsSync = deps.existsSync ?? fs.existsSync;
+  for (const shellPath of ["/bin/bash", "/usr/bin/bash", "/bin/sh"]) {
+    if (existsSync(shellPath)) {
+      return shellPath;
+    }
+  }
+  return "/bin/sh";
+}
+
+export function buildTimedWatchCommand(
+  pidFilePath,
+  timeFilePath,
+  isolatedHomeDir,
+  port,
+  deps = {},
+) {
   const isolatedStateDir = path.join(isolatedHomeDir, ".openclaw");
   const isolatedConfigPath = path.join(isolatedStateDir, "openclaw.json");
+  // CI env hooks can contain bash-only `declare` lines; running the watch shell
+  // under sh delays gateway readiness behind stderr noise before the idle window.
+  const shellPath = deps.shellPath ?? resolveTimedWatchShell(deps);
+  const nodeExecPath = deps.nodeExecPath ?? process.execPath;
   const shellSource = [
     'echo "$$" > "$OPENCLAW_WATCH_PID_FILE"',
     'mkdir -p "$OPENCLAW_STATE_DIR"',
     `printf '%s\n' '{"gateway":{"controlUi":{"enabled":false}},"plugins":{"enabled":false}}' > "$OPENCLAW_CONFIG_PATH"`,
-    `exec node scripts/watch-node.mjs gateway --force --allow-unconfigured --port ${String(port)} --token watch-regression-token`,
+    `exec ${shellQuote(nodeExecPath)} scripts/watch-node.mjs gateway --force --allow-unconfigured --port ${String(port)} --token watch-regression-token`,
   ].join("\n");
+  const nodeBinDir = path.dirname(nodeExecPath);
   const env = {
     OPENCLAW_WATCH_PID_FILE: pidFilePath,
     HOME: isolatedHomeDir,
     OPENCLAW_HOME: isolatedHomeDir,
     OPENCLAW_CONFIG_PATH: isolatedConfigPath,
     OPENCLAW_STATE_DIR: isolatedStateDir,
+    PATH: `${nodeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
     XDG_CONFIG_HOME: path.join(isolatedHomeDir, ".config"),
     ...WATCH_GATEWAY_SKIP_ENV,
   };
@@ -471,14 +520,14 @@ function buildTimedWatchCommand(pidFilePath, timeFilePath, isolatedHomeDir, port
   if (process.platform === "darwin") {
     return {
       command: "/usr/bin/time",
-      args: ["-lp", "-o", timeFilePath, "/bin/sh", "-lc", shellSource],
+      args: ["-lp", "-o", timeFilePath, shellPath, "-lc", shellSource],
       env,
     };
   }
 
   if (!fs.existsSync("/usr/bin/time")) {
     return {
-      command: "/bin/sh",
+      command: shellPath,
       args: ["-lc", shellSource],
       env,
     };
@@ -491,7 +540,7 @@ function buildTimedWatchCommand(pidFilePath, timeFilePath, isolatedHomeDir, port
       "__TIMING__ user=%U sys=%S elapsed=%e",
       "-o",
       timeFilePath,
-      "/bin/sh",
+      shellPath,
       "-lc",
       shellSource,
     ],
@@ -580,22 +629,34 @@ export async function runTimedWatch(options, outputDir, deps = {}) {
         resolve({ code: null, signal: null, error: error.message });
       });
     });
-    const raceSpawnError = async (operation) =>
+    const childExit = new Promise((resolve) => {
+      child.once("exit", (code, signal) => resolve({ code, signal }));
+    });
+    const raceChildLifecycle = async (operation) =>
       await Promise.race([
         Promise.resolve(operation).then((value) => ({ type: "value", value })),
         spawnErrorExit.then((value) => ({ type: "spawn-error", value })),
+        childExit.then((value) => ({ type: "child-exit", value })),
       ]);
 
     let watchPid = null;
     let exit = null;
+    let exitedBeforeReady = false;
+    let exitedBeforeStop = false;
     for (let attempt = 0; attempt < 50; attempt += 1) {
       if (fs.existsSync(pidFilePath)) {
         watchPid = Number(fs.readFileSync(pidFilePath, "utf8").trim());
         break;
       }
-      const waitResult = await raceSpawnError(sleepMs(100));
+      const waitResult = await raceChildLifecycle(sleepMs(100));
       if (waitResult.type === "spawn-error") {
         exit = waitResult.value;
+        break;
+      }
+      if (waitResult.type === "child-exit") {
+        exit = waitResult.value;
+        exitedBeforeReady = true;
+        exitedBeforeStop = true;
         break;
       }
     }
@@ -604,32 +665,42 @@ export async function runTimedWatch(options, outputDir, deps = {}) {
     let idleCpuStartMs = null;
     let idleCpuEndMs = null;
     if (!exit) {
-      const readyResult = await raceSpawnError(
+      const readyResult = await raceChildLifecycle(
         waitReady(() => `${stdout}\n${stderr}`, options.readyTimeoutMs),
       );
       if (readyResult.type === "spawn-error") {
         exit = readyResult.value;
+      } else if (readyResult.type === "child-exit") {
+        exit = readyResult.value;
+        exitedBeforeReady = true;
+        exitedBeforeStop = true;
       } else {
         readyBeforeWindow = readyResult.value;
       }
     }
     if (!exit && readyBeforeWindow && options.readySettleMs > 0) {
-      const settleResult = await raceSpawnError(sleepMs(options.readySettleMs));
+      const settleResult = await raceChildLifecycle(sleepMs(options.readySettleMs));
       if (settleResult.type === "spawn-error") {
         exit = settleResult.value;
+      } else if (settleResult.type === "child-exit") {
+        exit = settleResult.value;
+        exitedBeforeStop = true;
       }
     }
     if (!exit) {
       idleCpuStartMs = watchPid ? readCpuMs(watchPid) : null;
-      const windowResult = await raceSpawnError(sleepMs(options.windowMs));
+      const windowResult = await raceChildLifecycle(sleepMs(options.windowMs));
       if (windowResult.type === "spawn-error") {
         exit = windowResult.value;
+      } else if (windowResult.type === "child-exit") {
+        exit = windowResult.value;
+        exitedBeforeStop = true;
       } else {
         idleCpuEndMs = watchPid ? readCpuMs(watchPid) : null;
       }
     }
     if (!exit) {
-      const stopResult = await raceSpawnError(stopChild(child, watchPid, options));
+      const stopResult = await raceChildLifecycle(stopChild(child, watchPid, options));
       exit = stopResult.value;
     }
 
@@ -646,6 +717,8 @@ export async function runTimedWatch(options, outputDir, deps = {}) {
       timingFileMissing,
       timing,
       readyBeforeWindow,
+      exitedBeforeReady,
+      exitedBeforeStop,
       idleCpuMs:
         idleCpuStartMs == null || idleCpuEndMs == null
           ? null
@@ -809,8 +882,15 @@ export function collectGatewayWatchFindings(params) {
   if (watchResult.spawnError) {
     failures.push(`gateway:watch failed to start: ${watchResult.spawnError}`);
   }
-  if (!watchResult.readyBeforeWindow) {
+  if (!watchResult.readyBeforeWindow && watchResult.exitedBeforeReady) {
+    failures.push(`gateway:watch exited before ready (${formatWatchExit(watchResult.exit)})`);
+  } else if (!watchResult.readyBeforeWindow) {
     failures.push("gateway:watch did not report ready before the idle CPU window");
+  }
+  if (watchResult.readyBeforeWindow && watchResult.exitedBeforeStop) {
+    failures.push(
+      `gateway:watch exited before the idle CPU window completed (${formatWatchExit(watchResult.exit)})`,
+    );
   }
   if (watchResult.timingFileMissing && !Number.isFinite(watchResult.idleCpuMs)) {
     failures.push(
@@ -848,6 +928,32 @@ export function collectGatewayWatchFindings(params) {
     );
   }
   return { failures, warnings };
+}
+
+export function shouldReportDuplicateDistRuntimeRegression(failures) {
+  return failures.some((message) => message.startsWith("dist-runtime "));
+}
+
+function printWatchLogDiagnostics(watchResult) {
+  const artifacts = [
+    ["stderr", watchResult.stderrPath],
+    ["stdout", watchResult.stdoutPath],
+  ];
+  for (const [label, filePath] of artifacts) {
+    if (!filePath || !fs.existsSync(filePath)) {
+      continue;
+    }
+    const tail = readTextTail(filePath).trimEnd();
+    if (!tail) {
+      warn(`gateway:watch ${label} artifact is empty (${filePath})`);
+      continue;
+    }
+    console.error(
+      `--- gateway:watch ${label} tail (${filePath}, last ${WATCH_LOG_FAILURE_TAIL_CHARS} chars) ---`,
+    );
+    console.error(tail);
+    console.error(`--- end gateway:watch ${label} tail ---`);
+  }
 }
 
 async function main() {
@@ -933,6 +1039,8 @@ async function main() {
     cpuMs,
     totalCpuMs,
     readyBeforeWindow: watchResult.readyBeforeWindow,
+    exitedBeforeReady: watchResult.exitedBeforeReady,
+    exitedBeforeStop: watchResult.exitedBeforeStop,
     cpuWarnMs: options.cpuWarnMs,
     cpuFailMs: options.cpuFailMs,
     distRuntimeFileGrowth,
@@ -944,6 +1052,8 @@ async function main() {
     removedPaths: diff.removed.length,
     watchExit: watchResult.exit,
     spawnError: watchResult.spawnError,
+    stdoutPath: watchResult.stdoutPath,
+    stderrPath: watchResult.stderrPath,
     timingFileMissing: watchResult.timingFileMissing,
     timing: watchResult.timing,
   };
@@ -972,7 +1082,8 @@ async function main() {
     for (const message of failures) {
       fail(message);
     }
-    if (!failures.every((message) => message.includes("dirty watched source tree"))) {
+    printWatchLogDiagnostics(watchResult);
+    if (shouldReportDuplicateDistRuntimeRegression(failures)) {
       fail(
         "Possible duplicate dist-runtime graph regression: this can reintroduce split runtime personalities where plugins and core observe different global state, including Telegram missing /voice, /phone, or /pair.",
       );

--- a/test/scripts/check-gateway-watch-regression.test.ts
+++ b/test/scripts/check-gateway-watch-regression.test.ts
@@ -6,11 +6,14 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   appendBoundedWatchLog,
+  buildTimedWatchCommand,
   collectGatewayWatchFindings,
   hasGatewayReadyLog,
   parseArgs,
+  resolveTimedWatchShell,
   runTimedWatch,
   readNonNegativeInteger,
+  shouldReportDuplicateDistRuntimeRegression,
   shouldRefreshBuildStampForRestoredArtifacts,
   stopTimedWatchChild,
   updateWatchBuildDetection,
@@ -120,6 +123,52 @@ describe("check-gateway-watch-regression", () => {
     expect(coalesced.reason).toBe("config_newer");
   });
 
+  it("uses bash for timed watch commands when available", () => {
+    expect(
+      resolveTimedWatchShell({
+        existsSync: (candidate: string) => candidate === "/usr/bin/bash",
+      }),
+    ).toBe("/usr/bin/bash");
+
+    const command = buildTimedWatchCommand(
+      "watch.pid",
+      "watch.time",
+      "/tmp/openclaw-watch",
+      19042,
+      {
+        existsSync: (candidate: string) =>
+          candidate === "/usr/bin/bash" || candidate === "/usr/bin/time",
+      },
+    );
+    const shellIndex = command.args.indexOf("/usr/bin/bash");
+
+    if (shellIndex >= 0) {
+      expect(command.args[shellIndex + 1]).toBe("-lc");
+    } else {
+      expect(command.command).toBe("/usr/bin/bash");
+      expect(command.args[0]).toBe("-lc");
+    }
+  });
+
+  it("runs gateway watch through the parent Node binary", () => {
+    const nodeExecPath = "/opt/hostedtoolcache/node/24.11.1/x64/bin/node";
+    const command = buildTimedWatchCommand(
+      "watch.pid",
+      "watch.time",
+      "/tmp/openclaw-watch",
+      19042,
+      {
+        existsSync: (candidate: string) =>
+          candidate === "/usr/bin/bash" || candidate === "/usr/bin/time",
+        nodeExecPath,
+      },
+    );
+    const shellSource = command.args.at(-1);
+
+    expect(shellSource).toContain(`exec '${nodeExecPath}' scripts/watch-node.mjs gateway --force`);
+    expect(command.env.PATH?.split(path.delimiter)[0]).toBe(path.dirname(nodeExecPath));
+  });
+
   it("fails the regression gate when gateway watch never becomes ready", () => {
     const findings = collectGatewayWatchFindings({
       cpuMs: 0,
@@ -146,6 +195,84 @@ describe("check-gateway-watch-regression", () => {
       "gateway:watch did not report ready before the idle CPU window",
     );
     expect(findings.warnings).toEqual([]);
+  });
+
+  it("reports early gateway watch exit before readiness distinctly", () => {
+    const findings = collectGatewayWatchFindings({
+      cpuMs: 0,
+      distRuntimeByteGrowth: 0,
+      distRuntimeFileGrowth: 0,
+      options: {
+        cpuFailMs: 8000,
+        cpuWarnMs: 1000,
+        distRuntimeByteGrowthMax: 2 * 1024 * 1024,
+        distRuntimeFileGrowthMax: 200,
+        windowMs: 10_000,
+      },
+      watchBuildReason: null,
+      watchResult: {
+        exit: { code: 1, signal: null },
+        exitedBeforeReady: true,
+        idleCpuMs: 0,
+        readyBeforeWindow: false,
+        spawnError: null,
+        timingFileMissing: false,
+      },
+      watchTriggeredBuild: false,
+    });
+
+    expect(findings.failures).toContain("gateway:watch exited before ready (code 1, signal null)");
+    expect(findings.failures).not.toContain(
+      "gateway:watch did not report ready before the idle CPU window",
+    );
+    expect(findings.warnings).toEqual([]);
+  });
+
+  it("reports gateway watch exit after readiness before the idle window completes", () => {
+    const findings = collectGatewayWatchFindings({
+      cpuMs: 0,
+      distRuntimeByteGrowth: 0,
+      distRuntimeFileGrowth: 0,
+      options: {
+        cpuFailMs: 8000,
+        cpuWarnMs: 1000,
+        distRuntimeByteGrowthMax: 2 * 1024 * 1024,
+        distRuntimeFileGrowthMax: 200,
+        windowMs: 10_000,
+      },
+      watchBuildReason: null,
+      watchResult: {
+        exit: { code: 0, signal: null },
+        exitedBeforeReady: false,
+        exitedBeforeStop: true,
+        idleCpuMs: 0,
+        readyBeforeWindow: true,
+        spawnError: null,
+        timingFileMissing: false,
+      },
+      watchTriggeredBuild: false,
+    });
+
+    expect(findings.failures).toContain(
+      "gateway:watch exited before the idle CPU window completed (code 0, signal null)",
+    );
+    expect(findings.warnings).toEqual([]);
+  });
+
+  it("reports duplicate dist-runtime regression only for dist-runtime growth failures", () => {
+    expect(
+      shouldReportDuplicateDistRuntimeRegression([
+        "gateway:watch did not report ready before the idle CPU window",
+      ]),
+    ).toBe(false);
+    expect(
+      shouldReportDuplicateDistRuntimeRegression(["dist-runtime file growth 201 exceeded max 200"]),
+    ).toBe(true);
+    expect(
+      shouldReportDuplicateDistRuntimeRegression([
+        "dist-runtime apparent byte growth 2097153 exceeded max 2097152",
+      ]),
+    ).toBe(true);
   });
 
   it("refreshes restored build stamps only for skip-build config mtime drift", () => {
@@ -270,6 +397,166 @@ describe("check-gateway-watch-regression", () => {
       expect(fs.existsSync(path.join(outputDir, "watch.home.txt"))).toBe(true);
       expect(spawn.mock.calls[0]?.[2]?.env?.OPENCLAW_RUNTIME_POSTBUILD_STATIC_ASSETS).toBe("0");
       expect(waitForGatewayReady).not.toHaveBeenCalled();
+      expect(stopChild).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("stops waiting for readiness when the watch process exits early", async () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-watch-output-"));
+    const child = new EventEmitter() as EventEmitter & {
+      stderr: EventEmitter;
+      stdout: EventEmitter;
+    };
+    child.stderr = new EventEmitter();
+    child.stdout = new EventEmitter();
+    const sleep = vi.fn(() => new Promise<never>(() => {}));
+    const stopChild = vi.fn(async () => ({ code: null, signal: "SIGTERM" }));
+    const waitForGatewayReady = vi.fn(
+      () =>
+        new Promise<never>(() => {
+          // Child exit must win before readiness timeout.
+        }),
+    );
+    const spawn = vi.fn(() => {
+      process.nextTick(() => {
+        child.stderr.emit("data", "gateway startup failed\n");
+        child.emit("exit", 1, null);
+      });
+      return child;
+    });
+
+    try {
+      const result = await runTimedWatch(
+        {
+          readySettleMs: 0,
+          readyTimeoutMs: 30_000,
+          sigkillGraceMs: 1,
+          windowMs: 10_000,
+        },
+        outputDir,
+        {
+          allocateLoopbackPort: async () => 19042,
+          spawn,
+          sleep,
+          stopTimedWatchChild: stopChild,
+          waitForGatewayReady,
+        },
+      );
+
+      expect(result.exit).toEqual({ code: 1, signal: null });
+      expect(result.exitedBeforeReady).toBe(true);
+      expect(result.exitedBeforeStop).toBe(true);
+      expect(result.readyBeforeWindow).toBe(false);
+      expect(result.spawnError).toBeNull();
+      expect(fs.readFileSync(result.stderrPath, "utf8")).toContain("gateway startup failed");
+      expect(waitForGatewayReady).not.toHaveBeenCalled();
+      expect(stopChild).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("records a ready gateway watch exit during the settle window as unplanned", async () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-watch-output-"));
+    const child = new EventEmitter() as EventEmitter & {
+      stderr: EventEmitter;
+      stdout: EventEmitter;
+    };
+    child.stderr = new EventEmitter();
+    child.stdout = new EventEmitter();
+    const stopChild = vi.fn(async () => ({ code: null, signal: "SIGTERM" }));
+    const sleep = vi.fn(
+      () =>
+        new Promise<never>(() => {
+          process.nextTick(() => {
+            child.emit("exit", 0, null);
+          });
+        }),
+    );
+    const spawn = vi.fn(() => {
+      fs.writeFileSync(path.join(outputDir, "watch.pid"), "1234\n", "utf8");
+      return child;
+    });
+
+    try {
+      const result = await runTimedWatch(
+        {
+          readySettleMs: 10_000,
+          readyTimeoutMs: 30_000,
+          sigkillGraceMs: 1,
+          windowMs: 10_000,
+        },
+        outputDir,
+        {
+          allocateLoopbackPort: async () => 19042,
+          spawn,
+          sleep,
+          stopTimedWatchChild: stopChild,
+          waitForGatewayReady: async () => true,
+        },
+      );
+
+      expect(result.exit).toEqual({ code: 0, signal: null });
+      expect(result.exitedBeforeReady).toBe(false);
+      expect(result.exitedBeforeStop).toBe(true);
+      expect(result.readyBeforeWindow).toBe(true);
+      expect(result.idleCpuMs).toBeNull();
+      expect(stopChild).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("records a ready gateway watch exit during the idle window as unplanned", async () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-watch-output-"));
+    const child = new EventEmitter() as EventEmitter & {
+      stderr: EventEmitter;
+      stdout: EventEmitter;
+    };
+    child.stderr = new EventEmitter();
+    child.stdout = new EventEmitter();
+    const stopChild = vi.fn(async () => ({ code: null, signal: "SIGTERM" }));
+    const sleep = vi.fn(
+      () =>
+        new Promise<never>(() => {
+          process.nextTick(() => {
+            child.emit("exit", 0, null);
+          });
+        }),
+    );
+    const readProcessTreeCpuMs = vi.fn(() => 12);
+    const spawn = vi.fn(() => {
+      fs.writeFileSync(path.join(outputDir, "watch.pid"), "1234\n", "utf8");
+      return child;
+    });
+
+    try {
+      const result = await runTimedWatch(
+        {
+          readySettleMs: 0,
+          readyTimeoutMs: 30_000,
+          sigkillGraceMs: 1,
+          windowMs: 10_000,
+        },
+        outputDir,
+        {
+          allocateLoopbackPort: async () => 19042,
+          readProcessTreeCpuMs,
+          spawn,
+          sleep,
+          stopTimedWatchChild: stopChild,
+          waitForGatewayReady: async () => true,
+        },
+      );
+
+      expect(result.exit).toEqual({ code: 0, signal: null });
+      expect(result.exitedBeforeReady).toBe(false);
+      expect(result.exitedBeforeStop).toBe(true);
+      expect(result.readyBeforeWindow).toBe(true);
+      expect(result.idleCpuMs).toBeNull();
+      expect(readProcessTreeCpuMs).toHaveBeenCalledOnce();
       expect(stopChild).not.toHaveBeenCalled();
     } finally {
       fs.rmSync(outputDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

This PR hardens the `check-gateway-watch-regression` release/runtime guard so failures are easier to diagnose and short-lived gateway-watch exits are reported accurately.

The change is intentionally narrow. It only touches the gateway watch regression script and its focused tests.

## What Problem This Solves

The watch regression guard currently has a few sharp edges that make release/runtime failures harder to reason about:

- The timed watch command can run under `/bin/sh`, but CI/bootstrap environments may inject shell hooks that assume bash semantics. That can add noisy stderr output or delay gateway readiness before the idle window.
- If the child process exits before readiness, the script can collapse that into a generic “did not report ready” failure instead of reporting that the watch process actually exited.
- When the watch guard fails, stdout/stderr artifacts are written, but the actionable tail is not surfaced inline with the failure.
- The duplicate dist-runtime warning was gated too broadly; unrelated failures could print the split-runtime warning even when no dist-runtime graph regression was detected.

## What changed

- Prefer bash for the timed watch shell when available, while retaining `/bin/sh` fallback.
- Quote the Node executable path explicitly and put its directory at the front of `PATH` for the isolated watch process.
- Track child process exit during PID-file wait, readiness wait, settle, idle window, and stop phases.
- Report `gateway:watch exited before ready (...)` when the child exits before readiness.
- Include bounded stdout/stderr tails on watch failures.
- Only print the duplicate dist-runtime warning when a dist-runtime failure is actually present.
- Add focused unit coverage for:
  - bash selection/fallback
  - generated timed watch command/env
  - early exit before readiness
  - duplicate dist-runtime warning gating
  - stderr/stdout artifact metadata in the watch result

## Evidence

### Rebase/squash proof — 2026-06-23 UTC

Latest pushed commit after same-base rebase and squash: `4ea42a587047d35cb4f54814488f0ded22524eb7`.

All six coordinated PR branches in this batch were rebased onto the same pinned upstream base commit:

```text
dc9c11be917ebdc711b956250aa80a8e5b47bea6
```

Post-rebase local verification included conflict-marker/diff hygiene plus focused branch-specific gates. Final proof marker for this PR:

```text
POST_REBASE_20260623_GATEWAY_WATCH_GATES_OK
```

Local validation run from `/home/kklouzal/.openclaw/workspace/repos/openclaw`:

```text
node scripts/run-vitest.mjs test/scripts/check-gateway-watch-regression.test.ts
```

Result:

```text
1 passed test file
15 passed tests
```

Additional checks:

```text
node --check scripts/check-gateway-watch-regression.mjs
git diff --check
git diff --cached --check
```

Result: all passed.

## Real Behavior Proof

Redacted terminal output from a real gateway-watch guard invocation on this PR head:

```text
$ git rev-parse HEAD
dfbc96e4178989869ebfc06da80d7519fd199f7e
$ node scripts/check-gateway-watch-regression.mjs --skip-build
{
  "windowMs": 10000,
  "watchTriggeredBuild": false,
  "watchBuildReason": null,
  "cpuMs": 1000,
  "totalCpuMs": null,
  "readyBeforeWindow": true,
  "exitedBeforeReady": false,
  "cpuWarnMs": 1000,
  "cpuFailMs": 8000,
  "distRuntimeFileGrowth": 0,
  "distRuntimeFileGrowthMax": 200,
  "distRuntimeByteGrowth": 0,
  "distRuntimeByteGrowthMax": 2097152,
  "distRuntimeAddedPaths": 0,
  "addedPaths": 0,
  "removedPaths": 0,
  "watchExit": {
    "code": 143,
    "signal": null
  },
  "spawnError": null,
  "stdoutPath": "<repo>/.local/gateway-watch-regression/watch/watch.stdout.log",
  "stderrPath": "<repo>/.local/gateway-watch-regression/watch/watch.stderr.log",
  "timingFileMissing": true,
  "timing": {
    "userSeconds": null,
    "sysSeconds": null,
    "elapsedSeconds": null
  }
}
WARN: bounded gateway:watch timing artifact is missing; using process-tree idle CPU sample
```

Notes:

- This was run from the PR head commit shown above: `dfbc96e4178989869ebfc06da80d7519fd199f7e`.
- Private local paths are redacted as `<repo>`.
- The successful guard run reported `readyBeforeWindow: true`, `exitedBeforeReady: false`, no dist-runtime growth, and bounded stdout/stderr artifact paths.
- This run did not naturally exercise the early-exit failure path; no failure-path output is claimed here.

## Synthetic Failure-Path Proof

Redacted terminal output from a synthetic failure-path invocation on the same PR head. This intentionally lowers the CPU failure threshold to `0` so the guard exits non-zero and prints the new bounded failure diagnostics without needing to break the gateway:

```text
$ git rev-parse HEAD
dfbc96e4178989869ebfc06da80d7519fd199f7e
$ node scripts/check-gateway-watch-regression.mjs --skip-build --cpu-fail-ms 0 --cpu-warn-ms 0
{
  "windowMs": 10000,
  "watchTriggeredBuild": false,
  "watchBuildReason": null,
  "cpuMs": 1000,
  "totalCpuMs": null,
  "readyBeforeWindow": true,
  "exitedBeforeReady": false,
  "cpuWarnMs": 0,
  "cpuFailMs": 0,
  "distRuntimeFileGrowth": 0,
  "distRuntimeFileGrowthMax": 200,
  "distRuntimeByteGrowth": 0,
  "distRuntimeByteGrowthMax": 2097152,
  "distRuntimeAddedPaths": 0,
  "addedPaths": 0,
  "removedPaths": 0,
  "watchExit": {
    "code": 143,
    "signal": null
  },
  "spawnError": null,
  "stdoutPath": "<repo>/.local/gateway-watch-regression/watch/watch.stdout.log",
  "stderrPath": "<repo>/.local/gateway-watch-regression/watch/watch.stderr.log",
  "timingFileMissing": true,
  "timing": {
    "userSeconds": null,
    "sysSeconds": null,
    "elapsedSeconds": null
  }
}
WARN: bounded gateway:watch timing artifact is missing; using process-tree idle CPU sample
FAIL: LOUD ALARM: gateway:watch used 1000ms CPU in 10000ms window, above loud-alarm threshold 0ms
WARN: gateway:watch stderr artifact is empty (<repo>/.local/gateway-watch-regression/watch/watch.stderr.log)
--- gateway:watch stdout tail (<repo>/.local/gateway-watch-regression/watch/watch.stdout.log, last 12000 chars) ---
2026-06-21T04:12:04.753+00:00 [gateway] loading configuration…
2026-06-21T04:12:04.845+00:00 [gateway] force: no listeners on port 40195
2026-06-21T04:12:04.853+00:00 [gateway] resolving authentication…
2026-06-21T04:12:04.874+00:00 [gateway] starting...
2026-06-21T04:12:05.459+00:00 [gateway] starting HTTP server...
2026-06-21T04:12:05.478+00:00 [health-monitor] started (interval: 300s, startup-grace: 60s, channel-connect-grace: 120s)
2026-06-21T04:12:05.561+00:00 [gateway] agent model: openai/gpt-5.5 (thinking=medium, fast=off)
2026-06-21T04:12:05.562+00:00 [gateway] http server listening (0 plugins, 0.7s)
2026-06-21T04:12:05.564+00:00 [gateway] log file: /tmp/openclaw/openclaw-2026-06-21.log
2026-06-21T04:12:05.566+00:00 [gateway] ready
2026-06-21T04:12:16.094+00:00 [gateway] signal SIGTERM received
2026-06-21T04:12:16.097+00:00 [gateway] received SIGTERM; shutting down
2026-06-21T04:12:16.203+00:00 [shutdown] started: gateway stopping
2026-06-21T04:12:16.248+00:00 [gmail-watcher] gmail watcher stopped
2026-06-21T04:12:16.256+00:00 [shutdown] completed cleanly in 53ms
--- end gateway:watch stdout tail ---
```

Notes:

- This was run from the same PR head commit as the real behavior proof: `dfbc96e4178989869ebfc06da80d7519fd199f7e`.
- Private local paths are redacted as `<repo>`.
- The failure was intentionally triggered by `--cpu-fail-ms 0`; the transcript demonstrates the failure reporting path, including the bounded stdout artifact tail and empty-stderr warning.

## Synthetic Early-Exit Proof

Redacted synthetic transcript exercising the new `gateway:watch exited before ready` finding path directly. This uses the PR script's exported `collectGatewayWatchFindings` helper with a synthetic pre-ready child exit result, so the failure text is produced by the same finding collector used by the full regression command:

```text
$ git rev-parse HEAD
dfbc96e4178989869ebfc06da80d7519fd199f7e
$ node /tmp/openclaw-pr-proof/pr-95473-early-exit-proof.mjs
FAIL: gateway:watch exited before ready (code 1, signal null)
FAIL: failed to collect CPU timing from the bounded gateway:watch run; timing artifact is missing
FAIL: failed to parse CPU timing from the bounded gateway:watch run
```

Notes:

- This was run from PR head commit `dfbc96e4178989869ebfc06da80d7519fd199f7e`.
- The synthetic input models `readyBeforeWindow: false`, `exitedBeforeReady: true`, and `exit: { code: 1, signal: null }`.
- This complements the existing log-tail synthetic proof by covering the separate early-exit-before-ready diagnostic branch.

## Current-Head Post-Ready-Exit Proof

Redacted proof from current PR head `19ff518eb0ee305bf21812ed19423290dd41ea9d`, covering the latest post-ready-exit repair. The focused test file now includes the ready-then-exit cases for both the settle window and the idle window, plus the collector-level failure text assertion.

```text
$ git rev-parse HEAD
19ff518eb0ee305bf21812ed19423290dd41ea9d
$ node scripts/run-vitest.mjs test/scripts/check-gateway-watch-regression.test.ts
[test] starting test/vitest/vitest.tooling.config.ts

 RUN  v4.1.8 <repo>

 ✓  tooling  test/scripts/check-gateway-watch-regression.test.ts (18 tests) 85ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
[test] passed 1 Vitest shard in 6.84s
$ node --check scripts/check-gateway-watch-regression.mjs
$ git diff --check HEAD^..HEAD
```

Synthetic collector transcript from the same current head showing the new post-ready unplanned-exit failure text directly:

```text
$ git rev-parse HEAD
19ff518eb0ee305bf21812ed19423290dd41ea9d
$ node /tmp/openclaw-pr-proof/pr-95473-current-head-finding-proof.mjs
FAIL: gateway:watch exited before the idle CPU window completed (code 0, signal null)
```

Notes:

- The synthetic collector input models a watch process that reached readiness (`readyBeforeWindow: true`) and then exited before the expected stop phase (`exitedBeforeStop: true`, `exit: { code: 0, signal: null }`).
- Private local paths are redacted as `<repo>`.
- Full local redacted transcripts were saved during validation as `/tmp/openclaw-pr-proof/pr-95473-current-head-post-ready-exit.redacted.log` and `/tmp/openclaw-pr-proof/pr-95473-current-head-finding-proof.redacted.log`.

## Current-Head Full Guard Proof

Redacted terminal output from current PR head `19ff518eb0ee305bf21812ed19423290dd41ea9d` showing a full guard invocation, not just focused tests or a synthetic collector path:

```text
$ git rev-parse HEAD
19ff518eb0ee305bf21812ed19423290dd41ea9d
$ node scripts/check-gateway-watch-regression.mjs --skip-build
{
  "windowMs": 10000,
  "watchTriggeredBuild": false,
  "watchBuildReason": null,
  "cpuMs": 0,
  "totalCpuMs": null,
  "readyBeforeWindow": true,
  "exitedBeforeReady": false,
  "exitedBeforeStop": false,
  "cpuWarnMs": 1000,
  "cpuFailMs": 8000,
  "distRuntimeFileGrowth": 0,
  "distRuntimeFileGrowthMax": 200,
  "distRuntimeByteGrowth": 0,
  "distRuntimeByteGrowthMax": 2097152,
  "distRuntimeAddedPaths": 0,
  "addedPaths": 0,
  "removedPaths": 0,
  "watchExit": {
    "code": 143,
    "signal": null
  },
  "spawnError": null,
  "stdoutPath": "<repo>/.local/gateway-watch-regression/watch/watch.stdout.log",
  "stderrPath": "<repo>/.local/gateway-watch-regression/watch/watch.stderr.log",
  "timingFileMissing": true,
  "timing": {
    "userSeconds": null,
    "sysSeconds": null,
    "elapsedSeconds": null
  }
}
WARN: bounded gateway:watch timing artifact is missing; using process-tree idle CPU sample
```

Notes:

- This is the full `node scripts/check-gateway-watch-regression.mjs --skip-build` guard run from current head `19ff518eb0ee305bf21812ed19423290dd41ea9d`.
- Private local paths are redacted as `<repo>`.
- The expected post-window stop is visible as `watchExit.code: 143`, while the current-head lifecycle repair reports `exitedBeforeReady: false` and `exitedBeforeStop: false`.
- Full local redacted transcript saved during validation as `/tmp/openclaw-pr-proof/pr-95473-current-head-full-guard.redacted.log`.

## Current-Head Full Guard Proof Refresh — 2026-06-23

Redacted terminal output from current PR head `b34c5fc8e29b19dbaa43e248e7bfc1467f054abf` showing the full guard invocation ClawSweeper requested:

```text
$ git rev-parse HEAD
b34c5fc8e29b19dbaa43e248e7bfc1467f054abf
$ node scripts/check-gateway-watch-regression.mjs --skip-build
{
  "windowMs": 10000,
  "watchTriggeredBuild": false,
  "watchBuildReason": null,
  "cpuMs": 1000,
  "totalCpuMs": null,
  "readyBeforeWindow": true,
  "exitedBeforeReady": false,
  "exitedBeforeStop": false,
  "cpuWarnMs": 1000,
  "cpuFailMs": 8000,
  "distRuntimeFileGrowth": 0,
  "distRuntimeFileGrowthMax": 200,
  "distRuntimeByteGrowth": 0,
  "distRuntimeByteGrowthMax": 2097152,
  "distRuntimeAddedPaths": 0,
  "addedPaths": 0,
  "removedPaths": 0,
  "watchExit": {
    "code": 143,
    "signal": null
  },
  "spawnError": null,
  "stdoutPath": "<repo>/.local/gateway-watch-regression/watch/watch.stdout.log",
  "stderrPath": "<repo>/.local/gateway-watch-regression/watch/watch.stderr.log",
  "timingFileMissing": true,
  "timing": {
    "userSeconds": null,
    "sysSeconds": null,
    "elapsedSeconds": null
  }
}
WARN: bounded gateway:watch timing artifact is missing; using process-tree idle CPU sample
```

Notes:

- This run was collected after building this PR worktree with `node scripts/build-all.mjs gatewayWatch`, because the worktree initially had no `dist` or `dist-runtime` artifacts.
- Private local paths are redacted as `<repo>`.
- The guard reached readiness on the current head, did not exit before readiness or before the idle window completed, did not trigger a watch rebuild, and reported no dist-runtime growth.
- Full local transcripts were saved during validation as `/tmp/openclaw-pr-proof/pr-95473-b34c5fc-full-guard.raw.log` and `/tmp/openclaw-pr-proof/pr-95473-b34c5fc-full-guard.redacted.log`.

## Risk

Low to moderate. This changes release/runtime diagnostic behavior, not production gateway behavior. The highest-impact runtime-adjacent change is using bash for the timed watch command when available; fallback behavior remains `/bin/sh` if bash is unavailable.

The failure output becomes more verbose only when the watch guard fails, and stdout/stderr tails are bounded.

## PR/Commit Surface Breakdown

Source: 1 files, +124 / -13
Tests: 1 files, +287 / -0
Total: 2 files, +411 / -13

## Rebase / Proof Refresh (2026-06-23)

- Base: `654544b6b7c49d78afbacacd4861bcc830172780`
- Head after refresh: `b34c5fc8e29b19dbaa43e248e7bfc1467f054abf`
- Conflict resolution: None. Rebase applied cleanly.
- Validation: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-cache-pr95473 node scripts/run-vitest.mjs test/scripts/check-gateway-watch-regression.test.ts` -> passed, 1 file / 18 tests.
- Push: force-with-lease to `kklouzal/openclaw:extract/gateway-watch-regression-hardening` completed.

