### PR TITLE
fix(memory): backfill provider.model in createWithAdapter when adapter returns empty string

### DIFF
--- a/extensions/memory-core/src/memory/embeddings.ts
+++ b/extensions/memory-core/src/memory/embeddings.ts
@@ -226,12 +226,19 @@ async function createWithAdapter(
   adapter: MemoryEmbeddingProviderAdapter,
   options: CreateEmbeddingProviderOptions,
 ): Promise<EmbeddingProviderResult> {
+  const resolvedModel = resolveProviderModel(adapter, options.model);
   const result = await adapter.create({
     ...options,
-    model: resolveProviderModel(adapter, options.model),
+    model: resolvedModel,
   });
   return {
-    provider: result.provider,
+    // Backfill provider.model when the adapter returns an empty string so
+    // callers always see the resolved model name.  An empty model string
+    // during boot can overwrite a correct index identity and leave the
+    // search index permanently dirty.
+    provider: result.provider
+      ? { ...result.provider, model: result.provider.model || resolvedModel }
+      : null,
     requestedProvider: options.provider,
     runtime: result.runtime,
   };


### PR DESCRIPTION
## What Problem This Solves

Backfill `provider.model` when the adapter returns an empty string so callers
always see the resolved model name. An empty model string during boot can
overwrite a correct index identity and leave the search index permanently dirty.

## Changes

- Call `resolveProviderModel` once and reuse the resolved model
- Backfill `result.provider.model` with `resolvedModel` when adapter returns
  an empty string: `result.provider ? { ...result.provider, model: result.provider.model || resolvedModel } : null`

## Evidence

### Before (empty model → dirty index)
```
provider.model = ""  // adapter returned empty string, index identity was lost
```

### After (model backfilled from resolved default)
```
provider.model = "text-embedding-3-small"  // resolved from adapter.defaultModel
```

_AI-assisted._