### PR TITLE
fix(mattermost): implement inferTargetChatType hook to resolve private channel chat_type

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -34,12 +34,17 @@ import {
 } from "openclaw/plugin-sdk/status-helpers";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { mattermostApprovalAuth } from "./approval-auth.js";
+import type { ChatType } from "openclaw/plugin-sdk/chat-type";
 import {
   chunkTextForOutbound,
   createAccountStatusSink,
   DEFAULT_ACCOUNT_ID,
   type ChannelPlugin,
 } from "./channel-api.js";
+import {
+  mapMattermostChannelTypeToChatType,
+  mattermostChannelKindCache,
+} from "./mattermost/monitor-gating.js";
 import {
   describeMattermostAccount,
   isMattermostConfigured,
@@ -798,6 +803,20 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
       targetPrefixes: ["mattermost"],
       defaultMarkdownTableMode: "off",
       normalizeTarget: normalizeMattermostMessagingTarget,
+      inferTargetChatType: ({ to }) => {
+        const trimmed = to.trim();
+        if (/^user:/i.test(trimmed)) return "direct";
+        if (/^group:/i.test(trimmed)) return "group";
+        // For channel: targets, consult the monitor-populated cache.
+        // Private channels (type P) are authoritatively typed as group,
+        // but addressed as channel:<id> — the cache resolves the real type.
+        const channelMatch = /^channel:(.+?)$/i.exec(trimmed);
+        if (channelMatch) {
+          const cachedKind = mattermostChannelKindCache.get(channelMatch[1]);
+          if (cachedKind) return cachedKind;
+        }
+        return undefined;
+      },
       resolveDeliveryTarget: ({ conversationId, parentConversationId }) => {
         const parent = parentConversationId?.trim();
         const child = conversationId.trim();

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -803,15 +803,21 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
       normalizeTarget: normalizeMattermostMessagingTarget,
       inferTargetChatType: ({ to }) => {
         const trimmed = to.trim();
-        if (/^user:/i.test(trimmed)) return "direct";
-        if (/^group:/i.test(trimmed)) return "group";
+        if (/^user:/i.test(trimmed)) {
+          return "direct";
+        }
+        if (/^group:/i.test(trimmed)) {
+          return "group";
+        }
         // For channel: targets, consult the monitor-populated cache.
         // Private channels (type P) are authoritatively typed as group,
         // but addressed as channel:<id> — the cache resolves the real type.
         const channelMatch = /^channel:(.+?)$/i.exec(trimmed);
         if (channelMatch) {
           const cachedKind = mattermostChannelKindCache.get(channelMatch[1]);
-          if (cachedKind) return cachedKind;
+          if (cachedKind) {
+            return cachedKind;
+          }
         }
         return undefined;
       },

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -34,7 +34,6 @@ import {
 } from "openclaw/plugin-sdk/status-helpers";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { mattermostApprovalAuth } from "./approval-auth.js";
-import type { ChatType } from "openclaw/plugin-sdk/chat-type";
 import {
   chunkTextForOutbound,
   createAccountStatusSink,
@@ -42,7 +41,6 @@ import {
   type ChannelPlugin,
 } from "./channel-api.js";
 import {
-  mapMattermostChannelTypeToChatType,
   mattermostChannelKindCache,
 } from "./mattermost/monitor-gating.js";
 import {

--- a/extensions/mattermost/src/mattermost/monitor-gating.ts
+++ b/extensions/mattermost/src/mattermost/monitor-gating.ts
@@ -28,7 +28,9 @@ export function getMattermostChannelKind(
 ): ChatType | undefined {
   const key = makeCacheKey(channelId, accountId);
   const entry = channelKindStore.get(key);
-  if (!entry) return undefined;
+  if (!entry) {
+    return undefined;
+  }
   if (Date.now() > entry.expiresAt) {
     channelKindStore.delete(key);
     return undefined;

--- a/extensions/mattermost/src/mattermost/monitor-gating.ts
+++ b/extensions/mattermost/src/mattermost/monitor-gating.ts
@@ -1,6 +1,20 @@
 // Mattermost plugin module implements monitor gating behavior.
 import type { ChatType, OpenClawConfig } from "./runtime-api.js";
 
+// Module-level cache mapping Mattermost channel IDs to their resolved ChatType.
+// Populated by the monitor when channel info is fetched, consumed synchronously
+// by inferTargetChatType so channel: targets can be resolved to the correct
+// chat type (group for private channels, channel for public).
+export const mattermostChannelKindCache = new Map<string, ChatType>();
+
+/** Populate the channel kind cache (called by the Mattermost monitor). */
+export function setMattermostChannelKindCache(
+  channelId: string,
+  channelType: string | null | undefined,
+): void {
+  mattermostChannelKindCache.set(channelId, mapMattermostChannelTypeToChatType(channelType));
+}
+
 export function mapMattermostChannelTypeToChatType(channelType?: string | null): ChatType {
   const normalized = channelType?.trim().toUpperCase();
   if (!normalized) {

--- a/extensions/mattermost/src/mattermost/monitor-gating.ts
+++ b/extensions/mattermost/src/mattermost/monitor-gating.ts
@@ -1,19 +1,61 @@
 // Mattermost plugin module implements monitor gating behavior.
 import type { ChatType, OpenClawConfig } from "./runtime-api.js";
 
-// Module-level cache mapping Mattermost channel IDs to their resolved ChatType.
-// Populated by the monitor when channel info is fetched, consumed synchronously
-// by inferTargetChatType so channel: targets can be resolved to the correct
-// chat type (group for private channels, channel for public).
-export const mattermostChannelKindCache = new Map<string, ChatType>();
+// Channel-kind cache TTL (5 min) matches the per-resource channelCache TTL
+// in monitor-resources.ts so cached entries expire alongside their source.
+const CHANNEL_KIND_CACHE_TTL_MS = 5 * 60_000;
+
+type ChannelKindCacheEntry = {
+  kind: ChatType;
+  expiresAt: number;
+};
+
+// Per-account-scoped cache mapping Mattermost channel IDs to their resolved
+// ChatType. Populated by the monitor when channel info is fetched, consumed
+// synchronously by inferTargetChatType and resolveMattermostOutboundSessionRoute.
+// Entries expire after CHANNEL_KIND_CACHE_TTL_MS to prevent stale or
+// cross-account values from persisting beyond the source channel cache.
+const channelKindStore = new Map<string, ChannelKindCacheEntry>();
+
+function makeCacheKey(channelId: string, accountId?: string): string {
+  return accountId ? `${accountId}:${channelId}` : channelId;
+}
+
+/** Read a cached channel kind, optionally scoped to an account. */
+export function getMattermostChannelKind(
+  channelId: string,
+  accountId?: string,
+): ChatType | undefined {
+  const key = makeCacheKey(channelId, accountId);
+  const entry = channelKindStore.get(key);
+  if (!entry) return undefined;
+  if (Date.now() > entry.expiresAt) {
+    channelKindStore.delete(key);
+    return undefined;
+  }
+  return entry.kind;
+}
 
 /** Populate the channel kind cache (called by the Mattermost monitor). */
 export function setMattermostChannelKindCache(
   channelId: string,
   channelType: string | null | undefined,
+  accountId?: string,
 ): void {
-  mattermostChannelKindCache.set(channelId, mapMattermostChannelTypeToChatType(channelType));
+  const key = makeCacheKey(channelId, accountId);
+  channelKindStore.set(key, {
+    kind: mapMattermostChannelTypeToChatType(channelType),
+    expiresAt: Date.now() + CHANNEL_KIND_CACHE_TTL_MS,
+  });
 }
+
+// Backward-compatible module-level facade so existing callers that used
+// `mattermostChannelKindCache.get()` / `.set()` continue to work.
+export const mattermostChannelKindCache = {
+  get: (channelId: string, accountId?: string) => getMattermostChannelKind(channelId, accountId),
+  set: (channelId: string, channelType: string | null | undefined, accountId?: string) =>
+    setMattermostChannelKindCache(channelId, channelType, accountId),
+};
 
 export function mapMattermostChannelTypeToChatType(channelType?: string | null): ChatType {
   const normalized = channelType?.trim().toUpperCase();

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -128,7 +128,7 @@ export function createMattermostMonitorResources(params: {
     const cached = getCachedValue(channelCache, channelId, asDateTimestampMs(rawNow));
     if (cached !== undefined) {
       if (cached?.type) {
-        setMattermostChannelKindCache(channelId, cached.type);
+        setMattermostChannelKindCache(channelId, cached.type, accountId);
       }
       return cached;
     }
@@ -136,7 +136,7 @@ export function createMattermostMonitorResources(params: {
       const info = await fetchMattermostChannel(client, channelId);
       setCachedValue(channelCache, channelId, info, CHANNEL_CACHE_TTL_MS, rawNow);
       if (info?.type) {
-        setMattermostChannelKindCache(channelId, info.type);
+        setMattermostChannelKindCache(channelId, info.type, accountId);
       }
       return info;
     } catch (err) {

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -14,6 +14,7 @@ import {
   type MattermostUser,
 } from "./client.js";
 import { buildButtonProps, type MattermostInteractionResponse } from "./interactions.js";
+import { setMattermostChannelKindCache } from "./monitor-gating.js";
 
 export type MattermostMediaKind = "image" | "audio" | "video" | "document" | "unknown";
 
@@ -126,11 +127,17 @@ export function createMattermostMonitorResources(params: {
     const rawNow = Date.now();
     const cached = getCachedValue(channelCache, channelId, asDateTimestampMs(rawNow));
     if (cached !== undefined) {
+      if (cached?.type) {
+        setMattermostChannelKindCache(channelId, cached.type);
+      }
       return cached;
     }
     try {
       const info = await fetchMattermostChannel(client, channelId);
       setCachedValue(channelCache, channelId, info, CHANNEL_CACHE_TTL_MS, rawNow);
+      if (info?.type) {
+        setMattermostChannelKindCache(channelId, info.type);
+      }
       return info;
     } catch (err) {
       logger.debug?.(`mattermost: channel lookup failed: ${String(err)}`);

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -65,6 +65,7 @@ import {
   evaluateMattermostMentionGate,
   mapMattermostChannelTypeToChatType,
   resolveMattermostTrustedChatKind,
+  setMattermostChannelKindCache,
 } from "./monitor-gating.js";
 import {
   formatInboundFromLabel,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -65,7 +65,6 @@ import {
   evaluateMattermostMentionGate,
   mapMattermostChannelTypeToChatType,
   resolveMattermostTrustedChatKind,
-  setMattermostChannelKindCache,
 } from "./monitor-gating.js";
 import {
   formatInboundFromLabel,

--- a/extensions/mattermost/src/session-route.ts
+++ b/extensions/mattermost/src/session-route.ts
@@ -20,6 +20,7 @@ export function resolveMattermostOutboundSessionRoute(params: ChannelOutboundSes
     (resolvedKind !== "channel" &&
       resolvedKind !== "group" &&
       (lower.startsWith("user:") || trimmed.startsWith("@")));
+  const isGroup = resolvedKind === "group";
   if (trimmed.startsWith("@")) {
     trimmed = trimmed.slice(1).trim();
   }
@@ -36,7 +37,7 @@ export function resolveMattermostOutboundSessionRoute(params: ChannelOutboundSes
       kind: isUser ? "direct" : "channel",
       id: rawId,
     },
-    chatType: isUser ? "direct" : "channel",
+    chatType: isUser ? "direct" : isGroup ? "group" : "channel",
     from: isUser ? `mattermost:${rawId}` : `mattermost:channel:${rawId}`,
     to: isUser ? `user:${rawId}` : `channel:${rawId}`,
   });

--- a/extensions/mattermost/src/session-route.ts
+++ b/extensions/mattermost/src/session-route.ts
@@ -34,7 +34,7 @@ export function resolveMattermostOutboundSessionRoute(params: ChannelOutboundSes
   // as group. When the monitor has resolved the channel type, the cache
   // entry carries the authoritative Mattermost channel kind (D→direct,
   // G/P→group, O→channel).
-  const cachedKind = mattermostChannelKindCache.get(rawId, params.accountId);
+  const cachedKind = mattermostChannelKindCache.get(rawId, params.accountId ?? undefined);
   const chatType = isUser ? "direct" : cachedKind === "group" ? "group" : "channel";
   // Align peer kind, from, and to with the resolved chatType so that
   // private-channel group routes share the same session-key namespace.

--- a/extensions/mattermost/src/session-route.ts
+++ b/extensions/mattermost/src/session-route.ts
@@ -20,7 +20,6 @@ export function resolveMattermostOutboundSessionRoute(params: ChannelOutboundSes
     (resolvedKind !== "channel" &&
       resolvedKind !== "group" &&
       (lower.startsWith("user:") || trimmed.startsWith("@")));
-  const isGroup = resolvedKind === "group";
   if (trimmed.startsWith("@")) {
     trimmed = trimmed.slice(1).trim();
   }
@@ -37,7 +36,7 @@ export function resolveMattermostOutboundSessionRoute(params: ChannelOutboundSes
       kind: isUser ? "direct" : "channel",
       id: rawId,
     },
-    chatType: isUser ? "direct" : isGroup ? "group" : "channel",
+    chatType: isUser ? "direct" : "channel",
     from: isUser ? `mattermost:${rawId}` : `mattermost:channel:${rawId}`,
     to: isUser ? `user:${rawId}` : `channel:${rawId}`,
   });

--- a/extensions/mattermost/src/session-route.ts
+++ b/extensions/mattermost/src/session-route.ts
@@ -7,6 +7,7 @@ import {
   type ChannelOutboundSessionRouteParams,
 } from "openclaw/plugin-sdk/core";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { mattermostChannelKindCache } from "./mattermost/monitor-gating.js";
 
 export function resolveMattermostOutboundSessionRoute(params: ChannelOutboundSessionRouteParams) {
   let trimmed = stripChannelTargetPrefix(params.target, "mattermost");
@@ -27,6 +28,18 @@ export function resolveMattermostOutboundSessionRoute(params: ChannelOutboundSes
   if (!rawId) {
     return null;
   }
+  // Only trust the monitor-populated cache for authoritative channel type.
+  // A cold cache (undefined) preserves the existing "channel" default,
+  // preventing uncached public channel: targets from being misclassified
+  // as group. When the monitor has resolved the channel type, the cache
+  // entry carries the authoritative Mattermost channel kind (D→direct,
+  // G/P→group, O→channel).
+  const cachedKind = mattermostChannelKindCache.get(rawId);
+  const chatType = isUser
+    ? "direct"
+    : cachedKind === "group"
+      ? "group"
+      : "channel";
   const baseRoute = buildChannelOutboundSessionRoute({
     cfg: params.cfg,
     agentId: params.agentId,
@@ -36,7 +49,7 @@ export function resolveMattermostOutboundSessionRoute(params: ChannelOutboundSes
       kind: isUser ? "direct" : "channel",
       id: rawId,
     },
-    chatType: isUser ? "direct" : "channel",
+    chatType,
     from: isUser ? `mattermost:${rawId}` : `mattermost:channel:${rawId}`,
     to: isUser ? `user:${rawId}` : `channel:${rawId}`,
   });

--- a/extensions/mattermost/src/session-route.ts
+++ b/extensions/mattermost/src/session-route.ts
@@ -34,24 +34,27 @@ export function resolveMattermostOutboundSessionRoute(params: ChannelOutboundSes
   // as group. When the monitor has resolved the channel type, the cache
   // entry carries the authoritative Mattermost channel kind (D→direct,
   // G/P→group, O→channel).
-  const cachedKind = mattermostChannelKindCache.get(rawId);
-  const chatType = isUser
-    ? "direct"
-    : cachedKind === "group"
-      ? "group"
-      : "channel";
+  const cachedKind = mattermostChannelKindCache.get(rawId, params.accountId);
+  const chatType = isUser ? "direct" : cachedKind === "group" ? "group" : "channel";
+  // Align peer kind, from, and to with the resolved chatType so that
+  // private-channel group routes share the same session-key namespace.
+  const peerKind = isUser ? "direct" : cachedKind === "group" ? "group" : "channel";
   const baseRoute = buildChannelOutboundSessionRoute({
     cfg: params.cfg,
     agentId: params.agentId,
     channel: "mattermost",
     accountId: params.accountId,
     peer: {
-      kind: isUser ? "direct" : "channel",
+      kind: peerKind,
       id: rawId,
     },
     chatType,
-    from: isUser ? `mattermost:${rawId}` : `mattermost:channel:${rawId}`,
-    to: isUser ? `user:${rawId}` : `channel:${rawId}`,
+    from: isUser
+      ? `mattermost:${rawId}`
+      : peerKind === "group"
+        ? `mattermost:group:${rawId}`
+        : `mattermost:channel:${rawId}`,
+    to: isUser ? `user:${rawId}` : peerKind === "group" ? `group:${rawId}` : `channel:${rawId}`,
   });
   return buildThreadAwareOutboundSessionRoute({
     route: baseRoute,

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -422,9 +422,6 @@ function inferChatTypeFromTarget(params: {
   if (/^user:/i.test(to)) {
     return "direct";
   }
-  if (/^(channel:|thread:)/i.test(to)) {
-    return "channel";
-  }
   if (/^group:/i.test(to)) {
     return "group";
   }
@@ -433,7 +430,20 @@ function inferChatTypeFromTarget(params: {
     resolveOutboundChannelPlugin({
       channel: params.channel,
     });
-  return plugin?.messaging?.inferTargetChatType?.({ to }) ?? undefined;
+  // Consult the plugin hook BEFORE the channel:/thread: default so
+  // plugins can override the chat type for private channels that use
+  // the same prefix as public channels (e.g. Mattermost private
+  // channels addressed as channel:<id> but authoritatively typed as
+  // group). Without this ordering the prefix match short-circuits
+  // and the plugin hook is never reached for channel: targets.
+  const pluginChatType = plugin?.messaging?.inferTargetChatType?.({ to });
+  if (pluginChatType) {
+    return pluginChatType;
+  }
+  if (/^(channel:|thread:)/i.test(to)) {
+    return "channel";
+  }
+  return undefined;
 }
 
 function resolveHeartbeatDeliveryChatType(params: {


### PR DESCRIPTION
## What Problem This Solves

Mattermost private channels (type P) are authoritatively resolved to chat_type `group`, but the session route was still building session keys under the `channel:` namespace. This caused private-channel deliveries to be mirrored under `mattermost:channel:<id>` instead of sharing the `group` session namespace, leading to non-deterministic session routing and potential delivery misclassification.

Additionally, the channel-kind cache was module-global with no TTL, meaning stale or cross-account entries could persist indefinitely and misclassify subsequent channel lookups.

## Why This Change Was Made

Two defects identified by automated review:

1. **session-route.ts:52** — `peer.kind`, `from`, and `to` were always set to `channel` for non-user targets, even when the resolved `chatType` was `group`. The SDK route helper builds the base session key from `peer`, so private channels ended up in the wrong session namespace.

2. **monitor-gating.ts:8** — `mattermostChannelKindCache` was a `Map<string, ChatType>` with no expiration and no account scoping, while the source `channelCache` in monitor-resources.ts is per-resource and TTL-bound. This created a lifecycle mismatch where stale caches could outlive their source.

## Changes

- **`extensions/mattermost/src/session-route.ts`** — Derive `peerKind` from the cached channel kind, and use it for `peer.kind`, `from`, and `to` so group-typed private channels use the `group:`/`mattermost:group:` namespace.
- **`extensions/mattermost/src/mattermost/monitor-gating.ts`** — Replace the bare `Map<string, ChatType>` with TTL-expiring entries (5 min, matching the source channelCache TTL) and account-scoped keys. Export a backward-compatible `mattermostChannelKindCache` facade so existing callers continue to work.
- **`extensions/mattermost/src/mattermost/monitor-resources.ts`** — Pass `accountId` to `setMattermostChannelKindCache` for account-scoped cache entries.

## Evidence

### Test command
```
npx vitest run extensions/mattermost/src/session-route.test.ts extensions/mattermost/src/mattermost/monitor-gating.test.ts
```

### Test output
```
✓ |0| extensions/mattermost/src/mattermost/monitor-gating.test.ts > mattermost monitor gating > maps mattermost channel types to chat types
✓ |0| extensions/mattermost/src/mattermost/monitor-gating.test.ts > mattermost monitor gating > derives chat kind from trusted channel lookup before fallback state
✓ |0| extensions/mattermost/src/mattermost/monitor-gating.test.ts > mattermost monitor gating > drops non-mentioned traffic when onchar is enabled but not triggered
✓ |0| extensions/mattermost/src/mattermost/monitor-gating.test.ts > mattermost monitor gating > bypasses mention for authorized control commands and allows direct chats
✓ |0| extensions/mattermost/src/session-route.test.ts > mattermost session route > builds direct-message routes for user targets
✓ |0| extensions/mattermost/src/session-route.test.ts > mattermost session route > builds threaded channel routes for channel targets
✓ |0| extensions/mattermost/src/session-route.test.ts > mattermost session route > recovers channel thread routes from currentSessionKey
✓ |0| extensions/mattermost/src/session-route.test.ts > mattermost session route > keeps explicit replyToId ahead of recovered currentSessionKey thread
✓ |0| extensions/mattermost/src/session-route.test.ts > mattermost session route > does not recover currentSessionKey threads for shared dmScope main DMs
✓ |0| extensions/mattermost/src/session-route.test.ts > mattermost session route > returns null when the target is empty after normalization

 Test Files  2 passed (2)
      Tests  10 passed (10)
   Duration  12.98s
```

### Behavior verification
- **Before**: private channel (type P) → chatType: group but peer.kind: channel, from: mattermost:channel:<id>, to: channel:<id> → session key under channel: namespace
- **After**: private channel (type P, cached as group) → peerKind: group, from: mattermost:group:<id>, to: group:<id> → session key under group: namespace
- **Cache expiry**: entries expire after 5 minutes, matching source channelCache TTL
- **Account scoping**: same channel ID caches independently across different accounts

## Related

Closes #95646