### PR TITLE
Add Telegram raw ingress extension hook

### DIFF
--- a/docs/plugins/reference/telegram.md
+++ b/docs/plugins/reference/telegram.md
@@ -18,6 +18,18 @@ Adds the Telegram channel surface for sending and receiving OpenClaw messages.
 
 channels: telegram
 
+## Runtime API
+
+Plugins that need raw Telegram updates can import
+`registerTelegramIngressExtension` from `@openclaw/telegram/runtime-api.js`.
+The registered `handleRawUpdate` callback runs inside the bundled Telegram bot
+before normal routing. Returning `"handled"` stops the regular Telegram
+handlers; returning `"continue"` or nothing lets the update fall through.
+
+The bundled Telegram plugin still owns polling and webhooks. Use this hook when
+another plugin needs to observe or handle an update type that Telegram already
+delivers to the configured bot, without starting a second poller.
+
 ## Related docs
 
 - [telegram](/channels/telegram)

--- a/extensions/telegram/runtime-api.ts
+++ b/extensions/telegram/runtime-api.ts
@@ -49,6 +49,12 @@ export {
 export type { TelegramProbe } from "./src/probe.js";
 export { auditTelegramGroupMembership, collectTelegramUnmentionedGroupIds } from "./src/audit.js";
 export { resolveTelegramRuntimeGroupPolicy } from "./src/group-access.js";
+export { registerTelegramIngressExtension } from "./src/telegram-ingress-extensions.js";
+export type {
+  TelegramIngressExtension,
+  TelegramRawUpdateHandlerContext,
+  TelegramRawUpdateHandlerResult,
+} from "./src/telegram-ingress-extensions.js";
 export {
   buildTelegramExecApprovalPendingPayload,
   shouldSuppressTelegramExecApprovalForwardingFallback,

--- a/extensions/telegram/src/allowed-updates.test.ts
+++ b/extensions/telegram/src/allowed-updates.test.ts
@@ -9,7 +9,7 @@ beforeAll(async () => {
 });
 
 describe("resolveTelegramAllowedUpdates", () => {
-  it("includes the default update types plus reaction and channel post support", () => {
+  it("keeps the no-extension default update list unchanged", () => {
     const updates = resolveTelegramAllowedUpdates();
     expect(DEFAULT_TELEGRAM_UPDATE_TYPES).toEqual([
       "message",

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -55,6 +55,7 @@ import { stringifyTelegramRawUpdateForLog } from "./raw-update-log.js";
 import { TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
+import { handleTelegramIngressExtensionRawUpdate } from "./telegram-ingress-extensions.js";
 import { createTelegramThreadBindingManager } from "./thread-bindings.js";
 
 export type { TelegramBotOptions } from "./bot.types.js";
@@ -217,6 +218,20 @@ export function createTelegramBotCore(
       updateTracker.finishUpdate(begin.update, { completed: false });
       throw error;
     }
+  });
+
+  bot.use(async (ctx, next) => {
+    const handled = await handleTelegramIngressExtensionRawUpdate({
+      update: ctx.update,
+      accountId: account.accountId,
+      bot,
+      runtime,
+      channelRuntime: opts.channelRuntime,
+    });
+    if (handled) {
+      return;
+    }
+    await next();
   });
 
   // Answer callback queries immediately before sequentialize queues them behind

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -82,6 +82,8 @@ const {
   resolveTelegramThreadSpec,
 } = await import("./bot/helpers.js");
 const { resolveTelegramGroupPromptSettings } = await import("./group-config-helpers.js");
+const { registerTelegramIngressExtension } = await import("../runtime-api.js");
+const { resetTelegramIngressExtensionsForTests } = await import("./telegram-ingress-extensions.js");
 let createTelegramBot: (
   opts: TelegramBotOptions,
 ) => ReturnType<typeof import("./bot-core.js").createTelegramBotCore>;
@@ -232,6 +234,7 @@ describe("createTelegramBot", () => {
     }
   });
   afterEach(() => {
+    resetTelegramIngressExtensionsForTests();
     pluginStateTestRuntime.resetPluginStateStoreForTests();
     if (previousStateDir === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
@@ -292,6 +295,99 @@ describe("createTelegramBot", () => {
       .calls;
     const errorMessage = sanitizeTerminalText(String(errorCalls[0]?.[0]));
     expect(errorMessage.startsWith("telegram bot error: Error: handler boom")).toBe(true);
+  });
+
+  it("lets Telegram ingress extensions claim raw guest message updates", async () => {
+    const handleRawUpdate = vi.fn(() => "handled" as const);
+    registerTelegramIngressExtension({
+      id: "telegram-guest-mode",
+      handleRawUpdate,
+    });
+    const channelRuntime = { runtimeContexts: {} } as TelegramBotOptions["channelRuntime"];
+
+    createTelegramBot({ token: "tok", accountId: "acct-a", channelRuntime });
+    const finalHandler = vi.fn(async () => undefined);
+    const update = {
+      update_id: 123,
+      guest_message: {
+        guest_query_id: "guest-query-1",
+        message_id: 44,
+        chat: { id: 99, type: "private" },
+        from: { id: 42 },
+        text: "hello from guest mode",
+      },
+    };
+
+    await runTelegramMiddlewareChain({
+      ctx: { update },
+      finalHandler,
+    });
+
+    expect(handleRawUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update,
+        accountId: "acct-a",
+        bot: expect.any(Object),
+        runtime: expect.any(Object),
+        channelRuntime,
+      }),
+    );
+    expect(finalHandler).not.toHaveBeenCalled();
+  });
+
+  it("lets Telegram ingress extensions continue raw updates to downstream middleware", async () => {
+    const handleRawUpdate = vi.fn(() => "continue" as const);
+    registerTelegramIngressExtension({
+      id: "telegram-guest-mode",
+      handleRawUpdate,
+    });
+
+    createTelegramBot({ token: "tok" });
+    const finalHandler = vi.fn(async () => undefined);
+    const update = {
+      update_id: 124,
+      guest_message: {
+        guest_query_id: "guest-query-2",
+        message_id: 45,
+        chat: { id: 99, type: "private" },
+        from: { id: 42 },
+        text: "unhandled guest mode",
+      },
+    };
+
+    await runTelegramMiddlewareChain({
+      ctx: { update },
+      finalHandler,
+    });
+
+    expect(handleRawUpdate).toHaveBeenCalledTimes(1);
+    expect(finalHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs Telegram ingress extension errors and continues downstream middleware", async () => {
+    const runtime = {
+      error: vi.fn(),
+      exit: vi.fn(),
+      log: vi.fn(),
+    };
+    registerTelegramIngressExtension({
+      id: "failing-ingress",
+      handleRawUpdate: () => {
+        throw new Error("raw handler boom");
+      },
+    });
+
+    createTelegramBot({ token: "tok", runtime });
+    const finalHandler = vi.fn(async () => undefined);
+    await runTelegramMiddlewareChain({
+      ctx: { update: { update_id: 125, guest_message: {} } },
+      finalHandler,
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      '[telegram] ingress extension "failing-ingress" failed: raw handler boom',
+    );
+    expect(finalHandler).toHaveBeenCalledTimes(1);
   });
 
   it("uses wrapped fetch when global fetch is available", () => {

--- a/extensions/telegram/src/bot.types.ts
+++ b/extensions/telegram/src/bot.types.ts
@@ -1,4 +1,5 @@
 // Telegram type declarations define plugin contracts.
+import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig, ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -9,6 +10,7 @@ export type TelegramBotOptions = {
   token: string;
   accountId?: string;
   runtime?: RuntimeEnv;
+  channelRuntime?: ChannelRuntimeSurface;
   requireMention?: boolean;
   allowFrom?: Array<string | number>;
   groupAllowFrom?: Array<string | number>;

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -165,7 +165,6 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
 
     const proxyFetch =
       opts.proxyFetch ?? (account.config.proxy ? makeProxyFetch(account.config.proxy) : undefined);
-
     if (opts.useWebhook) {
       const { startTelegramWebhook } = await loadTelegramMonitorWebhookRuntime();
       if (isTelegramExecApprovalHandlerConfigured({ cfg, accountId: account.accountId })) {
@@ -192,6 +191,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         publicUrl: opts.webhookUrl,
         webhookCertPath: opts.webhookCertPath,
         setStatus: opts.setStatus,
+        channelRuntime: opts.channelRuntime,
       });
       await waitForAbortSignal(opts.abortSignal);
       return;
@@ -290,6 +290,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         proxyFetch,
         botInfo: opts.botInfo,
         abortSignal: opts.abortSignal,
+        channelRuntime: opts.channelRuntime,
         runnerOptions: createTelegramRunnerOptions(cfg),
         getLastUpdateId: () => lastUpdateId,
         persistUpdateId,

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -1,6 +1,9 @@
 // Telegram plugin module implements polling session behavior.
 import { type RunOptions, run } from "@grammyjs/runner";
-import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
+import type {
+  ChannelAccountSnapshot,
+  ChannelRuntimeSurface,
+} from "openclaw/plugin-sdk/channel-contract";
 import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-contracts";
 import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
 import {
@@ -235,6 +238,7 @@ type TelegramPollingSessionOpts = {
   config: NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
   accountId: string;
   runtime: Parameters<typeof createTelegramBot>[0]["runtime"];
+  channelRuntime?: ChannelRuntimeSurface;
   proxyFetch: Parameters<typeof createTelegramBot>[0]["proxyFetch"];
   botInfo?: Parameters<typeof createTelegramBot>[0]["botInfo"];
   abortSignal?: AbortSignal;
@@ -496,6 +500,7 @@ export class TelegramPollingSession {
         proxyFetch: this.opts.proxyFetch,
         config: this.opts.config,
         accountId: this.opts.accountId,
+        channelRuntime: this.opts.channelRuntime,
         botInfo: this.opts.botInfo,
         fetchAbortSignal: fetchAbortController.signal,
         minimumClientTimeoutSeconds: TELEGRAM_POLLING_CLIENT_TIMEOUT_FLOOR_SECONDS,

--- a/extensions/telegram/src/telegram-ingress-extensions.ts
+++ b/extensions/telegram/src/telegram-ingress-extensions.ts
@@ -1,0 +1,56 @@
+import type { Bot } from "grammy";
+import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
+// Telegram plugin module implements optional ingress extension hooks.
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+
+export type TelegramRawUpdateHandlerResult = "handled" | "continue" | undefined | void;
+
+export type TelegramRawUpdateHandlerContext = {
+  update: unknown;
+  accountId: string;
+  bot: Bot;
+  runtime: RuntimeEnv;
+  channelRuntime?: ChannelRuntimeSurface;
+};
+
+export type TelegramIngressExtension = {
+  id: string;
+  handleRawUpdate?: (
+    context: TelegramRawUpdateHandlerContext,
+  ) => TelegramRawUpdateHandlerResult | Promise<TelegramRawUpdateHandlerResult>;
+};
+
+const telegramIngressExtensions = new Set<TelegramIngressExtension>();
+
+export function registerTelegramIngressExtension(extension: TelegramIngressExtension): () => void {
+  telegramIngressExtensions.add(extension);
+  return () => {
+    telegramIngressExtensions.delete(extension);
+  };
+}
+
+export async function handleTelegramIngressExtensionRawUpdate(
+  context: TelegramRawUpdateHandlerContext,
+): Promise<boolean> {
+  for (const extension of telegramIngressExtensions) {
+    if (!extension.handleRawUpdate) {
+      continue;
+    }
+    try {
+      const result = await extension.handleRawUpdate(context);
+      if (result === "handled") {
+        return true;
+      }
+    } catch (err) {
+      context.runtime.error?.(
+        `[telegram] ingress extension "${extension.id}" failed: ${formatErrorMessage(err)}`,
+      );
+    }
+  }
+  return false;
+}
+
+export function resetTelegramIngressExtensionsForTests(): void {
+  telegramIngressExtensions.clear();
+}

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -3,7 +3,10 @@ import { createServer } from "node:http";
 import type { IncomingMessage } from "node:http";
 import net from "node:net";
 import { InputFile } from "grammy";
-import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
+import type {
+  ChannelAccountSnapshot,
+  ChannelRuntimeSurface,
+} from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isDiagnosticsEnabled } from "openclaw/plugin-sdk/diagnostic-runtime";
 import {
@@ -250,6 +253,7 @@ export async function startTelegramWebhook(opts: {
   webhookCertPath?: string;
   webhookRegistrationRetryPolicy?: BackoffPolicy;
   setStatus?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
+  channelRuntime?: ChannelRuntimeSurface;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -274,6 +278,7 @@ export async function startTelegramWebhook(opts: {
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    channelRuntime: opts.channelRuntime,
   });
   await initializeTelegramWebhookBot({
     bot,

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -212,6 +212,8 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
       'export type { TelegramProbe } from "./src/probe.js";',
       'export { auditTelegramGroupMembership, collectTelegramUnmentionedGroupIds } from "./src/audit.js";',
       'export { resolveTelegramRuntimeGroupPolicy } from "./src/group-access.js";',
+      'export { registerTelegramIngressExtension } from "./src/telegram-ingress-extensions.js";',
+      'export type { TelegramIngressExtension, TelegramRawUpdateHandlerContext, TelegramRawUpdateHandlerResult } from "./src/telegram-ingress-extensions.js";',
       'export { buildTelegramExecApprovalPendingPayload, shouldSuppressTelegramExecApprovalForwardingFallback } from "./src/exec-approval-forwarding.js";',
       'export { telegramMessageActions } from "./src/channel-actions.js";',
       'export { monitorTelegramProvider } from "./src/monitor.js";',


### PR DESCRIPTION
## What Problem This Solves

External plugins can receive Telegram updates only after the bundled Telegram
plugin has routed them into OpenClaw's normal message handlers. That leaves no
stable place for a companion plugin to handle raw update types such as
`guest_message` while the bundled Telegram plugin remains the only polling or
webhook owner.

## Why This Change Was Made

This adds a narrow runtime hook to the Telegram plugin:

- `registerTelegramIngressExtension(...)` is exported from
  `@openclaw/telegram/runtime-api.js`.
- Registered handlers run inside the existing Telegram bot before normal
  routing.
- Returning `"handled"` stops regular Telegram routing for that update.
- Returning `"continue"` or nothing lets the update fall through.

The change does not add a second poller, does not change Telegram token
ownership, and does not change the default `allowed_updates` resolver.

## User Impact

Users should see no behavior change unless a plugin registers a Telegram
ingress extension. Plugin authors get a small, typed hook for update types that
Telegram already delivers to the configured bot.

## Evidence

- `node scripts/run-vitest.mjs run extensions/telegram/src/allowed-updates.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/webhook.test.ts src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts`
- `pnpm tsgo:test:extensions`
