### PR TITLE
fix(discord): reserve closing-fence space on fence-closing lines

### DIFF
--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -78,6 +78,17 @@ describe("chunkDiscordText", () => {
     }
   });
 
+  it("keeps chunks within maxChars when a closing fence line carries trailing text", () => {
+    // A line that both closes the fence and carries a long tail must still reserve closing-fence
+    // space; otherwise a mid-line flush appended "```" and overflowed maxChars (e.g. 2004 > 2000).
+    for (let pad = 1990; pad <= 2000; pad++) {
+      const text = "hi\n```lang\n```" + "z".repeat(pad);
+      for (const chunk of chunkDiscordText(text, { maxChars: 2000, maxLines: 100 })) {
+        expect(chunk.length).toBeLessThanOrEqual(2000);
+      }
+    }
+  });
+
   it("preserves whitespace when splitting long lines", () => {
     const text = Array.from({ length: 40 }, () => "word").join(" ");
     const chunks = chunkDiscordText(text, { maxChars: 20, maxLines: 50 });

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -207,8 +207,12 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
       }
     }
 
-    const reserveChars = nextOpenFence ? closeFenceLine(nextOpenFence).length + 1 : 0;
-    const reserveLines = nextOpenFence ? 1 : 0;
+    // A flush can fire mid-line, before `openFence` advances to `nextOpenFence` below, so it closes
+    // against the still-open `openFence`. A fence-closing line that also carries trailing text would
+    // otherwise reserve 0 yet still get a closing fence appended on flush, overflowing maxChars.
+    const fenceToReserve = nextOpenFence ?? openFence;
+    const reserveChars = fenceToReserve ? closeFenceLine(fenceToReserve).length + 1 : 0;
+    const reserveLines = fenceToReserve ? 1 : 0;
     const effectiveMaxChars = maxChars - reserveChars;
     const effectiveMaxLines = maxLines - reserveLines;
     const charLimit = effectiveMaxChars > 0 ? effectiveMaxChars : maxChars;


### PR DESCRIPTION
## Summary

`chunkDiscordText` (`extensions/discord/src/chunk.ts`) could emit a chunk **longer than `maxChars`**, which Discord hard-rejects (HTTP 400) — so the whole message fails to send. The chunker keeps fenced code blocks balanced by reserving room for a closing fence, but it reserved using the **post-line** fence state:

```ts
const reserveChars = nextOpenFence ? closeFenceLine(nextOpenFence).length + 1 : 0;
```

The loop's `flush()` appends the closing fence based on the loop variable `openFence`, which is advanced to `nextOpenFence` only **after** the line's segment loop. So on a line that **closes** a fence but also carries trailing text (e.g. `` ``` `` followed by a long tail, which `parseFenceLine` treats as a closing fence with an info string), `reserveChars` was `0`, yet a mid-line `flush()` still appended `` \n``` `` because `openFence` was still open — producing a chunk of `maxChars + 4` (e.g. **2004 > 2000**).

### Changes
- `chunk.ts` — reserve against `nextOpenFence ?? openFence` (whichever fence a flush can actually close: the still-open `openFence` for a mid-line flush, `nextOpenFence` once the line settles), with an inline comment.
- `chunk.test.ts` — regression test sweeping the boundary (tail lengths 1990–2000) and asserting every chunk stays `<= maxChars`.

`openFence` is null exactly when not inside a fence, so `nextOpenFence ?? openFence` is `nextOpenFence` when still/newly inside, the just-closed fence on a closing line, else null.

## Real behavior proof

Behavior addressed: a Discord reply whose text contained a fence-closing line with a long trailing tail produced an over-2000-char chunk that Discord rejects (HTTP 400), dropping the message. After the fix every chunk stays within `maxChars`.

Real environment tested: Node 22.22.1, macOS, no model / network / Discord. A `./node_modules/.bin/tsx` harness imports the real `chunkDiscordText` and (a) chunks the repro and (b) sweeps tail lengths around the boundary, checking the max chunk length. BEFORE is `origin/main`'s `chunk.ts` (swapped in via `git show`, no other change).

Exact steps or command run after this patch:
```bash
./node_modules/.bin/tsx _discord-proof.mts
```

Evidence after fix:
```
input: "hi\n```lang\n``` + z*1995"  at maxChars 2000

BEFORE (origin/main):
  repro: 2 chunks, lengths=[2004,16], over2000=1
  sweep pad 1980..2010: 24 inputs produced an over-2000 chunk
AFTER (this branch):
  repro: 2 chunks, lengths=[2000,20], over2000=0
  sweep pad 1980..2010: 0 inputs produced an over-2000 chunk
```

Observed result after fix: no chunk exceeds `maxChars` for the repro or anywhere across the boundary sweep; the 16 existing chunk tests are unchanged.

What was not tested: a live send to Discord (the harness drives the real `chunkDiscordText`, which is exactly what the Discord sender calls to split a reply before posting). The new regression test fails on `origin/main` and passes after this change.

## Additional checks
- `node scripts/run-vitest.mjs extensions/discord/src/chunk.test.ts` — all pass with the fix; verified fail-before by swapping in `origin/main`'s `chunk.ts` → the new boundary-sweep test fails (over-limit chunk), the 16 existing tests still pass.
- `oxlint --tsconfig config/tsconfig/oxlint.extensions.json` and `tsgo:extensions` pass. Diff: +6/−2 prod, +11 test.
- Note: unrelated CI lanes that run the full suite (e.g. `build-artifacts`) currently fail on `src/channels/progress-draft-compositor.test.ts`, a pre-existing failure on `main` (commit `8a75c4dd5f`) untouched by this Discord-only change; I'll rebase once `main` is green.

### Scope / out of scope

This fixes the **closing-fence-tail** overflow specifically. The `reserveChars` math is unique to the Discord chunker (the qqbot and embedded-agent chunkers use different structures), so no sibling is left half-fixed. Two *other*, **pre-existing** ways a chunk can exceed `maxChars` are present on `main` already and are out of scope here (separate mechanisms, not the reserve logic):
- an **opening fence line longer than `maxChars`** (a very long info-string/language tag): `openFence.openLine` stores the whole oversized line and `flush()` re-prepends it on each reopen.
- `rebalanceReasoningItalics` appends `_` markers to already-emitted chunks with no `maxChars` accounting, so a chunk landing exactly at the limit can be pushed 1–2 over.

Both are worth separate follow-ups; this PR neither introduces nor worsens them on realistic input (verified: realistic code blocks stay within limit and balanced before and after).
