### PR TITLE
fix(reply): let preflight compaction use compaction timeout

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1078,10 +1078,21 @@ describe("runMemoryFlushIfNeeded", () => {
     };
     const replyAbortController = new AbortController();
     const explicitAbortController = new AbortController();
-    replyAbortController.abort(new Error("reply lifecycle timeout"));
+    const timeoutError = new Error("reply lifecycle timeout");
+    timeoutError.name = "TimeoutError";
     const replyOperation = createReplyOperation({
       abortSignal: replyAbortController.signal,
       explicitAbortSignal: explicitAbortController.signal,
+    });
+    let compactAbortSignal: AbortSignal | undefined;
+    compactEmbeddedAgentSessionMock.mockImplementationOnce(async (call) => {
+      compactAbortSignal = (call as CompactEmbeddedAgentSessionParams).abortSignal;
+      expect(compactAbortSignal?.aborted).toBe(false);
+
+      replyAbortController.abort(timeoutError);
+
+      expect(compactAbortSignal?.aborted).toBe(false);
+      return { ok: true, compacted: true, result: { tokensAfter: 42 } };
     });
 
     await runPreflightCompactionIfNeeded({
@@ -1102,9 +1113,105 @@ describe("runMemoryFlushIfNeeded", () => {
 
     expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
     const compactCall = requireCompactEmbeddedAgentSessionCall();
-    expect(compactCall.abortSignal).toBe(explicitAbortController.signal);
+    expect(compactCall.abortSignal).not.toBe(explicitAbortController.signal);
     expect(compactCall.abortSignal).not.toBe(replyOperation.abortSignal);
-    expect(compactCall.abortSignal?.aborted).toBe(false);
+    expect(compactCall.abortSignal).toBe(compactAbortSignal);
+    expect(compactAbortSignal?.aborted).toBe(false);
+  });
+
+  it("cancels required preflight compaction on upstream non-timeout abort", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 180_499,
+      totalTokensFresh: true,
+    };
+    const replyAbortController = new AbortController();
+    const replyOperation = createReplyOperation({
+      abortSignal: replyAbortController.signal,
+    });
+    const abortError = new Error("chat run aborted");
+    abortError.name = "AbortError";
+    let compactAbortSignal: AbortSignal | undefined;
+    compactEmbeddedAgentSessionMock.mockImplementationOnce(async (call) => {
+      compactAbortSignal = (call as CompactEmbeddedAgentSessionParams).abortSignal;
+      expect(compactAbortSignal?.aborted).toBe(false);
+
+      replyAbortController.abort(abortError);
+
+      expect(compactAbortSignal?.aborted).toBe(true);
+      expect(compactAbortSignal?.reason).toBe(abortError);
+      return { ok: true, compacted: true, result: { tokensAfter: 42 } };
+    });
+
+    await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionKey: "agent:main:main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      sessionEntry,
+      sessionStore: { "agent:main:main": sessionEntry },
+      sessionKey: "agent:main:main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+    expect(compactAbortSignal?.aborted).toBe(true);
+  });
+
+  it("still cancels required preflight compaction on explicit abort after lifecycle timeout", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 180_499,
+      totalTokensFresh: true,
+    };
+    const replyAbortController = new AbortController();
+    const explicitAbortController = new AbortController();
+    const timeoutError = new Error("reply lifecycle timeout");
+    timeoutError.name = "TimeoutError";
+    replyAbortController.abort(timeoutError);
+    const replyOperation = createReplyOperation({
+      abortSignal: replyAbortController.signal,
+      explicitAbortSignal: explicitAbortController.signal,
+    });
+    const explicitAbortError = new Error("reply operation aborted by user");
+    explicitAbortError.name = "AbortError";
+    let compactAbortSignal: AbortSignal | undefined;
+    compactEmbeddedAgentSessionMock.mockImplementationOnce(async (call) => {
+      compactAbortSignal = (call as CompactEmbeddedAgentSessionParams).abortSignal;
+      expect(compactAbortSignal?.aborted).toBe(false);
+
+      explicitAbortController.abort(explicitAbortError);
+
+      expect(compactAbortSignal?.aborted).toBe(true);
+      expect(compactAbortSignal?.reason).toBe(explicitAbortError);
+      return { ok: true, compacted: true, result: { tokensAfter: 42 } };
+    });
+
+    await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionKey: "agent:main:main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      sessionEntry,
+      sessionStore: { "agent:main:main": sessionEntry },
+      sessionKey: "agent:main:main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+    expect(compactAbortSignal?.aborted).toBe(true);
   });
 
   it("fails when required preflight context-engine compaction is deferred to background maintenance", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -105,6 +105,7 @@ type EmbeddedAgentParams = {
 type CompactEmbeddedAgentSessionParams = {
   agentId?: string;
   authProfileId?: string;
+  abortSignal?: AbortSignal;
   contextTokenBudget?: number;
   sessionKey?: string;
   sandboxSessionKey?: string;
@@ -1060,6 +1061,37 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(incrementCompactionCountMock).not.toHaveBeenCalled();
     expect(onCompactionNotice).toHaveBeenNthCalledWith(1, "start");
     expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "skipped");
+  });
+
+  it("does not cap required preflight compaction with the reply operation abort signal", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 180_499,
+      totalTokensFresh: true,
+    };
+    const replyOperation = createReplyOperation();
+
+    await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionKey: "agent:main:main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      sessionEntry,
+      sessionStore: { "agent:main:main": sessionEntry },
+      sessionKey: "agent:main:main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+    const compactCall = requireCompactEmbeddedAgentSessionCall();
+    expect(compactCall.abortSignal).toBeUndefined();
+    expect(compactCall.abortSignal).not.toBe(replyOperation.abortSignal);
   });
 
   it("fails when required preflight context-engine compaction is deferred to background maintenance", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -40,11 +40,17 @@ type TestReplyOperation = ReplyOperation & {
   updateSessionId: ReturnType<typeof vi.fn<ReplyOperation["updateSessionId"]>>;
 };
 
-function createReplyOperation(): TestReplyOperation {
+function createReplyOperation(
+  opts: {
+    abortSignal?: AbortSignal;
+    explicitAbortSignal?: AbortSignal;
+  } = {},
+): TestReplyOperation {
   return {
     key: "test",
     sessionId: "session",
-    abortSignal: new AbortController().signal,
+    abortSignal: opts.abortSignal ?? new AbortController().signal,
+    ...(opts.explicitAbortSignal ? { explicitAbortSignal: opts.explicitAbortSignal } : {}),
     resetTriggered: false,
     phase: "queued",
     result: null,
@@ -1070,7 +1076,13 @@ describe("runMemoryFlushIfNeeded", () => {
       totalTokens: 180_499,
       totalTokensFresh: true,
     };
-    const replyOperation = createReplyOperation();
+    const replyAbortController = new AbortController();
+    const explicitAbortController = new AbortController();
+    replyAbortController.abort(new Error("reply lifecycle timeout"));
+    const replyOperation = createReplyOperation({
+      abortSignal: replyAbortController.signal,
+      explicitAbortSignal: explicitAbortController.signal,
+    });
 
     await runPreflightCompactionIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
@@ -1090,8 +1102,9 @@ describe("runMemoryFlushIfNeeded", () => {
 
     expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
     const compactCall = requireCompactEmbeddedAgentSessionCall();
-    expect(compactCall.abortSignal).toBeUndefined();
+    expect(compactCall.abortSignal).toBe(explicitAbortController.signal);
     expect(compactCall.abortSignal).not.toBe(replyOperation.abortSignal);
+    expect(compactCall.abortSignal?.aborted).toBe(false);
   });
 
   it("fails when required preflight context-engine compaction is deferred to background maintenance", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -978,7 +978,6 @@ export async function runPreflightCompactionIfNeeded(params: {
       contextTokenBudget: contextWindowTokens,
       currentTokenCount: tokenCountForCompaction ?? freshPersistedTokens,
       ownerNumbers: params.followupRun.run.ownerNumbers,
-      abortSignal: params.replyOperation.abortSignal,
     });
 
     if (!result?.ok) {

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -969,6 +969,9 @@ export async function runPreflightCompactionIfNeeded(params: {
         entry.sessionId === params.followupRun.run.sessionId ? entry.agentHarnessId : undefined,
       thinkLevel: params.followupRun.run.thinkLevel,
       bashElevated: params.followupRun.run.bashElevated,
+      ...(params.replyOperation.explicitAbortSignal
+        ? { abortSignal: params.replyOperation.explicitAbortSignal }
+        : {}),
       trigger: "budget",
       force: true,
       forcePreflight: true,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -9,6 +9,7 @@ import {
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { estimateMessagesTokens } from "../../agents/compaction.js";
 import { classifyCompactionReason } from "../../agents/embedded-agent-runner/compact-reasons.js";
+import { isSignalTimeoutReason } from "../../agents/failover-error.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-plugin.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
@@ -63,6 +64,10 @@ import type { ReplyOperation } from "./reply-run-registry.js";
 import { incrementCompactionCount } from "./session-updates.js";
 
 type EmbeddedAgentRuntime = typeof import("../../agents/embedded-agent.js");
+type ScopedAbortSignal = {
+  abortSignal: AbortSignal;
+  cleanup: () => void;
+};
 type UpdateSessionEntryParams = {
   storePath: string;
   sessionKey: string;
@@ -83,6 +88,44 @@ const embeddedAgentRuntimeLoader = createLazyImportLoader<EmbeddedAgentRuntime>(
 
 function loadEmbeddedAgentRuntime(): Promise<EmbeddedAgentRuntime> {
   return embeddedAgentRuntimeLoader.load();
+}
+
+function createPreflightCompactionAbortSignal(operation: ReplyOperation): ScopedAbortSignal {
+  const controller = new AbortController();
+  const cleanupHandlers: Array<() => void> = [];
+  const abortFrom = (signal: AbortSignal, opts?: { ignoreTimeoutReason?: boolean }) => {
+    if (controller.signal.aborted) {
+      return;
+    }
+    if (opts?.ignoreTimeoutReason && isSignalTimeoutReason(signal.reason)) {
+      return;
+    }
+    controller.abort(signal.reason);
+  };
+  const watch = (signal: AbortSignal | undefined, opts?: { ignoreTimeoutReason?: boolean }) => {
+    if (!signal) {
+      return;
+    }
+    if (signal.aborted) {
+      abortFrom(signal, opts);
+      return;
+    }
+    const onAbort = () => abortFrom(signal, opts);
+    signal.addEventListener("abort", onAbort, { once: true });
+    cleanupHandlers.push(() => signal.removeEventListener("abort", onAbort));
+  };
+
+  watch(operation.abortSignal, { ignoreTimeoutReason: true });
+  watch(operation.explicitAbortSignal);
+
+  return {
+    abortSignal: controller.signal,
+    cleanup: () => {
+      for (const cleanup of cleanupHandlers.splice(0)) {
+        cleanup();
+      }
+    },
+  };
 }
 
 async function compactEmbeddedAgentSessionDefault(
@@ -943,45 +986,49 @@ export async function runPreflightCompactionIfNeeded(params: {
       params.sessionKey ?? params.followupRun.run.sessionKey,
       { storePath: params.storePath },
     );
-    const result = await deps.compactEmbeddedAgentSession({
-      sessionId: entry.sessionId,
-      sessionKey: params.sessionKey,
-      sandboxSessionKey: params.runtimePolicySessionKey,
-      allowGatewaySubagentBinding: true,
-      messageChannel: params.followupRun.run.messageProvider,
-      groupId: entry.groupId ?? params.followupRun.run.groupId,
-      groupChannel: entry.groupChannel ?? params.followupRun.run.groupChannel,
-      groupSpace: entry.space ?? params.followupRun.run.groupSpace,
-      senderId: params.followupRun.run.senderId,
-      senderName: params.followupRun.run.senderName,
-      senderUsername: params.followupRun.run.senderUsername,
-      senderE164: params.followupRun.run.senderE164,
-      sessionFile: sessionFile ?? params.followupRun.run.sessionFile,
-      workspaceDir: params.followupRun.run.workspaceDir,
-      cwd: params.followupRun.run.cwd,
-      agentDir: params.followupRun.run.agentDir,
-      config: params.cfg,
-      skillsSnapshot: entry.skillsSnapshot ?? params.followupRun.run.skillsSnapshot,
-      provider: params.followupRun.run.provider,
-      model: params.followupRun.run.model,
-      authProfileId: params.followupRun.run.authProfileId,
-      agentHarnessId:
-        entry.sessionId === params.followupRun.run.sessionId ? entry.agentHarnessId : undefined,
-      thinkLevel: params.followupRun.run.thinkLevel,
-      bashElevated: params.followupRun.run.bashElevated,
-      ...(params.replyOperation.explicitAbortSignal
-        ? { abortSignal: params.replyOperation.explicitAbortSignal }
-        : {}),
-      trigger: "budget",
-      force: true,
-      forcePreflight: true,
-      preflightRequired: true,
-      preflightCompactionTrigger: compactionTrigger,
-      deferOwningContextEngineCompaction: false,
-      contextTokenBudget: contextWindowTokens,
-      currentTokenCount: tokenCountForCompaction ?? freshPersistedTokens,
-      ownerNumbers: params.followupRun.run.ownerNumbers,
-    });
+    const preflightAbort = createPreflightCompactionAbortSignal(params.replyOperation);
+    let result: Awaited<ReturnType<typeof deps.compactEmbeddedAgentSession>> | undefined;
+    try {
+      result = await deps.compactEmbeddedAgentSession({
+        sessionId: entry.sessionId,
+        sessionKey: params.sessionKey,
+        sandboxSessionKey: params.runtimePolicySessionKey,
+        allowGatewaySubagentBinding: true,
+        messageChannel: params.followupRun.run.messageProvider,
+        groupId: entry.groupId ?? params.followupRun.run.groupId,
+        groupChannel: entry.groupChannel ?? params.followupRun.run.groupChannel,
+        groupSpace: entry.space ?? params.followupRun.run.groupSpace,
+        senderId: params.followupRun.run.senderId,
+        senderName: params.followupRun.run.senderName,
+        senderUsername: params.followupRun.run.senderUsername,
+        senderE164: params.followupRun.run.senderE164,
+        sessionFile: sessionFile ?? params.followupRun.run.sessionFile,
+        workspaceDir: params.followupRun.run.workspaceDir,
+        cwd: params.followupRun.run.cwd,
+        agentDir: params.followupRun.run.agentDir,
+        config: params.cfg,
+        skillsSnapshot: entry.skillsSnapshot ?? params.followupRun.run.skillsSnapshot,
+        provider: params.followupRun.run.provider,
+        model: params.followupRun.run.model,
+        authProfileId: params.followupRun.run.authProfileId,
+        agentHarnessId:
+          entry.sessionId === params.followupRun.run.sessionId ? entry.agentHarnessId : undefined,
+        thinkLevel: params.followupRun.run.thinkLevel,
+        bashElevated: params.followupRun.run.bashElevated,
+        abortSignal: preflightAbort.abortSignal,
+        trigger: "budget",
+        force: true,
+        forcePreflight: true,
+        preflightRequired: true,
+        preflightCompactionTrigger: compactionTrigger,
+        deferOwningContextEngineCompaction: false,
+        contextTokenBudget: contextWindowTokens,
+        currentTokenCount: tokenCountForCompaction ?? freshPersistedTokens,
+        ownerNumbers: params.followupRun.run.ownerNumbers,
+      });
+    } finally {
+      preflightAbort.cleanup();
+    }
 
     if (!result?.ok) {
       const reason = result?.reason ?? "not_compacted";

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -124,6 +124,48 @@ describe("reply run registry", () => {
     expect(replyRunRegistry.isActive("agent:main:main")).toBe(false);
   });
 
+  it("keeps explicit cancellation separate from upstream lifecycle aborts", () => {
+    const upstreamAbortController = new AbortController();
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:main",
+      sessionId: "session-lifecycle-abort",
+      resetTriggered: false,
+      upstreamAbortSignal: upstreamAbortController.signal,
+    });
+    const explicitAbortSignal = operation.explicitAbortSignal;
+
+    expect(operation.abortSignal.aborted).toBe(false);
+    expect(explicitAbortSignal?.aborted).toBe(false);
+
+    upstreamAbortController.abort(new Error("reply lifecycle timeout"));
+
+    expect(operation.abortSignal.aborted).toBe(true);
+    expect(explicitAbortSignal?.aborted).toBe(false);
+    expect(operation.result).toBeNull();
+
+    operation.abortByUser();
+
+    expect(explicitAbortSignal?.aborted).toBe(true);
+    expect(operation.result).toEqual({ kind: "aborted", code: "aborted_by_user" });
+    expect(replyRunRegistry.isActive("agent:main:main")).toBe(false);
+  });
+
+  it("aborts the explicit cancellation signal on restart abort", () => {
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:main",
+      sessionId: "session-restart-abort",
+      resetTriggered: false,
+    });
+    const explicitAbortSignal = operation.explicitAbortSignal;
+
+    operation.abortForRestart();
+
+    expect(operation.abortSignal.aborted).toBe(true);
+    expect(explicitAbortSignal?.aborted).toBe(true);
+    expect(operation.result).toEqual({ kind: "aborted", code: "aborted_for_restart" });
+    expect(replyRunRegistry.isActive("agent:main:main")).toBe(false);
+  });
+
   it("runs completeThen callbacks after active state clears", () => {
     const operation = createReplyOperation({
       sessionKey: "agent:main:main",

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -55,6 +55,11 @@ export type ReplyOperation = {
   readonly sessionId: string;
   readonly routeThreadId?: string | number;
   readonly abortSignal: AbortSignal;
+  /**
+   * Aborts only for explicit user/restart cancellation. Upstream reply
+   * lifecycle aborts use abortSignal and must not cap required preflight work.
+   */
+  readonly explicitAbortSignal?: AbortSignal;
   readonly resetTriggered: boolean;
   readonly phase: ReplyOperationPhase;
   readonly result: ReplyOperationResult | null;
@@ -386,6 +391,7 @@ export function createReplyOperation(params: {
   }
 
   const controller = new AbortController();
+  const explicitAbortController = new AbortController();
   let currentSessionId = sessionId;
   let phase: ReplyOperationPhase = "queued";
   let result: ReplyOperationResult | null = null;
@@ -428,6 +434,11 @@ export function createReplyOperation(params: {
       controller.abort(reason);
     }
   };
+  const abortExplicitly = (reason?: unknown) => {
+    if (!explicitAbortController.signal.aborted) {
+      explicitAbortController.abort(reason);
+    }
+  };
 
   const abortWithReason = (
     reason: ReplyBackendCancelReason,
@@ -438,6 +449,7 @@ export function createReplyOperation(params: {
       result = { kind: "aborted", code: opts.abortedCode };
     }
     phase = "aborted";
+    abortExplicitly(abortReason);
     abortInternally(abortReason);
     getAttachedBackend(operation)?.cancel(reason);
   };
@@ -468,6 +480,9 @@ export function createReplyOperation(params: {
     },
     get abortSignal() {
       return controller.signal;
+    },
+    get explicitAbortSignal() {
+      return explicitAbortController.signal;
     },
     get resetTriggered() {
       return params.resetTriggered;


### PR DESCRIPTION
## What Problem This Solves

Fixes #95553. Required preflight compaction could inherit the outer reply-operation abort signal, so a short reply lifecycle timeout could cancel compaction before the configured compaction timeout had a chance to govern the required preflight work.

## Why This Change Was Made

This keeps required preflight compaction bounded by the compaction layer while still preserving real cancellation. `ReplyOperation` exposes an explicit cancellation signal for user stop and restart cancellation, and required preflight compaction now receives a scoped preflight abort signal that:

- ignores upstream lifecycle `TimeoutError` aborts so the compaction timeout owns slow required compaction;
- preserves upstream non-timeout aborts such as chat/RPC/user/restart cancellation;
- preserves explicit stop/restart cancellation even if the lifecycle timeout has already aborted the main reply signal.

The patch is intentionally narrow: normal reply runs still use the existing operation abort signal, while required preflight compaction uses the filtered signal because it already has its own safety timeout.

## User Impact

When a reply needs preflight compaction, users should see compaction complete or fail according to `compaction.timeoutSeconds`, instead of being prematurely canceled by the reply lifecycle timeout path. If the user explicitly stops the run, an RPC abort arrives, or the run is restarted, the preflight compaction still cancels promptly instead of waiting for the compaction timeout.

This PR is split out from #95563 to keep the P1 behavior fix reviewable on its own.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts src/auto-reply/reply/reply-run-registry.test.ts src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts` passed after rebasing onto `origin/main`: 2 auto-reply files / 68 tests and 1 agents file / 22 tests.
- `corepack pnpm tsgo:core` passed after rebasing onto `origin/main`.
- `git diff --check` passed.
- 2026-06-24 redacted production preflight proof: `node --import tsx` invoked the production `runPreflightCompactionIfNeeded` path with a real `ReplyOperation`, a slow compaction seam, a simulated lifecycle `TimeoutError`, and a real `abortByUser()` explicit cancellation. Redacted terminal output:

```text
OpenClaw preflight compaction cancellation proof
paths redacted; no credentials or channel identifiers used
  notice=start
SCENARIO lifecycle-timeout-ignored
  preflight-start phase=preflight_compacting
  compact-signal-initially-aborted=false
  lifecycle-timeout-aborted-at-ms=261
  compact-signal-after-lifecycle-timeout=false
  slow-compaction-finished-at-ms=440
  compact-signal-at-finish=false
  compaction-count-incremented=true
  notice=end
  preflight-result=completed
  operation-phase-after=preflight_compacting
  notice=start
SCENARIO explicit-user-abort-cancels
  preflight-start phase=preflight_compacting
  compact-signal-initially-aborted=false
  explicit-user-abort-called-at-ms=83
  compact-signal-after-explicit-abort=true
  compact-signal-reason-name=AbortError
  explicit-abort-observed-at-ms=83
  notice=incomplete
  preflight-result=threw-AbortError
  operation-phase-after=aborted
```

Known remaining proof gap: I still have not added logs from the reporter's exact slow vLLM/Qwen backend. The new proof above exercises the production preflight entry and reply cancellation contract with a slow compaction seam, plus focused regression tests and typecheck.
