### PR TITLE
fix(agents): keep long-context tool-result prompts cache-stable

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2926,9 +2926,8 @@ describe("runEmbeddedAttempt tool-result guard budget wiring", () => {
     expect(sumToolResultTextChars(sessionMessages)).toBeGreaterThan(4_000);
     expect(sumToolResultTextChars(promptHandlerMessages)).toBeGreaterThan(4_000);
     const submittedCurrentPromptMessages = submittedMessages.slice(sessionMessages.length);
-    expect(submittedMessages.slice(0, sessionMessages.length)).toEqual(sessionMessages);
     expect(
-      submittedCurrentPromptMessages
+      submittedMessages
         .filter((message) => message.role === "toolResult")
         .every((message) => sumToolResultTextChars([message]) <= 2_000),
     ).toBe(true);

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4183,7 +4183,7 @@ export async function runEmbeddedAttempt(
             promptToolResultMaxChars * PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER,
             toolResultPromptProjectionState,
           );
-          if (promptToolResultTruncation.truncatedCount > 0) {
+          if (promptToolResultTruncation.messages !== activeSession.messages) {
             promptHistoryMessages = promptToolResultTruncation.messages;
             log.info(
               `[tool-result-truncation] Truncated ${promptToolResultTruncation.truncatedCount} ` +
@@ -4725,7 +4725,7 @@ export async function runEmbeddedAttempt(
                     promptToolResultMaxChars * PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER,
                     toolResultPromptProjectionState,
                   );
-                  return providerPromptHistoryTruncation.truncatedCount > 0
+                  return providerPromptHistoryTruncation.messages !== messages
                     ? providerPromptHistoryTruncation.messages
                     : messages;
                 },

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -325,7 +325,9 @@ import {
 } from "../tool-result-context-guard.js";
 import {
   resolveLiveToolResultMaxChars,
+  createToolResultPromptProjectionState,
   truncateOversizedToolResultsInMessages,
+  type ToolResultPromptProjectionState,
   truncateOversizedToolResultsInSessionManager,
 } from "../tool-result-truncation.js";
 import { splitSdkTools } from "../tool-split.js";
@@ -2579,6 +2581,8 @@ export async function runEmbeddedAttempt(
           await baseConvertToLlm(normalizeMessagesForLlmBoundary(messages, buildBoundaryOptions()));
       }
       let prePromptMessageCount = activeSession.messages.length;
+      const toolResultPromptProjectionState: ToolResultPromptProjectionState =
+        createToolResultPromptProjectionState();
       let contextEngineAfterTurnCheckpoint: number | null = null;
       let unwindowedContextEngineMessagesForPrecheck: AgentMessage[] | undefined;
       let contextEnginePromptAuthority: NonNullable<AssembleResult["promptAuthority"]> =
@@ -4177,6 +4181,7 @@ export async function runEmbeddedAttempt(
             contextTokenBudget,
             promptToolResultMaxChars,
             promptToolResultMaxChars * PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER,
+            toolResultPromptProjectionState,
           );
           if (promptToolResultTruncation.truncatedCount > 0) {
             promptHistoryMessages = promptToolResultTruncation.messages;
@@ -4717,7 +4722,8 @@ export async function runEmbeddedAttempt(
                     messages,
                     contextTokenBudget,
                     promptToolResultMaxChars,
-                    null,
+                    promptToolResultMaxChars * PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER,
+                    toolResultPromptProjectionState,
                   );
                   return providerPromptHistoryTruncation.truncatedCount > 0
                     ? providerPromptHistoryTruncation.messages

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -562,6 +562,8 @@ describe("truncateOversizedToolResultsInMessages", () => {
     const duplicate = (text: string) => ({
       role: "toolResult" as const,
       toolCallId: "duplicate-call",
+      toolName: "duplicate",
+      isError: false,
       timestamp: 1,
       content: [{ type: "text" as const, text }],
     });

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -507,7 +507,13 @@ describe("truncateOversizedToolResultsInMessages", () => {
     ] as never;
     truncateOversizedToolResultsInMessages([source], 128_000, 12_000, 12_000, projectionState);
 
-    const providerMessage = { ...source, content: [{ type: "text", text: "x".repeat(15_000) }] };
+    const providerMessage = {
+      ...source,
+      content: [
+        { type: "text", text: "Image reading is disabled." },
+        { type: "text", text: "x".repeat(15_000) },
+      ],
+    };
     const result = truncateOversizedToolResultsInMessages(
       [providerMessage],
       128_000,
@@ -516,7 +522,13 @@ describe("truncateOversizedToolResultsInMessages", () => {
       projectionState,
     ).messages[0];
 
-    expect(result?.content).toEqual([{ type: "text", text: expect.stringContaining("truncated") }]);
+    expect(result?.content?.[0]).toEqual({
+      type: "text",
+      text: "Image reading is disabled.",
+    });
+    expect(
+      result?.content?.[1] && "text" in result.content[1] ? result.content[1].text.length : 0,
+    ).toBeLessThan(15_000);
   });
 });
 

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -556,6 +556,33 @@ describe("truncateOversizedToolResultsInMessages", () => {
       result?.content?.[1] && "text" in result.content[1] ? result.content[1].text.length : 0,
     ).toBeLessThan(15_000);
   });
+
+  it("does not reuse ambiguous projections across filtered history", () => {
+    const projectionState = createToolResultPromptProjectionState();
+    const duplicate = (text: string) => ({
+      role: "toolResult" as const,
+      toolCallId: "duplicate-call",
+      timestamp: 1,
+      content: [{ type: "text" as const, text }],
+    });
+    const first = truncateOversizedToolResultsInMessages(
+      [duplicate("a".repeat(100)), duplicate("b".repeat(100))],
+      128_000,
+      100,
+      100,
+      projectionState,
+    );
+    const filtered = truncateOversizedToolResultsInMessages(
+      [duplicate("b".repeat(100))],
+      128_000,
+      100,
+      100,
+      projectionState,
+    );
+
+    expect(first.messages[0]).not.toEqual(first.messages[1]);
+    expect(filtered.messages[0]).toEqual(duplicate("b".repeat(100)));
+  });
 });
 
 describe("truncateOversizedToolResultsInSession", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -507,6 +507,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
       12_000,
       stableState,
     );
+    expect(stableThird.messages).toHaveLength(4);
     const stableFourth = truncateOversizedToolResultsInMessages(
       [
         ...stableHistory,

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -22,6 +22,7 @@ let sessionLikelyHasOversizedToolResults: typeof import("./tool-result-truncatio
 let estimateToolResultReductionPotential: typeof import("./tool-result-truncation.js").estimateToolResultReductionPotential;
 let DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS: typeof import("./tool-result-truncation.js").DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
 let resolveLiveToolResultMaxChars: typeof import("./tool-result-truncation.js").resolveLiveToolResultMaxChars;
+let createToolResultPromptProjectionState: typeof import("./tool-result-truncation.js").createToolResultPromptProjectionState;
 let tmpDir: string | undefined;
 
 async function loadFreshToolResultTruncationModuleForTest() {
@@ -40,6 +41,7 @@ async function loadFreshToolResultTruncationModuleForTest() {
     estimateToolResultReductionPotential,
     DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
     resolveLiveToolResultMaxChars,
+    createToolResultPromptProjectionState,
   } = await import("./tool-result-truncation.js"));
 }
 
@@ -448,17 +450,25 @@ describe("truncateOversizedToolResultsInMessages", () => {
       makeToolResult("y".repeat(15_000), "current_2"),
     ];
     const messages = [...prefix, ...suffix];
+    const projectionState = createToolResultPromptProjectionState();
 
-    const first = truncateOversizedToolResultsInMessages(messages, 128_000, 12_000, null);
+    const first = truncateOversizedToolResultsInMessages(
+      messages,
+      128_000,
+      12_000,
+      12_000,
+      projectionState,
+    );
     const second = truncateOversizedToolResultsInMessages(
       [...messages, makeToolResult("z".repeat(15_000), "current_3")],
       128_000,
       12_000,
-      null,
+      12_000,
+      projectionState,
     );
 
     expect(first.truncatedCount).toBe(4);
-    expect(second.truncatedCount).toBe(5);
+    expect(second.truncatedCount).toBe(1);
     expect(second.messages.slice(0, messages.length)).toEqual(first.messages);
     expect(second.messages.every((message) => getToolResultTextLength(message) <= 12_000)).toBe(
       true,

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -497,6 +497,27 @@ describe("truncateOversizedToolResultsInMessages", () => {
     expect(stableFirst.truncatedCount).toBe(0);
     expect(stableSecond.messages.slice(0, stableHistory.length)).toEqual(stableFirst.messages);
   });
+
+  it("does not restore filtered image blocks when reusing a projection", () => {
+    const projectionState = createToolResultPromptProjectionState();
+    const source = makeToolResult("x".repeat(15_000), "image_call");
+    source.content = [
+      { type: "image", data: "filtered-after-conversion" },
+      { type: "text", text: "x".repeat(15_000) },
+    ] as never;
+    truncateOversizedToolResultsInMessages([source], 128_000, 12_000, 12_000, projectionState);
+
+    const providerMessage = { ...source, content: [{ type: "text", text: "x".repeat(15_000) }] };
+    const result = truncateOversizedToolResultsInMessages(
+      [providerMessage],
+      128_000,
+      12_000,
+      12_000,
+      projectionState,
+    ).messages[0];
+
+    expect(result?.content).toEqual([{ type: "text", text: expect.stringContaining("truncated") }]);
+  });
 });
 
 describe("truncateOversizedToolResultsInSession", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -474,6 +474,28 @@ describe("truncateOversizedToolResultsInMessages", () => {
       true,
     );
     expect(messages).toEqual([...prefix, ...suffix]);
+
+    const stableState = createToolResultPromptProjectionState();
+    const stableHistory = [
+      makeToolResult("a".repeat(4_000), "stable_1"),
+      makeToolResult("b".repeat(4_000), "stable_2"),
+    ];
+    const stableFirst = truncateOversizedToolResultsInMessages(
+      stableHistory,
+      128_000,
+      12_000,
+      12_000,
+      stableState,
+    );
+    const stableSecond = truncateOversizedToolResultsInMessages(
+      [...stableHistory, makeToolResult("c".repeat(15_000), "stable_3")],
+      128_000,
+      12_000,
+      12_000,
+      stableState,
+    );
+    expect(stableFirst.truncatedCount).toBe(0);
+    expect(stableSecond.messages.slice(0, stableHistory.length)).toEqual(stableFirst.messages);
   });
 });
 

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -496,6 +496,31 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
     expect(stableFirst.truncatedCount).toBe(0);
     expect(stableSecond.messages.slice(0, stableHistory.length)).toEqual(stableFirst.messages);
+    const stableThird = truncateOversizedToolResultsInMessages(
+      [
+        ...stableHistory,
+        makeToolResult("c".repeat(15_000), "stable_3"),
+        makeToolResult("d".repeat(15_000), "stable_4"),
+      ],
+      128_000,
+      12_000,
+      12_000,
+      stableState,
+    );
+    const stableFourth = truncateOversizedToolResultsInMessages(
+      [
+        ...stableHistory,
+        makeToolResult("c".repeat(15_000), "stable_3"),
+        makeToolResult("d".repeat(15_000), "stable_4"),
+        makeToolResult("e".repeat(15_000), "stable_5"),
+      ],
+      128_000,
+      12_000,
+      12_000,
+      stableState,
+    );
+    const lastText = stableFourth.messages.at(-1);
+    expect(lastText && getToolResultTextLength(lastText)).toBeLessThanOrEqual(12_000);
   });
 
   it("does not restore filtered image blocks when reusing a projection", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -352,17 +352,20 @@ export function truncateOversizedToolResultsInMessages(
   );
   const branch = messages.map((message, index) => {
     const projectionKey = projectionState ? getToolResultProjectionKey(message) : undefined;
+    const projectedMessage = projectionKey
+      ? projectionState?.replacements.get(projectionKey)
+      : undefined;
+    const mergedMessage = projectedMessage
+      ? mergeProjectedToolResultMessage(message, projectedMessage)
+      : message;
     return {
       id: `message-${index}`,
       type: "message",
-      message:
-        projectionKey && projectionState?.replacements.get(projectionKey)
-          ? mergeProjectedToolResultMessage(
-              message,
-              projectionState.replacements.get(projectionKey)!,
-            )
-          : message,
-      aggregateEligible: !projectionKey || !projectionState?.frozen.has(projectionKey),
+      message: mergedMessage,
+      aggregateEligible:
+        !projectionKey ||
+        !projectionState?.frozen.has(projectionKey) ||
+        (projectedMessage !== undefined && mergedMessage === message),
     };
   });
   const plan = buildToolResultReplacementPlan({

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -350,7 +350,9 @@ export function truncateOversizedToolResultsInMessages(
     maxChars,
     aggregateMaxCharsOverride,
   );
-  const projectionKeys = projectionState ? getToolResultProjectionKeys(messages) : [];
+  const projectionKeys = projectionState
+    ? getToolResultProjectionKeys(messages, projectionState)
+    : [];
   const branch = messages.map((message, index) => {
     const projectionKey = projectionKeys[index];
     const projectedMessage = projectionKey
@@ -453,10 +455,15 @@ type ToolResultReplacement = {
 export type ToolResultPromptProjectionState = {
   replacements: Map<string, AgentMessage>;
   frozen: Set<string>;
+  ambiguousBaseKeys: Set<string>;
 };
 
 export function createToolResultPromptProjectionState(): ToolResultPromptProjectionState {
-  return { replacements: new Map<string, AgentMessage>(), frozen: new Set<string>() };
+  return {
+    replacements: new Map<string, AgentMessage>(),
+    frozen: new Set<string>(),
+    ambiguousBaseKeys: new Set<string>(),
+  };
 }
 
 function getToolResultProjectionBaseKey(message: AgentMessage): string | undefined {
@@ -472,11 +479,28 @@ function getToolResultProjectionBaseKey(message: AgentMessage): string | undefin
   return typeof timestamp === "number" ? `timestamp:${timestamp}` : undefined;
 }
 
-function getToolResultProjectionKeys(messages: AgentMessage[]): Array<string | undefined> {
+function getToolResultProjectionKeys(
+  messages: AgentMessage[],
+  projectionState: ToolResultPromptProjectionState,
+): Array<string | undefined> {
+  const baseKeys = messages.map((message) => getToolResultProjectionBaseKey(message));
+  const baseKeyCounts = new Map<string, number>();
+  for (const baseKey of baseKeys) {
+    if (baseKey) {
+      baseKeyCounts.set(baseKey, (baseKeyCounts.get(baseKey) ?? 0) + 1);
+    }
+  }
+  for (const [baseKey, count] of baseKeyCounts) {
+    if (count > 1) {
+      projectionState.ambiguousBaseKeys.add(baseKey);
+    }
+  }
   const occurrences = new Map<string, number>();
-  return messages.map((message) => {
-    const baseKey = getToolResultProjectionBaseKey(message);
+  return baseKeys.map((baseKey) => {
     if (!baseKey) {
+      return undefined;
+    }
+    if (projectionState.ambiguousBaseKeys.has(baseKey)) {
       return undefined;
     }
     const occurrence = occurrences.get(baseKey) ?? 0;

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -487,6 +487,13 @@ function mergeProjectedToolResultMessage(
       (block as { type?: unknown }).type === "text" &&
       typeof (block as { text?: unknown }).text === "string",
   );
+  const currentTextCount = currentContent.filter(
+    (block) =>
+      Boolean(block) && typeof block === "object" && (block as { type?: unknown }).type === "text",
+  ).length;
+  if (currentTextCount !== projectedText.length) {
+    return message;
+  }
   let textIndex = 0;
   const mergedContent = currentContent.map((block) => {
     if (!block || typeof block !== "object" || (block as { type?: unknown }).type !== "text") {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -366,8 +366,12 @@ export function truncateOversizedToolResultsInMessages(
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
   });
   if (plan.replacements.length === 0) {
+    const projectedMessages = branch.map((entry) => entry.message as AgentMessage);
+    const hasProjectedChanges = projectedMessages.some(
+      (message, index) => message !== messages[index],
+    );
     return {
-      messages: branch.map((entry) => entry.message as AgentMessage),
+      messages: hasProjectedChanges ? projectedMessages : messages,
       truncatedCount: 0,
     };
   }

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -350,8 +350,9 @@ export function truncateOversizedToolResultsInMessages(
     maxChars,
     aggregateMaxCharsOverride,
   );
+  const projectionKeys = projectionState ? getToolResultProjectionKeys(messages) : [];
   const branch = messages.map((message, index) => {
-    const projectionKey = projectionState ? getToolResultProjectionKey(message) : undefined;
+    const projectionKey = projectionKeys[index];
     const projectedMessage = projectionKey
       ? projectionState?.replacements.get(projectionKey)
       : undefined;
@@ -375,8 +376,8 @@ export function truncateOversizedToolResultsInMessages(
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
   });
   if (projectionState) {
-    for (const message of messages) {
-      const projectionKey = getToolResultProjectionKey(message);
+    for (const [index] of messages.entries()) {
+      const projectionKey = projectionKeys[index];
       if (projectionKey) {
         projectionState.frozen.add(projectionKey);
       }
@@ -398,7 +399,7 @@ export function truncateOversizedToolResultsInMessages(
   if (projectionState) {
     for (const [index, originalMessage] of messages.entries()) {
       const projectedMessage = replacedBranch[index]?.message;
-      const projectionKey = getToolResultProjectionKey(originalMessage);
+      const projectionKey = projectionKeys[index];
       if (projectionKey) {
         projectionState.frozen.add(projectionKey);
         if (projectedMessage && projectedMessage !== originalMessage) {
@@ -458,7 +459,7 @@ export function createToolResultPromptProjectionState(): ToolResultPromptProject
   return { replacements: new Map<string, AgentMessage>(), frozen: new Set<string>() };
 }
 
-function getToolResultProjectionKey(message: AgentMessage): string | undefined {
+function getToolResultProjectionBaseKey(message: AgentMessage): string | undefined {
   if (message.role !== "toolResult") {
     return undefined;
   }
@@ -469,6 +470,19 @@ function getToolResultProjectionKey(message: AgentMessage): string | undefined {
     return `tool:${toolCallId}${timestampKey}`;
   }
   return typeof timestamp === "number" ? `timestamp:${timestamp}` : undefined;
+}
+
+function getToolResultProjectionKeys(messages: AgentMessage[]): Array<string | undefined> {
+  const occurrences = new Map<string, number>();
+  return messages.map((message) => {
+    const baseKey = getToolResultProjectionBaseKey(message);
+    if (!baseKey) {
+      return undefined;
+    }
+    const occurrence = occurrences.get(baseKey) ?? 0;
+    occurrences.set(baseKey, occurrence + 1);
+    return `${baseKey}:${occurrence}`;
+  });
 }
 
 function mergeProjectedToolResultMessage(
@@ -604,7 +618,15 @@ function buildAggregateToolResultReplacements(params: {
       if (actualReduction <= 0) {
         continue;
       }
-      replacements.push({ entryId: candidate.entryId, message: emptyMessage });
+      const replacement = { entryId: candidate.entryId, message: emptyMessage };
+      const existingIndex = replacements.findIndex(
+        (existing) => existing.entryId === candidate.entryId,
+      );
+      if (existingIndex >= 0) {
+        replacements[existingIndex] = replacement;
+      } else {
+        replacements.push(replacement);
+      }
       remainingReduction -= actualReduction;
     }
   }

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -593,10 +593,10 @@ function buildAggregateToolResultReplacements(params: {
       if (remainingReduction <= 0) {
         break;
       }
-      if (replacements.some((replacement) => replacement.entryId === candidate.entryId)) {
-        continue;
-      }
-      const emptyMessage = clearToolResultText(candidate.message);
+      const existingReplacement = replacements.find(
+        (replacement) => replacement.entryId === candidate.entryId,
+      );
+      const emptyMessage = clearToolResultText(existingReplacement?.message ?? candidate.message);
       const actualReduction = Math.max(
         0,
         candidate.textLength - getToolResultTextLength(emptyMessage),

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -525,7 +525,6 @@ function buildAggregateToolResultReplacements(params: {
       } =>
         item.entry.type === "message" &&
         Boolean(item.entry.message) &&
-        item.entry.aggregateEligible !== false &&
         (item.entry.message as { role?: string }).role === "toolResult",
     )
     .map((item) => ({
@@ -533,6 +532,7 @@ function buildAggregateToolResultReplacements(params: {
       entryId: item.entry.id,
       message: item.entry.message,
       textLength: getToolResultTextLength(item.entry.message),
+      aggregateEligible: item.entry.aggregateEligible !== false,
     }))
     .filter((item) => item.textLength > 0);
 
@@ -556,12 +556,14 @@ function buildAggregateToolResultReplacements(params: {
   const replacements: Array<{ entryId: string; message: AgentMessage }> = [];
 
   // Spend aggregate reduction on older entries first so fresh tool output stays intact.
-  for (const candidate of candidates.toSorted((a, b) => {
-    if (a.index !== b.index) {
-      return a.index - b.index;
-    }
-    return b.textLength - a.textLength;
-  })) {
+  for (const candidate of candidates
+    .filter((item) => item.aggregateEligible)
+    .toSorted((a, b) => {
+      if (a.index !== b.index) {
+        return a.index - b.index;
+      }
+      return b.textLength - a.textLength;
+    })) {
     if (remainingReduction <= 0) {
       break;
     }

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -338,27 +338,27 @@ export function truncateOversizedToolResultsInMessages(
   messages: AgentMessage[],
   contextWindowTokens: number,
   maxCharsOverride?: number,
-  aggregateMaxCharsOverride?: number | null,
+  aggregateMaxCharsOverride?: number,
+  projectionState?: ToolResultPromptProjectionState,
 ): { messages: AgentMessage[]; truncatedCount: number } {
   const maxChars = Math.max(
     1,
     maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
   );
-  // Live prompt assembly disables aggregate rewriting so unchanged history stays byte-stable
-  // for provider prefix caches; recovery and persisted-session callers keep the aggregate guard.
-  const aggregateBudgetChars =
-    aggregateMaxCharsOverride === null
-      ? Number.POSITIVE_INFINITY
-      : calculateRecoveryAggregateToolResultChars(
-          contextWindowTokens,
-          maxChars,
-          aggregateMaxCharsOverride,
-        );
-  const branch = messages.map((message, index) => ({
-    id: `message-${index}`,
-    type: "message",
-    message,
-  }));
+  const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(
+    contextWindowTokens,
+    maxChars,
+    aggregateMaxCharsOverride,
+  );
+  const branch = messages.map((message, index) => {
+    const projectionKey = projectionState ? getToolResultProjectionKey(message) : undefined;
+    return {
+      id: `message-${index}`,
+      type: "message",
+      message: (projectionKey && projectionState?.replacements.get(projectionKey)) ?? message,
+      aggregateEligible: !projectionKey || !projectionState?.replacements.has(projectionKey),
+    };
+  });
   const plan = buildToolResultReplacementPlan({
     branch,
     maxChars,
@@ -366,11 +366,23 @@ export function truncateOversizedToolResultsInMessages(
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
   });
   if (plan.replacements.length === 0) {
-    return { messages, truncatedCount: 0 };
+    return {
+      messages: branch.map((entry) => entry.message as AgentMessage),
+      truncatedCount: 0,
+    };
   }
 
   const replacementIds = new Set(plan.replacements.map((replacement) => replacement.entryId));
   const replacedBranch = applyToolResultReplacementsToBranch(branch, plan.replacements);
+  if (projectionState) {
+    for (const [index, originalMessage] of messages.entries()) {
+      const projectedMessage = replacedBranch[index]?.message;
+      const projectionKey = getToolResultProjectionKey(originalMessage);
+      if (projectionKey && projectedMessage && projectedMessage !== originalMessage) {
+        projectionState.replacements.set(projectionKey, projectedMessage);
+      }
+    }
+  }
   return {
     messages: replacedBranch.map((entry) => entry.message as AgentMessage),
     truncatedCount: replacementIds.size,
@@ -405,12 +417,33 @@ type ToolResultBranchEntry = {
   id: string;
   type: string;
   message?: AgentMessage;
+  aggregateEligible?: boolean;
 };
 
 type ToolResultReplacement = {
   entryId: string;
   message: AgentMessage;
 };
+
+export type ToolResultPromptProjectionState = {
+  replacements: Map<string, AgentMessage>;
+};
+
+export function createToolResultPromptProjectionState(): ToolResultPromptProjectionState {
+  return { replacements: new Map<string, AgentMessage>() };
+}
+
+function getToolResultProjectionKey(message: AgentMessage): string | undefined {
+  if (message.role !== "toolResult") {
+    return undefined;
+  }
+  const toolCallId = (message as { toolCallId?: unknown }).toolCallId;
+  if (typeof toolCallId === "string" && toolCallId.length > 0) {
+    return `tool:${toolCallId}`;
+  }
+  const timestamp = (message as { timestamp?: unknown }).timestamp;
+  return typeof timestamp === "number" ? `timestamp:${timestamp}` : undefined;
+}
 
 function buildAggregateToolResultReplacements(params: {
   branch: ToolResultBranchEntry[];
@@ -429,6 +462,7 @@ function buildAggregateToolResultReplacements(params: {
       } =>
         item.entry.type === "message" &&
         Boolean(item.entry.message) &&
+        item.entry.aggregateEligible !== false &&
         (item.entry.message as { role?: string }).role === "toolResult",
     )
     .map((item) => ({

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -355,7 +355,13 @@ export function truncateOversizedToolResultsInMessages(
     return {
       id: `message-${index}`,
       type: "message",
-      message: (projectionKey && projectionState?.replacements.get(projectionKey)) ?? message,
+      message:
+        projectionKey && projectionState?.replacements.get(projectionKey)
+          ? mergeProjectedToolResultMessage(
+              message,
+              projectionState.replacements.get(projectionKey)!,
+            )
+          : message,
       aggregateEligible: !projectionKey || !projectionState?.frozen.has(projectionKey),
     };
   });
@@ -460,6 +466,36 @@ function getToolResultProjectionKey(message: AgentMessage): string | undefined {
     return `tool:${toolCallId}${timestampKey}`;
   }
   return typeof timestamp === "number" ? `timestamp:${timestamp}` : undefined;
+}
+
+function mergeProjectedToolResultMessage(
+  message: AgentMessage,
+  projectedMessage: AgentMessage,
+): AgentMessage {
+  if (message.role !== "toolResult" || projectedMessage.role !== "toolResult") {
+    return projectedMessage;
+  }
+  const currentContent = (message as { content?: unknown }).content;
+  const projectedContent = (projectedMessage as { content?: unknown }).content;
+  if (!Array.isArray(currentContent) || !Array.isArray(projectedContent)) {
+    return projectedMessage;
+  }
+  const projectedText = projectedContent.filter(
+    (block): block is { type: "text"; text: string } =>
+      Boolean(block) &&
+      typeof block === "object" &&
+      (block as { type?: unknown }).type === "text" &&
+      typeof (block as { text?: unknown }).text === "string",
+  );
+  let textIndex = 0;
+  const mergedContent = currentContent.map((block) => {
+    if (!block || typeof block !== "object" || (block as { type?: unknown }).type !== "text") {
+      return block;
+    }
+    const projectedBlock = projectedText[textIndex++];
+    return projectedBlock ? { ...block, text: projectedBlock.text } : block;
+  });
+  return { ...message, content: mergedContent } as AgentMessage;
 }
 
 function buildAggregateToolResultReplacements(params: {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -356,7 +356,7 @@ export function truncateOversizedToolResultsInMessages(
       id: `message-${index}`,
       type: "message",
       message: (projectionKey && projectionState?.replacements.get(projectionKey)) ?? message,
-      aggregateEligible: !projectionKey || !projectionState?.replacements.has(projectionKey),
+      aggregateEligible: !projectionKey || !projectionState?.frozen.has(projectionKey),
     };
   });
   const plan = buildToolResultReplacementPlan({
@@ -365,6 +365,14 @@ export function truncateOversizedToolResultsInMessages(
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
   });
+  if (projectionState) {
+    for (const message of messages) {
+      const projectionKey = getToolResultProjectionKey(message);
+      if (projectionKey) {
+        projectionState.frozen.add(projectionKey);
+      }
+    }
+  }
   if (plan.replacements.length === 0) {
     const projectedMessages = branch.map((entry) => entry.message as AgentMessage);
     const hasProjectedChanges = projectedMessages.some(
@@ -382,8 +390,11 @@ export function truncateOversizedToolResultsInMessages(
     for (const [index, originalMessage] of messages.entries()) {
       const projectedMessage = replacedBranch[index]?.message;
       const projectionKey = getToolResultProjectionKey(originalMessage);
-      if (projectionKey && projectedMessage && projectedMessage !== originalMessage) {
-        projectionState.replacements.set(projectionKey, projectedMessage);
+      if (projectionKey) {
+        projectionState.frozen.add(projectionKey);
+        if (projectedMessage && projectedMessage !== originalMessage) {
+          projectionState.replacements.set(projectionKey, projectedMessage);
+        }
       }
     }
   }
@@ -431,10 +442,11 @@ type ToolResultReplacement = {
 
 export type ToolResultPromptProjectionState = {
   replacements: Map<string, AgentMessage>;
+  frozen: Set<string>;
 };
 
 export function createToolResultPromptProjectionState(): ToolResultPromptProjectionState {
-  return { replacements: new Map<string, AgentMessage>() };
+  return { replacements: new Map<string, AgentMessage>(), frozen: new Set<string>() };
 }
 
 function getToolResultProjectionKey(message: AgentMessage): string | undefined {
@@ -442,10 +454,11 @@ function getToolResultProjectionKey(message: AgentMessage): string | undefined {
     return undefined;
   }
   const toolCallId = (message as { toolCallId?: unknown }).toolCallId;
-  if (typeof toolCallId === "string" && toolCallId.length > 0) {
-    return `tool:${toolCallId}`;
-  }
   const timestamp = (message as { timestamp?: unknown }).timestamp;
+  const timestampKey = typeof timestamp === "number" ? `:${timestamp}` : "";
+  if (typeof toolCallId === "string" && toolCallId.length > 0) {
+    return `tool:${toolCallId}${timestampKey}`;
+  }
   return typeof timestamp === "number" ? `timestamp:${timestamp}` : undefined;
 }
 

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -588,7 +588,43 @@ function buildAggregateToolResultReplacements(params: {
     remainingReduction -= actualReduction;
   }
 
+  if (remainingReduction > 0) {
+    for (const candidate of candidates.filter((item) => item.aggregateEligible)) {
+      if (remainingReduction <= 0) {
+        break;
+      }
+      if (replacements.some((replacement) => replacement.entryId === candidate.entryId)) {
+        continue;
+      }
+      const emptyMessage = clearToolResultText(candidate.message);
+      const actualReduction = Math.max(
+        0,
+        candidate.textLength - getToolResultTextLength(emptyMessage),
+      );
+      if (actualReduction <= 0) {
+        continue;
+      }
+      replacements.push({ entryId: candidate.entryId, message: emptyMessage });
+      remainingReduction -= actualReduction;
+    }
+  }
+
   return replacements;
+}
+
+function clearToolResultText(message: AgentMessage): AgentMessage {
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return message;
+  }
+  return {
+    ...message,
+    content: content.map((block) =>
+      block && typeof block === "object" && (block as { type?: unknown }).type === "text"
+        ? { ...block, text: "" }
+        : block,
+    ),
+  } as AgentMessage;
 }
 
 function buildOversizedToolResultReplacements(params: {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -358,8 +358,15 @@ export function truncateOversizedToolResultsInMessages(
     const projectedMessage = projectionKey
       ? projectionState?.replacements.get(projectionKey)
       : undefined;
+    if (projectionKey && projectionState && !projectionState.sourceTextByKey.has(projectionKey)) {
+      projectionState.sourceTextByKey.set(projectionKey, getToolResultTextBlocks(message));
+    }
     const mergedMessage = projectedMessage
-      ? mergeProjectedToolResultMessage(message, projectedMessage)
+      ? mergeProjectedToolResultMessage(
+          message,
+          projectedMessage,
+          projectionState?.sourceTextByKey.get(projectionKey ?? ""),
+        )
       : message;
     return {
       id: `message-${index}`,
@@ -456,6 +463,7 @@ export type ToolResultPromptProjectionState = {
   replacements: Map<string, AgentMessage>;
   frozen: Set<string>;
   ambiguousBaseKeys: Set<string>;
+  sourceTextByKey: Map<string, string[]>;
 };
 
 export function createToolResultPromptProjectionState(): ToolResultPromptProjectionState {
@@ -463,6 +471,7 @@ export function createToolResultPromptProjectionState(): ToolResultPromptProject
     replacements: new Map<string, AgentMessage>(),
     frozen: new Set<string>(),
     ambiguousBaseKeys: new Set<string>(),
+    sourceTextByKey: new Map<string, string[]>(),
   };
 }
 
@@ -512,6 +521,7 @@ function getToolResultProjectionKeys(
 function mergeProjectedToolResultMessage(
   message: AgentMessage,
   projectedMessage: AgentMessage,
+  sourceText: string[] | undefined,
 ): AgentMessage {
   if (message.role !== "toolResult" || projectedMessage.role !== "toolResult") {
     return projectedMessage;
@@ -528,6 +538,10 @@ function mergeProjectedToolResultMessage(
       (block as { type?: unknown }).type === "text" &&
       typeof (block as { text?: unknown }).text === "string",
   );
+  const currentText = getToolResultTextBlocks(message);
+  if (sourceText && currentText.some((text, index) => text !== sourceText[index])) {
+    return message;
+  }
   const currentTextCount = currentContent.filter(
     (block) =>
       Boolean(block) && typeof block === "object" && (block as { type?: unknown }).type === "text",
@@ -544,6 +558,22 @@ function mergeProjectedToolResultMessage(
     return projectedBlock ? { ...block, text: projectedBlock.text } : block;
   });
   return { ...message, content: mergedContent } as AgentMessage;
+}
+
+function getToolResultTextBlocks(message: AgentMessage): string[] {
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return content.flatMap((block) =>
+    block && typeof block === "object" && (block as { type?: unknown }).type === "text"
+      ? [
+          typeof (block as { text?: unknown }).text === "string"
+            ? (block as { text: string }).text
+            : "",
+        ]
+      : [],
+  );
 }
 
 function buildAggregateToolResultReplacements(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where long-running agent sessions on large-context models would lose the cached conversation prefix and rewrite hundreds of thousands of tokens on every turn once accumulated tool-result text crossed the aggregate prompt cap. The system prompt cache survived, but the conversation cache thrashed during active source-gather phases.

## Why This Change Was Made

Prompt assembly now keeps a per-attempt, byte-stable projection of cacheable tool-result history instead of repeatedly truncating already-projected results. Aggregate accounting includes frozen projected bytes, reductions apply only to new eligible results, and the fallback clears new result text when the aggregate budget cannot otherwise be met. Projection reuse is occurrence-safe for duplicate identities and refuses to overwrite content transformed by history/media filters. The operator-configurable `agents.defaults.contextLimits.toolResultMaxChars` ceiling is raised to `1,000,000` as an additional mitigation for 1M-context models, with matching docs.

## User Impact

Long-context sessions retain incremental prompt caching as tool results accumulate, reducing cache-write thrash and avoidable latency/cost. Existing session data is not rewritten by the prompt-only projection path, and transformed or filtered history remains authoritative.

## Evidence

- `98` focused agent regression tests pass, including repeated-build cache stability, provider-boundary behavior, duplicate identity handling, image/media-filter preservation, aggregate fallback, and context-engine integration.
- `35` config regression tests pass, including acceptance of `toolResultMaxChars: 1_000_000`.
- `node scripts/check-database-first-legacy-stores.mjs` passes.
- `git diff --check` passes.
- Final autoreview: `autoreview clean: no accepted/actionable findings reported`.
- The broad `OPENCLAW_TESTBOX=1 pnpm check:changed` attempt completed core typecheck/lint lanes but the remote Testbox stopped during the database-first guard; the same guard passes locally. This is an environment/runner limitation, not a reported test failure.

This PR was prepared with AI assistance and reviewed against the repository maintainer workflow.
