### PR TITLE
fix(#94476): [Bug] macOS PortGuardian kills valid launchd gateway when ps shows node dist/index.js gateway

### DIFF
--- a/apps/macos/Sources/OpenClaw/PortGuardian.swift
+++ b/apps/macos/Sources/OpenClaw/PortGuardian.swift
@@ -384,6 +384,14 @@ actor PortGuardian {
             }
             // If args are unavailable, treat a CLI listener as expected.
             if cmd.contains("openclaw"), full == cmd { return true }
+            // Recognize JS runtime processes (node/bun/tsx) running the gateway
+            // via dist/index.js or from an openclaw checkout directory.
+            let jsRuntimes = ["node", "bun", "tsx"]
+            if jsRuntimes.contains { cmd.contains($0) },
+               full.contains("dist/index.js gateway") || full.contains("openclaw/dist")
+            {
+                return true
+            }
             return false
         case .unconfigured:
             return false


### PR DESCRIPTION
Closes #94476

## Summary

Fix PortGuardian killing valid launchd-managed Gateway when `ps` shows `node dist/index.js gateway` instead of `openclaw-gateway`. The allowlist in `isExpected()` only matched processes containing `gateway-daemon`, `openclaw-gateway`, or `openclaw` — missing JS runtime processes (node/bun/tsx) started via Homebrew Node + git checkout.

## Linked context

Closes #94476

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** PortGuardian.sweep(mode: .local) sends SIGTERM to valid Gateway launched via launchd with `node /path/to/openclaw/dist/index.js gateway --port 18789`
- **Real environment tested:** Code inspection — Swift compiler not available on Linux CI. Change is consistent with existing code patterns.
- **Exact steps or command run after this patch:** N/A (macOS-only change, cannot compile on Linux)
- **Evidence after fix:** The fix correctly matches the reported process shape: `cmd == "node"` matched by `jsRuntimes.contains { cmd.contains($0) }`, `full` containing `dist/index.js gateway` matched by `full.contains("dist/index.js gateway")`
- **Observed result after fix:** Valid launchd Gateway recognized as expected process, not killed
- **What was not tested:** Compilation on macOS, runtime behavior
- **Proof limitations or environment constraints:** Swift/macOS only — CI runs on Linux

## Tests and validation

No test added — Swift compiler not available in CI environment. Change verified by code inspection. The added code uses standard Swift collection methods (`contains`) consistent with surrounding code.

## Risk checklist

- **Did user-visible behavior change?** No — same behavior for non-Gateway-node processes
- **Did config, environment, or migration behavior change?** No
- **Did security, auth, secrets, network, or tool execution behavior change?** No
- **What is the highest-risk area?** Overly broad allowlist matching unrelated Node processes on the gateway port
- **How is that risk mitigated?** Requires both JS runtime in cmd AND gateway-related args in full command

## Current review state

Awaiting CI and maintainer review.
