### PR TITLE
fix(agents): reject bind specs with extra colon segments

### DIFF
--- a/src/commands/agents.bind.matrix.integration.test.ts
+++ b/src/commands/agents.bind.matrix.integration.test.ts
@@ -33,6 +33,32 @@ describe("agents bind matrix integration", () => {
     ]);
   });
 
+  it("rejects a binding spec with extra colon segments instead of silently truncating", () => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "matrix", plugin: matrixBindingPlugin, source: "test" }]),
+    );
+
+    const parsed = parseBindingSpecs({ agentId: "main", specs: ["matrix:work:extra"], config: {} });
+
+    expect(parsed.bindings).toEqual([]);
+    expect(parsed.errors).toEqual([
+      'Invalid binding "matrix:work:extra". Account id cannot contain ":". Use <channel>:<account>, for example telegram:default.',
+    ]);
+  });
+
+  it("still accepts a single channel:account binding", () => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "matrix", plugin: matrixBindingPlugin, source: "test" }]),
+    );
+
+    const parsed = parseBindingSpecs({ agentId: "main", specs: ["matrix:work"], config: {} });
+
+    expect(parsed.errors).toStrictEqual([]);
+    expect(parsed.bindings).toEqual([
+      { type: "route", agentId: "main", match: { channel: "matrix", accountId: "work" } },
+    ]);
+  });
+
   afterEach(() => {
     setActivePluginRegistry(createTestRegistry());
   });

--- a/src/commands/agents.bindings.ts
+++ b/src/commands/agents.bindings.ts
@@ -316,18 +316,18 @@ export function parseBindingSpecs(params: {
     if (!trimmed) {
       continue;
     }
-    // Account ids never contain ":" (VALID_ID_RE in routing/account-id), so split fully: a third
-    // segment is a malformed spec, not an account id to silently truncate to (split(":", 2) drops it).
+    // Bind specs are exactly <channel> or <channel>:<account>; extra colon
+    // segments would silently change the requested account if truncated.
     const [channelRaw, accountRaw, ...extraSegments] = trimmed.split(":");
-    const channel = normalizeBindingChannelId(channelRaw, params.config);
-    if (!channel) {
-      errors.push(formatUnknownChannelMessage({ channel: channelRaw }));
-      continue;
-    }
     if (extraSegments.length > 0) {
       errors.push(
         `Invalid binding "${trimmed}". Account id cannot contain ":". Use <channel>:<account>, for example telegram:default.`,
       );
+      continue;
+    }
+    const channel = normalizeBindingChannelId(channelRaw, params.config);
+    if (!channel) {
+      errors.push(formatUnknownChannelMessage({ channel: channelRaw }));
       continue;
     }
     let accountId: string | undefined = accountRaw?.trim();

--- a/src/commands/agents.bindings.ts
+++ b/src/commands/agents.bindings.ts
@@ -316,10 +316,18 @@ export function parseBindingSpecs(params: {
     if (!trimmed) {
       continue;
     }
-    const [channelRaw, accountRaw] = trimmed.split(":", 2);
+    // Account ids never contain ":" (VALID_ID_RE in routing/account-id), so split fully: a third
+    // segment is a malformed spec, not an account id to silently truncate to (split(":", 2) drops it).
+    const [channelRaw, accountRaw, ...extraSegments] = trimmed.split(":");
     const channel = normalizeBindingChannelId(channelRaw, params.config);
     if (!channel) {
       errors.push(formatUnknownChannelMessage({ channel: channelRaw }));
+      continue;
+    }
+    if (extraSegments.length > 0) {
+      errors.push(
+        `Invalid binding "${trimmed}". Account id cannot contain ":". Use <channel>:<account>, for example telegram:default.`,
+      );
       continue;
     }
     let accountId: string | undefined = accountRaw?.trim();


### PR DESCRIPTION
## Summary

`openclaw agents bind --bind <spec>` silently mis-parsed any spec carrying an extra colon segment. `parseBindingSpecs` (`src/commands/agents.bindings.ts`) split each spec with `split(":", 2)`, which **truncates**: `matrix:work:extra` parsed as `["matrix", "work"]`, the `:extra` was dropped, and a binding was created for account `work` with **no error reported** — the user asked to bind one thing and silently got another.

Account ids can never contain `:` — they are constrained by `VALID_ID_RE` (`/^[a-z0-9][a-z0-9_-]{0,63}$/i`, `src/routing/account-id.ts:9`) — so a third colon segment is *always* a malformed spec, not an account id to truncate to.

### Changes
- `src/commands/agents.bindings.ts` — split the spec fully (`split(":")` capturing `...extraSegments`); if any extra segment is present, push an `Invalid binding ... Account id cannot contain ":"` error and skip, matching the existing empty-account guard's shape. Check ordering is unknown-channel → extra-segments → empty-account → resolve.
- `src/commands/agents.bind.matrix.integration.test.ts` — regression test that `matrix:work:extra` yields the extra-segments error with no binding, plus a control that `matrix:work` still parses.

This is the correct owner boundary: `parseBindingSpecs` is the only place that owns splitting `<channel>:<account>`; `account-id.ts` is a coercing normalizer (never rejects); and there is **no** `VALID_ID_RE` validation later on the bind write path, so a malformed id would otherwise persist to `openclaw.json` and later canonicalize to a *different* account (`work:extra` → `work-extra`). Rejecting at parse time is strictly safer than truncating or rejoining.

## Real behavior proof

Behavior addressed: `agents bind --bind matrix:work:extra` silently dropped `:extra` and bound account `work` with no error (`split(":", 2)` truncation). It now reports `Invalid binding "matrix:work:extra". Account id cannot contain ":". Use <channel>:<account>, for example telegram:default.` and creates no binding. Valid specs are unchanged.

Real environment tested: Node 22.22.1, macOS, no model / network / device. A `./node_modules/.bin/tsx` harness imports the real `parseBindingSpecs`, registers a `matrix` channel in the plugin registry, and calls it with `matrix:work:extra`, `matrix:work`, and `matrix`. BEFORE is `origin/main`'s `parseBindingSpecs` (swapped in via `git show`, no other change).

Exact steps or command run after this patch:
```bash
# harness imports the real parseBindingSpecs + sets up the channel registry
./node_modules/.bin/tsx _bind-proof.mts
```

Evidence after fix:
```
BEFORE (origin/main):
  spec="matrix:work:extra" -> bindings=[{...accountId:"work"}] errors=[]    # silent wrong bind
  spec="matrix:work"       -> bindings=[{...accountId:"work"}] errors=[]
  spec="matrix"            -> bindings=[{...accountId:"main"}] errors=[]
AFTER (this branch):
  spec="matrix:work:extra" -> bindings=[] errors=["Invalid binding ... Account id cannot contain ':' ..."]
  spec="matrix:work"       -> bindings=[{...accountId:"work"}] errors=[]    # unchanged
  spec="matrix"            -> bindings=[{...accountId:"main"}] errors=[]    # unchanged
```

Observed result after fix: the malformed 3-segment spec is rejected with an explicit error and produces no binding; `matrix:work` and `matrix` are byte-identical before and after. Single trailing colon (`telegram:`) still hits the pre-existing empty-account error (unchanged).

What was not tested: a full `openclaw agents bind` run against a built CLI (the harness drives the real `parseBindingSpecs`, which is exactly what the command calls to turn `--bind` args into route bindings). The new regression test in `agents.bind.matrix.integration.test.ts` fails on `origin/main` and passes after this change.

## Additional checks
- `node scripts/run-vitest.mjs src/commands/agents.bind.matrix.integration.test.ts` — 3 pass with the fix; verified fail-before by swapping in `origin/main`'s `agents.bindings.ts` → the new test fails.
- Formatter (`oxfmt`), static analysis (`oxlint --tsconfig`), and `tsgo:core` pass for the changed files. Diff: +9/−1 prod, +26 test.
