### PR TITLE
fix(doctor): prevent writing groupAllowFrom to external channel plugins without schema

### DIFF
--- a/src/commands/doctor/shared/allowfrom-fallback-migration.ts
+++ b/src/commands/doctor/shared/allowfrom-fallback-migration.ts
@@ -105,7 +105,7 @@ function schemaAllowsConfigPath(schema: unknown, path: SchemaPath): boolean {
 
 function generatedSchemaAllowsGroupAllowFrom(channelName: string, path: SchemaPath): boolean {
   const schema = findGeneratedChannelConfigSchema(channelName);
-  return !schema || schemaAllowsConfigPath(schema, path);
+  return !!schema && schemaAllowsConfigPath(schema, path);
 }
 
 function migrateRecord(params: {


### PR DESCRIPTION
## Summary

The doctor migration `maybeRepairGroupAllowFromFallback` copies legacy `allowFrom` entries into explicit `groupAllowFrom` for channels that support it. However, its schema guard `generatedSchemaAllowsGroupAllowFrom` defaults to `true` (permissive) when a channel has no entry in the bundled channel config metadata — causing it to write `groupAllowFrom` to external/community plugins (e.g. ClawMail email) that don't accept that field in their schema. This breaks Gateway startup with a config validation error.

**Fix:** Flip the default from permissive (`!schema || ...`) to conservative (`!!schema && ...`). When we don't know a channel's schema, we should not write to it.

Fixes #95515

## Real behavior proof

**Behavior addressed**: Prevent `maybeRepairGroupAllowFromFallback` from injecting `groupAllowFrom` into external plugin channels whose schemas are not registered in the bundled channel config metadata.

**Real environment tested**: Linux x86_64, Node v25.9.0, OpenClaw main (73b35cc3ca)

**Exact steps or command run after this patch**: Shell commands and test runner output
```bash
# Run the affected migration unit tests
pnpm test src/commands/doctor/shared/allowfrom-fallback-migration.test.ts

# Run broader doctor shared tests
pnpm test src/commands/doctor/shared/

# Type check
pnpm tsgo:core:test
```

**After-fix evidence**: Test run output showing 636/636 tests passing, confirming no regression
```
# Before fix: generatedSchemaAllowsGroupAllowFrom returns true for unknown schemas
#   → email accounts get groupAllowFrom injected → config validation fails

# After fix: generatedSchemaAllowsGroupAllowFrom returns false for unknown schemas
#   → email accounts are skipped → no config corruption

$ pnpm test src/commands/doctor/shared/allowfrom-fallback-migration.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)

$ pnpm test src/commands/doctor/shared/
 Test Files  41 passed (41)
      Tests  636 passed (636)
```

**Observed result after the fix**: 
- The `generatedSchemaAllowsGroupAllowFrom("email", [...])` call now returns `false` instead of `true`, so `migrateRecord` receives `canWriteGroupAllowFrom: false` and skips the account.
- Bundled channels (telegram, signal, etc.) are unaffected — they have schemas in the generated metadata that correctly declare `groupAllowFrom`.
- The existing test "skips generated channel schemas that reject groupAllowFrom" continues to pass, confirming the schema guard works correctly for bundled channels that explicitly reject the field.

**What was not tested**: 
- Actual end-to-end upgrade from 2026.6.8 to 2026.6.9 on macOS (requires the ClawMail plugin + Apple Mail setup).
- Real running Gateway with the fixed migration.

## Tests and validation

### Unit tests

```
$ pnpm test src/commands/doctor/shared/allowfrom-fallback-migration.test.ts

 ✓ src/commands/doctor/shared/allowfrom-fallback-migration.test.ts (6 tests)
   ✓ doctor group allowFrom fallback migration
     ✓ copies fallback allowFrom into explicit groupAllowFrom
     ✓ uses canonical nested dm allowFrom for nested channels
     ✓ preserves account-scoped fallback without broadening to the channel
     ✓ does not shadow an inherited channel group allowlist for accounts
     ✓ skips disabled channels, disabled accounts, and channels without fallback
     ✓ skips generated channel schemas that reject groupAllowFrom

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

### Doctor shared tests (all)

```
$ pnpm test src/commands/doctor/shared/
 Test Files  41 passed (41)
      Tests  636 passed (636)
```

## Risk checklist

- [x] This change is backwards compatible
- [x] This change has been tested with existing configurations
- [ ] I have updated relevant documentation
- [x] Breaking changes (if any) are documented in Summary

**Risk details**: 
- Backwards compatible: Yes. The change only affects channels without bundled schemas (external plugins), which previously received an unwanted config field that broke their config validation.
- Documentation update: N/A — the behavior change is internal to the doctor migration guard logic.
- Non-bundled plugin authors who want the `groupAllowFrom` migration should register their channel schemas in `bundled-channel-config-metadata.generated.ts`.

## Current review state

- [x] Self-review completed
- [ ] At least one maintainer review
- [ ] All CI checks passed
