### PR TITLE
fix(agents): scrub non-conforming tool-call ids at the Anthropic wire (#95623)

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -1681,6 +1681,64 @@ describe("anthropic transport stream", () => {
     expect(toolUse.input).toEqual({});
   });
 
+  it("scrubs a failover-introduced composite tool-call id before the Anthropic wire (#95623)", async () => {
+    // A turn served by an openai-responses fallback writes a composite
+    // `call_…|fc_…` id into history. When its recorded provenance looks
+    // same-model as the Anthropic target, the cross-model transform skips
+    // normalization, so the boundary guard at serialization must still scrub
+    // the `|` (which Anthropic 400s) and keep the paired tool_result matched.
+    const compositeId = "call_AbCdEf0123456789|fc_01a7beefc0ffee";
+    await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [
+          { role: "user", content: "look it up" },
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            content: [{ type: "toolCall", id: compositeId, name: "lookup", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: compositeId,
+            toolName: "lookup",
+            content: [{ type: "text", text: "42" }],
+            isError: false,
+          },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const payload = latestAnthropicRequest().payload;
+    const assistantMessage = findRecord(payload.messages, (record) => record.role === "assistant");
+    const toolUse = findRecord(
+      assistantMessage.content,
+      (record) => record.type === "tool_use" && record.name === "lookup",
+    );
+    const wireId = toolUse.id;
+    expect(typeof wireId).toBe("string");
+    expect(wireId as string).not.toContain("|");
+    expect(wireId as string).toMatch(/^[a-zA-Z0-9_-]+$/);
+
+    const userMessage = findRecord(
+      payload.messages,
+      (record) =>
+        record.role === "user" &&
+        Array.isArray(record.content) &&
+        record.content.some((block) => (block as Record<string, unknown>).type === "tool_result"),
+    );
+    const toolResult = findRecord(userMessage.content, (record) => record.type === "tool_result");
+    // Pairing must survive the scrub or Anthropic rejects the unmatched result.
+    expect(toolResult.tool_use_id).toBe(wireId);
+  });
+
   it("replays reasoning_content from compatible Anthropic thinking blocks", async () => {
     const highSurrogate = String.fromCharCode(0xd83d);
     await runTransportStream(

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -498,7 +498,14 @@ function convertAnthropicMessages(
         if (block.type === "toolCall") {
           blocks.push({
             type: "tool_use",
-            id: block.id,
+            // Wire-charset guard: Anthropic 400s any tool_use.id outside
+            // ^[a-zA-Z0-9_-]+$. The transform pass only rewrites ids it treats
+            // as cross-model, so a failover-introduced foreign id (e.g. the
+            // openai-responses `call_…|fc_…` composite) can survive to here and
+            // brick the session (#95623). normalizeToolCallId is idempotent and
+            // a no-op for native ids, and deterministic so the paired
+            // tool_result id below scrubs identically.
+            id: normalizeToolCallId(block.id),
             name: isOAuthToken ? toClaudeCodeName(block.name) : block.name,
             input: coerceTransportToolCallArguments(block.arguments),
           });
@@ -527,7 +534,9 @@ function convertAnthropicMessages(
       const toolResults: Array<Record<string, unknown>> = [
         {
           type: "tool_result",
-          tool_use_id: toolResult.toolCallId,
+          // Paired with the tool_use.id guard above; same deterministic scrub
+          // keeps a failover composite id matched across the pair (#95623).
+          tool_use_id: normalizeToolCallId(toolResult.toolCallId),
           content: convertContentBlocks(toolResult.content),
           is_error: toolResult.isError,
         },
@@ -540,7 +549,7 @@ function convertAnthropicMessages(
         >;
         toolResults.push({
           type: "tool_result",
-          tool_use_id: nextMsg.toolCallId,
+          tool_use_id: normalizeToolCallId(nextMsg.toolCallId),
           content: convertContentBlocks(nextMsg.content),
           is_error: nextMsg.isError,
         });


### PR DESCRIPTION
## What Problem This Solves

Fixes #95623. The tool-call-id sanitizer from #61254 misses an OpenAI-responses composite id (`call_XXX|fc_YYY`) when it enters history via a cross-provider failover and is later replayed to Anthropic. The `|` survives to the wire and Anthropic hard-400s the whole replay (`tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'`), permanently bricking the session for its own primary provider.

## Why This Change Was Made

Root cause: the cross-model transform only rewrites tool-call ids it treats as foreign. A failover turn whose recorded provenance looks same-model as the Anthropic target skips normalization, so the composite id reaches serialization unscrubbed. The complete, provenance-independent fix is a wire-charset guard at the serialization boundary the 400 references: apply the existing idempotent `normalizeToolCallId` to both `tool_use.id` and the paired `tool_result` `tool_use_id`. Native `toolu_*` / `call_…` ids already conform (so #61254's cache preservation is unaffected); only a non-conforming id (the `|` composite) is scrubbed, deterministically and identically across the pair so pairing survives.

## User Impact

A mid-session Anthropic↔OpenAI-responses failover can no longer brick the session with a permanent 400 on subsequent Anthropic turns. Prompt-cache behavior for native ids is unchanged. The upstream provenance bug (transform treating a failover turn as same-model) is a worthwhile follow-up but is not required to stop the brick.

## Evidence

- `src/agents/anthropic-transport-stream.ts`: `normalizeToolCallId` applied at the three id-writing sites in `convertAnthropicMessages`.
- New test in `src/agents/anthropic-transport-stream.test.ts` reproduces a same-model turn carrying a `call_…|fc_…` id (the path the transform skips) and asserts the wire id matches `^[a-zA-Z0-9_-]+$` with the `tool_result` id still matched.
- `pnpm test src/agents/anthropic-transport-stream.test.ts` ✅ (77 passed).
