### PR TITLE
fix(ui): auto-reload Control UI when service worker activates a new version

### DIFF
--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -39,6 +39,15 @@ self.addEventListener("activate", (event) => {
       }),
     ]),
   );
+
+  // Notify all open clients that a new service worker version is active so
+  // they can reload and pick up updated assets. This prevents stale UI after
+  // gateway updates that change the protocol version.
+  self.clients.matchAll({ type: "window" }).then((clients) => {
+    for (const client of clients) {
+      client.postMessage({ type: "sw-updated", version: CACHE_VERSION });
+    }
+  });
 });
 
 self.addEventListener("fetch", (event) => {

--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -45,7 +45,7 @@ self.addEventListener("activate", (event) => {
   // gateway updates that change the protocol version.
   self.clients.matchAll({ type: "window" }).then((clients) => {
     for (const client of clients) {
-      client.postMessage({ type: "sw-updated", version: CACHE_VERSION });
+      client.postMessage({ type: "sw-updated", version: CACHE_VERSION }, "*");
     }
   });
 });

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -19,6 +19,16 @@ if (isProd && "serviceWorker" in navigator) {
   const swUrl = new URL(inferControlUiPublicAssetPath("sw.js"), window.location.origin);
   swUrl.searchParams.set("v", OPENCLAW_CONTROL_UI_BUILD_ID || "dev");
   void navigator.serviceWorker.register(swUrl, { updateViaCache: "none" });
+
+  // When the service worker activates a new version (e.g. after a gateway
+  // update that changes the build id), reload the page so the Control UI
+  // picks up updated assets instead of showing a stale cached version that
+  // may be incompatible with the current gateway protocol.
+  navigator.serviceWorker.addEventListener("message", (event) => {
+    if (event.data?.type === "sw-updated") {
+      window.location.reload();
+    }
+  });
 } else if (!isProd && "serviceWorker" in navigator) {
   // Unregister any leftover dev SW to avoid stale cache issues.
   void navigator.serviceWorker.getRegistrations().then((registrations) => {


### PR DESCRIPTION
## What Problem This Solves

After a gateway update, browsers hold a stale service worker serving an older
Control UI bundle. The old SW passes the old protocol version to the gateway
while the gateway expects the new version, causing a persistent "Protocol
Mismatch" error. Hard-refresh and cache-clear workarounds fail when the SW
intercepts navigation or the user is behind token-based auth (cloud
deployments like Zeabur, Fly, Railway).

Users are completely locked out of their own system after every update until
they manually clear browser site data through DevTools — a workflow that is
especially difficult for non-technical users on cloud deployments where no
local terminal is available.

## Why This Change Was Made

The SW already detects version changes (the build id is embedded in the SW
URL as a `v` query parameter and in the cache name). When a new version
activates, `skipWaiting()` and `clients.claim()` take over immediately —
but open tabs still show the old cached bundle until the user manually
refreshes. This change closes that gap by having the new SW tell the page
to reload itself.

## Changes

- **`ui/public/sw.js`** — post a `{ type: "sw-updated", version }` message to
  all open clients in the `activate` handler so the page knows a new SW
  version is active
- **`ui/src/main.ts`** — listen for the `sw-updated` message on the SW
  registration and call `window.location.reload()` so the Control UI
  immediately picks up assets matching the current gateway protocol version

## Evidence

- Both changes are additive and minimal (no new dependencies, no API
  surface changes)
- The reload only fires on actual SW version changes (the build id
  embedded during Vite build changes only when the package version or git
  SHA changes)
- Existing SW tests cover the activate path; the postMessage call is
  fire-and-forget and a no-op when no clients are listening

## Related

Closes #95292