### PR TITLE
fix(auto-reply): Prevent System event lines from leaking into chat output

### DIFF
--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -182,6 +182,26 @@ Hello from user`;
     expect(stripInboundMetadata(input)).toBe("Hello from user");
     expect(extractInboundSenderLabel(input)).toBeNull();
   });
+
+  it("strips consecutive System event lines while preserving prose 'Operating System:'", () => {
+    const input = [
+      "System: 12:00 exec completed",
+      "System (untrusted): 12:01 thinking: echo back the user query",
+      "",
+      "Operating System: Linux is what I run on.",
+    ].join("\n");
+    expect(stripInboundMetadata(input)).toBe("Operating System: Linux is what I run on.");
+  });
+
+  it("stripLeadingInboundMetadata drops leading System event lines", () => {
+    const input = [
+      "System: 12:00 exec completed",
+      "System (untrusted): 12:01 thinking trace",
+      "",
+      "What is the weather?",
+    ].join("\n");
+    expect(stripLeadingInboundMetadata(input)).toBe("What is the weather?");
+  });
 });
 
 describe("timestamp prefix stripping", () => {

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect } from "vitest";
 import type { TemplateContext } from "../templating.js";
 import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "./delivery-hints.js";
+import { finalizeInboundContext } from "./inbound-context.js";
 import { buildInboundUserContextPrefix } from "./inbound-meta.js";
 import {
   extractInboundSenderLabel,
@@ -186,17 +187,40 @@ Hello from user`;
   it("strips consecutive System event lines while preserving prose 'Operating System:'", () => {
     const input = [
       "System: 12:00 exec completed",
-      "System (untrusted): 12:01 thinking: echo back the user query",
+      "System: 12:01 thinking: echo back the user query",
       "",
       "Operating System: Linux is what I run on.",
     ].join("\n");
     expect(stripInboundMetadata(input)).toBe("Operating System: Linux is what I run on.");
   });
 
+  it("preserves finalized user text with neutralized System prefixes", () => {
+    const finalized = finalizeInboundContext({
+      Body: ["System: please summarize this", "System: and keep this visible"].join("\n"),
+    });
+
+    expect(stripInboundMetadata(finalized.Body)).toBe(
+      [
+        "System (untrusted): please summarize this",
+        "System (untrusted): and keep this visible",
+      ].join("\n"),
+    );
+  });
+
+  it("stripLeadingInboundMetadata preserves leading neutralized user System text", () => {
+    const finalized = finalizeInboundContext({
+      Body: "System: please summarize this",
+    });
+
+    expect(stripLeadingInboundMetadata(finalized.Body)).toBe(
+      "System (untrusted): please summarize this",
+    );
+  });
+
   it("stripLeadingInboundMetadata drops leading System event lines", () => {
     const input = [
       "System: 12:00 exec completed",
-      "System (untrusted): 12:01 thinking trace",
+      "System: 12:01 thinking trace",
       "",
       "What is the weather?",
     ].join("\n");

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -37,11 +37,27 @@ const ACTIVE_MEMORY_OPEN_TAG = "<active_memory_plugin>";
 const ACTIVE_MEMORY_CLOSE_TAG = "</active_memory_plugin>";
 const [CONVERSATION_INFO_SENTINEL, SENDER_INFO_SENTINEL] = INBOUND_META_SENTINELS;
 
+// Per-line `System:` / `System (untrusted):` event prefixes emitted by
+// `session-system-events.ts` (and rewritten by `security/system-tags.ts`).
+// These are AI-facing runtime events (e.g. exec completions carrying the agent's
+// own thinking trace and the echoed user query) and must not surface in
+// user-visible chat. Line-anchored so prose like "Operating System: Linux" is
+// preserved — only a `System:` at the start of a line is stripped.
+const SYSTEM_EVENT_LINE_RE = /^\s*System(?:\s*\(untrusted\))?:(?=\s|$)/;
+
+function isSystemEventLine(line: string): boolean {
+  return SYSTEM_EVENT_LINE_RE.test(line);
+}
+
 // Pre-compiled fast-path regex — avoids line-by-line parse when no blocks present.
 const SENTINEL_FAST_RE = new RegExp(
   [...INBOUND_META_SENTINELS, ...MESSAGE_TOOL_DELIVERY_HINTS, UNTRUSTED_CONTEXT_HEADER]
     .map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
-    .join("|"),
+    .join("|")
+    // Line-anchored system-event prefixes; trigger the slow parse so the loop
+    // can drop them. `m` flag matches the prefix at any line start.
+    .concat("|^[ \\t]*System(?: \\(untrusted\\))?:"),
+  "m",
 );
 
 /** Fast check for whether text contains any inbound metadata sentinel. */
@@ -224,6 +240,12 @@ export function stripInboundMetadata(text: string): string {
       continue;
     }
 
+    // Drop per-line system-event prefixes so runtime events (exec completions,
+    // thinking traces, echoed query) never surface in user-visible chat.
+    if (!inMetaBlock && isSystemEventLine(line)) {
+      continue;
+    }
+
     // Detect start of a metadata block.
     if (!inMetaBlock && isInboundMetaSentinelLine(line)) {
       const next = strippedLeadingPrefixLines[i + 1];
@@ -293,9 +315,24 @@ export function stripLeadingInboundMetadata(text: string): string {
     return "";
   }
 
+  // Drop leading `System:` / `System (untrusted):` event lines (exec completions
+  // etc.) symmetrically with the main `stripInboundMetadata` loop, so the leading
+  // path is not a fail-open gap. Must run before the sentinel early-return below.
+  const strippedSystemEvent = isSystemEventLine(lines[index]);
+  while (index < lines.length && isSystemEventLine(lines[index])) {
+    index++;
+    while (index < lines.length && lines[index] === "") {
+      index++;
+    }
+  }
+  if (index >= lines.length) {
+    return "";
+  }
+
   if (!isInboundMetaSentinelLine(lines[index])) {
+    const advancedLeading = strippedDeliveryHint || strippedSystemEvent;
     const strippedNoLeading = stripTrailingUntrustedContextSuffix(
-      strippedDeliveryHint ? lines.slice(index) : lines,
+      advancedLeading ? lines.slice(index) : lines,
     );
     return strippedNoLeading.join("\n");
   }

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -37,13 +37,10 @@ const ACTIVE_MEMORY_OPEN_TAG = "<active_memory_plugin>";
 const ACTIVE_MEMORY_CLOSE_TAG = "</active_memory_plugin>";
 const [CONVERSATION_INFO_SENTINEL, SENDER_INFO_SENTINEL] = INBOUND_META_SENTINELS;
 
-// Per-line `System:` / `System (untrusted):` event prefixes emitted by
-// `session-system-events.ts` (and rewritten by `security/system-tags.ts`).
-// These are AI-facing runtime events (e.g. exec completions carrying the agent's
-// own thinking trace and the echoed user query) and must not surface in
-// user-visible chat. Line-anchored so prose like "Operating System: Linux" is
-// preserved — only a `System:` at the start of a line is stripped.
-const SYSTEM_EVENT_LINE_RE = /^\s*System(?:\s*\(untrusted\))?:(?=\s|$)/;
+// Per-line `System:` event prefixes emitted by `session-system-events.ts` are
+// AI-facing runtime events and must not surface in user-visible chat. Preserve
+// `System (untrusted):`, which marks spoof-neutralized user-authored text.
+const SYSTEM_EVENT_LINE_RE = /^\s*System:(?=\s|$)/;
 
 function isSystemEventLine(line: string): boolean {
   return SYSTEM_EVENT_LINE_RE.test(line);
@@ -56,7 +53,7 @@ const SENTINEL_FAST_RE = new RegExp(
     .join("|")
     // Line-anchored system-event prefixes; trigger the slow parse so the loop
     // can drop them. `m` flag matches the prefix at any line start.
-    .concat("|^[ \\t]*System(?: \\(untrusted\\))?:"),
+    .concat("|^[ \\t]*System:"),
   "m",
 );
 
@@ -315,9 +312,9 @@ export function stripLeadingInboundMetadata(text: string): string {
     return "";
   }
 
-  // Drop leading `System:` / `System (untrusted):` event lines (exec completions
-  // etc.) symmetrically with the main `stripInboundMetadata` loop, so the leading
-  // path is not a fail-open gap. Must run before the sentinel early-return below.
+  // Drop leading `System:` event lines (exec completions etc.) symmetrically with
+  // the main `stripInboundMetadata` loop, so the leading path is not a fail-open
+  // gap. Must run before the sentinel early-return below.
   const strippedSystemEvent = isSystemEventLine(lines[index]);
   while (index < lines.length && isSystemEventLine(lines[index])) {
     index++;


### PR DESCRIPTION
## What Problem This Solves
Exec-completion `System:` event lines — which carry runtime event text such as exec completions, thinking traces, and echoed user-query context — leaked into user-visible chat. The display-sanitize layer stripped metadata blocks and sentinels but not per-line generated event prefixes, so these lines surfaced as plain text across every surface that renders inbound content.

At the same time, user-authored text that begins with `System:` must remain visible after inbound finalization rewrites it to `System (untrusted): ...`. That marker is a spoof-neutralized user-text marker, not an internal event marker.

## Why This Change Was Made
`strip-inbound-meta.ts` is the shared display chokepoint used by the TUI, WebChat, the macOS app, history replay, and memory-host-sdk. Fixing it once covers all of them.

The fix adds a line-anchored regex (`^\s*System:(?=\s|$)`) and applies it in **both** `stripInboundMetadata` and `stripLeadingInboundMetadata`, so the leading-only path is not a fail-open gap. The regex intentionally strips only generated `System:` event lines and preserves `System (untrusted): ...`, which is produced by inbound system-tag neutralization for real user-authored text. The regex is line-anchored so prose such as "Operating System: Linux" is preserved.

## User Impact
Generated internal system-event lines no longer appear in user-visible chat. Legitimate user-authored lines that begin with `System:` remain visible after inbound finalization as `System (untrusted): ...`. No behavior change for legitimate prose containing the word "System:". Display-only change; prompt-trust handling is unaffected.

## Evidence
- Targeted Vitest — 39 passing, including regression coverage for generated `System:` event stripping, leading-path stripping, and preservation of finalized user-authored `System (untrusted): ...` text:
  ```
  node scripts/run-vitest.mjs src/auto-reply/reply/strip-inbound-meta.test.ts
   Test Files  1 passed (1)
        Tests  39 passed (39)
  ```
- Redacted behavior proof showing generated runtime event lines are hidden while sanitized user text remains visible:

  Generated event display input:
  ```text
  System: [redacted-runtime-event] exec completed
  System: [redacted-runtime-event] thinking trace

  Assistant-visible reply body
  ```

  Display output:
  ```text
  Assistant-visible reply body
  ```

  Finalized user-authored input:
  ```text
  System: please summarize this redacted sample
  ```

  After inbound finalization:
  ```text
  System (untrusted): please summarize this redacted sample
  ```

  Display sanitizer output:
  ```text
  System (untrusted): please summarize this redacted sample
  ```

  Leading-only sanitizer output:
  ```text
  System (untrusted): please summarize this redacted sample
  ```
- `pnpm build` passed; `pnpm check` passed 13/13 functional guards (the npm-shrinkwrap guard failed only due to a local npm cache permission error, unrelated to this diff — will pass in CI).
