### PR TITLE
fix(memory-core): skip forced sync for healthy zero-hit search

### DIFF
--- a/extensions/memory-core/src/memory-tool-manager.test-mocks.ts
+++ b/extensions/memory-core/src/memory-tool-manager.test-mocks.ts
@@ -24,6 +24,7 @@ type MemoryBackend = "builtin" | "qmd";
 let backend: MemoryBackend = "builtin";
 let workspaceDir = "/workspace";
 let customStatus: Record<string, unknown> | undefined;
+let statusOverrides: Record<string, unknown> | undefined;
 let searchImpl: SearchImpl = async () => [];
 let getManagerImpl:
   | ((params: { cfg?: unknown; agentId?: string; purpose?: string }) => Promise<{
@@ -54,6 +55,7 @@ const stubManager = {
     sources: ["memory" as const],
     sourceCounts: [{ source: "memory" as const, files: 1, chunks: 1 }],
     custom: customStatus,
+    ...statusOverrides,
   }),
   sync: vi.fn(),
   probeVectorAvailability: vi.fn(async () => true),
@@ -93,6 +95,10 @@ export function setMemoryCustomStatus(next: Record<string, unknown> | undefined)
   customStatus = next;
 }
 
+export function setMemoryStatusOverrides(next: Record<string, unknown> | undefined): void {
+  statusOverrides = next;
+}
+
 export function setMemorySearchImpl(next: SearchImpl): void {
   searchImpl = next;
 }
@@ -120,6 +126,7 @@ export function resetMemoryToolMockState(overrides?: {
   backend = overrides?.backend ?? "builtin";
   workspaceDir = "/workspace";
   customStatus = undefined;
+  statusOverrides = undefined;
   getManagerImpl = undefined;
   searchImpl = overrides?.searchImpl ?? (async () => []);
   readFileImpl =

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -11,6 +11,7 @@ import {
   setMemoryCustomStatus,
   setMemorySearchImpl,
   setMemorySearchManagerImpl,
+  setMemoryStatusOverrides,
 } from "./memory-tool-manager.test-mocks.js";
 import { createMemorySearchTool, testing as memoryToolsTesting } from "./tools.js";
 import { MemoryGetSchema, MemorySearchSchema } from "./tools.shared.js";
@@ -55,6 +56,67 @@ describe("memory tool schemas", () => {
     expect(searchCorpus.enum).toEqual(["memory", "wiki", "all", "sessions"]);
     expect(getCorpus.anyOf).toBeUndefined();
     expect(getCorpus.enum).toEqual(["memory", "wiki", "all"]);
+  });
+});
+
+describe("memory_search zero-hit sync decisions", () => {
+  it("only forces sync for unavailable or unready index status", () => {
+    const decide = memoryToolsTesting.shouldForceSyncAfterZeroResults;
+    const healthy = {
+      backend: "qmd",
+      dirty: false,
+      files: 27,
+      chunks: 472,
+      vector: { available: true },
+      fts: { available: true },
+      custom: { indexIdentity: { status: "valid" } },
+    };
+
+    expect(decide(healthy)).toEqual({
+      shouldSync: false,
+      reason: "healthy_zero_hit",
+    });
+    expect(decide({ ...healthy, dirty: true })).toEqual({
+      shouldSync: false,
+      reason: "healthy_zero_hit",
+    });
+    expect(decide({ ...healthy, backend: "builtin", dirty: true })).toEqual({
+      shouldSync: true,
+      reason: "dirty_index",
+    });
+    expect(decide({ ...healthy, backend: undefined, dirty: true })).toEqual({
+      shouldSync: true,
+      reason: "dirty_index",
+    });
+    expect(decide({ ...healthy, vector: { enabled: false, available: false } })).toEqual({
+      shouldSync: false,
+      reason: "healthy_zero_hit",
+    });
+    expect(decide({ ...healthy, fts: { enabled: false, available: false } })).toEqual({
+      shouldSync: false,
+      reason: "healthy_zero_hit",
+    });
+    expect(decide({ ...healthy, custom: { indexIdentity: { status: "missing" } } })).toEqual({
+      shouldSync: true,
+      reason: "index_identity_invalid",
+    });
+    expect(decide({ ...healthy, chunks: 0 })).toEqual({
+      shouldSync: true,
+      reason: "no_indexed_chunks",
+    });
+    expect(decide({ ...healthy, files: 0 })).toEqual({
+      shouldSync: true,
+      reason: "no_indexed_files",
+    });
+    expect(decide({ ...healthy, vector: { available: false } })).toEqual({
+      shouldSync: true,
+      reason: "vector_unavailable",
+    });
+    expect(decide({ ...healthy, fts: { available: false } })).toEqual({
+      shouldSync: true,
+      reason: "fts_unavailable",
+    });
+    expect(decide(null)).toEqual({ shouldSync: true, reason: "status_unavailable" });
   });
 });
 
@@ -313,7 +375,7 @@ describe("memory_search unavailable payloads", () => {
     expect(getMemoryCloseMockCalls()).toBe(1);
   });
 
-  it("forces a sync and retries once when the first search has zero hits", async () => {
+  it("returns a healthy zero-hit without forcing sync when the index is ready", async () => {
     let searchCalls = 0;
     setMemorySearchImpl(async () => {
       searchCalls += 1;
@@ -339,11 +401,45 @@ describe("memory_search unavailable payloads", () => {
       },
     });
     const result = await tool.execute("zero-hit-retry", { query: "hidden thread codename" });
+    const details = result.details as { results?: Array<{ path: string }> };
 
-    expect((result.details as { results?: Array<{ path: string }> }).results?.[0]?.path).toBe(
-      "MEMORY.md",
-    );
+    expect(details.results).toEqual([]);
+    expect(searchCalls).toBe(1);
+    expect(getMemorySyncMockCalls()).toBe(0);
+  });
+
+  it("preserves the dirty zero-hit retry for non-qmd backends", async () => {
+    let searchCalls = 0;
+    setMemoryStatusOverrides({ dirty: true });
+    setMemorySearchImpl(async () => {
+      searchCalls += 1;
+      if (searchCalls === 1) {
+        return [];
+      }
+      return [
+        {
+          path: "MEMORY.md",
+          startLine: 1,
+          endLine: 1,
+          score: 0.9,
+          snippet: "Thread-hidden codename: ORBIT-22.",
+          source: "memory" as const,
+        },
+      ];
+    });
+
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { citations: "off" },
+      },
+    });
+    const result = await tool.execute("zero-hit-retry", { query: "hidden thread codename" });
+    const details = result.details as { results?: Array<{ path: string }> };
+
+    expect(details.results).toEqual([expect.objectContaining({ path: "MEMORY.md" })]);
     expect(searchCalls).toBe(2);
+    expect(getMemorySyncMockCalls()).toBe(1);
   });
 
   it("returns unavailable metadata when the index identity is paused", async () => {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -44,6 +44,15 @@ type MemorySearchToolResult =
   | MemoryCorpusSearchResult;
 type MemoryManagerContext = Awaited<ReturnType<typeof getMemoryManagerContextWithPurpose>>;
 type ActiveMemoryManagerContext = Extract<MemoryManagerContext, { manager: unknown }>;
+type MemorySearchZeroResultStatus = {
+  backend?: unknown;
+  dirty?: unknown;
+  files?: unknown;
+  chunks?: unknown;
+  vector?: unknown;
+  fts?: unknown;
+  custom?: unknown;
+};
 
 const MEMORY_SEARCH_TOOL_TIMEOUT_MS = 15_000;
 const MEMORY_SEARCH_TOOL_COOLDOWN_MS = 60_000;
@@ -76,10 +85,42 @@ function recordMemorySearchToolCooldown(key: string, error: string): void {
   });
 }
 
+function shouldForceSyncAfterZeroResults(status: MemorySearchZeroResultStatus | null | undefined): {
+  shouldSync: boolean;
+  reason: string;
+} {
+  if (!status || typeof status !== "object") {
+    return { shouldSync: true, reason: "status_unavailable" };
+  }
+  const indexIdentity = asRecord(asRecord(status.custom)?.indexIdentity);
+  if (indexIdentity?.status && indexIdentity.status !== "valid") {
+    return { shouldSync: true, reason: "index_identity_invalid" };
+  }
+  if (typeof status.chunks === "number" && status.chunks <= 0) {
+    return { shouldSync: true, reason: "no_indexed_chunks" };
+  }
+  if (typeof status.files === "number" && status.files <= 0) {
+    return { shouldSync: true, reason: "no_indexed_files" };
+  }
+  const vectorStatus = asRecord(status.vector);
+  if (vectorStatus?.available === false && vectorStatus.enabled !== false) {
+    return { shouldSync: true, reason: "vector_unavailable" };
+  }
+  const ftsStatus = asRecord(status.fts);
+  if (ftsStatus?.available === false && ftsStatus.enabled !== false) {
+    return { shouldSync: true, reason: "fts_unavailable" };
+  }
+  if (status.dirty === true && status.backend !== "qmd") {
+    return { shouldSync: true, reason: "dirty_index" };
+  }
+  return { shouldSync: false, reason: "healthy_zero_hit" };
+}
+
 export const testing = {
   resetMemorySearchToolCooldowns() {
     memorySearchToolCooldowns.clear();
   },
+  shouldForceSyncAfterZeroResults,
 } as const;
 
 function isActiveMemoryManagerContext(
@@ -532,13 +573,16 @@ export function createMemorySearchTool(options: {
                     return;
                   }
                   if (rawResults.length === 0 && activeMemory.manager.sync) {
-                    await activeMemory.manager.sync({ reason: "search", force: true });
-                    rawResults = await activeMemory.manager.search(query, searchOptions);
-                    pausedIndexIdentityReason = resolvePausedMemoryIndexIdentityReason(
-                      activeMemory.manager.status(),
-                    );
-                    if (pausedIndexIdentityReason) {
-                      return;
+                    const syncDecision = shouldForceSyncAfterZeroResults(statusBeforeRetry);
+                    if (syncDecision.shouldSync) {
+                      await activeMemory.manager.sync({ reason: "search", force: true });
+                      rawResults = await activeMemory.manager.search(query, searchOptions);
+                      pausedIndexIdentityReason = resolvePausedMemoryIndexIdentityReason(
+                        activeMemory.manager.status(),
+                      );
+                      if (pausedIndexIdentityReason) {
+                        return;
+                      }
                     }
                   }
                   rawResults = await filterMemorySearchHitsBySessionVisibility({


### PR DESCRIPTION
## What Problem This Solves

A valid memory search can return zero hits while the index is marked dirty even though the index is otherwise healthy. Before this fix, the tool wrapper treated that dirty-only zero-hit as a reason to call `manager.sync({ reason: "search", force: true })` and wait inside the tool call. On hosts where the forced sync does not complete quickly, `memory_search` can hang until the tool timeout even though the correct user-facing answer is simply an empty result set.

This patch keeps the recall-preserving retry for non-QMD dirty indexes while preventing the QMD healthy dirty-only zero-hit path from forcing a blocking sync. Missing, invalid, empty, or unavailable index states still force sync.

## Summary

- skip blocking forced sync for healthy QMD zero-hit search results, including dirty-only QMD status
- preserve dirty zero-hit forced-sync retry for non-QMD or unknown backends
- keep forced sync for missing, invalid, empty, vector-unavailable, or FTS-unavailable memory states
- treat disabled vector/FTS modes as healthy instead of unavailable
- add regression coverage for QMD dirty healthy zero-hit no-sync and non-QMD dirty zero-hit retry behavior

## Evidence

Focused local verification on branch head `925495a4`:

```text
git diff --check
node scripts/run-vitest.mjs extensions/memory-core/src/tools.test.ts
```

Result:

```text
[test] starting test/vitest/vitest.extension-memory.config.ts

 RUN  v4.1.8 /home/lestat/openclaw-fresh/workspace/external/openclaw-source-preservation

 Test Files  1 passed (1)
      Tests  19 passed (19)
   Start at  20:29:09
   Duration  4.21s (transform 2.03s, setup 283ms, import 3.64s, tests 101ms, environment 0ms)

[test] passed 1 Vitest shard in 19.33s
```

Regression coverage now includes:

- `shouldForceSyncAfterZeroResults` returns `healthy_zero_hit` for QMD dirty healthy zero-hit status
- `shouldForceSyncAfterZeroResults` returns `dirty_index` for builtin or unknown dirty healthy zero-hit status
- `returns a healthy zero-hit without forcing sync when the index is ready` asserts one search call and zero sync calls
- `preserves the dirty zero-hit retry for non-qmd backends` asserts the wrapper syncs once, searches twice, and returns the second-search result
- disabled vector/FTS modes with `available: false` do not make the index unhealthy

Live installed-runtime proof before source promotion:

- `openclaw memory status --json` reported indexed and ready memory with `files: 159`, `chunks: 2519`, `dirty: false`, enabled/available FTS and vector, and `custom.indexIdentity.status: valid`
- a synthetic valid no-hit returned `0` results in about `491.6ms` with `forcedSync.attempted=false` and `forcedSync.reason=healthy_zero_hit` after gateway reload

## Safety Boundaries

- no model switch
- no production reindex
- no vector deletion
- no memory config change
- no secret/token output
- no unrelated Pi-hole/plugin work
