### PR TITLE
model-usage: narrow parse_date except Exception to ValueError

### DIFF
--- a/skills/model-usage/scripts/model_usage.py
+++ b/skills/model-usage/scripts/model_usage.py
@@ -88,7 +88,7 @@ def parse_daily_entries(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
 def parse_date(value: str) -> Optional[date]:
     try:
         return datetime.strptime(value, "%Y-%m-%d").date()
-    except Exception:
+    except ValueError:
         return None
 
 


### PR DESCRIPTION
## Summary

- `skills/model-usage/scripts/model_usage.py`: `parse_date` wraps `datetime.strptime(...)` in a bare `except Exception`. The only thing `strptime` raises for a well-formed string input that doesn't match the format is `ValueError`. The broad `except Exception` also swallows `KeyboardInterrupt`/`SystemExit` (which subclass `BaseException`, not `Exception`, so this point is technically safe, but it also conceals unrelated bugs like a custom exception raised from a patched `datetime` class, an `ImportError` if the module is shadowed by something broken, or a `MemoryError` from a pathological input).

- The caller (`filter_by_days`) already guards against non-string `date` fields with `isinstance(day, str)` before calling `parse_date`, so a `TypeError` (raised when strptime receives a non-string) can't actually occur in this code path.

- Narrowed to `except ValueError` so the function only converts an unparseable date string to `None` — its documented behaviour — and any other unexpected error surfaces.

## Verification

- `parse_date("2024-01-01")` returns `date(2024, 1, 1)` (unchanged)
- `parse_date("not-a-date")` returns `None` (was None, still None, still catches the only thing it should)
- `parse_date(None)` would now propagate `TypeError` instead of being silently swallowed — which is what we want since the caller guards against this case anyway
