### PR TITLE
feat(mattermost): auto-engage on replies to the bot's own thread

### DIFF
--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -311,11 +311,11 @@ Group messages require a mention unless overridden per group. Defaults live per 
 
 Supported implicit mention facts are channel-specific:
 
-| Fact                  | Current built-in producers                       |
-| --------------------- | ------------------------------------------------ |
-| Reply to the bot      | Discord, Microsoft Teams, QQBot, Slack, Telegram |
-| Quote of the bot      | WhatsApp, Zalo personal                          |
-| Bot joined the thread | Mattermost, Slack, Tlon                          |
+| Fact                  | Current built-in producers                                   |
+| --------------------- | ------------------------------------------------------------ |
+| Reply to the bot      | Discord, Mattermost, Microsoft Teams, QQBot, Slack, Telegram |
+| Quote of the bot      | WhatsApp, Zalo personal                                      |
+| Bot joined the thread | Mattermost, Slack, Tlon                                      |
 
 Each fact defaults to enabled when the channel produces it. Set the corresponding `implicitMentions` flag to `false` to stop that fact from bypassing mention gating; native explicit mentions remain unaffected. A flag has no effect on channels that do not produce that fact.
 

--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -169,6 +169,7 @@ Notes:
 - `onchar` still responds to explicit @mentions.
 - `channels.mattermost.requireMention` is still honored, but `chatmode` is preferred. Per-channel `groups.<channelId>.requireMention` settings win over both.
 - After the bot sends a visible reply in a channel thread, later messages in that same thread are answered without a new @mention or `onchar` prefix, so multi-turn thread conversations keep flowing. Participation is remembered for 7 days after the bot last replied in that thread and persists across gateway restarts. Threads the bot has only observed are unaffected; start a new top-level message to require an explicit mention again.
+- Replies in a thread whose **root post the bot authored** also auto-engage, even before the bot's first reply in that thread — for example replying to a bot announcement or to a non-threaded bot answer. Unlike remembered participation this needs no prior reply, so it works for old threads and across restarts (parity with Slack and Telegram reply-to-bot handling). On by default; set `channels.mattermost.implicitMentions.replyToBot` to `false` to disable.
 - Set `channels.mattermost.implicitMentions.threadParticipation: false` to stop participated-thread follow-ups from bypassing mention gating. Account overrides use `channels.mattermost.accounts.<id>.implicitMentions`. Mattermost does not currently produce `replyToBot` or `quotedBot` facts, so those flags have no effect here.
 
 ## Threading and sessions

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -313,6 +313,13 @@ export async function fetchMattermostChannel(
   return await client.request<MattermostChannel>(`/channels/${channelId}`);
 }
 
+export async function fetchMattermostPost(
+  client: MattermostClient,
+  postId: string,
+): Promise<MattermostPost> {
+  return await client.request<MattermostPost>(`/posts/${postId}`);
+}
+
 export async function fetchMattermostChannelByName(
   client: MattermostClient,
   teamId: string,

--- a/extensions/mattermost/src/mattermost/interactions.ts
+++ b/extensions/mattermost/src/mattermost/interactions.ts
@@ -7,7 +7,12 @@ import {
   normalizeStringifiedOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getMattermostRuntime } from "../runtime.js";
-import { updateMattermostPost, type MattermostClient, type MattermostPost } from "./client.js";
+import {
+  fetchMattermostPost,
+  updateMattermostPost,
+  type MattermostClient,
+  type MattermostPost,
+} from "./client.js";
 import {
   isTrustedProxyAddress,
   readRequestBodyWithLimit,
@@ -501,7 +506,7 @@ export function createMattermostInteractionHandler(params: {
     let originalPost: MattermostPost | null;
     let clickedButtonName: string | null = null;
     try {
-      originalPost = await client.request<MattermostPost>(`/posts/${payload.post_id}`);
+      originalPost = await fetchMattermostPost(client, payload.post_id);
       const postChannelId = originalPost.channel_id?.trim();
       if (!postChannelId || postChannelId !== payload.channel_id) {
         log?.(

--- a/extensions/mattermost/src/mattermost/monitor-activation.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-activation.test.ts
@@ -1,12 +1,17 @@
 // Mattermost tests cover shared mention activation wiring.
-import { describe, expect, it } from "vitest";
-import { resolveMattermostInboundMentionDecision } from "./monitor-activation.js";
+import { describe, expect, it, vi } from "vitest";
+import type { MattermostPost } from "./client.js";
+import {
+  resolveMattermostInboundMentionDecision,
+  resolveMattermostReplyToBot,
+} from "./monitor-activation.js";
 
 function resolveThreadDecision(params?: {
   accountId?: string;
   cfg?: Record<string, unknown>;
   wasMentioned?: boolean;
   commandAuthorized?: boolean;
+  implicitMentionKinds?: readonly ("bot_thread_participant" | "reply_to_bot")[];
 }) {
   return resolveMattermostInboundMentionDecision({
     cfg: (params?.cfg ?? {}) as never,
@@ -15,7 +20,7 @@ function resolveThreadDecision(params?: {
     requireMention: true,
     canDetectMention: true,
     wasMentioned: params?.wasMentioned ?? false,
-    implicitMentionKinds: ["bot_thread_participant"],
+    implicitMentionKinds: params?.implicitMentionKinds ?? ["bot_thread_participant"],
     allowTextCommands: true,
     hasControlCommand: params?.commandAuthorized ?? false,
     commandAuthorized: params?.commandAuthorized ?? false,
@@ -64,5 +69,68 @@ describe("mattermost monitor activation", () => {
       shouldSkip: false,
       shouldBypassMention: true,
     });
+  });
+
+  it("engages a reply to a bot-authored thread root by default and honors replyToBot=false", () => {
+    expect(resolveThreadDecision({ implicitMentionKinds: ["reply_to_bot"] })).toMatchObject({
+      shouldSkip: false,
+      effectiveWasMentioned: true,
+      matchedImplicitMentionKinds: ["reply_to_bot"],
+    });
+
+    const cfg = { channels: { mattermost: { implicitMentions: { replyToBot: false } } } };
+    expect(resolveThreadDecision({ cfg, implicitMentionKinds: ["reply_to_bot"] })).toMatchObject({
+      shouldSkip: true,
+      effectiveWasMentioned: false,
+      matchedImplicitMentionKinds: [],
+    });
+  });
+});
+
+describe("resolveMattermostReplyToBot", () => {
+  const rootPost = (userId: string): MattermostPost => ({ id: "root-1", user_id: userId }) as never;
+
+  it("returns false without a thread root and never fetches", async () => {
+    const fetchRootPost = vi.fn();
+    expect(
+      await resolveMattermostReplyToBot({
+        threadRootId: undefined,
+        botUserId: "bot-1",
+        fetchRootPost,
+      }),
+    ).toBe(false);
+    expect(
+      await resolveMattermostReplyToBot({ threadRootId: "  ", botUserId: "bot-1", fetchRootPost }),
+    ).toBe(false);
+    expect(fetchRootPost).not.toHaveBeenCalled();
+  });
+
+  it("detects a thread root authored by the bot", async () => {
+    const fetchRootPost = vi.fn(async () => rootPost("bot-1"));
+    expect(
+      await resolveMattermostReplyToBot({
+        threadRootId: "root-1",
+        botUserId: "bot-1",
+        fetchRootPost,
+      }),
+    ).toBe(true);
+    expect(fetchRootPost).toHaveBeenCalledWith("root-1");
+  });
+
+  it("returns false for a root authored by someone else or one that cannot be fetched", async () => {
+    expect(
+      await resolveMattermostReplyToBot({
+        threadRootId: "root-1",
+        botUserId: "bot-1",
+        fetchRootPost: async () => rootPost("user-9"),
+      }),
+    ).toBe(false);
+    expect(
+      await resolveMattermostReplyToBot({
+        threadRootId: "root-1",
+        botUserId: "bot-1",
+        fetchRootPost: async () => null,
+      }),
+    ).toBe(false);
   });
 });

--- a/extensions/mattermost/src/mattermost/monitor-activation.ts
+++ b/extensions/mattermost/src/mattermost/monitor-activation.ts
@@ -4,6 +4,8 @@ import {
   type InboundImplicitMentionKind,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveChannelImplicitMentions } from "openclaw/plugin-sdk/channel-ingress-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { MattermostPost } from "./client.js";
 import type { ChatType, OpenClawConfig } from "./runtime-api.js";
 
 export function resolveMattermostInboundMentionDecision(params: {
@@ -38,4 +40,24 @@ export function resolveMattermostInboundMentionDecision(params: {
       commandAuthorized: params.commandAuthorized,
     },
   });
+}
+
+/**
+ * Produces the `reply_to_bot` implicit-mention fact for Mattermost. Threads are flat: a reply
+ * carries only `root_id` (the thread root), so "replying to the bot" means the bot authored that
+ * root. The `posted` websocket payload omits the root author, so the caller injects a (cached)
+ * fetcher; no thread root means no reply-to-bot. Policy (`implicitMentions.replyToBot`) stays with
+ * the shared evaluator — this only reports the fact.
+ */
+export async function resolveMattermostReplyToBot(params: {
+  threadRootId?: string;
+  botUserId: string;
+  fetchRootPost: (postId: string) => Promise<MattermostPost | null>;
+}): Promise<boolean> {
+  const rootPostId = normalizeOptionalString(params.threadRootId);
+  if (!rootPostId) {
+    return false;
+  }
+  const rootPost = await params.fetchRootPost(rootPostId);
+  return normalizeOptionalString(rootPost?.user_id) === params.botUserId;
 }

--- a/extensions/mattermost/src/mattermost/monitor-resources.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchMattermostChannel = vi.hoisted(() => vi.fn());
+const fetchMattermostPost = vi.hoisted(() => vi.fn());
 const fetchMattermostUser = vi.hoisted(() => vi.fn());
 const sendMattermostTyping = vi.hoisted(() => vi.fn());
 const updateMattermostPost = vi.hoisted(() => vi.fn());
@@ -12,6 +13,7 @@ vi.mock("./client.js", async (importOriginal) => {
   return {
     ...actual,
     fetchMattermostChannel,
+    fetchMattermostPost,
     fetchMattermostUser,
     sendMattermostTyping,
     updateMattermostPost,
@@ -79,6 +81,7 @@ describe("mattermost monitor resources", () => {
 
   beforeEach(() => {
     fetchMattermostChannel.mockReset();
+    fetchMattermostPost.mockReset();
     fetchMattermostUser.mockReset();
     sendMattermostTyping.mockReset();
     updateMattermostPost.mockReset();
@@ -315,9 +318,10 @@ describe("mattermost monitor resources", () => {
     }
   });
 
-  it("caches channel and user lookups and falls back to empty picker props", async () => {
+  it("caches channel, user, and post lookups and falls back to empty picker props", async () => {
     fetchMattermostChannel.mockResolvedValue({ id: "chan-1", name: "town-square" });
     fetchMattermostUser.mockResolvedValue({ id: "user-1", username: "alice" });
+    fetchMattermostPost.mockResolvedValue({ id: "post-1", user_id: "bot-1" });
     buildButtonProps.mockReturnValue(undefined);
 
     const resources = createMattermostMonitorResources({
@@ -346,9 +350,18 @@ describe("mattermost monitor resources", () => {
       id: "user-1",
       username: "alice",
     });
+    await expect(resources.resolvePostInfo("post-1")).resolves.toEqual({
+      id: "post-1",
+      user_id: "bot-1",
+    });
+    await expect(resources.resolvePostInfo("post-1")).resolves.toEqual({
+      id: "post-1",
+      user_id: "bot-1",
+    });
 
     expect(fetchMattermostChannel).toHaveBeenCalledTimes(1);
     expect(fetchMattermostUser).toHaveBeenCalledTimes(1);
+    expect(fetchMattermostPost).toHaveBeenCalledTimes(1);
 
     await resources.updateModelPickerPost({
       channelId: "chan-1",

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -16,11 +16,13 @@ import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtim
 import {
   buildMattermostApiUrl,
   fetchMattermostChannel,
+  fetchMattermostPost,
   fetchMattermostUser,
   sendMattermostTyping,
   updateMattermostPost,
   type MattermostChannel,
   type MattermostClient,
+  type MattermostPost,
   type MattermostUser,
 } from "./client.js";
 import { buildButtonProps, type MattermostInteractionResponse } from "./interactions.js";
@@ -66,6 +68,7 @@ export function formatMattermostInboundMediaText(params: {
 
 const CHANNEL_CACHE_TTL_MS = 5 * 60_000;
 const USER_CACHE_TTL_MS = 10 * 60_000;
+const POST_CACHE_TTL_MS = 5 * 60_000;
 const MONITOR_RESOURCE_CACHE_MAX_ENTRIES = 1000;
 // Match Telegram/Tlon inbound media: header wait is independent of body idle.
 const MATTERMOST_MEDIA_RESPONSE_HEADER_TIMEOUT_MS = 120_000;
@@ -101,6 +104,7 @@ export function createMattermostMonitorResources(params: {
   } = params;
   const channelCache = new Map<string, { value: MattermostChannel | null; expiresAt: number }>();
   const userCache = new Map<string, { value: MattermostUser | null; expiresAt: number }>();
+  const postCache = new Map<string, { value: MattermostPost | null; expiresAt: number }>();
 
   const getCachedValue = <T>(
     cache: Map<string, { value: T | null; expiresAt: number }>,
@@ -234,6 +238,25 @@ export function createMattermostMonitorResources(params: {
     }
   };
 
+  // Caches the thread-root post so repeated reply-to-bot checks in the same thread reuse the
+  // author instead of re-fetching; the root author is stable for the cache lifetime.
+  const resolvePostInfo = async (postId: string): Promise<MattermostPost | null> => {
+    const rawNow = Date.now();
+    const cached = getCachedValue(postCache, postId, asDateTimestampMs(rawNow));
+    if (cached !== undefined) {
+      return cached;
+    }
+    try {
+      const info = await fetchMattermostPost(client, postId);
+      setCachedValue(postCache, postId, info, POST_CACHE_TTL_MS, rawNow);
+      return info;
+    } catch (err) {
+      logger.debug?.(`mattermost: post lookup failed: ${String(err)}`);
+      setCachedValue(postCache, postId, null, POST_CACHE_TTL_MS, rawNow);
+      return null;
+    }
+  };
+
   const buildModelPickerProps = (
     channelId: string,
     buttons: Array<unknown>,
@@ -266,6 +289,7 @@ export function createMattermostMonitorResources(params: {
     sendTypingIndicator,
     resolveChannelInfo,
     resolveUserInfo,
+    resolvePostInfo,
     updateModelPickerPost,
   };
 }

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -4,7 +4,9 @@ import {
   formatInboundEnvelope,
   implicitMentionKindWhen,
   type ChannelInboundTurnPlan,
+  type InboundImplicitMentionKind,
 } from "openclaw/plugin-sdk/channel-inbound";
+import { resolveChannelImplicitMentions } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import {
   bindIngressLifecycleToReplyOptions,
   buildChannelProgressDraftLineForEntry,
@@ -50,7 +52,10 @@ import {
   renderMattermostProviderPickerView,
   resolveMattermostModelPickerCurrentModel,
 } from "./model-picker.js";
-import { resolveMattermostInboundMentionDecision } from "./monitor-activation.js";
+import {
+  resolveMattermostInboundMentionDecision,
+  resolveMattermostReplyToBot,
+} from "./monitor-activation.js";
 import {
   authorizeMattermostCommandInvocation,
   formatMattermostDirectMessageDropLog,
@@ -576,6 +581,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     sendTypingIndicator,
     resolveChannelInfo,
     resolveUserInfo,
+    resolvePostInfo,
     updateModelPickerPost,
   } = createMattermostMonitorResources({
     accountId: account.accountId,
@@ -1185,22 +1191,46 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         groupId: channelId,
         requireMentionOverride: account.requireMention,
       });
-    const implicitMentionKinds = implicitMentionKindWhen(
+    const buildMentionDecision = (implicitMentionKinds: readonly InboundImplicitMentionKind[]) =>
+      resolveMattermostInboundMentionDecision({
+        cfg,
+        accountId: account.accountId,
+        kind,
+        requireMention: shouldRequireMention || oncharEnabled,
+        canDetectMention: canDetectMention || oncharEnabled,
+        wasMentioned: wasMentioned || oncharTriggered,
+        implicitMentionKinds,
+        allowTextCommands,
+        hasControlCommand: isControlCommand,
+        commandAuthorized,
+      });
+    const participantKinds = implicitMentionKindWhen(
       "bot_thread_participant",
       threadAlreadyEngaged,
     );
-    const mentionDecision = resolveMattermostInboundMentionDecision({
-      cfg,
-      accountId: account.accountId,
-      kind,
-      requireMention: shouldRequireMention || oncharEnabled,
-      canDetectMention: canDetectMention || oncharEnabled,
-      wasMentioned: wasMentioned || oncharTriggered,
-      implicitMentionKinds,
-      allowTextCommands,
-      hasControlCommand: isControlCommand,
-      commandAuthorized,
-    });
+    let mentionDecision = buildMentionDecision(participantKinds);
+    // Reply-to-bot parity (Slack/Telegram): a reply whose thread root the bot authored counts as
+    // addressing it. The root author is absent from the `posted` payload, so resolve it only when
+    // the cheap decision would otherwise drop this reply and the operator left reply-to-bot enabled,
+    // then re-evaluate so the shared resolver still owns policy.
+    if (
+      mentionDecision.shouldSkip &&
+      threadRootId &&
+      resolveChannelImplicitMentions({
+        cfg,
+        channel: "mattermost",
+        accountId: account.accountId,
+      }).replyToBot
+    ) {
+      const replyToBot = await resolveMattermostReplyToBot({
+        threadRootId,
+        botUserId,
+        fetchRootPost: resolvePostInfo,
+      });
+      if (replyToBot) {
+        mentionDecision = buildMentionDecision([...participantKinds, "reply_to_bot"]);
+      }
+    }
     const { shouldBypassMention } = mentionDecision;
 
     if (


### PR DESCRIPTION
Related: #43456

## What Problem This Solves

In Mattermost channels and private/group threads, OpenClaw requires an explicit `@`-mention before it will respond (`requireMention` defaults to on). So when the bot posts a message and a user replies to it in the thread, the bot stays silent unless the user remembers to `@`-mention it again — an awkward, un-chatlike experience. Slack and Telegram users don't hit this, because those plugins already treat "replying to the bot" as addressing it.

## Why This Change Was Made

This adds reply-to-bot auto-engage to the Mattermost plugin: a thread reply now bypasses the mention requirement when the **thread-root post was authored by the bot**. Mattermost threads are flat — the current post model has no `parent_id` (only `root_id`), so unlike Slack (which uses the immediate parent) the only meaningful "who am I replying to" signal is the thread root's author. The websocket `posted` event omits that author, so it's fetched once via the Mattermost API — but only when a non-mentioned thread reply would otherwise be dropped, and the result is cached (reusing the plugin's existing channel/user lookup cache) so an active thread never re-fetches the same root.

The signal is folded into the plugin's existing bespoke mention gate. Non-goal: replying inside a human-rooted thread the bot merely participated in — that is intentionally left to the separate in-flight participated-thread change (#95552), which this composes with. Ships on by default; no new config or env.

## User Impact

In a Mattermost channel or group thread, users can now reply to one of the bot's own messages and get a response **without** re-`@`-mentioning it — matching how the Slack and Telegram plugins already behave. DMs, channels that don't require a mention, and explicit mentions are unaffected.

## Evidence

Local verification (run against the branch base; CI validates against current `main`):

- `node scripts/run-vitest.mjs run extensions/mattermost/src/mattermost` → **29 files, 385 tests pass**. New coverage: the `replyToBot` gate input (engages over `requireMention`, and over the `onchar` trigger gate), the root-author detection helper (root authored by bot / by someone else / unfetchable / no thread root), and the new cached post lookup.
- `pnpm build` → clean (no type errors, no `[INEFFECTIVE_DYNAMIC_IMPORT]`).
- `oxlint` and `oxfmt --check` on all changed files → clean.
- Docs updated (`docs/channels/mattermost.md`, `docs/channels/groups.md`) to document the new implicit reply-to-bot behavior; `format-docs --check` clean.

Not yet run at PR-open time: a real-Mattermost roundtrip (post as the bot in a thread, reply from another user without a mention, confirm the bot engages). See PR comments for roundtrip status.

The branch is based on an older `main` but touches no files changed upstream since, so it rebases cleanly.
