### PR TITLE
fix #89466: [Bug]: Control UI chat input text not cleared after sending

### DIFF
--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -252,6 +252,57 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("keeps the composer clear when a stale native input replay arrives after send", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        {
+          content: [{ text: "Ready for stale replay check.", type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.getByText("Ready for stale replay check.").waitFor({ timeout: 10_000 });
+
+      const prompt = "submitted message";
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill(prompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+      await gateway.waitForRequest("chat.send");
+      expect(await composer.inputValue()).toBe("");
+
+      const afterReplay = await composer.evaluate((element, submitted) => {
+        const textarea = element as HTMLTextAreaElement;
+        textarea.value = submitted;
+        textarea.dispatchEvent(
+          new InputEvent("input", {
+            bubbles: true,
+            data: submitted,
+            inputType: "insertText",
+          }),
+        );
+        return textarea.value;
+      }, prompt);
+
+      expect(afterReplay).toBe("");
+      expect(await composer.inputValue()).toBe("");
+
+      await composer.pressSequentially(prompt);
+      expect(await composer.inputValue()).toBe(prompt);
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("copies a code block over a non-secure context via the execCommand fallback", async () => {
     const context = await newBrowserContext({
       locale: "en-US",

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -2009,6 +2009,59 @@ describe("chat slash menu accessibility", () => {
     expect(onDraftChange).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a new same-session draft when a delayed stale replay arrives", () => {
+    let draft = "";
+    const container = document.createElement("div");
+    const onDraftChange = vi.fn((next: string) => {
+      draft = next;
+    });
+    const onSend = vi.fn(() => {
+      draft = "";
+    });
+    const renderWithDraft = () => {
+      render(
+        renderChat(createChatProps({ draft, getDraft: () => draft, onDraftChange, onSend })),
+        container,
+      );
+    };
+
+    renderWithDraft();
+    inputDraft(container, "submitted message");
+    container.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    expect(textarea?.value).toBe("");
+
+    textarea!.dispatchEvent(
+      new InputEvent("beforeinput", {
+        bubbles: true,
+        data: "new draft",
+        inputType: "insertText",
+      }),
+    );
+    textarea!.value = "new draft";
+    textarea!.dispatchEvent(
+      new InputEvent("input", {
+        bubbles: true,
+        data: "new draft",
+        inputType: "insertText",
+      }),
+    );
+    expect(textarea?.value).toBe("new draft");
+
+    textarea!.value = "submitted message";
+    textarea!.dispatchEvent(
+      new InputEvent("input", {
+        bubbles: true,
+        data: "submitted message",
+        inputType: "insertText",
+      }),
+    );
+
+    expect(textarea?.value).toBe("new draft");
+    expect(onDraftChange).toHaveBeenCalledTimes(1);
+  });
+
   it("does not apply a stale submitted draft replay to another session", () => {
     const drafts: Record<string, string> = {
       "stale-replay-a": "",

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -2009,6 +2009,56 @@ describe("chat slash menu accessibility", () => {
     expect(onDraftChange).toHaveBeenCalledTimes(1);
   });
 
+  it("does not apply a stale submitted draft replay to another session", () => {
+    const drafts: Record<string, string> = {
+      "stale-replay-a": "",
+      "stale-replay-b": "",
+    };
+    const onDraftChange = vi.fn((sessionKey: string, next: string) => {
+      drafts[sessionKey] = next;
+    });
+    const container = document.createElement("div");
+    const renderSession = (sessionKey: string) => {
+      render(
+        renderChat(
+          createChatProps({
+            currentAgentId: "stale-replay-agent",
+            draft: drafts[sessionKey],
+            getDraft: () => drafts[sessionKey],
+            onDraftChange: (next) => onDraftChange(sessionKey, next),
+            onSend: () => {
+              drafts[sessionKey] = "";
+            },
+            sessionKey,
+          }),
+        ),
+        container,
+      );
+    };
+
+    renderSession("stale-replay-a");
+    inputDraft(container, "submitted message");
+    container.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("");
+
+    renderSession("stale-replay-b");
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    expect(textarea?.value).toBe("");
+
+    textarea!.value = "submitted message";
+    textarea!.dispatchEvent(
+      new InputEvent("input", {
+        bubbles: true,
+        data: "submitted message",
+        inputType: "insertText",
+      }),
+    );
+
+    expect(textarea?.value).toBe("");
+    expect(drafts["stale-replay-b"]).toBe("");
+    expect(onDraftChange).toHaveBeenCalledTimes(1);
+  });
+
   it("commits local draft input before Enter sends", () => {
     const onDraftChange = vi.fn();
     const onSend = vi.fn();

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -2059,6 +2059,73 @@ describe("chat slash menu accessibility", () => {
     expect(onDraftChange).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps an intervening session draft when a delayed stale replay arrives", () => {
+    const drafts: Record<string, string> = {
+      "delayed-replay-a": "",
+      "delayed-replay-b": "",
+    };
+    const onDraftChange = vi.fn((sessionKey: string, next: string) => {
+      drafts[sessionKey] = next;
+    });
+    const container = document.createElement("div");
+    const renderSession = (sessionKey: string) => {
+      render(
+        renderChat(
+          createChatProps({
+            currentAgentId: "delayed-replay-agent",
+            draft: drafts[sessionKey],
+            getDraft: () => drafts[sessionKey],
+            onDraftChange: (next) => onDraftChange(sessionKey, next),
+            onSend: () => {
+              drafts[sessionKey] = "";
+            },
+            sessionKey,
+          }),
+        ),
+        container,
+      );
+    };
+
+    renderSession("delayed-replay-a");
+    inputDraft(container, "submitted message");
+    container.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("");
+
+    renderSession("delayed-replay-b");
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    expect(textarea?.value).toBe("");
+
+    textarea!.dispatchEvent(
+      new InputEvent("beforeinput", {
+        bubbles: true,
+        data: "session b draft",
+        inputType: "insertText",
+      }),
+    );
+    textarea!.value = "session b draft";
+    textarea!.dispatchEvent(
+      new InputEvent("input", {
+        bubbles: true,
+        data: "session b draft",
+        inputType: "insertText",
+      }),
+    );
+    expect(textarea?.value).toBe("session b draft");
+
+    textarea!.value = "submitted message";
+    textarea!.dispatchEvent(
+      new InputEvent("input", {
+        bubbles: true,
+        data: "submitted message",
+        inputType: "insertText",
+      }),
+    );
+
+    expect(textarea?.value).toBe("session b draft");
+    expect(drafts["delayed-replay-b"]).toBe("");
+    expect(onDraftChange).toHaveBeenCalledTimes(1);
+  });
+
   it("commits local draft input before Enter sends", () => {
     const onDraftChange = vi.fn();
     const onSend = vi.fn();

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1973,6 +1973,42 @@ describe("chat slash menu accessibility", () => {
     expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("");
   });
 
+  it("ignores a stale native InputEvent replay after send clears the host draft", () => {
+    let draft = "";
+    const container = document.createElement("div");
+    const onDraftChange = vi.fn((next: string) => {
+      draft = next;
+    });
+    const onSend = vi.fn(() => {
+      draft = "";
+    });
+    const renderWithDraft = () => {
+      render(
+        renderChat(createChatProps({ draft, getDraft: () => draft, onDraftChange, onSend })),
+        container,
+      );
+    };
+
+    renderWithDraft();
+    inputDraft(container, "submitted message");
+    container.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    expect(textarea?.value).toBe("");
+
+    textarea!.value = "submitted message";
+    textarea!.dispatchEvent(
+      new InputEvent("input", {
+        bubbles: true,
+        data: "submitted message",
+        inputType: "insertText",
+      }),
+    );
+
+    expect(textarea?.value).toBe("");
+    expect(onDraftChange).toHaveBeenCalledTimes(1);
+  });
+
   it("commits local draft input before Enter sends", () => {
     const onDraftChange = vi.fn();
     const onSend = vi.fn();

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -616,8 +616,8 @@ function markComposerInputIntent(): void {
   vs.composerInputVersion += 1;
 }
 
-function clearPendingClearedSubmittedDraft(key: string): void {
-  if (vs.pendingClearedSubmittedDraft?.key === key) {
+function clearPendingClearedSubmittedDraft(key?: string): void {
+  if (!key || vs.pendingClearedSubmittedDraft?.key === key) {
     vs.pendingClearedSubmittedDraft = null;
   }
 }
@@ -633,12 +633,12 @@ function suppressStaleSubmittedDraftReplay(
   draftMirror: ComposerDraftMirror,
 ): boolean {
   const pending = vs.pendingClearedSubmittedDraft;
-  if (!pending || pending.key !== composerDraftMirrorKey(props)) {
+  if (!pending) {
     return false;
   }
   const hostDraft = props.getDraft?.();
   if (
-    hostDraft !== "" ||
+    typeof hostDraft !== "string" ||
     target.value !== pending.value ||
     pending.inputVersion !== vs.composerInputVersion ||
     isExplicitComposerInsertion(event)
@@ -2499,7 +2499,7 @@ export function renderChat(props: ChatProps) {
     if (suppressStaleSubmittedDraftReplay(props, target, e, draftMirror)) {
       return;
     }
-    clearPendingClearedSubmittedDraft(composerDraftMirrorKey(props));
+    clearPendingClearedSubmittedDraft();
     syncComposerValue(target);
   };
   const handleCompositionEnd = (e: CompositionEvent) => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -525,7 +525,8 @@ interface ChatEphemeralState {
   searchQuery: string;
   pinnedExpanded: boolean;
   composerComposing: boolean;
-  composerInputVersion: number;
+  composerInputIntentKey: string | null;
+  composerInputVersions: Map<string, number>;
   pendingClearedSubmittedDraft: PendingClearedSubmittedDraft | null;
   historyRenderSessionKey: string | null;
   historyRenderMessagesRef: unknown[] | null;
@@ -554,7 +555,8 @@ function createChatEphemeralState(): ChatEphemeralState {
     searchQuery: "",
     pinnedExpanded: false,
     composerComposing: false,
-    composerInputVersion: 0,
+    composerInputIntentKey: null,
+    composerInputVersions: new Map(),
     pendingClearedSubmittedDraft: null,
     historyRenderSessionKey: null,
     historyRenderMessagesRef: null,
@@ -612,12 +614,25 @@ function commitComposerDraft(props: ChatProps, value: string): void {
   props.onDraftChange(value);
 }
 
-function markComposerInputIntent(): void {
-  vs.composerInputVersion += 1;
+function currentComposerInputVersion(key: string): number {
+  return vs.composerInputVersions.get(key) ?? 0;
 }
 
-function clearPendingClearedSubmittedDraft(key?: string): void {
-  if (!key || vs.pendingClearedSubmittedDraft?.key === key) {
+function markComposerInputIntent(key: string): void {
+  vs.composerInputVersions.set(key, currentComposerInputVersion(key) + 1);
+  vs.composerInputIntentKey = key;
+}
+
+function consumeComposerInputIntent(key: string): boolean {
+  if (vs.composerInputIntentKey !== key) {
+    return false;
+  }
+  vs.composerInputIntentKey = null;
+  return true;
+}
+
+function clearPendingClearedSubmittedDraft(key: string): void {
+  if (vs.pendingClearedSubmittedDraft?.key === key) {
     vs.pendingClearedSubmittedDraft = null;
   }
 }
@@ -627,28 +642,25 @@ function isExplicitComposerInsertion(event: InputEvent): boolean {
 }
 
 function suppressStaleSubmittedDraftReplay(
-  props: ChatProps,
   target: HTMLTextAreaElement,
   event: InputEvent,
   draftMirror: ComposerDraftMirror,
+  hasInputIntent: boolean,
 ): boolean {
   const pending = vs.pendingClearedSubmittedDraft;
   if (!pending) {
     return false;
   }
-  const hostDraft = props.getDraft?.();
   if (
-    typeof hostDraft !== "string" ||
     target.value !== pending.value ||
-    pending.inputVersion !== vs.composerInputVersion ||
+    pending.inputVersion !== currentComposerInputVersion(pending.key) ||
+    hasInputIntent ||
     isExplicitComposerInsertion(event)
   ) {
     return false;
   }
 
-  target.value = hostDraft;
-  draftMirror.hostDraft = hostDraft;
-  draftMirror.value = hostDraft;
+  target.value = draftMirror.value;
   adjustTextareaHeight(target);
   return true;
 }
@@ -2326,7 +2338,7 @@ export function renderChat(props: ChatProps) {
       vs.pendingClearedSubmittedDraft = {
         key: mirrorKey,
         value: submittedDraft,
-        inputVersion: vs.composerInputVersion,
+        inputVersion: currentComposerInputVersion(mirrorKey),
       };
     } else {
       clearPendingClearedSubmittedDraft(mirrorKey);
@@ -2483,11 +2495,13 @@ export function renderChat(props: ChatProps) {
   };
   const handleBeforeInput = (e: InputEvent) => {
     if (!vs.composerComposing && !e.isComposing) {
-      markComposerInputIntent();
+      markComposerInputIntent(composerDraftMirrorKey(props));
     }
   };
   const handleInput = (e: InputEvent) => {
     const target = e.target as HTMLTextAreaElement;
+    const mirrorKey = composerDraftMirrorKey(props);
+    const hasInputIntent = consumeComposerInputIntent(mirrorKey);
     if (vs.composerComposing || e.isComposing) {
       // Skip adjustTextareaHeight during IME composition — each pinyin
       // keystroke fires `input` and the height read/write forces a
@@ -2496,10 +2510,10 @@ export function renderChat(props: ChatProps) {
       draftMirror.value = target.value;
       return;
     }
-    if (suppressStaleSubmittedDraftReplay(props, target, e, draftMirror)) {
+    if (suppressStaleSubmittedDraftReplay(target, e, draftMirror, hasInputIntent)) {
       return;
     }
-    clearPendingClearedSubmittedDraft();
+    clearPendingClearedSubmittedDraft(mirrorKey);
     syncComposerValue(target);
   };
   const handleCompositionEnd = (e: CompositionEvent) => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -509,7 +509,6 @@ function renderRealtimeTalkConversation(props: ChatProps) {
 type PendingClearedSubmittedDraft = {
   key: string;
   value: string;
-  inputVersion: number;
 };
 
 interface ChatEphemeralState {
@@ -526,7 +525,6 @@ interface ChatEphemeralState {
   pinnedExpanded: boolean;
   composerComposing: boolean;
   composerInputIntentKey: string | null;
-  composerInputVersions: Map<string, number>;
   pendingClearedSubmittedDraft: PendingClearedSubmittedDraft | null;
   historyRenderSessionKey: string | null;
   historyRenderMessagesRef: unknown[] | null;
@@ -556,7 +554,6 @@ function createChatEphemeralState(): ChatEphemeralState {
     pinnedExpanded: false,
     composerComposing: false,
     composerInputIntentKey: null,
-    composerInputVersions: new Map(),
     pendingClearedSubmittedDraft: null,
     historyRenderSessionKey: null,
     historyRenderMessagesRef: null,
@@ -614,12 +611,7 @@ function commitComposerDraft(props: ChatProps, value: string): void {
   props.onDraftChange(value);
 }
 
-function currentComposerInputVersion(key: string): number {
-  return vs.composerInputVersions.get(key) ?? 0;
-}
-
 function markComposerInputIntent(key: string): void {
-  vs.composerInputVersions.set(key, currentComposerInputVersion(key) + 1);
   vs.composerInputIntentKey = key;
 }
 
@@ -651,12 +643,7 @@ function suppressStaleSubmittedDraftReplay(
   if (!pending) {
     return false;
   }
-  if (
-    target.value !== pending.value ||
-    pending.inputVersion !== currentComposerInputVersion(pending.key) ||
-    hasInputIntent ||
-    isExplicitComposerInsertion(event)
-  ) {
+  if (target.value !== pending.value || hasInputIntent || isExplicitComposerInsertion(event)) {
     return false;
   }
 
@@ -2338,7 +2325,6 @@ export function renderChat(props: ChatProps) {
       vs.pendingClearedSubmittedDraft = {
         key: mirrorKey,
         value: submittedDraft,
-        inputVersion: currentComposerInputVersion(mirrorKey),
       };
     } else {
       clearPendingClearedSubmittedDraft(mirrorKey);
@@ -2513,7 +2499,6 @@ export function renderChat(props: ChatProps) {
     if (suppressStaleSubmittedDraftReplay(target, e, draftMirror, hasInputIntent)) {
       return;
     }
-    clearPendingClearedSubmittedDraft(mirrorKey);
     syncComposerValue(target);
   };
   const handleCompositionEnd = (e: CompositionEvent) => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -33,13 +33,13 @@ import { CHAT_HISTORY_RENDER_LIMIT } from "../chat/history-limits.ts";
 import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "../chat/input-history.ts";
 import { PinnedMessages } from "../chat/pinned-messages.ts";
 import { getPinnedMessageSummary } from "../chat/pinned-summary.ts";
-import type { RealtimeTalkConversationEntry } from "../chat/realtime-talk-conversation.ts";
 import {
   REALTIME_TALK_FALLBACK_PROVIDERS,
   listSelectableRealtimeTalkProviders,
   resolveControlUiRealtimeTalkProviderTransports,
   type RealtimeTalkCatalogProvider,
 } from "../chat/realtime-talk-catalog.ts";
+import type { RealtimeTalkConversationEntry } from "../chat/realtime-talk-conversation.ts";
 import type { RealtimeTalkStatus } from "../chat/realtime-talk.ts";
 import { renderChatRunControls } from "../chat/run-controls.ts";
 import type { ChatRunUiStatus } from "../chat/run-lifecycle.ts";
@@ -506,6 +506,12 @@ function renderRealtimeTalkConversation(props: ChatProps) {
   `;
 }
 
+type PendingClearedSubmittedDraft = {
+  key: string;
+  value: string;
+  inputVersion: number;
+};
+
 interface ChatEphemeralState {
   slashMenuOpen: boolean;
   slashMenuItems: SlashCommandDef[];
@@ -519,6 +525,8 @@ interface ChatEphemeralState {
   searchQuery: string;
   pinnedExpanded: boolean;
   composerComposing: boolean;
+  composerInputVersion: number;
+  pendingClearedSubmittedDraft: PendingClearedSubmittedDraft | null;
   historyRenderSessionKey: string | null;
   historyRenderMessagesRef: unknown[] | null;
   historyRenderMessageCount: number;
@@ -546,6 +554,8 @@ function createChatEphemeralState(): ChatEphemeralState {
     searchQuery: "",
     pinnedExpanded: false,
     composerComposing: false,
+    composerInputVersion: 0,
+    pendingClearedSubmittedDraft: null,
     historyRenderSessionKey: null,
     historyRenderMessagesRef: null,
     historyRenderMessageCount: 0,
@@ -600,6 +610,47 @@ function commitComposerDraft(props: ChatProps, value: string): void {
   }
   mirror.hostDraft = value;
   props.onDraftChange(value);
+}
+
+function markComposerInputIntent(): void {
+  vs.composerInputVersion += 1;
+}
+
+function clearPendingClearedSubmittedDraft(key: string): void {
+  if (vs.pendingClearedSubmittedDraft?.key === key) {
+    vs.pendingClearedSubmittedDraft = null;
+  }
+}
+
+function isExplicitComposerInsertion(event: InputEvent): boolean {
+  return event.inputType === "insertFromPaste" || event.inputType === "insertFromDrop";
+}
+
+function suppressStaleSubmittedDraftReplay(
+  props: ChatProps,
+  target: HTMLTextAreaElement,
+  event: InputEvent,
+  draftMirror: ComposerDraftMirror,
+): boolean {
+  const pending = vs.pendingClearedSubmittedDraft;
+  if (!pending || pending.key !== composerDraftMirrorKey(props)) {
+    return false;
+  }
+  const hostDraft = props.getDraft?.();
+  if (
+    hostDraft !== "" ||
+    target.value !== pending.value ||
+    pending.inputVersion !== vs.composerInputVersion ||
+    isExplicitComposerInsertion(event)
+  ) {
+    return false;
+  }
+
+  target.value = hostDraft;
+  draftMirror.hostDraft = hostDraft;
+  draftMirror.value = hostDraft;
+  adjustTextareaHeight(target);
+  return true;
 }
 
 function sameChatItemsInput(previous: BuildChatItemsProps, next: BuildChatItemsProps): boolean {
@@ -2263,10 +2314,23 @@ export function renderChat(props: ChatProps) {
     if (typeof hostDraft !== "string") {
       return;
     }
+    const mirrorKey = composerDraftMirrorKey(props);
+    const submittedDraft = draftMirror.value;
+    const clearedSubmittedDraft =
+      hostDraft === "" && submittedDraft !== "" && target?.value === submittedDraft;
     // Sends can clear the host draft synchronously before Lit rerenders; keep
     // the local mirror aligned so the submitted text does not stay editable.
     draftMirror.hostDraft = hostDraft;
     draftMirror.value = hostDraft;
+    if (clearedSubmittedDraft) {
+      vs.pendingClearedSubmittedDraft = {
+        key: mirrorKey,
+        value: submittedDraft,
+        inputVersion: vs.composerInputVersion,
+      };
+    } else {
+      clearPendingClearedSubmittedDraft(mirrorKey);
+    }
     if (target && target.value !== hostDraft) {
       target.value = hostDraft;
       adjustTextareaHeight(target);
@@ -2417,6 +2481,11 @@ export function renderChat(props: ChatProps) {
     }
     updateSlashMenu(target.value, requestUpdate, props, {}, () => target.value);
   };
+  const handleBeforeInput = (e: InputEvent) => {
+    if (!vs.composerComposing && !e.isComposing) {
+      markComposerInputIntent();
+    }
+  };
   const handleInput = (e: InputEvent) => {
     const target = e.target as HTMLTextAreaElement;
     if (vs.composerComposing || e.isComposing) {
@@ -2427,6 +2496,10 @@ export function renderChat(props: ChatProps) {
       draftMirror.value = target.value;
       return;
     }
+    if (suppressStaleSubmittedDraftReplay(props, target, e, draftMirror)) {
+      return;
+    }
+    clearPendingClearedSubmittedDraft(composerDraftMirrorKey(props));
     syncComposerValue(target);
   };
   const handleCompositionEnd = (e: CompositionEvent) => {
@@ -2538,6 +2611,7 @@ export function renderChat(props: ChatProps) {
           aria-activedescendant=${ifDefined(activeSlashMenuOptionId ?? undefined)}
           aria-describedby=${SLASH_MENU_ACTIVE_ANNOUNCEMENT_ID}
           @keydown=${handleKeyDown}
+          @beforeinput=${handleBeforeInput}
           @input=${handleInput}
           @compositionstart=${() => {
             vs.composerComposing = true;


### PR DESCRIPTION
## Summary

What problem does this PR solve?

Fixes an issue where Control UI chat users could send a message and then see the composer repopulate with the text they just sent when the browser delivered a delayed native input replay after the send cleared the draft.

- Fix classification: Root-cause fix.
- Root cause: the composer treated every non-composition `input` event as current user draft state, so an input-only replay of the just-submitted text could become the local draft after the host draft had already been cleared.
- Why this is root-cause fix: the source invariant is that a send-cleared submitted draft must not be accepted again unless the current input event has user intent. The patch records the cleared submitted draft, suppresses later input-only replay of that same text, and restores the current composer mirror instead of masking the symptom at send time only.

Why does this matter now?

Users can send a prompt, switch sessions, or immediately start typing the next prompt without the previous sent prompt reappearing in the composer or replacing the new draft.

What is the intended outcome?

The Control UI composer stays empty after send unless the user intentionally types or pastes new content, including if that content matches the previously sent text.

What is intentionally out of scope?

This only changes Control UI composer draft state handling for stale native input replay. It does not change chat transport, message persistence, session storage, gateway APIs, config, schema, migrations, auth, secrets, model routing, or provider behavior.

What does success look like?

After a successful send, delayed browser input replay of the submitted text is ignored, while real `beforeinput` and paste/drop insertions still update the composer normally.

What should reviewers focus on?

Review the session-state boundary around `pendingClearedSubmittedDraft`: it is intentionally scoped to the local composer mirror and uses the current input event's lack of `beforeinput` as the replay signal. The source-of-truth remains the host draft plus local composer mirror; no public contract or persisted session data is introduced.

## Linked context

Which issue does this close?

Closes #89466

Which issues, PRs, or discussions are related?

Related #89714

Was this requested by a maintainer or owner?

No direct maintainer request; this follows the user-reported Control UI chat composer bug.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Control UI chat composer could repopulate with the just-sent text after send when a stale native input replay arrived, including across session switches or after the next draft had started.
- Real environment tested: Control UI browser e2e with mocked Gateway send flow, plus focused jsdom unit coverage for same-session and cross-session composer state transitions.
- Exact steps or command run after this patch: `corepack pnpm@11.2.2 exec vitest run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts -t "stale native input replay"` and `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree corepack pnpm@11.2.2 test ui/src/ui/views/chat.test.ts`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

  ```text
  $ node scripts/test-projects.mjs ui/src/ui/views/chat.test.ts
  [test] starting test/vitest/vitest.unit-ui.config.ts

   RUN  v4.1.8 [local path redacted]


   Test Files  1 passed (1)
        Tests  114 passed (114)
     Start at  14:23:58
     Duration  4.56s (transform 608ms, setup 49ms, import 974ms, tests 2.21s, environment 1.03s)

  [test] passed 1 Vitest shard in 5.24s
  ```

  ```text
   RUN  v4.1.8 [local path redacted]


   Test Files  1 passed (1)
        Tests  1 passed | 14 skipped (15)
     Start at  14:24:04
     Duration  4.58s (transform 23ms, setup 0ms, import 665ms, tests 3.71s, environment 0ms)
  ```

- Observed result after fix: the unit suite passes the immediate replay, same-session delayed replay, cross-session replay, and intervening-session-draft replay cases; the browser e2e keeps the composer clear after send, suppresses a stale native replay, and still allows manually re-entering the same prompt.
- What was not tested: live model/provider completion was not tested.
- Proof limitations or environment constraints: the issue is in frontend composer DOM event state after a send clears the host draft, so the browser e2e uses a mocked Gateway send response to exercise the real Control UI composer path without depending on an external model provider.
- Before evidence (optional but encouraged): focused regression tests failed before the fix with the stale submitted text remaining in the textarea instead of the expected empty or current draft value.

## Tests and validation

Which commands did you run?

- `corepack pnpm@11.2.2 exec oxfmt --check --threads=1 ui/src/ui/views/chat.ts ui/src/ui/views/chat.test.ts ui/src/ui/e2e/chat-flow.e2e.test.ts`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree corepack pnpm@11.2.2 test ui/src/ui/views/chat.test.ts`
- `corepack pnpm@11.2.2 exec vitest run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts -t "stale native input replay"`
- `corepack pnpm@11.2.2 tsgo:test:ui`

What regression coverage was added or updated?

- Target test file: `ui/src/ui/views/chat.test.ts` and `ui/src/ui/e2e/chat-flow.e2e.test.ts`.
- Scenario locked in: sending clears the composer, stale input-only replay of the submitted text does not repopulate it, cross-session replay does not pollute another session, same-session delayed replay does not replace a newly typed draft, and manual re-entry of the same prompt still works.
- Why this is the smallest reliable guardrail: the tests exercise the exact composer lifecycle and native event ordering that caused the bug, without broadening into unrelated chat delivery, provider, or session persistence behavior.

What failed before this fix, if known?

The new stale replay regressions failed before the production change: the textarea value became `submitted message` instead of staying empty or preserving the current `new draft` / `session b draft` value.

If no test was added, why not?

Not applicable; regression tests and browser e2e coverage were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. The composer now ignores input-only stale replay of the just-submitted text after send, while preserving intentional typing and paste/drop behavior.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Risk labels considered: session-state; security-boundary scanner signal.
- Risk explanation: this touches ephemeral Control UI session-state for the composer mirror. The security-boundary signal is a false positive from an internal composer key string; no auth, secrets, network, permission, or tool execution boundary changes.
- Architecture / source-of-truth check: the source-of-truth boundary remains the host draft and local composer mirror. The pending replay marker is ephemeral UI state only and does not alter public API, config, schema, validation, protocol, migration, persisted session rows, or default behavior.
- What did NOT change: chat send transport, message delivery, gateway contract, provider routing, stored session state, input history semantics, and paste/drop user intent are unchanged.

How is that risk mitigated?

- Why acceptable: suppression requires the textarea value to exactly match the submitted draft that was just cleared and the current input event to lack `beforeinput`; explicit paste/drop and real current user typing are allowed through.
- Patch quality notes: default returns are simple guard exits in small helper functions, not fallback behavior. The e2e timeout only waits for the mocked chat history line before interacting with the composer and does not hide failures in the replay assertion.

## Current review state

What is the next action?

- Maintainer-ready confidence: High. The next action is maintainer review after CI runs on the submitted PR.

What is still waiting on author, maintainer, CI, or external proof?

Nothing known is waiting on the author locally; ClawSweeper commit review passed and focused validation passed. Remote CI will still need to run after the PR is created.

Which bot or reviewer comments were addressed?

No PR review comments exist yet. Local ClawSweeper commit-review findings were addressed before submission: cross-session stale replay, delayed cross-session replay after intervening input, and same-session delayed replay after a new draft starts.
