### PR TITLE
fix(doctor): skip groupAllowFrom migration for schemaless external channels

### DIFF
--- a/src/commands/doctor/shared/allowfrom-fallback-migration.test.ts
+++ b/src/commands/doctor/shared/allowfrom-fallback-migration.test.ts
@@ -130,4 +130,21 @@ describe("doctor group allowFrom fallback migration", () => {
 
     expect(maybeRepairGroupAllowFromFallback(cfg)).toEqual({ config: cfg, changes: [] });
   });
+
+  it("skips external channels whose config schema core cannot verify", () => {
+    // email is provided by an external plugin (ClawMail) and is absent from the bundled
+    // generated metadata; injecting groupAllowFrom there breaks gateway startup on upgrade.
+    const cfg = {
+      channels: {
+        email: {
+          allowFrom: ["*"],
+          accounts: {
+            default: { allowFrom: ["*"] },
+          },
+        },
+      },
+    };
+
+    expect(maybeRepairGroupAllowFromFallback(cfg)).toEqual({ config: cfg, changes: [] });
+  });
 });

--- a/src/commands/doctor/shared/allowfrom-fallback-migration.ts
+++ b/src/commands/doctor/shared/allowfrom-fallback-migration.ts
@@ -105,7 +105,13 @@ function schemaAllowsConfigPath(schema: unknown, path: SchemaPath): boolean {
 
 function generatedSchemaAllowsGroupAllowFrom(channelName: string, path: SchemaPath): boolean {
   const schema = findGeneratedChannelConfigSchema(channelName);
-  return !schema || schemaAllowsConfigPath(schema, path);
+  if (!schema) {
+    // External channel plugins (e.g. ClawMail email) aren't in the bundled generated
+    // metadata, so core can't verify their schema accepts groupAllowFrom. Fail closed:
+    // writing it into a schema that forbids it breaks gateway startup on upgrade.
+    return false;
+  }
+  return schemaAllowsConfigPath(schema, path);
 }
 
 function migrateRecord(params: {


### PR DESCRIPTION
## What Problem This Solves

Upgrading OpenClaw 2026.6.8 → 2026.6.9 corrupts the external ClawMail `email`
channel config. The doctor migration `maybeRepairGroupAllowFromFallback` injects
a `groupAllowFrom` key into `channels.email.accounts.default`, which the email
plugin's schema rejects, so the Gateway fails to start:

```
Config validation failed: channels.email.accounts.default: invalid config for plugin email: must not have additional properties: "groupAllowFrom"
```

Fixes #95515. (Supersedes #95518, which was auto-closed for the author's active-PR
queue limit, not on merit.)

## Why This Change Was Made

`generatedSchemaAllowsGroupAllowFrom` defaulted to **permissive** (`!schema || …`)
when a channel had no entry in the bundled channel-config metadata. `email` is an
external plugin (ClawMail) — it is not in this repo and is absent from
`GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA` — so core cannot verify its schema and
must not write keys into it. Per the owner boundary in `AGENTS.md`
("plugin-owned config repairs live in that plugin's doctor contract"), external
plugin config repair belongs to that plugin's own doctor, not core.

The schema guard is the correct, minimal fix: it now **fails closed** when core
cannot confirm the target schema accepts the key. The capability default stays
permissive for warnings; only actual config *writes* are now schema-verified. This
is the only place core can fix this, since the email plugin lives outside the repo.

## User Impact

- Bundled channels (e.g. `feishu`) still migrate exactly as before — no regression.
- External channels with no bundled schema are left untouched on upgrade, so the
  Gateway no longer crash-loops after 2026.6.8 → 2026.6.9.

## Evidence

real-behavior proof — drove the actual `maybeRepairGroupAllowFromFallback` with the
exact config from the issue (external `email` account alongside a bundled `feishu`
channel), comparing current `main` behavior against the fix:

BEFORE (fix reverted, current `main` behavior) — reproduces the bug:
```
[repro95515] email.account after: {"allowFrom":["*"],"groupAllowFrom":["*"]}
[repro95515] changes: [
  "channels.feishu.groupAllowFrom: copied 1 sender entry ...",
  "channels.email.accounts.default.groupAllowFrom: copied 1 sender entry ..."
]
```

AFTER (this fix) — email untouched, feishu still migrated (no regression):
```
[repro95515] email.account after: {"allowFrom":["*"]}
[repro95515] changes: [
  "channels.feishu.groupAllowFrom: copied 1 sender entry ..."
]
```

Unit tests: `allowfrom-fallback-migration.test.ts` 7/7 pass (adds a case asserting
external schemaless channels are skipped). Format (`oxfmt --check`) and lint
(`oxlint`) clean on the changed files.
