### PR TITLE
fix(synology-chat): remove duplicate local deliver timeout

### DIFF
--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -619,6 +619,37 @@ describe("createWebhookHandler", () => {
     expectBotReplySentTo("123");
   });
 
+  it("awaits deliver directly with no local hardcoded timeout wrapper", async () => {
+    // Previously this webhook handler wrapped deliver with a hardcoded 120s
+    // Promise.race that overrode the configurable agents.defaults.timeoutSeconds
+    // from core. That wrapper created a setTimeout(_, 120000) on every deliver
+    // call. We spy on setTimeout to prove no such call exists in the current code.
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+    try {
+      const deliver = vi.fn().mockResolvedValue("late reply");
+      const handler = createWebhookHandler({
+        account: makeAccount({ accountId: "no-hardcoded-timeout-" + Date.now() }),
+        deliver,
+        log,
+      });
+
+      const res = makeRes();
+      const req = makeReq("POST", validBody);
+      await handler(req, res);
+
+      expect(res.status).toBe(204);
+
+      // Collect all setTimeout delays used during this handler run
+      const delays = setTimeoutSpy.mock.calls.map((call) => call[1]);
+      // Every delay should be well under 120s — the old hardcoded wrapper would
+      // have produced exactly one call with delay === 120000.
+      const longDelays = delays.filter((d) => typeof d === "number" && d >= 120_000);
+      expect(longDelays).toEqual([]);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("sanitizes input before delivery", async () => {
     const deliver = vi.fn().mockResolvedValue(null);
     const handler = createWebhookHandler({

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -554,7 +554,7 @@ async function processAuthorizedSynologyWebhook(params: {
       log: params.log,
     });
 
-    const deliverPromise = params.deliver({
+    const reply = await params.deliver({
       body: params.message.body,
       from: authorizedWebhookUserId,
       senderName: params.message.payload.username,
@@ -564,10 +564,6 @@ async function processAuthorizedSynologyWebhook(params: {
       commandAuthorized: params.message.commandAuthorized,
       chatUserId: deliveryUserId,
     });
-    const timeoutPromise = new Promise<null>((_, reject) => {
-      setTimeout(() => reject(new Error("Agent response timeout (120s)")), 120_000);
-    });
-    const reply = await Promise.race([deliverPromise, timeoutPromise]);
     if (!reply) {
       return;
     }


### PR DESCRIPTION
What Problem This Solves

Synology Chat wrapped agent delivery in a second hardcoded 120-second `Promise.race`, which could reject a valid slow delivery before the core agent timeout policy applied.

Why This Change Was Made

This maintainer replacement is based on contributor PR #90592 and cherry-picks its original commit (`4c280deb28d228377c852263959265709c863289`) onto current `main`. It keeps the fix narrow: remove the duplicate local race and add focused regression coverage. The original author metadata is preserved.

User Impact

Synology Chat deliveries longer than 120 seconds are no longer rejected by a duplicate channel-local timer; the existing core delivery timeout remains authoritative.

Evidence

- `node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-messaging.config.ts extensions/synology-chat/src/webhook-handler.test.ts` — 23/23 passed.
- `autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.
- Current diff against `origin/main` is limited to `extensions/synology-chat/src/webhook-handler.ts` and its colocated test.
- Original contributor PR: https://github.com/openclaw/openclaw/pull/90592

Credit

Original implementation by @sahibzada-allahyar. This replacement preserves the original commit author metadata.
