### PR TITLE
fix(mattermost): key resolved group targets under group: namespace (#95646)

### DIFF
--- a/extensions/mattermost/src/session-route.test.ts
+++ b/extensions/mattermost/src/session-route.test.ts
@@ -43,6 +43,27 @@ describe("mattermost session route", () => {
     expect(channelRoute.sessionKey).toContain("thread456");
   });
 
+  it("keys a resolved group target under group:, matching inbound classification (#95646)", () => {
+    const route = resolveMattermostOutboundSessionRoute({
+      cfg: {},
+      agentId: "main",
+      accountId: "acct-1",
+      target: "mattermost:channel:priv123",
+      resolvedTarget: { kind: "group", to: "channel:priv123" },
+    });
+
+    const groupRoute = expectRoute(route);
+    expect(groupRoute.peer.kind).toBe("group");
+    expect(groupRoute.peer.id).toBe("priv123");
+    expect(groupRoute.chatType).toBe("group");
+    expect(groupRoute.from).toBe("mattermost:group:priv123");
+    // Delivery target string stays channel: — Mattermost addresses all channels
+    // (including private) by id; only the session namespace is type-aware.
+    expect(groupRoute.to).toBe("channel:priv123");
+    expect(groupRoute.baseSessionKey).toContain(":group:priv123");
+    expect(groupRoute.baseSessionKey).not.toContain(":channel:priv123");
+  });
+
   it("recovers channel thread routes from currentSessionKey", () => {
     const route = resolveMattermostOutboundSessionRoute({
       cfg: {},

--- a/extensions/mattermost/src/session-route.ts
+++ b/extensions/mattermost/src/session-route.ts
@@ -20,6 +20,14 @@ export function resolveMattermostOutboundSessionRoute(params: ChannelOutboundSes
     (resolvedKind !== "channel" &&
       resolvedKind !== "group" &&
       (lower.startsWith("user:") || trimmed.startsWith("@")));
+  // Honor an authoritative `group` kind (private channel / group DM, from the
+  // directory resolver) instead of flattening every non-user target to
+  // `channel`. The inbound path keys these under `group:<id>` via
+  // mapMattermostChannelKind (P/G -> group); a `channel:<id>` outbound route
+  // would split the same conversation across two session namespaces (#95646).
+  // A bare `channel:<id>` with no resolved kind stays `channel` since the real
+  // channel type is not knowable from the target string alone.
+  const isGroup = !isUser && resolvedKind === "group";
   if (trimmed.startsWith("@")) {
     trimmed = trimmed.slice(1).trim();
   }
@@ -27,17 +35,18 @@ export function resolveMattermostOutboundSessionRoute(params: ChannelOutboundSes
   if (!rawId) {
     return null;
   }
+  const kind = isUser ? "direct" : isGroup ? "group" : "channel";
   const baseRoute = buildChannelOutboundSessionRoute({
     cfg: params.cfg,
     agentId: params.agentId,
     channel: "mattermost",
     accountId: params.accountId,
     peer: {
-      kind: isUser ? "direct" : "channel",
+      kind,
       id: rawId,
     },
-    chatType: isUser ? "direct" : "channel",
-    from: isUser ? `mattermost:${rawId}` : `mattermost:channel:${rawId}`,
+    chatType: kind,
+    from: isUser ? `mattermost:${rawId}` : `mattermost:${kind}:${rawId}`,
     to: isUser ? `user:${rawId}` : `channel:${rawId}`,
   });
   return buildThreadAwareOutboundSessionRoute({


### PR DESCRIPTION
## What Problem This Solves

Fixes #95646. The `chat_type` reported for a Mattermost **private channel** was non-deterministic across code paths: `group` when derived from the channel type (authoritative inbound path, `mapMattermostChannelKind`: `P`/`G` → group), but `channel` when derived from the delivery target string (a private channel is addressed as `channel:<id>`, same prefix as a public channel). The same conversation was keyed under two session namespaces — `group:<id>:thread:<root>` (inbound) and a phantom `channel:<id>:thread:<root>` (delivery) — so threaded/scheduled deliveries failed to match.

## Why This Change Was Made

The outbound session route flattened every non-user target to `channel`, discarding an authoritative `group` kind that the directory resolver already produces (`directory.ts` emits `kind: "group"` for private channels / group DMs). The route now honors that resolved `group` kind for the session namespace and `from`, aligning delivery with the inbound classification. The delivery target string stays `channel:<id>` because Mattermost addresses all channels by id; only the session namespace is type-aware.

## User Impact

Directory-resolved private-channel / group-DM deliveries now key under the same `group:` session as inbound, fixing the split-session / fail-closed delivery. A bare `channel:<id>` target with no resolved kind still resolves to `channel`, since the real channel type is not knowable from the target string alone — that residual path warrants live-Mattermost follow-up and is called out here rather than silently half-fixed.

## Evidence

- `extensions/mattermost/src/session-route.ts`: honor resolved `group` kind in `peer.kind` / `chatType` / `from`.
- New test in `extensions/mattermost/src/session-route.test.ts` asserts a resolved `group` target keys under `:group:<id>` (not `:channel:<id>`) while keeping `to: channel:<id>`.
- `pnpm test extensions/mattermost/src/session-route.test.ts` ✅ (7 passed).
