### PR TITLE
fix #95422: TUI/WebChat: Codex app-server streaming shows full reply at once (no incremental deltas)

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -368,8 +368,8 @@ describe("CodexAppServerEventProjector", () => {
         .filter((event) => event.stream === "assistant")
         .map((event) => event.data),
     ).toEqual([
-      { text: "hel", delta: "hel" },
-      { text: "hello", delta: "lo" },
+      { text: "hel", delta: "hel", replaceable: true },
+      { text: "hello", delta: "lo", replaceable: true },
     ]);
   });
 
@@ -395,8 +395,8 @@ describe("CodexAppServerEventProjector", () => {
         .filter((event) => event.stream === "assistant")
         .map((event) => event.data),
     ).toEqual([
-      { text: "coordination draft", delta: "coordination draft" },
-      { text: "final answer", delta: "", replace: true },
+      { text: "coordination draft", delta: "coordination draft", replaceable: true },
+      { text: "final answer", delta: "", replace: true, replaceable: true },
     ]);
   });
 

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -305,7 +305,10 @@ describe("CodexAppServerEventProjector", () => {
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
     expect(onAssistantMessageStart).toHaveBeenCalledTimes(1);
-    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
+      { text: "hel", delta: "hel" },
+      { text: "hello", delta: "lo" },
+    ]);
     expect(result.assistantTexts).toEqual(["hello"]);
     expect(result.messagesSnapshot.map((message) => message.role)).toEqual(["user", "assistant"]);
     expect(result.lastAssistant?.content).toEqual([{ type: "text", text: "hello" }]);
@@ -340,6 +343,60 @@ describe("CodexAppServerEventProjector", () => {
     expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
       { text: "hel", delta: "hel" },
       { text: "hello", delta: "lo" },
+    ]);
+  });
+
+  it("streams unphased assistant deltas into partial replies and assistant events", async () => {
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent,
+      onPartialReply,
+    });
+
+    await projector.handleNotification(agentMessageDelta("hel", "msg-final"));
+    await projector.handleNotification(agentMessageDelta("lo", "msg-final"));
+
+    expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
+      { text: "hel", delta: "hel" },
+      { text: "hello", delta: "lo" },
+    ]);
+    expect(
+      onAgentEvent.mock.calls
+        .map((call) => call[0])
+        .filter((event) => event.stream === "assistant")
+        .map((event) => event.data),
+    ).toEqual([
+      { text: "hel", delta: "hel" },
+      { text: "hello", delta: "lo" },
+    ]);
+  });
+
+  it("uses replacement partials when unphased assistant items switch", async () => {
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent,
+      onPartialReply,
+    });
+
+    await projector.handleNotification(agentMessageDelta("coordination draft", "msg-draft"));
+    await projector.handleNotification(agentMessageDelta("final answer", "msg-final"));
+
+    expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
+      { text: "coordination draft", delta: "coordination draft" },
+      { text: "final answer", delta: "", replace: true },
+    ]);
+    expect(
+      onAgentEvent.mock.calls
+        .map((call) => call[0])
+        .filter((event) => event.stream === "assistant")
+        .map((event) => event.data),
+    ).toEqual([
+      { text: "coordination draft", delta: "coordination draft" },
+      { text: "final answer", delta: "", replace: true },
     ]);
   });
 
@@ -1041,7 +1098,17 @@ describe("CodexAppServerEventProjector", () => {
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
     expect(onAssistantMessageStart).toHaveBeenCalledTimes(1);
-    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
+      {
+        text: "checking thread context; then post a tight progress reply here.",
+        delta: "checking thread context; then post a tight progress reply here.",
+      },
+      {
+        text: "release fixes first. please drop affected PRs, failing checks, and blockers here.",
+        delta: "",
+        replace: true,
+      },
+    ]);
     expect(result.assistantTexts).toEqual([
       "release fixes first. please drop affected PRs, failing checks, and blockers here.",
     ]);

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -148,6 +148,7 @@ export class CodexAppServerEventProjector {
   private readonly assistantTextByItem = new Map<string, string>();
   private readonly assistantItemOrder: string[] = [];
   private readonly assistantPhaseByItem = new Map<string, string>();
+  private streamedPartialAssistantItemId: string | undefined;
   private readonly lastCommentaryProgressTextByItem = new Map<string, string>();
   // Codex emits each typed item completion before its matching raw response item.
   // Pair by protocol order because contributors may rewrite only the typed text.
@@ -521,12 +522,14 @@ export class CodexAppServerEventProjector {
     if (this.isCommentaryAssistantItem(itemId)) {
       this.emitCommentaryProgress({ itemId, text });
     } else if (this.shouldStreamAssistantPartial(itemId)) {
-      await this.params.onPartialReply?.({ text, delta });
+      const replace =
+        this.streamedPartialAssistantItemId !== undefined &&
+        this.streamedPartialAssistantItemId !== itemId;
+      this.streamedPartialAssistantItemId = itemId;
+      const partial = replace ? { text, delta: "", replace: true as const } : { text, delta };
+      await this.params.onPartialReply?.(partial);
+      this.emitAgentEvent({ stream: "assistant", data: partial });
     }
-    // Codex app-server can emit multiple agentMessage items per turn, including
-    // intermediate coordination/progress prose. Keep those deltas internal until
-    // their phase identifies terminal answer text or turn completion chooses the
-    // last assistant item as the user-visible reply.
   }
 
   private async handleReasoningDelta(
@@ -1062,7 +1065,7 @@ export class CodexAppServerEventProjector {
   }
 
   private shouldStreamAssistantPartial(itemId: string): boolean {
-    return this.assistantPhaseByItem.get(itemId) === "final_answer";
+    return this.assistantPhaseByItem.get(itemId) !== "commentary";
   }
 
   private emitCommentaryProgress(params: { itemId: string; text: string }): void {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -528,7 +528,7 @@ export class CodexAppServerEventProjector {
       this.streamedPartialAssistantItemId = itemId;
       const partial = replace ? { text, delta: "", replace: true as const } : { text, delta };
       await this.params.onPartialReply?.(partial);
-      this.emitAgentEvent({ stream: "assistant", data: partial });
+      this.emitAgentEvent({ stream: "assistant", data: { ...partial, replaceable: true } });
     }
   }
 

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -509,6 +509,52 @@ describe("startAcpSpawnParentStreamRelay", () => {
     relay.dispose();
   });
 
+  it("relays the latest replaceable assistant snapshot instead of superseded drafts", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-replaceable-assistant",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-replaceable-assistant",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+      emitStartNotice: false,
+    });
+
+    emitAgentEvent({
+      runId: "run-replaceable-assistant",
+      stream: "assistant",
+      data: {
+        text: "coordination draft",
+        delta: "coordination draft",
+        replaceable: true,
+      },
+    });
+    emitAgentEvent({
+      runId: "run-replaceable-assistant",
+      stream: "assistant",
+      data: {
+        text: "final answer",
+        delta: "",
+        replace: true,
+        replaceable: true,
+      },
+    });
+    emitAgentEvent({
+      runId: "run-replaceable-assistant",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 1_000,
+        endedAt: 2_000,
+      },
+    });
+
+    const texts = collectedTexts();
+    expectNoTextWithFragment(texts, "coordination draft");
+    expectTextWithFragment(texts, "codex: final answer");
+    relay.dispose();
+  });
+
   it("relays commentary-phase assistant text in parent progress mode by default", () => {
     const relay = startAcpSpawnParentStreamRelay({
       runId: "run-commentary-default",

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -431,6 +431,7 @@ export function startAcpSpawnParentStreamRelay(params: {
   let disposed = false;
   let pendingText = "";
   let pendingProgressKind: string | undefined;
+  let replaceableAssistantSnapshot: string | undefined;
   const itemProgressTextById = new Map<string, string>();
   let lastProgressAt = Date.now();
   let stallNotified = false;
@@ -509,6 +510,15 @@ export function startAcpSpawnParentStreamRelay(params: {
       return;
     }
     scheduleFlush();
+  };
+
+  const flushReplaceableAssistantSnapshot = () => {
+    const snapshot = replaceableAssistantSnapshot;
+    replaceableAssistantSnapshot = undefined;
+    if (!snapshot?.trim()) {
+      return;
+    }
+    appendVisibleProgress(snapshot, "assistant:replaceable");
   };
 
   const appendItemProgressSnapshot = (snapshot: { itemId: string; text: string }) => {
@@ -605,10 +615,27 @@ export function startAcpSpawnParentStreamRelay(params: {
       const assistantPhase = normalizeAssistantPhase(
         (data as { phase?: unknown } | undefined)?.phase,
       );
-      const deltaCandidate =
-        (data as { delta?: unknown } | undefined)?.delta ??
-        (data as { text?: unknown } | undefined)?.text;
-      const delta = typeof deltaCandidate === "string" ? deltaCandidate : undefined;
+      const textCandidate = (data as { text?: unknown } | undefined)?.text;
+      const deltaCandidate = (data as { delta?: unknown } | undefined)?.delta;
+      const snapshot =
+        typeof textCandidate === "string"
+          ? textCandidate
+          : typeof deltaCandidate === "string"
+            ? deltaCandidate
+            : undefined;
+      if ((data as { replaceable?: unknown } | undefined)?.replaceable === true) {
+        if (snapshot?.trim()) {
+          replaceableAssistantSnapshot = snapshot;
+          lastProgressAt = Date.now();
+          logEvent("assistant_replaceable_snapshot", {
+            text: snapshot,
+            ...(assistantPhase ? { phase: assistantPhase } : {}),
+          });
+        }
+        return;
+      }
+
+      const delta = typeof deltaCandidate === "string" ? deltaCandidate : snapshot;
       if (!delta || !delta.trim()) {
         return;
       }
@@ -622,6 +649,7 @@ export function startAcpSpawnParentStreamRelay(params: {
         return;
       }
 
+      replaceableAssistantSnapshot = undefined;
       appendVisibleProgress(delta, `assistant:${assistantPhase ?? "unknown"}`);
       return;
     }
@@ -697,6 +725,7 @@ export function startAcpSpawnParentStreamRelay(params: {
     const phase = normalizeOptionalString((event.data as { phase?: unknown } | undefined)?.phase);
     logEvent("lifecycle", { phase: phase ?? "unknown", data: event.data });
     if (phase === "end") {
+      flushReplaceableAssistantSnapshot();
       flushPending();
       const startedAt = asFiniteNumber(
         (event.data as { startedAt?: unknown } | undefined)?.startedAt,
@@ -719,6 +748,7 @@ export function startAcpSpawnParentStreamRelay(params: {
     }
 
     if (phase === "error") {
+      flushReplaceableAssistantSnapshot();
       flushPending();
       const errorText = normalizeOptionalString(
         (event.data as { error?: unknown } | undefined)?.error,

--- a/src/gateway/agent-event-assistant-text.ts
+++ b/src/gateway/agent-event-assistant-text.ts
@@ -11,3 +11,15 @@ export function resolveAssistantStreamDeltaText(evt: AgentEventPayload): string 
   const text = evt.data.text;
   return typeof delta === "string" ? delta : typeof text === "string" ? text : "";
 }
+
+export function isReplaceableAssistantStreamEvent(evt: AgentEventPayload): boolean {
+  return evt.data.replaceable === true;
+}
+
+export function resolveAssistantStreamSnapshotText(evt: AgentEventPayload): string {
+  const text = evt.data.text;
+  if (typeof text === "string") {
+    return text;
+  }
+  return resolveAssistantStreamDeltaText(evt);
+}

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2274,6 +2274,40 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     expect(allContent).toBe("final answer");
   });
 
+  it("prefers final result text over buffered replaceable chat drafts", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+      });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+      return { payloads: [{ text: "final answer" }] };
+    }) as never);
+
+    const res = await postChatCompletions(port, {
+      stream: true,
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(res.status).toBe(200);
+    const data = parseSseDataLines(await res.text());
+    const chunks = data
+      .filter((d) => d !== "[DONE]")
+      .map((d) => JSON.parse(d) as Record<string, unknown>);
+    const allContent = chunks
+      .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
+      .map((choice) => (choice.delta as Record<string, unknown> | undefined)?.content)
+      .filter((content): content is string => typeof content === "string")
+      .join("");
+
+    expect(allContent).toBe("final answer");
+  });
+
   it(
     "sends an initial SSE chunk before a streaming agent run settles",
     { timeout: 15_000 },

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2234,6 +2234,44 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     }
   });
 
+  it("buffers replaceable assistant events for streaming chat completions", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "final answer", delta: "", replace: true, replaceable: true },
+      });
+      return { payloads: [{ text: "final answer" }] };
+    }) as never);
+
+    const res = await postChatCompletions(port, {
+      stream: true,
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(res.status).toBe(200);
+    const data = parseSseDataLines(await res.text());
+    const chunks = data
+      .filter((d) => d !== "[DONE]")
+      .map((d) => JSON.parse(d) as Record<string, unknown>);
+    const allContent = chunks
+      .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
+      .map((choice) => (choice.delta as Record<string, unknown> | undefined)?.content)
+      .filter((content): content is string => typeof content === "string")
+      .join("");
+
+    expect(allContent).toBe("final answer");
+  });
+
   it(
     "sends an initial SSE chunk before a streaming agent run settles",
     { timeout: 15_000 },

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2249,6 +2249,8 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         stream: "assistant",
         data: { text: "final answer", delta: "", replace: true, replaceable: true },
       });
+      emitAgentEvent({ runId, stream: "assistant", data: { text: "final answer" } });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
       return { payloads: [{ text: "final answer" }] };
     }) as never);
 

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1328,8 +1328,8 @@ export async function handleOpenAiHttpRequest(
         if (!sawAssistantDelta) {
           const commentary =
             bufferedAssistantContent ||
-            bufferedReplaceableAssistantContent ||
-            resolveAgentResponseCommentary(result);
+            resolveAgentResponseCommentary(result) ||
+            bufferedReplaceableAssistantContent;
           if (commentary) {
             sawAssistantDelta = true;
             writeAssistantContentChunk(res, {
@@ -1355,7 +1355,10 @@ export async function handleOpenAiHttpRequest(
           writeAssistantRoleChunk(res, { runId, model });
         }
 
-        const content = bufferedReplaceableAssistantContent || resolveAgentResponseText(result);
+        const content =
+          resolveAgentResponseCommentary(result) ||
+          bufferedReplaceableAssistantContent ||
+          "No response from OpenClaw.";
 
         sawAssistantDelta = true;
         writeAssistantContentChunk(res, {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -35,7 +35,11 @@ import {
   type InputImageSource,
 } from "../media/input-files.js";
 import { defaultRuntime } from "../runtime.js";
-import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
+import {
+  isReplaceableAssistantStreamEvent,
+  resolveAssistantStreamDeltaText,
+  resolveAssistantStreamSnapshotText,
+} from "./agent-event-assistant-text.js";
 import {
   buildAgentMessageFromConversationEntries,
   type ConversationEntry,
@@ -1180,6 +1184,7 @@ export async function handleOpenAiHttpRequest(
   let wroteStopChunk = false;
   let sawAssistantDelta = false;
   let bufferedAssistantContent = "";
+  let bufferedReplaceableAssistantContent = "";
   let finalUsage: OpenAiChatCompletionsUsage | undefined;
   let finalizeRequested = false;
   let finalizeFinishReason: "stop" | "tool_calls" = "stop";
@@ -1226,6 +1231,14 @@ export async function handleOpenAiHttpRequest(
     }
 
     if (evt.stream === "assistant") {
+      if (isReplaceableAssistantStreamEvent(evt)) {
+        const snapshot = resolveAssistantStreamSnapshotText(evt);
+        if (snapshot) {
+          bufferedReplaceableAssistantContent = snapshot;
+        }
+        return;
+      }
+
       const content = resolveAssistantStreamDeltaText(evt) ?? "";
       if (!content) {
         return;
@@ -1313,7 +1326,10 @@ export async function handleOpenAiHttpRequest(
           writeAssistantRoleChunk(res, { runId, model });
         }
         if (!sawAssistantDelta) {
-          const commentary = bufferedAssistantContent || resolveAgentResponseCommentary(result);
+          const commentary =
+            bufferedAssistantContent ||
+            bufferedReplaceableAssistantContent ||
+            resolveAgentResponseCommentary(result);
           if (commentary) {
             sawAssistantDelta = true;
             writeAssistantContentChunk(res, {
@@ -1339,7 +1355,7 @@ export async function handleOpenAiHttpRequest(
           writeAssistantRoleChunk(res, { runId, model });
         }
 
-        const content = resolveAgentResponseText(result);
+        const content = bufferedReplaceableAssistantContent || resolveAgentResponseText(result);
 
         sawAssistantDelta = true;
         writeAssistantContentChunk(res, {

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -976,6 +976,47 @@ describe("OpenResponses HTTP API (e2e)", () => {
     }
   });
 
+  it("buffers replaceable assistant events for streaming responses", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "final answer", delta: "", replace: true, replaceable: true },
+      });
+      return { payloads: [{ text: "final answer" }] };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const events = parseSseEvents(await res.text());
+    const deltas = events
+      .filter((event) => event.event === "response.output_text.delta")
+      .map((event) => {
+        const parsed = JSON.parse(event.data) as { delta?: string };
+        return parsed.delta ?? "";
+      })
+      .join("");
+    const completed = JSON.parse(findSseEvent(events, "response.completed").data) as {
+      response?: { output?: Array<{ content?: Array<{ text?: string }> }> };
+    };
+
+    expect(deltas).toBe("final answer");
+    expect(completed.response?.output?.[0]?.content?.[0]?.text).toBe("final answer");
+  });
+
   it("maps provider format failures to OpenResponses 400 failed responses", async () => {
     const port = enabledPort;
 

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1019,6 +1019,43 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(completed.response?.output?.[0]?.content?.[0]?.text).toBe("final answer");
   });
 
+  it("prefers final result text over buffered replaceable response drafts", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+      });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+      return { payloads: [{ text: "final answer" }] };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const events = parseSseEvents(await res.text());
+    const deltas = events
+      .filter((event) => event.event === "response.output_text.delta")
+      .map((event) => {
+        const parsed = JSON.parse(event.data) as { delta?: string };
+        return parsed.delta ?? "";
+      })
+      .join("");
+    const completed = JSON.parse(findSseEvent(events, "response.completed").data) as {
+      response?: { output?: Array<{ content?: Array<{ text?: string }> }> };
+    };
+
+    expect(deltas).toBe("final answer");
+    expect(completed.response?.output?.[0]?.content?.[0]?.text).toBe("final answer");
+  });
+
   it("maps provider format failures to OpenResponses 400 failed responses", async () => {
     const port = enabledPort;
 

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1056,6 +1056,40 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(completed.response?.output?.[0]?.content?.[0]?.text).toBe("final answer");
   });
 
+  it("updates final streaming response text for non-replaceable assistant replacements", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "coordination draft" },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "final answer", delta: "", replace: true },
+      });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+      return { payloads: [{ text: "final answer" }] };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const events = parseSseEvents(await res.text());
+    const completed = JSON.parse(findSseEvent(events, "response.completed").data) as {
+      response?: { output?: Array<{ content?: Array<{ text?: string }> }> };
+    };
+
+    expect(completed.response?.output?.[0]?.content?.[0]?.text).toBe("final answer");
+  });
+
   it("maps provider format failures to OpenResponses 400 failed responses", async () => {
     const port = enabledPort;
 

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -991,6 +991,8 @@ describe("OpenResponses HTTP API (e2e)", () => {
         stream: "assistant",
         data: { text: "final answer", delta: "", replace: true, replaceable: true },
       });
+      emitAgentEvent({ runId, stream: "assistant", data: { text: "final answer" } });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
       return { payloads: [{ text: "final answer" }] };
     }) as never);
 

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1090,6 +1090,48 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(completed.response?.output?.[0]?.content?.[0]?.text).toBe("final answer");
   });
 
+  it("emits a final delta for the first non-replaceable empty assistant replacement", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "final answer", delta: "", replace: true },
+      });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+      return { payloads: [{ text: "final answer" }] };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const events = parseSseEvents(await res.text());
+    const deltas = events
+      .filter((event) => event.event === "response.output_text.delta")
+      .map((event) => {
+        const parsed = JSON.parse(event.data) as { delta?: string };
+        return parsed.delta ?? "";
+      })
+      .join("");
+    const completed = JSON.parse(findSseEvent(events, "response.completed").data) as {
+      response?: { output?: Array<{ content?: Array<{ text?: string }> }> };
+    };
+
+    expect(deltas).toBe("final answer");
+    expect(completed.response?.output?.[0]?.content?.[0]?.text).toBe("final answer");
+  });
+
   it("maps provider format failures to OpenResponses 400 failed responses", async () => {
     const port = enabledPort;
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -1106,6 +1106,12 @@ export async function handleOpenResponsesHttpRequest(
       // Check for pending client tool calls BEFORE maybeFinalize() because the
       // lifecycle:end event may already have requested finalization.
       const resultAny = result as { payloads?: Array<{ text?: string }>; meta?: unknown };
+      const resultPayloadText = Array.isArray(resultAny.payloads)
+        ? resultAny.payloads
+            .map((p) => (typeof p.text === "string" ? p.text : ""))
+            .filter(Boolean)
+            .join("\n\n")
+        : "";
       const meta = resultAny.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 
@@ -1146,14 +1152,7 @@ export async function handleOpenResponsesHttpRequest(
       ) {
         const usage = finalUsage ?? createEmptyUsage();
         const finalText =
-          accumulatedText ||
-          bufferedReplaceableAssistantContent ||
-          (Array.isArray(resultAny.payloads)
-            ? resultAny.payloads
-                .map((p) => (typeof p.text === "string" ? p.text : ""))
-                .filter(Boolean)
-                .join("\n\n")
-            : "");
+          accumulatedText || resultPayloadText || bufferedReplaceableAssistantContent;
 
         if (toolChoiceConstraint && finalText && !sawAssistantDelta) {
           sawAssistantDelta = true;
@@ -1247,27 +1246,16 @@ export async function handleOpenResponsesHttpRequest(
         return;
       }
 
-      maybeFinalize();
-
-      if (closed) {
-        return;
-      }
-
       // Fallback: if no streaming deltas were received, send the full response as text
       if (!sawAssistantDelta) {
-        const payloads = resultAny.payloads;
         const content =
-          accumulatedText ||
-          bufferedReplaceableAssistantContent ||
-          (Array.isArray(payloads) && payloads.length > 0
-            ? payloads
-                .map((p) => (typeof p.text === "string" ? p.text : ""))
-                .filter(Boolean)
-                .join("\n\n")
-            : "No response from OpenClaw.");
+          resultPayloadText || bufferedReplaceableAssistantContent || "No response from OpenClaw.";
 
         accumulatedText = content;
         sawAssistantDelta = true;
+        if (finalizeRequested) {
+          finalizeRequested = { ...finalizeRequested, text: content };
+        }
 
         writeSseEvent(res, {
           type: "response.output_text.delta",
@@ -1277,6 +1265,8 @@ export async function handleOpenResponsesHttpRequest(
           delta: content,
         });
       }
+
+      maybeFinalize();
     } catch (err) {
       if (closed || abortController.signal.aborted) {
         return;

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -33,7 +33,11 @@ import {
   type InputImageSource,
 } from "../media/input-files.js";
 import { defaultRuntime } from "../runtime.js";
-import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
+import {
+  isReplaceableAssistantStreamEvent,
+  resolveAssistantStreamDeltaText,
+  resolveAssistantStreamSnapshotText,
+} from "./agent-event-assistant-text.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import {
@@ -1028,11 +1032,14 @@ export async function handleOpenResponsesHttpRequest(
     }
 
     if (evt.stream === "assistant") {
-      const text = evt.data?.text;
-      const replace = evt.data?.replace === true;
-      if (replace && typeof text === "string") {
-        accumulatedText = text;
+      if (isReplaceableAssistantStreamEvent(evt)) {
+        const snapshot = resolveAssistantStreamSnapshotText(evt);
+        if (snapshot) {
+          accumulatedText = snapshot;
+        }
+        return;
       }
+
       const content = resolveAssistantStreamDeltaText(evt);
       if (!content) {
         return;
@@ -1247,12 +1254,13 @@ export async function handleOpenResponsesHttpRequest(
       if (!sawAssistantDelta) {
         const payloads = resultAny.payloads;
         const content =
-          Array.isArray(payloads) && payloads.length > 0
+          accumulatedText ||
+          (Array.isArray(payloads) && payloads.length > 0
             ? payloads
                 .map((p) => (typeof p.text === "string" ? p.text : ""))
                 .filter(Boolean)
                 .join("\n\n")
-            : "No response from OpenClaw.";
+            : "No response from OpenClaw.");
 
         accumulatedText = content;
         sawAssistantDelta = true;

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -1041,6 +1041,15 @@ export async function handleOpenResponsesHttpRequest(
         return;
       }
 
+      const text = evt.data?.text;
+      const replace = evt.data?.replace === true;
+      if (replace && typeof text === "string") {
+        accumulatedText = text;
+        if (!toolChoiceConstraint) {
+          sawAssistantDelta = true;
+        }
+      }
+
       const content = resolveAssistantStreamDeltaText(evt);
       if (!content) {
         return;

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -1043,15 +1043,29 @@ export async function handleOpenResponsesHttpRequest(
 
       const text = evt.data?.text;
       const replace = evt.data?.replace === true;
+      const hadAssistantDelta = sawAssistantDelta;
       if (replace && typeof text === "string") {
         accumulatedText = text;
-        if (!toolChoiceConstraint) {
-          sawAssistantDelta = true;
-        }
       }
 
       const content = resolveAssistantStreamDeltaText(evt);
       if (!content) {
+        if (
+          replace &&
+          typeof text === "string" &&
+          text &&
+          !toolChoiceConstraint &&
+          !hadAssistantDelta
+        ) {
+          sawAssistantDelta = true;
+          writeSseEvent(res, {
+            type: "response.output_text.delta",
+            item_id: outputItemId,
+            output_index: 0,
+            content_index: 0,
+            delta: text,
+          });
+        }
         return;
       }
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -916,6 +916,7 @@ export async function handleOpenResponsesHttpRequest(
   setSseHeaders(res);
 
   let accumulatedText = "";
+  let bufferedReplaceableAssistantContent = "";
   let sawAssistantDelta = false;
   let closed = false;
   let unsubscribe = () => {};
@@ -1035,7 +1036,7 @@ export async function handleOpenResponsesHttpRequest(
       if (isReplaceableAssistantStreamEvent(evt)) {
         const snapshot = resolveAssistantStreamSnapshotText(evt);
         if (snapshot) {
-          accumulatedText = snapshot;
+          bufferedReplaceableAssistantContent = snapshot;
         }
         return;
       }
@@ -1071,7 +1072,8 @@ export async function handleOpenResponsesHttpRequest(
     if (evt.stream === "lifecycle") {
       const phase = evt.data?.phase;
       if (phase === "end" || phase === "error") {
-        const finalText = accumulatedText || "No response from OpenClaw.";
+        const finalText =
+          accumulatedText || bufferedReplaceableAssistantContent || "No response from OpenClaw.";
         const finalStatus = phase === "error" ? "failed" : "completed";
         requestFinalize(finalStatus, finalText);
       }
@@ -1145,6 +1147,7 @@ export async function handleOpenResponsesHttpRequest(
         const usage = finalUsage ?? createEmptyUsage();
         const finalText =
           accumulatedText ||
+          bufferedReplaceableAssistantContent ||
           (Array.isArray(resultAny.payloads)
             ? resultAny.payloads
                 .map((p) => (typeof p.text === "string" ? p.text : ""))
@@ -1152,14 +1155,14 @@ export async function handleOpenResponsesHttpRequest(
                 .join("\n\n")
             : "");
 
-        if (toolChoiceConstraint && accumulatedText) {
+        if (toolChoiceConstraint && finalText && !sawAssistantDelta) {
           sawAssistantDelta = true;
           writeSseEvent(res, {
             type: "response.output_text.delta",
             item_id: outputItemId,
             output_index: 0,
             content_index: 0,
-            delta: accumulatedText,
+            delta: finalText,
           });
         }
         writeSseEvent(res, {
@@ -1255,6 +1258,7 @@ export async function handleOpenResponsesHttpRequest(
         const payloads = resultAny.payloads;
         const content =
           accumulatedText ||
+          bufferedReplaceableAssistantContent ||
           (Array.isArray(payloads) && payloads.length > 0
             ? payloads
                 .map((p) => (typeof p.text === "string" ? p.text : ""))

--- a/src/gateway/server-chat.stream-text-merge.test.ts
+++ b/src/gateway/server-chat.stream-text-merge.test.ts
@@ -60,6 +60,16 @@ describe("server chat stream text merge", () => {
     ).toBe("Before tool call\nAfter tool call");
   });
 
+  it("replaces superseded assistant item text when the replacement delta is empty", () => {
+    expect(
+      resolveMergedAssistantText({
+        previousText: "coordination draft",
+        nextText: "final answer",
+        nextDelta: "",
+      }),
+    ).toBe("final answer");
+  });
+
   it("caps merged live text while preserving the newest assistant output", () => {
     const result = resolveMergedAssistantText({
       previousText: "a".repeat(MAX_LIVE_CHAT_BUFFER_CHARS - 2),


### PR DESCRIPTION
## Summary

What problem does this PR solve?
Fixes an issue where Codex app-server backed TUI/WebChat runs did not show incremental assistant text. Users would only see the complete assistant reply after the turn finished when Codex emitted `item/agentMessage/delta` notifications without a final-answer `phase` field.

Why does this matter now?
The current Codex app-server protocol streams assistant deltas by `itemId` and `delta`, while completed items carry optional phase metadata later. OpenClaw was gating partial assistant projection on phase metadata that is not present on the delta event, so the user-visible streaming path was blocked at the source.

What is the intended outcome?
Root-cause fix: treat non-commentary Codex assistant deltas as the streaming source-of-truth for partial assistant text, emit replacement-aware snapshots when the assistant item changes, and make downstream non-rewritable surfaces buffer replaceable snapshots until final authoritative text is known.

What is intentionally out of scope?
This does not change Codex protocol/schema, provider routing, model selection, auth, config, migrations, or commentary suppression policy. It only updates OpenClaw projection and stream assembly for assistant text that Codex already emits.

What does success look like?
TUI/WebChat can receive incremental assistant chunks again, while OpenAI-compatible Chat Completions, OpenResponses, and ACP parent relay outputs do not leak superseded draft assistant items or duplicate final text.

What should reviewers focus on?
The source-of-truth boundary is the Codex app-server delta contract: deltas have `itemId` and `delta`, not `phase`. Reviewers should focus on replacement semantics for item switches and on the downstream buffering paths that prevent replaceable snapshots from becoming stale public output.

- Fix classification: Root-cause fix at the projection contract boundary, with downstream stream-state handling for consumers that cannot rewrite already emitted chunks.
- Maintainer-ready confidence: High. The fix is covered by focused projector, gateway streaming, OpenResponses replacement, and ACP relay regression tests on the current branch head.
- Root cause: OpenClaw required Codex assistant delta events to have final-answer phase metadata before projecting partial assistant text, but the upstream Codex delta contract does not include phase on `item/agentMessage/delta`; phase exists only on completed assistant items.
- Why this is root-cause fix: The projector now maps the actual upstream delta contract instead of waiting for unavailable phase metadata, and it marks multi-item assistant snapshots as replaceable so downstream surfaces preserve final-answer authority instead of masking the symptom in one UI consumer.
- Why it matters / User impact: Users regain incremental assistant streaming in Codex-backed TUI/WebChat sessions, and API/ACP consumers keep receiving clean final answers without stale draft text.
- What did NOT change: No unrelated refactor, no Codex protocol change, no config/default/migration change, and no security/auth/tool-execution behavior change.
- Architecture / source-of-truth check: Codex app-server delta notifications are the canonical partial-text source; OpenClaw projection is a mirror of that protocol and final result payloads remain authoritative for completed API responses.
- Patch quality notes: Patch-quality warning categories are expected because this touches streaming availability/session-state surfaces and public HTTP response assembly; the risk is guarded by focused regression tests for each touched consumer rather than a catch-all fallback.

## Linked context

Which issue does this close?
Closes #95422

Which issues, PRs, or discussions are related?
Related scan: #95404 is an existing linked PR for the same issue. This PR keeps a focused independent fix for the Codex delta contract and downstream replacement leak paths.

Was this requested by a maintainer or owner?
No maintainer request was found in the local issue context; this is a contributor fix for the reported issue.

## Real behavior proof

- Behavior or issue addressed: Codex app-server assistant text should stream incrementally through OpenClaw TUI/WebChat instead of appearing only after turn completion; replacement assistant items must not leave stale draft text in API or ACP outputs.
- Real environment tested: Local OpenClaw worktree with the project Vitest gateway, agents, and extension-Codex configurations, plus lint on the modified TypeScript files.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts src/gateway/server-chat.stream-text-merge.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts src/agents/acp-spawn-parent-stream.test.ts`; `pnpm exec oxlint extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts src/gateway/agent-event-assistant-text.ts src/gateway/openai-http.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.ts src/gateway/openresponses-http.test.ts src/gateway/server-chat.stream-text-merge.test.ts src/agents/acp-spawn-parent-stream.ts src/agents/acp-spawn-parent-stream.test.ts`.
- Evidence after fix: Vitest passed all relevant shards: gateway streaming tests reported 8 files passed and 175 tests passed; agents relay tests reported 1 file passed and 34 tests passed; extension-Codex projector tests reported 1 file passed and 97 tests passed. The regression assertion for non-replaceable OpenResponses replacement now completes with `final answer` instead of stale `coordination draft`. Oxlint on modified files exited successfully.
- Observed result after fix: Unphased Codex assistant deltas now produce incremental assistant snapshots, replacement payloads keep `delta: ""` for item switches, OpenResponses `response.completed` text uses the replacement/final answer, OpenAI-compatible streaming prefers final result payloads over replaceable drafts, and ACP parent relay flushes only the latest replaceable assistant snapshot.
- What was not tested: A manual live TUI/WebChat session was not run in this environment; the behavior was validated through the projector and gateway/ACP stream tests that exercise the same event and SSE assembly paths.
- Proof limitations or environment constraints: ClawSweeper review found no actionable issue but its sandbox could not bind localhost for Gateway HTTP suites; the daily-fix validation outside that sandbox ran the relevant Gateway HTTP suites successfully.

## Tests and validation

Which commands did you run?
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts src/gateway/server-chat.stream-text-merge.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts src/agents/acp-spawn-parent-stream.test.ts`
- `pnpm exec oxlint extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts src/gateway/agent-event-assistant-text.ts src/gateway/openai-http.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.ts src/gateway/openresponses-http.test.ts src/gateway/server-chat.stream-text-merge.test.ts src/agents/acp-spawn-parent-stream.ts src/agents/acp-spawn-parent-stream.test.ts`

What regression coverage was added or updated?
Added projector coverage for unphased assistant deltas and assistant item replacement, live-chat merge coverage for empty-delta replacement snapshots, OpenAI-compatible streaming coverage for replaceable draft buffering and final-result precedence, OpenResponses coverage for replaceable snapshots, final-result precedence, and non-replaceable `replace: true` events, and ACP relay coverage for suppressing superseded replaceable drafts.

What failed before this fix, if known?
The newly added OpenResponses regression failed before the final patch: `response.completed` kept `coordination draft` instead of `final answer` after a non-replaceable assistant replacement event.

If no test was added, why not?
Regression tests were added for every changed stream consumer path in this PR scope.

- Target test file: `extensions/codex/src/app-server/event-projector.test.ts`, `src/gateway/server-chat.stream-text-merge.test.ts`, `src/gateway/openai-http.test.ts`, `src/gateway/openresponses-http.test.ts`, and `src/agents/acp-spawn-parent-stream.test.ts`.
- Scenario locked in: Codex unphased deltas stream incrementally; assistant item switches use empty-delta replacement snapshots; replaceable drafts are buffered until final authoritative text; OpenResponses legacy `replace: true` events still update final completed text.
- Why this is the smallest reliable guardrail: These tests pin the exact protocol and event-stream contracts at the projector and each public consumer boundary, avoiding broad end-to-end flakiness while covering the state transitions that caused the issue.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
Yes. Codex-backed chat surfaces should now show incremental assistant text instead of waiting for turn completion.

Did config, environment, or migration behavior change? (`Yes/No`)
No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
No security, auth, secrets, or tool-execution behavior changed. The public HTTP streaming assembly behavior changes only to preserve final assistant text authority and avoid stale replaceable drafts.

What is the highest-risk area?
Streaming session-state and public response assembly for assistant text across TUI/WebChat, OpenAI-compatible Chat Completions, OpenResponses, and ACP relay.

How is that risk mitigated?
Each touched consumer has focused regression coverage for replacement or buffering behavior, final result payloads remain authoritative, commentary remains excluded from partial assistant streaming, and no source schema or provider contract is changed.

- Risk labels considered: availability, session-state, public HTTP streaming contract, and security-boundary signal from assistant event projection.
- Risk explanation: The diff touches multiple streaming consumers because a root projector fix would otherwise expose replaceable multi-item assistant snapshots to consumers that cannot rewrite prior chunks.
- Why acceptable: The change keeps the canonical Codex protocol unchanged, limits behavior to assistant text projection/assembly, and adds targeted tests proving stale draft suppression and final-answer precedence.

## Current review state

What is the next action?
Submit this PR after daily-fix local-submit-ready passes on the current verified head.

What is still waiting on author, maintainer, CI, or external proof?
CI and maintainer review are still pending after PR submission; no known author-side code finding remains.

Which bot or reviewer comments were addressed?
Codex diff review P2 for OpenResponses non-replaceable `replace: true` events was addressed with a regression test and source fix. ClawSweeper review reported no actionable issue; its remaining limitation was sandbox inability to bind localhost for Gateway HTTP suites, while local daily-fix validation ran those suites successfully.
