### PR TITLE
feat(mattermost): persist participated threads for mention-free follow-ups

### DIFF
--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -155,6 +155,7 @@ Notes:
 
 - `onchar` still responds to explicit @mentions.
 - `channels.mattermost.requireMention` is honored for legacy configs but `chatmode` is preferred.
+- After the bot sends a visible reply in a channel thread, later messages in that same thread are answered without a new @mention or `onchar` prefix, so multi-turn thread conversations keep flowing. Participation is remembered for 7 days of thread inactivity (refreshed on each reply) and persists across gateway restarts. Threads the bot has only observed are unaffected; start a new top-level message to require an explicit mention again.
 
 ## Threading and sessions
 

--- a/extensions/mattermost/src/mattermost/monitor-gating.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-gating.test.ts
@@ -59,6 +59,84 @@ describe("mattermost monitor gating", () => {
     });
   });
 
+  it("processes engaged thread follow-ups without a mention", () => {
+    const resolveRequireMention = vi.fn(() => true);
+
+    expect(
+      evaluateMattermostMentionGate({
+        kind: "channel",
+        cfg: {} as never,
+        accountId: "default",
+        channelId: "chan-1",
+        resolveRequireMention,
+        wasMentioned: false,
+        threadAlreadyEngaged: true,
+        isControlCommand: false,
+        commandAuthorized: false,
+        oncharEnabled: false,
+        oncharTriggered: false,
+        canDetectMention: true,
+      }),
+    ).toEqual({
+      shouldRequireMention: true,
+      shouldBypassMention: false,
+      effectiveWasMentioned: true,
+      dropReason: null,
+    });
+  });
+
+  it("engaged threads respond even when onchar is enabled but not triggered", () => {
+    const resolveRequireMention = vi.fn(() => true);
+
+    expect(
+      evaluateMattermostMentionGate({
+        kind: "channel",
+        cfg: {} as never,
+        accountId: "default",
+        channelId: "chan-1",
+        resolveRequireMention,
+        wasMentioned: false,
+        threadAlreadyEngaged: true,
+        isControlCommand: false,
+        commandAuthorized: false,
+        oncharEnabled: true,
+        oncharTriggered: false,
+        canDetectMention: true,
+      }),
+    ).toEqual({
+      shouldRequireMention: true,
+      shouldBypassMention: false,
+      effectiveWasMentioned: true,
+      dropReason: null,
+    });
+  });
+
+  it("drops non-mentioned channel traffic outside an engaged thread", () => {
+    const resolveRequireMention = vi.fn(() => true);
+
+    expect(
+      evaluateMattermostMentionGate({
+        kind: "channel",
+        cfg: {} as never,
+        accountId: "default",
+        channelId: "chan-1",
+        resolveRequireMention,
+        wasMentioned: false,
+        threadAlreadyEngaged: false,
+        isControlCommand: false,
+        commandAuthorized: false,
+        oncharEnabled: false,
+        oncharTriggered: false,
+        canDetectMention: true,
+      }),
+    ).toEqual({
+      shouldRequireMention: true,
+      shouldBypassMention: false,
+      effectiveWasMentioned: false,
+      dropReason: "missing-mention",
+    });
+  });
+
   it("bypasses mention for authorized control commands and allows direct chats", () => {
     const resolveRequireMention = vi.fn(() => true);
 

--- a/extensions/mattermost/src/mattermost/monitor-gating.ts
+++ b/extensions/mattermost/src/mattermost/monitor-gating.ts
@@ -43,6 +43,9 @@ export type MattermostMentionGateInput = {
   requireMentionOverride?: boolean;
   resolveRequireMention: (params: MattermostRequireMentionResolverInput) => boolean;
   wasMentioned: boolean;
+  // Bot has already replied in this thread; treat follow-ups as addressed so the
+  // user need not re-mention on every turn (parity with Slack thread participation).
+  threadAlreadyEngaged?: boolean;
   isControlCommand: boolean;
   commandAuthorized: boolean;
   oncharEnabled: boolean;
@@ -75,12 +78,16 @@ export function evaluateMattermostMentionGate(
     !params.wasMentioned &&
     params.commandAuthorized;
   const effectiveWasMentioned =
-    params.wasMentioned || shouldBypassMention || params.oncharTriggered;
+    params.wasMentioned ||
+    shouldBypassMention ||
+    params.oncharTriggered ||
+    params.threadAlreadyEngaged === true;
   if (
     params.oncharEnabled &&
     !params.oncharTriggered &&
     !params.wasMentioned &&
-    !params.isControlCommand
+    !params.isControlCommand &&
+    params.threadAlreadyEngaged !== true
   ) {
     return {
       shouldRequireMention,

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -371,6 +371,7 @@ describe("deliverMattermostReplyWithDraftPreview", () => {
   it("suppresses reasoning-prefixed finals before preview finalization", async () => {
     const draftStream = createDraftStreamMock();
     const deliverFinal = vi.fn(async () => {});
+    const recordThreadParticipation = vi.fn();
 
     await deliverMattermostReplyWithDraftPreview({
       payload: { text: "  \n > Reasoning:\n> _hidden_" } as never,
@@ -382,6 +383,7 @@ describe("deliverMattermostReplyWithDraftPreview", () => {
       resolvePreviewFinalText: (text) => text?.trim(),
       previewState: { finalizedViaPreviewPost: false },
       logVerboseMessage: vi.fn(),
+      recordThreadParticipation,
       deliverPayload: deliverFinal,
     });
 
@@ -390,6 +392,36 @@ describe("deliverMattermostReplyWithDraftPreview", () => {
     expect(draftStream.discardPending).not.toHaveBeenCalled();
     expect(draftStream.clear).not.toHaveBeenCalled();
     expect(updateMattermostPostSpy).not.toHaveBeenCalled();
+    // No visible reply was sent, so the thread must not be marked as participated.
+    expect(recordThreadParticipation).not.toHaveBeenCalled();
+  });
+
+  it("records thread participation when a same-thread final finalizes the preview in place", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = vi.fn(async () => {});
+    const recordThreadParticipation = vi.fn();
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "All good" } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText: (text) => text?.trim(),
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      recordThreadParticipation,
+      deliverPayload: deliverFinal,
+    });
+
+    // Default streaming finalizes by editing the preview post, bypassing deliverPayload —
+    // participation must still be recorded (regression: PR #95552 review P1).
+    expect(updateMattermostPostSpy).toHaveBeenCalledWith(expect.anything(), "preview-post-1", {
+      message: "All good",
+    });
+    expect(deliverFinal).not.toHaveBeenCalled();
+    expect(recordThreadParticipation).toHaveBeenCalledTimes(1);
   });
 
   it("deletes the preview after a successful normal final send", async () => {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -116,6 +116,10 @@ import {
 import { sendMessageMattermost } from "./send.js";
 import { cleanupSlashCommands } from "./slash-commands.js";
 import { deactivateSlashCommands, getSlashCommandState } from "./slash-state.js";
+import {
+  hasMattermostThreadParticipationWithPersistence,
+  recordMattermostThreadParticipation,
+} from "./thread-participation.js";
 
 export {
   evaluateMattermostMentionGate,
@@ -1484,6 +1488,16 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           : { triggered: false, stripped: rawText };
         const oncharTriggered = oncharResult.triggered;
         const canDetectMention = Boolean(botUsername) || mentionRegexes.length > 0;
+        // Threads the bot already replied in auto-engage: follow-ups resume without
+        // a re-mention even under requireMention. Keyed by the thread root id.
+        const threadAlreadyEngaged =
+          kind !== "direct" && effectiveReplyToId
+            ? await hasMattermostThreadParticipationWithPersistence({
+                accountId: account.accountId,
+                channelId,
+                threadRootId: effectiveReplyToId,
+              })
+            : false;
         const mentionDecision = evaluateMattermostMentionGate({
           kind,
           cfg,
@@ -1493,6 +1507,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           requireMentionOverride: account.requireMention,
           resolveRequireMention: core.channel.groups.resolveRequireMention,
           wasMentioned,
+          threadAlreadyEngaged,
           isControlCommand,
           commandAuthorized,
           oncharEnabled,
@@ -1809,6 +1824,20 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                     sendMessage: sendMessageMattermost,
                     onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
                   });
+                  // Record only on a visible send so threads we merely observed
+                  // (reasoning-only/empty/suppressed) do not auto-engage later.
+                  if (
+                    kind !== "direct" &&
+                    effectiveReplyToId &&
+                    (outcome === "text" || outcome === "media")
+                  ) {
+                    recordMattermostThreadParticipation(
+                      account.accountId,
+                      channelId,
+                      effectiveReplyToId,
+                      { agentId: route.agentId },
+                    );
+                  }
                   const deliveryLog = formatMattermostFinalDeliveryOutcomeLog({
                     outcome,
                     payload: payloadToDeliver,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -331,6 +331,10 @@ type MattermostDraftPreviewDeliverParams = {
   previewState: MattermostDraftPreviewState;
   logVerboseMessage: (message: string) => void;
   deliverPayload: (payload: ReplyPayload) => Promise<void>;
+  // Visible same-thread finals can be delivered by editing the draft preview in
+  // place (onPreviewFinalized) without ever calling deliverPayload; this lets the
+  // caller record thread participation on that path too.
+  recordThreadParticipation?: () => void;
 };
 
 export async function deliverMattermostReplyWithDraftPreview(
@@ -378,6 +382,9 @@ export async function deliverMattermostReplyWithDraftPreview(
       },
       onPreviewFinalized: () => {
         params.previewState.finalizedViaPreviewPost = true;
+        // The visible final reply landed by editing the preview post, so the normal
+        // deliverPayload record path is skipped; record participation explicitly here.
+        params.recordThreadParticipation?.();
       },
       buildSupplementalPayload: (payload) =>
         getReplyPayloadTtsSupplement(payload) ? buildTtsSupplementMediaPayload(payload) : undefined,
@@ -1796,6 +1803,18 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               if (info.kind === "final") {
                 progressDraft.markFinalReplyStarted();
               }
+              // A visible same-thread final arrives either via a normal send or by editing
+              // the draft preview in place; record participation on whichever path fires.
+              const markThreadParticipation = () => {
+                if (kind !== "direct" && effectiveReplyToId) {
+                  recordMattermostThreadParticipation(
+                    account.accountId,
+                    channelId,
+                    effectiveReplyToId,
+                    { agentId: route.agentId },
+                  );
+                }
+              };
               await deliverMattermostReplyWithDraftPreview({
                 payload: payloadEntry,
                 info,
@@ -1806,6 +1825,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 resolvePreviewFinalText,
                 previewState,
                 logVerboseMessage,
+                recordThreadParticipation: markThreadParticipation,
                 deliverPayload: async (payloadToDeliver) => {
                   const outcome = await deliverMattermostReplyPayload({
                     core,
@@ -1826,17 +1846,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   });
                   // Record only on a visible send so threads we merely observed
                   // (reasoning-only/empty/suppressed) do not auto-engage later.
-                  if (
-                    kind !== "direct" &&
-                    effectiveReplyToId &&
-                    (outcome === "text" || outcome === "media")
-                  ) {
-                    recordMattermostThreadParticipation(
-                      account.accountId,
-                      channelId,
-                      effectiveReplyToId,
-                      { agentId: route.agentId },
-                    );
+                  if (outcome === "text" || outcome === "media") {
+                    markThreadParticipation();
                   }
                   const deliveryLog = formatMattermostFinalDeliveryOutcomeLog({
                     outcome,

--- a/extensions/mattermost/src/mattermost/thread-participation.test.ts
+++ b/extensions/mattermost/src/mattermost/thread-participation.test.ts
@@ -15,7 +15,10 @@ import {
 
 // Drain microtasks + the immediate queue so the fire-and-forget persistent write
 // in recordMattermostThreadParticipation has settled before we assert on it.
-const flush = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+const flush = (): Promise<void> =>
+  new Promise((resolve) => {
+    setImmediate(resolve);
+  });
 
 function setRuntime(openKeyedStore: (options: OpenKeyedStoreOptions) => unknown): void {
   setMattermostRuntime({

--- a/extensions/mattermost/src/mattermost/thread-participation.test.ts
+++ b/extensions/mattermost/src/mattermost/thread-participation.test.ts
@@ -1,0 +1,112 @@
+// Mattermost tests cover thread participation cache plugin behavior.
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { setMattermostRuntime } from "../runtime.js";
+import {
+  clearMattermostThreadParticipationCache,
+  hasMattermostThreadParticipationWithPersistence,
+  recordMattermostThreadParticipation,
+} from "./thread-participation.js";
+
+// Drain microtasks + the immediate queue so the fire-and-forget persistent write
+// in recordMattermostThreadParticipation has settled before we assert on it.
+const flush = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+function setRuntime(openKeyedStore: (options: OpenKeyedStoreOptions) => unknown): void {
+  setMattermostRuntime({
+    state: { openKeyedStore },
+    logging: { getChildLogger: () => ({ warn() {} }) },
+  } as unknown as PluginRuntime);
+}
+
+function setPersistentRuntime(): void {
+  setRuntime((options) => createPluginStateKeyedStoreForTests("mattermost", options));
+}
+
+describe("mattermost thread participation", () => {
+  beforeEach(() => {
+    resetPluginStateStoreForTests();
+    clearMattermostThreadParticipationCache();
+    setPersistentRuntime();
+  });
+
+  afterEach(() => {
+    clearMattermostThreadParticipationCache();
+    resetPluginStateStoreForTests();
+  });
+
+  it("remembers a thread the bot replied in", async () => {
+    recordMattermostThreadParticipation("acct", "chan", "root-1");
+    await expect(
+      hasMattermostThreadParticipationWithPersistence({
+        accountId: "acct",
+        channelId: "chan",
+        threadRootId: "root-1",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("isolates participation by account, channel, and thread", async () => {
+    recordMattermostThreadParticipation("acct", "chan", "root-1");
+    await flush();
+    for (const probe of [
+      { accountId: "other", channelId: "chan", threadRootId: "root-1" },
+      { accountId: "acct", channelId: "other", threadRootId: "root-1" },
+      { accountId: "acct", channelId: "chan", threadRootId: "root-2" },
+    ]) {
+      await expect(hasMattermostThreadParticipationWithPersistence(probe)).resolves.toBe(false);
+    }
+  });
+
+  it("ignores empty identifiers", async () => {
+    recordMattermostThreadParticipation("", "chan", "root-1");
+    await expect(
+      hasMattermostThreadParticipationWithPersistence({
+        accountId: "",
+        channelId: "chan",
+        threadRootId: "root-1",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("recovers participation from the persistent store after the in-memory cache is lost", async () => {
+    recordMattermostThreadParticipation("acct", "chan", "root-1");
+    await flush();
+    // Simulate a restart: in-memory cache cleared, persistent SQLite store intact.
+    clearMattermostThreadParticipationCache();
+    await expect(
+      hasMattermostThreadParticipationWithPersistence({
+        accountId: "acct",
+        channelId: "chan",
+        threadRootId: "root-1",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("degrades to in-memory only when the persistent store fails", async () => {
+    setRuntime(() => {
+      throw new Error("sqlite unavailable");
+    });
+    // record + read must not throw; the in-memory cache still answers.
+    recordMattermostThreadParticipation("acct", "chan", "root-1");
+    await expect(
+      hasMattermostThreadParticipationWithPersistence({
+        accountId: "acct",
+        channelId: "chan",
+        threadRootId: "root-1",
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      hasMattermostThreadParticipationWithPersistence({
+        accountId: "acct",
+        channelId: "chan",
+        threadRootId: "missing",
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/extensions/mattermost/src/mattermost/thread-participation.ts
+++ b/extensions/mattermost/src/mattermost/thread-participation.ts
@@ -1,0 +1,151 @@
+// Mattermost plugin module implements thread participation cache behavior.
+import { resolveGlobalDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
+import { getOptionalMattermostRuntime } from "../runtime.js";
+
+/**
+ * In-memory + persisted cache of Mattermost threads the bot has replied in.
+ * Lets the bot auto-respond to thread follow-ups without a re-mention after its
+ * first visible reply. Mirrors the Slack `sent-thread-cache` dual-layer pattern.
+ */
+
+const TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const MAX_ENTRIES = 5000;
+const PERSISTENT_MAX_ENTRIES = 1000;
+const PERSISTENT_NAMESPACE = "mattermost.thread-participation";
+
+type MattermostThreadParticipationRecord = {
+  agentId?: string;
+  repliedAt: number;
+};
+
+type MattermostThreadParticipationStore = {
+  register(
+    key: string,
+    value: MattermostThreadParticipationRecord,
+    opts?: { ttlMs?: number },
+  ): Promise<void>;
+  lookup(key: string): Promise<MattermostThreadParticipationRecord | undefined>;
+};
+
+/**
+ * Keep thread participation shared across bundled chunks so thread auto-reply
+ * gating does not diverge between the inbound-gate and reply-dispatch paths.
+ */
+const MATTERMOST_THREAD_PARTICIPATION_KEY = Symbol.for("openclaw.mattermostThreadParticipation");
+const threadParticipation = resolveGlobalDedupeCache(MATTERMOST_THREAD_PARTICIPATION_KEY, {
+  ttlMs: TTL_MS,
+  maxSize: MAX_ENTRIES,
+});
+
+let persistentStore: MattermostThreadParticipationStore | undefined;
+let persistentStoreDisabled = false;
+
+function makeKey(accountId: string, channelId: string, threadRootId: string): string {
+  return `${accountId}:${channelId}:${threadRootId}`;
+}
+
+function reportPersistentThreadParticipationError(error: unknown): void {
+  try {
+    getOptionalMattermostRuntime()
+      ?.logging.getChildLogger({ plugin: "mattermost", feature: "thread-participation-state" })
+      .warn("Mattermost persistent thread participation state failed", { error: String(error) });
+  } catch {
+    // Best effort only: persistent state must never break Mattermost message handling.
+  }
+}
+
+function disablePersistentThreadParticipation(error: unknown): void {
+  persistentStoreDisabled = true;
+  persistentStore = undefined;
+  reportPersistentThreadParticipationError(error);
+}
+
+function getPersistentThreadParticipationStore(): MattermostThreadParticipationStore | undefined {
+  if (persistentStoreDisabled) {
+    return undefined;
+  }
+  if (persistentStore) {
+    return persistentStore;
+  }
+  const runtime = getOptionalMattermostRuntime();
+  if (!runtime) {
+    return undefined;
+  }
+  try {
+    persistentStore = runtime.state.openKeyedStore<MattermostThreadParticipationRecord>({
+      namespace: PERSISTENT_NAMESPACE,
+      maxEntries: PERSISTENT_MAX_ENTRIES,
+      defaultTtlMs: TTL_MS,
+    });
+    return persistentStore;
+  } catch (error) {
+    disablePersistentThreadParticipation(error);
+    return undefined;
+  }
+}
+
+function rememberPersistentThreadParticipation(params: { key: string; agentId?: string }): void {
+  const store = getPersistentThreadParticipationStore();
+  if (!store) {
+    return;
+  }
+  void store
+    .register(params.key, {
+      // Stored for future per-agent thread routing; current reads only need presence.
+      ...(params.agentId ? { agentId: params.agentId } : {}),
+      repliedAt: Date.now(),
+    })
+    .catch(disablePersistentThreadParticipation);
+}
+
+async function lookupPersistentThreadParticipation(key: string): Promise<boolean> {
+  const store = getPersistentThreadParticipationStore();
+  if (!store) {
+    return false;
+  }
+  try {
+    return Boolean(await store.lookup(key));
+  } catch (error) {
+    disablePersistentThreadParticipation(error);
+    return false;
+  }
+}
+
+export function recordMattermostThreadParticipation(
+  accountId: string,
+  channelId: string,
+  threadRootId: string,
+  opts?: { agentId?: string },
+): void {
+  if (!accountId || !channelId || !threadRootId) {
+    return;
+  }
+  const key = makeKey(accountId, channelId, threadRootId);
+  threadParticipation.check(key);
+  rememberPersistentThreadParticipation({ key, agentId: opts?.agentId });
+}
+
+export async function hasMattermostThreadParticipationWithPersistence(params: {
+  accountId: string;
+  channelId: string;
+  threadRootId: string;
+}): Promise<boolean> {
+  if (!params.accountId || !params.channelId || !params.threadRootId) {
+    return false;
+  }
+  const key = makeKey(params.accountId, params.channelId, params.threadRootId);
+  if (threadParticipation.peek(key)) {
+    return true;
+  }
+  const found = await lookupPersistentThreadParticipation(key);
+  if (found) {
+    threadParticipation.check(key);
+  }
+  return found;
+}
+
+export function clearMattermostThreadParticipationCache(): void {
+  threadParticipation.clear();
+  persistentStore = undefined;
+  persistentStoreDisabled = false;
+}

--- a/extensions/mattermost/src/runtime.ts
+++ b/extensions/mattermost/src/runtime.ts
@@ -2,9 +2,12 @@
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 
-const { setRuntime: setMattermostRuntime, getRuntime: getMattermostRuntime } =
-  createPluginRuntimeStore<PluginRuntime>({
-    pluginId: "mattermost",
-    errorMessage: "Mattermost runtime not initialized",
-  });
-export { getMattermostRuntime, setMattermostRuntime };
+const {
+  setRuntime: setMattermostRuntime,
+  getRuntime: getMattermostRuntime,
+  tryGetRuntime: getOptionalMattermostRuntime,
+} = createPluginRuntimeStore<PluginRuntime>({
+  pluginId: "mattermost",
+  errorMessage: "Mattermost runtime not initialized",
+});
+export { getMattermostRuntime, getOptionalMattermostRuntime, setMattermostRuntime };


### PR DESCRIPTION
## What Problem This Solves

In Mattermost channels/groups the bot drops any message that doesn't explicitly @-mention it (`requireMention` defaults to `true`), and it keeps **no memory of threads it is already conversing in**. So a user must re-mention the bot on *every* follow-up in an active thread. Sibling channels already solve this — Slack tracks participated threads (in-memory + SQLite) and feeds a `bot_thread_participant` implicit-mention into the shared gate. Mattermost was the outlier: it even passes the thread root id into its mention gate but never reads it.

## Why This Change Was Made

Bring Mattermost to parity with Slack's thread-participation behaviour, persisted so it survives a gateway restart. Scoped deliberately to a **bounded, Mattermost-local** change (no Slack edits; keep the existing `evaluateMattermostMentionGate`) per maintainer direction.

## User Impact

- After the bot posts a visible reply in a thread, later messages in that thread are answered **without** a re-mention — matching Slack.
- **Survives restart:** participation is mirrored to the SQLite plugin-state store (namespace `mattermost.thread-participation`, **7-day TTL**, bounded entries), so the bot no longer "forgets" active threads on restart. TTL refreshes on every reply, so active threads stay engaged and only genuinely idle ones expire.
- Always-on (matches Slack's default); **no new config**. DMs unchanged (already mention-free). Threads the bot only *observed* (reasoning-only / empty / suppressed outcomes) do **not** auto-engage.
- Best-effort persistence: if the store is unavailable it degrades to in-memory only and never blocks message handling.

## Evidence

- New `extensions/mattermost/src/mattermost/thread-participation.ts` mirrors Slack's `sent-thread-cache.ts` (dual layer: `resolveGlobalDedupeCache` + `runtime.state.openKeyedStore`).
- Gate: `evaluateMattermostMentionGate` gains a `threadAlreadyEngaged` input, folded into `effectiveWasMentioned` and the onchar-not-triggered guard.
- Monitor: awaits the participation check before the gate; records after a visible thread reply (`outcome` `text`/`media`) keyed by `effectiveReplyToId`.
- Tests: the two touched test files pass — **2 files, 12 tests** — covering remember/lookup, account/channel/thread isolation, **persist→reload across a simulated restart**, graceful degradation when the store fails, and the new gate cases (engaged thread bypasses mention + onchar; non-engaged still drops with `missing-mention`).
- Build: `pnpm build` clean (`tsdown` OK, no `[INEFFECTIVE_DYNAMIC_IMPORT]` for the lazy monitor boundary).

### Follow-ups (tracked separately, not in this PR)
- **reply-to-bot parity** — engage when a user replies directly to the bot's own message (Slack/Telegram already do this); queued as its own session.
- **Shared extraction** — Slack's and this cache are near-identical; a future change can extract one channel-generic helper and migrate both. Slack still ships a 24h TTL, so that extraction is the natural place to standardise the window across channels.
