### PR TITLE
fix(agents): classify generic external run failure text as fallback-eligible (fixes #95489)

### DIFF
--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -1,5 +1,6 @@
 // Coverage for deciding when embedded run results should trigger model fallback.
 import { describe, expect, it } from "vitest";
+import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "../../auto-reply/reply/agent-runner-failure-copy.js";
 import { classifyEmbeddedAgentRunResultForModelFallback } from "./result-fallback-classifier.js";
 
 describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
@@ -258,5 +259,70 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     });
 
     expect(result).toBeNull();
+  });
+
+  it("triggers fallback when the only visible payload is the generic external run failure text", () => {
+    // Some subprocess runners (e.g. claude-cli) deliver their error text as a
+    // regular text payload (isError: false). The classifier should treat this
+    // as invisible and allow fallback to the next provider in the chain.
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "openai",
+      model: "gpt-5.5",
+      result: {
+        payloads: [
+          {
+            text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+          },
+        ],
+        meta: { durationMs: 42 },
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).toMatchObject({
+      code: "empty_result",
+      reason: "format",
+    });
+  });
+
+  it("does not trigger fallback when generic failure text is mixed with normal payloads", () => {
+    // If there is real visible text alongside the generic failure text, the
+    // run made progress and should not trigger model fallback.
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "openai",
+      model: "gpt-5.5",
+      result: {
+        payloads: [
+          { text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT },
+          { text: "Actual assistant response content" },
+        ],
+        meta: { durationMs: 42 },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("does not suppress business-denial error payload classification when generic failure text is present", () => {
+    // The pre-check only strips the generic failure text from visible-content
+    // consideration; if a business-denial error payload also exists, it must
+    // still be classified by the existing error-payload path.
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "openrouter",
+      model: "gpt-5.5",
+      result: {
+        payloads: [
+          { text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT },
+          { isError: true, text: "Key limit exceeded" },
+        ],
+        meta: { durationMs: 42 },
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).toMatchObject({
+      code: "embedded_error_payload",
+      reason: "billing",
+    });
   });
 });

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -1,6 +1,7 @@
 /**
  * Classifies embedded-agent run results for model fallback decisions.
  */
+import { isGenericExternalRunFailureText } from "../../auto-reply/reply/agent-runner-failure-copy.js";
 import { isSilentReplyPayloadText } from "../../auto-reply/tokens.js";
 import { classifyFailoverReason } from "../embedded-agent-helpers/errors.js";
 import type { FailoverReason } from "../embedded-agent-helpers/types.js";
@@ -122,6 +123,16 @@ function classifyBusinessDenialErrorPayloadReason(
   }
 }
 
+/** True when all non-reasoning, non-error text payloads match the generic external run failure text. */
+function haveAllTextPayloadsGenericFailureText(result: EmbeddedAgentRunResult): boolean {
+  const textPayloads = (result.payloads ?? []).filter(
+    (p): p is { text: string } => !p.isReasoning && !p.isError && typeof p.text === "string",
+  );
+  return (
+    textPayloads.length > 0 && textPayloads.every((p) => isGenericExternalRunFailureText(p.text))
+  );
+}
+
 /** Returns a fallback classification when an embedded run failed without user-visible output. */
 export function classifyEmbeddedAgentRunResultForModelFallback(params: {
   provider: string;
@@ -136,13 +147,24 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
   if (
     params.result.meta.aborted ||
     params.hasDirectlySentBlockReply === true ||
-    params.hasBlockReplyPipelineOutput === true ||
-    hasVisibleAgentPayload(params.result, {
-      includeErrorPayloads: false,
-      includeReasoningPayloads: false,
-    })
+    params.hasBlockReplyPipelineOutput === true
   ) {
     return null;
+  }
+  // Pre-check: when all non-reasoning, non-error text payloads are the generic
+  // external run failure text, bypass hasVisibleAgentPayload. Some subprocess
+  // runners (e.g. claude-cli) deliver their error text as a regular text
+  // payload (isError: false), which hasVisibleAgentPayload would consider
+  // visible and incorrectly block fallback to the next provider.
+  if (!haveAllTextPayloadsGenericFailureText(params.result)) {
+    if (
+      hasVisibleAgentPayload(params.result, {
+        includeErrorPayloads: false,
+        includeReasoningPayloads: false,
+      })
+    ) {
+      return null;
+    }
   }
   const incompleteTurn = params.result.meta.error?.kind === "incomplete_turn";
   if (incompleteTurn && params.result.meta.error?.fallbackSafe !== true) {
@@ -206,7 +228,11 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
   if (payloads.length === 0 && hasDeliberateSilentTerminalReply(params.result)) {
     return null;
   }
-  if (payloads.length === 0) {
+  // Treat payloads that consist solely of the generic external run failure text
+  // as empty for fallback classification. The text was already used to bypass
+  // hasVisibleAgentPayload above; this ensures the payload-analysis section
+  // reaches the empty_result branch rather than returning null.
+  if (haveAllTextPayloadsGenericFailureText(params.result) || payloads.length === 0) {
     return {
       message: `${params.provider}/${params.model} ended without a visible assistant reply`,
       reason: "format",


### PR DESCRIPTION
## What Problem This Solves

When claude-cli/claude-sonnet-4-6 is the primary model and the underlying Claude Code subscription has exhausted its credits, the configured fallback chain is never attempted. The CLI's error text is delivered to the user as the final assistant response, silently bypassing all configured fallback providers.

The root cause is in `classifyEmbeddedAgentRunResultForModelFallback`: the function's `hasVisibleAgentPayload` check sees the generic failure text as a visible payload (because `isError: false` on the claude-cli subprocess output) and returns `null` — preventing fallback classification from ever running.

## Changes Made

- Added `haveAllTextPayloadsGenericFailureText()` helper in `result-fallback-classifier.ts` that checks whether all non-error, non-reasoning text payloads match `GENERIC_EXTERNAL_RUN_FAILURE_TEXT`
- Modified the `hasVisibleAgentPayload` guard to bypass it when all visible text payloads are the generic failure text, allowing the classifier to reach the `empty_result` branch
- Added 3 test cases covering: sole generic failure text triggers fallback, mixed payloads preserve existing behavior, and business-denial error payloads are not suppressed

## Evidence

- **Behavior addressed:** claude-cli out-of-credit errors now trigger model fallback instead of being delivered as final responses
- **Environment tested:** local OpenClaw checkout on macOS, branch `fix/claude-cli-fallback-generic-failure-text`, commit `87618735`
- **Steps run after the patch:** build + targeted test suite for result-fallback-classifier
- **Evidence after fix:**

```
$ node scripts/verification run src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
 ✓  unit-fast  src/agents/embedded-agent-runner/result-fallback-classifier.test.ts (14 tests) 9ms
 Test Files  1 passed (1)
      Tests  14 passed (14)

$ grep -n 'haveAllTextPayloadsGenericFailureText\|isGenericExternalRunFailureText' src/agents/embedded-agent-runner/result-fallback-classifier.ts
5:import { isGenericExternalRunFailureText } from "../../auto-reply/reply/agent-runner-failure-copy.js";
127:/** True when all non-reasoning, non-error text payloads match the generic external run failure text. */
128:function haveAllTextPayloadsGenericFailureText(result: EmbeddedAgentRunResult): boolean {
133:    textPayloads.length > 0 && textPayloads.every((p) => isGenericExternalRunFailureText(p.text))
158:  if (!haveAllTextPayloadsGenericFailureText(params.result)) {
236:  if (haveAllTextPayloadsGenericFailureText(params.result) || payloads.length === 0) {

$ node -e "const fs=require('fs'); const c=fs.readFileSync('dist/result-fallback-classifier-CVEt40v7.js','utf8'); console.log('has haveAllTextPayloadsGenericFailureText:', c.includes('haveAllTextPayloadsGenericFailureText')); console.log('has isGenericExternalRunFailureText:', c.includes('isGenericExternalRunFailureText'));"
has haveAllTextPayloadsGenericFailureText: true
has isGenericExternalRunFailureText: true
```

- **Observed result after fix:** All 14 classifier pass (11 existing + 3 new). Build succeeds. The dist bundle contains the new helper function and the imported `isGenericExternalRunFailureText` check.
- **What was not tested:** Live claude-cli credit exhaustion scenario (requires actual Claude Code subscription with `cachedExtraUsageDisabledReason: "out_of_credits"` in ~/.claude.json).

- [x] AI-assisted (Hermes Agent)

## Real behavior proof

- **Behavior addressed:** claude-cli out-of-credit errors now trigger model fallback instead of being delivered as final responses
- **Environment tested:** local OpenClaw checkout on macOS, branch `fix/claude-cli-fallback-generic-failure-text`, commit `87618735`
- **Steps run after the patch:** build + targeted test suite for result-fallback-classifier
- **Evidence after fix:**

```
$ node scripts/verification run src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
 ✓  unit-fast  src/agents/embedded-agent-runner/result-fallback-classifier.test.ts (14 tests) 9ms
 Test Files  1 passed (1)
      Tests  14 passed (14)

$ grep -n 'haveAllTextPayloadsGenericFailureText\|isGenericExternalRunFailureText' src/agents/embedded-agent-runner/result-fallback-classifier.ts
5:import { isGenericExternalRunFailureText } from "../../auto-reply/reply/agent-runner-failure-copy.js";
127:/** True when all non-reasoning, non-error text payloads match the generic external run failure text. */
128:function haveAllTextPayloadsGenericFailureText(result: EmbeddedAgentRunResult): boolean {
133:    textPayloads.length > 0 && textPayloads.every((p) => isGenericExternalRunFailureText(p.text))
158:  if (!haveAllTextPayloadsGenericFailureText(params.result)) {
236:  if (haveAllTextPayloadsGenericFailureText(params.result) || payloads.length === 0) {

$ node -e "const fs=require('fs'); const c=fs.readFileSync('dist/result-fallback-classifier-CVEt40v7.js','utf8'); console.log('has haveAllTextPayloadsGenericFailureText:', c.includes('haveAllTextPayloadsGenericFailureText')); console.log('has isGenericExternalRunFailureText:', c.includes('isGenericExternalRunFailureText'));"
has haveAllTextPayloadsGenericFailureText: true
has isGenericExternalRunFailureText: true
```

- **Observed result after fix:** All 14 classifier pass (11 existing + 3 new). Build succeeds. The dist bundle contains the new helper function and the imported `isGenericExternalRunFailureText` check.
- **What was not tested:** Live claude-cli credit exhaustion scenario (requires actual Claude Code subscription with `cachedExtraUsageDisabledReason: "out_of_credits"` in ~/.claude.json).