### PR TITLE
fix(qqbot): recognize GFM table separators with one or two dashes

### DIFF
--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
@@ -46,6 +46,15 @@ describe("chunkQQBotMarkdownText", () => {
     ).toEqual([["| Id | Value |", "|---:|---|", "| 1 | alpha |", "| 2 | beta |"].join("\n")]);
   });
 
+  it("confirms a table when the separator uses one or two dashes, not only three", () => {
+    // GFM delimiter cells need only one or more dashes; a sub-3-dash separator previously failed
+    // recognition, so the header and all rows but the last were silently dropped on send.
+    for (const separator of ["|--|--|", "|-|-|", "|:--|--:|"]) {
+      const text = ["| Id | Value |", separator, "| 1 | alpha |", "| 2 | beta |"].join("\n");
+      expect(chunkQQBotMarkdownText(text, 200, baseChunker)).toEqual([text]);
+    }
+  });
+
   it("flushes a possible table header as text when the next block is not a separator", () => {
     const chunker = createQQBotMarkdownChunker((text) => [text]);
 

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -433,7 +433,10 @@ function isTableSeparatorLine(line: string): boolean {
     return false;
   }
   const cells = splitTableCells(line);
-  return cells.length > 0 && cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()));
+  // GFM delimiter cells need only one or more hyphens (optionally colon-aligned), so accept "-+",
+  // not "-{3,}": a valid 1/2-dash separator (e.g. |--|--|) was not recognized here, leaving the
+  // header pending and silently overwritten by later rows so the table's header and rows vanished.
+  return cells.length > 0 && cells.every((cell) => /^:?-+:?$/.test(cell.trim()));
 }
 
 function splitTableCells(line: string): string[] {


### PR DESCRIPTION
## Summary

The QQ Bot outbound markdown chunker silently dropped most of a table when its separator used one or two dashes. `isTableSeparatorLine` (`extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts:436`) required **3+** dashes per cell:

```ts
return cells.length > 0 && cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()));
```

A GFM delimiter cell needs only **one or more** dashes, so a perfectly valid table whose separator was `|--|--|` (two dashes) or `|-|-|` (one dash) was **not recognized as a separator**. Tracing the chunker state machine: the `if (this.pendingHeaderLine && isTableSeparatorLine(line))` branch never fires, so the table is never confirmed; each following row then hits the `isTableRowLine(line) && !isTableSeparatorLine(line)` branch and **overwrites `pendingHeaderLine` without flushing the prior one** (the only flush is at end of input). The result is silent data loss: the header, the separator, and every row but the last disappear from the message the user receives.

### Changes
- `markdown-table-chunking.ts` — accept `-+` instead of `-{3,}` in `isTableSeparatorLine`, with an inline comment explaining the GFM rule and the failure it prevents.
- `markdown-table-chunking.test.ts` — regression test asserting a table with a one-dash, two-dash, or colon-aligned separator is preserved intact.

The fix matches the GFM spec (delimiter cell = one or more hyphens, optional colons) and the sibling LINE channel (`extensions/line/src/markdown-to-line.ts:22`, `\|[-:\s|]+\|`). Every existing QQ test separator already uses 3+ dashes, so `-{3,}` → `-+` is byte-identical on them (zero test churn).

## Real behavior proof

Behavior addressed: a QQ markdown reply containing a table with a 1- or 2-dash separator lost its header and all rows but the last. After the fix the full table is preserved; 3-dash tables are unchanged.

Real environment tested: Node 22.22.1, macOS, no model / network / channel. A `./node_modules/.bin/tsx` harness imports the real exported `chunkQQBotMarkdownText` with a passthrough base chunker (`t => [t]`) and chunks the same table with a 2-dash, 1-dash, and 3-dash separator. BEFORE is `origin/main`'s regex (swapped in via `git show`, no other change).

Exact steps or command run after this patch:
```bash
# harness imports the real chunkQQBotMarkdownText and prints chunks per separator
./node_modules/.bin/tsx _qq-proof.mts
```

Evidence after fix:
```
input: "结果如下：\n| 名称 | 数量 |\n<SEP>\n| 苹果 | 3 |\n| 香蕉 | 5 |"  (limit 500)

BEFORE (origin/main, -{3,}):
  2-dash |--|--|: chunks=["结果如下：","| 香蕉 | 5 |"]   header(名称)=false firstRow(苹果)=false
  1-dash |-|-|  : chunks=["结果如下：","| 香蕉 | 5 |"]   header(名称)=false firstRow(苹果)=false
  3-dash |---|---| (control): full intact table            header(名称)=true  firstRow(苹果)=true
AFTER (this branch, -+):
  2-dash |--|--|: chunks=["结果如下：","| 名称 | 数量 |\n|--|--|\n| 苹果 | 3 |\n| 香蕉 | 5 |"]  header=true firstRow=true
  1-dash |-|-|  : full intact table   header=true firstRow=true
  3-dash |---|---| (control): unchanged
```

Observed result after fix: the 2-dash and 1-dash tables are preserved in full (header + separator + every row); the 3-dash control is byte-identical before and after. A colon-only cell (`|:|:|`, no dash) is still correctly rejected as a non-separator.

What was not tested: a full live QQ send against the QQ platform (the harness drives the real `chunkQQBotMarkdownText`, which is exactly what the outbound dispatcher calls to split a text reply). The new regression test fails on `origin/main` and passes after this change.

## Additional checks
- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts` — 18 pass with the fix; verified fail-before by swapping in `origin/main`'s regex → the new test fails, all 17 existing tests still pass (no churn).
- `oxlint --tsconfig config/tsconfig/oxlint.extensions.json` and `tsgo:extensions` pass. Diff: +4/−1 prod, +9 test.
