### PR TITLE
fix(backup): sweep stale temp artifacts before creating new backup

### DIFF
--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -1,9 +1,10 @@
 // Covers backup archive creation and verification filtering.
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import * as tar from "tar";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { backupVerifyCommand } from "../commands/backup-verify.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -18,6 +19,7 @@ import {
   buildExtensionsNodeModulesFilter,
   createBackupArchive,
   formatBackupCreateSummary,
+  sweepStaleBackupArtifacts,
   type BackupCreateResult,
 } from "./backup-create.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
@@ -1202,5 +1204,86 @@ describe("createBackupArchive", () => {
         }
       },
     );
+  });
+});
+
+describe("sweepStaleBackupArtifacts", () => {
+  let testRoot: string;
+  let outputDir: string;
+  let outputPath: string;
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sweep-test-"));
+    outputDir = path.join(testRoot, "backups");
+    outputPath = path.join(outputDir, "backup.tar.gz");
+    tempRoot = path.join(testRoot, "staging-root");
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.mkdir(tempRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(testRoot, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it("removes stale openclaw-backup-* directories from the selected temp root", async () => {
+    const staleDir = path.join(tempRoot, "openclaw-backup-abc123");
+    await fs.mkdir(staleDir);
+    await fs.writeFile(path.join(staleDir, "manifest.json"), "{}");
+    const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+    await fs.utimes(staleDir, new Date(twoHoursAgo), new Date(twoHoursAgo));
+
+    const entries = await fs.readdir(tempRoot, { withFileTypes: true });
+    expect(entries.some((e) => e.name === "openclaw-backup-abc123")).toBe(true);
+
+    await sweepStaleBackupArtifacts({ outputPath, tempRoot });
+
+    const after = await fs.readdir(tempRoot);
+    expect(after).not.toContain("openclaw-backup-abc123");
+  });
+
+  it("removes stale temp archive files next to the output path", async () => {
+    const uuid = randomUUID();
+    const tempFile = path.join(outputDir, `backup.tar.gz.${uuid}.tmp`);
+    await fs.writeFile(tempFile, "data");
+    const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+    await fs.utimes(tempFile, new Date(twoHoursAgo), new Date(twoHoursAgo));
+
+    await sweepStaleBackupArtifacts({ outputPath, tempRoot });
+
+    const after = await fs.readdir(outputDir);
+    expect(after).not.toContain(`backup.tar.gz.${uuid}.tmp`);
+  });
+
+  it("preserves recent artifacts within grace window", async () => {
+    const recentDir = path.join(tempRoot, "openclaw-backup-recent");
+    await fs.mkdir(recentDir);
+    await fs.writeFile(path.join(recentDir, "data"), "x");
+
+    const uuid = randomUUID();
+    const recentFile = path.join(outputDir, `backup.tar.gz.${uuid}.tmp`);
+    await fs.writeFile(recentFile, "data");
+
+    await sweepStaleBackupArtifacts({ outputPath, tempRoot });
+
+    expect(await fs.readdir(tempRoot)).toContain("openclaw-backup-recent");
+    expect(await fs.readdir(outputDir)).toContain(`backup.tar.gz.${uuid}.tmp`);
+  });
+
+  it("ignores unrelated files and uuid temp files that do not match the output basename", async () => {
+    const uuid = randomUUID();
+    const unrelatedArchiveTemp = path.join(outputDir, `other-backup.tar.gz.${uuid}.tmp`);
+    await fs.writeFile(path.join(outputDir, "unrelated.txt"), "keep me");
+    await fs.writeFile(unrelatedArchiveTemp, "keep me");
+    await fs.mkdir(path.join(tempRoot, "some-other-dir"));
+    const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+    await fs.utimes(unrelatedArchiveTemp, new Date(twoHoursAgo), new Date(twoHoursAgo));
+
+    await sweepStaleBackupArtifacts({ outputPath, tempRoot });
+
+    expect(await fs.readdir(outputDir)).toEqual(
+      expect.arrayContaining(["unrelated.txt", `other-backup.tar.gz.${uuid}.tmp`]),
+    );
+    expect(await fs.readdir(tempRoot)).toContain("some-other-dir");
   });
 });

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -24,6 +24,9 @@ import {
 } from "./backup-create.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 
+const BACKUP_STAGING_OWNER_FILE = ".openclaw-backup-owner.json";
+const BACKUP_ARCHIVE_OWNER_SUFFIX = ".openclaw-owner.json";
+
 function makeResult(overrides: Partial<BackupCreateResult> = {}): BackupCreateResult {
   return {
     createdAt: "2026-01-01T00:00:00.000Z",
@@ -1226,12 +1229,20 @@ describe("sweepStaleBackupArtifacts", () => {
     await fs.rm(testRoot, { recursive: true, force: true }).catch(() => undefined);
   });
 
+  async function markOld(targetPath: string): Promise<void> {
+    const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+    await fs.utimes(targetPath, new Date(twoHoursAgo), new Date(twoHoursAgo));
+  }
+
+  async function writeOwner(ownerPath: string, pid: number): Promise<void> {
+    await fs.writeFile(ownerPath, `${JSON.stringify({ pid, startedAtMs: Date.now() })}\n`, "utf8");
+  }
+
   it("removes stale openclaw-backup-* directories from the selected temp root", async () => {
     const staleDir = path.join(tempRoot, "openclaw-backup-abc123");
     await fs.mkdir(staleDir);
     await fs.writeFile(path.join(staleDir, "manifest.json"), "{}");
-    const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
-    await fs.utimes(staleDir, new Date(twoHoursAgo), new Date(twoHoursAgo));
+    await markOld(staleDir);
 
     const entries = await fs.readdir(tempRoot, { withFileTypes: true });
     expect(entries.some((e) => e.name === "openclaw-backup-abc123")).toBe(true);
@@ -1246,8 +1257,7 @@ describe("sweepStaleBackupArtifacts", () => {
     const uuid = randomUUID();
     const tempFile = path.join(outputDir, `backup.tar.gz.${uuid}.tmp`);
     await fs.writeFile(tempFile, "data");
-    const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
-    await fs.utimes(tempFile, new Date(twoHoursAgo), new Date(twoHoursAgo));
+    await markOld(tempFile);
 
     await sweepStaleBackupArtifacts({ outputPath, tempRoot });
 
@@ -1276,8 +1286,7 @@ describe("sweepStaleBackupArtifacts", () => {
     await fs.writeFile(path.join(outputDir, "unrelated.txt"), "keep me");
     await fs.writeFile(unrelatedArchiveTemp, "keep me");
     await fs.mkdir(path.join(tempRoot, "some-other-dir"));
-    const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
-    await fs.utimes(unrelatedArchiveTemp, new Date(twoHoursAgo), new Date(twoHoursAgo));
+    await markOld(unrelatedArchiveTemp);
 
     await sweepStaleBackupArtifacts({ outputPath, tempRoot });
 
@@ -1285,5 +1294,61 @@ describe("sweepStaleBackupArtifacts", () => {
       expect.arrayContaining(["unrelated.txt", `other-backup.tar.gz.${uuid}.tmp`]),
     );
     expect(await fs.readdir(tempRoot)).toContain("some-other-dir");
+  });
+
+  it("preserves stale artifacts while their owner process is still alive", async () => {
+    const staleDir = path.join(tempRoot, "openclaw-backup-active");
+    await fs.mkdir(staleDir);
+    await fs.writeFile(path.join(staleDir, "manifest.json"), "{}");
+    await writeOwner(path.join(staleDir, BACKUP_STAGING_OWNER_FILE), process.pid);
+    await markOld(staleDir);
+
+    const uuid = randomUUID();
+    const tempFileName = `backup.tar.gz.${uuid}.tmp`;
+    const tempFile = path.join(outputDir, tempFileName);
+    await fs.writeFile(tempFile, "data");
+    await writeOwner(`${tempFile}${BACKUP_ARCHIVE_OWNER_SUFFIX}`, process.pid);
+    await markOld(tempFile);
+
+    await sweepStaleBackupArtifacts({ outputPath, tempRoot });
+
+    expect(await fs.readdir(tempRoot)).toContain("openclaw-backup-active");
+    expect(await fs.readdir(outputDir)).toEqual(
+      expect.arrayContaining([tempFileName, `${tempFileName}${BACKUP_ARCHIVE_OWNER_SUFFIX}`]),
+    );
+  });
+
+  it("removes stale artifacts and owner markers when their owner is not live", async () => {
+    const staleDir = path.join(tempRoot, "openclaw-backup-dead-owner");
+    await fs.mkdir(staleDir);
+    await writeOwner(path.join(staleDir, BACKUP_STAGING_OWNER_FILE), -1);
+    await markOld(staleDir);
+
+    const uuid = randomUUID();
+    const tempFileName = `backup.tar.gz.${uuid}.tmp`;
+    const tempFile = path.join(outputDir, tempFileName);
+    const ownerFileName = `${tempFileName}${BACKUP_ARCHIVE_OWNER_SUFFIX}`;
+    await fs.writeFile(tempFile, "data");
+    await writeOwner(path.join(outputDir, ownerFileName), -1);
+    await markOld(tempFile);
+
+    await sweepStaleBackupArtifacts({ outputPath, tempRoot });
+
+    expect(await fs.readdir(tempRoot)).not.toContain("openclaw-backup-dead-owner");
+    expect(await fs.readdir(outputDir)).not.toEqual(
+      expect.arrayContaining([tempFileName, ownerFileName]),
+    );
+  });
+
+  it("preserves stale owner sidecars without archive files when their owner is still alive", async () => {
+    const uuid = randomUUID();
+    const ownerFileName = `backup.tar.gz.${uuid}.tmp${BACKUP_ARCHIVE_OWNER_SUFFIX}`;
+    const ownerPath = path.join(outputDir, ownerFileName);
+    await writeOwner(ownerPath, process.pid);
+    await markOld(ownerPath);
+
+    await sweepStaleBackupArtifacts({ outputPath, tempRoot });
+
+    expect(await fs.readdir(outputDir)).toContain(ownerFileName);
   });
 });

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -690,6 +690,74 @@ async function createStateSqliteBackupPlan(params: {
   return { snapshots, discoveredSourcePaths: discovery.discoveredSourcePaths };
 }
 
+const STALE_SWEEP_GRACE_MS = 60 * 60 * 1000;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function sweepStaleBackupArtifacts(params: {
+  outputPath: string;
+  tempRoot: string;
+}): Promise<void> {
+  await Promise.all([
+    sweepStaleBackupStagingDirs(params.tempRoot),
+    sweepStaleBackupArchiveTemps(params.outputPath),
+  ]);
+}
+
+async function sweepStaleBackupStagingDirs(tempRoot: string): Promise<void> {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(tempRoot, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith("openclaw-backup-"))
+      .map((entry) => removeStalePath(path.join(tempRoot, entry.name))),
+  );
+}
+
+async function sweepStaleBackupArchiveTemps(outputPath: string): Promise<void> {
+  const outputDir = path.dirname(outputPath);
+  const outputBaseName = path.basename(outputPath);
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(outputDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && isBackupArchiveTempName(entry.name, outputBaseName))
+      .map((entry) => removeStalePath(path.join(outputDir, entry.name))),
+  );
+}
+
+async function removeStalePath(targetPath: string): Promise<void> {
+  let stat: import("node:fs").Stats;
+  try {
+    stat = await fs.stat(targetPath);
+  } catch {
+    return;
+  }
+  if (Date.now() - stat.mtimeMs < STALE_SWEEP_GRACE_MS) {
+    return;
+  }
+  await fs.rm(targetPath, { recursive: true, force: true }).catch(() => undefined);
+}
+
+function isBackupArchiveTempName(name: string, outputBaseName: string): boolean {
+  const prefix = `${outputBaseName}.`;
+  const suffix = ".tmp";
+  if (!name.startsWith(prefix) || !name.endsWith(suffix)) {
+    return false;
+  }
+  return UUID_RE.test(name.slice(prefix.length, -suffix.length));
+}
+
 export async function createBackupArchive(
   opts: BackupCreateOptions = {},
 ): Promise<BackupCreateResult> {
@@ -748,6 +816,7 @@ export async function createBackupArchive(
   await fs.mkdir(path.dirname(outputPath), { recursive: true });
   const tempRoot = await chooseBackupTempRoot({ assets: result.assets, outputPath });
   await fs.mkdir(tempRoot, { recursive: true });
+  await sweepStaleBackupArtifacts({ outputPath, tempRoot });
   const tempDir = await fs.mkdtemp(path.join(tempRoot, "openclaw-backup-"));
   const manifestPath = path.join(tempDir, "manifest.json");
   const tempArchivePath = buildTempArchivePath(outputPath);

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -691,8 +691,15 @@ async function createStateSqliteBackupPlan(params: {
 }
 
 const STALE_SWEEP_GRACE_MS = 60 * 60 * 1000;
+const BACKUP_STAGING_OWNER_FILE = ".openclaw-backup-owner.json";
+const BACKUP_ARCHIVE_OWNER_SUFFIX = ".openclaw-owner.json";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type BackupArtifactOwner = {
+  pid: number;
+  startedAtMs: number;
+};
 
 export async function sweepStaleBackupArtifacts(params: {
   outputPath: string;
@@ -715,7 +722,10 @@ async function sweepStaleBackupStagingDirs(tempRoot: string): Promise<void> {
   await Promise.all(
     entries
       .filter((entry) => entry.isDirectory() && entry.name.startsWith("openclaw-backup-"))
-      .map((entry) => removeStalePath(path.join(tempRoot, entry.name))),
+      .map((entry) => {
+        const artifactPath = path.join(tempRoot, entry.name);
+        return removeStalePath(artifactPath, path.join(artifactPath, BACKUP_STAGING_OWNER_FILE));
+      }),
   );
 }
 
@@ -729,14 +739,32 @@ async function sweepStaleBackupArchiveTemps(outputPath: string): Promise<void> {
     return;
   }
 
+  const entryNames = new Set(entries.map((entry) => entry.name));
   await Promise.all(
     entries
-      .filter((entry) => entry.isFile() && isBackupArchiveTempName(entry.name, outputBaseName))
-      .map((entry) => removeStalePath(path.join(outputDir, entry.name))),
+      .filter((entry) => entry.isFile())
+      .flatMap((entry) => {
+        if (isBackupArchiveTempName(entry.name, outputBaseName)) {
+          const artifactPath = path.join(outputDir, entry.name);
+          return [removeStalePath(artifactPath, resolveBackupArchiveOwnerPath(artifactPath))];
+        }
+        const archiveTempName = resolveBackupArchiveTempNameFromOwnerName(
+          entry.name,
+          outputBaseName,
+        );
+        if (!archiveTempName || entryNames.has(archiveTempName)) {
+          return [];
+        }
+        const ownerPath = path.join(outputDir, entry.name);
+        return [removeStalePath(ownerPath, ownerPath)];
+      }),
   );
 }
 
-async function removeStalePath(targetPath: string): Promise<void> {
+async function removeStalePath(targetPath: string, ownerPath?: string): Promise<void> {
+  if (ownerPath && (await hasLiveBackupArtifactOwner(ownerPath))) {
+    return;
+  }
   let stat: import("node:fs").Stats;
   try {
     stat = await fs.stat(targetPath);
@@ -747,6 +775,9 @@ async function removeStalePath(targetPath: string): Promise<void> {
     return;
   }
   await fs.rm(targetPath, { recursive: true, force: true }).catch(() => undefined);
+  if (ownerPath && ownerPath !== targetPath) {
+    await fs.rm(ownerPath, { force: true }).catch(() => undefined);
+  }
 }
 
 function isBackupArchiveTempName(name: string, outputBaseName: string): boolean {
@@ -756,6 +787,58 @@ function isBackupArchiveTempName(name: string, outputBaseName: string): boolean 
     return false;
   }
   return UUID_RE.test(name.slice(prefix.length, -suffix.length));
+}
+
+function resolveBackupArchiveOwnerPath(tempArchivePath: string): string {
+  return `${tempArchivePath}${BACKUP_ARCHIVE_OWNER_SUFFIX}`;
+}
+
+function resolveBackupArchiveTempNameFromOwnerName(
+  name: string,
+  outputBaseName: string,
+): string | undefined {
+  if (!name.endsWith(BACKUP_ARCHIVE_OWNER_SUFFIX)) {
+    return undefined;
+  }
+  const archiveTempName = name.slice(0, -BACKUP_ARCHIVE_OWNER_SUFFIX.length);
+  return isBackupArchiveTempName(archiveTempName, outputBaseName) ? archiveTempName : undefined;
+}
+
+function buildBackupArtifactOwner(): BackupArtifactOwner {
+  return { pid: process.pid, startedAtMs: Date.now() };
+}
+
+async function writeBackupArtifactOwner(
+  ownerPath: string,
+  owner: BackupArtifactOwner,
+): Promise<void> {
+  await fs.writeFile(ownerPath, `${JSON.stringify(owner)}\n`, "utf8");
+}
+
+async function hasLiveBackupArtifactOwner(ownerPath: string): Promise<boolean> {
+  let owner: BackupArtifactOwner;
+  try {
+    owner = JSON.parse(await fs.readFile(ownerPath, "utf8")) as BackupArtifactOwner;
+  } catch {
+    return false;
+  }
+  return isLiveBackupOwner(owner);
+}
+
+function isLiveBackupOwner(owner: BackupArtifactOwner): boolean {
+  if (!Number.isSafeInteger(owner.pid) || owner.pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(owner.pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") {
+      return false;
+    }
+    return code === "EPERM";
+  }
 }
 
 export async function createBackupArchive(
@@ -820,8 +903,12 @@ export async function createBackupArchive(
   const tempDir = await fs.mkdtemp(path.join(tempRoot, "openclaw-backup-"));
   const manifestPath = path.join(tempDir, "manifest.json");
   const tempArchivePath = buildTempArchivePath(outputPath);
+  const tempArchiveOwnerPath = resolveBackupArchiveOwnerPath(tempArchivePath);
   const stateAsset = result.assets.find((asset) => asset.kind === "state");
   try {
+    const backupOwner = buildBackupArtifactOwner();
+    await writeBackupArtifactOwner(path.join(tempDir, BACKUP_STAGING_OWNER_FILE), backupOwner);
+    await writeBackupArtifactOwner(tempArchiveOwnerPath, backupOwner);
     const stateSqliteBackup = stateAsset
       ? await createStateSqliteBackupPlan({
           stateDir: stateAsset.sourcePath,
@@ -948,6 +1035,7 @@ export async function createBackupArchive(
     await publishTempArchive({ tempArchivePath, outputPath });
   } finally {
     await fs.rm(tempArchivePath, { force: true }).catch(() => undefined);
+    await fs.rm(tempArchiveOwnerPath, { force: true }).catch(() => undefined);
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where interrupted `backup create` runs can leave stale backup staging directories and full-size temporary archive files behind. A hard kill, OOM, host reboot, or process restart skips the in-process cleanup block, so these artifacts can accumulate and consume disk space across later backup runs.

Fixes #95582

## Why This Change Was Made

The backup startup path now sweeps only OpenClaw-owned stale backup artifacts older than one hour before creating a new archive. The sweep is scoped to the selected backup staging temp root for `openclaw-backup-*` directories and to the requested output path's sibling temp files matching `<output basename>.<uuid>.tmp`, avoiding broad deletion of unrelated shared-temp files.

Active backup runs now write owner markers for both artifact classes. Startup cleanup checks those owner markers and skips artifacts whose owner PID is still live, so long-running or concurrent backups are not removed by an age-only sweep.

## User Impact

Users and operators can rerun `backup create` after a killed or interrupted backup and have old OpenClaw backup temp artifacts cleaned automatically before the new backup starts. Recent artifacts and artifacts owned by a live backup process remain protected.

## Evidence

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run -c test/vitest/vitest.infra.config.ts src/infra/backup-create.test.ts -t "sweepStaleBackupArtifacts"` -> 7 passed, 38 skipped
- `git diff --check` -> passed
- Real backup proof with a temporary HOME/state/config and seeded stale artifacts:

```text
beforeStagingExists=True
beforeArchiveTempExists=True
Backup archive: <temp>\backups\proof-backup.tar.gz
Included 2 paths:
- state: <temp>\state
- config: <temp>\openclaw.json
Created <temp>\backups\proof-backup.tar.gz
afterStagingExists=False
afterArchiveTempExists=False
backupExists=True
backupBytes=19407
```

- Earlier broader Windows validation note: `node scripts/run-vitest.mjs src/infra/backup-create.test.ts` reached 28 passed before existing `createBackupArchive` tests failed on Windows with `EBUSY` unlinking temp SQLite files during test cleanup.
- Earlier broader Windows validation note: `node scripts/run-vitest.mjs src/commands/backup.atomic.test.ts src/commands/backup.test.ts` had `backup.atomic.test.ts` pass; `backup.test.ts` had 13 passed and 1 Windows `EBUSY` cleanup failure on a temp SQLite WAL file.