### PR TITLE
fix(scripts): type windows taskkill helper

### DIFF
--- a/scripts/lib/windows-taskkill.d.mts
+++ b/scripts/lib/windows-taskkill.d.mts
@@ -1,0 +1,6 @@
+export function resolveWindowsPowerShellPath(env?: NodeJS.ProcessEnv): string;
+export function resolveWindowsSystem32Path(
+  executableName: string,
+  env?: NodeJS.ProcessEnv,
+): string;
+export function resolveWindowsTaskkillPath(env?: NodeJS.ProcessEnv): string;


### PR DESCRIPTION
## Summary
- Add a colocated declaration file for `scripts/lib/windows-taskkill.mjs`.
- Cover all current runtime exports: `resolveWindowsTaskkillPath`, `resolveWindowsSystem32Path`, and `resolveWindowsPowerShellPath`.
- Let TypeScript resolve the helper from TS scripts such as `scripts/control-ui-i18n.ts`.

## What Problem This Solves
Current main imports `./lib/windows-taskkill.mjs` from TypeScript, but the JavaScript helper did not have a colocated declaration file. The CI type shard reported:

```text
scripts/control-ui-i18n.ts(11,44): error TS7016: Could not find a declaration file for module './lib/windows-taskkill.mjs'.
```

After main moved the helper to re-export Windows path helpers, the declaration also needs to describe those exports so TypeScript consumers see the real module surface.

## Linked context
- Found while triaging #93351 after rebasing onto current main.
- The same current-main type failure also appeared in #94084 CI.

## Real behavior proof (required for external PRs)
- Behavior or issue addressed: TypeScript could not type-check TS scripts that import `scripts/lib/windows-taskkill.mjs`; after the latest main changes, the declaration also needed to cover the helper module's three exported functions.
- Real environment tested: Windows PowerShell checkout at `F:\openclaw\worktrees\openclaw-windows-taskkill-types`, rebased onto current `origin/main`.
- Exact steps or command run after this patch: `pnpm exec tsgo --ignoreConfig --noEmit --target ES2023 --lib ES2023 --module NodeNext --moduleResolution NodeNext --types node --skipLibCheck .artifacts\windows-taskkill-types-probe.ts`
- Evidence after fix: The focused probe imported `resolveWindowsTaskkillPath`, `resolveWindowsSystem32Path`, and `resolveWindowsPowerShellPath` from `../scripts/lib/windows-taskkill.mjs`, assigned each result to `string`, and the command exited 0 with no TypeScript diagnostics.
- Observed result after fix: TypeScript resolves the colocated declaration and accepts all current runtime exports used by TS consumers.
- What was not tested: I did not rerun the full `pnpm tsgo:core:test` shard in this branch because a prior full local run stalled after passing the original TS7016 point; this PR uses the focused type probe for the changed declaration surface.
- Proof limitations or environment constraints: This is declaration-only proof; it validates type resolution, not Windows process execution.
- Before evidence: Current-main CI and local triage both reported TS7016 for `scripts/control-ui-i18n.ts` importing `./lib/windows-taskkill.mjs`.

## Evidence
Before this patch, current main reports TS7016 for the `windows-taskkill.mjs` import in `scripts/control-ui-i18n.ts`.

After this patch, the focused TypeScript probe covering all three exports exits 0 with no diagnostics.

## Tests and validation
- `pnpm exec tsgo --ignoreConfig --noEmit --target ES2023 --lib ES2023 --module NodeNext --moduleResolution NodeNext --types node --skipLibCheck .artifacts\windows-taskkill-types-probe.ts`
- `git diff --check`

## Risk checklist
- [x] Declaration-only change; no runtime code path changes.
- [x] No dependency, workflow, or generated artifact changes.
- [x] Declaration now matches the current `windows-taskkill.mjs` runtime export surface.

## Current review state
Ready for ClawSweeper re-review and maintainer review.
