### PR TITLE
fix(feishu): parse interactive card text in merge_forward sub-messages

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -1,7 +1,7 @@
 // Feishu plugin module implements bot content behavior.
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
-import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ClawdbotConfig } from "../runtime-api.js";
+import { extractFeishuCardText } from "./card-content.js";
 import { buildFeishuConversationId } from "./conversation-id.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
 import { saveMessageResourceFeishu } from "./media.js";
@@ -176,136 +176,6 @@ export function parseMessageContent(content: string, messageType: string): strin
   } catch {
     return content;
   }
-}
-
-// Whitelisted text-bearing card element tags. Restricting to these keeps button
-// values, action payloads, and other non-display `content` fields out of the
-// extracted text.
-const FEISHU_CARD_TEXT_TAGS = new Set(["div", "markdown", "lark_md", "plain_text"]);
-
-function normalizeCardTemplateVariable(value: unknown): string | undefined {
-  if (typeof value === "string") {
-    return value;
-  }
-  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
-    return String(value);
-  }
-  return undefined;
-}
-
-function readCardTemplateVariables(card: Record<string, unknown>): Map<string, string> {
-  const variables = new Map<string, string>();
-  for (const source of [card.template_variable, card.template_variables]) {
-    if (!isRecord(source)) {
-      continue;
-    }
-    for (const [key, value] of Object.entries(source)) {
-      const normalized = normalizeCardTemplateVariable(value);
-      if (normalized !== undefined) {
-        variables.set(key, normalized);
-      }
-    }
-  }
-  return variables;
-}
-
-function applyCardTemplateVariables(text: string, variables: Map<string, string>): string {
-  if (variables.size === 0) {
-    return text;
-  }
-  return text.replace(/\$\{([A-Za-z0-9_.-]+)\}|\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/g, (match, a, b) => {
-    const variableName = typeof a === "string" ? a : b;
-    return variables.get(variableName) ?? match;
-  });
-}
-
-// Pull the display string off a single leaf element (div text, markdown, plain
-// text). Returns undefined for structural/non-text nodes so the walker keeps
-// descending instead of treating them as leaves.
-function readCardElementText(record: Record<string, unknown>): string | undefined {
-  const tag = typeof record.tag === "string" ? record.tag : "";
-  if (!FEISHU_CARD_TEXT_TAGS.has(tag)) {
-    return undefined;
-  }
-  if (tag === "div") {
-    const text = isRecord(record.text) ? record.text : undefined;
-    return typeof text?.content === "string" ? text.content : undefined;
-  }
-  return typeof record.content === "string" ? record.content : undefined;
-}
-
-// Default-locale element arrays, falling back to a single i18n locale so a
-// multilingual card does not emit every translation of the same content.
-function selectCardElementArrays(card: Record<string, unknown>): unknown[][] {
-  const body = isRecord(card.body) ? card.body : undefined;
-  const direct: unknown[][] = [];
-  for (const candidate of [card.elements, body?.elements]) {
-    if (Array.isArray(candidate)) {
-      direct.push(candidate);
-    }
-  }
-  if (direct.length > 0) {
-    return direct;
-  }
-  for (const candidate of [card.i18n_elements, body?.i18n_elements]) {
-    if (!isRecord(candidate)) {
-      continue;
-    }
-    for (const localeElements of Object.values(candidate)) {
-      if (Array.isArray(localeElements)) {
-        return [localeElements];
-      }
-    }
-  }
-  return [];
-}
-
-// Interactive card text nests under whitelisted tags at arbitrary depth
-// (column_set, table, columns). Walk the header plus default-locale elements,
-// resolve template variables, and collect the text so forwarded cards keep
-// their content instead of collapsing to a bare `[interactive]` placeholder.
-// NOTE: send.ts has a sibling `parseInteractiveCardContent`; these should be
-// unified into one shared extractor in a follow-up.
-function extractFeishuCardText(card: unknown): string {
-  if (!isRecord(card)) {
-    return "";
-  }
-  const variables = readCardTemplateVariables(card);
-  const parts: string[] = [];
-  const push = (text: string): void => {
-    const resolved = applyCardTemplateVariables(text, variables).trim();
-    if (resolved) {
-      parts.push(resolved);
-    }
-  };
-  const visit = (node: unknown): void => {
-    if (Array.isArray(node)) {
-      for (const item of node) {
-        visit(item);
-      }
-      return;
-    }
-    if (!isRecord(node)) {
-      return;
-    }
-    const text = readCardElementText(node);
-    if (text !== undefined) {
-      // Leaf text element: stop here so a div is not re-read through its nested
-      // `text` node.
-      push(text);
-      return;
-    }
-    for (const value of Object.values(node)) {
-      if (value && typeof value === "object") {
-        visit(value);
-      }
-    }
-  };
-  visit(card.header);
-  for (const elements of selectCardElementArrays(card)) {
-    visit(elements);
-  }
-  return parts.join("\n");
 }
 
 function formatSubMessageContent(content: string, contentType: string): string {

--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -177,6 +177,42 @@ export function parseMessageContent(content: string, messageType: string): strin
   }
 }
 
+// Interactive card bodies nest display text under `content` (header title, div
+// text, markdown, note) at arbitrary depth (column_set, table, action). Walk the
+// whole card and collect those strings so forwarded cards keep their text
+// instead of collapsing to a bare `[interactive]` placeholder.
+function extractFeishuCardText(content: string): string {
+  let card: unknown;
+  try {
+    card = JSON.parse(content);
+  } catch {
+    return "";
+  }
+  const parts: string[] = [];
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        visit(item);
+      }
+      return;
+    }
+    if (!node || typeof node !== "object") {
+      return;
+    }
+    const record = node as Record<string, unknown>;
+    if (typeof record.content === "string" && record.content.trim()) {
+      parts.push(record.content.trim());
+    }
+    for (const value of Object.values(record)) {
+      if (value && typeof value === "object") {
+        visit(value);
+      }
+    }
+  };
+  visit(card);
+  return parts.join("\n");
+}
+
 function formatSubMessageContent(content: string, contentType: string): string {
   try {
     const parsed = JSON.parse(content);
@@ -195,6 +231,8 @@ function formatSubMessageContent(content: string, contentType: string): string {
         return "[Video]";
       case "sticker":
         return "[Sticker]";
+      case "interactive":
+        return extractFeishuCardText(content) || "[Interactive Card]";
       case "merge_forward":
         return "[Nested Merged Forward]";
       default:

--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -1,5 +1,6 @@
 // Feishu plugin module implements bot content behavior.
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { buildFeishuConversationId } from "./conversation-id.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
@@ -177,18 +178,106 @@ export function parseMessageContent(content: string, messageType: string): strin
   }
 }
 
-// Interactive card bodies nest display text under `content` (header title, div
-// text, markdown, note) at arbitrary depth (column_set, table, action). Walk the
-// whole card and collect those strings so forwarded cards keep their text
-// instead of collapsing to a bare `[interactive]` placeholder.
-function extractFeishuCardText(content: string): string {
-  let card: unknown;
-  try {
-    card = JSON.parse(content);
-  } catch {
+// Whitelisted text-bearing card element tags. Restricting to these keeps button
+// values, action payloads, and other non-display `content` fields out of the
+// extracted text.
+const FEISHU_CARD_TEXT_TAGS = new Set(["div", "markdown", "lark_md", "plain_text"]);
+
+function normalizeCardTemplateVariable(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  return undefined;
+}
+
+function readCardTemplateVariables(card: Record<string, unknown>): Map<string, string> {
+  const variables = new Map<string, string>();
+  for (const source of [card.template_variable, card.template_variables]) {
+    if (!isRecord(source)) {
+      continue;
+    }
+    for (const [key, value] of Object.entries(source)) {
+      const normalized = normalizeCardTemplateVariable(value);
+      if (normalized !== undefined) {
+        variables.set(key, normalized);
+      }
+    }
+  }
+  return variables;
+}
+
+function applyCardTemplateVariables(text: string, variables: Map<string, string>): string {
+  if (variables.size === 0) {
+    return text;
+  }
+  return text.replace(/\$\{([A-Za-z0-9_.-]+)\}|\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/g, (match, a, b) => {
+    const variableName = typeof a === "string" ? a : b;
+    return variables.get(variableName) ?? match;
+  });
+}
+
+// Pull the display string off a single leaf element (div text, markdown, plain
+// text). Returns undefined for structural/non-text nodes so the walker keeps
+// descending instead of treating them as leaves.
+function readCardElementText(record: Record<string, unknown>): string | undefined {
+  const tag = typeof record.tag === "string" ? record.tag : "";
+  if (!FEISHU_CARD_TEXT_TAGS.has(tag)) {
+    return undefined;
+  }
+  if (tag === "div") {
+    const text = isRecord(record.text) ? record.text : undefined;
+    return typeof text?.content === "string" ? text.content : undefined;
+  }
+  return typeof record.content === "string" ? record.content : undefined;
+}
+
+// Default-locale element arrays, falling back to a single i18n locale so a
+// multilingual card does not emit every translation of the same content.
+function selectCardElementArrays(card: Record<string, unknown>): unknown[][] {
+  const body = isRecord(card.body) ? card.body : undefined;
+  const direct: unknown[][] = [];
+  for (const candidate of [card.elements, body?.elements]) {
+    if (Array.isArray(candidate)) {
+      direct.push(candidate);
+    }
+  }
+  if (direct.length > 0) {
+    return direct;
+  }
+  for (const candidate of [card.i18n_elements, body?.i18n_elements]) {
+    if (!isRecord(candidate)) {
+      continue;
+    }
+    for (const localeElements of Object.values(candidate)) {
+      if (Array.isArray(localeElements)) {
+        return [localeElements];
+      }
+    }
+  }
+  return [];
+}
+
+// Interactive card text nests under whitelisted tags at arbitrary depth
+// (column_set, table, columns). Walk the header plus default-locale elements,
+// resolve template variables, and collect the text so forwarded cards keep
+// their content instead of collapsing to a bare `[interactive]` placeholder.
+// NOTE: send.ts has a sibling `parseInteractiveCardContent`; these should be
+// unified into one shared extractor in a follow-up.
+function extractFeishuCardText(card: unknown): string {
+  if (!isRecord(card)) {
     return "";
   }
+  const variables = readCardTemplateVariables(card);
   const parts: string[] = [];
+  const push = (text: string): void => {
+    const resolved = applyCardTemplateVariables(text, variables).trim();
+    if (resolved) {
+      parts.push(resolved);
+    }
+  };
   const visit = (node: unknown): void => {
     if (Array.isArray(node)) {
       for (const item of node) {
@@ -196,20 +285,26 @@ function extractFeishuCardText(content: string): string {
       }
       return;
     }
-    if (!node || typeof node !== "object") {
+    if (!isRecord(node)) {
       return;
     }
-    const record = node as Record<string, unknown>;
-    if (typeof record.content === "string" && record.content.trim()) {
-      parts.push(record.content.trim());
+    const text = readCardElementText(node);
+    if (text !== undefined) {
+      // Leaf text element: stop here so a div is not re-read through its nested
+      // `text` node.
+      push(text);
+      return;
     }
-    for (const value of Object.values(record)) {
+    for (const value of Object.values(node)) {
       if (value && typeof value === "object") {
         visit(value);
       }
     }
   };
-  visit(card);
+  visit(card.header);
+  for (const elements of selectCardElementArrays(card)) {
+    visit(elements);
+  }
   return parts.join("\n");
 }
 
@@ -232,7 +327,7 @@ function formatSubMessageContent(content: string, contentType: string): string {
       case "sticker":
         return "[Sticker]";
       case "interactive":
-        return extractFeishuCardText(content) || "[Interactive Card]";
+        return extractFeishuCardText(parsed) || "[Interactive Card]";
       case "merge_forward":
         return "[Nested Merged Forward]";
       default:

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2856,6 +2856,86 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("expands a forwarded interactive card to its text in BodyForAgent", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    const card = {
+      schema: "2.0",
+      header: { title: { tag: "plain_text", content: "Q2 Sales Report" } },
+      body: {
+        elements: [
+          { tag: "markdown", content: "**Region**: APAC  |  **Total**: 1,240" },
+          {
+            tag: "column_set",
+            columns: [
+              {
+                tag: "column",
+                elements: [{ tag: "div", text: { tag: "lark_md", content: "Q1: 540" } }],
+              },
+              {
+                tag: "column",
+                elements: [{ tag: "div", text: { tag: "plain_text", content: "Q2: 700" } }],
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const mockGetMerged = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "container",
+            msg_type: "merge_forward",
+            body: { content: JSON.stringify({ text: "Merged and Forwarded Message" }) },
+          },
+          {
+            message_id: "card",
+            upper_message_id: "container",
+            msg_type: "interactive",
+            body: { content: JSON.stringify(card) },
+            create_time: "1000",
+          },
+        ],
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }),
+        },
+      },
+      im: { message: { get: mockGetMerged } },
+    } as unknown as PluginRuntime);
+
+    const cfg: ClawdbotConfig = {
+      channels: { feishu: { dmPolicy: "open" } },
+    } as ClawdbotConfig;
+
+    await dispatchMessage({
+      cfg,
+      event: {
+        sender: { sender_id: { open_id: "ou-merge-card" } },
+        message: {
+          message_id: "msg-merge-forward-card",
+          chat_id: "oc-dm",
+          chat_type: "p2p",
+          message_type: "merge_forward",
+          content: JSON.stringify({ text: "Merged and Forwarded Message" }),
+        },
+      },
+    });
+
+    expect(mockGetMerged).toHaveBeenCalledWith({
+      params: { card_msg_content_type: "user_card_content" },
+      path: { message_id: "msg-merge-forward-card" },
+    });
+    const context = mockCallArg<{ BodyForAgent?: string }>(mockFinalizeInboundContext, 0, 0);
+    expect(context.BodyForAgent).toContain(
+      "[Merged and Forwarded Messages]\n- Q2 Sales Report\n**Region**: APAC  |  **Total**: 1,240\nQ1: 540\nQ2: 700",
+    );
+  });
+
   it("does not partially parse malformed merge_forward create_time values", () => {
     const content = JSON.stringify([
       {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2847,6 +2847,7 @@ describe("handleFeishuMessage command authorization", () => {
     await dispatchMessage({ cfg, event });
 
     expect(mockGetMerged).toHaveBeenCalledWith({
+      params: { card_msg_content_type: "user_card_content" },
       path: { message_id: "msg-merge-forward" },
     });
     const context = mockCallArg<{ BodyForAgent?: string }>(mockFinalizeInboundContext, 0, 0);

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2883,6 +2883,72 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("extracts text from interactive card sub-messages instead of dropping to a placeholder", () => {
+    const card = {
+      schema: "2.0",
+      config: { wide_screen_mode: true },
+      header: { title: { tag: "plain_text", content: "Quarterly Report" } },
+      body: {
+        elements: [
+          { tag: "markdown", content: "Revenue is **up 12%**" },
+          { tag: "hr" },
+          {
+            tag: "column_set",
+            columns: [
+              {
+                tag: "column",
+                elements: [{ tag: "div", text: { tag: "lark_md", content: "Q1: 100" } }],
+              },
+              {
+                tag: "column",
+                elements: [{ tag: "div", text: { tag: "plain_text", content: "Q2: 140" } }],
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const content = JSON.stringify([
+      {
+        message_id: "container",
+        msg_type: "merge_forward",
+        body: { content: JSON.stringify({ text: "Merged and Forwarded Message" }) },
+      },
+      {
+        message_id: "card",
+        upper_message_id: "container",
+        msg_type: "interactive",
+        body: { content: JSON.stringify(card) },
+        create_time: "1000",
+      },
+    ]);
+
+    expect(parseMergeForwardContent({ content })).toBe(
+      "[Merged and Forwarded Messages]\n- Quarterly Report\nRevenue is **up 12%**\nQ1: 100\nQ2: 140",
+    );
+  });
+
+  it("keeps a placeholder when an interactive card carries no text", () => {
+    const content = JSON.stringify([
+      {
+        message_id: "container",
+        msg_type: "merge_forward",
+        body: { content: JSON.stringify({ text: "Merged and Forwarded Message" }) },
+      },
+      {
+        message_id: "image-only-card",
+        upper_message_id: "container",
+        msg_type: "interactive",
+        body: { content: JSON.stringify({ elements: [{ tag: "img", img_key: "img_xxx" }] }) },
+        create_time: "1000",
+      },
+    ]);
+
+    expect(parseMergeForwardContent({ content })).toBe(
+      "[Merged and Forwarded Messages]\n- [Interactive Card]",
+    );
+  });
+
   it("falls back when merge_forward API returns no sub-messages", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockCreateFeishuClient.mockReturnValue({

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2949,6 +2949,60 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("resolves template variables in interactive card sub-messages", () => {
+    const card = {
+      schema: "2.0",
+      template_variable: { name: "Bob", count: 3 },
+      body: {
+        elements: [{ tag: "markdown", content: "Hello ${name}, you have {{ count }} updates" }],
+      },
+    };
+    const content = JSON.stringify([
+      {
+        message_id: "container",
+        msg_type: "merge_forward",
+        body: { content: JSON.stringify({ text: "Merged and Forwarded Message" }) },
+      },
+      {
+        message_id: "card",
+        upper_message_id: "container",
+        msg_type: "interactive",
+        body: { content: JSON.stringify(card) },
+        create_time: "1000",
+      },
+    ]);
+
+    expect(parseMergeForwardContent({ content })).toBe(
+      "[Merged and Forwarded Messages]\n- Hello Bob, you have 3 updates",
+    );
+  });
+
+  it("emits a single locale for i18n interactive card sub-messages", () => {
+    const card = {
+      schema: "2.0",
+      i18n_elements: {
+        en_us: [{ tag: "markdown", content: "Hello" }],
+        zh_cn: [{ tag: "markdown", content: "你好" }],
+      },
+    };
+    const content = JSON.stringify([
+      {
+        message_id: "container",
+        msg_type: "merge_forward",
+        body: { content: JSON.stringify({ text: "Merged and Forwarded Message" }) },
+      },
+      {
+        message_id: "card",
+        upper_message_id: "container",
+        msg_type: "interactive",
+        body: { content: JSON.stringify(card) },
+        create_time: "1000",
+      },
+    ]);
+
+    expect(parseMergeForwardContent({ content })).toBe("[Merged and Forwarded Messages]\n- Hello");
+  });
+
   it("falls back when merge_forward API returns no sub-messages", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockCreateFeishuClient.mockReturnValue({

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -516,7 +516,11 @@ export async function handleFeishuMessage(params: {
       // Websocket event doesn't include sub-messages, need to fetch via API
       // The API returns all sub-messages in the items array
       const client = createFeishuClient(account);
+      // Request original card JSON for interactive sub-messages; without
+      // user_card_content the fetch returns degraded payloads and forwarded
+      // cards collapse to a bare placeholder. Mirrors getMessageFeishu.
       const response = (await client.im.message.get({
+        params: { card_msg_content_type: "user_card_content" },
         path: { message_id: event.message.message_id },
       })) as { code?: number; data?: { items?: unknown[] } };
 

--- a/extensions/feishu/src/card-content.ts
+++ b/extensions/feishu/src/card-content.ts
@@ -1,0 +1,154 @@
+// Shared Feishu interactive-card text extractor. Both the fetched-message read
+// path (`send.ts`) and the merge_forward sub-message formatter (`bot-content.ts`)
+// must turn a card JSON payload into the same display text; keeping one walker
+// here stops the two paths drifting on whitelisted tags, template variables,
+// i18n locale selection, and post fallback.
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { parsePostContent } from "./post.js";
+
+// Generic placeholder parsePostContent yields when a card carries no rich-text
+// post body; treat it as "no text" so we keep walking instead of surfacing it.
+const POST_FALLBACK_TEXT = "[Rich text message]";
+
+// Whitelisted text-bearing card element tags. Restricting to these keeps button
+// values, action payloads, and other non-display `content` fields out of the
+// extracted text.
+const FEISHU_CARD_TEXT_TAGS = new Set(["div", "markdown", "lark_md", "plain_text"]);
+
+function normalizeCardTemplateVariable(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  return undefined;
+}
+
+function readCardTemplateVariables(card: Record<string, unknown>): Map<string, string> {
+  const variables = new Map<string, string>();
+  for (const source of [card.template_variable, card.template_variables]) {
+    if (!isRecord(source)) {
+      continue;
+    }
+    for (const [key, value] of Object.entries(source)) {
+      const normalized = normalizeCardTemplateVariable(value);
+      if (normalized !== undefined) {
+        variables.set(key, normalized);
+      }
+    }
+  }
+  return variables;
+}
+
+function applyCardTemplateVariables(text: string, variables: Map<string, string>): string {
+  if (variables.size === 0) {
+    return text;
+  }
+  return text.replace(/\$\{([A-Za-z0-9_.-]+)\}|\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/g, (match, a, b) => {
+    const variableName = typeof a === "string" ? a : b;
+    return variables.get(variableName) ?? match;
+  });
+}
+
+// Pull the display string off a single leaf element (div text, markdown, plain
+// text). Returns undefined for structural/non-text nodes so the walker keeps
+// descending instead of treating them as leaves.
+function readCardElementText(record: Record<string, unknown>): string | undefined {
+  const tag = typeof record.tag === "string" ? record.tag : "";
+  if (!FEISHU_CARD_TEXT_TAGS.has(tag)) {
+    return undefined;
+  }
+  if (tag === "div") {
+    const text = isRecord(record.text) ? record.text : undefined;
+    return typeof text?.content === "string" ? text.content : undefined;
+  }
+  return typeof record.content === "string" ? record.content : undefined;
+}
+
+// Card text nests under whitelisted tags at arbitrary depth (column_set, table,
+// columns). Walk into every object/array, resolve template variables, and push
+// each leaf's text so nested layouts keep their content.
+function walkCardText(node: unknown, variables: Map<string, string>, parts: string[]): void {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      walkCardText(item, variables, parts);
+    }
+    return;
+  }
+  if (!isRecord(node)) {
+    return;
+  }
+  const text = readCardElementText(node);
+  if (text !== undefined) {
+    // Leaf text element: stop here so a div is not re-read through its nested
+    // `text` node.
+    const resolved = applyCardTemplateVariables(text, variables).trim();
+    if (resolved) {
+      parts.push(resolved);
+    }
+    return;
+  }
+  for (const value of Object.values(node)) {
+    if (value && typeof value === "object") {
+      walkCardText(value, variables, parts);
+    }
+  }
+}
+
+// Candidate element arrays in precedence order: direct elements, body elements,
+// then each i18n locale. Callers walk these until one yields text, so a
+// multilingual card emits a single locale instead of every translation.
+function collectCardElementArrays(card: Record<string, unknown>): unknown[][] {
+  const body = isRecord(card.body) ? card.body : undefined;
+  const arrays: unknown[][] = [];
+  for (const candidate of [card.elements, body?.elements]) {
+    if (Array.isArray(candidate)) {
+      arrays.push(candidate);
+    }
+  }
+  for (const candidate of [card.i18n_elements, body?.i18n_elements]) {
+    if (!isRecord(candidate)) {
+      continue;
+    }
+    for (const localeElements of Object.values(candidate)) {
+      if (Array.isArray(localeElements)) {
+        arrays.push(localeElements);
+      }
+    }
+  }
+  return arrays;
+}
+
+function parseCardPostFallback(card: Record<string, unknown>): string | undefined {
+  const textContent = parsePostContent(JSON.stringify(card)).textContent.trim();
+  return textContent && textContent !== POST_FALLBACK_TEXT ? textContent : undefined;
+}
+
+// Extract the display text from a parsed Feishu interactive card, or "" when the
+// card carries no text-bearing content (e.g. image-only cards). Callers decide
+// the placeholder to surface in that case.
+export function extractFeishuCardText(card: unknown): string {
+  if (!isRecord(card)) {
+    return "";
+  }
+  const variables = readCardTemplateVariables(card);
+  const headerParts: string[] = [];
+  walkCardText(card.header, variables, headerParts);
+
+  let bodyText = "";
+  for (const elements of collectCardElementArrays(card)) {
+    const parts: string[] = [];
+    walkCardText(elements, variables, parts);
+    if (parts.length > 0) {
+      bodyText = parts.join("\n");
+      break;
+    }
+  }
+
+  const combined = [...headerParts, bodyText].filter(Boolean).join("\n");
+  if (combined) {
+    return combined;
+  }
+  return parseCardPostFallback(card) ?? "";
+}

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -2,13 +2,13 @@
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import {
-  isRecord,
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { extractFeishuCardText } from "./card-content.js";
 import { createFeishuClient } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import type { MentionTarget } from "./mention-target.types.js";
@@ -24,7 +24,6 @@ import type { FeishuChatType, FeishuMessageInfo, FeishuSendResult } from "./type
 
 const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
 const INTERACTIVE_CARD_FALLBACK_TEXT = "[Interactive Card]";
-const POST_FALLBACK_TEXT = "[Rich text message]";
 const FEISHU_CARD_TEMPLATES = new Set([
   "blue",
   "green",
@@ -210,121 +209,8 @@ async function sendReplyOrFallbackDirect(
   );
 }
 
-function normalizeCardTemplateVariable(value: unknown): string | undefined {
-  if (typeof value === "string") {
-    return value;
-  }
-  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
-    return String(value);
-  }
-  return undefined;
-}
-
-function readCardTemplateVariables(parsed: Record<string, unknown>): Map<string, string> {
-  const variables = new Map<string, string>();
-  for (const source of [parsed.template_variable, parsed.template_variables]) {
-    if (!isRecord(source)) {
-      continue;
-    }
-    for (const [key, value] of Object.entries(source)) {
-      const normalized = normalizeCardTemplateVariable(value);
-      if (normalized !== undefined) {
-        variables.set(key, normalized);
-      }
-    }
-  }
-  return variables;
-}
-
-function applyCardTemplateVariables(text: string, variables: Map<string, string>): string {
-  if (variables.size === 0) {
-    return text;
-  }
-  return text.replace(/\$\{([A-Za-z0-9_.-]+)\}|\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/g, (match, a, b) => {
-    const variableName = typeof a === "string" ? a : b;
-    return variables.get(variableName) ?? match;
-  });
-}
-
-function extractInteractiveElementText(
-  element: unknown,
-  variables: Map<string, string>,
-): string | undefined {
-  if (!isRecord(element)) {
-    return undefined;
-  }
-  const tag = typeof element.tag === "string" ? element.tag : "";
-  const text = isRecord(element.text) ? element.text : undefined;
-
-  if (tag === "div" && typeof text?.content === "string") {
-    return applyCardTemplateVariables(text.content, variables);
-  }
-  if ((tag === "markdown" || tag === "lark_md") && typeof element.content === "string") {
-    return applyCardTemplateVariables(element.content, variables);
-  }
-  if (tag === "plain_text" && typeof element.content === "string") {
-    return applyCardTemplateVariables(element.content, variables);
-  }
-  return undefined;
-}
-
-function extractInteractiveElementsText(
-  elements: unknown[],
-  variables: Map<string, string>,
-): string {
-  const texts: string[] = [];
-  for (const element of elements) {
-    const text = extractInteractiveElementText(element, variables);
-    if (text !== undefined) {
-      texts.push(text);
-    }
-  }
-  return texts.join("\n").trim();
-}
-
-function readInteractiveElementArrays(parsed: Record<string, unknown>): unknown[][] {
-  const body = isRecord(parsed.body) ? parsed.body : undefined;
-  const elementArrays: unknown[][] = [];
-
-  for (const candidate of [parsed.elements, body?.elements]) {
-    if (Array.isArray(candidate)) {
-      elementArrays.push(candidate);
-    }
-  }
-
-  for (const candidate of [parsed.i18n_elements, body?.i18n_elements]) {
-    if (!isRecord(candidate)) {
-      continue;
-    }
-    for (const localeElements of Object.values(candidate)) {
-      if (Array.isArray(localeElements)) {
-        elementArrays.push(localeElements);
-      }
-    }
-  }
-
-  return elementArrays;
-}
-
-function parseInteractivePostFallback(parsed: unknown): string | undefined {
-  const textContent = parsePostContent(JSON.stringify(parsed)).textContent.trim();
-  return textContent && textContent !== POST_FALLBACK_TEXT ? textContent : undefined;
-}
-
 function parseInteractiveCardContent(parsed: unknown): string {
-  if (!isRecord(parsed)) {
-    return INTERACTIVE_CARD_FALLBACK_TEXT;
-  }
-
-  const variables = readCardTemplateVariables(parsed);
-  for (const elements of readInteractiveElementArrays(parsed)) {
-    const text = extractInteractiveElementsText(elements, variables);
-    if (text) {
-      return text;
-    }
-  }
-
-  return parseInteractivePostFallback(parsed) ?? INTERACTIVE_CARD_FALLBACK_TEXT;
+  return extractFeishuCardText(parsed) || INTERACTIVE_CARD_FALLBACK_TEXT;
 }
 
 function parseFeishuMessageContent(rawContent: string, msgType: string): string {


### PR DESCRIPTION
## What Problem This Solves

When a Feishu bot receives a **merge_forward** message, OpenClaw fetches the full
content via `im.message.get` and expands each sub-message through
`formatSubMessageContent` (`extensions/feishu/src/bot-content.ts`). That function
had no case for `interactive` (card) sub-messages, so any forwarded card — tables,
rich layouts, columns — fell through to the `default` branch and collapsed to the
bare placeholder `[interactive]`, losing all of its text.

This is the exact symptom in #77909:

```
feishu[default]: Feishu[default] DM from ou_xxx: [Merged and Forwarded Messages] - [interactive]
```

The API returns the card body, but the parser discarded it.

## Why This Change Was Made

Feishu interactive cards nest their display text under whitelisted tag `content`
fields at arbitrary depth — header `title.content`, `{tag:"markdown", content}`,
and `div`/column `text.content`. The fix walks the card and collects those strings
so forwarded cards keep their text, resolving template variables and emitting a
single i18n locale. If a card genuinely has no text (e.g. image-only), it falls
back to a readable `[Interactive Card]` placeholder.

This revision also addresses the two correctness findings from the prior review:

1. **One shared extractor, not a second parser.** The interactive-card text walker
   now lives in `extensions/feishu/src/card-content.ts` (`extractFeishuCardText`).
   Both the fetched-message read path (`send.ts`, `parseInteractiveCardContent`)
   and the merge_forward sub-message formatter (`bot-content.ts`) call it, so the
   two paths can no longer drift on whitelisted tags, template variables, i18n
   locale, or post fallback. Net `send.ts` −114 / `bot-content.ts` −126 lines.
2. **Request the original card JSON on the merge_forward fetch.** The merge_forward
   `im.message.get` now passes `card_msg_content_type: "user_card_content"`,
   mirroring `getMessageFeishu`, so forwarded interactive cards return the full
   card body instead of a degraded payload.

## User Impact

Forwarding a Feishu card (including tables) to the bot now preserves the original
text content instead of dropping it. No config or API changes.

## Evidence

AI-assisted implementation. Proof drives the **real** channel path
(`handleFeishuMessage` → `finalizeInboundContext`), not just the parser, for a
merge_forward carrying one interactive card (header + markdown summary + a
two-column table-like layout), before vs after the fix.

### Channel-path proof (`handleFeishuMessage` → `BodyForAgent`)

New integration test `expands a forwarded interactive card to its text in
BodyForAgent` (`extensions/feishu/src/bot.test.ts`) dispatches a real
merge_forward websocket event through `handleFeishuMessage`, stubs only the
Feishu API client, and asserts both the agent-visible body and the fetch
parameter:

```
$ node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts -t "forwarded interactive card"
 Test Files  1 passed (1)
      Tests  1 passed | 91 skipped (92)
```

The test asserts the fetch requests full card JSON:

```
expect(mockGetMerged).toHaveBeenCalledWith({
  params: { card_msg_content_type: "user_card_content" },
  path: { message_id: "msg-merge-forward-card" },
});
```

and that the extracted card text reaches `BodyForAgent`:

```
[Merged and Forwarded Messages]
- Q2 Sales Report
**Region**: APAC  |  **Total**: 1,240
Q1: 540
Q2: 700
```

### Before vs after (real exported `parseMergeForwardContent`)

Same realistic `im.message.get` payload, driven through the real exported
function. **Before** is captured by checking out the pre-fix `bot-content.ts`
(base `25e2017062`) and reproduces the reporter's production symptom:

**Before (pre-fix):**

```
---PARSE OUTPUT START---
[Merged and Forwarded Messages]
- [interactive]
---PARSE OUTPUT END---
```

**After (this PR):**

```
---PARSE OUTPUT START---
[Merged and Forwarded Messages]
- Q2 Sales Report
**Region**: APAC  |  **Total**: 1,240
Q1: 540
Q2: 700
---PARSE OUTPUT END---
```

### Unit coverage

`extensions/feishu/src/bot.test.ts` also covers, through the real
`parseMergeForwardContent`: nested column/table extraction, the no-text
`[Interactive Card]` fallback, template-variable resolution, and single-locale
i18n selection. Full `extensions/feishu/src/{bot,send}.test.ts` suites green
(111 passed); oxlint + oxfmt clean.

## Merge risk

Low / additive on the runtime path. The merge_forward formatter gains an
`interactive` arm reached solely by merge_forward sub-message expansion, and the
fetch gains one read-only parameter that mirrors the existing sibling read. The
card walker only reads whitelisted `content` strings, so it cannot throw on
unexpected card shapes (returns `""` → falls back to `[Interactive Card]`). The
fetched-message read path (`send.ts`) now shares the same extractor; its behavior
is unchanged except that header title text is now included, matching the
merge_forward path.

Closes #77909
