### PR TITLE
fix(agents): classify upstream_error errorType as server_error for model fallback (fixes #95519) (AI-assisted)

### DIFF
--- a/src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
+++ b/src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
@@ -130,4 +130,31 @@ describe("provider failover hook structured signals", () => {
     ).toBeNull();
     expect(providerRuntimeMocks.classifyProviderPluginError).not.toHaveBeenCalled();
   });
+
+  it("classifies upstream_error errorType as server_error for model fallback", () => {
+    // When a provider returns an upstream_error type (e.g. OpenAI-compatible
+    // providers wrapping transient backend failures), the error should be
+    // classified as server_error so that configured fallback models are tried.
+    expect(
+      classifyFailoverSignal({
+        provider: "openai",
+        errorType: "upstream_error",
+        message: "Upstream request failed",
+      }),
+    ).toEqual({ kind: "reason", reason: "server_error" });
+  });
+
+  it("does not override provider plugin classification for upstream_error", () => {
+    // If a provider plugin hook already classifies the error, the
+    // errorType-based fallback should not interfere.
+    providerRuntimeMocks.classifyProviderPluginError.mockReturnValue("overloaded");
+
+    expect(
+      classifyFailoverSignal({
+        provider: "demo-provider",
+        errorType: "upstream_error",
+        message: "Upstream request failed",
+      }),
+    ).toEqual({ kind: "reason", reason: "overloaded" });
+  });
 });

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1197,6 +1197,16 @@ export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassifi
   if (codeReason) {
     return toReasonClassification(codeReason);
   }
+  // Provider-reported upstream errors are transient server-side failures that
+  // should trigger model fallback when a fallback chain is configured.
+  if (
+    signal.errorType === "upstream_error" &&
+    !statusClassification &&
+    !providerPluginReason &&
+    !codeReason
+  ) {
+    return toReasonClassification("server_error");
+  }
   return effectiveMessageClassification;
 }
 


### PR DESCRIPTION
## What Problem This Solves

When the primary provider returns an error with `type: "upstream_error"` (e.g. OpenAI-compatible providers wrapping transient backend failures), the configured fallback chain is never attempted. The turn ends immediately with "LLM request failed" instead of trying the next fallback model.

The root cause is in `classifyFailoverSignal`: the `errorType: "upstream_error"` is not recognized by any stage of the failover classification chain — provider plugin hooks don't handle it, the message "Upstream request failed" doesn't match existing message patterns, and there's no HTTP status code in the error payload to trigger status-based classification. The function returns `null`, so `shouldRotateAssistant` returns `false` and no fallback occurs.

## Changes Made

- Added `errorType`-based classification in `classifyFailoverSignal` (`src/agents/embedded-agent-helpers/errors.ts`): when `signal.errorType === "upstream_error"` and no provider plugin hook, HTTP status, or error code classification matched, the error is classified as `"server_error"` — the correct semantic category for transient server-side failures
- The check runs **after** provider plugin hooks and HTTP status/code classification, so provider-specific refinements always take precedence
- Added 2 test cases in `errors-provider-structured-signals.test.ts`:
  - Verifies `upstream_error` errorType is classified as `server_error`
  - Verifies provider plugin hook classification is not overridden

## Evidence

- **Behavior addressed:** Provider `upstream_error` errors now trigger model fallback when fallback models are configured
- **Environment tested:** macOS, Node.js, openclaw main branch (2026-06-21)
- **Steps run after the patch:** Ran failover classification test suite + build
- **Evidence after fix:**

```
$ node scripts/run-the verification suite.mjs run src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
 ✓  agents  src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts (7 tests) 29ms
 Test Files  1 passed (1)
      Tests  7 passed (7)

$ grep -n 'upstream_error' src/agents/embedded-agent-helpers/errors.ts
1203:    signal.errorType === "upstream_error" &&

$ grep -n 'upstream_error' dist/errors-DIAwurmw.js
706:	if (signal.errorType === "upstream_error" && !statusClassification && !providerPluginReason && !codeReason) return toReasonClassification("server_error");

$ pnpm build
[build-all] phase timings: total 149.7s (success)
```

- **Observed result after fix:** The `upstream_error` errorType is now classified as `server_error`, enabling fallback model rotation. Provider plugin hooks still take precedence when they classify the error.
- **What was not tested:** Live provider error injection (requires a provider returning `upstream_error` on demand). The classification logic is verified through unit tests with controlled test data.

- [x] AI-assisted (Hermes Agent)

## Real behavior proof

- **Behavior addressed:** Provider `upstream_error` errors now trigger model fallback when fallback models are configured
- **Environment tested:** macOS, Node.js, openclaw main branch (2026-06-21)
- **Steps run after the patch:** Ran failover classification test suite + build
- **Evidence after fix:**

```
$ node scripts/run-the verification suite.mjs run src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
 ✓  agents  src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts (7 tests) 29ms
 Test Files  1 passed (1)
      Tests  7 passed (7)

$ grep -n 'upstream_error' src/agents/embedded-agent-helpers/errors.ts
1203:    signal.errorType === "upstream_error" &&

$ grep -n 'upstream_error' dist/errors-DIAwurmw.js
706:	if (signal.errorType === "upstream_error" && !statusClassification && !providerPluginReason && !codeReason) return toReasonClassification("server_error");

$ pnpm build
[build-all] phase timings: total 149.7s (success)
```

- **Observed result after fix:** The `upstream_error` errorType is now classified as `server_error`, enabling fallback model rotation. Provider plugin hooks still take precedence when they classify the error.
- **What was not tested:** Live provider error injection (requires a provider returning `upstream_error` on demand). The classification logic is verified through unit tests with controlled test data.