### PR TITLE
fix(openai): Codex OAuth token refresh bypasses proxy in restricted regions

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -176,6 +176,8 @@ async function postTokenForm(
     timeoutMs,
     signal: options.signal,
     auditContext: "openai-chatgpt-oauth-token",
+    proxy: "env",
+    dangerouslyAllowEnvProxyWithoutPinnedDns: true,
   });
   try {
     const responseBody = await response.arrayBuffer();


### PR DESCRIPTION
## What Problem This Solves

<img width="2127" height="437" alt="image" src="https://github.com/user-attachments/assets/1033a4cb-a26e-435f-a8a0-97af0157e646" />


Fixes an issue where users in OpenAI-unsupported regions would encounter `unsupported_country_region_territory` errors when the Codex OAuth token refreshes, even when the gateway systemd unit is configured with `HTTP_PROXY`/`HTTPS_PROXY` environment variables.

The error manifests as:
```
OAuthRefreshFailureError: OAuth token refresh failed for openai:
OpenAI Codex token refresh failed (403):
{"error":{"code":"unsupported_country_region_territory",...}}
```

This blocks the `openai/gpt-5.5` model (and any model using the `codex` agent runtime) after the initial OAuth token expires.

## Why This Change Was Made

The `postTokenForm()` function in the OpenAI Codex OAuth flow calls `fetchWithSsrFGuard()` without `proxy: "env"`, causing the token refresh request to `auth.openai.com` to bypass the system proxy configured via environment variables. In restricted regions, this direct connection is blocked by OpenAI.

The fix passes `proxy: "env"` and `dangerouslyAllowEnvProxyWithoutPinnedDns: true` to `fetchWithSsrFGuard()`, which are already supported parameters — the OAuth flow simply was not using them. This lets the token refresh respect `HTTP_PROXY`/`HTTPS_PROXY` set in the systemd unit `proxy.conf` drop-in.

## User Impact

Users behind a proxy in restricted regions can now use Codex OAuth authentication without manual workarounds. No configuration changes needed — if the gateway already has proxy env vars configured, the OAuth token refresh will automatically use them.


## Evidence

- Before: gateway journal shows repeated `OAuthRefreshFailureError` with 403 `unsupported_country_region_territory` from `auth.openai.com` every time the token expired (observed across multiple sessions: main agent, Discord, cron tasks).
- After: gateway restart with the patched binary shows clean startup, provider auth state pre-warmed successfully, and no OAuth errors in subsequent requests.
- The `fetchWithSsrFGuard` function already supports `proxy: "env"` and `dangerouslyAllowEnvProxyWithoutPinnedDns: true` — this change only passes them through from a call site that was missing them.

<img width="1192" height="353" alt="image" src="https://github.com/user-attachments/assets/d0cdf358-8827-4682-97fe-c735e48812ad" />

<img width="2106" height="402" alt="image" src="https://github.com/user-attachments/assets/bef4a421-5ff8-4dfa-a1cd-0bbc0ffc3681" />
