### PR TITLE
fix(mattermost): keep private channels in group sessions across delivery paths

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -58,6 +58,7 @@ import {
   resolveMattermostReplyToMode,
   type ResolvedMattermostAccount,
 } from "./mattermost/accounts.js";
+import { inferMattermostTargetChatType } from "./mattermost/chat-type-cache.js";
 import { looksLikeMattermostTargetId, normalizeMattermostMessagingTarget } from "./normalize.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { resolveMattermostOutboundSessionRoute } from "./session-route.js";
@@ -798,6 +799,7 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
       targetPrefixes: ["mattermost"],
       defaultMarkdownTableMode: "off",
       normalizeTarget: normalizeMattermostMessagingTarget,
+      inferTargetChatType: ({ to }) => inferMattermostTargetChatType(to),
       resolveDeliveryTarget: ({ conversationId, parentConversationId }) => {
         const parent = parentConversationId?.trim();
         const child = conversationId.trim();

--- a/extensions/mattermost/src/mattermost/chat-type-cache.test.ts
+++ b/extensions/mattermost/src/mattermost/chat-type-cache.test.ts
@@ -1,0 +1,42 @@
+// Mattermost tests cover chat-type cache plugin behavior.
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  inferMattermostTargetChatType,
+  recordMattermostChannelChatType,
+  resetMattermostChatTypeCacheForTests,
+} from "./chat-type-cache.js";
+
+const PRIVATE_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaa";
+const PUBLIC_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+afterEach(() => {
+  resetMattermostChatTypeCacheForTests();
+});
+
+describe("inferMattermostTargetChatType", () => {
+  it("classifies an explicit user target as direct without a cache entry", () => {
+    expect(inferMattermostTargetChatType(`user:${PRIVATE_ID}`)).toBe("direct");
+  });
+
+  it("returns undefined for an unknown channel id so core keeps its channel default", () => {
+    expect(inferMattermostTargetChatType(`channel:${PRIVATE_ID}`)).toBeUndefined();
+  });
+
+  it("resolves a recorded private channel as group", () => {
+    recordMattermostChannelChatType(PRIVATE_ID, "P");
+    expect(inferMattermostTargetChatType(`channel:${PRIVATE_ID}`)).toBe("group");
+    // A bare id (no prefix) resolves the same way.
+    expect(inferMattermostTargetChatType(PRIVATE_ID)).toBe("group");
+  });
+
+  it("keeps a recorded public channel as channel", () => {
+    recordMattermostChannelChatType(PUBLIC_ID, "O");
+    expect(inferMattermostTargetChatType(`channel:${PUBLIC_ID}`)).toBe("channel");
+  });
+
+  it("ignores non-Mattermost ids and missing channel types", () => {
+    recordMattermostChannelChatType("short", "P");
+    recordMattermostChannelChatType(PRIVATE_ID, undefined);
+    expect(inferMattermostTargetChatType(`channel:${PRIVATE_ID}`)).toBeUndefined();
+  });
+});

--- a/extensions/mattermost/src/mattermost/chat-type-cache.ts
+++ b/extensions/mattermost/src/mattermost/chat-type-cache.ts
@@ -1,0 +1,53 @@
+// Mattermost plugin module implements chat-type cache behavior.
+import { mapMattermostChannelTypeToChatType } from "./monitor-gating.js";
+import type { ChatType } from "./runtime-api.js";
+
+/** Mattermost IDs are 26-character lowercase alphanumeric strings. */
+export function isMattermostId(value: string): boolean {
+  return /^[a-z0-9]{26}$/.test(value);
+}
+
+// Id-keyed chat-type cache for the sync `inferTargetChatType` hook. That hook only
+// receives `{ to }` (no account/baseUrl), so it cannot key the per-account resolution
+// cache in target-resolution; this map lets outbound resolution and inbound monitor
+// reads share the authoritative channel type. Mattermost channel ids are server-unique
+// 26-char strings, so id-only keying is safe in practice. Kept as a leaf module (no
+// client/runtime deps) so `channel.ts` can import the sync hook without pulling the lazy
+// `channel.runtime` chunk eager.
+const chatTypeByChannelId = new Map<string, ChatType>();
+
+/** Records an authoritative channel type so the sync `inferTargetChatType` hook can read it. */
+export function recordMattermostChannelChatType(
+  channelId: string,
+  channelType?: string | null,
+): void {
+  const id = channelId.trim();
+  if (!isMattermostId(id) || !channelType) {
+    return;
+  }
+  chatTypeByChannelId.set(id, mapMattermostChannelTypeToChatType(channelType));
+}
+
+// Sync hook for core target -> chat-type inference. Returns a definitive type only when
+// the channel type is already known (resolved outbound or seen inbound); otherwise core
+// keeps its generic `channel:` default. A private channel (`P`/`G`) addressed as
+// `channel:<id>` resolves to `group`, which keeps it in one session namespace.
+export function inferMattermostTargetChatType(to: string): ChatType | undefined {
+  const trimmed = to.trim();
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith("user:") || lower.startsWith("mattermost:")) {
+    return "direct";
+  }
+  if (lower.startsWith("group:")) {
+    return "group";
+  }
+  const id = lower.startsWith("channel:") ? trimmed.slice("channel:".length).trim() : trimmed;
+  if (!isMattermostId(id)) {
+    return undefined;
+  }
+  return chatTypeByChannelId.get(id);
+}
+
+export function resetMattermostChatTypeCacheForTests(): void {
+  chatTypeByChannelId.clear();
+}

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -4,6 +4,7 @@ import {
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { recordMattermostChannelChatType } from "./chat-type-cache.js";
 import {
   fetchMattermostChannel,
   fetchMattermostUser,
@@ -131,6 +132,9 @@ export function createMattermostMonitorResources(params: {
     try {
       const info = await fetchMattermostChannel(client, channelId);
       setCachedValue(channelCache, channelId, info, CHANNEL_CACHE_TTL_MS, rawNow);
+      // Warm the id-keyed chat-type cache so the sync `inferTargetChatType` hook can
+      // classify private (`P`/`G`) channels as group on later outbound deliveries.
+      recordMattermostChannelChatType(channelId, info?.type);
       return info;
     } catch (err) {
       logger.debug?.(`mattermost: channel lookup failed: ${String(err)}`);

--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -26,6 +26,7 @@ const mockState = vi.hoisted(() => ({
   createMattermostDirectChannel: vi.fn(),
   createMattermostDirectChannelWithRetry: vi.fn(),
   createMattermostPost: vi.fn(),
+  fetchMattermostChannel: vi.fn(),
   fetchMattermostChannelByName: vi.fn(),
   fetchMattermostMe: vi.fn(),
   fetchMattermostUser: vi.fn(),
@@ -157,6 +158,7 @@ vi.mock("./client.js", () => ({
   createMattermostDirectChannel: mockState.createMattermostDirectChannel,
   createMattermostDirectChannelWithRetry: mockState.createMattermostDirectChannelWithRetry,
   createMattermostPost: mockState.createMattermostPost,
+  fetchMattermostChannel: mockState.fetchMattermostChannel,
   fetchMattermostChannelByName: mockState.fetchMattermostChannelByName,
   fetchMattermostMe: mockState.fetchMattermostMe,
   fetchMattermostUser: mockState.fetchMattermostUser,
@@ -205,6 +207,7 @@ describe("sendMessageMattermost", () => {
     mockState.createMattermostDirectChannel.mockReset();
     mockState.createMattermostDirectChannelWithRetry.mockReset();
     mockState.createMattermostPost.mockReset();
+    mockState.fetchMattermostChannel.mockReset();
     mockState.fetchMattermostChannelByName.mockReset();
     mockState.fetchMattermostMe.mockReset();
     mockState.fetchMattermostUser.mockReset();
@@ -217,6 +220,7 @@ describe("sendMessageMattermost", () => {
     mockState.fetchMattermostMe.mockResolvedValue({ id: "bot-user" });
     mockState.fetchMattermostUserTeams.mockResolvedValue([{ id: "team-1" }]);
     mockState.fetchMattermostChannelByName.mockResolvedValue({ id: "town-square" });
+    mockState.fetchMattermostChannel.mockResolvedValue({ id: "town-square", type: "O" });
     mockState.uploadMattermostFile.mockResolvedValue({ id: "file-1" });
     ({ parseMattermostTarget, sendMessageMattermost } = await import("./send.js"));
     ({ resetMattermostOpaqueTargetCacheForTests } = await import("./target-resolution.js"));

--- a/extensions/mattermost/src/mattermost/target-resolution.test.ts
+++ b/extensions/mattermost/src/mattermost/target-resolution.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 const resolveMattermostAccount = vi.fn();
 const createMattermostClient = vi.fn();
 const fetchMattermostUser = vi.fn();
+const fetchMattermostChannel = vi.fn();
 const normalizeMattermostBaseUrl = vi.fn((value: string | undefined) => value?.trim());
 
 vi.mock("./accounts.js", () => ({
@@ -12,6 +13,7 @@ vi.mock("./accounts.js", () => ({
 
 vi.mock("./client.js", () => ({
   createMattermostClient,
+  fetchMattermostChannel,
   fetchMattermostUser,
   normalizeMattermostBaseUrl,
 }));
@@ -36,6 +38,7 @@ describe("mattermost target resolution", () => {
   beforeEach(() => {
     resolveMattermostAccount.mockReset();
     createMattermostClient.mockReset();
+    fetchMattermostChannel.mockReset();
     fetchMattermostUser.mockReset();
     normalizeMattermostBaseUrl.mockClear();
   });
@@ -91,6 +94,7 @@ describe("mattermost target resolution", () => {
   it("falls back to channel targets on 404 lookups", async () => {
     createMattermostClient.mockReturnValue({ client: true });
     fetchMattermostUser.mockRejectedValue(new Error("Mattermost API 404 Not Found"));
+    fetchMattermostChannel.mockRejectedValue(new Error("Mattermost API 404 Not Found"));
     const input = "bcde1234abcd1234abcd1234ab";
 
     await expect(
@@ -103,6 +107,49 @@ describe("mattermost target resolution", () => {
       kind: "channel",
       id: input,
       to: `channel:${input}`,
+    });
+  });
+
+  it("uses channel type to classify private channel ids as group targets", async () => {
+    createMattermostClient.mockReturnValue({ client: true });
+    fetchMattermostUser.mockRejectedValue(new Error("Mattermost API 404 Not Found"));
+    fetchMattermostChannel.mockResolvedValue({
+      id: "bcde1234abcd1234abcd1234ab",
+      type: "P",
+    });
+    const input = "channel:bcde1234abcd1234abcd1234ab";
+
+    await expect(
+      resolveMattermostOpaqueTarget({
+        input,
+        token: "token",
+        baseUrl: "https://mm.example.com",
+      }),
+    ).resolves.toEqual({
+      kind: "group",
+      id: "bcde1234abcd1234abcd1234ab",
+      to: "channel:bcde1234abcd1234abcd1234ab",
+    });
+  });
+
+  it("uses channel type to keep public channel ids as channel targets", async () => {
+    createMattermostClient.mockReturnValue({ client: true });
+    fetchMattermostUser.mockRejectedValue(new Error("Mattermost API 404 Not Found"));
+    fetchMattermostChannel.mockResolvedValue({
+      id: "bcde1234abcd1234abcd1234ab",
+      type: "O",
+    });
+
+    await expect(
+      resolveMattermostOpaqueTarget({
+        input: "bcde1234abcd1234abcd1234ab",
+        token: "token",
+        baseUrl: "https://mm.example.com",
+      }),
+    ).resolves.toEqual({
+      kind: "channel",
+      id: "bcde1234abcd1234abcd1234ab",
+      to: "channel:bcde1234abcd1234abcd1234ab",
     });
   });
 

--- a/extensions/mattermost/src/mattermost/target-resolution.ts
+++ b/extensions/mattermost/src/mattermost/target-resolution.ts
@@ -3,27 +3,33 @@ import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveMattermostAccount } from "./accounts.js";
 import {
+  isMattermostId,
+  recordMattermostChannelChatType,
+  resetMattermostChatTypeCacheForTests,
+} from "./chat-type-cache.js";
+import {
   createMattermostClient,
+  fetchMattermostChannel,
   fetchMattermostUser,
   normalizeMattermostBaseUrl,
 } from "./client.js";
+import { mapMattermostChannelTypeToChatType } from "./monitor-gating.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 
+export { isMattermostId };
+
 export type MattermostOpaqueTargetResolution = {
-  kind: "user" | "channel";
+  kind: "user" | "channel" | "group";
   id: string;
   to: string;
 };
 
-const mattermostOpaqueTargetCache = new Map<string, boolean>();
+type MattermostOpaqueTargetKind = MattermostOpaqueTargetResolution["kind"];
+
+const mattermostOpaqueTargetCache = new Map<string, MattermostOpaqueTargetKind>();
 
 function cacheKey(baseUrl: string, token: string, id: string): string {
   return `${baseUrl}::${token}::${id}`;
-}
-
-/** Mattermost IDs are 26-character lowercase alphanumeric strings. */
-export function isMattermostId(value: string): boolean {
-  return /^[a-z0-9]{26}$/.test(value);
 }
 
 export function isExplicitMattermostTarget(raw: string): boolean {
@@ -51,6 +57,44 @@ export function parseMattermostApiStatus(err: unknown): number | undefined {
   return Number.isFinite(code) ? code : undefined;
 }
 
+function parseExplicitMattermostTarget(raw: string):
+  | {
+      kind: MattermostOpaqueTargetKind;
+      id: string;
+    }
+  | undefined {
+  const trimmed = raw.trim();
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith("user:")) {
+    return { kind: "user", id: trimmed.slice("user:".length).trim() };
+  }
+  if (lower.startsWith("mattermost:")) {
+    return { kind: "user", id: trimmed.slice("mattermost:".length).trim() };
+  }
+  if (lower.startsWith("group:")) {
+    return { kind: "group", id: trimmed.slice("group:".length).trim() };
+  }
+  if (lower.startsWith("channel:")) {
+    return { kind: "channel", id: trimmed.slice("channel:".length).trim() };
+  }
+  return undefined;
+}
+
+function buildMattermostOpaqueTarget(
+  kind: MattermostOpaqueTargetKind,
+  id: string,
+): MattermostOpaqueTargetResolution {
+  return {
+    kind,
+    id,
+    to: kind === "user" ? `user:${id}` : `channel:${id}`,
+  };
+}
+
+function mapMattermostChannelTargetKind(channelType?: string | null): "channel" | "group" {
+  return mapMattermostChannelTypeToChatType(channelType) === "group" ? "group" : "channel";
+}
+
 export async function resolveMattermostOpaqueTarget(params: {
   input: string;
   cfg?: OpenClawConfig;
@@ -59,7 +103,12 @@ export async function resolveMattermostOpaqueTarget(params: {
   baseUrl?: string;
 }): Promise<MattermostOpaqueTargetResolution | null> {
   const input = params.input.trim();
-  if (!input || isExplicitMattermostTarget(input) || !isMattermostId(input)) {
+  if (!input) {
+    return null;
+  }
+  const explicit = parseExplicitMattermostTarget(input);
+  const lookupId = explicit?.id ?? input;
+  if (!lookupId || !isMattermostId(lookupId)) {
     return null;
   }
 
@@ -73,13 +122,14 @@ export async function resolveMattermostOpaqueTarget(params: {
     return null;
   }
 
-  const key = cacheKey(baseUrl, token, input);
-  const cached = mattermostOpaqueTargetCache.get(key);
-  if (cached === true) {
-    return { kind: "user", id: input, to: `user:${input}` };
+  if (explicit?.kind === "user" || explicit?.kind === "group") {
+    return buildMattermostOpaqueTarget(explicit.kind, lookupId);
   }
-  if (cached === false) {
-    return { kind: "channel", id: input, to: `channel:${input}` };
+
+  const key = cacheKey(baseUrl, token, lookupId);
+  const cached = mattermostOpaqueTargetCache.get(key);
+  if (cached) {
+    return buildMattermostOpaqueTarget(cached, lookupId);
   }
 
   const client = createMattermostClient({
@@ -87,18 +137,33 @@ export async function resolveMattermostOpaqueTarget(params: {
     botToken: token,
     allowPrivateNetwork: isPrivateNetworkOptInEnabled(account?.config),
   });
+  if (!explicit) {
+    try {
+      await fetchMattermostUser(client, lookupId);
+      mattermostOpaqueTargetCache.set(key, "user");
+      return buildMattermostOpaqueTarget("user", lookupId);
+    } catch (err) {
+      if (parseMattermostApiStatus(err) !== 404) {
+        return buildMattermostOpaqueTarget("channel", lookupId);
+      }
+    }
+  }
+
   try {
-    await fetchMattermostUser(client, input);
-    mattermostOpaqueTargetCache.set(key, true);
-    return { kind: "user", id: input, to: `user:${input}` };
+    const channel = await fetchMattermostChannel(client, lookupId);
+    const kind = mapMattermostChannelTargetKind(channel.type);
+    mattermostOpaqueTargetCache.set(key, kind);
+    recordMattermostChannelChatType(lookupId, channel.type);
+    return buildMattermostOpaqueTarget(kind, lookupId);
   } catch (err) {
     if (parseMattermostApiStatus(err) === 404) {
-      mattermostOpaqueTargetCache.set(key, false);
+      mattermostOpaqueTargetCache.set(key, "channel");
     }
-    return { kind: "channel", id: input, to: `channel:${input}` };
+    return buildMattermostOpaqueTarget("channel", lookupId);
   }
 }
 
 export function resetMattermostOpaqueTargetCacheForTests(): void {
   mattermostOpaqueTargetCache.clear();
+  resetMattermostChatTypeCacheForTests();
 }

--- a/extensions/mattermost/src/session-route.test.ts
+++ b/extensions/mattermost/src/session-route.test.ts
@@ -43,6 +43,29 @@ describe("mattermost session route", () => {
     expect(channelRoute.sessionKey).toContain("thread456");
   });
 
+  it("preserves resolved private-channel routes as group sessions", () => {
+    const route = resolveMattermostOutboundSessionRoute({
+      cfg: {},
+      agentId: "main",
+      accountId: "acct-1",
+      target: "mattermost:channel:private123",
+      resolvedTarget: {
+        kind: "group",
+        to: "channel:private123",
+        source: "directory",
+      },
+      threadId: "thread456",
+    });
+
+    const groupRoute = expectRoute(route);
+    expect(groupRoute.peer.kind).toBe("group");
+    expect(groupRoute.peer.id).toBe("private123");
+    expect(groupRoute.chatType).toBe("group");
+    expect(groupRoute.from).toBe("mattermost:group:private123");
+    expect(groupRoute.to).toBe("channel:private123");
+    expect(groupRoute.sessionKey).toBe("agent:main:mattermost:group:private123:thread:thread456");
+  });
+
   it("recovers channel thread routes from currentSessionKey", () => {
     const route = resolveMattermostOutboundSessionRoute({
       cfg: {},

--- a/extensions/mattermost/src/session-route.ts
+++ b/extensions/mattermost/src/session-route.ts
@@ -27,17 +27,22 @@ export function resolveMattermostOutboundSessionRoute(params: ChannelOutboundSes
   if (!rawId) {
     return null;
   }
+  const chatType = isUser ? "direct" : resolvedKind === "group" ? "group" : "channel";
   const baseRoute = buildChannelOutboundSessionRoute({
     cfg: params.cfg,
     agentId: params.agentId,
     channel: "mattermost",
     accountId: params.accountId,
     peer: {
-      kind: isUser ? "direct" : "channel",
+      kind: chatType,
       id: rawId,
     },
-    chatType: isUser ? "direct" : "channel",
-    from: isUser ? `mattermost:${rawId}` : `mattermost:channel:${rawId}`,
+    chatType,
+    from: isUser
+      ? `mattermost:${rawId}`
+      : chatType === "group"
+        ? `mattermost:group:${rawId}`
+        : `mattermost:channel:${rawId}`,
     to: isUser ? `user:${rawId}` : `channel:${rawId}`,
   });
   return buildThreadAwareOutboundSessionRoute({

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -866,18 +866,22 @@ function inferDeliveryTargetChatType(target: {
   ) {
     return "direct";
   }
-  if (normalizedTo.startsWith("channel:") || normalizedTo.startsWith("thread:")) {
-    return "channel";
-  }
   if (normalizedTo.startsWith("group:")) {
     return "group";
   }
   const channel = normalizeMessageChannel(target.channel);
-  return channel
+  const hookChatType = channel
     ? getLoadedChannelPluginForRead(channel as ChannelId)?.messaging?.inferTargetChatType?.({
         to: target.to ?? "",
       })
     : undefined;
+  // A `channel:<id>` target can be a private channel a plugin classifies as group
+  // (Mattermost private/`P` channels). Consult the plugin hook before the generic
+  // `channel` default so threaded/scheduled deliveries keep the inbound namespace.
+  if (normalizedTo.startsWith("channel:") || normalizedTo.startsWith("thread:")) {
+    return hookChatType ?? "channel";
+  }
+  return hookChatType;
 }
 
 function isDirectMessageDeliveryTarget(

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -1687,3 +1687,42 @@ describe("resolveSessionDeliveryTarget — cross-channel reply guard (#24152)", 
     expect(resolved.to).toBe("room-one");
   });
 });
+
+describe("inferChatTypeFromTarget plugin hook ordering for channel: targets", () => {
+  const PRIVATE = "aaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const registerHookPlugin = (hook?: (to: string) => "group" | "channel" | undefined) => {
+    setActivePluginRegistry(
+      createTargetsTestRegistry([
+        createTestChannelPlugin({
+          id: "mm",
+          messaging: {
+            targetPrefixes: ["mm"],
+            ...(hook ? { inferTargetChatType: ({ to }: { to: string }) => hook(to) } : {}),
+          },
+        }),
+      ]),
+    );
+  };
+
+  it("consults the plugin hook before the generic channel default", () => {
+    // A private channel addressed as channel:<id> must reach the plugin hook (which
+    // classifies it as group) instead of short-circuiting to the channel default.
+    registerHookPlugin((to) => (to === `channel:${PRIVATE}` ? "group" : undefined));
+    const resolved = resolveHeartbeatDeliveryTarget({
+      cfg: {},
+      entry: { sessionId: "s", updatedAt: 1, lastChannel: "mm", lastTo: `channel:${PRIVATE}` },
+      heartbeat: { target: "last" },
+    });
+    expect(resolved.chatType).toBe("group");
+  });
+
+  it("falls back to the channel default when the hook returns undefined", () => {
+    registerHookPlugin(() => undefined);
+    const resolved = resolveHeartbeatDeliveryTarget({
+      cfg: {},
+      entry: { sessionId: "s", updatedAt: 1, lastChannel: "mm", lastTo: `channel:${PRIVATE}` },
+      heartbeat: { target: "last" },
+    });
+    expect(resolved.chatType).toBe("channel");
+  });
+});

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -422,9 +422,6 @@ function inferChatTypeFromTarget(params: {
   if (/^user:/i.test(to)) {
     return "direct";
   }
-  if (/^(channel:|thread:)/i.test(to)) {
-    return "channel";
-  }
   if (/^group:/i.test(to)) {
     return "group";
   }
@@ -433,7 +430,14 @@ function inferChatTypeFromTarget(params: {
     resolveOutboundChannelPlugin({
       channel: params.channel,
     });
-  return plugin?.messaging?.inferTargetChatType?.({ to }) ?? undefined;
+  const hookChatType = plugin?.messaging?.inferTargetChatType?.({ to });
+  // A `channel:<id>` target can be a private channel a plugin classifies as group
+  // (Mattermost private/`P` channels). Consult the plugin hook before the generic
+  // `channel` default so the session namespace matches the inbound classification.
+  if (/^(channel:|thread:)/i.test(to)) {
+    return hookChatType ?? "channel";
+  }
+  return hookChatType ?? undefined;
 }
 
 function resolveHeartbeatDeliveryChatType(params: {


### PR DESCRIPTION
## What Problem This Solves

A Mattermost **private channel** (`P`/`G`) is addressed as `channel:<id>` — the
same target prefix as a public channel — yet its authoritative chat type is
`group`. Inbound classification keys it under `group:<id>`, but every
delivery-side path that derived chat type from the target *string* returned
`channel` at the `channel:` rule **before** consulting the per-plugin
`messaging.inferTargetChatType` hook. Mattermost also never implemented that
hook. So outbound replies, scheduled/threaded subagent announcements, and
heartbeat deliveries to a private channel landed under a phantom
`channel:<id>` session namespace, split from the inbound `group:<id>` one —
fail-closed delivery or a conversation split across two session keys.

Closes #95646

## Why This Change Was Made

The previous revision of this PR only fixed `resolveMattermostOutboundSessionRoute`.
That left the two generic string-inference paths the issue calls out
(`inferChatTypeFromTarget` and announce-delivery `inferDeliveryTargetChatType`)
still collapsing private channels to `channel`. This revision closes the whole
decision surface:

- **Implements `messaging.inferTargetChatType` for Mattermost**, backed by an
  id-keyed chat-type cache warmed both by outbound target resolution
  (`/api/v4/channels/<id>` type lookup) and by inbound monitor channel reads
  (`resolveChannelInfo`). The cache lives in a leaf module (`chat-type-cache.ts`)
  with no client/runtime deps, so the **sync** hook stays off the lazy
  `channel.runtime` chunk (build-verified, no `INEFFECTIVE_DYNAMIC_IMPORT`).
- **Consults the plugin hook before the generic `channel:` default** in both
  `inferChatTypeFromTarget` (`src/infra/outbound/targets.ts`) and
  `inferDeliveryTargetChatType` (`src/agents/subagent-announce-delivery.ts`).
  Plugins that do not classify the target return `undefined` and keep the exact
  existing `channel` default — so this is behavior-preserving for every other
  channel.
- **Keeps the resolved `group` kind in `peer`/`from`** in the outbound session
  route so the derived session key matches the inbound `group:<id>` namespace
  (this addresses the sibling PR #95655's reported gap, where `chatType` changed
  but `peer`/`from` stayed `channel`).

Because the hook is synchronous (`{ to } => ChatType | undefined`), it answers
authoritatively only when the channel type is already known (resolved outbound
or seen inbound). Otherwise it returns `undefined` and core keeps the safe
`channel` default. The cache is refreshed on every `resolveChannelInfo` (5-min
monitor TTL), so a private↔public conversion self-corrects within the TTL.

This stays inside the Mattermost plugin boundary plus the two generic
target→chat-type inference sites; it adds no config, migration, or new
channel-specific policy in core.

## User Impact

Mattermost private-channel replies, scheduled/threaded subagent announcements,
and heartbeat deliveries now stay in the same `group:<id>` session namespace as
the inbound conversation instead of creating a phantom public-channel session.
Public channels still resolve to `channel`; direct messages still resolve to
`direct`. No other channel changes behavior (non-implementing plugins keep the
prior `channel:`/`thread:` default).

## Evidence

Dependency premise — Mattermost upstream channel types (`O` open, `P` private,
`D` direct, `G` group), `server/public/model/channel.go` L25-31:
https://github.com/mattermost/mattermost/blob/master/server/public/model/channel.go#L25-L31

New behavior tests (`group` reached through the hook before the generic
`channel` default):

```text
$ node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/chat-type-cache.test.ts src/infra/outbound/targets.test.ts
extensions/.../chat-type-cache.test.ts > resolves a recorded private channel as group  ✓
extensions/.../chat-type-cache.test.ts > keeps a recorded public channel as channel    ✓
src/infra/outbound/targets.test.ts > consults the plugin hook before the generic channel default  ✓  (chatType === "group")
src/infra/outbound/targets.test.ts > falls back to the channel default when the hook returns undefined  ✓  (chatType === "channel")
```

Affected suites, full pass (no regressions across the two reordered generic
inference sites and the whole Mattermost plugin):

```text
$ node scripts/run-vitest.mjs extensions/mattermost src/infra/outbound/targets.test.ts src/agents/subagent-announce-delivery.test.ts
src/agents/subagent-announce-delivery.test.ts   Tests 101 passed (101)
src/infra/outbound/targets.test.ts              Tests  81 passed (81)
extensions/mattermost (41 files)                Tests 507 passed (507)
[test] passed 3 Vitest shards
```

Type, build, cycles, format:

```text
$ pnpm tsgo:core && pnpm tsgo:extensions
# exit 0

$ pnpm build
# exit 0, no [INEFFECTIVE_DYNAMIC_IMPORT]  (sync hook leaf module stays off the lazy channel.runtime chunk)

$ pnpm check:import-cycles
Import cycle check: 0 runtime value cycle(s).

$ pnpm exec oxfmt --check --threads=1 <changed files>
All matched files use the correct format.
```

What was not tested: no live Mattermost workspace round-trip — this checkout
has no Mattermost credentials. The fix is **network-before** classification
logic (it reads the authoritative channel type and chooses a session namespace;
the Mattermost send target stays `channel:<id>`), which the unit + plugin-level
tests above drive through the real resolver, the real `inferTargetChatType`
hook, and both generic inference sites. Live workspace proof would only re-show
the same deterministic classification.

AI-assisted (Claude). Proof above was run manually in a clean worktree.
