### PR TITLE
chore(release): update appcast for 2026.6.9

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -3,6 +3,472 @@
     <channel>
         <title>OpenClaw</title>
         <item>
+            <title>2026.6.9</title>
+            <pubDate>Sun, 21 Jun 2026 03:38:20 +0000</pubDate>
+            <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
+            <sparkle:version>2606000990</sparkle:version>
+            <sparkle:shortVersionString>2026.6.9</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+            <description><![CDATA[<h2>OpenClaw 2026.6.9</h2>
+<h3>Highlights</h3>
+<ul>
+<li><strong>Richer Telegram delivery:</strong> Telegram now sends rich HTML, preserves rich markdown and sticker paths, renders progress drafts and command output more faithfully, normalizes HTML tables safely, and keeps mentions and spooled handlers on the right delivery path. (#93286, #93164, #93124, #93364, #93130, #93088, #93281, #94891, #94856) Thanks @obviyus, @vincentkoc, @goutamadwant, @kesslerio, @NianJiuZst, @SweetSophia, @Marvinthebored, @aaajiao, @zhangqueping, and @jairrab.</li>
+<li><strong>More dependable agent recovery:</strong> retries, terminal outcomes, usage after compaction, session history repair, and reply reconciliation now keep more interrupted or partial turns moving toward a visible final result. (#92191, #93073, #93228, #93084, #93469, #93291, #90943) Thanks @ai-hpc, @lml2468, @fuller-stack-dev, @Hollychou924, @leno23, @de1tydev, @425072024, @wuwahe3, @drvoss, @yetval, @sandieman2, and @vincentkoc.</li>
+<li><strong>A stronger Codex integration:</strong> Codex gains automatic plugin approvals, GPT-5.3 Spark OAuth routing, remote-node <code>exec</code> as a dynamic tool, and more reliable app-server teardown and terminal outcomes. (#92625, #89133, #93654, #91767, #93287) Thanks @kevinslin, @VACInc, @vincentkoc, @JPKay-AI, and @aliahnaf2013-max.</li>
+<li><strong>Standalone official provider plugins:</strong> external provider packages are now first-class npm releases, externally installed channel plugins load at Gateway startup, and StepFun is available from npm and ClawHub. (#93470) Thanks @sunlit-deng, @cxdnicole, and @vincentkoc.</li>
+<li><strong>More capable web and native clients:</strong> the Control UI adds a session workspace rail and extension health, iOS adds Watch controls, and Android shows chat context. (#92856, #91952, #93387, #92837) Thanks @Solvely-Colin, @jalehman, @joshavant, and @Tosko4.</li>
+<li><strong>More useful search and skills:</strong> Codex Hosted Search is available, key-free search providers remain deliberate opt-ins, and ClawHub skill installs retain verified source provenance. (#93446, #93616, #93283, #93506) Thanks @fuller-stack-dev, @davemorin, @momothemage, @nmccready-tars, and @vincentkoc.</li>
+</ul>
+<h3>Changes</h3>
+<ul>
+<li>Providers and auth: add Codex Hosted Search, improve Gemini CLI OAuth behind proxies, and keep external provider onboarding on current choices and package metadata. (#93446, #92815) Thanks @fuller-stack-dev, @yetval, @EvetteYoung, and @vincentkoc.</li>
+<li>Plugins and installs: externalized official providers publish as independent npm packages, Gateway discovers installed channel plugins at startup, and StepFun installs from npm or ClawHub. (#93470) Thanks @sunlit-deng, @cxdnicole, and @vincentkoc.</li>
+<li>Dashboard and mobile: add a session workspace rail, plugin health in status, compact cron lists, and iOS Watch controls. (#92856, #91952, #93395, #93387) Thanks @Solvely-Colin, @jalehman, @yu-xin-c, @centralpc, @joshavant, and @vincentkoc.</li>
+<li>Codex, observability, and skills: add automatic plugin approvals and SecretRefs, preserve ClawHub skill provenance, add OpenTelemetry log export, and expose remote-node execution to Codex when a node is connected. (#92625, #94324, #93283, #94561, #93654) Thanks @kevinslin, @kevinlin-openai, @momothemage, @nmccready-tars, @jesse-merhi, @vincentkoc, and @JPKay-AI.</li>
+<li>QA and release engineering: QA scenarios now use YAML, with broader profile evidence and release coverage for the plugin and channel matrix. Thanks @vincentkoc.</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>Security and privacy: redact secrets from debug/config output, block internal HTTP session overrides, audit open-DM tool exposure, and retain plugin write ownership checks. (#93333, #88496, #93443, #92883, #93353) Thanks @Alix-007, @jason-allen-oneal, @coygeek, @RichardCao, @yu-xin-c, @cjg20ss, @eleqtrizit, and @vincentkoc.</li>
+<li>Agent and session runtime: retry thinking-only and empty post-tool turns, prevent duplicate hook execution, preserve pending subagent delivery, preserve fresh usage through compaction, and repair partial JSON/history artifacts. (#92191, #93073, #93009, #93084, #93469, #94349, #92383, #94257) Thanks @ai-hpc, @lml2468, @fuller-stack-dev, @zenglingbiao, @dertbv, @Hollychou924, @leno23, @de1tydev, @425072024, @wuwahe3, @drvoss, @vincentkoc, @sallyom, @oiGaDio, @Hidetsugu55, and @Nas01010101.</li>
+<li>Channels and replies: fix Telegram rich delivery, table rendering, action-error handling, and ingress recovery; preserve command progress detail across channel adapters; retain WhatsApp opening text after a media failure; keep Mattermost thread replies intact; and harden Discord action handling. (#93286, #93364, #93281, #93076, #93334, #93424, #93488, #94868, #94891, #94856, #94810, #93823) Thanks @obviyus, @NianJiuZst, @mcaxtr, @rushindrasinha, @amknight, @lzyyzznl, @darealgege, @vincentkoc, @zhangqueping, @jairrab, @ZOOWH, @parveshsaini, and @yetval.</li>
+<li>Storage and migrations: avoid SQLite WAL on network filesystems, clean reindex artifacts, keep setup state out of workspace dot-directories, and import default-agent auth profiles into SQLite. (#93454, #92891, #93182, #93295, #93520, #93156) Thanks @vincentkoc, @ZengWen-DT, @Zeng-wen, @potterdigital, @Alix-007, @Pick-cat, @sallyom, @1qh, and @Tazio7.</li>
+<li>Provider and model behavior: fix Gemini CLI proxy OAuth, restore Codex Spark OAuth routing, correct Bedrock embedding model IDs, and preserve configured defaults in embedded runs. (#92815, #89133, #93452, #93428) Thanks @yetval, @EvetteYoung, @VACInc, @LiuwqGit, @aleck31, @zenglingbiao, @danielgerlag, and @vincentkoc.</li>
+<li>CLI, TUI, and apps: accept global flags after subcommands, keep terminal output and activity indicators visible, preserve CJK IME composition, and refresh stale UI state. (#93455, #93460, #93006, #93427, #93498, #93606) Thanks @ooiuuii, @Alix-007, @ZengWen-DT, @Zeng-wen, @AlethiaQuizForge, @Zhaoqj2016, @liuhao1024, @BrianClaw1955, @vincentkoc, and @NicoBoom13.</li>
+<li>Operations and updates: harden official plugin recovery, restart managed Gateways after failed update handoff, keep safe cron delivery defaults, avoid Node-specific npm prefixes, and keep package validation paths reliable. (#93325, #92111, #93650, #94453, #91685) Thanks @vincentkoc, @yetval, @ofan, @yaanfpv, @jincheng-xydt, @sallyom, @davectr, and @nxmxbbd.</li>
+</ul>
+<h3>Complete contribution record</h3>
+This audited record covers the complete v2026.6.8..HEAD history: 422 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
+<h4>Pull requests</h4>
+<ul>
+<li><strong>PR #90463</strong> refactor: add session accessor seam with gateway consumer. Thanks @jalehman.</li>
+<li><strong>PR #88656</strong> Drop reasoning-only length turns from replay. Thanks @abel-zer0.</li>
+<li><strong>PR #92856</strong> feat(webui): add session workspace rail. Thanks @Solvely-Colin.</li>
+<li><strong>PR #92845</strong> docs(browser-control): document OPENCLAW_EAGER_BROWSER_CONTROL_SERVER requirement. Related #92841. Thanks @liuhao1024 and @jeugregg.</li>
+<li><strong>PR #82366</strong> fix: use passive periodic sqlite wal checkpoints. Related #81715. Thanks @honor2030 and @KrasimirKralev.</li>
+<li><strong>PR #92815</strong> fix(google): route Gemini CLI OAuth through the env proxy (#46184). Thanks @yetval and @EvetteYoung.</li>
+<li><strong>PR #91331</strong> fix(mattermost): merge progress preview lines by identity. Related #89761. Thanks @iloveleon19 and @leonthe8th and @vincentkoc.</li>
+<li><strong>PR #92909</strong> fix(tui): keep spinner active when toggling tools. Related #49763. Thanks @ZengWen-DT and @Zeng-wen and @vincentkoc and @CrimsonDump.</li>
+<li><strong>PR #92904</strong> fix(elevenlabs): use current TTS model ids. Thanks @vortexopenclaw and @vincentkoc.</li>
+<li><strong>PR #92642</strong> fix #86872: Subagent run reports success but fails to write output file. Thanks @zhangguiping-xydt and @vincentkoc and @zapper35.</li>
+<li><strong>PR #89122</strong> refactor: route command session reads through seam. Thanks @jalehman.</li>
+<li><strong>PR #90943</strong> fix(reply): deliver final reply when queued follow-up claims session; scope dedupe to routed thread. Thanks @sandieman2 and @vincentkoc.</li>
+<li><strong>PR #92894</strong> fix(skills): keep managed prompt paths readable. Related #92875. Thanks @kesslerio and @sallyom.</li>
+<li><strong>PR #39617</strong> fix: reload config in slash command routing so dmScope is respected. Related #39605. Thanks @Ciward.</li>
+<li><strong>PR #92191</strong> fix(agents): retry thinking-only errored turns. Related #91953. Thanks @ai-hpc and @lml2468.</li>
+<li><strong>PR #92891</strong> fix(memory): clean stale reindex temp files. Related #92874. Thanks @ZengWen-DT and @Zeng-wen and @vincentkoc and @potterdigital.</li>
+<li><strong>PR #93005</strong> Add OpenRouter Fusion guidance and prompt context. Related #92984. Thanks @sallyom.</li>
+<li><strong>PR #88792</strong> fix(state): harden sqlite path caching. Thanks @vincentkoc.</li>
+<li><strong>PR #93022</strong> fix(gateway): repair usage cost aggregation across agents. Thanks @luke-skywalker-open-claw and @stablegenius49.</li>
+<li><strong>PR #93020</strong> fix(telegram): cool down transient sendChatAction failures. Related #56096. Thanks @Boulea7 and @sumaiazaman and @Pick-cat and @cal-rufus.</li>
+<li><strong>PR #89160</strong> fix(agents): detect truncated API responses to prevent silent session hang. Related #89051. Thanks @joelnishanth and @ArthurusDent.</li>
+<li><strong>PR #93009</strong> fix(agents): make wrapToolWithBeforeToolCallHook idempotent to prevent double hook execution (fixes #92973). Thanks @zenglingbiao and @dertbv.</li>
+<li><strong>PR #92991</strong> fix(agents): tolerate missing attribution baseUrl. Related #92974. Thanks @samrusani and @Haderach-Ram.</li>
+<li><strong>PR #92913</strong> fix(opencode-go): register model catalog to fix context window detection. Related #92912. Thanks @kumaxs.</li>
+<li><strong>PR #89129</strong> refactor: route bundled plugin session callers through seam. Thanks @jalehman.</li>
+<li><strong>PR #93084</strong> fix(agents): preserve fresh usage after compaction. Related #50795. Thanks @Hollychou924 and @leno23 and @de1tydev and @425072024 and @vincentkoc and @wuwahe3.</li>
+<li><strong>PR #92869</strong> fix #90333: [Bug]: Discord image build aborts at step 66 — openclaw-build-messaging-plugins.py exits 1. Thanks @zhangguiping-xydt and @vincentkoc and @chriskosys.</li>
+<li><strong>PR #93011</strong> fix(gateway): accept file-only input on /v1/responses (parity with image-only). Thanks @yetval and @vincentkoc.</li>
+<li><strong>PR #92915</strong> Convert QA scenarios to YAML files. Thanks @RomneyDa.</li>
+<li><strong>PR #91767</strong> Fix one-shot Codex app-server teardown. Thanks @aliahnaf2013-max.</li>
+<li><strong>PR #92625</strong> feat(codex): add auto plugin approvals. Thanks @kevinslin.</li>
+<li><strong>PR #91587</strong> test(qa): add qa run --qa-profile and unified output summary/evidence. Thanks @RomneyDa.</li>
+<li><strong>PR #93104</strong> test(reply): seed channel fixtures for dedupe tests. Thanks @RomneyDa.</li>
+<li><strong>PR #93107</strong> test(reply): preserve telegram dedupe fallback. Thanks @RomneyDa.</li>
+<li><strong>PR #92954</strong> fix(memory): accept local default model path migration. Thanks @mushuiyu886 and @vincentkoc.</li>
+<li><strong>PR #90936</strong> fix(agents): do not misclassify client-disconnect abort as run timeout. Related #90764. Thanks @openperf and @reginaldomarcilon.</li>
+<li><strong>PR #90812</strong> fix(voice-call): preserve live Twilio streams in stale reaper. Related #79121. Thanks @Takhoffman and @sahibzada-allahyar and @donkeykong91.</li>
+<li><strong>PR #93094</strong> fix(whatsapp): bound socket operations. Thanks @mcaxtr.</li>
+<li><strong>PR #91629</strong> fix(scripts): add database-first legacy store guard. Related #91628. Thanks @galiniliev.</li>
+<li><strong>PR #93124</strong> fix(telegram): render progress drafts as rich previews. Thanks @Marvinthebored.</li>
+<li><strong>PR #93109</strong> test(qa): embed profile scorecard evidence. Thanks @RomneyDa.</li>
+<li><strong>PR #87298</strong> test: add temp directory helper guidance. Thanks @hxy91819.</li>
+<li><strong>PR #92318</strong> fix(cron): require explicit message target proof. Thanks @hxy91819.</li>
+<li><strong>PR #93137</strong> fix(imessage): honor disabled reply actions. Related #92142. Thanks @omarshahine and @dprev.</li>
+<li><strong>PR #93134</strong> fix(feishu): pass card_msg_content_type to get full card content (fixes #78289). Thanks @liuhao1024 and @vincentkoc and @longdoubled7.</li>
+<li><strong>PR #93138</strong> fix(agents): preserve literal current session resolution. Thanks @liuhao1024 and @vincentkoc.</li>
+<li><strong>PR #91225</strong> fix #83830: [Bug]: Dreaming diary repeats "first day" narrative every sweep — same early memories dominate snippets. Thanks @mushuiyu886 and @YinLiuLiu66.</li>
+<li><strong>PR #93153</strong> simplify QA evidence profile and mappings/coverage shape. Thanks @RomneyDa.</li>
+<li><strong>PR #93164</strong> fix(telegram): preserve rich markdown line breaks. Thanks @vincentkoc.</li>
+<li><strong>PR #93119</strong> fix: accept mixed source/dist bundled roots. Related #87730. Thanks @arkyu2077 and @vincentkoc and @jasonftl.</li>
+<li><strong>PR #93130</strong> fix(telegram): preserve sticker media paths. Related #83748. Thanks @goutamadwant and @vincentkoc and @aaajiao.</li>
+<li><strong>PR #93073</strong> fix(agents): retry empty post-tool final turns. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #91784</strong> fix(voice-call): require realtime websocket path boundary. Thanks @jason-allen-oneal.</li>
+<li><strong>PR #89133</strong> Restore GPT-5.3 Codex Spark OAuth routing. Thanks @VACInc.</li>
+<li><strong>PR #91996</strong> refactor: prune unused iOS code. Thanks @zats.</li>
+<li><strong>PR #90231</strong> fix #69443: [Bug] Subagent RPC callback to WeChat session key routed to main session instead. Thanks @zhangguiping-xydt and @sliverp and @chen11221.</li>
+<li><strong>PR #89920</strong> fix(matrix): replace recovered command progress lines. Thanks @bdjben and @jesse-merhi.</li>
+<li><strong>PR #93159</strong> fix(tui): keep parent stdin paused after exit. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #93201</strong> fix(auto-reply): clear pending-final state before honoring post-send abort (#89115). Thanks @amknight and @danashburn.</li>
+<li><strong>PR #93228</strong> fix(agents): replace prose terminal classifiers. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #93231</strong> fix(status): correct pinned model clear hint. Thanks @hxy91819.</li>
+<li><strong>PR #92428</strong> fix(qqbot): keep markdown table chunks valid. Thanks @sliverp.</li>
+<li><strong>PR #93220</strong> fix(status): avoid stale session context windows. Thanks @hxy91819.</li>
+<li><strong>PR #91957</strong> perf(sessions): share one enumeration across archive retention sweeps. Thanks @amknight.</li>
+<li><strong>PR #93281</strong> fix(telegram): recover pid-reused ingress claims. Thanks @obviyus.</li>
+<li><strong>PR #93287</strong> fix(codex): preserve terminal outcome ordering.</li>
+<li><strong>PR #93182</strong> fix(memory): clean rollback-journal reindex temp sidecar on NFS stores. Thanks @Alix-007.</li>
+<li><strong>PR #93283</strong> Persist ClawHub skill install provenance. Related #92077. Thanks @momothemage and @nmccready-tars.</li>
+<li><strong>PR #88872</strong> fix: attribute spawned task runs to child agent. Related #66670. Thanks @Alix-007 and @Neomail2.</li>
+<li><strong>PR #92837</strong> fix(android): show live chat context usage. Thanks @Tosko4.</li>
+<li><strong>PR #93325</strong> fix(cli): harden official plugin recovery. Thanks @vincentkoc.</li>
+<li><strong>PR #93286</strong> feat(telegram): send rich messages as rich html. Thanks @obviyus.</li>
+<li><strong>PR #92910</strong> fix(memory-core): safely refresh qmd index during collection repair.</li>
+<li><strong>PR #93329</strong> fix(cli): allow zero Discord timeout duration. Related #93327. Thanks @rohitjavvadi.</li>
+<li><strong>PR #91625</strong> fix(cron): add cron edit --clear-model to clear a job's model override. Thanks @ly-wang19.</li>
+<li><strong>PR #91691</strong> [AI] fix(memory): prevent empty-string expectedModel in resolveMemory…. Thanks @xydt-tanshanshan.</li>
+<li><strong>PR #93006</strong> fix(tui): keep stderr visible when local shell stdout fills the output cap. Thanks @Alix-007.</li>
+<li><strong>PR #93001</strong> fix(daemon): prefer stderr over stale stdout in gateway restart diagnostics. Thanks @Alix-007.</li>
+<li><strong>PR #91117</strong> refactor: remove dead code and improve string concatenation. Thanks @Pommelle.</li>
+<li><strong>PR #90893</strong> fix(models): mask paste-token input in CLI auth prompt. Thanks @anurag-bg-neu.</li>
+<li><strong>PR #90571</strong> fix(configure): mask gateway password input in CLI wizard prompt. Thanks @anurag-bg-neu.</li>
+<li><strong>PR #91768</strong> fix(ios): respect chat header safe area. Thanks @zats.</li>
+<li><strong>PR #93245</strong> fix(cron): resolve lastRunStatus in cron list/show human output. Thanks @ly-wang19.</li>
+<li><strong>PR #78765</strong> fix(tui): avoid inserting spaces into long CJK text. Thanks @hpt.</li>
+<li><strong>PR #91776</strong> fix(ios): refresh permission rows after grants. Thanks @zats.</li>
+<li><strong>PR #92817</strong> fix(cron): trust agent output when channel is unresolved without explicit delivery. Related #90664. Thanks @fsdwen and @dertbv.</li>
+<li><strong>PR #93297</strong> fix(control-ui): respect agents.defaults.timeFormat for timestamps. Related #58147. Thanks @ZengWen-DT and @Zeng-wen and @TommoT2.</li>
+<li><strong>PR #93364</strong> Fix Telegram rich progress command output. Thanks @obviyus.</li>
+<li><strong>PR #91952</strong> feat(status): surface plugin health. Thanks @jalehman.</li>
+<li><strong>PR #75025</strong> fix(heartbeat): refresh stale Current time line on every helper call (#44993). Thanks @MoerAI and @mclee1975.</li>
+<li><strong>PR #90992</strong> docs(windows): fix WSL gateway-autostart recipe for WSL ≥ 2.6.1.0 idle-termination. Thanks @spencer2211.</li>
+<li><strong>PR #86544</strong> fix(cli): show Gemini CLI runtime auth status. Related #79585. Thanks @giodl73-repo and @fabricefoy.</li>
+<li><strong>PR #88945</strong> fix(plugins): serialize binding approval saves. Related #64065. Thanks @Alix-007 and @lihaokun.</li>
+<li><strong>PR #90115</strong> fix(gateway): pass managed inbound PDFs through chat.send. Related #90097. Thanks @harjothkhara and @joeykrug.</li>
+<li><strong>PR #74613</strong> docs(cli): add agent selector to CLI backend quick start. Related #68940. Thanks @vyctorbrzezowski and @drmarcopapa.</li>
+<li><strong>PR #89121</strong> refactor: add transcript reader seam. Thanks @jalehman.</li>
+<li><strong>PR #84434</strong> fix(cli): disable ScheduleWakeup/CronCreate in --print claude runs. Thanks @SkyWolfDreamer.</li>
+<li><strong>PR #66985</strong> fix(agents): resolve requestedNode to canonical ID before boundNode comparison. Related #87213. Thanks @mujiannan.</li>
+<li><strong>PR #91488</strong> fix(reply): project preflight compaction gate by next-input size on fresh tokens. Thanks @yetval.</li>
+<li><strong>PR #93353</strong> fix(plugins): require owner for plugin writes. Thanks @eleqtrizit.</li>
+<li><strong>PR #91499</strong> fix(cron): preserve scheduled turn tool policy [AI]. Thanks @mmaps.</li>
+<li><strong>PR #90412</strong> fix(sessions): cache warm transcript reads to avoid per-turn re-parse. Related #83943. Thanks @Alix-007 and @yyds-xxxx.</li>
+<li><strong>PR #93118</strong> fix(gateway): guard fast-path startup migrations. Related #93032. Thanks @openperf and @Haderach-Ram.</li>
+<li><strong>PR #93355</strong> fix(ci): verify performance workflow downloads. Thanks @eleqtrizit.</li>
+<li><strong>PR #93358</strong> fix(outbound): guard cross-context message mutations. Thanks @eleqtrizit.</li>
+<li><strong>PR #93362</strong> fix(flock): bind allow-always to wrapped command. Thanks @eleqtrizit.</li>
+<li><strong>PR #92578</strong> refactor(whatsapp): add inbound admission foundation. Thanks @mcaxtr.</li>
+<li><strong>PR #89547</strong> Control Telegram group history context. Thanks @mmaps.</li>
+<li><strong>PR #89201</strong> refactor: add transcript runtime identity contract. Thanks @jalehman.</li>
+<li><strong>PR #93357</strong> fix(plugins): enforce install policy in wrappers. Thanks @eleqtrizit.</li>
+<li><strong>PR #93156</strong> fix(doctor): import default-agent auth profiles into sqlite. Related #93145. Thanks @Pick-cat and @sallyom and @Tazio7.</li>
+<li><strong>PR #93179</strong> Add slim evidence mode for QA profile evidence. Thanks @RomneyDa.</li>
+<li><strong>PR #93349</strong> fix(control-ui): keep workboard card titles visible in overflowing columns (fixes #91717). Thanks @Pick-cat and @NicoBoom13.</li>
+<li><strong>PR #93324</strong> fix(cli): accept --no-color after subcommands. Thanks @ooiuuii.</li>
+<li><strong>PR #89621</strong> Return Google Chat thread metadata from message sends. Thanks @franco-viotti.</li>
+<li><strong>PR #82458</strong> fix(infra): drop duplicated "restart" word in restart-sentinel summary. Thanks @jameswniu.</li>
+<li><strong>PR #85471</strong> Suppress cron announce control replies. Related #85421. Thanks @TurboTheTurtle and @leatherneck-33.</li>
+<li><strong>PR #85316</strong> fix(auth): keep alias-compatible auth-profile overrides instead of clearing them. Thanks @SkyWolfDreamer.</li>
+<li><strong>PR #89260</strong> fix(doctor): separate platform-incompatible skills from missing requirements. Related #89232. Thanks @Alix-007 and @CameronWeller.</li>
+<li><strong>PR #90846</strong> fix(media): stop pruning media on write; let the configured timer do it. Thanks @lundog.</li>
+<li><strong>PR #88062</strong> fix(logging): avoid stalled warnings for active model calls. Thanks @litang9.</li>
+<li><strong>PR #93308</strong> fix(discord): reject malformed realtime consult calls. Thanks @khoek.</li>
+<li><strong>PR #93334</strong> fix(whatsapp): notify user when trailing media send fails instead of silent drop. Thanks @rushindrasinha.</li>
+<li><strong>PR #92575</strong> fix(sessions): preserve user behavior overrides across daily/idle rollover (#92562) [AI-assisted]. Thanks @harjothkhara and @civiltox.</li>
+<li><strong>PR #89124</strong> refactor: route auto-reply sessions through session seam. Thanks @jalehman.</li>
+<li><strong>PR #93431</strong> fix: stabilize transcript cache and CLI env isolation. Thanks @shakkernerd.</li>
+<li><strong>PR #93412</strong> fix(discord): suppress tool progress for message-tool replies. Thanks @mgunnin and @vincentkoc.</li>
+<li><strong>PR #93409</strong> fix(whatsapp): stop markdownToWhatsApp dropping code spans followed by a digit. Thanks @rushindrasinha.</li>
+<li><strong>PR #93295</strong> fix(memory): swap rollback-journal sidecar during atomic reindex. Thanks @Alix-007.</li>
+<li><strong>PR #93076</strong> fix(whatsapp): preserve auth on terminal disconnects. Thanks @mcaxtr.</li>
+<li><strong>PR #93435</strong> fix(agents): bound autoreview scope. Thanks @vincentkoc.</li>
+<li><strong>PR #93279</strong> fix(telegram): restore readable default text sends. Related #93263. Thanks @NianJiuZst and @SweetSophia.</li>
+<li><strong>PR #93429</strong> fix(line): cap carousel column text at 60 chars when a title or image is set. Thanks @harjothkhara and @vincentkoc.</li>
+<li><strong>PR #93428</strong> fix(agents): resolve configured default model in runEmbeddedAgent (fixes #93419). Thanks @zenglingbiao and @vincentkoc and @danielgerlag.</li>
+<li><strong>PR #93427</strong> fix(tui): show activity indicator for system-injected runs. Related #51825. Thanks @ZengWen-DT and @vincentkoc and @Zeng-wen and @AlethiaQuizForge.</li>
+<li><strong>PR #90003</strong> feat(policy): cover exec approvals artifact. Thanks @giodl73-repo.</li>
+<li><strong>PR #93448</strong> fix(guards): allow auth profile sqlite reader. Thanks @amknight.</li>
+<li><strong>PR #93424</strong> fix(mattermost): keep message tool replies in threads. Thanks @amknight and @vincentkoc.</li>
+<li><strong>PR #93418</strong> fix(telegram): forward Bot API 10.1 rich_message content to agent. Related #93410. Thanks @xzh-icenter and @vincentkoc and @0pen7ech.</li>
+<li><strong>PR #93175</strong> test(qa): taxonomy profiles: includeAllCategories for release profile, update some coverage. Thanks @RomneyDa.</li>
+<li><strong>PR #93456</strong> fix(agents): handle string assistant message content. Thanks @vincentkoc.</li>
+<li><strong>PR #93441</strong> fix(outbound): ignore schema-padded poll metadata on send. Related #43015. Thanks @weichengdeng and @charzhou.</li>
+<li><strong>PR #93443</strong> fix(gateway): block internal HTTP session overrides. Thanks @RichardCao.</li>
+<li><strong>PR #93454</strong> fix(sqlite): disable WAL on network filesystems. Thanks @vincentkoc.</li>
+<li><strong>PR #90275</strong> test: make install-safe-path symlink tests compatible with Windows. Thanks @aniruddhaadak80.</li>
+<li><strong>PR #93464</strong> fix(qa): suppress empty WhatsApp debug artifacts. Thanks @vincentkoc.</li>
+<li><strong>PR #90861</strong> fix(cli): preserve sessions_yield over MCP. Related #77426. Thanks @zhangguiping-xydt and @jarvisagimuspicard-hub.</li>
+<li><strong>PR #90946</strong> fix(infra): preserve inherited gateway PID across reparent during cleanup. Thanks @amittell.</li>
+<li><strong>PR #92220</strong> fix(media): extract large managed inbound PDFs via media-understanding. Related #90096, #90097. Thanks @amknight and @joeykrug.</li>
+<li><strong>PR #91208</strong> fix #91047: Plugin session-extension registry not pinned; sessions.pluginPatch fails after agent/subagent plugin-load churn. Thanks @mushuiyu886 and @teamadams.</li>
+<li><strong>PR #92111</strong> fix(update): restart managed gateway when update handoff fails after stop. Related #92088. Thanks @yetval and @ofan.</li>
+<li><strong>PR #93238</strong> fix(agents): honor disabled envelope timestamps at model boundary. Thanks @osolmaz.</li>
+<li><strong>PR #93343</strong> fix(codex): de-duplicate commentary notes across the raw response lane. Related #93296. Thanks @Marvinthebored and @Peetiegonzalez.</li>
+<li><strong>PR #93361</strong> fix(openshell): pin mirror remote mutations. Thanks @eleqtrizit.</li>
+<li><strong>PR #93354</strong> fix(discord): block cross-provider guild admin actions. Thanks @eleqtrizit.</li>
+<li><strong>PR #92178</strong> fix(gateway): normalize malformed paired access lists. Related #90654. Thanks @wangmiao0668000666 and @EmilioNicolas.</li>
+<li><strong>PR #85254</strong> perf(plugins): thread prepared manifestPlugins through runtime model-id normalize chain. Thanks @zeroaltitude.</li>
+<li><strong>PR #93489</strong> Add ClawHub content rights docs to sidebar. Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #93466</strong> [AI] fix(feishu): guard against missing inbound in channelRuntime fallback. Thanks @xydt-tanshanshan.</li>
+<li><strong>PR #93460</strong> fix(cli): honor --log-level in route-first commands. Related #93457. Thanks @ooiuuii.</li>
+<li><strong>PR #93495</strong> fix(cron): clear delivery routing fields from cron edit. Thanks @ly-wang19 and @vincentkoc.</li>
+<li><strong>PR #93494</strong> docs: point PR landing at maintainer workflow. Thanks @fuller-stack-dev and @vincentkoc.</li>
+<li><strong>PR #93487</strong> fix(ui): add agent selector to skills page. Related #78553. Thanks @goutamadwant and @vincentkoc and @xiaobu1112.</li>
+<li><strong>PR #93488</strong> fix(discord): apply tool status emojis immediately to avoid override by thinking reactions. Related #92715. Thanks @lzyyzznl and @vincentkoc and @darealgege.</li>
+<li><strong>PR #93055</strong> fix(ui): restore provider usage pill in desktop chat composer [AI]. Thanks @harjothkhara.</li>
+<li><strong>PR #83156</strong> fix(matrix): accept bracketed display-name mentions. Related #83142. Thanks @wdx-agent-io and @wdongxv.</li>
+<li><strong>PR #93333</strong> fix(auto-reply): redact secrets in /debug show and /debug set output. Thanks @Alix-007.</li>
+<li><strong>PR #88496</strong> fix(auto-reply): redact secrets in config show output. Related #65623. Thanks @jason-allen-oneal and @coygeek.</li>
+<li><strong>PR #93105</strong> fix(doctor): repair null agents.list[].workspace values. Related #77718. Thanks @xydigit-sj and @slideshow-dingo.</li>
+<li><strong>PR #73923</strong> fix(ui): preserve gateway token during safe websocket url edits. Related #41545. Thanks @wsyjh8.</li>
+<li><strong>PR #88970</strong> fix #85871: [Bug]: Heartbeat scheduler silently fails to fire on 5.20 and all 5.x versions (regression from 4.23). Thanks @zhangguiping-xydt and @vincentkoc and @carlbjson.</li>
+<li><strong>PR #93511</strong> fix(imessage): normalize leading NUL echo-cache prefixes. Thanks @vincentkoc and @drvoss.</li>
+<li><strong>PR #92594</strong> [Bug]: ollama-cloud runtime fails DNS lookup for ai.ollama.com, while ollama/<model>:cloud works. Related #92391. Thanks @zhangguiping-xydt and @vincentkoc and @kvzsolt.</li>
+<li><strong>PR #93512</strong> build(docs): finish PowerShell-safe docs formatting. Related #44293. Thanks @vincentkoc and @yil337 and @aniruddhaadak80.</li>
+<li><strong>PR #93513</strong> fix(skills): refresh persisted snapshots after restart. Thanks @vincentkoc and @fif911 and @skadauke.</li>
+<li><strong>PR #93517</strong> fix(skills): quote skill-creator template description. Thanks @vincentkoc and @parubets.</li>
+<li><strong>PR #73976</strong> fix(memory): use per-keyword FTS search in hybrid mode #39484. Thanks @joshuakeithpa-sudo.</li>
+<li><strong>PR #93520</strong> fix(workspace): store setup state outside workspace dot-dir. Thanks @vincentkoc and @1qh.</li>
+<li><strong>PR #93521</strong> fix(onboard): skip Homebrew prompt on unsupported platforms. Related #68893. Thanks @vincentkoc and @yurivict.</li>
+<li><strong>PR #93522</strong> fix(feishu): send post mentions as native at elements. Thanks @vincentkoc and @gavin-ali and @YizukiAme and @Panniantong.</li>
+<li><strong>PR #93496</strong> fix(gateway): rotate already-stale generated transcript filename on /reset. Thanks @harjothkhara and @vincentkoc.</li>
+<li><strong>PR #93471</strong> fix(cron): preserve aborted isolated-run failure. Thanks @BhargavSatya and @vincentkoc.</li>
+<li><strong>PR #93473</strong> fix(memory): report skipped QMD embedding probe. Related #77645. Thanks @TurboTheTurtle and @vincentkoc and @aderius.</li>
+<li><strong>PR #93498</strong> fix(ui): preserve CJK IME composition. Related #86035. Thanks @Zhaoqj2016 and @vincentkoc.</li>
+<li><strong>PR #93088</strong> fix(telegram): bind bot mentions to assistant identity. Thanks @kesslerio and @vincentkoc.</li>
+<li><strong>PR #93499</strong> fix(nodes): return screen snapshots as media. Related #90126. Thanks @zenglingbiao and @vincentkoc and @JeffSteinbok.</li>
+<li><strong>PR #93506</strong> fix(skills): trust verified ClawHub source provenance. Thanks @vincentkoc.</li>
+<li><strong>PR #93525</strong> agents: notify chat exec empty-success completions. Thanks @vincentkoc and @wenkang-xie.</li>
+<li><strong>PR #93446</strong> feat: add Codex hosted web search. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #92883</strong> fix(security): audit open dm tool exposure. Related #55612. Thanks @yu-xin-c and @vincentkoc and @cjg20ss.</li>
+<li><strong>PR #93476</strong> fix(mattermost): preserve Codex progress preview. Related #88766. Thanks @goutamadwant and @vincentkoc and @KelTech-Services.</li>
+<li><strong>PR #93395</strong> feat(cron): add compact list responses. Related #93366. Thanks @yu-xin-c and @vincentkoc and @centralpc.</li>
+<li><strong>PR #93527</strong> fix(cron): preserve model overrides for text payloads. Thanks @vincentkoc and @liaoandi.</li>
+<li><strong>PR #90487</strong> fix: harden ChatGPT Responses missing content-type streams. Thanks @anyech and @vincentkoc.</li>
+<li><strong>PR #93528</strong> fix(gateway): tolerate transient pre-hello clean closes. Thanks @vincentkoc and @ruanrrn.</li>
+<li><strong>PR #93529</strong> fix(auto-reply): allow message tool for group attachments. Related #43146. Thanks @vincentkoc and @Robcis.</li>
+<li><strong>PR #93291</strong> fix(reply): preserve pending thread evidence when reconciling partial send results. Thanks @yetval and @vincentkoc.</li>
+<li><strong>PR #90572</strong> fix(feishu): drop self-authored receive echoes. Thanks @baskduf.</li>
+<li><strong>PR #93455</strong> fix(cli): accept --log-level after subcommands. Thanks @ooiuuii and @vincentkoc.</li>
+<li><strong>PR #93452</strong> fix(bedrock): strip inference profile prefix from model ID in embedding adapter. Related #79212. Thanks @LiuwqGit and @vincentkoc and @aleck31.</li>
+<li><strong>PR #89799</strong> fix(cli): skip compile cache on early Node 24.x to avoid startup deadlock. Related #86550. Thanks @zhangguiping-xydt and @vincentkoc and @renyuliang000.</li>
+<li><strong>PR #93469</strong> fix(agents): drop partialJson streaming artifacts from session history repair. Thanks @drvoss and @vincentkoc.</li>
+<li><strong>PR #93463</strong> fix(codex): log app-server compaction completion. Related #83932. Thanks @goutamadwant and @vincentkoc and @aounakram.</li>
+<li><strong>PR #93562</strong> fix(tui): refresh after external session reset. Related #38966. Thanks @vincentkoc and @wsyjh8 and @yizhanzjz.</li>
+<li><strong>PR #93470</strong> fix(plugins): load externally-installed channel plugins at gateway startup. Related #93219. Thanks @sunlit-deng and @vincentkoc and @cxdnicole.</li>
+<li><strong>PR #88796</strong> fix(discord): resolve guildId from session channel for search actions. Related #88790. Thanks @SebTardif and @vincentkoc and @mugabuga.</li>
+<li><strong>PR #93194</strong> fix(agents): preserve prompt-released session metadata. Related #93193. Thanks @snowzlm.</li>
+<li><strong>PR #89483</strong> fix(gateway): project failed agent turns in chat history. Related #89197. Thanks @IWhatsskill and @vincentkoc and @yangiit.</li>
+<li><strong>PR #93434</strong> fix: avoid parent group allowlist false positive. Related #92684. Thanks @kingrubic and @vincentkoc and @motteman.</li>
+<li><strong>PR #93449</strong> fix(feishu): dedupe redelivered text by stable retry identity. Related #46778. Thanks @ZengWen-DT and @vincentkoc and @kingcuty.</li>
+<li><strong>PR #93407</strong> AGT-80 AGT-81 Fix Discord ingress ack ordering. Thanks @mgunnin and @vincentkoc.</li>
+<li><strong>PR #93439</strong> fix(agents): honor embedded run default model. Related #93419. Thanks @harjothkhara and @vincentkoc and @danielgerlag.</li>
+<li><strong>PR #93565</strong> fix(cli): summarize cleanup dry-run by label. Related #76826. Thanks @AgentArcLab and @vincentkoc and @renatomaluhy.</li>
+<li><strong>PR #93509</strong> fix(skills): clear orphaned idempotency pointer on corrupt-metadata re-begin. Thanks @Alix-007 and @vincentkoc.</li>
+<li><strong>PR #93274</strong> Clarify plugin channel config additional-property errors. Thanks @zhangguiping-xydt and @vincentkoc.</li>
+<li><strong>PR #93555</strong> fix(read): route text decoding through shared Windows codepage fallba…. Thanks @zhanxingxin1998 and @vincentkoc.</li>
+<li><strong>PR #93314</strong> fix(skills): preserve ClawHub origin provenance on readback. Thanks @Alix-007 and @vincentkoc.</li>
+<li><strong>PR #93573</strong> fix(acp): keep bridge sessions out of stale ACP classification [AI-assisted]. Related #38907. Thanks @eldar702 and @vincentkoc and @ninaopenclaw.</li>
+<li><strong>PR #93398</strong> fix(cron): emit isolated model usage diagnostics. Related #92338. Thanks @849261680 and @vincentkoc and @niks999.</li>
+<li><strong>PR #93367</strong> Fix SSH sandbox remote directory args. Related #93344. Thanks @dmorn and @vincentkoc.</li>
+<li><strong>PR #93574</strong> fix(feishu): suppress log noise for bot_p2p_chat_entered_v1 event [AI-assisted]. Related #42351. Thanks @eldar702 and @vincentkoc and @sunking0223.</li>
+<li><strong>PR #93269</strong> Fix tokenjuice bash results without details. Thanks @moeedahmed and @vincentkoc.</li>
+<li><strong>PR #93575</strong> fix(telegram): hydrate group reply-chain media into model context [AI-assisted]. Thanks @eldar702 and @vincentkoc.</li>
+<li><strong>PR #93261</strong> fix(plugins): resolve provider policy surface for plugin-owned CLI backends. Related #93259. Thanks @BitmapAsset and @vincentkoc.</li>
+<li><strong>PR #93303</strong> fix(whatsapp): bound stalled read-receipt socket operations. Thanks @Alix-007 and @vincentkoc.</li>
+<li><strong>PR #93242</strong> fix(mattermost): keep bare @mention with empty body instead of dropping it. Related #93205. Thanks @iloveleon19 and @vincentkoc.</li>
+<li><strong>PR #93606</strong> fix(ui): clear stale Talk error when session transitions to non-error state (fixes #88176). Thanks @liuhao1024 and @vincentkoc and @BrianClaw1955.</li>
+<li><strong>PR #93607</strong> perf(tasks): memoize reconcileInspectableTasks for same-tick calls (fixes #73531). Thanks @liuhao1024 and @vincentkoc and @slideshow-dingo.</li>
+<li><strong>PR #93612</strong> fix(gateway): compute sessions.usage aggregate totals from all sessions, not just the limited page (fixes #76496). Thanks @liuhao1024 and @vincentkoc and @bobsahur-robot.</li>
+<li><strong>PR #93615</strong> fix(telegram): recover lone active spooled handler on timeout (#84158). Thanks @0xghost42 and @vincentkoc and @crash2kx.</li>
+<li><strong>PR #93616</strong> Keep key-free web search providers opt-in. Thanks @davemorin and @vincentkoc.</li>
+<li><strong>PR #93298</strong> fix #93044: control-ui webchat double-renders agent replies when dmScope=main. Thanks @zhangguiping-xydt and @vincentkoc and @cfmilam.</li>
+<li><strong>PR #93618</strong> fix(feishu): filter temporary card-action-c-\* IDs from reply target to prevent Invalid open_message_id errors (fixes #56818). Thanks @liuhao1024 and @vincentkoc and @SwordImmortal.</li>
+<li><strong>PR #93387</strong> feat(ios): add watch action surface. Thanks @Solvely-Colin and @joshavant.</li>
+<li><strong>PR #93648</strong> fix(doctor): archive superseded plugin install index conflicts. Related #90418. Thanks @vincentkoc and @ramitrkar-hash.</li>
+<li><strong>PR #93649</strong> fix(qwen): place DashScope image prompts in user content. Related #92688. Thanks @vincentkoc and @Yachiyo404.</li>
+<li><strong>PR #93650</strong> fix(update): avoid per-Node npm prefixes during self-update. Related #80387. Thanks @vincentkoc and @yaanfpv.</li>
+<li><strong>PR #93653</strong> fix(skill-workshop): skip helper sessions during auto-capture. Thanks @vincentkoc and @zhangguiping-xydt.</li>
+<li><strong>PR #93654</strong> fix(codex): expose remote node exec as a Codex dynamic tool. Related #92141. Thanks @vincentkoc and @JPKay-AI.</li>
+<li><strong>PR #93662</strong> fix(discord): protect mention aliases in code fences. Thanks @vincentkoc and @rohitjavvadi.</li>
+<li><strong>PR #93663</strong> fix(clawdock): open dashboard on published port without starting deps. Related #77344. Thanks @vincentkoc and @dhoman.</li>
+<li><strong>PR #93670</strong> fix(browser): recover stale managed Chrome CDP listener. Related #41750. Thanks @vincentkoc and @rohitjavvadi and @kissman911.</li>
+<li><strong>PR #93672</strong> fix(commands): preserve multiline slash skill args. Related #79155. Thanks @vincentkoc and @web3blind.</li>
+<li><strong>PR #93674</strong> fix(browser): accept top-level act fields with nested requests. Related #38762. Thanks @vincentkoc and @angelusbr and @Lumos-789.</li>
+<li><strong>PR #93678</strong> fix(plugins): allow Dreaming sidecar through restrictive memory allowlists. Related #92536. Thanks @vincentkoc and @pradeep7127 and @resYuto.</li>
+<li><strong>PR #93306</strong> fix(status): ignore stale context after model switch. Thanks @hxy91819.</li>
+<li><strong>PR #93666</strong> fix(control-ui): copy code blocks over plain HTTP via clipboard fallback. Related #93628. Thanks @Pick-cat and @pjq2926.</li>
+<li><strong>PR #93629</strong> fix(reply): preserve unsent text-only finals after block pipeline streamed partial content (fixes #81078). Thanks @liuhao1024 and @Jackten.</li>
+<li><strong>PR #93690</strong> fix(telegram): dispatch MEDIA directives as attachments. Related #77702. Thanks @vincentkoc and @butttersbot.</li>
+<li><strong>PR #93693</strong> fix(gateway): ignore stale sudo scope for root user services. Related #81410. Thanks @vincentkoc and @Ericksza.</li>
+<li><strong>PR #93646</strong> fix(agents): return string assistant content in getLastAssistantText. Thanks @Alix-007 and @vincentkoc.</li>
+<li><strong>PR #93687</strong> fix(i18n): retain Codex error tails in logs. Thanks @hxy91819.</li>
+<li><strong>PR #93630</strong> fix(heartbeat): bootstrap plugin session targets. Thanks @ZengWen-DT and @vincentkoc.</li>
+<li><strong>PR #93658</strong> fix(wizard): preserve existing default model during setup auth choice [AI-assisted]. Related #64129. Thanks @ml12580 and @vegapunk9527.</li>
+<li><strong>PR #93671</strong> fix(respawn): rewrite pnpm versioned entry paths to stable wrapper (fixes #52313). Thanks @liuhao1024 and @vincentkoc and @RichardCao.</li>
+<li><strong>PR #93698</strong> Fix Telegram rich progress detail updates. Thanks @obviyus.</li>
+<li><strong>PR #93656</strong> fix(gateway): send approval route notices with write scope. Related #93563. Thanks @mushuiyu886 and @vincentkoc and @clawbot247-commits.</li>
+<li><strong>PR #93665</strong> fix(gateway): surface codex app-server returned failures. Thanks @litang9 and @vincentkoc.</li>
+<li><strong>PR #93727</strong> fix(context-engine): avoid turn-maintenance lane livelock. Related #77340. Thanks @vincentkoc and @baghvn and @Veda-openclaw.</li>
+<li><strong>PR #93681</strong> fix(llm): handle string assistant content on the OpenAI-compatible completion path. Thanks @Alix-007.</li>
+<li><strong>PR #93722</strong> chore(release): update appcast for 2026.6.8. Thanks @vincentkoc.</li>
+<li><strong>PR #93677</strong> fix(google-meet): declare realtime provider secret inputs. Related #81891. Thanks @goutamadwant and @vincentkoc and @chachi-max.</li>
+<li><strong>PR #92947</strong> fix(qqbot): deliver cron auto-TTS voice by trusting OpenClaw temp root. Related #92816. Thanks @ZengWen-DT and @Zeng-wen and @lewiswu1209.</li>
+<li><strong>PR #93679</strong> fix(whatsapp): extract GIF metadata and distinguish gifPlayback in media placeholders (fixes #49099). Thanks @liuhao1024 and @vincentkoc and @bugkill3r.</li>
+<li><strong>PR #93688</strong> fix(minimax): check base_resp envelope errors in TTS provider. Related #76904. Thanks @dwc1997 and @najef1979-code.</li>
+<li><strong>PR #93714</strong> fix: isolate async model resolution mock from sync mock in flaky test. Related #92117. Thanks @lsr911 and @wangwllu.</li>
+<li><strong>PR #93705</strong> test(macos): cover root command dispatch. Related #83879. Thanks @markoub and @vincentkoc and @davinci282828.</li>
+<li><strong>PR #93711</strong> Keep command text in progress drafts. Thanks @keshavbotagent and @vincentkoc.</li>
+<li><strong>PR #93712</strong> fix: scope assistant avatar override to agent ID. Related #90890. Thanks @lsr911 and @vincentkoc and @najef1979-code.</li>
+<li><strong>PR #93725</strong> fix(usage): prune stale usage cache temp files. Related #78939. Thanks @markoub and @Tramsrepus.</li>
+<li><strong>PR #93726</strong> fix(typing): start typing on reasoning deltas in thinking mode before visible text. Related #79681. Thanks @xialonglee and @novaflash82.</li>
+<li><strong>PR #93716</strong> fix(discord): propagate timeout through channel capabilities diagnostics. Related #77040. Thanks @xialonglee and @vincentkoc and @unicebondoc.</li>
+<li><strong>PR #93729</strong> fix(ollama): preserve configured API during discovery. Related #93710. Thanks @zhangguiping-xydt and @vincentkoc and @obnoxious2011-cmd.</li>
+<li><strong>PR #93719</strong> fix: pin plugin workspace dir for sessions.list to avoid O(rows) memo busting. Related #90814. Thanks @lsr911 and @vincentkoc and @k-l-lambda.</li>
+<li><strong>PR #93732</strong> fix(agents): preserve re-sent user prompt during compaction transcript rotation. Thanks @yetval.</li>
+<li><strong>PR #93738</strong> fix: break plugin registry type import cycle. Thanks @giodl73-repo.</li>
+<li><strong>PR #93740</strong> fix(sessions): release retained locks after takeover. Thanks @TurboTheTurtle.</li>
+<li><strong>PR #93745</strong> fix(usage): reject invalid explicit dates in usage RPC date parsing. Thanks @harjothkhara and @vincentkoc.</li>
+<li><strong>PR #93746</strong> fix(ui): populate realtime talk provider and transport options from talk.catalog. Thanks @shushushv and @vincentkoc.</li>
+<li><strong>PR #93751</strong> fix(ios): fix quick setup sheet layout design. Thanks @zats.</li>
+<li><strong>PR #93749</strong> fix(compaction): ignore stale persisted totalTokens in preflight gate. Thanks @yetval.</li>
+<li><strong>PR #93753</strong> fix: correct tautological uppercase check in tool description summarizer. Thanks @GautamKumarOffical.</li>
+<li><strong>PR #89123</strong> refactor: route transcript writers through session seam. Thanks @jalehman.</li>
+<li><strong>PR #93758</strong> feat(memory): apply outputDimensionality truncation to local GGUF embeddings (fixes #58765). Thanks @liuhao1024 and @vincentkoc and @losz5000.</li>
+<li><strong>PR #93754</strong> feat(inbound-meta): expose per-turn source modality. Related #50482. Thanks @liuhao1024 and @vincentkoc and @JTOrca.</li>
+<li><strong>PR #93767</strong> fix(reasoning-tags): strip MiniMax <code>mm:</code> namespaced reasoning tags. Thanks @DrHack1 and @vincentkoc.</li>
+<li><strong>PR #93772</strong> fix(feishu): recover CJK filenames from JSON file_name field (fixes #81103). Thanks @liuhao1024 and @vincentkoc and @pjuneye.</li>
+<li><strong>PR #93773</strong> fix(ui): scope Skill Workshop proposals to selected agent. Related #93760. Thanks @TurboTheTurtle and @vincentkoc and @hannesrudolph.</li>
+<li><strong>PR #88750</strong> feat(context-engine): pass runtime settings into lifecycle. Thanks @ragesaq and @jalehman.</li>
+<li><strong>PR #93763</strong> fix(agents): use neutral billing copy for subscription auth. Related #80877. Thanks @eldar702 and @vincentkoc and @22kyasue.</li>
+<li><strong>PR #93818</strong> List all ClawHub docs in sidebar. Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #93779</strong> fix(webchat): skip textarea resize during IME composition to eliminate typing lag. Related #90800. Thanks @joelnishanth and @vincentkoc and @w10497-create.</li>
+<li><strong>PR #93786</strong> fix(plugins): treat refreshable catalogs as requiring runtime discovery (fixes #93775). Thanks @liuhao1024 and @St0rmz1.</li>
+<li><strong>PR #93791</strong> fix(memory): await search-sync before returning results to prevent stale index (fixes #52115). Thanks @liuhao1024 and @vincentkoc and @FicheallADa.</li>
+<li><strong>PR #93780</strong> fix(google): keep parallel Gemini tool responses in the turn after the model. Thanks @yetval and @vincentkoc.</li>
+<li><strong>PR #93789</strong> fix(agents): make lane suspension consistent across cooldown-precheck and embedded-runner paths. Related #93036. Thanks @joelnishanth and @vincentkoc and @kumaxs.</li>
+<li><strong>PR #93798</strong> fix(status): show 0 (not ?) for fresh-session context tokens. Related #93771. Thanks @Alix-007 and @vincentkoc and @anarchia-99.</li>
+<li><strong>PR #93810</strong> fix(cron): preserve startup overflow catch-up deferrals in start() maintenance pass. Thanks @yetval.</li>
+<li><strong>PR #93811</strong> Strip UTF-8 BOM when reading SKILL.md in quick_validate. Thanks @HrachShah.</li>
+<li><strong>PR #93803</strong> fix(ui): preserve WebChat visible messages across session switches. Related #80855. Thanks @LiuwqGit and @vincentkoc and @viagarsuker.</li>
+<li><strong>PR #93792</strong> fix(android): wait for node capability approval before onboarding. Thanks @Solvely-Colin and @vincentkoc.</li>
+<li><strong>PR #93796</strong> fix(feishu): paginate wiki node and space listing (#37626). Thanks @ZengWen-DT and @vincentkoc and @ritou11.</li>
+<li><strong>PR #93797</strong> fix(browser): use openTab return value to prevent wsUrl race in ensureTabAvailable (fixes #63343). Thanks @liuhao1024 and @vincentkoc and @OpenCodeEngineer.</li>
+<li><strong>PR #93806</strong> fix(reasoning-tags): strip MiniMax mm: tags on silent-reply and streaming paths missed by #93767. Thanks @Alix-007 and @vincentkoc.</li>
+<li><strong>PR #93691</strong> refactor: add gateway sessions.create lifecycle seam. Thanks @jalehman.</li>
+<li><strong>PR #88748</strong> fix(gemini): bridge OAuth profiles into CLI runtime. Related #88742. Thanks @jason-allen-oneal.</li>
+<li><strong>PR #93857</strong> fix(deps): remediate Dependabot alerts. Thanks @vincentkoc.</li>
+<li><strong>PR #93874</strong> fix(slack): recognize MiniMax mm: namespaced reasoning tags in monitor preview. Thanks @Alix-007.</li>
+<li><strong>PR #93832</strong> feat(providers): add ClawRouter managed proxy. Thanks @vincentkoc.</li>
+<li><strong>PR #93880</strong> fix(macos): preserve approvals migration data. Thanks @vincentkoc.</li>
+<li><strong>PR #93903</strong> fix(cron): reject invalid absolute timestamps. Thanks @Alix-007 and @vincentkoc.</li>
+<li><strong>PR #93879</strong> fix(update): use configured npm registry for update metadata. Related #79140. Thanks @vincentkoc and @sixerLiu.</li>
+<li><strong>PR #93924</strong> revert(providers): remove ClawRouter provider. Thanks @vincentkoc.</li>
+<li><strong>PR #93955</strong> fix(telegram): surface rich-message disabled state. Thanks @obviyus.</li>
+<li><strong>PR #93881</strong> fix(agents): route BTW through canonical Codex runtime. Related #88902. Thanks @vincentkoc and @TurboTheTurtle and @khalil-omer.</li>
+<li><strong>PR #90192</strong> fix(feishu): fetch quoted content before empty-message guard. Related #90177. Thanks @bladin and @sliverp and @lkxlaz.</li>
+<li><strong>PR #93237</strong> Fix Mattermost open DM validation. Thanks @amknight.</li>
+<li><strong>PR #93945</strong> feat(diagnostics): add SIEM security events. Thanks @vincentkoc.</li>
+<li><strong>PR #87487</strong> fix(cli): clarify mcp list registry scope. Related #65209. Thanks @Alix-007 and @slideshow-dingo.</li>
+<li><strong>PR #24661</strong> feat(cohere): add provider plugin. Thanks @vincentkoc.</li>
+<li><strong>PR #93532</strong> Expose verified ClawHub source in skill verify output. Thanks @momothemage.</li>
+<li><strong>PR #93538</strong> feat(codex): support app-server network proxy profiles. Thanks @vincentkoc.</li>
+<li><strong>PR #93938</strong> fix(telegram): guard UTF-16 surrogate pairs in outbound chunkers. Related #93921. Thanks @Nas01010101 and @vincentkoc.</li>
+<li><strong>PR #94104</strong> feat(agents): trace compaction summarization model calls. Thanks @amknight.</li>
+<li><strong>PR #94108</strong> Fix package Telegram temp root. Thanks @obviyus.</li>
+<li><strong>PR #94113</strong> Fix Telegram package output mount. Thanks @obviyus.</li>
+<li><strong>PR #89062</strong> feat(docker): support offline setup reruns. Related #70443. Thanks @Alix-007 and @safrano9999.</li>
+<li><strong>PR #93929</strong> fix(secrets): explicitly pass BWS_SERVER_URL to resolver for self-hosted instances. Related #93851. Thanks @Pandah97 and @vincentkoc and @AdoShan.</li>
+<li><strong>PR #90057</strong> Polish Workboard operations view. Thanks @fuller-stack-dev.</li>
+<li><strong>PR #89396</strong> fix(doctor): drop inert legacy cron notify when cron.webhook is unset. Related #44460. Thanks @Alix-007.</li>
+<li><strong>PR #94138</strong> fix(session): prevent stale finalizer from recreating deleted session rows. Related #40840. Thanks @xialonglee and @vincentkoc and @AL-knows.</li>
+<li><strong>PR #93739</strong> refactor: add session patch projection seam. Thanks @jalehman.</li>
+<li><strong>PR #94178</strong> fix(workspace): skip optional bootstrap files when workspace setup is already completed. Related #83593. Thanks @dwc1997 and @jsompis.</li>
+<li><strong>PR #93363</strong> fix(feishu): enforce account tool family gates. Thanks @eleqtrizit.</li>
+<li><strong>PR #93813</strong> fix(codex): keep message registered for internal turns. Related #93750. Thanks @jalehman and @hannesrudolph.</li>
+<li><strong>PR #93659</strong> refactor: add session reset delete lifecycle seam. Thanks @jalehman.</li>
+<li><strong>PR #93852</strong> ci(release): harden release controls. Thanks @vincentkoc.</li>
+<li><strong>PR #94203</strong> feat(codex): support remote app-server plugins. Thanks @kevinslin.</li>
+<li><strong>PR #94263</strong> chore: migrate claw-score skill. Thanks @RomneyDa and @kevinslin.</li>
+<li><strong>PR #93695</strong> refactor: add compact trim lifecycle seam. Thanks @jalehman.</li>
+<li><strong>PR #93114</strong> test: fold lifecycle and package proof into QA Lab. Thanks @RomneyDa.</li>
+<li><strong>PR #93181</strong> test: fold otel smoke into qa e2e. Thanks @RomneyDa.</li>
+<li><strong>PR #93178</strong> test: fold gateway smoke into qa e2e. Thanks @RomneyDa.</li>
+<li><strong>PR #94276</strong> qa-lab: support script-backed evidence scenarios. Thanks @Solvely-Colin and @RomneyDa.</li>
+<li><strong>PR #94282</strong> Support owner-qualified ClawHub skill installs. Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #93704</strong> refactor: add session cleanup lifecycle seam. Thanks @jalehman.</li>
+<li><strong>PR #94296</strong> fix: require all taxonomy coverage ids for a feature - AND not OR. Thanks @RomneyDa.</li>
+<li><strong>PR #92016</strong> fix(plugins): compose live hook registry view for tool-call hooks. Related #91918. Thanks @amknight and @vokaplok.</li>
+<li><strong>PR #89596</strong> fix(policy): recognize declared tool allowlists. Thanks @giodl73-repo.</li>
+<li><strong>PR #93713</strong> fix: route deleted-agent session purge through lifecycle seam. Thanks @jalehman.</li>
+<li><strong>PR #84172</strong> fix(exec): rebuild command authorization on the Tree-sitter command planner. Thanks @jesse-merhi.</li>
+<li><strong>PR #94332</strong> docs: add ClawHub namespace claims to sidebar. Thanks @Patrick-Erichsen.</li>
+<li><strong>PR #86360</strong> fix(codex): honor bound agent exec host policy. Thanks @jesse-merhi.</li>
+<li><strong>PR #73162</strong> fix(slack): remove socket reconnect attempt cap so gateway stays connected indefinitely. Related #72808. Thanks @suboss87 and @tleyden.</li>
+<li><strong>PR #94156</strong> fix: expose OpenAI image quality and moderation CLI options. Thanks @lastguru-net and @fuller-stack-dev.</li>
+<li><strong>PR #94350</strong> feat: externalize GMI provider plugin. Thanks @Patrick-Erichsen and @vincentkoc.</li>
+<li><strong>PR #94543</strong> fix(gateway): bound config.get middleware results. Related #94265. Thanks @vincentkoc and @v-s-gusev.</li>
+<li><strong>PR #91409</strong> fix(update): run plugin convergence after RPC git updates. Thanks @masatohoshino.</li>
+<li><strong>PR #94556</strong> chore(extensions): bump tokenjuice to 0.8.1. Thanks @vincentkoc.</li>
+<li><strong>PR #94580</strong> fix(ci): stabilize update run gates.</li>
+<li><strong>PR #94394</strong> fix(infra): probe 127.0.0.1 in ensurePortAvailable to detect IPv4-only occupants. Related #94379. Thanks @Pandah97 and @wangwllu.</li>
+<li><strong>PR #94421</strong> fix(agents): preserve active compaction retries. Related #94391. Thanks @dexiosmb.</li>
+<li><strong>PR #94428</strong> fix(feishu): preserve replies before error finals. Related #94360. Thanks @xunx33.</li>
+<li><strong>PR #93735</strong> refactor: add restart recovery lifecycle seam. Thanks @jalehman.</li>
+<li><strong>PR #94591</strong> docs(release): backfill complete contribution records. Thanks @vincentkoc.</li>
+<li><strong>PR #94588</strong> fix(cron): retry isolated setup timeouts. Thanks @aaroneden.</li>
+<li><strong>PR #94082</strong> fix(cron): prevent lane timeout during long tool execution. Related #94033. Thanks @ajwan8998 and @JingWang-Star996.</li>
+<li><strong>PR #94551</strong> feat(firecrawl): add keyless scrape support. Thanks @vincentkoc and @developersdigest.</li>
+<li><strong>PR #94619</strong> test(ci): stabilize timeout-sensitive shards. Thanks @vincentkoc.</li>
+<li><strong>PR #94048</strong> fix(telegram): set richMessages default to false explicitly in schema. Related #93770, #93794. Thanks @Monkey-wusky and @obviyus and @Nardoa375 and @laurenceputra.</li>
+<li><strong>PR #94118</strong> [codex] Fix Telegram rich local Markdown link hrefs. Related #94117. Thanks @dankarization and @obviyus.</li>
+<li><strong>PR #94646</strong> refactor(sqlite): land database-first memory and proxy alignment. Thanks @vincentkoc.</li>
+<li><strong>PR #94658</strong> test(sqlite): use shared temp directory helper. Thanks @vincentkoc.</li>
+<li><strong>PR #92135</strong> fix(openai-embedding): preserve openai/ prefix for non-native base URLs. Related #92124. Thanks @xialonglee and @Kambrian.</li>
+<li><strong>PR #93737</strong> refactor: add session maintenance transaction seam. Thanks @jalehman.</li>
+<li><strong>PR #93685</strong> refactor(auto-reply): add lifecycle storage seams. Thanks @jalehman.</li>
+<li><strong>PR #94349</strong> fix(agents): preserve pending subagent completion announces. Related #93323. Thanks @sallyom and @oiGaDio.</li>
+<li><strong>PR #93174</strong> test: fold channel message flows into qa e2e. Thanks @RomneyDa.</li>
+<li><strong>PR #94093</strong> Prevent Codex thread rotation from losing next-step context. Thanks @VACInc.</li>
+<li><strong>PR #53920</strong> fix(scripts): avoid mutating tracked auth-monitor template during setup. Thanks @JackWuGlobal.</li>
+<li><strong>PR #94702</strong> Standardize QA coverage IDs on dotted names. Thanks @RomneyDa.</li>
+<li><strong>PR #81825</strong> fix(skills/1password): stop forcing tmux for desktop app auth (#52540). Thanks @koshaji and @tylerbittner.</li>
+<li><strong>PR #94725</strong> fix(doctor): warn on volatile SQLite state. Thanks @vincentkoc.</li>
+<li><strong>PR #88551</strong> fix(agents): skip auth gate for CLI-owned transport. Thanks @yu-xin-c.</li>
+<li><strong>PR #88581</strong> feat(commands): add /name to rename the current session from chat. Thanks @BSG2000.</li>
+<li><strong>PR #94324</strong> feat(codex): support app-server SecretRefs. Thanks @kevinlin-openai and @kevinslin.</li>
+<li><strong>PR #90882</strong> fix: add self-knowledge docs rule to system prompt. Related #90713. Thanks @SutraHsing.</li>
+<li><strong>PR #94684</strong> fix: #80507 show dry-run output for message send/poll. Thanks @lzyyzznl and @YB0y.</li>
+<li><strong>PR #93823</strong> fix(whatsapp): keep opening text chunk when first media fails on multi-chunk reply. Thanks @yetval.</li>
+<li><strong>PR #89203</strong> refactor: route SDK session compatibility through seam. Thanks @jalehman.</li>
+<li><strong>PR #94453</strong> fix: default cron runMode to "due" instead of "force" (#94270). Thanks @jincheng-xydt and @sallyom and @davectr.</li>
+<li><strong>PR #94746</strong> fix(note): prevent clack from re-breaking copy-sensitive tokens. Related #94730. Thanks @xzh-icenter and @berkgungor.</li>
+<li><strong>PR #89904</strong> refactor: route sdk session compatibility through accessor. Thanks @jalehman.</li>
+<li><strong>PR #86719</strong> fix(skills): retarget stale plugin skill symlinks. Related #85925. Thanks @stevenepalmer and @shakkernerd.</li>
+<li><strong>PR #94337</strong> fix(tui): show 0 not ? for fresh-session context tokens in footer. Thanks @mushuiyu886.</li>
+<li><strong>PR #94539</strong> fix(android): group settings by intent. Thanks @Tosko4.</li>
+<li><strong>PR #92383</strong> fix(gateway): never return an empty chat.history transcript. Thanks @Hidetsugu55.</li>
+<li><strong>PR #92574</strong> test(browser): cover action-input CLI request bodies. Related #83877. Thanks @yu-xin-c and @davinci282828.</li>
+<li><strong>PR #92873</strong> test(diffs): add viewerState, toolbar toggle, shadow root, and hydrateProps tests (fixes #83915). Thanks @liuhao1024 and @davinci282828.</li>
+<li><strong>PR #94257</strong> fix(sessions): preserve Media\* index alignment when reading user-turn fields. Thanks @Nas01010101.</li>
+<li><strong>PR #94756</strong> fix(codex): bound turn/start text when context budget is non-positive. Related #94748. Thanks @Nas01010101.</li>
+<li><strong>PR #94729</strong> fix(skills/trello): add curl to requires.bins to match body examples (fixes #94727). Thanks @liuhao1024 and @berkgungor.</li>
+<li><strong>PR #94790</strong> feat(slack): log INFO receipt for inbound app_mention events. Related #94691. Thanks @ZengWen-DT and @BryceMurray.</li>
+<li><strong>PR #81696</strong> fix: guard tool event callbacks (AI-assisted). Thanks @enjoylife1243.</li>
+<li><strong>PR #94809</strong> chore: forward-port alpha release fixes.</li>
+<li><strong>PR #94612</strong> fix(macos): open NSOpenPanel for embedded Control UI file inputs (#94468). Thanks @bbblending and @DINGDANGMAOUP.</li>
+<li><strong>PR #89806</strong> fix(feishu): avoid axios interceptor internals. Related #83913. Thanks @sweetcornna and @davinci282828.</li>
+<li><strong>PR #91923</strong> fix(ios): clean up notification settings state. Thanks @zats.</li>
+<li><strong>PR #91345</strong> fix: suggest close CLI commands. Related #83999. Thanks @glenn-agent and @HannesOberreiter.</li>
+<li><strong>PR #94561</strong> Add stdout diagnostics OTEL log exporter. Thanks @jesse-merhi.</li>
+<li><strong>PR #91013</strong> fix(gateway): ignore stale abort markers for fresh chat events. Related #91012. Thanks @nxmxbbd.</li>
+<li><strong>PR #89279</strong> fix(tasks): deliver ACP completions to bound Discord threads. Related #84022. Thanks @anyech and @h-mascot.</li>
+<li><strong>PR #91656</strong> test(cron): expand parseAbsoluteTimeMs test coverage to 39 cases. Related #91654. Thanks @SpecialLeon.</li>
+<li><strong>PR #94810</strong> fix(telegram): classify sendChatAction 401 by structured error_code, not bare substring match. Related #94787. Thanks @ZOOWH and @parveshsaini.</li>
+<li><strong>PR #94737</strong> fix(reply): clarify provider internal error copy. Thanks @snowzlmbot.</li>
+<li><strong>PR #94868</strong> fix(channels): preserve command progress detail. Thanks @vincentkoc.</li>
+<li><strong>PR #94891</strong> fix(telegram): send progress previews as html text. Thanks @obviyus.</li>
+<li><strong>PR #94683</strong> fix(outbound): keep direct-only targets out of group sessions. Related #92384. Thanks @scotthuang and @haiwei01.</li>
+<li><strong>PR #92477</strong> fix: migrate watch app to single-target app (Xcode 27+ compat). Thanks @zats and @joshavant.</li>
+<li><strong>PR #94812</strong> test(perf): compare saved CLI startup benchmarks. Thanks @FelixIsaac.</li>
+<li><strong>PR #94856</strong> fix(telegram): normalize all HTML tables before entity-escaping in rich messages. Related #94317. Thanks @zhangqueping and @jairrab.</li>
+<li><strong>PR #91685</strong> fix(cron): refuse keyless implicit isolated cron delivery inherited from shared agent-main bucket. Thanks @nxmxbbd.</li>
+</ul>
+<p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
+]]></description>
+            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.6.9/OpenClaw-2026.6.9.zip" length="56109134" type="application/octet-stream" sparkle:edSignature="LVSWrdPpUtbyfNCZUrMm+I0SHoJA/CU4HHQmHyup4IVoAAa5drdtyYaXmNQPk/OXclhgOBJrVKv7Vw+R1VXLCg=="/>
+        </item>
+        <item>
             <title>2026.6.8</title>
             <pubDate>Tue, 16 Jun 2026 17:17:20 +0000</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
@@ -123,133 +589,6 @@
 <p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
 ]]></description>
             <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.6.5/OpenClaw-2026.6.5.zip" length="55725877" type="application/octet-stream" sparkle:edSignature="EKr7gCfpEVStis9HSADJk1CWYbmH2MHMqSgNfZvLbBFCBWmk3pjBJS6K2qkxkq5lIbTj4H+Lo7Iri6ip/xTGDA=="/>
-        </item>
-        <item>
-            <title>2026.6.1</title>
-            <pubDate>Wed, 03 Jun 2026 21:26:22 +0000</pubDate>
-            <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>2026060190</sparkle:version>
-            <sparkle:shortVersionString>2026.6.1</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
-            <description><![CDATA[<h2>OpenClaw 2026.6.1</h2>
-<h3>Highlights</h3>
-<ul>
-<li>Agents and CLI-backed runtimes recover more cleanly from interrupted tool calls, stale session bindings, compaction handoffs, and media delivery retries. (#88129, #88136, #88141, #88162, #88182)</li>
-<li>Channels and mobile delivery are steadier across Telegram, WhatsApp, iMessage, Slack, Discord, Microsoft Teams, Google Chat, Google Meet, and iOS realtime Talk. (#88096, #88105, #88183, #88231)</li>
-<li>Provider and plugin requests now bound more timers, retries, OAuth/device-code lifetimes, media downloads, local service probes, and generated-content polling paths before they can hang a run.</li>
-<li>Skills, session metadata, gateway runtime state, plugin metadata, memory watchers, and store writes do less repeated work on hot paths while keeping config, dispatch, and Linux file-watch behavior stable. (#89185, #89188, #85351) Thanks @RomneyDa and @NianJiuZst.</li>
-<li>Skills and plugin loading now handle stale disabled snapshots and loader failures more clearly, so channel turns avoid disabled SecretRefs and operators get better recovery guidance. (#79072, #79173) Thanks @zeus1959.</li>
-<li>Workboard, SecretRef plugin manifests, hosted iOS push relay, and external Copilot/Tokenjuice packaging add broader orchestration, integration, and plugin delivery surfaces. (#82326, #87469, #87796, #88107, #88117)</li>
-<li>Skill Workshop now has a fuller Control UI flow with proposal lists, today actions, revision handoff, searchable file previews, review states, locale coverage, and reusable session routing.</li>
-<li>Chat and Control UI startup paths keep sends alive through history loading, stream deltas incrementally, skip markdown work while streaming, keep drafts local while typing, clear the composer after sends, trace first-output latency, prioritize first connect, and expose calmer composer controls. (#88772, #88825, #88998, #89030, #89106) Thanks @vincentkoc and @sallyom.</li>
-<li>Provider coverage and model metadata now include MiniMax M3, account OAuth endpoints, Google/Vertex catalog fixes, OpenRouter SQLite model caching, Copilot Claude 1M capabilities, Foundry reasoning alignment, and OpenAI response replay guards. (#88480, #88512, #88851, #88860)</li>
-<li>iMessage monitor state, inbound queues, and plugin install ledgers moved toward SQLite-backed state so restarts and local monitors recover with less duplicate filesystem scanning. (#88794, #88797)</li>
-<li>Release, CI, Docker, E2E, plugin install, and diagnostics lanes now cap more logs, response bodies, readiness probes, artifact checks, status polling, child workflow waits, docker package cleanup, quiet test stalls, and rollback snapshots so failures report bounded proof instead of stalling. (#88966) Thanks @RomneyDa.</li>
-</ul>
-<h3>Changes</h3>
-<ul>
-<li>Docs: add a dedicated Skill Workshop guide covering governed skill creation, reviewable proposals, CLI, Gateway, agent tool behavior, approval policy, support files, and recovery, and refresh the ClawHub showcase cards. (#88734) Thanks @shakkernerd and @vyctorbrzezowski.</li>
-<li>Skills: let the <code>skill_workshop</code> agent tool apply, reject, and quarantine explicit proposals through the guarded review flow. Thanks @shakkernerd.</li>
-<li>Skills: let proposals carry approved support files under standard skill folders, with scanner, hash, and rollback safeguards. Thanks @shakkernerd.</li>
-<li>Skills: let pending proposals be revised in place with versioned, dated proposal frontmatter before approval. Thanks @shakkernerd.</li>
-<li>Skills: add Skill Workshop with pending proposals, CLI/Gateway review actions, rollback metadata, and the <code>skill_workshop</code> agent tool. Thanks @shakkernerd.</li>
-<li>Skill Workshop: add the Control UI navigation, styled dashboard, proposal today view, revision dialog, file preview modal, searchable preview files, reusable session handoff, and localized strings.</li>
-<li>Plugins: externalize Tokenjuice as the official <code>@openclaw/tokenjuice</code> plugin with npm and ClawHub publish metadata.</li>
-<li>Plugins: externalize the GitHub Copilot agent runtime as the official <code>@openclaw/copilot</code> plugin with npm and ClawHub publish metadata.</li>
-<li>iOS: add hosted push relay defaults, realtime Talk playback, and a guarded WebSocket ping path for more reliable mobile sessions. (#88096, #88105, #88231)</li>
-<li>iOS: support native iPad display layouts.</li>
-<li>Workboard: add orchestration primitives and agent coordination tools for multi-agent planning and run tracking. (#87469)</li>
-<li>Workboard: wire task-backed board runs and show task comments in the edit modal.</li>
-<li>Code mode: add internal namespaces for scoped agent/global sessions and exact namespace tool dispatch. (#88043)</li>
-<li>Code mode: add MCP API files and docs for code-mode integrations.</li>
-<li>Control UI: add a Dreaming-tab agent selector and propagate the selected agent through Dreaming status, diary, and diary actions. (#78748) Thanks @stevenepalmer.</li>
-<li>Control UI: add calmer chat composer controls, local draft typing state, and first-output latency instrumentation for active chat entry. (#88772, #88998) Thanks @vincentkoc.</li>
-<li>Plugins: add a SecretRef provider integration manifest contract and extract shared LLM core packages for provider/plugin reuse. (#82326, #88117)</li>
-<li>Plugins: persist the plugin install index in SQLite so installed package lookup survives reloads with less filesystem scanning. (#88794)</li>
-<li>Providers: add MiniMax M3 model support. (#88860)</li>
-<li>Doctor: add disk space health checks and stabilize post-upgrade JSON probes.</li>
-<li>Channels: store inbound queues in SQLite and migrate iMessage monitor state to SQLite-backed tracking. (#88797)</li>
-<li>Skills: add the core skills index and centralize skills runtime loading, status, filtering, and prompt formatting.</li>
-</ul>
-<h3>Fixes</h3>
-<ul>
-<li>Release/CI/E2E: fail early when Crabbox sparse-sync full checkouts do not have enough local disk, with guidance for moving the sync root.</li>
-<li>Build: render independent CLI startup metadata help snapshots concurrently to cut cold build-all metadata time.</li>
-<li>Plugins: stop timed-out package-boundary prep steps by process group so descendant TypeScript/helper processes do not survive local check cleanup.</li>
-<li>Control UI: serve static assets asynchronously after safe-open checks so large UI files do not block Gateway request handling.</li>
-<li>Scripts/UI: forward direct wrapper SIGHUP shutdown to child processes so terminal hangups do not leave wrapped dev commands running.</li>
-<li>Gateway: return the post-expiration pending-work revision from node drains so reconnecting nodes do not observe stale queue revisions after expired items are pruned.</li>
-<li>Release/CI/E2E: keep temporary full-sync checkouts alive while slow Crabbox leases boot, so sparse worktree runs do not lose their sync source before file-list generation.</li>
-<li>Release/CI/E2E: normalize inherited Linux <code>C.UTF-8</code> locale settings before raw AWS macOS Crabbox bootstrap commands, avoiding macOS locale warnings during package-manager hydration.</li>
-<li>Release/CI/E2E: keep gateway watch regression checks from copying large static plugin assets inside the measured idle window.</li>
-<li>Update: keep core updates nonblocking when a missing external plugin repair download stalls, while still blocking installed active plugin payload smoke failures.</li>
-<li>Agents/providers: keep streaming tool-call argument parsing record-shaped when providers emit valid non-object JSON such as <code>null</code> or arrays.</li>
-<li>Release/CI/E2E: reset incremental log readers when watched log files rotate without shrinking, so same-size replacements do not hide new readiness or RPC lines.</li>
-<li>Talk: preserve explicit <code>null</code> payloads on controller-created turn and output-audio lifecycle events.</li>
-<li>Agents/TUI: keep local custom provider runs from loading plugin runtime and auth alias metadata when plugins are disabled.</li>
-<li>Agents/TUI: restore in-flight TUI run switch-back behavior, keep no-policy native hook fallback available, guard vanished workspaces, and keep lightweight isolated subagents lightweight.</li>
-<li>Agents/media: keep async image, music, and video generation starts from ending the Codex turn, so mixed requests can continue with summaries or other work while media renders in the background.</li>
-<li>Agents/Codex: keep public OpenAI API-key profiles from being treated as native Codex app-server auth while preserving persisted Codex OAuth sessions.</li>
-<li>Agents/Codex: stream Codex app-server final-answer partials to live reply previews, preserve ACP metadata in SQLite, prefer real tool results over synthetic repair output, prevent aborted app-server turn handles from lingering, migrate legacy OpenAI Codex <code>lastGood</code> auth state, and preserve workspace/session metadata through ACP runtime refactors. (#88405, #88724, #88730) Thanks @vincentkoc.</li>
-<li>Control UI: keep collapsed tool cards labeled with the tool name and action instead of generic output text. Thanks @shakkernerd.</li>
-<li>Agents/Codex: surface Skill Workshop guidance in Codex app-server prompts when <code>skill_workshop</code> is available. Thanks @shakkernerd.</li>
-<li>Skill Workshop: restore and localize the Control UI board/today view switcher so review workflows keep their intended layout toggle across locales. Thanks @shakkernerd.</li>
-<li>Agents/auth: write auth profiles atomically, dispatch auth failures by type, add force re-login recovery, preserve workspaces during state-only uninstall, and compact before oversized turns so recovery paths avoid partial state. (#89181) Thanks @RomneyDa.</li>
-<li>Skills: skip disabled skill env overrides from stale persisted snapshots so disabled skill <code>apiKey</code> SecretRefs cannot abort embedded or channel turns. (#79072, #79173) Thanks @zeus1959.</li>
-<li>Skill Workshop: render the Control UI tab from filtered navigation state and keep filtered fallback routing stable.</li>
-<li>CLI: avoid live catalog validation during <code>openclaw agents add</code>, so adding a secondary agent no longer depends on provider catalog availability. (#76284, #88314) Thanks @zhangguiping-xydt.</li>
-<li>CLI: keep <code>plugins list --json</code> on the snapshot-only path so plugin sweeps avoid loading the full runtime status graph.</li>
-<li>CLI/desktop: bridge WSL clipboard operations through the shell, recognize manual-update launchd jobs, and keep machine-readable startup output parseable during progress setup. (#88764, #88689) Thanks @alexzhu0.</li>
-<li>Plugins: make PixVerse external-plugin ClawHub metadata explicit and keep it out of bundled dist builds.</li>
-<li>Plugins: clarify plugin loader failure guidance so missing or incompatible plugin packages point operators at the right repair path.</li>
-<li>Plugins: preserve npm plugin roots after blocked installs, skip plugin-local <code>openclaw</code> peer symlinks during rollback snapshots, relink those peers after restore, isolate cached tool runtime siblings, and isolate web-provider factory failures so one bad plugin does not poison sibling runtime paths. (#77237, #88807)</li>
-<li>Cron: keep SQLite cron migrations compatible with legacy run-log tables, archived job stores, diagnostic cron names, and legacy one-shot delete-after-run behavior. (#88285)</li>
-<li>Cron: keep update delivery validation scoped, harden restart state, and retire MCP runtimes on isolated cron cleanup.</li>
-<li>Memory: serialize QMD update/embed writes per store, reduce Linux watcher fan-out, retry transient FileProvider-backed reads, preserve phase signals on read errors, harden envelope metadata sanitization, reattach Linux native watchers when directories are recreated, and rewrite generated transcript paths on rollover so memory/search state survives concurrent gateway and CLI activity. (#66339, #85931, #89185, #89188, #85351) Thanks @openperf, @amittell, @RomneyDa, and @NianJiuZst.</li>
-<li>Memory: keep vector-disabled FTS indexes from resolving embedding providers during sync and search.</li>
-<li>Providers: bound generated media downloads from OpenAI, Runway, xAI, MiniMax, BytePlus, DashScope-compatible, FAL, OpenRouter, Google, Vydra, and Comfy providers.</li>
-<li>Providers: resolve Google defaults to <code>google-generative-ai</code>, register Vertex static catalog rows, align Foundry reasoning metadata, skip DeepSeek V4 thinking params on Foundry fallback, use MiniMax account OAuth endpoints, preserve Copilot Claude 1M capabilities, suppress disabled Ollama reasoning output, forward Gemini stop sequences, strip Kimi-incompatible Anthropic cache markers, keep OpenAI stop-finished tool calls, and avoid replay ids when the Responses store is disabled. (#88480, #88512, #76612) Thanks @coder999999999, @BryanTegomoh, and @vliuyt.</li>
-<li>Providers: cap GitHub Copilot OAuth request timeouts before creating abort signals.</li>
-<li>Cron: retry recurring jobs after transient model rate limits before waiting for the next scheduled slot.</li>
-<li>Agents/Codex: keep live session locks during cleanup, recover interrupted CLI tool transcripts, preserve Codex auth and compaction session identity, clear orphan tool state, cap app-server idle timers, and keep media completion delivery retryable. (#88129, #88136, #88141, #88162, #88182)</li>
-<li>Chat/UI: show Gateway chat failures as visible assistant messages in the Control UI instead of only setting an invisible error state.</li>
-<li>Channels: cap Telegram, Discord, WhatsApp, Signal, Feishu, Google Chat, Microsoft Teams, QQBot, Nostr, Zalo, Zalouser, and Nextcloud-style request/retry timers; preserve SMS approval reply routes; and retry WhatsApp QR login 408 timeouts. (#88183)</li>
-<li>Security/config parsing: reject unsafe OAuth/token lifetimes, retry-after delays, inbound timestamps, response body sizes, command timeout config, sandbox observer token TTLs, and gateway WebSocket calls after close.</li>
-<li>Providers/media: cap local service, model, usage, queue, generated media, TTS, music, workflow polling, and provider OAuth request timers across hosted and local providers.</li>
-<li>Release/CI/E2E: bound release candidate reads, beta smoke REST calls, plugin npm verification commands, changelog restore, cross-OS process groups, kitchen-sink and bundled plugin readiness probes, secret-provider probes, Telegram credential timeouts, Control UI i18n and CLI startup metadata generation, Vitest routing, dependency guard admin approvals, child workflow failure detection, quiet Node test shard stalls, docker package cleanup, and mainline test flakes. (#88127, #88137, #88155, #88160, #88966) Thanks @RomneyDa.</li>
-<li>Release/CI/E2E: keep Kitchen Sink live plugin MCP probes resolving source-checkout workspace packages and align the live gauntlet with current Kitchen Sink diagnostics.</li>
-<li>Release/CI/E2E: run the secret-provider integration proof through the repo pnpm runner so native macOS and Windows validation use the hydrated package-manager shim.</li>
-<li>Release/CI/E2E: run the Telegram desktop proof gateway through the repo pnpm runner so native macOS proof uses the hydrated package-manager shim.</li>
-<li>Docs/CI: run Mintlify anchor checks through the repo pnpm runner so docs link validation works when pnpm is only available through the hydrated package-manager shim.</li>
-<li>Agents: keep configured fallback model metadata typed so provider params, context-token caps, and media input limits do not break changed-gate typechecks.</li>
-<li>Agents: accept hidden <code>sessions_send</code> body aliases before validation while keeping the model-facing <code>message</code> schema canonical. (#88229) Thanks @zhangguiping-xydt.</li>
-<li>Chat/UI: preserve startup chat sends during history loading, unblock the initial Control UI chat send, stream chat deltas incrementally, skip markdown parsing while streaming, keep drafts local while typing, guard composer rerenders, honor Chromium executable overrides, and detect system Chromium for E2E. (#88998) Thanks @vincentkoc.</li>
-<li>Channels: stop schema-padded poll modifiers from turning normal <code>send</code> actions into invalid poll sends. (#89601) Thanks @codezz.</li>
-<li>Channels: preserve long Feishu streaming replies, send visible fallbacks when accepted Feishu turns produce no final reply, tolerate iMessage self-chat timestamp skew, preserve colon-prefixed slash commands in mention parsing, decode Nostr <code>npub</code> allowlists correctly, and suppress raw provider errors during channel delivery. (#87896)</li>
-<li>Config/status/doctor: skip unresolved shell references in state-dir dotenv files, resolve gateway auth secrets during deep status audits, respect explicit PI runtime policy, report runtime tool-schema errors, and keep post-upgrade JSON stable. (#88288)</li>
-<li>Gateway/session state: list commands from the Gateway plugin registry, harden MCP loopback tool schemas, hide phantom agent-store rows from <code>sessions.list</code>, make task persistence failures explicit, and carry session UUIDs on interactive dispatch events.</li>
-<li>Gateway/plugins: narrow plugin lookup memoization to the stable plugin/runtime inputs, avoiding repeated lookup work without mixing disabled or filtered plugin state.</li>
-<li>OpenAI/TTS: handle speed directives for OpenAI TTS voices. (#74089)</li>
-<li>CI/Crabbox: keep default runner capacity on the Azure credit-backed on-demand D4 lane with the Azure SSH port and a Git-independent full check job, so broad validation avoids low-priority spot quota stalls, hydrate port mismatches, non-Git hydrated workspaces, and stale AWS region hints.</li>
-<li>CI/Crabbox: route Crabbox wrapper and Testbox workflow edits to their regression tests so changed-test gates do not silently run zero specs.</li>
-<li>CI/workflows: route workflow sanity helper edits to their guard tests and cover composite-action input interpolation checks.</li>
-<li>CI/tooling: route CI scope, dependency, changelog, and docs helper edits to their owner tests instead of silently skipping changed-test coverage.</li>
-<li>CI/tooling: route package, release, and install helper edits to their owner tests so changed-test gates cover publish and installer script changes.</li>
-<li>CI/tooling: route shared script library edits through their owner tests so lock, process, safety, and scan helpers do not skip changed-test coverage.</li>
-<li>CI/tooling: skip expensive import-graph scans once a changed diff already requires broad fallback, keeping local changed-test planning fast while still collecting explicit owner tests.</li>
-<li>CI/tooling: route script edits through conventional owner tests when matching <code>test/scripts</code> or <code>src/scripts</code> coverage already exists.</li>
-<li>CI/tooling: honor option terminators in the memory FD repro script so follow-on arguments are not reparsed.</li>
-<li>Release/CI/E2E: assert plugin lifecycle runtime inspect output instead of only capturing it.</li>
-<li>Release/CI/E2E: make gateway-network prove the advertised health RPC and retry early WebSocket closes without burning full open timeouts.</li>
-<li>Release/CI/E2E: honor option terminators across release, Parallels smoke, plugin gauntlet, and extension-memory scripts.</li>
-<li>Release/CI/E2E: fail plugin gateway gauntlet QA chunks when the requested suite summary is missing or invalid.</li>
-<li>Performance: prebuild QA runtime probes with generated plugin assets but without CLI startup metadata.</li>
-<li>Performance: skip declaration bundling for runtime-only CLI startup and gateway watch build profiles.</li>
-<li>Performance: reuse prepared provider handles, strict tool schemas, gateway runtime metadata, session maintenance config, plugin metadata, bundled skill allowlists, package-local plugin artifacts, single-entry store writes, and validated/serialized session prompt blobs.</li>
-</ul>
-<p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
-]]></description>
-            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.6.1/OpenClaw-2026.6.1.zip" length="55062100" type="application/octet-stream" sparkle:edSignature="PVp8E2HBCvikB/0LCr36lFEyHPAzoFA2ScT6LW27FlzvP+m4r1AEuVN2UrtgWlpkGSsn4Eav0kPJe32u4ObNBw=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
Updates the stable Sparkle appcast generated by macOS publish for v2026.6.9.