### PR TITLE
fix(agents): expand embedded fallback classifier to accept transient provider errors

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1658,7 +1658,11 @@ function isStructuredServerErrorMessage(raw: string): boolean {
     return false;
   }
   const value = normalizeLowercaseStringOrEmpty(raw);
-  return value.includes('"type":"server_error"') || value.includes('"code":"server_error"');
+  return (
+    value.includes('"type":"server_error"') ||
+    value.includes('"code":"server_error"') ||
+    value.includes('"type":"upstream_error"')
+  );
 }
 
 export function parseImageDimensionError(raw: string): {

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -119,6 +119,7 @@ const ERROR_PATTERNS = {
     "bad gateway",
     "gateway timeout",
     "upstream error",
+    "upstream request failed",
     "upstream connect error",
     "connection reset",
     // Chinese provider server error messages

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -137,7 +137,7 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     expect(result).toBeNull();
   });
 
-  it("does not retry non-business transport error payloads", () => {
+  it("classifies transient server-error payloads as fallback-worthy", () => {
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "custom",
       model: "llama-3.1",
@@ -154,7 +154,58 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
       },
     });
 
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      message: "custom/llama-3.1 ended with a provider error: HTTP 500: internal server error",
+      reason: "timeout",
+      code: "embedded_error_payload",
+      rawError: "HTTP 500: internal server error",
+    });
+  });
+
+  it("classifies upstream request failed as fallback-worthy (#95519)", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "custom",
+      model: "llama-3.1",
+      result: {
+        payloads: [
+          {
+            isError: true,
+            text: "Upstream request failed",
+          },
+        ],
+        meta: {
+          durationMs: 42,
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      message: "custom/llama-3.1 ended with a provider error: Upstream request failed",
+      reason: "timeout",
+      code: "embedded_error_payload",
+      rawError: "Upstream request failed",
+    });
+  });
+
+  it("classifies upstream_error JSON payload as fallback-worthy (#95519)", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "custom",
+      model: "llama-3.1",
+      result: {
+        payloads: [
+          {
+            isError: true,
+            text: '{"error":{"message":"Upstream request failed","type":"upstream_error"}}',
+          },
+        ],
+        meta: {
+          durationMs: 42,
+        },
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.reason).toBe("server_error");
   });
 
   it("keeps tool-authored incomplete summaries fallback-eligible", () => {

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -103,23 +103,30 @@ function classifyHarnessResult(params: {
   }
 }
 
-/** Maps provider error payloads to fallback-safe business reasons. */
-function classifyBusinessDenialErrorPayloadReason(
+/** Failover reasons that should trigger model fallback when detected in provider error payloads. */
+const FALLBACKABLE_PROVIDER_ERROR_REASONS = new Set<FailoverReason>([
+  "auth",
+  "auth_permanent",
+  "billing",
+  "rate_limit",
+  "overloaded",
+  "server_error",
+  "timeout",
+]);
+
+/** Maps provider error payloads to fallback-eligible reasons. */
+function classifyFailoverErrorPayloadReason(
   errorText: string,
   provider: string,
-): Extract<FailoverReason, "auth" | "auth_permanent" | "billing"> | null {
+): FailoverReason | null {
   if (!errorText.trim()) {
     return null;
   }
   const failoverReason = classifyFailoverReason(errorText, { provider });
-  switch (failoverReason) {
-    case "auth":
-    case "auth_permanent":
-    case "billing":
-      return failoverReason;
-    default:
-      return null;
+  if (failoverReason && FALLBACKABLE_PROVIDER_ERROR_REASONS.has(failoverReason)) {
+    return failoverReason;
   }
+  return null;
 }
 
 /** Returns a fallback classification when an embedded run failed without user-visible output. */
@@ -189,7 +196,7 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
     .filter((payload) => payload?.isError === true)
     .map((payload) => (typeof payload.text === "string" ? payload.text : ""))
     .join("\n");
-  const failoverReason = classifyBusinessDenialErrorPayloadReason(errorText, params.provider);
+  const failoverReason = classifyFailoverErrorPayloadReason(errorText, params.provider);
   if (failoverReason) {
     return {
       message: `${params.provider}/${params.model} ended with a provider error: ${errorText}`,


### PR DESCRIPTION
## Summary

When the primary provider returns an `upstream_error` (e.g. "Upstream request failed"), OpenClaw ends the turn with "LLM request failed" instead of trying configured fallback models. The root cause is a two-layer gap: the error classifier only recognized `auth`/`billing` payloads as fallback-worthy, and the message pattern matcher did not include "upstream request failed" as a recognized server error.

This PR fixes both layers:

1. **Classifier filter** (`result-fallback-classifier.ts`): Renames `classifyBusinessDenialErrorPayloadReason` → `classifyFailoverErrorPayloadReason` and expands the accepted reasons set to include `rate_limit`, `overloaded`, `server_error`, and `timeout` alongside the existing `auth`/`auth_permanent`/`billing`. Uses a `Set<FailoverReason>` for clarity and maintainability.

2. **Pattern matcher** (`failover-matches.ts`): Adds "upstream request failed" to the `serverError` patterns list so that the bare text error from providers is recognized by `classifyFailoverClassificationFromMessage`.

3. **Structured JSON matcher** (`errors.ts`): Adds `"type":"upstream_error"` to `isStructuredServerErrorMessage` so that full JSON error payloads with this type are classified as `server_error`.

Fixes #95519

## Real behavior proof (required for external PRs)

**Behavior addressed**: Provider-side transient errors (upstream_error, HTTP 500, rate_limit, overload) now trigger the configured fallback chain instead of ending the turn with "LLM request failed".

**Real setup tested**:
- **Runtime**: Node v24.16.0, Linux x86_64
- **Code analysis path**: See [issue-95519-01-analysis.md](docs/.local/issue-95519-01-analysis.md)
- **Test framework**: Vitest with project test config

**Exact steps or command run after this patch**:

```bash
# Run fallback classifier tests
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/result-fallback-classifier.test.ts

# Run regression tests for related modules
node scripts/run-vitest.mjs src/agents/model-fallback.test.ts src/agents/outcome-fallback-runtime-contract.test.ts
```

**After-fix evidence**:

| Test | Before | After |
|------|--------|-------|
| Transient server-error payloads | `null` (no fallback) | `timeout` fallback triggered |
| "Upstream request failed" text | `null` (no fallback) | `timeout` fallback triggered |
| `{"type":"upstream_error",...}` JSON | `null` (no fallback) | `server_error` fallback triggered |
| Business-denial payloads (auth/billing) | fallback triggered | fallback triggered (unchanged) |
| All 13 classifier tests | pass | pass |
| 92 model-fallback + outcome-fallback tests | pass | pass |

**Git stats**:
```bash
5 files changed, 80 insertions(+), 14 deletions(-)
```

**Observed result after the fix**: 
The fallback classifier now correctly identifies transient provider errors as fallback-eligible. Previously, `classifyFailoverErrorPayloadReason("Upstream request failed")` returned `null`; now it returns `"timeout"`, which triggers the configured fallback chain.

**What was not tested**: 
- Live gateway/provider reproduction was not performed (requires real provider credentials with specific error conditions)
- Other non-transient error categories (format, model_not_found, session_expired) remain unchanged — they correctly do not trigger fallback
- Cross-provider edge cases: the fix uses the shared `classifyFailoverReason` infrastructure, so all provider text variants benefit from the expanded classification

## Tests and validation

| Test Type | Result | Details |
|-----------|--------|---------|
| Unit Tests (classifier) | ✅ 13/13 passing | 3 new test cases added: transient server error, upstream request text, upstream_error JSON |
| Unit Tests (model-fallback) | ✅ pass | 92 tests passing, no regressions |
| Unit Tests (outcome-fallback) | ✅ pass | Included in above |
| Regression (helpers) | ✅ 180/183 passing | 3 pre-existing failures in sandbox tool-policy audit (unrelated) |
| Type Check | ⏳ Pending CI | TypeScript compilation verified locally |

## Risk checklist

**Did user-visible behavior change?** `Yes` — Transient provider errors (upstream_error, rate_limit, overloaded, server_error, timeout) now trigger the configured fallback model chain instead of ending the turn. This matches documented fallback behavior.

**Did config, environment, or migration behavior change?** `No` — No configuration schema changes, no environment variables, no database migrations.

**Did security, auth, secrets, network, or tool execution behavior change?** `No` — Only affects fallback classification logic. No changes to authentication, authorization, network protocols, or tool execution paths.

**What is the highest-risk area?**
- Broadening the accepted failover reasons could cause fallback to trigger for errors that should NOT be fallback-eligible (e.g., schema/format errors masquerading as transient errors)

**How is that risk mitigated?**
- The fix uses an explicit allowlist (`FALLBACKABLE_PROVIDER_ERROR_REASONS`) — only `auth`, `auth_permanent`, `billing`, `rate_limit`, `overloaded`, `server_error`, and `timeout` are allowed
- Non-transient reasons (`format`, `model_not_found`, `empty_response`, `unclassified`) are explicitly excluded
- Existing guards (visible output check, hook block check, side-effect check, abort check) remain in place
- The "upstream request failed" pattern addition is a narrow substring match that only applies to server Error pattern matching

## Current review state

**What is the next action?**
- Maintainer review requested
- CI validation pending (tests will run automatically on PR creation)

**Related contributors** (based on ClawSweeper analysis):
- steipete: Recent result-fallback classifier and model-failover docs work defining this fallback boundary
- vincentkoc: Recent area contributor for result-fallback-classifier.ts and model-fallback.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
