### PR TITLE
fix(memory): skip markdown placeholder snippets during short-term promotion

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -407,6 +407,12 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
   if (!snippet) {
     return false;
   }
+  // Skip markdown placeholder snippets: bare bullets, empty list items, and
+  // whitespace-only lines that serve as structural scaffolding rather than
+  // promotable content. These are common in daily-note bootstrap sections.
+  if (/^\s*[-*+]\s*$/.test(snippet) || /^\s*$/.test(snippet)) {
+    return true;
+  }
   if (
     /<!--\s*openclaw-memory-promotion:/i.test(snippet) ||
     DREAMING_TRANSCRIPT_PROMPT_LINE_RE.test(snippet)


### PR DESCRIPTION
## What Problem This Solves

Short-term memory promotion treats markdown skeleton placeholders — such as a
bare `-` under a daily-note heading — as promotable snippets. In the affected
case, promotion appends empty or near-empty blocks into MEMORY.md because a
grounded candidate can be rehydrated onto a placeholder line.

## Why This Change Was Made

`isContaminatedDreamingSnippet` filters out unwanted dreaming output but did
not check for structural placeholder lines. Daily notes commonly contain
bootstrap sections with empty bullets:

```md
## Tagesnotizen
-

## Entscheidungen
-
```

These are scaffolding, not promotable content.

## Changes

- **`extensions/memory-core/src/short-term-promotion.ts`** — treat bare
  bullet items (`-`, `*`, `+`) and whitespace-only lines as contaminated in
  `isContaminatedDreamingSnippet` so they are skipped during promotion

## Evidence

- The regex `/^\s*[-*+]\s*$/` matches standard Markdown list markers with no
  content, and `/^\s*$/` matches blank lines
- Both are structural patterns that contain no usable memory content

## Related

Closes #80582