### PR TITLE
fix(agents): classify 'upstream request failed' as server_error for failover

### DIFF
--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -119,6 +119,7 @@ const ERROR_PATTERNS = {
     "gateway timeout",
     "upstream error",
     "upstream connect error",
+    "upstream request failed",
     "connection reset",
     // Chinese provider server error messages
     "内部错误",


### PR DESCRIPTION
## Summary

Provider errors with message `Upstream request failed` (error type `upstream_error`) were not matched by the existing `upstream error` or `upstream connect error` patterns, causing them to fall through to `unclassified` and preventing model fallback from triggering.

Add `upstream request failed` to the server error message patterns.

Fixes #95519.

## Change

`failover-matches.ts`: add `"upstream request failed"` to the `serverError` pattern list alongside existing `"upstream error"` and `"upstream connect error"` entries.

## Tests and validation

| Suite | Result |
|-------|--------|
| `failover-matches.test.ts` | ✅ 23/23 passed |

## Risk

- **Minimal**: one-line addition to an existing pattern list
- The pattern is specific enough to avoid false positives
- All existing server error classification behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)