### PR TITLE
perf(imessage): show typing sooner for slow replies

### DIFF
--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -579,7 +579,7 @@ When `imsg launch` is running and `openclaw channels status --probe` reports `pr
   </Accordion>
 
   <Accordion title="Read receipts and typing">
-    When the private API bridge is up, accepted inbound chats are marked read before dispatch and a typing bubble is shown to the sender while the agent generates. Disable read-marking with:
+    When the private API bridge is up, accepted inbound chats are marked read and direct chats show a typing bubble as soon as the turn is accepted, while the agent prepares context and generates. Disable read-marking with:
 
     ```json5
     {

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -346,6 +346,13 @@ describe("iMessage monitor last-route updates", () => {
       expect.objectContaining({ typing: true }),
       expect.anything(),
     );
+    await vi.waitFor(() => {
+      expect(earlyTypingClient.request).toHaveBeenCalledWith(
+        "typing",
+        expect.objectContaining({ typing: false, to: "+15550001111" }),
+        expect.any(Object),
+      );
+    });
   });
 
   it.each(["never", "message", "thinking"] as const)(

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -256,6 +256,84 @@ describe("iMessage monitor last-route updates", () => {
     });
   });
 
+  it("keeps direct progress options when imsg lacks native typing support", async () => {
+    setCachedIMessagePrivateApiStatus("imsg", {
+      available: true,
+      v2Ready: true,
+      selectors: {},
+      rpcMethods: ["watch.subscribe", "send", "read"],
+    });
+    dispatchInboundMessageMock.mockImplementationOnce(async (params) => {
+      expect(params.replyOptions?.suppressDefaultToolProgressMessages).toBe(true);
+      expect(params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed).toBe(true);
+      expect(params.replyOptions?.onToolStart).toBeUndefined();
+      return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
+    });
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async (method: string) => {
+        if (method === "watch.subscribe") {
+          return { subscription: 1 };
+        }
+        if (method === "typing") {
+          throw new Error("typing should not start without native typing support");
+        }
+        throw new Error(`unexpected imsg method ${method}`);
+      }),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: {
+            message: {
+              id: 13,
+              chat_id: 123,
+              sender: "+15550001111",
+              is_from_me: false,
+              text: "run a long script without native typing",
+              is_group: false,
+              created_at: new Date().toISOString(),
+            },
+          },
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550001111"],
+            sendReadReceipts: false,
+          },
+        },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    await vi.waitFor(() => {
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    });
+    expect(client.request).not.toHaveBeenCalledWith(
+      "typing",
+      expect.objectContaining({ typing: true }),
+      expect.anything(),
+    );
+  });
+
   it("starts direct typing before dispatching the inbound turn", async () => {
     setCachedIMessagePrivateApiStatus("imsg", {
       available: true,

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -256,6 +256,98 @@ describe("iMessage monitor last-route updates", () => {
     });
   });
 
+  it("starts direct typing before dispatching the inbound turn", async () => {
+    setCachedIMessagePrivateApiStatus("imsg", {
+      available: true,
+      v2Ready: true,
+      selectors: {},
+      rpcMethods: ["watch.subscribe", "send", "typing"],
+    });
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const earlyTypingClient = {
+      request: vi.fn(async (method: string) => {
+        if (method === "typing") {
+          return { ok: true };
+        }
+        throw new Error(`unexpected imsg typing-client method ${method}`);
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    const watchClient = {
+      request: vi.fn(async (method: string) => {
+        if (method === "watch.subscribe") {
+          return { subscription: 1 };
+        }
+        if (method === "typing") {
+          return { ok: true };
+        }
+        throw new Error(`unexpected imsg watch-client method ${method}`);
+      }),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: {
+            message: {
+              id: 12,
+              chat_id: 123,
+              sender: "+15550001111",
+              is_from_me: false,
+              text: "respond after a slow context build",
+              is_group: false,
+              created_at: new Date().toISOString(),
+            },
+          },
+        });
+        await vi.waitFor(() => {
+          expect(earlyTypingClient.request).toHaveBeenCalledWith(
+            "typing",
+            expect.objectContaining({ typing: true, to: "+15550001111" }),
+            expect.any(Object),
+          );
+          expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+        });
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (params?.onNotification) {
+        onNotification = params.onNotification;
+        return watchClient as never;
+      }
+      return earlyTypingClient as never;
+    });
+    dispatchInboundMessageMock.mockImplementationOnce(async () => {
+      expect(earlyTypingClient.request).toHaveBeenCalledWith(
+        "typing",
+        expect.objectContaining({ typing: true, to: "+15550001111" }),
+        expect.any(Object),
+      );
+      return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550001111"],
+            sendReadReceipts: false,
+          },
+        },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    expect(watchClient.request).not.toHaveBeenCalledWith(
+      "typing",
+      expect.objectContaining({ typing: true }),
+      expect.anything(),
+    );
+  });
+
   it.each(["never", "message", "thinking"] as const)(
     "does not start direct tool typing when typingMode is %s",
     async (typingMode) => {
@@ -418,6 +510,87 @@ describe("iMessage monitor last-route updates", () => {
       expect.objectContaining({ typing: true }),
       expect.anything(),
     );
+  });
+
+  it("does not wait for read receipts before dispatching the inbound turn", async () => {
+    setCachedIMessagePrivateApiStatus("imsg", {
+      available: true,
+      v2Ready: true,
+      selectors: {},
+      rpcMethods: ["watch.subscribe", "read"],
+    });
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const readClient = {
+      request: vi.fn((method: string) => {
+        if (method === "read") {
+          return new Promise(() => {});
+        }
+        return Promise.reject(new Error(`unexpected imsg read-client method ${method}`));
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    const watchClient = {
+      request: vi.fn((method: string) => {
+        if (method === "watch.subscribe") {
+          return Promise.resolve({ subscription: 1 });
+        }
+        return Promise.reject(new Error(`unexpected imsg watch-client method ${method}`));
+      }),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: {
+            message: {
+              id: 11,
+              chat_id: 123,
+              sender: "+15550001111",
+              is_from_me: false,
+              text: "respond without waiting for read receipt",
+              is_group: false,
+              created_at: new Date().toISOString(),
+            },
+          },
+        });
+        await vi.waitFor(() => {
+          expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+        });
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (params?.onNotification) {
+        onNotification = params.onNotification;
+        return watchClient as never;
+      }
+      return readClient as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550001111"],
+          },
+        },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    expect(readClient.request).toHaveBeenCalledWith(
+      "read",
+      expect.objectContaining({ to: "+15550001111" }),
+      expect.any(Object),
+    );
+    expect(watchClient.request).not.toHaveBeenCalledWith(
+      "read",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
   });
 
   it.each([

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -1087,7 +1087,7 @@ function buildIMessageEchoScope(params: {
   return scopes;
 }
 
-function buildDirectIMessageReplyTarget(params: {
+export function buildDirectIMessageReplyTarget(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
   sender: string;

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -1072,22 +1072,54 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           sender: decision.sender,
         })
       : undefined;
+    let stopEarlyDirectTyping: (() => void) | undefined;
     if (earlyDirectTypingTarget) {
       // Start channel-native feedback before the expensive history/context/model
       // path. Use a short-lived client so a slow typing RPC cannot block the
-      // monitor client's watch stream or later dispatcher typing teardown.
-      void sendIMessageTyping(earlyDirectTypingTarget, true, {
+      // monitor client's watch stream. Stop is sequenced after start so fast
+      // command replies cannot leave a late true after typing:false.
+      const earlyDirectTypingStarted = sendIMessageTyping(earlyDirectTypingTarget, true, {
         cfg,
         accountId: accountInfo.accountId,
-      }).catch((err) => {
-        logTypingFailure({
-          log: (msg) => logVerbose(msg),
-          channel: "imessage",
-          action: "start",
-          target: earlyDirectTypingTarget,
-          error: err,
-        });
-      });
+      }).then(
+        () => true,
+        (err) => {
+          logTypingFailure({
+            log: (msg) => logVerbose(msg),
+            channel: "imessage",
+            action: "start",
+            target: earlyDirectTypingTarget,
+            error: err,
+          });
+          return false;
+        },
+      );
+      let earlyTypingStopQueued = false;
+      stopEarlyDirectTyping = () => {
+        if (earlyTypingStopQueued) {
+          return;
+        }
+        earlyTypingStopQueued = true;
+        void earlyDirectTypingStarted
+          .then(async (started) => {
+            if (!started) {
+              return;
+            }
+            await sendIMessageTyping(earlyDirectTypingTarget, false, {
+              cfg,
+              accountId: accountInfo.accountId,
+            });
+          })
+          .catch((err) => {
+            logTypingFailure({
+              log: (msg) => logVerbose(msg),
+              channel: "imessage",
+              action: "stop",
+              target: earlyDirectTypingTarget,
+              error: err,
+            });
+          });
+      };
     }
     const stagedAttachments = remoteHost
       ? []
@@ -1352,11 +1384,13 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
             historyMap: groupHistories,
             limit: historyLimit,
           },
-          onPreDispatchFailure: () =>
+          onPreDispatchFailure: () => {
+            stopEarlyDirectTyping?.();
             settleReplyDispatcher({
               dispatcher,
               onSettled: () => markDispatchIdle(),
-            }),
+            });
+          },
           runDispatch: async () => {
             try {
               return await dispatchInboundMessage({
@@ -1375,6 +1409,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
               });
             } finally {
               markDispatchIdle();
+              stopEarlyDirectTyping?.();
             }
           },
         }),

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -1083,7 +1083,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         accountId: accountInfo.accountId,
       }).then(
         () => true,
-        (err) => {
+        (err: unknown) => {
           logTypingFailure({
             log: (msg) => logVerbose(msg),
             channel: "imessage",
@@ -1110,7 +1110,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
               accountId: accountInfo.accountId,
             });
           })
-          .catch((err) => {
+          .catch((err: unknown) => {
             logTypingFailure({
               log: (msg) => logVerbose(msg),
               channel: "imessage",
@@ -1200,7 +1200,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       void markIMessageChatRead(typingTarget, {
         cfg,
         accountId: accountInfo.accountId,
-      }).catch((err) => {
+      }).catch((err: unknown) => {
         runtime.error?.(`imessage: mark read failed: ${String(err)}`);
       });
     }
@@ -1386,7 +1386,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           },
           onPreDispatchFailure: () => {
             stopEarlyDirectTyping?.();
-            settleReplyDispatcher({
+            void settleReplyDispatcher({
               dispatcher,
               onSettled: () => markDispatchIdle(),
             });

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -94,6 +94,7 @@ import {
   releaseIMessageInboundReplay,
 } from "./inbound-dedupe.js";
 import {
+  buildDirectIMessageReplyTarget,
   buildIMessageInboundContext,
   rememberIMessageSkippedFromMeForSelfChatDedupe,
   resolveIMessageReactionContext,
@@ -1039,6 +1040,55 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     const storePath = resolveStorePath(cfg.session?.store, {
       agentId: decision.route.agentId,
     });
+    const privateApiStatus = getCachedIMessagePrivateApiStatus(cliPath);
+    const supportsTyping = imessageRpcSupportsMethod(privateApiStatus, "typing");
+    const supportsRead = imessageRpcSupportsMethod(privateApiStatus, "read");
+    if (privateApiStatus?.available === true) {
+      // Surface a single warning per restart when the bridge is up but we
+      // had to gate off typing/read because the imsg build pre-dates the
+      // capability list. Otherwise the user sees no typing bubble / no
+      // "Read" receipt with no visible reason.
+      if (!supportsTyping || !supportsRead) {
+        warnIfImsgUpgradeNeeded.fireOnce(privateApiStatus.rpcMethods, runtime);
+      }
+    }
+    const configuredTypingMode = resolveConfiguredIMessageTypingMode(cfg);
+    const sendPolicy = resolveSendPolicy({
+      cfg,
+      entry: getSessionEntry({ storePath, sessionKey: decision.route.sessionKey }),
+      sessionKey: decision.route.sessionKey,
+      channel: "imessage",
+      chatType: decision.isGroup ? "group" : "direct",
+    });
+    const shouldStartDirectTyping =
+      supportsTyping &&
+      !decision.isGroup &&
+      sendPolicy !== "deny" &&
+      (configuredTypingMode === undefined || configuredTypingMode === "instant");
+    const earlyDirectTypingTarget = shouldStartDirectTyping
+      ? buildDirectIMessageReplyTarget({
+          cfg,
+          accountId: decision.route.accountId,
+          sender: decision.sender,
+        })
+      : undefined;
+    if (earlyDirectTypingTarget) {
+      // Start channel-native feedback before the expensive history/context/model
+      // path. Use a short-lived client so a slow typing RPC cannot block the
+      // monitor client's watch stream or later dispatcher typing teardown.
+      void sendIMessageTyping(earlyDirectTypingTarget, true, {
+        cfg,
+        accountId: accountInfo.accountId,
+      }).catch((err) => {
+        logTypingFailure({
+          log: (msg) => logVerbose(msg),
+          channel: "imessage",
+          action: "start",
+          target: earlyDirectTypingTarget,
+          error: err,
+        });
+      });
+    }
     const stagedAttachments = remoteHost
       ? []
       : await stageIMessageAttachments(validAttachments, {
@@ -1107,31 +1157,20 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       );
     }
 
-    const privateApiStatus = getCachedIMessagePrivateApiStatus(cliPath);
-    const supportsTyping = imessageRpcSupportsMethod(privateApiStatus, "typing");
-    const supportsRead = imessageRpcSupportsMethod(privateApiStatus, "read");
-    if (privateApiStatus?.available === true) {
-      // Surface a single warning per restart when the bridge is up but we
-      // had to gate off typing/read because the imsg build pre-dates the
-      // capability list. Otherwise the user sees no typing bubble / no
-      // "Read" receipt with no visible reason.
-      if (!supportsTyping || !supportsRead) {
-        warnIfImsgUpgradeNeeded.fireOnce(privateApiStatus.rpcMethods, runtime);
-      }
-    }
     const sendReadReceipts = imessageCfg.sendReadReceipts !== false;
     const typingTarget = ctxPayload.To;
 
     if (supportsRead && sendReadReceipts && typingTarget) {
-      try {
-        await markIMessageChatRead(typingTarget, {
-          cfg,
-          accountId: accountInfo.accountId,
-          client: getActiveClient(),
-        });
-      } catch (err) {
+      // Read receipts are best-effort channel UI. Do not put them on the
+      // critical path before model dispatch; slow private-API reads otherwise
+      // make accepted iMessage turns feel stuck before the agent starts. Use
+      // a short-lived client so a stuck read cannot block monitor-client typing.
+      void markIMessageChatRead(typingTarget, {
+        cfg,
+        accountId: accountInfo.accountId,
+      }).catch((err) => {
         runtime.error?.(`imessage: mark read failed: ${String(err)}`);
-      }
+      });
     }
 
     const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
@@ -1234,19 +1273,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       },
     });
     let directTypingController: IMessageTypingController | undefined;
-    const configuredTypingMode = resolveConfiguredIMessageTypingMode(cfg);
-    const sendPolicy = resolveSendPolicy({
-      cfg,
-      entry: getSessionEntry({ storePath, sessionKey: decision.route.sessionKey }),
-      sessionKey: decision.route.sessionKey,
-      channel: "imessage",
-      chatType: decision.isGroup ? "group" : "direct",
-    });
-    const shouldStartToolTyping =
-      !decision.isGroup &&
-      sendPolicy !== "deny" &&
-      (configuredTypingMode === undefined || configuredTypingMode === "instant");
-    const directToolTypingOptions = shouldStartToolTyping
+    const directToolTypingOptions = shouldStartDirectTyping
       ? ({
           // iMessage's native typing bubble is channel-owned UI, not a
           // visible tool-progress message. The suppress flag is what lets

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -1060,11 +1060,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       channel: "imessage",
       chatType: decision.isGroup ? "group" : "direct",
     });
-    const shouldStartDirectTyping =
-      supportsTyping &&
+    const shouldUseDirectToolTypingOptions =
       !decision.isGroup &&
       sendPolicy !== "deny" &&
       (configuredTypingMode === undefined || configuredTypingMode === "instant");
+    const shouldStartDirectTyping = supportsTyping && shouldUseDirectToolTypingOptions;
     const earlyDirectTypingTarget = shouldStartDirectTyping
       ? buildDirectIMessageReplyTarget({
           cfg,
@@ -1305,23 +1305,27 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       },
     });
     let directTypingController: IMessageTypingController | undefined;
-    const directToolTypingOptions = shouldStartDirectTyping
+    const directToolTypingOptions = shouldUseDirectToolTypingOptions
       ? ({
           // iMessage's native typing bubble is channel-owned UI, not a
           // visible tool-progress message. The suppress flag is what lets
           // dispatch forward this callback even when verbose progress is off;
           // allowProgress covers message_tool_only source delivery. Keep this on
-          // the direct instant/default path so configured typingMode values still
-          // decide when typing can begin.
+          // the direct instant/default path even when older imsg builds do not
+          // report native typing support.
           suppressDefaultToolProgressMessages: true,
           allowProgressCallbacksWhenSourceDeliverySuppressed: true,
           onTypingController: (typing: IMessageTypingController) => {
             directTypingController = typing;
             typingReplyOptions.onTypingController?.(typing);
           },
-          onToolStart: async () => {
-            await directTypingController?.startTypingLoop();
-          },
+          ...(supportsTyping
+            ? {
+                onToolStart: async () => {
+                  await directTypingController?.startTypingLoop();
+                },
+              }
+            : {}),
         } as const)
       : {};
     const configuredBlockStreaming = resolveChannelStreamingBlockEnabled(accountInfo.config);


### PR DESCRIPTION
## What Problem This Solves

Live iMessage turns can feel sluggish when the accepted message enters expensive setup before the model starts responding. In the profiled path, iMessage dispatch itself was quick, but context/session/model setup could leave the sender with no immediate feedback.

Read receipts were also on the accepted-turn critical path, so a slow private API `read` RPC could delay dispatch before the agent even started.

## Why This Change Was Made

This moves iMessage private-API UI feedback off the critical path:

- accepted direct iMessage turns now send an early native typing cue before attachment/history/context/model setup;
- early typing is gated to direct, allowed sessions that use the instant/default typing mode and have `imsg` typing support;
- early typing is explicitly stopped after dispatch completion or pre-dispatch failure, including fast command paths that never activate the normal typing controller;
- read receipts are now best-effort and use a short-lived RPC client, so a slow `read` call cannot block dispatch or the monitor client's watch stream.

The direct typing target reuses the existing iMessage reply target builder, so SMS-vs-iMessage service selection remains consistent with final replies.

## User Impact

Users most likely to benefit are people using OpenClaw over iMessage direct messages where responses can take several seconds because of long context, tool setup, model latency, or context-engine work. They should see the iMessage typing bubble sooner after the turn is accepted, which improves perceived responsiveness even when the underlying model path is still slow.

Required setup for the visible typing/read-receipt benefit:

- iMessage channel enabled and receiving accepted direct-message turns;
- `imsg` private API bridge available via `imsg launch`;
- `imsg status --json` reporting RPC methods that include `typing` for early typing, and `read` for read receipts;
- `session.typingMode` / `agents.defaults.typingMode` unset or set to `instant`;
- source delivery not denied by session send policy;
- direct chats only for the early typing cue. Group chats keep the existing behavior so group traffic does not show broad typing feedback.

The read-receipt optimization benefits hosts with private-API `read` support when `channels.imessage.sendReadReceipts` is not disabled.

## Performance Savings

Live dogfood runs showed the user-visible read/typing feedback delay drop from about `10s` send-to-read before this work to about `2s` after moving the read receipt off the accepted-turn critical path. On the same setup, disabling the older 7s iMessage split-send debounce produced about `1s` send-to-read, which confirmed this PR removes the private-API read RPC from the hot path and leaves the remaining delay to debounce/model/context work.

For slow model/context turns, the savings are mostly perceived responsiveness: the native iMessage typing cue is emitted before attachment/history/context/model setup, so users get immediate channel feedback while the expensive turn continues.

## Evidence

Fresh live iMessage proof on commit `26a1d38904` (`2026-06-23`):

- Ran Gateway from the PR checkout in the foreground after stopping the installed LaunchAgent; startup printed `OpenClaw 2026.6.9 (26a1d38)` and loaded `extensions/imessage` from this checkout.
- A real direct iMessage inbound row arrived from a separate device/account: DB row `6340`, `is_from_me=0`, text `Test`, created `2026-06-23T14:20:55.574Z`.
- The PR checkout processed that row after startup catch-up and marked it read: DB row `6340` had `is_read=1` and non-zero `date_read=803917326885792000`.
- No `imessage: mark read failed` or typing failure log appeared during the validation window.

Redacted live log sequence from the same PR checkout run:

```text
2026-06-23T07:22:06.402-07:00 [routing] resolveAgentRoute: channel=imessage accountId=default peer=direct:*** bindings=0
2026-06-23T07:22:06.416-07:00 imessage inbound: chatId=3 from=imessage:*** len=276 preview="[iMessage *** +8h ...] ***: Test ..."
2026-06-23T07:22:07.026-07:00 message received: channel=imessage chatId=imessage:*** messageId=896 source=dispatchInboundMessage
2026-06-23T07:22:10.645-07:00 message queued: sessionKey=agent:lobster:imessage:direct:*** source=dispatch queueDepth=1 sessionState=idle
2026-06-23T07:22:10.674-07:00 message dispatch started: channel=imessage sessionKey=agent:lobster:imessage:direct:*** source=replyResolver
2026-06-23T07:22:22.449-07:00 preflightCompaction skipped: sessionKey=agent:lobster:imessage:direct:*** runtime=codex reason=codex_native_auto_compaction
2026-06-23T07:22:22.482-07:00 memoryFlush check: sessionKey=agent:lobster:imessage:direct:*** transcriptBytes=2509900 forceFlushByTranscriptSize=true
2026-06-23T07:22:49.109-07:00 message dispatch completed: channel=imessage sessionKey=agent:lobster:imessage:direct:*** source=replyResolver outcome=completed duration=38435ms
2026-06-23T07:22:49.111-07:00 message processed: channel=imessage chatId=imessage:*** messageId=896 outcome=completed duration=42081ms
```

Older local live proof:

- Live dogfood read-status proof on the same host/setup: before this change, send-to-read feedback was roughly `10s`; with this PR it was roughly `2s`; disabling the older 7s inbound debounce on the same setup reached roughly `1s`. That shows this PR removes the private-API read RPC from the accepted-turn hot path and leaves remaining delay to debounce/model/context work.
- `imsg status` confirmed advanced IMCore features were available, including read receipts and typing.
- Explicit private-API timing checks during validation: `imsg read --chat-id 7 --json` returned in `0.06s`, `0.07s`, and `0.11s`; `imsg typing --chat-id 7 --duration 1s --json` returned in `1.15s`, `1.20s`, and `1.21s`.

Local proof:

- `git diff --check` passed.
- `node scripts/run-vitest.mjs extensions/imessage/src/monitor.last-route.test.ts` passed, 33 tests.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` reported no accepted/actionable findings.
- `pnpm exec oxlint extensions/imessage/src/monitor/monitor-provider.ts` passed after the lint follow-up.

Current PR CI proof on commit `26a1d389044`:

- [`Real behavior proof`](https://github.com/openclaw/openclaw/actions/runs/28004825451/job/82884478716) passed.
- [`check-lint`](https://github.com/openclaw/openclaw/actions/runs/28003203017/job/82879712864) passed after the lint follow-up.
- [`check-additional-extension-bundled`](https://github.com/openclaw/openclaw/actions/runs/28003203017/job/82879712863) passed after the lint follow-up.
- Full PR check set has no pending or failing checks after the proof-label cleanup.

Docs updated: https://docs.openclaw.ai/channels/imessage
