### PR TITLE
fix(whatsapp): remove dead watchdog timeout clamp

### DIFF
--- a/extensions/whatsapp/src/connection-controller.test.ts
+++ b/extensions/whatsapp/src/connection-controller.test.ts
@@ -669,4 +669,52 @@ describe("WhatsAppConnectionController", () => {
       vi.useRealTimers();
     }
   });
+
+  it("uses messageTimeoutMs * 4 as the app-silence window for fresh connections with no inbound", async () => {
+    // Verifies the watchdog respects appSilenceTimeoutMs = messageTimeoutMs * 4 on first open.
+    // Transport is kept well within its own timeout so only app-silence fires.
+    vi.useFakeTimers();
+    const msgTimeoutMs = 100;
+    const controllerLocal = new WhatsAppConnectionController({
+      accountId: "work",
+      authDir: "/tmp/wa-auth",
+      verbose: false,
+      keepAlive: true,
+      heartbeatSeconds: 1,
+      transportTimeoutMs: 10_000,
+      messageTimeoutMs: msgTimeoutMs,
+      watchdogCheckMs: 10,
+      reconnectPolicy: {
+        initialMs: 250,
+        maxMs: 1_000,
+        factor: 2,
+        jitter: 0,
+        maxAttempts: 5,
+      },
+    });
+
+    try {
+      const sock = createSocketWithTransportEmitter();
+      createWaSocketMock.mockResolvedValueOnce(sock as never);
+      waitForWaConnectionMock.mockResolvedValueOnce(undefined);
+
+      const timeouts: string[] = [];
+      await controllerLocal.openConnection({
+        connectionId: "conn-app-silence",
+        createListener: async () => createListenerStub() as never,
+        onWatchdogTimeout: () => timeouts.push("timeout"),
+      });
+
+      // Just before messageTimeoutMs * 4 — no force-close expected
+      await vi.advanceTimersByTimeAsync(msgTimeoutMs * 4 - 20);
+      expect(timeouts).toHaveLength(0);
+
+      // Past messageTimeoutMs * 4 — force-close must fire
+      await vi.advanceTimersByTimeAsync(40);
+      expect(timeouts.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await controllerLocal.shutdown();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -404,7 +404,7 @@ export class WhatsAppConnectionController {
     this.heartbeatSeconds = params.heartbeatSeconds;
     this.transportTimeoutMs = params.transportTimeoutMs;
     this.messageTimeoutMs = params.messageTimeoutMs;
-    this.appSilenceTimeoutMs = Math.max(params.messageTimeoutMs, params.messageTimeoutMs * 4);
+    this.appSilenceTimeoutMs = params.messageTimeoutMs * 4;
     this.watchdogCheckMs = params.watchdogCheckMs;
     this.reconnectPolicy = params.reconnectPolicy;
     this.abortSignal = params.abortSignal;


### PR DESCRIPTION
What Problem This Solves

WhatsApp's app-silence watchdog computed `Math.max(messageTimeoutMs, messageTimeoutMs * 4)`, although the second term always wins for valid positive timeouts. The dead clamp obscured the intended four-times silence window.

Why This Change Was Made

This maintainer replacement is based on contributor PR #93330 and cherry-picks its original commit (`f0c6cab75359e38371834c4aae3a425ddfe324e4`) onto current `main`. It keeps the change narrow: one production expression and one focused regression test. The original author and Co-Authored-By trailer are preserved.

User Impact

Fresh WhatsApp connections keep the intended `messageTimeoutMs * 4` app-silence window, with no transport-timeout behavior change.

Evidence

- `node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-whatsapp.config.ts extensions/whatsapp/src/connection-controller.test.ts` — 18/18 passed.
- `autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.
- Current diff against `origin/main` is limited to `extensions/whatsapp/src/connection-controller.ts` and its colocated test.
- Original contributor PR: https://github.com/openclaw/openclaw/pull/93330

Credit

Original implementation by @rushindrasinha. This replacement preserves the original commit author and Co-Authored-By metadata.
