### PR TITLE
fix(imessage): detect namespaced thinking reflections

### DIFF
--- a/extensions/imessage/src/monitor/reflection-guard.test.ts
+++ b/extensions/imessage/src/monitor/reflection-guard.test.ts
@@ -31,6 +31,16 @@ describe("detectReflectedContent", () => {
     expect(result.matchedLabels).toContain("thinking-tag");
   });
 
+  it("detects namespaced thinking tags", () => {
+    const mm = detectReflectedContent("<mm:think>internal reasoning</mm:think>");
+    const antml = detectReflectedContent("<antml:thinking>internal reasoning</antml:thinking>");
+
+    expect(mm.isReflection).toBe(true);
+    expect(mm.matchedLabels).toContain("thinking-tag");
+    expect(antml.isReflection).toBe(true);
+    expect(antml.matchedLabels).toContain("thinking-tag");
+  });
+
   it("detects <thought> tags", () => {
     const result = detectReflectedContent("<thought>secret</thought>");
     expect(result.isReflection).toBe(true);

--- a/extensions/imessage/src/monitor/reflection-guard.ts
+++ b/extensions/imessage/src/monitor/reflection-guard.ts
@@ -4,7 +4,8 @@ import { findCodeRegions, isInsideCode } from "openclaw/plugin-sdk/text-chunking
 const INTERNAL_SEPARATOR_RE = /(?:#\+){2,}#?/;
 const ASSISTANT_ROLE_MARKER_RE = /\bassistant\s+to\s*=\s*\w+/i;
 // Require closing `>` to avoid false-positives on phrases like "<thought experiment>".
-const THINKING_TAG_RE = /<\s*\/?\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/i;
+const THINKING_TAG_RE =
+  /<\s*\/?\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/i;
 const RELEVANT_MEMORIES_TAG_RE = /<\s*\/?\s*relevant[-_]memories\b[^<>]*>/i;
 // Require closing `>` to avoid false-positives on phrases like "<final answer>".
 const FINAL_TAG_RE = /<\s*\/?\s*final\b[^<>]*>/i;


### PR DESCRIPTION
## What Problem This Solves

iMessage's reflection guard had a local thinking-tag detector that recognized bare `<think>` / `<thinking>` / `<thought>` tags, but not the namespaced forms already handled by the shared reasoning-tag helper and Slack path. Reflected assistant content containing `<mm:think>...</mm:think>` or `<antml:thinking>...</antml:thinking>` could therefore bypass `detectReflectedContent()` and continue through inbound processing.

## Why This Change Was Made

`extensions/imessage/src/monitor/inbound-processing.ts` drops inbound messages when `detectReflectedContent()` identifies assistant-internal markers. The detector in `extensions/imessage/src/monitor/reflection-guard.ts` kept a local thinking-tag regex that had not picked up the known `mm:` and `antml:` namespace prefixes. This change aligns that detector with the shared/Slack thinking tag family while preserving the existing requirement for a complete tag close bracket.

## User Impact

iMessage users get stronger loop/reflection protection for model outputs that use MiniMax or Anthropic-style namespaced thinking tags. Normal user text and code examples remain protected by the existing code-region checks.

## Evidence

- Verified the bug exists on current `main` (`8e76feb482`): temporarily added the same regression assertions to `extensions/imessage/src/monitor/reflection-guard.test.ts` and ran `node scripts/run-vitest.mjs extensions/imessage/src/monitor/reflection-guard.test.ts`.
- Result on `main`: failed as expected. `detectReflectedContent("<mm:think>internal reasoning</mm:think>").isReflection` returned `false`.
- Ran the same command on this branch after the fix: passed, 1 test file / 19 tests.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings.
