### PR TITLE
fix(agent): reset finalize retry transcript

### DIFF
--- a/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
@@ -79,8 +79,8 @@ async function createFinalizeRetrySession(): Promise<{
   return { tempDir, sessionFile, manager };
 }
 
-function appendAssistantTurn(manager: SessionManager, text: string): void {
-  manager.appendMessage({
+function appendAssistantTurn(manager: SessionManager, text: string): string {
+  return manager.appendMessage({
     role: "assistant",
     content: [{ type: "text", text }],
     stopReason: "stop",
@@ -191,6 +191,45 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
 
       expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
       expect(result.payloads).toEqual([{ text: "Revised answer." }]);
+      expect(readVisibleTranscriptTexts(sessionFile, tempDir)).toEqual([
+        "Question?",
+        "Revised answer.",
+      ]);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves trailing metadata while resetting a finalize retry transcript", async () => {
+    const { tempDir, sessionFile, manager } = await createFinalizeRetrySession();
+    try {
+      mockedRunEmbeddedAttempt
+        .mockImplementationOnce(async () => {
+          const assistantId = appendAssistantTurn(manager, "First answer.");
+          manager.appendLabelChange(assistantId, "reviewed");
+          return finalAnswerAttempt("First answer.", {
+            beforeAgentFinalizeRevisionReason: "Tighten the final wording.",
+          });
+        })
+        .mockImplementationOnce(async () => {
+          expect(readVisibleTranscriptTexts(sessionFile, tempDir)).toEqual(["Question?"]);
+          appendAssistantTurn(
+            SessionManager.open(sessionFile, tempDir, tempDir),
+            "Revised answer.",
+          );
+          return finalAnswerAttempt("Revised answer.");
+        });
+
+      await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        sessionFile,
+        workspaceDir: tempDir,
+        provider: "openai",
+        model: "gpt-5.5",
+        runId: "run-before-finalize-retry-trailing-metadata",
+      });
+
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
       expect(readVisibleTranscriptTexts(sessionFile, tempDir)).toEqual([
         "Question?",
         "Revised answer.",

--- a/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
@@ -1,8 +1,15 @@
 // Coverage for before_agent_finalize revision handling in embedded runs.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { extractAssistantVisibleText, isAssistantMessage } from "../embedded-agent-utils.js";
+import { SessionManager } from "../sessions/session-manager.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
+  mockedBuildEmbeddedRunPayloads,
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
@@ -11,6 +18,12 @@ import {
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
 let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
+
+function buildPayloadsStrippingSilentTokens(params: { assistantTexts: string[] }) {
+  return params.assistantTexts
+    .filter((text) => !isSilentReplyText(text, SILENT_REPLY_TOKEN))
+    .map((text) => ({ text }));
+}
 
 function finalAnswerAttempt(
   text: string,
@@ -45,6 +58,50 @@ function attemptCall(index: number): {
     throw new Error(`Expected embedded attempt call ${index}`);
   }
   return call[0] as { prompt?: string; suppressNextUserMessagePersistence?: boolean };
+}
+
+async function createFinalizeRetrySession(): Promise<{
+  tempDir: string;
+  sessionFile: string;
+  manager: SessionManager;
+}> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-finalize-retry-"));
+  const manager = SessionManager.create(tempDir, tempDir);
+  manager.appendMessage({
+    role: "user",
+    content: "Question?",
+    timestamp: 1,
+  });
+  const sessionFile = manager.getSessionFile();
+  if (!sessionFile) {
+    throw new Error("Expected test session file.");
+  }
+  return { tempDir, sessionFile, manager };
+}
+
+function appendAssistantTurn(manager: SessionManager, text: string): void {
+  manager.appendMessage({
+    role: "assistant",
+    content: [{ type: "text", text }],
+    stopReason: "stop",
+    provider: "openai",
+    model: "gpt-5.5",
+    timestamp: Date.now(),
+  } as Parameters<SessionManager["appendMessage"]>[0]);
+}
+
+function readVisibleTranscriptTexts(sessionFile: string, tempDir: string): string[] {
+  return SessionManager.open(sessionFile, tempDir, tempDir)
+    .buildSessionContext()
+    .messages.map((message) => {
+      if (isAssistantMessage(message)) {
+        return extractAssistantVisibleText(message);
+      }
+      if (message.role === "user" && typeof message.content === "string") {
+        return message.content;
+      }
+      return "";
+    });
 }
 
 describe("runEmbeddedAgent before_agent_finalize", () => {
@@ -101,6 +158,87 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
     expect(attemptCall(1).prompt).toContain("Mention the validated behavior.");
     expect(attemptCall(1).prompt).not.toContain("hello");
     expect(attemptCall(1).suppressNextUserMessagePersistence).toBe(true);
+  });
+
+  it("removes the rejected answer from transcript before a finalize retry", async () => {
+    const { tempDir, sessionFile, manager } = await createFinalizeRetrySession();
+    try {
+      mockedBuildEmbeddedRunPayloads.mockImplementation(buildPayloadsStrippingSilentTokens);
+      mockedRunEmbeddedAttempt
+        .mockImplementationOnce(async () => {
+          appendAssistantTurn(manager, "First answer.");
+          return finalAnswerAttempt("First answer.", {
+            beforeAgentFinalizeRevisionReason: "Tighten the final wording.",
+          });
+        })
+        .mockImplementationOnce(async () => {
+          expect(readVisibleTranscriptTexts(sessionFile, tempDir)).toEqual(["Question?"]);
+          appendAssistantTurn(
+            SessionManager.open(sessionFile, tempDir, tempDir),
+            "Revised answer.",
+          );
+          return finalAnswerAttempt("Revised answer.");
+        });
+
+      const result = await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        sessionFile,
+        workspaceDir: tempDir,
+        provider: "openai",
+        model: "gpt-5.5",
+        runId: "run-before-finalize-retry-transcript",
+      });
+
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+      expect(result.payloads).toEqual([{ text: "Revised answer." }]);
+      expect(readVisibleTranscriptTexts(sessionFile, tempDir)).toEqual([
+        "Question?",
+        "Revised answer.",
+      ]);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a silent finalize retry authoritative after transcript reset", async () => {
+    const { tempDir, sessionFile, manager } = await createFinalizeRetrySession();
+    try {
+      mockedBuildEmbeddedRunPayloads.mockImplementation(buildPayloadsStrippingSilentTokens);
+      mockedRunEmbeddedAttempt
+        .mockImplementationOnce(async () => {
+          appendAssistantTurn(manager, "First answer.");
+          return finalAnswerAttempt("First answer.", {
+            beforeAgentFinalizeRevisionReason: "Tighten the final wording.",
+          });
+        })
+        .mockImplementationOnce(async () => {
+          expect(readVisibleTranscriptTexts(sessionFile, tempDir)).toEqual(["Question?"]);
+          appendAssistantTurn(
+            SessionManager.open(sessionFile, tempDir, tempDir),
+            SILENT_REPLY_TOKEN,
+          );
+          return finalAnswerAttempt(SILENT_REPLY_TOKEN);
+        });
+
+      const result = await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        sessionFile,
+        workspaceDir: tempDir,
+        provider: "openai",
+        model: "gpt-5.5",
+        runId: "run-before-finalize-silent-authoritative",
+        allowEmptyAssistantReplyAsSilent: true,
+      });
+
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+      expect(result.payloads).toEqual([{ text: SILENT_REPLY_TOKEN }]);
+      expect(readVisibleTranscriptTexts(sessionFile, tempDir)).toEqual([
+        "Question?",
+        SILENT_REPLY_TOKEN,
+      ]);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("keeps finalizing when the attempt accepted a side-effecting revise decision", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2,6 +2,7 @@
  * Top-level embedded-agent run orchestration entrypoint.
  */
 import { randomBytes } from "node:crypto";
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
@@ -138,6 +139,7 @@ import {
   suspendSession,
   type SessionSuspensionParams,
 } from "../session-suspension.js";
+import { SessionManager } from "../sessions/session-manager.js";
 import { resolveToolLoopDetectionConfig } from "../tool-loop-detection-config.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../usage.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
@@ -260,6 +262,7 @@ const BEFORE_AGENT_FINALIZE_RETRY_PROMPT_PREFIX =
 const MAX_BEFORE_AGENT_FINALIZE_REVISIONS = 3;
 type EmbeddedRunAttemptForRunner = Awaited<ReturnType<typeof runEmbeddedAttemptWithBackend>>;
 type RunEmbeddedAgentParamsWithSessionFile = RunEmbeddedAgentParams & { sessionFile: string };
+type BeforeAgentFinalizeRevisionTranscriptReset = "removed" | "not_found" | "error";
 
 function isNoRealConversationCompactionNoop(params: {
   ok?: boolean;
@@ -348,6 +351,54 @@ function resolveAttemptDispatchApiKey(params: {
 
 function buildBeforeAgentFinalizeRetryPrompt(reason: string): string {
   return `${BEFORE_AGENT_FINALIZE_RETRY_PROMPT_PREFIX}\n\n${reason}`;
+}
+
+function resolveAssistantRevisionMatchText(
+  assistant: EmbeddedRunAttemptForRunner["lastAssistant"],
+): string | undefined {
+  return (
+    normalizeOptionalString(resolveFinalAssistantVisibleText(assistant)) ??
+    normalizeOptionalString(resolveFinalAssistantRawText(assistant))
+  );
+}
+
+function resetBeforeAgentFinalizeRevisionTranscript(params: {
+  sessionFile: string;
+  sessionId: string;
+  runId: string;
+  lastAssistant: EmbeddedRunAttemptForRunner["lastAssistant"];
+}): BeforeAgentFinalizeRevisionTranscriptReset {
+  const expectedText = resolveAssistantRevisionMatchText(params.lastAssistant);
+  if (!expectedText) {
+    return "not_found";
+  }
+  if (!existsSync(params.sessionFile)) {
+    return "not_found";
+  }
+  try {
+    const sessionManager = SessionManager.open(params.sessionFile);
+    const leafEntry = sessionManager.getLeafEntry();
+    if (leafEntry?.type !== "message" || leafEntry.message.role !== "assistant") {
+      return "not_found";
+    }
+    const leafText = resolveAssistantRevisionMatchText(
+      leafEntry.message as EmbeddedRunAttemptForRunner["lastAssistant"],
+    );
+    if (leafText !== expectedText) {
+      return "not_found";
+    }
+
+    // The revision pass is authoritative. Remove the rejected terminal answer
+    // before retrying so the model does not see it as finalized history.
+    const removed = sessionManager.removeTrailingEntries((entry) => entry.id === leafEntry.id);
+    return removed > 0 ? "removed" : "not_found";
+  } catch (err) {
+    log.warn(
+      `before_agent_finalize transcript reset failed before retry: ` +
+        `runId=${params.runId} sessionId=${params.sessionId} error=${formatErrorMessage(err)}`,
+    );
+    return "error";
+  }
 }
 
 function resolveEmbeddedRunLaneTimeoutMs(timeoutMs: number): number | undefined {
@@ -4010,6 +4061,12 @@ async function runEmbeddedAgentInternal(
             !emptyAssistantReplyIsSilent;
           if (beforeAgentFinalizeRevisionReason && shouldHonorBeforeAgentFinalizeRevision) {
             beforeAgentFinalizeRevisionAttempts += 1;
+            const revisionTranscriptReset = resetBeforeAgentFinalizeRevisionTranscript({
+              sessionFile: activeSessionFile ?? params.sessionFile,
+              sessionId: activeSessionId ?? params.sessionId,
+              runId: params.runId,
+              lastAssistant: sessionLastAssistant,
+            });
             nextAttemptPromptOverride = buildBeforeAgentFinalizeRetryPrompt(
               beforeAgentFinalizeRevisionReason,
             );
@@ -4020,7 +4077,8 @@ async function runEmbeddedAgentInternal(
             log.warn(
               `before_agent_finalize requested one more pass: ` +
                 `runId=${params.runId} sessionId=${params.sessionId} ` +
-                `attempt=${beforeAgentFinalizeRevisionAttempts}/${MAX_BEFORE_AGENT_FINALIZE_REVISIONS}`,
+                `attempt=${beforeAgentFinalizeRevisionAttempts}/${MAX_BEFORE_AGENT_FINALIZE_REVISIONS} ` +
+                `transcriptReset=${revisionTranscriptReset}`,
             );
             continue;
           }

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -37,6 +37,7 @@ import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveProviderAuthProfileId } from "../../plugins/provider-runtime.js";
 import { enqueueCommandInLane, getCommandLaneSnapshot } from "../../process/command-queue.js";
 import type { CommandQueueEnqueueOptions } from "../../process/command-queue.types.js";
+import { isTranscriptOnlyOpenClawAssistantMessage } from "../../shared/transcript-only-openclaw-assistant.js";
 import { createAgentHarnessTaskRuntimeScope } from "../../tasks/agent-harness-task-runtime-scope.js";
 import { resolveUserPath } from "../../utils.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
@@ -362,6 +363,17 @@ function resolveAssistantRevisionMatchText(
   );
 }
 
+function shouldPreserveBeforeAgentFinalizeRevisionTrailingEntry(
+  entry: ReturnType<SessionManager["getEntries"]>[number],
+): boolean {
+  return (
+    entry.type === "custom" ||
+    entry.type === "label" ||
+    entry.type === "session_info" ||
+    (entry.type === "message" && isTranscriptOnlyOpenClawAssistantMessage(entry.message))
+  );
+}
+
 function resetBeforeAgentFinalizeRevisionTranscript(params: {
   sessionFile: string;
   sessionId: string;
@@ -377,20 +389,21 @@ function resetBeforeAgentFinalizeRevisionTranscript(params: {
   }
   try {
     const sessionManager = SessionManager.open(params.sessionFile);
-    const leafEntry = sessionManager.getLeafEntry();
-    if (leafEntry?.type !== "message" || leafEntry.message.role !== "assistant") {
-      return "not_found";
-    }
-    const leafText = resolveAssistantRevisionMatchText(
-      leafEntry.message as EmbeddedRunAttemptForRunner["lastAssistant"],
-    );
-    if (leafText !== expectedText) {
-      return "not_found";
-    }
-
     // The revision pass is authoritative. Remove the rejected terminal answer
     // before retrying so the model does not see it as finalized history.
-    const removed = sessionManager.removeTrailingEntries((entry) => entry.id === leafEntry.id);
+    const removed = sessionManager.removeTrailingEntries(
+      (entry) => {
+        if (entry.type !== "message" || entry.message.role !== "assistant") {
+          return false;
+        }
+        return (
+          resolveAssistantRevisionMatchText(
+            entry.message as EmbeddedRunAttemptForRunner["lastAssistant"],
+          ) === expectedText
+        );
+      },
+      { preserveTrailing: shouldPreserveBeforeAgentFinalizeRevisionTrailingEntry },
+    );
     return removed > 0 ? "removed" : "not_found";
   } catch (err) {
     log.warn(


### PR DESCRIPTION
Closes #93166.

## What Problem This Solves
`before_agent_finalize` retries could leave the rejected first assistant answer as finalized session history before the revision pass, so the retry could see its own rejected draft as prior conversation and group-chat silence handling could collapse final delivery.

## Summary
When `before_agent_finalize` requests a revision, the runner now trims the rejected assistant leaf from the session transcript before dispatching the retry. The revision pass remains authoritative, including intentional `NO_REPLY`, and the rejected first answer is not restored.

## Evidence
A temporary embedded-runner proof against this branch showed the transcript rewrite at the retry boundary:

```text
proof after first attempt=["Question?","First answer."]
proof before revision attempt=["Question?"]
proof delivered payloads=[{"text":"Revised answer."}]
proof final transcript=["Question?","Revised answer."]
```

On rebased head `61d680f1bc`, hosted `Real behavior proof`, `check-test-types`, `Critical Quality (agent-runtime-boundary)`, and the full PR check rollup are passing.
