### PR TITLE
fix: npm plugin updates break running gateway imports

### DIFF
--- a/src/cli/plugins-install-persist.test.ts
+++ b/src/cli/plugins-install-persist.test.ts
@@ -1,6 +1,10 @@
 // Plugin install persist tests cover saving installed plugin records after install.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { hasRetainedManagedNpmInstallMarker } from "../plugins/managed-npm-retention.js";
 import {
   applyExclusiveSlotSelection,
   buildPluginDiagnosticsReport,
@@ -289,6 +293,108 @@ describe("persistPluginInstall", () => {
 
     expect(planPluginUninstall).not.toHaveBeenCalled();
     expect(applyPluginUninstallDirectoryRemoval).not.toHaveBeenCalled();
+  });
+
+  it("preserves replaced npm install directories across generation updates", async () => {
+    const { persistPluginInstall } = await import("./plugins-install-persist.js");
+    const baseConfig = {
+      plugins: {
+        entries: {},
+      },
+    } as OpenClawConfig;
+    const enabledConfig = {
+      plugins: {
+        entries: {
+          codex: { enabled: true },
+        },
+      },
+    } as OpenClawConfig;
+    enablePluginInConfig.mockReturnValue({ config: enabledConfig });
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-persist-"));
+    const previousProjectRoot = path.join(tempRoot, "npm", "projects", "codex-v1");
+    const previousInstallPath = path.join(
+      previousProjectRoot,
+      "node_modules",
+      "@openclaw",
+      "codex",
+    );
+    const nextInstallPath = path.join(
+      tempRoot,
+      "npm",
+      "projects",
+      "codex-v2",
+      "node_modules",
+      "@openclaw",
+      "codex",
+    );
+    fs.mkdirSync(previousInstallPath, { recursive: true });
+    setInstalledPluginIndexInstallRecords({
+      codex: {
+        source: "npm",
+        spec: "@openclaw/codex@1.0.0",
+        installPath: previousInstallPath,
+      },
+    });
+    planPluginUninstall.mockReturnValueOnce({
+      ok: true,
+      config: {} as OpenClawConfig,
+      pluginId: "codex",
+      actions: {
+        entry: false,
+        install: true,
+        allowlist: false,
+        denylist: false,
+        loadPath: false,
+        memorySlot: false,
+        contextEngineSlot: false,
+        channelConfig: false,
+        directory: false,
+      },
+      directoryRemoval: {
+        target: previousInstallPath,
+        cleanup: {
+          kind: "npm",
+          npmRoot: previousProjectRoot,
+          packageName: "@openclaw/codex",
+        },
+      },
+    });
+
+    try {
+      await persistPluginInstall({
+        snapshot: {
+          config: baseConfig,
+          baseHash: "config-1",
+          writeOptions: installWriteOptions,
+        },
+        pluginId: "codex",
+        install: {
+          source: "npm",
+          spec: "@openclaw/codex@2.0.0",
+          installPath: nextInstallPath,
+        },
+      });
+
+      expect(planPluginUninstall).toHaveBeenCalledWith({
+        config: {
+          plugins: {
+            installs: {
+              codex: {
+                source: "npm",
+                spec: "@openclaw/codex@1.0.0",
+                installPath: previousInstallPath,
+              },
+            },
+          },
+        },
+        pluginId: "codex",
+        deleteFiles: true,
+      });
+      expect(applyPluginUninstallDirectoryRemoval).not.toHaveBeenCalled();
+      expect(hasRetainedManagedNpmInstallMarker(previousInstallPath)).toBe(true);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("warns when an installed npm plugin remains shadowed by a config-selected source", async () => {

--- a/src/cli/plugins-install-persist.ts
+++ b/src/cli/plugins-install-persist.ts
@@ -388,6 +388,11 @@ function resolveReplacedManagedInstallRemoval(params: {
   if (!previousInstallPath || !nextInstallPath) {
     return null;
   }
+  if (params.previousInstall.source === "npm" && params.nextInstall.source === "npm") {
+    // npm plugin updates can leave a running gateway holding imports into the
+    // previous dist tree until restart; keep replaced generations available.
+    return null;
+  }
   if (
     shouldPreserveReplacedInstallPath({
       removalTarget: previousInstallPath,
@@ -450,9 +455,10 @@ export async function persistPluginInstall(params: {
     () => loadInstalledPluginIndexInstallRecords(),
     { command: "install" },
   );
+  const previousInstall = installRecords[params.pluginId];
   const replacedInstallRemoval = resolveReplacedManagedInstallRemoval({
     pluginId: params.pluginId,
-    previousInstall: installRecords[params.pluginId],
+    previousInstall,
     nextInstall: params.install,
   });
   const nextInstallRecords = recordPluginInstallInRecords(installRecords, {

--- a/src/cli/plugins-install-record-commit.test.ts
+++ b/src/cli/plugins-install-record-commit.test.ts
@@ -1,7 +1,15 @@
 // Plugin install record commit tests cover install record persistence after CLI installs.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import {
+  hasRetainedManagedNpmInstallMarker,
+  markRetainedManagedNpmInstall,
+} from "../plugins/managed-npm-retention.js";
+import { withEnvAsync } from "../test-utils/env.js";
 
 const mocks = vi.hoisted(() => ({
   loadInstalledPluginIndexInstallRecords: vi.fn(),
@@ -27,6 +35,7 @@ vi.mock("../plugins/installed-plugin-index-records.js", async (importOriginal) =
 import {
   commitConfigWithPendingPluginInstalls,
   commitConfigWriteWithPendingPluginInstalls,
+  commitPluginInstallRecordsWithConfig,
   stripPendingPluginInstallRecords,
   unchangedPendingPluginInstallRecordIds,
 } from "./plugins-install-record-commit.js";
@@ -176,6 +185,294 @@ describe("commitConfigWithPendingPluginInstalls", () => {
         unsetPaths: [["plugins", "installs"]],
       },
     });
+  });
+
+  it("marks replaced managed npm generations when install records are committed", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-record-commit-"));
+    const previousInstallPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "codex-v1",
+      "node_modules",
+      "@openclaw",
+      "codex",
+    );
+    const nextInstallPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "codex-v2",
+      "node_modules",
+      "@openclaw",
+      "codex",
+    );
+    fs.mkdirSync(previousInstallPath, { recursive: true });
+    fs.mkdirSync(nextInstallPath, { recursive: true });
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        await commitPluginInstallRecordsWithConfig({
+          previousInstallRecords: {
+            codex: {
+              source: "npm",
+              spec: "@openclaw/codex@1.0.0",
+              installPath: previousInstallPath,
+            },
+          },
+          nextInstallRecords: {
+            codex: {
+              source: "npm",
+              spec: "@openclaw/codex@2.0.0",
+              installPath: nextInstallPath,
+            },
+          },
+          nextConfig: {},
+        });
+      });
+
+      expect(hasRetainedManagedNpmInstallMarker(previousInstallPath)).toBe(true);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not mark arbitrary npm paths outside the managed npm root", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-record-commit-"));
+    const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-record-outside-"));
+    const previousInstallPath = path.join(
+      outsideRoot,
+      "npm",
+      "projects",
+      "codex-v1",
+      "node_modules",
+      "@openclaw",
+      "codex",
+    );
+    const nextInstallPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "codex-v2",
+      "node_modules",
+      "@openclaw",
+      "codex",
+    );
+    fs.mkdirSync(previousInstallPath, { recursive: true });
+    fs.mkdirSync(nextInstallPath, { recursive: true });
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        await commitPluginInstallRecordsWithConfig({
+          previousInstallRecords: {
+            codex: {
+              source: "npm",
+              spec: "@openclaw/codex@1.0.0",
+              installPath: previousInstallPath,
+            },
+          },
+          nextInstallRecords: {
+            codex: {
+              source: "npm",
+              spec: "@openclaw/codex@2.0.0",
+              installPath: nextInstallPath,
+            },
+          },
+          nextConfig: {},
+        });
+      });
+
+      expect(hasRetainedManagedNpmInstallMarker(previousInstallPath)).toBe(false);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+      fs.rmSync(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("marks replaced npm generations across install record id migrations", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-record-commit-"));
+    const previousInstallPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "voice-call-v1",
+      "node_modules",
+      "@openclaw",
+      "voice-call",
+    );
+    const nextInstallPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "voice-call-v2",
+      "node_modules",
+      "@openclaw",
+      "voice-call",
+    );
+    fs.mkdirSync(previousInstallPath, { recursive: true });
+    fs.mkdirSync(nextInstallPath, { recursive: true });
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        await commitPluginInstallRecordsWithConfig({
+          previousInstallRecords: {
+            "voice-call": {
+              source: "npm",
+              spec: "@openclaw/voice-call@1.0.0",
+              installPath: previousInstallPath,
+            },
+          },
+          nextInstallRecords: {
+            "@openclaw/voice-call": {
+              source: "npm",
+              spec: "@openclaw/voice-call@2.0.0",
+              installPath: nextInstallPath,
+            },
+          },
+          nextConfig: {},
+        });
+      });
+
+      expect(hasRetainedManagedNpmInstallMarker(previousInstallPath)).toBe(true);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("removes newly retained npm markers when the config commit rolls back", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-record-commit-"));
+    const previousInstallPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "codex-v1",
+      "node_modules",
+      "@openclaw",
+      "codex",
+    );
+    const nextInstallPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "codex-v2",
+      "node_modules",
+      "@openclaw",
+      "codex",
+    );
+    fs.mkdirSync(previousInstallPath, { recursive: true });
+    fs.mkdirSync(nextInstallPath, { recursive: true });
+    mocks.replaceConfigFile.mockRejectedValueOnce(new Error("config changed"));
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        await expect(
+          commitPluginInstallRecordsWithConfig({
+            previousInstallRecords: {
+              codex: {
+                source: "npm",
+                spec: "@openclaw/codex@1.0.0",
+                installPath: previousInstallPath,
+              },
+            },
+            nextInstallRecords: {
+              codex: {
+                source: "npm",
+                spec: "@openclaw/codex@2.0.0",
+                installPath: nextInstallPath,
+              },
+            },
+            nextConfig: {},
+          }),
+        ).rejects.toThrow("config changed");
+      });
+
+      expect(hasRetainedManagedNpmInstallMarker(previousInstallPath)).toBe(false);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("clears retained npm markers for active committed install records", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-record-commit-"));
+    const installPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "codex-v2",
+      "node_modules",
+      "@openclaw",
+      "codex",
+    );
+    fs.mkdirSync(installPath, { recursive: true });
+    await markRetainedManagedNpmInstall({
+      packageDir: installPath,
+      pluginId: "codex",
+      retainedAt: "2026-04-25T00:00:00.000Z",
+      reason: "test-retained-generation",
+    });
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        await commitPluginInstallRecordsWithConfig({
+          previousInstallRecords: {},
+          nextInstallRecords: {
+            codex: {
+              source: "npm",
+              spec: "@openclaw/codex@2.0.0",
+              installPath,
+            },
+          },
+          nextConfig: {},
+        });
+      });
+
+      expect(hasRetainedManagedNpmInstallMarker(installPath)).toBe(false);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("restores cleared active npm markers when the config commit rolls back", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-record-commit-"));
+    const installPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "codex-v2",
+      "node_modules",
+      "@openclaw",
+      "codex",
+    );
+    fs.mkdirSync(installPath, { recursive: true });
+    await markRetainedManagedNpmInstall({
+      packageDir: installPath,
+      pluginId: "codex",
+      retainedAt: "2026-04-25T00:00:00.000Z",
+      reason: "test-retained-generation",
+    });
+    mocks.replaceConfigFile.mockRejectedValueOnce(new Error("config changed"));
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        await expect(
+          commitPluginInstallRecordsWithConfig({
+            previousInstallRecords: {},
+            nextInstallRecords: {
+              codex: {
+                source: "npm",
+                spec: "@openclaw/codex@2.0.0",
+                installPath,
+              },
+            },
+            nextConfig: {},
+          }),
+        ).rejects.toThrow("config changed");
+      });
+
+      expect(hasRetainedManagedNpmInstallMarker(installPath)).toBe(true);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("rolls back plugin index writes when the config write fails", async () => {

--- a/src/cli/plugins-install-record-commit.test.ts
+++ b/src/cli/plugins-install-record-commit.test.ts
@@ -392,6 +392,93 @@ describe("commitConfigWithPendingPluginInstalls", () => {
     }
   });
 
+  it("removes earlier retained markers when a later marker creation fails", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-record-commit-"));
+    const firstPreviousInstallPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "codex-v1",
+      "node_modules",
+      "@openclaw",
+      "codex",
+    );
+    const firstNextInstallPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "codex-v2",
+      "node_modules",
+      "@openclaw",
+      "codex",
+    );
+    const secondPreviousInstallPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "voice-call-v1",
+      "node_modules",
+      "@openclaw",
+      "voice-call",
+    );
+    const secondNextInstallPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "voice-call-v2",
+      "node_modules",
+      "@openclaw",
+      "voice-call",
+    );
+    fs.mkdirSync(firstPreviousInstallPath, { recursive: true });
+    fs.mkdirSync(firstNextInstallPath, { recursive: true });
+    fs.mkdirSync(secondPreviousInstallPath, { recursive: true });
+    fs.mkdirSync(secondNextInstallPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(stateDir, "npm", "projects", "voice-call-v1", ".openclaw-retained-npm-installs"),
+      "not a directory",
+      "utf8",
+    );
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        await expect(
+          commitPluginInstallRecordsWithConfig({
+            previousInstallRecords: {
+              codex: {
+                source: "npm",
+                spec: "@openclaw/codex@1.0.0",
+                installPath: firstPreviousInstallPath,
+              },
+              "voice-call": {
+                source: "npm",
+                spec: "@openclaw/voice-call@1.0.0",
+                installPath: secondPreviousInstallPath,
+              },
+            },
+            nextInstallRecords: {
+              codex: {
+                source: "npm",
+                spec: "@openclaw/codex@2.0.0",
+                installPath: firstNextInstallPath,
+              },
+              "voice-call": {
+                source: "npm",
+                spec: "@openclaw/voice-call@2.0.0",
+                installPath: secondNextInstallPath,
+              },
+            },
+            nextConfig: {},
+          }),
+        ).rejects.toThrow();
+      });
+
+      expect(hasRetainedManagedNpmInstallMarker(firstPreviousInstallPath)).toBe(false);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("clears retained npm markers for active committed install records", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-record-commit-"));
     const installPath = path.join(

--- a/src/cli/plugins-install-record-commit.ts
+++ b/src/cli/plugins-install-record-commit.ts
@@ -177,8 +177,8 @@ function findReplacementNpmRecordForRemovedRecord(params: {
 async function markRetainedReplacedManagedNpmInstallRecords(params: {
   previousInstallRecords: Record<string, PluginInstallRecord>;
   nextInstallRecords: Record<string, PluginInstallRecord>;
-}): Promise<string[]> {
-  const createdMarkerPaths: string[] = [];
+  createdMarkerPaths: string[];
+}): Promise<void> {
   const markedPreviousPluginIds = new Set<string>();
   const markReplacement = async (
     pluginId: string,
@@ -201,7 +201,8 @@ async function markRetainedReplacedManagedNpmInstallRecords(params: {
       reason: "replaced-by-managed-npm-generation-update",
     });
     if (marked && !markerAlreadyExisted) {
-      createdMarkerPaths.push(markerPath);
+      // Record each marker immediately so a later filesystem failure can roll it back.
+      params.createdMarkerPaths.push(markerPath);
     }
     markedPreviousPluginIds.add(pluginId);
   };
@@ -222,7 +223,6 @@ async function markRetainedReplacedManagedNpmInstallRecords(params: {
       }) ?? undefined,
     );
   }
-  return createdMarkerPaths;
 }
 
 async function removeCreatedRetainedManagedNpmInstallMarkers(markerPaths: string[]): Promise<void> {
@@ -285,12 +285,12 @@ async function commitPluginInstallRecordsWithWriter(params: {
   try {
     await writePersistedInstalledPluginIndexInstallRecords(params.nextInstallRecords);
     try {
-      retainedMarkerPaths.push(
-        ...(await markRetainedReplacedManagedNpmInstallRecords({
-          previousInstallRecords,
-          nextInstallRecords: params.nextInstallRecords,
-        })),
-      );
+      await markRetainedReplacedManagedNpmInstallRecords({
+        previousInstallRecords,
+        nextInstallRecords: params.nextInstallRecords,
+        // Keep partial progress visible to the outer rollback path.
+        createdMarkerPaths: retainedMarkerPaths,
+      });
       clearedMarkerSnapshots.push(
         ...(await clearActiveRetainedManagedNpmInstallMarkers(params.nextInstallRecords)),
       );

--- a/src/cli/plugins-install-record-commit.ts
+++ b/src/cli/plugins-install-record-commit.ts
@@ -1,4 +1,6 @@
 // Commit helpers that move transient plugin install records into the persisted install index.
+import fs from "node:fs";
+import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import {
   replaceConfigFile,
@@ -12,12 +14,20 @@ import {
 import type { ConfigWriteOptions } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { isPathInside } from "../infra/path-guards.js";
 import {
   loadInstalledPluginIndexInstallRecords,
   PLUGIN_INSTALLS_CONFIG_PATH,
   withoutPluginInstallRecords,
   writePersistedInstalledPluginIndexInstallRecords,
 } from "../plugins/installed-plugin-index-records.js";
+import {
+  clearRetainedManagedNpmInstallMarker,
+  markRetainedManagedNpmInstall,
+  resolveRetainedManagedNpmInstallPackageInfo,
+  resolveRetainedManagedNpmInstallMarkerPath,
+} from "../plugins/managed-npm-retention.js";
+import { planPluginUninstall } from "../plugins/uninstall.js";
 
 function mergeUnsetPaths(
   left?: ConfigWriteOptions["unsetPaths"],
@@ -89,6 +99,178 @@ function mergeAfterWrite(
   };
 }
 
+function installPathsOverlap(left: string, right: string): boolean {
+  const resolvedLeft = path.resolve(left);
+  const resolvedRight = path.resolve(right);
+  return (
+    resolvedLeft === resolvedRight ||
+    isPathInside(resolvedLeft, resolvedRight) ||
+    isPathInside(resolvedRight, resolvedLeft)
+  );
+}
+
+function resolveRetainedManagedNpmInstallMarkerTarget(params: {
+  pluginId: string;
+  previousRecord?: PluginInstallRecord;
+  nextRecord?: PluginInstallRecord;
+}): string | null {
+  if (params.previousRecord?.source !== "npm" || params.nextRecord?.source !== "npm") {
+    return null;
+  }
+  const previousInstallPath = params.previousRecord.installPath?.trim();
+  const nextInstallPath = params.nextRecord.installPath?.trim();
+  if (!previousInstallPath || !nextInstallPath) {
+    return null;
+  }
+  if (installPathsOverlap(previousInstallPath, nextInstallPath)) {
+    return null;
+  }
+
+  const plan = planPluginUninstall({
+    config: {
+      plugins: {
+        installs: {
+          [params.pluginId]: params.previousRecord,
+        },
+      },
+    } as OpenClawConfig,
+    pluginId: params.pluginId,
+    deleteFiles: true,
+  });
+  if (
+    !plan.ok ||
+    !plan.directoryRemoval ||
+    plan.directoryRemoval.cleanup?.kind !== "npm" ||
+    path.resolve(plan.directoryRemoval.target) !== path.resolve(previousInstallPath)
+  ) {
+    return null;
+  }
+  if (installPathsOverlap(plan.directoryRemoval.target, nextInstallPath)) {
+    return null;
+  }
+  return plan.directoryRemoval.target;
+}
+
+function resolveNpmInstallRecordPackageName(record: PluginInstallRecord): string | null {
+  if (record.source !== "npm" || !record.installPath?.trim()) {
+    return null;
+  }
+  return resolveRetainedManagedNpmInstallPackageInfo(record.installPath)?.packageName ?? null;
+}
+
+function findReplacementNpmRecordForRemovedRecord(params: {
+  previousRecord: PluginInstallRecord;
+  nextInstallRecords: Record<string, PluginInstallRecord>;
+}): PluginInstallRecord | null {
+  const previousPackageName = resolveNpmInstallRecordPackageName(params.previousRecord);
+  if (!previousPackageName) {
+    return null;
+  }
+  for (const nextRecord of Object.values(params.nextInstallRecords)) {
+    if (resolveNpmInstallRecordPackageName(nextRecord) === previousPackageName) {
+      return nextRecord;
+    }
+  }
+  return null;
+}
+
+async function markRetainedReplacedManagedNpmInstallRecords(params: {
+  previousInstallRecords: Record<string, PluginInstallRecord>;
+  nextInstallRecords: Record<string, PluginInstallRecord>;
+}): Promise<string[]> {
+  const createdMarkerPaths: string[] = [];
+  const markedPreviousPluginIds = new Set<string>();
+  const markReplacement = async (
+    pluginId: string,
+    previousRecord: PluginInstallRecord | undefined,
+    nextRecord: PluginInstallRecord | undefined,
+  ) => {
+    const packageDir = resolveRetainedManagedNpmInstallMarkerTarget({
+      pluginId,
+      previousRecord,
+      nextRecord,
+    });
+    if (!packageDir) {
+      return;
+    }
+    const markerPath = resolveRetainedManagedNpmInstallMarkerPath(packageDir);
+    const markerAlreadyExisted = fs.existsSync(markerPath);
+    const marked = await markRetainedManagedNpmInstall({
+      packageDir,
+      pluginId,
+      reason: "replaced-by-managed-npm-generation-update",
+    });
+    if (marked && !markerAlreadyExisted) {
+      createdMarkerPaths.push(markerPath);
+    }
+    markedPreviousPluginIds.add(pluginId);
+  };
+
+  for (const [pluginId, nextRecord] of Object.entries(params.nextInstallRecords)) {
+    await markReplacement(pluginId, params.previousInstallRecords[pluginId], nextRecord);
+  }
+  for (const [pluginId, previousRecord] of Object.entries(params.previousInstallRecords)) {
+    if (markedPreviousPluginIds.has(pluginId) || params.nextInstallRecords[pluginId]) {
+      continue;
+    }
+    await markReplacement(
+      pluginId,
+      previousRecord,
+      findReplacementNpmRecordForRemovedRecord({
+        previousRecord,
+        nextInstallRecords: params.nextInstallRecords,
+      }) ?? undefined,
+    );
+  }
+  return createdMarkerPaths;
+}
+
+async function removeCreatedRetainedManagedNpmInstallMarkers(markerPaths: string[]): Promise<void> {
+  for (const markerPath of markerPaths) {
+    await fs.promises.rm(markerPath, { force: true });
+  }
+}
+
+async function clearActiveRetainedManagedNpmInstallMarkers(
+  nextInstallRecords: Record<string, PluginInstallRecord>,
+): Promise<Array<{ markerPath: string; contents: string }>> {
+  const clearedMarkers: Array<{ markerPath: string; contents: string }> = [];
+  for (const record of Object.values(nextInstallRecords)) {
+    if (record.source !== "npm" || !record.installPath?.trim()) {
+      continue;
+    }
+    let markerPath: string;
+    try {
+      markerPath = resolveRetainedManagedNpmInstallMarkerPath(record.installPath);
+    } catch {
+      continue;
+    }
+    let contents: string;
+    try {
+      contents = await fs.promises.readFile(markerPath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+    const cleared = await clearRetainedManagedNpmInstallMarker(record.installPath);
+    if (cleared) {
+      clearedMarkers.push({ markerPath, contents });
+    }
+  }
+  return clearedMarkers;
+}
+
+async function restoreClearedRetainedManagedNpmInstallMarkers(
+  markerSnapshots: Array<{ markerPath: string; contents: string }>,
+): Promise<void> {
+  for (const snapshot of markerSnapshots) {
+    await fs.promises.mkdir(path.dirname(snapshot.markerPath), { recursive: true });
+    await fs.promises.writeFile(snapshot.markerPath, snapshot.contents, "utf8");
+  }
+}
+
 async function commitPluginInstallRecordsWithWriter(params: {
   previousInstallRecords?: Record<string, PluginInstallRecord>;
   nextInstallRecords: Record<string, PluginInstallRecord>;
@@ -98,31 +280,48 @@ async function commitPluginInstallRecordsWithWriter(params: {
 }): Promise<ConfigReplaceResult | void> {
   const previousInstallRecords =
     params.previousInstallRecords ?? (await loadInstalledPluginIndexInstallRecords());
-  await writePersistedInstalledPluginIndexInstallRecords(params.nextInstallRecords);
+  const retainedMarkerPaths: string[] = [];
+  const clearedMarkerSnapshots: Array<{ markerPath: string; contents: string }> = [];
   try {
-    const installRecordsChanged = !isDeepStrictEqual(
-      previousInstallRecords,
-      params.nextInstallRecords,
-    );
-    return await params.commit(params.nextConfig, {
-      ...params.writeOptions,
-      ...(installRecordsChanged && params.writeOptions?.afterWrite === undefined
-        ? { afterWrite: { mode: "restart", reason: PLUGIN_SOURCE_CHANGED_RESTART_REASON } }
-        : {}),
-      unsetPaths: mergeUnsetPaths(params.writeOptions?.unsetPaths, [
-        Array.from(PLUGIN_INSTALLS_CONFIG_PATH),
-      ]),
-    });
-  } catch (error) {
+    await writePersistedInstalledPluginIndexInstallRecords(params.nextInstallRecords);
     try {
-      // Keep config and install index atomic from the caller's perspective.
-      await writePersistedInstalledPluginIndexInstallRecords(previousInstallRecords);
-    } catch (rollbackError) {
-      throw new Error(
-        "Failed to commit plugin install records and could not restore the previous plugin index",
-        { cause: rollbackError },
+      retainedMarkerPaths.push(
+        ...(await markRetainedReplacedManagedNpmInstallRecords({
+          previousInstallRecords,
+          nextInstallRecords: params.nextInstallRecords,
+        })),
       );
+      clearedMarkerSnapshots.push(
+        ...(await clearActiveRetainedManagedNpmInstallMarkers(params.nextInstallRecords)),
+      );
+      const installRecordsChanged = !isDeepStrictEqual(
+        previousInstallRecords,
+        params.nextInstallRecords,
+      );
+      return await params.commit(params.nextConfig, {
+        ...params.writeOptions,
+        ...(installRecordsChanged && params.writeOptions?.afterWrite === undefined
+          ? { afterWrite: { mode: "restart", reason: PLUGIN_SOURCE_CHANGED_RESTART_REASON } }
+          : {}),
+        unsetPaths: mergeUnsetPaths(params.writeOptions?.unsetPaths, [
+          Array.from(PLUGIN_INSTALLS_CONFIG_PATH),
+        ]),
+      });
+    } catch (error) {
+      try {
+        // Keep config and install index atomic from the caller's perspective.
+        await writePersistedInstalledPluginIndexInstallRecords(previousInstallRecords);
+      } catch (rollbackError) {
+        throw new Error(
+          "Failed to commit plugin install records and could not restore the previous plugin index",
+          { cause: rollbackError },
+        );
+      }
+      throw error;
     }
+  } catch (error) {
+    await restoreClearedRetainedManagedNpmInstallMarkers(clearedMarkerSnapshots);
+    await removeCreatedRetainedManagedNpmInstallMarkers(retainedMarkerPaths);
     throw error;
   }
 }

--- a/src/commands/doctor-plugin-registry.test.ts
+++ b/src/commands/doctor-plugin-registry.test.ts
@@ -10,6 +10,7 @@ import {
   writePersistedInstalledPluginIndex,
 } from "../plugins/installed-plugin-index-store.js";
 import type { InstalledPluginIndex } from "../plugins/installed-plugin-index.js";
+import { markRetainedManagedNpmInstall } from "../plugins/managed-npm-retention.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
 import { maybeRepairPluginRegistryState } from "./doctor-plugin-registry.js";
 import { DISABLE_PLUGIN_REGISTRY_MIGRATION_ENV } from "./doctor/shared/plugin-registry-migration.js";
@@ -429,6 +430,55 @@ describe("maybeRepairPluginRegistryState", () => {
       }),
     ]);
     expect(vi.mocked(note).mock.calls.join("\n")).toContain(
+      "Removed stale managed npm plugin package",
+    );
+  });
+
+  it("does not remove retained managed npm packages during stale bundled repair", async () => {
+    const stateDir = makeTempDir();
+    const bundledDir = path.join(stateDir, "bundled", "google-meet");
+    fs.mkdirSync(bundledDir, { recursive: true });
+    const managed = createManagedNpmPlugin({
+      stateDir,
+      id: "google-meet",
+      packageName: "@openclaw/google-meet",
+      version: "2026.5.2",
+    });
+    await markRetainedManagedNpmInstall({
+      packageDir: managed.packageDir,
+      pluginId: "google-meet",
+      retainedAt: "2026-04-25T00:00:00.000Z",
+      reason: "test-retained-generation",
+    });
+    await writePersistedInstalledPluginIndex(createCurrentIndex(), { stateDir });
+
+    await maybeRepairPluginRegistryState({
+      stateDir,
+      candidates: [
+        createBundledCandidate({
+          rootDir: bundledDir,
+          id: "google-meet",
+          packageName: "@openclaw/google-meet",
+          version: "2026.5.3",
+        }),
+      ],
+      env: hermeticEnv(),
+      config: {
+        plugins: {
+          allow: ["google-meet"],
+          entries: {
+            "google-meet": {
+              enabled: true,
+              config: {},
+            },
+          },
+        },
+      },
+      prompter: { shouldRepair: true },
+    });
+
+    expect(fs.existsSync(managed.packageDir)).toBe(true);
+    expect(vi.mocked(note).mock.calls.join("\n")).not.toContain(
       "Removed stale managed npm plugin package",
     );
   });

--- a/src/commands/doctor-plugin-registry.ts
+++ b/src/commands/doctor-plugin-registry.ts
@@ -14,6 +14,7 @@ import {
   type InstalledPluginIndexRecordStoreOptions,
 } from "../plugins/installed-plugin-index-records.js";
 import { loadInstalledPluginIndex } from "../plugins/installed-plugin-index.js";
+import { hasRetainedManagedNpmInstallMarker } from "../plugins/managed-npm-retention.js";
 import { listManagedPluginNpmRootsSync } from "../plugins/npm-project-roots.js";
 import {
   auditOpenClawPeerDependenciesInManagedNpmRoot,
@@ -126,6 +127,9 @@ function listStaleManagedNpmBundledPlugins(
         continue;
       }
       const packageDir = path.join(npmRoot, "node_modules", ...packageName.split("/"));
+      if (hasRetainedManagedNpmInstallMarker(packageDir)) {
+        continue;
+      }
       const pluginId = readPluginManifestId(packageDir);
       if (!pluginId || pluginId !== bundled.pluginId) {
         continue;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -46,6 +46,8 @@ import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/di
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import type { PluginHookGatewayCronService } from "../plugins/hook-types.js";
+import { loadInstalledPluginIndexInstallRecordsSync } from "../plugins/installed-plugin-index-records.js";
+import { cleanupRetainedManagedNpmInstallGenerations } from "../plugins/managed-npm-retention.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import {
   pinActivePluginChannelRegistry,
@@ -551,6 +553,23 @@ export async function startGatewayServer(
   opts: GatewayServerOptions = {},
 ): Promise<GatewayServer> {
   normalizeStateDirEnv(process.env);
+  // runGatewayLoop calls this after closing the previous server on both fresh
+  // and in-process restarts, making retired plugin generations safe to remove.
+  try {
+    const installRecords = loadInstalledPluginIndexInstallRecordsSync();
+    const removedGenerations = await cleanupRetainedManagedNpmInstallGenerations({
+      activeInstallPaths: Object.values(installRecords).flatMap((record) =>
+        record.installPath ? [record.installPath] : [],
+      ),
+      onError: (error, projectRoot) =>
+        log.warn(`failed to clean retained npm generation ${projectRoot}: ${String(error)}`),
+    });
+    if (removedGenerations > 0) {
+      log.info(`cleaned ${removedGenerations} retained npm plugin generation(s)`);
+    }
+  } catch (error) {
+    log.warn(`retained npm generation cleanup unavailable: ${String(error)}`);
+  }
   const { bootstrapGatewayNetworkRuntime } = await import("./server-network-runtime.js");
   bootstrapGatewayNetworkRuntime();
 

--- a/src/plugins/install-paths.ts
+++ b/src/plugins/install-paths.ts
@@ -120,6 +120,27 @@ export function resolvePluginNpmProjectDir(params: {
   );
 }
 
+const PLUGIN_NPM_GENERATION_PROJECT_SEPARATOR = "__openclaw-generation__";
+
+/** Resolves the managed npm artifact-generation project directory prefix for a package. */
+export function resolvePluginNpmGenerationProjectDirPrefix(packageName: string): string {
+  return `${encodePluginNpmProjectDirName(packageName)}${PLUGIN_NPM_GENERATION_PROJECT_SEPARATOR}`;
+}
+
+/** Resolves an artifact-generation-specific managed npm project directory. */
+export function resolvePluginNpmGenerationProjectDir(params: {
+  packageName: string;
+  generationKey: string;
+  npmDir?: string;
+}): string {
+  return path.join(
+    resolvePluginNpmProjectsDir(params.npmDir),
+    `${resolvePluginNpmGenerationProjectDirPrefix(params.packageName)}${safePathSegmentHashed(
+      params.generationKey,
+    )}`,
+  );
+}
+
 /** Resolves the installed node_modules package directory for a managed npm plugin. */
 export function resolvePluginNpmPackageDir(params: {
   packageName: string;

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -218,8 +218,12 @@ function writeInstalledNpmPlugin(params: {
   hoistedDependency?: { name: string; version: string };
   peerDependencies?: Record<string, string>;
   openclaw?: Record<string, unknown>;
+  replaceExisting?: boolean;
 }) {
   const pluginDir = path.join(params.npmRoot, "node_modules", params.packageName);
+  if (params.replaceExisting) {
+    fs.rmSync(pluginDir, { recursive: true, force: true });
+  }
   fs.mkdirSync(path.join(pluginDir, "dist"), { recursive: true });
   fs.writeFileSync(
     path.join(pluginDir, "package.json"),
@@ -302,6 +306,7 @@ type MockNpmPackage = {
   skipLockfileEntry?: boolean;
   packArchivePath?: string;
   packTarballName?: string;
+  replaceExisting?: boolean;
 };
 
 function writeNpmRootPackageLock(params: {
@@ -903,7 +908,7 @@ describe("installPluginFromNpmSpec", () => {
     });
   });
 
-  it("installs npm updates into artifact generations so stale dist imports remain available", async () => {
+  it("keeps lazy imports from a loaded old npm generation available across updates", async () => {
     const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
     const packageName = "@openclaw/codex";
     mockNpmViewAndInstall({
@@ -914,7 +919,10 @@ describe("installPluginFromNpmSpec", () => {
       npmRoot,
       integrity: "sha512-codex-v1",
       shasum: "codexv1sha",
-      indexJs: `require("./run-attempt-old.js");\nmodule.exports = { version: "v1" };\n`,
+      indexJs: `module.exports = {
+  version: "v1",
+  runAttempt: async () => (await import("./run-attempt-old.js")).default,
+};\n`,
       extraDistFiles: {
         "run-attempt-old.js": "module.exports = { chunk: 'old' };\n",
       },
@@ -933,6 +941,8 @@ describe("installPluginFromNpmSpec", () => {
     }
     const firstEntry = path.join(first.targetDir, "dist", "index.js");
     expect(first.targetDir).toBe(resolveTestPluginPackageDir(npmRoot, packageName));
+    const oldModule = await import(pathToFileURL(firstEntry).href);
+    expect(oldModule.default.version).toBe("v1");
 
     mockNpmViewAndInstall({
       spec: `${packageName}@2.0.0`,
@@ -942,10 +952,14 @@ describe("installPluginFromNpmSpec", () => {
       npmRoot,
       integrity: "sha512-codex-v2",
       shasum: "codexv2sha",
-      indexJs: `require("./run-attempt-new.js");\nmodule.exports = { version: "v2" };\n`,
+      indexJs: `module.exports = {
+  version: "v2",
+  runAttempt: async () => (await import("./run-attempt-new.js")).default,
+};\n`,
       extraDistFiles: {
         "run-attempt-new.js": "module.exports = { chunk: 'new' };\n",
       },
+      replaceExisting: true,
       expectedDependencySpec: "2.0.0",
     });
 
@@ -978,8 +992,11 @@ describe("installPluginFromNpmSpec", () => {
     expect(fs.existsSync(path.join(first.targetDir, "dist", "run-attempt-old.js"))).toBe(true);
     expect(fs.existsSync(path.join(update.targetDir, "dist", "run-attempt-new.js"))).toBe(true);
 
-    const oldModule = await import(pathToFileURL(firstEntry).href);
-    expect(oldModule.default).toEqual({ version: "v1" });
+    await expect(oldModule.default.runAttempt()).resolves.toEqual({ chunk: "old" });
+    const newModule = await import(
+      pathToFileURL(path.join(update.targetDir, "dist", "index.js")).href
+    );
+    await expect(newModule.default.runAttempt()).resolves.toEqual({ chunk: "new" });
   });
 
   it("installs into a fresh generation when the legacy npm target is retained", async () => {

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -1,12 +1,20 @@
 // Covers npm spec parsing for plugin install inputs.
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   expectIntegrityDriftRejected,
   mockNpmViewMetadataResult,
 } from "../test-utils/npm-spec-install-test-helpers.js";
-import { resolvePluginNpmProjectDir } from "./install-paths.js";
+import {
+  resolvePluginNpmGenerationProjectDir,
+  resolvePluginNpmProjectDir,
+} from "./install-paths.js";
+import {
+  hasRetainedManagedNpmInstallMarker,
+  markRetainedManagedNpmInstall,
+} from "./managed-npm-retention.js";
 import { createSuiteTempRootTracker } from "./test-helpers/fs-fixtures.js";
 
 const runCommandWithTimeoutMock = vi.fn();
@@ -165,12 +173,47 @@ function resolveTestPluginPackageDir(npmRoot: string, packageName: string): stri
   );
 }
 
+function resolveTestPluginGenerationProjectDir(params: {
+  npmRoot: string;
+  packageName: string;
+  version: string;
+  integrity?: string;
+  shasum?: string;
+}): string {
+  return resolvePluginNpmGenerationProjectDir({
+    npmDir: params.npmRoot,
+    packageName: params.packageName,
+    generationKey: [
+      params.packageName,
+      params.version,
+      `${params.packageName}@${params.version}`,
+      params.integrity ?? "sha512-plugin-test",
+      params.shasum ?? "pluginshasum",
+    ].join("\n"),
+  });
+}
+
+function resolveTestPluginGenerationPackageDir(params: {
+  npmRoot: string;
+  packageName: string;
+  version: string;
+  integrity?: string;
+  shasum?: string;
+}): string {
+  return path.join(
+    resolveTestPluginGenerationProjectDir(params),
+    "node_modules",
+    ...params.packageName.split("/"),
+  );
+}
+
 function writeInstalledNpmPlugin(params: {
   npmRoot: string;
   packageName: string;
   version: string;
   pluginId?: string;
   indexJs?: string;
+  extraDistFiles?: Record<string, string>;
   dependency?: { name: string; version: string };
   hoistedDependency?: { name: string; version: string };
   peerDependencies?: Record<string, string>;
@@ -205,6 +248,11 @@ function writeInstalledNpmPlugin(params: {
     params.indexJs ?? "export {};",
     "utf-8",
   );
+  for (const [relativePath, contents] of Object.entries(params.extraDistFiles ?? {})) {
+    const targetPath = path.join(pluginDir, "dist", relativePath);
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.writeFileSync(targetPath, contents, "utf-8");
+  }
   if (params.dependency) {
     const depDir = path.join(pluginDir, "node_modules", params.dependency.name);
     fs.mkdirSync(depDir, { recursive: true });
@@ -241,6 +289,7 @@ type MockNpmPackage = {
   integrity?: string;
   shasum?: string;
   indexJs?: string;
+  extraDistFiles?: Record<string, string>;
   dependency?: { name: string; version: string };
   hoistedDependency?: { name: string; version: string };
   peerDependencies?: Record<string, string>;
@@ -358,26 +407,7 @@ function prunePluginLocalOpenClawPeerLinks(npmRoot: string) {
   }
 }
 
-function mockNpmViewAndInstall(params: {
-  spec: string;
-  packageName: string;
-  version: string;
-  npmRoot: string;
-  pluginId?: string;
-  integrity?: string;
-  shasum?: string;
-  indexJs?: string;
-  dependency?: { name: string; version: string };
-  hoistedDependency?: { name: string; version: string };
-  peerDependencies?: Record<string, string>;
-  openclaw?: Record<string, unknown>;
-  expectedDependencySpec?: string;
-  versions?: string[];
-  installedVersion?: string;
-  installedIntegrity?: string;
-  materializesRootOpenClaw?: boolean;
-  skipLockfileEntry?: boolean;
-}) {
+function mockNpmViewAndInstall(params: MockNpmPackage & { spec: string }) {
   mockNpmViewAndInstallMany([params]);
 }
 
@@ -801,7 +831,19 @@ describe("installPluginFromNpmSpec", () => {
     if (!update.ok) {
       return;
     }
-    expect(readTextFileTree(npmProjectRoot)).not.toEqual(projectBefore);
+    const updateGenerationRoot = resolvePluginNpmGenerationProjectDir({
+      npmDir: npmRoot,
+      packageName,
+      generationKey: [
+        packageName,
+        "2.0.0",
+        `${packageName}@2.0.0`,
+        "sha512-pack-demo-v2",
+        "packdemoshav2",
+      ].join("\n"),
+    });
+    expect(readTextFileTree(npmProjectRoot)).toEqual(projectBefore);
+    expect(readTextFileTree(updateGenerationRoot)).not.toEqual(projectBefore);
   });
 
   it("installs staged npm pack archives with dangerous-looking code", async () => {
@@ -859,6 +901,177 @@ describe("installPluginFromNpmSpec", () => {
       npmRoot,
       packageName: "@openclaw/voice-call",
     });
+  });
+
+  it("installs npm updates into artifact generations so stale dist imports remain available", async () => {
+    const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
+    const packageName = "@openclaw/codex";
+    mockNpmViewAndInstall({
+      spec: `${packageName}@1.0.0`,
+      packageName,
+      version: "1.0.0",
+      pluginId: "codex",
+      npmRoot,
+      integrity: "sha512-codex-v1",
+      shasum: "codexv1sha",
+      indexJs: `require("./run-attempt-old.js");\nmodule.exports = { version: "v1" };\n`,
+      extraDistFiles: {
+        "run-attempt-old.js": "module.exports = { chunk: 'old' };\n",
+      },
+      expectedDependencySpec: "1.0.0",
+    });
+
+    const first = await installPluginFromNpmSpec({
+      spec: `${packageName}@1.0.0`,
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(first.ok).toBe(true);
+    if (!first.ok) {
+      return;
+    }
+    const firstEntry = path.join(first.targetDir, "dist", "index.js");
+    expect(first.targetDir).toBe(resolveTestPluginPackageDir(npmRoot, packageName));
+
+    mockNpmViewAndInstall({
+      spec: `${packageName}@2.0.0`,
+      packageName,
+      version: "2.0.0",
+      pluginId: "codex",
+      npmRoot,
+      integrity: "sha512-codex-v2",
+      shasum: "codexv2sha",
+      indexJs: `require("./run-attempt-new.js");\nmodule.exports = { version: "v2" };\n`,
+      extraDistFiles: {
+        "run-attempt-new.js": "module.exports = { chunk: 'new' };\n",
+      },
+      expectedDependencySpec: "2.0.0",
+    });
+
+    const update = await installPluginFromNpmSpec({
+      spec: `${packageName}@2.0.0`,
+      npmDir: npmRoot,
+      mode: "update",
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(update.ok).toBe(true);
+    if (!update.ok) {
+      return;
+    }
+    const updateGenerationRoot = resolvePluginNpmGenerationProjectDir({
+      npmDir: npmRoot,
+      packageName,
+      generationKey: [
+        packageName,
+        "2.0.0",
+        `${packageName}@2.0.0`,
+        "sha512-codex-v2",
+        "codexv2sha",
+      ].join("\n"),
+    });
+    expect(update.targetDir).toBe(
+      path.join(updateGenerationRoot, "node_modules", ...packageName.split("/")),
+    );
+    expect(update.targetDir).not.toBe(first.targetDir);
+    expect(fs.existsSync(path.join(first.targetDir, "dist", "run-attempt-old.js"))).toBe(true);
+    expect(fs.existsSync(path.join(update.targetDir, "dist", "run-attempt-new.js"))).toBe(true);
+
+    const oldModule = await import(pathToFileURL(firstEntry).href);
+    expect(oldModule.default).toEqual({ version: "v1" });
+  });
+
+  it("installs into a fresh generation when the legacy npm target is retained", async () => {
+    const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
+    const packageName = "@openclaw/codex";
+    const legacyPackageDir = resolveTestPluginPackageDir(npmRoot, packageName);
+    fs.mkdirSync(legacyPackageDir, { recursive: true });
+    await markRetainedManagedNpmInstall({
+      packageDir: legacyPackageDir,
+      pluginId: "codex",
+      retainedAt: "2026-04-25T00:00:00.000Z",
+      reason: "replaced-by-managed-npm-generation-update",
+    });
+    mockNpmViewAndInstall({
+      spec: `${packageName}@2.0.0`,
+      packageName,
+      version: "2.0.0",
+      pluginId: "codex",
+      npmRoot,
+      integrity: "sha512-codex-v2",
+      shasum: "codexv2sha",
+      expectedDependencySpec: "2.0.0",
+    });
+
+    const result = await installPluginFromNpmSpec({
+      spec: `${packageName}@2.0.0`,
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.targetDir).toBe(
+      resolveTestPluginGenerationPackageDir({
+        npmRoot,
+        packageName,
+        version: "2.0.0",
+        integrity: "sha512-codex-v2",
+        shasum: "codexv2sha",
+      }),
+    );
+    expect(result.targetDir).not.toBe(legacyPackageDir);
+    expect(fs.existsSync(legacyPackageDir)).toBe(true);
+  });
+
+  it("allows plain installs to reactivate an existing retained generation", async () => {
+    const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
+    const packageName = "@openclaw/codex";
+    const legacyPackageDir = resolveTestPluginPackageDir(npmRoot, packageName);
+    const retainedGenerationPackageDir = resolveTestPluginGenerationPackageDir({
+      npmRoot,
+      packageName,
+      version: "2.0.0",
+      integrity: "sha512-codex-v2",
+      shasum: "codexv2sha",
+    });
+    fs.mkdirSync(legacyPackageDir, { recursive: true });
+    fs.mkdirSync(retainedGenerationPackageDir, { recursive: true });
+    for (const packageDir of [legacyPackageDir, retainedGenerationPackageDir]) {
+      await markRetainedManagedNpmInstall({
+        packageDir,
+        pluginId: "codex",
+        retainedAt: "2026-04-25T00:00:00.000Z",
+        reason: "test-retained-generation",
+      });
+    }
+    mockNpmViewAndInstall({
+      spec: `${packageName}@2.0.0`,
+      packageName,
+      version: "2.0.0",
+      pluginId: "codex",
+      npmRoot,
+      integrity: "sha512-codex-v2",
+      shasum: "codexv2sha",
+      expectedDependencySpec: "2.0.0",
+    });
+
+    const result = await installPluginFromNpmSpec({
+      spec: `${packageName}@2.0.0`,
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.targetDir).toBe(retainedGenerationPackageDir);
+    expect(hasRetainedManagedNpmInstallMarker(retainedGenerationPackageDir)).toBe(true);
+    expect(hasRetainedManagedNpmInstallMarker(legacyPackageDir)).toBe(true);
   });
 
   it("pins mutable npm specs to the verified resolved version", async () => {
@@ -1319,7 +1532,9 @@ describe("installPluginFromNpmSpec", () => {
     if (!result.ok) {
       expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
       expect(result.error).toContain('blocked dependencies "plain-crypto-js" as package name');
-      expect(result.error).toContain("node_modules/plain-crypto-js/package.json");
+      expect(result.error.replaceAll("\\", "/")).toContain(
+        "node_modules/plain-crypto-js/package.json",
+      );
     }
   });
 
@@ -2504,10 +2719,13 @@ describe("installPluginFromNpmSpec", () => {
     if (!result.ok) {
       return;
     }
-    expectNpmInstallIntoProject({
+    expectNpmInstallIntoRoot({
       calls: runCommandWithTimeoutMock.mock.calls,
-      npmRoot,
-      packageName: "dangerous-plugin",
+      npmRoot: resolveTestPluginGenerationProjectDir({
+        npmRoot,
+        packageName: "dangerous-plugin",
+        version: "2.0.0",
+      }),
     });
     expect(fs.readFileSync(path.join(npmRoot, "package.json"), "utf8")).toBe(legacyManifestBefore);
     expect(fs.readFileSync(path.join(npmRoot, "package-lock.json"), "utf8")).toBe(
@@ -2679,12 +2897,22 @@ describe("installPluginFromNpmSpec", () => {
     if (!result.ok) {
       throw new Error(result.error);
     }
-    expect(result.targetDir).toBe(installRoot);
+    expect(result.targetDir).toBe(
+      resolveTestPluginGenerationPackageDir({
+        npmRoot,
+        packageName: "@openclaw/voice-call",
+        version: "0.0.2",
+      }),
+    );
+    expect(fs.existsSync(path.join(installRoot, "old.txt"))).toBe(true);
     expect(result.npmResolution?.version).toBe("0.0.2");
-    expectNpmInstallIntoProject({
+    expectNpmInstallIntoRoot({
       calls: runCommandWithTimeoutMock.mock.calls,
-      npmRoot,
-      packageName: "@openclaw/voice-call",
+      npmRoot: resolveTestPluginGenerationProjectDir({
+        npmRoot,
+        packageName: "@openclaw/voice-call",
+        version: "0.0.2",
+      }),
     });
   });
 

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -999,6 +999,89 @@ describe("installPluginFromNpmSpec", () => {
     await expect(newModule.default.runAttempt()).resolves.toEqual({ chunk: "new" });
   });
 
+  it("does not mutate a retained generation when an exact rollback reuses its artifact key", async () => {
+    const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
+    const packageName = "@openclaw/codex";
+    const install = async (version: string, options: { mode?: "update" }) =>
+      installPluginFromNpmSpec({
+        spec: `${packageName}@${version}`,
+        npmDir: npmRoot,
+        mode: options.mode,
+        logger: { info: () => {}, warn: () => {} },
+      });
+
+    mockNpmViewAndInstall({
+      spec: `${packageName}@2.0.0`,
+      packageName,
+      version: "2.0.0",
+      pluginId: "codex",
+      npmRoot,
+      integrity: "sha512-codex-v2",
+      shasum: "codexv2sha",
+      indexJs: `module.exports = {
+  version: "v2",
+  runAttempt: async () => (await import("./run-attempt-v2.js")).default,
+};\n`,
+      extraDistFiles: {
+        "run-attempt-v2.js": "module.exports = { chunk: 'v2' };\n",
+      },
+      expectedDependencySpec: "2.0.0",
+    });
+    const first = await install("2.0.0", {});
+    expect(first.ok).toBe(true);
+    if (!first.ok) {
+      return;
+    }
+    const retainedModule = await import(
+      pathToFileURL(path.join(first.targetDir, "dist", "index.js")).href
+    );
+    const retainedPackageDir = first.targetDir;
+
+    mockNpmViewAndInstall({
+      spec: `${packageName}@3.0.0`,
+      packageName,
+      version: "3.0.0",
+      pluginId: "codex",
+      npmRoot,
+      integrity: "sha512-codex-v3",
+      shasum: "codexv3sha",
+      indexJs: "module.exports = { version: 'v3' };\n",
+      replaceExisting: true,
+      expectedDependencySpec: "3.0.0",
+    });
+    const update = await install("3.0.0", { mode: "update" });
+    expect(update.ok).toBe(true);
+    if (!update.ok) {
+      return;
+    }
+    await markRetainedManagedNpmInstall({
+      packageDir: retainedPackageDir,
+      pluginId: "codex",
+      reason: "test-rollback-retention",
+    });
+
+    mockNpmViewAndInstall({
+      spec: `${packageName}@2.0.0`,
+      packageName,
+      version: "2.0.0",
+      pluginId: "codex",
+      npmRoot,
+      integrity: "sha512-codex-v2",
+      shasum: "codexv2sha",
+      indexJs: "module.exports = { version: 'v2-rollback' };\n",
+      replaceExisting: true,
+      expectedDependencySpec: "2.0.0",
+    });
+    const rollback = await install("2.0.0", { mode: "update" });
+    expect(rollback.ok).toBe(true);
+    if (!rollback.ok) {
+      return;
+    }
+    expect(rollback.targetDir).not.toBe(retainedPackageDir);
+    await expect(retainedModule.default.runAttempt()).resolves.toEqual({ chunk: "v2" });
+    expect(fs.existsSync(path.join(retainedPackageDir, "dist", "run-attempt-v2.js"))).toBe(true);
+  });
+
   it("installs into a fresh generation when the legacy npm target is retained", async () => {
     const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
     const packageName = "@openclaw/codex";
@@ -1044,7 +1127,7 @@ describe("installPluginFromNpmSpec", () => {
     expect(fs.existsSync(legacyPackageDir)).toBe(true);
   });
 
-  it("allows plain installs to reactivate an existing retained generation", async () => {
+  it("allocates a fresh generation when a plain install selects a retained artifact", async () => {
     const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
     const packageName = "@openclaw/codex";
     const legacyPackageDir = resolveTestPluginPackageDir(npmRoot, packageName);
@@ -1086,7 +1169,8 @@ describe("installPluginFromNpmSpec", () => {
     if (!result.ok) {
       return;
     }
-    expect(result.targetDir).toBe(retainedGenerationPackageDir);
+    expect(result.targetDir).not.toBe(retainedGenerationPackageDir);
+    expect(hasRetainedManagedNpmInstallMarker(result.targetDir)).toBe(false);
     expect(hasRetainedManagedNpmInstallMarker(retainedGenerationPackageDir)).toBe(true);
     expect(hasRetainedManagedNpmInstallMarker(legacyPackageDir)).toBe(true);
   });

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -14,6 +14,10 @@ import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { initializeGlobalHookRunner, resetGlobalHookRunner } from "./hook-runner-global.js";
 import { createMockPluginRegistry } from "./hooks.test-helpers.js";
+import {
+  resolvePluginNpmGenerationProjectDir,
+  resolvePluginNpmProjectDir,
+} from "./install-paths.js";
 import * as installSecurityScan from "./install-security-scan.js";
 import {
   installPluginFromArchive,
@@ -24,6 +28,7 @@ import {
   PLUGIN_INSTALL_ERROR_CODE,
   resolvePluginInstallDir,
 } from "./install.js";
+import { markRetainedManagedNpmInstall } from "./managed-npm-retention.js";
 import { packToArchive } from "./test-helpers/archive-fixtures.js";
 import { createSuiteTempRootTracker } from "./test-helpers/fs-fixtures.js";
 import {
@@ -1999,7 +2004,7 @@ describe("installPluginFromArchive", () => {
       expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
       expect(result.error).toContain('Bundle "denied-dependency-bundle" installation blocked');
       expect(result.error).toContain('"plain-crypto-js" as package name');
-      expect(result.error).toContain("vendor/plain-crypto-js/package.json");
+      expect(result.error.replaceAll("\\", "/")).toContain("vendor/plain-crypto-js/package.json");
     }
     expect(warnings.some((warning) => warning.includes('"plain-crypto-js" as package name'))).toBe(
       true,
@@ -2579,12 +2584,14 @@ describe("installPluginFromNpmSpec", () => {
       ]),
     });
     mockSuccessfulManagedNpmInstall({ packageName, version: "1.2.3" });
-    const scanSpy = vi.spyOn(installSecurityScan, "scanPackageInstallSource").mockResolvedValueOnce({
-      blocked: {
-        code: "security_scan_blocked",
-        reason: "blocked by package scan",
-      },
-    });
+    const scanSpy = vi
+      .spyOn(installSecurityScan, "scanPackageInstallSource")
+      .mockResolvedValueOnce({
+        blocked: {
+          code: "security_scan_blocked",
+          reason: "blocked by package scan",
+        },
+      });
     const captured = captureSecurityEvents();
 
     let result: Awaited<ReturnType<typeof installPluginFromNpmPackArchive>>;
@@ -2730,6 +2737,204 @@ describe("installPluginFromNpmSpec", () => {
       expect(result.error).toContain("fresh npm installs are disabled by policy");
     }
     expect(vi.mocked(runCommandWithTimeout)).toHaveBeenCalledTimes(1);
+    const requests = readCapturedInstallPolicyRequests(logPath);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.request.mode).toBe("install");
+    expect(requests[0]?.request.kind).toBe("plugin-npm");
+  });
+
+  it("does not treat similarly named npm projects as update generations", async () => {
+    const root = suiteTempRootTracker.makeTempDir();
+    const npmDir = path.join(root, "npm");
+    const extensionsDir = path.join(root, "extensions");
+    const packageName = "foo";
+    const legacyProjectRoot = resolvePluginNpmProjectDir({ npmDir, packageName });
+    const unrelatedProjectRoot = path.join(
+      path.dirname(legacyProjectRoot),
+      `${path.basename(legacyProjectRoot)}-unrelated`,
+    );
+    const unrelatedDependencyDir = path.join(unrelatedProjectRoot, "node_modules", packageName);
+    fs.mkdirSync(unrelatedDependencyDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(unrelatedDependencyDir, "package.json"),
+      JSON.stringify({ name: packageName, version: "0.9.0" }),
+      "utf8",
+    );
+    const { scriptPath, logPath } = writeInstallOnlyBlockingPolicyScript(root);
+    mockNpmViewMetadata({ name: packageName, version: "1.0.0" });
+    mockSuccessfulManagedNpmInstall({ packageName, version: "1.0.0" });
+
+    const result = await installPluginFromNpmSpec({
+      spec: `${packageName}@1.0.0`,
+      extensionsDir,
+      npmDir,
+      config: configWithInstallPolicy(scriptPath, logPath),
+      mode: "update",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code, result.error).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain("fresh npm installs are disabled by policy");
+    }
+    const requests = readCapturedInstallPolicyRequests(logPath);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.request.mode).toBe("install");
+  });
+
+  it("reports update mode to policy when npm update installs a new artifact generation", async () => {
+    const root = suiteTempRootTracker.makeTempDir();
+    const npmDir = path.join(root, "npm");
+    const extensionsDir = path.join(root, "extensions");
+    const packageName = "@acme/policy-generation-plugin";
+    const existingProjectRoot = resolvePluginNpmProjectDir({ npmDir, packageName });
+    const existingPackageDir = path.join(
+      existingProjectRoot,
+      "node_modules",
+      ...packageName.split("/"),
+    );
+    fs.mkdirSync(existingPackageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(existingPackageDir, "package.json"),
+      JSON.stringify({
+        name: packageName,
+        version: "0.9.0",
+        openclaw: { extensions: ["index.js"] },
+      }),
+    );
+    fs.writeFileSync(path.join(existingPackageDir, "index.js"), "export {};\n");
+    const { scriptPath, logPath } = writeInstallOnlyBlockingPolicyScript(root);
+    mockNpmViewMetadata({ name: packageName, version: "1.2.3" });
+    mockSuccessfulManagedNpmInstall({ packageName, version: "1.2.3" });
+    const captured = captureSecurityEvents();
+
+    let result: Awaited<ReturnType<typeof installPluginFromNpmSpec>>;
+    try {
+      result = await installPluginFromNpmSpec({
+        spec: `${packageName}@1.2.3`,
+        extensionsDir,
+        npmDir,
+        config: configWithInstallPolicy(scriptPath, logPath),
+        mode: "update",
+      });
+    } finally {
+      captured.stop();
+    }
+
+    expect(result!.ok).toBe(true);
+    if (!result!.ok) {
+      return;
+    }
+    expect(result.targetDir).not.toBe(existingPackageDir);
+    const requests = readCapturedInstallPolicyRequests(logPath);
+    expect(requests.length).toBeGreaterThan(0);
+    expect(requests.map((request) => request.request.mode)).toEqual(requests.map(() => "update"));
+    expect(captured.events).toHaveLength(1);
+    expect(captured.events[0]).toMatchObject({
+      action: "plugin.updated",
+      outcome: "success",
+      target: { kind: "plugin", name: packageName },
+      attributes: {
+        source_family: "npm",
+        mode: "update",
+      },
+    });
+  });
+
+  it("reports install mode to policy when a retained npm legacy target needs a new generation", async () => {
+    const root = suiteTempRootTracker.makeTempDir();
+    const npmDir = path.join(root, "npm");
+    const extensionsDir = path.join(root, "extensions");
+    const packageName = "@acme/policy-generation-plugin";
+    const legacyProjectRoot = resolvePluginNpmProjectDir({ npmDir, packageName });
+    const legacyPackageDir = path.join(
+      legacyProjectRoot,
+      "node_modules",
+      ...packageName.split("/"),
+    );
+    fs.mkdirSync(legacyPackageDir, { recursive: true });
+    await markRetainedManagedNpmInstall({
+      packageDir: legacyPackageDir,
+      pluginId: "policy-generation-plugin",
+      retainedAt: "2026-04-25T00:00:00.000Z",
+      reason: "test-retained-generation",
+    });
+    const { scriptPath, logPath } = writeInstallOnlyBlockingPolicyScript(root);
+    mockNpmViewMetadata({ name: packageName, version: "1.2.3" });
+
+    const result = await installPluginFromNpmSpec({
+      spec: `${packageName}@1.2.3`,
+      extensionsDir,
+      npmDir,
+      config: configWithInstallPolicy(scriptPath, logPath),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code, result.error).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain("fresh npm installs are disabled by policy");
+    }
+    const requests = readCapturedInstallPolicyRequests(logPath);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.request.mode).toBe("install");
+    expect(requests[0]?.request.kind).toBe("plugin-npm");
+  });
+
+  it("reports install mode to policy when update-mode reactivates retained-only generations", async () => {
+    const root = suiteTempRootTracker.makeTempDir();
+    const npmDir = path.join(root, "npm");
+    const extensionsDir = path.join(root, "extensions");
+    const packageName = "@acme/policy-generation-plugin";
+    const legacyProjectRoot = resolvePluginNpmProjectDir({ npmDir, packageName });
+    const generationProjectRoot = resolvePluginNpmGenerationProjectDir({
+      npmDir,
+      packageName,
+      generationKey: [
+        packageName,
+        "1.2.3",
+        `${packageName}@1.2.3`,
+        "sha512-plugin-test",
+        "pluginshasum",
+      ].join("\n"),
+    });
+    const legacyPackageDir = path.join(
+      legacyProjectRoot,
+      "node_modules",
+      ...packageName.split("/"),
+    );
+    const generationPackageDir = path.join(
+      generationProjectRoot,
+      "node_modules",
+      ...packageName.split("/"),
+    );
+    for (const packageDir of [legacyPackageDir, generationPackageDir]) {
+      fs.mkdirSync(packageDir, { recursive: true });
+      await markRetainedManagedNpmInstall({
+        packageDir,
+        pluginId: "policy-generation-plugin",
+        retainedAt: "2026-04-25T00:00:00.000Z",
+        reason: "test-retained-generation",
+      });
+    }
+    const { scriptPath, logPath } = writeInstallOnlyBlockingPolicyScript(root);
+    mockNpmViewMetadata({
+      name: packageName,
+      version: "1.2.3",
+    });
+
+    const result = await installPluginFromNpmSpec({
+      spec: `${packageName}@1.2.3`,
+      extensionsDir,
+      npmDir,
+      config: configWithInstallPolicy(scriptPath, logPath),
+      mode: "update",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code, result.error).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain("fresh npm installs are disabled by policy");
+    }
     const requests = readCapturedInstallPolicyRequests(logPath);
     expect(requests).toHaveLength(1);
     expect(requests[0]?.request.mode).toBe("install");
@@ -3014,7 +3219,9 @@ describe("installPluginFromDir", () => {
     if (!result.ok) {
       expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
       expect(result.error).toContain('blocked dependencies "plain-crypto-js" as package name');
-      expect(result.error).toContain("node_modules/plain-crypto-js/package.json");
+      expect(result.error.replaceAll("\\", "/")).toContain(
+        "node_modules/plain-crypto-js/package.json",
+      );
     }
     expect(captured.events).toHaveLength(1);
     expect(captured.events[0]).toMatchObject({

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -2880,7 +2880,7 @@ describe("installPluginFromNpmSpec", () => {
     expect(requests[0]?.request.kind).toBe("plugin-npm");
   });
 
-  it("reports install mode to policy when update-mode reactivates retained-only generations", async () => {
+  it("reports install mode to policy when update-mode reactivates retained generations", async () => {
     const root = suiteTempRootTracker.makeTempDir();
     const npmDir = path.join(root, "npm");
     const extensionsDir = path.join(root, "extensions");
@@ -2889,12 +2889,19 @@ describe("installPluginFromNpmSpec", () => {
     const generationProjectRoot = resolvePluginNpmGenerationProjectDir({
       npmDir,
       packageName,
+      generationKey: [packageName, "1.2.3", `${packageName}@1.2.3`, "sha512-test", "abc123"].join(
+        "\n",
+      ),
+    });
+    const activeGenerationProjectRoot = resolvePluginNpmGenerationProjectDir({
+      npmDir,
+      packageName,
       generationKey: [
         packageName,
-        "1.2.3",
-        `${packageName}@1.2.3`,
-        "sha512-plugin-test",
-        "pluginshasum",
+        "2.0.0",
+        `${packageName}@2.0.0`,
+        "sha512-active",
+        "active123",
       ].join("\n"),
     });
     const legacyPackageDir = path.join(
@@ -2907,6 +2914,11 @@ describe("installPluginFromNpmSpec", () => {
       "node_modules",
       ...packageName.split("/"),
     );
+    const activeGenerationPackageDir = path.join(
+      activeGenerationProjectRoot,
+      "node_modules",
+      ...packageName.split("/"),
+    );
     for (const packageDir of [legacyPackageDir, generationPackageDir]) {
       fs.mkdirSync(packageDir, { recursive: true });
       await markRetainedManagedNpmInstall({
@@ -2916,6 +2928,7 @@ describe("installPluginFromNpmSpec", () => {
         reason: "test-retained-generation",
       });
     }
+    fs.mkdirSync(activeGenerationPackageDir, { recursive: true });
     const { scriptPath, logPath } = writeInstallOnlyBlockingPolicyScript(root);
     mockNpmViewMetadata({
       name: packageName,

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -55,6 +55,8 @@ import {
   matchesExpectedPluginId,
   resolveDefaultPluginExtensionsDir,
   resolveDefaultPluginNpmDir,
+  resolvePluginNpmGenerationProjectDir,
+  resolvePluginNpmGenerationProjectDirPrefix,
   resolvePluginNpmProjectDir,
   safePluginInstallFileName,
   validatePluginId,
@@ -64,6 +66,7 @@ import {
   type InstallSecurityScanResult,
   type InstallSafetyOverrides,
 } from "./install-security-scan.js";
+import { hasRetainedManagedNpmInstallMarker } from "./managed-npm-retention.js";
 import {
   resolvePackageExtensionEntries,
   type OpenClawPackageManifest,
@@ -1099,6 +1102,104 @@ function resolveManagedNpmRootPackageDir(npmRoot: string, packageName: string): 
   return path.join(npmRoot, "node_modules", ...packageName.split("/"));
 }
 
+function resolveManagedNpmRootGenerationKey(params: {
+  packageName: string;
+  npmResolution: NpmSpecResolution;
+}): string {
+  return [
+    params.npmResolution.name ?? params.packageName,
+    params.npmResolution.version ?? "",
+    params.npmResolution.resolvedSpec ?? "",
+    params.npmResolution.integrity ?? "",
+    params.npmResolution.shasum ?? "",
+  ].join("\n");
+}
+
+function resolveManagedNpmRootForInstall(params: {
+  npmBaseDir: string;
+  packageName: string;
+  npmResolution: NpmSpecResolution;
+  useGeneration: boolean;
+}): string {
+  if (!params.useGeneration) {
+    return resolvePluginNpmProjectDir({
+      npmDir: params.npmBaseDir,
+      packageName: params.packageName,
+    });
+  }
+  return resolvePluginNpmGenerationProjectDir({
+    npmDir: params.npmBaseDir,
+    packageName: params.packageName,
+    generationKey: resolveManagedNpmRootGenerationKey({
+      packageName: params.packageName,
+      npmResolution: params.npmResolution,
+    }),
+  });
+}
+
+async function listManagedNpmPackageDirsForPackage(params: {
+  runtime: Awaited<ReturnType<typeof loadPluginInstallRuntime>>;
+  npmBaseDir: string;
+  packageName: string;
+}): Promise<string[]> {
+  const packageDirs: string[] = [];
+  const legacyProjectRoot = resolvePluginNpmProjectDir({
+    npmDir: params.npmBaseDir,
+    packageName: params.packageName,
+  });
+  const legacyPackageDir = resolveManagedNpmRootPackageDir(legacyProjectRoot, params.packageName);
+  if (await params.runtime.fileExists(legacyPackageDir)) {
+    packageDirs.push(legacyPackageDir);
+  }
+  const projectsDir = path.dirname(legacyProjectRoot);
+  const generationPrefix = resolvePluginNpmGenerationProjectDirPrefix(params.packageName);
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(projectsDir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return packageDirs;
+    }
+    throw error;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith(generationPrefix)) {
+      continue;
+    }
+    const packageDir = resolveManagedNpmRootPackageDir(
+      path.join(projectsDir, entry.name),
+      params.packageName,
+    );
+    if (await params.runtime.fileExists(packageDir)) {
+      packageDirs.push(packageDir);
+    }
+  }
+  return packageDirs;
+}
+
+async function resolveManagedNpmGenerationUseForInstall(params: {
+  runtime: Awaited<ReturnType<typeof loadPluginInstallRuntime>>;
+  npmBaseDir: string;
+  packageName: string;
+  requestedMode: "install" | "update";
+}): Promise<"none" | "update" | "retained-install"> {
+  const packageDirs = await listManagedNpmPackageDirsForPackage({
+    runtime: params.runtime,
+    npmBaseDir: params.npmBaseDir,
+    packageName: params.packageName,
+  });
+  const hasNonRetainedPackageDir = packageDirs.some(
+    (packageDir) => !hasRetainedManagedNpmInstallMarker(packageDir),
+  );
+  if (packageDirs.length > 0 && !hasNonRetainedPackageDir) {
+    return "retained-install";
+  }
+  if (params.requestedMode === "update") {
+    return hasNonRetainedPackageDir ? "update" : "none";
+  }
+  return "none";
+}
+
 function resolveRequiredPlatformPackageNames(
   packageMetadata?: OpenClawPackageManifest,
 ): { ok: true; packageNames: string[] } | { ok: false; error: string } {
@@ -1202,20 +1303,37 @@ async function installPluginFromManagedNpmRoot(
   );
   const expectedPluginId = params.expectedPluginId;
   const npmBaseDir = params.npmDir ? resolveUserPath(params.npmDir) : resolveDefaultPluginNpmDir();
-  const npmRoot = resolvePluginNpmProjectDir({
-    npmDir: npmBaseDir,
+  const generationUse = await resolveManagedNpmGenerationUseForInstall({
+    runtime,
+    npmBaseDir,
     packageName: params.packageName,
+    requestedMode: mode,
+  });
+  const npmRoot = resolveManagedNpmRootForInstall({
+    npmBaseDir,
+    packageName: params.packageName,
+    npmResolution: params.npmResolution,
+    useGeneration: generationUse !== "none",
   });
   const installRoot = resolveManagedNpmRootPackageDir(npmRoot, params.packageName);
-  const effectiveMode = await resolveEffectiveInstallMode({
-    runtime,
-    requestedMode: mode,
-    targetPath: installRoot,
-  });
+  const targetMode =
+    generationUse === "retained-install" && hasRetainedManagedNpmInstallMarker(installRoot)
+      ? "update"
+      : await resolveEffectiveInstallMode({
+          runtime,
+          requestedMode: mode,
+          targetPath: installRoot,
+        });
+  const policyMode =
+    generationUse === "update"
+      ? "update"
+      : generationUse === "retained-install"
+        ? "install"
+        : targetMode;
   const availability = await ensureInstallTargetAvailableForMode({
     runtime,
     targetPath: installRoot,
-    mode: effectiveMode,
+    mode: targetMode,
   });
   if (!availability.ok) {
     return availability;
@@ -1225,13 +1343,13 @@ async function installPluginFromManagedNpmRoot(
     const preflightPolicyResult = await runInstallSourceScan({
       subject: `Plugin "${expectedPluginId ?? params.packageName}"`,
       pluginId: expectedPluginId ?? params.packageName,
-      mode: effectiveMode,
+      mode: policyMode,
       sourceFamily: sourceFamilyForInstallPolicySource(params.installPolicyRequest.source, "npm"),
       scan: async () =>
         await preflightPluginNpmInstallPolicy({
           config: params.config,
           logger,
-          mode: effectiveMode,
+          mode: policyMode,
           packageName: params.packageName,
           ...(expectedPluginId ? { pluginId: expectedPluginId } : {}),
           requestedSpecifier: params.installPolicyRequest.requestedSpecifier ?? params.displaySpec,
@@ -1626,7 +1744,7 @@ async function installPluginFromManagedNpmRoot(
       logger,
       expectedPluginId,
       trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
-      mode: effectiveMode,
+      mode: policyMode,
       installPolicyRequest: params.installPolicyRequest,
       emitSuccessSecurityEvent: false,
     });
@@ -2532,7 +2650,6 @@ async function installPluginFromInstalledPackageDirInternal(
   return result;
 }
 
-
 async function installPluginFromPackageDir(
   params: {
     packageDir: string;
@@ -2861,18 +2978,6 @@ export async function installPluginFromNpmSpec(
     };
   }
 
-  const npmBaseDir = params.npmDir ? resolveUserPath(params.npmDir) : resolveDefaultPluginNpmDir();
-  const npmRoot = resolvePluginNpmProjectDir({
-    npmDir: npmBaseDir,
-    packageName: parsedSpec.name,
-  });
-  const installRoot = resolveManagedNpmRootPackageDir(npmRoot, parsedSpec.name);
-  const effectiveMode = await resolveEffectiveInstallMode({
-    runtime,
-    requestedMode: mode,
-    targetPath: installRoot,
-  });
-
   const metadataResult = await resolveNpmSpecMetadata({ spec, timeoutMs });
   if (!metadataResult.ok) {
     return {
@@ -2958,6 +3063,34 @@ export async function installPluginFromNpmSpec(
   if (driftResult.error) {
     return { ok: false, error: driftResult.error };
   }
+  const npmBaseDir = params.npmDir ? resolveUserPath(params.npmDir) : resolveDefaultPluginNpmDir();
+  const generationUse = await resolveManagedNpmGenerationUseForInstall({
+    runtime,
+    npmBaseDir,
+    packageName: parsedSpec.name,
+    requestedMode: mode,
+  });
+  const npmRoot = resolveManagedNpmRootForInstall({
+    npmBaseDir,
+    packageName: parsedSpec.name,
+    npmResolution,
+    useGeneration: generationUse !== "none",
+  });
+  const installRoot = resolveManagedNpmRootPackageDir(npmRoot, parsedSpec.name);
+  const targetMode =
+    generationUse === "retained-install" && hasRetainedManagedNpmInstallMarker(installRoot)
+      ? "update"
+      : await resolveEffectiveInstallMode({
+          runtime,
+          requestedMode: mode,
+          targetPath: installRoot,
+        });
+  const policyMode =
+    generationUse === "update"
+      ? "update"
+      : generationUse === "retained-install"
+        ? "install"
+        : targetMode;
 
   const policyTempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-npm-policy-"));
   try {
@@ -2978,13 +3111,13 @@ export async function installPluginFromNpmSpec(
     const preflightPolicyResult = await runInstallSourceScan({
       subject: `Plugin "${expectedPluginId ?? parsedSpec.name}"`,
       pluginId: expectedPluginId ?? parsedSpec.name,
-      mode: effectiveMode,
+      mode: policyMode,
       sourceFamily: "npm",
       scan: async () =>
         await preflightPluginNpmInstallPolicy({
           config: params.config,
           logger,
-          mode: effectiveMode,
+          mode: policyMode,
           packageName: parsedSpec.name,
           ...(expectedPluginId ? { pluginId: expectedPluginId } : {}),
           requestedSpecifier: spec,
@@ -3028,7 +3161,7 @@ export async function installPluginFromNpmSpec(
   });
   emitSuccessfulPluginInstallSecurityEvent(result, {
     dryRun,
-    mode: effectiveMode,
+    mode: policyMode,
     sourceFamily: "npm",
     trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
   });
@@ -3081,16 +3214,33 @@ export async function installPluginFromNpmPackArchive(
   }
   const packageName = packageNameResult.packageName;
   const npmBaseDir = params.npmDir ? resolveUserPath(params.npmDir) : resolveDefaultPluginNpmDir();
-  const npmProjectRoot = resolvePluginNpmProjectDir({
-    npmDir: npmBaseDir,
+  const generationUse = await resolveManagedNpmGenerationUseForInstall({
+    runtime,
+    npmBaseDir,
     packageName,
+    requestedMode: mode,
+  });
+  const npmProjectRoot = resolveManagedNpmRootForInstall({
+    npmBaseDir,
+    packageName,
+    npmResolution,
+    useGeneration: generationUse !== "none",
   });
   const installRoot = resolveManagedNpmRootPackageDir(npmProjectRoot, packageName);
-  const effectiveMode = await resolveEffectiveInstallMode({
-    runtime,
-    requestedMode: mode,
-    targetPath: installRoot,
-  });
+  const targetMode =
+    generationUse === "retained-install" && hasRetainedManagedNpmInstallMarker(installRoot)
+      ? "update"
+      : await resolveEffectiveInstallMode({
+          runtime,
+          requestedMode: mode,
+          targetPath: installRoot,
+        });
+  const policyMode =
+    generationUse === "update"
+      ? "update"
+      : generationUse === "retained-install"
+        ? "install"
+        : targetMode;
 
   const result = await installPluginFromManagedNpmRoot({
     dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
@@ -3138,7 +3288,7 @@ export async function installPluginFromNpmPackArchive(
   });
   emitSuccessfulPluginInstallSecurityEvent(result, {
     dryRun,
-    mode: effectiveMode,
+    mode: policyMode,
     sourceFamily: "archive",
     trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
   });

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -1149,7 +1149,7 @@ function resolveManagedNpmInstallRoot(params: {
   });
   const npmRoot = resolveManagedNpmRootForInstall(params);
   const installRoot = resolveManagedNpmRootPackageDir(npmRoot, params.packageName);
-  if (!params.useGeneration || !hasRetainedManagedNpmInstallMarker(installRoot)) {
+  if (!hasRetainedManagedNpmInstallMarker(installRoot)) {
     return npmRoot;
   }
   // Never mutate a retained tree: an older process may still hold lazy imports
@@ -1206,6 +1206,7 @@ async function resolveManagedNpmGenerationUseForInstall(params: {
   npmBaseDir: string;
   packageName: string;
   requestedMode: "install" | "update";
+  npmResolution?: NpmSpecResolution;
 }): Promise<"none" | "update" | "retained-install"> {
   const packageDirs = await listManagedNpmPackageDirsForPackage({
     runtime: params.runtime,
@@ -1217,6 +1218,20 @@ async function resolveManagedNpmGenerationUseForInstall(params: {
   );
   if (packageDirs.length > 0 && !hasNonRetainedPackageDir) {
     return "retained-install";
+  }
+  const generationUse =
+    params.requestedMode === "update" && hasNonRetainedPackageDir ? "update" : "none";
+  if (params.npmResolution) {
+    const candidateRoot = resolveManagedNpmRootForInstall({
+      npmBaseDir: params.npmBaseDir,
+      packageName: params.packageName,
+      npmResolution: params.npmResolution,
+      useGeneration: generationUse !== "none",
+    });
+    const candidatePackageDir = resolveManagedNpmRootPackageDir(candidateRoot, params.packageName);
+    if (hasRetainedManagedNpmInstallMarker(candidatePackageDir)) {
+      return "retained-install";
+    }
   }
   if (params.requestedMode === "update") {
     return hasNonRetainedPackageDir ? "update" : "none";
@@ -1332,6 +1347,7 @@ async function installPluginFromManagedNpmRoot(
     npmBaseDir,
     packageName: params.packageName,
     requestedMode: mode,
+    npmResolution: params.npmResolution,
   });
   const npmRoot = resolveManagedNpmInstallRoot({
     npmBaseDir,
@@ -3093,6 +3109,7 @@ export async function installPluginFromNpmSpec(
     npmBaseDir,
     packageName: parsedSpec.name,
     requestedMode: mode,
+    npmResolution,
   });
   const npmRoot = resolveManagedNpmRootForInstall({
     npmBaseDir,
@@ -3243,6 +3260,7 @@ export async function installPluginFromNpmPackArchive(
     npmBaseDir,
     packageName,
     requestedMode: mode,
+    npmResolution,
   });
   const npmProjectRoot = resolveManagedNpmRootForInstall({
     npmBaseDir,

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -1,5 +1,5 @@
 // Installs plugins from package specs, local paths, and catalogs.
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { constants as fsConstants, type Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -1137,6 +1137,30 @@ function resolveManagedNpmRootForInstall(params: {
   });
 }
 
+function resolveManagedNpmInstallRoot(params: {
+  npmBaseDir: string;
+  packageName: string;
+  npmResolution: NpmSpecResolution;
+  useGeneration: boolean;
+}): string {
+  const generationKey = resolveManagedNpmRootGenerationKey({
+    packageName: params.packageName,
+    npmResolution: params.npmResolution,
+  });
+  const npmRoot = resolveManagedNpmRootForInstall(params);
+  const installRoot = resolveManagedNpmRootPackageDir(npmRoot, params.packageName);
+  if (!params.useGeneration || !hasRetainedManagedNpmInstallMarker(installRoot)) {
+    return npmRoot;
+  }
+  // Never mutate a retained tree: an older process may still hold lazy imports
+  // rooted there. A fresh activation root keeps that module graph importable.
+  return resolvePluginNpmGenerationProjectDir({
+    npmDir: params.npmBaseDir,
+    packageName: params.packageName,
+    generationKey: `${generationKey}\nactivation\n${randomUUID()}`,
+  });
+}
+
 async function listManagedNpmPackageDirsForPackage(params: {
   runtime: Awaited<ReturnType<typeof loadPluginInstallRuntime>>;
   npmBaseDir: string;
@@ -1309,7 +1333,7 @@ async function installPluginFromManagedNpmRoot(
     packageName: params.packageName,
     requestedMode: mode,
   });
-  const npmRoot = resolveManagedNpmRootForInstall({
+  const npmRoot = resolveManagedNpmInstallRoot({
     npmBaseDir,
     packageName: params.packageName,
     npmResolution: params.npmResolution,

--- a/src/plugins/installed-plugin-index-record-reader.ts
+++ b/src/plugins/installed-plugin-index-record-reader.ts
@@ -16,6 +16,7 @@ import {
   resolveInstalledPluginIndexStorePath,
   type InstalledPluginIndexStoreOptions,
 } from "./installed-plugin-index-store-path.js";
+import { hasRetainedManagedNpmInstallMarker } from "./managed-npm-retention.js";
 import { listManagedPluginNpmProjectRootsSync } from "./npm-project-roots.js";
 
 export { clearLoadInstalledPluginIndexInstallRecordsCache } from "./installed-plugin-index-record-cache.js";
@@ -125,6 +126,9 @@ function buildRecoveredManagedNpmInstallRecordsForRoot(
       continue;
     }
     if (!stat.isDirectory()) {
+      continue;
+    }
+    if (hasRetainedManagedNpmInstallMarker(packageDir)) {
       continue;
     }
     const pluginId = resolveRecoveredManagedNpmPluginId({ packageName, packageDir });

--- a/src/plugins/managed-npm-retention.test.ts
+++ b/src/plugins/managed-npm-retention.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolvePluginNpmGenerationProjectDir } from "./install-paths.js";
+import {
+  cleanupRetainedManagedNpmInstallGenerations,
+  hasRetainedManagedNpmInstallMarker,
+  markRetainedManagedNpmInstall,
+} from "./managed-npm-retention.js";
+
+describe("managed npm retention", () => {
+  it("cleans retired generations while preserving the active install root", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-retention-"));
+    const npmDir = path.join(stateDir, "npm");
+    const packageName = "@openclaw/codex";
+    const oldProjectRoot = resolvePluginNpmGenerationProjectDir({
+      npmDir,
+      packageName,
+      generationKey: "codex-v1",
+    });
+    const activeProjectRoot = resolvePluginNpmGenerationProjectDir({
+      npmDir,
+      packageName,
+      generationKey: "codex-v2",
+    });
+    const oldPackageDir = path.join(oldProjectRoot, "node_modules", "@openclaw", "codex");
+    const activePackageDir = path.join(activeProjectRoot, "node_modules", "@openclaw", "codex");
+    fs.mkdirSync(oldPackageDir, { recursive: true });
+    fs.mkdirSync(activePackageDir, { recursive: true });
+    await markRetainedManagedNpmInstall({
+      packageDir: oldPackageDir,
+      pluginId: "codex",
+      reason: "test-retired-generation",
+    });
+
+    try {
+      await expect(
+        cleanupRetainedManagedNpmInstallGenerations({
+          npmDir,
+          activeInstallPaths: [activePackageDir],
+        }),
+      ).resolves.toBe(1);
+      expect(fs.existsSync(oldProjectRoot)).toBe(false);
+      expect(fs.existsSync(activeProjectRoot)).toBe(true);
+      expect(hasRetainedManagedNpmInstallMarker(activePackageDir)).toBe(false);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/plugins/managed-npm-retention.test.ts
+++ b/src/plugins/managed-npm-retention.test.ts
@@ -48,4 +48,28 @@ describe("managed npm retention", () => {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
+
+  it("cleans retained packages from the legacy shared npm root", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-retention-"));
+    const npmDir = path.join(stateDir, "npm");
+    const packageDir = path.join(npmDir, "node_modules", "@openclaw", "codex");
+    fs.mkdirSync(packageDir, { recursive: true });
+    await markRetainedManagedNpmInstall({
+      packageDir,
+      pluginId: "codex",
+      reason: "test-legacy-generation",
+    });
+
+    try {
+      await expect(
+        cleanupRetainedManagedNpmInstallGenerations({
+          npmDir,
+        }),
+      ).resolves.toBe(1);
+      expect(fs.existsSync(packageDir)).toBe(false);
+      expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(false);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/plugins/managed-npm-retention.ts
+++ b/src/plugins/managed-npm-retention.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { safePathSegmentHashed } from "../infra/install-safe-path.js";
 import { resolveDefaultPluginNpmDir, resolvePluginNpmProjectsDir } from "./install-paths.js";
-import { listManagedPluginNpmProjectRootsSync } from "./npm-project-roots.js";
+import { listManagedPluginNpmRootsSync } from "./npm-project-roots.js";
 
 export const RETAINED_MANAGED_NPM_INSTALL_MARKER = ".openclaw-retained-npm-install.json";
 const RETAINED_MANAGED_NPM_INSTALL_MARKER_DIR = ".openclaw-retained-npm-installs";
@@ -117,6 +117,55 @@ function isPathEqualOrInside(parentPath: string, childPath: string): boolean {
   return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`));
 }
 
+function listManagedNpmPackageDirs(npmRoot: string): string[] {
+  const nodeModulesDir = path.join(npmRoot, "node_modules");
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(nodeModulesDir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+  return entries.flatMap((entry) => {
+    if (!entry.isDirectory()) {
+      return [];
+    }
+    if (!entry.name.startsWith("@")) {
+      return [path.join(nodeModulesDir, entry.name)];
+    }
+    return fs
+      .readdirSync(path.join(nodeModulesDir, entry.name), { withFileTypes: true })
+      .filter((scopedEntry) => scopedEntry.isDirectory())
+      .map((scopedEntry) => path.join(nodeModulesDir, entry.name, scopedEntry.name));
+  });
+}
+
+async function cleanupRetainedLegacyNpmPackages(params: {
+  npmRoot: string;
+  activeInstallPaths: string[];
+  onError?: (error: unknown, projectRoot: string) => void;
+}): Promise<number> {
+  let removed = 0;
+  for (const packageDir of listManagedNpmPackageDirs(params.npmRoot)) {
+    if (
+      !hasRetainedManagedNpmInstallMarker(packageDir) ||
+      params.activeInstallPaths.some((installPath) => isPathEqualOrInside(packageDir, installPath))
+    ) {
+      continue;
+    }
+    try {
+      await fs.promises.rm(packageDir, { recursive: true, force: true });
+      await clearRetainedManagedNpmInstallMarker(packageDir);
+      removed += 1;
+    } catch (error) {
+      params.onError?.(error, packageDir);
+    }
+  }
+  return removed;
+}
+
 export async function cleanupRetainedManagedNpmInstallGenerations(
   params: {
     activeInstallPaths?: Iterable<string>;
@@ -133,7 +182,15 @@ export async function cleanupRetainedManagedNpmInstallGenerations(
     path.resolve(installPath),
   );
   let removed = 0;
-  for (const projectRoot of listManagedPluginNpmProjectRootsSync(npmDir)) {
+  for (const projectRoot of listManagedPluginNpmRootsSync(npmDir)) {
+    if (path.resolve(projectRoot) === path.resolve(npmDir)) {
+      removed += await cleanupRetainedLegacyNpmPackages({
+        npmRoot: projectRoot,
+        activeInstallPaths,
+        onError: params.onError,
+      });
+      continue;
+    }
     const markerDir = path.join(projectRoot, RETAINED_MANAGED_NPM_INSTALL_MARKER_DIR);
     let markerEntries: fs.Dirent[];
     try {

--- a/src/plugins/managed-npm-retention.ts
+++ b/src/plugins/managed-npm-retention.ts
@@ -2,6 +2,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { safePathSegmentHashed } from "../infra/install-safe-path.js";
+import { resolveDefaultPluginNpmDir, resolvePluginNpmProjectsDir } from "./install-paths.js";
+import { listManagedPluginNpmProjectRootsSync } from "./npm-project-roots.js";
 
 export const RETAINED_MANAGED_NPM_INSTALL_MARKER = ".openclaw-retained-npm-install.json";
 const RETAINED_MANAGED_NPM_INSTALL_MARKER_DIR = ".openclaw-retained-npm-installs";
@@ -108,4 +110,56 @@ export async function markRetainedManagedNpmInstall(params: {
     "utf8",
   );
   return true;
+}
+
+function isPathEqualOrInside(parentPath: string, childPath: string): boolean {
+  const relative = path.relative(path.resolve(parentPath), path.resolve(childPath));
+  return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`));
+}
+
+export async function cleanupRetainedManagedNpmInstallGenerations(
+  params: {
+    activeInstallPaths?: Iterable<string>;
+    env?: NodeJS.ProcessEnv;
+    npmDir?: string;
+    onError?: (error: unknown, projectRoot: string) => void;
+  } = {},
+): Promise<number> {
+  // Callers run this after the previous gateway server has closed and before
+  // the next one loads plugins, so retired module graphs no longer need these trees.
+  const npmDir = params.npmDir ?? resolveDefaultPluginNpmDir(params.env);
+  const projectsDir = resolvePluginNpmProjectsDir(npmDir);
+  const activeInstallPaths = Array.from(params.activeInstallPaths ?? [], (installPath) =>
+    path.resolve(installPath),
+  );
+  let removed = 0;
+  for (const projectRoot of listManagedPluginNpmProjectRootsSync(npmDir)) {
+    const markerDir = path.join(projectRoot, RETAINED_MANAGED_NPM_INSTALL_MARKER_DIR);
+    let markerEntries: fs.Dirent[];
+    try {
+      markerEntries = fs
+        .readdirSync(markerDir, { withFileTypes: true })
+        .filter((entry) => entry.isFile());
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      params.onError?.(error, projectRoot);
+      continue;
+    }
+    if (
+      markerEntries.length === 0 ||
+      !isPathEqualOrInside(projectsDir, projectRoot) ||
+      activeInstallPaths.some((installPath) => isPathEqualOrInside(projectRoot, installPath))
+    ) {
+      continue;
+    }
+    try {
+      await fs.promises.rm(projectRoot, { recursive: true, force: true });
+      removed += 1;
+    } catch (error) {
+      params.onError?.(error, projectRoot);
+    }
+  }
+  return removed;
 }

--- a/src/plugins/managed-npm-retention.ts
+++ b/src/plugins/managed-npm-retention.ts
@@ -1,0 +1,111 @@
+// Marks retained managed npm package trees that should stay importable but not recoverable.
+import fs from "node:fs";
+import path from "node:path";
+import { safePathSegmentHashed } from "../infra/install-safe-path.js";
+
+export const RETAINED_MANAGED_NPM_INSTALL_MARKER = ".openclaw-retained-npm-install.json";
+const RETAINED_MANAGED_NPM_INSTALL_MARKER_DIR = ".openclaw-retained-npm-installs";
+
+export function resolveRetainedManagedNpmInstallPackageInfo(packageDir: string): {
+  packageName: string;
+  projectRoot: string;
+  markerPath: string;
+} | null {
+  const resolvedPackageDir = path.resolve(packageDir);
+  const packageBase = path.basename(resolvedPackageDir);
+  const parentDir = path.dirname(resolvedPackageDir);
+  const parentBase = path.basename(parentDir);
+  const scopedPackage = parentBase.startsWith("@");
+  const nodeModulesRoot = scopedPackage ? path.dirname(parentDir) : parentDir;
+  if (path.basename(nodeModulesRoot) !== "node_modules") {
+    return null;
+  }
+  const packageName = scopedPackage ? `${parentBase}/${packageBase}` : packageBase;
+  if (!packageBase || packageBase === "." || !packageName.trim()) {
+    return null;
+  }
+  const projectRoot = path.dirname(nodeModulesRoot);
+  return {
+    packageName,
+    projectRoot,
+    markerPath: path.join(
+      projectRoot,
+      RETAINED_MANAGED_NPM_INSTALL_MARKER_DIR,
+      `${safePathSegmentHashed(packageName)}.json`,
+    ),
+  };
+}
+
+export function resolveRetainedManagedNpmInstallMarkerPath(packageDir: string): string {
+  const info = resolveRetainedManagedNpmInstallPackageInfo(packageDir);
+  if (!info) {
+    throw new Error("retained npm install marker requires a node_modules package directory");
+  }
+  return info.markerPath;
+}
+
+export function hasRetainedManagedNpmInstallMarker(packageDir: string): boolean {
+  const info = resolveRetainedManagedNpmInstallPackageInfo(packageDir);
+  return info ? fs.existsSync(info.markerPath) : false;
+}
+
+export async function clearRetainedManagedNpmInstallMarker(packageDir: string): Promise<boolean> {
+  const info = resolveRetainedManagedNpmInstallPackageInfo(packageDir);
+  if (!info) {
+    return false;
+  }
+  try {
+    await fs.promises.rm(info.markerPath, { force: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+  try {
+    await fs.promises.rmdir(path.dirname(info.markerPath));
+  } catch {
+    // Best effort: keep the OpenClaw-owned marker directory if it is not empty.
+  }
+  return true;
+}
+
+export async function markRetainedManagedNpmInstall(params: {
+  packageDir: string;
+  pluginId: string;
+  retainedAt?: string;
+  reason: string;
+}): Promise<boolean> {
+  const info = resolveRetainedManagedNpmInstallPackageInfo(params.packageDir);
+  if (!info) {
+    return false;
+  }
+  let stat: fs.Stats;
+  try {
+    stat = await fs.promises.stat(params.packageDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+  if (!stat.isDirectory()) {
+    return false;
+  }
+  await fs.promises.mkdir(path.dirname(info.markerPath), { recursive: true });
+  await fs.promises.writeFile(
+    info.markerPath,
+    `${JSON.stringify(
+      {
+        version: 1,
+        pluginId: params.pluginId,
+        retainedAt: params.retainedAt ?? new Date().toISOString(),
+        reason: params.reason,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  return true;
+}

--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -9,12 +9,17 @@ import {
   setCurrentPluginMetadataSnapshot,
 } from "./current-plugin-metadata-snapshot.js";
 import type { PluginCandidate } from "./discovery.js";
+import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
 import {
   loadInstalledPluginIndex,
   resolveInstalledPluginIndexPolicyHash,
   type InstalledPluginIndex,
 } from "./installed-plugin-index.js";
+import {
+  markRetainedManagedNpmInstall,
+  RETAINED_MANAGED_NPM_INSTALL_MARKER,
+} from "./managed-npm-retention.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry-snapshot.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
@@ -435,6 +440,69 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
     });
     const whatsappPlugin = requirePluginRecord(result.snapshot.plugins, "whatsapp");
     expect(whatsappPlugin.origin).toBe("global");
+  });
+
+  it("does not recover retained managed npm generations as install records", async () => {
+    const tempRoot = makeTempDir();
+    const stateDir = path.join(tempRoot, "state");
+    const env = {
+      ...createHermeticEnv(tempRoot),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+    const config = {};
+    const codexDir = writeManagedNpmPlugin({
+      stateDir,
+      packageName: "@openclaw/codex",
+      pluginId: "codex",
+      version: "2026.6.10-beta.1",
+    });
+    await markRetainedManagedNpmInstall({
+      packageDir: codexDir,
+      pluginId: "codex",
+      retainedAt: "2026-06-21T00:00:00.000Z",
+      reason: "test-retained-generation",
+    });
+    const staleIndex = loadInstalledPluginIndex({
+      config,
+      env,
+      stateDir,
+      installRecords: {},
+    });
+    writePersistedInstalledPluginIndexSync(staleIndex, { stateDir });
+
+    expect(loadInstalledPluginIndexInstallRecordsSync({ env, stateDir }).codex).toBeUndefined();
+    const result = loadPluginRegistrySnapshotWithMetadata({
+      config,
+      env,
+      stateDir,
+    });
+
+    expect(result.snapshot.installRecords.codex).toBeUndefined();
+    expect(result.snapshot.plugins.map((plugin) => plugin.pluginId)).not.toContain("codex");
+  });
+
+  it("does not trust package-owned retained npm marker files during recovery", () => {
+    const tempRoot = makeTempDir();
+    const stateDir = path.join(tempRoot, "state");
+    const env = {
+      ...createHermeticEnv(tempRoot),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+    const codexDir = writeManagedNpmPlugin({
+      stateDir,
+      packageName: "@openclaw/codex",
+      pluginId: "codex",
+      version: "2026.6.10-beta.1",
+    });
+    fs.writeFileSync(
+      path.join(codexDir, RETAINED_MANAGED_NPM_INSTALL_MARKER),
+      '{"version":1,"pluginId":"codex"}\n',
+      "utf8",
+    );
+
+    expect(loadInstalledPluginIndexInstallRecordsSync({ env, stateDir }).codex).toBeDefined();
   });
 
   it("keeps vanished recovered install records on the persisted fast path", () => {


### PR DESCRIPTION
Related: #85844

## What Problem This Solves

Fixes an issue where users updating managed npm/ClawHub plugins could keep a running gateway pointed at old hashed `dist` chunks while the updater removed that old package tree. In the observed Windows 2026.6.10-beta.1 failure, the gateway later failed to talk to the user because Node could not import a stale `run-attempt-*.js` file from the previous `@openclaw/codex` install.

This PR addresses the managed npm plugin replacement slice of #85844. It does not try to solve every stale core-dist or process-restart lifecycle case.

## Why This Change Was Made

Managed npm updates now install into artifact-generation project roots instead of replacing the previous package directory in place. Replaced npm generations stay on disk long enough for already-loaded module graphs to finish their work, and OpenClaw records an OpenClaw-owned retained marker during the install-record commit so registry recovery and doctor repair do not treat them as active installs.

The marker state is kept in the same commit/rollback path as install records: old generations are marked only after the next records are written, active retained generations are unmarked when committed, and marker changes are restored if the config commit rolls back. Marker paths are tracked incrementally so a later filesystem failure cannot strand earlier markers. Install/update policy mode remains tied to the user-visible operation, so retained-only generations do not turn fresh installs into policy updates.

Retention is bounded, not indefinite. At the next gateway start, after the previous server has closed and before the next plugin registry loads, OpenClaw removes only marked generations that are not referenced by an active install record. The cleanup covers both generation project roots and the legacy shared npm root, while preserving the active package tree. This keeps the compatibility window needed by a running gateway without creating an unbounded disk leak.

Rollback safety is explicit: if an exact npm spec resolves to a deterministic generation root that is already marked retained, the installer allocates a fresh activation root instead of running npm in the retained tree. This protects an older process that still holds lazy imports from that generation. The effective operation remains `install` for policy enforcement, even when an active generation and retained rollback target coexist.

## User Impact

Users can update an npm-backed plugin without breaking already-running code that still imports chunks from the previous plugin generation. After restart or recovery, OpenClaw sees only the committed active generation; retired generations are ignored by registry recovery and protected from destructive doctor cleanup until the safe cleanup boundary.

Operators still get install-policy semantics: retained-only package trees do not make a fresh `install` or forced update look like a real update.

## Evidence

Real before evidence: #85844 includes a Windows 2026.6.10-beta.1 gateway failure where `@openclaw/codex` tried to import a missing stale hashed dist chunk after update: https://github.com/openclaw/openclaw/issues/85844#issuecomment-4761855575

Live managed-npm update proof on Windows source checkout, isolated state, 2026-06-21 UTC:

- Created a local fixture npm registry with `@openclaw/proof-plugin@1.0.0` and `@openclaw/proof-plugin@1.0.1`.
- Created isolated `HOME`, `USERPROFILE`, `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, `NPM_CONFIG_CACHE`, and `NPM_CONFIG_USERCONFIG` under temp directories.
- Installed v1, verified runtime import and `proof.ping` gateway method registration, started a real loopback gateway, updated to v2 while that gateway was running, then verified both the old retained generation and the new active generation remain importable.

Key redacted terminal excerpt:

```text
COMMAND: update proof plugin to v2 while gateway is running
Installing @openclaw/proof-plugin@1.0.1 into <temp-state>\\.openclaw\\npm\\projects\\openclaw-proof-plugin-e727ac5dd4__openclaw-generation__...
Updated proof-plugin: 1.0.0 -> 1.0.1.
Restart the gateway to load plugins and hooks.
EXIT(update proof plugin to v2 while gateway is running): 0

gatewayReadyAfterUpdate=HTTP 200: {"ready":true,"failing":[]...}
oldGenerationExistsAfterUpdate=True
newGenerationExistsAfterUpdate=True
RESULT: PASS - running gateway survived npm plugin update, active record rotated to v2, old managed generation remained importable
```

Regression proof added in this branch:

- Load a v1 plugin entry before update.
- Replace the package on disk with v2.
- Invoke the already-loaded v1 entry's lazy dynamic import after replacement and verify it still resolves the old chunk.
- Load the fresh v2 entry and verify it resolves the new chunk.
- Exercise `v2 -> v3 -> exact v2` while the original v2 module graph remains loaded; verify rollback uses a fresh activation root and install-only policy still sees `install`.

Focused validation after the hardening:

- `node scripts/run-vitest.mjs src/plugins/managed-npm-retention.test.ts src/cli/plugins-install-record-commit.test.ts src/plugins/install.npm-spec.test.ts src/plugins/install.test.ts src/cli/plugins-install-persist.test.ts src/plugins/plugin-registry-snapshot.test.ts src/commands/doctor-plugin-registry.test.ts` — 4 shards, 186 passed.
- `node scripts/run-vitest.mjs src/gateway/server-startup.test.ts src/gateway/server.lazy.test.ts src/gateway/server-startup-plugins.test.ts` — 6 files, 54 passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile /tmp/openclaw-95589-test.tsbuildinfo` — passed.
- `oxlint` on all touched files — passed.
- `oxfmt --check` on all touched files — passed.
- Commit autoreview on `9e2ecf3a64` and `29855c76d2` — clean; no accepted/actionable findings.
- `git diff --check` — passed.

The full build was not runnable in this linked worktree because `scripts/build-all.mjs` invokes pnpm reconciliation and pnpm refused to purge the shared `node_modules` directory without a TTY. A full published-package upgrade from npm was also not rerun; the Windows live proof above and the source-level regression fixture cover the managed npm replacement path without touching a user's real state.