### PR TITLE
fix(github-copilot): strip encrypted_content from reasoning replay items

### DIFF
--- a/extensions/github-copilot/connection-bound-ids.test.ts
+++ b/extensions/github-copilot/connection-bound-ids.test.ts
@@ -1,9 +1,9 @@
 // Github Copilot tests cover connection bound ids plugin behavior.
 import { describe, expect, it } from "vitest";
-import { rewriteCopilotResponsePayloadConnectionBoundIds } from "./connection-bound-ids.js";
+import { sanitizeCopilotReplayResponsePayload } from "./connection-bound-ids.js";
 
 function rewriteInputIds(input: unknown): boolean {
-  return rewriteCopilotResponsePayloadConnectionBoundIds({ input });
+  return sanitizeCopilotReplayResponsePayload({ input });
 }
 
 describe("github-copilot connection-bound response IDs", () => {
@@ -91,9 +91,9 @@ describe("github-copilot connection-bound response IDs", () => {
     const messageId = Buffer.from(`message-${"m".repeat(24)}`).toString("base64");
     const payload = { input: [{ id: messageId, type: "message" }] };
 
-    expect(rewriteCopilotResponsePayloadConnectionBoundIds(payload)).toBe(true);
+    expect(sanitizeCopilotReplayResponsePayload(payload)).toBe(true);
     expect(payload.input[0]?.id).toMatch(/^msg_[a-f0-9]{16}$/);
-    expect(rewriteCopilotResponsePayloadConnectionBoundIds(undefined)).toBe(false);
-    expect(rewriteCopilotResponsePayloadConnectionBoundIds({ input: "text" })).toBe(false);
+    expect(sanitizeCopilotReplayResponsePayload(undefined)).toBe(false);
+    expect(sanitizeCopilotReplayResponsePayload({ input: "text" })).toBe(false);
   });
 });

--- a/extensions/github-copilot/connection-bound-ids.test.ts
+++ b/extensions/github-copilot/connection-bound-ids.test.ts
@@ -37,7 +37,7 @@ describe("github-copilot connection-bound response IDs", () => {
     expect(input[4]?.id).toMatch(/^msg_[a-f0-9]{16}$/);
   });
 
-  it("preserves valid reasoning IDs regardless of encrypted_content", () => {
+  it("preserves valid reasoning IDs but strips encrypted_content", () => {
     const withEncrypted = Buffer.from(`reasoning-${"e".repeat(24)}`).toString("base64");
     const withNull = Buffer.from(`reasoning-${"n".repeat(24)}`).toString("base64");
     const withoutField = Buffer.from(`reasoning-${"a".repeat(24)}`).toString("base64");
@@ -47,13 +47,13 @@ describe("github-copilot connection-bound response IDs", () => {
       { id: withoutField, type: "reasoning" },
     ];
 
-    expect(rewriteInputIds(input)).toBe(false);
-    expect(input[0]?.id).toBe(withEncrypted);
-    expect(input[1]?.id).toBe(withNull);
-    expect(input[2]?.id).toBe(withoutField);
+    expect(rewriteInputIds(input)).toBe(true);
+    expect(input[0]).toEqual({ id: withEncrypted, type: "reasoning" });
+    expect(input[1]).toEqual({ id: withNull, type: "reasoning" });
+    expect(input[2]).toEqual({ id: withoutField, type: "reasoning" });
   });
 
-  it("preserves valid base64-ish reasoning IDs with and without encrypted content", () => {
+  it("strips encrypted_content from valid reasoning IDs at payload send time", () => {
     const withEncrypted = "abcDEF0123+/=";
     const withoutEncrypted = "reasoning/abc+123=";
     const input = [
@@ -61,11 +61,12 @@ describe("github-copilot connection-bound response IDs", () => {
       { id: withoutEncrypted, type: "reasoning" },
     ];
 
-    expect(rewriteInputIds(input)).toBe(false);
-    expect(input.map((item) => item.id)).toEqual([withEncrypted, withoutEncrypted]);
+    expect(rewriteInputIds(input)).toBe(true);
+    expect(input[0]).toEqual({ id: withEncrypted, type: "reasoning" });
+    expect(input[1]).toEqual({ id: withoutEncrypted, type: "reasoning" });
   });
 
-  it("drops unsafe reasoning replay item IDs while keeping idless reasoning replay", () => {
+  it("drops unsafe reasoning IDs and strips encrypted_content from kept items", () => {
     const overlongId = `5PX6gLHXT5wE+Y2tPmUV4gn+${"B".repeat(384)}`;
     const input = [
       {
@@ -81,8 +82,8 @@ describe("github-copilot connection-bound response IDs", () => {
 
     expect(rewriteInputIds(input)).toBe(true);
     expect(input).toEqual([
-      { type: "reasoning", encrypted_content: "missing-id", summary: [] },
-      { id: "rs_valid", type: "reasoning", encrypted_content: "valid", summary: [] },
+      { type: "reasoning", summary: [] },
+      { id: "rs_valid", type: "reasoning", summary: [] },
     ]);
   });
 

--- a/extensions/github-copilot/connection-bound-ids.ts
+++ b/extensions/github-copilot/connection-bound-ids.ts
@@ -45,12 +45,15 @@ function sanitizeCopilotReplayResponseIds(input: unknown): boolean {
       continue;
     }
     const id = item.id;
-    // Reasoning items with replay IDs reference server-side encrypted state
-    // bound to that ID. Drop unsafe IDs, but keep the store-disabled idless
-    // replay form produced by core Responses conversion.
+    // Reasoning encrypted_content is tied to the Copilot connection token,
+    // which rotates per request. Drop items with unsafe IDs; strip
+    // encrypted_content from kept items so summary-only replay is sent.
     if (item.type === "reasoning") {
       if (id !== undefined && !isValidReasoningReplayId(id)) {
         input.splice(index, 1);
+        rewrote = true;
+      } else if ("encrypted_content" in item) {
+        delete (item as Record<string, unknown>)["encrypted_content"];
         rewrote = true;
       }
       continue;

--- a/extensions/github-copilot/connection-bound-ids.ts
+++ b/extensions/github-copilot/connection-bound-ids.ts
@@ -53,7 +53,7 @@ function sanitizeCopilotReplayResponseIds(input: unknown): boolean {
         input.splice(index, 1);
         rewrote = true;
       } else if ("encrypted_content" in item) {
-        delete (item as Record<string, unknown>)["encrypted_content"];
+        delete item.encrypted_content;
         rewrote = true;
       }
       continue;
@@ -69,13 +69,9 @@ function sanitizeCopilotReplayResponseIds(input: unknown): boolean {
   return rewrote;
 }
 
-function sanitizeCopilotReplayResponsePayloadIds(payload: unknown): boolean {
+export function sanitizeCopilotReplayResponsePayload(payload: unknown): boolean {
   if (!payload || typeof payload !== "object") {
     return false;
   }
   return sanitizeCopilotReplayResponseIds((payload as { input?: unknown }).input);
-}
-
-export function rewriteCopilotResponsePayloadConnectionBoundIds(payload: unknown): boolean {
-  return sanitizeCopilotReplayResponsePayloadIds(payload);
 }

--- a/extensions/github-copilot/stream.test.ts
+++ b/extensions/github-copilot/stream.test.ts
@@ -240,6 +240,8 @@ describe("wrapCopilotAnthropicStream", () => {
     ]);
     expect(payloads[0]?.input[1]?.id).toBeUndefined();
     expect(payloads[0]?.input[2]?.id).toMatch(/^msg_[a-f0-9]{16}$/);
+    expect(payloads[0]?.input[0]).not.toHaveProperty("encrypted_content");
+    expect(payloads[0]?.input[1]).not.toHaveProperty("encrypted_content");
   });
 
   it("rewrites Copilot Responses IDs returned by an existing payload hook", async () => {

--- a/extensions/github-copilot/stream.ts
+++ b/extensions/github-copilot/stream.ts
@@ -7,7 +7,7 @@ import {
   applyAnthropicEphemeralCacheControlMarkers,
   streamWithPayloadPatch,
 } from "openclaw/plugin-sdk/provider-stream-shared";
-import { rewriteCopilotResponsePayloadConnectionBoundIds } from "./connection-bound-ids.js";
+import { sanitizeCopilotReplayResponsePayload } from "./connection-bound-ids.js";
 import { stripCopilotAssistantThinkingMessages } from "./replay-policy.js";
 
 type StreamOptions = Parameters<StreamFn>[2];
@@ -62,11 +62,11 @@ function buildCopilotDynamicHeaders(params: {
 function patchOnPayloadResult(result: unknown): unknown {
   if (result && typeof result === "object" && "then" in result) {
     return Promise.resolve(result).then((next) => {
-      rewriteCopilotResponsePayloadConnectionBoundIds(next);
+      sanitizeCopilotReplayResponsePayload(next);
       return next;
     });
   }
-  rewriteCopilotResponsePayloadConnectionBoundIds(result);
+  sanitizeCopilotReplayResponsePayload(result);
   return result;
 }
 
@@ -132,7 +132,7 @@ function wrapCopilotOpenAIResponsesStream(
       ...options,
       headers: buildCopilotRequestHeaders(context, options?.headers),
       onPayload: (payload, payloadModel) => {
-        rewriteCopilotResponsePayloadConnectionBoundIds(payload);
+        sanitizeCopilotReplayResponsePayload(payload);
         return patchOnPayloadResult(originalOnPayload?.(payload, payloadModel));
       },
     };


### PR DESCRIPTION
### Summary

- **Problem**: `github-copilot/gpt-5.5` sessions fail with `400 invalid_encrypted_content` on later turns even after the merged fixes #84367, #90682, #92941, and #71448. Persisted session transcripts contain `thinkingSignature` blocks with `encrypted_content`, and those get replayed into subsequent Copilot requests — which the provider then rejects.
- **Root Cause**: `sanitizeCopilotReplayResponseIds` (called via `onPayload` in `wrapCopilotOpenAIResponsesStream`) only drops reasoning items whose IDs are unsafe/connection-bound, but it passes through all reasoning items that have valid short IDs or no ID — including those carrying `encrypted_content`. Meanwhile, the core replay function `prepareOpenAIResponsesReasoningItemForReplay` keeps `encrypted_content` when `encryptedReasoningReplayMetadataMatches` returns true (same OpenClaw session, same auth profile, same model). The mismatch: the context-match check uses the stable OpenClaw session ID and auth profile ID, but Copilot's `encrypted_content` is actually bound to the ephemeral per-request Copilot access token, which rotates between turns. So the core layer thinks it can replay safely, but the provider disagrees.
- **Fix**: In `sanitizeCopilotReplayResponseIds`, after dropping items with unsafe IDs, also strip `encrypted_content` from any reasoning items that remain (valid ID or idless). This runs at the final `onPayload` boundary — just before the request leaves for the Copilot provider — and covers both the embedded runner transport path and the shared Responses converter path.
- **What changed**: `extensions/github-copilot/connection-bound-ids.ts` — one new `else if` branch strips `encrypted_content` from kept reasoning items; updated comment. `extensions/github-copilot/connection-bound-ids.test.ts` — three tests updated to reflect the corrected behavior (IDs preserved, `encrypted_content` stripped).
- **What did NOT change**: Core replay logic, the ID-drop branch, the Anthropic/Claude replay path, or any other provider path. Config surface unchanged. Plugin surface unchanged.

### Reproduction

1. Start a channel session using `github-copilot/gpt-5.5` that produces reasoning output (reasoning effort enabled).
2. Complete several turns so the session JSONL accumulates `thinkingSignature` blocks containing `encrypted_content`.
3. On a later turn (Copilot's access token has rotated), replay the history.
4. **Before this PR**: `prepareOpenAIResponsesReasoningItemForReplay` keeps `encrypted_content` (context matches: same session, same auth profile); `sanitizeCopilotReplayResponseIds` passes through the item unchanged; Copilot rejects with `400 invalid_encrypted_content`; user sees `LLM request failed`.
5. **After this PR**: `sanitizeCopilotReplayResponseIds` strips `encrypted_content` from reasoning items at payload send time before they reach the provider; the request succeeds with summary-only reasoning replay.

### Real behavior proof

**Behavior addressed (#95441)**: `sanitizeCopilotReplayResponseIds` now strips `encrypted_content` from all reasoning items in the outgoing Copilot payload, so stale connection-token-bound encrypted state never reaches the provider.

**Real environment tested (Linux, Node 22 — Vitest against the production `sanitizeCopilotReplayResponseIds` function and the full github-copilot extension suite)**: the three updated tests directly exercise the changed code path — items with valid IDs and `encrypted_content` are stripped; idless items with `encrypted_content` are stripped; items with unsafe IDs are still dropped.

**Exact steps or command run after this patch**: `pnpm test extensions/github-copilot/connection-bound-ids.test.ts`; `pnpm test extensions/github-copilot`; `node scripts/run-oxlint.mjs` and `pnpm format:diff` on changed files.

**Evidence after fix (Vitest output)**:

```text
 Test Files  10 passed (10)
      Tests  95 passed (95)
```

**Observed result after fix**: `sanitizeCopilotReplayResponseIds` returns `true` and removes `encrypted_content` from reasoning items with valid IDs or no ID. Items with unsafe (connection-bound long) IDs are still dropped from the input array. Items with no `encrypted_content` field pass through unchanged.

**What was not tested**: a live end-to-end `github-copilot/gpt-5.5` channel session with a rotated Copilot token — the failing setup requires private Copilot credentials and an aged session transcript. The changed function is fully covered deterministically by the updated tests against the production code path.

### Risk / Mitigation

- **Risk**: Stripping `encrypted_content` may reduce reasoning continuity if Copilot uses it for multi-turn reasoning context. **Mitigation**: the existing retry path (`createResponsesStreamWithEncryptedContentRetry`) already strips `encrypted_content` on `invalid_encrypted_content` errors, proving that requests succeed without it. This fix is proactive rather than reactive.
- **Risk**: Over-broad strip for reasoning items that would have replayed successfully. **Mitigation**: the strip only fires at the Copilot `onPayload` boundary for `github-copilot/openai-responses` calls; other providers are unaffected. Reasoning summaries (non-encrypted content) are preserved for context continuity.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Providers / models
- [x] Tests

### Linked Issue/PR

Fixes #95441