### PR TITLE
fix(agents): classify missing_tool_result as tool_error to prevent cross-provider failover

### DIFF
--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -88,7 +88,8 @@ export type AuthProfileFailureReason =
   | "empty_response"
   | "no_error_details"
   | "unclassified"
-  | "unknown";
+  | "unknown"
+  | "tool_error";
 
 /** Profile-wide blocked reason reported by provider usage probes. */
 export type AuthProfileBlockedReason = "subscription_limit";

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -399,7 +399,8 @@ export type ProviderRuntimeFailureKind =
   | "empty_response"
   | "no_error_details"
   | "unclassified"
-  | "unknown";
+  | "unknown"
+  | "tool_error";
 
 const BILLING_402_HINTS = [
   "insufficient credits",
@@ -1055,6 +1056,11 @@ function classifyFailoverClassificationFromMessage(
   if (isGenericProviderInternalError(raw)) {
     return toReasonClassification("timeout");
   }
+  // Local tool-execution failures (e.g. hung bash → missing_tool_result) are
+  // not model/provider faults and must not trigger cross-provider failover.
+  if (/missing_tool_result/i.test(raw)) {
+    return toReasonClassification("tool_error");
+  }
   // Auth classifiers run before the broad isJsonApiInternalServerError check so that
   // provider errors like {"type":"api_error","message":"invalid api key"} are
   // correctly classified as "auth" rather than "timeout".
@@ -1266,6 +1272,11 @@ export function classifyProviderRuntimeFailureKind(
   }
   if (message && isSchemaErrorMessage(message)) {
     return "schema";
+  }
+  // Local tool-execution failures (e.g. hung bash → missing_tool_result) are
+  // not model/provider faults and must not trigger cross-provider failover.
+  if (message && /missing_tool_result/i.test(message)) {
+    return "tool_error";
   }
   // Plain HTTP 401 / invalid-token replies should be safe chat copy, but the
   // same failover reason also covers plain 403 and status-less auth payloads.

--- a/src/agents/embedded-agent-helpers/types.ts
+++ b/src/agents/embedded-agent-helpers/types.ts
@@ -16,4 +16,5 @@ export type FailoverReason =
   | "empty_response"
   | "no_error_details"
   | "unclassified"
-  | "unknown";
+  | "unknown"
+  | "tool_error";

--- a/src/agents/failover-policy.ts
+++ b/src/agents/failover-policy.ts
@@ -43,6 +43,7 @@ export function shouldPreserveTransientCooldownProbeSlot(
     reason === "format" ||
     reason === "auth" ||
     reason === "auth_permanent" ||
-    reason === "session_expired"
+    reason === "session_expired" ||
+    reason === "tool_error"
   );
 }

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -46,7 +46,8 @@ export type AgentRuntimeFailoverReason =
   | "empty_response"
   | "no_error_details"
   | "unclassified"
-  | "unknown";
+  | "unknown"
+  | "tool_error";
 
 /** Provider/runtime config object passed through plugin boundaries. */
 export type AgentRuntimeConfig = unknown;


### PR DESCRIPTION
## What Problem This Solves

When a local tool execution fails (e.g. hung `bash` → `missing_tool_result`), the error was classified as `unclassified` which triggers cross-provider model fallback. A hung local command is not a model/provider fault, so switching providers cannot remedy it — the user sees the model bounce between providers with no benefit.

Add `tool_error` as a new `FailoverReason` and detect `missing_tool_result` in error classification to prevent cross-provider failover.

Fixes #95474.

## Change

| File | Change |
|------|--------|
| `embedded-agent-helpers/types.ts` | Add `"tool_error"` to `FailoverReason` union |
| `embedded-agent-helpers/errors.ts` | Detect `missing_tool_result` in `classifyFailoverClassificationFromMessage` and `classifyProviderRuntimeFailureKind` |
| `failover-policy.ts` | Add `tool_error` to `shouldPreserveTransientCooldownProbeSlot` (non-failover) |
| `auth-profiles/types.ts` | Add `"tool_error"` to `AuthProfileFailureReason` |
| `runtime-plan/types.ts` | Add `"tool_error"` to `AgentRuntimeFailoverReason` |

## Evidence

| Suite | Result |
|-------|--------|
| `embedded-agent-helpers.isbillingerrormessage.test.ts` | ✅ 143/143 passed |
| `runtime-plan/types.compat.test.ts` | ✅ 3/3 passed |
| oxlint + boundary dts | ✅ clean |

## Risk

- **Low risk**: adds a new error classification without changing existing behavior
- `tool_error` is treated as non-transient — no cooldown probe, no cross-provider failover
- The existing `shouldPreserveTransientCooldownProbeSlot` guard ensures fallback loop does not advance to next candidate for `tool_error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
