### PR TITLE
fix #95291: message tool fails to deliver files/images on Feishu (400 volc-dcdn / write ECONNRESET) while same Lark SDK upload succeeds standalone

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -376,18 +376,34 @@ describe("createFeishuClient HTTP timeout", () => {
     expect(Buffer.from(await media.arrayBuffer())).toEqual(testCase.mediaBytes);
   });
 
-  it("leaves unrelated SDK multipart uploads on the SDK serialization path", async () => {
+  it.each([
+    {
+      name: "other endpoints",
+      url: "https://open.feishu.cn/open-apis/drive/v1/files/upload_all",
+      method: "POST",
+    },
+    {
+      name: "upload paths mentioned only in a query",
+      url: "https://open.feishu.cn/upload?return=/open-apis/im/v1/files",
+      method: "POST",
+    },
+    {
+      name: "non-POST requests",
+      url: "https://open.feishu.cn/open-apis/im/v1/files",
+      method: "GET",
+    },
+  ])("leaves $name on the SDK multipart serialization path", async ({ url, method }) => {
     createFeishuClient({
-      appId: "app_upload_other",
+      appId: `app_upload_other_${method}`,
       appSecret: "test-app-secret", // pragma: allowlist secret
-      accountId: "multipart-upload-other",
+      accountId: `multipart-upload-other-${method}-${url.length}`,
     });
     const httpInstance = readLastClientHttpInstance();
     const data = { file_name: "drive.txt", file: Buffer.from("drive") };
 
     await httpInstance.request({
-      url: "https://open.feishu.cn/open-apis/drive/v1/files/upload_all",
-      method: "POST",
+      url,
+      method,
       headers: { "Content-Type": "multipart/form-data" },
       data,
     });

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -325,6 +325,40 @@ describe("createFeishuClient HTTP timeout", () => {
     });
   });
 
+  it("normalizes Feishu SDK multipart uploads to explicit FormData", async () => {
+    createFeishuClient({
+      appId: "app_upload",
+      appSecret: "secret_upload", // pragma: allowlist secret
+      accountId: "multipart-upload",
+    });
+
+    const httpInstance = readLastClientHttpInstance();
+
+    await httpInstance.request({
+      url: "https://open.feishu.cn/open-apis/im/v1/files",
+      method: "POST",
+      headers: { "Content-Type": "multipart/form-data", Authorization: "Bearer token" },
+      data: {
+        file_type: "stream",
+        file_name: "tiny.txt",
+        file: Buffer.from("tiny"),
+      },
+    });
+
+    const delegated = readCallOptions(mockBaseHttpInstance.request);
+    expect(delegated.timeout).toBe(FEISHU_HTTP_TIMEOUT_MS);
+    expect(delegated.headers).toEqual({
+      "Content-Type": "multipart/form-data",
+      Authorization: "Bearer token",
+    });
+    expect(delegated.data).toBeInstanceOf(FormData);
+    expect(delegated.data).not.toEqual({
+      file_type: "stream",
+      file_name: "tiny.txt",
+      file: Buffer.from("tiny"),
+    });
+  });
+
   it("uses config-configured default timeout when provided", async () => {
     createFeishuClient({
       appId: "app_4",

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -357,7 +357,7 @@ describe("createFeishuClient HTTP timeout", () => {
     await httpInstance.request({
       url: testCase.url,
       method: "POST",
-      headers: { "Content-Type": "multipart/form-data", Authorization: "Bearer token" },
+      headers: { "Content-Type": "multipart/form-data", Authorization: "Bearer test-token" },
       data: testCase.data,
     });
 
@@ -365,7 +365,7 @@ describe("createFeishuClient HTTP timeout", () => {
     expect(delegated.timeout).toBe(FEISHU_HTTP_TIMEOUT_MS);
     expect(delegated.headers).toEqual({
       "Content-Type": "multipart/form-data",
-      Authorization: "Bearer token",
+      Authorization: "Bearer test-token",
     });
     const form = delegated.data as FormData;
     expect(form).toBeInstanceOf(FormData);

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -325,24 +325,40 @@ describe("createFeishuClient HTTP timeout", () => {
     });
   });
 
-  it("normalizes Feishu SDK multipart uploads to explicit FormData", async () => {
+  it.each([
+    {
+      kind: "file",
+      url: "https://open.feishu.cn/open-apis/im/v1/files",
+      data: { file_type: "stream", file_name: "tiny.txt", file: Buffer.from("tiny") },
+      mediaField: "file",
+      mediaBytes: Buffer.from("tiny"),
+      fileName: "tiny.txt",
+      scalarField: "file_type",
+      scalarValue: "stream",
+    },
+    {
+      kind: "image",
+      url: "https://open.feishu.cn/open-apis/im/v1/images",
+      data: { image_type: "message", image: Buffer.from("pixels") },
+      mediaField: "image",
+      mediaBytes: Buffer.from("pixels"),
+      fileName: "image.bin",
+      scalarField: "image_type",
+      scalarValue: "message",
+    },
+  ])("normalizes Feishu SDK $kind uploads to explicit FormData", async (testCase) => {
     createFeishuClient({
-      appId: "app_upload",
-      appSecret: "secret_upload", // pragma: allowlist secret
-      accountId: "multipart-upload",
+      appId: `app_upload_${testCase.kind}`,
+      appSecret: "test-secret", // pragma: allowlist secret
+      accountId: `multipart-upload-${testCase.kind}`,
     });
-
     const httpInstance = readLastClientHttpInstance();
 
     await httpInstance.request({
-      url: "https://open.feishu.cn/open-apis/im/v1/files",
+      url: testCase.url,
       method: "POST",
       headers: { "Content-Type": "multipart/form-data", Authorization: "Bearer token" },
-      data: {
-        file_type: "stream",
-        file_name: "tiny.txt",
-        file: Buffer.from("tiny"),
-      },
+      data: testCase.data,
     });
 
     const delegated = readCallOptions(mockBaseHttpInstance.request);
@@ -351,12 +367,32 @@ describe("createFeishuClient HTTP timeout", () => {
       "Content-Type": "multipart/form-data",
       Authorization: "Bearer token",
     });
-    expect(delegated.data).toBeInstanceOf(FormData);
-    expect(delegated.data).not.toEqual({
-      file_type: "stream",
-      file_name: "tiny.txt",
-      file: Buffer.from("tiny"),
+    const form = delegated.data as FormData;
+    expect(form).toBeInstanceOf(FormData);
+    expect(form.get(testCase.scalarField)).toBe(testCase.scalarValue);
+    const media = form.get(testCase.mediaField) as File;
+    expect(media).toBeInstanceOf(Blob);
+    expect(media.name).toBe(testCase.fileName);
+    expect(Buffer.from(await media.arrayBuffer())).toEqual(testCase.mediaBytes);
+  });
+
+  it("leaves unrelated SDK multipart uploads on the SDK serialization path", async () => {
+    createFeishuClient({
+      appId: "app_upload_other",
+      appSecret: "test-secret", // pragma: allowlist secret
+      accountId: "multipart-upload-other",
     });
+    const httpInstance = readLastClientHttpInstance();
+    const data = { file_name: "drive.txt", file: Buffer.from("drive") };
+
+    await httpInstance.request({
+      url: "https://open.feishu.cn/open-apis/drive/v1/files/upload_all",
+      method: "POST",
+      headers: { "Content-Type": "multipart/form-data" },
+      data,
+    });
+
+    expect(readCallOptions(mockBaseHttpInstance.request).data).toBe(data);
   });
 
   it("uses config-configured default timeout when provided", async () => {

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -349,7 +349,7 @@ describe("createFeishuClient HTTP timeout", () => {
   ])("normalizes Feishu SDK $kind uploads to explicit FormData", async (testCase) => {
     createFeishuClient({
       appId: `app_upload_${testCase.kind}`,
-      appSecret: "test-secret", // pragma: allowlist secret
+      appSecret: "test-app-secret", // pragma: allowlist secret
       accountId: `multipart-upload-${testCase.kind}`,
     });
     const httpInstance = readLastClientHttpInstance();
@@ -379,7 +379,7 @@ describe("createFeishuClient HTTP timeout", () => {
   it("leaves unrelated SDK multipart uploads on the SDK serialization path", async () => {
     createFeishuClient({
       appId: "app_upload_other",
-      appSecret: "test-secret", // pragma: allowlist secret
+      appSecret: "test-app-secret", // pragma: allowlist secret
       accountId: "multipart-upload-other",
     });
     const httpInstance = readLastClientHttpInstance();

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -85,6 +85,90 @@ type FeishuHttpInstanceLike = Pick<
   "request" | "get" | "post" | "put" | "patch" | "delete" | "head" | "options"
 >;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readHeader(headers: unknown, name: string): string | undefined {
+  if (!isRecord(headers)) {
+    return undefined;
+  }
+  const normalizedName = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== normalizedName) {
+      continue;
+    }
+    if (typeof value === "string") {
+      return value;
+    }
+    if (Array.isArray(value)) {
+      const first = value.find((entry) => typeof entry === "string");
+      return typeof first === "string" ? first : undefined;
+    }
+  }
+  return undefined;
+}
+
+function isMultipartFormRequest(opts: Lark.HttpRequestOptions<unknown>): boolean {
+  return /^multipart\/form-data(?:;|$)/i.test(readHeader(opts.headers, "content-type") ?? "");
+}
+
+function hasFeishuUploadPart(data: Record<string, unknown>): boolean {
+  return Buffer.isBuffer(data.file) || Buffer.isBuffer(data.image);
+}
+
+function stringifyMultipartFieldValue(value: unknown): string | undefined {
+  switch (typeof value) {
+    case "string":
+      return value;
+    case "number":
+    case "boolean":
+    case "bigint":
+      return String(value);
+    default:
+      return undefined;
+  }
+}
+
+function bufferToBlobPart(value: Buffer): Uint8Array<ArrayBuffer> {
+  const bytes = new Uint8Array(value.byteLength);
+  bytes.set(value);
+  return bytes;
+}
+
+function normalizeMultipartUploadData<D>(
+  opts: Lark.HttpRequestOptions<D>,
+): Lark.HttpRequestOptions<D> {
+  if (!isMultipartFormRequest(opts) || !isRecord(opts.data) || !hasFeishuUploadPart(opts.data)) {
+    return opts;
+  }
+
+  const form = new FormData();
+  const fileName =
+    typeof opts.data.file_name === "string" && opts.data.file_name
+      ? opts.data.file_name
+      : undefined;
+  for (const [key, value] of Object.entries(opts.data)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (Buffer.isBuffer(value)) {
+      form.append(
+        key,
+        new Blob([bufferToBlobPart(value)]),
+        key === "file" && fileName ? fileName : `${key}.bin`,
+      );
+      continue;
+    }
+    const fieldValue = stringifyMultipartFieldValue(value);
+    if (fieldValue !== undefined) {
+      form.append(key, fieldValue);
+    }
+  }
+
+  return { ...opts, data: form as D };
+}
+
 function isManagedProxyActive() {
   return process.env["OPENCLAW_PROXY_ACTIVE"] === "1";
 }
@@ -193,7 +277,8 @@ function createFeishuHttpInstance(defaultTimeoutMs: number): Lark.HttpInstance {
   }
 
   return {
-    request: async (opts) => base.request(await injectRequestOptions(opts)),
+    request: async (opts) =>
+      base.request(await injectRequestOptions(normalizeMultipartUploadData(opts))),
     get: async (url, opts) => base.get(url, await injectRequestOptions(opts)),
     post: async (url, data, opts) => base.post(url, data, await injectRequestOptions(opts)),
     put: async (url, data, opts) => base.put(url, data, await injectRequestOptions(opts)),

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -113,15 +113,26 @@ function isMultipartFormRequest(opts: Lark.HttpRequestOptions<unknown>): boolean
   return /^multipart\/form-data(?:;|$)/i.test(readHeader(opts.headers, "content-type") ?? "");
 }
 
-const FEISHU_MESSAGE_MEDIA_UPLOAD_PATH_RE = /\/open-apis\/im\/v1\/(?:files|images)(?:[?#]|$)/;
+const FEISHU_MESSAGE_MEDIA_UPLOAD_PATHS = new Set([
+  "/open-apis/im/v1/files",
+  "/open-apis/im/v1/images",
+]);
 
 function isFeishuMessageMediaUploadRequest(
   opts: Lark.HttpRequestOptions<unknown>,
   data: Record<string, unknown>,
 ): boolean {
+  if (typeof opts.url !== "string" || opts.method?.toUpperCase() !== "POST") {
+    return false;
+  }
+  let pathname: string;
+  try {
+    pathname = new URL(opts.url).pathname;
+  } catch {
+    return false;
+  }
   return (
-    typeof opts.url === "string" &&
-    FEISHU_MESSAGE_MEDIA_UPLOAD_PATH_RE.test(opts.url) &&
+    FEISHU_MESSAGE_MEDIA_UPLOAD_PATHS.has(pathname) &&
     (Buffer.isBuffer(data.file) || Buffer.isBuffer(data.image))
   );
 }

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -113,8 +113,17 @@ function isMultipartFormRequest(opts: Lark.HttpRequestOptions<unknown>): boolean
   return /^multipart\/form-data(?:;|$)/i.test(readHeader(opts.headers, "content-type") ?? "");
 }
 
-function hasFeishuUploadPart(data: Record<string, unknown>): boolean {
-  return Buffer.isBuffer(data.file) || Buffer.isBuffer(data.image);
+const FEISHU_MESSAGE_MEDIA_UPLOAD_PATH_RE = /\/open-apis\/im\/v1\/(?:files|images)(?:[?#]|$)/;
+
+function isFeishuMessageMediaUploadRequest(
+  opts: Lark.HttpRequestOptions<unknown>,
+  data: Record<string, unknown>,
+): boolean {
+  return (
+    typeof opts.url === "string" &&
+    FEISHU_MESSAGE_MEDIA_UPLOAD_PATH_RE.test(opts.url) &&
+    (Buffer.isBuffer(data.file) || Buffer.isBuffer(data.image))
+  );
 }
 
 function stringifyMultipartFieldValue(value: unknown): string | undefined {
@@ -139,7 +148,11 @@ function bufferToBlobPart(value: Buffer): Uint8Array<ArrayBuffer> {
 function normalizeMultipartUploadData<D>(
   opts: Lark.HttpRequestOptions<D>,
 ): Lark.HttpRequestOptions<D> {
-  if (!isMultipartFormRequest(opts) || !isRecord(opts.data) || !hasFeishuUploadPart(opts.data)) {
+  if (
+    !isMultipartFormRequest(opts) ||
+    !isRecord(opts.data) ||
+    !isFeishuMessageMediaUploadRequest(opts, opts.data)
+  ) {
     return opts;
   }
 


### PR DESCRIPTION
Closes #95291

## What Problem This Solves

Fixes an issue where Feishu/Lark users sending local files or images through the OpenClaw `message` tool could see media delivery fail with CDN-edge upload errors, even though the same app credentials and media succeeded through a standalone Lark SDK upload.

## Why This Change Was Made

OpenClaw intentionally wraps the Lark SDK HTTP instance to inject request timeouts. The SDK upload helpers provide multipart upload data as a plain object containing Buffer media parts; relying on implicit serialization in the wrapped transport path was fragile. This change keeps the canonical SDK upload APIs and normalizes only Feishu media upload requests into explicit native `FormData` before delegating to the SDK default HTTP instance.

The follow-up type repair also copies each Buffer media part into an `ArrayBuffer`-backed `Uint8Array` before constructing the native `Blob`. That preserves the uploaded bytes while satisfying the current TypeScript `BlobPart` contract, which rejects `Buffer<ArrayBufferLike>` because it can be backed by `SharedArrayBuffer`.

## User Impact

Users can send Feishu `message` media attachments from local files/images through OpenClaw without hitting the malformed multipart upload path. The fix applies to both file and image uploads while leaving unrelated Feishu requests unchanged.

## Evidence

- Main sync completed for the PR branch before this round of validation.
- Type checks: `node scripts/run-tsgo.mjs -p tsconfig.extensions.json`, `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`, `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`, and `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo` — passed.
- Current-head `check-test-types` follow-up: the Feishu client regression test now reads the delegated request options from the actual `request` mock, matching the helper's typed input and preserving the runtime assertion.
- Focused Feishu Vitest: `CI=1 node scripts/run-vitest.mjs extensions/feishu/src/client.test.ts extensions/feishu/src/media.test.ts` — passed.
- Extension package boundary compile: `node scripts/check-extension-package-tsc-boundary.mjs --mode=compile` — passed.
- Extension lint: `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions` — passed.
- Tooling attribution check for the prior visible tooling failure: `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts --reporter=verbose src/scripts/test-projects.test.ts` — passed after syncing current main and refreshing dependencies.
- Whitespace check: `git diff --check` — passed.
- Authorized live Feishu proof from the earlier round on this PR: standalone SDK file/image uploads succeeded; OpenClaw Feishu helper file/image uploads succeeded; OpenClaw Feishu media-send path delivered file and image messages to both a private test DM and a private test group.
- Regression coverage: the focused client test verifies SDK-style multipart upload data with a Buffer media part is converted to explicit `FormData` while preserving timeout injection and headers.

## Summary

- **Behavior or issue addressed:** Fix Feishu/Lark `message` media delivery for local files and images when the SDK upload goes through OpenClaw's timeout-aware HTTP instance.
- **Why it matters / User impact:** The `message` tool could fail before Feishu returned a normal OpenAPI JSON response, producing CDN-edge upload errors even though the same app credentials and media worked through a standalone Lark SDK upload.
- **Fix classification:** Root-cause transport/request-shaping fix for Feishu SDK multipart uploads, plus a mechanical TypeScript `BlobPart` compatibility repair.
- **What did NOT change:** This does not change Feishu public config, target routing, message schema, SDK method selection, retry policy, or any unrelated provider behavior; only the Feishu media-upload request body representation is normalized.
- **Architecture / source-of-truth check:** The canonical source-of-truth remains the Lark SDK upload APIs (`im.file.create` and `im.image.create`) plus OpenClaw's existing timeout-aware HTTP wrapper. The Buffer-to-Blob conversion only adapts Node Buffer bytes to the native `BlobPart` type accepted by the wrapper boundary.

## Root Cause

- **Root cause:** The Feishu SDK generated file/image upload calls pass a plain object with a Buffer part while setting `Content-Type: multipart/form-data`. OpenClaw wraps the SDK default HTTP instance to inject timeouts; in that wrapped path, relying on implicit multipart serialization was fragile and caused malformed upload requests to be rejected at the Feishu CDN edge before normal OpenAPI handling. The review follow-up then exposed that passing a Node `Buffer<ArrayBufferLike>` directly to `new Blob(...)` is not accepted by current TypeScript DOM typings because the Buffer backing store may be `SharedArrayBuffer`.
- **Why this is root-cause fix:** The patch fixes the source contract mismatch at the HTTP wrapper boundary rather than masking the send failure downstream. When a multipart request contains a Buffer `file` or `image` part, the wrapper now builds an explicit native `FormData` payload before delegating to the SDK default HTTP instance, so the SDK upload request has the multipart shape Feishu expects while the canonical SDK methods and timeout behavior remain unchanged. The follow-up copies the Buffer into a fresh `Uint8Array<ArrayBuffer>` before creating the `Blob`, preserving bytes while using a BlobPart that TypeScript and native Blob accept.
- **Patch quality notes:** The normalization is narrowly gated on multipart requests with Feishu media Buffer parts, preserves timeout injection and headers, skips null/undefined fields, serializes only explicit scalar form fields, and preserves uploaded file names where available. The Buffer copy is local to media parts and does not change non-upload request handling.

## Real behavior proof

- **Real environment tested:** Authorized live Feishu self-built app and bot in private test DM and group conversations during the earlier live-proof round on this PR.
- **Exact live steps run after the multipart normalization patch:** Exercised standalone SDK file/image uploads, OpenClaw Feishu helper file/image uploads, and OpenClaw Feishu media-send delivery to both a DM and a group.
- **Evidence after fix:** Standalone SDK upload succeeded for a small text file and PNG image; OpenClaw helper upload succeeded for the same media classes; OpenClaw Feishu `message` media-send path delivered file and image messages to both DM and group.
- **Observed result after fix:** All live upload/send checks completed successfully with Feishu message receipts for the DM and group deliveries; no CDN-edge multipart upload failure was observed after the fix.
- **What was not re-run in this round:** The private Feishu tenant live path was not replayed for the mechanical Buffer-to-`BlobPart` type repair. This round revalidated the code path with focused Feishu tests plus full relevant type/lint/package-boundary checks after syncing main.

## Regression Test Plan

- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json` — passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` — passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` — passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo` — passed.
- `CI=1 node scripts/run-vitest.mjs extensions/feishu/src/client.test.ts extensions/feishu/src/media.test.ts` — passed.
- `node scripts/check-extension-package-tsc-boundary.mjs --mode=compile` — passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions` — passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts --reporter=verbose src/scripts/test-projects.test.ts` — passed.
- `git diff --check` — passed.
- **Target test file:** `extensions/feishu/src/client.test.ts`.
- **Scenario locked in:** A Feishu SDK-style multipart file upload request containing a Buffer `file` part is passed through the timeout-aware HTTP wrapper and must be delegated as explicit `FormData` rather than the original plain object.
- **Why this is the smallest reliable guardrail:** The regression test locks the wrapper boundary where the malformed multipart request was introduced, while existing media tests continue covering message routing and upload/send integration behavior.

## Review findings addressed

- **RF-001 (`status: ⏳ waiting on author`):** addressed by syncing main, applying the requested repair, and revalidating the PR branch. The label itself is expected to clear only after exact-head CI/bot or maintainer re-evaluation.
- **RF-002 / RF-006 (`check-prod-types` / extension type checks):** fixed. `node scripts/run-tsgo.mjs -p tsconfig.extensions.json` passed after copying Buffer media parts into `Uint8Array<ArrayBuffer>` before `new Blob(...)`.
- **RF-003 (live Feishu proof not independently replayed by reviewer):** disclosed. The public-safe live proof from the earlier round remains applicable to the multipart normalization behavior; this mechanical type repair was not replayed against the private tenant path.
- **RF-004 / RF-005 (single mechanical repair; convert the Buffer before constructing the Blob):** fixed in `extensions/feishu/src/client.ts` by adding a local Buffer-to-BlobPart adapter before constructing the native `Blob`.
- **RF-007 (extension package boundary compile):** passed with `node scripts/check-extension-package-tsc-boundary.mjs --mode=compile`.
- **RF-008 (focused Feishu tests):** passed with `CI=1 node scripts/run-vitest.mjs extensions/feishu/src/client.test.ts extensions/feishu/src/media.test.ts`.
- **Current-head `check-test-types` follow-up:** fixed by passing `mockBaseHttpInstance.request` to the test helper that reads mock call options; `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo` now passes.
- **RF-009 (extension lint):** passed with `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions`.

## Merge risk

- **Risk labels considered:** Feishu plugin, media upload, SDK HTTP wrapper, multipart request handling, native `FormData`/`Blob`, public contract scan.
- **Risk explanation:** Low-to-moderate. The change sits in a shared Feishu client wrapper, but the new behavior is narrowly gated to multipart requests that contain media Buffer parts. Non-upload requests, public config/schema, target normalization, provider routing, and timeout defaults remain unchanged. The follow-up Buffer copy is local to Blob construction and only changes the in-memory representation passed to native `Blob`.
- **Why acceptable:** The affected path already intends to send multipart Feishu uploads, and live proof covered both upload and message delivery for file/image media through the OpenClaw path. The out-of-scope boundary is explicit: no unrelated attachment-size, retry, routing, or public API/config behavior is changed.
- **Maintainer-ready confidence:** High for the reported Feishu media delivery failure; focused Feishu tests, relevant full type/lint/package-boundary checks, and authorized live Feishu proof are now all accounted for.
