### PR TITLE
Preserve inherited channel account policies during migration

### DIFF
--- a/extensions/mattermost/src/mattermost/accounts.test.ts
+++ b/extensions/mattermost/src/mattermost/accounts.test.ts
@@ -76,6 +76,32 @@ describe("resolveDefaultMattermostAccountId", () => {
     expect(listMattermostAccountIds(cfg)).toEqual(["default", "work"]);
     expect(resolveDefaultMattermostAccountId(cfg)).toBe("default");
   });
+
+  it("inherits top-level access policy for named accounts before doctor migration", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          dmPolicy: "open",
+          groupPolicy: "open",
+          allowFrom: ["*"],
+          groupAllowFrom: ["*"],
+          accounts: {
+            tony: {
+              botToken: "tok-tony",
+              baseUrl: "https://chat.example.com",
+            },
+          },
+        },
+      },
+    };
+
+    const account = resolveMattermostAccount({ cfg, accountId: "tony" });
+
+    expect(account.config.dmPolicy).toBe("open");
+    expect(account.config.groupPolicy).toBe("open");
+    expect(account.config.allowFrom).toEqual(["*"]);
+    expect(account.config.groupAllowFrom).toEqual(["*"]);
+  });
 });
 
 describe("resolveMattermostReplyToMode", () => {

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -391,7 +391,7 @@ describe("normalizeCompatibilityConfigValues", () => {
     expect(res.changes).toStrictEqual([]);
   });
 
-  it("moves WhatsApp access defaults into accounts.default for named accounts", () => {
+  it("preserves inherited WhatsApp access policy when seeding accounts.default", () => {
     const res = normalizeCompatibilityConfigValues({
       channels: {
         whatsapp: {
@@ -420,10 +420,145 @@ describe("normalizeCompatibilityConfigValues", () => {
       groupPolicy: "open",
       groupAllowFrom: [],
     });
+    expect(res.config.channels?.whatsapp?.accounts?.work).toEqual({
+      enabled: true,
+      authDir: "/tmp/wa-work",
+      dmPolicy: "allowlist",
+      allowFrom: ["+15550001111"],
+      groupPolicy: "open",
+      groupAllowFrom: [],
+    });
     expect(res.changes).toContain(
       "Moved channels.whatsapp single-account top-level values into channels.whatsapp.accounts.default.",
     );
   });
+
+  it.each(["discord", "slack", "telegram", "signal", "imessage", "irc"])(
+    "preserves inherited %s access policy when seeding accounts.default",
+    (channelId) => {
+      const res = normalizeCompatibilityConfigValues({
+        channels: {
+          [channelId]: {
+            dmPolicy: "allowlist",
+            allowFrom: ["sender-1"],
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["group-sender-1"],
+            accounts: {
+              work: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig);
+      const channel = (res.config.channels as Record<string, { accounts?: Record<string, unknown> }>)?.[
+        channelId
+      ];
+
+      expect(channel?.accounts?.default).toEqual({
+        dmPolicy: "allowlist",
+        allowFrom: ["sender-1"],
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["group-sender-1"],
+      });
+      expect(channel?.accounts?.work).toEqual({
+        enabled: true,
+        dmPolicy: "allowlist",
+        allowFrom: ["sender-1"],
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["group-sender-1"],
+      });
+    },
+  );
+
+  it("keeps named-account access policy overrides when seeding accounts.default", () => {
+    const res = normalizeCompatibilityConfigValues({
+      channels: {
+        discord: {
+          dmPolicy: "allowlist",
+          allowFrom: ["top-dm"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["top-group"],
+          accounts: {
+            work: {
+              token: "work-token",
+              allowFrom: ["work-dm"],
+              groupPolicy: "disabled",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(res.config.channels?.discord?.accounts?.work).toEqual({
+      token: "work-token",
+      dmPolicy: "allowlist",
+      allowFrom: ["work-dm"],
+      groupPolicy: "disabled",
+      groupAllowFrom: ["top-group"],
+    });
+  });
+
+  it("preserves inherited Mattermost access policy when seeding accounts.default", () => {
+    const res = normalizeCompatibilityConfigValues({
+      channels: {
+        mattermost: {
+          dmPolicy: "open",
+          groupPolicy: "open",
+          allowFrom: ["*"],
+          groupAllowFrom: ["*"],
+          accounts: {
+            tony: {
+              name: "Tony",
+              enabled: true,
+              botToken: "tony-token",
+              groups: {
+                tboek5jq9fremk5ecmd6n7f5nw: { requireMention: false },
+              },
+            },
+            research: {
+              name: "Research",
+              enabled: true,
+              botToken: "research-token",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.config.channels?.mattermost?.dmPolicy).toBeUndefined();
+    expect(res.config.channels?.mattermost?.allowFrom).toBeUndefined();
+    expect(res.config.channels?.mattermost?.groupPolicy).toBeUndefined();
+    expect(res.config.channels?.mattermost?.groupAllowFrom).toBeUndefined();
+    expect(res.config.channels?.mattermost?.accounts?.default).toEqual({
+      dmPolicy: "open",
+      groupPolicy: "open",
+      allowFrom: ["*"],
+      groupAllowFrom: ["*"],
+    });
+    expect(res.config.channels?.mattermost?.accounts?.tony).toEqual({
+      name: "Tony",
+      enabled: true,
+      botToken: "tony-token",
+      dmPolicy: "open",
+      groupPolicy: "open",
+      allowFrom: ["*"],
+      groupAllowFrom: ["*"],
+      groups: {
+        tboek5jq9fremk5ecmd6n7f5nw: { requireMention: false },
+      },
+    });
+    expect(res.config.channels?.mattermost?.accounts?.research).toEqual({
+      name: "Research",
+      enabled: true,
+      botToken: "research-token",
+      dmPolicy: "open",
+      groupPolicy: "open",
+      allowFrom: ["*"],
+      groupAllowFrom: ["*"],
+    });
+  });
+
   it("migrates browser ssrfPolicy allowPrivateNetwork to dangerouslyAllowPrivateNetwork", () => {
     const res = normalizeCompatibilityConfigValues({
       browser: {

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -19,6 +19,8 @@ import {
 } from "./legacy-runtime-model-providers.js";
 export { normalizeLegacyTalkConfig } from "./legacy-talk-config-normalizer.js";
 
+const INHERITED_ACCOUNT_POLICY_KEYS = ["dmPolicy", "allowFrom", "groupPolicy", "groupAllowFrom"];
+
 /** Remove deprecated command config keys that no runtime reads anymore. */
 export function normalizeLegacyCommandsConfig(
   cfg: OpenClawConfig,
@@ -174,10 +176,34 @@ export function seedMissingDefaultAccountsFromSingleAccountBase(
     for (const key of keysToMove) {
       delete nextChannel[key];
     }
-    nextChannel.accounts = {
+    const inheritedPolicyKeys = INHERITED_ACCOUNT_POLICY_KEYS.filter((key) =>
+      keysToMove.includes(key),
+    );
+    const nextAccounts: Record<string, unknown> = {
       ...rawAccounts,
       [DEFAULT_ACCOUNT_ID]: defaultAccount,
     };
+    if (inheritedPolicyKeys.length > 0) {
+      for (const [accountId, rawAccount] of Object.entries(rawAccounts)) {
+        if (!isRecord(rawAccount)) {
+          continue;
+        }
+        const nextAccount = { ...rawAccount };
+        let accountChanged = false;
+        for (const key of inheritedPolicyKeys) {
+          if (hasOwnKey(nextAccount, key)) {
+            continue;
+          }
+          const value = rawChannel[key];
+          nextAccount[key] = value && typeof value === "object" ? structuredClone(value) : value;
+          accountChanged = true;
+        }
+        if (accountChanged) {
+          nextAccounts[accountId] = nextAccount;
+        }
+      }
+    }
+    nextChannel.accounts = nextAccounts;
 
     nextChannels[channelId] = nextChannel;
     channelsChanged = true;


### PR DESCRIPTION
## What Problem This Solves

OpenClaw 2026.6.10-beta.1 exposed a doctor/config migration regression for legacy multi-account channel configs. When the migration seeded `accounts.default`, it moved top-level access policy (`dmPolicy`, `allowFrom`, `groupPolicy`, and `groupAllowFrom`) off the channel root, but existing named accounts that previously inherited those root policy values did not receive equivalent account-scoped policy.

For Mattermost, that left accounts without the effective group allowlist they had before migration, so runtime saw group/channel messages and could drop them before routing with `mattermost: drop group message (no group allowlist)`.

## Why This Change Was Made

The correct repair is in doctor's shared migration, not in the Mattermost runtime. Runtime channels already treat `accounts.default` and named account fallback differently; the migration is the code path that removes the inherited root values, so it must preserve the pre-migration effective policy before doing that removal.

When doctor seeds `accounts.default`, it now copies the moved access-policy keys into each existing named account that does not already define that key. Existing account-specific overrides still win.

The fix is shared across the single-account-to-`accounts.default` migration path, because the same inherited policy keys are promoted for Discord, Slack, Telegram, Signal, WhatsApp, iMessage, IRC, and Mattermost configs.

## User Impact

Users updating legacy multi-account channel configs keep the same effective DM and group access policy after doctor/config migration. Mattermost named accounts like `tony` and `research` continue accepting previously allowed group/channel traffic without manual per-account policy edits, and sibling channel migrations keep their documented inheritance behavior as well.

## Evidence

- Reproduced the broken migration with the installed 2026.6.10-beta.1 CLI on `knight@100.89.129.82` using an isolated fake Mattermost config: doctor moved policy only into `channels.mattermost.accounts.default`, leaving `tony` and `research` without `dmPolicy`, `allowFrom`, `groupPolicy`, or `groupAllowFrom`.
- Reproduced the fixed behavior from this branch's built source on the same fixture: doctor removes root policy and writes the policy to `accounts.default`, `accounts.tony`, and `accounts.research`.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/commands/doctor-legacy-config.migrations.test.ts -- --reporter=verbose`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/accounts.test.ts -- --reporter=verbose`
- `git diff --check origin/main...HEAD`
- `pnpm build`

Autoreview intentionally not run per maintainer instruction in this thread.
