### PR TITLE
fix(plugins): skip update when npm metadata is unavailable instead of producing spurious spec error

### DIFF
--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1583,6 +1583,17 @@ export async function updateNpmInstalledPlugins(params: {
         logger.warn?.(
           `Could not check ${pluginId} before update; falling back to installer path: ${metadataResult.error}`,
         );
+        // When npm metadata is unavailable (transient registry error, rate
+        // limit, etc.), the spec validation in installPluginFromNpmSpec will
+        // reject ranges and produce a confusing second error.  Skip the update
+        // for this plugin instead of falling through to a guaranteed failure.
+        outcomes.push({
+          pluginId,
+          status: "error",
+          currentVersion: currentVersion ?? "unknown",
+          message: `Skipped update for ${pluginId}: ${metadataResult.error}`,
+        });
+        continue;
       }
     }
 


### PR DESCRIPTION
## What Problem This Solves

Plugin update check emits a confusing chain of two errors when `npm view`
fails transiently:

1. "Could not check X before update; falling back to installer path:
   npm view produced incomplete package metadata"
2. "Failed to update X: unsupported npm spec: use an exact version or
   dist-tag (ranges are not allowed)"

The second message is spurious — the spec validation rejects the version
range only because the metadata it depends on was never fetched. Users
see two errors for a single transient registry failure.

## Why This Change Was Made

When npm metadata is unavailable (transient registry error, rate limit,
etc.), the update flow logged a warning and fell through to
`installPluginFromNpmSpec`, which calls `validateRegistryNpmSpec`. That
validator rejects version ranges with "unsupported npm spec", producing
a confusing second error.

The fix records the error and skips the plugin update entirely when
metadata is unavailable, avoiding the guaranteed-to-fail installer path.

## Changes

- **`src/plugins/update.ts`** — when `fetchNpmMetadataForUpdate` fails,
  record an error outcome and `continue` to the next plugin instead of
  falling through to spec validation

## Evidence

- This eliminates the double-error UX for a single transient failure
- Existing tests at `plugins/update.test.ts` and `install.npm-spec.test.ts`
  cover the surrounding update and spec-validation logic

## Related

Closes #77616