### PR TITLE
Avoid copying process.env in ingress queue state DB opens

### DIFF
--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -9,7 +9,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import { createChannelIngressQueue } from "./ingress-queue.js";
+import { createChannelIngressQueue, createStateDirEnv } from "./ingress-queue.js";
 
 type ChannelIngressTestDatabase = Pick<OpenClawStateKyselyDatabase, "channel_ingress_events">;
 
@@ -26,6 +26,33 @@ async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T
 describe("channel ingress queue", () => {
   afterEach(() => {
     closeOpenClawStateDatabaseForTest();
+  });
+
+  it("opens a custom state database without copying the full process env", async () => {
+    const baseEnv: NodeJS.ProcessEnv = {
+      HOME: "/home/openclaw",
+      PATH: "/usr/local/bin:/usr/bin",
+    };
+    for (let index = 0; index < 10_000; index += 1) {
+      baseEnv[`KUBERNETES_SERVICE_${index}`] = "tcp://10.0.0.1:443";
+    }
+    const inheritedEnv = new Proxy(baseEnv, {
+      ownKeys() {
+        throw new Error("inherited env should not be enumerated");
+      },
+    });
+
+    await withTempState(async (stateDir) => {
+      const env = createStateDirEnv(stateDir, inheritedEnv);
+
+      expect(env.OPENCLAW_STATE_DIR).toBe(stateDir);
+      expect(env.HOME).toBe("/home/openclaw");
+      expect(Object.getPrototypeOf(env)).toBe(inheritedEnv);
+      expect(Object.keys(env)).toEqual(["OPENCLAW_STATE_DIR"]);
+
+      const database = openOpenClawStateDatabase({ env });
+      expect(database.path).toBe(path.join(stateDir, "state", "openclaw.sqlite"));
+    });
   });
 
   it("deduplicates pending and completed ingress events", async () => {
@@ -284,7 +311,7 @@ describe("channel ingress queue", () => {
       await queue.complete("retry", { completedAt: 27 });
 
       const database = openOpenClawStateDatabase({
-        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+        env: createStateDirEnv(stateDir),
       });
       const kysely = getNodeSqliteKysely<ChannelIngressTestDatabase>(database.db);
       const rows = executeSqliteQuerySync(

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -186,9 +186,19 @@ function normalizePart(value: string | undefined, fallback: string): string {
   return normalized ? normalized : fallback;
 }
 
+// Keep inherited lookups for HOME/etc. without enumerating large Kubernetes service envs.
+export function createStateDirEnv(
+  stateDir: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env = Object.create(baseEnv) as NodeJS.ProcessEnv;
+  env.OPENCLAW_STATE_DIR = stateDir;
+  return env;
+}
+
 function openStateDatabase(stateDir?: string) {
   return openOpenClawStateDatabase({
-    env: stateDir ? { ...process.env, OPENCLAW_STATE_DIR: stateDir } : process.env,
+    env: stateDir ? createStateDirEnv(stateDir) : process.env,
   });
 }
 


### PR DESCRIPTION
## Summary
- Reopens the focused env-overlay fix from #94573 on a fresh contributor-owned branch based on current `main`.
- Replaces the hot-path `{ ...process.env, OPENCLAW_STATE_DIR }` copy in channel ingress queue DB opens with a prototype-backed env overlay.
- Adds regression coverage proving a custom state DB can open without enumerating a large inherited environment.

## What Problem This Solves
Telegram isolated polling ingress drains its durable local spool every ~500ms. Each drain calls channel ingress queue operations such as `recoverStaleClaims`, `listClaims`, and `listPending`. Those operations open the OpenClaw state DB through `src/channels/message/ingress-queue.ts`.

In Kubernetes pods with service links enabled, `process.env` can contain thousands of service variables. The old custom-state DB opener copied the full environment on every queue operation:

```ts
{ ...process.env, OPENCLAW_STATE_DIR: stateDir }
```

That repeated env enumeration can dominate the Telegram ingress drain loop and saturate CPU/event-loop responsiveness. This PR changes the opener to create a one-key prototype overlay, preserving inherited lookups such as `HOME` while making only `OPENCLAW_STATE_DIR` an own enumerable key.

## Evidence
Observed on a real Kubernetes OpenClaw runtime pod running OpenClaw 2026.6.6 with Telegram isolated ingress enabled and Kubernetes service env links present:

```text
before fix: env keys = 9274
before fix: { ...process.env } once = 917ms to 1192ms
before fix: ingress queue listPending() once = ~982ms
before fix: ingress queue listClaims() once = ~816ms
before fix: ingress queue recoverStaleClaims() once = ~869ms
control: direct sqlite SELECT count(*) x10000 = ~118ms
control: direct OpenClaw state DB + Kysely query = ~0-2ms
after fix: prototype env overlay own keys = 1 (OPENCLAW_STATE_DIR)
after fix: inherited HOME lookup preserved through the overlay
after fix: queue wrapper calls returned to normal SQLite-level timings after warmup instead of spending ~0.8-1.2s copying env per queue operation
local exact-helper check: {"spreadOwnKeys":10002,"overlayOwnKeys":1,"overlayHome":"/home/openclaw","spreadMs":3,"overlayMs":0}
```

The focused regression test in this PR constructs a 10k-key inherited env proxy whose `ownKeys()` throws, opens a custom state database with the overlay, and asserts the database path resolves correctly. That proves the queue state DB path no longer needs to enumerate the inherited environment.

## Context
The original contributor PR #94573 was closed after ClawSweeper could not push/rebase the fork branch and opened replacement PR #95278. The replacement PR kept the fix, but it is currently blocked by unrelated CI failures and ClawSweeper repair-lane failures, not by this patch.

This PR restores a clean contributor-owned path from the latest `main`, with maintainer edits enabled, so maintainers can either merge this PR or continue with #95278 if that lane recovers first.

Fixes #94571.
Supersedes #94573 if maintainers prefer this clean contributor-owned lane.
Alternative to #95278 while that replacement lane is blocked.

## Validation
- Compared against current `openclaw/main`: ahead by 1, behind by 0.
- Diff is limited to:
  - `src/channels/message/ingress-queue.ts`
  - `src/channels/message/ingress-queue.test.ts`
