### PR TITLE
perf(gateway): drop redundant per-access session-key case scan

### DIFF
--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -191,7 +191,6 @@ export async function markRestartAbortedMainSessions(params: {
         const target = resolveGatewaySessionStoreTarget({
           cfg,
           key: sessionKey,
-          scanLegacyKeys: true,
         });
         storePaths.add(path.resolve(target.storePath));
         for (const storeKey of target.storeKeys) {
@@ -711,7 +710,6 @@ function isRoutableRecoveryStore(params: {
     const target = resolveGatewaySessionStoreTarget({
       cfg: params.cfg,
       key: params.sessionKey,
-      scanLegacyKeys: true,
     });
     return path.resolve(target.storePath) === path.resolve(params.storePath);
   } catch (err) {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -369,7 +369,7 @@ describe("session accessor file-backed seam", () => {
           sessionId: "canonical-session",
           updatedAt: 10,
         },
-        "AGENT:MAIN:MAIN": {
+        main: {
           sessionId: "legacy-session",
           updatedAt: 20,
         },
@@ -381,7 +381,7 @@ describe("session accessor file-backed seam", () => {
       storePath,
       resolveTarget: () => ({
         primaryKey: "agent:main:main",
-        candidateKeys: ["agent:main:main"],
+        candidateKeys: ["agent:main:main", "main"],
       }),
       project: ({ entries, existingEntry, primaryKey }) => {
         expect(primaryKey).toBe("agent:main:main");
@@ -420,7 +420,7 @@ describe("session accessor file-backed seam", () => {
           sessionId: "canonical-session",
           updatedAt: 10,
         },
-        "AGENT:MAIN:MAIN": {
+        main: {
           sessionId: "legacy-session",
           updatedAt: 20,
         },
@@ -432,7 +432,7 @@ describe("session accessor file-backed seam", () => {
       storePath,
       resolveTarget: () => ({
         primaryKey: "agent:main:main",
-        candidateKeys: ["agent:main:main"],
+        candidateKeys: ["agent:main:main", "main"],
       }),
       project: () => ({
         ok: false as const,

--- a/src/config/sessions/startup-migration.ts
+++ b/src/config/sessions/startup-migration.ts
@@ -1,0 +1,45 @@
+import { migrateOrphanedSessionKeys } from "../../infra/state-migrations.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
+
+export type SessionStartupMigrationLogger = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+};
+
+/**
+ * Run orphan-key session migration before runtime session store reads.
+ *
+ * The migration is idempotent and best-effort: startup continues if the repair
+ * fails, but warnings stay visible so exact-key runtime access does not hide
+ * legacy store states that still need operator attention.
+ */
+export async function runSessionStartupMigration(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  log: SessionStartupMigrationLogger;
+  deps?: {
+    migrateOrphanedSessionKeys?: typeof migrateOrphanedSessionKeys;
+  };
+}): Promise<void> {
+  const migrate = params.deps?.migrateOrphanedSessionKeys ?? migrateOrphanedSessionKeys;
+  try {
+    const result = await migrate({
+      cfg: params.cfg,
+      env: params.env ?? process.env,
+    });
+    if (result.changes.length > 0) {
+      params.log.info(
+        `session: canonicalized orphaned session keys:\n${result.changes.map((c) => `- ${c}`).join("\n")}`,
+      );
+    }
+    if (result.warnings.length > 0) {
+      params.log.warn(
+        `session: session key migration warnings:\n${result.warnings.map((w) => `- ${w}`).join("\n")}`,
+      );
+    }
+  } catch (err) {
+    params.log.warn(
+      `session: orphaned session key migration failed during startup; continuing: ${String(err)}`,
+    );
+  }
+}

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1,10 +1,7 @@
 // Session store facade coordinates reads, writes, maintenance, delivery metadata, and exports.
 import fs from "node:fs";
 import path from "node:path";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { resolveStoredSessionOwnerAgentId } from "../../gateway/session-store-key.js";
 import { writeTextAtomic } from "../../infra/json-files.js";
@@ -1037,9 +1034,6 @@ function resolveFreshestProjectedEntry(params: {
       continue;
     }
     keys.add(trimmed);
-    for (const match of findSessionStoreKeysIgnoreCase(params.store, trimmed)) {
-      keys.add(match);
-    }
   }
   for (const key of keys) {
     const entry = params.store[key];
@@ -1051,14 +1045,6 @@ function resolveFreshestProjectedEntry(params: {
     }
   }
   return freshest;
-}
-
-function findSessionStoreKeysIgnoreCase(
-  store: Record<string, SessionEntry>,
-  targetKey: string,
-): string[] {
-  const lowered = normalizeLowercaseStringOrEmpty(targetKey);
-  return Object.keys(store).filter((key) => normalizeLowercaseStringOrEmpty(key) === lowered);
 }
 
 function migrateSessionEntryProjectionTarget(params: {
@@ -1086,11 +1072,6 @@ function migrateSessionEntryProjectionTarget(params: {
     }
     if (trimmed !== params.target.primaryKey) {
       keysToDelete.add(trimmed);
-    }
-    for (const match of findSessionStoreKeysIgnoreCase(params.store, trimmed)) {
-      if (match !== params.target.primaryKey) {
-        keysToDelete.add(match);
-      }
     }
   }
   for (const key of keysToDelete) {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -648,7 +648,16 @@ describe("gateway agent handler", () => {
   });
 
   it("disables single-entry persistence when admission prunes legacy store keys", async () => {
-    mockMainSessionEntry({});
+    mocks.loadConfigReturn = {
+      session: { mainKey: "work" },
+      agents: { list: [{ id: "main", default: true }] },
+    };
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: mocks.loadConfigReturn,
+      storePath: "/tmp/sessions.json",
+      entry: { sessionId: "existing-session-id", updatedAt: Date.now() },
+      canonicalKey: "agent:main:work",
+    });
     let capturedOptions:
       | {
           resolveSingleEntryPersistence?: (result: unknown) => unknown;
@@ -657,8 +666,8 @@ describe("gateway agent handler", () => {
     let persistedResult: unknown;
     mocks.updateSessionStore.mockImplementation(async (_path, updater, opts) => {
       const store: Record<string, Record<string, unknown>> = {
-        "agent:main:main": buildExistingMainStoreEntry({ updatedAt: 100 }),
-        "Agent:main:main": buildExistingMainStoreEntry({ updatedAt: 50 }),
+        "agent:main:work": buildExistingMainStoreEntry({ updatedAt: 100 }),
+        "agent:main:main": buildExistingMainStoreEntry({ updatedAt: 50 }),
       };
       persistedResult = await updater(store);
       capturedOptions = opts;
@@ -5071,7 +5080,7 @@ describe("gateway agent handler", () => {
     mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
       const store: Record<string, unknown> = {
         "agent:main:work": { sessionId: "existing-session-id", updatedAt: 10 },
-        "agent:main:MAIN": { sessionId: "legacy-session-id", updatedAt: 5 },
+        "agent:main:main": { sessionId: "legacy-session-id", updatedAt: 5 },
       };
       await updater(store);
       capturedStore = store;
@@ -5095,7 +5104,7 @@ describe("gateway agent handler", () => {
     expect(mocks.updateSessionStore).toHaveBeenCalled();
     const sessionStore = requireValue(capturedStore, "updated session store missing");
     expect(sessionStore).toHaveProperty("agent:main:work");
-    expect(sessionStore["agent:main:MAIN"]).toBeUndefined();
+    expect(sessionStore["agent:main:main"]).toBeUndefined();
   });
 
   it("handles bare /new by resetting the same session without running the model", async () => {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1091,7 +1091,6 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         const cachedStoreTarget = resolveGatewaySessionStoreTargetWithStore({
           cfg,
           key,
-          scanLegacyKeys: false,
         });
         const store = storeCache.get(cachedStoreTarget.storePath) ?? cachedStoreTarget.store;
         storeCache.set(cachedStoreTarget.storePath, store);

--- a/src/gateway/server-startup-session-migration.ts
+++ b/src/gateway/server-startup-session-migration.ts
@@ -1,12 +1,10 @@
-// Gateway startup session-store migration runner.
-// Keeps old orphaned session keys from surviving process upgrades.
+import {
+  runSessionStartupMigration,
+  type SessionStartupMigrationLogger,
+} from "../config/sessions/startup-migration.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { migrateOrphanedSessionKeys } from "../infra/state-migrations.js";
 
-type SessionMigrationLogger = {
-  info: (message: string) => void;
-  warn: (message: string) => void;
-};
+type SessionMigrationDeps = Parameters<typeof runSessionStartupMigration>[0]["deps"];
 
 /**
  * Run orphan-key session migration at gateway startup.
@@ -19,30 +17,8 @@ type SessionMigrationLogger = {
 export async function runStartupSessionMigration(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
-  log: SessionMigrationLogger;
-  deps?: {
-    migrateOrphanedSessionKeys?: typeof migrateOrphanedSessionKeys;
-  };
+  log: SessionStartupMigrationLogger;
+  deps?: SessionMigrationDeps;
 }): Promise<void> {
-  const migrate = params.deps?.migrateOrphanedSessionKeys ?? migrateOrphanedSessionKeys;
-  try {
-    const result = await migrate({
-      cfg: params.cfg,
-      env: params.env ?? process.env,
-    });
-    if (result.changes.length > 0) {
-      params.log.info(
-        `gateway: canonicalized orphaned session keys:\n${result.changes.map((c) => `- ${c}`).join("\n")}`,
-      );
-    }
-    if (result.warnings.length > 0) {
-      params.log.warn(
-        `gateway: session key migration warnings:\n${result.warnings.map((w) => `- ${w}`).join("\n")}`,
-      );
-    }
-  } catch (err) {
-    params.log.warn(
-      `gateway: orphaned session key migration failed during startup; continuing: ${String(err)}`,
-    );
-  }
+  await runSessionStartupMigration(params);
 }

--- a/src/gateway/server.sessions.preview-resolve.test.ts
+++ b/src/gateway/server.sessions.preview-resolve.test.ts
@@ -80,7 +80,7 @@ test("sessions.preview returns transcript previews", async () => {
   expect(entry?.items[1]?.text).toContain("call weather");
 });
 
-test("sessions.preview resolves legacy mixed-case main alias with custom mainKey", async () => {
+test("sessions.preview resolves legacy main alias with custom mainKey", async () => {
   const sessionId = "sess-legacy-main";
 
   const entry = await previewMainAliasFromStore({
@@ -88,7 +88,7 @@ test("sessions.preview resolves legacy mixed-case main alias with custom mainKey
       [sessionId]: "Legacy alias transcript",
     },
     store: {
-      "agent:ops:MAIN": {
+      "agent:ops:main": {
         sessionId,
         updatedAt: Date.now(),
       },
@@ -97,7 +97,7 @@ test("sessions.preview resolves legacy mixed-case main alias with custom mainKey
   expect(entry?.items[0]?.text).toContain("Legacy alias transcript");
 });
 
-test("sessions.preview prefers the freshest duplicate row for a legacy mixed-case main alias", async () => {
+test("sessions.preview prefers the freshest duplicate row for a legacy main alias", async () => {
   const entry = await previewMainAliasFromStore({
     transcripts: {
       "sess-stale-main": "stale preview",
@@ -108,7 +108,7 @@ test("sessions.preview prefers the freshest duplicate row for a legacy mixed-cas
         sessionId: "sess-stale-main",
         updatedAt: 1,
       },
-      "agent:ops:WORK": {
+      "agent:ops:main": {
         sessionId: "sess-fresh-main",
         updatedAt: 2,
       },
@@ -139,8 +139,7 @@ test("sessions.resolve and mutators clean legacy main-alias ghost keys", async (
     JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, Record<string, unknown>>;
 
   await writeRawStore({
-    "agent:ops:MAIN": { sessionId, updatedAt: Date.now() - 2_000 },
-    "agent:ops:Main": { sessionId, updatedAt: Date.now() - 1_000 },
+    "agent:ops:main": { sessionId, updatedAt: Date.now() - 1_000 },
   });
 
   const { ws } = await openClient();
@@ -155,7 +154,7 @@ test("sessions.resolve and mutators clean legacy main-alias ghost keys", async (
 
   await writeRawStore({
     ...store,
-    "agent:ops:MAIN": { ...store["agent:ops:work"] },
+    "agent:ops:main": { ...store["agent:ops:work"] },
   });
   const patched = await rpcReq<{ ok: true; key: string }>(ws, "sessions.patch", {
     key: "main",
@@ -169,7 +168,7 @@ test("sessions.resolve and mutators clean legacy main-alias ghost keys", async (
 
   await writeRawStore({
     ...store,
-    "agent:ops:MAIN": { ...store["agent:ops:work"] },
+    "agent:ops:main": { ...store["agent:ops:work"] },
   });
   const compacted = await rpcReq<{ ok: true; compacted: boolean }>(ws, "sessions.compact", {
     key: "main",
@@ -182,7 +181,7 @@ test("sessions.resolve and mutators clean legacy main-alias ghost keys", async (
 
   await writeRawStore({
     ...store,
-    "agent:ops:MAIN": { ...store["agent:ops:work"] },
+    "agent:ops:main": { ...store["agent:ops:work"] },
   });
   const reset = await rpcReq<{ ok: true; key: string }>(ws, "sessions.reset", { key: "main" });
   expect(reset.ok).toBe(true);

--- a/src/gateway/session-transcript-key.ts
+++ b/src/gateway/session-transcript-key.ts
@@ -28,7 +28,6 @@ function sessionKeyMatchesTranscriptPath(params: {
   const target = resolveGatewaySessionStoreTarget({
     cfg: params.cfg,
     key: params.key,
-    scanLegacyKeys: false,
     store: params.store,
   });
   const sessionAgentId = normalizeAgentId(target.agentId);

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1054,53 +1054,12 @@ describe("gateway session utils", () => {
     expect(target.storePath).toBe(path.resolve(storeTemplate.replace("{agentId}", "ops")));
   });
 
-  test("resolveGatewaySessionStoreTarget includes legacy mixed-case store key", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-utils-case-"));
-    const storePath = path.join(dir, "sessions.json");
-    fs.writeFileSync(
-      storePath,
-      JSON.stringify({ "agent:ops:MySession": { sessionId: "s1", updatedAt: 1 } }),
-      "utf8",
-    );
-    const cfg = {
-      session: { mainKey: "main", store: storePath },
-      agents: { list: [{ id: "ops", default: true }] },
-    } as OpenClawConfig;
-    const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:ops:mysession" });
-    expect(target.canonicalKey).toBe("agent:ops:mysession");
-    expect(target.storeKeys).toContain("agent:ops:mysession");
-    expect(target.storeKeys).toContain("agent:ops:MySession");
-    const store = JSON.parse(fs.readFileSync(storePath, "utf8"));
-    const found = target.storeKeys.some((k) => Boolean(store[k]));
-    expect(found).toBe(true);
-  });
-
-  test("resolveGatewaySessionStoreTarget includes all case-variant duplicate keys", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-utils-dupes-"));
-    const storePath = path.join(dir, "sessions.json");
-    fs.writeFileSync(
-      storePath,
-      JSON.stringify({
-        "agent:ops:mysession": { sessionId: "s-lower", updatedAt: 2 },
-        "agent:ops:MySession": { sessionId: "s-mixed", updatedAt: 1 },
-      }),
-      "utf8",
-    );
-    const cfg = {
-      session: { mainKey: "main", store: storePath },
-      agents: { list: [{ id: "ops", default: true }] },
-    } as OpenClawConfig;
-    const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:ops:mysession" });
-    expect(target.storeKeys).toContain("agent:ops:mysession");
-    expect(target.storeKeys).toContain("agent:ops:MySession");
-  });
-
-  test("resolveGatewaySessionStoreTarget finds legacy main alias key when mainKey is customized", () => {
+  test("resolveGatewaySessionStoreTarget resolves a customized main alias to its canonical key", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-utils-alias-"));
     const storePath = path.join(dir, "sessions.json");
     fs.writeFileSync(
       storePath,
-      JSON.stringify({ "agent:ops:MAIN": { sessionId: "s1", updatedAt: 1 } }),
+      JSON.stringify({ "agent:ops:main": { sessionId: "s1", updatedAt: 1 } }),
       "utf8",
     );
     const cfg = {
@@ -1109,7 +1068,7 @@ describe("gateway session utils", () => {
     } as OpenClawConfig;
     const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:ops:main" });
     expect(target.canonicalKey).toBe("agent:ops:work");
-    expect(target.storeKeys).toContain("agent:ops:MAIN");
+    expect(target.storeKeys).toContain("agent:ops:main");
   });
 
   test("resolveGatewaySessionStoreTarget preserves discovered store paths for non-round-tripping agent dirs", async () => {
@@ -1333,43 +1292,6 @@ describe("gateway session utils", () => {
     }
   });
 
-  test("loadSessionEntry prefers the freshest duplicate row for a logical key", async () => {
-    resetConfigRuntimeState();
-    try {
-      await withStateDirEnv("session-utils-load-entry-freshest-", async ({ stateDir }) => {
-        const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
-        fs.mkdirSync(sessionsDir, { recursive: true });
-        const storePath = path.join(sessionsDir, "sessions.json");
-        fs.writeFileSync(
-          storePath,
-          JSON.stringify(
-            {
-              "agent:main:main": { sessionId: "sess-stale", updatedAt: 1 },
-              "agent:main:MAIN": { sessionId: "sess-fresh", updatedAt: 2 },
-            },
-            null,
-            2,
-          ),
-          "utf8",
-        );
-        const cfg = {
-          session: {
-            mainKey: "main",
-            store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
-          },
-          agents: { list: [{ id: "main", default: true }] },
-        } as OpenClawConfig;
-        setRuntimeConfigSnapshot(cfg, cfg);
-
-        const loaded = loadSessionEntry("agent:main:main");
-
-        expect(loaded.entry?.sessionId).toBe("sess-fresh");
-      });
-    } finally {
-      resetConfigRuntimeState();
-    }
-  });
-
   test("loadSessionEntry prefers the freshest duplicate row across discovered stores", async () => {
     resetConfigRuntimeState();
     try {
@@ -1380,8 +1302,7 @@ describe("gateway session utils", () => {
           path.join(canonicalSessionsDir, "sessions.json"),
           JSON.stringify(
             {
-              "agent:main:main": { sessionId: "sess-canonical-stale", updatedAt: 10 },
-              "agent:main:MAIN": { sessionId: "sess-canonical-fresh", updatedAt: 1000 },
+              "agent:main:main": { sessionId: "sess-canonical-fresh", updatedAt: 1000 },
             },
             null,
             2,
@@ -1421,12 +1342,10 @@ describe("gateway session utils", () => {
     }
   });
 
-  test("pruneLegacyStoreKeys removes alias and case-variant ghost keys", () => {
+  test("pruneLegacyStoreKeys removes alias ghost keys", () => {
     const store: Record<string, unknown> = {
       "agent:ops:work": { sessionId: "canonical", updatedAt: 3 },
-      "agent:ops:MAIN": { sessionId: "legacy-upper", updatedAt: 1 },
-      "agent:ops:Main": { sessionId: "legacy-mixed", updatedAt: 2 },
-      "agent:ops:main": { sessionId: "legacy-lower", updatedAt: 4 },
+      "agent:ops:main": { sessionId: "legacy-alias", updatedAt: 4 },
     };
     pruneLegacyStoreKeys({
       store,
@@ -1436,17 +1355,17 @@ describe("gateway session utils", () => {
     expect(Object.keys(store).toSorted()).toEqual(["agent:ops:work"]);
   });
 
-  test("migrateAndPruneGatewaySessionStoreKey promotes the freshest duplicate row", () => {
+  test("migrateAndPruneGatewaySessionStoreKey promotes the freshest alias row to canonical", () => {
     const cfg = {
-      session: { mainKey: "main" },
-      agents: { list: [{ id: "main", default: true }] },
+      session: { mainKey: "work" },
+      agents: { list: [{ id: "ops", default: true }] },
     } as OpenClawConfig;
     const store: Record<string, SessionEntry> = {
-      "agent:main:Main": {
+      "agent:ops:work": {
         sessionId: "sess-stale",
         updatedAt: 1,
       } as SessionEntry,
-      "agent:main:MAIN": {
+      "agent:ops:main": {
         sessionId: "sess-fresh",
         updatedAt: 2,
       } as SessionEntry,
@@ -1454,43 +1373,14 @@ describe("gateway session utils", () => {
 
     const result = migrateAndPruneGatewaySessionStoreKey({
       cfg,
-      key: "agent:main:main",
+      key: "agent:ops:main",
       store,
     });
 
-    expect(result.primaryKey).toBe("agent:main:main");
+    expect(result.primaryKey).toBe("agent:ops:work");
     expect(result.entry?.sessionId).toBe("sess-fresh");
-    expect(store["agent:main:main"]?.sessionId).toBe("sess-fresh");
-    expect(store["agent:main:MAIN"]).toBeUndefined();
-    expect(store["agent:main:Main"]).toBeUndefined();
-  });
-
-  test("migrateAndPruneGatewaySessionStoreKey replaces a stale canonical row with a fresher duplicate", () => {
-    const cfg = {
-      session: { mainKey: "main" },
-      agents: { list: [{ id: "main", default: true }] },
-    } as OpenClawConfig;
-    const store: Record<string, SessionEntry> = {
-      "agent:main:main": {
-        sessionId: "sess-stale",
-        updatedAt: 1,
-      } as SessionEntry,
-      "agent:main:MAIN": {
-        sessionId: "sess-fresh",
-        updatedAt: 2,
-      } as SessionEntry,
-    };
-
-    const result = migrateAndPruneGatewaySessionStoreKey({
-      cfg,
-      key: "agent:main:main",
-      store,
-    });
-
-    expect(result.primaryKey).toBe("agent:main:main");
-    expect(result.entry?.sessionId).toBe("sess-fresh");
-    expect(store["agent:main:main"]?.sessionId).toBe("sess-fresh");
-    expect(store["agent:main:MAIN"]).toBeUndefined();
+    expect(store["agent:ops:work"]?.sessionId).toBe("sess-fresh");
+    expect(store["agent:ops:main"]).toBeUndefined();
   });
 
   test("listAgentsForGateway rejects avatar symlink escapes outside workspace", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1064,12 +1064,6 @@ function findFreshestStoreMatch(
     if (exact) {
       matches.set(trimmed, { entry: exact, key: trimmed });
     }
-    for (const key of findStoreKeysIgnoreCase(store, trimmed)) {
-      const entry = store[key];
-      if (entry) {
-        matches.set(key, { entry, key });
-      }
-    }
   }
   if (matches.size === 0) {
     return undefined;
@@ -1081,24 +1075,6 @@ function findFreshestStoreMatch(
     }
   }
   return freshest;
-}
-
-/**
- * Find all on-disk store keys that match the given key case-insensitively.
- * Returns every key from the store whose lowercased form equals the target's lowercased form.
- */
-export function findStoreKeysIgnoreCase(
-  store: Record<string, unknown>,
-  targetKey: string,
-): string[] {
-  const lowered = normalizeLowercaseStringOrEmpty(targetKey);
-  const matches: string[] = [];
-  for (const key of Object.keys(store)) {
-    if (normalizeLowercaseStringOrEmpty(key) === lowered) {
-      matches.push(key);
-    }
-  }
-  return matches;
 }
 
 /**
@@ -1118,11 +1094,6 @@ export function pruneLegacyStoreKeys(params: {
     }
     if (trimmed !== params.canonicalKey) {
       keysToDelete.add(trimmed);
-    }
-    for (const match of findStoreKeysIgnoreCase(params.store, trimmed)) {
-      if (match !== params.canonicalKey) {
-        keysToDelete.add(match);
-      }
     }
   }
   for (const key of keysToDelete) {
@@ -1445,7 +1416,6 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
   cfg: OpenClawConfig;
   key: string;
   clone?: boolean;
-  scanLegacyKeys?: boolean;
 }): GatewaySessionStoreTargetWithStore | null {
   const parsed = parseAgentSessionKey(params.key);
   const legacyAgentId = normalizeAgentId(parsed?.agentId);
@@ -1498,13 +1468,8 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
     storeKeys.add(params.key);
   }
   storeKeys.add(best.match.key);
-  if (params.scanLegacyKeys !== false) {
-    for (const seed of lookupSeeds) {
-      storeKeys.add(seed);
-      for (const legacyKey of findStoreKeysIgnoreCase(best.store, seed)) {
-        storeKeys.add(legacyKey);
-      }
-    }
+  for (const seed of lookupSeeds) {
+    storeKeys.add(seed);
   }
   return {
     agentId: legacyAgentId,
@@ -1520,7 +1485,6 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
   key: string;
   agentId?: string;
   clone?: boolean;
-  scanLegacyKeys?: boolean;
   store?: Record<string, SessionEntry>;
 }): GatewaySessionStoreTargetWithStore {
   const key = normalizeOptionalString(params.key) ?? "";
@@ -1528,7 +1492,6 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     cfg: params.cfg,
     key,
     clone: params.clone,
-    scanLegacyKeys: params.scanLegacyKeys,
   });
   if (explicitDeletedMainTarget) {
     return explicitDeletedMainTarget;
@@ -1557,26 +1520,9 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     return { agentId, storePath, canonicalKey, storeKeys, store };
   }
 
-  const storeKeys = new Set<string>();
-  storeKeys.add(canonicalKey);
-  if (key && key !== canonicalKey) {
-    storeKeys.add(key);
-  }
-  if (params.scanLegacyKeys !== false) {
-    // Scan the on-disk store for case variants of every target to find
-    // legacy mixed-case entries (e.g. "agent:ops:MAIN" when canonical is "agent:ops:work").
-    const scanTargets = buildGatewaySessionStoreScanTargets({
-      cfg: params.cfg,
-      key,
-      canonicalKey,
-      agentId,
-    });
-    for (const seed of scanTargets) {
-      for (const legacyKey of findStoreKeysIgnoreCase(store, seed)) {
-        storeKeys.add(legacyKey);
-      }
-    }
-  }
+  const storeKeys = new Set<string>(
+    buildGatewaySessionStoreScanTargets({ cfg: params.cfg, key, canonicalKey, agentId }),
+  );
   return {
     agentId,
     storePath,
@@ -1591,7 +1537,6 @@ export function resolveGatewaySessionStoreTarget(params: {
   key: string;
   agentId?: string;
   clone?: boolean;
-  scanLegacyKeys?: boolean;
   store?: Record<string, SessionEntry>;
 }): GatewaySessionStoreTarget {
   const { store: _store, ...target } = resolveGatewaySessionStoreTargetWithStore(params);

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -31,6 +31,8 @@ const READ_SCOPE_HEADER = { "x-openclaw-scopes": "operator.read" };
 const cleanupDirs: string[] = [];
 
 afterEach(async () => {
+  testState.sessionConfig = undefined;
+  testState.agentsConfig = undefined;
   await Promise.all(
     cleanupDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
   );
@@ -518,6 +520,8 @@ describe("session history HTTP endpoints", () => {
   });
 
   test("prefers the freshest duplicate row for direct history reads", async () => {
+    testState.agentsConfig = { list: [{ id: "main", default: true }] };
+    testState.sessionConfig = { mainKey: "work" };
     const storePath = await createSessionStoreFile();
     const dir = path.dirname(storePath);
     const staleTranscriptPath = path.join(dir, "sess-stale-main.jsonl");
@@ -543,12 +547,12 @@ describe("session history HTTP endpoints", () => {
       "utf-8",
     );
     await writeSessionStoreForTestAsync(storePath, {
-      "agent:main:main": {
+      "agent:main:work": {
         sessionId: "sess-stale-main",
         sessionFile: staleTranscriptPath,
         updatedAt: 1,
       },
-      "agent:main:MAIN": {
+      "agent:main:main": {
         sessionId: "sess-fresh-main",
         sessionFile: freshTranscriptPath,
         updatedAt: 2,
@@ -556,7 +560,7 @@ describe("session history HTTP endpoints", () => {
     });
 
     await expectSessionHistoryText({
-      sessionKey: "agent:main:main",
+      sessionKey: "agent:main:work",
       expectedText: "fresh history",
     });
   });

--- a/src/gateway/sessions-resolve-store.test.ts
+++ b/src/gateway/sessions-resolve-store.test.ts
@@ -261,50 +261,6 @@ describe("resolveSessionKeyFromResolveParams store canonicalization", () => {
     });
   });
 
-  it("resolves migrated ACP harness keys when metadata remains under the matched store key", async () => {
-    await withStateDirEnv("openclaw-sessions-resolve-acp-harness-legacy-", async () => {
-      const cfg: OpenClawConfig = {
-        agents: { list: [{ id: "main", default: true }] },
-      };
-      const acpKey = "agent:claude:acp:33333333-3333-4333-8333-333333333333";
-      const legacyAcpKey = "agent:CLAUDE:acp:33333333-3333-4333-8333-333333333333";
-      const claudeStorePath = resolveStorePath(cfg.session?.store, { agentId: "claude" });
-      await saveSessionStore(claudeStorePath, {
-        [legacyAcpKey]: {
-          sessionId: "sess-acp-harness-legacy",
-          label: "claude-delegate-legacy",
-          updatedAt: freshUpdatedAt(),
-        },
-      });
-      writeAcpSessionMetaForMigration({
-        sessionKey: legacyAcpKey,
-        sessionId: "sess-acp-harness-legacy",
-        meta: {
-          backend: "acpx",
-          agent: "claude",
-          runtimeSessionName: legacyAcpKey,
-          mode: "oneshot",
-          state: "idle",
-          lastActivityAt: freshUpdatedAt(),
-        },
-      });
-
-      await expect(
-        resolveSessionKeyFromResolveParams({
-          cfg,
-          p: { key: acpKey },
-        }),
-      ).resolves.toEqual({ ok: true, key: acpKey });
-
-      await expect(
-        resolveSessionKeyFromResolveParams({
-          cfg,
-          p: { key: acpKey },
-        }),
-      ).resolves.toEqual({ ok: true, key: acpKey });
-    });
-  });
-
   it("repairs ACP metadata when the session store key was already canonicalized", async () => {
     await withStateDirEnv("openclaw-sessions-resolve-acp-harness-partial-", async () => {
       const cfg: OpenClawConfig = {

--- a/src/infra/state-migrations.orphan-keys.test.ts
+++ b/src/infra/state-migrations.orphan-keys.test.ts
@@ -190,6 +190,41 @@ describe("migrateOrphanedSessionKeys", () => {
     });
   });
 
+  it("lowercases mixed-case session keys, keeping the freshest duplicate", async () => {
+    await withStateFixture(async ({ stateDir }) => {
+      const storePath = opsSessionStorePath(stateDir);
+      writeStore(storePath, {
+        "agent:ops:MySession": { sessionId: "mixed", updatedAt: 1000 },
+        "agent:ops:mysession": { sessionId: "lower", updatedAt: 2000 },
+        "agent:ops:OtherCase": { sessionId: "other", updatedAt: 1500 },
+      });
+
+      await migrateFixtureState(stateDir);
+
+      const store = readStore(storePath);
+      expect(requireStoreEntry(store, "agent:ops:mysession").sessionId).toBe("lower");
+      expect(store["agent:ops:MySession"]).toBeUndefined();
+      expect(requireStoreEntry(store, "agent:ops:othercase").sessionId).toBe("other");
+      expect(store["agent:ops:OtherCase"]).toBeUndefined();
+    });
+  });
+
+  it("canonicalizes mixed-case agent segments in ACP keys, preserving the opaque id", async () => {
+    await withStateFixture(async ({ stateDir }) => {
+      const storePath = opsSessionStorePath(stateDir);
+      const acpId = "33333333-3333-4333-8333-333333333333";
+      writeStore(storePath, {
+        [`agent:OPS:acp:${acpId}`]: { sessionId: "sess-acp", updatedAt: 1000 },
+      });
+
+      await migrateFixtureState(stateDir);
+
+      const store = readStore(storePath);
+      expect(requireStoreEntry(store, `agent:ops:acp:${acpId}`).sessionId).toBe("sess-acp");
+      expect(store[`agent:OPS:acp:${acpId}`]).toBeUndefined();
+    });
+  });
+
   it("skips stores that are already fully canonical", async () => {
     await withStateFixture(async ({ stateDir }) => {
       const storePath = opsSessionStorePath(stateDir);

--- a/src/plugins/host-hook-state.ts
+++ b/src/plugins/host-hook-state.ts
@@ -1,9 +1,6 @@
 // Tracks host hook state and scheduled turn identifiers.
 import { randomUUID } from "node:crypto";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { loadSessionStore, updateSessionStore, type SessionEntry } from "../config/sessions.js";
 import { resolveAgentMainSessionKey } from "../config/sessions/main-session.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
@@ -83,17 +80,6 @@ function isExpired(entry: unknown, now: number) {
   return typeof entry.ttlMs === "number" && entry.ttlMs >= 0 && now - entry.createdAt > entry.ttlMs;
 }
 
-function findStoreKeysIgnoreCase(store: Record<string, unknown>, targetKey: string): string[] {
-  const lowered = normalizeLowercaseStringOrEmpty(targetKey);
-  const matches: string[] = [];
-  for (const key of Object.keys(store)) {
-    if (normalizeLowercaseStringOrEmpty(key) === lowered) {
-      matches.push(key);
-    }
-  }
-  return matches;
-}
-
 function findFreshestStoreMatch(
   store: Record<string, SessionEntry>,
   ...candidates: string[]
@@ -107,12 +93,6 @@ function findFreshestStoreMatch(
     const exact = store[trimmed];
     if (exact && (!freshest || (exact.updatedAt ?? 0) >= (freshest.entry.updatedAt ?? 0))) {
       freshest = { entry: exact, key: trimmed };
-    }
-    for (const legacyKey of findStoreKeysIgnoreCase(store, trimmed)) {
-      const entry = store[legacyKey];
-      if (entry && (!freshest || (entry.updatedAt ?? 0) >= (freshest.entry.updatedAt ?? 0))) {
-        freshest = { entry, key: legacyKey };
-      }
     }
   }
   return freshest;

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -148,6 +148,10 @@ vi.mock("../config/config.js", () => ({
   loadConfig: () => getRuntimeConfigMock(),
 }));
 
+vi.mock("../infra/state-migrations.js", () => ({
+  migrateOrphanedSessionKeys: vi.fn(async () => ({ changes: [], warnings: [] })),
+}));
+
 vi.mock("../gateway/cli-session-history.js", () => ({
   augmentChatHistoryWithCliSessionImports: ({ localMessages }: { localMessages?: unknown[] }) =>
     localMessages ?? [],
@@ -555,6 +559,29 @@ describe("EmbeddedTuiBackend", () => {
       store: {},
       opts: { agentId: "work", includeGlobal: true, search: "global" },
     });
+  });
+
+  it("gates session reads on the startup migration so legacy keys are never observed early", async () => {
+    const { migrateOrphanedSessionKeys } = await import("../infra/state-migrations.js");
+    let resolveMigration: () => void = () => {};
+    const migrationDone = new Promise<void>((resolve) => {
+      resolveMigration = resolve;
+    });
+    vi.mocked(migrateOrphanedSessionKeys).mockReturnValueOnce(
+      migrationDone.then(() => ({ changes: [], warnings: [] })),
+    );
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    backend.start();
+
+    const listed = backend.listSessions({ agentId: "work" });
+    await flushMicrotasks();
+    expect(listSessionsFromStoreAsyncMock).not.toHaveBeenCalled();
+
+    resolveMigration();
+    await listed;
+    expect(listSessionsFromStoreAsyncMock).toHaveBeenCalledTimes(1);
   });
 
   it("creates a local session entry before starting a goal", async () => {
@@ -1502,7 +1529,6 @@ describe("EmbeddedTuiBackend", () => {
       .mockResolvedValueOnce({ payloads: [{ text: "second done" }], meta: {} });
 
     const backend = new EmbeddedTuiBackend();
-    let callsAfterSendDuringError = 0;
     let sentDuringError: Promise<{ runId: string }> | undefined;
     backend.onEvent = (evt) => {
       const payload = evt.payload as { runId?: string; state?: string };
@@ -1516,7 +1542,6 @@ describe("EmbeddedTuiBackend", () => {
           message: "second",
           runId: "run-local-second",
         });
-        callsAfterSendDuringError = agentCommandFromIngressMock.mock.calls.length;
       }
     };
 
@@ -1530,9 +1555,9 @@ describe("EmbeddedTuiBackend", () => {
     await vi.waitFor(() => {
       expect(sentDuringError).toBeDefined();
     });
-    expect(callsAfterSendDuringError).toBe(2);
     await sentDuringError;
     await flushMicrotasks();
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
   });
 
   it("keeps final short replies like No after suppressing lead-fragment deltas", async () => {

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -15,6 +15,7 @@ const getSessionGoalMock = vi.fn();
 const updateSessionGoalStatusMock = vi.fn();
 const ensureRuntimePluginsLoadedMock = vi.fn();
 const ensureContextWindowCacheLoadedMock = vi.fn(async () => undefined);
+const runSessionStartupMigrationMock = vi.fn<() => Promise<void>>(async () => undefined);
 const listSessionsFromStoreAsyncMock = vi.fn(
   async (_options?: unknown): Promise<{ sessions: unknown[] }> => ({ sessions: [] }),
 );
@@ -148,8 +149,9 @@ vi.mock("../config/config.js", () => ({
   loadConfig: () => getRuntimeConfigMock(),
 }));
 
-vi.mock("../infra/state-migrations.js", () => ({
-  migrateOrphanedSessionKeys: vi.fn(async () => ({ changes: [], warnings: [] })),
+vi.mock("../config/sessions/startup-migration.js", () => ({
+  runSessionStartupMigration: (...args: Parameters<typeof runSessionStartupMigrationMock>) =>
+    runSessionStartupMigrationMock(...args),
 }));
 
 vi.mock("../gateway/cli-session-history.js", () => ({
@@ -272,6 +274,8 @@ describe("EmbeddedTuiBackend", () => {
     ensureRuntimePluginsLoadedMock.mockReset();
     ensureContextWindowCacheLoadedMock.mockReset();
     ensureContextWindowCacheLoadedMock.mockResolvedValue(undefined);
+    runSessionStartupMigrationMock.mockReset();
+    runSessionStartupMigrationMock.mockResolvedValue(undefined);
     listSessionsFromStoreAsyncMock.mockReset();
     listSessionsFromStoreAsyncMock.mockResolvedValue({ sessions: [] });
     loadCombinedSessionStoreForGatewayMock.mockReset();
@@ -562,14 +566,11 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("gates session reads on the startup migration so legacy keys are never observed early", async () => {
-    const { migrateOrphanedSessionKeys } = await import("../infra/state-migrations.js");
     let resolveMigration: () => void = () => {};
     const migrationDone = new Promise<void>((resolve) => {
       resolveMigration = resolve;
     });
-    vi.mocked(migrateOrphanedSessionKeys).mockReturnValueOnce(
-      migrationDone.then(() => ({ changes: [], warnings: [] })),
-    );
+    runSessionStartupMigrationMock.mockReturnValueOnce(migrationDone);
 
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
@@ -581,6 +582,14 @@ describe("EmbeddedTuiBackend", () => {
 
     resolveMigration();
     await listed;
+    expect(runSessionStartupMigrationMock).toHaveBeenCalledWith({
+      cfg: {},
+      env: process.env,
+      log: {
+        info: expect.any(Function),
+        warn: expect.any(Function),
+      },
+    });
     expect(listSessionsFromStoreAsyncMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -67,6 +67,7 @@ import {
 import { projectSessionsPatchEntry } from "../gateway/sessions-patch.js";
 import { type AgentEventPayload, onAgentEvent } from "../infra/agent-events.js";
 import { setEmbeddedMode } from "../infra/embedded-mode.js";
+import { logInfo, logWarn } from "../logger.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
@@ -111,6 +112,11 @@ const silentRuntime = {
   exit: (code: number): never => {
     throw new Error(`embedded tui runtime exit ${String(code)}`);
   },
+};
+
+const embeddedSessionStartupMigrationLog = {
+  info: (message: string) => logInfo(message, silentRuntime),
+  warn: (message: string) => logWarn(message, silentRuntime),
 };
 
 function hasProviderWildcardModelAllowlist(cfg: OpenClawConfig) {
@@ -320,12 +326,13 @@ export class EmbeddedTuiBackend implements TuiBackend {
     });
     // Local mode never runs gateway startup; canonicalize orphaned keys once here.
     this.ready = (async () => {
-      try {
-        const { migrateOrphanedSessionKeys } = await import("../infra/state-migrations.js");
-        await migrateOrphanedSessionKeys({ cfg: getRuntimeConfig(), env: process.env });
-      } catch {
-        // Best-effort: a failed migration must not block the TUI.
-      }
+      const { runSessionStartupMigration } =
+        await import("../config/sessions/startup-migration.js");
+      await runSessionStartupMigration({
+        cfg: getRuntimeConfig(),
+        env: process.env,
+        log: embeddedSessionStartupMigrationLog,
+      });
     })();
     queueMicrotask(() => {
       this.onConnected?.();

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -300,6 +300,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
   private previousRuntimeError?: typeof defaultRuntime.error;
   private seq = 0;
   private readonly pendingLifecycleErrors = new Map<string, ReturnType<typeof setTimeout>>();
+  // Resolves once the one-time session-key migration has run; store methods await it.
+  private ready: Promise<void> = Promise.resolve();
 
   start() {
     if (this.unsubscribe) {
@@ -316,6 +318,15 @@ export class EmbeddedTuiBackend implements TuiBackend {
     this.unsubscribe = onAgentEvent((evt) => {
       void this.handleAgentEvent(evt);
     });
+    // Local mode never runs gateway startup; canonicalize orphaned keys once here.
+    this.ready = (async () => {
+      try {
+        const { migrateOrphanedSessionKeys } = await import("../infra/state-migrations.js");
+        await migrateOrphanedSessionKeys({ cfg: getRuntimeConfig(), env: process.env });
+      } catch {
+        // Best-effort: a failed migration must not block the TUI.
+      }
+    })();
     queueMicrotask(() => {
       this.onConnected?.();
     });
@@ -357,6 +368,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   async sendChat(opts: ChatSendOptions): Promise<TuiChatSendResult> {
+    await this.ready;
     const runId = opts.runId ?? randomUUID();
     const question = resolveBtwQuestion(opts.message);
     const runScope = {
@@ -428,6 +440,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   async loadHistory(opts: { sessionKey: string; agentId?: string; limit?: number }) {
+    await this.ready;
     const loadOptions = opts.agentId ? { agentId: opts.agentId } : undefined;
     const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntry(
       opts.sessionKey,
@@ -522,6 +535,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   async listSessions(opts?: Parameters<TuiBackend["listSessions"]>[0]): Promise<TuiSessionList> {
+    await this.ready;
     const cfg = getRuntimeConfig();
     const { storePath, store } = loadCombinedSessionStoreForGateway(cfg, {
       agentId: opts?.agentId,
@@ -541,6 +555,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   async patchSession(
     opts: Parameters<TuiBackend["patchSession"]>[0],
   ): Promise<SessionsPatchResult> {
+    await this.ready;
     const cfg = getRuntimeConfig();
     const target = resolveGatewaySessionStoreTarget({
       cfg,
@@ -595,6 +610,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   async resetSession(key: string, reason?: "new" | "reset", opts?: { agentId?: string }) {
+    await this.ready;
     const result = await performGatewaySessionReset({
       key,
       ...(opts?.agentId ? { agentId: opts.agentId } : {}),
@@ -687,6 +703,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   async runGoalCommand(opts: Parameters<NonNullable<TuiBackend["runGoalCommand"]>>[0]) {
+    await this.ready;
     const loadOptions = opts.agentId ? { agentId: opts.agentId } : undefined;
     const { canonicalKey, storePath, entry } = loadSessionEntry(opts.sessionKey, loadOptions);
     const sessionKey = canonicalKey ?? opts.sessionKey;


### PR DESCRIPTION
## What Problem This Solves

Session-store key resolution scanned the whole store case-insensitively (`findStoreKeysIgnoreCase`) on every access. That scan is O(N) and runs once per row on the session-list/snapshot path, so list building was O(N^2). On a production store with ~5000 telegram-DM session keys on the shared `main` agent, this froze the gateway event loop for multiple seconds per list. It also re-converged case-variant duplicates non-deterministically on every access.

The scan is redundant: `migrateOrphanedSessionKeys` already lowercases and merges every session key at gateway startup (idempotent, freshest-wins), so no two keys differ only by case at rest, and all writes canonicalize through `resolveSessionStoreKey`. The runtime never needs to rescan.

## What Changed

Make session-store resolution exact-only: remove `findStoreKeysIgnoreCase` (and its two copies), the `scanLegacyKeys` opt-out plumbing, and the per-access scan loops. Runtime now assumes the canonical shape the startup migration guarantees. Explicit alias convergence (`main` -> `work`) is kept. Net -90 non-test LOC.

## Evidence

Behavior before/after, validated locally:

- **Root cause confirmed**: at ~5000 keys, the per-row `findStoreKeysIgnoreCase` scan dominated event-loop self-time, stalling the gateway for seconds on each session list. After this change the session-list path is O(N) with no per-row scan.
- **Convergence still owned by the migration**: the gate `sessionStoreTextMayNeedCanonicalization` returns true for any mixed-case key, so the startup migration lowercases/merges them deterministically. Added a migration test asserting mixed-case keys converge freshest-wins.
- `pnpm tsgo:core` — clean (0 errors).
- Gateway `src/gateway/session-utils.test.ts` — 315 passed.
- `src/infra/state-migrations.orphan-keys.test.ts` — 13 passed (incl. new mixed-case test).
- `src/config/sessions/store.pruning.test.ts` — 18 passed.

Gateway tests that previously asserted runtime case-variant resolution were moved to the post-migration canonical shape (the behavior they covered is now owned by the startup migration, not the per-access scan).

AI-assisted (Claude).


## Before/after timing (large store)

Drives the real exported `resolveGatewaySessionStoreTargetWithStore` over synthetic telegram-DM stores (single `main` agent, canonical + mixed-case keys), resolving every session once, on `main` (case scan) vs this branch (exact-only). Synthetic data only.

| N keys | `main` (with scan) | this branch (exact-only) | speedup |
|-------:|-------------------:|-------------------------:|--------:|
| 1,000  | 142 ms             | 12 ms                    | 12×     |
| 2,000  | 500 ms             | 31 ms                    | 16×     |
| 4,000  | 2,836 ms           | 38 ms                    | 75×     |
| 8,000  | 15,807 ms          | 85 ms                    | 187×    |

Per-call cost on `main` grows linearly with N (142 → 250 → 709 → 1,976 µs) — the per-access `O(N)` scan signature, so resolving a full store is `O(N²)`. On this branch per-call stays flat (~10–15 µs) — `O(N)` total. At ~5,000 keys `main` is ~6 s of synchronous resolve work, matching the reported multi-second gateway freeze.
