### PR TITLE
fix(telegram): preserve rich message blank lines

### DIFF
--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -606,6 +606,63 @@ function preserveSupportedTelegramHtmlTags(
   return result;
 }
 
+const TELEGRAM_RICH_HTML_BLANK_LINE_FILLER = "\u200B";
+
+function preserveTelegramRichHtmlBlankLinesInText(text: string): string {
+  if (!text.includes("\n\n")) {
+    return text;
+  }
+  return text
+    .split("\n")
+    .map((line, index, lines) =>
+      line.trim() === "" && index > 0 && index < lines.length - 1
+        ? TELEGRAM_RICH_HTML_BLANK_LINE_FILLER
+        : line,
+    )
+    .join("\n");
+}
+
+export function preserveTelegramRichHtmlBlankLines(html: string): string {
+  if (!html.includes("\n\n")) {
+    return html;
+  }
+
+  let codeDepth = 0;
+  let preDepth = 0;
+  let result = "";
+  let lastIndex = 0;
+
+  HTML_TAG_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = HTML_TAG_PATTERN.exec(html)) !== null) {
+    const tagStart = match.index;
+    const tagEnd = HTML_TAG_PATTERN.lastIndex;
+    const tagName = normalizeLowercaseStringOrEmpty(match[2]);
+    const isClosing = match[1] === "</";
+    const textBefore = html.slice(lastIndex, tagStart);
+    result +=
+      codeDepth > 0 || preDepth > 0
+        ? textBefore
+        : preserveTelegramRichHtmlBlankLinesInText(textBefore);
+
+    if (tagName === "code") {
+      codeDepth = isClosing ? Math.max(0, codeDepth - 1) : codeDepth + 1;
+    } else if (tagName === "pre") {
+      preDepth = isClosing ? Math.max(0, preDepth - 1) : preDepth + 1;
+    }
+
+    result += html.slice(tagStart, tagEnd);
+    lastIndex = tagEnd;
+  }
+
+  const remainingText = html.slice(lastIndex);
+  result +=
+    codeDepth > 0 || preDepth > 0
+      ? remainingText
+      : preserveTelegramRichHtmlBlankLinesInText(remainingText);
+  return result;
+}
+
 function getFileReferencePattern(): RegExp {
   if (fileReferencePattern) {
     return fileReferencePattern;

--- a/extensions/telegram/src/rich-message.test.ts
+++ b/extensions/telegram/src/rich-message.test.ts
@@ -1,0 +1,41 @@
+// Telegram rich-message tests cover Bot API 10.1 payload normalization.
+import { describe, expect, it } from "vitest";
+import { buildTelegramRichHtml, buildTelegramRichMarkdown } from "./rich-message.js";
+
+const BLANK_LINE_FILLER = "\u200B";
+
+describe("buildTelegramRichMessage", () => {
+  it("preserves visible blank lines in rich Markdown paragraphs", () => {
+    const message = buildTelegramRichMarkdown(["First block", "", "Second block"].join("\n"));
+
+    expect(message.html).toBe(`First block\n${BLANK_LINE_FILLER}\nSecond block`);
+  });
+
+  it("preserves visible blank lines in emoji work reports", () => {
+    const message = buildTelegramRichMarkdown(
+      ["✅ Výsledek: OK", "", "Co to znamená: OK", "", "☑️ Ověřeno: OK"].join("\n"),
+    );
+
+    expect(message.html).toBe(
+      `✅ Výsledek: OK\n${BLANK_LINE_FILLER}\nCo to znamená: OK\n${BLANK_LINE_FILLER}\n☑️ Ověřeno: OK`,
+    );
+  });
+
+  it("does not add blank-line fillers inside Markdown code blocks", () => {
+    const message = buildTelegramRichMarkdown(["```", "line 1", "", "line 2", "```"].join("\n"));
+
+    expect(message.html).toBe("<pre><code>line 1\n\nline 2\n</code></pre>");
+  });
+
+  it("preserves rich HTML blank lines without touching pre/code content", () => {
+    const message = buildTelegramRichHtml(
+      ["First block", "", "<pre><code>line 1", "", "line 2</code></pre>", "", "Second block"].join(
+        "\n",
+      ),
+    );
+
+    expect(message.html).toBe(
+      `First block\n${BLANK_LINE_FILLER}\n<pre><code>line 1\n\nline 2</code></pre>\n${BLANK_LINE_FILLER}\nSecond block`,
+    );
+  });
+});

--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -14,6 +14,7 @@ import {
   escapeTelegramHtml,
   limitTelegramRichHtmlNesting,
   markdownToTelegramRichHtml,
+  preserveTelegramRichHtmlBlankLines,
   sanitizeTelegramRichHtml,
   splitTelegramHtmlChunks,
   telegramHtmlToPlainTextFallback,
@@ -187,7 +188,10 @@ export function buildTelegramRichMessage(
 }
 
 function prepareTelegramRichHtml(html: string): string {
-  return limitTelegramRichHtmlNesting(sanitizeTelegramRichHtml(html), TELEGRAM_RICH_NESTING_LIMIT);
+  return limitTelegramRichHtmlNesting(
+    preserveTelegramRichHtmlBlankLines(sanitizeTelegramRichHtml(html)),
+    TELEGRAM_RICH_NESTING_LIMIT,
+  );
 }
 
 const TELEGRAM_RICH_HTML_CHUNK_LIMITS = {


### PR DESCRIPTION
## What Problem This Solves

Telegram rich-message work reports can contain intentional blank lines between short blocks, for example an emoji status line followed by a separate "what it means" block. In the Telegram client those blocks were rendering too tightly, so an owner-facing report looked like one dense message even though the source payload contained paragraph breaks.

This became visible in real owner work reports that used this shape:

```md
✅ Výsledek: OK

Co to znamená: OK
```

The goal is not to change Telegram message formatting broadly. The goal is only to preserve visually blank lines in Telegram rich-message rendering when those blank lines are part of normal text content.

## Minimal Reproduction Before This Fix

Render the Markdown above through the Telegram rich-message path and send it as a rich Telegram message.

Before this change, blank text lines outside rich `pre`/`code` regions did not get a visible filler in the generated rich HTML. A clean install of public `openclaw@2026.6.9` was probed with the emoji/blank-line payload and returned `NO_ZWSP`, which means the installed runtime did not preserve a visible blank-line marker for Telegram.

## Expected vs Actual

Expected:

- Blank lines between normal text blocks remain visibly separated in Telegram.
- The formatter does not alter content inside Markdown code fences or rich `pre`/`code` regions.

Actual before this fix:

- Normal paragraph separators could visually collapse in Telegram rich-message rendering.
- This made owner-facing work reports hard to scan, especially once emoji status markers made the dense grouping more obvious.

## Fix Scope

This fix is intentionally limited to Telegram rich-message blank-line preservation.

- It inserts a zero-width filler only on blank text lines.
- It skips rich `pre`/`code` regions.
- It preserves Markdown code fences.
- It does not refactor the formatter.
- It does not change non-Telegram behavior.

## Summary

- Preserve visually blank lines in Telegram rich-message HTML payloads by inserting a zero-width filler only on blank text lines outside `pre`/`code` regions.
- Add regression coverage for Markdown paragraph blank lines, emoji work-report style blank lines, rich HTML blank lines, and Markdown code fences.

## Evidence

- `./node_modules/.bin/vitest run extensions/telegram/src/rich-message.test.ts` passed.
- `./node_modules/.bin/oxfmt --check extensions/telegram/src/format.ts extensions/telegram/src/rich-message.ts extensions/telegram/src/rich-message.test.ts` passed.
- The same patch was verified on clean `v2026.6.9` and current `origin/main`.
- Normal package path was verified on `v2026.6.9`: `npm pack` through `prepack/build-all`, clean temp install from the generated tarball, and installed runtime probe returning `HAS_ZWSP` for the emoji/blank-line payload.
- Baseline public `openclaw@2026.6.9` returned `NO_ZWSP` for the same emoji/blank-line payload, confirming the published package did not already contain the behavior.

## Boundaries

The regression tests explicitly cover that fenced code content is not changed. The rich HTML formatter also tracks `pre`/`code` regions so blank-line fillers are only added to normal text content.
