### PR TITLE
fix(matrix): suppress namespaced thinking replies

### DIFF
--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -183,6 +183,8 @@ describe("deliverMatrixReplies", () => {
       replies: [
         { text: "Reasoning:\n_hidden_" },
         { text: "<think>still hidden</think>" },
+        { text: "<mm:think>model reasoning</mm:think>" },
+        { text: "<antml:thinking>more reasoning</antml:thinking>" },
         { text: "Visible answer" },
       ],
       roomId: "room:5",

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -5,9 +5,13 @@ import type { MatrixClient } from "../sdk.js";
 import { chunkMatrixText, sendMessageMatrix } from "../send.js";
 import type { MarkdownTableMode, OpenClawConfig, ReplyPayload, RuntimeEnv } from "./runtime-api.js";
 
-const THINKING_TAG_RE = /<\s*\/?\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;
+const THINKING_TAG_NAME_RE = String.raw`(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)`;
+const THINKING_TAG_RE = new RegExp(String.raw`<\s*\/?\s*${THINKING_TAG_NAME_RE}\b[^<>]*>`, "gi");
 const THINKING_BLOCK_RE =
-  /<\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>[\s\S]*?<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+  new RegExp(
+    String.raw`<\s*${THINKING_TAG_NAME_RE}\b[^<>]*>[\s\S]*?<\s*\/\s*${THINKING_TAG_NAME_RE}\s*>`,
+    "gi",
+  );
 
 function shouldSuppressReasoningReplyText(text?: string): boolean {
   if (typeof text !== "string") {


### PR DESCRIPTION
## What Problem This Solves

Matrix reply delivery had a local reasoning-only suppression regex that recognized bare `<think>`/`<thinking>`/`<thought>` tags, but not the namespaced forms already handled by the shared text helper and Slack path. A pure Matrix reply such as `<mm:think>internal reasoning</mm:think>` or `<antml:thinking>internal reasoning</antml:thinking>` could therefore be treated as visible text instead of being suppressed.

## Why This Change Was Made

The Matrix monitor keeps a local suppression guard in `extensions/matrix/src/matrix/monitor/replies.ts` before sending reply payloads. This change aligns that guard's recognized thinking tag family with the shared and Slack behavior by accepting the known `mm:` and `antml:` namespace prefixes for thinking tags.

## User Impact

Matrix users no longer see reasoning-only replies when models emit MiniMax or Anthropic-style namespaced thinking tags. Visible replies continue to send normally, and suppression remains limited to payloads that contain only reasoning markers/content.

## Evidence

- Verified the bug exists on current `main`: `extensions/matrix/src/matrix/monitor/replies.ts` lacked `mm:`/`antml:` support while `src/shared/text/reasoning-tags.ts` and Slack already included namespaced thinking tags.
- Added Matrix regression coverage for `<mm:think>...</mm:think>` and `<antml:thinking>...</antml:thinking>` reasoning-only replies.
- `node scripts/run-vitest.mjs extensions/matrix/src/matrix/monitor/replies.test.ts` passed: 1 file, 6 tests.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings.
