### PR TITLE
fix(scripts): route i18n formatter through pnpm runner

### DIFF
--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -10,6 +10,19 @@ import * as ts from "typescript";
 import { formatErrorMessage } from "../src/infra/errors.ts";
 import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 
+const { formatGeneratedModule } = (await import(
+  new URL("./lib/format-generated-module.mjs", import.meta.url).href
+)) as {
+  formatGeneratedModule: (
+    source: string,
+    options: {
+      errorLabel: string;
+      outputPath: string;
+      repoRoot: string;
+    },
+  ) => string;
+};
+
 interface TranslationMap {
   [key: string]: string | TranslationMap;
 }
@@ -1222,18 +1235,12 @@ export async function runProcess(
 }
 
 async function formatGeneratedTypeScript(filePath: string, source: string): Promise<string> {
-  const directFormatterPath = path.join(ROOT, "node_modules", ".bin", "oxfmt");
-  const formatterCommand =
-    process.platform !== "win32" && existsSync(directFormatterPath) ? directFormatterPath : "pnpm";
-  const formatterArgs =
-    formatterCommand === directFormatterPath
-      ? ["--stdin-filepath", path.relative(ROOT, filePath)]
-      : ["exec", "oxfmt", "--stdin-filepath", path.relative(ROOT, filePath)];
-  const result = await runProcess(formatterCommand, formatterArgs, {
-    input: source,
-    rejectOnFailure: true,
+  const formatted = formatGeneratedModule(source, {
+    errorLabel: "control ui locale",
+    outputPath: filePath,
+    repoRoot: ROOT,
   });
-  return restoreReplacementCorruptedStringLiterals(source, result.stdout);
+  return restoreReplacementCorruptedStringLiterals(source, formatted);
 }
 
 function restoreReplacementCorruptedStringLiterals(source: string, formatted: string): string {


### PR DESCRIPTION
## Summary
- Route `control-ui-i18n` generated TypeScript formatting through the shared `scripts/lib/format-generated-module.mjs` helper.
- Reuse the existing direct `oxfmt` plus pnpm-runner fallback path instead of spawning bare `pnpm` from `control-ui-i18n`.
- Preserve the replacement-character restoration guard used by locale generation.

## What Problem This Solves
On Windows, `pnpm ui:i18n:check` can fail during generated locale formatting with `spawn pnpm ENOENT` even when pnpm is available through the usual `.cmd` shim. The script fell back to spawning bare `pnpm`, bypassing the repository's existing `scripts/pnpm-runner.mjs` portability logic.

The fix keeps generated formatter command resolution in the existing shared formatter helper, avoiding a second ownership path for `oxfmt` and pnpm-runner behavior.

## Linked context
- Found while validating #90610 locally on Windows.
- If `check-test-types` is red before #95527 merges, that is the separate missing `windows-taskkill.mjs` declaration fixed by #95527, not this formatter runner change.

## Real behavior proof (required for external PRs)
- Behavior or issue addressed: `control-ui-i18n` formatting could reach a bare `spawn("pnpm", ...)` fallback on Windows, causing `spawn pnpm ENOENT` instead of using the repo's Windows-safe pnpm runner.
- Real environment tested: Windows PowerShell checkout at `F:\openclaw\worktrees\openclaw-control-ui-i18n-pnpm-runner`, rebased onto current `origin/main`, hydrated with `pnpm install --frozen-lockfile`.
- Exact steps or command run after this patch: `pnpm ui:i18n:check`
- Evidence after fix: The command completed through all 18 locales and ended with clean locale output, including `fa: clean (fallbacks=0)`, without `spawn pnpm ENOENT`.
- Observed result after fix: Generated TypeScript formatting now goes through the shared generated-module formatter path, which already wraps Windows pnpm `.cmd` execution through the repo pnpm runner.
- What was not tested: I did not run the full CI matrix locally. The focused Vitest run covers `control-ui-i18n` process behavior and the shared `format-generated-module` Windows pnpm-runner contract; the real command validates the end-to-end i18n check on Windows.
- Proof limitations or environment constraints: The command used fallback-only translation mode because no provider credentials were configured; the bug and fix are in local formatter process spawning, not translation provider calls.
- Before evidence: Before this patch, local Windows validation reached the formatter step and failed with `spawn pnpm ENOENT`.

## Evidence
After this patch, `pnpm ui:i18n:check` completes on Windows:

```text
control-ui-i18n: command=check locales=18 provider=fallback-only model=n/a
...
fa: clean (fallbacks=0)
```

The focused test run also includes `test/scripts/format-generated-module.test.ts`, whose Windows pnpm-runner coverage asserts the formatter resolves through `cmd.exe /d /s /c ... pnpm.cmd exec oxfmt ...` with `windowsVerbatimArguments` enabled.

## Tests and validation
- `node scripts/run-vitest.mjs test/scripts/control-ui-i18n.test.ts test/scripts/format-generated-module.test.ts`
- `pnpm ui:i18n:check`
- `git diff --check`

## Risk checklist
- [x] Keeps formatter command resolution in the existing shared generated-module helper.
- [x] Preserves the existing direct formatter path on non-Windows when `node_modules/.bin/oxfmt` exists.
- [x] No translation content, locale snapshots, dependency, security, auth, or network behavior changes.
- [x] Highest risk is formatter behavior drift; mitigated by reusing the shared formatter owner instead of adding a second resolver.

## Current review state
Ready for ClawSweeper re-review and maintainer review. If type CI is still blocked by the current-main `windows-taskkill.mjs` declaration gap, rebase after #95527 merges rather than duplicating that declaration in this PR.
