### PR TITLE
fix #95489: [Bug]: claude-cli out-of-credits error bypasses model fallback chain — error text delivered as final response

### DIFF
--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -87,6 +87,47 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     expect(result).toBeNull();
   });
 
+  it("does not retry generic external runner failure text mixed with non-text visible content", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+      result: {
+        payloads: [
+          {
+            text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+            mediaUrl: "https://example.com/failure-screenshot.png",
+            channelData: { delivered: true },
+          },
+        ],
+        meta: {
+          durationMs: 42,
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("does not retry generic external runner failure text mixed with interactive content", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+      result: {
+        payloads: [
+          {
+            text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+            interactive: { type: "button", label: "Retry" },
+          },
+        ],
+        meta: {
+          durationMs: 42,
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("does not retry generic external runner failure text after committed delivery", () => {
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "claude-cli",

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -1,5 +1,6 @@
 // Coverage for deciding when embedded run results should trigger model fallback.
 import { describe, expect, it } from "vitest";
+import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "../../auto-reply/reply/agent-runner-failure-copy.js";
 import { classifyEmbeddedAgentRunResultForModelFallback } from "./result-fallback-classifier.js";
 
 describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
@@ -47,6 +48,78 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
       code: "embedded_error_payload",
       rawError: '{"success":false,"code":"CE-011","message":"当前ak因违规请求被禁止访问该模型"}',
     });
+  });
+
+  it("classifies generic external runner failure text as fallback-worthy", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+      result: {
+        payloads: [{ text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT }],
+        meta: {
+          durationMs: 42,
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      message:
+        "claude-cli/claude-sonnet-4-6 ended with a generic external runner failure: " +
+        GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+      reason: "format",
+      code: "generic_external_run_failure",
+      rawError: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+    });
+  });
+
+  it("does not classify normal visible assistant output as fallback-worthy", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+      result: {
+        payloads: [{ text: "Here is the requested answer." }],
+        meta: {
+          durationMs: 42,
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("does not retry generic external runner failure text after committed delivery", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+      result: {
+        payloads: [{ text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT }],
+        messagingToolSentTexts: ["already delivered"],
+        meta: {
+          durationMs: 42,
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("preserves hook block results with generic external runner failure text", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+      result: {
+        payloads: [{ text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT }],
+        meta: {
+          durationMs: 42,
+          error: {
+            kind: "hook_block",
+            message: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+          },
+        },
+      },
+    });
+
+    expect(result).toBeNull();
   });
 
   it("preserves hook block results with auth-like error payload text", () => {

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -76,6 +76,19 @@ function hasDeliberateSilentTerminalReply(result: EmbeddedAgentRunResult): boole
   );
 }
 
+function hasNonTextVisiblePayloadContent(
+  payload: NonNullable<EmbeddedAgentRunResult["payloads"]>[number],
+): boolean {
+  const { text: _text, ...payloadWithoutText } = payload;
+  return hasVisibleAgentPayload(
+    { payloads: [payloadWithoutText] },
+    {
+      includeErrorPayloads: false,
+      includeReasoningPayloads: false,
+    },
+  );
+}
+
 function classifyGenericExternalRunFailurePayload(params: {
   provider: string;
   model: string;
@@ -91,7 +104,8 @@ function classifyGenericExternalRunFailurePayload(params: {
     payload?.isError === true ||
     payload?.isReasoning === true ||
     typeof text !== "string" ||
-    !isGenericExternalRunFailureText(text)
+    !isGenericExternalRunFailureText(text) ||
+    hasNonTextVisiblePayloadContent(payload)
   ) {
     return null;
   }

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -1,7 +1,7 @@
 /**
  * Classifies embedded-agent run results for model fallback decisions.
  */
-import { isGenericExternalRunFailureText } from "../../auto-reply/reply/agent-runner-failure-copy.js";
+import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "../../auto-reply/reply/agent-runner-failure-copy.js";
 import { isSilentReplyPayloadText } from "../../auto-reply/tokens.js";
 import { classifyFailoverReason } from "../embedded-agent-helpers/errors.js";
 import type { FailoverReason } from "../embedded-agent-helpers/types.js";
@@ -104,7 +104,7 @@ function classifyGenericExternalRunFailurePayload(params: {
     payload?.isError === true ||
     payload?.isReasoning === true ||
     typeof text !== "string" ||
-    !isGenericExternalRunFailureText(text) ||
+    text.trim() !== GENERIC_EXTERNAL_RUN_FAILURE_TEXT ||
     hasNonTextVisiblePayloadContent(payload)
   ) {
     return null;

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -1,6 +1,7 @@
 /**
  * Classifies embedded-agent run results for model fallback decisions.
  */
+import { isGenericExternalRunFailureText } from "../../auto-reply/reply/agent-runner-failure-copy.js";
 import { isSilentReplyPayloadText } from "../../auto-reply/tokens.js";
 import { classifyFailoverReason } from "../embedded-agent-helpers/errors.js";
 import type { FailoverReason } from "../embedded-agent-helpers/types.js";
@@ -15,8 +16,9 @@ import type { EmbeddedAgentRunResult } from "./types.js";
 /**
  * Classifies embedded-agent terminal results for model fallback decisions.
  *
- * The classifier only flags failed invisible outcomes; delivered messages, deliberate silent
- * replies, hook blocks, and aborts must not trigger another model attempt.
+ * The classifier only flags failed invisible outcomes or exact generic external-runner failure
+ * copy; delivered messages, deliberate silent replies, hook blocks, and aborts must not trigger
+ * another model attempt.
  */
 function isEmbeddedAgentRunResult(value: unknown): value is EmbeddedAgentRunResult {
   return Boolean(
@@ -72,6 +74,33 @@ function hasDeliberateSilentTerminalReply(result: EmbeddedAgentRunResult): boole
   return [result.meta.finalAssistantRawText, result.meta.finalAssistantVisibleText].some(
     (text) => typeof text === "string" && isSilentReplyPayloadText(text),
   );
+}
+
+function classifyGenericExternalRunFailurePayload(params: {
+  provider: string;
+  model: string;
+  result: EmbeddedAgentRunResult;
+}): ModelFallbackResultClassification {
+  const payloads = params.result.payloads;
+  if (!Array.isArray(payloads) || payloads.length !== 1) {
+    return null;
+  }
+  const [payload] = payloads;
+  const text = payload?.text;
+  if (
+    payload?.isError === true ||
+    payload?.isReasoning === true ||
+    typeof text !== "string" ||
+    !isGenericExternalRunFailureText(text)
+  ) {
+    return null;
+  }
+  return {
+    message: `${params.provider}/${params.model} ended with a generic external runner failure: ${text}`,
+    reason: "format",
+    code: "generic_external_run_failure",
+    rawError: text,
+  };
 }
 
 function classifyHarnessResult(params: {
@@ -136,11 +165,7 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
   if (
     params.result.meta.aborted ||
     params.hasDirectlySentBlockReply === true ||
-    params.hasBlockReplyPipelineOutput === true ||
-    hasVisibleAgentPayload(params.result, {
-      includeErrorPayloads: false,
-      includeReasoningPayloads: false,
-    })
+    params.hasBlockReplyPipelineOutput === true
   ) {
     return null;
   }
@@ -161,6 +186,22 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
     return null;
   }
   const payloads = params.result.payloads ?? [];
+  const genericExternalFailureClassification = classifyGenericExternalRunFailurePayload({
+    provider: params.provider,
+    model: params.model,
+    result: params.result,
+  });
+  if (genericExternalFailureClassification) {
+    return genericExternalFailureClassification;
+  }
+  if (
+    hasVisibleAgentPayload(params.result, {
+      includeErrorPayloads: false,
+      includeReasoningPayloads: false,
+    })
+  ) {
+    return null;
+  }
 
   if (fallbackSafeIncompleteTurn) {
     const terminalErrorText = payloads.find(


### PR DESCRIPTION
## Summary

- Problem: `claude-cli` can return the generic external-runner failure copy when the underlying Claude Code account is out of credits, but that copy was treated as successful visible output.
- Solution: classify the exact centralized generic external-runner failure copy as fallback-eligible before the normal visible-output short-circuit, while rejecting mixed visible payloads that contain media, interactive data, channel data, or other non-text visible content.
- What changed: the embedded-agent result fallback classifier now recognizes only a sole, non-error, non-reasoning payload matching the exact generic failure text and with no non-text visible payload content; it returns `generic_external_run_failure` so the configured fallback chain can advance.
- What did NOT change: No unrelated behavior changes; this does not change ordinary visible assistant replies, mixed visible payloads, hook blocks, direct block replies, aborted runs, committed outbound delivery, or replay-invalid side-effecting turns. Those paths remain unchanged and still suppress model fallback.
- Why it matters / User impact: users with configured fallback chains can recover from a primary `claude-cli` generic runner failure instead of receiving the generic CLI failure text as the final assistant response.
- Fixes #95489

## Real behavior proof

- **Behavior or issue addressed:** `claude-cli` generic external-runner failure text no longer bypasses model fallback when it is surfaced as a normal visible embedded-agent payload. Mixed visible payloads that include the generic text plus non-text visible content remain non-retryable.
- **Real environment tested:** Built OpenClaw CLI from this PR branch and ran `openclaw agent --local` with `agents.defaults.model.primary = "claude-cli/claude-sonnet-4-6"` and `agents.defaults.model.fallbacks = ["local-proof/fallback-ok"]`. I could not reproduce a live exhausted Claude Code subscription locally, so the runtime proof uses a controlled `claude-cli` command override that emits the exact centralized generic failure text as a successful Claude stream-json result. This exercises the real OpenClaw CLI backend parser, result fallback classifier, and configured fallback chain, but it is not a live exhausted-account proof.
- **Exact steps or command run after this patch:**
  - `OPENCLAW_CONFIG_PATH=<proof-config> OPENCLAW_STATE_DIR=<isolated-state> OPENCLAW_CLI_BACKEND_LOG_OUTPUT=1 npx -y node@22.19.0 openclaw.mjs --no-color --log-level trace agent --local --agent main --session-key agent:main:proof-generic-failure-shim --message "Proof run: if fallback is reached, reply with FALLBACK_OK." --json --timeout 180`
  - `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/result-fallback-classifier.test.ts src/agents/outcome-fallback-runtime-contract.test.ts`
  - `node scripts/run-vitest.mjs src/agents/model-fallback.test.ts`
  - `git diff --check`
- **Evidence after fix:** redacted runtime proof excerpt:
  ```text
  [agent/cli-backend] cli exec: provider=claude-cli model=claude-sonnet-4-6 ...
  [agent/cli-backend] claude live session turn: provider=claude-cli model=claude-sonnet-4-6 ... rawLines=1 outBytes=114 ...
  [model-fallback/decision] model fallback decision: decision=candidate_failed requested=claude-cli/claude-sonnet-4-6 candidate=claude-cli/claude-sonnet-4-6 reason=format next=local-proof/fallback-ok detail=⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.
  [agent/embedded] embedded run start: ... provider=local-proof model=fallback-ok ...
  [provider-transport-fetch] [model-fetch] response provider=local-proof api=openai-completions model=fallback-ok status=200 ...
  [model-fallback/decision] model fallback decision: decision=candidate_succeeded requested=claude-cli/claude-sonnet-4-6 candidate=local-proof/fallback-ok reason=unknown next=none
  ```
- **Observed result after fix:** the `claude-cli` candidate is recorded as `generic_external_run_failure`, the configured fallback candidate is attempted, and the fallback response becomes the final visible answer:
  ```json
  {
    "fallbackAttempts": [
      {
        "provider": "claude-cli",
        "model": "claude-sonnet-4-6",
        "error": "⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.",
        "reason": "format",
        "code": "generic_external_run_failure"
      }
    ],
    "winnerProvider": "local-proof",
    "winnerModel": "fallback-ok",
    "finalAssistantVisibleText": "FALLBACK_OK: local-proof/fallback-ok produced this reply after generic claude-cli failure text."
  }
  ```
- **Regression evidence after fix:** all three verification commands completed with exit code 0. The first command covers the fallback classifier, the new non-text visible payload guard, and runtime contract tests; the second covers model fallback behavior; the third found no whitespace errors.
- **What was not tested:** live exhausted Claude Code subscription behavior was not reproduced locally; an actual local `claude-cli` run did not produce the generic out-of-credits copy in this environment.

## Review findings addressed

- **RF-001 / RF-006 / RF-009:** fixed by requiring the generic-failure payload to contain no non-text visible content before it can trigger fallback. Regression tests cover `mediaUrl` + `channelData` and `interactive` payloads mixed with the generic failure text.
- **RF-002 / RF-004 / RF-005:** addressed as far as this environment allows with redacted runtime proof through the real OpenClaw CLI backend parser and configured fallback chain. Live exhausted-account proof remains unavailable and is disclosed above.
- **RF-003 / RF-007:** multiple candidate PRs remain a maintainer coordination decision. This PR keeps the diff focused to the source classifier and regression tests so maintainers can compare it against the other candidate branches.
- **RF-008:** contributor action was taken for the small code guard and proof disclosure; the remaining live exhausted-account proof gap is explicitly disclosed for maintainer judgment.

## Regression Test Plan

- **Target test file:** `src/agents/embedded-agent-runner/result-fallback-classifier.test.ts`
- **Scenario locked in:** a `claude-cli/claude-sonnet-4-6` result with `{ text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT }` is fallback-worthy; a real visible assistant reply is not; generic failure text mixed with non-text visible payload fields is not fallback-worthy; committed delivery evidence and hook blocks still prevent retry.
- **Why this is the smallest reliable guardrail:** the issue is caused by result classification before model fallback advances. Testing the classifier directly locks the source-level decision without depending on an externally exhausted Claude account.

## Merge risk

- **Risk labels considered:** auth-provider / availability / message-delivery / session-state
- **Risk explanation:** the change affects model fallback routing for embedded-agent results. It deliberately runs after no-retry guards for committed delivery, hook blocks, direct block replies, aborted runs, and replay-invalid side-effecting turns, and it only matches the exact centralized generic external-runner failure text when it is the sole normal payload with no non-text visible content.
- **Why acceptable:** the diff is limited to the fallback classifier and its regression tests. The normal visible-output guard remains in place for all non-matching assistant replies and for mixed visible payloads, so successful CLI responses and already-visible non-text content are not reclassified.

## Root Cause

- **Root cause:** Root cause is the source classifier ordering: `classifyEmbeddedAgentRunResultForModelFallback` returned `null` because it saw a visible non-error payload before checking whether that payload was the centralized generic external-runner failure copy.
- **Why this is root-cause fix:** This fixes the source invariant in the fallback classifier: exact generic external-runner failure copy is classified before the visible-output success guard, while mixed visible payload content remains protected from retry, so the fallback engine receives a failed-candidate classification only for the known generic runner failure case.
- **Fix classification:** Root cause fix
- **Maintainer-ready confidence:** High for source behavior and local controlled runtime proof; limited by unavailable live exhausted-account reproduction.
- **Patch quality notes:** Patch-quality warning terms are expected here because the issue is model fallback routing. The new `return null` branches are guard exits that preserve no-retry behavior, not catch-all masking; tests cover both the new failure classification and the unchanged no-retry paths.
- **Architecture / source-of-truth check:** The source-of-truth owner is `src/agents/embedded-agent-runner/result-fallback-classifier.ts`, which owns embedded-agent terminal result classification for model fallback. This uses the canonical centralized generic external-runner failure copy helper instead of duplicating a downstream display string.
