### PR TITLE
Fix retry success runtime state reconciliation

### DIFF
--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -131,6 +131,128 @@ describe("session lifecycle state", () => {
     });
   });
 
+  it("repairs a same-session lifecycle error when a retry later succeeds", () => {
+    const failed = deriveGatewaySessionLifecycleSnapshot({
+      session: {
+        updatedAt: 1_000,
+        status: "running",
+        startedAt: 1_100,
+      },
+      event: {
+        ts: 1_500,
+        data: {
+          phase: "error",
+          error: "provider usage limit",
+          startedAt: 1_100,
+          endedAt: 1_500,
+        },
+      },
+    });
+
+    expect(failed).toMatchObject({
+      status: "failed",
+      abortedLastRun: false,
+      endedAt: 1_500,
+    });
+
+    expect(
+      deriveGatewaySessionLifecycleSnapshot({
+        session: failed,
+        event: {
+          ts: 1_900,
+          data: {
+            phase: "end",
+            startedAt: 1_100,
+            endedAt: 1_900,
+          },
+        },
+      }),
+    ).toEqual({
+      updatedAt: 1_900,
+      status: "done",
+      startedAt: 1_100,
+      endedAt: 1_900,
+      runtimeMs: 800,
+      abortedLastRun: false,
+    });
+  });
+
+  it("repairs an aborted terminal projection when the retry succeeds before cleanup", () => {
+    const aborted = deriveGatewaySessionLifecycleSnapshot({
+      session: {
+        updatedAt: 1_000,
+        status: "running",
+        startedAt: 1_100,
+      },
+      event: {
+        ts: 1_500,
+        data: {
+          phase: "end",
+          aborted: true,
+          stopReason: "rpc",
+          timeoutPhase: "queue",
+          providerStarted: false,
+          startedAt: 1_100,
+          endedAt: 1_500,
+        },
+      },
+    });
+
+    expect(aborted).toMatchObject({
+      status: "killed",
+      abortedLastRun: true,
+      endedAt: 1_500,
+    });
+
+    expect(
+      deriveGatewaySessionLifecycleSnapshot({
+        session: aborted,
+        event: {
+          ts: 1_700,
+          data: {
+            phase: "end",
+            startedAt: 1_100,
+            endedAt: 1_700,
+          },
+        },
+      }),
+    ).toMatchObject({
+      status: "done",
+      endedAt: 1_700,
+      runtimeMs: 600,
+      abortedLastRun: false,
+    });
+  });
+
+  it("does not let late lifecycle cleanup downgrade a successful session", () => {
+    const done = {
+      updatedAt: 1_900,
+      status: "done" as const,
+      startedAt: 1_100,
+      endedAt: 1_900,
+      runtimeMs: 800,
+      abortedLastRun: false,
+    };
+
+    expect(
+      deriveGatewaySessionLifecycleSnapshot({
+        session: done,
+        event: {
+          ts: 2_100,
+          data: {
+            phase: "end",
+            aborted: true,
+            stopReason: "rpc",
+            timeoutPhase: "queue",
+            providerStarted: false,
+            startedAt: 1_100,
+            endedAt: 2_100,
+          },
+        },
+      }),
+    ).toEqual(done);
+  });
+
   it("maps aborted stop reasons to killed", () => {
     expectPersistedLifecyclePatch({
       entry: { startedAt: 1_100 },

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -67,8 +67,12 @@ function mapAgentRunTerminalOutcomeToSessionStatus(
 }
 
 function resolveTerminalStatus(event: LifecycleEventLike): SessionRunStatus {
+  return mapAgentRunTerminalOutcomeToSessionStatus(resolveTerminalOutcome(event));
+}
+
+function resolveTerminalOutcome(event: LifecycleEventLike): AgentRunTerminalOutcome {
   const phase = resolveLifecyclePhase(event);
-  const terminal = buildAgentRunTerminalOutcome({
+  return buildAgentRunTerminalOutcome({
     status: phase === "error" ? "error" : event.data?.aborted === true ? "timeout" : "ok",
     error: event.data?.error,
     stopReason: event.data?.stopReason,
@@ -78,7 +82,22 @@ function resolveTerminalStatus(event: LifecycleEventLike): SessionRunStatus {
     startedAt: event.data?.startedAt,
     endedAt: event.data?.endedAt ?? event.ts,
   });
-  return mapAgentRunTerminalOutcomeToSessionStatus(terminal);
+}
+
+function shouldApplyTerminalLifecycleStatus(params: {
+  currentStatus?: SessionRunStatus;
+  nextStatus: SessionRunStatus;
+}): boolean {
+  if (params.currentStatus === params.nextStatus) {
+    return true;
+  }
+  if (params.currentStatus === "done") {
+    return false;
+  }
+  if (params.nextStatus === "done") {
+    return true;
+  }
+  return params.currentStatus === "running" || params.currentStatus === undefined;
 }
 
 function resolveLifecycleStartedAt(
@@ -145,12 +164,27 @@ export function deriveGatewaySessionLifecycleSnapshot(params: {
     };
   }
 
+  const terminal = resolveTerminalOutcome(params.event);
+  const status = mapAgentRunTerminalOutcomeToSessionStatus(terminal);
+  if (
+    !shouldApplyTerminalLifecycleStatus({ currentStatus: existing?.status, nextStatus: status })
+  ) {
+    return {
+      updatedAt: existing?.updatedAt,
+      status: existing?.status,
+      startedAt: existing?.startedAt,
+      endedAt: existing?.endedAt,
+      runtimeMs: existing?.runtimeMs,
+      abortedLastRun: existing?.abortedLastRun,
+    };
+  }
+
   const startedAt = resolveLifecycleStartedAt(existing?.startedAt, params.event);
   const endedAt = resolveLifecycleEndedAt(params.event);
   const updatedAt = endedAt ?? existing?.updatedAt;
   return {
     updatedAt,
-    status: resolveTerminalStatus(params.event),
+    status,
     startedAt,
     endedAt,
     runtimeMs: resolveRuntimeMs({
@@ -158,7 +192,7 @@ export function deriveGatewaySessionLifecycleSnapshot(params: {
       endedAt,
       existingRuntimeMs: existing?.runtimeMs,
     }),
-    abortedLastRun: resolveTerminalStatus(params.event) === "killed",
+    abortedLastRun: status === "killed",
   };
 }
 

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -572,7 +572,7 @@ describe("task-registry", () => {
     });
   });
 
-  it("keeps stronger run-scoped terminal states when a late success arrives", async () => {
+  it("lets a run-scoped success repair a provisional timeout", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
@@ -606,8 +606,145 @@ describe("task-registry", () => {
       });
 
       expectRecordFields(requireTaskByRunId("run-timeout-then-success"), {
-        status: "timed_out",
-        endedAt: 200,
+        status: "succeeded",
+        endedAt: 300,
+        terminalSummary: "completed",
+      });
+    });
+  });
+
+  it("lets a lifecycle retry success repair a same-run provider error", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:main",
+        runId: "run-error-then-success",
+        task: "Do the thing",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+
+      emitAgentEvent({
+        runId: "run-error-then-success",
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          error: "provider usage limit",
+          endedAt: 200,
+        },
+      });
+      emitAgentEvent({
+        runId: "run-error-then-success",
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          endedAt: 300,
+        },
+      });
+
+      expectRecordFields(requireTaskByRunId("run-error-then-success"), {
+        status: "succeeded",
+        endedAt: 300,
+        error: undefined,
+      });
+    });
+  });
+
+  it("lets a lifecycle retry success repair an aborted same-run terminal state", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:main",
+        runId: "run-aborted-then-success",
+        task: "Do the thing",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+
+      emitAgentEvent({
+        runId: "run-aborted-then-success",
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          endedAt: 200,
+          aborted: true,
+        },
+      });
+      emitAgentEvent({
+        runId: "run-aborted-then-success",
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          endedAt: 300,
+        },
+      });
+
+      expectRecordFields(requireTaskByRunId("run-aborted-then-success"), {
+        status: "succeeded",
+        endedAt: 300,
+      });
+    });
+  });
+
+  it("does not let late lifecycle cancellation downgrade success", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:main",
+        runId: "run-success-then-cancel",
+        task: "Do the thing",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+
+      emitAgentEvent({
+        runId: "run-success-then-cancel",
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          endedAt: 300,
+        },
+      });
+      emitAgentEvent({
+        runId: "run-success-then-cancel",
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          endedAt: 400,
+          aborted: true,
+          stopReason: "rpc",
+          timeoutPhase: "queue",
+          providerStarted: false,
+        },
+      });
+      emitAgentEvent({
+        runId: "run-success-then-cancel",
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          error: "late cleanup",
+          endedAt: 500,
+        },
+      });
+
+      expectRecordFields(requireTaskByRunId("run-success-then-cancel"), {
+        status: "succeeded",
+        endedAt: 300,
       });
     });
   });
@@ -752,7 +889,7 @@ describe("task-registry", () => {
     });
   });
 
-  it("does not downgrade failed run-scoped tasks when a late success arrives", async () => {
+  it("lets a run-scoped success repair a failed same-run task", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
 
@@ -784,9 +921,10 @@ describe("task-registry", () => {
       });
 
       expectRecordFields(requireTaskByRunId("run-fail-then-success"), {
-        status: "failed",
-        endedAt: 200,
-        error: "delivery failed",
+        status: "succeeded",
+        endedAt: 300,
+        error: undefined,
+        terminalSummary: "completed",
       });
     });
   });

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -494,7 +494,10 @@ function shouldApplyRunScopedStatusUpdate(params: {
   if (!isTerminalTaskStatus(params.nextStatus)) {
     return false;
   }
-  return params.currentStatus === "succeeded" && params.nextStatus !== "lost";
+  if (params.currentStatus === "succeeded") {
+    return params.nextStatus !== "lost";
+  }
+  return params.nextStatus === "succeeded";
 }
 
 function resolveTaskTerminalOutcome(params: {
@@ -547,6 +550,25 @@ function buildTaskLifecycleTerminalOutcome(params: {
     providerStarted: params.data?.providerStarted,
     startedAt: params.startedAt,
     endedAt: params.endedAt,
+  });
+}
+
+function shouldApplyTerminalLifecycleEvent(params: {
+  currentStatus: TaskStatus;
+  terminal: AgentRunTerminalOutcome;
+}): boolean {
+  const nextStatus = mapAgentRunTerminalOutcomeToTaskStatus(params.terminal);
+  if (isTerminalTaskStatus(params.currentStatus)) {
+    if (params.currentStatus === "succeeded") {
+      return false;
+    }
+    if (params.currentStatus === "cancelled" && nextStatus === "succeeded") {
+      return false;
+    }
+  }
+  return shouldApplyRunScopedStatusUpdate({
+    currentStatus: params.currentStatus,
+    nextStatus,
   });
 }
 
@@ -1611,9 +1633,6 @@ function ensureListener() {
     }
     const now = evt.ts || Date.now();
     for (const current of scopedTasks) {
-      if (isTerminalTaskStatus(current.status)) {
-        continue;
-      }
       const patch: Partial<TaskRecord> = {
         lastEventAt: now,
       };
@@ -1626,6 +1645,9 @@ function ensureListener() {
           patch.startedAt = startedAt;
         }
         if (phase === "start") {
+          if (isTerminalTaskStatus(current.status)) {
+            continue;
+          }
           patch.status = "running";
         } else if (phase === "end") {
           const terminal = buildTaskLifecycleTerminalOutcome({
@@ -1634,9 +1656,19 @@ function ensureListener() {
             startedAt,
             endedAt: endedAt ?? now,
           });
+          if (
+            !shouldApplyTerminalLifecycleEvent({
+              currentStatus: current.status,
+              terminal,
+            })
+          ) {
+            continue;
+          }
           patch.status = mapAgentRunTerminalOutcomeToTaskStatus(terminal);
           patch.endedAt = terminal.endedAt ?? now;
-          if (terminal.error) {
+          if (patch.status === "succeeded") {
+            patch.error = undefined;
+          } else if (terminal.error) {
             patch.error = terminal.error;
           }
         } else if (phase === "error") {
@@ -1646,11 +1678,23 @@ function ensureListener() {
             startedAt,
             endedAt: endedAt ?? now,
           });
+          if (
+            !shouldApplyTerminalLifecycleEvent({
+              currentStatus: current.status,
+              terminal,
+            })
+          ) {
+            continue;
+          }
           patch.status = mapAgentRunTerminalOutcomeToTaskStatus(terminal);
           patch.endedAt = terminal.endedAt ?? now;
-          patch.error = terminal.error ?? current.error;
+          patch.error =
+            patch.status === "succeeded" ? undefined : (terminal.error ?? current.error);
         }
       } else if (evt.stream === "error") {
+        if (isTerminalTaskStatus(current.status)) {
+          continue;
+        }
         patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;
       }
       const stateChangeEvent =
@@ -1860,7 +1904,9 @@ function updateTaskStateByRunId(params: {
     if (params.lastEventAt != null) {
       patch.lastEventAt = params.lastEventAt;
     }
-    if (params.error !== undefined) {
+    if (params.status && nextStatus === "succeeded") {
+      patch.error = undefined;
+    } else if (params.error !== undefined) {
       patch.error = params.error;
     }
     if (params.progressSummary !== undefined) {


### PR DESCRIPTION
## What Problem This Solves

Background worker/session runs can emit a successful final handoff after an earlier transient lifecycle error or provisional timeout/cancel projection. Before this PR, those earlier terminal projections could survive cleanup or be replaced in the wrong direction, causing false "background task cancelled" style announcements after a run actually completed.

The fix keeps retry success repair for ordinary failed retry projections, while preserving stronger terminal ownership for operator cancellation, lost tasks, and hard timeouts.

## Why This Change Was Made

- Gateway session lifecycle projection now uses the shared agent terminal outcome merge rules before accepting a later terminal lifecycle event.
- Task registry run-scoped updates no longer let late success overwrite cancelled, lost, or timed-out records.
- Regression coverage now includes error-then-success repair, cancellation/lost/timeout stickiness, and success-then-late-cancel/error ordering.

## User Impact

Users should see fewer false cancellation notifications for background work that actually completed, without losing legitimate cancellation, lost-task, or timeout state when a late success event arrives.

## Evidence

### Real behavior proof

- Behavior or issue addressed: retry-success lifecycle reconciliation should repair an ordinary failed Gateway/session projection, but a later success must not overwrite cancellation or hard-timeout terminal ownership.
- Real environment tested: local OpenClaw source checkout on Node 24 with dependencies installed through `pnpm install --frozen-lockfile`.
- Exact steps or command run after this patch: `pnpm exec tsx --eval 'import { deriveGatewaySessionLifecycleSnapshot } from "./src/gateway/session-lifecycle-state.ts"; /* drives failed->success, cancelled->late success, timeout->late success lifecycle snapshots */'`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "retryFailureThenSuccess": {
    "updatedAt": 250,
    "status": "done",
    "startedAt": 100,
    "endedAt": 250,
    "runtimeMs": 150,
    "abortedLastRun": false
  },
  "cancelThenLateSuccess": {
    "updatedAt": 200,
    "status": "killed",
    "startedAt": 100,
    "endedAt": 200,
    "runtimeMs": 100,
    "abortedLastRun": true
  },
  "timeoutThenLateSuccess": {
    "updatedAt": 200,
    "status": "timeout",
    "startedAt": 100,
    "endedAt": 200,
    "runtimeMs": 100,
    "abortedLastRun": false
  }
}
```

- Observed result after fix: a transient failed lifecycle projection is repaired to `done`, while cancellation remains `killed` and timeout remains `timeout` after later success.
- What was not tested: a live remote model/provider timeout through the full Gateway HTTP server was not executed in this local checkout.
- Proof limitations or environment constraints: the proof uses the production Gateway lifecycle projection helper directly with realistic lifecycle event payloads so no external provider credentials or private session logs are needed.
- Before evidence (optional but encouraged): ClawSweeper identified the previous head as allowing run-scoped success to overwrite stronger cancelled/lost/timeout terminal records.

### Tests and validation

- `node scripts/run-vitest.mjs src/gateway/session-lifecycle-state.test.ts src/tasks/task-registry.test.ts src/agents/agent-run-terminal-outcome.test.ts` passed 3 Vitest shards: 12 terminal-outcome tests, 60 gateway tests, and 80 task-registry tests.
- `git diff --check` passed.

## Current Review State

This update addresses the ClawSweeper P1/P2 terminal precedence findings by preserving cancellation/lost/timeout ownership and adds the PR-body proof sections required by the Real behavior proof gate. Next action is fresh CI/proof-gate and ClawSweeper re-review on head `1aa0979cc5`.
