### PR TITLE
feat(compaction): add compaction.preflight.enabled config gate (#95553)

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -645,6 +645,7 @@ Periodic heartbeat runs.
         model: "openrouter/anthropic/claude-sonnet-4-6", // optional compaction-only model override
         truncateAfterCompaction: true, // rotate to a smaller successor JSONL after compaction
         maxActiveTranscriptBytes: "20mb", // optional preflight local compaction trigger
+        preflight: { enabled: false }, // optional gate that skips the pre-turn threshold check
         notifyUser: true, // send brief notices when compaction starts and completes (default: false)
         memoryFlush: {
           enabled: true,
@@ -670,6 +671,7 @@ Periodic heartbeat runs.
 - `postCompactionSections`: optional AGENTS.md H2/H3 section names to re-inject after compaction. Reinjection is disabled when unset or set to `[]`. Explicitly setting `["Session Startup", "Red Lines"]` enables that pair and preserves the legacy `Every Session`/`Safety` fallback. Enable this only when the extra context is worth the risk of duplicating project guidance already captured in the compaction summary.
 - `model`: optional `provider/model-id` override for compaction summarization only. Use this when the main session should keep one model but compaction summaries should run on another; when unset, compaction uses the session's primary model.
 - `maxActiveTranscriptBytes`: optional byte threshold (`number` or strings like `"20mb"`) that triggers normal local compaction before a run when the active JSONL grows past the threshold. Requires `truncateAfterCompaction` so successful compaction can rotate to a smaller successor transcript. Disabled when unset or `0`.
+- `preflight`: optional gate around the pre-turn budget-triggered preflight compaction path. Set `preflight.enabled: false` to skip the pre-turn threshold check entirely and let every turn fall through to overflow recovery (which honors `timeoutSeconds`). Default: `preflight.enabled` is `true` and the existing preflight path runs as before.
 - `notifyUser`: when `true`, sends brief notices to the user when compaction starts and when it completes (for example, "Compacting context..." and "Compaction complete"). Disabled by default to keep compaction silent.
 - `memoryFlush`: silent agentic turn before auto-compaction to store durable memories. Set `model` to an exact provider/model such as `ollama/qwen3:8b` when this housekeeping turn should stay on a local model; the override does not inherit the active session fallback chain. Skipped when workspace is read-only.
 

--- a/scripts/repro/issue-95553-preflight-disabled-gate.mts
+++ b/scripts/repro/issue-95553-preflight-disabled-gate.mts
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Live repro for issue #95553 — preflight (budget-triggered) compaction gate.
+ *
+ * Issue #95553 reports that preflight compaction cannot be disabled via config.
+ * When a user adds a new compaction preflight entry, the pre-turn check in
+ * `runPreflightCompactionIfNeeded` always runs, even though the user wanted
+ * the budget-triggered preflight path turned off so every turn falls through
+ * to overflow recovery (which already honors `compaction.timeoutSeconds`).
+ *
+ * Run: pnpm exec tsx scripts/repro/issue-95553-preflight-disabled-gate.mts
+ *
+ * Behavior proved here:
+ *   1. `preflight.enabled === false` short-circuits the preflight check and
+ *      `compactEmbeddedAgentSession` is NOT called.
+ *   2. `preflight.enabled === true` proceeds to the preflight path (mock
+ *      resolves ok; gate does not interfere).
+ *   3. `preflight` key absent preserves the existing default-on behavior
+ *      (preflight runs as before — the fix is strictly additive).
+ *
+ * Real environment: this script runs against the real production
+ * `runPreflightCompactionIfNeeded` function with vitest-style mocks for
+ * `compactEmbeddedAgentSession`, `runEmbeddedAgent`, and `runWithModelFallback`.
+ * The mocks are the same ones the unit tests use, so this script proves the
+ * full production code path including the early-return gate.
+ */
+import assert from "node:assert/strict";
+import { runPreflightCompactionIfNeeded } from "../../src/auto-reply/reply/agent-runner-memory.ts";
+
+type SessionEntry = Parameters<typeof runPreflightCompactionIfNeeded>[0]["sessionEntry"];
+
+function makeSessionEntry(): SessionEntry {
+  return {
+    sessionId: "session-95553-repro",
+    sessionFile: "/tmp/openclaw-95553-repro/session.jsonl",
+    updatedAt: Date.now(),
+    totalTokens: 180_500,
+    totalTokensFresh: true,
+  };
+}
+
+function makeReplyOperation(): Parameters<typeof runPreflightCompactionIfNeeded>[0]["replyOperation"] {
+  return {
+    key: "test-95553",
+    sessionId: "session-95553-repro",
+    abortSignal: new AbortController().signal,
+    resetTriggered: false,
+    phase: "queued",
+    result: null,
+    setPhase: () => undefined,
+    updateSessionId: () => undefined,
+    attachBackend: () => undefined,
+    detachBackend: () => undefined,
+    retainFailureUntilComplete: () => undefined,
+    complete: () => undefined,
+  };
+}
+
+async function main(): Promise<void> {
+  let exitCode = 0;
+  console.log("=== Reproduction for issue #95553 — preflight gate ===");
+
+  // 1. preflight.enabled === false → no compactEmbeddedAgentSession call.
+  // We rely on the unit test that proves this for the full path; here we
+  // demonstrate the config-gate read is the only path that needs production
+  // verification (no model resolution needed when gate is false).
+  const cfg = {
+    agents: {
+      defaults: {
+        compaction: {
+          preflight: { enabled: false },
+        },
+      },
+    },
+  };
+  const sessionEntry = makeSessionEntry();
+  const replyOperation = makeReplyOperation();
+
+  // The function returns synchronously when the gate is engaged and no
+  // preflight work is needed; the gate is evaluated before any model lookup
+  // or compactEmbeddedAgentSession call.
+  const result = await runPreflightCompactionIfNeeded({
+    cfg: cfg as never,
+    followupRun: {
+      run: {
+        sessionId: sessionEntry.sessionId,
+        sessionFile: sessionEntry.sessionFile,
+        sessionKey: "agent:main:main",
+        prompt: "x".repeat(5_000),
+        model: "anthropic/claude-opus-4-6",
+        provider: "anthropic",
+        ownerNumbers: [],
+      },
+    } as never,
+    defaultModel: "anthropic/claude-opus-4-6",
+    agentCfgContextTokens: 200_000,
+    sessionEntry,
+    sessionStore: { "agent:main:main": sessionEntry },
+    sessionKey: "agent:main:main",
+    storePath: "/tmp/openclaw-95553-repro/sessions.json",
+    isHeartbeat: false,
+    replyOperation,
+  });
+
+  assert.equal(result, sessionEntry, "result must be the same session entry");
+  console.log("PASS  1. preflight.enabled === false short-circuits preflight check");
+  console.log(`        sessionEntry returned unchanged: ${result?.sessionId}`);
+
+  // 2-3 are covered by the unit test in
+  // src/auto-reply/reply/agent-runner-memory.test.ts
+  // ("skips preflight compaction when ... enabled === false") which
+  // additionally verifies the negative path: that compactEmbeddedAgentSession
+  // is never called and incrementCompactionCount is never called.
+
+  if (exitCode !== 0) {
+    console.error("FAIL");
+  } else {
+    console.log("=== All repro assertions passed ===");
+  }
+  process.exit(exitCode);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/repro/issue-95553-preflight-disabled-gate.mts
+++ b/scripts/repro/issue-95553-preflight-disabled-gate.mts
@@ -57,7 +57,7 @@ function makeReplyOperation(): Parameters<typeof runPreflightCompactionIfNeeded>
 }
 
 async function main(): Promise<void> {
-  let exitCode = 0;
+  const exitCode = 0;
   console.log("=== Reproduction for issue #95553 — preflight gate ===");
 
   // 1. preflight.enabled === false → no compactEmbeddedAgentSession call.
@@ -120,7 +120,7 @@ async function main(): Promise<void> {
   process.exit(exitCode);
 }
 
-main().catch((err) => {
+main().catch((err: unknown) => {
   console.error(err);
   process.exit(1);
 });

--- a/scripts/repro/issue-95553-preflight-disabled-gate.mts
+++ b/scripts/repro/issue-95553-preflight-disabled-gate.mts
@@ -10,29 +10,35 @@
  *
  * Run: pnpm exec tsx scripts/repro/issue-95553-preflight-disabled-gate.mts
  *
- * Behavior proved here:
- *   1. `preflight.enabled === false` short-circuits the preflight check and
- *      `compactEmbeddedAgentSession` is NOT called.
- *   2. `preflight.enabled === true` proceeds to the preflight path (mock
- *      resolves ok; gate does not interfere).
- *   3. `preflight` key absent preserves the existing default-on behavior
- *      (preflight runs as before — the fix is strictly additive).
+ * Behavior proved here (real-environment proof, not a unit-test mock):
+ *   1. Writes a real `openclaw.json` to a temp state dir with
+ *      `agents.defaults.compaction.preflight.enabled: false`.
+ *   2. Loads it via the production `loadConfig()` (same code path as gateway
+ *      startup) so the gate value is read from a parsed config, not a cast.
+ *   3. Calls the production `runPreflightCompactionIfNeeded` with that
+ *      config plus a real on-disk session entry. The function short-circuits
+ *      before `compactEmbeddedAgentSession` is reached, returning the original
+ *      session entry unchanged.
  *
- * Real environment: this script runs against the real production
- * `runPreflightCompactionIfNeeded` function with vitest-style mocks for
- * `compactEmbeddedAgentSession`, `runEmbeddedAgent`, and `runWithModelFallback`.
- * The mocks are the same ones the unit tests use, so this script proves the
- * full production code path including the early-return gate.
+ * Real environment: this script runs against the production
+ * `runPreflightCompactionIfNeeded` function and the production config loader.
+ * The only stub is `replyOperation` (an in-process callback bag with no
+ * behavior exercised by the gate path).
  */
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { loadConfig } from "../../src/config/io.ts";
 import { runPreflightCompactionIfNeeded } from "../../src/auto-reply/reply/agent-runner-memory.ts";
+import { withEnvAsync } from "../../src/test-utils/env.ts";
 
 type SessionEntry = Parameters<typeof runPreflightCompactionIfNeeded>[0]["sessionEntry"];
 
-function makeSessionEntry(): SessionEntry {
+function makeSessionEntry(sessionFile: string): SessionEntry {
   return {
     sessionId: "session-95553-repro",
-    sessionFile: "/tmp/openclaw-95553-repro/session.jsonl",
+    sessionFile,
     updatedAt: Date.now(),
     totalTokens: 180_500,
     totalTokensFresh: true,
@@ -57,67 +63,87 @@ function makeReplyOperation(): Parameters<typeof runPreflightCompactionIfNeeded>
 }
 
 async function main(): Promise<void> {
-  const exitCode = 0;
-  console.log("=== Reproduction for issue #95553 — preflight gate ===");
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-95553-repro-"));
+  const configDir = path.join(tmpDir, "config");
+  const sessionsDir = path.join(tmpDir, "sessions");
+  await fs.mkdir(configDir, { recursive: true });
+  await fs.mkdir(sessionsDir, { recursive: true });
+  const configPath = path.join(configDir, "openclaw.json");
+  const sessionFile = path.join(sessionsDir, "session.jsonl");
+  const storePath = path.join(sessionsDir, "sessions.json");
 
-  // 1. preflight.enabled === false → no compactEmbeddedAgentSession call.
-  // We rely on the unit test that proves this for the full path; here we
-  // demonstrate the config-gate read is the only path that needs production
-  // verification (no model resolution needed when gate is false).
-  const cfg = {
+  const openclawJson = {
     agents: {
       defaults: {
+        model: "anthropic/claude-opus-4-6",
         compaction: {
           preflight: { enabled: false },
         },
       },
     },
   };
-  const sessionEntry = makeSessionEntry();
-  const replyOperation = makeReplyOperation();
+  await fs.writeFile(configPath, JSON.stringify(openclawJson, null, 2), "utf8");
+  await fs.writeFile(sessionFile, "", "utf8");
 
-  // The function returns synchronously when the gate is engaged and no
-  // preflight work is needed; the gate is evaluated before any model lookup
-  // or compactEmbeddedAgentSession call.
-  const result = await runPreflightCompactionIfNeeded({
-    cfg: cfg as never,
-    followupRun: {
-      run: {
-        sessionId: sessionEntry.sessionId,
-        sessionFile: sessionEntry.sessionFile,
-        sessionKey: "agent:main:main",
-        prompt: "x".repeat(5_000),
-        model: "anthropic/claude-opus-4-6",
-        provider: "anthropic",
-        ownerNumbers: [],
+  console.log("=== Reproduction for issue #95553 — preflight gate ===");
+  console.log(`tmpDir: ${tmpDir}`);
+  console.log(`openclaw.json: ${configPath}`);
+  console.log(`sessionFile: ${sessionFile}`);
+
+  try {
+    const cfg = await withEnvAsync(
+      {
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: tmpDir,
       },
-    } as never,
-    defaultModel: "anthropic/claude-opus-4-6",
-    agentCfgContextTokens: 200_000,
-    sessionEntry,
-    sessionStore: { "agent:main:main": sessionEntry },
-    sessionKey: "agent:main:main",
-    storePath: "/tmp/openclaw-95553-repro/sessions.json",
-    isHeartbeat: false,
-    replyOperation,
-  });
+      async () => loadConfig({ pin: false }),
+    );
 
-  assert.equal(result, sessionEntry, "result must be the same session entry");
-  console.log("PASS  1. preflight.enabled === false short-circuits preflight check");
-  console.log(`        sessionEntry returned unchanged: ${result?.sessionId}`);
+    const gateValue = cfg.agents?.defaults?.compaction?.preflight?.enabled;
+    console.log(`loaded config: agents.defaults.compaction.preflight.enabled = ${gateValue}`);
+    assert.equal(
+      gateValue,
+      false,
+      "loaded config must carry preflight.enabled=false from openclaw.json",
+    );
 
-  // 2-3 are covered by the unit test in
-  // src/auto-reply/reply/agent-runner-memory.test.ts
-  // ("skips preflight compaction when ... enabled === false") which
-  // additionally verifies the negative path: that compactEmbeddedAgentSession
-  // is never called and incrementCompactionCount is never called.
+    const sessionEntry = makeSessionEntry(sessionFile);
+    const replyOperation = makeReplyOperation();
 
-  if (exitCode !== 0) {
-    console.error("FAIL");
-  } else {
+    const result = await runPreflightCompactionIfNeeded({
+      cfg,
+      followupRun: {
+        run: {
+          sessionId: sessionEntry.sessionId,
+          sessionFile: sessionEntry.sessionFile,
+          sessionKey: "agent:main:main",
+          prompt: "x".repeat(5_000),
+          model: "anthropic/claude-opus-4-6",
+          provider: "anthropic",
+          ownerNumbers: [],
+        },
+      } as never,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      sessionEntry,
+      sessionStore: { "agent:main:main": sessionEntry },
+      sessionKey: "agent:main:main",
+      storePath,
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    assert.equal(
+      result,
+      sessionEntry,
+      "result must be the same session entry (preflight gate short-circuits)",
+    );
+    console.log("PASS  preflight.enabled === false short-circuits preflight check");
+    console.log(`      sessionEntry returned unchanged: ${result?.sessionId}`);
     console.log("=== All repro assertions passed ===");
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
   }
-  process.exit(exitCode);
 }
 
 main().catch((err: unknown) => {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2119,3 +2119,66 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(flushCall.bootstrapPromptWarningSignature).toBe("sig-b");
   });
 });
+
+describe("runPreflightCompactionIfNeeded with compaction.preflight.enabled", () => {
+  function makeSessionEntry(): SessionEntry {
+    return {
+      sessionId: "session-preflight",
+      sessionFile: path.join(os.tmpdir(), "openclaw-preflight-disabled-session.jsonl"),
+      updatedAt: Date.now(),
+      totalTokens: 180_500,
+      totalTokensFresh: true,
+    };
+  }
+
+  beforeEach(() => {
+    runWithModelFallbackMock.mockReset().mockImplementation(async ({ provider, model, run }) => ({
+      result: await run(provider, model),
+      provider,
+      model,
+      attempts: [],
+    }));
+    runEmbeddedAgentMock.mockReset().mockResolvedValue({ payloads: [], meta: {} });
+    compactEmbeddedAgentSessionMock.mockReset().mockResolvedValue({
+      ok: true,
+      compacted: true,
+      result: { tokensAfter: 42 },
+    });
+    incrementCompactionCountMock.mockReset();
+    refreshQueuedFollowupSessionMock.mockReset();
+  });
+
+  it("skips preflight compaction when cfg.agents.defaults.compaction.preflight.enabled === false", async () => {
+    const sessionEntry = makeSessionEntry();
+    const replyOperation = createReplyOperation();
+
+    const result = await runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              preflight: { enabled: false },
+            },
+          },
+        },
+      },
+      followupRun: createTestFollowupRun({
+        sessionId: sessionEntry.sessionId,
+        sessionFile: sessionEntry.sessionFile,
+        sessionKey: "agent:main:main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      sessionEntry,
+      sessionStore: { "agent:main:main": sessionEntry },
+      sessionKey: "agent:main:main",
+      storePath: path.join(os.tmpdir(), "openclaw-preflight-disabled-sessions.json"),
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+    expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+    expect(result).toBe(sessionEntry);
+  });
+});

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -711,6 +711,13 @@ export async function runPreflightCompactionIfNeeded(params: {
   if (params.isHeartbeat || isCli) {
     return entry ?? params.sessionEntry;
   }
+  // `compaction.preflight.enabled: false` short-circuits the budget-triggered
+  // preflight path entirely; subsequent turns then rely on overflow recovery,
+  // which already honors `compaction.timeoutSeconds` (~15min budget). The check
+  // is `=== false` so an unset key preserves the existing default-on behavior.
+  if (params.cfg.agents?.defaults?.compaction?.preflight?.enabled === false) {
+    return entry ?? params.sessionEntry;
+  }
   if (
     followupUsesCodexRuntime({
       cfg: params.cfg,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -713,8 +713,8 @@ export async function runPreflightCompactionIfNeeded(params: {
   }
   // `compaction.preflight.enabled: false` short-circuits the budget-triggered
   // preflight path entirely; subsequent turns then rely on overflow recovery,
-  // which already honors `compaction.timeoutSeconds` (~15min budget). The check
-  // is `=== false` so an unset key preserves the existing default-on behavior.
+  // which already honors `compaction.timeoutSeconds`. The check is `=== false`
+  // so an unset key preserves the existing default-on behavior.
   if (params.cfg.agents?.defaults?.compaction?.preflight?.enabled === false) {
     return entry ?? params.sessionEntry;
   }

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1512,6 +1512,10 @@ export const FIELD_HELP: Record<string, string> = {
     "User-prompt template used for the pre-compaction memory flush turn when generating memory candidates. Use this only when you need custom extraction instructions beyond the default memory flush behavior.",
   "agents.defaults.compaction.memoryFlush.systemPrompt":
     "System-prompt override for the pre-compaction memory flush turn to control extraction style and safety constraints. Use carefully so custom instructions do not reduce memory quality or leak sensitive context.",
+  "agents.defaults.compaction.preflight":
+    "Preflight (budget-triggered) compaction gate. Disable to skip the pre-turn threshold check entirely and let every turn fall through to overflow recovery (which honors `compaction.timeoutSeconds`).",
+  "agents.defaults.compaction.preflight.enabled":
+    "Enable preflight (budget-triggered) compaction. Default: true. Set false to skip preflight compaction; subsequent turns then rely on overflow recovery, which has its own 15-minute budget and is the only path that honors `compaction.timeoutSeconds` without being capped by the ~60s reply lifecycle.",
   "agents.defaults.runRetries":
     "Outer run loop retry iteration boundaries for the embedded OpenClaw runner to prevent infinite execution loops during failure recovery.",
   "agents.defaults.runRetries.base":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1515,7 +1515,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.compaction.preflight":
     "Preflight (budget-triggered) compaction gate. Disable to skip the pre-turn threshold check entirely and let every turn fall through to overflow recovery (which honors `compaction.timeoutSeconds`).",
   "agents.defaults.compaction.preflight.enabled":
-    "Enable preflight (budget-triggered) compaction. Default: true. Set false to skip preflight compaction; subsequent turns then rely on overflow recovery, which has its own 15-minute budget and is the only path that honors `compaction.timeoutSeconds` without being capped by the ~60s reply lifecycle.",
+    "Enable preflight (budget-triggered) compaction. Default: true. Set false to skip preflight compaction; subsequent turns then rely on overflow recovery, which honors `compaction.timeoutSeconds` without being capped by the reply lifecycle.",
   "agents.defaults.runRetries":
     "Outer run loop retry iteration boundaries for the embedded OpenClaw runner to prevent infinite execution loops during failure recovery.",
   "agents.defaults.runRetries.base":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -705,6 +705,8 @@ export const FIELD_LABELS: Record<string, string> = {
     "Compaction Memory Flush Transcript Size Threshold",
   "agents.defaults.compaction.memoryFlush.prompt": "Compaction Memory Flush Prompt",
   "agents.defaults.compaction.memoryFlush.systemPrompt": "Compaction Memory Flush System Prompt",
+  "agents.defaults.compaction.preflight": "Compaction Preflight",
+  "agents.defaults.compaction.preflight.enabled": "Compaction Preflight Enabled",
   "agents.defaults.runRetries": "Run Retries",
   "agents.defaults.runRetries.base": "Run Retries Base",
   "agents.defaults.runRetries.perProfile": "Run Retries Per Profile",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -569,6 +569,18 @@ export type AgentCompactionConfig = {
    * Default: false (silent by default).
    */
   notifyUser?: boolean;
+  /**
+   * Preflight (budget-triggered) compaction gate. When disabled, the pre-turn
+   * threshold check in `runPreflightCompactionIfNeeded` short-circuits to the
+   * existing session entry; subsequent turns fall through to overflow recovery
+   * (which already honors `compaction.timeoutSeconds`).
+   */
+  preflight?: AgentCompactionPreflightConfig;
+};
+
+export type AgentCompactionPreflightConfig = {
+  /** Enable preflight (budget-triggered) compaction. Default: true. */
+  enabled?: boolean;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -200,6 +200,12 @@ export const AgentDefaultsSchema = z
         truncateAfterCompaction: z.boolean().optional(),
         maxActiveTranscriptBytes: NonNegativeByteSizeSchema.optional(),
         notifyUser: z.boolean().optional(),
+        preflight: z
+          .object({
+            enabled: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## What Problem This Solves

Issue #95553 reports that preflight (budget-triggered) compaction cannot be disabled via config. The issue's "Expected behavior" section explicitly lists two user-asked solutions:

> 1. Honor `agents.defaults.compaction.timeoutSeconds` for the preflight/budget path too, **or**
> 2. Add a config toggle `agents.defaults.compaction.preflight: false` to skip preflight compaction entirely

This PR addresses **solution 2**: a strict, additive `compaction.preflight.enabled` config gate that short-circuits the preflight check and lets every turn fall through to overflow recovery (which already honors `compaction.timeoutSeconds`).

The check is `=== false` against the literal value, so an unset key preserves the existing default-on behavior — the fix is strictly additive and does not change shipped behavior for any current user.

## Why This Change Was Made

There are four open PRs already working on #95553, all focused on the same surface: the `abortSignal` source for the preflight path:

- #95561 — `AbortSignal.any([replyOp, AbortSignal.timeout(resolveCompactionTimeoutMs(cfg))])`
- #95563 — drop `abortSignal: replyOp.signal` and add a separate `mcp.runtimeScope` change
- #95580 — new `createPreflightCompactionCancelSignal` helper that filters out `TimeoutError`
- #95590 — drop `abortSignal` line entirely

None of those four PRs addresses the **user-facing config dimension** the issue explicitly requests. The preflight path is *currently* running for every user that hits the soft threshold, even users who would prefer to skip it. This PR ships the missing config dimension that complements any of the four abortSignal approaches once a maintainer picks one.

The change is narrow: a single 6-line early return placed after the `isHeartbeat || isCli` gate and before the Codex runtime gate, so it only affects OpenClaw's own preflight path. It is fully orthogonal to whichever abortSignal shape a maintainer chooses.

## Changes

- `src/config/types.agent-defaults.ts` — new `AgentCompactionPreflightConfig` type with optional `enabled: boolean`
- `src/config/zod-schema.agent-defaults.ts` — `preflight: z.object({ enabled: z.boolean().optional() }).strict().optional()`
- `src/config/schema.help.ts` — two help entries: parent `agents.defaults.compaction.preflight` + leaf `.enabled`
- `src/config/schema.labels.ts` — two labels matching the help entries
- `src/auto-reply/reply/agent-runner-memory.ts` — 6-line early-return gate in `runPreflightCompactionIfNeeded`, placed after `isHeartbeat/isCli` and before the Codex runtime gate (only OpenClaw's own preflight path is gated)
- `src/auto-reply/reply/agent-runner-memory.test.ts` — new test "skips preflight compaction when cfg.agents.defaults.compaction.preflight.enabled === false" (uses the same fixture pattern as adjacent tests)
- `docs/gateway/config-agents.md` — add `preflight.enabled` to the JSON5 example and bullet list under `agents.defaults.compaction`, matching the schema/help coverage
- `scripts/repro/issue-95553-preflight-disabled-gate.mts` — standalone real-environment proof that writes a real `openclaw.json` and loads it via the production `loadConfig()` (not a cast)

## User Impact

A user who adds the following to their `openclaw.json` now skips the budget-triggered preflight check and lets every turn fall through to overflow recovery:

```json
{
  "agents": {
    "defaults": {
      "compaction": {
        "preflight": { "enabled": false }
      }
    }
  }
}
```

For users who do not set the key, behavior is unchanged.

## Evidence

- **Behavior addressed:** preflight (budget-triggered) compaction can now be disabled via config, complementing the four open PRs that are all working on the `abortSignal` source for the same path
- **Real environment tested:** Linux x86_64, Node v24.14.1, repo at `5210d8b121` rebased onto `personal/main` (base `c57fee8239ed`)
- **Exact steps run after this patch:**

  ```console
  $ node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts

   RUN  v4.1.7 /home/0668000666/0668000666/AI/OpenClaw/new_open_claw

   Test Files  1 passed (1)
        Tests  41 passed (41)
     Start at  15:45:38
     Duration  17.86s (transform 4.48s, setup 395ms, import 8.27s, tests 8.90s, environment 0ms)

  [test] passed 1 Vitest shard in 28.18s
  ```

  ```console
  $ node --import tsx scripts/repro/issue-95553-preflight-disabled-gate.mts

  === Reproduction for issue #95553 — preflight gate ===
  tmpDir: /tmp/openclaw-95553-repro-XTtBDw
  openclaw.json: /tmp/openclaw-95553-repro-XTtBDw/config/openclaw.json
  sessionFile: /tmp/openclaw-95553-repro-XTtBDw/sessions/session.jsonl
  loaded config: agents.defaults.compaction.preflight.enabled = false
  PASS  preflight.enabled === false short-circuits preflight check
        sessionEntry returned unchanged: session-95553-repro
  === All repro assertions passed ===
  ```

  The repro script proves the **real `openclaw.json` → production `loadConfig()` → production `runPreflightCompactionIfNeeded`** path. It writes `openclaw.json` to a temp state dir, points `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` at it via `withEnvAsync`, calls the production `loadConfig({ pin: false })`, asserts the gate value is parsed from disk, and then exercises the gate on the production preflight function. The function returns the original session entry unchanged; `compactEmbeddedAgentSession` is never reached.

- **Observed result after fix:** the production `runPreflightCompactionIfNeeded` returns the existing `sessionEntry` unchanged when `compaction.preflight.enabled === false`; `compactEmbeddedAgentSession` is never called; `incrementCompactionCount` is never called
- **What was not tested:** I did not exercise the live gateway path (the four open PRs also exercise the unit-test surface, not the live gateway); the unit test and repro script cover the full production gate code path through `runPreflightCompactionIfNeeded`

## ClawSweeper review fixes (commit `5210d8b121`)

The 🦪 silver shellfish review flagged three P1 findings on commit `a140b0bb1b` / `ffd17f3a85`; all three are addressed in commit `5210d8b121`:

1. **[P1] schema.help.ts:1518 timeout wording** — replaced hardcoded "15-minute budget" claim with neutral wording that references `compaction.timeoutSeconds` only (no specific default minutes). The same wording fix applies to the inline code comment in `agent-runner-memory.ts`. The PR does not need to assume which timeout default the merge target carries.
2. **[P1] public docs coverage** — added `preflight.enabled` to the JSON5 example and the bullet list under `agents.defaults.compaction` in `docs/gateway/config-agents.md`. Public docs now describe the new knob consistently with the schema help.
3. **[P1] real OpenClaw setup proof** — rewrote the repro script to write a real `openclaw.json` to a temp state dir and load it through the production `loadConfig()`. The gate value is now parsed from disk through the same code path the gateway startup uses, not cast from an inline literal.

The single remaining CI failure (`checks-node-core-fast`, surface budget `public exports 10328 > 10327` and `public callable exports 5185 > 5184`) is **pre-existing on `openclaw/main`** HEAD alone — see [comment](https://github.com/openclaw/openclaw/pull/95675#issuecomment-4765586623). This PR adds zero new public SDK exports; `git diff c57fee8239ed..HEAD -- src/plugin-sdk/` is empty.

## Related

- Refs #95553
- Complements (does not duplicate) #95561, #95563, #95580, #95590
- Branch: `fix/95553-preflight-config-gate` (carries only the preflight config gate; the prior `feat/task-route-lease-module` branch was abandoned per PR #95648 close reason)
- Commits on branch: `a140b0bb1b feat`, `ffd17f3a85 lint fix`, `5210d8b121 review fixes`