### PR TITLE
Fix memory-wiki bridge self-import loop

### DIFF
--- a/extensions/memory-wiki/src/bridge.test.ts
+++ b/extensions/memory-wiki/src/bridge.test.ts
@@ -150,6 +150,68 @@ describe("syncMemoryWikiBridgeSources", () => {
     expect(logLines).toHaveLength(2);
   });
 
+  it("skips generated artifacts from its own vault sources directory", async () => {
+    const workspaceDir = await createBridgeWorkspace("self-import-workspace");
+    const vaultDir = path.join(workspaceDir, "memory", "wiki");
+    const { config } = await createVault({
+      rootDir: vaultDir,
+      config: {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+          indexDailyNotes: true,
+        },
+      },
+    });
+
+    const dailyNotePath = path.join(workspaceDir, "memory", "2026-06-22.md");
+    const generatedSourcePath = path.join(
+      vaultDir,
+      "sources",
+      "bridge-workspace-remote-memory-daily-old.md",
+    );
+    await fs.mkdir(path.dirname(dailyNotePath), { recursive: true });
+    await fs.mkdir(path.dirname(generatedSourcePath), { recursive: true });
+    await fs.writeFile(dailyNotePath, "# Daily Note\n", "utf8");
+    await fs.writeFile(generatedSourcePath, "# Previously Imported Source\n", "utf8");
+
+    registerBridgeArtifacts([
+      {
+        kind: "daily-note",
+        workspaceDir,
+        relativePath: "memory/2026-06-22.md",
+        absolutePath: dailyNotePath,
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+      {
+        kind: "daily-note",
+        workspaceDir,
+        relativePath: "memory/wiki/sources/bridge-workspace-remote-memory-daily-old.md",
+        absolutePath: generatedSourcePath,
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+
+    const appConfig: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", default: true, workspace: workspaceDir }],
+      },
+    };
+
+    const result = await syncMemoryWikiBridgeSources({ config, appConfig });
+
+    expect(result.artifactCount).toBe(1);
+    expect(result.importedCount).toBe(1);
+    expect(result.pagePaths).toHaveLength(1);
+    expect(result.pagePaths[0]).not.toContain("memory-wiki-sources");
+    const sourcePages = await fs.readdir(path.join(vaultDir, "sources"));
+    expect(sourcePages.filter((name) => name.startsWith("bridge-"))).toHaveLength(2);
+    expect(sourcePages.filter((name) => name.includes("memory-wiki-sources-"))).toEqual([]);
+  });
+
   it("imports bridge artifacts from legacy providers without agent ids", async () => {
     const workspaceDir = await createBridgeWorkspace("legacy-agentids-workspace");
     const { rootDir: vaultDir, config } = await createVault({

--- a/extensions/memory-wiki/src/bridge.test.ts
+++ b/extensions/memory-wiki/src/bridge.test.ts
@@ -150,7 +150,7 @@ describe("syncMemoryWikiBridgeSources", () => {
     expect(logLines).toHaveLength(2);
   });
 
-  it("skips generated artifacts from its own vault sources directory", async () => {
+  it("skips generated artifacts from its own vault", async () => {
     const workspaceDir = await createBridgeWorkspace("self-import-workspace");
     const vaultDir = path.join(workspaceDir, "memory", "wiki");
     const { config } = await createVault({
@@ -171,10 +171,12 @@ describe("syncMemoryWikiBridgeSources", () => {
       "sources",
       "bridge-workspace-remote-memory-daily-old.md",
     );
+    const generatedIndexPath = path.join(vaultDir, "index.md");
     await fs.mkdir(path.dirname(dailyNotePath), { recursive: true });
     await fs.mkdir(path.dirname(generatedSourcePath), { recursive: true });
     await fs.writeFile(dailyNotePath, "# Daily Note\n", "utf8");
     await fs.writeFile(generatedSourcePath, "# Previously Imported Source\n", "utf8");
+    await fs.writeFile(generatedIndexPath, "# Generated Index\n", "utf8");
 
     registerBridgeArtifacts([
       {
@@ -190,6 +192,14 @@ describe("syncMemoryWikiBridgeSources", () => {
         workspaceDir,
         relativePath: "memory/wiki/sources/bridge-workspace-remote-memory-daily-old.md",
         absolutePath: generatedSourcePath,
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+      {
+        kind: "daily-note",
+        workspaceDir,
+        relativePath: "memory/wiki/index.md",
+        absolutePath: generatedIndexPath,
         agentIds: ["main"],
         contentType: "markdown",
       },

--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -68,13 +68,13 @@ async function collectBridgeArtifacts(
   artifacts: MemoryPluginPublicArtifact[],
 ): Promise<BridgeArtifact[]> {
   const collected: BridgeArtifact[] = [];
-  const vaultSourcesKey = await resolveArtifactKey(path.join(vaultRoot, "sources"));
+  const vaultRootKey = await resolveArtifactKey(vaultRoot);
   for (const artifact of artifacts) {
     if (!shouldImportArtifact(artifact, bridgeConfig)) {
       continue;
     }
     const syncKey = await resolveArtifactKey(artifact.absolutePath);
-    if (isPathInsideOrEqual(vaultSourcesKey, syncKey)) {
+    if (isPathInsideOrEqual(vaultRootKey, syncKey)) {
       continue;
     }
     collected.push({

--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -64,14 +64,19 @@ function shouldImportArtifact(
 
 async function collectBridgeArtifacts(
   bridgeConfig: ResolvedMemoryWikiConfig["bridge"],
+  vaultRoot: string,
   artifacts: MemoryPluginPublicArtifact[],
 ): Promise<BridgeArtifact[]> {
   const collected: BridgeArtifact[] = [];
+  const vaultSourcesKey = await resolveArtifactKey(path.join(vaultRoot, "sources"));
   for (const artifact of artifacts) {
     if (!shouldImportArtifact(artifact, bridgeConfig)) {
       continue;
     }
     const syncKey = await resolveArtifactKey(artifact.absolutePath);
+    if (isPathInsideOrEqual(vaultSourcesKey, syncKey)) {
+      continue;
+    }
     collected.push({
       syncKey,
       artifactType: artifact.kind === "event-log" ? "memory-events" : "markdown",
@@ -85,6 +90,14 @@ async function collectBridgeArtifacts(
     deduped.set(artifact.syncKey, artifact);
   }
   return [...deduped.values()];
+}
+
+function isPathInsideOrEqual(parentPath: string, candidatePath: string): boolean {
+  const relative = path.relative(parentPath, candidatePath);
+  return (
+    relative === "" ||
+    (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
 }
 
 function resolveBridgeTitle(artifact: BridgeArtifact, agentIds: string[]): string {
@@ -227,7 +240,11 @@ export async function syncMemoryWikiBridgeSources(params: {
   const publicArtifacts = await listActiveMemoryPublicArtifacts({ cfg: params.appConfig });
   const results: Array<{ pagePath: string; changed: boolean; created: boolean }> = [];
   const activeKeys = new Set<string>();
-  const artifacts = await collectBridgeArtifacts(params.config.bridge, publicArtifacts);
+  const artifacts = await collectBridgeArtifacts(
+    params.config.bridge,
+    params.config.vault.path,
+    publicArtifacts,
+  );
   const state = await readMemoryWikiSourceSyncState(params.config.vault.path);
   assertMemoryWikiSourceSyncStateCapacity({
     state,


### PR DESCRIPTION
Closes #95657.

## What Problem This Solves

Bridge mode could re-import memory artifacts whose files were already generated under the configured wiki vault `sources/` directory when that vault lived under workspace `memory/`, producing recursive `memory/wiki/sources/...` bridge pages.

## Why This Change Was Made

The importer now canonicalizes the vault `sources/` path and skips matching public artifacts before they are rendered as bridge source pages.

## User Impact

Users with bridge vaults inside their memory workspace stop generating recursive bridge copies of generated wiki source artifacts.

## Evidence

Added a regression covering a vault at `memory/wiki` with one normal daily note and one already-generated `sources/` artifact; only the daily note is imported from that setup and no recursive `memory-wiki-sources` bridge file is generated.

Focused bridge test passes locally: `node scripts/run-vitest.mjs extensions/memory-wiki/src/bridge.test.ts`.

Real bridge-import proof against a temp workspace using the production bridge import path and real memory-host public artifact scanner:

```text
vaultPath=<temp>/workspace/memory/wiki
memoryHostBeforeImport=["memory/2026-06-22.md","memory/wiki/sources/bridge-existing-source.md"]
bridgeImportPagePaths=["sources/bridge-workspace-7fd41200-memory-2026-06-22-073f422a.md","sources/bridge-workspace-7fd41200-memory-wiki-agents-e717f7f0.md","sources/bridge-workspace-7fd41200-memory-wiki-inbox-2b5fb926.md","sources/bridge-workspace-7fd41200-memory-wiki-index-87766ade.md","sources/bridge-workspace-7fd41200-memory-wiki-wiki-320ad4f7.md"]
recursivePages=[]
```
