### PR TITLE
fix(whatsapp): preserve native quote replies

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-12393c35023a5bdddd276edc2b6669fa432454be9bee643138395e2106936945  plugin-sdk-api-baseline.json
-62ffb6cd4a433281f571fdf552be9c3f953f6fa055937f822b18de7dd4e20d23  plugin-sdk-api-baseline.jsonl
+ff4189ec2cee68078a70db7fe0373ee7831405560e5def784fad458a02e784fd  plugin-sdk-api-baseline.json
+c8109f3aa3e23ad7f4bc2696e674e346b80f4a239bc267a78d8bade861cf5ae8  plugin-sdk-api-baseline.jsonl

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -302,13 +302,13 @@ Live transport runners should import the shared scenario ids, baseline
 coverage helpers, and scenario-selection helper from
 `openclaw/plugin-sdk/qa-live-transport-scenarios`.
 
-| Lane     | Canary | Mention gating | Bot-to-bot | Allowlist block | Top-level reply | Restart resume | Thread follow-up | Thread isolation | Reaction observation | Help command | Native command registration |
-| -------- | ------ | -------------- | ---------- | --------------- | --------------- | -------------- | ---------------- | ---------------- | -------------------- | ------------ | --------------------------- |
-| Matrix   | x      | x              | x          | x               | x               | x              | x                | x                | x                    |              |                             |
-| Telegram | x      | x              | x          |                 |                 |                |                  |                  |                      | x            |                             |
-| Discord  | x      | x              | x          |                 |                 |                |                  |                  |                      |              | x                           |
-| Slack    | x      | x              | x          | x               | x               | x              | x                | x                |                      |              |                             |
-| WhatsApp | x      | x              |            | x               | x               | x              |                  |                  | x                    | x            |                             |
+| Lane     | Canary | Mention gating | Bot-to-bot | Allowlist block | Top-level reply | Quote reply | Restart resume | Thread follow-up | Thread isolation | Reaction observation | Help command | Native command registration |
+| -------- | ------ | -------------- | ---------- | --------------- | --------------- | ----------- | -------------- | ---------------- | ---------------- | -------------------- | ------------ | --------------------------- |
+| Matrix   | x      | x              | x          | x               | x               |             | x              | x                | x                | x                    |              |                             |
+| Telegram | x      | x              | x          |                 |                 |             |                |                  |                  |                      | x            |                             |
+| Discord  | x      | x              | x          |                 |                 |             |                |                  |                  |                      |              | x                           |
+| Slack    | x      | x              | x          | x               | x               |             | x              | x                | x                |                      |              |                             |
+| WhatsApp | x      | x              |            | x               | x               | x           | x              |                  |                  | x                    | x            |                             |
 
 This keeps `qa-channel` as the broad product-behavior suite while Matrix,
 Telegram, and other live transports share one explicit transport-contract checklist.
@@ -731,8 +731,9 @@ Scenario catalog (`extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.
   `whatsapp-whoami-command`, `whatsapp-context-command`,
   `whatsapp-native-new-command`.
 - Reply and final-output behavior: `whatsapp-tool-only-usage-footer`,
-  `whatsapp-reply-to-message`, `whatsapp-reply-context-isolation`,
-  `whatsapp-reply-delivery-shape`, `whatsapp-stream-final-message-accounting`.
+  `whatsapp-reply-to-message`, `whatsapp-group-reply-to-message`,
+  `whatsapp-reply-context-isolation`, `whatsapp-reply-delivery-shape`,
+  `whatsapp-stream-final-message-accounting`.
 - Inbound media and structured messages: `whatsapp-inbound-image-caption`,
   `whatsapp-audio-preflight`, `whatsapp-inbound-structured-messages`,
   `whatsapp-group-audio-gating`. These send real WhatsApp image, audio,
@@ -749,9 +750,9 @@ Scenario catalog (`extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.
   `whatsapp-approval-plugin-native`.
 - Status reactions: `whatsapp-status-reactions`.
 
-The catalog currently contains 35 scenarios. The `live-frontier` default lane is
-kept small at 8 scenarios for fast smoke coverage. The `mock-openai` default
-lane runs 29 deterministic scenarios through the real WhatsApp transport while
+The catalog currently contains 36 scenarios. The `live-frontier` default lane is
+kept small at 10 scenarios for fast smoke coverage. The `mock-openai` default
+lane runs 31 deterministic scenarios through the real WhatsApp transport while
 mocking only model output. Approval scenarios and a few heavier/blocking checks
 remain explicit by scenario id.
 

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-scenarios.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-scenarios.ts
@@ -76,6 +76,8 @@ export const LIVE_TRANSPORT_COVERAGE_LANES: readonly LiveTransportCoverageLane[]
       { standardId: "top-level-reply-shape", scenarioId: "whatsapp-top-level-reply-shape" },
       { standardId: "restart-resume", scenarioId: "whatsapp-restart-resume" },
       { standardId: "help-command", scenarioId: "whatsapp-help-command" },
+      { standardId: "quote-reply", scenarioId: "whatsapp-reply-to-message" },
+      { standardId: "quote-reply", scenarioId: "whatsapp-group-reply-to-message" },
       { standardId: "reaction-observation", scenarioId: "whatsapp-status-reactions" },
       { standardId: "allowlist-block", scenarioId: "whatsapp-group-allowlist-block" },
     ],

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
@@ -428,6 +428,7 @@ describe("WhatsApp QA live runtime", () => {
       "top-level-reply-shape",
       "restart-resume",
       "help-command",
+      "quote-reply",
       "reaction-observation",
       "allowlist-block",
     ]);
@@ -631,6 +632,8 @@ describe("WhatsApp QA live runtime", () => {
       "whatsapp-top-level-reply-shape",
       "whatsapp-restart-resume",
       "whatsapp-help-command",
+      "whatsapp-reply-to-message",
+      "whatsapp-group-reply-to-message",
       "whatsapp-status-reactions",
       "whatsapp-group-allowlist-block",
     ];
@@ -656,6 +659,8 @@ describe("WhatsApp QA live runtime", () => {
       "whatsapp-whoami-command",
       "whatsapp-context-command",
       "whatsapp-tool-only-usage-footer",
+      "whatsapp-reply-to-message",
+      "whatsapp-group-reply-to-message",
       "whatsapp-reply-context-isolation",
       "whatsapp-inbound-image-caption",
       "whatsapp-audio-preflight",
@@ -675,6 +680,68 @@ describe("WhatsApp QA live runtime", () => {
       "whatsapp-status-reactions",
       "whatsapp-group-allowlist-block",
     ]);
+  });
+
+  it("defines quote-reply scenarios for DM and group replies", () => {
+    const scenarios = testing.findScenarios([
+      "whatsapp-reply-to-message",
+      "whatsapp-group-reply-to-message",
+    ]);
+    const runs = scenarios.map((scenario) => {
+      const run = scenario.buildRun();
+      if (run.kind === "approval" || !run.verify) {
+        throw new Error(`${scenario.id} unexpectedly built a non-message run`);
+      }
+      return { scenario, run };
+    });
+
+    expect(
+      runs.map(({ scenario, run }) => ({
+        id: scenario.id,
+        requiresGroupJid: scenario.requiresGroupJid,
+        standardId: scenario.standardId,
+        target: run.target,
+      })),
+    ).toEqual([
+      {
+        id: "whatsapp-reply-to-message",
+        requiresGroupJid: undefined,
+        standardId: "quote-reply",
+        target: "dm",
+      },
+      {
+        id: "whatsapp-group-reply-to-message",
+        requiresGroupJid: true,
+        standardId: "quote-reply",
+        target: "group",
+      },
+    ]);
+    expect(runs[0]?.run.input).not.toContain("openclawqa");
+    expect(runs[1]?.run.input).toMatch(/^openclawqa\b/u);
+
+    for (const { run } of runs) {
+      expect(() =>
+        run.verify?.(
+          {
+            kind: "text",
+            observedAt: "2026-06-05T01:00:01.000Z",
+            quoted: { messageId: "trigger-message-id" },
+            text: "reply",
+          },
+          { sent: { messageId: "trigger-message-id" } } as never,
+        ),
+      ).not.toThrow();
+      expect(() =>
+        run.verify?.(
+          {
+            kind: "text",
+            observedAt: "2026-06-05T01:00:01.000Z",
+            text: "reply",
+          },
+          { sent: { messageId: "trigger-message-id" } } as never,
+        ),
+      ).toThrow("expected reply quote trigger-message-id, got <missing>");
+    }
   });
 
   it("seeds the structured-message location check through text context", () => {

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
@@ -70,6 +70,7 @@ type WhatsAppQaScenarioId =
   | "whatsapp-context-command"
   | "whatsapp-group-allowlist-block"
   | "whatsapp-group-audio-gating"
+  | "whatsapp-group-reply-to-message"
   | "whatsapp-help-command"
   | "whatsapp-inbound-image-caption"
   | "whatsapp-inbound-structured-messages"
@@ -423,6 +424,31 @@ const whatsappQaCredentialPayloadSchema = z.object({
   groupJid: z.string().trim().min(1).optional(),
 });
 
+function buildWhatsAppQuoteReplyRun(target: "dm" | "group"): WhatsAppQaMessageScenarioRun {
+  const token = `WHATSAPP_QA_REPLY_TO_${target.toUpperCase()}_${randomUUID().slice(0, 8).toUpperCase()}`;
+  const input =
+    target === "group"
+      ? `openclawqa reply with only this exact marker: ${token}`
+      : `Reply with only this exact marker: ${token}`;
+  return {
+    configMode: "allowlist",
+    expectReply: true,
+    input,
+    matchText: token,
+    target,
+    verify: (reply, context) => {
+      if (!context.sent.messageId) {
+        throw new Error("WhatsApp driver did not return a triggering message id.");
+      }
+      if (reply.quoted?.messageId !== context.sent.messageId) {
+        throw new Error(
+          `expected reply quote ${context.sent.messageId}, got ${reply.quoted?.messageId ?? "<missing>"}`,
+        );
+      }
+    },
+  };
+}
+
 const WHATSAPP_QA_SCENARIOS: WhatsAppQaScenarioDefinition[] = [
   {
     id: "whatsapp-canary",
@@ -649,31 +675,24 @@ const WHATSAPP_QA_SCENARIOS: WhatsAppQaScenarioDefinition[] = [
   },
   {
     id: "whatsapp-reply-to-message",
+    standardId: "quote-reply",
     title: "WhatsApp DM reply-to mode quotes the triggering message",
     timeoutMs: 60_000,
     configOverrides: {
       replyToMode: "all",
     },
-    buildRun: () => {
-      const token = `WHATSAPP_QA_REPLY_TO_${randomUUID().slice(0, 8).toUpperCase()}`;
-      return {
-        configMode: "allowlist",
-        expectReply: true,
-        input: `Reply with only this exact marker: ${token}`,
-        matchText: token,
-        target: "dm",
-        verify: (reply, context) => {
-          if (!context.sent.messageId) {
-            throw new Error("WhatsApp driver did not return a triggering message id.");
-          }
-          if (reply.quoted?.messageId !== context.sent.messageId) {
-            throw new Error(
-              `expected reply quote ${context.sent.messageId}, got ${reply.quoted?.messageId ?? "<missing>"}`,
-            );
-          }
-        },
-      };
+    buildRun: () => buildWhatsAppQuoteReplyRun("dm"),
+  },
+  {
+    id: "whatsapp-group-reply-to-message",
+    standardId: "quote-reply",
+    title: "WhatsApp group reply-to mode quotes the triggering message",
+    timeoutMs: 60_000,
+    configOverrides: {
+      replyToMode: "all",
     },
+    requiresGroupJid: true,
+    buildRun: () => buildWhatsAppQuoteReplyRun("group"),
   },
   {
     id: "whatsapp-reply-context-isolation",

--- a/extensions/whatsapp/src/channel-outbound.test.ts
+++ b/extensions/whatsapp/src/channel-outbound.test.ts
@@ -1,5 +1,6 @@
 // Whatsapp tests cover channel outbound plugin behavior.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { cacheInboundMessageMeta } from "./quoted-message.js";
 
 const hoisted = vi.hoisted(() => ({
   sendMessageWhatsApp: vi.fn(async () => ({ messageId: "wa-1", toJid: "jid" })),
@@ -98,6 +99,82 @@ describe("whatsappChannelOutbound", () => {
       cfg: {},
       accountId: undefined,
       gifPlayback: undefined,
+      preserveLeadingWhitespace: true,
+    });
+  });
+
+  it("uses the live WhatsApp sender for quoted text replies", async () => {
+    const legacySend = vi.fn(async () => ({ messageId: "legacy-1", toJid: "legacy-jid" }));
+    cacheInboundMessageMeta("default", "5511999999999@c.us", "reply-live-1", {
+      body: "original live body",
+      fromMe: false,
+      participant: "5511999999999@s.whatsapp.net",
+    });
+
+    await whatsappChannelOutbound.sendText!({
+      cfg: {},
+      to: "5511999999999@c.us",
+      text: "quoted reply",
+      replyToId: "reply-live-1",
+      deps: {
+        whatsapp: legacySend,
+      },
+    });
+
+    expect(legacySend).not.toHaveBeenCalled();
+    expect(hoisted.sendMessageWhatsApp).toHaveBeenCalledWith("5511999999999@c.us", "quoted reply", {
+      verbose: false,
+      cfg: {},
+      accountId: undefined,
+      gifPlayback: undefined,
+      quotedMessageKey: {
+        id: "reply-live-1",
+        remoteJid: "5511999999999@c.us",
+        fromMe: false,
+        participant: "5511999999999@s.whatsapp.net",
+        messageText: "original live body",
+      },
+      preserveLeadingWhitespace: true,
+    });
+  });
+
+  it("uses the live WhatsApp sender for quoted media replies", async () => {
+    const legacySend = vi.fn(async () => ({ messageId: "legacy-1", toJid: "legacy-jid" }));
+    cacheInboundMessageMeta("default", "5511999999999@c.us", "reply-media-1", {
+      body: "original media body",
+      fromMe: false,
+      participant: "5511999999999@s.whatsapp.net",
+    });
+
+    await whatsappChannelOutbound.sendMedia!({
+      cfg: {},
+      to: "5511999999999@c.us",
+      text: "quoted image",
+      mediaUrl: "/tmp/photo.png",
+      replyToId: "reply-media-1",
+      deps: {
+        whatsapp: legacySend,
+      },
+    });
+
+    expect(legacySend).not.toHaveBeenCalled();
+    expect(hoisted.sendMessageWhatsApp).toHaveBeenCalledWith("5511999999999@c.us", "quoted image", {
+      verbose: false,
+      cfg: {},
+      mediaUrl: "/tmp/photo.png",
+      mediaAccess: undefined,
+      mediaLocalRoots: undefined,
+      mediaReadFile: undefined,
+      accountId: undefined,
+      gifPlayback: undefined,
+      forceDocument: undefined,
+      quotedMessageKey: {
+        id: "reply-media-1",
+        remoteJid: "5511999999999@c.us",
+        fromMe: false,
+        participant: "5511999999999@s.whatsapp.net",
+        messageText: "original media body",
+      },
       preserveLeadingWhitespace: true,
     });
   });

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -164,16 +164,17 @@ export function createWhatsAppOutboundBase({
         if (skipEmptyText && !normalizedText) {
           return { messageId: "" };
         }
-        const send =
-          resolveOutboundSendDep<WhatsAppSendMessage>(deps, "whatsapp", {
-            legacyKeys: WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS,
-          }) ?? sendMessageWhatsApp;
         const lookupAccountId = resolveQuoteLookupAccountId(cfg, accountId);
         const quotedMessageKey = resolveQuotedMessageKey({
           accountId: lookupAccountId,
           to,
           replyToId,
         });
+        const send = quotedMessageKey
+          ? sendMessageWhatsApp
+          : (resolveOutboundSendDep<WhatsAppSendMessage>(deps, "whatsapp", {
+              legacyKeys: WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS,
+            }) ?? sendMessageWhatsApp);
         return await send(to, normalizedText, {
           verbose: false,
           cfg,
@@ -197,16 +198,17 @@ export function createWhatsAppOutboundBase({
         forceDocument,
         replyToId,
       }) => {
-        const send =
-          resolveOutboundSendDep<WhatsAppSendMessage>(deps, "whatsapp", {
-            legacyKeys: WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS,
-          }) ?? sendMessageWhatsApp;
         const lookupAccountId = resolveQuoteLookupAccountId(cfg, accountId);
         const quotedMessageKey = resolveQuotedMessageKey({
           accountId: lookupAccountId,
           to,
           replyToId,
         });
+        const send = quotedMessageKey
+          ? sendMessageWhatsApp
+          : (resolveOutboundSendDep<WhatsAppSendMessage>(deps, "whatsapp", {
+              legacyKeys: WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS,
+            }) ?? sendMessageWhatsApp);
         return await send(to, normalizeText(text), {
           verbose: false,
           cfg,

--- a/extensions/whatsapp/src/outbound-payload.contract.test.ts
+++ b/extensions/whatsapp/src/outbound-payload.contract.test.ts
@@ -8,9 +8,19 @@ import {
   verifyChannelMessageAdapterCapabilityProofs,
   verifyDurableFinalCapabilityProofs,
 } from "openclaw/plugin-sdk/channel-outbound";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { whatsappMessageAdapter } from "./channel-outbound.js";
 import { whatsappOutbound } from "./outbound-adapter.js";
+
+const hoisted = vi.hoisted(() => ({
+  sendMessageWhatsApp: vi.fn(async () => ({ messageId: "wa-live-1", toJid: "jid-live" })),
+  sendPollWhatsApp: vi.fn(async () => ({ messageId: "poll-live-1", toJid: "jid-live" })),
+}));
+
+vi.mock("./send.js", () => ({
+  sendMessageWhatsApp: hoisted.sendMessageWhatsApp,
+  sendPollWhatsApp: hoisted.sendPollWhatsApp,
+}));
 
 function createWhatsAppHarness(params: OutboundPayloadHarnessParams) {
   const sendWhatsApp = vi.fn();
@@ -32,6 +42,10 @@ function createWhatsAppHarness(params: OutboundPayloadHarnessParams) {
 }
 
 describe("WhatsApp outbound payload contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   installChannelOutboundPayloadContractSuite({
     channel: "whatsapp",
     chunking: { mode: "split", longTextLength: 5000, maxChunkLength: 4000 },
@@ -96,7 +110,12 @@ describe("WhatsApp outbound payload contract", () => {
         replyToId: "msg-1",
         deps: { whatsapp: sendWhatsApp },
       });
-      expect(sendWhatsApp).toHaveBeenLastCalledWith("5511999999999@c.us", "reply", {
+      expect(sendWhatsApp).not.toHaveBeenCalledWith(
+        "5511999999999@c.us",
+        "reply",
+        expect.anything(),
+      );
+      expect(hoisted.sendMessageWhatsApp).toHaveBeenLastCalledWith("5511999999999@c.us", "reply", {
         verbose: false,
         cfg: {},
         accountId: undefined,
@@ -160,20 +179,30 @@ describe("WhatsApp outbound payload contract", () => {
           } as Parameters<NonNullable<typeof whatsappMessageAdapter.send.text>>[0] & {
             deps: { whatsapp: typeof sendWhatsApp };
           });
-          expect(sendWhatsApp).toHaveBeenLastCalledWith("5511999999999@c.us", "reply", {
-            verbose: false,
-            cfg: {},
-            accountId: undefined,
-            gifPlayback: undefined,
-            quotedMessageKey: {
-              id: "msg-1",
-              remoteJid: "5511999999999@c.us",
-              fromMe: false,
-              participant: undefined,
-              messageText: undefined,
+          expect(sendWhatsApp).not.toHaveBeenCalledWith(
+            "5511999999999@c.us",
+            "reply",
+            expect.anything(),
+          );
+          expect(hoisted.sendMessageWhatsApp).toHaveBeenLastCalledWith(
+            "5511999999999@c.us",
+            "reply",
+            {
+              verbose: false,
+              cfg: {},
+              accountId: undefined,
+              gifPlayback: undefined,
+              quotedMessageKey: {
+                id: "msg-1",
+                remoteJid: "5511999999999@c.us",
+                fromMe: false,
+                participant: undefined,
+                messageText: undefined,
+              },
+              preserveLeadingWhitespace: true,
             },
-          });
-          expect(result?.receipt.platformMessageIds).toEqual(["wa-1"]);
+          );
+          expect(result?.receipt.platformMessageIds).toEqual(["wa-live-1"]);
         },
         messageSendingHooks: () => {
           expect(whatsappMessageAdapter.send.text).toBeTypeOf("function");

--- a/src/plugin-sdk/qa-live-transport-scenarios.ts
+++ b/src/plugin-sdk/qa-live-transport-scenarios.ts
@@ -4,6 +4,7 @@ export type LiveTransportStandardScenarioId =
   | "mention-gating"
   | "allowlist-block"
   | "top-level-reply-shape"
+  | "quote-reply"
   | "restart-resume"
   | "thread-follow-up"
   | "thread-isolation"
@@ -48,6 +49,11 @@ const LIVE_TRANSPORT_STANDARD_SCENARIOS: readonly LiveTransportStandardScenarioD
     id: "top-level-reply-shape",
     title: "Top-level reply shape",
     description: "Top-level replies stay top-level when the lane is configured that way.",
+  },
+  {
+    id: "quote-reply",
+    title: "Quote reply",
+    description: "Reply-mode responses quote the triggering transport message.",
   },
   {
     id: "restart-resume",


### PR DESCRIPTION
## What Problem This Solves

WhatsApp reply-mode sends advertised `replyTo` support, but quoted replies could still go through an injected legacy outbound send dependency instead of the live WhatsApp sender.

That mattered because native WhatsApp quote replies are not just a message id in OpenClaw. The live sender builds the WhatsApp/Baileys quote payload from cached inbound metadata, including the original remote JID, participant, sender direction, and preview text. When a quoted reply used the legacy dependency path, the send could look successful to the channel contract while the actual WhatsApp message did not reliably quote the triggering message.

## Why This Change Was Made

The outbound adapter now treats quoted WhatsApp sends as a live transport operation. When `replyToId` resolves to a WhatsApp `quotedMessageKey`, text and media sends use the real `sendMessageWhatsApp` implementation. Ordinary non-quoted sends still use the injected dependency when one is provided, so existing harnesses and non-quoted send behavior stay intact.

The QA lane now has explicit quote-reply coverage for both direct messages and groups:

- `whatsapp-reply-to-message` checks that DM reply-mode responses quote the triggering WhatsApp message.
- `whatsapp-group-reply-to-message` checks the same behavior in the QA group. The group scenario includes the configured QA mention so it exercises quote replies without being filtered by group mention gating.

The standard live-transport coverage taxonomy also has a `quote-reply` bucket now, so this behavior is visible in QA coverage reporting rather than being hidden inside the general WhatsApp lane.

## User Impact

Users should see WhatsApp reply-mode responses as real native quoted replies in WhatsApp, not just top-level messages that happen to be related in OpenClaw's internal state.

This is most visible when an agent answers a direct WhatsApp message or a group message with reply mode enabled. The response should point back to the exact triggering WhatsApp message, including group replies where participant metadata matters.

## Evidence

Live WhatsApp QA passed on the renamed fix branch:

- Branch/head tested: `fix/whatsapp-quote-reply @ 46d30f794b91ee424c3b55a6b7e6cfadae3429d8`
- Base: `origin/main @ 27551123538624170518e34afbbf585b00b996fd`
- Command: `/home/cactux/.agents/skills/whatsapp-qa-branch/scripts/run-whatsapp-qa-branch.sh --current`
- Provider mode: `mock-openai`
- Driver account: `default`
- SUT account: `work`
- QA group: configured/redacted
- Result: `36 passed / 0 failed / 0 skipped`, discovered 36 scenarios

Artifacts:

- `.artifacts/qa-e2e/whatsapp-full-current-46d30f794b9-20260621-024903/whatsapp-qa-report.md`
- `.artifacts/qa-e2e/whatsapp-full-current-46d30f794b9-20260621-024903/qa-evidence.json`
- `.artifacts/qa-e2e/whatsapp-full-current-46d30f794b9-20260621-024903/whatsapp-qa-observed-messages.json`

Focused proof from the live run:

- `[13/36] whatsapp-reply-to-message` passed: DM reply-mode response quoted the triggering message.
- `[14/36] whatsapp-group-reply-to-message` passed: group reply-mode response quoted the triggering group message.
- Gateway was restarted after the run.
- Post-run health check showed the installed Gateway running and both WhatsApp accounts linked, running, connected, and healthy after a short settle period.
