### PR TITLE
Fix current lint regressions

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -790,7 +790,9 @@ export async function runCodexAppServerAttempt(
     onYieldDetected: () => {
       yieldDetected = true;
     },
-    onCodexAppServerEvent: (event) => emitCodexAppServerEvent(params, event),
+    onCodexAppServerEvent: (event) => {
+      void emitCodexAppServerEvent(params, event);
+    },
     onPersistentWebSearchPolicyResolved: (allowed) => {
       persistentWebSearchAllowed = allowed;
     },

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -7,10 +7,7 @@ import type {
   ContextEngineRuntimeSettings,
 } from "../../context-engine/types.js";
 import type { AgentMessage } from "../runtime/index.js";
-import {
-  CONTEXT_LIMIT_TRUNCATION_NOTICE,
-  formatContextLimitTruncationNotice,
-} from "./context-truncation-notice.js";
+import { formatContextLimitTruncationNotice } from "./context-truncation-notice.js";
 import { log } from "./logger.js";
 import { MidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./run/midturn-precheck.js";
 import { shouldPreemptivelyCompactBeforePrompt } from "./run/preemptive-compaction.js";


### PR DESCRIPTION
## What Problem This Solves

Current CI lint checks fail on `origin/main` for two lint-contract issues outside the Gemini web-search freshness PR:

- `src/agents/embedded-agent-runner/tool-result-context-guard.ts` imports `CONTEXT_LIMIT_TRUNCATION_NOTICE` without using it.
- `extensions/codex/src/app-server/run-attempt.ts` passes an async helper directly to a void callback slot.

## Why This Change Was Made

This keeps the current mainline lint gate unblocked without mixing unrelated fixes into the Gemini provider behavior PR.

The changes are intentionally narrow:

- remove the unused import
- wrap `emitCodexAppServerEvent(...)` in a block and explicitly discard the returned promise with `void`

## User Impact

No runtime behavior change is intended. This only restores lint cleanliness for existing code paths.

## Evidence

Validated on top of `origin/main@65388233e2`:

- `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json src/agents/embedded-agent-runner/tool-result-context-guard.ts`
- `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/run-attempt.ts`
- `pnpm lint`

Not run:

- `pnpm build`
- full test suite

## AI Assistance

This PR was prepared with AI assistance.
