### PR TITLE
test(agents): add large prompt cache coverage

### DIFF
--- a/qa/scenarios/runtime/long-context-cache-stability.yaml
+++ b/qa/scenarios/runtime/long-context-cache-stability.yaml
@@ -84,7 +84,7 @@ flow:
           value:
             expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))] : []"
         - assert:
-            expr: "!env.mock || debugRequests.some((request) => request.plannedToolName === 'read' && String(request.toolOutput ?? '').length >= 100000)"
+            expr: "!env.mock || debugRequests.some((request) => request.plannedToolName === 'read' && String(request.allInputText ?? '').length >= 100000)"
             message:
               expr: "`large read tool result was not observed: ${JSON.stringify(debugRequests.slice(-8))}`"
       detailsExpr: "outbound?.text ?? config.hitMarker"

--- a/qa/scenarios/runtime/long-context-cache-stability.yaml
+++ b/qa/scenarios/runtime/long-context-cache-stability.yaml
@@ -1,0 +1,90 @@
+title: Large tool-result prompt cache stability
+
+scenario:
+  id: runtime-long-context-cache-stability
+  surface: runtime
+  runtimeParityTier: soak
+  coverage:
+    primary:
+      - runtime.reasoning-and-cache-controls
+    secondary:
+      - runtime.long-context
+  objective: Exercise repeated same-session turns after a large tool result so prompt assembly and provider cache reuse remain stable.
+  successCriteria:
+    - The agent reads a large workspace fixture and returns the warmup marker.
+    - A follow-up turn reuses the same session and returns the hit marker.
+    - Mock-provider evidence shows the large tool result remained in the assembled prompt.
+  docsRefs:
+    - docs/concepts/qa-e2e-automation.md
+    - docs/reference/test.md
+  codeRefs:
+    - src/agents/embedded-agent-runner/run/attempt.ts
+    - src/agents/embedded-agent-runner/tool-result-truncation.ts
+  execution:
+    kind: flow
+    summary: Read a large fixture, then verify a cache-sensitive follow-up turn.
+    config:
+      sessionKey: agent:qa:long-context-cache-stability
+      fixtureFile: large-cache-fixture.txt
+      warmupMarker: QA-LARGE-CACHE-WARMUP-OK
+      hitMarker: QA-LARGE-CACHE-HIT-OK
+
+flow:
+  steps:
+    - name: preserves the large tool-result prompt across follow-up turns
+      actions:
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: reset
+        - set: fixturePath
+          value:
+            expr: "path.join(env.gateway.workspaceDir, config.fixtureFile)"
+        - call: fs.writeFile
+          args:
+            - ref: fixturePath
+            - expr: "Array.from({ length: 1600 }, (_entry, index) => `CACHE-FIXTURE-${String(index + 1).padStart(4, '0')}: stable tool-result evidence for prompt-cache reuse across long sessions.\\n`).join('')"
+            - utf8
+        - set: sessionKey
+          value:
+            expr: config.sessionKey
+        - call: runAgentPrompt
+          args:
+            - ref: env
+            - sessionKey:
+                ref: sessionKey
+              message:
+                expr: "`Read ${config.fixtureFile}, verify it contains CACHE-FIXTURE-1600, then reply exactly ${config.warmupMarker}.`"
+              timeoutMs:
+                expr: liveTurnTimeoutMs(env, 120000)
+        - call: waitForCondition
+          args:
+            - lambda:
+                expr: "state.getSnapshot().messages.some((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && normalizeLowercaseStringOrEmpty(candidate.text).includes(normalizeLowercaseStringOrEmpty(config.warmupMarker)))"
+            - expr: liveTurnTimeoutMs(env, 120000)
+            - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+        - call: runAgentPrompt
+          args:
+            - ref: env
+            - sessionKey:
+                ref: sessionKey
+              message:
+                expr: "`Using the already-read ${config.fixtureFile}, confirm CACHE-FIXTURE-1600 is still present and reply exactly ${config.hitMarker}.`"
+              timeoutMs:
+                expr: liveTurnTimeoutMs(env, 120000)
+        - call: waitForCondition
+          saveAs: outbound
+          args:
+            - lambda:
+                expr: "state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && normalizeLowercaseStringOrEmpty(candidate.text).includes(normalizeLowercaseStringOrEmpty(config.hitMarker))).at(-1)"
+            - expr: liveTurnTimeoutMs(env, 120000)
+            - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+        - set: debugRequests
+          value:
+            expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))] : []"
+        - assert:
+            expr: "!env.mock || debugRequests.some((request) => request.plannedToolName === 'read' && String(request.toolOutput ?? '').length >= 100000)"
+            message:
+              expr: "`large read tool result was not observed: ${JSON.stringify(debugRequests.slice(-8))}`"
+      detailsExpr: "outbound?.text ?? config.hitMarker"

--- a/src/agents/embedded-agent-runner.cache.live.test.ts
+++ b/src/agents/embedded-agent-runner.cache.live.test.ts
@@ -36,6 +36,7 @@ const OPENAI_TOOL_MIN_CACHE_READ = 4_096;
 const OPENAI_TOOL_MIN_HIT_RATE = 0.85;
 const OPENAI_IMAGE_MIN_CACHE_READ = 3_840;
 const OPENAI_IMAGE_MIN_HIT_RATE = 0.82;
+const LARGE_CACHE_PROMPT_SECTIONS = 1_024;
 const LIVE_TEST_PNG_URL = new URL(
   "../../apps/android/app/src/main/res/mipmap-xhdpi/ic_launcher.png",
   import.meta.url,
@@ -1027,6 +1028,40 @@ describeCacheLive("embedded agent runner prompt caching (live)", () => {
     );
 
     it(
+      "keeps OpenAI cache reuse across a large embedded prompt",
+      async () => {
+        const sessionId = `${OPENAI_SESSION_ID}-large`;
+        const warmup = await runEmbeddedCacheProbe({
+          ...fixture,
+          cacheRetention: "short",
+          prefix: OPENAI_PREFIX,
+          providerTag: "openai",
+          sessionId,
+          suffix: "large-warmup",
+          promptSections: LARGE_CACHE_PROMPT_SECTIONS,
+        });
+        const hit = await runEmbeddedCacheProbe({
+          ...fixture,
+          cacheRetention: "short",
+          prefix: OPENAI_PREFIX,
+          providerTag: "openai",
+          sessionId,
+          suffix: "large-hit",
+          promptSections: LARGE_CACHE_PROMPT_SECTIONS,
+        });
+        logLiveCache(
+          `openai large prompt sections=${LARGE_CACHE_PROMPT_SECTIONS} warmup=${warmup.usage.cacheWrite} hit=${hit.usage.cacheRead} input=${hit.usage.input} rate=${hit.hitRate.toFixed(3)}`,
+        );
+
+        expect(warmup.usage.cacheWrite ?? 0).toBeGreaterThan(0);
+        expect(hit.usage.cacheRead ?? 0).toBeGreaterThan(4_096);
+        expect(hit.hitRate).toBeGreaterThanOrEqual(0.4);
+        await expectCacheTraceStages(sessionId, ["cache:state", "cache:result"]);
+      },
+      12 * 60_000,
+    );
+
+    it(
       "keeps OpenAI cache reuse when structured system context only changes by whitespace and line endings",
       async () => {
         const sessionId = `${OPENAI_SESSION_ID}-structured-normalization`;
@@ -1362,6 +1397,40 @@ describeCacheLive("embedded agent runner prompt caching (live)", () => {
         await expectCacheTraceStages(sessionId, ["cache:state", "cache:result"]);
       },
       8 * 60_000,
+    );
+
+    it(
+      "keeps Anthropic cache reuse across a large embedded prompt",
+      async () => {
+        const sessionId = `${ANTHROPIC_SESSION_ID}-large`;
+        const warmup = await runEmbeddedCacheProbe({
+          ...fixture,
+          cacheRetention: "short",
+          prefix: ANTHROPIC_PREFIX,
+          providerTag: "anthropic",
+          sessionId,
+          suffix: "large-warmup",
+          promptSections: LARGE_CACHE_PROMPT_SECTIONS,
+        });
+        const hit = await runEmbeddedCacheProbe({
+          ...fixture,
+          cacheRetention: "short",
+          prefix: ANTHROPIC_PREFIX,
+          providerTag: "anthropic",
+          sessionId,
+          suffix: "large-hit",
+          promptSections: LARGE_CACHE_PROMPT_SECTIONS,
+        });
+        logLiveCache(
+          `anthropic large prompt sections=${LARGE_CACHE_PROMPT_SECTIONS} warmup=${warmup.usage.cacheWrite} hit=${hit.usage.cacheRead} input=${hit.usage.input} rate=${hit.hitRate.toFixed(3)}`,
+        );
+
+        expect(warmup.usage.cacheWrite ?? 0).toBeGreaterThan(0);
+        expect(hit.usage.cacheRead ?? 0).toBeGreaterThan(4_096);
+        expect(hit.hitRate).toBeGreaterThanOrEqual(0.3);
+        await expectCacheTraceStages(sessionId, ["cache:state", "cache:result"]);
+      },
+      12 * 60_000,
     );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Adds larger provider-backed prompt-cache tests and one QA Lab scenario to exercise the long-context tool-result path covered by #95624.

## Why This Change Was Made

The existing PR has focused regression coverage, but not enough large-prompt evidence. These tests keep a 1,024-section embedded prompt stable across OpenAI and Anthropic cache follow-ups, while the QA scenario drives a large read result through the real gateway and qa-channel loop.

## User Impact

No runtime behavior changes. This increases confidence that large tool-result histories do not destabilize prompt caching.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts` — 26 passed.
- `node_modules/.bin/oxfmt --check src/agents/embedded-agent-runner.cache.live.test.ts qa/scenarios/runtime/long-context-cache-stability.yaml` — clean.
- `git diff --check` — clean.
- The provider-backed tests are live-gated and were not run without live provider credentials.
- The mock QA flow completed the large read/audit path; its first run exposed that the harness caps `toolOutput`, so the scenario now asserts the uncapped request `allInputText` evidence instead.
- The existing PR `#95624` remains unchanged because GitHub kept its head SHA pinned; this companion PR carries only the added coverage.
