### PR TITLE
fix(memory-wiki): filter self-referential artifacts from bridge import to prevent recursive loop (fixes #95657) (AI-assisted)

### DIFF
--- a/extensions/memory-wiki/src/bridge.test.ts
+++ b/extensions/memory-wiki/src/bridge.test.ts
@@ -551,4 +551,66 @@ describe("syncMemoryWikiBridgeSources", () => {
       "# Deep Unicode Note",
     );
   });
+
+  it("filters out artifacts from the wiki vault sources directory to prevent self-import loops", async () => {
+    const workspaceDir = await createBridgeWorkspace("self-import-workspace");
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("self-import-vault"),
+      config: {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+          indexMemoryRoot: true,
+          indexDailyNotes: true,
+        },
+      },
+    });
+
+    // Simulate: the vault lives inside the workspace memory directory
+    // and the memory indexer has picked up a bridge-generated source file
+    const externalMemoryPath = path.join(workspaceDir, "memory", "2026-04-05.md");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(externalMemoryPath, "# Daily Note\n", "utf8");
+
+    // This artifact simulates a bridge-generated file that the memory indexer
+    // found inside the wiki vault's own sources directory — it should be filtered
+    const selfReferentialPath = path.join(vaultDir, "sources", "bridge-workspace-abc123.md");
+    await fs.mkdir(path.join(vaultDir, "sources"), { recursive: true });
+    await fs.writeFile(selfReferentialPath, "# Bridge Import\n", "utf8");
+
+    registerBridgeArtifacts([
+      {
+        kind: "daily-note",
+        workspaceDir,
+        relativePath: "memory/2026-04-05.md",
+        absolutePath: externalMemoryPath,
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+      {
+        kind: "daily-note",
+        workspaceDir,
+        relativePath: "sources/bridge-workspace-abc123.md",
+        absolutePath: selfReferentialPath,
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+
+    const appConfig: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", default: true, workspace: workspaceDir }],
+      },
+    };
+
+    const result = await syncMemoryWikiBridgeSources({ config, appConfig });
+
+    // Only the external artifact should be imported; the self-referential one
+    // from the vault's own sources/ directory must be filtered out.
+    expect(result.artifactCount).toBe(1);
+    expect(result.importedCount).toBe(1);
+    expect(result.pagePaths).toHaveLength(1);
+    expect(result.pagePaths[0]).not.toContain("bridge-workspace-abc123");
+  });
 });

--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -225,9 +225,15 @@ export async function syncMemoryWikiBridgeSources(params: {
   }
 
   const publicArtifacts = await listActiveMemoryPublicArtifacts({ cfg: params.appConfig });
+  // Filter out artifacts from the wiki vault's own sources directory to prevent
+  // recursive self-import loops when the vault lives inside memory/. See #95657.
+  const wikiSourcesDir = path.resolve(params.config.vault.path, "sources") + path.sep;
+  const filteredArtifacts = publicArtifacts.filter(
+    (a) => !path.resolve(a.absolutePath).startsWith(wikiSourcesDir),
+  );
   const results: Array<{ pagePath: string; changed: boolean; created: boolean }> = [];
   const activeKeys = new Set<string>();
-  const artifacts = await collectBridgeArtifacts(params.config.bridge, publicArtifacts);
+  const artifacts = await collectBridgeArtifacts(params.config.bridge, filteredArtifacts);
   const state = await readMemoryWikiSourceSyncState(params.config.vault.path);
   assertMemoryWikiSourceSyncStateCapacity({
     state,
@@ -235,7 +241,7 @@ export async function syncMemoryWikiBridgeSources(params: {
     incomingCount: artifacts.length,
   });
   const agentIdsByWorkspace = new Map<string, string[]>();
-  for (const artifact of publicArtifacts) {
+  for (const artifact of filteredArtifacts) {
     agentIdsByWorkspace.set(artifact.workspaceDir, artifact.agentIds);
   }
   const artifactCount = artifacts.length;


### PR DESCRIPTION
## What Problem This Solves

When `memory-wiki` is configured in `bridge` mode with the vault inside the workspace `memory/` directory (the default location), the memory indexer recursively scans `memory/wiki/sources/` as regular memory files. The bridge import then re-imports those same files as wiki source artifacts, creating a recursive self-referential loop that causes unbounded growth of `memory/wiki/sources/` and the SQLite memory index database.

Reported impact: DB grew to 1.5 GB in ~2 months (82% duplicates), 44K chunks vs 13K needed (3.3x overhead), 45 MB duplicate files on disk.

## Why This Change Was Made

The bridge import in `syncMemoryWikiBridgeSources` passes all public memory artifacts to `collectBridgeArtifacts` without checking whether an artifact originates from the wiki vault's own `sources/` directory. When the vault path is inside `memory/`, bridge-generated source pages get indexed as memory artifacts on the next scan, then re-imported as new bridge pages — a classic recursive loop.

The fix adds a path-based filter that excludes any artifact whose resolved absolute path starts with the wiki vault's `sources/` directory. This is the minimal, surgical change that directly addresses the cycle.

## User Impact

- Eliminates unbounded growth of wiki source files and memory database
- No configuration changes required — works automatically when vault is inside `memory/`
- No behavioral change for legitimate cross-workspace bridge imports

## Evidence

- **Behavior addressed:** Bridge import re-imports artifacts from the wiki vault's own `sources/` directory, causing recursive loop and unbounded DB growth
- **Environment tested:** macOS 26.4.1, Node v22.19, OpenClaw 2026.5.28
- **Steps run after the patch:** Ran `node scripts/run-vitest.mjs run extensions/memory-wiki/src/bridge.test.ts` including the new regression test `filters out artifacts from the wiki vault sources directory to prevent self-import loops`
- **Evidence after fix:**
  ```
  $ node scripts/run-vitest.mjs run extensions/memory-wiki/src/bridge.test.ts
  ✓  extension-memory  extensions/memory-wiki/src/bridge.test.ts (12 tests) 135ms
   Test Files  1 passed (1)
        Tests  12 passed (12)
  ```
- **Observed result after fix:** All 12 bridge tests pass. The new test verifies that an artifact whose path is inside the vault's `sources/` directory is filtered out (artifactCount=1, only the external artifact imported).
- **What was not tested:** Live memory-wiki bridge with real vault on disk — the fix is a path-based filter in `syncMemoryWikiBridgeSources`, verified through the production function exercised via test suite.

- [x] AI-assisted (Hermes Agent)

## Real behavior proof

- **Behavior addressed:** Bridge import should not re-import artifacts from the wiki vault's own `sources/` directory
- **Environment tested:** macOS 26.4.1, Node v22.19, OpenClaw 2026.5.28
- **Steps run after the patch:** Ran `node scripts/run-vitest.mjs run extensions/memory-wiki/src/bridge.test.ts` which includes a new test `filters out artifacts from the wiki vault sources directory to prevent self-import loops`
- **Evidence after fix:**
  ```
  $ node scripts/run-vitest.mjs run extensions/memory-wiki/src/bridge.test.ts
  ✓  extension-memory  extensions/memory-wiki/src/bridge.test.ts (12 tests) 135ms
   Test Files  1 passed (1)
        Tests  12 passed (12)

  $ grep -n "wikiSourcesDir\|filteredArtifacts" extensions/memory-wiki/src/bridge.ts
  230:  const wikiSourcesDir = path.resolve(params.config.vault.path, "sources") + path.sep;
  231:  const filteredArtifacts = publicArtifacts.filter(
  232:    (a) => !path.resolve(a.absolutePath).startsWith(wikiSourcesDir),
  236:  const artifacts = await collectBridgeArtifacts(params.config.bridge, filteredArtifacts);
  244:  for (const artifact of filteredArtifacts) {
  ```
- **Observed result after fix:** All 12 bridge tests pass. The new test verifies that an artifact whose path is inside the vault's `sources/` directory is filtered out (artifactCount=1, only the external artifact imported).
- **What was not tested:** Multi-workspace bridge scenarios with real memory indexer — the test uses registered mock artifacts. The filtering logic is path-based and deterministic, so the behavior is fully covered by the unit test.
