### PR TITLE
fix(memory): skip placeholder short-term promotions

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -11,6 +11,7 @@ vi.mock("openclaw/plugin-sdk/memory-host-events", () => ({
   appendMemoryHostEvent: vi.fn(async () => {}),
 }));
 
+import { appendMemoryHostEvent } from "openclaw/plugin-sdk/memory-host-events";
 import {
   configureMemoryCoreDreamingState,
   configureMemoryCoreDreamingStateForTests,
@@ -1620,6 +1621,273 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("classifies markdown placeholders without dropping meaningful snippets", () => {
+    for (const raw of [
+      "-",
+      "* ",
+      "- -",
+      ">",
+      "```",
+      "```ts",
+      "``` ts",
+      "~~~ qmd",
+      "| --- |",
+      "- [ ]",
+      "- [x]",
+      "@@ -1,2\n## Tagesnotizen\n-",
+      "@@ -1,2 ## Tagesnotizen -",
+      "## Tagesnotizen\n-\n\n## Entscheidungen:\n-",
+      "## Tagesnotizen ## Entscheidungen",
+      "## Morning ## Light Sleep",
+      "## Tagesnotizen ## Morning",
+      "## 2026-05-28 ## Morning",
+      "# 2026-05-28",
+      "@@ -1,2 # 2026-05-28 -",
+      "## Morning",
+      "## Morning:",
+      "@@ -1,2 ## Morning -",
+      "@@ -1,2 ## Morning: -",
+      "## Light Sleep",
+      "## Light Sleep:",
+      "Morning:",
+      "Light Sleep:",
+    ]) {
+      expect(testing.resolvePromotableShortTermSnippet(raw)).toMatchObject({
+        promotable: false,
+        reason: "markdown-placeholder",
+      });
+    }
+
+    for (const raw of [
+      "- Keep gateway restarts supervised.",
+      "- [ ] rotate API keys",
+      "- [x] backups verified",
+      "## API keys rotated",
+      "## Decision: Move backups to S3",
+      "## Morning backup verification",
+      "## Morning - backup verification",
+      "@@ -7,1\nrouter glacier backup",
+      "@@ -1,1\n- Keep gateway restarts supervised.",
+      "- ## 修复备份轮换",
+    ]) {
+      expect(testing.resolvePromotableShortTermSnippet(raw)).toMatchObject({
+        promotable: true,
+      });
+    }
+
+    expect(
+      testing.resolvePromotableShortTermSnippet(
+        "@@ -6,2\n## Morning\n- Reviewed travel timing before the workshop.",
+      ),
+    ).toMatchObject({
+      promotable: true,
+      snippet: "- Reviewed travel timing before the workshop.",
+    });
+    expect(
+      testing.resolvePromotableShortTermSnippet(
+        "@@ -6,2 ## Morning - Reviewed travel timing before the workshop.",
+      ),
+    ).toMatchObject({
+      promotable: true,
+      snippet: "Reviewed travel timing before the workshop.",
+    });
+    expect(
+      testing.resolvePromotableShortTermSnippet(
+        "@@ -6,2 ## Tagesnotizen - Rotate backups before deploy.",
+      ),
+    ).toMatchObject({
+      promotable: true,
+      snippet: "Rotate backups before deploy.",
+    });
+    expect(
+      testing.resolvePromotableShortTermSnippet("@@ -7,1 router glacier backup"),
+    ).toMatchObject({
+      promotable: true,
+      snippet: "router glacier backup",
+    });
+    expect(
+      testing.resolvePromotableShortTermSnippet("## Morning - backup verification"),
+    ).toMatchObject({
+      promotable: true,
+      snippet: "backup verification",
+    });
+    expect(
+      testing.resolvePromotableShortTermSnippet("## Morning: - backup verification"),
+    ).toMatchObject({
+      promotable: true,
+      snippet: "backup verification",
+    });
+    expect(
+      testing.resolvePromotableShortTermSnippet("Morning:: Reviewed travel timing."),
+    ).toMatchObject({
+      promotable: true,
+      snippet: "Reviewed travel timing.",
+    });
+    expect(
+      testing.resolvePromotableShortTermSnippet("Light Sleep: useful dream note"),
+    ).toMatchObject({
+      promotable: true,
+      snippet: "useful dream note",
+    });
+    expect(
+      testing.resolvePromotableShortTermSnippet("- Morning: Reviewed travel timing."),
+    ).toMatchObject({
+      promotable: true,
+      snippet: "Reviewed travel timing.",
+    });
+    expect(
+      testing.resolvePromotableShortTermSnippet("@@ -6,1 - Light Sleep: useful note"),
+    ).toMatchObject({
+      promotable: true,
+      snippet: "useful note",
+    });
+    expect(testing.resolvePromotableShortTermSnippet("Decision: Move backups to S3")).toMatchObject(
+      {
+        promotable: true,
+        snippet: "Decision: Move backups to S3",
+      },
+    );
+    expect(
+      testing.resolvePromotableShortTermSnippet("- Decision: Move backups to S3"),
+    ).toMatchObject({
+      promotable: true,
+      snippet: "- Decision: Move backups to S3",
+    });
+    expect(
+      testing.resolvePromotableShortTermSnippet(
+        "~~~ qmd\n- Keep gateway restarts supervised.\n~~~",
+      ),
+    ).toMatchObject({
+      promotable: true,
+      snippet: "- Keep gateway restarts supervised.",
+    });
+  });
+
+  it("skips placeholder short-term recalls before recording and reports them separately", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const notePath = await writeDailyMemoryNote(workspaceDir, "2026-04-19", [
+        "## Tagesnotizen",
+        "-",
+        "Rotate backups before deploy.",
+      ]);
+      const relativePath = path.relative(workspaceDir, notePath).replaceAll("\\", "/");
+      const appendEventMock = vi.mocked(appendMemoryHostEvent);
+      appendEventMock.mockClear();
+
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "backup recall",
+        results: [
+          {
+            path: relativePath,
+            source: "memory",
+            startLine: 1,
+            endLine: 2,
+            score: 0.8,
+            snippet: "@@ -1,2\n## Tagesnotizen\n-",
+          },
+          {
+            path: relativePath,
+            source: "memory",
+            startLine: 3,
+            endLine: 3,
+            score: 0.9,
+            snippet: "Rotate backups before deploy.",
+          },
+        ],
+      });
+
+      const entries = Object.values(await readRecallStoreEntries(workspaceDir));
+      expect(entries).toHaveLength(1);
+      expect(readEntrySnippet(entries[0])).toBe("Rotate backups before deploy.");
+
+      const events = appendEventMock.mock.calls.map(
+        ([, event]) =>
+          event as {
+            type?: string;
+            reason?: string;
+            resultCount?: number;
+            skippedResultCount?: number;
+            results?: unknown[];
+          },
+      );
+      expect(events.find((event) => event.type === "memory.recall.recorded")).toMatchObject({
+        resultCount: 1,
+        results: [expect.objectContaining({ startLine: 3, endLine: 3 })],
+      });
+      expect(
+        events.find(
+          (event) =>
+            event.type === "memory.recall.skipped" &&
+            event.reason === "unpromotable-short-term-snippet",
+        ),
+      ).toMatchObject({
+        skippedResultCount: 1,
+        results: [expect.objectContaining({ startLine: 1, endLine: 2 })],
+      });
+    });
+  });
+
+  it("drops placeholder snippets from existing and grounded short-term candidates", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await testing.writeRawRecallStore(workspaceDir, {
+        version: 1,
+        updatedAt: "2026-04-04T00:00:00.000Z",
+        entries: {
+          placeholder: {
+            key: "placeholder",
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 2,
+            source: "memory",
+            snippet: "## Tagesnotizen\n-",
+            recallCount: 4,
+            dailyCount: 0,
+            groundedCount: 0,
+            totalScore: 3.6,
+            maxScore: 0.95,
+            firstRecalledAt: "2026-04-03T00:00:00.000Z",
+            lastRecalledAt: "2026-04-04T00:00:00.000Z",
+            queryHashes: ["a", "b"],
+            recallDays: ["2026-04-03", "2026-04-04"],
+            conceptTags: ["notes"],
+          },
+        },
+      });
+      await recordGroundedShortTermCandidates({
+        workspaceDir,
+        query: "backup recall",
+        items: [
+          {
+            path: "memory/2026-04-04.md",
+            startLine: 1,
+            endLine: 2,
+            score: 0.95,
+            snippet: "## Entscheidungen:\n-",
+          },
+          {
+            path: "memory/2026-04-04.md",
+            startLine: 3,
+            endLine: 3,
+            score: 0.95,
+            snippet: "- Keep gateway restarts supervised.",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+
+      expect(ranked.map((candidate) => candidate.snippet)).toStrictEqual([
+        "- Keep gateway restarts supervised.",
+      ]);
+    });
+  });
+
   it("treats diff-prefixed dreaming snippets as contaminated", () => {
     expect(
       testing.isContaminatedDreamingSnippet(
@@ -1954,6 +2222,48 @@ describe("short-term promotion", () => {
         .catch(() => "");
       expect(memoryText).not.toContain("Promoted From Short-Term Memory");
       expect(memoryText).not.toContain("staged dream scratchwork");
+    });
+  });
+
+  it("refuses placeholder-only direct promotion candidates", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        candidates: [
+          {
+            key: "memory:memory/2026-04-19.md:2:2",
+            path: "memory/2026-04-19.md",
+            startLine: 2,
+            endLine: 2,
+            source: "memory",
+            snippet: "-",
+            recallCount: 3,
+            avgScore: 0.9,
+            maxScore: 0.9,
+            uniqueQueries: 2,
+            firstRecalledAt: "2026-04-18T00:00:00.000Z",
+            lastRecalledAt: "2026-04-19T00:00:00.000Z",
+            ageDays: 1,
+            score: 0.9,
+            recallDays: ["2026-04-18", "2026-04-19"],
+            conceptTags: ["notes"],
+            components: {
+              frequency: 1,
+              relevance: 0.9,
+              diversity: 1,
+              recency: 1,
+              consolidation: 0.5,
+              conceptual: 0.2,
+            },
+          },
+        ],
+      });
+
+      expect(applied.applied).toBe(0);
+      await expectEnoent(fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8"));
     });
   });
 

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -358,6 +358,29 @@ function normalizeSnippet(raw: string): string {
   return trimmed.replace(/\s+/g, " ");
 }
 
+type MarkdownPromotionLine = { kind: "content"; text: string } | { kind: "structural" };
+
+type ShortTermSnippetSkipReason = "empty" | "dreaming-contaminated" | "markdown-placeholder";
+
+type ShortTermSnippetPromotionResolution =
+  | { promotable: true; snippet: string }
+  | { promotable: false; reason: ShortTermSnippetSkipReason };
+
+const MARKDOWN_PLACEHOLDER_HEADING_LABELS = new Set([
+  "daily notes",
+  "decisions",
+  "entscheidungen",
+  "ideas",
+  "notes",
+  "scratch",
+  "tasks",
+  "tagesnotizen",
+  "todo",
+  "todos",
+]);
+const QMD_SNIPPET_HUNK_HEADER_PREFIX_RE =
+  /^@@\s+-\d+(?:,\d+)?(?:\s+\+\d+(?:,\d+)?)?(?:\s+@@)?(?:\s+|$)/u;
+
 function truncateShortTermSnippet(snippet: string): string {
   if (snippet.length <= SHORT_TERM_RECALL_MAX_SNIPPET_CHARS) {
     return snippet;
@@ -443,6 +466,189 @@ function isContaminatedDreamingSnippet(
   const hasStatus = /\bstatus:\s*staged\b/i.test(snippet);
   const hasRecalls = /\brecalls:\s*\d+\b/i.test(snippet);
   return hasNarrativeLead && hasConfidence && hasEvidence && hasStatus && hasRecalls;
+}
+
+function hasDurableSnippetContent(raw: string): boolean {
+  return /[\p{L}\p{N}]/u.test(raw);
+}
+
+function normalizeMarkdownPlaceholderLabel(raw: string): string {
+  return raw
+    .normalize("NFKC")
+    .trim()
+    .replace(/[:：]+$/u, "")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function isMarkdownPlaceholderLabel(raw: string): boolean {
+  const label = normalizeMarkdownPlaceholderLabel(raw);
+  return label.length > 0 && MARKDOWN_PLACEHOLDER_HEADING_LABELS.has(label);
+}
+
+function isMarkdownPlaceholderHeadingBody(raw: string): boolean {
+  const segments = raw
+    .split(/#{1,6}\s*/u)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+  return (
+    segments.length > 0 &&
+    segments.every(
+      (segment) =>
+        isMarkdownPlaceholderLabel(segment) ||
+        isGenericDailyHeadingForPromotion(normalizeStructuralHeadingForPromotion(segment)),
+    )
+  );
+}
+
+function stripLeadingMarkdownDecorators(rawLine: string): string {
+  let text = rawLine.trim();
+  let previous = "";
+  while (text && text !== previous) {
+    previous = text;
+    text = text
+      .replace(QMD_SNIPPET_HUNK_HEADER_PREFIX_RE, "")
+      .replace(/^(?:>\s*)+/u, "")
+      .replace(/^(?:[-*+]\s*)+/u, "")
+      .replace(/^\d+[.)]\s*/u, "")
+      .replace(/^\[[ xX]\]\s*/u, "")
+      .trim();
+  }
+  return text;
+}
+
+function stripLeadingQmdSnippetHeader(rawLine: string): string {
+  return rawLine.trim().replace(QMD_SNIPPET_HUNK_HEADER_PREFIX_RE, "").trim();
+}
+
+function stripTrailingMarkdownDecorators(rawLine: string): string {
+  let text = rawLine.trim();
+  let previous = "";
+  while (text && text !== previous) {
+    previous = text;
+    text = text
+      .replace(/\s+(?:[-*+]|>|`{3,}|~{3,})$/u, "")
+      .replace(/\s+\[[ xX]\]$/u, "")
+      .trim();
+  }
+  return text;
+}
+
+function normalizeStructuralHeadingForPromotion(rawLine: string): string {
+  return normalizeSnippet(stripTrailingMarkdownDecorators(rawLine).replace(/[:：]+$/u, ""));
+}
+
+function isStructuralHeadingForPromotion(rawLine: string): boolean {
+  const normalized = normalizeStructuralHeadingForPromotion(rawLine);
+  return (
+    normalized.length > 0 &&
+    (isMarkdownPlaceholderHeadingBody(rawLine) || isGenericDailyHeadingForPromotion(normalized))
+  );
+}
+
+function stripCollapsedStructuralHeadingPrefix(rawLine: string): string {
+  const text = rawLine.trim();
+  const candidates = [text];
+  const withoutLeadingDecorators = stripLeadingMarkdownDecorators(text);
+  if (withoutLeadingDecorators && withoutLeadingDecorators !== text) {
+    candidates.push(withoutLeadingDecorators);
+  }
+
+  for (const candidate of candidates) {
+    const heading = candidate.match(/^#{1,6}\s+(.+)$/u);
+    const headingBody = heading?.[1]?.trim() ?? candidate;
+    for (const collapsed of [
+      headingBody.match(/^(.+?)\s+[-*+]\s+(.+)$/u),
+      headingBody.match(/^(.+?[:：]+)\s*(.+)$/u),
+    ]) {
+      if (!collapsed) {
+        continue;
+      }
+      const headingPrefix = stripTrailingMarkdownDecorators(collapsed[1]?.trim() ?? "");
+      const content = collapsed[2]?.trim() ?? "";
+      if (headingPrefix && content && isStructuralHeadingForPromotion(headingPrefix)) {
+        return content;
+      }
+    }
+  }
+  return text;
+}
+
+function isMarkdownFenceOnly(raw: string): boolean {
+  return /^(?:`{3,}|~{3,})(?:\s*\S.*)?$/u.test(raw.trim());
+}
+
+function classifyMarkdownPromotionLine(rawLine: string): MarkdownPromotionLine {
+  let text = stripLeadingMarkdownDecorators(rawLine);
+  if (!text) {
+    return { kind: "structural" };
+  }
+  if (isMarkdownFenceOnly(text) || /^<!--.*-->$/u.test(text)) {
+    return { kind: "structural" };
+  }
+
+  const heading = text.match(/^#{1,6}\s*(.*?)\s*#*$/u);
+  if (heading) {
+    const headingBody = heading[1]?.trim() ?? "";
+    const headingContent = stripTrailingMarkdownDecorators(headingBody);
+    if (
+      !headingContent ||
+      isMarkdownPlaceholderHeadingBody(headingBody) ||
+      isMarkdownPlaceholderHeadingBody(headingContent) ||
+      isStructuralHeadingForPromotion(headingContent)
+    ) {
+      return { kind: "structural" };
+    }
+    text = headingContent;
+  }
+
+  text = stripLeadingMarkdownDecorators(text);
+  if (
+    !text ||
+    isMarkdownFenceOnly(text) ||
+    isMarkdownPlaceholderLabel(text) ||
+    isStructuralHeadingForPromotion(text)
+  ) {
+    return { kind: "structural" };
+  }
+  if (!hasDurableSnippetContent(text)) {
+    return { kind: "structural" };
+  }
+  return { kind: "content", text };
+}
+
+function normalizeMarkdownPromotionSnippet(raw: string): string | null {
+  const contentLines: string[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const classification = classifyMarkdownPromotionLine(line);
+    if (classification.kind === "structural") {
+      continue;
+    }
+    const contentLine = stripLeadingQmdSnippetHeader(line);
+    const normalizedLine = stripCollapsedStructuralHeadingPrefix(contentLine);
+    contentLines.push(normalizedLine || classification.text);
+  }
+  const snippet = normalizeSnippet(contentLines.join("\n"));
+  return snippet || null;
+}
+
+function resolvePromotableShortTermSnippet(
+  raw: string,
+  opts: { allowTranscriptTurnSnippet?: boolean } = {},
+): ShortTermSnippetPromotionResolution {
+  const snippet = normalizeSnippet(raw);
+  if (!snippet) {
+    return { promotable: false, reason: "empty" };
+  }
+  if (isContaminatedDreamingSnippet(snippet, opts)) {
+    return { promotable: false, reason: "dreaming-contaminated" };
+  }
+  const markdownSnippet = normalizeMarkdownPromotionSnippet(raw);
+  if (!markdownSnippet) {
+    return { promotable: false, reason: "markdown-placeholder" };
+  }
+  return { promotable: true, snippet: markdownSnippet };
 }
 
 function normalizeMemoryPath(rawPath: string): string {
@@ -620,15 +826,16 @@ export function normalizeShortTermRecallStore(raw: unknown, nowIso: string): Sho
         typeof entry.claimHash === "string" && entry.claimHash.trim().length > 0
           ? entry.claimHash.trim()
           : undefined;
-      const fullSnippet = typeof entry.snippet === "string" ? normalizeSnippet(entry.snippet) : "";
-      if (
-        fullSnippet &&
-        isContaminatedDreamingSnippet(fullSnippet, {
-          allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(entryPath),
-        })
-      ) {
+      const snippetResolution =
+        typeof entry.snippet === "string"
+          ? resolvePromotableShortTermSnippet(entry.snippet, {
+              allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(entryPath),
+            })
+          : null;
+      if (!snippetResolution?.promotable) {
         continue;
       }
+      const fullSnippet = snippetResolution.snippet;
       const snippet = truncateShortTermSnippet(fullSnippet);
       const queryHashes = Array.isArray(entry.queryHashes)
         ? normalizeDistinctStrings(entry.queryHashes, MAX_QUERY_HASHES)
@@ -1360,14 +1567,16 @@ export async function filterLiveShortTermRecallEntries(params: {
 function buildMemoryRecallSkippedEvent(params: {
   timestamp: string;
   query: string;
+  reason?: "non-short-term-memory-path" | "unpromotable-short-term-snippet";
   eligibleResultCount: number;
   skipped: MemorySearchResult[];
 }) {
+  const reason = params.reason ?? "non-short-term-memory-path";
   return {
     type: "memory.recall.skipped" as const,
     timestamp: params.timestamp,
     query: params.query,
-    reason: "non-short-term-memory-path" as const,
+    reason,
     eligibleResultCount: params.eligibleResultCount,
     skippedResultCount: params.skipped.length,
     results: params.skipped.map((result) => ({
@@ -1375,7 +1584,7 @@ function buildMemoryRecallSkippedEvent(params: {
       startLine: Math.max(1, Math.floor(result.startLine)),
       endLine: Math.max(1, Math.floor(result.endLine)),
       score: clampScore(result.score),
-      reason: "non-short-term-memory-path" as const,
+      reason,
     })),
   };
 }
@@ -1419,6 +1628,59 @@ export async function recordShortTermRecalls(params: {
     );
     return;
   }
+  const promotableRelevant: Array<{
+    result: MemorySearchResult;
+    normalizedPath: string;
+    startLine: number;
+    endLine: number;
+    rawSnippet: string;
+    snippet: string;
+  }> = [];
+  const unpromotable: MemorySearchResult[] = [];
+  for (const result of relevant) {
+    const normalizedPath = normalizeMemoryPath(result.path);
+    const resolution = resolvePromotableShortTermSnippet(result.snippet, {
+      allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(normalizedPath),
+    });
+    if (!resolution.promotable) {
+      unpromotable.push(result);
+      continue;
+    }
+    promotableRelevant.push({
+      result,
+      normalizedPath,
+      startLine: Math.max(1, Math.floor(result.startLine)),
+      endLine: Math.max(1, Math.floor(result.endLine)),
+      rawSnippet: resolution.snippet,
+      snippet: truncateShortTermSnippet(resolution.snippet),
+    });
+  }
+  if (promotableRelevant.length === 0) {
+    if (unpromotable.length > 0) {
+      await appendMemoryHostEvent(
+        workspaceDir,
+        buildMemoryRecallSkippedEvent({
+          timestamp: nowIso,
+          query,
+          reason: "unpromotable-short-term-snippet",
+          eligibleResultCount: relevant.length,
+          skipped: unpromotable,
+        }),
+      );
+    }
+    if (skipped.length > 0) {
+      await appendMemoryHostEvent(
+        workspaceDir,
+        buildMemoryRecallSkippedEvent({
+          timestamp: nowIso,
+          query,
+          eligibleResultCount: relevant.length,
+          skipped,
+        }),
+      );
+    }
+    return;
+  }
   const signalType = params.signalType ?? "recall";
   const queryHash = hashQuery(query);
   const todayBucket =
@@ -1426,29 +1688,24 @@ export async function recordShortTermRecalls(params: {
   await withShortTermLock(workspaceDir, async () => {
     const store = await readStore(workspaceDir, nowIso);
 
-    for (const result of relevant) {
-      const normalizedPath = normalizeMemoryPath(result.path);
-      const rawSnippet = normalizeSnippet(result.snippet);
-      const snippet = truncateShortTermSnippet(rawSnippet);
-      if (
-        !rawSnippet ||
-        isContaminatedDreamingSnippet(rawSnippet, {
-          allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(normalizedPath),
-        })
-      ) {
-        continue;
-      }
+    for (const item of promotableRelevant) {
+      const { result, normalizedPath, startLine, endLine, rawSnippet, snippet } = item;
       const claimHash = buildClaimHash(rawSnippet);
       const groundedKey = claimHash
         ? buildEntryKey({
             path: normalizedPath,
-            startLine: Math.max(1, Math.floor(result.startLine)),
-            endLine: Math.max(1, Math.floor(result.endLine)),
+            startLine,
+            endLine,
             source: "memory",
             claimHash,
           })
         : null;
-      const baseKey = buildEntryKey(result);
+      const baseKey = buildEntryKey({
+        path: normalizedPath,
+        startLine,
+        endLine,
+        source: "memory",
+      });
       const key = groundedKey && store.entries[groundedKey] ? groundedKey : baseKey;
       const existing = store.entries[key];
       const score = clampScore(result.score);
@@ -1483,8 +1740,8 @@ export async function recordShortTermRecalls(params: {
       store.entries[key] = {
         key,
         path: normalizedPath,
-        startLine: Math.max(1, Math.floor(result.startLine)),
-        endLine: Math.max(1, Math.floor(result.endLine)),
+        startLine,
+        endLine,
         source: "memory",
         snippet: snippet || existing?.snippet || "",
         recallCount,
@@ -1508,14 +1765,26 @@ export async function recordShortTermRecalls(params: {
       type: "memory.recall.recorded",
       timestamp: nowIso,
       query,
-      resultCount: relevant.length,
-      results: relevant.map((result) => ({
-        path: normalizeMemoryPath(result.path),
-        startLine: Math.max(1, Math.floor(result.startLine)),
-        endLine: Math.max(1, Math.floor(result.endLine)),
-        score: clampScore(result.score),
+      resultCount: promotableRelevant.length,
+      results: promotableRelevant.map((item) => ({
+        path: item.normalizedPath,
+        startLine: item.startLine,
+        endLine: item.endLine,
+        score: clampScore(item.result.score),
       })),
     });
+    if (unpromotable.length > 0) {
+      await appendMemoryHostEvent(
+        workspaceDir,
+        buildMemoryRecallSkippedEvent({
+          timestamp: nowIso,
+          query,
+          reason: "unpromotable-short-term-snippet",
+          eligibleResultCount: relevant.length,
+          skipped: unpromotable,
+        }),
+      );
+    }
     if (skipped.length > 0) {
       await appendMemoryHostEvent(
         workspaceDir,
@@ -1558,12 +1827,10 @@ export async function recordGroundedShortTermCandidates(params: {
   }
   const relevant = params.items
     .map((item) => {
-      const rawSnippet = normalizeSnippet(item.snippet);
-      const snippet = truncateShortTermSnippet(rawSnippet);
+      const snippetResolution = resolvePromotableShortTermSnippet(item.snippet);
       const normalizedPath = normalizeMemoryPath(item.path);
       if (
-        !rawSnippet ||
-        isContaminatedDreamingSnippet(rawSnippet) ||
+        !snippetResolution.promotable ||
         !normalizedPath ||
         !isShortTermMemoryPath(normalizedPath) ||
         !Number.isFinite(item.startLine) ||
@@ -1571,6 +1838,8 @@ export async function recordGroundedShortTermCandidates(params: {
       ) {
         return null;
       }
+      const rawSnippet = snippetResolution.snippet;
+      const snippet = truncateShortTermSnippet(rawSnippet);
       return {
         path: normalizedPath,
         startLine: Math.max(1, Math.floor(item.startLine)),
@@ -1861,11 +2130,10 @@ export async function rankShortTermPromotionCandidates(
     if (!entry || entry.source !== "memory" || !isShortTermMemoryPath(entry.path)) {
       continue;
     }
-    if (
-      isContaminatedDreamingSnippet(entry.snippet, {
-        allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(entry.path),
-      })
-    ) {
+    const snippetResolution = resolvePromotableShortTermSnippet(entry.snippet, {
+      allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(entry.path),
+    });
+    if (!snippetResolution.promotable) {
       continue;
     }
     if (!includePromoted && entry.promotedAt) {
@@ -1926,7 +2194,7 @@ export async function rankShortTermPromotionCandidates(
       startLine: entry.startLine,
       endLine: entry.endLine,
       source: entry.source,
-      snippet: entry.snippet,
+      snippet: snippetResolution.snippet,
       recallCount,
       dailyCount,
       groundedCount,
@@ -2129,16 +2397,20 @@ function compareCandidateWindow(
   targetSnippet: string,
   windowSnippet: string,
 ): { matched: boolean; quality: number } {
-  if (!targetSnippet || !windowSnippet) {
+  const targetResolution = resolvePromotableShortTermSnippet(targetSnippet);
+  const windowResolution = resolvePromotableShortTermSnippet(windowSnippet);
+  if (!targetResolution.promotable || !windowResolution.promotable) {
     return { matched: false, quality: 0 };
   }
-  if (windowSnippet === targetSnippet) {
+  const target = targetResolution.snippet;
+  const window = windowResolution.snippet;
+  if (window === target) {
     return { matched: true, quality: 3 };
   }
-  if (windowSnippet.includes(targetSnippet)) {
+  if (window.includes(target)) {
     return { matched: true, quality: 2 };
   }
-  if (targetSnippet.includes(windowSnippet)) {
+  if (target.includes(window)) {
     return { matched: true, quality: 1 };
   }
   return { matched: false, quality: 0 };
@@ -2148,19 +2420,12 @@ function relocateCandidateRange(
   lines: string[],
   candidate: PromotionCandidate,
 ): { startLine: number; endLine: number; snippet: string } | null {
-  const targetSnippet = normalizeSnippet(candidate.snippet);
-  const preferredSpan = Math.max(1, candidate.endLine - candidate.startLine + 1);
-  if (targetSnippet.length === 0) {
-    const fallbackSnippet = normalizeRangeSnippet(lines, candidate.startLine, candidate.endLine);
-    if (!fallbackSnippet) {
-      return null;
-    }
-    return {
-      startLine: candidate.startLine,
-      endLine: candidate.endLine,
-      snippet: fallbackSnippet,
-    };
+  const targetResolution = resolvePromotableShortTermSnippet(candidate.snippet);
+  if (!targetResolution.promotable) {
+    return null;
   }
+  const targetSnippet = targetResolution.snippet;
+  const preferredSpan = Math.max(1, candidate.endLine - candidate.startLine + 1);
 
   const exactSnippet = normalizeRangeSnippet(lines, candidate.startLine, candidate.endLine);
   if (exactSnippet === targetSnippet) {
@@ -2321,6 +2586,10 @@ async function rehydratePromotionCandidate(
     if (!relocated) {
       continue;
     }
+    const relocatedResolution = resolvePromotableShortTermSnippet(relocated.snippet);
+    if (!relocatedResolution.promotable) {
+      continue;
+    }
     // Managed dreaming blocks in daily memory files are scratchwork, not durable
     // content. If rehydration lands inside an openclaw:dreaming fence (for example
     // because file edits shifted lines between ranking and apply), refuse the
@@ -2332,7 +2601,7 @@ async function rehydratePromotionCandidate(
       ...candidate,
       startLine: relocated.startLine,
       endLine: relocated.endLine,
-      snippet: relocated.snippet,
+      snippet: relocatedResolution.snippet,
     };
   }
   return null;
@@ -2447,7 +2716,7 @@ export async function applyShortTermPromotions(
     const store = await readStore(workspaceDir, nowIso);
     const selected = options.candidates
       .filter((candidate) => {
-        if (isContaminatedDreamingSnippet(candidate.snippet)) {
+        if (!resolvePromotableShortTermSnippet(candidate.snippet).promotable) {
           return false;
         }
         if (candidate.promotedAt) {
@@ -2476,7 +2745,7 @@ export async function applyShortTermPromotions(
     const rehydratedSelected: PromotionCandidate[] = [];
     for (const candidate of selected) {
       const rehydrated = await rehydratePromotionCandidate(workspaceDir, candidate);
-      if (rehydrated && !isContaminatedDreamingSnippet(rehydrated.snippet)) {
+      if (rehydrated && resolvePromotableShortTermSnippet(rehydrated.snippet).promotable) {
         rehydratedSelected.push(rehydrated);
       }
     }
@@ -2897,6 +3166,7 @@ async function writeRawShortTermStoreForTest(
 export const testing = {
   parseLockOwnerPid,
   isProcessLikelyAlive,
+  resolvePromotableShortTermSnippet,
   readRecallStore: readStore,
   readPhaseSignalStore,
   writeRawRecallStore: (workspaceDir: string, raw: unknown) =>

--- a/src/memory-host-sdk/events.ts
+++ b/src/memory-host-sdk/events.ts
@@ -21,12 +21,16 @@ export type MemoryHostRecallRecordedEvent = {
   }>;
 };
 
+export type MemoryHostRecallSkippedReason =
+  | "non-short-term-memory-path"
+  | "unpromotable-short-term-snippet";
+
 /** Event emitted when recall hits are visible but excluded from short-term promotion. */
 export type MemoryHostRecallSkippedEvent = {
   type: "memory.recall.skipped";
   timestamp: string;
   query: string;
-  reason: "non-short-term-memory-path";
+  reason: MemoryHostRecallSkippedReason;
   eligibleResultCount: number;
   skippedResultCount: number;
   results: Array<{
@@ -34,7 +38,7 @@ export type MemoryHostRecallSkippedEvent = {
     startLine: number;
     endLine: number;
     score: number;
-    reason: "non-short-term-memory-path";
+    reason: MemoryHostRecallSkippedReason;
   }>;
 };
 

--- a/src/plugin-sdk/memory-host-events.test.ts
+++ b/src/plugin-sdk/memory-host-events.test.ts
@@ -135,6 +135,23 @@ describe("memory host event journal helpers", () => {
         },
       ],
     });
+    await appendMemoryHostEvent(workspaceDir, {
+      type: "memory.recall.skipped",
+      timestamp: "2026-04-05T12:15:00.000Z",
+      query: "daily placeholder",
+      reason: "unpromotable-short-term-snippet",
+      eligibleResultCount: 1,
+      skippedResultCount: 1,
+      results: [
+        {
+          path: "memory/2026-04-05.md",
+          startLine: 5,
+          endLine: 6,
+          score: 0.7,
+          reason: "unpromotable-short-term-snippet",
+        },
+      ],
+    });
 
     const legacyEvents = await readMemoryHostEvents({ workspaceDir });
     const legacyTail = await readMemoryHostEvents({ workspaceDir, limit: 1 });
@@ -146,7 +163,13 @@ describe("memory host event journal helpers", () => {
       "memory.recall.skipped",
       "memory.recall.recorded",
       "memory.recall.skipped",
+      "memory.recall.skipped",
     ]);
+    expect(records.at(-1)).toMatchObject({
+      type: "memory.recall.skipped",
+      reason: "unpromotable-short-term-snippet",
+      results: [expect.objectContaining({ reason: "unpromotable-short-term-snippet" })],
+    });
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Closes #80582.

Short-term memory promotion could treat markdown and QMD scaffolding as durable content. That included empty list/checklist/fence/table fragments, placeholder daily-note headings, generic daily/dreaming headings, QMD hunk wrappers, collapsed persisted heading prefixes, and mixed snippets that carried structural text alongside real content.

## Why This Change Was Made

The fix centralizes short-term snippet promotability in the promotion resolver and applies that resolver across recall recording, store normalization, grounded candidates, ranking, relocation/rehydration, and direct promotion application.

Placeholder-only snippets are skipped. Mixed snippets keep real content while dropping structural wrappers such as QMD hunk headers, generic daily/dreaming headings, collapsed heading prefixes, and bullet-prefixed collapsed heading prefixes. Ordinary non-generic bullets remain intact.

The diagnostic skipped recall event now has an additive `unpromotable-short-term-snippet` reason, with the Plugin SDK API baseline hash regenerated for the exported event type change.

## User Impact

Memory promotion should carry actual remembered content instead of daily-note scaffolding or QMD placeholder text. Existing meaningful snippets still promote, and legacy event readers continue to read recorded recall events while diagnostic readers can see skipped recall records.

## Evidence

### Real-behavior proof — actual `MEMORY.md` written to disk

This drives the **real promotion pipeline** end-to-end against a temp workspace — `rankShortTermPromotionCandidates` -> `applyShortTermPromotions` — with real note files on disk and the real SQLite recall store. No mocks; the only inputs are seeded recalls (one markdown placeholder skeleton `## Tagesnotizen\n-`, one meaningful note), both crossing promotion thresholds. The transcript below is the `MEMORY.md` the production code wrote.

**Before — `origin/main` @ `e43bd3d57bc`** (`applied: 2` — the placeholder is promoted into long-term memory):
```
## Promoted From Short-Term Memory (2026-07-12)

<!-- openclaw-memory-promotion:placeholder -->
- ## Tagesnotizen - [score=0.532 signals=4 recalls=4 avg=0.900 source=memory/2026-04-03.md:1-2]
<!-- openclaw-memory-promotion:meaningful -->
- Keep gateway restarts supervised. [score=0.532 signals=4 recalls=4 avg=0.900 source=memory/2026-04-04.md:3-3]
```

**After — this branch @ `144693f8816`** (`applied: 1` — the placeholder is excluded, the real note is kept):
```
## Promoted From Short-Term Memory (2026-07-12)

<!-- openclaw-memory-promotion:meaningful -->
- Keep gateway restarts supervised. [score=0.532 signals=4 recalls=4 avg=0.900 source=memory/2026-04-04.md:3-3]
```

The harness is a vitest spec asserting the real file contains `Keep gateway restarts supervised.` and does **not** contain `Tagesnotizen`; it passes on this branch and fails on main (`AssertionError: expected '# Long-Term Memory…' not to contain 'Tagesnotizen'`).

<details><summary>Reproduce (drop into <code>extensions/memory-core/src/</code> and <code>pnpm test</code> it on either checkout)</summary>

```ts
// Real-behavior proof for issue #80582 / PR #95598.
// Drives the ACTUAL short-term promotion pipeline (rank -> apply) against a real
// temp workspace and prints the real MEMORY.md written to disk. No mocks: the
// only inputs are a seeded recall store and real filesystem writes by the
// production `applyShortTermPromotions` path. Run:
//   pnpm test extensions/memory-core/src/short-term-promotion.proof.test.ts
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";
import { afterAll, beforeAll, expect, it } from "vitest";
import { configureMemoryCoreDreamingStateForTests } from "./dreaming-state.js";
import {
  applyShortTermPromotions,
  rankShortTermPromotionCandidates,
  testing,
} from "./short-term-promotion.js";

let root: string;
beforeAll(async () => {
  await configureMemoryCoreDreamingStateForTests();
  root = await fs.mkdtemp(path.join(os.tmpdir(), "proof-80582-"));
});
afterAll(async () => {
  await fs.rm(root, { recursive: true, force: true });
});

it("PROOF #80582: real MEMORY.md excludes placeholder skeletons, keeps meaningful notes", async () => {
  const workspaceDir = path.join(root, "ws");
  await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });

  // Real note files on disk backing the recall entries (the promotion path
  // rehydrates each candidate from its source note before writing).
  await fs.writeFile(
    path.join(workspaceDir, "memory", "2026-04-03.md"),
    "## Tagesnotizen\n-\n",
    "utf8",
  );
  await fs.writeFile(
    path.join(workspaceDir, "memory", "2026-04-04.md"),
    "## Entscheidungen:\n-\n- Keep gateway restarts supervised.\n",
    "utf8",
  );

  // Seed the real recall store the way the running agent would after repeated
  // recalls: two entries that BOTH clear promotion thresholds — one is a
  // markdown placeholder skeleton (heading + empty bullet), one is a real note.
  await testing.writeRawRecallStore(workspaceDir, {
    version: 1,
    updatedAt: "2026-04-04T00:00:00.000Z",
    entries: {
      placeholder: {
        key: "placeholder",
        path: "memory/2026-04-03.md",
        startLine: 1,
        endLine: 2,
        source: "memory",
        snippet: "## Tagesnotizen\n-",
        recallCount: 4,
        dailyCount: 0,
        groundedCount: 0,
        totalScore: 3.6,
        maxScore: 0.95,
        firstRecalledAt: "2026-04-03T00:00:00.000Z",
        lastRecalledAt: "2026-04-04T00:00:00.000Z",
        queryHashes: ["a", "b"],
        recallDays: ["2026-04-03", "2026-04-04"],
        conceptTags: ["notes"],
      },
      meaningful: {
        key: "meaningful",
        path: "memory/2026-04-04.md",
        startLine: 3,
        endLine: 3,
        source: "memory",
        snippet: "- Keep gateway restarts supervised.",
        recallCount: 4,
        dailyCount: 0,
        groundedCount: 0,
        totalScore: 3.6,
        maxScore: 0.95,
        firstRecalledAt: "2026-04-03T00:00:00.000Z",
        lastRecalledAt: "2026-04-04T00:00:00.000Z",
        queryHashes: ["a", "b"],
        recallDays: ["2026-04-03", "2026-04-04"],
        conceptTags: ["notes"],
      },
    },
  });

  const ranked = await rankShortTermPromotionCandidates({
    workspaceDir,
    minScore: 0,
    minRecallCount: 0,
    minUniqueQueries: 0,
  });

  const result = await applyShortTermPromotions({
    workspaceDir,
    candidates: ranked,
    minScore: 0,
    minRecallCount: 0,
    minUniqueQueries: 0,
  });

  const memory = await fs.readFile(result.memoryPath, "utf8").catch(() => "<no MEMORY.md written>");

  const transcript = [
    "================ REAL MEMORY.md ON DISK ================",
    `path: ${path.relative(workspaceDir, result.memoryPath)}`,
    `promotion candidates ranked: ${ranked.map((c) => JSON.stringify(c.snippet)).join(", ") || "(none)"}`,
    `applied: ${result.applied}`,
    "-------------------------------------------------------",
    memory.trimEnd(),
    "=======================================================",
  ].join("\n");
  await fs.writeFile(path.join(os.tmpdir(), "proof-80582-out.txt"), transcript, "utf8");

  // The real file must contain the meaningful note and must NOT contain the
  // placeholder skeleton heading.
  expect(memory).toContain("Keep gateway restarts supervised.");
  expect(memory).not.toContain("Tagesnotizen");
});
```
</details>

### Source-level red-green

`CI=true pnpm test extensions/memory-core/src/short-term-promotion.test.ts` — 99 pass on branch; copying that same test file onto `origin/main` fails 3 (`… to have a length of 1 but got 2`), because main records the placeholder skeletons this branch filters. `pnpm tsgo:core`, `pnpm tsgo:extensions`, and the plugin-sdk surface budgets are clean.
