### PR TITLE
fix(cli): show working commands for pinned plugin drift

### DIFF
--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -649,7 +649,43 @@ describe("printDaemonStatus", () => {
     );
 
     expectMockLineContains(runtime.log, "- whatsapp: 2026.5.3 (clawhub)");
-    expectMockLineContains(runtime.log, "openclaw plugins update <plugin-id>");
+    expectMockLineContains(runtime.log, "openclaw plugins update whatsapp");
+    expectMockLineContains(runtime.log, "openclaw gateway restart");
+  });
+
+  it("prints exact package update commands for pinned npm plugin drift in deep mode", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: { status: "running", pid: 8000 },
+        },
+        pluginVersionDrift: {
+          gatewayVersion: "2026.6.10-beta.1",
+          drifts: [
+            {
+              pluginId: "brave",
+              installedVersion: "2026.6.9",
+              gatewayVersion: "2026.6.10-beta.1",
+              source: "npm",
+              packageName: "@openclaw/brave-plugin",
+              spec: "@openclaw/brave-plugin@2026.6.9",
+            },
+          ],
+        },
+        extraServices: [],
+      },
+      { json: false, deep: true },
+    );
+
+    expectMockLineContains(runtime.log, "- brave: 2026.6.9 (npm)");
+    expectMockLineContains(
+      runtime.log,
+      "openclaw plugins update @openclaw/brave-plugin@2026.6.10-beta.1",
+    );
     expectMockLineContains(runtime.log, "openclaw gateway restart");
   });
 

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -18,6 +18,7 @@ import { classifySystemdUnavailableDetail } from "../../daemon/systemd-unavailab
 import { resolveControlUiLinks } from "../../gateway/control-ui-links.js";
 import { formatGatewayRestartHandoffDiagnostic } from "../../infra/restart-handoff.js";
 import { isWSLEnv } from "../../infra/wsl.js";
+import { resolvePluginVersionDriftUpdateCommand } from "../../plugins/plugin-version-drift.js";
 import { defaultRuntime } from "../../runtime.js";
 import { shortenHomePath } from "../../utils.js";
 import { formatCliCommand } from "../command-format.js";
@@ -327,9 +328,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
     isSystemdUnavailableDetail(service.runtime?.detail);
   if (systemdUnavailable) {
     const serviceEnv = service.command?.environment ?? process.env;
-    const container = Boolean(
-      resolveDaemonContainerContext(serviceEnv),
-    );
+    const container = Boolean(resolveDaemonContainerContext(serviceEnv));
     defaultRuntime.error(errorText("systemd user services unavailable."));
     for (const hint of renderSystemdUnavailableHints({
       wsl: isWSLEnv(serviceEnv),
@@ -483,9 +482,20 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
           `- ${warnText(entry.pluginId)}: ${entry.installedVersion} (${sourceLabel}) → expected ${drift.gatewayVersion}`,
         );
       }
-      defaultRuntime.log(
-        `${label("Fix:")} ${formatCliCommand("openclaw plugins update <plugin-id>")} for each drifted plugin, then ${formatCliCommand("openclaw gateway restart")}.`,
+      const updateCommands = drift.drifts.map((entry) =>
+        formatCliCommand(resolvePluginVersionDriftUpdateCommand(entry)),
       );
+      if (updateCommands.length === 1) {
+        defaultRuntime.log(
+          `${label("Fix:")} ${updateCommands[0]} && ${formatCliCommand("openclaw gateway restart")}.`,
+        );
+      } else {
+        defaultRuntime.log(`${label("Fix:")} update each drifted plugin:`);
+        for (const command of updateCommands) {
+          defaultRuntime.log(`- ${command}`);
+        }
+        defaultRuntime.log(`Then run ${formatCliCommand("openclaw gateway restart")}.`);
+      }
     } else {
       defaultRuntime.log(
         infoText(

--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -205,6 +205,54 @@ describe("noteWorkspaceStatus", () => {
     }
   });
 
+  it("uses package-version update commands for exact npm plugin drift", async () => {
+    const noteSpy = await runNoteWorkspaceStatusForTest(
+      createPluginLoadResult({
+        plugins: [
+          createPluginRecord({
+            id: "brave",
+            name: "Brave",
+            origin: "global",
+            source: "/tmp/brave/index.js",
+          }),
+        ],
+      }),
+      [],
+      {
+        cfg: {
+          plugins: {
+            entries: {
+              brave: { enabled: true },
+            },
+          },
+        },
+        pluginVersionDrift: {
+          gatewayVersion: "2026.6.10-beta.1",
+          drifts: [
+            {
+              pluginId: "brave",
+              installedVersion: "2026.6.9",
+              gatewayVersion: "2026.6.10-beta.1",
+              source: "npm",
+              packageName: "@openclaw/brave-plugin",
+              spec: "@openclaw/brave-plugin@2026.6.9",
+            },
+          ],
+        },
+      },
+    );
+    try {
+      const driftCalls = noteSpy.mock.calls.filter(([, title]) => title === "Plugin version drift");
+      expect(driftCalls).toHaveLength(1);
+      const [[body]] = driftCalls;
+      expect(body).toContain("openclaw plugins update @openclaw/brave-plugin@2026.6.10-beta.1");
+      expect(body).not.toContain("openclaw plugins update brave");
+      expect(body).toContain("openclaw gateway restart");
+    } finally {
+      noteSpy.mockRestore();
+    }
+  });
+
   it("omits plugin version drift when no daemon status report is supplied", async () => {
     const noteSpy = await runNoteWorkspaceStatusForTest(
       createPluginLoadResult({
@@ -324,7 +372,10 @@ describe("noteWorkspaceStatus", () => {
     }
   });
 
-  const makeSkill = (skillKey: string, fields: { eligible: boolean; platformIncompatible: boolean }) =>
+  const makeSkill = (
+    skillKey: string,
+    fields: { eligible: boolean; platformIncompatible: boolean },
+  ) =>
     ({
       skillKey,
       disabled: false,

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -3,7 +3,10 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { PluginVersionDriftReport } from "../plugins/plugin-version-drift.js";
+import {
+  resolvePluginVersionDriftUpdateCommand,
+  type PluginVersionDriftReport,
+} from "../plugins/plugin-version-drift.js";
 import {
   buildPluginCompatibilityWarnings,
   buildPluginRegistrySnapshotReport,
@@ -62,6 +65,9 @@ function notePluginVersionDrift(drift: PluginVersionDriftReport | undefined) {
     return;
   }
   const singleDrift = drift.drifts.length === 1 ? drift.drifts[0] : undefined;
+  const updateCommands = drift.drifts.map((entry) =>
+    formatCliCommand(resolvePluginVersionDriftUpdateCommand(entry)),
+  );
   const lines = [
     `${drift.drifts.length} active official plugin${
       drift.drifts.length === 1 ? "" : "s"
@@ -71,12 +77,12 @@ function notePluginVersionDrift(drift: PluginVersionDriftReport | undefined) {
       return `- ${entry.pluginId}: ${entry.installedVersion} (${sourceLabel}) -> expected ${drift.gatewayVersion}`;
     }),
     singleDrift
-      ? `Fix: ${formatCliCommand(
-          `openclaw plugins update ${singleDrift.pluginId}`,
-        )} && ${formatCliCommand("openclaw gateway restart")}.`
-      : `Fix: ${formatCliCommand(
-          "openclaw plugins update <plugin-id>",
-        )} for each drifted plugin, then ${formatCliCommand("openclaw gateway restart")}.`,
+      ? `Fix: ${updateCommands[0]} && ${formatCliCommand("openclaw gateway restart")}.`
+      : [
+          "Fix each drifted plugin:",
+          ...updateCommands.map((command) => `- ${command}`),
+          `Then run ${formatCliCommand("openclaw gateway restart")}.`,
+        ].join("\n"),
   ];
   note(lines.join("\n"), "Plugin version drift");
 }

--- a/src/plugins/plugin-version-drift.test.ts
+++ b/src/plugins/plugin-version-drift.test.ts
@@ -2,7 +2,10 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
-import { detectPluginVersionDrift } from "./plugin-version-drift.js";
+import {
+  detectPluginVersionDrift,
+  resolvePluginVersionDriftUpdateCommand,
+} from "./plugin-version-drift.js";
 
 function npmRecord(
   version: string,
@@ -316,5 +319,45 @@ describe("detectPluginVersionDrift", () => {
     });
 
     expect(result.drifts.map((d) => d.pluginId)).toEqual(["discord", "matrix", "whatsapp"]);
+  });
+});
+
+describe("resolvePluginVersionDriftUpdateCommand", () => {
+  it("uses an exact npm package target when the drifted install is pinned", () => {
+    expect(
+      resolvePluginVersionDriftUpdateCommand({
+        pluginId: "brave",
+        installedVersion: "2026.6.9",
+        gatewayVersion: "2026.6.10-beta.1",
+        source: "npm",
+        packageName: "@openclaw/brave-plugin",
+        spec: "@openclaw/brave-plugin@2026.6.9",
+      }),
+    ).toBe("openclaw plugins update @openclaw/brave-plugin@2026.6.10-beta.1");
+  });
+
+  it("parses the package name from exact npm specs when drift metadata is sparse", () => {
+    expect(
+      resolvePluginVersionDriftUpdateCommand({
+        pluginId: "brave",
+        installedVersion: "2026.6.9",
+        gatewayVersion: "2026.6.10-beta.1",
+        source: "npm",
+        spec: "@openclaw/brave-plugin@2026.6.9",
+      }),
+    ).toBe("openclaw plugins update @openclaw/brave-plugin@2026.6.10-beta.1");
+  });
+
+  it("keeps plugin-id updates for floating npm install records", () => {
+    expect(
+      resolvePluginVersionDriftUpdateCommand({
+        pluginId: "brave",
+        installedVersion: "2026.6.9",
+        gatewayVersion: "2026.6.10-beta.1",
+        source: "npm",
+        packageName: "@openclaw/brave-plugin",
+        spec: "@openclaw/brave-plugin",
+      }),
+    ).toBe("openclaw plugins update brave");
   });
 });

--- a/src/plugins/plugin-version-drift.test.ts
+++ b/src/plugins/plugin-version-drift.test.ts
@@ -373,4 +373,17 @@ describe("resolvePluginVersionDriftUpdateCommand", () => {
       }),
     ).toBe("openclaw plugins update brave");
   });
+
+  it("keeps plugin-id updates when the gateway version is not a registry version", () => {
+    expect(
+      resolvePluginVersionDriftUpdateCommand({
+        pluginId: "brave",
+        installedVersion: "2026.6.9",
+        gatewayVersion: "unknown",
+        source: "npm",
+        packageName: "@openclaw/brave-plugin",
+        spec: "@openclaw/brave-plugin@2026.6.9",
+      }),
+    ).toBe("openclaw plugins update brave");
+  });
 });

--- a/src/plugins/plugin-version-drift.test.ts
+++ b/src/plugins/plugin-version-drift.test.ts
@@ -348,6 +348,19 @@ describe("resolvePluginVersionDriftUpdateCommand", () => {
     ).toBe("openclaw plugins update @openclaw/brave-plugin@2026.6.10-beta.1");
   });
 
+  it("prefers the parsed exact npm spec package over inconsistent drift metadata", () => {
+    expect(
+      resolvePluginVersionDriftUpdateCommand({
+        pluginId: "brave",
+        installedVersion: "2026.6.9",
+        gatewayVersion: "2026.6.10-beta.1",
+        source: "npm",
+        packageName: "@openclaw/other-plugin",
+        spec: "@openclaw/brave-plugin@2026.6.9",
+      }),
+    ).toBe("openclaw plugins update @openclaw/brave-plugin@2026.6.10-beta.1");
+  });
+
   it("keeps plugin-id updates for floating npm install records", () => {
     expect(
       resolvePluginVersionDriftUpdateCommand({

--- a/src/plugins/plugin-version-drift.ts
+++ b/src/plugins/plugin-version-drift.ts
@@ -31,7 +31,7 @@ function resolveExactNpmPinPackageName(entry: PluginVersionDriftEntry): string |
   if (parsed?.selectorKind !== "exact-version") {
     return undefined;
   }
-  return entry.packageName ?? parsed.name;
+  return parsed.name;
 }
 
 /** Exact npm pins need a package@version target; id-only updates preserve the old pin. */

--- a/src/plugins/plugin-version-drift.ts
+++ b/src/plugins/plugin-version-drift.ts
@@ -23,6 +23,26 @@ export type PluginVersionDriftReport = {
   drifts: PluginVersionDriftEntry[];
 };
 
+function resolveExactNpmPinPackageName(entry: PluginVersionDriftEntry): string | undefined {
+  if (entry.source !== "npm" || !entry.spec) {
+    return undefined;
+  }
+  const parsed = parseRegistryNpmSpec(entry.spec);
+  if (parsed?.selectorKind !== "exact-version") {
+    return undefined;
+  }
+  return entry.packageName ?? parsed.name;
+}
+
+/** Exact npm pins need a package@version target; id-only updates preserve the old pin. */
+export function resolvePluginVersionDriftUpdateCommand(entry: PluginVersionDriftEntry): string {
+  const exactNpmPackageName = resolveExactNpmPinPackageName(entry);
+  if (exactNpmPackageName) {
+    return `openclaw plugins update ${exactNpmPackageName}@${entry.gatewayVersion}`;
+  }
+  return `openclaw plugins update ${entry.pluginId}`;
+}
+
 /**
  * Strip a trailing build qualifier (e.g. `2026.5.4-1` -> `2026.5.4`) so that
  * a gateway packaged as `2026.5.4-1` is not reported as drifted from a

--- a/src/plugins/plugin-version-drift.ts
+++ b/src/plugins/plugin-version-drift.ts
@@ -38,7 +38,10 @@ function resolveExactNpmPinPackageName(entry: PluginVersionDriftEntry): string |
 export function resolvePluginVersionDriftUpdateCommand(entry: PluginVersionDriftEntry): string {
   const exactNpmPackageName = resolveExactNpmPinPackageName(entry);
   if (exactNpmPackageName) {
-    return `openclaw plugins update ${exactNpmPackageName}@${entry.gatewayVersion}`;
+    const exactNpmTarget = `${exactNpmPackageName}@${entry.gatewayVersion}`;
+    if (parseRegistryNpmSpec(exactNpmTarget)?.selectorKind === "exact-version") {
+      return `openclaw plugins update ${exactNpmTarget}`;
+    }
   }
   return `openclaw plugins update ${entry.pluginId}`;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who saw official managed plugin version drift after an upgrade could be given a repair command that did not actually advance exact npm pins.

During a Windows upgrade to `2026.6.10-beta.1`, `doctor` / `status --deep` reported active official plugins such as `brave`, `discord`, `qqbot`, and `whatsapp` still on `2026.6.9`. The suggested `openclaw plugins update <plugin-id>` command was not sufficient for those records because their install records were exact npm pins like `@openclaw/brave-plugin@2026.6.9`; an id-only update preserves that pin and reports the stale version as up to date.

## Why This Change Was Made

This keeps the existing plugin update semantics intact and fixes the operator guidance instead. Plugin drift now resolves the update command for each drift entry: floating installs still use `openclaw plugins update <plugin-id>`, while exact npm pins use an explicit `openclaw plugins update <package>@<gatewayVersion>` target derived from the parsed exact npm spec.

Related: #94084 owns the bulk `openclaw plugins update --all` official-sync path. This PR is intentionally narrower: it makes the per-plugin repair command printed by `doctor` / `gateway status --deep` actionable without changing targeted id updates or `--all` behavior.

Out of scope: changing manual `plugins update <id>` behavior, unpinning installs automatically, changing bulk update semantics, or changing how version drift is detected.

## User Impact

Operators can copy the drift repair command from `openclaw doctor` or `openclaw gateway status --deep` and get the plugin onto the gateway version. For the beta upgrade case above, the advice becomes:

```text
openclaw plugins update @openclaw/brave-plugin@2026.6.10-beta.1 && openclaw gateway restart
```

instead of an id-only command that can preserve `@openclaw/brave-plugin@2026.6.9`.

## Evidence

Before evidence from the real upgrade:

```text
backup SQLite install records before manual repair:
brave    spec=@openclaw/brave-plugin@2026.6.9  resolvedVersion=2026.6.9
discord  spec=@openclaw/discord@2026.6.9       resolvedVersion=2026.6.9
qqbot    spec=@openclaw/qqbot@2026.6.9         resolvedVersion=2026.6.9
whatsapp spec=@openclaw/whatsapp@2026.6.9      resolvedVersion=2026.6.9
codex    spec=@openclaw/codex@2026.6.10-beta.1 resolvedVersion=2026.6.10-beta.1
```

Observed symptom during that upgrade: `openclaw plugins update brave`, `discord`, `qqbot`, and `whatsapp` each reported the `2026.6.9` install as up to date while the gateway was already on `2026.6.10-beta.1`; manually installing `@openclaw/<package>@2026.6.10-beta.1 --force --pin` repaired the drift.

After-fix real CLI proof from this PR head:

- Real environment tested: Windows source checkout, PR head `623e3dfcd6`, OpenClaw source version `2026.6.9`.
- Setup: temporary `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH`; seeded the temporary SQLite `installed_plugin_index` with a stale exact npm record `brave` / `@openclaw/brave-plugin@2026.6.8`.
- Exact command run after this patch:

```powershell
node openclaw.mjs gateway status --deep --no-probe
```

- Evidence after fix:

```text
Plugin version drift: 1 active official plugin not on gateway 2026.6.9
- brave: 2026.6.8 (npm) -> expected 2026.6.9
Fix: openclaw plugins update @openclaw/brave-plugin@2026.6.9 && openclaw gateway restart.
```

- Observed result after fix: the real `gateway status --deep` CLI path printed an exact package update command derived from the pinned npm spec, not `openclaw plugins update brave` or the generic `<plugin-id>` placeholder.
- What was not tested: full CI and packaged npm release artifacts. `doctor` shares the same formatter helper and has focused coverage, but the real CLI proof above uses `gateway status --deep --no-probe` to avoid this machine's unrelated live gateway/device-identity state.

Local validation:

```text
node scripts/run-vitest.mjs src/plugins/plugin-version-drift.test.ts src/commands/doctor-workspace-status.test.ts src/cli/daemon-cli/status.print.test.ts
# 3 shards passed: 21 tests, 17 tests, 11 tests

node scripts/run-oxlint.mjs src\plugins\plugin-version-drift.ts src\plugins\plugin-version-drift.test.ts src\commands\doctor-workspace-status.ts src\commands\doctor-workspace-status.test.ts src\cli\daemon-cli\status.print.ts src\cli\daemon-cli\status.print.test.ts
# exited 0

node_modules\.bin\oxfmt.cmd --check --threads=1 src\plugins\plugin-version-drift.ts src\plugins\plugin-version-drift.test.ts src\commands\doctor-workspace-status.ts src\commands\doctor-workspace-status.test.ts src\cli\daemon-cli\status.print.ts src\cli\daemon-cli\status.print.test.ts
# all matched files use the correct format

git diff --check
# passed
```

ClawSweeper follow-up addressed:

- The exact npm command now uses the package parsed from `entry.spec` after verifying it is an exact npm version.
- Added regression coverage for inconsistent `packageName` metadata so the command still targets the pinned spec package.