### PR TITLE
Fix Gemini web search freshness handling

### DIFF
--- a/docs/tools/gemini-search.md
+++ b/docs/tools/gemini-search.md
@@ -88,11 +88,10 @@ still returns one synthesized answer with citations rather than an N-result
 list.
 
 `freshness` accepts `day`, `week`, `month`, `year`, and the shared shortcuts
-`pd`, `pw`, `pm`, and `py`. OpenClaw adds a recency instruction to the Gemini
-query for these values; this is a prioritization hint, not a hard grounding
-range. Use an explicit `date_after`/`date_before` range when you need OpenClaw
-to set Gemini Google Search grounding's `timeRangeFilter`. `country`,
-`language`, and `domain_filter` are not supported.
+`pd`, `pw`, `pm`, and `py`. `day`/`pd` adds a recency instruction to the Gemini
+query instead of a hard 24-hour range. `week`, `month`, `year`, and explicit
+`date_after`/`date_before` ranges set Gemini Google Search grounding's
+`timeRangeFilter`. `country`, `language`, and `domain_filter` are not supported.
 
 ## Model selection
 

--- a/docs/tools/gemini-search.md
+++ b/docs/tools/gemini-search.md
@@ -88,9 +88,11 @@ still returns one synthesized answer with citations rather than an N-result
 list.
 
 `freshness` accepts `day`, `week`, `month`, `year`, and the shared shortcuts
-`pd`, `pw`, `pm`, and `py`. OpenClaw converts these values, or an explicit
-`date_after`/`date_before` range, into Gemini Google Search grounding's
-`timeRangeFilter`. `country`, `language`, and `domain_filter` are not supported.
+`pd`, `pw`, `pm`, and `py`. OpenClaw adds a recency instruction to the Gemini
+query for these values; this is a prioritization hint, not a hard grounding
+range. Use an explicit `date_after`/`date_before` range when you need OpenClaw
+to set Gemini Google Search grounding's `timeRangeFilter`. `country`,
+`language`, and `domain_filter` are not supported.
 
 ## Model selection
 

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -389,8 +389,8 @@ show the `x_search` prompt.
   freshness ranges require both start and end dates.
   Gemini, Grok, and Kimi return one synthesized answer with citations. They
   accept `count` for shared-tool compatibility, but it does not change the
-  grounded answer shape. Gemini treats `freshness` as a recency hint, while
-  `date_after` and `date_before` set Google Search grounding time ranges.
+  grounded answer shape. Gemini treats `day` freshness as a recency hint; wider
+  freshness values and explicit dates set Google Search grounding time ranges.
   Perplexity behaves the same way when you use the Sonar/OpenRouter
   compatibility path (`plugins.entries.perplexity.config.webSearch.baseUrl` /
   `model` or `OPENROUTER_API_KEY`).

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -389,8 +389,8 @@ show the `x_search` prompt.
   freshness ranges require both start and end dates.
   Gemini, Grok, and Kimi return one synthesized answer with citations. They
   accept `count` for shared-tool compatibility, but it does not change the
-  grounded answer shape. Gemini supports `freshness`, `date_after`, and
-  `date_before` by converting them to Google Search grounding time ranges.
+  grounded answer shape. Gemini treats `freshness` as a recency hint, while
+  `date_after` and `date_before` set Google Search grounding time ranges.
   Perplexity behaves the same way when you use the Sonar/OpenRouter
   compatibility path (`plugins.entries.perplexity.config.webSearch.baseUrl` /
   `model` or `OPENROUTER_API_KEY`).

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -790,7 +790,9 @@ export async function runCodexAppServerAttempt(
     onYieldDetected: () => {
       yieldDetected = true;
     },
-    onCodexAppServerEvent: (event) => emitCodexAppServerEvent(params, event),
+    onCodexAppServerEvent: (event) => {
+      void emitCodexAppServerEvent(params, event);
+    },
     onPersistentWebSearchPolicyResolved: (allowed) => {
       persistentWebSearchAllowed = allowed;
     },

--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -66,12 +66,14 @@ function throwMalformedGeminiResponse(): never {
   throw new Error("Gemini API error: malformed JSON response");
 }
 
-const GEMINI_FRESHNESS_HINTS: Record<GeminiFreshness, string> = {
-  day: "Prioritize web sources published in the last 24 hours.",
-  week: "Prioritize web sources published in the last 7 days.",
-  month: "Prioritize web sources published in the last 30 days.",
-  year: "Prioritize web sources published in the last 365 days.",
+const GEMINI_FRESHNESS_DAYS: Record<GeminiFreshness, number> = {
+  day: 1,
+  week: 7,
+  month: 30,
+  year: 365,
 };
+
+const GEMINI_DAY_FRESHNESS_HINT = "Prioritize web sources published in the last 24 hours.";
 
 // Gemini's google_search.time_range_filter accepts second-precision RFC 3339
 // only. Despite the underlying google.protobuf.Timestamp type accepting "0, 3,
@@ -93,18 +95,24 @@ function isoDateExclusiveEnd(value: string): string {
   return toGeminiTimeRangeTimestamp(end);
 }
 
-function queryWithSoftFreshness(query: string, freshness?: GeminiFreshness): string {
-  if (!freshness) {
+function freshnessStartTime(freshness: GeminiFreshness, now: Date): string {
+  const start = new Date(now);
+  start.setUTCDate(start.getUTCDate() - GEMINI_FRESHNESS_DAYS[freshness]);
+  return toGeminiTimeRangeTimestamp(start);
+}
+
+function queryWithSoftFreshness(query: string, freshness?: "day"): string {
+  if (freshness !== "day") {
     return query;
   }
-  return `${query}\n\nSearch recency instruction: ${GEMINI_FRESHNESS_HINTS[freshness]} If no matching recent sources are available, state that limitation and use the most relevant available sources.`;
+  return `${query}\n\nSearch recency instruction: ${GEMINI_DAY_FRESHNESS_HINT} If no matching recent sources are available, state that limitation and use the most relevant available sources.`;
 }
 
 function resolveGeminiTimeRangeFilter(
   args: Record<string, unknown>,
   now = new Date(),
 ):
-  | { timeRangeFilter?: GeminiTimeRangeFilter; freshness?: GeminiFreshness }
+  | { timeRangeFilter?: GeminiTimeRangeFilter; freshness?: "day" }
   | {
       error:
         | "invalid_freshness"
@@ -134,8 +142,18 @@ function resolveGeminiTimeRangeFilter(
 
   const { freshness, dateAfter, dateBefore } = parsedTimeFilters;
   if (freshness) {
+    // Gemini rejects 24-hour google_search.timeRangeFilter windows, while
+    // wider freshness windows still preserve the hard grounding contract.
+    if (freshness === "day") {
+      return {
+        freshness,
+      };
+    }
     return {
-      freshness,
+      timeRangeFilter: {
+        startTime: freshnessStartTime(freshness, now),
+        endTime: toGeminiTimeRangeTimestamp(now),
+      },
     };
   }
 

--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -66,11 +66,11 @@ function throwMalformedGeminiResponse(): never {
   throw new Error("Gemini API error: malformed JSON response");
 }
 
-const GEMINI_FRESHNESS_DAYS: Record<GeminiFreshness, number> = {
-  day: 1,
-  week: 7,
-  month: 30,
-  year: 365,
+const GEMINI_FRESHNESS_HINTS: Record<GeminiFreshness, string> = {
+  day: "Prioritize web sources published in the last 24 hours.",
+  week: "Prioritize web sources published in the last 7 days.",
+  month: "Prioritize web sources published in the last 30 days.",
+  year: "Prioritize web sources published in the last 365 days.",
 };
 
 // Gemini's google_search.time_range_filter accepts second-precision RFC 3339
@@ -93,17 +93,18 @@ function isoDateExclusiveEnd(value: string): string {
   return toGeminiTimeRangeTimestamp(end);
 }
 
-function freshnessStartTime(freshness: GeminiFreshness, now: Date): string {
-  const start = new Date(now);
-  start.setUTCDate(start.getUTCDate() - GEMINI_FRESHNESS_DAYS[freshness]);
-  return toGeminiTimeRangeTimestamp(start);
+function queryWithSoftFreshness(query: string, freshness?: GeminiFreshness): string {
+  if (!freshness) {
+    return query;
+  }
+  return `${query}\n\nSearch recency instruction: ${GEMINI_FRESHNESS_HINTS[freshness]} If no matching recent sources are available, state that limitation and use the most relevant available sources.`;
 }
 
 function resolveGeminiTimeRangeFilter(
   args: Record<string, unknown>,
   now = new Date(),
 ):
-  | { timeRangeFilter?: GeminiTimeRangeFilter }
+  | { timeRangeFilter?: GeminiTimeRangeFilter; freshness?: GeminiFreshness }
   | {
       error:
         | "invalid_freshness"
@@ -134,10 +135,7 @@ function resolveGeminiTimeRangeFilter(
   const { freshness, dateAfter, dateBefore } = parsedTimeFilters;
   if (freshness) {
     return {
-      timeRangeFilter: {
-        startTime: freshnessStartTime(freshness, now),
-        endTime: toGeminiTimeRangeTimestamp(now),
-      },
+      freshness,
     };
   }
 
@@ -321,6 +319,7 @@ export async function executeGeminiSearch(
     resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
     baseUrl,
     model,
+    timeRange.freshness,
     timeRange.timeRangeFilter?.startTime,
     timeRange.timeRangeFilter?.endTime,
   ]);
@@ -331,7 +330,7 @@ export async function executeGeminiSearch(
 
   const start = Date.now();
   const result = await runGeminiSearch({
-    query,
+    query: queryWithSoftFreshness(query, timeRange.freshness),
     apiKey,
     baseUrl,
     model,

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -41,7 +41,7 @@ const GEMINI_TOOL_PARAMETERS = {
     freshness: {
       type: "string",
       description:
-        "Ask Gemini to prioritize recent sources: day, week, month, or year. This is a recency hint, not a hard Google Search time range.",
+        "Filter Gemini search freshness: week, month, and year use hard Google Search time ranges; day prioritizes the last 24 hours as a recency hint.",
     },
     date_after: {
       type: "string",

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -40,7 +40,8 @@ const GEMINI_TOOL_PARAMETERS = {
     language: { type: "string", description: "Not supported by Gemini." },
     freshness: {
       type: "string",
-      description: "Limit Google Search grounding to recent results: day, week, month, or year.",
+      description:
+        "Ask Gemini to prioritize recent sources: day, week, month, or year. This is a recency hint, not a hard Google Search time range.",
     },
     date_after: {
       type: "string",

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -479,7 +479,38 @@ describe("google web search provider", () => {
     );
   });
 
-  it("uses soft recency hints for Gemini freshness instead of time ranges", async () => {
+  it("uses a soft recency hint for Gemini day freshness shortcuts instead of a 24-hour range", async () => {
+    const mockFetch = installGeminiFetch();
+    const provider = createGeminiWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: "AIza-plugin-test",
+                },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: { provider: "gemini" },
+    });
+
+    await tool?.execute({ query: "latest ai news timestamp precision", freshness: "pd" });
+
+    const body = parseGeminiFetchBody(mockFetch);
+    expect(body.tools?.[0]?.google_search?.timeRangeFilter).toBeUndefined();
+    expect(body.contents?.[0]?.parts?.[0]?.text).toContain(
+      "Prioritize web sources published in the last 24 hours.",
+    );
+  });
+
+  it("preserves hard Gemini time ranges for wider freshness values", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-15T12:00:00.123Z"));
     const mockFetch = installGeminiFetch();
     const provider = createGeminiWebSearchProvider();
     const tool = provider.createTool({
@@ -502,13 +533,16 @@ describe("google web search provider", () => {
     await tool?.execute({ query: "latest ai news timestamp precision", freshness: "week" });
 
     const body = parseGeminiFetchBody(mockFetch);
-    expect(body.tools?.[0]?.google_search?.timeRangeFilter).toBeUndefined();
-    expect(body.contents?.[0]?.parts?.[0]?.text).toContain(
-      "Prioritize web sources published in the last 7 days.",
-    );
+    expect(body.contents?.[0]?.parts?.[0]?.text).toBe("latest ai news timestamp precision");
+    expect(body.tools?.[0]?.google_search?.timeRangeFilter).toEqual({
+      startTime: "2026-04-08T12:00:00Z",
+      endTime: "2026-04-15T12:00:00Z",
+    });
   });
 
-  it("keeps freshness out of the hard filter while partitioning the cache", async () => {
+  it("partitions Gemini cache entries for soft day freshness, hard week freshness, and no freshness", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-15T12:00:00.123Z"));
     const mockFetch = installGeminiFetch();
     const provider = createGeminiWebSearchProvider();
     const tool = provider.createTool({
@@ -529,10 +563,11 @@ describe("google web search provider", () => {
     });
 
     await tool?.execute({ query: "same query cache partition", freshness: "day" });
+    await tool?.execute({ query: "same query cache partition", freshness: "week" });
     await tool?.execute({ query: "same query cache partition" });
 
     const postCalls = mockFetch.mock.calls.filter(([, init]) => typeof init?.body === "string");
-    expect(postCalls).toHaveLength(2);
+    expect(postCalls).toHaveLength(3);
     const parsePostedBody = (call: (typeof postCalls)[number] | undefined) => {
       const body = call?.[1]?.body;
       if (typeof body !== "string") {
@@ -545,11 +580,18 @@ describe("google web search provider", () => {
     };
     const firstBody = parsePostedBody(postCalls[0]);
     const secondBody = parsePostedBody(postCalls[1]);
+    const thirdBody = parsePostedBody(postCalls[2]);
     expect(firstBody.tools?.[0]?.google_search?.timeRangeFilter).toBeUndefined();
     expect(firstBody.contents?.[0]?.parts?.[0]?.text).toContain(
       "Prioritize web sources published in the last 24 hours.",
     );
+    expect(secondBody.tools?.[0]?.google_search?.timeRangeFilter).toEqual({
+      startTime: "2026-04-08T12:00:00Z",
+      endTime: "2026-04-15T12:00:00Z",
+    });
     expect(secondBody.contents?.[0]?.parts?.[0]?.text).toBe("same query cache partition");
+    expect(thirdBody.tools?.[0]?.google_search?.timeRangeFilter).toBeUndefined();
+    expect(thirdBody.contents?.[0]?.parts?.[0]?.text).toBe("same query cache partition");
   });
 
   it("strips sub-second precision from date-range timestamps so Gemini accepts them", async () => {

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -66,6 +66,7 @@ function getGeminiFetchUrl(mockFetch: ReturnType<typeof installGeminiFetch>): st
 }
 
 function parseGeminiFetchBody(mockFetch: ReturnType<typeof installGeminiFetch>): {
+  contents?: Array<{ parts?: Array<{ text?: string }> }>;
   tools?: Array<{ google_search?: { timeRangeFilter?: unknown } }>;
 } {
   const [, init] = requireFirstGeminiFetchCall(mockFetch);
@@ -74,6 +75,7 @@ function parseGeminiFetchBody(mockFetch: ReturnType<typeof installGeminiFetch>):
     throw new Error("Expected Gemini fetch body string");
   }
   return JSON.parse(body) as {
+    contents?: Array<{ parts?: Array<{ text?: string }> }>;
     tools?: Array<{ google_search?: { timeRangeFilter?: unknown } }>;
   };
 }
@@ -477,11 +479,7 @@ describe("google web search provider", () => {
     );
   });
 
-  it("passes freshness to Gemini Google Search grounding as a time range", async () => {
-    vi.useFakeTimers({ toFake: ["Date"] });
-    // Use a wall-clock-realistic moment with non-zero milliseconds; the helper
-    // must strip them to avoid Gemini's "Granularity of nano is not supported".
-    vi.setSystemTime(new Date("2026-04-15T12:00:00.123Z"));
+  it("uses soft recency hints for Gemini freshness instead of time ranges", async () => {
     const mockFetch = installGeminiFetch();
     const provider = createGeminiWebSearchProvider();
     const tool = provider.createTool({
@@ -504,13 +502,57 @@ describe("google web search provider", () => {
     await tool?.execute({ query: "latest ai news timestamp precision", freshness: "week" });
 
     const body = parseGeminiFetchBody(mockFetch);
-    expect(body.tools?.[0]?.google_search?.timeRangeFilter).toEqual({
-      startTime: "2026-04-08T12:00:00Z",
-      endTime: "2026-04-15T12:00:00Z",
-    });
+    expect(body.tools?.[0]?.google_search?.timeRangeFilter).toBeUndefined();
+    expect(body.contents?.[0]?.parts?.[0]?.text).toContain(
+      "Prioritize web sources published in the last 7 days.",
+    );
   });
 
-  it("strips sub-second precision from freshness timestamps so Gemini accepts them", async () => {
+  it("keeps freshness out of the hard filter while partitioning the cache", async () => {
+    const mockFetch = installGeminiFetch();
+    const provider = createGeminiWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: "AIza-plugin-test",
+                },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: { provider: "gemini" },
+    });
+
+    await tool?.execute({ query: "same query cache partition", freshness: "day" });
+    await tool?.execute({ query: "same query cache partition" });
+
+    const postCalls = mockFetch.mock.calls.filter(([, init]) => typeof init?.body === "string");
+    expect(postCalls).toHaveLength(2);
+    const parsePostedBody = (call: (typeof postCalls)[number] | undefined) => {
+      const body = call?.[1]?.body;
+      if (typeof body !== "string") {
+        throw new Error("Expected Gemini fetch body to be a string");
+      }
+      return JSON.parse(body) as {
+        contents?: Array<{ parts?: Array<{ text?: string }> }>;
+        tools?: Array<{ google_search?: { timeRangeFilter?: unknown } }>;
+      };
+    };
+    const firstBody = parsePostedBody(postCalls[0]);
+    const secondBody = parsePostedBody(postCalls[1]);
+    expect(firstBody.tools?.[0]?.google_search?.timeRangeFilter).toBeUndefined();
+    expect(firstBody.contents?.[0]?.parts?.[0]?.text).toContain(
+      "Prioritize web sources published in the last 24 hours.",
+    );
+    expect(secondBody.contents?.[0]?.parts?.[0]?.text).toBe("same query cache partition");
+  });
+
+  it("strips sub-second precision from date-range timestamps so Gemini accepts them", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     // "now" with non-zero milliseconds. Without stripping, toISOString() emits
     // "2026-04-15T12:00:00.123Z", which Gemini's google_search.time_range_filter
@@ -535,7 +577,7 @@ describe("google web search provider", () => {
       searchConfig: { provider: "gemini" },
     });
 
-    await tool?.execute({ query: "latest ai news", freshness: "week" });
+    await tool?.execute({ query: "latest ai news", date_after: "2026-04-01" });
 
     const body = parseGeminiFetchBody(mockFetch);
     const filter = body.tools?.[0]?.google_search?.timeRangeFilter as
@@ -544,7 +586,7 @@ describe("google web search provider", () => {
     expect(filter?.startTime).not.toMatch(/\.\d+Z$/);
     expect(filter?.endTime).not.toMatch(/\.\d+Z$/);
     expect(filter).toEqual({
-      startTime: "2026-04-08T12:00:00Z",
+      startTime: "2026-04-01T00:00:00Z",
       endTime: "2026-04-15T12:00:00Z",
     });
   });

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -7,10 +7,7 @@ import type {
   ContextEngineRuntimeSettings,
 } from "../../context-engine/types.js";
 import type { AgentMessage } from "../runtime/index.js";
-import {
-  CONTEXT_LIMIT_TRUNCATION_NOTICE,
-  formatContextLimitTruncationNotice,
-} from "./context-truncation-notice.js";
+import { formatContextLimitTruncationNotice } from "./context-truncation-notice.js";
 import { log } from "./logger.js";
 import { MidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./run/midturn-precheck.js";
 import { shouldPreemptivelyCompactBeforePrompt } from "./run/preemptive-compaction.js";


### PR DESCRIPTION
## Superseded

This PR is superseded by #95682.

Reason: the replacement PR keeps the same Gemini freshness fix focused on one change and restarts review with a CONTRIBUTING-aligned, de-identified PR body.

This PR is intentionally no longer the durable review surface.
