### PR TITLE
fix(agents): allow model fallback on harness-owned prompt timeout

### DIFF
--- a/scripts/repro/issue-95574-harness-timeout-fallback.mts
+++ b/scripts/repro/issue-95574-harness-timeout-fallback.mts
@@ -1,0 +1,64 @@
+// Real behavior proof for #95574: drives the production resolveRunFailoverDecision
+// to verify harness-owned prompt timeout falls back when fallback is configured.
+//
+// Run: node --import tsx scripts/repro/issue-95574-harness-timeout-fallback.mts
+import { resolveRunFailoverDecision } from "../../src/agents/embedded-agent-runner/run/failover-policy.ts";
+
+function fail(message: string): never {
+  console.error(`FAIL: ${message}`);
+  process.exitCode = 1;
+  throw new Error(message);
+}
+
+// Case 1: harness timeout + fallback configured -> fallback_model
+const withFallback = resolveRunFailoverDecision({
+  stage: "prompt",
+  aborted: false,
+  externalAbort: false,
+  harnessOwnsTransport: true,
+  fallbackConfigured: true,
+  failoverFailure: true,
+  failoverReason: "timeout",
+  profileRotated: false,
+});
+
+if (withFallback.action !== "fallback_model") {
+  fail(`expected fallback_model, got ${withFallback.action}`);
+}
+console.log(`PASS: harness timeout + fallback -> ${withFallback.action} (reason: ${withFallback.reason})`);
+
+// Case 2: harness timeout + no fallback -> surface_error
+const noFallback = resolveRunFailoverDecision({
+  stage: "prompt",
+  aborted: false,
+  externalAbort: false,
+  harnessOwnsTransport: true,
+  fallbackConfigured: false,
+  failoverFailure: true,
+  failoverReason: "timeout",
+  profileRotated: false,
+});
+
+if (noFallback.action !== "surface_error") {
+  fail(`expected surface_error, got ${noFallback.action}`);
+}
+console.log(`PASS: harness timeout + no fallback -> ${noFallback.action} (reason: ${noFallback.reason})`);
+
+// Case 3: non-harness timeout still falls back normally
+const nonHarness = resolveRunFailoverDecision({
+  stage: "prompt",
+  aborted: false,
+  externalAbort: false,
+  harnessOwnsTransport: false,
+  fallbackConfigured: true,
+  failoverFailure: true,
+  failoverReason: "timeout",
+  profileRotated: false,
+});
+
+if (nonHarness.action !== "fallback_model") {
+  fail(`expected fallback_model for non-harness, got ${nonHarness.action}`);
+}
+console.log(`PASS: non-harness timeout + fallback -> ${nonHarness.action}`);
+
+console.log("\nALL CHECKS PASSED — harness-owned prompt timeout honors fallback config.");

--- a/scripts/repro/issue-95574-harness-timeout-fallback.mts
+++ b/scripts/repro/issue-95574-harness-timeout-fallback.mts
@@ -1,5 +1,6 @@
 // Real behavior proof for #95574: drives the production resolveRunFailoverDecision
-// to verify harness-owned prompt timeout falls back when fallback is configured.
+// to verify harness-owned prompt timeout falls back when fallback is configured,
+// while preserving plugin-harness timeout isolation (#86476).
 //
 // Run: node --import tsx scripts/repro/issue-95574-harness-timeout-fallback.mts
 import { resolveRunFailoverDecision } from "../../src/agents/embedded-agent-runner/run/failover-policy.ts";
@@ -10,7 +11,7 @@ function fail(message: string): never {
   throw new Error(message);
 }
 
-// Case 1: harness timeout + fallback configured -> fallback_model
+// Case 1: harness timeout + fallback configured + NOT aborted -> fallback_model
 const withFallback = resolveRunFailoverDecision({
   stage: "prompt",
   aborted: false,
@@ -25,7 +26,7 @@ const withFallback = resolveRunFailoverDecision({
 if (withFallback.action !== "fallback_model") {
   fail(`expected fallback_model, got ${withFallback.action}`);
 }
-console.log(`PASS: harness timeout + fallback -> ${withFallback.action} (reason: ${withFallback.reason})`);
+console.log(`PASS: harness timeout + fallback -> ${withFallback.action}`);
 
 // Case 2: harness timeout + no fallback -> surface_error
 const noFallback = resolveRunFailoverDecision({
@@ -42,9 +43,26 @@ const noFallback = resolveRunFailoverDecision({
 if (noFallback.action !== "surface_error") {
   fail(`expected surface_error, got ${noFallback.action}`);
 }
-console.log(`PASS: harness timeout + no fallback -> ${noFallback.action} (reason: ${noFallback.reason})`);
+console.log(`PASS: harness timeout + no fallback -> ${noFallback.action}`);
 
-// Case 3: non-harness timeout still falls back normally
+// Case 3: plugin-harness timeout isolation: aborted + fallback -> still surface_error (#86476)
+const pluginAborted = resolveRunFailoverDecision({
+  stage: "prompt",
+  aborted: true,
+  externalAbort: false,
+  harnessOwnsTransport: true,
+  fallbackConfigured: true,
+  failoverFailure: true,
+  failoverReason: "timeout",
+  profileRotated: false,
+});
+
+if (pluginAborted.action !== "surface_error") {
+  fail(`expected surface_error for aborted harness timeout, got ${pluginAborted.action}`);
+}
+console.log(`PASS: aborted harness timeout -> ${pluginAborted.action} (isolation preserved)`);
+
+// Case 4: non-harness timeout still falls back normally
 const nonHarness = resolveRunFailoverDecision({
   stage: "prompt",
   aborted: false,
@@ -61,4 +79,4 @@ if (nonHarness.action !== "fallback_model") {
 }
 console.log(`PASS: non-harness timeout + fallback -> ${nonHarness.action}`);
 
-console.log("\nALL CHECKS PASSED — harness-owned prompt timeout honors fallback config.");
+console.log("\nALL CHECKS PASSED — harness timeout fallback + plugin-harness isolation both verified.");

--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -281,6 +281,24 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("preserves plugin-harness timeout isolation: aborted harness timeout surfaces error even with fallback (#86476)", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "prompt",
+        aborted: true,
+        externalAbort: false,
+        harnessOwnsTransport: true,
+        fallbackConfigured: true,
+        failoverFailure: true,
+        failoverReason: "timeout",
+        profileRotated: false,
+      }),
+    ).toEqual({
+      action: "surface_error",
+      reason: "timeout",
+    });
+  });
+
   it("does not rotate or fallback assistant timeouts that fired during tool execution (#52147)", () => {
     expect(
       resolveRunFailoverDecision({

--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -245,6 +245,42 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("falls back on prompt harness-owned transport timeout when fallback is configured (#95574)", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "prompt",
+        aborted: false,
+        externalAbort: false,
+        harnessOwnsTransport: true,
+        fallbackConfigured: true,
+        failoverFailure: true,
+        failoverReason: "timeout",
+        profileRotated: false,
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "timeout",
+    });
+  });
+
+  it("surfaces error on prompt harness-owned transport timeout when no fallback is configured (#95574)", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "prompt",
+        aborted: false,
+        externalAbort: false,
+        harnessOwnsTransport: true,
+        fallbackConfigured: false,
+        failoverFailure: true,
+        failoverReason: "timeout",
+        profileRotated: false,
+      }),
+    ).toEqual({
+      action: "surface_error",
+      reason: "timeout",
+    });
+  });
+
   it("does not rotate or fallback assistant timeouts that fired during tool execution (#52147)", () => {
     expect(
       resolveRunFailoverDecision({
@@ -520,7 +556,7 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
-  it("surfaces harness-owned prompt timeouts instead of falling back", () => {
+  it("falls back on harness-owned prompt timeout when fallback is configured (#95574)", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "prompt",
@@ -533,7 +569,7 @@ describe("resolveRunFailoverDecision", () => {
         profileRotated: true,
       }),
     ).toEqual({
-      action: "surface_error",
+      action: "fallback_model",
       reason: "timeout",
     });
   });

--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -574,6 +574,27 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("surfaces error on harness-owned plugin lifecycle timeout even with fallback (#86476)", () => {
+    // Plugin-harness lifecycle timeouts (aborted=true) keep isolation policy:
+    // the harness owns the retry, so OpenClaw should surface immediately even
+    // when a model fallback is configured.
+    expect(
+      resolveRunFailoverDecision({
+        stage: "prompt",
+        aborted: true,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: true,
+        failoverReason: "timeout",
+        harnessOwnsTransport: true,
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "surface_error",
+      reason: "timeout",
+    });
+  });
+
   it("surfaces error on LLM idle timeout when no fallback is configured and rotation is exhausted", () => {
     expect(
       resolveRunFailoverDecision({

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -178,7 +178,16 @@ export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): R
         reason: params.failoverReason,
       };
     }
-    if (params.harnessOwnsTransport && params.failoverReason === "timeout") {
+    // Harness-owned transports (Ollama, OpenRouter, ...) implement their own
+    // retry envelope, so a timeout should not double-rotate the auth profile.
+    // It must still honor an explicitly configured model fallback, though:
+    // falling back switches to a different model the operator chose for
+    // resilience, which is exactly what a prompt timeout should trigger.
+    if (
+      params.harnessOwnsTransport &&
+      params.failoverReason === "timeout" &&
+      !(params.fallbackConfigured && params.failoverFailure)
+    ) {
       return {
         action: "surface_error",
         reason: params.failoverReason,

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -178,15 +178,15 @@ export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): R
         reason: params.failoverReason,
       };
     }
-    // Harness-owned transports (Ollama, OpenRouter, ...) implement their own
-    // retry envelope, so a timeout should not double-rotate the auth profile.
-    // It must still honor an explicitly configured model fallback, though:
-    // falling back switches to a different model the operator chose for
-    // resilience, which is exactly what a prompt timeout should trigger.
+    // Harness-owned transports implement their own retry envelope. Plugin-harness
+    // lifecycle timeouts (aborted by the harness) keep the isolation policy from
+    // #86476 — they surface immediately so the harness owns the retry. A direct
+    // provider timeout (not aborted, e.g. Ollama HTTP timeout) still honors an
+    // explicitly configured model fallback (#95574).
     if (
       params.harnessOwnsTransport &&
       params.failoverReason === "timeout" &&
-      !(params.fallbackConfigured && params.failoverFailure)
+      (params.aborted || !(params.fallbackConfigured && params.failoverFailure))
     ) {
       return {
         action: "surface_error",


### PR DESCRIPTION
## Summary

When a harness-owned transport (Ollama, OpenRouter, ...) times out at the prompt stage, `resolveRunFailoverDecision` returns `surface_error` unconditionally, preempting the `fallbackConfigured` guard below. Operators who configured explicit model fallbacks see the timeout surface to the user with no fallback attempt.

The fix adds a `fallbackConfigured && failoverFailure` guard with an `aborted` check: plugin-harness lifecycle timeouts (aborted=true) keep the existing isolation policy from #86476 and surface immediately; direct provider timeouts (aborted=false, e.g. Ollama HTTP timeout) honor an explicitly configured model fallback.

## Changes

- `src/agents/embedded-agent-runner/run/failover-policy.ts`: Add the `fallbackConfigured && failoverFailure` guard to the harness-owned prompt timeout early-return, with `aborted` check to preserve plugin-harness timeout isolation.
- `src/agents/embedded-agent-runner/run/failover-policy.test.ts`: Add 3 prompt-stage tests — (1) harness timeout + fallback returns `fallback_model`, (2) harness timeout + no fallback returns `surface_error`, (3) aborted harness timeout returns `surface_error` (isolation preserved).
- `scripts/repro/issue-95574-harness-timeout-fallback.mts`: Real behavior proof script with 4 verification paths.

## Real behavior proof

**Behavior addressed**: Harness-owned transport prompt timeout falls back to the next configured model when `aborted=false` and fallback is configured, while preserving plugin-harness timeout isolation when `aborted=true`.

**Real environment tested**: Windows 10, Node.js v22.19.2, source tree at commit f500f27ec2.

**Exact steps or command run after this patch**:
- `node --import tsx scripts/repro/issue-95574-harness-timeout-fallback.mts`

**Evidence after fix**:
```text
PASS: harness timeout + fallback -> fallback_model
PASS: harness timeout + no fallback -> surface_error
PASS: aborted harness timeout -> surface_error (isolation preserved)
PASS: non-harness timeout + fallback -> fallback_model

ALL CHECKS PASSED — harness timeout fallback + plugin-harness isolation both verified.
```

**Observed result after fix**: Before the fix, all harness timeout cases returned `surface_error`. After the fix:
1. `aborted=false` + fallback configured → `fallback_model` (the fix)
2. `aborted=false` + no fallback → `surface_error` (preserved)
3. `aborted=true` + fallback → `surface_error` (plugin-harness isolation from #86476 preserved)
4. Non-harness timeout → `fallback_model` (unchanged)

**What was not tested**: Live Ollama timeout round-trip against a real model. The fix is unit-level, driven by `resolveRunFailoverDecision` which is the single decision function the runtime uses.

## Verification

- 35/35 failover-policy tests pass (vitest).
- 4/4 real behavior proof checks pass (node-tsx repro script).
- No other files changed.

Fixes #95574
