### PR TITLE
fix(cli): resolve trajectory export stores consistently

### DIFF
--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -327,7 +327,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .option("--session-key <key>", "Session key to export")
     .option("--output <path>", "Output directory name inside .openclaw/trajectory-exports")
     .option("--workspace <path>", "Workspace root for the export (default: current directory)")
-    .option("--store <path>", "Path to session store (default: resolved from session key)")
+    .option("--store <path>", "Path to session store (default: resolved from config)")
     .option("--agent <id>", "Agent id for resolving the default session store")
     .option("--request-json-base64 <payload>", "Base64url-encoded export request")
     .option("--json", "Output JSON", false)

--- a/src/commands/export-trajectory.test.ts
+++ b/src/commands/export-trajectory.test.ts
@@ -4,8 +4,13 @@ import type { RuntimeEnv } from "../runtime.js";
 import { exportTrajectoryCommand } from "./export-trajectory.js";
 
 const mocks = vi.hoisted(() => ({
+  getRuntimeConfig: vi.fn(),
   loadSessionEntry: vi.fn(),
-  resolveDefaultSessionStorePath: vi.fn(),
+  resolveStorePath: vi.fn(),
+}));
+
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: mocks.getRuntimeConfig,
 }));
 
 vi.mock("../config/sessions/session-accessor.js", () => ({
@@ -16,7 +21,7 @@ vi.mock("../config/sessions/paths.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/sessions/paths.js")>();
   return {
     ...actual,
-    resolveDefaultSessionStorePath: mocks.resolveDefaultSessionStorePath,
+    resolveStorePath: mocks.resolveStorePath,
   };
 });
 
@@ -31,7 +36,8 @@ function createRuntime(): RuntimeEnv {
 describe("exportTrajectoryCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.resolveDefaultSessionStorePath.mockReturnValue("/tmp/openclaw/sessions.json");
+    mocks.getRuntimeConfig.mockReturnValue({});
+    mocks.resolveStorePath.mockReturnValue("/tmp/openclaw/sessions.json");
     mocks.loadSessionEntry.mockReturnValue(undefined);
   });
 
@@ -64,6 +70,7 @@ describe("exportTrajectoryCommand", () => {
       JSON.stringify({ output: "/tmp/export.json" }),
       "utf8",
     ).toString("base64url");
+    mocks.resolveStorePath.mockReturnValue("/tmp/direct-store.json");
 
     await exportTrajectoryCommand(
       {
@@ -74,7 +81,10 @@ describe("exportTrajectoryCommand", () => {
       runtime,
     );
 
-    expect(mocks.resolveDefaultSessionStorePath).not.toHaveBeenCalled();
+    expect(mocks.getRuntimeConfig).not.toHaveBeenCalled();
+    expect(mocks.resolveStorePath).toHaveBeenCalledWith("/tmp/direct-store.json", {
+      agentId: "main",
+    });
     expect(mocks.loadSessionEntry).toHaveBeenCalledWith({
       agentId: "main",
       sessionKey: "agent:main:telegram:direct:123",
@@ -86,11 +96,91 @@ describe("exportTrajectoryCommand", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
-  it("points missing session users at the sessions command", async () => {
+  it.each([
+    ["home-prefixed", "~/x/sessions.json", "/home/demo/x/sessions.json"],
+    [
+      "agent template",
+      "/tmp/openclaw/agents/{agentId}/sessions/sessions.json",
+      "/tmp/openclaw/agents/work/sessions/sessions.json",
+    ],
+  ])(
+    "resolves explicit --store %s paths through the shared resolver",
+    async (_name, store, resolvedStore) => {
+      const runtime = createRuntime();
+      mocks.resolveStorePath.mockReturnValue(resolvedStore);
+
+      await exportTrajectoryCommand(
+        { sessionKey: "agent:work:telegram:direct:123", store },
+        runtime,
+      );
+
+      expect(mocks.getRuntimeConfig).not.toHaveBeenCalled();
+      expect(mocks.resolveStorePath).toHaveBeenCalledWith(store, { agentId: "work" });
+      expect(mocks.loadSessionEntry).toHaveBeenCalledWith({
+        agentId: "work",
+        sessionKey: "agent:work:telegram:direct:123",
+        storePath: resolvedStore,
+      });
+      expect(runtime.error).toHaveBeenCalledWith(
+        "Session not found: agent:work:telegram:direct:123. Run openclaw sessions to see available sessions.",
+      );
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+    },
+  );
+
+  it("uses configured session.store when no explicit store is provided", async () => {
+    const runtime = createRuntime();
+    mocks.getRuntimeConfig.mockReturnValue({
+      session: { store: "/tmp/openclaw/agents/{agentId}/sessions/sessions.json" },
+    });
+    mocks.resolveStorePath.mockReturnValue("/tmp/openclaw/agents/work/sessions/sessions.json");
+
+    await exportTrajectoryCommand({ sessionKey: "agent:work:telegram:direct:123" }, runtime);
+
+    expect(mocks.resolveStorePath).toHaveBeenCalledWith(
+      "/tmp/openclaw/agents/{agentId}/sessions/sessions.json",
+      { agentId: "work" },
+    );
+    expect(mocks.loadSessionEntry).toHaveBeenCalledWith({
+      agentId: "work",
+      sessionKey: "agent:work:telegram:direct:123",
+      storePath: "/tmp/openclaw/agents/work/sessions/sessions.json",
+    });
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Session not found: agent:work:telegram:direct:123. Run openclaw sessions to see available sessions.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("falls back through resolveStorePath when no session.store is configured", async () => {
     const runtime = createRuntime();
 
     await exportTrajectoryCommand({ sessionKey: "agent:main:telegram:direct:123" }, runtime);
 
+    expect(mocks.resolveStorePath).toHaveBeenCalledWith(undefined, { agentId: "main" });
+    expect(mocks.loadSessionEntry).toHaveBeenCalledWith({
+      agentId: "main",
+      sessionKey: "agent:main:telegram:direct:123",
+      storePath: "/tmp/openclaw/sessions.json",
+    });
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Session not found: agent:main:telegram:direct:123. Run openclaw sessions to see available sessions.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("passes blank configured session.store through the default-store resolver", async () => {
+    const runtime = createRuntime();
+    mocks.getRuntimeConfig.mockReturnValue({ session: { store: "" } });
+
+    await exportTrajectoryCommand({ sessionKey: "agent:main:telegram:direct:123" }, runtime);
+
+    expect(mocks.resolveStorePath).toHaveBeenCalledWith("", { agentId: "main" });
+    expect(mocks.loadSessionEntry).toHaveBeenCalledWith({
+      agentId: "main",
+      sessionKey: "agent:main:telegram:direct:123",
+      storePath: "/tmp/openclaw/sessions.json",
+    });
     expect(runtime.error).toHaveBeenCalledWith(
       "Session not found: agent:main:telegram:direct:123. Run openclaw sessions to see available sessions.",
     );

--- a/src/commands/export-trajectory.ts
+++ b/src/commands/export-trajectory.ts
@@ -1,10 +1,11 @@
 /** CLI command for exporting a session transcript as a trajectory artifact. */
 import path from "node:path";
 import { formatCliCommand } from "../cli/command-format.js";
+import { getRuntimeConfig } from "../config/config.js";
 import {
-  resolveDefaultSessionStorePath,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
+  resolveStorePath,
 } from "../config/sessions/paths.js";
 import { loadSessionEntry } from "../config/sessions/session-accessor.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -116,8 +117,8 @@ export async function exportTrajectoryCommand(
   }
   const targetAgentId = resolvedOpts.agent ?? resolveAgentIdFromSessionKey(sessionKey);
   const storePath = resolvedOpts.store
-    ? path.resolve(resolvedOpts.store)
-    : resolveDefaultSessionStorePath(targetAgentId);
+    ? resolveStorePath(resolvedOpts.store, { agentId: targetAgentId })
+    : resolveStorePath(getRuntimeConfig().session?.store, { agentId: targetAgentId });
   const entry = loadSessionEntry({
     agentId: targetAgentId,
     sessionKey,

--- a/src/config/sessions/paths.test.ts
+++ b/src/config/sessions/paths.test.ts
@@ -1,0 +1,18 @@
+// Session path helper tests pin default store path contracts used by CLI commands.
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveStorePath } from "./paths.js";
+
+describe("resolveStorePath", () => {
+  it("uses the default agent store when session.store is absent or blank", () => {
+    const stateDir = path.join(path.parse(process.cwd()).root, "openclaw-test-state");
+    const env = {
+      ...process.env,
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+    const expected = path.join(stateDir, "agents", "work", "sessions", "sessions.json");
+
+    expect(resolveStorePath(undefined, { agentId: "work", env })).toBe(expected);
+    expect(resolveStorePath("", { agentId: "work", env })).toBe(expected);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes #95568.

`openclaw sessions export-trajectory` used different session-store path semantics from the rest of the `openclaw sessions` CLI surface. That could make trajectory export miss sessions that `openclaw sessions` can list.

This PR fixes both store-resolution gaps:

- when `--store` is omitted, export now honors configured `session.store`
- when explicit `--store` is provided, export keeps it as the highest-priority override but resolves it through the shared store resolver so `~` and `{agentId}` behave like `openclaw sessions`

## Why This Change Was Made

The export command already knows the target agent id from `--agent` or the modern `agent:<id>:...` session key. Both implicit and explicit store paths can therefore use the same `resolveStorePath(..., { agentId })` contract as session listing.

The command help now matches the behavior by describing the default store as resolved from config.

## User Impact

Users with a custom `session.store`, including `{agentId}` templates, can run:

```bash
openclaw sessions export-trajectory --session-key "agent:work:telegram:direct:123"
```

without also passing `--store`, and the command will look in the same configured store path that session listing uses.

Users who do pass explicit `--store` still override config, but values such as these now use the same resolver semantics as `openclaw sessions`:

```bash
openclaw sessions export-trajectory --session-key "agent:work:telegram:direct:123" --store "~/x/sessions.json"
openclaw sessions export-trajectory --session-key "agent:work:telegram:direct:123" --store "/tmp/openclaw/agents/{agentId}/sessions/sessions.json"
```

## Evidence

Current follow-up proof on `4eac6229c7`:

- `node scripts/run-vitest.mjs src/commands/export-trajectory.test.ts`
- `pnpm format:check src/commands/export-trajectory.ts src/commands/export-trajectory.test.ts`
- `git diff --check`

The updated unit coverage checks configured `session.store`, default fallback through `resolveStorePath`, explicit absolute `--store`, explicit `~/...`, and explicit `{agentId}` template paths.

Earlier branch proof before this follow-up:

- `pnpm changed:lanes --json --base upstream/main`
- `pnpm test src/commands/export-trajectory.test.ts src/cli/program/register.status-health-sessions.test.ts src/config/sessions/targets.test.ts src/commands/sessions.default-agent-store.test.ts -- --reporter=verbose`
- `node scripts/test-projects.mjs --changed upstream/main --reporter=verbose`
- `pnpm openclaw sessions export-trajectory --help`
- Temporary-home CLI smoke showed configured `session.store` export succeeds without `--store`, and explicit `--store` still overrides config.
- `pnpm format:check src/commands/export-trajectory.ts src/commands/export-trajectory.test.ts src/cli/program/register.status-health-sessions.ts`
- `git diff --check upstream/main...HEAD`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm check:changed --base upstream/main`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` clean

Note: I prepared the local Crabbox/Blacksmith tooling for the earlier branch proof, but did not run remote Blacksmith Testbox proof because this machine's Blacksmith account is not authenticated. The local changed-check child mode above ran the same core/coreTests changed lanes successfully.
