### PR TITLE
fix(cron): trim trailing whitespace from recognized job object keys

### DIFF
--- a/src/agents/tools/cron-tool-canonicalize.ts
+++ b/src/agents/tools/cron-tool-canonicalize.ts
@@ -250,9 +250,11 @@ function canonicalizeCronToolPayload(value: Record<string, unknown>): void {
  * validation to reject the job with "unexpected property" errors.
  *
  * Only recognized CRON_RECOVERABLE_OBJECT_KEYS are trimmed — arbitrary keys
- * (including special ones like "__proto__") are never mutated. If both the
- * padded and canonical form of a key exist (e.g. "schedule " and "schedule"),
- * the canonical key wins and the padded variant is discarded.
+ * (including special ones like "__proto__") are never mutated.
+ *
+ * If both the padded and canonical form of a key exist (e.g. "schedule " and
+ * "schedule"), the padded key is preserved so strict gateway validation
+ * rejects the ambiguous input rather than silently picking one value.
  */
 function repairPaddedCronKeys(value: Record<string, unknown>): void {
   for (const key of Object.keys(value)) {
@@ -260,8 +262,10 @@ function repairPaddedCronKeys(value: Record<string, unknown>): void {
     if (trimmed !== key && CRON_RECOVERABLE_OBJECT_KEYS.has(trimmed)) {
       if (!(trimmed in value)) {
         value[trimmed] = value[key];
+        delete value[key];
       }
-      delete value[key];
+      // When the canonical key already exists, preserve the padded duplicate
+      // so strict gateway validation sees the conflict and rejects the input.
     }
   }
 }

--- a/src/agents/tools/cron-tool-canonicalize.ts
+++ b/src/agents/tools/cron-tool-canonicalize.ts
@@ -243,12 +243,36 @@ function canonicalizeCronToolPayload(value: Record<string, unknown>): void {
   }
 }
 
+/**
+ * Normalizes whitespace-padded cron object keys. Some tool-call
+ * extraction/serialization pipelines can produce keys with trailing spaces
+ * (e.g. "schedule " instead of "schedule"), which causes strict gateway
+ * validation to reject the job with "unexpected property" errors.
+ *
+ * Only recognized CRON_RECOVERABLE_OBJECT_KEYS are trimmed — arbitrary keys
+ * (including special ones like "__proto__") are never mutated. If both the
+ * padded and canonical form of a key exist (e.g. "schedule " and "schedule"),
+ * the canonical key wins and the padded variant is discarded.
+ */
+function repairPaddedCronKeys(value: Record<string, unknown>): void {
+  for (const key of Object.keys(value)) {
+    const trimmed = key.trim();
+    if (trimmed !== key && CRON_RECOVERABLE_OBJECT_KEYS.has(trimmed)) {
+      if (!(trimmed in value)) {
+        value[trimmed] = value[key];
+      }
+      delete value[key];
+    }
+  }
+}
+
 /** Converts model-friendly cron tool shorthands into the nested gateway job/patch shape. */
 export function canonicalizeCronToolObject(
   value: Record<string, unknown>,
 ): Record<string, unknown> {
   const unwrapped = isRecord(value.data) ? value.data : isRecord(value.job) ? value.job : value;
   const next = { ...unwrapped };
+  repairPaddedCronKeys(next);
   repairConcatenatedCronToolKeys(next);
   canonicalizeCronToolSchedule(next);
   canonicalizeCronToolPayload(next);

--- a/src/agents/tools/cron-tool.flat-params.test.ts
+++ b/src/agents/tools/cron-tool.flat-params.test.ts
@@ -181,4 +181,135 @@ describe("cron tool flat-params", () => {
       staggerMs: 30_000,
     });
   });
+
+  it("trims trailing whitespace from recognized job object keys (#95407)", async () => {
+    const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
+
+    await tool.execute("call-trailing-space", {
+      action: "add",
+      job: {
+        name: "Holiday Check-in",
+        description: "Casual check-in",
+        "schedule ": { kind: "cron", expr: "30 10,20 * * *", tz: "Europe/Madrid" },
+        "sessionTarget ": "isolated",
+        "payload ": { kind: "agentTurn", message: "How's it going?" },
+        "enabled ": true,
+      },
+    });
+
+    const [method, _gatewayOpts, params] = firstGatewayToolCall<{
+      name?: string;
+      schedule?: unknown;
+      sessionTarget?: string;
+      payload?: unknown;
+      enabled?: boolean;
+    }>();
+    expect(method).toBe("cron.add");
+    expect(params.name).toBe("Holiday Check-in");
+    expect(params.schedule).toBeDefined();
+    expect(params.sessionTarget).toBe("isolated");
+    expect(params.payload).toBeDefined();
+    expect(params.enabled).toBe(true);
+    expect(params).not.toHaveProperty("schedule ");
+    expect(params).not.toHaveProperty("sessionTarget ");
+    expect(params).not.toHaveProperty("payload ");
+    expect(params).not.toHaveProperty("enabled ");
+  });
+
+  it("trims trailing whitespace from recognized patch object keys (#95407)", async () => {
+    const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
+
+    await tool.execute("call-patch-trailing-space", {
+      action: "update",
+      jobId: "job-123",
+      patch: {
+        "schedule ": { kind: "cron", expr: "0 9 * * 1-5", tz: "America/New_York" },
+        "enabled ": false,
+      },
+    });
+
+    const [method, _gatewayOpts, params] = firstGatewayToolCall<{
+      id?: string;
+      patch?: { schedule?: unknown; enabled?: boolean };
+    }>();
+    expect(method).toBe("cron.update");
+    expect(params.id).toBe("job-123");
+    expect(params.patch?.schedule).toBeDefined();
+    expect((params.patch?.schedule as Record<string, unknown>)?.kind).toBe("cron");
+    expect(params.patch?.enabled).toBe(false);
+    expect(params.patch).not.toHaveProperty("schedule ");
+    expect(params.patch).not.toHaveProperty("enabled ");
+  });
+
+  it("does not trim unrecognized keys to prevent prototype pollution (#95407)", async () => {
+    const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
+
+    await tool.execute("call-unsafe-keys", {
+      action: "add",
+      job: {
+        name: "Safe trim",
+        schedule: { kind: "cron", expr: "0 12 * * *", tz: "UTC" },
+        payload: { kind: "agentTurn", message: "work" },
+        // Non-recognized keys with trailing spaces should NOT be trimmed
+        // (prevents "__proto__ " → "__proto__" style attacks)
+        "__proto__ ": { malicious: true },
+        "constructor ": "should not be trimmed",
+      },
+    });
+
+    const [method, _gatewayOpts, params] = firstGatewayToolCall<Record<string, unknown>>();
+    expect(method).toBe("cron.add");
+    // Non-recognized padded keys should remain as-is
+    expect(params).toHaveProperty("__proto__ ");
+    expect(params).toHaveProperty("constructor ");
+  });
+
+  it("preserves canonical key when both padded and clean form exist (#95407)", async () => {
+    const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
+
+    await tool.execute("call-duplicate-keys", {
+      action: "add",
+      job: {
+        name: "Duplicate test",
+        schedule: { kind: "cron", expr: "0 9 * * 1-5", tz: "UTC" },
+        // Both "schedule" and "schedule " exist — canonical wins
+        "schedule ": { kind: "every", everyMs: 60000 },
+        payload: { kind: "agentTurn", message: "work" },
+        "enabled ": true,
+        enabled: false,
+      },
+    });
+
+    const [method, _gatewayOpts, params] = firstGatewayToolCall<Record<string, unknown>>();
+    expect(method).toBe("cron.add");
+    // Canonical keys should not be overwritten by padded variants
+    expect((params.schedule as Record<string, unknown>)?.kind).toBe("cron");
+    expect(params.enabled).toBe(false);
+    // Padded keys should be removed
+    expect(params).not.toHaveProperty("schedule ");
+    expect(params).not.toHaveProperty("enabled ");
+  });
+
+  it("preserves normal keys without any whitespace", async () => {
+    const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
+
+    await tool.execute("call-clean-keys", {
+      action: "add",
+      job: {
+        name: "Clean keys",
+        schedule: { kind: "cron", expr: "0 12 * * *", tz: "UTC" },
+        payload: { kind: "agentTurn", message: "test" },
+        enabled: true,
+        description: "All keys should be preserved as-is",
+      },
+    });
+
+    const [method, _gatewayOpts, params] = firstGatewayToolCall<Record<string, unknown>>();
+    expect(method).toBe("cron.add");
+    expect(params.name).toBe("Clean keys");
+    expect(params.schedule).toBeDefined();
+    expect(params.payload).toBeDefined();
+    expect(params.enabled).toBe(true);
+    expect(params.description).toBe("All keys should be preserved as-is");
+  });
 });

--- a/src/agents/tools/cron-tool.flat-params.test.ts
+++ b/src/agents/tools/cron-tool.flat-params.test.ts
@@ -264,7 +264,10 @@ describe("cron tool flat-params", () => {
     expect(params).toHaveProperty("constructor ");
   });
 
-  it("preserves canonical key when both padded and clean form exist (#95407)", async () => {
+  it("preserves padded duplicate when canonical key already exists (#95407)", async () => {
+    // When both canonical and padded forms exist, the padded key is preserved
+    // so strict gateway validation rejects the ambiguous input rather than
+    // silently picking one value.
     const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
 
     await tool.execute("call-duplicate-keys", {
@@ -272,7 +275,7 @@ describe("cron tool flat-params", () => {
       job: {
         name: "Duplicate test",
         schedule: { kind: "cron", expr: "0 9 * * 1-5", tz: "UTC" },
-        // Both "schedule" and "schedule " exist — canonical wins
+        // Both "schedule" and "schedule " exist — padded preserved for rejection
         "schedule ": { kind: "every", everyMs: 60000 },
         payload: { kind: "agentTurn", message: "work" },
         "enabled ": true,
@@ -282,12 +285,14 @@ describe("cron tool flat-params", () => {
 
     const [method, _gatewayOpts, params] = firstGatewayToolCall<Record<string, unknown>>();
     expect(method).toBe("cron.add");
-    // Canonical keys should not be overwritten by padded variants
+    // Canonical key is untouched
     expect((params.schedule as Record<string, unknown>)?.kind).toBe("cron");
     expect(params.enabled).toBe(false);
-    // Padded keys should be removed
-    expect(params).not.toHaveProperty("schedule ");
-    expect(params).not.toHaveProperty("enabled ");
+    // Padded keys are preserved so gateway schema validation sees the conflict
+    // and rejects with "unexpected property 'schedule '" instead of silently
+    // accepting one of the two conflicting values.
+    expect(params).toHaveProperty("schedule ");
+    expect(params).toHaveProperty("enabled ");
   });
 
   it("preserves normal keys without any whitespace", async () => {


### PR DESCRIPTION
Fixes #95407

## What Problem This Solves

Some tool-call extraction/serialization pipelines produce cron object keys with trailing spaces (e.g. "schedule " instead of "schedule"), causing gateway validation to reject the job with "unexpected property" errors.

Only specific top-level keys are affected (schedule, sessionTarget, payload, enabled). Nested keys and keys like name/description are not affected.

## Evidence

### Fix

Added `repairPaddedCronKeys()` to `canonicalizeCronToolObject()` that trims whitespace from recognized cron object keys before any schema processing.

Safety design:
- **Only recognized `CRON_RECOVERABLE_OBJECT_KEYS`** are trimmed — arbitrary keys (including `__proto__`, `constructor`) are never mutated
- **Duplicate preservation**: when both padded and canonical form exist (e.g. `"schedule"` and `"schedule "`), the padded key is **preserved** so strict gateway validation rejects the ambiguous input rather than silently picking one value
- **Non-duplicate trimming**: when only the padded form exists, it is trimmed to its canonical form

### Real behavior proof

- Behavior addressed: cron tool add/update actions fail with "unexpected property 'schedule '" when model generates keys with trailing whitespace
- Real environment tested: local source checkout, Node.js v24.13.1, Linux x64
- Exact steps or command run after this patch:
  ```
  $ node --import tsx scripts/cron-trim-proof.ts
  ```
- Evidence after fix:
  ```
  === Real behavior proof: cron key trimming (#95407) ===

  Test 1: Only padded 'schedule ' key -> trimmed to 'schedule'
    Input:  {"schedule ":...,"enabled ":true}
    Output: {"schedule":...,"enabled":true}
    schedule: present OK
    'schedule ' removed: yes OK

  Test 2: Both 'schedule' and 'schedule ' -> padded preserved (gateway rejects)
    Input:  {"schedule":{every},"schedule ":{cron}}
    Output: {"schedule":{every},"schedule ":{cron}}
    schedule.kind: every (canonical untouched OK)
    'schedule ' preserved: true (gateway will reject OK)

  Test 3: Non-recognized '__proto__ ' key -> NOT trimmed
    Input:  {"name":"safe"," __proto__ ":{"malicious":true}}
    Output: {"name":"safe"," __proto__ ":{"malicious":true}}
    ' __proto__ ' preserved: true (safe OK)

  Test 4: Normal keys without whitespace -> unchanged
    All keys preserved: yes OK

  === All checks passed ===
  ```
- Observed result after fix: padded-only keys are correctly trimmed to canonical form; duplicate padded+canonical keys are preserved for gateway rejection; non-recognized keys (including `__proto__`) are never mutated; normal keys are unchanged
- What was not tested: live E2E with Qwen 3.5B via llama.cpp (requires specific hardware/model setup)

### Tests (5 new, 133 total)

| Test | Scenario | Result |
|------|----------|--------|
| trailing-space job keys | add with schedule / sessionTarget / payload / enabled | OK |
| trailing-space patch keys | update with padded keys in patch | OK |
| non-recognized keys untouched | __proto__, constructor with spaces | NOT trimmed OK |
| duplicate canonical+ padded | both schedule and schedule present | padded preserved OK |
| clean keys preserved | normal keys without whitespace | unchanged OK |

```
Test Files  2 passed (2)
Tests  133 passed (133)
```

### Checks
- Format: `oxfmt` ✓
- Lint: `oxlint` ✓
- Diff: +24 source, +131 test (155 total)
- Branch: clean from `origin/main`
