### PR TITLE
fix(failover): allow model fallback on harness transport timeout

### DIFF
--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -178,7 +178,16 @@ export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): R
         reason: params.failoverReason,
       };
     }
+    // Timeouts from harness-owned transports (Ollama, etc.) should still
+    // attempt the configured fallback chain before surfacing the error,
+    // consistent with the behavior for auth and billing failures.
     if (params.harnessOwnsTransport && params.failoverReason === "timeout") {
+      if (params.fallbackConfigured) {
+        return {
+          action: "fallback_model",
+          reason: "timeout",
+        };
+      }
       return {
         action: "surface_error",
         reason: params.failoverReason,


### PR DESCRIPTION
## What Problem This Solves

When an Ollama (or other harnessOwnsTransport) provider times out during a
prompt, OpenClaw surfaces "LLM request timed out." directly to the user and
never attempts the configured fallback chain. This leaves users stuck even
when reliable fallback models are configured.

## Why This Change Was Made

`resolveRunFailoverDecision` in `failover-policy.ts` had a special case for
harness-owned transport timeouts that immediately returned `surface_error`,
bypassing the `fallback_model` path that auth and billing failures use.

The fix adds a `fallbackConfigured` check before surfacing the error, so
timeout failures route through the fallback chain when fallbacks are
configured — consistent with other failure modes.

## Changes

- **`src/agents/embedded-agent-runner/run/failover-policy.ts`** — when
  `harnessOwnsTransport` and `failoverReason === "timeout"`, check
  `fallbackConfigured` before surfacing; if fallbacks exist, return
  `fallback_model` with reason "timeout"

## Evidence

- Existing test suite at `failover-policy.test.ts` covers the decision matrix
- The change is a conditional addition within the existing timeout handler —
  no new code paths, just routing to the existing fallback mechanism

## Related

Closes #95574