### PR TITLE
feat(tts): strip emoji characters before speech synthesis (fixes #95478)

### DIFF
--- a/packages/speech-core/src/tts.test.ts
+++ b/packages/speech-core/src/tts.test.ts
@@ -1479,4 +1479,50 @@ describe("speech-core per-agent TTS config", () => {
     expect(resolved.rawConfig?.providers?.openai).toEqual({ voice: "nova" });
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
   });
+
+  it("strips emoji characters before sending text to the speech provider", async () => {
+    synthesizeMock.mockClear();
+    const cfg = createTtsConfig("openclaw-speech-core-emoji-strip-test");
+    installSpeechProviders([createMockSpeechProvider("mock")]);
+    let mediaDir: string | undefined;
+    try {
+      const result = await maybeApplyTtsToPayload({
+        payload: { text: "Hello 🌸 world 🎉! This is great ✨." },
+        cfg,
+        channel: "telegram",
+        kind: "final",
+      });
+      expect(synthesizeMock).toHaveBeenCalled();
+      const request = requireFirstSynthesisRequest("emoji strip request");
+      expect(request.text).toBe("Hello world! This is great.");
+      mediaDir = result.mediaUrl ? path.dirname(result.mediaUrl) : undefined;
+    } finally {
+      if (mediaDir) {
+        rmSync(mediaDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("strips complex emoji sequences with ZWJ and modifiers", async () => {
+    synthesizeMock.mockClear();
+    const cfg = createTtsConfig("openclaw-speech-core-emoji-complex-test");
+    installSpeechProviders([createMockSpeechProvider("mock")]);
+    let mediaDir: string | undefined;
+    try {
+      const result = await maybeApplyTtsToPayload({
+        payload: { text: "Test 👨‍👩‍👧‍👦 family 👋🏽 wave 🏳️‍🌈 flag end." },
+        cfg,
+        channel: "telegram",
+        kind: "final",
+      });
+      expect(synthesizeMock).toHaveBeenCalled();
+      const request = requireFirstSynthesisRequest("emoji complex request");
+      expect(request.text).toBe("Test family wave flag end.");
+      mediaDir = result.mediaUrl ? path.dirname(result.mediaUrl) : undefined;
+    } finally {
+      if (mediaDir) {
+        rmSync(mediaDir, { recursive: true, force: true });
+      }
+    }
+  });
 });

--- a/packages/speech-core/src/tts.ts
+++ b/packages/speech-core/src/tts.ts
@@ -1184,6 +1184,17 @@ function resolveReadySpeechProvider(params: {
   };
 }
 
+const EMOJI_RE = /(?:\p{Extended_Pictographic}(?:\uFE0F|\u200D|\p{Extended_Pictographic}|\p{Emoji_Modifier})*)+/gu;
+
+function stripEmojisForSpeech(text: string): string {
+  return text
+    .replace(EMOJI_RE, " ")
+    .replace(/\s+([?!.,:;])/g, "$1")
+    .replace(/[ \t]{2,}/g, " ")
+    .replace(/ *\n */g, "\n")
+    .trim();
+}
+
 async function prepareSpeechSynthesis(params: {
   provider: NonNullable<ReturnType<typeof getSpeechProvider>>;
   text: string;
@@ -1199,15 +1210,17 @@ async function prepareSpeechSynthesis(params: {
   providerConfig: SpeechProviderConfig;
   providerOverrides?: SpeechProviderOverrides;
 }> {
+  const emojiStripped = stripEmojisForSpeech(params.text);
+  const inputText = emojiStripped.length > 0 ? emojiStripped : params.text;
   if (!params.provider.prepareSynthesis) {
     return {
-      text: params.text,
+      text: inputText,
       providerConfig: params.providerConfig,
       providerOverrides: params.providerOverrides,
     };
   }
   const prepared = await params.provider.prepareSynthesis({
-    text: params.text,
+    text: inputText,
     cfg: params.cfg,
     providerConfig: params.providerConfig,
     providerOverrides: params.providerOverrides,
@@ -1217,7 +1230,7 @@ async function prepareSpeechSynthesis(params: {
     timeoutMs: params.timeoutMs,
   });
   return {
-    text: prepared?.text ?? params.text,
+    text: prepared?.text ?? inputText,
     providerConfig: prepared?.providerConfig
       ? { ...params.providerConfig, ...prepared.providerConfig }
       : params.providerConfig,


### PR DESCRIPTION
## What Problem This Solves

TTS providers read emoji characters aloud (e.g. 🌸 becomes "cherry blossom", 🎉 becomes "party popper"), producing awkward speech output. The `tts-local-cli` and `discord` extensions already strip emojis locally before synthesis, but the core TTS pipeline in `packages/speech-core` did not — meaning all other providers (OpenAI, ElevenLabs, etc.) still spoke emojis.

## Changes Made

- Added `stripEmojisForSpeech()` in `packages/speech-core/src/tts.ts` using the same `Extended_Pictographic` regex pattern already proven in `tts-local-cli` and `discord` extensions
- Emoji stripping runs in the shared `prepareSpeechSynthesis` path before provider-specific preparation, so all TTS providers receive clean text
- Falls back to original text if stripping would leave nothing speakable
- Handles complex emoji sequences: ZWJ families (👨‍👩‍👧‍👦), skin-tone modifiers (👋🏽), flag sequences (🏳️‍🌈)
## Evidence

- **Behavior addressed:** Emoji characters are stripped from text before TTS synthesis across all providers
- **Environment tested:** local OpenClaw checkout on macOS, branch `fix/tts-strip-emojis`, commit `d835b334`
- **Steps run after the patch:** `pnpm build` + targeted test suite for speech-core TTS module
- **Evidence after fix:**

```
$ the speech-core TTS verification suite (44 checks)
 ✓  unit  packages/speech-core/src/tts.test.ts (44 tests) 29ms
 Test Files  1 passed (1)
      Tests  44 passed (44)

$ node -e "const fs=require('fs'); const c=fs.readFileSync('dist/tts-runtime-DUOn7_47.js','utf8'); console.log('Has stripEmojisForSpeech:', c.includes('stripEmojisForSpeech'));"
Has stripEmojisForSpeech: true

$ node -e "
const EMOJI_RE = /(?:\\p{Extended_Pictographic}(?:\\uFE0F|\\u200D|\\p{Extended_Pictographic}|\\p{Emoji_Modifier})*)+/gu;
const text = 'Hello 🌸 world 🎉! This is great ✨.';
const stripped = text.replace(EMOJI_RE, ' ').replace(/\\s+([?!.,:;])/g, '\$1').replace(/[ \\t]{2,}/g, ' ').trim();
console.log('Input:', text);
console.log('Output:', stripped);
"
Input: Hello 🌸 world 🎉! This is great ✨.
Output: Hello world! This is great.
```

- **Observed result after fix:** All 44 TTS verification checks pass including 2 new emoji-stripping checks. Build succeeds. Emoji characters are stripped from synthesis input while preserving punctuation and whitespace.
- **What was not tested:** Individual TTS provider APIs are not called directly (tests use stub providers). The regex covers Unicode 15.0 emoji ranges; exotic future emoji sequences may need pattern updates.

- [x] AI-assisted (Hermes Agent)

## Real behavior proof


- **Behavior addressed:** Emoji characters are stripped from text before TTS synthesis across all providers
- **Environment tested:** local OpenClaw checkout on macOS, branch `fix/tts-strip-emojis`, commit `d835b334`
- **Steps run after the patch:** `pnpm build` + targeted test suite for speech-core TTS module
- **Evidence after fix:**

```
$ the speech-core TTS verification suite (44 checks)
 ✓  unit  packages/speech-core/src/tts.test.ts (44 tests) 29ms
 Test Files  1 passed (1)
      Tests  44 passed (44)

$ node -e "const fs=require('fs'); const c=fs.readFileSync('dist/tts-runtime-DUOn7_47.js','utf8'); console.log('Has stripEmojisForSpeech:', c.includes('stripEmojisForSpeech'));"
Has stripEmojisForSpeech: true

$ node -e "
const EMOJI_RE = /(?:\\p{Extended_Pictographic}(?:\\uFE0F|\\u200D|\\p{Extended_Pictographic}|\\p{Emoji_Modifier})*)+/gu;
const text = 'Hello 🌸 world 🎉! This is great ✨.';
const stripped = text.replace(EMOJI_RE, ' ').replace(/\\s+([?!.,:;])/g, '\$1').replace(/[ \\t]{2,}/g, ' ').trim();
console.log('Input:', text);
console.log('Output:', stripped);
"
Input: Hello 🌸 world 🎉! This is great ✨.
Output: Hello world! This is great.
```

- **Observed result after fix:** All 44 TTS verification checks pass including 2 new emoji-stripping checks. Build succeeds. Emoji characters are stripped from synthesis input while preserving punctuation and whitespace.
- **What was not tested:** Individual TTS provider APIs are not called directly (tests use stub providers). The regex covers Unicode 15.0 emoji ranges; exotic future emoji sequences may need pattern updates.

- [x] AI-assisted (Hermes Agent)