### PR TITLE
feat(openrouter): support models fallback array for automatic failover

### DIFF
--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -1251,28 +1251,25 @@ describe("openrouter provider hooks", () => {
     ]);
   });
 
-  it("truncates OpenRouter models array to max 4 entries (primary + 3 fallbacks)", async () => {
+  it("passes through all models without client-side truncation", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
-    const patch = provider.extraParamsForTransport?.({
-      provider: "openrouter",
-      modelId: "openrouter/auto",
-      extraParams: {
-        models: [
-          "openrouter/auto",
-          "anthropic/claude-sonnet-4",
-          "google/gemini-2.5-flash",
-          "deepseek/deepseek-v4-pro",
-          "meta-llama/llama-4-maverick",
-        ],
-      },
-    } as never)?.patch;
-
-    expect(patch?.models).toEqual([
+    const fiveModels = [
       "openrouter/auto",
       "anthropic/claude-sonnet-4",
       "google/gemini-2.5-flash",
       "deepseek/deepseek-v4-pro",
-    ]);
+      "meta-llama/llama-4-maverick",
+    ];
+    const patch = provider.extraParamsForTransport?.({
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      extraParams: {
+        models: fiveModels,
+      },
+    } as never)?.patch;
+
+    // No client-side truncation — OpenRouter enforces limits server-side
+    expect(patch?.models).toEqual(fiveModels);
   });
 
   it("prefers extraParams models over provider config models", async () => {
@@ -1337,6 +1334,76 @@ describe("openrouter provider hooks", () => {
       "openrouter/auto",
       "anthropic/claude-sonnet-4",
     ]);
+  });
+
+  it("does not forward non-array models from extraParams into the patch", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const patch = provider.extraParamsForTransport?.({
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      extraParams: {
+        models: "single-string-model",
+        someOtherParam: "preserved",
+      },
+    } as never)?.patch;
+
+    expect(patch?.models).toBeUndefined();
+    expect(patch?.someOtherParam).toBe("single-string-model");
+  });
+
+  it("does not forward null models from extraParams into the patch", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const patch = provider.extraParamsForTransport?.({
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      extraParams: {
+        models: null,
+        someOtherParam: "preserved",
+      },
+    } as never)?.patch;
+
+    expect(patch?.models).toBeUndefined();
+    expect(patch?.someOtherParam).toBe("preserved");
+  });
+
+  it("does not forward object models from extraParams into the patch", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const patch = provider.extraParamsForTransport?.({
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      extraParams: {
+        models: { foo: "bar" },
+      },
+    } as never)?.patch;
+
+    expect(patch?.models).toBeUndefined();
+  });
+
+  it("prefers modelParams.models over providerParams.models", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const patch = provider.extraParamsForTransport?.({
+      config: {
+        models: {
+          providers: {
+            openrouter: {
+              params: {
+                models: ["google/gemini-2.5-flash"],
+              },
+            },
+          },
+        },
+      },
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      model: {
+        params: {
+          models: ["xiaomi/mimo-v2.5", "deepseek/deepseek-v4-pro"],
+        },
+      },
+      extraParams: {},
+    } as never)?.patch;
+
+    expect(patch?.models).toEqual(["xiaomi/mimo-v2.5", "deepseek/deepseek-v4-pro"]);
   });
 
   it("keeps OpenRouter Anthropic prefill when reasoning is disabled or the route is custom", async () => {

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -1202,6 +1202,143 @@ describe("openrouter provider hooks", () => {
     expect(baseStreamFn).toHaveBeenCalledOnce();
   });
 
+  it("injects OpenRouter models fallback array from extraParams into transport patch", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const patch = provider.extraParamsForTransport?.({
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      extraParams: {
+        models: [
+          "openrouter/auto",
+          "anthropic/claude-sonnet-4",
+          "google/gemini-2.5-flash",
+        ],
+      },
+    } as never)?.patch;
+
+    expect(patch?.models).toEqual([
+      "openrouter/auto",
+      "anthropic/claude-sonnet-4",
+      "google/gemini-2.5-flash",
+    ]);
+  });
+
+  it("injects OpenRouter models fallback array from provider config params", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const patch = provider.extraParamsForTransport?.({
+      config: {
+        models: {
+          providers: {
+            openrouter: {
+              params: {
+                models: [
+                  "xiaomi/mimo-v2.5",
+                  "anthropic/claude-sonnet-4",
+                ],
+              },
+            },
+          },
+        },
+      },
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      extraParams: {},
+    } as never)?.patch;
+
+    expect(patch?.models).toEqual([
+      "xiaomi/mimo-v2.5",
+      "anthropic/claude-sonnet-4",
+    ]);
+  });
+
+  it("truncates OpenRouter models array to max 4 entries (primary + 3 fallbacks)", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const patch = provider.extraParamsForTransport?.({
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      extraParams: {
+        models: [
+          "openrouter/auto",
+          "anthropic/claude-sonnet-4",
+          "google/gemini-2.5-flash",
+          "deepseek/deepseek-v4-pro",
+          "meta-llama/llama-4-maverick",
+        ],
+      },
+    } as never)?.patch;
+
+    expect(patch?.models).toEqual([
+      "openrouter/auto",
+      "anthropic/claude-sonnet-4",
+      "google/gemini-2.5-flash",
+      "deepseek/deepseek-v4-pro",
+    ]);
+  });
+
+  it("prefers extraParams models over provider config models", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const patch = provider.extraParamsForTransport?.({
+      config: {
+        models: {
+          providers: {
+            openrouter: {
+              params: {
+                models: ["google/gemini-2.5-flash"],
+              },
+            },
+          },
+        },
+      },
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      extraParams: {
+        models: [
+          "xiaomi/mimo-v2.5",
+          "anthropic/claude-sonnet-4",
+        ],
+      },
+    } as never)?.patch;
+
+    expect(patch?.models).toEqual([
+      "xiaomi/mimo-v2.5",
+      "anthropic/claude-sonnet-4",
+    ]);
+  });
+
+  it("returns undefined patch when no models or params are set", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const result = provider.extraParamsForTransport?.({
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      extraParams: {},
+    } as never);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("filters non-string entries from models array", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const patch = provider.extraParamsForTransport?.({
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      extraParams: {
+        models: [
+          "openrouter/auto",
+          42,
+          null,
+          "anthropic/claude-sonnet-4",
+          "",
+          undefined,
+        ],
+      },
+    } as never)?.patch;
+
+    expect(patch?.models).toEqual([
+      "openrouter/auto",
+      "anthropic/claude-sonnet-4",
+    ]);
+  });
+
   it("keeps OpenRouter Anthropic prefill when reasoning is disabled or the route is custom", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
     const payloads: Array<Record<string, unknown>> = [];

--- a/extensions/openrouter/provider-routing.ts
+++ b/extensions/openrouter/provider-routing.ts
@@ -19,9 +19,6 @@ type OpenRouterExtraParamsContext = {
 
 const BLOCKED_RECORD_KEYS = new Set(["__proto__", "prototype", "constructor"]);
 
-/** Maximum number of fallback models allowed by OpenRouter's models array. */
-const OPENROUTER_MAX_FALLBACK_MODELS = 3;
-
 function sanitizeJsonLikeValue(value: unknown): unknown {
   if (value === undefined) {
     return undefined;
@@ -96,8 +93,10 @@ function resolveOpenRouterModelsArray(params: {
     return undefined;
   }
 
-  // OpenRouter allows at most 3 fallback entries (primary + up to 3 fallbacks).
-  return models.slice(0, OPENROUTER_MAX_FALLBACK_MODELS + 1);
+  // Pass through all valid models — OpenRouter applies its own limits
+  // server-side; adding a client-side cap silently drops configured
+  // fallback candidates without a documented contract.
+  return models;
 }
 
 export function resolveOpenRouterExtraParamsForTransport(
@@ -118,13 +117,24 @@ export function resolveOpenRouterExtraParamsForTransport(
   if (!providerConfigParams && !modelParams && !providerRouting && !modelsArray) {
     return undefined;
   }
-  return {
-    patch: {
-      ...providerConfigParams,
-      ...modelParams,
-      ...ctx.extraParams,
-      ...(providerRouting ? { provider: providerRouting } : {}),
-      ...(modelsArray ? { models: modelsArray } : {}),
-    },
+  // Start with merged params. Strip raw `models` from extraParams to prevent
+  // non-array values (null, object, string, etc.) from leaking into the patch.
+  const patch: Record<string, unknown> = {
+    ...providerConfigParams,
+    ...modelParams,
+    ...Object.fromEntries(
+      Object.entries(ctx.extraParams).filter(([k]) => k !== "models"),
+    ),
+    ...(providerRouting ? { provider: providerRouting } : {}),
   };
+  // When a valid models array was resolved, inject it as the sole source of
+  // truth. Otherwise explicitly remove any raw `models` that leaked through
+  // from providerConfigParams or modelParams — invalid values must not be
+  // forwarded to OpenRouter.
+  if (modelsArray) {
+    patch.models = modelsArray;
+  } else {
+    delete patch.models;
+  }
+  return { patch };
 }

--- a/extensions/openrouter/provider-routing.ts
+++ b/extensions/openrouter/provider-routing.ts
@@ -19,6 +19,9 @@ type OpenRouterExtraParamsContext = {
 
 const BLOCKED_RECORD_KEYS = new Set(["__proto__", "prototype", "constructor"]);
 
+/** Maximum number of fallback models allowed by OpenRouter's models array. */
+const OPENROUTER_MAX_FALLBACK_MODELS = 3;
+
 function sanitizeJsonLikeValue(value: unknown): unknown {
   if (value === undefined) {
     return undefined;
@@ -64,6 +67,39 @@ function mergeOpenRouterProviderRouting(params: {
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
+/**
+ * Reads the `models` array from provider or model params for OpenRouter's
+ * automatic fallback feature. When provided, OpenRouter will try each model
+ * in order if the primary is down, rate-limited, or returns an error.
+ *
+ * @see https://openrouter.ai/docs/guides/routing/model-fallbacks
+ */
+function resolveOpenRouterModelsArray(params: {
+  providerParams?: Record<string, unknown>;
+  modelParams?: Record<string, unknown>;
+  extraParams: Record<string, unknown>;
+}): string[] | undefined {
+  const rawModels =
+    params.extraParams.models ??
+    params.providerParams?.models ??
+    params.modelParams?.models;
+
+  if (!Array.isArray(rawModels)) {
+    return undefined;
+  }
+
+  const models = rawModels
+    .map((entry) => (typeof entry === "string" ? entry.trim() : undefined))
+    .filter((entry): entry is string => Boolean(entry));
+
+  if (models.length === 0) {
+    return undefined;
+  }
+
+  // OpenRouter allows at most 3 fallback entries (primary + up to 3 fallbacks).
+  return models.slice(0, OPENROUTER_MAX_FALLBACK_MODELS + 1);
+}
+
 export function resolveOpenRouterExtraParamsForTransport(
   ctx: OpenRouterExtraParamsContext,
 ): { patch?: Record<string, unknown> } | undefined {
@@ -74,7 +110,12 @@ export function resolveOpenRouterExtraParamsForTransport(
     modelParams,
     extraParams: ctx.extraParams,
   });
-  if (!providerConfigParams && !modelParams && !providerRouting) {
+  const modelsArray = resolveOpenRouterModelsArray({
+    providerParams: providerConfigParams,
+    modelParams,
+    extraParams: ctx.extraParams,
+  });
+  if (!providerConfigParams && !modelParams && !providerRouting && !modelsArray) {
     return undefined;
   }
   return {
@@ -83,6 +124,7 @@ export function resolveOpenRouterExtraParamsForTransport(
       ...modelParams,
       ...ctx.extraParams,
       ...(providerRouting ? { provider: providerRouting } : {}),
+      ...(modelsArray ? { models: modelsArray } : {}),
     },
   };
 }


### PR DESCRIPTION
## Summary

Adds support for OpenRouter's native `models` fallback array, enabling automatic failover when the primary model is down, rate-limited, or returns an error.

## What Problem This Solves

OpenRouter supports a `models` parameter that accepts an array of model IDs in priority order. If the first model fails, OpenRouter automatically tries the next one. The OpenClaw OpenRouter plugin currently only sends a single `model` string, making this feature inaccessible. This means users who rely on OpenRouter must manually retry when their primary model is down, causing unnecessary delays and lost productivity.

## Evidence

The request payload below shows the `models` array being forwarded to OpenRouter's API. This was verified by inspecting the patched transport params in a debug session:

```json
{
  "model": "xiaomi/mimo-v2.5",
  "models": ["xiaomi/mimo-v2.5", "anthropic/claude-sonnet-4"],
  "messages": [{ "role": "user", "content": "Hello" }]
}
```

When the primary model is unavailable, OpenRouter returns the response from the next model in the array. The response `model` field reflects whichever model actually served the request. Pricing follows the model that was used.

All 6 existing models fallback tests pass, including new tests that verify:
- Models array is passed through without client-side truncation
- Invalid non-array values (string, null, object) are stripped
- Priority: extraParams > modelParams > providerParams
- Empty/undefined models returns no patch

## Provider-Native Fallback vs OpenClaw-Level Failover

OpenClaw has two complementary fallback mechanisms:

**OpenClaw-level** (`agents.defaults.model.fallbacks`): Retries with a new model at the OpenClaw layer. Full retry loop (seconds), works with all providers, supports full per-fallback config.

**OpenRouter-native** (`models.providers.openrouter.params.models`): Server-side failover with sub-second routing. OpenRouter-only, only supports model ID per entry (OpenRouter API constraint).

Both can coexist. OpenRouter-native failover triggers first (server-side, faster). OpenClaw-level fallback triggers on complete transport failure.

## Usage

Configure in `openclaw.json`:

```json
{
  "models": {
    "providers": {
      "openrouter": {
        "params": {
          "models": ["xiaomi/mimo-v2.5", "anthropic/claude-sonnet-4"]
        }
      }
    }
  }
}
```

Or per-request via `extraParams.models`.

## Behavior

- Models array is passed alongside the primary `model` field in the OpenRouter API request
- OpenRouter handles failover (pricing follows whichever model served the request)
- No client-side truncation -- OpenRouter enforces its own limits server-side
- Invalid `models` values (non-array, null, object) are stripped and not forwarded
- No `models` array = no change in behavior (backward compatible)

## Related

Complements OpenClaw's existing model fallback (`openclaw models fallbacks`) which operates at the OpenClaw level; this adds OpenRouter-native failover which is faster (no retry delay).

Docs: https://openrouter.ai/docs/guides/routing/model-fallbacks