### PR TITLE
test(commands): align doctor catalog mock with channel env lookup

### DIFF
--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -52,6 +52,7 @@ const mocks = vi.hoisted(() => ({
   installPluginFromNpmSpec: vi.fn(),
   listChannelPluginCatalogEntries: vi.fn(),
   listOfficialExternalPluginCatalogEntries: vi.fn(),
+  listOfficialExternalChannelEnvVars: vi.fn(),
   loadInstalledPluginIndex: vi.fn(),
   loadInstalledPluginIndexInstallRecords: vi.fn(),
   loadPluginMetadataSnapshot: vi.fn(),
@@ -160,6 +161,7 @@ vi.mock("../../../plugins/plugin-metadata-snapshot.js", () => ({
 
 vi.mock("../../../plugins/official-external-plugin-catalog.js", () => ({
   getOfficialExternalPluginCatalogManifest: mocks.getOfficialExternalPluginCatalogManifest,
+  listOfficialExternalChannelEnvVars: mocks.listOfficialExternalChannelEnvVars,
   listOfficialExternalPluginCatalogEntries: mocks.listOfficialExternalPluginCatalogEntries,
   resolveOfficialExternalPluginId: mocks.resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginInstall: mocks.resolveOfficialExternalPluginInstall,
@@ -195,6 +197,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
     mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue({});
     mocks.listChannelPluginCatalogEntries.mockReturnValue([]);
+    mocks.listOfficialExternalChannelEnvVars.mockReturnValue([]);
     mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([]);
     mocks.resolveDefaultPluginExtensionsDir.mockReturnValue("/tmp/openclaw-plugins");
     mocks.resolveDefaultPluginNpmDir.mockReturnValue("/tmp/openclaw-npm");


### PR DESCRIPTION
## What Problem This Solves

The current-main `checks-node-agentic-command-support` CI shard fails in `src/commands/doctor/shared/missing-configured-plugin-install.test.ts` because its official external plugin catalog mock is missing `listOfficialExternalChannelEnvVars`.

## Why This Change Was Made

`src/channels/config-presence.ts` now calls `listOfficialExternalChannelEnvVars()` while the doctor test still replaces the catalog module with a mock that does not expose that export. This patch adds the missing mock and defaults it to an empty list, matching the test's isolated catalog setup.

## User Impact

No production behavior changes. The doctor command test shard runs again.

## Evidence

- Before: focused test run reported 70 failures from the missing mock export.
- After: Testbox `tbx_01kvq786en9zm97vhh0nyhxawg` ran all 71 tests successfully.
- `git diff --check` passed.
- autoreview reported no accepted/actionable findings.
