### PR TITLE
fix(agents): guard restart-recovery timing heuristic to stale-gen runs only

### DIFF
--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -410,6 +410,72 @@ describe("main-session-restart-recovery", () => {
     expect(store["agent:main:main"]?.restartRecoveryRuns).toBeUndefined();
   });
 
+  it("does not reopen a completed session matched by current-generation abort controller", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: 3_000,
+        status: "done",
+      },
+    });
+
+    const result = await markRestartAbortedMainSessions({
+      stateDir: tmpDir,
+      sessionKeys: ["agent:main:main"],
+      sessionIds: ["main-session"],
+      activeRuns: [
+        {
+          runId: "maintenance-expired-run",
+          lifecycleGeneration,
+          sessionKey: "agent:main:main",
+          sessionId: "main-session",
+          observedAt: 5_000,
+        },
+      ],
+      isActiveRun: () => true,
+    });
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(result).toEqual({ marked: 0, skipped: 0 });
+    expect(store["agent:main:main"]?.status).toBe("done");
+    expect(store["agent:main:main"]?.restartRecoveryRuns).toBeUndefined();
+  });
+
+  it("still reopens a running session matched by current-generation abort controller", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: 3_000,
+        status: "running",
+      },
+    });
+
+    const result = await markRestartAbortedMainSessions({
+      stateDir: tmpDir,
+      sessionKeys: ["agent:main:main"],
+      sessionIds: ["main-session"],
+      activeRuns: [
+        {
+          runId: "maintenance-expired-run",
+          lifecycleGeneration,
+          sessionKey: "agent:main:main",
+          sessionId: "main-session",
+          observedAt: 5_000,
+        },
+      ],
+      isActiveRun: () => true,
+    });
+
+    expect(result).toEqual({ marked: 1, skipped: 0 });
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(store["agent:main:main"]?.status).toBe("running");
+    expect(store["agent:main:main"]?.abortedLastRun).toBe(true);
+  });
+
   it("preserves current-generation markers across repeated restart marking", async () => {
     const sessionsDir = await makeSessionsDir();
     const lifecycleGeneration = getAgentEventLifecycleGeneration();

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -230,7 +230,9 @@ export async function markRestartAbortedMainSessions(params: {
               (entry.status === "running" ||
                 run.observedAt === undefined ||
                 normalizeFiniteTimestamp(entry.updatedAt) === undefined ||
-                entry.updatedAt < run.observedAt) &&
+                // Timing heuristic only valid for stale-gen (pre-restart) runs; same-gen runs must not reopen completed sessions.
+                (entry.updatedAt < run.observedAt &&
+                  run.lifecycleGeneration !== currentLifecycleGeneration)) &&
               params.isActiveRun?.(run) !== false,
           );
           if (


### PR DESCRIPTION
### Summary

- **Problem**: A Telegram main session that completed normally (`status: "success"`, idle gap 8h54min < 12h configured threshold) was silently reset on the next user message. The old transcript was archived to `.jsonl.reset.<timestamp>` and a new empty session created. The new session carried `restartRecoveryRuns` with `lifecycleGeneration` matching the **live** gateway — confirming restart-recovery machinery fired for a legitimately finished session.
- **Root Cause**: `markRestartAbortedMainSessions` applies a timing heuristic `entry.updatedAt < run.observedAt` intended to detect sessions that were running when a pre-restart abort event was observed. This is correct for **stale-generation** (pre-restart) runs where `observedAt` is the pre-shutdown observation time. However, the condition also evaluates to `true` for **current-generation** abort controllers that expire later during maintenance sweeps or shutdown drain, because `updatedAt` (session completion time, e.g. 23:26) is always earlier than `observedAt` (sweep time, e.g. 08:20 next morning). A current-gen run has `lifecycleGeneration === currentLifecycleGeneration`, meaning no restart occurred — the session finished cleanly and must not be reopened.
- **Fix**: Guard the timing heuristic with `run.lifecycleGeneration !== currentLifecycleGeneration`. Stale-gen runs (pre-restart captures) keep the timing check and continue to trigger recovery correctly. Current-gen runs with `observedAt > updatedAt` no longer match completed sessions; they still match sessions with `status === "running"` via condition 1, which is the correct gate for in-flight sessions.
- **What changed**: `src/agents/main-session-restart-recovery.ts` — narrowed timing condition in `matchingActiveRuns` filter; `src/agents/main-session-restart-recovery.test.ts` — two new tests covering the bug scenario and a regression guard for the positive (running-session) path.
- **What did NOT change (scope boundary)**: No change to session store schema, `recoverStore`, `recoverRestartAbortedMainSessions`, any channel/gateway/config surface, or the behavior of stale-gen (pre-restart) recovery. All 33 pre-existing tests continue to pass.

### Reproduction

1. Configure OpenClaw with `session.reset.idleMinutes=720` (12h idle reset, no daily reset override).
2. Use a Telegram direct session actively.
3. Let the session end normally at ~23:26 local time (`status: "success"`, `aborted: false`, `timedOut: false`).
4. Leave the gateway running overnight without restart. Gateway uptime ≥ 2d at message time.
5. Send a new message the following morning (~08:20, 8h54min elapsed — below the 12h idle threshold).
6. **Before this fix**: Session forcibly reset. Old transcript renamed to `<id>.jsonl.reset.<ts>`. New session has `restartRecoveryRuns: [{runId, lifecycleGeneration: <current_gw_gen>}]`. Context lost.
7. **After this fix**: `markRestartAbortedMainSessions` returns `{ marked: 0, skipped: 0 }` for the completed entry. Session reuse continues. No reset. No context loss.

### Risk / Mitigation

- **Risk**: Completed session whose `status` was not yet written as `"done"` at sweep time. **Mitigation**: `entry.status === "running"` (condition 1 in the OR chain) still matches unconditionally; this case is fully covered regardless of the timing guard.
- **Risk**: Pre-restart (stale-gen) runs losing recovery coverage. **Mitigation**: stale-gen runs satisfy `run.lifecycleGeneration !== currentLifecycleGeneration` = `true`, so the timing heuristic is unchanged for them. Guarded by existing tests including `"marks queued abort-registry runs before lifecycle start changes session status"`.

### Real-behavior proof

**Behavior addressed**: Completed session (`status: "done"`) with a current-generation abort controller observedAt > updatedAt must NOT be marked for restart recovery.

**Real environment tested**: Linux x86_64, Node v22.19.0, OpenClaw checkout branch `fix/95443-session-restart-recovery-current-gen`.

**Exact steps or command run after this patch**:

```
node scripts/run-vitest.mjs src/agents/main-session-restart-recovery.test.ts
```

**Evidence after fix (real terminal output)**:

```
Test Files  1 passed (1)
     Tests  35 passed (35)
  Duration  7.89s (transform 3.86s, setup 546ms, import 6.60s, tests 477ms)
```

**Observed result after fix**:
- New test `"does not reopen a completed session matched by current-generation abort controller"`: `{ marked: 0, skipped: 0 }`, `status` stays `"done"`, `restartRecoveryRuns` stays `undefined`. Fix confirmed.
- New test `"still reopens a running session matched by current-generation abort controller"`: `{ marked: 1, skipped: 0 }`, `abortedLastRun: true`. Positive path unaffected.
- All 33 pre-existing tests pass without modification.

**What was not tested**: E2E with a live Telegram session (requires real environment). The fix targets the `markRestartAbortedMainSessions` boundary where the incorrect marking originates, and is fully covered by unit tests at that boundary.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Session state

### Linked Issue/PR

Fixes #95443
