### PR TITLE
fix(memory-wiki): preserve human notes block on source re-ingest

### DIFF
--- a/extensions/memory-wiki/src/ingest-human-notes.test.ts
+++ b/extensions/memory-wiki/src/ingest-human-notes.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { ingestMemoryWikiSource } from "./ingest.js";
+import { createMemoryWikiTestHarness } from "./test-helpers.js";
+
+const { createTempDir, createVault } = createMemoryWikiTestHarness();
+
+describe("ingestMemoryWikiSource human notes", () => {
+  it("preserves user notes when the same source is re-ingested", async () => {
+    const rootDir = await createTempDir("memory-wiki-reingest-");
+    const inputPath = path.join(rootDir, "roadmap.txt");
+    const { config } = await createVault({ rootDir: path.join(rootDir, "vault") });
+
+    await fs.writeFile(inputPath, "v1 content\n", "utf8");
+    await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+    });
+
+    const pagePath = path.join(config.vault.path, "sources", "roadmap.md");
+    const userNote = "KEY INSIGHT: covers $1 of the Q2 roadmap";
+    const edited = (await fs.readFile(pagePath, "utf8")).replace(
+      "<!-- openclaw:human:start -->\n<!-- openclaw:human:end -->",
+      `<!-- openclaw:human:start -->\n${userNote}\n<!-- openclaw:human:end -->`,
+    );
+    await fs.writeFile(pagePath, edited, "utf8");
+
+    await fs.writeFile(inputPath, "v2 content updated\n", "utf8");
+    await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 6, 12, 0, 0),
+    });
+
+    const after = await fs.readFile(pagePath, "utf8");
+    expect(after).toContain("v2 content updated");
+    expect(after).toContain(userNote);
+  });
+
+  it("preserves notes without corrupting source content that contains human markers", async () => {
+    const rootDir = await createTempDir("memory-wiki-markers-");
+    const inputPath = path.join(rootDir, "notes.txt");
+    const { config } = await createVault({ rootDir: path.join(rootDir, "vault") });
+
+    await fs.writeFile(inputPath, "first body\n", "utf8");
+    await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+    });
+
+    const pagePath = path.join(config.vault.path, "sources", "notes.md");
+    const userNote = "MY PRIVATE NOTE";
+    const edited = (await fs.readFile(pagePath, "utf8")).replace(
+      "<!-- openclaw:human:start -->\n<!-- openclaw:human:end -->",
+      `<!-- openclaw:human:start -->\n${userNote}\n<!-- openclaw:human:end -->`,
+    );
+    await fs.writeFile(pagePath, edited, "utf8");
+
+    const sourceWithMarkers = [
+      "second body",
+      "<!-- openclaw:human:start -->",
+      "INJECTED FROM SOURCE",
+      "<!-- openclaw:human:end -->",
+      "",
+    ].join("\n");
+    await fs.writeFile(inputPath, sourceWithMarkers, "utf8");
+    await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 6, 12, 0, 0),
+    });
+
+    const after = await fs.readFile(pagePath, "utf8");
+    const notesBlock = after.slice(after.indexOf("## Notes"));
+    expect(after).toContain("INJECTED FROM SOURCE");
+    expect(notesBlock).toContain(userNote);
+    expect(notesBlock).not.toContain("INJECTED FROM SOURCE");
+  });
+
+  it("preserves the whole note when the note text itself contains a marker comment", async () => {
+    const rootDir = await createTempDir("memory-wiki-innermarker-");
+    const inputPath = path.join(rootDir, "diary.txt");
+    const { config } = await createVault({ rootDir: path.join(rootDir, "vault") });
+
+    await fs.writeFile(inputPath, "first body\n", "utf8");
+    await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+    });
+
+    const pagePath = path.join(config.vault.path, "sources", "diary.md");
+    const noteWithMarker = [
+      "EARLY NOTE before any quoted marker",
+      "<!-- openclaw:human:start -->",
+      "LATE NOTE after a pasted marker",
+    ].join("\n");
+    const edited = (await fs.readFile(pagePath, "utf8")).replace(
+      "<!-- openclaw:human:start -->\n<!-- openclaw:human:end -->",
+      `<!-- openclaw:human:start -->\n${noteWithMarker}\n<!-- openclaw:human:end -->`,
+    );
+    await fs.writeFile(pagePath, edited, "utf8");
+
+    await fs.writeFile(inputPath, "second body\n", "utf8");
+    await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 6, 12, 0, 0),
+    });
+
+    const after = await fs.readFile(pagePath, "utf8");
+    expect(after).toContain("second body");
+    expect(after).toContain("EARLY NOTE before any quoted marker");
+    expect(after).toContain("LATE NOTE after a pasted marker");
+  });
+
+  it("preserves the note when the note text contains a Markdown heading", async () => {
+    const rootDir = await createTempDir("memory-wiki-heading-");
+    const inputPath = path.join(rootDir, "log.txt");
+    const { config } = await createVault({ rootDir: path.join(rootDir, "vault") });
+
+    await fs.writeFile(inputPath, "first body\n", "utf8");
+    await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+    });
+
+    const pagePath = path.join(config.vault.path, "sources", "log.md");
+    const noteWithHeading = ["NOTE TOP", "## Notes", "NOTE BOTTOM under a pasted heading"].join(
+      "\n",
+    );
+    const edited = (await fs.readFile(pagePath, "utf8")).replace(
+      "<!-- openclaw:human:start -->\n<!-- openclaw:human:end -->",
+      `<!-- openclaw:human:start -->\n${noteWithHeading}\n<!-- openclaw:human:end -->`,
+    );
+    await fs.writeFile(pagePath, edited, "utf8");
+
+    await fs.writeFile(inputPath, "second body\n", "utf8");
+    await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 6, 12, 0, 0),
+    });
+
+    const after = await fs.readFile(pagePath, "utf8");
+    expect(after).toContain("second body");
+    expect(after).toContain("NOTE TOP");
+    expect(after).toContain("NOTE BOTTOM under a pasted heading");
+  });
+});

--- a/extensions/memory-wiki/src/ingest-human-notes.test.ts
+++ b/extensions/memory-wiki/src/ingest-human-notes.test.ts
@@ -80,6 +80,47 @@ describe("ingestMemoryWikiSource human notes", () => {
     expect(notesBlock).not.toContain("INJECTED FROM SOURCE");
   });
 
+  it("preserves CRLF notes without copying marker comments from existing source content", async () => {
+    const rootDir = await createTempDir("memory-wiki-crlf-markers-");
+    const inputPath = path.join(rootDir, "windows-notes.txt");
+    const { config } = await createVault({ rootDir: path.join(rootDir, "vault") });
+
+    const sourceWithMarkers = [
+      "first body",
+      "<!-- openclaw:human:start -->",
+      "OLD SOURCE MARKER PAYLOAD",
+      "<!-- openclaw:human:end -->",
+      "",
+    ].join("\n");
+    await fs.writeFile(inputPath, sourceWithMarkers, "utf8");
+    await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+    });
+
+    const pagePath = path.join(config.vault.path, "sources", "windows-notes.md");
+    const userNote = "CRLF USER NOTE";
+    const edited = (await fs.readFile(pagePath, "utf8")).replace(
+      "<!-- openclaw:human:start -->\n<!-- openclaw:human:end -->",
+      `<!-- openclaw:human:start -->\n${userNote}\n<!-- openclaw:human:end -->`,
+    );
+    await fs.writeFile(pagePath, edited.replace(/\n/g, "\r\n"), "utf8");
+
+    await fs.writeFile(inputPath, "second body without marker comments\n", "utf8");
+    await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 6, 12, 0, 0),
+    });
+
+    const after = await fs.readFile(pagePath, "utf8");
+    const notesBlock = after.slice(after.indexOf("## Notes"));
+    expect(after).toContain("second body without marker comments");
+    expect(notesBlock).toContain(userNote);
+    expect(notesBlock).not.toContain("OLD SOURCE MARKER PAYLOAD");
+  });
+
   it("preserves the whole note when the note text itself contains a marker comment", async () => {
     const rootDir = await createTempDir("memory-wiki-innermarker-");
     const inputPath = path.join(rootDir, "diary.txt");

--- a/extensions/memory-wiki/src/ingest.ts
+++ b/extensions/memory-wiki/src/ingest.ts
@@ -5,7 +5,12 @@ import { pathExists } from "openclaw/plugin-sdk/security-runtime";
 import { compileMemoryWikiVault } from "./compile.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import { appendMemoryWikiLog } from "./log.js";
-import { renderMarkdownFence, renderWikiMarkdown, slugifyWikiSegment } from "./markdown.js";
+import {
+  preserveHumanNotesBlock,
+  renderMarkdownFence,
+  renderWikiMarkdown,
+  slugifyWikiSegment,
+} from "./markdown.js";
 import { resolveMemoryWikiTimestamp } from "./time.js";
 import { initializeMemoryWikiVault } from "./vault.js";
 
@@ -82,7 +87,12 @@ export async function ingestMemoryWikiSource(params: {
     ].join("\n"),
   });
 
-  await fs.writeFile(pagePath, markdown, "utf8");
+  const existing = created ? "" : await fs.readFile(pagePath, "utf8").catch(() => "");
+  await fs.writeFile(
+    pagePath,
+    existing ? preserveHumanNotesBlock(markdown, existing) : markdown,
+    "utf8",
+  );
   await appendMemoryWikiLog(params.config.vault.path, {
     type: "ingest",
     timestamp,

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -446,23 +446,24 @@ function hasHumanNotesBlock(markdown: string): boolean {
   return markdown.includes(HUMAN_START_MARKER) && markdown.includes(HUMAN_END_MARKER);
 }
 
-const SOURCE_CONTENT_HEADING = "\n## Content\n";
+const SOURCE_CONTENT_HEADING = /(?:^|\r?\n)## Content\r?\n/u;
 
 function afterSourceContentFence(page: string): number {
-  const headingIndex = page.indexOf(SOURCE_CONTENT_HEADING);
-  if (headingIndex === -1) {
+  const heading = SOURCE_CONTENT_HEADING.exec(page);
+  if (!heading) {
     return 0;
   }
-  const fenceLineStart = headingIndex + SOURCE_CONTENT_HEADING.length;
+  const fenceLineStart = heading.index + heading[0].length;
   const fence = /^`+/.exec(page.slice(fenceLineStart))?.[0];
   if (!fence) {
     return fenceLineStart;
   }
-  const closeIndex = page.indexOf(`\n${fence}`, fenceLineStart + fence.length);
-  if (closeIndex === -1) {
+  const closingFence = new RegExp(`\\r?\\n${fence}(?=\\r?\\n|$)`, "u");
+  const close = closingFence.exec(page.slice(fenceLineStart + fence.length));
+  if (!close) {
     return fenceLineStart;
   }
-  return closeIndex + fence.length + 1;
+  return fenceLineStart + fence.length + close.index + close[0].length;
 }
 
 function findNotesHumanBlock(page: string): { start: number; end: number } | null {

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -446,6 +446,51 @@ function hasHumanNotesBlock(markdown: string): boolean {
   return markdown.includes(HUMAN_START_MARKER) && markdown.includes(HUMAN_END_MARKER);
 }
 
+const SOURCE_CONTENT_HEADING = "\n## Content\n";
+
+function afterSourceContentFence(page: string): number {
+  const headingIndex = page.indexOf(SOURCE_CONTENT_HEADING);
+  if (headingIndex === -1) {
+    return 0;
+  }
+  const fenceLineStart = headingIndex + SOURCE_CONTENT_HEADING.length;
+  const fence = /^`+/.exec(page.slice(fenceLineStart))?.[0];
+  if (!fence) {
+    return fenceLineStart;
+  }
+  const closeIndex = page.indexOf(`\n${fence}`, fenceLineStart + fence.length);
+  if (closeIndex === -1) {
+    return fenceLineStart;
+  }
+  return closeIndex + fence.length + 1;
+}
+
+function findNotesHumanBlock(page: string): { start: number; end: number } | null {
+  const searchFrom = afterSourceContentFence(page);
+  const start = page.indexOf(HUMAN_START_MARKER, searchFrom);
+  if (start === -1) {
+    return null;
+  }
+  const endMarker = page.lastIndexOf(HUMAN_END_MARKER);
+  if (endMarker < start) {
+    return null;
+  }
+  return { start, end: endMarker + HUMAN_END_MARKER.length };
+}
+
+export function preserveHumanNotesBlock(rendered: string, existing: string): string {
+  const existingBlock = findNotesHumanBlock(existing);
+  const renderedBlock = findNotesHumanBlock(rendered);
+  if (!existingBlock || !renderedBlock) {
+    return rendered;
+  }
+  return (
+    rendered.slice(0, renderedBlock.start) +
+    existing.slice(existingBlock.start, existingBlock.end) +
+    rendered.slice(renderedBlock.end)
+  );
+}
+
 function detectGeneratedSourceBody(markdown: string): GeneratedSourceBody | undefined {
   const lines = normalizeMarkdownLines(markdown);
   const normalized = lines.join("\n");

--- a/extensions/memory-wiki/src/source-page-shared.test.ts
+++ b/extensions/memory-wiki/src/source-page-shared.test.ts
@@ -3,7 +3,32 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderMarkdownFence, renderWikiMarkdown } from "./markdown.js";
 import { writeImportedSourcePage } from "./source-page-shared.js";
+
+function buildSourcePage(raw: string, updatedAt: string): string {
+  return renderWikiMarkdown({
+    frontmatter: {
+      pageType: "source",
+      id: "source.imported",
+      title: "imported",
+      sourceType: "memory-unsafe-local",
+      status: "active",
+      updatedAt,
+    },
+    body: [
+      "# imported",
+      "",
+      "## Content",
+      renderMarkdownFence(raw, "text"),
+      "",
+      "## Notes",
+      "<!-- openclaw:human:start -->",
+      "<!-- openclaw:human:end -->",
+      "",
+    ].join("\n"),
+  });
+}
 
 describe("writeImportedSourcePage", () => {
   let suiteRoot: string;
@@ -45,5 +70,55 @@ describe("writeImportedSourcePage", () => {
     );
     expect(result).toEqual({ pagePath: "pages/source.md", changed: true, created: true });
     expect(state.entries["unsafe:source"]?.sourceUpdatedAtMs).toBe(8_700_000_000_000_000);
+  });
+
+  it("preserves the human Notes block when an imported source page is updated", async () => {
+    const sourcePath = path.join(suiteRoot, "imported.txt");
+    const pagePath = "sources/imported.md";
+    const state: Parameters<typeof writeImportedSourcePage>[0]["state"] = {
+      entries: {},
+      version: 1,
+    };
+
+    await fs.writeFile(sourcePath, "first body", "utf8");
+    await writeImportedSourcePage({
+      vaultRoot: suiteRoot,
+      syncKey: "bridge:imported",
+      sourcePath,
+      sourceUpdatedAtMs: Date.UTC(2026, 4, 1),
+      sourceSize: 10,
+      renderFingerprint: "fp-1",
+      pagePath,
+      group: "bridge",
+      state,
+      buildRendered: buildSourcePage,
+    });
+
+    const absPage = path.join(suiteRoot, pagePath);
+    const userNote = "IMPORTED PAGE NOTE";
+    const edited = (await fs.readFile(absPage, "utf8")).replace(
+      "<!-- openclaw:human:start -->\n<!-- openclaw:human:end -->",
+      `<!-- openclaw:human:start -->\n${userNote}\n<!-- openclaw:human:end -->`,
+    );
+    await fs.writeFile(absPage, edited, "utf8");
+
+    await fs.writeFile(sourcePath, "second body changed", "utf8");
+    const result = await writeImportedSourcePage({
+      vaultRoot: suiteRoot,
+      syncKey: "bridge:imported",
+      sourcePath,
+      sourceUpdatedAtMs: Date.UTC(2026, 4, 2),
+      sourceSize: 19,
+      renderFingerprint: "fp-2",
+      pagePath,
+      group: "bridge",
+      state,
+      buildRendered: buildSourcePage,
+    });
+
+    const after = await fs.readFile(absPage, "utf8");
+    expect(result.changed).toBe(true);
+    expect(after).toContain("second body changed");
+    expect(after).toContain(userNote);
   });
 });

--- a/extensions/memory-wiki/src/source-page-shared.test.ts
+++ b/extensions/memory-wiki/src/source-page-shared.test.ts
@@ -121,4 +121,63 @@ describe("writeImportedSourcePage", () => {
     expect(after).toContain("second body changed");
     expect(after).toContain(userNote);
   });
+
+  it("preserves CRLF human notes without copying marker comments from existing imported content", async () => {
+    const sourcePath = path.join(suiteRoot, "imported-crlf.txt");
+    const pagePath = "sources/imported-crlf.md";
+    const state: Parameters<typeof writeImportedSourcePage>[0]["state"] = {
+      entries: {},
+      version: 1,
+    };
+
+    const sourceWithMarkers = [
+      "first imported body",
+      "<!-- openclaw:human:start -->",
+      "OLD IMPORTED SOURCE MARKER PAYLOAD",
+      "<!-- openclaw:human:end -->",
+      "",
+    ].join("\n");
+    await fs.writeFile(sourcePath, sourceWithMarkers, "utf8");
+    await writeImportedSourcePage({
+      vaultRoot: suiteRoot,
+      syncKey: "bridge:imported-crlf",
+      sourcePath,
+      sourceUpdatedAtMs: Date.UTC(2026, 4, 1),
+      sourceSize: sourceWithMarkers.length,
+      renderFingerprint: "fp-1",
+      pagePath,
+      group: "bridge",
+      state,
+      buildRendered: buildSourcePage,
+    });
+
+    const absPage = path.join(suiteRoot, pagePath);
+    const userNote = "CRLF IMPORTED PAGE NOTE";
+    const edited = (await fs.readFile(absPage, "utf8")).replace(
+      "<!-- openclaw:human:start -->\n<!-- openclaw:human:end -->",
+      `<!-- openclaw:human:start -->\n${userNote}\n<!-- openclaw:human:end -->`,
+    );
+    await fs.writeFile(absPage, edited.replace(/\n/g, "\r\n"), "utf8");
+
+    await fs.writeFile(sourcePath, "second imported body without marker comments", "utf8");
+    const result = await writeImportedSourcePage({
+      vaultRoot: suiteRoot,
+      syncKey: "bridge:imported-crlf",
+      sourcePath,
+      sourceUpdatedAtMs: Date.UTC(2026, 4, 2),
+      sourceSize: 44,
+      renderFingerprint: "fp-2",
+      pagePath,
+      group: "bridge",
+      state,
+      buildRendered: buildSourcePage,
+    });
+
+    const after = await fs.readFile(absPage, "utf8");
+    const notesBlock = after.slice(after.indexOf("## Notes"));
+    expect(result.changed).toBe(true);
+    expect(after).toContain("second imported body without marker comments");
+    expect(notesBlock).toContain(userNote);
+    expect(notesBlock).not.toContain("OLD IMPORTED SOURCE MARKER PAYLOAD");
+  });
 });

--- a/extensions/memory-wiki/src/source-page-shared.ts
+++ b/extensions/memory-wiki/src/source-page-shared.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import { timestampMsToIsoString } from "openclaw/plugin-sdk/number-runtime";
 import { FsSafeError, root as fsRoot } from "openclaw/plugin-sdk/security-runtime";
+import { preserveHumanNotesBlock } from "./markdown.js";
 import {
   setImportedSourceEntry,
   shouldSkipImportedSourceWrite,
@@ -52,11 +53,12 @@ export async function writeImportedSourcePage(params: {
   const raw = await fs.readFile(params.sourcePath, "utf8");
   const rendered = params.buildRendered(raw, updatedAt);
   const existing = pageStat ? await vault.readText(params.pagePath).catch(() => "") : "";
-  if (existing !== rendered) {
+  const nextRendered = existing ? preserveHumanNotesBlock(rendered, existing) : rendered;
+  if (existing !== nextRendered) {
     await writeGuardedVaultPage({
       vault,
       pagePath: params.pagePath,
-      content: rendered,
+      content: nextRendered,
       pageStat,
       pageLabel: "imported source page",
     });
@@ -74,5 +76,5 @@ export async function writeImportedSourcePage(params: {
       renderFingerprint: params.renderFingerprint,
     },
   });
-  return { pagePath: params.pagePath, changed: existing !== rendered, created };
+  return { pagePath: params.pagePath, changed: existing !== nextRendered, created };
 }


### PR DESCRIPTION
## Summary

Re-ingesting an already-ingested memory-wiki source destroys the user's notes. memory-wiki source pages carry a `## Notes` block delimited by `<!-- openclaw:human:start -->` / `<!-- openclaw:human:end -->` markers that the user is meant to edit. When the page is regenerated (same slug, same `sources/<slug>.md` path), it is rewritten with an empty Notes block, silently dropping anything the user wrote inside the human-managed block. This affects every source-page writer: `openclaw wiki ingest <path>` / the gateway ingest tool, and the bridge and unsafe-local imported-source sync paths.

This contradicts the documented contract in `docs/plugins/memory-wiki.md:129`: "Managed content stays inside generated blocks. Human note blocks are preserved."

## Root cause

`extensions/memory-wiki/src/ingest.ts` rebuilds the full page body with a hardcoded empty human block and writes it unconditionally, never reading the existing page:

```ts
// before
      "## Notes",
      "<!-- openclaw:human:start -->",
      "<!-- openclaw:human:end -->",
      "",
    ].join("\n"),
  });

  await fs.writeFile(pagePath, markdown, "utf8");
```

The shared imported-source writer `source-page-shared.ts` `writeImportedSourcePage` (used by `bridge.ts` and `unsafe-local.ts`) has the same defect: it reads the existing page only to compare, then writes the freshly rendered page over it. The synthesis (`apply.ts`) and ChatGPT-import (`chatgpt-import.ts`) writers already preserve the human block; ingest and the imported-source writer were the ones that skipped it.

## Fix

Add one helper next to the existing human-block markers in `markdown.ts`, and call it from both writers before writing.

```ts
// after - markdown.ts
const SOURCE_CONTENT_HEADING = "\n## Content\n";

function afterSourceContentFence(page: string): number {
  const headingIndex = page.indexOf(SOURCE_CONTENT_HEADING);
  if (headingIndex === -1) {
    return 0;
  }
  const fenceLineStart = headingIndex + SOURCE_CONTENT_HEADING.length;
  const fence = /^`+/.exec(page.slice(fenceLineStart))?.[0];
  if (!fence) {
    return fenceLineStart;
  }
  const closeIndex = page.indexOf(`\n${fence}`, fenceLineStart + fence.length);
  if (closeIndex === -1) {
    return fenceLineStart;
  }
  return closeIndex + fence.length + 1;
}

function findNotesHumanBlock(page: string): { start: number; end: number } | null {
  const searchFrom = afterSourceContentFence(page);
  const start = page.indexOf(HUMAN_START_MARKER, searchFrom);
  if (start === -1) {
    return null;
  }
  const endMarker = page.lastIndexOf(HUMAN_END_MARKER);
  if (endMarker < start) {
    return null;
  }
  return { start, end: endMarker + HUMAN_END_MARKER.length };
}

export function preserveHumanNotesBlock(rendered: string, existing: string): string {
  const existingBlock = findNotesHumanBlock(existing);
  const renderedBlock = findNotesHumanBlock(rendered);
  if (!existingBlock || !renderedBlock) {
    return rendered;
  }
  return (
    rendered.slice(0, renderedBlock.start) +
    existing.slice(existingBlock.start, existingBlock.end) +
    rendered.slice(renderedBlock.end)
  );
}
```

```ts
// after - ingest.ts
  const existing = created ? "" : await fs.readFile(pagePath, "utf8").catch(() => "");
  await fs.writeFile(
    pagePath,
    existing ? preserveHumanNotesBlock(markdown, existing) : markdown,
    "utf8",
  );
```

```ts
// after - source-page-shared.ts (writeImportedSourcePage)
  const existing = pageStat ? await vault.readText(params.pagePath).catch(() => "") : "";
  const nextRendered = existing ? preserveHumanNotesBlock(rendered, existing) : rendered;
  if (existing !== nextRendered) {
    ...
    await vault.write(params.pagePath, nextRendered);
```

The only untrusted region on the page is the source text, which is fenced inside `## Content`. `renderMarkdownFence` chooses a fence delimiter strictly longer than any backtick run in the content, so the source can never close its own fence early; the rest of the page (the `## Notes` block, then the generated `## Related` block, which carries only `openclaw:wiki:related` markers) is structurally trusted. The helper scans for the human block only after that fence closes, taking the first start marker and the last end marker, so the whole Notes block is preserved verbatim even when the source content or the user's own note text contains the human marker comments or Markdown headings. New page creation is unchanged.

## Why this is the right boundary

There are four memory-wiki source-page writers. Two already preserved the human block (synthesis, ChatGPT import); this change fixes the other two by routing both through one shared `preserveHumanNotesBlock` helper colocated with the markers it protects: `ingestMemoryWikiSource` (the `wiki ingest` CLI command at `cli.ts:588` and the gateway ingest tool) and `writeImportedSourcePage` (the bridge and unsafe-local sync paths). No writer is left one-sided.

## Verification

- `node scripts/run-vitest.mjs extensions/memory-wiki/src/ingest-human-notes.test.ts` (four ingest cases) and `extensions/memory-wiki/src/source-page-shared.test.ts` (imported-source update case) pass with the patch; each new case fails on the unpatched writer.
- `node scripts/run-vitest.mjs extensions/memory-wiki/src/ingest.test.ts` (existing create-path assertion) passes unchanged.
- `node scripts/run-oxlint.mjs` and `oxfmt --check` clean on the five changed files.
- tsgo core typecheck clean.

## Real behavior proof

Behavior addressed: regenerating a memory-wiki source page (via `wiki ingest` or via the bridge/unsafe-local imported-source writer) wiped user notes in the human-managed `## Notes` block; with the patch the notes survive while the regenerated source content is still updated, including when the source content or the note text contains the human markers or a Markdown heading.
Real environment tested: drove the real `ingestMemoryWikiSource` and the real `writeImportedSourcePage` runtime functions against a real on-disk vault on pristine base `4cb94cc2cf` and on the patched head `1095fe887c`, with identical inputs across five scenarios. Everything stayed real (real vault on disk, real render/write paths); nothing was stubbed.
Exact steps or command run after this patch: for each scenario, write the source page, edit its Notes block to add a note, change the source, write the page again through the real writer, then read the page back from disk.
Evidence after fix:
```
# BEFORE (pristine base 4cb94cc2cf)
[scenario 1: wiki ingest plain re-ingest]
updated source content present: true
user note present after re-ingest: false
[scenario 2: wiki ingest, source content itself contains the human markers]
source content INJECTED FROM SOURCE present: true
Notes block keeps user note: false
Notes block free of source content: true
[scenario 3: wiki ingest, note text itself contains a marker comment]
note kept before pasted marker (EARLY NOTE): false
note kept after pasted marker (LATE NOTE): false
[scenario 4: wiki ingest, note text contains a Markdown heading]
note kept above pasted heading (NOTE TOP): false
note kept below pasted heading (NOTE BOTTOM): false
[scenario 5: bridge/unsafe-local imported source page update via writeImportedSourcePage]
updated source content present: true
user note present after update: false

# AFTER (this patch 1095fe887c, identical inputs)
[scenario 1: wiki ingest plain re-ingest]
updated source content present: true
user note present after re-ingest: true
[scenario 2: wiki ingest, source content itself contains the human markers]
source content INJECTED FROM SOURCE present: true
Notes block keeps user note: true
Notes block free of source content: true
[scenario 3: wiki ingest, note text itself contains a marker comment]
note kept before pasted marker (EARLY NOTE): true
note kept after pasted marker (LATE NOTE): true
[scenario 4: wiki ingest, note text contains a Markdown heading]
note kept above pasted heading (NOTE TOP): true
note kept below pasted heading (NOTE BOTTOM): true
[scenario 5: bridge/unsafe-local imported source page update via writeImportedSourcePage]
updated source content present: true
user note present after update: true
```
Observed result after fix: across all five scenarios the regenerated page keeps the user's note while still showing the updated source content; on pristine base every note is gone. This holds for both the `wiki ingest` writer and the bridge/unsafe-local imported-source writer, and even when the source content or note text contains the markers or a `## Notes` heading.
What was not tested: no live network or provider request is involved; full repo build not run.
