### PR TITLE
fix(channels): word group-chat intro by authoritative ChatType (#95645)

### DIFF
--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -81,6 +81,23 @@ describe("group runtime loading", () => {
     vi.doUnmock("./groups.runtime.js");
   });
 
+  it("declares a channel ChatType as a channel, not a group chat (#95645)", () => {
+    const channelContext = groups.buildGroupChatContext({
+      sessionCtx: { ChatType: "channel", Provider: "mattermost" },
+      silentReplyPolicy: "allow",
+      silentToken: "NO_REPLY",
+    });
+    expect(channelContext).toContain("You are in a Mattermost channel.");
+    expect(channelContext).not.toContain("You are in a Mattermost group chat.");
+
+    const groupContext = groups.buildGroupChatContext({
+      sessionCtx: { ChatType: "group", Provider: "mattermost" },
+      silentReplyPolicy: "allow",
+      silentToken: "NO_REPLY",
+    });
+    expect(groupContext).toContain("You are in a Mattermost group chat.");
+  });
+
   it("builds direct chat context without silent-token guidance", () => {
     expect(
       groups.buildDirectChatContext({

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -240,7 +240,13 @@ export function buildGroupChatContext(params: {
   const botUsername = normalizeOptionalString(params.sessionCtx.BotUsername);
 
   const lines: string[] = [];
-  lines.push(`You are in a ${providerLabel} group chat.`);
+  // Declare the venue by its authoritative ChatType. "group chat" is overloaded
+  // (the `group` enum value *and* a loose adjective), so calling a `channel` a
+  // "group chat" here contradicts the trusted `chat_type: channel` meta and makes
+  // agents emit `group` for public/private channels (#95645).
+  const chatType = normalizeOptionalLowercaseString(params.sessionCtx.ChatType);
+  const venueNoun = chatType === "channel" ? "channel" : "group chat";
+  lines.push(`You are in a ${providerLabel} ${venueNoun}.`);
   if (params.sessionCtx.ExplicitlyMentionedBot === true && botUsername) {
     lines.push(
       `The incoming message explicitly mentions your channel identity @${botUsername}. Treat that mention as addressed to you, even if your persona name differs.`,


### PR DESCRIPTION
## What Problem This Solves

Fixes #95645. For any non-DM Mattermost conversation — including a public channel — the system-prompt intro declared *"You are in a `<provider>` group chat."*, while the trusted inbound-meta block reported `chat_type: "channel"`. The two contradicted each other, and the salient "group chat" prose nudged agents to emit `chat_type: group` (or `--chat-type group`) for channels. Because session keys are namespaced by chat type, a wrong `group` addresses a non-existent session and breaks downstream routing.

## Why This Change Was Made

"group" is overloaded: it is both a specific `chat_type` enum value and a loose adjective in the prose. The declarative intro line is the one place that should match the authoritative `ChatType`, so it now words the venue by `ChatType` (`channel` → "channel"; `group` stays "group chat"). The remaining colloquial "group" delivery mentions are left as-is — they describe role/delivery, not the chat type.

## User Impact

Agents in Mattermost public/private channels no longer receive a system-prompt line that contradicts the trusted `chat_type`, so they stop mislabeling channels as `group` and mis-addressing sessions. No config or API change.

## Evidence

- `src/auto-reply/reply/groups.ts`: intro line now derived from `ChatType`.
- New test in `src/auto-reply/reply/groups.test.ts` asserts a `channel` ChatType yields "You are in a Mattermost channel." and a `group` ChatType still yields "group chat".
- `pnpm test src/auto-reply/reply/groups.test.ts` ✅ (7 passed); `src/agents/prompt-composition.test.ts` ✅ (Slack `group` wording unchanged).
