### PR TITLE
test: save ~79 CI hours/mo in gateway session utils

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1691,6 +1691,45 @@ describe("gateway session utils", () => {
   });
 
   test("listAgentsForGateway reports per-agent thinking defaults from the agent model", () => {
+    const resolveDeepSeekThinkingProfile = vi.fn(() => ({
+      levels: [
+        { id: "off" as const },
+        { id: "minimal" as const },
+        { id: "low" as const },
+        { id: "medium" as const },
+        { id: "high" as const },
+        { id: "xhigh" as const },
+      ],
+      defaultLevel: "medium" as const,
+    }));
+    const registry = createEmptyPluginRegistry();
+    registry.providers.push(
+      {
+        pluginId: "test-minimax",
+        source: "test",
+        provider: {
+          id: "minimax",
+          label: "MiniMax",
+          auth: [],
+          resolveThinkingProfile: () => ({
+            levels: [{ id: "off" }],
+            defaultLevel: "off",
+          }),
+        },
+      },
+      {
+        pluginId: "test-deepseek",
+        source: "test",
+        provider: {
+          id: "deepseek",
+          label: "DeepSeek",
+          auth: [],
+          resolveThinkingProfile: resolveDeepSeekThinkingProfile,
+        },
+      },
+    );
+    setActivePluginRegistry(registry);
+
     const cfg = {
       session: { mainKey: "main" },
       agents: {
@@ -1713,6 +1752,12 @@ describe("gateway session utils", () => {
     const agent = result.agents.find((row) => row.id === "investment-master");
 
     expect(agent?.model).toEqual({ primary: "deepseek/deepseek-v4-flash" });
+    expect(resolveDeepSeekThinkingProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "deepseek",
+        modelId: "deepseek-v4-flash",
+      }),
+    );
     expect(agent?.thinkingDefault).toBe("xhigh");
     expect(agent?.thinkingLevels?.map((level) => level.id)).toEqual(
       expect.arrayContaining(["off", "minimal", "low", "medium", "high", "xhigh"]),


### PR DESCRIPTION
## What Problem This Solves

`src/gateway/session-utils.test.ts` had a gateway behavior test that accidentally loaded real bundled provider policy metadata to answer one fixture question: whether the per-agent DeepSeek model exposes `xhigh` thinking.

That made the gateway-core shard spend seconds in bundled provider/plugin infrastructure while the test's actual goal was narrower: verify `listAgentsForGateway` uses the agent-specific model when returning thinking controls.

CI impact estimate from the 30-day actions report:

- Report window: 30 days, generated 2026-06-19.
- `CI/checks-node-agentic-gateway-core`: estimated `36,902` executions/month, avg `99.3s`, p50 `92s`, p95 `151s`.
- Sample event mix for this job: `207/258` sampled executions were `pull_request` (`80.2%`).
- Local paired full-file timing showed Vitest `tests` phase improved by `7.66s/run` on average.
- Estimated total CI runner savings: `36,902 * 7.66s = 78.5 runner-hours/month`.
- Estimated PR-facing subset: `78.5h * 80.2% = 63.0 runner-hours/month`.

## Why This Change Was Made

The test now installs a tiny in-test provider registry for MiniMax and DeepSeek, then asserts the DeepSeek thinking resolver is called with `modelId: "deepseek-v4-flash"`.

This keeps the gateway behavior coverage focused:

- per-agent model is used
- returned agent model stays `deepseek/deepseek-v4-flash`
- `thinkingDefault: "xhigh"` survives
- DeepSeek thinking levels are used
- `thinkingOptions` still mirrors `thinkingLevels`

Bundled DeepSeek provider-policy behavior remains covered by the DeepSeek plugin tests.

## User Impact

No production behavior changes. This is a test-only CI speedup for the gateway-core shard, reducing feedback time and runner spend across CI, including PR runs.

## Evidence

Focused proof after rebasing on latest `origin/main`:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 corepack pnpm exec vitest run --config test/vitest/vitest.gateway-core.config.ts src/gateway/session-utils.test.ts --reporter=verbose
```

Result:

```text
Test Files  1 passed (1)
Tests       109 passed (109)
Target test 165ms
Duration    24.51s (tests 17.26s)
```

Before/after timing, 3 paired runs of the full `src/gateway/session-utils.test.ts` file, alternating revisions with a fresh Vitest fs-module cache path per run:

```text
Wall clock avg:          32.54s -> 24.75s  (-7.79s, -24%)
Vitest total avg:        22.90s -> 14.57s  (-8.33s, -36%)
Vitest tests phase avg:  15.58s -> 7.91s   (-7.66s, -49%)
Target test avg:         7.90s  -> 0.11s   (-7.80s, -99%)
```

Other checks:

```text
corepack pnpm exec oxfmt --check src/gateway/session-utils.test.ts
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

Autoreview result:

```text
autoreview clean: no accepted/actionable findings reported
```
