### PR TITLE
fix(telegram): preserve line breaks in /status card with rich messages enabled

### DIFF
--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -1114,5 +1114,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     activationLine,
   ]
     .filter((line): line is string => Boolean(line))
-    .join("\n");
+    // Use double newlines so Markdown renderers (Telegram rich messages) treat
+    // each status field as a separate block instead of collapsing into one line.
+    .join("\n\n");
 }


### PR DESCRIPTION
Fixes #95538

## 修复动机

当 Telegram `richMessages: true` 时，`/status` 状态卡的所有字段会合并为一行。
根因是 `buildStatusMessage` 使用 `\n`（单换行）拼接行，而在 Telegram 的
Markdown 渲染模式下，单换行被当作 soft break 而非硬换行，导致字段合为一段。

## 改动文件

- `src/status/status-message.ts` — 将 `.join("\n")` 改为 `.join("\n\n")`，
  使每个状态字段成为独立段落

## 验证步骤

1. 单元测试：`node scripts/run-vitest.mjs src/status/status-message.test.ts`
2. 手动验证：在 Telegram 中开启 richMessages，执行 `/status`，确认字段分行显示

## 兼容性说明

- 普通渠道（Discord/Slack/CLI）中 `\n\n` 仅增加一个空白行间隔，不影响可读性
- 仅更改字符串拼接方式，无逻辑变更
- 无破坏性变更

## CHANGELOG

No CHANGELOG entry needed — minimal non-functional formatting change.