### PR TITLE
improve: refresh Android overview control surface

### DIFF
--- a/apps/android/app/src/debug/AndroidManifest.xml
+++ b/apps/android/app/src/debug/AndroidManifest.xml
@@ -1,7 +1,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <permission
+        android:name="${applicationId}.permission.RUN_VOICE_E2E"
+        android:protectionLevel="signature" />
+
+    <uses-permission android:name="${applicationId}.permission.RUN_VOICE_E2E" />
+
     <application>
         <receiver
             android:name=".VoiceE2eReceiver"
+            android:permission="${applicationId}.permission.RUN_VOICE_E2E"
             android:exported="true">
             <intent-filter>
                 <action android:name="ai.openclaw.app.debug.RUN_VOICE_E2E" />

--- a/apps/android/app/src/debug/AndroidManifest.xml
+++ b/apps/android/app/src/debug/AndroidManifest.xml
@@ -10,7 +10,7 @@
         <receiver
             android:name=".VoiceE2eReceiver"
             android:permission="${applicationId}.permission.RUN_VOICE_E2E"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="ai.openclaw.app.debug.RUN_VOICE_E2E" />
             </intent-filter>

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -538,8 +538,7 @@ class ChatController internal constructor(
     }
   }
 
-  private fun parseEventSessionEntry(payload: JsonObject): ChatSessionEntry? =
-    payload["session"].asObjectOrNull()?.let(::parseSessionEntry) ?: parseSessionEntry(payload)
+  private fun parseEventSessionEntry(payload: JsonObject): ChatSessionEntry? = payload["session"].asObjectOrNull()?.let(::parseSessionEntry) ?: parseSessionEntry(payload)
 
   private fun handleAgentEvent(payloadJson: String) {
     val payload = json.parseToJsonElement(payloadJson).asObjectOrNull() ?: return
@@ -747,9 +746,16 @@ class ChatController internal constructor(
   ): ChatSessionEntry? {
     if (obj == null) return null
     val key =
-      obj["key"].asStringOrNull()?.trim().orEmpty()
-        .ifEmpty { obj["sessionKey"].asStringOrNull()?.trim().orEmpty() }
-        .ifEmpty { fallbackKey?.trim().orEmpty() }
+      obj["key"]
+        .asStringOrNull()
+        ?.trim()
+        .orEmpty()
+        .ifEmpty {
+          obj["sessionKey"]
+            .asStringOrNull()
+            ?.trim()
+            .orEmpty()
+        }.ifEmpty { fallbackKey?.trim().orEmpty() }
     if (key.isEmpty()) return null
     return ChatSessionEntry(
       key = key,

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
@@ -1,6 +1,5 @@
 package ai.openclaw.app.gateway
 
-import android.annotation.TargetApi
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.DnsResolver
@@ -12,6 +11,7 @@ import android.net.nsd.NsdServiceInfo
 import android.os.Build
 import android.os.CancellationSignal
 import android.util.Log
+import androidx.annotation.RequiresApi
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -56,7 +56,7 @@ private fun createDnsResolver(context: Context): DnsResolver =
     createLegacyDnsResolver()
   }
 
-@TargetApi(Build.VERSION_CODES.CINNAMON_BUN)
+@RequiresApi(Build.VERSION_CODES.CINNAMON_BUN)
 private fun createContextDnsResolver(context: Context): DnsResolver = DnsResolver(context, null)
 
 @Suppress("DEPRECATION")
@@ -189,7 +189,7 @@ class GatewayDiscovery(
     }
   }
 
-  @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+  @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
   private fun resolveWithServiceInfoCallback(serviceInfo: NsdServiceInfo) {
     val serviceName = BonjourEscapes.decode(serviceInfo.serviceName)
     val id = stableId(serviceName, "local.")

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceHandler.kt
@@ -4,6 +4,7 @@ import ai.openclaw.app.BuildConfig
 import ai.openclaw.app.SensitiveFeatureConfig
 import ai.openclaw.app.gateway.GatewaySession
 import android.Manifest
+import android.annotation.SuppressLint
 import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
@@ -63,7 +64,7 @@ private class AndroidDeviceAppSource(
 
     val appInfos =
       if (includeNonLaunchable) {
-        packageManager.getInstalledApplications(PackageManager.MATCH_ALL)
+        visibleInstalledApplications(packageManager)
       } else {
         launchablePackages.mapNotNull { packageName ->
           runCatching { packageManager.getApplicationInfo(packageName, 0) }.getOrNull()
@@ -89,6 +90,13 @@ private class AndroidDeviceAppSource(
       }.distinctBy { it.packageName }
       .sortedWith(compareBy<DeviceAppEntry> { it.label.lowercase() }.thenBy { it.packageName })
       .toList()
+  }
+
+  @SuppressLint("QueryPermissionsNeeded")
+  private fun visibleInstalledApplications(packageManager: PackageManager): List<ApplicationInfo> {
+    // Android package visibility intentionally bounds this result to packages the app can see.
+    // OpenClaw should not request QUERY_ALL_PACKAGES for this optional device-context surface.
+    return packageManager.getInstalledApplications(PackageManager.MATCH_ALL)
   }
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1378,7 +1378,12 @@ private fun rememberPermissionState(
       photosGranted = permissions[photosPermission] ?: photosGranted
       contactsGranted = permissions[Manifest.permission.READ_CONTACTS] ?: contactsGranted
       calendarGranted = permissions[Manifest.permission.READ_CALENDAR] ?: calendarGranted
-      notificationsGranted = permissions[Manifest.permission.POST_NOTIFICATIONS] ?: notificationsGranted
+      notificationsGranted =
+        if (Build.VERSION.SDK_INT >= 33) {
+          permissions[Manifest.permission.POST_NOTIFICATIONS] ?: notificationsGranted
+        } else {
+          true
+        }
       motionGranted = permissions[Manifest.permission.ACTIVITY_RECOGNITION] ?: motionGranted
       smsGranted =
         (permissions[Manifest.permission.SEND_SMS] ?: smsGranted) &&

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt
@@ -55,7 +55,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
-/** Session browser for recent and currently-live chat sessions. */
+/** Session browser for recent and current chat sessions. */
 @Composable
 internal fun SessionsScreen(
   viewModel: MainViewModel,
@@ -73,7 +73,7 @@ internal fun SessionsScreen(
       .let { rows ->
         when (filter) {
           SessionFilter.Recent -> rows
-          SessionFilter.Live -> rows.filter { it.key == chatSessionKey }
+          SessionFilter.Current -> rows.filter { it.key == chatSessionKey }
         }
       }.let { rows ->
         if (recentFirst) {
@@ -92,12 +92,12 @@ internal fun SessionsScreen(
   }
 
   ClawScaffold(
-    contentPadding = PaddingValues(start = 20.dp, top = 14.dp, end = 20.dp, bottom = 6.dp),
+    contentPadding = PaddingValues(start = 16.dp, top = 10.dp, end = 16.dp, bottom = 4.dp),
     contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
   ) {
     LazyColumn(
       modifier = Modifier.fillMaxSize(),
-      verticalArrangement = Arrangement.spacedBy(7.dp),
+      verticalArrangement = Arrangement.spacedBy(9.dp),
       contentPadding = PaddingValues(bottom = 4.dp),
     ) {
       item {
@@ -106,7 +106,7 @@ internal fun SessionsScreen(
           verticalAlignment = Alignment.CenterVertically,
           horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-          Text(text = "Sessions", style = ClawTheme.type.display.copy(fontSize = 17.4.sp, lineHeight = 21.sp), color = ClawTheme.colors.text, modifier = Modifier.weight(1f))
+          Text(text = "Sessions", style = ClawTheme.type.display.copy(fontSize = 24.sp, lineHeight = 28.sp), color = ClawTheme.colors.text, modifier = Modifier.weight(1f))
           SessionPlainIconButton(icon = Icons.Default.Search, contentDescription = "Search sessions", onClick = onOpenCommand)
           SessionPlainIconButton(icon = Icons.Default.SwapVert, contentDescription = "Reverse session sort", onClick = { recentFirst = !recentFirst })
         }
@@ -115,7 +115,7 @@ internal fun SessionsScreen(
       item {
         Row(horizontalArrangement = Arrangement.spacedBy(5.dp)) {
           FilterPill(text = "Recent", icon = Icons.Outlined.AccessTime, active = filter == SessionFilter.Recent, onClick = { filter = SessionFilter.Recent })
-          FilterPill(text = "Live", icon = Icons.Outlined.MicNone, active = filter == SessionFilter.Live, live = sessions.any { it.key == chatSessionKey }, onClick = { filter = SessionFilter.Live })
+          FilterPill(text = "Current", icon = Icons.Outlined.MicNone, active = filter == SessionFilter.Current, showDot = sessions.any { it.key == chatSessionKey }, onClick = { filter = SessionFilter.Current })
         }
       }
 
@@ -179,7 +179,7 @@ private fun FilterPill(
   text: String,
   icon: ImageVector? = null,
   active: Boolean = false,
-  live: Boolean = false,
+  showDot: Boolean = false,
   dropdown: Boolean = false,
   onClick: (() -> Unit)? = null,
 ) {
@@ -198,7 +198,7 @@ private fun FilterPill(
     ) {
       icon?.let { Icon(imageVector = it, contentDescription = null, modifier = Modifier.size(12.dp), tint = ClawTheme.colors.text) }
       Text(text = text, style = ClawTheme.type.label, color = ClawTheme.colors.text, maxLines = 1)
-      if (live) {
+      if (showDot) {
         Box(modifier = Modifier.size(4.dp).clip(CircleShape).background(ClawTheme.colors.success))
       }
       if (dropdown) {
@@ -258,7 +258,7 @@ private fun SessionRow(
             Text(text = subtitle, style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textMuted, maxLines = 1)
             Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
               SessionMiniTag(text = "Workspace")
-              SessionMiniTag(text = if (active) "Active" else "OpenClaw")
+              SessionMiniTag(text = if (active) "Current" else "OpenClaw")
             }
           }
         }
@@ -320,21 +320,21 @@ private fun SessionMiniTag(text: String) {
 
 private enum class SessionFilter {
   Recent,
-  Live,
+  Current,
 }
 
 /** Empty-state title selected by the active session browser filter. */
 private fun emptySessionTitle(filter: SessionFilter): String =
   when (filter) {
     SessionFilter.Recent -> "No sessions yet"
-    SessionFilter.Live -> "No live session"
+    SessionFilter.Current -> "No current session"
   }
 
 /** Empty-state body selected by the active session browser filter. */
 private fun emptySessionBody(filter: SessionFilter): String =
   when (filter) {
     SessionFilter.Recent -> "Start a new conversation and it will show up here."
-    SessionFilter.Live -> "Open Chat to start or resume the current session."
+    SessionFilter.Current -> "Open Chat to start or resume the current session."
   }
 
 /** Formats session timestamps for compact mobile metadata. */

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -106,6 +106,7 @@ internal enum class SettingsRoute {
   Profile,
   Voice,
   Agents,
+  ProvidersModels,
   Approvals,
   CronJobs,
   Usage,
@@ -136,6 +137,7 @@ internal fun SettingsDetailScreen(
     SettingsRoute.Profile -> ProfileSettingsScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.Voice -> VoiceSettingsScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.Agents -> AgentsSettingsScreen(viewModel = viewModel, onBack = onBack)
+    SettingsRoute.ProvidersModels -> ProvidersModelsScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.Approvals -> ApprovalsSettingsScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.CronJobs -> CronJobsSettingsScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.Usage -> UsageSettingsScreen(viewModel = viewModel, onBack = onBack)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -819,7 +819,7 @@ private fun TalkEntryPanel(
       }
       Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
         Text(text = "Talk", style = ClawTheme.type.caption.copy(fontSize = 12.sp, lineHeight = 15.sp), color = ClawTheme.colors.textMuted)
-        Text(text = "Hold to talk", style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Text(text = "Open Talk", style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
       }
       PlainIconButton(icon = Icons.Default.Tune, contentDescription = "Talk settings", onClick = onOpenVoiceSettings)
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.BuildConfig
+import ai.openclaw.app.GatewayAgentSummary
 import ai.openclaw.app.GatewayChannelsSummary
 import ai.openclaw.app.GatewayDreamingSummary
 import ai.openclaw.app.GatewayNodeApprovalState
@@ -9,6 +10,7 @@ import ai.openclaw.app.GatewaySkillSummary
 import ai.openclaw.app.HomeDestination
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.NodeRuntime
+import ai.openclaw.app.R
 import ai.openclaw.app.ui.chat.ChatScreen
 import ai.openclaw.app.ui.design.ClawBottomNav
 import ai.openclaw.app.ui.design.ClawDesignTheme
@@ -18,6 +20,7 @@ import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawPrimaryButton
 import ai.openclaw.app.ui.design.ClawScaffold
 import ai.openclaw.app.ui.design.ClawSecondaryButton
+import ai.openclaw.app.ui.design.ClawStatus
 import ai.openclaw.app.ui.design.ClawTheme
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
@@ -29,16 +32,19 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -47,7 +53,11 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.ScreenShare
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.GraphicEq
+import androidx.compose.material.icons.filled.Groups
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Mic
@@ -55,8 +65,10 @@ import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Storage
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
 import androidx.compose.material.icons.outlined.Inventory2
@@ -82,6 +94,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -351,6 +364,8 @@ private fun OverviewScreen(
   val cronStatus by viewModel.cronStatus.collectAsState()
   val nodesDevicesSummary by viewModel.nodesDevicesSummary.collectAsState()
   val channelsSummary by viewModel.channelsSummary.collectAsState()
+  val agents by viewModel.gatewayAgents.collectAsState()
+  val defaultAgentId by viewModel.gatewayDefaultAgentId.collectAsState()
   val readyProviderCount = providerRows(providers = providers, models = models).count { it.ready }
   val attentionRows =
     homeAttentionRows(
@@ -360,10 +375,29 @@ private fun OverviewScreen(
       nodesDevicesSummary = nodesDevicesSummary,
       readyProviderCount = readyProviderCount,
     )
+  val secondaryAttentionRows =
+    if (nodesDevicesSummary.hasNodeCapabilityApprovalPending()) {
+      attentionRows.filterNot { it.title == "Nodes & Devices" }
+    } else {
+      attentionRows
+    }
+  val headerState = overviewHeaderState(isConnected = isConnected, hasAttention = attentionRows.isNotEmpty())
+  val headerRoute = overviewHeaderRoute(attentionRows)
+  val activeAgentName = overviewAgentName(agents = agents, defaultAgentId = defaultAgentId)
+  val activeAgentBadge = overviewAgentBadgeText(agents = agents, defaultAgentId = defaultAgentId)
+  val metricCards =
+    overviewMetricCards(
+      isConnected = isConnected,
+      hasAttention = attentionRows.isNotEmpty(),
+      nodesDevicesSummary = nodesDevicesSummary,
+      pendingApprovals = pendingToolCalls.size,
+      sessionCount = sessions.size,
+    )
 
   LaunchedEffect(isConnected) {
     if (isConnected) {
       viewModel.refreshChatSessions(limit = 20)
+      viewModel.refreshAgents()
       viewModel.refreshModelCatalog()
       viewModel.refreshCronJobs()
       viewModel.refreshNodesDevices()
@@ -372,58 +406,58 @@ private fun OverviewScreen(
   }
 
   ClawScaffold(
-    contentPadding = PaddingValues(start = 20.dp, top = 14.dp, end = 20.dp, bottom = 6.dp),
+    contentPadding = PaddingValues(start = 16.dp, top = 10.dp, end = 16.dp, bottom = 4.dp),
     contentWindowInsets = shellContentInsets,
   ) {
     Box(modifier = Modifier.fillMaxSize()) {
-      LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(12.dp), contentPadding = PaddingValues(bottom = 4.dp)) {
+      LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(9.dp), contentPadding = PaddingValues(bottom = 4.dp)) {
         item {
-          Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(9.dp),
-          ) {
-            Text(
-              text = "O P E N C L A W",
-              style = ClawTheme.type.title.copy(fontSize = 16.sp, lineHeight = 20.sp),
-              color = ClawTheme.colors.text,
-              modifier = Modifier.weight(1f),
-            )
-            PlainIconButton(icon = Icons.Default.Search, contentDescription = "Search", onClick = onOpenCommand)
-            OverviewAvatar(text = "OC")
-          }
+          OverviewHeader(status = headerState, onOpenStatus = { onOpenSettingsRoute(headerRoute) }, onOpenCommand = onOpenCommand)
         }
 
         item {
-          CompanionHeroPanel(
+          Text(
+            text = "Overview",
+            style = ClawTheme.type.display.copy(fontSize = 24.sp, lineHeight = 28.sp),
+            color = ClawTheme.colors.text,
+          )
+        }
+
+        item {
+          OverviewPrimaryPanel(
+            agentName = activeAgentName,
+            agentBadge = activeAgentBadge,
             statusText = gatewaySummary(statusText, isConnected),
             isConnected = isConnected,
             pendingRunCount = pendingRunCount,
+            sessionCount = sessions.size,
+            cronJobCount = cronStatus.jobs,
             onOpenChat = { onSelectTab(Tab.Chat) },
             onOpenVoice = { onSelectTab(Tab.Voice) },
+            onOpenAgent = { onOpenSettingsRoute(SettingsRoute.Agents) },
             onOpenGateway = { onOpenSettingsRoute(SettingsRoute.Gateway) },
           )
         }
 
-        if (attentionRows.isNotEmpty()) {
-          item {
-            HomeAttentionPanel(rows = attentionRows, onSelectTab = onSelectTab, onOpenSettingsRoute = onOpenSettingsRoute)
-          }
-        }
-
         item {
-          SectionLabel(
-            title = "Recent Sessions",
-            action = {
-              Text(
-                text = "View all",
-                modifier = Modifier.clickable { onSelectTab(Tab.Sessions) },
-                style = ClawTheme.type.caption,
-                color = ClawTheme.colors.textMuted,
-              )
+          OverviewMetricGrid(
+            cards = metricCards,
+            onOpen = { card ->
+              val route = card.settingsRoute
+              if (route == null) {
+                onSelectTab(card.tab)
+              } else {
+                onOpenSettingsRoute(route)
+              }
             },
           )
         }
+
+        item {
+          TalkEntryPanel(onOpenVoice = { onSelectTab(Tab.Voice) }, onOpenVoiceSettings = { onOpenSettingsRoute(SettingsRoute.Voice) })
+        }
+
+        item { RecentSessionsHeader(onOpenSessions = { onSelectTab(Tab.Sessions) }) }
 
         if (sessions.isEmpty()) {
           item {
@@ -437,11 +471,12 @@ private fun OverviewScreen(
           item {
             RecentSessionList(
               rows =
-                sessions.take(5).map { session ->
+                sessions.take(3).map { session ->
+                  val title = displaySessionTitle(session.displayName)
                   RecentSessionListItem(
                     key = session.key,
-                    title = displaySessionTitle(session.displayName),
-                    subtitle = if (pendingRunCount > 0) "Assistant working" else "OpenClaw session",
+                    title = title,
+                    source = sessionSourceLabel(session.key, channelsSummary),
                     metadata = session.updatedAtMs?.let(::relativeSessionTime) ?: "",
                   )
                 },
@@ -453,35 +488,10 @@ private fun OverviewScreen(
           }
         }
 
-        item {
-          SectionLabel(title = "Control center")
-        }
-
-        item {
-          ModuleList(
-            rows =
-              listOf(
-                ModuleRow("Sessions", "Conversation history", if (sessions.isEmpty()) "Empty" else "${sessions.size} recent", Icons.Outlined.AccessTime, Tab.Sessions),
-                ModuleRow(
-                  title = "Providers & Models",
-                  subtitle = "Provider readiness",
-                  metadata =
-                    when {
-                      !isConnected -> "Offline"
-                      readyProviderCount > 0 -> "$readyProviderCount ready"
-                      else -> "No ready"
-                    },
-                  icon = Icons.Outlined.Inventory2,
-                  tab = Tab.ProvidersModels,
-                ),
-                ModuleRow("Channels", "Connected messengers", channelsSummaryText(channelsSummary), Icons.Default.Notifications, Tab.Settings, SettingsRoute.Channels),
-                ModuleRow("Nodes & Devices", "Phone and node health", nodesDevicesSummaryText(nodesDevicesSummary), Icons.Default.Cloud, Tab.Settings, SettingsRoute.NodesDevices),
-                ModuleRow("Approvals", "Tool decisions", approvalsSummary(pendingToolCalls.size), Icons.Default.Lock, Tab.Settings, SettingsRoute.Approvals),
-                ModuleRow("Settings", "More runtime controls", null, Icons.Outlined.Settings, Tab.Settings, SettingsRoute.Home),
-              ),
-            onSelectTab = onSelectTab,
-            onOpenSettingsRoute = onOpenSettingsRoute,
-          )
+        if (secondaryAttentionRows.isNotEmpty()) {
+          item {
+            HomeAttentionPanel(rows = secondaryAttentionRows, onSelectTab = onSelectTab, onOpenSettingsRoute = onOpenSettingsRoute)
+          }
         }
       }
     }
@@ -491,48 +501,613 @@ private fun OverviewScreen(
 private data class ModuleRow(
   val title: String,
   val subtitle: String?,
-  val metadata: String?,
   val icon: ImageVector,
   val tab: Tab,
   val settingsRoute: SettingsRoute? = null,
 )
 
 @Composable
-private fun CompanionHeroPanel(
+private fun OverviewHeader(
+  status: OverviewHeaderState,
+  onOpenStatus: () -> Unit,
+  onOpenCommand: () -> Unit,
+) {
+  Row(
+    modifier = Modifier.fillMaxWidth(),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Icon(
+      painter = painterResource(id = R.drawable.openclaw_logo),
+      contentDescription = null,
+      modifier = Modifier.size(25.dp),
+      tint = ClawTheme.colors.text,
+    )
+    Text(
+      text = "OpenClaw",
+      style = ClawTheme.type.title.copy(fontSize = 17.sp, lineHeight = 21.sp),
+      color = ClawTheme.colors.text,
+      modifier = Modifier.weight(1f),
+      maxLines = 1,
+      overflow = TextOverflow.Ellipsis,
+    )
+    OverviewStatusPill(status = status, onClick = onOpenStatus)
+    PlainIconButton(icon = Icons.Default.Search, contentDescription = "Search", onClick = onOpenCommand)
+  }
+}
+
+@Composable
+private fun OverviewStatusPill(
+  status: OverviewHeaderState,
+  onClick: () -> Unit,
+) {
+  val colors = ClawTheme.colors
+  val (dotColor, backgroundColor) =
+    when (status.status) {
+      ClawStatus.Success -> colors.success to colors.successSoft
+      ClawStatus.Warning -> colors.warning to colors.warningSoft
+      ClawStatus.Danger -> colors.danger to colors.dangerSoft
+      ClawStatus.Neutral -> colors.textSubtle to colors.surfaceRaised
+    }
+  Surface(
+    onClick = onClick,
+    modifier = Modifier.heightIn(min = ClawTheme.spacing.touchTarget),
+    shape = RoundedCornerShape(ClawTheme.radii.control),
+    color = backgroundColor.copy(alpha = 0.82f),
+    border = BorderStroke(1.dp, ClawTheme.colors.border.copy(alpha = 0.32f)),
+  ) {
+    Row(
+      modifier = Modifier.padding(horizontal = 9.dp, vertical = 5.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+      Box(modifier = Modifier.size(6.dp).clip(CircleShape).background(dotColor))
+      Text(text = status.label, style = ClawTheme.type.caption.copy(fontSize = 13.sp, lineHeight = 17.sp), color = ClawTheme.colors.text, maxLines = 1)
+      Icon(imageVector = Icons.Default.ArrowDropDown, contentDescription = null, modifier = Modifier.size(15.dp), tint = ClawTheme.colors.textMuted)
+    }
+  }
+}
+
+@Composable
+private fun OverviewPrimaryPanel(
+  agentName: String,
+  agentBadge: String,
   statusText: String,
   isConnected: Boolean,
   pendingRunCount: Int,
+  sessionCount: Int,
+  cronJobCount: Int,
   onOpenChat: () -> Unit,
   onOpenVoice: () -> Unit,
+  onOpenAgent: () -> Unit,
   onOpenGateway: () -> Unit,
 ) {
-  ClawPanel(contentPadding = PaddingValues(16.dp)) {
-    Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
-      Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-        Surface(
-          modifier = Modifier.size(38.dp),
-          shape = CircleShape,
-          color = if (isConnected) ClawTheme.colors.successSoft else ClawTheme.colors.surfacePressed,
-          border = BorderStroke(1.dp, if (isConnected) ClawTheme.colors.success else ClawTheme.colors.border),
-        ) {
-          Box(contentAlignment = Alignment.Center) {
-            Icon(imageVector = Icons.Outlined.ChatBubbleOutline, contentDescription = null, modifier = Modifier.size(19.dp), tint = if (isConnected) ClawTheme.colors.success else ClawTheme.colors.text)
-          }
-        }
+  OverviewLayeredPanel(contentPadding = PaddingValues(14.dp), elevated = true) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+      Text(text = "ACTIVE AGENT", style = ClawTheme.type.caption.copy(fontSize = 12.sp, lineHeight = 15.sp), color = ClawTheme.colors.textMuted)
+      Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(9.dp)) {
+        OverviewAgentBadge(text = agentBadge, active = isConnected)
         Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
-          Text(text = if (pendingRunCount > 0) "OpenClaw is working" else "Ready when you are", style = ClawTheme.type.title.copy(fontSize = 20.sp, lineHeight = 24.sp), color = ClawTheme.colors.text)
-          Text(text = statusText, style = ClawTheme.type.body, color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
+          Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+            Text(text = if (pendingRunCount > 0) "$agentName is working" else agentName, style = ClawTheme.type.title.copy(fontSize = 19.sp, lineHeight = 23.sp), color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f, fill = false))
+          }
+          Text(text = overviewAgentActivityText(isConnected = isConnected, pendingRunCount = pendingRunCount, sessionCount = sessionCount, cronJobCount = cronJobCount, statusText = statusText), style = ClawTheme.type.caption.copy(fontSize = 13.5.sp, lineHeight = 17.sp), color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
+        ClawSecondaryButton(text = "View", onClick = onOpenAgent)
       }
-      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(9.dp)) {
-        ClawPrimaryButton(text = "Start chat", icon = Icons.Outlined.ChatBubbleOutline, onClick = onOpenChat, modifier = Modifier.weight(1f))
-        ClawSecondaryButton(text = "Voice", icon = Icons.Outlined.MicNone, onClick = onOpenVoice, modifier = Modifier.weight(1f))
+      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        OverviewStateChip(label = "Runs", value = if (pendingRunCount > 0) "$pendingRunCount active" else "Idle", modifier = Modifier.weight(1f))
+        OverviewStateChip(label = "Sessions", value = if (sessionCount == 0) "None" else "$sessionCount recent", modifier = Modifier.weight(1f))
+        OverviewStateChip(label = "Cron", value = cronJobsSummary(cronJobCount), modifier = Modifier.weight(1f))
+      }
+      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        OverviewActionPill(text = "Chat", icon = Icons.Outlined.ChatBubbleOutline, emphasized = true, onClick = onOpenChat, modifier = Modifier.weight(1f))
+        OverviewActionPill(text = "Talk", icon = Icons.Outlined.MicNone, emphasized = false, onClick = onOpenVoice, modifier = Modifier.weight(1f))
       }
       if (!isConnected) {
         ClawSecondaryButton(text = "Reconnect gateway", icon = Icons.Default.Cloud, onClick = onOpenGateway, modifier = Modifier.fillMaxWidth())
       }
     }
   }
+}
+
+@Composable
+private fun OverviewActionPill(
+  text: String,
+  icon: ImageVector,
+  emphasized: Boolean,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Surface(
+    onClick = onClick,
+    modifier = modifier.heightIn(min = ClawTheme.spacing.touchTarget),
+    shape = RoundedCornerShape(ClawTheme.radii.control),
+    color =
+      if (emphasized) {
+        ClawTheme.colors.surfacePressed.copy(alpha = 0.9f)
+      } else {
+        ClawTheme.colors.surfaceRaised.copy(alpha = 0.72f)
+      },
+    contentColor = ClawTheme.colors.text,
+    border =
+      if (emphasized) {
+        null
+      } else {
+        BorderStroke(1.dp, ClawTheme.colors.borderStrong.copy(alpha = 0.7f))
+      },
+    tonalElevation = if (emphasized) 2.dp else 0.dp,
+  ) {
+    Row(
+      modifier = Modifier.padding(horizontal = 12.dp, vertical = 9.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.Center,
+    ) {
+      Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(17.dp))
+      Spacer(modifier = Modifier.width(8.dp))
+      Text(text = text, style = ClawTheme.type.body, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    }
+  }
+}
+
+@Composable
+private fun OverviewLayeredPanel(
+  modifier: Modifier = Modifier,
+  contentPadding: PaddingValues = PaddingValues(14.dp),
+  elevated: Boolean = false,
+  content: @Composable () -> Unit,
+) {
+  Surface(
+    modifier = modifier.fillMaxWidth(),
+    shape = RoundedCornerShape(7.dp),
+    color = if (elevated) ClawTheme.colors.surfaceRaised.copy(alpha = 0.98f) else ClawTheme.colors.surfaceRaised.copy(alpha = 0.86f),
+    contentColor = ClawTheme.colors.text,
+    tonalElevation = if (elevated) 4.dp else 1.dp,
+    shadowElevation = if (elevated) 9.dp else 2.dp,
+  ) {
+    Column(modifier = Modifier.padding(contentPadding)) {
+      content()
+    }
+  }
+}
+
+@Composable
+private fun OverviewAgentBadge(
+  text: String,
+  active: Boolean,
+) {
+  Surface(
+    modifier = Modifier.size(42.dp),
+    shape = CircleShape,
+    color = if (active) ClawTheme.colors.successSoft else ClawTheme.colors.surfacePressed,
+    contentColor = if (active) ClawTheme.colors.success else ClawTheme.colors.textMuted,
+    tonalElevation = if (active) 3.dp else 1.dp,
+    shadowElevation = if (active) 5.dp else 1.dp,
+  ) {
+    Box(contentAlignment = Alignment.Center) {
+      Text(
+        text = text,
+        style = ClawTheme.type.title.copy(fontSize = 16.sp, lineHeight = 20.sp),
+        maxLines = 1,
+      )
+    }
+  }
+}
+
+@Composable
+private fun OverviewStateChip(
+  label: String,
+  value: String,
+  modifier: Modifier = Modifier,
+) {
+  Surface(
+    modifier = modifier,
+    shape = RoundedCornerShape(ClawTheme.radii.control),
+    color = ClawTheme.colors.surfacePressed.copy(alpha = 0.58f),
+  ) {
+    Column(modifier = Modifier.padding(horizontal = 9.dp, vertical = 6.dp), verticalArrangement = Arrangement.spacedBy(1.dp)) {
+      Text(text = label.uppercase(), style = ClawTheme.type.caption.copy(fontSize = 10.5.sp, lineHeight = 13.sp), color = ClawTheme.colors.textSubtle, maxLines = 1)
+      Text(text = value, style = ClawTheme.type.caption.copy(fontSize = 14.sp, lineHeight = 17.sp), color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    }
+  }
+}
+
+@Composable
+private fun OverviewMetricGrid(
+  cards: List<OverviewMetricCard>,
+  onOpen: (OverviewMetricCard) -> Unit,
+) {
+  Column(verticalArrangement = Arrangement.spacedBy(7.dp)) {
+    cards.chunked(2).forEach { row ->
+      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(7.dp)) {
+        row.forEach { card ->
+          OverviewMetricTile(card = card, onClick = { onOpen(card) }, modifier = Modifier.weight(1f))
+        }
+        if (row.size == 1) {
+          Box(modifier = Modifier.weight(1f))
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun OverviewMetricTile(
+  card: OverviewMetricCard,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Surface(
+    onClick = onClick,
+    modifier = modifier.heightIn(min = 88.dp),
+    shape = RoundedCornerShape(7.dp),
+    color = ClawTheme.colors.surfaceRaised.copy(alpha = 0.84f),
+    contentColor = ClawTheme.colors.text,
+    tonalElevation = 2.dp,
+    shadowElevation = 3.dp,
+  ) {
+    Column(modifier = Modifier.padding(10.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+      Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Icon(imageVector = card.icon, contentDescription = null, modifier = Modifier.size(17.dp), tint = card.tint)
+        Text(text = card.title.uppercase(), style = ClawTheme.type.caption.copy(fontSize = 10.5.sp, lineHeight = 13.sp), color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
+        Icon(imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = "Open ${card.title}", modifier = Modifier.size(15.dp), tint = ClawTheme.colors.textMuted)
+      }
+      Text(text = card.value, style = ClawTheme.type.title.copy(fontSize = 22.sp, lineHeight = 25.sp), color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
+      Text(text = card.subtitle, style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textSubtle, maxLines = 2, overflow = TextOverflow.Ellipsis)
+      card.progressFraction?.let { progress ->
+        OverviewProgressBar(progress = progress, tint = card.tint)
+      }
+    }
+  }
+}
+
+@Composable
+private fun OverviewProgressBar(
+  progress: Float,
+  tint: Color,
+) {
+  val visualProgress =
+    if (progress <= 0f) {
+      0f
+    } else {
+      progress.coerceIn(0.16f, 1f)
+    }
+  Box(
+    modifier =
+      Modifier
+        .fillMaxWidth()
+        .height(4.dp)
+        .clip(RoundedCornerShape(2.dp))
+        .background(ClawTheme.colors.surfacePressed),
+  ) {
+    Box(
+      modifier =
+        Modifier
+          .fillMaxWidth(visualProgress)
+          .height(4.dp)
+          .clip(RoundedCornerShape(2.dp))
+          .background(tint),
+    )
+  }
+}
+
+@Composable
+private fun TalkEntryPanel(
+  onOpenVoice: () -> Unit,
+  onOpenVoiceSettings: () -> Unit,
+) {
+  Surface(
+    onClick = onOpenVoice,
+    modifier = Modifier.fillMaxWidth(),
+    shape = RoundedCornerShape(7.dp),
+    color = ClawTheme.colors.surfaceRaised.copy(alpha = 0.9f),
+    contentColor = ClawTheme.colors.text,
+    tonalElevation = 2.dp,
+    shadowElevation = 3.dp,
+  ) {
+    Row(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+      Surface(
+        modifier = Modifier.size(48.dp),
+        shape = CircleShape,
+        color = Color(0xFF1976D2),
+        tonalElevation = 2.dp,
+        shadowElevation = 5.dp,
+      ) {
+        Box(contentAlignment = Alignment.Center) {
+          Icon(imageVector = Icons.Default.GraphicEq, contentDescription = null, modifier = Modifier.size(25.dp), tint = Color.White)
+        }
+      }
+      Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(text = "Talk", style = ClawTheme.type.caption.copy(fontSize = 12.sp, lineHeight = 15.sp), color = ClawTheme.colors.textMuted)
+        Text(text = "Hold to talk", style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
+      }
+      PlainIconButton(icon = Icons.Default.Tune, contentDescription = "Talk settings", onClick = onOpenVoiceSettings)
+    }
+  }
+}
+
+@Composable
+private fun RecentSessionsHeader(onOpenSessions: () -> Unit) {
+  SectionLabel(
+    title = "Recent Sessions",
+    action = {
+      Surface(
+        onClick = onOpenSessions,
+        modifier = Modifier.heightIn(min = ClawTheme.spacing.touchTarget),
+        color = Color.Transparent,
+        contentColor = ClawTheme.colors.textMuted,
+      ) {
+        Box(contentAlignment = Alignment.Center) {
+          Text(
+            text = "View all",
+            style = ClawTheme.type.caption,
+            color = ClawTheme.colors.textMuted,
+          )
+        }
+      }
+    },
+  )
+}
+
+internal data class OverviewHeaderState(
+  val label: String,
+  val status: ClawStatus,
+)
+
+internal fun overviewHeaderState(
+  isConnected: Boolean,
+  hasAttention: Boolean,
+): OverviewHeaderState =
+  when {
+    !isConnected -> OverviewHeaderState("Offline", ClawStatus.Neutral)
+    hasAttention -> OverviewHeaderState("Needs attention", ClawStatus.Warning)
+    else -> OverviewHeaderState("Online", ClawStatus.Success)
+  }
+
+internal fun overviewHeaderRoute(attentionRows: List<HomeAttentionRow>): SettingsRoute = attentionRows.firstNotNullOfOrNull { it.settingsRoute } ?: SettingsRoute.Gateway
+
+internal data class OverviewMetricCard(
+  val title: String,
+  val value: String,
+  val subtitle: String,
+  val icon: ImageVector,
+  val tint: Color,
+  val tab: Tab,
+  val settingsRoute: SettingsRoute? = null,
+  val progressFraction: Float? = null,
+)
+
+@Composable
+private fun overviewMetricCards(
+  isConnected: Boolean,
+  hasAttention: Boolean,
+  nodesDevicesSummary: GatewayNodesDevicesSummary,
+  pendingApprovals: Int,
+  sessionCount: Int,
+): List<OverviewMetricCard> =
+  overviewMetricCardSpecs(
+    isConnected = isConnected,
+    hasAttention = hasAttention,
+    nodesDevicesSummary = nodesDevicesSummary,
+    pendingApprovals = pendingApprovals,
+    sessionCount = sessionCount,
+  ).map { spec ->
+    OverviewMetricCard(
+      title = spec.title,
+      value = spec.value,
+      subtitle = spec.subtitle,
+      icon = spec.icon,
+      tint =
+        when (spec.status) {
+          ClawStatus.Success -> ClawTheme.colors.success
+          ClawStatus.Warning -> ClawTheme.colors.warning
+          ClawStatus.Danger -> ClawTheme.colors.danger
+          ClawStatus.Neutral -> ClawTheme.colors.textMuted
+        },
+      tab = spec.tab,
+      settingsRoute = spec.settingsRoute,
+      progressFraction = spec.progressFraction,
+    )
+  }
+
+internal data class OverviewMetricCardSpec(
+  val title: String,
+  val value: String,
+  val subtitle: String,
+  val icon: ImageVector,
+  val status: ClawStatus,
+  val tab: Tab,
+  val settingsRoute: SettingsRoute? = null,
+  val progressFraction: Float? = null,
+)
+
+internal fun overviewMetricCardSpecs(
+  isConnected: Boolean,
+  hasAttention: Boolean,
+  nodesDevicesSummary: GatewayNodesDevicesSummary,
+  pendingApprovals: Int,
+  sessionCount: Int,
+): List<OverviewMetricCardSpec> {
+  val onlineNodes = nodesDevicesSummary.nodes.count { it.connected }
+  val nodeCount = nodesDevicesSummary.nodes.size
+  return listOf(
+    OverviewMetricCardSpec(
+      title = "Gateway",
+      value =
+        when {
+          !isConnected -> "Offline"
+          hasAttention -> "Online"
+          else -> "Healthy"
+        },
+      subtitle =
+        when {
+          !isConnected -> "Reconnect to continue"
+          hasAttention -> "Review highlighted items"
+          else -> "All systems nominal"
+        },
+      icon = Icons.Default.Favorite,
+      status =
+        when {
+          !isConnected -> ClawStatus.Neutral
+          hasAttention -> ClawStatus.Warning
+          else -> ClawStatus.Success
+        },
+      tab = Tab.Settings,
+      settingsRoute = SettingsRoute.Gateway,
+    ),
+    OverviewMetricCardSpec(
+      title = "Nodes",
+      value = if (nodeCount == 0) "None" else "$onlineNodes/$nodeCount",
+      subtitle =
+        if (nodesDevicesSummary.hasNodeCapabilityApprovalPending()) {
+          "Review node access"
+        } else if (nodeCount > 0) {
+          "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+        } else {
+          nodesDevicesSummaryText(nodesDevicesSummary)
+        },
+      icon = Icons.Default.Cloud,
+      status =
+        when {
+          nodesDevicesSummary.pendingDevices.isNotEmpty() || nodesDevicesSummary.hasNodeCapabilityApprovalPending() -> ClawStatus.Warning
+          onlineNodes > 0 -> ClawStatus.Success
+          else -> ClawStatus.Neutral
+        },
+      tab = Tab.Settings,
+      settingsRoute = SettingsRoute.NodesDevices,
+      progressFraction = if (nodeCount > 0) onlineNodes.toFloat() / nodeCount.toFloat() else null,
+    ),
+    OverviewMetricCardSpec(
+      title = "Approvals",
+      value = pendingApprovals.toString(),
+      subtitle = approvalsSummary(pendingApprovals),
+      icon = Icons.Default.Security,
+      status = if (pendingApprovals > 0) ClawStatus.Warning else ClawStatus.Neutral,
+      tab = Tab.Settings,
+      settingsRoute = SettingsRoute.Approvals,
+    ),
+    OverviewMetricCardSpec(
+      title = "Sessions",
+      value = sessionCount.toString(),
+      subtitle = if (sessionCount == 0) "No recent sessions" else "Recent conversations",
+      icon = Icons.Default.Groups,
+      status = if (sessionCount > 0) ClawStatus.Success else ClawStatus.Neutral,
+      tab = Tab.Sessions,
+    ),
+  )
+}
+
+internal fun overviewAgentName(
+  agents: List<GatewayAgentSummary>,
+  defaultAgentId: String?,
+): String {
+  val agent = overviewAgent(agents = agents, defaultAgentId = defaultAgentId)
+  return agent?.name?.takeIf { it.isNotBlank() } ?: agent?.id?.takeIf { it.isNotBlank() } ?: "OpenClaw"
+}
+
+internal fun overviewAgentBadgeText(
+  agents: List<GatewayAgentSummary>,
+  defaultAgentId: String?,
+): String {
+  val agent = overviewAgent(agents = agents, defaultAgentId = defaultAgentId)
+  agent
+    ?.emoji
+    ?.trim()
+    ?.takeIf { it.isNotEmpty() }
+    ?.let { return it }
+  if (agent == null) return "OC"
+  val source = agent.name?.takeIf { it.isNotBlank() } ?: agent.id.takeIf { it.isNotBlank() } ?: "OpenClaw"
+  return agentInitials(source)
+}
+
+private fun overviewAgent(
+  agents: List<GatewayAgentSummary>,
+  defaultAgentId: String?,
+): GatewayAgentSummary? {
+  val defaultId = defaultAgentId?.trim().orEmpty()
+  return if (defaultId.isBlank()) {
+    agents.firstOrNull()
+  } else {
+    agents.firstOrNull { it.id == defaultId } ?: agents.firstOrNull()
+  }
+}
+
+internal fun overviewAgentActivityText(
+  isConnected: Boolean,
+  pendingRunCount: Int,
+  sessionCount: Int,
+  cronJobCount: Int,
+  statusText: String,
+): String {
+  if (!isConnected) return statusText
+  if (pendingRunCount > 0) return "Working · $pendingRunCount active ${pluralize("run", pendingRunCount)}"
+  return when {
+    sessionCount > 0 -> "Monitoring · $sessionCount ${pluralize("session", sessionCount)}"
+    cronJobCount > 0 -> "Monitoring · ${cronJobsSummary(cronJobCount)}"
+    else -> statusText
+  }
+}
+
+internal fun nodeOnlinePercent(
+  onlineNodes: Int,
+  nodeCount: Int,
+): Int =
+  if (nodeCount <= 0) {
+    0
+  } else {
+    ((onlineNodes.coerceAtLeast(0) * 100) + (nodeCount / 2)) / nodeCount
+  }
+
+private fun pluralize(
+  noun: String,
+  count: Int,
+): String = if (count == 1) noun else "${noun}s"
+
+private fun agentInitials(name: String): String =
+  name
+    .split(' ', '-', '_')
+    .filter { it.isNotBlank() }
+    .take(2)
+    .mapNotNull { it.firstOrNull()?.uppercaseChar()?.toString() }
+    .joinToString("")
+    .ifBlank { "OC" }
+
+private val sessionSourceLabels =
+  mapOf(
+    "cron" to "Cron",
+    "discord" to "Discord",
+    "guildchat" to "Guildchat",
+    "imessage" to "iMessage",
+    "matrix" to "Matrix",
+    "slack" to "Slack",
+    "telegram" to "Telegram",
+    "whatsapp" to "WhatsApp",
+    "workspace" to "Workspace",
+  )
+
+internal fun sessionSourceLabel(sessionKey: String): String = sessionSourceLabel(sessionKey, GatewayChannelsSummary(channels = emptyList()))
+
+internal fun sessionSourceLabel(
+  sessionKey: String,
+  channelsSummary: GatewayChannelsSummary,
+): String {
+  val normalized = sessionKey.trim()
+  val scopedKey =
+    if (normalized.startsWith("agent:", ignoreCase = true)) {
+      normalized.substringAfter(':', missingDelimiterValue = "").substringAfter(':', missingDelimiterValue = "")
+    } else {
+      normalized
+    }
+  if (!scopedKey.contains(':') && !scopedKey.contains('#')) return "OpenClaw"
+  val source = scopedKey.substringBefore(':').substringBefore('#').lowercase()
+  val channelLabel =
+    channelsSummary.channels
+      .firstOrNull { channel ->
+        channel.id.equals(source, ignoreCase = true)
+      }?.label
+      ?.takeIf { it.isNotBlank() }
+  if (channelLabel != null) return channelLabel
+  return sessionSourceLabels[source] ?: "OpenClaw"
 }
 
 internal data class HomeAttentionRow(
@@ -549,7 +1124,6 @@ internal fun homeAttentionRows(
   channelsSummary: GatewayChannelsSummary,
   nodesDevicesSummary: GatewayNodesDevicesSummary,
   readyProviderCount: Int,
-  expiringProviderCount: Int = 0,
 ): List<HomeAttentionRow> =
   listOfNotNull(
     if (!isConnected) {
@@ -573,7 +1147,7 @@ internal fun homeAttentionRows(
       null
     },
     if (isConnected && readyProviderCount == 0) {
-      HomeAttentionRow("Providers", "No ready providers", Icons.Outlined.Inventory2, Tab.Settings, SettingsRoute.Gateway)
+      HomeAttentionRow("Providers", "No ready providers", Icons.Outlined.Inventory2, Tab.Settings, SettingsRoute.ProvidersModels)
     } else {
       null
     },
@@ -585,12 +1159,12 @@ private fun HomeAttentionPanel(
   onSelectTab: (Tab) -> Unit,
   onOpenSettingsRoute: (SettingsRoute) -> Unit,
 ) {
-  ClawPanel(contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp)) {
+  OverviewLayeredPanel(contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp)) {
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
       Text(text = "Needs attention", style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.warning)
       rows.forEach { row ->
         ModuleListRow(
-          row = ModuleRow(row.title, row.subtitle, null, row.icon, row.tab, row.settingsRoute),
+          row = ModuleRow(row.title, row.subtitle, row.icon, row.tab, row.settingsRoute),
           onClick = {
             val route = row.settingsRoute
             if (route == null) {
@@ -601,21 +1175,6 @@ private fun HomeAttentionPanel(
           },
         )
       }
-    }
-  }
-}
-
-@Composable
-private fun OverviewAvatar(text: String) {
-  Surface(
-    modifier = Modifier.size(34.dp),
-    shape = CircleShape,
-    color = ClawTheme.colors.surfaceRaised,
-    contentColor = ClawTheme.colors.text,
-    border = BorderStroke(1.dp, ClawTheme.colors.border),
-  ) {
-    Box(contentAlignment = Alignment.Center) {
-      Text(text = text.take(2).uppercase(), style = ClawTheme.type.label)
     }
   }
 }
@@ -632,34 +1191,6 @@ private fun SectionLabel(
   ) {
     Text(text = title.uppercase(), style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textMuted)
     action?.invoke()
-  }
-}
-
-@Composable
-private fun ModuleList(
-  rows: List<ModuleRow>,
-  onSelectTab: (Tab) -> Unit,
-  onOpenSettingsRoute: (SettingsRoute) -> Unit,
-) {
-  ClawPanel(contentPadding = PaddingValues(horizontal = 14.dp, vertical = 4.dp)) {
-    Column(verticalArrangement = Arrangement.spacedBy(0.dp)) {
-      rows.forEachIndexed { index, row ->
-        ModuleListRow(
-          row = row,
-          onClick = {
-            val route = row.settingsRoute
-            if (route == null) {
-              onSelectTab(row.tab)
-            } else {
-              onOpenSettingsRoute(route)
-            }
-          },
-        )
-        if (index != rows.lastIndex) {
-          HorizontalDivider(color = ClawTheme.colors.border.copy(alpha = 0.82f), thickness = 1.dp)
-        }
-      }
-    }
   }
 }
 
@@ -693,12 +1224,6 @@ private fun ModuleListRow(
           Text(text = it, style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textSubtle, maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
       }
-      row.metadata?.let {
-        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-          Box(modifier = Modifier.size(4.5.dp).clip(CircleShape).background(statusDotColor(it)))
-          Text(text = it, style = ClawTheme.type.caption.copy(fontSize = 13.sp, lineHeight = 17.sp), color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
-        }
-      }
       Icon(
         imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
         contentDescription = "Open ${row.title}",
@@ -712,7 +1237,7 @@ private fun ModuleListRow(
 private data class RecentSessionListItem(
   val key: String,
   val title: String,
-  val subtitle: String,
+  val source: String,
   val metadata: String,
 )
 
@@ -722,17 +1247,17 @@ private fun RecentSessionList(
   rows: List<RecentSessionListItem>,
   onOpen: (String) -> Unit,
 ) {
-  ClawPanel(contentPadding = PaddingValues(horizontal = 14.dp, vertical = 4.dp)) {
+  OverviewLayeredPanel(contentPadding = PaddingValues(horizontal = 12.dp, vertical = 3.dp)) {
     Column {
       rows.forEachIndexed { index, row ->
         RecentSessionRowContent(
           title = row.title,
-          subtitle = row.subtitle,
+          source = row.source,
           metadata = row.metadata,
           onClick = { onOpen(row.key) },
         )
         if (index != rows.lastIndex) {
-          HorizontalDivider(color = ClawTheme.colors.border.copy(alpha = 0.82f), thickness = 1.dp)
+          HorizontalDivider(color = ClawTheme.colors.border.copy(alpha = 0.48f), thickness = 1.dp)
         }
       }
     }
@@ -742,7 +1267,7 @@ private fun RecentSessionList(
 @Composable
 private fun RecentSessionRowContent(
   title: String,
-  subtitle: String,
+  source: String,
   metadata: String,
   onClick: () -> Unit,
 ) {
@@ -751,28 +1276,28 @@ private fun RecentSessionRowContent(
       modifier =
         Modifier
           .fillMaxWidth()
-          .heightIn(min = 58.dp)
+          .heightIn(min = 50.dp)
           .clip(RoundedCornerShape(ClawTheme.radii.row))
           .clickable(onClick = onClick)
-          .padding(horizontal = 0.dp, vertical = 7.dp),
+          .padding(horizontal = 0.dp, vertical = 5.dp),
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
       Surface(
-        modifier = Modifier.size(30.dp),
+        modifier = Modifier.size(28.dp),
         shape = CircleShape,
         color = ClawTheme.colors.canvas,
-        border = BorderStroke(1.dp, ClawTheme.colors.borderStrong),
+        border = BorderStroke(1.dp, ClawTheme.colors.border.copy(alpha = 0.7f)),
       ) {
         Box(contentAlignment = Alignment.Center) {
-          Icon(imageVector = Icons.Outlined.ChatBubbleOutline, contentDescription = null, modifier = Modifier.size(15.dp), tint = ClawTheme.colors.text)
+          Icon(imageVector = Icons.Outlined.ChatBubbleOutline, contentDescription = null, modifier = Modifier.size(14.dp), tint = ClawTheme.colors.text)
         }
       }
       Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
-        Text(text = title, style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1)
-        Text(text = subtitle, style = ClawTheme.type.caption.copy(fontSize = 13.sp, lineHeight = 17.sp), color = ClawTheme.colors.textSubtle, maxLines = 1)
+        Text(text = title, style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Text(text = source, style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textSubtle, maxLines = 1, overflow = TextOverflow.Ellipsis)
       }
-      Text(text = metadata, style = ClawTheme.type.caption.copy(fontSize = 13.sp, lineHeight = 17.sp), color = ClawTheme.colors.textMuted)
+      Text(text = metadata, style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textMuted)
       Icon(
         imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
         contentDescription = "Open session",
@@ -833,6 +1358,8 @@ private fun SettingsShellScreen(
   val displayName by viewModel.displayName.collectAsState()
   val isConnected by viewModel.isConnected.collectAsState()
   val statusText by viewModel.statusText.collectAsState()
+  val models by viewModel.modelCatalog.collectAsState()
+  val providers by viewModel.modelAuthProviders.collectAsState()
   val cameraEnabled by viewModel.cameraEnabled.collectAsState()
   val notificationForwardingEnabled by viewModel.notificationForwardingEnabled.collectAsState()
   val speakerEnabled by viewModel.speakerEnabled.collectAsState()
@@ -845,10 +1372,12 @@ private fun SettingsShellScreen(
   val channelsSummary by viewModel.channelsSummary.collectAsState()
   val dreamingSummary by viewModel.dreamingSummary.collectAsState()
   val appearanceThemeMode by viewModel.appearanceThemeMode.collectAsState()
+  val readyProviderCount = providerRows(providers = providers, models = models).count { it.ready }
 
   LaunchedEffect(isConnected) {
     if (isConnected) {
       viewModel.refreshAgents()
+      viewModel.refreshModelCatalog()
       viewModel.refreshCronJobs()
       viewModel.refreshUsage()
       viewModel.refreshSkills()
@@ -868,10 +1397,10 @@ private fun SettingsShellScreen(
   }
 
   ClawScaffold(
-    contentPadding = PaddingValues(start = 20.dp, top = 14.dp, end = 20.dp, bottom = 6.dp),
+    contentPadding = PaddingValues(start = 16.dp, top = 10.dp, end = 16.dp, bottom = 4.dp),
     contentWindowInsets = shellContentInsets,
   ) {
-    LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(13.dp), contentPadding = PaddingValues(bottom = 4.dp)) {
+    LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(9.dp), contentPadding = PaddingValues(bottom = 4.dp)) {
       item {
         Row(
           modifier = Modifier.fillMaxWidth(),
@@ -879,7 +1408,7 @@ private fun SettingsShellScreen(
           horizontalArrangement = Arrangement.spacedBy(9.dp),
         ) {
           PlainIconButton(icon = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back to home", onClick = onBackHome)
-          Text(text = "Settings", style = ClawTheme.type.title.copy(fontSize = 16.sp, lineHeight = 20.sp), color = ClawTheme.colors.text, modifier = Modifier.weight(1f))
+          Text(text = "Settings", style = ClawTheme.type.display.copy(fontSize = 24.sp, lineHeight = 28.sp), color = ClawTheme.colors.text, modifier = Modifier.weight(1f))
           SettingsSearchButton(onClick = onOpenCommand)
         }
       }
@@ -894,6 +1423,13 @@ private fun SettingsShellScreen(
           SettingsRow("Nodes & Devices", nodesDevicesSummaryText(nodesDevicesSummary), Icons.Default.Cloud, status = nodesDevicesStatus(nodesDevicesSummary), route = SettingsRoute.NodesDevices),
           SettingsRow("Channels", channelsSummaryText(channelsSummary), Icons.Default.Notifications, status = channelsStatus(channelsSummary), route = SettingsRoute.Channels),
           SettingsRow("Agents", if (agents.isEmpty()) "Load from gateway" else "${agents.size} available", Icons.Default.Person, status = agents.isNotEmpty(), route = SettingsRoute.Agents),
+          SettingsRow(
+            "Providers & Models",
+            if (readyProviderCount > 0) "$readyProviderCount ready" else "Review readiness",
+            Icons.Outlined.Inventory2,
+            status = if (isConnected) readyProviderCount > 0 else false,
+            route = SettingsRoute.ProvidersModels,
+          ),
           SettingsRow("Approvals", approvalsSummary(pendingToolCalls.size), Icons.Default.Lock, status = approvalsStatus(pendingToolCalls.size), route = SettingsRoute.Approvals),
           SettingsRow("Cron Jobs", cronJobsSummary(cronStatus.jobs), Icons.Outlined.AccessTime, status = if (cronStatus.jobs > 0) cronStatus.enabled else null, route = SettingsRoute.CronJobs),
           SettingsRow("Usage", usageSummaryText(usageSummary.providers.size), Icons.Default.Storage, status = if (usageSummary.providers.isNotEmpty()) true else null, route = SettingsRoute.Usage),
@@ -1089,6 +1625,7 @@ internal fun settingsSectionTitleForRoute(route: SettingsRoute): String =
     -> "Connection"
 
     SettingsRoute.Agents,
+    SettingsRoute.ProvidersModels,
     SettingsRoute.Approvals,
     SettingsRoute.CronJobs,
     SettingsRoute.Usage,
@@ -1260,15 +1797,6 @@ private fun relativeSessionTime(updatedAtMs: Long): String {
 }
 
 private fun displaySessionTitle(displayName: String?): String = displayName?.takeIf { it.isNotBlank() } ?: "Main session"
-
-private fun statusDotColor(status: String): Color {
-  val normalized = status.trim().lowercase()
-  return when {
-    normalized.contains("offline") || normalized.contains("not connected") -> Color(0xFFFF6B6B)
-    normalized.contains("ready") || normalized.contains("active") || normalized.contains("online") -> Color(0xFF3EDB82)
-    else -> Color(0xFF707070)
-  }
-}
 
 private fun gatewaySummary(
   statusText: String,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.R
 import ai.openclaw.app.VoiceCaptureMode
 import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawPrimaryButton
@@ -68,6 +69,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -177,8 +179,8 @@ fun VoiceScreen(
       Modifier
         .fillMaxSize()
         .imePadding()
-        .padding(horizontal = 20.dp, vertical = 8.dp),
-    verticalArrangement = Arrangement.spacedBy(10.dp),
+        .padding(horizontal = 16.dp, vertical = 10.dp),
+    verticalArrangement = Arrangement.spacedBy(9.dp),
   ) {
     VoiceHeader(
       statusText = voiceAttentionStatus ?: if (voiceActive || !gatewayReady) activeStatus else "Your voice command center.",
@@ -547,14 +549,19 @@ private fun VoiceHeader(
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
+      Icon(
+        painter = painterResource(id = R.drawable.openclaw_logo),
+        contentDescription = null,
+        modifier = Modifier.size(25.dp),
+        tint = ClawTheme.colors.text,
+      )
       Text(
-        text = "O P E N C L A W",
-        style = ClawTheme.type.title.copy(fontSize = 18.sp, lineHeight = 23.sp),
+        text = "OpenClaw",
+        style = ClawTheme.type.title.copy(fontSize = 17.sp, lineHeight = 21.sp),
         color = ClawTheme.colors.text,
         modifier = Modifier.weight(1f),
       )
       VoicePlainIconButton(icon = Icons.Default.Search, contentDescription = "Search voice", onClick = onOpenCommand)
-      VoiceAvatar(text = "OC")
     }
     Row(
       modifier = Modifier.fillMaxWidth(),
@@ -562,7 +569,7 @@ private fun VoiceHeader(
       horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
       Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
-        Text(text = "Voice", style = ClawTheme.type.display.copy(fontSize = 16.sp, lineHeight = 20.sp), color = ClawTheme.colors.text)
+        Text(text = "Voice", style = ClawTheme.type.display.copy(fontSize = 24.sp, lineHeight = 28.sp), color = ClawTheme.colors.text)
         Text(
           text = statusText,
           style = ClawTheme.type.body,
@@ -576,21 +583,6 @@ private fun VoiceHeader(
         contentDescription = if (speakerEnabled) "Mute speaker" else "Unmute speaker",
         onClick = onToggleSpeaker,
       )
-    }
-  }
-}
-
-@Composable
-private fun VoiceAvatar(text: String) {
-  Surface(
-    modifier = Modifier.size(34.dp),
-    shape = CircleShape,
-    color = ClawTheme.colors.surfaceRaised,
-    contentColor = ClawTheme.colors.text,
-    border = BorderStroke(1.dp, ClawTheme.colors.border),
-  ) {
-    Box(contentAlignment = Alignment.Center) {
-      Text(text = text.take(2).uppercase(), style = ClawTheme.type.label)
     }
   }
 }
@@ -861,8 +853,10 @@ private fun VoiceOrb(
   Surface(
     modifier = Modifier.size(112.dp),
     shape = CircleShape,
-    color = if (active) ClawTheme.colors.surfacePressed else ClawTheme.colors.surface,
-    border = BorderStroke(1.dp, if (active) ClawTheme.colors.borderStrong else ClawTheme.colors.border),
+    color = if (active || listening || speaking) Color(0xFF1976D2) else Color(0xFF123B63),
+    contentColor = Color.White,
+    tonalElevation = 3.dp,
+    shadowElevation = 7.dp,
   ) {
     Box(contentAlignment = Alignment.Center) {
       Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -875,7 +869,7 @@ private fun VoiceOrb(
             },
           contentDescription = null,
           modifier = Modifier.size(32.dp),
-          tint = ClawTheme.colors.text,
+          tint = Color.White,
         )
         Waveform(active = active)
       }
@@ -892,7 +886,7 @@ private fun Waveform(active: Boolean) {
           Modifier
             .size(width = 2.dp, height = (if (active) height else 6 + index % 3 * 3).dp)
             .clip(RoundedCornerShape(999.dp))
-            .background(if (active) ClawTheme.colors.text else ClawTheme.colors.textSubtle),
+            .background(if (active) Color.White else Color.White.copy(alpha = 0.52f)),
       )
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.R
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatMessageContent
 import ai.openclaw.app.chat.ChatPendingToolCall
@@ -39,6 +40,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Mic
@@ -63,6 +65,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -153,12 +156,11 @@ fun ChatScreen(
     modifier =
       Modifier
         .fillMaxSize()
-        .padding(horizontal = 18.dp, vertical = 6.dp),
-    verticalArrangement = Arrangement.spacedBy(5.dp),
+        .padding(horizontal = 16.dp, vertical = 10.dp),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {
     ChatHeader(
       sessionTitle = currentSessionTitle(sessionKey = sessionKey, sessions = sessions),
-      thinkingLevel = thinkingLevel,
       healthOk = healthOk,
       pendingRunCount = pendingRunCount,
       onMore = {
@@ -261,11 +263,11 @@ private fun ChatSessionSwitcher(
     if (sessions.size > choices.size) {
       Surface(
         onClick = onOpenSessions,
-        modifier = Modifier.heightIn(min = 36.dp),
+        modifier = Modifier.heightIn(min = ClawTheme.spacing.touchTarget),
         shape = RoundedCornerShape(ClawTheme.radii.pill),
-        color = ClawTheme.colors.canvas,
+        color = ClawTheme.colors.surfaceRaised.copy(alpha = 0.72f),
         contentColor = ClawTheme.colors.textMuted,
-        border = BorderStroke(1.dp, ClawTheme.colors.border),
+        border = BorderStroke(1.dp, ClawTheme.colors.border.copy(alpha = 0.7f)),
       ) {
         Row(
           modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp),
@@ -288,11 +290,11 @@ private fun ChatSessionChip(
 ) {
   Surface(
     onClick = onClick,
-    modifier = Modifier.heightIn(min = 36.dp),
+    modifier = Modifier.heightIn(min = ClawTheme.spacing.touchTarget),
     shape = RoundedCornerShape(ClawTheme.radii.pill),
-    color = if (active) ClawTheme.colors.primary else ClawTheme.colors.surfaceRaised,
-    contentColor = if (active) ClawTheme.colors.primaryText else ClawTheme.colors.text,
-    border = BorderStroke(1.dp, if (active) ClawTheme.colors.primary else ClawTheme.colors.border),
+    color = if (active) ClawTheme.colors.surfacePressed.copy(alpha = 0.9f) else ClawTheme.colors.surfaceRaised.copy(alpha = 0.72f),
+    contentColor = ClawTheme.colors.text,
+    border = BorderStroke(1.dp, if (active) ClawTheme.colors.borderStrong else ClawTheme.colors.border.copy(alpha = 0.7f)),
   ) {
     Text(
       text = text,
@@ -307,48 +309,56 @@ private fun ChatSessionChip(
 @Composable
 private fun ChatHeader(
   sessionTitle: String,
-  thinkingLevel: String,
   healthOk: Boolean,
   pendingRunCount: Int,
   onMore: () -> Unit,
 ) {
-  Row(
-    modifier = Modifier.fillMaxWidth(),
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(6.dp),
-  ) {
-    Box(modifier = Modifier.size(ClawTheme.spacing.touchTarget))
-
-    Column(
-      modifier = Modifier.weight(1f),
-      horizontalAlignment = Alignment.CenterHorizontally,
-      verticalArrangement = Arrangement.spacedBy(3.dp),
+  Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
+      Icon(
+        painter = painterResource(id = R.drawable.openclaw_logo),
+        contentDescription = null,
+        modifier = Modifier.size(25.dp),
+        tint = ClawTheme.colors.text,
+      )
       Text(
-        text = sessionTitle,
-        style = ClawTheme.type.title.copy(fontSize = 18.sp, lineHeight = 23.sp),
+        text = "OpenClaw",
+        style = ClawTheme.type.title.copy(fontSize = 17.sp, lineHeight = 21.sp),
         color = ClawTheme.colors.text,
+        modifier = Modifier.weight(1f),
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
-        textAlign = TextAlign.Center,
       )
       ModelPill(
         text =
           when {
             pendingRunCount > 0 -> "Working"
-            healthOk -> "auto"
-            else -> "offline"
+            healthOk -> "Ready"
+            else -> "Offline"
           },
         status =
           when {
             pendingRunCount > 0 -> ClawStatus.Warning
-            healthOk -> ClawStatus.Neutral
+            healthOk -> ClawStatus.Success
             else -> ClawStatus.Danger
           },
       )
+      HeaderIcon(icon = Icons.Default.Refresh, contentDescription = "Refresh chat", onClick = onMore)
     }
-
-    HeaderIcon(icon = Icons.Default.Refresh, contentDescription = "Refresh chat", onClick = onMore)
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+      Text(text = "Chat", style = ClawTheme.type.display.copy(fontSize = 24.sp, lineHeight = 28.sp), color = ClawTheme.colors.text, maxLines = 1)
+      Text(
+        text = sessionTitle,
+        style = ClawTheme.type.caption.copy(fontSize = 13.sp, lineHeight = 17.sp),
+        color = ClawTheme.colors.textMuted,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+      )
+    }
   }
 }
 
@@ -365,7 +375,13 @@ private fun ModelPill(
     }
   Surface(
     shape = RoundedCornerShape(ClawTheme.radii.pill),
-    color = ClawTheme.colors.surfaceRaised,
+    color =
+      when (status) {
+        ClawStatus.Success -> ClawTheme.colors.successSoft
+        ClawStatus.Warning -> ClawTheme.colors.warningSoft
+        ClawStatus.Danger -> ClawTheme.colors.dangerSoft
+        ClawStatus.Neutral -> ClawTheme.colors.surfaceRaised
+      },
     contentColor = ClawTheme.colors.textMuted,
     border = BorderStroke(1.dp, borderColor),
   ) {
@@ -577,13 +593,15 @@ private fun ChatBubble(
     horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start,
   ) {
     Surface(
-      modifier = Modifier.fillMaxWidth(if (isUser) 0.64f else 0.56f),
+      modifier = Modifier.fillMaxWidth(if (isUser) 0.84f else 0.94f),
       shape = RoundedCornerShape(7.dp),
-      color = ClawTheme.colors.surfaceRaised,
+      color = if (isUser) ClawTheme.colors.surfacePressed.copy(alpha = 0.86f) else ClawTheme.colors.surfaceRaised.copy(alpha = 0.84f),
       contentColor = ClawTheme.colors.text,
-      border = BorderStroke(1.dp, if (live) ClawTheme.colors.borderStrong else ClawTheme.colors.border),
+      border = BorderStroke(1.dp, if (live) ClawTheme.colors.borderStrong else ClawTheme.colors.border.copy(alpha = 0.45f)),
+      tonalElevation = 1.dp,
+      shadowElevation = 2.dp,
     ) {
-      Column(modifier = Modifier.padding(horizontal = 7.dp, vertical = 3.5.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+      Column(modifier = Modifier.padding(horizontal = 11.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Text(
           text =
             when {
@@ -764,7 +782,7 @@ private fun ChatContextMeter(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
       ) {
-        Icon(imageVector = Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(12.dp), tint = ClawTheme.colors.textSubtle)
+        Icon(imageVector = Icons.Default.ArrowDropDown, contentDescription = null, modifier = Modifier.size(13.dp), tint = ClawTheme.colors.textSubtle)
         Text(
           text = contextMeterLabel(contextUsage, thinkingLevel),
           style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp),
@@ -936,7 +954,7 @@ internal fun resolveChatContextUsage(
         sessionKey = sessionKey,
         mainSessionKey = mainSessionKey,
       )
-  }
+    }
   return ChatContextUsage(
     totalTokens = entry?.totalTokens,
     totalTokensFresh = entry?.totalTokensFresh,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawNavigation.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawNavigation.kt
@@ -95,15 +95,17 @@ internal fun ClawBottomNav(
   Box(modifier = modifier.fillMaxWidth().background(ClawTheme.colors.canvas)) {
     Surface(
       modifier = Modifier.fillMaxWidth(),
-      color = ClawTheme.colors.surface.copy(alpha = 0.96f),
-      border = BorderStroke(1.dp, ClawTheme.colors.border),
+      color = ClawTheme.colors.surface.copy(alpha = 0.92f),
+      border = BorderStroke(1.dp, ClawTheme.colors.border.copy(alpha = 0.42f)),
       shape = RoundedCornerShape(topStart = ClawTheme.radii.sheet, topEnd = ClawTheme.radii.sheet),
+      tonalElevation = 2.dp,
+      shadowElevation = 8.dp,
     ) {
       Row(
         modifier =
           Modifier
             .windowInsetsPadding(safeInsets)
-            .padding(horizontal = 8.dp, vertical = 8.dp),
+            .padding(horizontal = 8.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
       ) {
@@ -131,13 +133,13 @@ private fun ClawBottomNavItem(
     onClick = onClick,
     modifier = modifier.heightIn(min = 48.dp),
     shape = RoundedCornerShape(ClawTheme.radii.control),
-    color = if (selected) ClawTheme.colors.primary else Color.Transparent,
-    contentColor = if (selected) ClawTheme.colors.primaryText else ClawTheme.colors.textMuted,
+    color = if (selected) ClawTheme.colors.surfacePressed.copy(alpha = 0.72f) else Color.Transparent,
+    contentColor = if (selected) ClawTheme.colors.text else ClawTheme.colors.textMuted,
   ) {
     Column(
-      modifier = Modifier.padding(horizontal = 5.dp, vertical = 6.dp),
+      modifier = Modifier.padding(horizontal = 5.dp, vertical = 5.dp),
       horizontalAlignment = Alignment.CenterHorizontally,
-      verticalArrangement = Arrangement.spacedBy(3.dp),
+      verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
       Icon(imageVector = item.icon, contentDescription = item.label, modifier = Modifier.size(18.dp))
       Text(text = item.label, style = ClawTheme.type.caption, maxLines = 1, overflow = TextOverflow.Ellipsis)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawSurfaces.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawSurfaces.kt
@@ -27,9 +27,11 @@ internal fun ClawPanel(
   Surface(
     modifier = modifier.fillMaxWidth(),
     shape = RoundedCornerShape(ClawTheme.radii.panel),
-    color = ClawTheme.colors.surfaceRaised,
+    color = ClawTheme.colors.surfaceRaised.copy(alpha = 0.82f),
     contentColor = ClawTheme.colors.text,
-    border = BorderStroke(1.dp, ClawTheme.colors.border),
+    border = null,
+    tonalElevation = 2.dp,
+    shadowElevation = 4.dp,
   ) {
     Column(modifier = Modifier.padding(contentPadding)) {
       content()

--- a/apps/android/app/src/play/AndroidManifest.xml
+++ b/apps/android/app/src/play/AndroidManifest.xml
@@ -4,12 +4,10 @@
         android:name="android.permission.READ_MEDIA_IMAGES"
         tools:node="remove" />
     <uses-permission
-        android:name="android.permission.READ_MEDIA_VIDEO"
-        tools:node="remove" />
-    <uses-permission
         android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED"
         tools:node="remove" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32"
         tools:node="remove" />
 </manifest>

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
@@ -1,12 +1,14 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.AppearanceThemeMode
+import ai.openclaw.app.GatewayAgentSummary
 import ai.openclaw.app.GatewayChannelSummary
 import ai.openclaw.app.GatewayChannelsSummary
 import ai.openclaw.app.GatewayNodeApprovalState
 import ai.openclaw.app.GatewayNodeSummary
 import ai.openclaw.app.GatewayNodesDevicesSummary
 import ai.openclaw.app.GatewayPendingDeviceSummary
+import ai.openclaw.app.ui.design.ClawStatus
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import org.junit.Assert.assertEquals
@@ -105,7 +107,7 @@ class ShellScreenLogicTest {
     assertEquals(listOf("Approvals", "Channels", "Nodes & Devices", "Providers"), rows.map { it.title })
     val providersRow = rows.single { it.title == "Providers" }
     assertEquals(Tab.Settings, providersRow.tab)
-    assertEquals(SettingsRoute.Gateway, providersRow.settingsRoute)
+    assertEquals(SettingsRoute.ProvidersModels, providersRow.settingsRoute)
   }
 
   @Test
@@ -158,9 +160,205 @@ class ShellScreenLogicTest {
   }
 
   @Test
+  fun overviewHeaderStateReflectsGatewayConnectionAndAttention() {
+    assertEquals(OverviewHeaderState("Offline", ClawStatus.Neutral), overviewHeaderState(isConnected = false, hasAttention = true))
+    assertEquals(OverviewHeaderState("Needs attention", ClawStatus.Warning), overviewHeaderState(isConnected = true, hasAttention = true))
+    assertEquals(OverviewHeaderState("Online", ClawStatus.Success), overviewHeaderState(isConnected = true, hasAttention = false))
+  }
+
+  @Test
+  fun overviewHeaderRouteUsesFirstAttentionDestination() {
+    assertEquals(SettingsRoute.Gateway, overviewHeaderRoute(emptyList()))
+    assertEquals(
+      SettingsRoute.Approvals,
+      overviewHeaderRoute(
+        listOf(
+          HomeAttentionRow("Approvals", "2 pending", Icons.Default.Settings, Tab.Settings, SettingsRoute.Approvals),
+          HomeAttentionRow("Nodes & Devices", "Review node access", Icons.Default.Settings, Tab.Settings, SettingsRoute.NodesDevices),
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun overviewMetricCardsUseRealGatewayNodeApprovalAndSessionCounts() {
+    val cards =
+      overviewMetricCardSpecs(
+        isConnected = true,
+        hasAttention = true,
+        nodesDevicesSummary =
+          GatewayNodesDevicesSummary(
+            nodes =
+              listOf(
+                GatewayNodeSummary(
+                  id = "android-node",
+                  displayName = "Android",
+                  remoteIp = null,
+                  version = null,
+                  deviceFamily = "Android",
+                  paired = true,
+                  connected = true,
+                  approvalState = GatewayNodeApprovalState.PendingReapproval,
+                  pendingRequestId = "node-request",
+                  capabilities = emptyList(),
+                  commands = emptyList(),
+                ),
+              ),
+            pendingDevices = emptyList(),
+            pairedDevices = emptyList(),
+          ),
+        pendingApprovals = 2,
+        sessionCount = 4,
+      )
+
+    assertEquals(listOf("Gateway", "Nodes", "Approvals", "Sessions"), cards.map { it.title })
+    assertEquals("Online", cards.single { it.title == "Gateway" }.value)
+    assertEquals("Review highlighted items", cards.single { it.title == "Gateway" }.subtitle)
+    assertEquals("1/1", cards.single { it.title == "Nodes" }.value)
+    assertEquals("Review node access", cards.single { it.title == "Nodes" }.subtitle)
+    assertEquals(ClawStatus.Warning, cards.single { it.title == "Nodes" }.status)
+    assertEquals(1f, cards.single { it.title == "Nodes" }.progressFraction ?: 0f, 0.001f)
+    assertEquals("2", cards.single { it.title == "Approvals" }.value)
+    assertEquals("4", cards.single { it.title == "Sessions" }.value)
+  }
+
+  @Test
+  fun overviewNodeCardShowsRoundedOnlinePercentWhenNoNodeApprovalIsPending() {
+    val cards =
+      overviewMetricCardSpecs(
+        isConnected = true,
+        hasAttention = false,
+        nodesDevicesSummary =
+          GatewayNodesDevicesSummary(
+            nodes =
+              (1..3).map { index ->
+                GatewayNodeSummary(
+                  id = "node-$index",
+                  displayName = "Node $index",
+                  remoteIp = null,
+                  version = null,
+                  deviceFamily = null,
+                  paired = true,
+                  connected = index <= 2,
+                  approvalState = GatewayNodeApprovalState.Approved,
+                  pendingRequestId = null,
+                  capabilities = emptyList(),
+                  commands = emptyList(),
+                )
+              },
+            pendingDevices = emptyList(),
+            pairedDevices = emptyList(),
+          ),
+        pendingApprovals = 0,
+        sessionCount = 0,
+      )
+
+    val nodes = cards.single { it.title == "Nodes" }
+    assertEquals("2/3", nodes.value)
+    assertEquals("67% online", nodes.subtitle)
+    assertEquals(2f / 3f, nodes.progressFraction ?: 0f, 0.001f)
+  }
+
+  @Test
+  fun overviewGatewayCardOnlyClaimsNominalWhenNoAttentionExists() {
+    val cards =
+      overviewMetricCardSpecs(
+        isConnected = true,
+        hasAttention = false,
+        nodesDevicesSummary = emptyNodesDevices(),
+        pendingApprovals = 0,
+        sessionCount = 0,
+      )
+
+    val gateway = cards.single { it.title == "Gateway" }
+    assertEquals("Healthy", gateway.value)
+    assertEquals("All systems nominal", gateway.subtitle)
+    assertEquals(ClawStatus.Success, gateway.status)
+  }
+
+  @Test
+  fun overviewAgentNameUsesDefaultAgentWhenPresent() {
+    val agents =
+      listOf(
+        GatewayAgentSummary(id = "main", name = "Main", emoji = null),
+        GatewayAgentSummary(id = "scout", name = "Scout", emoji = "🦾"),
+      )
+
+    assertEquals("Scout", overviewAgentName(agents = agents, defaultAgentId = "scout"))
+    assertEquals("Main", overviewAgentName(agents = agents, defaultAgentId = null))
+    assertEquals("OpenClaw", overviewAgentName(agents = emptyList(), defaultAgentId = null))
+  }
+
+  @Test
+  fun overviewAgentBadgeUsesEmojiBeforeInitials() {
+    val agents =
+      listOf(
+        GatewayAgentSummary(id = "main", name = "Main Agent", emoji = null),
+        GatewayAgentSummary(id = "scout", name = "Scout", emoji = "🦾"),
+      )
+
+    assertEquals("🦾", overviewAgentBadgeText(agents = agents, defaultAgentId = "scout"))
+    assertEquals("MA", overviewAgentBadgeText(agents = agents, defaultAgentId = "main"))
+    assertEquals("OC", overviewAgentBadgeText(agents = emptyList(), defaultAgentId = null))
+  }
+
+  @Test
+  fun overviewAgentActivityTextUsesRealRuntimeCounts() {
+    assertEquals(
+      "Working · 2 active runs",
+      overviewAgentActivityText(isConnected = true, pendingRunCount = 2, sessionCount = 50, cronJobCount = 19, statusText = "Online and ready"),
+    )
+    assertEquals(
+      "Monitoring · 50 sessions",
+      overviewAgentActivityText(isConnected = true, pendingRunCount = 0, sessionCount = 50, cronJobCount = 19, statusText = "Online and ready"),
+    )
+    assertEquals(
+      "Gateway offline",
+      overviewAgentActivityText(isConnected = false, pendingRunCount = 0, sessionCount = 50, cronJobCount = 19, statusText = "Gateway offline"),
+    )
+  }
+
+  @Test
+  fun sessionSourceLabelDerivesCompactSourceFromRealSessionKey() {
+    assertEquals("Telegram", sessionSourceLabel("telegram:8227096397"))
+    assertEquals("Discord", sessionSourceLabel("discord:1465779285020381361#daily-inf"))
+    assertEquals("Cron", sessionSourceLabel("Cron: nightly-reflection"))
+    assertEquals("Telegram", sessionSourceLabel("agent:main:telegram:direct:584667058"))
+    assertEquals("Discord", sessionSourceLabel("agent:main:discord:channel:1001"))
+    assertEquals("Slack", sessionSourceLabel("agent:main:slack:channel:C123"))
+    assertEquals("OpenClaw", sessionSourceLabel("agent:main:node-android"))
+    assertEquals("OpenClaw", sessionSourceLabel("agent:main:main"))
+    assertEquals("OpenClaw", sessionSourceLabel("Daily standup"))
+  }
+
+  @Test
+  fun sessionSourceLabelUsesGatewayChannelLabelsForFutureSources() {
+    val channels =
+      GatewayChannelsSummary(
+        channels =
+          listOf(
+            GatewayChannelSummary(
+              id = "matrix",
+              label = "Matrix",
+              accountCount = 1,
+              enabled = true,
+              configured = true,
+              linked = true,
+              running = true,
+              connected = true,
+              error = null,
+            ),
+          ),
+      )
+
+    assertEquals("Matrix", sessionSourceLabel("agent:main:matrix:room:abc", channels))
+  }
+
+  @Test
   fun settingsSectionTitlesGroupPowerSettingsByMeaning() {
     assertEquals("Connection", settingsSectionTitleForRoute(SettingsRoute.Gateway))
     assertEquals("Connection", settingsSectionTitleForRoute(SettingsRoute.NodesDevices))
+    assertEquals("Agents & automation", settingsSectionTitleForRoute(SettingsRoute.ProvidersModels))
     assertEquals("Agents & automation", settingsSectionTitleForRoute(SettingsRoute.Approvals))
     assertEquals("Agents & automation", settingsSectionTitleForRoute(SettingsRoute.CronJobs))
     assertEquals("Phone context & privacy", settingsSectionTitleForRoute(SettingsRoute.PhoneCapabilities))

--- a/apps/android/scripts/voice-e2e.sh
+++ b/apps/android/scripts/voice-e2e.sh
@@ -164,7 +164,7 @@ run_mode() {
     no_connect_flag=false
   fi
 
-  adb shell am broadcast \
+  adb shell run-as "$PACKAGE_NAME" am broadcast --user 0 \
     -a "$RUN_ACTION" \
     -n "$RECEIVER" \
     --es mode "$test_mode" \
@@ -224,7 +224,7 @@ adb logcat -d -v time |
   tail -250 >"$ARTIFACT_DIR/logcat.txt" || true
 
 if [[ "$CLEANUP" -eq 1 ]]; then
-  adb shell am broadcast -a "$RUN_ACTION" -n "$RECEIVER" --es mode stop >/dev/null
+  adb shell run-as "$PACKAGE_NAME" am broadcast --user 0 -a "$RUN_ACTION" -n "$RECEIVER" --es mode stop >/dev/null
 fi
 
 echo "$ARTIFACT_DIR"


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Android Overview and adjacent main tabs felt visually heavier and flatter than the intended native mobile control surface. The Overview also over-emphasized warning states and dashboard-like boxes, which made real gateway/node/session state harder to scan.

## Why This Change Was Made

This refresh treats the generated concept as visual direction, not a data contract: the Overview now uses stronger hierarchy, layered dark surfaces, semantic status/icon treatment, a prominent Talk entry point, real agent/session/node/provider signals, and aligned Chat/Voice/Settings styling without adding fake CPU, memory, token, integration, or live-session data. Bottom navigation destinations remain unchanged.

The follow-up lint pass also clears Android platform lint blockers around legacy storage permission capping, Android 13 notification permission access, API-level annotations, non-exported debug-only receiver exposure, and Android package visibility.

Proof media is stored separately in the proof-assets repo, not in this OpenClaw code branch.

AI-assisted: yes. This was implemented and reviewed with Codex; I understand the code changes and kept the implementation bound to existing Android app data/routes rather than generated concept-only placeholders.

## User Impact

Android users get a cleaner mobile control surface that makes gateway health, node approval state, node/device status, sessions, Talk, Chat, and settings easier to understand at a glance. Existing routes remain wired to real screens, and the Overview continues to show only data already exposed by the Android app/view model.

## Evidence

Fresh proof from the installed Android APK:

![Fresh Android tabs](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/openclaw-android-overview-control-surface-20260621/openclaw-android-overview-control-surface-20260621/final/all-tabs-contact-sheet-final.png)

![Android tab walk](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/openclaw-android-overview-control-surface-20260621/openclaw-android-overview-control-surface-20260621/final/openclaw-pr-proof-final.gif)

Before/after comparison:

![Before and after tabs](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/openclaw-android-overview-control-surface-20260621/openclaw-android-overview-control-surface-20260621/before-after/all-tabs-before-after.png)

Proof bundle:
https://github.com/Solvely-Colin/pr-proof-assets/tree/openclaw-android-overview-control-surface-20260621/openclaw-android-overview-control-surface-20260621

Validation on rebased commit `bcd16901bc` over `origin/main` `2f33999898`:

- `codex review --base origin/main` - passed with no actionable correctness issues. The review command's own default Android test probe was blocked by the shell's missing default Java runtime, so Android Gradle proof below was run separately with explicit `JAVA_HOME`/SDK env.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - passed with no accepted/actionable findings; reported patch correct.
- `git diff --check origin/main...HEAD` - passed
- `bash -n apps/android/scripts/voice-e2e.sh` - passed
- `adb shell run-as ai.openclaw.app am broadcast --user 0 -a ai.openclaw.app.debug.RUN_VOICE_E2E -n ai.openclaw.app/.VoiceE2eReceiver --es mode stop` - passed; receiver wrote `{"ok":true,"mode":"stop"}` through the signature-protected debug path.
- `JAVA_HOME=/opt/homebrew/opt/java ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" PATH="/opt/homebrew/opt/java/bin:$PATH" ./gradlew :app:ktlintCheck` - passed
- `JAVA_HOME=/opt/homebrew/opt/java ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" PATH="/opt/homebrew/opt/java/bin:$PATH" ./gradlew :app:lintPlayDebug` - passed
- `JAVA_HOME=/opt/homebrew/opt/java ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" PATH="/opt/homebrew/opt/java/bin:$PATH" ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.ShellScreenLogicTest` - passed
- `JAVA_HOME=/opt/homebrew/opt/java ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" PATH="/opt/homebrew/opt/java/bin:$PATH" ./gradlew :app:assemblePlayDebug` - passed
