### PR TITLE
fix(memory): skip memory-wiki vault subtree in workspace memory scan (#95657)

### DIFF
--- a/src/plugin-sdk/memory-host-core.test.ts
+++ b/src/plugin-sdk/memory-host-core.test.ts
@@ -139,6 +139,35 @@ describe("memory-host-core helpers", () => {
     }
   });
 
+  it("skips a memory-wiki vault nested under memory/ to avoid the bridge self-import loop (#95657)", async () => {
+    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-wiki-skip-"));
+    try {
+      const workspaceDir = path.join(fixtureRoot, "workspace");
+      const wikiSources = path.join(workspaceDir, "memory", "wiki", "sources");
+      const wikiMarker = path.join(workspaceDir, "memory", "wiki", ".openclaw-wiki");
+      await fs.mkdir(wikiSources, { recursive: true });
+      await fs.mkdir(wikiMarker, { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, "memory", "real-note.md"), "# Note\n", "utf8");
+      // Bridge-generated source pages that must NOT be re-indexed as memory.
+      await fs.writeFile(
+        path.join(wikiSources, "bridge-workspace-abc-memory-real-note.md"),
+        "# Imported\n",
+        "utf8",
+      );
+
+      const artifacts = await listMemoryHostPublicArtifacts({
+        cfg: { agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] } },
+      });
+      const relativePaths = artifacts.map((artifact) => artifact.relativePath);
+      expect(relativePaths).toContain("memory/real-note.md");
+      expect(relativePaths.some((relativePath) => relativePath.includes("wiki/sources"))).toBe(
+        false,
+      );
+    } finally {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   it("keeps the deprecated memory-core alias wired to memory-host-core", () => {
     expect(memoryCoreAlias.buildActiveMemoryPromptSection).toBe(buildActiveMemoryPromptSection);
     expect(memoryCoreAlias.listActiveMemoryPublicArtifacts).toBe(listActiveMemoryPublicArtifacts);

--- a/src/plugin-sdk/memory-host-core.ts
+++ b/src/plugin-sdk/memory-host-core.ts
@@ -19,8 +19,18 @@ async function pathExists(filePath: string): Promise<boolean> {
   }
 }
 
+// A memory-wiki vault marks its root with a `.openclaw-wiki` directory. When a
+// vault lives inside `memory/` (the default bridge layout), its `sources/`
+// pages are bridge-generated artifacts, not user memory. Indexing them as
+// memory would feed the wiki bridge import its own output, an unbounded
+// self-import loop (#95657). Skip any vault subtree during the memory scan.
+const WIKI_VAULT_MARKER = ".openclaw-wiki";
+
 async function listMarkdownFilesRecursive(rootDir: string): Promise<string[]> {
   const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch(() => []);
+  if (entries.some((entry) => entry.isDirectory() && entry.name === WIKI_VAULT_MARKER)) {
+    return [];
+  }
   const files: string[] = [];
   for (const entry of entries) {
     const fullPath = path.join(rootDir, entry.name);


### PR DESCRIPTION
## What Problem This Solves

Fixes #95657. With `memory-wiki` in `bridge` mode and the vault inside the workspace `memory/` directory (the default layout), the recursive memory scan picked up the wiki's own bridge-generated `sources/*.md` pages as if they were user memory. Both consumers of that scan — the lancedb embedding indexer and the wiki bridge import — then re-ingested the wiki's own output, an unbounded self-import loop. Reporter saw the SQLite index grow to 1.5 GB in ~2 months (82% bridge duplicates), regenerating within hours of manual cleanup.

## Why This Change Was Made

`bridge.indexMemoryRoot: false` only covers memory-root files, not the wiki vault subtree. Rather than plumb the vault path into the core scanner, the scan now detects a wiki vault generically by its `.openclaw-wiki` marker directory and skips that whole subtree. This breaks the cycle at its source — wiki sources are never exposed as memory artifacts, so neither the indexer nor the bridge re-ingests them — regardless of where the vault is placed inside `memory/`.

## User Impact

No more unbounded SQLite growth or duplicate `bridge-workspace-<id>-*` regeneration for bridge-mode wikis nested under `memory/`. No config change; the fix is automatic on next index. Purely removes waste — no user data is dropped.

## Evidence

- `src/plugin-sdk/memory-host-core.ts`: `listMarkdownFilesRecursive` returns early on a `.openclaw-wiki` marker; both `listMemoryHostPublicArtifacts` (indexer) and `listActiveMemoryPublicArtifacts` (bridge) funnel through it.
- New test in `src/plugin-sdk/memory-host-core.test.ts` asserts a vault nested under `memory/wiki` is skipped while sibling real notes are still indexed.
- `pnpm test src/plugin-sdk/memory-host-core.test.ts` ✅ (5 passed).
