### PR TITLE
fix(memory-wiki): exempt sources/ directory from structured metadata lint

### DIFF
--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -512,8 +512,16 @@ function hasWikiSourceFrontmatter(frontmatter: Record<string, unknown>): boolean
 }
 
 export function isUnmanagedRawSourceSummary(page: WikiPageSummary): boolean {
+  // Sources under the canonical `sources/` directory are imported raw materials
+  // by convention, regardless of whether they carry a raw-source marker or have
+  // partial wiki frontmatter. This avoids lint noise for every file dropped
+  // into the sources directory.
+  const isInSourcesDir =
+    page.kind === "source" &&
+    (page.relativePath === "sources" || page.relativePath.startsWith("sources/"));
   return (
-    page.kind === "source" && page.unmanagedRawSourceBody === true && !page.generatedSourceBody
+    isInSourcesDir ||
+    (page.kind === "source" && page.unmanagedRawSourceBody === true && !page.generatedSourceBody)
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

The `wiki_lint` command reports errors for files in the `sources/` directory,
requiring `id`, `pageType`, and `updatedAt` frontmatter fields even when these
files are imported raw materials that should be preserved in their original
state.

The official documentation states that `sources/` is "for imported raw material
and bridge-backed pages" — yet the lint checker treats them identically to
structured wiki pages.

## Why This Change Was Made

The `isUnmanagedRawSourceSummary` function in `markdown.ts` only recognized a
page as an unmanaged raw source when its body contained a raw-source marker
(`<!-- openclaw:raw-source -->`). Files in `sources/` that lacked this marker
— or that carried partial wiki frontmatter inherited from their origin — were
incorrectly classified as structured pages and subjected to frontmatter
requirements.

The fix adds a directory-based check: any `source`-kind page whose
`relativePath` is `sources` or starts with `sources/` is treated as an
unmanaged raw source regardless of markers or frontmatter content.

## Changes

- **`extensions/memory-wiki/src/markdown.ts`** — expand `isUnmanagedRawSourceSummary`
  to treat any source page under `sources/` as unmanaged

## Evidence

- This is a pure path-based exemption — files under `sources/` are skipped for
  `missing-id`, `missing-page-type`, `stale-page`, and related structured
  metadata lint checks
- No behavioral change for files outside `sources/`

## Related

Closes #69700