### PR TITLE
feat(mattermost): register /oc_queue as a native slash command

### DIFF
--- a/extensions/mattermost/src/mattermost/slash-commands.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-commands.test.ts
@@ -108,6 +108,15 @@ describe("slash-commands", () => {
     ).toEqual(["oc_model", "oc_models"]);
   });
 
+  it("registers the queue command mapped to the core /queue directive", () => {
+    const queueSpec = DEFAULT_COMMAND_SPECS.find((spec) => spec.trigger === "oc_queue");
+    expect(queueSpec?.originalName).toBe("queue");
+    const triggerMap = new Map<string, string>([["oc_queue", "queue"]]);
+    expect(resolveCommandText("oc_queue", " collect drop:summarize ", triggerMap)).toBe(
+      "/queue collect drop:summarize",
+    );
+  });
+
   it("normalizes callback path in slash config", () => {
     const config = resolveSlashCommandConfig({ callbackPath: "api/channels/mattermost/command" });
     expect(config.callbackPath).toBe("/api/channels/mattermost/command");

--- a/extensions/mattermost/src/mattermost/slash-commands.ts
+++ b/extensions/mattermost/src/mattermost/slash-commands.ts
@@ -172,6 +172,13 @@ export const DEFAULT_COMMAND_SPECS: MattermostCommandSpec[] = [
     autoComplete: true,
     autoCompleteHint: "[on|off]",
   },
+  {
+    trigger: "oc_queue",
+    originalName: "queue",
+    description: "Adjust active-run queue behavior",
+    autoComplete: true,
+    autoCompleteHint: "[steer|followup|collect|interrupt] [debounce:2s] [cap:N] [drop:old|new|summarize]",
+  },
 ];
 
 // ─── Command registration ────────────────────────────────────────────────────


### PR DESCRIPTION
## What Problem This Solves

Mattermost's native slash-command registrar exposes a hard-coded allowlist of `oc_*` commands (`DEFAULT_COMMAND_SPECS` in `extensions/mattermost/src/mattermost/slash-commands.ts`). Unlike Slack — which derives native commands from the full chat-command registry — Mattermost's set is fixed, so the core `/queue` directive (queue mode / debounce / cap / drop) had no native entry and could not be invoked from a Mattermost client.

## Why This Change Was Made

Add a single `oc_queue` spec to `DEFAULT_COMMAND_SPECS`, mirroring the existing entries, with `originalName: "queue"` so the trigger maps back to the core `/queue` directive through the existing trigger-map + `resolveCommandText` path. No new dispatch logic — it rides the same registration and callback machinery as the other `oc_*` commands.

(Follow-up worth considering: have Mattermost derive its native set from the full command registry like Slack, instead of the hard-coded list. Out of scope here.)

## User Impact

With `channels.mattermost.commands.native: true`, the bot now registers `/oc_queue` alongside the existing native commands. Invoking `/oc_queue <mode> [debounce:..] [cap:..] [drop:..]` applies the session queue settings. Additive only: no change to existing commands, and none for channels that keep native commands disabled (the default).

## Evidence

- **Unit:** `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/slash-commands.test.ts` → 11/11 pass (added a case asserting `oc_queue` has `originalName: "queue"` and that `resolveCommandText` maps it to `/queue …`).
- **Live end-to-end (Mattermost 11.7.0):**
  - Registration: gateway log `registered command /oc_queue (id=…)`; the Mattermost `/api/v4/commands` API lists `oc_queue` as a custom command.
  - Dispatch: replaying the Mattermost slash callback with the real per-command token → the gateway applied the `/queue` directive and the bot posted `⚙️ Queue mode set to collect.` (log: `slash command /oc_queue from amk` → `delivered slash reply`).
