### PR TITLE
docs(tools): clarify sessions_yield is subagent-only, does not resume on cron completion

### DIFF
--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -19,7 +19,7 @@ export function createSessionsYieldTool(opts?: {
   return {
     label: "Yield",
     name: "sessions_yield",
-    description: "End current turn. Use after spawning subagents; results arrive as next message. Subagent-only — cron jobs do NOT resume the session. Use cron get <jobId> polling or sessions_spawn for cron workflows.",
+    description: "End current turn. Use after spawning subagents; results arrive as next message. Subagent-only — cron jobs do NOT resume the session. Use sessions_spawn for cron workflows, or openclaw cron run --wait / cron.runs to poll cron completion via CLI.",
     parameters: SessionsYieldToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -19,7 +19,7 @@ export function createSessionsYieldTool(opts?: {
   return {
     label: "Yield",
     name: "sessions_yield",
-    description: "End current turn. Use after spawning subagents; results arrive as next message.",
+    description: "End current turn. Use after spawning subagents; results arrive as next message. Subagent-only — cron jobs do NOT resume the session. Use cron get <jobId> polling or sessions_spawn for cron workflows.",
     parameters: SessionsYieldToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;


### PR DESCRIPTION
Fixes #95535

## Motivation

The `sessions_yield` tool description does not clarify that it only works with subagents, not with isolated cron jobs. When users call `sessions_yield` to wait for a cron job to complete, the main session never resumes, leaving the user confused.

## Changes

- `src/agents/tools/sessions-yield-tool.ts` — Update tool description to clarify:
  - `sessions_yield` is subagent-only
  - Cron job completion does NOT resume the yielded session
  - Use `sessions_spawn` for cron workflows, or `openclaw cron run --wait` / `cron.runs` to poll cron completion via CLI

## Verification

- `node scripts/run-vitest.mjs src/agents/tools/sessions-yield-tool.test.ts` → 4/4 passed
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts` → 4/4 passed

## Compatibility

- Only the tool description string was changed; no runtime behavior was modified
- No breaking changes
- No migration needed

## CHANGELOG

No CHANGELOG entry needed — documentation-only fix.