### PR TITLE
fix(cron): drop unenforceable default toolsAllow cap on CLI-backed runs

### DIFF
--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -27,11 +27,8 @@ function cronAgentTurnPayloadSchema(params: {
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
       lightContext: Type.Optional(Type.Boolean()),
       toolsAllow: Type.Optional(params.toolsAllow),
-      // Server-managed marker: set when toolsAllow is an auto-applied creator
-      // default (vs an explicit per-cron restriction). The cron tool stamps it,
-      // and it round-trips through persistence so a CLI-resolved run can drop an
-      // unenforceable default cap. Must be on the wire contract or the stamped
-      // payload is rejected by additionalProperties:false.
+      // Server-managed marker for auto-stamped defaults; persisted so CLI cron
+      // runs can drop only the cap that was never user-explicit.
       toolsAllowIsDefault: Type.Optional(Type.Boolean()),
     },
     { additionalProperties: false },

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -27,6 +27,12 @@ function cronAgentTurnPayloadSchema(params: {
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
       lightContext: Type.Optional(Type.Boolean()),
       toolsAllow: Type.Optional(params.toolsAllow),
+      // Server-managed marker: set when toolsAllow is an auto-applied creator
+      // default (vs an explicit per-cron restriction). The cron tool stamps it,
+      // and it round-trips through persistence so a CLI-resolved run can drop an
+      // unenforceable default cap. Must be on the wire contract or the stamped
+      // payload is rejected by additionalProperties:false.
+      toolsAllowIsDefault: Type.Optional(Type.Boolean()),
     },
     { additionalProperties: false },
   );

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -2167,6 +2167,7 @@ describe("cron tool", () => {
     expect(params?.patch?.payload).toEqual({
       kind: "agentTurn",
       toolsAllow: ["read", "cron"],
+      toolsAllowIsDefault: true,
     });
   });
 
@@ -2202,6 +2203,7 @@ describe("cron tool", () => {
           payload: {
             kind: "agentTurn",
             toolsAllow: ["read", "cron"],
+            toolsAllowIsDefault: true,
           },
         },
       },
@@ -2278,6 +2280,51 @@ describe("cron tool", () => {
     });
   });
 
+  it("preserves the default toolsAllow flag across an update that omits toolsAllow", async () => {
+    // Regression guard: a routine update (here, toggling enabled) of an
+    // agentTurn job whose cap was an auto-stamped default must keep
+    // toolsAllowIsDefault set. Otherwise the run-time CLI drop (which keys off
+    // the flag) stops applying and the job fails closed again after a restart —
+    // re-breaking the exact #91499 regression this change fixes.
+    callGatewayMock
+      .mockResolvedValueOnce({
+        id: "job-13",
+        payload: {
+          kind: "agentTurn",
+          message: "hi",
+          toolsAllow: ["read", "cron"],
+          toolsAllowIsDefault: true,
+        },
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool({
+      agentSessionKey: "agent:main:telegram:group:restricted-room",
+      creatorToolAllowlist: ["read", "cron"],
+    });
+    await tool.execute("call-update-preserve-default-flag", {
+      action: "update",
+      id: "job-13",
+      patch: { enabled: false },
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(2);
+    expect(readGatewayCall(1)).toEqual({
+      method: "cron.update",
+      params: {
+        id: "job-13",
+        patch: {
+          enabled: false,
+          payload: {
+            kind: "agentTurn",
+            toolsAllow: ["read", "cron"],
+            toolsAllowIsDefault: true,
+          },
+        },
+      },
+    });
+  });
+
   it("adds the creator tool surface when converting an existing job to agentTurn", async () => {
     callGatewayMock
       .mockResolvedValueOnce({
@@ -2310,6 +2357,7 @@ describe("cron tool", () => {
             kind: "agentTurn",
             message: "run later",
             toolsAllow: ["read", "cron"],
+            toolsAllowIsDefault: true,
           },
         },
       },

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -465,18 +465,28 @@ function capCronAgentTurnToolsAllow(params: {
     ? params.payload.toolsAllow
     : params.defaultToolsAllow;
   if (!Array.isArray(requestedRaw)) {
+    // No explicit user toolsAllow: stamp the full creator surface as the default
+    // cap and flag it so a CLI-resolved run (which cannot enforce a runtime
+    // toolsAllow) drops it rather than failing to start.
     params.payload.toolsAllow = creatorToolNames;
+    params.payload.toolsAllowIsDefault = true;
     return;
   }
   const requestedToolsAllow = normalizeCronToolsAllow(
     requestedRaw.filter((entry): entry is string => typeof entry === "string"),
   );
   if (requestedToolsAllow.length === 0) {
+    // Explicit empty allow-list is a real restriction (no tools): keep it
+    // fail-closed, never flagged as a droppable default.
     params.payload.toolsAllow = [];
+    delete params.payload.toolsAllowIsDefault;
     return;
   }
   if (requestedToolsAllow.includes("*")) {
+    // Wildcard requests the creator's full surface with no narrowing — a
+    // non-restrictive default, droppable on a non-enforcing CLI backend.
     params.payload.toolsAllow = creatorToolNames;
+    params.payload.toolsAllowIsDefault = true;
     return;
   }
   const pluginGroups = buildPluginToolGroups({
@@ -487,9 +497,13 @@ function capCronAgentTurnToolsAllow(params: {
     { allow: requestedToolsAllow },
     pluginGroups,
   );
+  // Explicit narrowing restriction: keep it fail-closed (no default flag) so a
+  // CLI backend that cannot enforce it surfaces the error instead of silently
+  // widening the requested tool surface.
   params.payload.toolsAllow = creatorToolNames.filter((toolName) =>
     isToolAllowedByPolicyName(toolName, requestedPolicy),
   );
+  delete params.payload.toolsAllowIsDefault;
 }
 
 function capCronAgentTurnJobToolsAllow(
@@ -549,8 +563,17 @@ async function capCronAgentTurnUpdatePatchToolsAllow(params: {
   capCronAgentTurnToolsAllow({
     payload: nextPayload,
     creatorToolAllowlist: params.creatorToolAllowlist,
+    // Carry the existing cap forward across a no-toolsAllow update ONLY when it
+    // was an explicit per-cron restriction. A previously auto-stamped default
+    // (toolsAllowIsDefault === true) must NOT be carried forward as a literal
+    // value: that would route it through the explicit-narrowing branch, strip
+    // the default flag, and re-break the job on a CLI backend after the next
+    // restart (the run-time drop keys off the flag). Omitting it lets the cap
+    // be re-derived as a flagged default from the current creator surface.
     defaultToolsAllow:
-      existingPayloadKind === "agentTurn" && isRecord(existingPayload)
+      existingPayloadKind === "agentTurn" &&
+      isRecord(existingPayload) &&
+      existingPayload.toolsAllowIsDefault !== true
         ? existingPayload.toolsAllow
         : undefined,
   });

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -465,9 +465,6 @@ function capCronAgentTurnToolsAllow(params: {
     ? params.payload.toolsAllow
     : params.defaultToolsAllow;
   if (!Array.isArray(requestedRaw)) {
-    // No explicit user toolsAllow: stamp the full creator surface as the default
-    // cap and flag it so a CLI-resolved run (which cannot enforce a runtime
-    // toolsAllow) drops it rather than failing to start.
     params.payload.toolsAllow = creatorToolNames;
     params.payload.toolsAllowIsDefault = true;
     return;
@@ -476,15 +473,11 @@ function capCronAgentTurnToolsAllow(params: {
     requestedRaw.filter((entry): entry is string => typeof entry === "string"),
   );
   if (requestedToolsAllow.length === 0) {
-    // Explicit empty allow-list is a real restriction (no tools): keep it
-    // fail-closed, never flagged as a droppable default.
     params.payload.toolsAllow = [];
     delete params.payload.toolsAllowIsDefault;
     return;
   }
   if (requestedToolsAllow.includes("*")) {
-    // Wildcard requests the creator's full surface with no narrowing — a
-    // non-restrictive default, droppable on a non-enforcing CLI backend.
     params.payload.toolsAllow = creatorToolNames;
     params.payload.toolsAllowIsDefault = true;
     return;
@@ -497,9 +490,6 @@ function capCronAgentTurnToolsAllow(params: {
     { allow: requestedToolsAllow },
     pluginGroups,
   );
-  // Explicit narrowing restriction: keep it fail-closed (no default flag) so a
-  // CLI backend that cannot enforce it surfaces the error instead of silently
-  // widening the requested tool surface.
   params.payload.toolsAllow = creatorToolNames.filter((toolName) =>
     isToolAllowedByPolicyName(toolName, requestedPolicy),
   );
@@ -563,13 +553,8 @@ async function capCronAgentTurnUpdatePatchToolsAllow(params: {
   capCronAgentTurnToolsAllow({
     payload: nextPayload,
     creatorToolAllowlist: params.creatorToolAllowlist,
-    // Carry the existing cap forward across a no-toolsAllow update ONLY when it
-    // was an explicit per-cron restriction. A previously auto-stamped default
-    // (toolsAllowIsDefault === true) must NOT be carried forward as a literal
-    // value: that would route it through the explicit-narrowing branch, strip
-    // the default flag, and re-break the job on a CLI backend after the next
-    // restart (the run-time drop keys off the flag). Omitting it lets the cap
-    // be re-derived as a flagged default from the current creator surface.
+    // Flagged defaults are re-derived so normal updates do not turn them into
+    // explicit restrictions or lose the marker needed after restart.
     defaultToolsAllow:
       existingPayloadKind === "agentTurn" &&
       isRecord(existingPayload) &&

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -161,8 +161,30 @@ function buildCronDeliveryTargetRuntimeContext(params: {
   ].join("\n");
 }
 
-function resolveCliRuntimeToolsAllow(toolsAllow?: string[]): string[] | undefined {
-  return toolsAllow?.some((toolName) => normalizeToolName(toolName) === "*")
+function resolveCliRuntimeToolsAllow(
+  toolsAllow?: string[],
+  toolsAllowIsDefault?: boolean,
+): string[] | undefined {
+  if (toolsAllow === undefined) {
+    return undefined;
+  }
+  // CLI backends do not enforce a runtime toolsAllow: cli-runner/prepare.ts
+  // rejects any defined allow-list, and a CLI backend runs with its own
+  // configured tool set as the operator on the local machine — it is not a
+  // runtime tool-policy boundary. #91499 auto-stamps the creator surface as a
+  // *default* cap on agentTurn payloads (toolsAllowIsDefault); on a CLI backend
+  // that default is unenforceable theatre, so drop it and let the scheduled run
+  // proceed instead of failing to start.
+  //
+  // An EXPLICIT per-cron restriction (the user narrowed this job; no isDefault
+  // flag) is deliberately NOT dropped: it falls through and prepare.ts fails it
+  // closed, surfacing that the requested policy needs an embedded runtime. So
+  // only the unenforceable inherited default is relaxed on CLI; explicit intent
+  // is still honoured.
+  if (toolsAllowIsDefault) {
+    return undefined;
+  }
+  return toolsAllow.some((toolName) => normalizeToolName(toolName) === "*")
     ? undefined
     : toolsAllow;
 }
@@ -326,7 +348,10 @@ export function createCronPromptExecutor(params: {
             messageChannel,
             sourceReplyDeliveryMode,
             requireExplicitMessageTarget: params.sourceDelivery.messageTool.requireExplicitTarget,
-            toolsAllow: resolveCliRuntimeToolsAllow(params.agentPayload?.toolsAllow),
+            toolsAllow: resolveCliRuntimeToolsAllow(
+              params.agentPayload?.toolsAllow,
+              params.agentPayload?.toolsAllowIsDefault,
+            ),
             abortSignal: params.abortSignal,
             onExecutionStarted: params.onExecutionStarted,
             onExecutionPhase: params.onExecutionPhase,

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -168,19 +168,8 @@ function resolveCliRuntimeToolsAllow(
   if (toolsAllow === undefined) {
     return undefined;
   }
-  // CLI backends do not enforce a runtime toolsAllow: cli-runner/prepare.ts
-  // rejects any defined allow-list, and a CLI backend runs with its own
-  // configured tool set as the operator on the local machine — it is not a
-  // runtime tool-policy boundary. #91499 auto-stamps the creator surface as a
-  // *default* cap on agentTurn payloads (toolsAllowIsDefault); on a CLI backend
-  // that default is unenforceable theatre, so drop it and let the scheduled run
-  // proceed instead of failing to start.
-  //
-  // An EXPLICIT per-cron restriction (the user narrowed this job; no isDefault
-  // flag) is deliberately NOT dropped: it falls through and prepare.ts fails it
-  // closed, surfacing that the requested policy needs an embedded runtime. So
-  // only the unenforceable inherited default is relaxed on CLI; explicit intent
-  // is still honoured.
+  // CLI runners reject runtime toolsAllow. Drop only the auto-stamped default;
+  // explicit per-cron restrictions stay fail-closed in prepareCliRunContext.
   if (toolsAllowIsDefault) {
     return undefined;
   }

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -825,6 +825,41 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(cliRun.prompt).toContain("Message delivery destination metadata");
   });
 
+  it("drops the auto-applied default toolsAllow cap for CLI-backed runs instead of failing", async () => {
+    // A CLI backend cannot enforce a runtime toolsAllow, so the auto-applied
+    // creator-surface cap (#91499, flagged toolsAllowIsDefault) is dropped at
+    // run time rather than handed to the CLI runner — which would otherwise
+    // reject the run. An explicit user restriction (no flag) is still
+    // propagated; see the "restricted toolsAllow" case above.
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());
+    isCliProviderMock.mockReturnValue(true);
+    runCliAgentMock.mockResolvedValue({
+      payloads: [{ text: "done" }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeMessageToolPolicyJob(
+        { mode: "announce", channel: "messagechat", to: "123" },
+        {
+          kind: "agentTurn",
+          message: "send a message",
+          toolsAllow: ["read", "cron"],
+          toolsAllowIsDefault: true,
+        },
+      ),
+    });
+
+    const cliRun = expectRecordFields(
+      getMockCallArg(runCliAgentMock, 0, 0, "CLI run"),
+      {},
+      "CLI run params",
+    );
+    expect(cliRun.toolsAllow).toBeUndefined();
+  });
+
   it("keeps automatic exec completion notifications when announce delivery is active", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -392,6 +392,63 @@ describe("applyJobPatch", () => {
     }
   });
 
+  it("clears the default toolsAllow flag when editing to an explicit restriction", () => {
+    const job = createIsolatedAgentTurnJob("job-tools-explicit", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = {
+      kind: "agentTurn",
+      message: "do it",
+      toolsAllow: ["exec", "read"],
+      toolsAllowIsDefault: true,
+    };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        message: "do it",
+        toolsAllow: ["read"],
+        toolsAllowIsDefault: true,
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.toolsAllow).toEqual(["read"]);
+      expect(job.payload.toolsAllowIsDefault).toBeUndefined();
+    }
+  });
+
+  it("preserves the default toolsAllow flag when a full payload edit keeps the default list", () => {
+    const job = createIsolatedAgentTurnJob("job-tools-default-edit", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = {
+      kind: "agentTurn",
+      message: "do it",
+      toolsAllow: ["exec", "read"],
+      toolsAllowIsDefault: true,
+    };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        message: "do it later",
+        toolsAllow: ["exec", "read"],
+        toolsAllowIsDefault: true,
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.message).toBe("do it later");
+      expect(job.payload.toolsAllow).toEqual(["exec", "read"]);
+      expect(job.payload.toolsAllowIsDefault).toBe(true);
+    }
+  });
+
   it("clears agentTurn payload.toolsAllow when patch requests null", () => {
     const job = createIsolatedAgentTurnJob("job-tools-clear", {
       mode: "announce",
@@ -401,6 +458,7 @@ describe("applyJobPatch", () => {
       kind: "agentTurn",
       message: "do it",
       toolsAllow: ["exec", "read"],
+      toolsAllowIsDefault: true,
     };
 
     applyJobPatch(job, {
@@ -414,6 +472,7 @@ describe("applyJobPatch", () => {
     expect(job.payload.kind).toBe("agentTurn");
     if (job.payload.kind === "agentTurn") {
       expect(job.payload.toolsAllow).toBeUndefined();
+      expect(job.payload.toolsAllowIsDefault).toBeUndefined();
     }
   });
 
@@ -524,6 +583,30 @@ describe("applyJobPatch", () => {
     expect(payload.kind).toBe("agentTurn");
     if (payload.kind === "agentTurn") {
       expect(payload.toolsAllow).toEqual(["exec", "read"]);
+    }
+  });
+
+  it("carries payload.toolsAllow default flag when replacing payload kind via patch", () => {
+    const job = createIsolatedAgentTurnJob("job-tools-default-switch", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = { kind: "systemEvent", text: "ping" };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        message: "do it",
+        toolsAllow: ["exec", "read"],
+        toolsAllowIsDefault: true,
+      },
+    });
+
+    const payload = job.payload as CronJob["payload"];
+    expect(payload.kind).toBe("agentTurn");
+    if (payload.kind === "agentTurn") {
+      expect(payload.toolsAllow).toEqual(["exec", "read"]);
+      expect(payload.toolsAllowIsDefault).toBe(true);
     }
   });
 

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -40,6 +40,9 @@ const STUCK_RUN_MS = 2 * 60 * 60 * 1000;
 const STAGGER_OFFSET_CACHE_MAX = 4096;
 const staggerOffsetCache = new Map<string, number>();
 
+type CronAgentTurnPayload = Extract<CronPayload, { kind: "agentTurn" }>;
+type CronAgentTurnPayloadPatch = Extract<CronPayloadPatch, { kind: "agentTurn" }>;
+
 /** Default retry delays applied after consecutive cron execution errors. */
 export const DEFAULT_ERROR_BACKOFF_SCHEDULE_MS = [
   30_000,
@@ -897,6 +900,42 @@ export function applyJobPatch(
   }
 }
 
+function applyAgentTurnToolsAllowPatch(
+  payload: CronAgentTurnPayload,
+  patch: CronAgentTurnPayloadPatch,
+  existing?: CronAgentTurnPayload,
+): void {
+  if (Array.isArray(patch.toolsAllow)) {
+    payload.toolsAllow = patch.toolsAllow;
+    // Same-kind edits keep the marker only when the default list is unchanged;
+    // kind replacements carry the cron-tool-stamped marker into persistence.
+    if (
+      patch.toolsAllowIsDefault === true &&
+      (!existing || (existing.toolsAllowIsDefault === true && toolsAllowEqual(existing, patch)))
+    ) {
+      payload.toolsAllowIsDefault = true;
+    } else {
+      delete payload.toolsAllowIsDefault;
+    }
+  } else if (patch.toolsAllow === null) {
+    delete payload.toolsAllow;
+    delete payload.toolsAllowIsDefault;
+  }
+}
+
+function toolsAllowEqual(
+  left: Pick<CronAgentTurnPayload, "toolsAllow">,
+  right: Pick<CronAgentTurnPayloadPatch, "toolsAllow">,
+): boolean {
+  const rightToolsAllow = right.toolsAllow;
+  return (
+    Array.isArray(left.toolsAllow) &&
+    Array.isArray(rightToolsAllow) &&
+    left.toolsAllow.length === rightToolsAllow.length &&
+    left.toolsAllow.every((toolName, index) => toolName === rightToolsAllow[index])
+  );
+}
+
 function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronPayload {
   if (patch.kind !== existing.kind) {
     return buildPayloadFromPatch(patch);
@@ -943,7 +982,7 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
     return buildPayloadFromPatch(patch);
   }
 
-  const next: Extract<CronPayload, { kind: "agentTurn" }> = { ...existing };
+  const next: CronAgentTurnPayload = { ...existing };
   if (typeof patch.message === "string") {
     next.message = patch.message;
   }
@@ -957,11 +996,7 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   } else if (patch.fallbacks === null) {
     delete next.fallbacks;
   }
-  if (Array.isArray(patch.toolsAllow)) {
-    next.toolsAllow = patch.toolsAllow;
-  } else if (patch.toolsAllow === null) {
-    delete next.toolsAllow;
-  }
+  applyAgentTurnToolsAllowPatch(next, patch, existing);
   if (typeof patch.thinking === "string") {
     next.thinking = patch.thinking;
   }
@@ -1005,17 +1040,18 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     throw new Error('cron.update payload.kind="agentTurn" requires message');
   }
 
-  return {
+  const next: CronAgentTurnPayload = {
     kind: "agentTurn",
     message: patch.message,
     model: typeof patch.model === "string" ? patch.model : undefined,
     fallbacks: Array.isArray(patch.fallbacks) ? patch.fallbacks : undefined,
-    toolsAllow: Array.isArray(patch.toolsAllow) ? patch.toolsAllow : undefined,
     thinking: patch.thinking,
     timeoutSeconds: patch.timeoutSeconds,
     lightContext: patch.lightContext,
     allowUnsafeExternalContent: patch.allowUnsafeExternalContent,
   };
+  applyAgentTurnToolsAllowPatch(next, patch);
+  return next;
 }
 
 function mergeCronDelivery(

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -522,6 +522,48 @@ describe("cron store", () => {
     });
   });
 
+  it("round-trips the toolsAllow default-cap flag through SQLite", async () => {
+    // The flag must survive a gateway restart: without it, a CLI-resolved run
+    // would re-hit the prepare.ts toolsAllow rejection after reload (#91499).
+    const store = await makeStorePath();
+    const payload = makeStore("tools-allow-default-job", true);
+    payload.jobs[0].sessionTarget = "isolated";
+    payload.jobs[0].payload = {
+      kind: "agentTurn",
+      message: "scheduled continuation",
+      toolsAllow: ["read", "cron"],
+      toolsAllowIsDefault: true,
+    };
+
+    await saveCronStore(store.storePath, payload);
+
+    expect((await loadCronStore(store.storePath)).jobs[0]?.payload).toMatchObject({
+      kind: "agentTurn",
+      toolsAllow: ["read", "cron"],
+      toolsAllowIsDefault: true,
+    });
+  });
+
+  it("does not persist a default-cap flag for an explicit toolsAllow restriction", async () => {
+    // An explicit user restriction is fail-closed: it carries no flag, so a CLI
+    // run still surfaces the prepare.ts rejection rather than silently dropping
+    // the requested policy.
+    const store = await makeStorePath();
+    const payload = makeStore("tools-allow-explicit-job", true);
+    payload.jobs[0].sessionTarget = "isolated";
+    payload.jobs[0].payload = {
+      kind: "agentTurn",
+      message: "scheduled continuation",
+      toolsAllow: ["read"],
+    };
+
+    await saveCronStore(store.storePath, payload);
+
+    const reloaded = (await loadCronStore(store.storePath)).jobs[0]?.payload;
+    expect(reloaded).toMatchObject({ kind: "agentTurn", toolsAllow: ["read"] });
+    expect(reloaded && "toolsAllowIsDefault" in reloaded).toBe(false);
+  });
+
   it("round-trips command payloads through SQLite", async () => {
     const store = await makeStorePath();
     const payload = makeStore("command-job", true);

--- a/src/cron/store/payload-codec.ts
+++ b/src/cron/store/payload-codec.ts
@@ -75,6 +75,7 @@ export function bindPayloadColumns(
   | "payload_thinking"
   | "payload_timeout_seconds"
   | "payload_tools_allow_json"
+  | "payload_tools_allow_is_default"
 > {
   if (payload.kind === "systemEvent") {
     return {
@@ -88,6 +89,7 @@ export function bindPayloadColumns(
       payload_external_content_source_json: null,
       payload_light_context: null,
       payload_tools_allow_json: null,
+      payload_tools_allow_is_default: null,
     };
   }
   if (payload.kind === "command") {
@@ -103,6 +105,7 @@ export function bindPayloadColumns(
       payload_external_content_source_json: null,
       payload_light_context: null,
       payload_tools_allow_json: null,
+      payload_tools_allow_is_default: null,
     };
   }
   return {
@@ -116,6 +119,12 @@ export function bindPayloadColumns(
     payload_external_content_source_json: serializeJson(payload.externalContentSource),
     payload_light_context: booleanToInteger(payload.lightContext),
     payload_tools_allow_json: serializeJson(payload.toolsAllow),
+    // Persist whether toolsAllow is the auto-applied creator-surface default
+    // (#91499) so a CLI-resolved run can drop the unenforceable cap after a
+    // restart instead of failing. Only meaningful when toolsAllow is set.
+    payload_tools_allow_is_default: payload.toolsAllow
+      ? booleanToInteger(payload.toolsAllowIsDefault)
+      : null,
   };
 }
 
@@ -144,6 +153,10 @@ export function payloadFromRow(row: CronJobRow): CronPayload | null {
     const toolsAllow = row.payload_tools_allow_json
       ? parseJsonArray(row.payload_tools_allow_json)
       : undefined;
+    const toolsAllowIsDefault =
+      row.payload_tools_allow_is_default != null
+        ? integerToBoolean(row.payload_tools_allow_is_default)
+        : undefined;
     return {
       kind: "agentTurn",
       message: row.payload_message,
@@ -155,6 +168,7 @@ export function payloadFromRow(row: CronJobRow): CronPayload | null {
       ...(externalContentSource ? { externalContentSource } : {}),
       ...(lightContext != null ? { lightContext } : {}),
       ...(toolsAllow ? { toolsAllow } : {}),
+      ...(toolsAllow && toolsAllowIsDefault ? { toolsAllowIsDefault: true } : {}),
     };
   }
   if (row.payload_kind === "command") {

--- a/src/cron/store/payload-codec.ts
+++ b/src/cron/store/payload-codec.ts
@@ -119,9 +119,6 @@ export function bindPayloadColumns(
     payload_external_content_source_json: serializeJson(payload.externalContentSource),
     payload_light_context: booleanToInteger(payload.lightContext),
     payload_tools_allow_json: serializeJson(payload.toolsAllow),
-    // Persist whether toolsAllow is the auto-applied creator-surface default
-    // (#91499) so a CLI-resolved run can drop the unenforceable cap after a
-    // restart instead of failing. Only meaningful when toolsAllow is set.
     payload_tools_allow_is_default: payload.toolsAllow
       ? booleanToInteger(payload.toolsAllowIsDefault)
       : null,

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -248,13 +248,7 @@ type CronAgentTurnPayloadFields = {
   lightContext?: boolean;
   /** Optional tool allow-list; when set, only these tools are sent to the model. */
   toolsAllow?: string[];
-  /**
-   * Set by the server when `toolsAllow` is the auto-applied creator-surface cap
-   * (#91499) rather than an explicit user restriction. CLI backends cannot
-   * enforce a runtime `toolsAllow`, so a CLI-resolved run drops this default cap
-   * (it is unenforceable) instead of failing; an explicit user restriction has
-   * no flag and stays fail-closed. Not user-settable.
-   */
+  /** Server-managed marker for auto-stamped defaults; explicit restrictions omit it. */
   toolsAllowIsDefault?: boolean;
 };
 

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -248,6 +248,14 @@ type CronAgentTurnPayloadFields = {
   lightContext?: boolean;
   /** Optional tool allow-list; when set, only these tools are sent to the model. */
   toolsAllow?: string[];
+  /**
+   * Set by the server when `toolsAllow` is the auto-applied creator-surface cap
+   * (#91499) rather than an explicit user restriction. CLI backends cannot
+   * enforce a runtime `toolsAllow`, so a CLI-resolved run drops this default cap
+   * (it is unenforceable) instead of failing; an explicit user restriction has
+   * no flag and stays fail-closed. Not user-settable.
+   */
+  toolsAllowIsDefault?: boolean;
 };
 
 type CronAgentTurnPayload = {

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -288,6 +288,7 @@ export interface CronJobs {
   payload_model: string | null;
   payload_thinking: string | null;
   payload_timeout_seconds: number | null;
+  payload_tools_allow_is_default: number | null;
   payload_tools_allow_json: string | null;
   running_at_ms: number | null;
   runtime_updated_at_ms: number | null;

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -712,6 +712,7 @@ function ensureAdditiveStateColumns(db: DatabaseSync): void {
   ensureColumn(db, "cron_jobs", "payload_external_content_source_json TEXT");
   ensureColumn(db, "cron_jobs", "payload_light_context INTEGER");
   ensureColumn(db, "cron_jobs", "payload_tools_allow_json TEXT");
+  ensureColumn(db, "cron_jobs", "payload_tools_allow_is_default INTEGER");
   ensureColumn(db, "cron_jobs", "delivery_mode TEXT");
   ensureColumn(db, "cron_jobs", "delivery_channel TEXT");
   ensureColumn(db, "cron_jobs", "delivery_to TEXT");

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -884,6 +884,7 @@ CREATE TABLE IF NOT EXISTS cron_jobs (
   payload_external_content_source_json TEXT,
   payload_light_context INTEGER,
   payload_tools_allow_json TEXT,
+  payload_tools_allow_is_default INTEGER,
   delivery_mode TEXT,
   delivery_channel TEXT,
   delivery_to TEXT,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -879,6 +879,7 @@ CREATE TABLE IF NOT EXISTS cron_jobs (
   payload_external_content_source_json TEXT,
   payload_light_context INTEGER,
   payload_tools_allow_json TEXT,
+  payload_tools_allow_is_default INTEGER,
   delivery_mode TEXT,
   delivery_channel TEXT,
   delivery_to TEXT,


### PR DESCRIPTION
## What Problem This Solves

CLI-backed scheduled agentTurn cron jobs fail before starting when an auto-stamped default toolsAllow cap reaches a CLI backend. CLI backends cannot enforce runtime toolsAllow, so the fix keeps explicit per-cron restrictions fail-closed but drops only the server-stamped default cap for CLI runs.

## Evidence

- Maintainer follow-up a7f24002a8 preserves default-marker persistence in the cron service, clears stale markers when explicit toolsAllow edits change the list, and trims excessive explanatory comments.
- Focused tests: node scripts/run-vitest.mjs src/cron/service.jobs.test.ts src/cron/store.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts src/agents/tools/cron-tool.test.ts (285 passing).
- Format/lint: oxfmt --check on touched files, direct oxlint on touched files, and git diff --check all passed.
- Autoreview: clean after the service-marker fix; no accepted/actionable findings.

## Problem

#91499 auto-stamps the creator's tool surface as a default `toolsAllow` cap on `agentTurn` cron payloads whenever the creating session is tool-restricted (a narrowing allow-policy or an explicit deny). CLI backends cannot enforce a runtime `toolsAllow` — `cli-runner/prepare.ts` rejects any defined allow-list — so every scheduled `agentTurn` that resolves to a CLI backend (e.g. `claude-cli`) fails to start. This silently broke per-thread scheduled continuations on CLI backends.

## Fix

A CLI backend is not a runtime tool-policy boundary: it runs with its own configured tool set, as the operator, on the local machine, and refuses a runtime allow-list outright. An inherited default cap is therefore unenforceable on a CLI backend. Decide at run time, where the backend is known:

- **Flag the default.** `capCronAgentTurnToolsAllow` stamps `toolsAllowIsDefault` when it fills in the creator surface because the cron requested nothing (or a bare `*`). An explicit narrowing or empty allow-list is a real per-cron restriction and carries no flag.
- **Drop only the default, only on CLI.** The run-executor drops a flagged default in the CLI branch and lets the run proceed. An explicit per-cron restriction (no flag) is deliberately passed through, so `prepare.ts` still fails it closed and surfaces that the requested policy needs an embedded runtime. Embedded runs are untouched and keep the full cap enforced.
- **Persist the flag.** New nullable `cron_jobs.payload_tools_allow_is_default` column (additive `ensureColumn` migration + codec read/write), plus `toolsAllowIsDefault` on the gateway-protocol `agentTurn` payload schema — the stamped payload is otherwise rejected by the contract's `additionalProperties: false`.
- **Preserve the flag across updates.** A no-`toolsAllow` update (reschedule, prompt edit) re-derives the default (flag intact) instead of carrying the stored value forward as a literal — which previously routed it through the explicit-narrowing branch, stripped the flag, and re-broke the job on CLI after the next restart.

Net policy: on CLI only the unenforceable inherited default is relaxed; explicit per-cron restrictions still fail closed; embedded backends are unchanged.

## Verification

- `tsgo:core` clean; `oxlint` clean on changed files.
- 683 passing across the cron + store + isolated-agent suites, including new coverage: run-executor drops the flagged default but propagates an explicit restriction on CLI; cron-tool stamps/clears the flag across create and update and preserves it across a no-`toolsAllow` update; store round-trips the flag (and its absence) through SQLite.

## Real-behaviour proof — BEFORE (the regression, live)

Captured on a production `claude-cli` gateway running the pre-fix build, by force-running an `agentTurn` cron that carries a `toolsAllow` cap:

- **Scenario:** `agentTurn` cron, `toolsAllow` cap stamped by capCron (sent `["exec"]`, capped to `[]`), forced run, resolves to the `claude-cli` backend.
- **Result:** run errors in **205 ms, before any agent work**:
  `Error: CLI backend claude-cli cannot enforce runtime toolsAllow; use an embedded runtime for restricted tool policy`
- **Mechanism:** the cap reaches `cli-runner/prepare.ts`, which rejects any defined runtime `toolsAllow` → the scheduled continuation never starts. This is the exact failure the fix removes for the *default* (unenforceable) cap.

AFTER behaviour (run-executor drops the flagged default on CLI and the run proceeds) is covered by `run.message-tool-policy.test.ts`; a filmed before/after cron-wake capture (reply landing back in the Telegram topic) is being assembled as a follow-up artifact.

## Risk / mitigation

- **Risk:** a reloaded job loses the in-memory flag and re-hits the rejection. **Mitigation:** the flag is persisted (SQLite column + wire-schema field) and round-tripped by the codec; preserved across no-`toolsAllow` updates.
- **Not covered:** `agentTurn` crons created during the regression window carry a flagless `toolsAllow` and remain fail-closed on CLI until recreated or updated with an explicit `toolsAllow`.

