### PR TITLE
fix(tui): recognize DEL (0x7f) as backspace alongside BS (0x08)

### DIFF
--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -250,7 +250,7 @@ export function createBackspaceDeduper(params?: { dedupeWindowMs?: number; now?:
   let lastBackspaceAt = -1;
 
   return (data: string): string => {
-    if (data !== "\x08" && !matchesKey(data, Key.backspace)) {
+    if (data !== "\x08" && data !== "\x7f" && !matchesKey(data, Key.backspace)) {
       return data;
     }
     const ts = now();


### PR DESCRIPTION
## What Problem This Solves

WSL2 Ubuntu terminals send `^?` (0x7f / DEL) for the Backspace key, but the
TUI backspace deduper in `src/tui/tui.ts` only recognizes `^H` (0x08 / BS).
After each agent response renders, the TUI re-enters raw mode and backspace
silently stops working for WSL users.

Users must exit and re-enter the TUI to restore backspace, or use Ctrl+H as an
unreliable workaround.

## Why This Change Was Made

The `createBackspaceDeduper` gate at `src/tui/tui.ts:253` checked only
`data !== "\x08"` to decide whether an input byte is a backspace event. The
fix adds `data !== "\x7f"` so that DEL — the standard backspace code on
Linux/WSL terminals — is handled identically to BS.

This is a one-line change with no effect on macOS terminals (which send `\x7f`
natively), or Windows terminals (where `Key.backspace` via `matchesKey`
already covers the system key path).

## Changes

- **`src/tui/tui.ts`** — add `data !== "\x7f"` to the `createBackspaceDeduper`
  gate so DEL is recognized as backspace alongside BS

## Evidence

- Existing test suite in `src/tui/tui.test.ts` already exercises `\x7f` as
  backspace in the `createBackspaceDeduper` tests — the tests describe the
  expected behavior that this fix now delivers
- Single-line change, no new dependencies or API surface

## Related

Closes #92777