### PR TITLE
fix(vercel-ai-gateway): resolve dynamic model selections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,32 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  # Keep the canonical main queue quiet long enough for a follow-up push to
+  # cancel this run before it registers the Blacksmith matrix.
+  runner-admission:
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    env:
+      OPENCLAW_MAIN_CI_DEBOUNCE_SECONDS: "90"
+    steps:
+      - name: Debounce canonical main pushes
+        if: github.event_name == 'push' && github.repository == 'openclaw/openclaw' && github.ref == 'refs/heads/main'
+        run: |
+          set -euo pipefail
+          echo "Waiting ${OPENCLAW_MAIN_CI_DEBOUNCE_SECONDS}s for a superseding main push before Blacksmith admission"
+          sleep "${OPENCLAW_MAIN_CI_DEBOUNCE_SECONDS}"
+      - name: Admit non-main CI runs immediately
+        if: github.event_name != 'push' || github.repository != 'openclaw/openclaw' || github.ref != 'refs/heads/main'
+        run: echo "No canonical main debounce required"
+
   # Preflight: establish routing truth and job matrices once, then let real
   # work fan out from a single source of truth.
   preflight:
     permissions:
       contents: read
+    needs: [runner-admission]
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 20
@@ -272,18 +293,22 @@ jobs:
             }
           }
 
+          const compactPullRequest = isCanonicalRepository && eventName === "pull_request";
           const nodeTestShards = runNodeFull
             ? createNodeTestShardBundles({
                 includeReleaseOnlyPluginShards: false,
+                compact: compactPullRequest,
               }).map((shard) => ({
                 check_name: shard.checkName,
                 runtime: "node",
                 task: "test-shard",
                 shard_name: shard.shardName,
+                groups: shard.groups,
                 configs: shard.configs,
                 includePatterns: shard.includePatterns,
                 requires_dist: shard.requiresDist,
                 runner: shard.runner,
+                timeout_minutes: shard.timeoutMinutes,
               }))
             : [];
           const nodeTestNonDistShards = nodeTestShards.filter((shard) => !shard.requires_dist);
@@ -361,6 +386,7 @@ jobs:
   security-fast:
     permissions:
       contents: read
+    needs: [runner-admission]
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 20
@@ -826,7 +852,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 8
       matrix: ${{ fromJson(needs.preflight.outputs.checks_fast_core_matrix) }}
     steps:
       - name: Checkout
@@ -916,7 +942,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 8
       matrix: ${{ fromJson(needs.preflight.outputs.plugin_contracts_matrix) }}
     steps:
       - name: Checkout
@@ -997,7 +1023,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 8
       matrix: ${{ fromJson(needs.preflight.outputs.channel_contracts_matrix) }}
     steps:
       - name: Checkout
@@ -1147,10 +1173,10 @@ jobs:
     needs: [preflight]
     if: needs.preflight.outputs.run_checks_node_core_nondist == 'true'
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
-    timeout-minutes: 60
+    timeout-minutes: ${{ matrix.timeout_minutes || 60 }}
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 12
       matrix: ${{ fromJson(needs.preflight.outputs.checks_node_core_nondist_matrix) }}
     steps:
       - name: Checkout
@@ -1209,6 +1235,7 @@ jobs:
       - name: Run Node test shard
         env:
           NODE_OPTIONS: --max-old-space-size=8192
+          OPENCLAW_NODE_TEST_GROUPS_JSON: ${{ toJson(matrix.groups || null) }}
           OPENCLAW_NODE_TEST_CONFIGS_JSON: ${{ toJson(matrix.configs) }}
           OPENCLAW_NODE_TEST_INCLUDE_PATTERNS_JSON: ${{ toJson(matrix.includePatterns) }}
           OPENCLAW_VITEST_SHARD_NAME: ${{ matrix.shard_name }}
@@ -1223,28 +1250,47 @@ jobs:
           import { writeFileSync } from "node:fs";
           import { join } from "node:path";
 
-          const configs = JSON.parse(process.env.OPENCLAW_NODE_TEST_CONFIGS_JSON ?? "[]");
-          if (!Array.isArray(configs) || configs.length === 0) {
-            console.error("Missing node test shard configs");
-            process.exit(1);
-          }
-          const includePatterns = JSON.parse(process.env.OPENCLAW_NODE_TEST_INCLUDE_PATTERNS_JSON ?? "null");
-          const childEnv = { ...process.env };
-          if (Array.isArray(includePatterns) && includePatterns.length > 0) {
-            const includeFile = join(
-              process.env.RUNNER_TEMP ?? ".",
-              `node-test-include-${process.env.GITHUB_JOB ?? "local"}-${Date.now()}.json`,
+          const groups = JSON.parse(process.env.OPENCLAW_NODE_TEST_GROUPS_JSON ?? "null");
+          const plans = Array.isArray(groups) && groups.length > 0
+            ? groups
+            : [{
+                configs: JSON.parse(process.env.OPENCLAW_NODE_TEST_CONFIGS_JSON ?? "[]"),
+                includePatterns: JSON.parse(
+                  process.env.OPENCLAW_NODE_TEST_INCLUDE_PATTERNS_JSON ?? "null",
+                ),
+                shard_name: process.env.OPENCLAW_VITEST_SHARD_NAME,
+              }];
+          for (const plan of plans) {
+            const configs = plan.configs;
+            if (!Array.isArray(configs) || configs.length === 0) {
+              console.error("Missing node test shard configs");
+              process.exit(1);
+            }
+            const childEnv = {
+              ...process.env,
+              ...(plan.shard_name ? { OPENCLAW_VITEST_SHARD_NAME: plan.shard_name } : {}),
+            };
+            if (Array.isArray(plan.includePatterns) && plan.includePatterns.length > 0) {
+              const includeFile = join(
+                process.env.RUNNER_TEMP ?? ".",
+                `node-test-include-${process.env.GITHUB_JOB ?? "local"}-${Date.now()}.json`,
+              );
+              writeFileSync(includeFile, JSON.stringify(plan.includePatterns), "utf8");
+              childEnv.OPENCLAW_VITEST_INCLUDE_FILE = includeFile;
+            } else {
+              delete childEnv.OPENCLAW_VITEST_INCLUDE_FILE;
+            }
+            const result = spawnSync(
+              "pnpm",
+              ["exec", "node", "scripts/test-projects.mjs", ...configs],
+              {
+                env: childEnv,
+                stdio: "inherit",
+              },
             );
-            writeFileSync(includeFile, JSON.stringify(includePatterns), "utf8");
-            childEnv.OPENCLAW_VITEST_INCLUDE_FILE = includeFile;
-          }
-
-          const result = spawnSync("pnpm", ["exec", "node", "scripts/test-projects.mjs", ...configs], {
-            env: childEnv,
-            stdio: "inherit",
-          });
-          if ((result.status ?? 1) !== 0) {
-            process.exit(result.status ?? 1);
+            if ((result.status ?? 1) !== 0) {
+              process.exit(result.status ?? 1);
+            }
           }
           EOF
 
@@ -1259,7 +1305,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 8
       matrix:
         include:
           - check_name: check-guards
@@ -1401,7 +1447,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 8
       matrix:
         include:
           - check_name: check-additional-boundaries-a

--- a/.github/workflows/openclaw-stable-main-closeout.yml
+++ b/.github/workflows/openclaw-stable-main-closeout.yml
@@ -244,6 +244,11 @@ jobs:
             exit 1
           fi
           if [[ -z "$ROLLBACK_DRILL_ID" || -z "$ROLLBACK_DRILL_DATE" ]]; then
+            if [[ "$EVENT_NAME" == "push" ]]; then
+              echo "::warning::Stable closeout skipped: rollback drill repository variables are missing; manual dispatch remains required to complete closeout."
+              echo "should_closeout=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "Stable closeout requires repository variables RELEASE_ROLLBACK_DRILL_ID and RELEASE_ROLLBACK_DRILL_DATE, or explicit manual overrides." >&2
             exit 1
           fi

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-172fe4e143964c0a20525428ff3e6c7631856a7d51c6ad48959a35c72363a410  plugin-sdk-api-baseline.json
-a4c18ea9f0b0d2c22183bf8c082e757b7f9852b4c518c8b8cb62a21a9dd766e9  plugin-sdk-api-baseline.jsonl
+05ce13ad6d2ef72af943a61a023e26f58d01e37a04f76e279a933df9b6aed05b  plugin-sdk-api-baseline.json
+628a6ac85acd5ed71236b07d5760e211b9c0698ea529d5b3101c20579926b0ea  plugin-sdk-api-baseline.jsonl

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -389,7 +389,7 @@ If the homeserver requires UIA to upload cross-signing keys, OpenClaw tries no-a
 Useful flags:
 
 - `--recovery-key-stdin` (pair with `printf '%s\n' "$MATRIX_RECOVERY_KEY" | …`) or `--recovery-key <key>`
-- `--force-reset-cross-signing` to discard the current cross-signing identity (intentional only)
+- `--force-reset-cross-signing` to discard the current cross-signing identity (intentional only; requires the active recovery key to be stored or supplied with `--recovery-key-stdin`)
 
 ### Room-key backup
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,38 +8,51 @@ read_when:
   - You are changing ClawSweeper dispatch or GitHub activity forwarding
 ---
 
-OpenClaw CI runs on every push to `main` and every pull request. The `preflight` job classifies the diff and turns expensive lanes off when only unrelated areas changed. Manual `workflow_dispatch` runs intentionally bypass smart scoping and fan out the full graph for release candidates and broad validation. Android lanes stay opt-in through `include_android`. Release-only plugin coverage lives in the separate [`Plugin Prerelease`](#plugin-prerelease) workflow and only runs from [`Full Release Validation`](#full-release-validation) or an explicit manual dispatch.
+OpenClaw CI runs on every push to `main` and every pull request. Canonical
+`main` pushes first pass through a 90-second hosted-runner admission window.
+The existing `CI` concurrency group cancels that waiting run when a newer
+commit lands, so sequential merges do not each register a full Blacksmith
+matrix. Pull requests and manual dispatches skip the wait. The `preflight` job
+then classifies the diff and turns expensive lanes off when only unrelated
+areas changed. Manual `workflow_dispatch` runs intentionally bypass smart
+scoping and fan out the full graph for release candidates and broad
+validation. Android lanes stay opt-in through `include_android`. Release-only
+plugin coverage lives in the separate [`Plugin Prerelease`](#plugin-prerelease)
+workflow and only runs from [`Full Release Validation`](#full-release-validation)
+or an explicit manual dispatch.
 
 ## Pipeline overview
 
-| Job                                | Purpose                                                                                                   | When it runs                       |
-| ---------------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| `preflight`                        | Detect docs-only changes, changed scopes, changed extensions, and build the CI manifest                   | Always on non-draft pushes and PRs |
-| `security-fast`                    | Private key detection, changed-workflow audit via `zizmor`, and production lockfile audit                 | Always on non-draft pushes and PRs |
-| `check-dependencies`               | Production Knip dependency-only pass plus the unused-file allowlist guard                                 | Node-relevant changes              |
-| `build-artifacts`                  | Build `dist/`, Control UI, built-CLI smoke checks, embedded built-artifact checks, and reusable artifacts | Node-relevant changes              |
-| `checks-fast-core`                 | Fast Linux correctness lanes such as bundled, protocol, and CI-routing checks                             | Node-relevant changes              |
-| `checks-fast-contracts-plugins-*`  | Two sharded plugin contract checks                                                                        | Node-relevant changes              |
-| `checks-fast-contracts-channels-*` | Two sharded channel contract checks                                                                       | Node-relevant changes              |
-| `checks-node-core-*`               | Core Node test shards, excluding channel, bundled, contract, and extension lanes                          | Node-relevant changes              |
-| `check-*`                          | Sharded main local gate equivalent: prod types, lint, guards, test types, and strict smoke                | Node-relevant changes              |
-| `check-additional-*`               | Architecture, sharded boundary/prompt drift, extension guards, package boundary, and runtime topology     | Node-relevant changes              |
-| `checks-node-compat-node22`        | Node 22 compatibility build and smoke lane                                                                | Manual CI dispatch for releases    |
-| `check-docs`                       | Docs formatting, lint, and broken-link checks                                                             | Docs changed                       |
-| `skills-python`                    | Ruff + pytest for Python-backed skills                                                                    | Python-skill-relevant changes      |
-| `checks-windows`                   | Windows-specific process/path tests plus shared runtime import specifier regressions                      | Windows-relevant changes           |
-| `macos-node`                       | macOS TypeScript test lane using the shared built artifacts                                               | macOS-relevant changes             |
-| `macos-swift`                      | Swift lint, build, and tests for the macOS app                                                            | macOS-relevant changes             |
-| `android`                          | Android unit tests for both flavors plus one debug APK build                                              | Android-relevant changes           |
-| `test-performance-agent`           | Daily Codex slow-test optimization after trusted activity                                                 | Main CI success or manual dispatch |
-| `openclaw-performance`             | Daily/on-demand Kova runtime performance reports with mock-provider, deep-profile, and GPT 5.5 live lanes | Scheduled and manual dispatch      |
+| Job                                | Purpose                                                                                                   | When it runs                                        |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `preflight`                        | Detect docs-only changes, changed scopes, changed extensions, and build the CI manifest                   | Always on non-draft pushes and PRs                  |
+| `runner-admission`                 | Hosted 90-second debounce for canonical `main` pushes before Blacksmith work is registered                | Every CI run; sleep only on canonical `main` pushes |
+| `security-fast`                    | Private key detection, changed-workflow audit via `zizmor`, and production lockfile audit                 | Always on non-draft pushes and PRs                  |
+| `check-dependencies`               | Production Knip dependency-only pass plus the unused-file allowlist guard                                 | Node-relevant changes                               |
+| `build-artifacts`                  | Build `dist/`, Control UI, built-CLI smoke checks, embedded built-artifact checks, and reusable artifacts | Node-relevant changes                               |
+| `checks-fast-core`                 | Fast Linux correctness lanes such as bundled, protocol, and CI-routing checks                             | Node-relevant changes                               |
+| `checks-fast-contracts-plugins-*`  | Two sharded plugin contract checks                                                                        | Node-relevant changes                               |
+| `checks-fast-contracts-channels-*` | Two sharded channel contract checks                                                                       | Node-relevant changes                               |
+| `checks-node-core-*`               | Core Node test shards, excluding channel, bundled, contract, and extension lanes                          | Node-relevant changes                               |
+| `check-*`                          | Sharded main local gate equivalent: prod types, lint, guards, test types, and strict smoke                | Node-relevant changes                               |
+| `check-additional-*`               | Architecture, sharded boundary/prompt drift, extension guards, package boundary, and runtime topology     | Node-relevant changes                               |
+| `checks-node-compat-node22`        | Node 22 compatibility build and smoke lane                                                                | Manual CI dispatch for releases                     |
+| `check-docs`                       | Docs formatting, lint, and broken-link checks                                                             | Docs changed                                        |
+| `skills-python`                    | Ruff + pytest for Python-backed skills                                                                    | Python-skill-relevant changes                       |
+| `checks-windows`                   | Windows-specific process/path tests plus shared runtime import specifier regressions                      | Windows-relevant changes                            |
+| `macos-node`                       | macOS TypeScript test lane using the shared built artifacts                                               | macOS-relevant changes                              |
+| `macos-swift`                      | Swift lint, build, and tests for the macOS app                                                            | macOS-relevant changes                              |
+| `android`                          | Android unit tests for both flavors plus one debug APK build                                              | Android-relevant changes                            |
+| `test-performance-agent`           | Daily Codex slow-test optimization after trusted activity                                                 | Main CI success or manual dispatch                  |
+| `openclaw-performance`             | Daily/on-demand Kova runtime performance reports with mock-provider, deep-profile, and GPT 5.5 live lanes | Scheduled and manual dispatch                       |
 
 ## Fail-fast order
 
-1. `preflight` decides which lanes exist at all. The `docs-scope` and `changed-scope` logic are steps inside this job, not standalone jobs.
-2. `security-fast`, `check-*`, `check-additional-*`, `check-docs`, and `skills-python` fail quickly without waiting on the heavier artifact and platform matrix jobs.
-3. `build-artifacts` overlaps with the fast Linux lanes so downstream consumers can start as soon as the shared build is ready.
-4. Heavier platform and runtime lanes fan out after that: `checks-fast-core`, `checks-fast-contracts-plugins-*`, `checks-fast-contracts-channels-*`, `checks-node-core-*`, `checks-windows`, `macos-node`, `macos-swift`, and `android`.
+1. `runner-admission` waits only for canonical `main` pushes; a newer push cancels the run before Blacksmith registration.
+2. `preflight` decides which lanes exist at all. The `docs-scope` and `changed-scope` logic are steps inside this job, not standalone jobs.
+3. `security-fast`, `check-*`, `check-additional-*`, `check-docs`, and `skills-python` fail quickly without waiting on the heavier artifact and platform matrix jobs.
+4. `build-artifacts` overlaps with the fast Linux lanes so downstream consumers can start as soon as the shared build is ready.
+5. Heavier platform and runtime lanes fan out after that: `checks-fast-core`, `checks-fast-contracts-plugins-*`, `checks-fast-contracts-channels-*`, `checks-node-core-*`, `checks-windows`, `macos-node`, `macos-swift`, and `android`.
 
 GitHub may mark superseded jobs as `cancelled` when a newer push lands on the same PR or `main` ref. Treat that as CI noise unless the newest run for the same ref is also failing. Matrix jobs use `fail-fast: false`, and `build-artifacts` reports embedded channel, core-support-boundary, and gateway-watch failures directly instead of queuing tiny verifier jobs. The automatic CI concurrency key is versioned (`CI-v7-*`) so a GitHub-side zombie in an old queue group cannot indefinitely block newer main runs. Manual full-suite runs use `CI-manual-v1-*` and do not cancel in-progress runs.
 
@@ -74,7 +87,15 @@ Scope logic lives in `scripts/ci-changed-scope.mjs` and is covered by unit tests
 - **CI routing-only edits, selected cheap core-test fixture edits, and narrow plugin contract helper/test-routing edits** use a fast Node-only manifest path: `preflight`, security, and a single `checks-fast-core` task. That path skips build artifacts, Node 22 compatibility, channel contracts, full core shards, bundled-plugin shards, and additional guard matrices when the change is limited to the routing or helper surfaces the fast task exercises directly.
 - **Windows Node checks** are scoped to Windows-specific process/path wrappers, npm/pnpm/UI runner helpers, package manager config, and the CI workflow surfaces that execute that lane; unrelated source, plugin, install-smoke, and test-only changes stay on the Linux Node lanes.
 
-The slowest Node test families are split or balanced so each job stays small without over-reserving runners: plugin contracts and channel contracts each run as two weighted Blacksmith-backed shards with the standard GitHub runner fallback, core unit fast/support lanes run separately, core runtime infra is split between state, process/config, shared, and three cron domain shards, auto-reply runs as balanced workers (with the reply subtree split into agent-runner, dispatch, and commands/state-routing shards), and agentic gateway/server configs are split across chat/auth/model/http-plugin/runtime/startup lanes instead of waiting on built artifacts. Normal CI then packs only isolated infra include-pattern shards into deterministic bundles of at most 64 test files, reducing the Node matrix without merging non-isolated command/cron, stateful agents-core, or gateway/server suites; heavy fixed suites stay on 8 vCPU while the bundled and lower-weight lanes use 4 vCPU. Broad browser, QA, media, and miscellaneous plugin tests use their dedicated Vitest configs instead of the shared plugin catch-all. Include-pattern shards record timing entries using the CI shard name, so `.artifacts/vitest-shard-timings.json` can distinguish a whole config from a filtered shard. `check-additional-*` keeps package-boundary compile/canary work together and separates runtime topology architecture from gateway watch coverage; the boundary guard list is striped into one prompt-heavy shard and one combined shard for the remaining guard stripes, each running selected independent guards concurrently and printing per-check timings. The expensive Codex happy-path prompt snapshot drift check runs as its own additional job for manual CI and for prompt-affecting changes only, so normal unrelated Node changes do not wait behind cold prompt snapshot generation and the boundary shards stay balanced while prompt drift is still pinned to the PR that caused it; the same flag skips prompt snapshot Vitest generation inside the built-artifact core support-boundary shard. Gateway watch, channel tests, and the core support-boundary shard run concurrently inside `build-artifacts` after `dist/` and `dist-runtime/` are already built.
+The slowest Node test families are split or balanced so each job stays small without over-reserving runners: plugin contracts and channel contracts each run as two weighted Blacksmith-backed shards with the standard GitHub runner fallback, core unit fast/support lanes run separately, core runtime infra is split between state, process/config, shared, and three cron domain shards, auto-reply runs as balanced workers (with the reply subtree split into agent-runner, dispatch, and commands/state-routing shards), and agentic gateway/server configs are split across chat/auth/model/http-plugin/runtime/startup lanes instead of waiting on built artifacts. Normal CI then packs only isolated infra include-pattern shards into deterministic bundles of at most 64 test files, reducing the Node matrix without merging non-isolated command/cron, stateful agents-core, or gateway/server suites; heavy fixed suites stay on 8 vCPU while the bundled and lower-weight lanes use 4 vCPU. Pull requests on the canonical repository use an additional compact admission plan: the same per-config groups run in isolated subprocesses inside the current 34-job Linux Node plan, so a single PR does not register the full 70-plus-job Node matrix. `main` pushes, manual dispatches, and release gates retain the full matrix. Broad browser, QA, media, and miscellaneous plugin tests use their dedicated Vitest configs instead of the shared plugin catch-all. Include-pattern shards record timing entries using the CI shard name, so `.artifacts/vitest-shard-timings.json` can distinguish a whole config from a filtered shard. `check-additional-*` keeps package-boundary compile/canary work together and separates runtime topology architecture from gateway watch coverage; the boundary guard list is striped into one prompt-heavy shard and one combined shard for the remaining guard stripes, each running selected independent guards concurrently and printing per-check timings. The expensive Codex happy-path prompt snapshot drift check runs as its own additional job for manual CI and for prompt-affecting changes only, so normal unrelated Node changes do not wait behind cold prompt snapshot generation and the boundary shards stay balanced while prompt drift is still pinned to the PR that caused it; the same flag skips prompt snapshot Vitest generation inside the built-artifact core support-boundary shard. Gateway watch, channel tests, and the core support-boundary shard run concurrently inside `build-artifacts` after `dist/` and `dist-runtime/` are already built.
+
+Once admitted, canonical Linux CI permits up to 12 concurrent Node jobs and 8 for
+the smaller fast/check lanes; Windows and Android stay at two because those
+runner pools are narrower.
+
+The compact PR plan emits 18 Node jobs for the current suite: whole-config
+groups are batched in isolated subprocesses with a 120-minute batch timeout,
+while include-pattern groups share the same bounded job budget.
 
 Android CI runs both `testPlayDebugUnitTest` and `testThirdPartyDebugUnitTest` and then builds the Play debug APK. The third-party flavor has no separate source set or manifest; its unit-test lane still compiles the flavor with the SMS/call-log BuildConfig flags, while avoiding a duplicate debug APK packaging job on every Android-relevant push.
 

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -191,10 +191,11 @@ release state.
    closeout requires both assets and a matching checksum. A partial manifest
    replays its recorded `main` SHA and rollback drill to regenerate identical
    bytes, then attaches the missing checksum; an invalid pair, or a checksum
-   without a manifest, stays blocking. A missing or more-than-90-day-old drill
-   record blocks a new evidence-backed closeout; private recovery commands
-   remain in the maintainer-only runbook. Use manual dispatch only to repair or
-   replay an evidence-backed stable closeout.
+   without a manifest, stays blocking. A push-triggered run without rollback
+   drill repository variables skips without completing closeout; a missing or
+   more-than-90-day-old drill record still blocks manual evidence-backed
+   closeout. Private recovery commands remain in the maintainer-only runbook.
+   Use manual dispatch only to repair or replay an evidence-backed stable closeout.
    A legacy fallback correction tag may reuse base-package evidence only when
    the correction tag resolves to the same source commit as the base stable tag.
    A correction with different source must publish and verify its own package

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -844,6 +844,79 @@ describe("active-memory plugin", () => {
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });
 
+  it("does not run for dreaming-narrative cron session keys", async () => {
+    const result = await hooks.before_prompt_build(
+      { prompt: "what wings should i order?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:dreaming-narrative-light-abc123",
+        messageProvider: "webchat",
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(runEmbeddedAgent).not.toHaveBeenCalled();
+  });
+
+  it("does not run when a session id resolves to a dreaming-narrative cron session key", async () => {
+    hoisted.sessionStore["agent:main:dreaming-narrative-light-abc123"] = {
+      sessionId: "dreaming-session",
+      updatedAt: 1,
+    };
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "what wings should i order?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionId: "dreaming-session",
+        messageProvider: "webchat",
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(runEmbeddedAgent).not.toHaveBeenCalled();
+  });
+
+  it("allows non-canonical session keys that merely contain the dreaming-narrative substring", async () => {
+    const result = await hooks.before_prompt_build(
+      { prompt: "what wings should i order?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:webchat:dreaming-narrative-room",
+        messageProvider: "webchat",
+      },
+    );
+
+    // Real session keys that happen to contain "dreaming-narrative" in a
+    // non-canonical way (not {light|rem|deep} phase suffix) must remain eligible.
+    // The session key "agent:main:webchat:dreaming-narrative-room" is a real chat
+    // whose topic happens to contain the string — not a dreaming cron key.
+    expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
+    expect(result).not.toBeUndefined();
+  });
+
+  it("allows real webchat session keys whose peer id starts with a phased dreaming-narrative prefix", async () => {
+    const result = await hooks.before_prompt_build(
+      { prompt: "what wings should i order?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:webchat:dreaming-narrative-light-room",
+        messageProvider: "webchat",
+      },
+    );
+
+    // A real webchat session key whose peer id begins with a phased dreaming-narrative
+    // phrase must not be excluded. Only the canonical bare or agent-prefixed key
+    // shape (dreaming-narrative-<phase>-<hash> directly after agentId or bare) should
+    // be rejected — not the same phrase appearing deeper in the key as a peer id.
+    expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
+    expect(result).not.toBeUndefined();
+  });
+
   it("defaults to direct-style sessions only", async () => {
     const result = await hooks.before_prompt_build(
       { prompt: "what wings should we order?", messages: [] },

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -1155,6 +1155,19 @@ function isEligibleInteractiveSession(ctx: {
   if (ctx.trigger !== "user") {
     return false;
   }
+  // Exclude only canonical dreaming-narrative session keys (bare or agent-prefixed).
+  // Canonical forms: "dreaming-narrative-<phase>-<hash>" or
+  // "agent:<agentId>:dreaming-narrative-<phase>-<hash>".
+  // A colon-delimited match would also exclude real chat session ids whose peer id
+  // begins with a phased dreaming-narrative phrase (e.g.
+  // "agent:main:feishu:group:dreaming-narrative-light-room").
+  const sessionKey = ctx.sessionKey ?? "";
+  if (
+    /^dreaming-narrative-(light|rem|deep)-/i.test(sessionKey) ||
+    /^agent:[^:]+:dreaming-narrative-(light|rem|deep)-/i.test(sessionKey)
+  ) {
+    return false;
+  }
   if (!ctx.sessionKey && !ctx.sessionId) {
     return false;
   }
@@ -3617,7 +3630,12 @@ export default definePluginEntry({
               });
               return undefined;
             }
-            if (!isEligibleInteractiveSession(ctx)) {
+            if (
+              !isEligibleInteractiveSession({
+                ...ctx,
+                sessionKey: resolvedSessionKey ?? ctx.sessionKey,
+              })
+            ) {
               await persistPluginStatusLines({
                 api,
                 agentId: effectiveAgentId,

--- a/extensions/canvas/scripts/copy-a2ui.mjs
+++ b/extensions/canvas/scripts/copy-a2ui.mjs
@@ -20,8 +20,27 @@ function shouldSkipMissingA2uiAssets(env = process.env) {
   return env.OPENCLAW_A2UI_SKIP_MISSING === "1" || Boolean(env.OPENCLAW_SPARSE_PROFILE);
 }
 
+function isRelativeWithin(relPath) {
+  return (
+    relPath === "" ||
+    (relPath !== ".." && !relPath.startsWith(`..${path.sep}`) && !path.isAbsolute(relPath))
+  );
+}
+
+function pathsOverlap(leftDir, rightDir) {
+  const left = path.resolve(leftDir);
+  const right = path.resolve(rightDir);
+  return (
+    isRelativeWithin(path.relative(left, right)) || isRelativeWithin(path.relative(right, left))
+  );
+}
+
 /** Copies A2UI assets, optionally tolerating missing bundles in sparse builds. */
 export async function copyA2uiAssets({ srcDir, outDir }) {
+  if (pathsOverlap(srcDir, outDir)) {
+    throw new Error("A2UI source and output directories must not overlap.");
+  }
+
   const skipMissing = shouldSkipMissingA2uiAssets(process.env);
   try {
     await fs.stat(path.join(srcDir, "index.html"));

--- a/extensions/canvas/scripts/copy-a2ui.test.ts
+++ b/extensions/canvas/scripts/copy-a2ui.test.ts
@@ -37,9 +37,9 @@ describe("canvas a2ui copy", () => {
 
   it("throws a helpful error when assets are missing", async () => {
     await withA2uiFixture(async (dir) => {
-      await expect(copyA2uiAssets({ srcDir: dir, outDir: path.join(dir, "out") })).rejects.toThrow(
-        'Run "pnpm canvas:a2ui:bundle"',
-      );
+      await expect(
+        copyA2uiAssets({ srcDir: path.join(dir, "src"), outDir: path.join(dir, "out") }),
+      ).rejects.toThrow('Run "pnpm canvas:a2ui:bundle"');
     });
   });
 
@@ -47,7 +47,7 @@ describe("canvas a2ui copy", () => {
     await withA2uiFixture(async (dir) => {
       process.env.OPENCLAW_A2UI_SKIP_MISSING = "1";
       await expect(
-        copyA2uiAssets({ srcDir: dir, outDir: path.join(dir, "out") }),
+        copyA2uiAssets({ srcDir: path.join(dir, "src"), outDir: path.join(dir, "out") }),
       ).resolves.toBeUndefined();
     });
   });
@@ -56,7 +56,7 @@ describe("canvas a2ui copy", () => {
     await withA2uiFixture(async (dir) => {
       process.env.OPENCLAW_SPARSE_PROFILE = "core";
       await expect(
-        copyA2uiAssets({ srcDir: dir, outDir: path.join(dir, "out") }),
+        copyA2uiAssets({ srcDir: path.join(dir, "src"), outDir: path.join(dir, "out") }),
       ).resolves.toBeUndefined();
     });
   });
@@ -100,6 +100,23 @@ describe("canvas a2ui copy", () => {
       await expect(fs.stat(path.join(outDir, "stale.txt"))).rejects.toMatchObject({
         code: "ENOENT",
       });
+    });
+  });
+
+  it("rejects overlapping source and output directories before cleaning output", async () => {
+    await withA2uiFixture(async (dir) => {
+      const srcDir = path.join(dir, "src");
+      await fs.mkdir(srcDir, { recursive: true });
+      await fs.writeFile(path.join(srcDir, "index.html"), "<html></html>", "utf8");
+      await fs.writeFile(path.join(srcDir, "a2ui.bundle.js"), "console.log(1);", "utf8");
+
+      await expect(copyA2uiAssets({ srcDir, outDir: srcDir })).rejects.toThrow("must not overlap");
+      await expect(fs.readFile(path.join(srcDir, "index.html"), "utf8")).resolves.toBe(
+        "<html></html>",
+      );
+      await expect(copyA2uiAssets({ srcDir, outDir: path.join(srcDir, "dist") })).rejects.toThrow(
+        "must not overlap",
+      );
     });
   });
 });

--- a/extensions/canvas/src/host/a2ui.ts
+++ b/extensions/canvas/src/host/a2ui.ts
@@ -23,6 +23,8 @@ let resolvingA2uiRoot: Promise<string | null> | null = null;
 let cachedA2uiResolvedAtMs = 0;
 const A2UI_ROOT_RETRY_NULL_AFTER_MS = 10_000;
 
+type A2uiRootResolver = () => Promise<string | null>;
+
 async function resolveA2uiRoot(): Promise<string | null> {
   const here = path.dirname(fileURLToPath(import.meta.url));
   const entryDir = process.argv[1] ? path.dirname(path.resolve(process.argv[1])) : null;
@@ -80,10 +82,10 @@ async function resolveA2uiRootReal(): Promise<string | null> {
   return resolvingA2uiRoot;
 }
 
-/** Handles one HTTP request for the hosted A2UI asset surface. */
-export async function handleA2uiHttpRequest(
+async function handleA2uiHttpRequestWithRootResolver(
   req: IncomingMessage,
   res: ServerResponse,
+  resolveRootReal: A2uiRootResolver,
 ): Promise<boolean> {
   const urlRaw = req.url;
   if (!urlRaw) {
@@ -103,7 +105,7 @@ export async function handleA2uiHttpRequest(
     return true;
   }
 
-  const a2uiRootReal = await resolveA2uiRootReal();
+  const a2uiRootReal = await resolveRootReal();
   if (!a2uiRootReal) {
     res.statusCode = 503;
     res.setHeader("Content-Type", "text/plain; charset=utf-8");
@@ -147,4 +149,23 @@ export async function handleA2uiHttpRequest(
   } finally {
     await result.handle.close().catch(() => {});
   }
+}
+
+/** Creates an HTTP handler for a specific hosted A2UI asset root. */
+export function createA2uiHttpRequestHandler(params: {
+  rootDir: string;
+}): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
+  let rootRealPromise: Promise<string> | null = null;
+  return async (req, res) => {
+    rootRealPromise ??= fs.realpath(params.rootDir);
+    return await handleA2uiHttpRequestWithRootResolver(req, res, async () => await rootRealPromise);
+  };
+}
+
+/** Handles one HTTP request for the hosted A2UI asset surface. */
+export async function handleA2uiHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  return await handleA2uiHttpRequestWithRootResolver(req, res, resolveA2uiRootReal);
 }

--- a/extensions/canvas/src/host/server.test.ts
+++ b/extensions/canvas/src/host/server.test.ts
@@ -108,9 +108,13 @@ async function captureHandlerResponse(
   return await captureHttpResponse(handler.handleHttpRequest, url, method);
 }
 
-async function captureA2uiResponse(url: string, method = "GET"): Promise<CapturedResponse> {
-  const { handleA2uiHttpRequest } = await import("./a2ui.js");
-  return await captureHttpResponse(handleA2uiHttpRequest, url, method);
+async function captureA2uiFixtureResponse(
+  rootDir: string,
+  url: string,
+  method = "GET",
+): Promise<CapturedResponse> {
+  const { createA2uiHttpRequestHandler } = await import("./a2ui.js");
+  return await captureHttpResponse(createA2uiHttpRequestHandler({ rootDir }), url, method);
 }
 
 describe("canvas host", () => {
@@ -439,46 +443,56 @@ describe("canvas host", () => {
   });
 
   it("serves A2UI scaffold and blocks traversal/symlink escapes", async () => {
-    const a2uiRoot = path.resolve(process.cwd(), "extensions/canvas/src/host/a2ui");
-    const bundlePath = path.join(a2uiRoot, "a2ui.bundle.js");
+    const a2uiRoot = await createCaseDir();
+    const nestedAssetDir = path.join(a2uiRoot, "assets", "demo");
     const linkName = `test-link-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`;
     const linkPath = path.join(a2uiRoot, linkName);
-    let createdBundle = false;
 
-    try {
-      await fs.stat(bundlePath);
-    } catch {
-      await fs.writeFile(bundlePath, "window.openclawA2UI = {};", "utf8");
-      createdBundle = true;
-    }
-
+    await fs.mkdir(nestedAssetDir, { recursive: true });
+    await fs.writeFile(
+      path.join(a2uiRoot, "index.html"),
+      `<openclaw-a2ui-host></openclaw-a2ui-host>
+<script>openclawCanvasA2UIAction</script>`,
+      "utf8",
+    );
+    await fs.writeFile(path.join(a2uiRoot, "a2ui.bundle.js"), "window.openclawA2UI = {};", "utf8");
+    await fs.writeFile(path.join(nestedAssetDir, "sample.txt"), "nested asset", "utf8");
     await fs.symlink(path.join(process.cwd(), "package.json"), linkPath);
 
     try {
-      const res = await captureA2uiResponse(`${A2UI_PATH}/`);
+      const res = await captureA2uiFixtureResponse(a2uiRoot, `${A2UI_PATH}/`);
       const html = res.body;
       expect(res.status).toBe(200);
       expect(html).toContain("openclaw-a2ui-host");
       expect(html).toContain("openclawCanvasA2UIAction");
 
-      const bundleRes = await captureA2uiResponse(`${A2UI_PATH}/a2ui.bundle.js`);
+      const bundleRes = await captureA2uiFixtureResponse(a2uiRoot, `${A2UI_PATH}/a2ui.bundle.js`);
       const js = bundleRes.body;
       expect(bundleRes.status).toBe(200);
       expect(js).toContain("openclawA2UI");
-      const traversalRes = await captureA2uiResponse(`${A2UI_PATH}/%2e%2e%2fpackage.json`);
+
+      const assetRes = await captureA2uiFixtureResponse(
+        a2uiRoot,
+        `${A2UI_PATH}/assets/demo/sample.txt`,
+      );
+      expect(assetRes.status).toBe(200);
+      expect(assetRes.headers["content-type"]).toBe("text/plain");
+      expect(assetRes.body).toBe("nested asset");
+
+      const traversalRes = await captureA2uiFixtureResponse(
+        a2uiRoot,
+        `${A2UI_PATH}/%2e%2e%2fpackage.json`,
+      );
       expect(traversalRes.status).toBe(404);
       expect(traversalRes.body).toBe("not found");
-      const malformedRes = await captureA2uiResponse(`${A2UI_PATH}/%E0%A4%A`);
+      const malformedRes = await captureA2uiFixtureResponse(a2uiRoot, `${A2UI_PATH}/%E0%A4%A`);
       expect(malformedRes.status).toBe(404);
       expect(malformedRes.body).toBe("not found");
-      const symlinkRes = await captureA2uiResponse(`${A2UI_PATH}/${linkName}`);
+      const symlinkRes = await captureA2uiFixtureResponse(a2uiRoot, `${A2UI_PATH}/${linkName}`);
       expect(symlinkRes.status).toBe(404);
       expect(symlinkRes.body).toBe("not found");
     } finally {
       await fs.rm(linkPath, { force: true });
-      if (createdBundle) {
-        await fs.rm(bundlePath, { force: true });
-      }
     }
   });
 });

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -278,6 +278,11 @@ describe("CodexAppServerEventProjector", () => {
     const { onAssistantMessageStart, onPartialReply, projector } =
       await createProjectorWithAssistantHooks();
 
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "msg-1", phase: "final_answer", text: "" },
+      }),
+    );
     await projector.handleNotification(agentMessageDelta("hel"));
     await projector.handleNotification(agentMessageDelta("lo"));
     await projector.handleNotification(
@@ -305,7 +310,10 @@ describe("CodexAppServerEventProjector", () => {
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
     expect(onAssistantMessageStart).toHaveBeenCalledTimes(1);
-    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
+      { text: "hel", delta: "hel" },
+      { text: "hello", delta: "lo" },
+    ]);
     expect(result.assistantTexts).toEqual(["hello"]);
     expect(result.messagesSnapshot.map((message) => message.role)).toEqual(["user", "assistant"]);
     expect(result.lastAssistant?.content).toEqual([{ type: "text", text: "hello" }]);
@@ -321,7 +329,13 @@ describe("CodexAppServerEventProjector", () => {
   });
 
   it("streams final-answer assistant deltas into partial replies", async () => {
-    const { onPartialReply, projector } = await createProjectorWithAssistantHooks();
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent,
+      onPartialReply,
+    });
 
     await projector.handleNotification(
       forCurrentTurn("item/started", {
@@ -340,6 +354,79 @@ describe("CodexAppServerEventProjector", () => {
     expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
       { text: "hel", delta: "hel" },
       { text: "hello", delta: "lo" },
+    ]);
+    expect(
+      onAgentEvent.mock.calls
+        .map((call) => call[0])
+        .filter((event) => event.stream === "assistant"),
+    ).toEqual([
+      { stream: "assistant", data: { text: "hel", delta: "hel" } },
+      { stream: "assistant", data: { text: "hello", delta: "lo" } },
+    ]);
+  });
+
+  it("streams assistant deltas when the app-server omits the item phase", async () => {
+    // Newer Codex app-servers (>= 0.139) stream agentMessage deltas without a
+    // "final_answer" phase. These surface on the replaceable agent-event path;
+    // legacy append-oriented partial callbacks stay quiet.
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+    const params = await createParams();
+    const projector = await createProjector({
+      ...params,
+      onAgentEvent,
+      onPartialReply,
+    });
+
+    await projector.handleNotification(agentMessageDelta("hel", "msg-final"));
+    await projector.handleNotification(agentMessageDelta("lo", "msg-final"));
+
+    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(onAgentEvent.mock.calls.map((call) => call[0])).toEqual([
+      { stream: "assistant", data: { text: "hel", delta: "hel", replaceable: true } },
+      { stream: "assistant", data: { text: "hello", delta: "lo", replaceable: true } },
+    ]);
+  });
+
+  it("marks partial replacement when an unphased intermediate item is superseded by a final item", async () => {
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+    const params = await createParams();
+    const projector = await createProjector({
+      ...params,
+      onAgentEvent,
+      onPartialReply,
+    });
+
+    await projector.handleNotification(agentMessageDelta("coordination ", "msg-intermediate"));
+    await projector.handleNotification(agentMessageDelta("draft", "msg-intermediate"));
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "msg-final", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("final ", "msg-final"));
+    await projector.handleNotification(agentMessageDelta("answer", "msg-final"));
+
+    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(
+      onAgentEvent.mock.calls
+        .map((call) => call[0])
+        .filter((event) => event.stream === "assistant"),
+    ).toEqual([
+      {
+        stream: "assistant",
+        data: { text: "coordination ", delta: "coordination ", replaceable: true },
+      },
+      {
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "draft", replaceable: true },
+      },
+      {
+        stream: "assistant",
+        data: { text: "final ", delta: "", replace: true, replaceable: true },
+      },
+      { stream: "assistant", data: { text: "final answer", delta: "answer", replaceable: true } },
     ]);
   });
 
@@ -1041,6 +1128,8 @@ describe("CodexAppServerEventProjector", () => {
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
     expect(onAssistantMessageStart).toHaveBeenCalledTimes(1);
+    // Phase-less snapshots stay on the replaceable agent-event path so legacy
+    // append-only channel previews do not render superseded coordination text.
     expect(onPartialReply).not.toHaveBeenCalled();
     expect(result.assistantTexts).toEqual([
       "release fixes first. please drop affected PRs, failing checks, and blockers here.",

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -196,6 +196,8 @@ export class CodexAppServerEventProjector {
   private assistantStarted = false;
   private reasoningStarted = false;
   private reasoningEnded = false;
+  private streamedPartialAssistantItemId: string | undefined;
+  private streamedPartialAssistantItemReplaceable = false;
   private completedTurn: CodexTurn | undefined;
   private promptError: unknown;
   private promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"] = null;
@@ -521,13 +523,46 @@ export class CodexAppServerEventProjector {
     this.assistantTextByItem.set(itemId, text);
     if (this.isCommentaryAssistantItem(itemId)) {
       this.emitCommentaryProgress({ itemId, text });
-    } else if (this.shouldStreamAssistantPartial(itemId)) {
-      await this.params.onPartialReply?.({ text, delta });
+    } else {
+      const knownFinalAnswer = this.shouldStreamAssistantPartial(itemId);
+      const replace =
+        this.streamedPartialAssistantItemId !== undefined &&
+        this.streamedPartialAssistantItemId !== itemId;
+      // Codex defines final_answer as terminal text. Replacement mode is for
+      // phase-unknown/provisional items; append-only consumers cannot retract
+      // bytes after a known terminal answer has started.
+      if (replace && (!knownFinalAnswer || this.streamedPartialAssistantItemReplaceable)) {
+        this.streamedPartialAssistantItemReplaceable = true;
+      } else if (this.streamedPartialAssistantItemId === undefined) {
+        this.streamedPartialAssistantItemReplaceable = !knownFinalAnswer;
+      }
+      this.streamedPartialAssistantItemId = itemId;
+      const replaceable = this.streamedPartialAssistantItemReplaceable;
+      const replacement = replace && replaceable;
+      const streamPayload = {
+        text,
+        delta: replacement ? "" : delta,
+        ...(replacement ? { replace: true as const } : {}),
+      };
+      this.emitAgentEvent({
+        stream: "assistant",
+        data: {
+          ...streamPayload,
+          ...(replaceable ? { replaceable: true as const } : {}),
+        },
+      });
+      // Legacy channel preview callbacks are append-oriented and do not all
+      // understand replacement snapshots. Keep them on the known final-answer
+      // path; replaceable snapshots stay on the typed agent-event path.
+      if (knownFinalAnswer && !replaceable) {
+        await this.params.onPartialReply?.(streamPayload);
+      }
     }
-    // Codex app-server can emit multiple agentMessage items per turn, including
-    // intermediate coordination/progress prose. Keep those deltas internal until
-    // their phase identifies terminal answer text or turn completion chooses the
-    // last assistant item as the user-visible reply.
+    // Stream non-commentary assistant deltas as partial replies and assistant
+    // agent events so live surfaces (TUI, WebChat) render incremental answer
+    // text via gateway emitChatDelta. When Codex switches to a new non-commentary
+    // item, mark replace:true with an empty delta so live merge and append-oriented
+    // partial consumers reset to the new cumulative text instead of concatenating.
   }
 
   private async handleReasoningDelta(

--- a/extensions/codex/src/app-server/run-attempt.hooks.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.hooks.test.ts
@@ -185,8 +185,14 @@ describe("runCodexAppServerAttempt hooks and model diagnostics", () => {
       (event) => event.stream === "lifecycle" && event.data.phase === "start",
     );
     expect(typeof lifecycleStart?.data.startedAt).toBe("number");
-    const assistantEvent = agentEvents.find((event) => event.stream === "assistant");
-    expect(assistantEvent?.data).toEqual({ text: "hello back" });
+    const assistantEvents = agentEvents.filter((event) => event.stream === "assistant");
+    expect(assistantEvents).toHaveLength(2);
+    expect(assistantEvents[0]?.data).toEqual({
+      text: "hello back",
+      delta: "hello back",
+      replaceable: true,
+    });
+    expect(assistantEvents[1]?.data).toEqual({ text: "hello back" });
     const lifecycleEnd = agentEvents.find(
       (event) => event.stream === "lifecycle" && event.data.phase === "end",
     );
@@ -202,10 +208,16 @@ describe("runCodexAppServerAttempt hooks and model diagnostics", () => {
     expect(startIndex).toBeGreaterThanOrEqual(0);
     expect(assistantIndex).toBeGreaterThan(startIndex);
     expect(endIndex).toBeGreaterThan(assistantIndex);
-    const globalAssistantEvent = globalAgentEvents.find((event) => event.stream === "assistant");
-    expect(globalAssistantEvent?.runId).toBe("run-1");
-    expect(globalAssistantEvent?.sessionKey).toBe("agent:main:session-1");
-    expect(globalAssistantEvent?.data).toEqual({ text: "hello back" });
+    const globalAssistantEvents = globalAgentEvents.filter((event) => event.stream === "assistant");
+    expect(globalAssistantEvents).toHaveLength(2);
+    expect(globalAssistantEvents[0]?.runId).toBe("run-1");
+    expect(globalAssistantEvents[0]?.sessionKey).toBe("agent:main:session-1");
+    expect(globalAssistantEvents[0]?.data).toEqual({
+      text: "hello back",
+      delta: "hello back",
+      replaceable: true,
+    });
+    expect(globalAssistantEvents[1]?.data).toEqual({ text: "hello back" });
     const globalEndEvent = globalAgentEvents.find(
       (event) => event.stream === "lifecycle" && event.data.phase === "end",
     );

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2720,6 +2720,8 @@ export async function runCodexAppServerAttempt(
   }
   turnIdRef.current = turn.turn.id;
   const activeTurnId = turn.turn.id;
+  let assistantStreamEventEmitted = false;
+  let assistantStreamNeedsTerminalSnapshot = false;
   emitExecutionPhaseOnce("turn_accepted", { phase: "turn_accepted" });
   userInputBridgeRef.current = createCodexUserInputBridge({
     paramsForRun: params,
@@ -2734,7 +2736,16 @@ export async function runCodexAppServerAttempt(
     imagesCount: params.images?.length ?? 0,
   });
   projectorRef.current = new CodexAppServerEventProjector(
-    dynamicToolParams,
+    {
+      ...dynamicToolParams,
+      onAgentEvent: (event) => {
+        if (event.stream === "assistant" && typeof event.data.delta === "string") {
+          assistantStreamEventEmitted = true;
+          assistantStreamNeedsTerminalSnapshot ||= event.data.replaceable === true;
+        }
+        return dynamicToolParams.onAgentEvent?.(event);
+      },
+    },
     thread.threadId,
     activeTurnId,
     {
@@ -3002,7 +3013,12 @@ export async function runCodexAppServerAttempt(
       turnId: activeTurnId,
     });
     const terminalAssistantText = collectTerminalAssistantText(result);
-    if (terminalAssistantText && !finalAborted && !finalPromptError) {
+    if (
+      terminalAssistantText &&
+      (!assistantStreamEventEmitted || assistantStreamNeedsTerminalSnapshot) &&
+      !finalAborted &&
+      !finalPromptError
+    ) {
       void emitCodexAppServerEvent(params, {
         stream: "assistant",
         data: { text: terminalAssistantText },

--- a/extensions/googlechat/src/monitor.test.ts
+++ b/extensions/googlechat/src/monitor.test.ts
@@ -30,6 +30,34 @@ beforeEach(() => {
   accessMocks.applyGoogleChatInboundAccessPolicy.mockReset();
 });
 
+function createInboundClassificationHarness() {
+  const resolveAgentRoute = vi.fn(() => ({
+    agentId: "agent-1",
+    accountId: "work",
+    sessionKey: "session-1",
+  }));
+  const buildContext = vi.fn((payload: unknown) => payload);
+  const runTurn = vi.fn();
+  const core = {
+    logging: { shouldLogVerbose: () => false },
+    channel: {
+      routing: { resolveAgentRoute },
+      session: {
+        resolveStorePath: () => "/tmp/openclaw-googlechat-test",
+        readSessionUpdatedAt: () => undefined,
+        recordInboundSession: vi.fn(),
+      },
+      reply: {
+        resolveEnvelopeFormatOptions: () => ({}),
+        formatAgentEnvelope: ({ body }: { body: string }) => body,
+        dispatchReplyWithBufferedBlockDispatcher: vi.fn(),
+      },
+      inbound: { buildContext, run: runTurn },
+    },
+  } as unknown as GoogleChatCoreRuntime;
+  return { buildContext, core, resolveAgentRoute, runTurn };
+}
+
 describe("googlechat monitor bot loop protection", () => {
   it("maps accepted bot-authored messages to shared channel-turn facts", () => {
     expect(
@@ -156,6 +184,74 @@ describe("googlechat monitor bot loop protection", () => {
     expect(apiMocks.sendGoogleChatMessage).not.toHaveBeenCalled();
     expect(apiMocks.downloadGoogleChatMedia).not.toHaveBeenCalled();
     expect(runTurn).not.toHaveBeenCalled();
+  });
+});
+
+describe("googlechat monitor inbound space classification", () => {
+  const cases = [
+    { name: "legacy DM", space: { type: "DM" }, peerKind: "direct" },
+    { name: "modern direct message", space: { spaceType: "DIRECT_MESSAGE" }, peerKind: "direct" },
+    { name: "single-user bot DM", space: { singleUserBotDm: true }, peerKind: "direct" },
+    { name: "modern space", space: { spaceType: "SPACE" }, peerKind: "group" },
+    { name: "modern group chat", space: { spaceType: "GROUP_CHAT" }, peerKind: "group" },
+    {
+      name: "modern space over legacy DM",
+      space: { type: "DM", spaceType: "SPACE" },
+      peerKind: "group",
+    },
+  ] as const;
+
+  it.each(cases)("$name uses the expected access and route branch", async ({ space, peerKind }) => {
+    const { buildContext, core, resolveAgentRoute, runTurn } = createInboundClassificationHarness();
+    const account = {
+      accountId: "work",
+      config: {},
+      credentialSource: "inline",
+    } as ResolvedGoogleChatAccount;
+    const event = {
+      type: "MESSAGE",
+      space: { name: "spaces/CLASSIFY", ...space },
+      message: {
+        name: "spaces/CLASSIFY/messages/1",
+        text: "hello",
+        sender: { name: "users/alice", displayName: "Alice", type: "HUMAN" },
+      },
+    } satisfies GoogleChatEvent;
+
+    accessMocks.applyGoogleChatInboundAccessPolicy.mockResolvedValue({
+      ok: true,
+      commandAuthorized: undefined,
+      effectiveWasMentioned: undefined,
+      groupBotLoopProtection: undefined,
+      groupSystemPrompt: undefined,
+    });
+
+    await testing.processMessageWithPipeline({
+      event,
+      account,
+      config: {},
+      runtime: { error: vi.fn(), log: vi.fn() },
+      core,
+      mediaMaxMb: 10,
+    });
+
+    const isGroup = peerKind === "group";
+    expect(accessMocks.applyGoogleChatInboundAccessPolicy).toHaveBeenCalledWith(
+      expect.objectContaining({ isGroup }),
+    );
+    expect(resolveAgentRoute).toHaveBeenCalledWith({
+      cfg: {},
+      channel: "googlechat",
+      accountId: "work",
+      peer: { kind: peerKind, id: "spaces/CLASSIFY" },
+    });
+    expect(buildContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversation: expect.objectContaining({ kind: isGroup ? "channel" : "direct" }),
+        extra: expect.objectContaining({ ChatType: isGroup ? "channel" : "direct" }),
+      }),
+    );
+    expect(runTurn).toHaveBeenCalledOnce();
   });
 });
 

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -29,7 +29,7 @@ import type {
 } from "./monitor-types.js";
 import { warnAppPrincipalMisconfiguration } from "./monitor-webhook.js";
 import { getGoogleChatRuntime } from "./runtime.js";
-import type { GoogleChatAttachment, GoogleChatEvent } from "./types.js";
+import type { GoogleChatAttachment, GoogleChatEvent, GoogleChatSpace } from "./types.js";
 
 setGoogleChatWebhookEventProcessor(processGoogleChatEvent);
 
@@ -60,6 +60,20 @@ function resolveGoogleChatTimestampMs(eventTime?: string): number | undefined {
   }
   const parsed = Date.parse(eventTime);
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isGoogleChatGroupSpace(space: GoogleChatSpace): boolean {
+  const spaceType = (space.spaceType ?? "").toUpperCase();
+  // Google Chat deprecates `type` in favor of `spaceType`; known modern
+  // values must win if the fields disagree. Fall back to the bot-DM flag and
+  // legacy type so incomplete payloads retain their existing direct routing.
+  if (spaceType === "DIRECT_MESSAGE") {
+    return false;
+  }
+  if (spaceType === "SPACE" || spaceType === "GROUP_CHAT") {
+    return true;
+  }
+  return space.singleUserBotDm !== true && (space.type ?? "").toUpperCase() !== "DM";
 }
 
 function resolveGoogleChatBotLoopProtection(params: {
@@ -186,8 +200,7 @@ async function processMessageWithPipeline(params: {
   if (!spaceId) {
     return;
   }
-  const spaceType = (space.type ?? "").toUpperCase();
-  const isGroup = spaceType !== "DM";
+  const isGroup = isGoogleChatGroupSpace(space);
   const sender = message.sender ?? event.user;
   const senderId = sender?.name ?? "";
   const senderName = sender?.displayName ?? "";

--- a/extensions/googlechat/src/types.ts
+++ b/extensions/googlechat/src/types.ts
@@ -3,6 +3,10 @@ export type GoogleChatSpace = {
   name?: string;
   displayName?: string;
   type?: string;
+  /** Current Google Chat field that replaces the deprecated `type` field. */
+  spaceType?: string;
+  /** True when the space is a 1:1 DM between a user and the Chat app. */
+  singleUserBotDm?: boolean;
 };
 
 export type GoogleChatUser = {

--- a/extensions/irc/src/normalize.test.ts
+++ b/extensions/irc/src/normalize.test.ts
@@ -4,7 +4,6 @@ import {
   buildIrcAllowlistCandidates,
   normalizeIrcAllowEntry,
   normalizeIrcMessagingTarget,
-  resolveIrcAllowlistMatch,
 } from "./normalize.js";
 
 describe("irc normalize", () => {
@@ -33,24 +32,5 @@ describe("irc normalize", () => {
     expect(buildIrcAllowlistCandidates(message)).toContain("alice!ident@example.org");
     expect(buildIrcAllowlistCandidates(message)).not.toContain("alice");
     expect(buildIrcAllowlistCandidates(message, { allowNameMatching: true })).toContain("alice");
-    expect(
-      resolveIrcAllowlistMatch({
-        allowFrom: ["alice!ident@example.org"],
-        message,
-      }).allowed,
-    ).toBe(true);
-    expect(
-      resolveIrcAllowlistMatch({
-        allowFrom: ["alice"],
-        message,
-      }).allowed,
-    ).toBe(false);
-    expect(
-      resolveIrcAllowlistMatch({
-        allowFrom: ["alice"],
-        message,
-        allowNameMatching: true,
-      }).allowed,
-    ).toBe(true);
   });
 });

--- a/extensions/irc/src/normalize.ts
+++ b/extensions/irc/src/normalize.ts
@@ -2,7 +2,6 @@
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
-  normalizeStringEntriesLower,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { hasIrcControlChars } from "./control-chars.js";
 import type { IrcInboundMessage } from "./types.js";
@@ -84,24 +83,4 @@ export function buildIrcAllowlistCandidates(
     candidates.add(`${nick}!${user}@${host}`);
   }
   return [...candidates];
-}
-
-export function resolveIrcAllowlistMatch(params: {
-  allowFrom: string[];
-  message: IrcInboundMessage;
-  allowNameMatching?: boolean;
-}): { allowed: boolean; source?: string } {
-  const allowFrom = new Set(normalizeStringEntriesLower(params.allowFrom));
-  if (allowFrom.has("*")) {
-    return { allowed: true, source: "wildcard" };
-  }
-  const candidates = buildIrcAllowlistCandidates(params.message, {
-    allowNameMatching: params.allowNameMatching,
-  });
-  for (const candidate of candidates) {
-    if (allowFrom.has(candidate)) {
-      return { allowed: true, source: candidate };
-    }
-  }
-  return { allowed: false };
 }

--- a/extensions/matrix/src/cli.ts
+++ b/extensions/matrix/src/cli.ts
@@ -1647,7 +1647,10 @@ export function registerMatrixCli(params: { program: Command }): void {
     .description("Enable Matrix E2EE, bootstrap verification, and print next steps")
     .option("--account <id>", "Account ID (for multi-account setups)")
     .option("--recovery-key <key>", "Recovery key to apply before bootstrap")
-    .option("--force-reset-cross-signing", "Force reset cross-signing identity before bootstrap")
+    .option(
+      "--force-reset-cross-signing",
+      "Force reset cross-signing identity before bootstrap (requires active recovery key)",
+    )
     .option("--verbose", "Show detailed diagnostics")
     .option("--json", "Output as JSON")
     .action(
@@ -2121,7 +2124,10 @@ export function registerMatrixCli(params: { program: Command }): void {
       "Recovery key to apply before bootstrap (prefer --recovery-key-stdin)",
     )
     .option("--recovery-key-stdin", "Read the Matrix recovery key from stdin")
-    .option("--force-reset-cross-signing", "Force reset cross-signing identity before bootstrap")
+    .option(
+      "--force-reset-cross-signing",
+      "Force reset cross-signing identity before bootstrap (requires active recovery key)",
+    )
     .option("--verbose", "Show detailed diagnostics")
     .option("--json", "Output as JSON")
     .action(

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1645,6 +1645,54 @@ describe("MatrixClient crypto bootstrapping", () => {
     expect(bootstrapSpy).toHaveBeenCalledTimes(2);
   });
 
+  it("rejects recovery keys when secret-storage metadata cannot authenticate them", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-sdk-test-"));
+    const recoveryKeyPath = path.join(tmpDir, "recovery-key.json");
+    fs.writeFileSync(
+      recoveryKeyPath,
+      JSON.stringify({
+        version: 1,
+        createdAt: new Date().toISOString(),
+        keyId: "SSSSKEY",
+        privateKeyBase64: Buffer.from([1, 2, 3, 4]).toString("base64"),
+      }),
+      "utf8",
+    );
+    const checkKey = vi.fn(async () => true);
+    Object.assign(matrixJsClient, {
+      secretStorage: {
+        getDefaultKeyId: vi.fn(async () => "SSSSKEY"),
+        getKey: vi.fn(async () => [
+          "SSSSKEY",
+          {
+            algorithm: "m.secret_storage.v1.aes-hmac-sha2",
+            iv: "authenticated-iv",
+          },
+        ]),
+        checkKey,
+      },
+    });
+    const client = new MatrixClient("https://matrix.example.org", "token", {
+      encryption: true,
+      recoveryKeyPath,
+    });
+    await (
+      client as unknown as {
+        ensureCryptoSupportInitialized: () => Promise<void>;
+      }
+    ).ensureCryptoSupportInitialized();
+    const bootstrapper = (
+      client as unknown as {
+        cryptoBootstrapper: {
+          deps: { canUnlockSecretStorage: () => Promise<boolean> };
+        };
+      }
+    ).cryptoBootstrapper;
+
+    await expect(bootstrapper.deps.canUnlockSecretStorage()).resolves.toBe(false);
+    expect(checkKey).not.toHaveBeenCalled();
+  });
+
   it("provides secret storage callbacks and resolves stored recovery key", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-sdk-test-"));
     const recoveryKeyPath = path.join(tmpDir, "recovery-key.json");

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -484,6 +484,22 @@ export class MatrixClient {
     this.cryptoBootstrapper ??= new runtime.MatrixCryptoBootstrapper<MatrixRawEvent>({
       getUserId: () => this.getUserId(),
       getPassword: () => this.password,
+      canUnlockSecretStorage: async () => {
+        const defaultKeyId = await this.client.secretStorage.getDefaultKeyId();
+        if (!defaultKeyId) {
+          return false;
+        }
+        const keyTuple = await this.client.secretStorage.getKey(defaultKeyId);
+        const key = this.recoveryKeyStore.getSecretStorageKeyCandidate(defaultKeyId);
+        if (!keyTuple || !key) {
+          return false;
+        }
+        const keyInfo = keyTuple[1];
+        if (!keyInfo.iv?.trim() || !keyInfo.mac?.trim()) {
+          return false;
+        }
+        return await this.client.secretStorage.checkKey(key, keyInfo);
+      },
       getDeviceId: () => this.client.getDeviceId(),
       verificationManager: this.verificationManager,
       recoveryKeyStore: this.recoveryKeyStore,
@@ -747,13 +763,9 @@ export class MatrixClient {
           "Cross-signing/bootstrap is incomplete for an already owner-signed device; skipping automatic reset and preserving the current identity. Restore the recovery key or run an explicit verification bootstrap if repair is needed.",
         );
       } else {
-        // No password guard: passwordless token-auth bots should still attempt repair.
-        // UIA failures inside bootstrap() are caught below and logged as warnings.
+        // Forced reset validates the active SSSS recovery key before rotating local keys.
+        // Missing or stale recovery material fails without mutating crypto state.
         try {
-          // The repair path already force-resets cross-signing; allow secret storage
-          // recreation so the new keys can be persisted. Without this, a device that
-          // lost its recovery key enters a permanent failure loop because the new
-          // cross-signing keys have nowhere to be stored.
           const repaired = await cryptoBootstrapper.bootstrap(
             crypto,
             MATRIX_AUTOMATIC_REPAIR_BOOTSTRAP_OPTIONS,

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -1,6 +1,7 @@
 // Matrix tests cover crypto bootstrap plugin behavior.
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { MatrixCryptoBootstrapper, type MatrixCryptoBootstrapperDeps } from "./crypto-bootstrap.js";
+import type { MatrixRecoveryKeyStore } from "./recovery-key-store.js";
 import type { MatrixCryptoBootstrapApi, MatrixRawEvent } from "./types.js";
 
 type BootstrapCrossSigningMock = Mock<MatrixCryptoBootstrapApi["bootstrapCrossSigning"]>;
@@ -39,12 +40,15 @@ function createBootstrapperDeps() {
   return {
     getUserId: vi.fn(async () => "@bot:example.org"),
     getPassword: vi.fn<() => string | undefined>(() => "super-secret-password"),
+    canUnlockSecretStorage: vi.fn(async () => true),
     getDeviceId: vi.fn(() => "DEVICE123"),
     verificationManager: {
       trackVerificationRequest: vi.fn(),
     },
     recoveryKeyStore: {
-      bootstrapSecretStorageWithRecoveryKey: vi.fn(async () => {}),
+      bootstrapSecretStorageWithRecoveryKey: vi.fn<
+        MatrixRecoveryKeyStore["bootstrapSecretStorageWithRecoveryKey"]
+      >(async () => {}),
     },
     decryptBridge: {
       bindCryptoRetrySignals: vi.fn(),
@@ -130,17 +134,6 @@ function createForcedResetHarness(bootstrapCrossSigning: BootstrapCrossSigningMo
     userHasCrossSigningKeys: vi.fn(async () => true),
     getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
   });
-}
-
-function expectForcedResetCrossSigningCalls(
-  bootstrapCrossSigning: BootstrapCrossSigningMock,
-  params: { setupNewCall: number; totalCalls: number },
-) {
-  expect(bootstrapCrossSigning).toHaveBeenCalledTimes(params.totalCalls);
-  expectBootstrapCrossSigningCall(bootstrapCrossSigning, params.setupNewCall, {
-    setupNewCrossSigning: true,
-  });
-  expectBootstrapCrossSigningCall(bootstrapCrossSigning, params.totalCalls);
 }
 
 async function bootstrapWithVerificationRequestListener(overrides?: {
@@ -406,32 +399,72 @@ describe("MatrixCryptoBootstrapper", () => {
     );
 
     expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
+    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
   });
 
-  it("recreates secret storage and retries a forced reset when stale server SSSS blocks it", async () => {
+  it("rejects forced reset before mutation when the active recovery key is unavailable", async () => {
+    const deps = createBootstrapperDeps();
+    deps.canUnlockSecretStorage = vi.fn(async () => false);
+    const bootstrapCrossSigning = vi.fn(async () => {});
+    const crypto = createCryptoApi({ bootstrapCrossSigning });
+    const bootstrapper = new MatrixCryptoBootstrapper(
+      deps as unknown as MatrixCryptoBootstrapperDeps<MatrixRawEvent>,
+    );
+
+    await expect(
+      bootstrapper.bootstrap(crypto, {
+        strict: true,
+        forceResetCrossSigning: true,
+        allowSecretStorageRecreateWithoutRecoveryKey: true,
+      }),
+    ).rejects.toThrow(
+      "Forced cross-signing reset requires the active Matrix recovery key; supply it before retrying",
+    );
+
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
+    expect(bootstrapCrossSigning).not.toHaveBeenCalled();
+  });
+
+  it("fails closed without recreating SSSS when forced reset cannot unlock it", async () => {
     const bootstrapCrossSigning = vi
       .fn<() => Promise<void>>()
-      .mockRejectedValueOnce(new Error("getSecretStorageKey callback returned falsey"))
-      .mockResolvedValueOnce(undefined);
+      .mockRejectedValueOnce(new Error("getSecretStorageKey callback returned falsey"));
     const { deps, crypto, bootstrapper } = createForcedResetHarness(bootstrapCrossSigning);
 
-    await bootstrapper.bootstrap(crypto, {
-      strict: true,
+    await expect(
+      bootstrapper.bootstrap(crypto, {
+        strict: true,
+        forceResetCrossSigning: true,
+        allowSecretStorageRecreateWithoutRecoveryKey: true,
+      }),
+    ).rejects.toThrow(
+      "Forced cross-signing reset cannot access secret storage; restore the Matrix recovery key before retrying",
+    );
+
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
+    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
+    expectBootstrapCrossSigningCall(bootstrapCrossSigning, 1, { setupNewCrossSigning: true });
+  });
+
+  it("does not repair SSSS after a non-strict forced reset failure", async () => {
+    const bootstrapCrossSigning = vi.fn(async () => {
+      throw new Error("getSecretStorageKey callback returned falsey");
+    });
+    const { deps, crypto, bootstrapper } = createForcedResetHarness(bootstrapCrossSigning);
+
+    const result = await bootstrapper.bootstrap(crypto, {
+      strict: false,
       forceResetCrossSigning: true,
       allowSecretStorageRecreateWithoutRecoveryKey: true,
     });
 
-    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledWith(
-      crypto,
-      {
-        allowSecretStorageRecreateWithoutRecoveryKey: true,
-        forceNewSecretStorage: true,
-      },
-    );
-    expectForcedResetCrossSigningCalls(bootstrapCrossSigning, {
-      setupNewCall: 2,
-      totalCalls: 3,
+    expect(result).toEqual({
+      crossSigningReady: false,
+      crossSigningPublished: false,
+      ownDeviceVerified: null,
     });
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
+    expect(bootstrapCrossSigning).toHaveBeenCalledOnce();
   });
 
   it("re-exports cross-signing keys after forced reset creates secret storage", async () => {
@@ -444,16 +477,16 @@ describe("MatrixCryptoBootstrapper", () => {
       allowSecretStorageRecreateWithoutRecoveryKey: true,
     });
 
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledOnce();
     expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledWith(
       crypto,
-      {
+      expect.objectContaining({
         allowSecretStorageRecreateWithoutRecoveryKey: true,
-      },
+      }),
     );
-    expectForcedResetCrossSigningCalls(bootstrapCrossSigning, {
-      setupNewCall: 1,
-      totalCalls: 2,
-    });
+    // No redundant second bootstrapCrossSigning call — no double reset (gh-78396).
+    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
+    expectBootstrapCrossSigningCall(bootstrapCrossSigning, 1, { setupNewCrossSigning: true });
   });
 
   it("trusts the fresh own identity after a forced cross-signing reset", async () => {

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -20,6 +20,7 @@ import { isMatrixDeviceOwnerVerified } from "./verification-status.js";
 export type MatrixCryptoBootstrapperDeps<TRawEvent extends MatrixRawEvent> = {
   getUserId: () => Promise<string>;
   getPassword?: () => string | undefined;
+  canUnlockSecretStorage: () => Promise<boolean>;
   getDeviceId: () => string | null | undefined;
   verificationManager: MatrixVerificationManager;
   recoveryKeyStore: MatrixRecoveryKeyStore;
@@ -51,11 +52,17 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
     options: MatrixCryptoBootstrapOptions = {},
   ): Promise<MatrixCryptoBootstrapResult> {
     const strict = options.strict === true;
-    const deferSecretStorageBootstrapUntilAfterCrossSigning =
-      options.forceResetCrossSigning === true;
+    const forceReset = options.forceResetCrossSigning === true;
+    const deferSecretStorageBootstrapUntilAfterCrossSigning = forceReset;
+    if (forceReset && !(await this.deps.canUnlockSecretStorage())) {
+      throw new Error(
+        "Forced cross-signing reset requires the active Matrix recovery key; supply it before retrying",
+      );
+    }
     // Register verification listeners before expensive bootstrap work so incoming requests
     // are not missed during startup.
     this.registerVerificationRequestHandler(crypto);
+
     if (!deferSecretStorageBootstrapUntilAfterCrossSigning) {
       await this.bootstrapSecretStorage(crypto, {
         strict,
@@ -63,30 +70,33 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
           options.allowSecretStorageRecreateWithoutRecoveryKey === true,
       });
     }
-    let crossSigning = await this.bootstrapCrossSigning(crypto, {
-      forceResetCrossSigning: options.forceResetCrossSigning === true,
+
+    const crossSigning = await this.bootstrapCrossSigning(crypto, {
+      forceResetCrossSigning: forceReset,
       allowAutomaticCrossSigningReset: options.allowAutomaticCrossSigningReset !== false,
-      allowSecretStorageRecreateWithoutRecoveryKey:
-        options.allowSecretStorageRecreateWithoutRecoveryKey === true,
+      // A repair retry would generate another identity after the SDK already rotated local keys.
+      // Fail closed instead; the server identity and existing recovery material remain authoritative.
+      allowSecretStorageRecreateWithoutRecoveryKey: forceReset
+        ? false
+        : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
       strict,
     });
-    // Forced repair may need password UIA to upload new cross-signing keys. Delay any
-    // secret-storage repair/recreation until after that step succeeds so passwordless bots do
-    // not partially mutate SSSS on homeservers that require password-based UIA.
+
+    if (forceReset && (!crossSigning.ready || !crossSigning.published)) {
+      return {
+        crossSigningReady: crossSigning.ready,
+        crossSigningPublished: crossSigning.published,
+        ownDeviceVerified: null,
+      };
+    }
+
+    // Second SSSS pass to pick up cross-signing keys published during bootstrap.
     await this.bootstrapSecretStorage(crypto, {
       strict,
       allowSecretStorageRecreateWithoutRecoveryKey:
         options.allowSecretStorageRecreateWithoutRecoveryKey === true,
     });
-    if (deferSecretStorageBootstrapUntilAfterCrossSigning) {
-      crossSigning = await this.bootstrapCrossSigning(crypto, {
-        forceResetCrossSigning: false,
-        allowAutomaticCrossSigningReset: false,
-        allowSecretStorageRecreateWithoutRecoveryKey:
-          options.allowSecretStorageRecreateWithoutRecoveryKey === true,
-        strict,
-      });
-    }
+
     const ownDeviceVerified = await this.ensureOwnDeviceTrust(crypto, {
       strict,
     });
@@ -234,6 +244,12 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
         }
         LogService.warn("MatrixClientLite", "Forced cross-signing reset failed:", err);
         if (options.strict) {
+          if (isRepairableSecretStorageAccessError(err)) {
+            throw new Error(
+              "Forced cross-signing reset cannot access secret storage; restore the Matrix recovery key before retrying",
+              { cause: err },
+            );
+          }
           throw err instanceof Error ? err : new Error(String(err));
         }
         return { ready: false, published: false };

--- a/extensions/matrix/src/matrix/sdk/recovery-key-store.test.ts
+++ b/extensions/matrix/src/matrix/sdk/recovery-key-store.test.ts
@@ -148,6 +148,7 @@ describe("MatrixRecoveryKeyStore", () => {
     expect(fs.existsSync(recoveryKeyPath)).toBe(false);
     expect(fs.existsSync(`${recoveryKeyPath}.migrated`)).toBe(true);
     const callbacks = store.buildCryptoCallbacks();
+    expect(store.getSecretStorageKeyCandidate("SSSS")).toEqual(new Uint8Array([1, 2, 3, 4]));
     const resolved = await callbacks.getSecretStorageKey?.(
       { keys: { SSSS: { name: "test" } } },
       "m.cross_signing.master",
@@ -155,6 +156,12 @@ describe("MatrixRecoveryKeyStore", () => {
 
     expect(resolved?.[0]).toBe("SSSS");
     expect(Array.from(resolved?.[1] ?? [])).toEqual([1, 2, 3, 4]);
+
+    const resolvedFromMultipleKeys = await callbacks.getSecretStorageKey?.(
+      { keys: { OLD: { name: "old" }, SSSS: { name: "active" } } },
+      "m.cross_signing.master",
+    );
+    expect(resolvedFromMultipleKeys?.[0]).toBe("SSSS");
   });
 
   it("keeps a readable legacy recovery key usable when SQLite migration fails", async () => {
@@ -231,6 +238,15 @@ describe("MatrixRecoveryKeyStore", () => {
     const saved = readStoredRecoveryKey(recoveryKeyPath);
     expect(saved.keyId).toBe("KEY123");
     expect(saved.privateKeyBase64).toBe(Buffer.from([9, 8, 7]).toString("base64"));
+  });
+
+  it("does not authorize destructive reset from an ephemeral cached key", () => {
+    const store = new MatrixRecoveryKeyStore();
+    const callbacks = store.buildCryptoCallbacks();
+
+    callbacks.cacheSecretStorageKey?.("KEY123", { name: "openclaw" }, new Uint8Array([9, 8, 7]));
+
+    expect(store.getSecretStorageKeyCandidate("KEY123")).toBeNull();
   });
 
   it("creates and persists a recovery key when secret storage is missing", async () => {

--- a/extensions/matrix/src/matrix/sdk/recovery-key-store.ts
+++ b/extensions/matrix/src/matrix/sdk/recovery-key-store.ts
@@ -135,6 +135,27 @@ export class MatrixRecoveryKeyStore {
     };
   }
 
+  getSecretStorageKeyCandidate(keyId: string): Uint8Array | null {
+    const normalizedKeyId = keyId.trim();
+    if (!normalizedKeyId) {
+      return null;
+    }
+    const staged = this.resolveStagedSecretStorageKey([normalizedKeyId]);
+    if (staged) {
+      return staged[1];
+    }
+    const stored = this.loadStoredRecoveryKey();
+    if (!stored?.privateKeyBase64) {
+      return null;
+    }
+    const privateKey = new Uint8Array(Buffer.from(stored.privateKeyBase64, "base64"));
+    if (privateKey.length === 0) {
+      return null;
+    }
+    this.rememberSecretStorageKey(normalizedKeyId, privateKey, stored.keyInfo);
+    return privateKey;
+  }
+
   private resolveEncodedRecoveryKeyInput(params: {
     encodedPrivateKey: string;
     keyId?: string | null;

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts
@@ -1536,6 +1536,8 @@ export async function runMatrixQaE2eeBootstrapSuccessScenario(
 ): Promise<MatrixQaScenarioExecution> {
   requireMatrixQaPassword(context, "driver");
   return await withMatrixQaE2eeDriver(context, "matrix-e2ee-bootstrap-success", async (client) => {
+    const initial = await client.bootstrapOwnDeviceVerification();
+    assertMatrixQaBootstrapSucceeded("driver initial", initial);
     const result = await client.bootstrapOwnDeviceVerification({
       forceResetCrossSigning: true,
     });
@@ -1550,7 +1552,7 @@ export async function runMatrixQaE2eeBootstrapSuccessScenario(
         recoveryKeyStored: result.verification.recoveryKeyStored,
       },
       details: [
-        "driver bootstrap succeeded through real Matrix crypto bootstrap",
+        "driver bootstrap and guarded cross-signing reset succeeded through real Matrix crypto bootstrap",
         `device verified: ${result.verification.verified ? "yes" : "no"}`,
         `cross-signing verified: ${result.verification.crossSigningVerified ? "yes" : "no"}`,
         `signed by owner: ${result.verification.signedByOwner ? "yes" : "no"}`,

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -619,6 +619,37 @@ describe("createWebhookHandler", () => {
     expectBotReplySentTo("123");
   });
 
+  it("awaits deliver directly with no local hardcoded timeout wrapper", async () => {
+    // Previously this webhook handler wrapped deliver with a hardcoded 120s
+    // Promise.race that overrode the configurable agents.defaults.timeoutSeconds
+    // from core. That wrapper created a setTimeout(_, 120000) on every deliver
+    // call. We spy on setTimeout to prove no such call exists in the current code.
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+    try {
+      const deliver = vi.fn().mockResolvedValue("late reply");
+      const handler = createWebhookHandler({
+        account: makeAccount({ accountId: "no-hardcoded-timeout-" + Date.now() }),
+        deliver,
+        log,
+      });
+
+      const res = makeRes();
+      const req = makeReq("POST", validBody);
+      await handler(req, res);
+
+      expect(res.status).toBe(204);
+
+      // Collect all setTimeout delays used during this handler run
+      const delays = setTimeoutSpy.mock.calls.map((call) => call[1]);
+      // Every delay should be well under 120s — the old hardcoded wrapper would
+      // have produced exactly one call with delay === 120000.
+      const longDelays = delays.filter((d) => typeof d === "number" && d >= 120_000);
+      expect(longDelays).toEqual([]);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("sanitizes input before delivery", async () => {
     const deliver = vi.fn().mockResolvedValue(null);
     const handler = createWebhookHandler({

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -554,7 +554,7 @@ async function processAuthorizedSynologyWebhook(params: {
       log: params.log,
     });
 
-    const deliverPromise = params.deliver({
+    const reply = await params.deliver({
       body: params.message.body,
       from: authorizedWebhookUserId,
       senderName: params.message.payload.username,
@@ -564,10 +564,6 @@ async function processAuthorizedSynologyWebhook(params: {
       commandAuthorized: params.message.commandAuthorized,
       chatUserId: deliveryUserId,
     });
-    const timeoutPromise = new Promise<null>((_, reject) => {
-      setTimeout(() => reject(new Error("Agent response timeout (120s)")), 120_000);
-    });
-    const reply = await Promise.race([deliverPromise, timeoutPromise]);
     if (!reply) {
       return;
     }

--- a/extensions/vercel-ai-gateway/index.test.ts
+++ b/extensions/vercel-ai-gateway/index.test.ts
@@ -1,0 +1,22 @@
+// Vercel Ai Gateway tests cover provider runtime hooks.
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+
+describe("vercel ai gateway provider hooks", () => {
+  it("resolves live-only model ids for the embedded runner", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const model = provider.resolveDynamicModel?.({
+      provider: "vercel-ai-gateway",
+      modelId: "custom/provider-model",
+      modelRegistry: { find: () => null },
+    } as never);
+
+    expect(model).toMatchObject({
+      id: "custom/provider-model",
+      provider: "vercel-ai-gateway",
+      api: "anthropic-messages",
+      baseUrl: "https://ai-gateway.vercel.sh",
+    });
+  });
+});

--- a/extensions/vercel-ai-gateway/index.ts
+++ b/extensions/vercel-ai-gateway/index.ts
@@ -4,6 +4,7 @@ import { applyVercelAiGatewayConfig, VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF } from 
 import {
   buildStaticVercelAiGatewayProvider,
   buildVercelAiGatewayProvider,
+  resolveVercelAiGatewayModel,
 } from "./provider-catalog.js";
 import { resolveVercelAiGatewayThinkingProfile } from "./thinking.js";
 
@@ -37,6 +38,7 @@ export default defineSingleProviderPluginEntry({
       buildProvider: buildVercelAiGatewayProvider,
       buildStaticProvider: buildStaticVercelAiGatewayProvider,
     },
+    resolveDynamicModel: ({ modelId }) => resolveVercelAiGatewayModel(modelId),
     resolveThinkingProfile: ({ modelId }) => resolveVercelAiGatewayThinkingProfile(modelId),
   },
 });

--- a/extensions/vercel-ai-gateway/models.ts
+++ b/extensions/vercel-ai-gateway/models.ts
@@ -142,6 +142,21 @@ function getStaticFallbackModel(id: string): ModelDefinitionConfig | undefined {
   return fallback ? buildStaticModelDefinition(fallback) : undefined;
 }
 
+/** Builds runtime metadata for models returned by the live gateway catalog. */
+export function resolveVercelAiGatewayDynamicModel(modelId: string): ModelDefinitionConfig {
+  return (
+    getStaticFallbackModel(modelId) ?? {
+      id: modelId,
+      name: modelId,
+      reasoning: false,
+      input: ["text"],
+      contextWindow: VERCEL_AI_GATEWAY_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: VERCEL_AI_GATEWAY_DEFAULT_MAX_TOKENS,
+      cost: VERCEL_AI_GATEWAY_DEFAULT_COST,
+    }
+  );
+}
+
 export function getStaticVercelAiGatewayModelCatalog(): ModelDefinitionConfig[] {
   return STATIC_VERCEL_AI_GATEWAY_MODEL_CATALOG.map(buildStaticModelDefinition);
 }

--- a/extensions/vercel-ai-gateway/provider-catalog.test.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.test.ts
@@ -114,7 +114,7 @@ describe("vercel ai gateway provider catalog", () => {
   it("preserves provider thinking metadata for known live-only upstream models", () => {
     expect(resolveVercelAiGatewayModel("openai/gpt-5.5")).toMatchObject({
       reasoning: true,
-      input: ["text"],
+      input: ["text", "image"],
     });
   });
 

--- a/extensions/vercel-ai-gateway/provider-catalog.test.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.test.ts
@@ -20,9 +20,11 @@ import {
   VERCEL_AI_GATEWAY_DEFAULT_CONTEXT_WINDOW,
   VERCEL_AI_GATEWAY_DEFAULT_MAX_TOKENS,
 } from "./api.js";
+import { resolveVercelAiGatewayDynamicModel } from "./models.js";
 import {
   buildStaticVercelAiGatewayProvider,
   buildVercelAiGatewayProvider,
+  resolveVercelAiGatewayModel,
 } from "./provider-catalog.js";
 
 const STATIC_MODEL_IDS = [
@@ -80,6 +82,32 @@ describe("vercel ai gateway provider catalog", () => {
       baseUrl: VERCEL_AI_GATEWAY_BASE_URL,
       api: "anthropic-messages",
       models: getStaticVercelAiGatewayModelCatalog(),
+    });
+  });
+
+  it("builds runtime metadata for live-only model ids", () => {
+    expect(resolveVercelAiGatewayDynamicModel("custom/provider-model")).toEqual({
+      id: "custom/provider-model",
+      name: "custom/provider-model",
+      reasoning: false,
+      input: ["text"],
+      contextWindow: VERCEL_AI_GATEWAY_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: VERCEL_AI_GATEWAY_DEFAULT_MAX_TOKENS,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+    });
+  });
+
+  it("adds transport metadata for runtime model resolution", () => {
+    expect(resolveVercelAiGatewayModel("custom/provider-model")).toMatchObject({
+      id: "custom/provider-model",
+      provider: "vercel-ai-gateway",
+      api: "anthropic-messages",
+      baseUrl: VERCEL_AI_GATEWAY_BASE_URL,
     });
   });
 

--- a/extensions/vercel-ai-gateway/provider-catalog.test.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.test.ts
@@ -116,6 +116,9 @@ describe("vercel ai gateway provider catalog", () => {
       reasoning: true,
       input: ["text", "image"],
     });
+    expect(resolveVercelAiGatewayModel("anthropic/claude-sonnet-4-6")).toMatchObject({
+      input: ["text", "image"],
+    });
   });
 
   it("falls back to the static catalog for malformed successful model list payloads", async () => {

--- a/extensions/vercel-ai-gateway/provider-catalog.test.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.test.ts
@@ -111,6 +111,13 @@ describe("vercel ai gateway provider catalog", () => {
     });
   });
 
+  it("preserves provider thinking metadata for known live-only upstream models", () => {
+    expect(resolveVercelAiGatewayModel("openai/gpt-5.5")).toMatchObject({
+      reasoning: true,
+      input: ["text"],
+    });
+  });
+
   it("falls back to the static catalog for malformed successful model list payloads", async () => {
     for (const payload of [[], { data: {} }, { data: [null] }]) {
       clearLiveCatalogCacheForTests();

--- a/extensions/vercel-ai-gateway/provider-catalog.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.ts
@@ -11,10 +11,13 @@ import { resolveVercelAiGatewayThinkingProfile } from "./thinking.js";
 
 export function resolveVercelAiGatewayModel(modelId: string) {
   const model = resolveVercelAiGatewayDynamicModel(modelId);
+  const input: Array<"text" | "image"> = model.input.includes("image")
+    ? ["text", "image"]
+    : ["text"];
   return {
     ...model,
     reasoning: model.reasoning || Boolean(resolveVercelAiGatewayThinkingProfile(modelId)),
-    input: model.input.includes("image") ? (["text", "image"] as const) : (["text"] as const),
+    input,
     api: "anthropic-messages" as const,
     provider: VERCEL_AI_GATEWAY_PROVIDER_ID,
     baseUrl: VERCEL_AI_GATEWAY_BASE_URL,

--- a/extensions/vercel-ai-gateway/provider-catalog.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.ts
@@ -13,7 +13,9 @@ export function resolveVercelAiGatewayModel(modelId: string) {
   const model = resolveVercelAiGatewayDynamicModel(modelId);
   const input: Array<"text" | "image"> = model.input.includes("image")
     ? ["text", "image"]
-    : ["text"];
+    : /^(?:anthropic|moonshotai|openai)\//.test(modelId)
+      ? ["text", "image"]
+      : ["text"];
   return {
     ...model,
     reasoning: model.reasoning || Boolean(resolveVercelAiGatewayThinkingProfile(modelId)),

--- a/extensions/vercel-ai-gateway/provider-catalog.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.ts
@@ -3,8 +3,19 @@ import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-sha
 import {
   discoverVercelAiGatewayModels,
   getStaticVercelAiGatewayModelCatalog,
+  resolveVercelAiGatewayDynamicModel,
   VERCEL_AI_GATEWAY_BASE_URL,
+  VERCEL_AI_GATEWAY_PROVIDER_ID,
 } from "./models.js";
+
+export function resolveVercelAiGatewayModel(modelId: string) {
+  return {
+    ...resolveVercelAiGatewayDynamicModel(modelId),
+    api: "anthropic-messages" as const,
+    provider: VERCEL_AI_GATEWAY_PROVIDER_ID,
+    baseUrl: VERCEL_AI_GATEWAY_BASE_URL,
+  };
+}
 
 export function buildStaticVercelAiGatewayProvider(): ModelProviderConfig {
   return {

--- a/extensions/vercel-ai-gateway/provider-catalog.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.ts
@@ -9,8 +9,10 @@ import {
 } from "./models.js";
 
 export function resolveVercelAiGatewayModel(modelId: string) {
+  const model = resolveVercelAiGatewayDynamicModel(modelId);
   return {
-    ...resolveVercelAiGatewayDynamicModel(modelId),
+    ...model,
+    input: model.input.includes("image") ? (["text", "image"] as const) : (["text"] as const),
     api: "anthropic-messages" as const,
     provider: VERCEL_AI_GATEWAY_PROVIDER_ID,
     baseUrl: VERCEL_AI_GATEWAY_BASE_URL,

--- a/extensions/vercel-ai-gateway/provider-catalog.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.ts
@@ -7,11 +7,13 @@ import {
   VERCEL_AI_GATEWAY_BASE_URL,
   VERCEL_AI_GATEWAY_PROVIDER_ID,
 } from "./models.js";
+import { resolveVercelAiGatewayThinkingProfile } from "./thinking.js";
 
 export function resolveVercelAiGatewayModel(modelId: string) {
   const model = resolveVercelAiGatewayDynamicModel(modelId);
   return {
     ...model,
+    reasoning: model.reasoning || Boolean(resolveVercelAiGatewayThinkingProfile(modelId)),
     input: model.input.includes("image") ? (["text", "image"] as const) : (["text"] as const),
     api: "anthropic-messages" as const,
     provider: VERCEL_AI_GATEWAY_PROVIDER_ID,

--- a/extensions/vercel-ai-gateway/provider-catalog.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.ts
@@ -27,7 +27,8 @@ export function resolveVercelAiGatewayModel(modelId: string) {
   const model = resolveVercelAiGatewayDynamicModel(modelId);
   const input: Array<"text" | "image"> = model.input.includes("image")
     ? ["text", "image"]
-    : VERCEL_AI_GATEWAY_IMAGE_MODEL_IDS.has(modelId)
+    : VERCEL_AI_GATEWAY_IMAGE_MODEL_IDS.has(modelId) ||
+        /^anthropic\/claude-(?:opus|sonnet|haiku)-/.test(modelId)
       ? ["text", "image"]
       : ["text"];
   return {

--- a/extensions/vercel-ai-gateway/provider-catalog.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.ts
@@ -9,11 +9,25 @@ import {
 } from "./models.js";
 import { resolveVercelAiGatewayThinkingProfile } from "./thinking.js";
 
+const VERCEL_AI_GATEWAY_IMAGE_MODEL_IDS = new Set([
+  "openai/gpt-5.5",
+  "openai/gpt-5.5-pro",
+  "openai/gpt-5.4",
+  "openai/gpt-5.4-pro",
+  "openai/gpt-5.4-mini",
+  "openai/gpt-5.4-nano",
+  "openai/gpt-5.3-codex",
+  "openai/gpt-5.3-codex-spark",
+  "openai/gpt-5.2",
+  "openai/gpt-5.2-codex",
+  "openai/gpt-5.1-codex",
+]);
+
 export function resolveVercelAiGatewayModel(modelId: string) {
   const model = resolveVercelAiGatewayDynamicModel(modelId);
   const input: Array<"text" | "image"> = model.input.includes("image")
     ? ["text", "image"]
-    : /^(?:anthropic|moonshotai|openai)\//.test(modelId)
+    : VERCEL_AI_GATEWAY_IMAGE_MODEL_IDS.has(modelId)
       ? ["text", "image"]
       : ["text"];
   return {

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.last-route.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.last-route.test.ts
@@ -5,7 +5,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { installWebAutoReplyUnitTestHooks, makeSessionStore } from "./auto-reply.test-harness.js";
 import { buildMentionConfig } from "./auto-reply/mentions.js";
 import { createEchoTracker } from "./auto-reply/monitor/echo.js";
-import { awaitBackgroundTasks } from "./auto-reply/monitor/last-route.js";
 import { createWebOnMessageHandler } from "./auto-reply/monitor/on-message.js";
 import { createTestWebInboundMessage } from "./inbound/test-message.test-helper.js";
 
@@ -134,7 +133,8 @@ describe("web auto-reply last-route", () => {
       }),
     );
 
-    await awaitBackgroundTasks(backgroundTasks);
+    await Promise.allSettled(backgroundTasks);
+    backgroundTasks.clear();
 
     expect(updateLastRouteInBackgroundMock).toHaveBeenCalledTimes(1);
     const updateParams = updateLastRouteInBackgroundMock.mock.calls.at(0)?.[0] as
@@ -211,7 +211,8 @@ describe("web auto-reply last-route", () => {
       }),
     );
 
-    await awaitBackgroundTasks(backgroundTasks);
+    await Promise.allSettled(backgroundTasks);
+    backgroundTasks.clear();
 
     expect(updateLastRouteInBackgroundMock).toHaveBeenCalledTimes(1);
     const updateParams = updateLastRouteInBackgroundMock.mock.calls.at(0)?.[0] as

--- a/extensions/whatsapp/src/auto-reply/monitor/last-route.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/last-route.ts
@@ -51,12 +51,3 @@ export function updateLastRouteInBackground(params: {
   });
   trackBackgroundTask(params.backgroundTasks, task);
 }
-
-export function awaitBackgroundTasks(backgroundTasks: Set<Promise<unknown>>) {
-  if (backgroundTasks.size === 0) {
-    return Promise.resolve();
-  }
-  return Promise.allSettled(backgroundTasks).then(() => {
-    backgroundTasks.clear();
-  });
-}

--- a/extensions/whatsapp/src/connection-controller.test.ts
+++ b/extensions/whatsapp/src/connection-controller.test.ts
@@ -669,4 +669,52 @@ describe("WhatsAppConnectionController", () => {
       vi.useRealTimers();
     }
   });
+
+  it("uses messageTimeoutMs * 4 as the app-silence window for fresh connections with no inbound", async () => {
+    // Verifies the watchdog respects appSilenceTimeoutMs = messageTimeoutMs * 4 on first open.
+    // Transport is kept well within its own timeout so only app-silence fires.
+    vi.useFakeTimers();
+    const msgTimeoutMs = 100;
+    const controllerLocal = new WhatsAppConnectionController({
+      accountId: "work",
+      authDir: "/tmp/wa-auth",
+      verbose: false,
+      keepAlive: true,
+      heartbeatSeconds: 1,
+      transportTimeoutMs: 10_000,
+      messageTimeoutMs: msgTimeoutMs,
+      watchdogCheckMs: 10,
+      reconnectPolicy: {
+        initialMs: 250,
+        maxMs: 1_000,
+        factor: 2,
+        jitter: 0,
+        maxAttempts: 5,
+      },
+    });
+
+    try {
+      const sock = createSocketWithTransportEmitter();
+      createWaSocketMock.mockResolvedValueOnce(sock as never);
+      waitForWaConnectionMock.mockResolvedValueOnce(undefined);
+
+      const timeouts: string[] = [];
+      await controllerLocal.openConnection({
+        connectionId: "conn-app-silence",
+        createListener: async () => createListenerStub() as never,
+        onWatchdogTimeout: () => timeouts.push("timeout"),
+      });
+
+      // Just before messageTimeoutMs * 4 — no force-close expected
+      await vi.advanceTimersByTimeAsync(msgTimeoutMs * 4 - 20);
+      expect(timeouts).toHaveLength(0);
+
+      // Past messageTimeoutMs * 4 — force-close must fire
+      await vi.advanceTimersByTimeAsync(40);
+      expect(timeouts.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await controllerLocal.shutdown();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -404,7 +404,7 @@ export class WhatsAppConnectionController {
     this.heartbeatSeconds = params.heartbeatSeconds;
     this.transportTimeoutMs = params.transportTimeoutMs;
     this.messageTimeoutMs = params.messageTimeoutMs;
-    this.appSilenceTimeoutMs = Math.max(params.messageTimeoutMs, params.messageTimeoutMs * 4);
+    this.appSilenceTimeoutMs = params.messageTimeoutMs * 4;
     this.watchdogCheckMs = params.watchdogCheckMs;
     this.reconnectPolicy = params.reconnectPolicy;
     this.abortSignal = params.abortSignal;

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -767,6 +767,154 @@ describe("agentLoop tool termination", () => {
     expect(events.filter((event) => event.type === "tool_execution_start")).toHaveLength(1);
     expect(events.at(-1)).toMatchObject({ type: "agent_end" });
   });
+
+  it("does not request another model turn after a tool aborts the run", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-abort", name: "abort_tool", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const abortTool: AgentTool = {
+      name: "abort_tool",
+      label: "abort_tool",
+      description: "Abort the active run",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        controller.abort(new Error("user aborted"));
+        return {
+          content: [{ type: "text", text: "aborted" }],
+          details: { aborted: true },
+        };
+      },
+    };
+    const events: AgentEvent[] = [];
+
+    const messages = await runAgentLoop(
+      [{ role: "user", content: "abort during tool", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [abortTool],
+      },
+      config,
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(streamCalls).toBe(1);
+    expect(messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
+    expect(messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "aborted" });
+    expect(events.map((event) => event.type)).toEqual([
+      "agent_start",
+      "turn_start",
+      "message_start",
+      "message_end",
+      "message_start",
+      "message_end",
+      "tool_execution_start",
+      "tool_execution_end",
+      "message_start",
+      "message_end",
+      "turn_end",
+      "turn_start",
+      "message_start",
+      "message_end",
+      "turn_end",
+      "agent_end",
+    ]);
+    expect(events.at(-1)).toMatchObject({ type: "agent_end" });
+  });
+
+  it("does not request another model turn when an async turn hook aborts the run", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-hook-abort", name: "hook_abort", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const events: AgentEvent[] = [];
+
+    const messages = await runAgentLoop(
+      [{ role: "user", content: "abort from hook", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [makeTool("hook_abort", [])],
+      },
+      {
+        ...config,
+        prepareNextTurn: async () => {
+          await Promise.resolve();
+          controller.abort(new Error("user aborted"));
+          return undefined;
+        },
+      },
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(streamCalls).toBe(1);
+    expect(messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
+    expect(messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "aborted" });
+    expect(events.map((event) => event.type)).toEqual([
+      "agent_start",
+      "turn_start",
+      "message_start",
+      "message_end",
+      "message_start",
+      "message_end",
+      "tool_execution_start",
+      "tool_execution_end",
+      "message_start",
+      "message_end",
+      "turn_end",
+      "turn_start",
+      "message_start",
+      "message_end",
+      "turn_end",
+      "agent_end",
+    ]);
+    expect(events.at(-1)).toMatchObject({ type: "agent_end" });
+  });
 });
 
 describe("agentLoop thinking state", () => {

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -267,8 +267,32 @@ async function runLoop(
   let currentContext = initialContext;
   let config = initialConfig;
   let firstTurn = true;
+  let turnOpen = true;
   // Check for steering messages at start (user may have typed while waiting)
   let pendingMessages: AgentMessage[] = (await config.getSteeringMessages?.()) || [];
+  const stopIfAborted = async (): Promise<boolean> => {
+    if (!signal?.aborted) {
+      return false;
+    }
+    // Persist an aborted assistant outcome so session post-processing does not
+    // compact or continue from the preceding toolUse message.
+    const abortedMessage = createLoopFailureMessage(
+      config,
+      signal.reason instanceof Error ? signal.reason : new Error("Agent run aborted"),
+      true,
+    );
+    newMessages.push(abortedMessage);
+    if (!turnOpen) {
+      await emit({ type: "turn_start" });
+      turnOpen = true;
+    }
+    await emit({ type: "message_start", message: abortedMessage });
+    await emit({ type: "message_end", message: abortedMessage });
+    await emit({ type: "turn_end", message: abortedMessage, toolResults: [] });
+    turnOpen = false;
+    await emit({ type: "agent_end", messages: newMessages });
+    return true;
+  };
 
   // Outer loop: continues when queued follow-up messages arrive after agent would stop
   while (true) {
@@ -276,8 +300,13 @@ async function runLoop(
 
     // Inner loop: process tool calls and steering messages
     while (hasMoreToolCalls || pendingMessages.length > 0) {
+      if (await stopIfAborted()) {
+        return;
+      }
+
       if (!firstTurn) {
         await emit({ type: "turn_start" });
+        turnOpen = true;
       } else {
         firstTurn = false;
       }
@@ -290,6 +319,10 @@ async function runLoop(
           currentContext.messages.push(message);
           newMessages.push(message);
         }
+      }
+
+      if (await stopIfAborted()) {
+        return;
       }
 
       // Stream assistant response
@@ -332,6 +365,10 @@ async function runLoop(
       }
 
       await emit({ type: "turn_end", message, toolResults });
+      turnOpen = false;
+      if (await stopIfAborted()) {
+        return;
+      }
 
       const nextTurnContext = {
         message,
@@ -357,6 +394,9 @@ async function runLoop(
           reasoning: nextReasoning,
         });
       }
+      if (await stopIfAborted()) {
+        return;
+      }
 
       if (
         await config.shouldStopAfterTurn?.({
@@ -371,6 +411,9 @@ async function runLoop(
       }
 
       pendingMessages = (await config.getSteeringMessages?.()) || [];
+      if (await stopIfAborted()) {
+        return;
+      }
     }
 
     const followUpMessages = (await config.getFollowUpMessages?.()) || [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1930,8 +1930,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/normalization-core
       dompurify:
-        specifier: 3.4.9
-        version: 3.4.9
+        specifier: 3.4.11
+        version: 3.4.11
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
@@ -5112,8 +5112,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.9:
-    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -11078,7 +11078,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.9:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 

--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -14,6 +14,10 @@ const EXCLUDED_PROJECT_CONFIGS = new Set(["test/vitest/vitest.channels.config.ts
 const DEFAULT_NODE_TEST_RUNNER = "blacksmith-8vcpu-ubuntu-2404";
 const BUNDLED_NODE_TEST_RUNNER = "blacksmith-4vcpu-ubuntu-2404";
 const MAX_BUNDLED_NODE_TEST_PATTERNS = 64;
+const COMPACT_NODE_TEST_JOB_WEIGHT = 192;
+const COMPACT_NODE_TEST_JOB_GROUPS = 8;
+const COMPACT_WHOLE_NODE_TEST_JOB_GROUPS = 6;
+const COMPACT_WHOLE_NODE_TEST_TIMEOUT_MINUTES = 120;
 // Commands and cron run non-isolated, so keep their split shards as separate
 // processes. Combining their include lists can retain test state across groups.
 const BUNDLEABLE_NODE_TEST_CONFIGS = new Set(["test/vitest/vitest.infra.config.ts"]);
@@ -979,6 +983,10 @@ function bundleNameForConfigs(configs) {
  * The base plan remains unchanged for release and coverage consumers.
  */
 export function createNodeTestShardBundles(options = {}) {
+  if (options.compact === true) {
+    return createCompactNodeTestShardBundles(options);
+  }
+
   const shards = createNodeTestShards(options);
   const unbundled = [];
   const groups = new Map();
@@ -1047,4 +1055,81 @@ export function createNodeTestShardBundles(options = {}) {
   }
 
   return [...unbundled, ...bundled].toSorted((a, b) => a.checkName.localeCompare(b.checkName));
+}
+
+function createCompactNodeTestShardBundles(options = {}) {
+  const shards = createNodeTestShards(options);
+  const groupsByRunner = new Map();
+
+  for (const shard of shards) {
+    const runner = resolveCiNodeTestRunner(shard);
+    const key = JSON.stringify([runner, shard.requiresDist]);
+    const groups = groupsByRunner.get(key) ?? [];
+    groups.push({
+      configs: shard.configs,
+      ...(shard.includePatterns ? { includePatterns: shard.includePatterns } : {}),
+      requiresDist: shard.requiresDist,
+      runner,
+      shard_name: shard.shardName,
+    });
+    groupsByRunner.set(key, groups);
+  }
+
+  const compactJobs = [];
+  for (const groups of groupsByRunner.values()) {
+    const bins = [];
+    const sortedGroups = groups.toSorted(
+      (a, b) =>
+        (b.includePatterns?.length ?? 1) - (a.includePatterns?.length ?? 1) ||
+        a.shard_name.localeCompare(b.shard_name),
+    );
+    for (const group of sortedGroups.filter((candidate) => candidate.includePatterns)) {
+      const weight = group.includePatterns.length;
+      const bin = bins.find(
+        (candidate) =>
+          candidate.groups.length < COMPACT_NODE_TEST_JOB_GROUPS &&
+          candidate.weight + weight <= COMPACT_NODE_TEST_JOB_WEIGHT,
+      );
+      if (bin) {
+        bin.groups.push(group);
+        bin.weight += weight;
+      } else {
+        bins.push({ groups: [group], weight });
+      }
+    }
+
+    const wholeGroups = sortedGroups.filter((candidate) => !candidate.includePatterns);
+    for (
+      let offset = 0;
+      offset < wholeGroups.length;
+      offset += COMPACT_WHOLE_NODE_TEST_JOB_GROUPS
+    ) {
+      const groupBatch = wholeGroups.slice(offset, offset + COMPACT_WHOLE_NODE_TEST_JOB_GROUPS);
+      const runnerClass = groupBatch[0].runner.includes("-8vcpu-") ? "large" : "small";
+      const distSuffix = groupBatch[0].requiresDist ? "-dist" : "";
+      const index = offset / COMPACT_WHOLE_NODE_TEST_JOB_GROUPS + 1;
+      compactJobs.push({
+        checkName: `checks-node-compact-${runnerClass}${distSuffix}-whole-${index}`,
+        groups: groupBatch,
+        requiresDist: groupBatch[0].requiresDist,
+        runner: groupBatch[0].runner,
+        shardName: `compact-${runnerClass}${distSuffix}-whole-${index}`,
+        timeoutMinutes: COMPACT_WHOLE_NODE_TEST_TIMEOUT_MINUTES,
+      });
+    }
+
+    for (const [index, bin] of bins.entries()) {
+      const runnerClass = bin.groups[0].runner.includes("-8vcpu-") ? "large" : "small";
+      const distSuffix = bin.groups[0].requiresDist ? "-dist" : "";
+      compactJobs.push({
+        checkName: `checks-node-compact-${runnerClass}${distSuffix}-${index + 1}`,
+        groups: bin.groups,
+        requiresDist: bin.groups[0].requiresDist,
+        runner: bin.groups[0].runner,
+        shardName: `compact-${runnerClass}-${index + 1}`,
+      });
+    }
+  }
+
+  return compactJobs.toSorted((a, b) => a.checkName.localeCompare(b.checkName));
 }

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -509,6 +509,52 @@ describe("startAcpSpawnParentStreamRelay", () => {
     relay.dispose();
   });
 
+  it("relays the latest replaceable assistant snapshot instead of superseded drafts", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-replaceable-assistant",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-replaceable-assistant",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+      emitStartNotice: false,
+    });
+
+    emitAgentEvent({
+      runId: "run-replaceable-assistant",
+      stream: "assistant",
+      data: {
+        text: "coordination draft",
+        delta: "coordination draft",
+        replaceable: true,
+      },
+    });
+    emitAgentEvent({
+      runId: "run-replaceable-assistant",
+      stream: "assistant",
+      data: {
+        text: "final answer",
+        delta: "",
+        replace: true,
+        replaceable: true,
+      },
+    });
+    emitAgentEvent({
+      runId: "run-replaceable-assistant",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 1_000,
+        endedAt: 2_000,
+      },
+    });
+
+    const texts = collectedTexts();
+    expectNoTextWithFragment(texts, "coordination draft");
+    expectTextWithFragment(texts, "codex: final answer");
+    relay.dispose();
+  });
+
   it("relays commentary-phase assistant text in parent progress mode by default", () => {
     const relay = startAcpSpawnParentStreamRelay({
       runId: "run-commentary-default",

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -431,6 +431,7 @@ export function startAcpSpawnParentStreamRelay(params: {
   let disposed = false;
   let pendingText = "";
   let pendingProgressKind: string | undefined;
+  let replaceableAssistantSnapshot: string | undefined;
   const itemProgressTextById = new Map<string, string>();
   let lastProgressAt = Date.now();
   let stallNotified = false;
@@ -509,6 +510,15 @@ export function startAcpSpawnParentStreamRelay(params: {
       return;
     }
     scheduleFlush();
+  };
+
+  const flushReplaceableAssistantSnapshot = () => {
+    const snapshot = replaceableAssistantSnapshot;
+    replaceableAssistantSnapshot = undefined;
+    if (!snapshot?.trim()) {
+      return;
+    }
+    appendVisibleProgress(snapshot, "assistant:replaceable");
   };
 
   const appendItemProgressSnapshot = (snapshot: { itemId: string; text: string }) => {
@@ -605,10 +615,27 @@ export function startAcpSpawnParentStreamRelay(params: {
       const assistantPhase = normalizeAssistantPhase(
         (data as { phase?: unknown } | undefined)?.phase,
       );
-      const deltaCandidate =
-        (data as { delta?: unknown } | undefined)?.delta ??
-        (data as { text?: unknown } | undefined)?.text;
-      const delta = typeof deltaCandidate === "string" ? deltaCandidate : undefined;
+      const textCandidate = (data as { text?: unknown } | undefined)?.text;
+      const deltaCandidate = (data as { delta?: unknown } | undefined)?.delta;
+      const snapshot =
+        typeof textCandidate === "string"
+          ? textCandidate
+          : typeof deltaCandidate === "string"
+            ? deltaCandidate
+            : undefined;
+      if ((data as { replaceable?: unknown } | undefined)?.replaceable === true) {
+        if (snapshot?.trim()) {
+          replaceableAssistantSnapshot = snapshot;
+          lastProgressAt = Date.now();
+          logEvent("assistant_replaceable_snapshot", {
+            text: snapshot,
+            ...(assistantPhase ? { phase: assistantPhase } : {}),
+          });
+        }
+        return;
+      }
+
+      const delta = typeof deltaCandidate === "string" ? deltaCandidate : snapshot;
       if (!delta || !delta.trim()) {
         return;
       }
@@ -622,6 +649,7 @@ export function startAcpSpawnParentStreamRelay(params: {
         return;
       }
 
+      replaceableAssistantSnapshot = undefined;
       appendVisibleProgress(delta, `assistant:${assistantPhase ?? "unknown"}`);
       return;
     }
@@ -697,6 +725,7 @@ export function startAcpSpawnParentStreamRelay(params: {
     const phase = normalizeOptionalString((event.data as { phase?: unknown } | undefined)?.phase);
     logEvent("lifecycle", { phase: phase ?? "unknown", data: event.data });
     if (phase === "end") {
+      flushReplaceableAssistantSnapshot();
       flushPending();
       const startedAt = asFiniteNumber(
         (event.data as { startedAt?: unknown } | undefined)?.startedAt,
@@ -719,6 +748,7 @@ export function startAcpSpawnParentStreamRelay(params: {
     }
 
     if (phase === "error") {
+      flushReplaceableAssistantSnapshot();
       flushPending();
       const errorText = normalizeOptionalString(
         (event.data as { error?: unknown } | undefined)?.error,

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -29,6 +29,7 @@ const resolveEmbeddedAgentStreamFnMock = vi.fn();
 const prepareCliRunContextMock = vi.fn();
 const executePreparedCliRunMock = vi.fn();
 const diagDebugMock = vi.fn();
+const ensureSelectedAgentHarnessPluginMock = vi.fn();
 
 vi.mock("../llm/stream.js", async () => {
   const original = await vi.importActual<typeof import("../llm/stream.js")>("../llm/stream.js");
@@ -119,7 +120,7 @@ vi.mock("./model-runtime-aliases.js", () => ({
         }
       }
     }
-    return runtime || undefined;
+    return runtime === "claude-cli" ? runtime : undefined;
   },
 }));
 
@@ -129,6 +130,11 @@ vi.mock("./cli-runner/prepare.runtime.js", () => ({
 
 vi.mock("./cli-runner/execute.runtime.js", () => ({
   executePreparedCliRun: (...args: unknown[]) => executePreparedCliRunMock(...args),
+}));
+
+vi.mock("./harness/runtime-plugin.js", () => ({
+  ensureSelectedAgentHarnessPlugin: (...args: unknown[]) =>
+    ensureSelectedAgentHarnessPluginMock(...args),
 }));
 
 vi.mock("./embedded-agent-runner/runs.js", () => ({
@@ -455,6 +461,7 @@ describe("runBtwSideQuestion", () => {
     prepareCliRunContextMock.mockReset();
     executePreparedCliRunMock.mockReset();
     diagDebugMock.mockReset();
+    ensureSelectedAgentHarnessPluginMock.mockReset();
     clearAgentHarnesses();
 
     readFileMock.mockResolvedValue("mock transcript");
@@ -833,6 +840,55 @@ describe("runBtwSideQuestion", () => {
 
     expect(result).toEqual({ text: "Direct fallback answer." });
     expect(streamSimpleMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads a cold Copilot harness before selecting the /btw provider fallback", async () => {
+    let loaded = false;
+    ensureSelectedAgentHarnessPluginMock.mockImplementation(async () => {
+      if (loaded) {
+        return;
+      }
+      loaded = true;
+      registerAgentHarness({
+        id: "copilot",
+        label: "Copilot test harness",
+        supports: () => ({ supported: true, priority: 100 }),
+        runAttempt: vi.fn(),
+      });
+    });
+    resolveModelWithRegistryMock.mockReturnValue({
+      provider: "github-copilot",
+      id: "gpt-4o",
+      api: "openai-completions",
+    });
+    mockDoneAnswer("Copilot fallback answer.");
+
+    const result = await runSideQuestion({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "github-copilot/gpt-4o": { agentRuntime: { id: "copilot" } },
+            },
+          },
+        },
+      } as never,
+      provider: "github-copilot",
+      model: "gpt-4o",
+      sessionKey: DEFAULT_SESSION_KEY,
+    });
+
+    expect(result).toEqual({ text: "Copilot fallback answer." });
+    expect(ensureSelectedAgentHarnessPluginMock).toHaveBeenCalledOnce();
+    expect(ensureSelectedAgentHarnessPluginMock).toHaveBeenCalledWith({
+      provider: "github-copilot",
+      modelId: "gpt-4o",
+      config: expect.any(Object),
+      agentId: "main",
+      sessionKey: DEFAULT_SESSION_KEY,
+      workspaceDir: "/tmp/workspace",
+    });
+    expect(streamSimpleMock).toHaveBeenCalledOnce();
   });
 
   it("runs CLI-runtime alias BTW as an ephemeral CLI side question", async () => {

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -30,6 +30,7 @@ import { EmbeddedBlockChunker, type BlockReplyChunking } from "./embedded-agent-
 import { resolveModelWithRegistry } from "./embedded-agent-runner/model.js";
 import { getActiveEmbeddedRunSnapshot } from "./embedded-agent-runner/runs.js";
 import { resolveEmbeddedAgentStreamFn } from "./embedded-agent-runner/stream-resolution.js";
+import { ensureSelectedAgentHarnessPlugin } from "./harness/runtime-plugin.js";
 import {
   resolveAvailableAgentHarnessPolicy,
   resolvePluginHarnessPolicyToolsAllow,
@@ -479,13 +480,32 @@ export async function runBtwSideQuestion(
     config: params.cfg,
   });
   const workspaceDir = resolveAgentWorkspaceDir(params.cfg, sessionAgentId);
-  const harness = selectAgentHarness({
-    provider: params.provider,
-    modelId: params.model,
-    config: params.cfg,
-    agentId: sessionAgentId,
-    sessionKey: params.sessionKey,
-  });
+  const preparedHarnesses = new Map<string, AgentHarness>();
+  const prepareHarness = async (provider: string, modelId: string): Promise<AgentHarness> => {
+    const key = `${provider}/${modelId}`;
+    const cached = preparedHarnesses.get(key);
+    if (cached) {
+      return cached;
+    }
+    await ensureSelectedAgentHarnessPlugin({
+      provider,
+      modelId,
+      config: params.cfg,
+      agentId: sessionAgentId,
+      sessionKey: params.sessionKey,
+      workspaceDir,
+    });
+    const harness = selectAgentHarness({
+      provider,
+      modelId,
+      config: params.cfg,
+      agentId: sessionAgentId,
+      sessionKey: params.sessionKey,
+    });
+    preparedHarnesses.set(key, harness);
+    return harness;
+  };
+  const harness = await prepareHarness(params.provider, params.model);
   let runtimeSelection: Awaited<ReturnType<typeof resolveRuntimeModel>> | undefined;
   const resolveRuntimeSelection = async () => {
     if (!runtimeSelection) {
@@ -647,13 +667,12 @@ export async function runBtwSideQuestion(
   }
 
   const runtimeSelectionForHarness = await resolveRuntimeSelection();
-  const runtimeHarness = selectAgentHarness({
-    provider: runtimeSelectionForHarness.model.provider,
-    modelId: runtimeSelectionForHarness.model.id,
-    config: params.cfg,
-    agentId: sessionAgentId,
-    sessionKey: params.sessionKey,
-  });
+  // Model resolution can canonicalize a legacy provider alias, so reselect against the resolved
+  // provider/model instead of reusing the raw route's selection.
+  const runtimeHarness = await prepareHarness(
+    runtimeSelectionForHarness.model.provider,
+    runtimeSelectionForHarness.model.id,
+  );
   if (runtimeHarness.runSideQuestion) {
     return runHarnessSideQuestion(runtimeHarness, runtimeSelectionForHarness);
   }

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -35,6 +35,31 @@ function estimateMessageBytes(message: AgentMessage): number {
   return Buffer.byteLength(JSON.stringify(message), "utf8");
 }
 
+function findTranscriptRewriteMatches(
+  branch: readonly SessionBranchEntry[],
+  replacementsById: ReadonlyMap<string, AgentMessage>,
+): { matchedIndices: number[]; bytesFreed: number } {
+  const matchedIndices: number[] = [];
+  let bytesFreed = 0;
+
+  for (let index = 0; index < branch.length; index++) {
+    const entry = branch[index];
+    if (entry.type !== "message") {
+      continue;
+    }
+    const replacement = replacementsById.get(entry.id);
+    if (!replacement) {
+      continue;
+    }
+    const originalBytes = estimateMessageBytes(entry.message);
+    const replacementBytes = estimateMessageBytes(replacement);
+    matchedIndices.push(index);
+    bytesFreed += Math.max(0, originalBytes - replacementBytes);
+  }
+
+  return { matchedIndices, bytesFreed };
+}
+
 function remapEntryId(
   entryId: string | null | undefined,
   rewrittenEntryIds: ReadonlyMap<string, string>,
@@ -185,23 +210,7 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
     };
   }
 
-  const matchedIndices: number[] = [];
-  let bytesFreed = 0;
-
-  for (let index = 0; index < branch.length; index++) {
-    const entry = branch[index];
-    if (entry.type !== "message") {
-      continue;
-    }
-    const replacement = replacementsById.get(entry.id);
-    if (!replacement) {
-      continue;
-    }
-    const originalBytes = estimateMessageBytes(entry.message);
-    const replacementBytes = estimateMessageBytes(replacement);
-    matchedIndices.push(index);
-    bytesFreed += Math.max(0, originalBytes - replacementBytes);
-  }
+  const { matchedIndices, bytesFreed } = findTranscriptRewriteMatches(branch, replacementsById);
 
   if (matchedIndices.length === 0) {
     return {
@@ -339,23 +348,7 @@ export function rewriteTranscriptEntriesInState(params: {
     };
   }
 
-  const matchedIndices: number[] = [];
-  let bytesFreed = 0;
-
-  for (let index = 0; index < branch.length; index++) {
-    const entry = branch[index];
-    if (entry.type !== "message") {
-      continue;
-    }
-    const replacement = replacementsById.get(entry.id);
-    if (!replacement) {
-      continue;
-    }
-    const originalBytes = estimateMessageBytes(entry.message);
-    const replacementBytes = estimateMessageBytes(replacement);
-    matchedIndices.push(index);
-    bytesFreed += Math.max(0, originalBytes - replacementBytes);
-  }
+  const { matchedIndices, bytesFreed } = findTranscriptRewriteMatches(branch, replacementsById);
 
   if (matchedIndices.length === 0) {
     return {

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   ensurePluginRegistryLoaded: vi.fn(),
   resolveActivatableProviderOwnerPluginIds: vi.fn(),
   resolveBundledProviderCompatPluginIds: vi.fn(),
+  resolveManifestActivationPlan: vi.fn(),
   resolveOwningPluginIdsForProvider: vi.fn(),
 }));
 
@@ -20,6 +21,10 @@ vi.mock("../../plugins/providers.js", () => ({
   resolveOwningPluginIdsForProviderRef: mocks.resolveOwningPluginIdsForProvider,
 }));
 
+vi.mock("../../plugins/activation-planner.js", () => ({
+  resolveManifestActivationPlan: mocks.resolveManifestActivationPlan,
+}));
+
 describe("ensureSelectedAgentHarnessPlugin", () => {
   let ensureSelectedAgentHarnessPlugin: typeof import("./runtime-plugin.js").ensureSelectedAgentHarnessPlugin;
 
@@ -27,7 +32,30 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     mocks.ensurePluginRegistryLoaded.mockReset();
     mocks.resolveActivatableProviderOwnerPluginIds.mockReset();
     mocks.resolveBundledProviderCompatPluginIds.mockReset();
+    mocks.resolveManifestActivationPlan.mockReset();
     mocks.resolveOwningPluginIdsForProvider.mockReset();
+    mocks.resolveManifestActivationPlan.mockImplementation(
+      ({
+        trigger,
+        config,
+      }: {
+        trigger: { kind: "agentHarness"; runtime: string };
+        config?: OpenClawConfig;
+      }) => {
+        const pluginId = trigger.runtime;
+        const allow = config?.plugins?.allow ?? [];
+        if (
+          config?.plugins?.entries?.[pluginId]?.enabled === false ||
+          (allow.length > 0 && !allow.includes(pluginId))
+        ) {
+          return { entries: [] };
+        }
+        return {
+          entries:
+            pluginId === "codex" || pluginId === "copilot" ? [{ pluginId, origin: "bundled" }] : [],
+        };
+      },
+    );
     mocks.resolveOwningPluginIdsForProvider.mockImplementation(
       ({ provider }: { provider: string }) => (provider === "openai" ? ["openai"] : undefined),
     );
@@ -132,6 +160,61 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     );
   });
 
+  it("loads a manifest-owned custom harness runtime before selection", async () => {
+    mocks.resolveManifestActivationPlan.mockReturnValueOnce({
+      entries: [{ pluginId: "custom-harness-plugin", origin: "workspace" }],
+    });
+
+    await ensureSelectedAgentHarnessPlugin({
+      provider: "custom-provider",
+      modelId: "custom-model",
+      config: {
+        plugins: {
+          entries: {
+            "custom-harness-plugin": { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+      agentHarnessRuntimeOverride: "custom-harness",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(mocks.resolveManifestActivationPlan).toHaveBeenCalledWith({
+      trigger: { kind: "agentHarness", runtime: "custom-harness" },
+      config: expect.any(Object),
+      workspaceDir: "/tmp/workspace",
+      requireExplicitManifestOwnerTrust: true,
+    });
+    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "all",
+        workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["custom-harness-plugin", "memory-core"],
+      }),
+    );
+  });
+
+  it("does not activate an untrusted workspace harness from manifest metadata alone", async () => {
+    mocks.resolveManifestActivationPlan.mockReturnValueOnce({
+      entries: [],
+    });
+
+    await ensureSelectedAgentHarnessPlugin({
+      provider: "custom-provider",
+      modelId: "custom-model",
+      agentHarnessRuntimeOverride: "custom-harness",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(mocks.resolveManifestActivationPlan).toHaveBeenCalledWith({
+      trigger: { kind: "agentHarness", runtime: "custom-harness" },
+      config: undefined,
+      workspaceDir: "/tmp/workspace",
+      requireExplicitManifestOwnerTrust: true,
+    });
+    expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
+  });
+
   it("does not bypass a restrictive allowlist that omits a configured Copilot harness", async () => {
     // A configured harness can request loading, but explicit plugin allowlists
     // remain the operator's boundary and are not widened implicitly.
@@ -158,21 +241,7 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       workspaceDir: "/tmp/workspace",
     });
 
-    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
-      expect.objectContaining({
-        scope: "all",
-        workspaceDir: "/tmp/workspace",
-        onlyPluginIds: ["copilot"],
-        config: expect.objectContaining({
-          plugins: expect.objectContaining({
-            allow: ["telegram"],
-            entries: expect.not.objectContaining({
-              copilot: expect.anything(),
-            }),
-          }),
-        }),
-      }),
-    );
+    expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
   });
 
   it("widens a scoped harness allowlist with the provider owner for openai models", async () => {
@@ -337,22 +406,7 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     expect(mocks.resolveOwningPluginIdsForProvider).not.toHaveBeenCalled();
     expect(mocks.resolveBundledProviderCompatPluginIds).not.toHaveBeenCalled();
     expect(mocks.resolveActivatableProviderOwnerPluginIds).not.toHaveBeenCalled();
-    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
-      expect.objectContaining({
-        scope: "all",
-        workspaceDir: "/tmp/workspace",
-        onlyPluginIds: ["codex"],
-        config: expect.objectContaining({
-          plugins: expect.objectContaining({
-            allow: ["telegram"],
-            entries: expect.not.objectContaining({
-              codex: expect.anything(),
-              openai: expect.anything(),
-            }),
-          }),
-        }),
-      }),
-    );
+    expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
   });
 
   it("keeps real bundled memory-core in a Codex scoped load when the provider has no owner plugin", async () => {
@@ -417,5 +471,6 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
 
     expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
     expect(mocks.resolveOwningPluginIdsForProvider).not.toHaveBeenCalled();
+    expect(mocks.resolveManifestActivationPlan).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -3,6 +3,7 @@
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withActivatedPluginIds } from "../../plugins/activation-context.js";
+import { resolveManifestActivationPlan } from "../../plugins/activation-planner.js";
 import { resolveEffectivePluginActivationState } from "../../plugins/config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "../../plugins/default-enablement.js";
 import {
@@ -16,15 +17,8 @@ import {
 } from "../../plugins/providers.js";
 import { isDefaultAgentRuntimeId, OPENCLAW_AGENT_RUNTIME_ID } from "../agent-runtime-id.js";
 import { normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
+import { isCliRuntimeAliasForProvider } from "../model-runtime-aliases.js";
 import { resolveAgentHarnessPolicy } from "./policy.js";
-
-/**
- * Lazy-loads plugin-backed harness runtimes before selection.
- *
- * Only cold-loadable runtimes live here; always-loaded core/openclaw runtimes should not trigger
- * plugin registry scans on every embedded-agent turn.
- */
-const COLD_LOADABLE_HARNESS_PLUGIN_IDS = new Set(["codex", "copilot"]);
 
 function dedupePluginIds(values: readonly string[]): string[] {
   const seen = new Set<string>();
@@ -82,13 +76,26 @@ function resolveHarnessPluginIds(params: {
   config?: OpenClawConfig;
   workspaceDir: string;
 }): string[] {
+  const activationPlan = resolveManifestActivationPlan({
+    trigger: { kind: "agentHarness", runtime: params.runtime },
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    requireExplicitManifestOwnerTrust: true,
+  });
+  const harnessPluginIds = activationPlan.entries.map((entry) => entry.pluginId);
+  if (harnessPluginIds.length === 0) {
+    return [];
+  }
   if (params.runtime !== "codex") {
-    return [params.runtime];
+    return harnessPluginIds;
+  }
+  if (!harnessPluginIds.includes("codex")) {
+    return harnessPluginIds;
   }
   if (restrictiveAllowlistOmitsPlugin(params.config, "codex")) {
     // Respect a restrictive allowlist even when Codex would normally pull in provider owner
     // plugins. Operators who set an allowlist expect no implicit plugin expansion.
-    return ["codex"];
+    return harnessPluginIds;
   }
   const providerOwnerPluginIds = dedupePluginIds(
     resolveOwningPluginIdsForProviderRef({
@@ -98,7 +105,7 @@ function resolveHarnessPluginIds(params: {
     }) ?? [],
   );
   if (providerOwnerPluginIds.length === 0) {
-    return ["codex"];
+    return harnessPluginIds;
   }
   const safeProviderOwnerPluginIds = dedupePluginIds([
     ...resolveBundledProviderCompatPluginIds({
@@ -114,6 +121,7 @@ function resolveHarnessPluginIds(params: {
   ]);
   return dedupePluginIds([
     "codex",
+    ...harnessPluginIds,
     ...providerOwnerPluginIds.filter(
       (pluginId) => pluginId !== "codex" && safeProviderOwnerPluginIds.includes(pluginId),
     ),
@@ -164,7 +172,11 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
   if (
     isDefaultAgentRuntimeId(runtime) ||
     runtime === OPENCLAW_AGENT_RUNTIME_ID ||
-    !COLD_LOADABLE_HARNESS_PLUGIN_IDS.has(runtime)
+    isCliRuntimeAliasForProvider({
+      runtime,
+      provider: params.provider,
+      cfg: params.config,
+    })
   ) {
     return;
   }
@@ -177,6 +189,9 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
     config: params.config,
     workspaceDir: params.workspaceDir,
   });
+  if (pluginIds.length === 0) {
+    return;
+  }
   const memoryPluginIds = resolveSelectedMemoryPluginIds({
     config: params.config,
     workspaceDir: params.workspaceDir,

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -71,6 +71,8 @@ export type SupplementalContextFacts = {
   };
   untrustedContext?: Array<{ label: string; source?: string; type?: string; payload: unknown }>;
   groupSystemPrompt?: string;
+  /** Prompt-like group metadata from user-controlled sources; never enters the system prompt. */
+  untrustedGroupSystemPrompt?: string;
 };
 
 /** Raw inbound message context accepted from channels before finalization. */

--- a/src/channels/turn/types.ts
+++ b/src/channels/turn/types.ts
@@ -13,6 +13,7 @@ import type {
   InboundSourceModality,
   MentionSource,
   MsgContext,
+  SupplementalContextFacts,
 } from "../../auto-reply/templating.js";
 import type { GroupKeyResolution } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -28,6 +29,7 @@ import type { InboundLastRouteUpdate, RecordInboundSession } from "../session.ty
 import type { ChannelBotLoopProtectionFacts } from "./bot-loop-protection.js";
 
 export type { InboundEventKind } from "../inbound-event/kind.js";
+export type { SupplementalContextFacts } from "../../auto-reply/templating.js";
 
 /** Admission decision for an inbound channel event before agent dispatch. */
 export type ChannelTurnAdmission =
@@ -217,39 +219,6 @@ export type CommandFacts = {
   body?: string;
   name?: string;
   authorized?: boolean;
-};
-
-/** Quoted, forwarded, thread, and untrusted context facts attached to an inbound turn. */
-export type SupplementalContextFacts = {
-  quote?: {
-    id?: string;
-    fullId?: string;
-    body?: string;
-    sender?: string;
-    senderAllowed?: boolean;
-    isExternal?: boolean;
-    isQuote?: boolean;
-  };
-  forwarded?: {
-    from?: string;
-    fromType?: string;
-    fromId?: string;
-    date?: number;
-    senderAllowed?: boolean;
-  };
-  thread?: {
-    id?: string;
-    starterBody?: string;
-    historyBody?: string;
-    label?: string;
-    parentSessionKey?: string;
-    modelParentSessionKey?: string;
-    senderAllowed?: boolean;
-  };
-  untrustedContext?: Array<{ label: string; source?: string; type?: string; payload: unknown }>;
-  groupSystemPrompt?: string;
-  /** Prompt-like group metadata from user-controlled sources; never enters the system prompt. */
-  untrustedGroupSystemPrompt?: string;
 };
 
 /** Inbound media facts supplied to the agent context. */

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -293,10 +293,11 @@ function consumeRootLogLevelToken(args: readonly string[], index: number): numbe
   return 0;
 }
 
-export function normalizeRootNoColorArgv(
-  argv: string[],
-  options: NormalizeRootNoColorArgvOptions = {},
-): string[] {
+function splitRootOptionPrefix(argv: string[]): {
+  prefix: string[];
+  rootPrefix: string[];
+  remainingArgs: string[];
+} {
   const prefix = argv.slice(0, 2);
   const args = argv.slice(2);
   let rootPrefixEnd = 0;
@@ -312,9 +313,18 @@ export function normalizeRootNoColorArgv(
     rootPrefixEnd = index + consumed;
     index += consumed - 1;
   }
+  return {
+    prefix,
+    rootPrefix: args.slice(0, rootPrefixEnd),
+    remainingArgs: args.slice(rootPrefixEnd),
+  };
+}
 
-  const rootPrefix = args.slice(0, rootPrefixEnd);
-  const remainingArgs = args.slice(rootPrefixEnd);
+export function normalizeRootNoColorArgv(
+  argv: string[],
+  options: NormalizeRootNoColorArgvOptions = {},
+): string[] {
+  const { prefix, rootPrefix, remainingArgs } = splitRootOptionPrefix(argv);
   const movedNoColorArgs: string[] = [];
   const nextArgs: string[] = [];
   for (let index = 0; index < remainingArgs.length; index += 1) {
@@ -349,24 +359,7 @@ export function normalizeRootLogLevelArgv(
   argv: string[],
   options: NormalizeRootLogLevelArgvOptions = {},
 ): string[] {
-  const prefix = argv.slice(0, 2);
-  const args = argv.slice(2);
-  let rootPrefixEnd = 0;
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (!arg || arg === FLAG_TERMINATOR) {
-      break;
-    }
-    const consumed = consumeRootOptionToken(args, index);
-    if (consumed <= 0) {
-      break;
-    }
-    rootPrefixEnd = index + consumed;
-    index += consumed - 1;
-  }
-
-  const rootPrefix = args.slice(0, rootPrefixEnd);
-  const remainingArgs = args.slice(rootPrefixEnd);
+  const { prefix, rootPrefix, remainingArgs } = splitRootOptionPrefix(argv);
   const movedLogLevelArgs: string[] = [];
   const nextArgs: string[] = [];
   for (let index = 0; index < remainingArgs.length; index += 1) {

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runRegisteredCli } from "../test-utils/command-runner.js";
-import { registerCapabilityCli } from "./capability-cli.js";
+import { CAPABILITY_METADATA, registerCapabilityCli } from "./capability-cli.js";
 
 const PNG_1X1_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+yf7kAAAAASUVORK5CYII=";
@@ -1891,6 +1891,37 @@ describe("capability cli", () => {
       "--output",
       "--json",
     ]);
+  });
+
+  it("keeps capability inspect metadata flags in sync with each command's registered options", () => {
+    const program = new Command();
+    registerCapabilityCli(program);
+    const capability =
+      program.commands.find((command) => command.name() === "infer") ??
+      program.commands.find((command) => command.aliases().includes("capability"));
+    expect(capability).toBeDefined();
+
+    const registeredFlags = (id: string): string[] => {
+      let command: Command | undefined = capability;
+      for (const segment of id.split(".")) {
+        command = command?.commands.find((child) => child.name() === segment);
+      }
+      if (!command) {
+        throw new Error(`no registered command for capability id ${id}`);
+      }
+      return command.options
+        .map((option) => option.long)
+        .filter((long): long is string => Boolean(long));
+    };
+
+    // CAPABILITY_METADATA.flags is the inspect/list contract; it must list exactly what each
+    // command actually registers, or `infer inspect` reports working flags as unsupported.
+    for (const entry of CAPABILITY_METADATA) {
+      expect({ id: entry.id, flags: entry.flags }).toEqual({
+        id: entry.id,
+        flags: registeredFlags(entry.id),
+      });
+    }
   });
 
   it("streams url-only generated videos to --output paths", async () => {

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -138,12 +138,12 @@ type CapabilityEnvelope = {
   error?: string;
 };
 
-const CAPABILITY_METADATA: CapabilityMetadata[] = [
+export const CAPABILITY_METADATA: CapabilityMetadata[] = [
   {
     id: "model.run",
     description: "Run a one-shot inference turn through the selected model provider.",
     transports: ["local", "gateway"],
-    flags: ["--prompt", "--file", "--model", "--local", "--gateway", "--json"],
+    flags: ["--prompt", "--file", "--model", "--thinking", "--local", "--gateway", "--json"],
     resultShape: "normalized payloads plus provider/model attribution",
   },
   {
@@ -171,14 +171,14 @@ const CAPABILITY_METADATA: CapabilityMetadata[] = [
     id: "model.auth.login",
     description: "Run the existing provider auth login flow.",
     transports: ["local"],
-    flags: ["--provider"],
+    flags: ["--provider", "--method"],
     resultShape: "interactive auth result",
   },
   {
     id: "model.auth.logout",
     description: "Remove saved auth profiles for one provider.",
     transports: ["local"],
-    flags: ["--provider", "--json"],
+    flags: ["--provider", "--agent", "--json"],
     resultShape: "removed profile ids",
   },
   {
@@ -257,7 +257,7 @@ const CAPABILITY_METADATA: CapabilityMetadata[] = [
     id: "audio.transcribe",
     description: "Transcribe one audio file.",
     transports: ["local"],
-    flags: ["--file", "--model", "--json"],
+    flags: ["--file", "--language", "--prompt", "--model", "--json"],
     resultShape: "normalized text output",
   },
   {

--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import JSON5 from "json5";
 import { beforeAll, describe, expect, it } from "vitest";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
-import { captureEnv } from "../test-utils/env.js";
+import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { runConfigSet } from "./config-cli.js";
 
 function createTestRuntime() {
@@ -91,8 +91,8 @@ async function withExecDryRunConfigHarness(
       "utf8",
     );
 
-    process.env.OPENCLAW_TEST_FAST = "1";
-    process.env.OPENCLAW_CONFIG_PATH = configPath;
+    setTestEnvValue("OPENCLAW_TEST_FAST", "1");
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
     clearConfigCache();
     clearRuntimeConfigSnapshot();
 
@@ -117,8 +117,8 @@ describe("config cli integration", () => {
     const envSnapshot = captureEnv(["OPENCLAW_CONFIG_PATH", "OPENCLAW_TEST_FAST"]);
     try {
       fs.writeFileSync(configPath, `${JSON.stringify({ gateway: { port: 18789 } }, null, 2)}\n`);
-      process.env.OPENCLAW_TEST_FAST = "1";
-      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      setTestEnvValue("OPENCLAW_TEST_FAST", "1");
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
       clearConfigCache();
       clearRuntimeConfigSnapshot();
       await runConfigSet({
@@ -152,8 +152,8 @@ describe("config cli integration", () => {
         "utf8",
       );
 
-      process.env.OPENCLAW_TEST_FAST = "1";
-      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      setTestEnvValue("OPENCLAW_TEST_FAST", "1");
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
       clearConfigCache();
       clearRuntimeConfigSnapshot();
 
@@ -222,9 +222,9 @@ describe("config cli integration", () => {
         "utf8",
       );
 
-      process.env.OPENCLAW_TEST_FAST = "1";
-      process.env.OPENCLAW_CONFIG_PATH = configPath;
-      process.env.DISCORD_BOT_TOKEN = "test-token";
+      setTestEnvValue("OPENCLAW_TEST_FAST", "1");
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      setTestEnvValue("DISCORD_BOT_TOKEN", "test-token");
       clearConfigCache();
       clearRuntimeConfigSnapshot();
 
@@ -293,9 +293,9 @@ describe("config cli integration", () => {
         "utf8",
       );
 
-      process.env.OPENCLAW_TEST_FAST = "1";
-      process.env.OPENCLAW_CONFIG_PATH = configPath;
-      delete process.env.MISSING_TEST_SECRET;
+      setTestEnvValue("OPENCLAW_TEST_FAST", "1");
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      deleteTestEnvValue("MISSING_TEST_SECRET");
       clearConfigCache();
       clearRuntimeConfigSnapshot();
 

--- a/src/commands/channels.resolve.test.ts
+++ b/src/commands/channels.resolve.test.ts
@@ -23,12 +23,16 @@ vi.mock("../cli/command-secret-targets.js", () => ({
   getChannelsCommandSecretTargetIds: mocks.getChannelsCommandSecretTargetIds,
 }));
 
-vi.mock("../config/config.js", () => ({
-  getRuntimeConfig: mocks.loadConfig,
-  loadConfig: mocks.loadConfig,
-  readConfigFileSnapshot: mocks.readConfigFileSnapshot,
-  replaceConfigFile: mocks.replaceConfigFile,
-}));
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return {
+    ...actual,
+    getRuntimeConfig: mocks.loadConfig,
+    loadConfig: mocks.loadConfig,
+    readConfigFileSnapshot: mocks.readConfigFileSnapshot,
+    replaceConfigFile: mocks.replaceConfigFile,
+  };
+});
 
 vi.mock("../cli/plugins-registry-refresh.js", () => ({
   refreshPluginRegistryAfterConfigMutation: mocks.refreshPluginRegistryAfterConfigMutation,

--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -18,12 +18,16 @@ const mocks = vi.hoisted(() => ({
   listReadOnlyChannelPluginsForConfig: vi.fn(),
 }));
 
-vi.mock("./shared.js", () => ({
-  requireValidConfig: vi.fn(async () => ({ channels: {} })),
-  formatChannelAccountLabel: vi.fn(
-    ({ channel, accountId }: { channel: string; accountId: string }) => `${channel}:${accountId}`,
-  ),
-}));
+vi.mock("./shared.js", async () => {
+  const actual = await vi.importActual<typeof import("./shared.js")>("./shared.js");
+  return {
+    ...actual,
+    requireValidConfig: vi.fn(async () => ({ channels: {} })),
+    formatChannelAccountLabel: vi.fn(
+      ({ channel, accountId }: { channel: string; accountId: string }) => `${channel}:${accountId}`,
+    ),
+  };
+});
 
 vi.mock("../../channels/plugins/index.js", () => ({
   listChannelPlugins: vi.fn(),
@@ -242,9 +246,7 @@ describe("channelsCapabilitiesCommand", () => {
 
     await channelsCapabilitiesCommand({ channel: "slack", timeout: "999999" }, runtime);
 
-    expect(probeAccount).toHaveBeenCalledWith(
-      expect.objectContaining({ timeoutMs: 30_000 }),
-    );
+    expect(probeAccount).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 30_000 }));
     expect(buildCapabilitiesDiagnostics).toHaveBeenCalledWith(
       expect.objectContaining({ timeoutMs: 30_000 }),
     );
@@ -274,10 +276,7 @@ describe("channelsCapabilitiesCommand", () => {
       configChanged: false,
     });
 
-    await channelsCapabilitiesCommand(
-      { channel: "slack", json: true, timeout: "1" },
-      runtime,
-    );
+    await channelsCapabilitiesCommand({ channel: "slack", json: true, timeout: "1" }, runtime);
 
     const payload = JSON.parse(logs[0] ?? "{}") as {
       channels?: Array<{ probe?: unknown }>;
@@ -343,10 +342,7 @@ describe("channelsCapabilitiesCommand", () => {
       configChanged: false,
     });
 
-    await channelsCapabilitiesCommand(
-      { channel: "slack", json: true, timeout: "1" },
-      runtime,
-    );
+    await channelsCapabilitiesCommand({ channel: "slack", json: true, timeout: "1" }, runtime);
 
     const payload = JSON.parse(logs[0] ?? "{}") as {
       channels?: Array<{ diagnostics?: unknown }>;

--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -19,17 +19,13 @@ import type {
 import { formatCliCommand } from "../../cli/command-format.js";
 import { formatUnknownChannelMessage } from "../../cli/error-format.js";
 import { parseTimeoutMsWithFallback } from "../../cli/parse-timeout.js";
-import { commitConfigWithPendingPluginInstalls } from "../../cli/plugins-install-record-commit.js";
-import { refreshPluginRegistryAfterConfigMutation } from "../../cli/plugins-registry-refresh.js";
-import {
-  readConfigFileSnapshot,
-  replaceConfigFile,
-  type OpenClawConfig,
-} from "../../config/config.js";
+import { readConfigFileSnapshot } from "../../config/config.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { danger } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { resolveInstallableChannelPlugin } from "../channel-setup/channel-plugin-resolution.js";
+import { persistResolvedChannelPluginConfig } from "./plugin-config-persistence.js";
 import { formatChannelAccountLabel, requireValidConfig } from "./shared.js";
 
 export type ChannelsCapabilitiesOptions = {
@@ -351,35 +347,11 @@ export async function channelsCapabilitiesCommand(
             allowInstall: true,
           });
           if (resolved.configChanged) {
-            cfg = resolved.cfg;
-            const shouldMovePluginInstalls = Boolean(
-              cfg.plugins?.installs && Object.keys(cfg.plugins.installs).length > 0,
-            );
-            if (shouldMovePluginInstalls) {
-              const committed = await commitConfigWithPendingPluginInstalls({
-                nextConfig: cfg,
-                baseHash: (await sourceSnapshotPromise)?.hash,
-              });
-              cfg = committed.config;
-              await refreshPluginRegistryAfterConfigMutation({
-                config: cfg,
-                reason: "source-changed",
-                installRecords: committed.installRecords,
-                logger: { warn: (message) => runtime.log(message) },
-              });
-            } else {
-              await replaceConfigFile({
-                nextConfig: cfg,
-                baseHash: (await sourceSnapshotPromise)?.hash,
-              });
-              if (resolved.pluginInstalled) {
-                await refreshPluginRegistryAfterConfigMutation({
-                  config: cfg,
-                  reason: "source-changed",
-                  logger: { warn: (message) => runtime.log(message) },
-                });
-              }
-            }
+            cfg = await persistResolvedChannelPluginConfig({
+              resolved,
+              baseHash: (await sourceSnapshotPromise)?.hash,
+              runtime,
+            });
           }
           return resolved.plugin ? [resolved.plugin] : null;
         })();

--- a/src/commands/channels/plugin-config-persistence.ts
+++ b/src/commands/channels/plugin-config-persistence.ts
@@ -1,0 +1,50 @@
+import { commitConfigWithPendingPluginInstalls } from "../../cli/plugins-install-record-commit.js";
+import { refreshPluginRegistryAfterConfigMutation } from "../../cli/plugins-registry-refresh.js";
+import { replaceConfigFile } from "../../config/config.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { RuntimeEnv } from "../../runtime.js";
+
+export async function persistResolvedChannelPluginConfig(params: {
+  resolved: {
+    cfg: OpenClawConfig;
+    configChanged: boolean;
+    pluginInstalled: boolean;
+  };
+  baseHash?: string;
+  runtime: RuntimeEnv;
+}): Promise<OpenClawConfig> {
+  if (!params.resolved.configChanged) {
+    return params.resolved.cfg;
+  }
+
+  const cfg = params.resolved.cfg;
+  const shouldMovePluginInstalls = Boolean(
+    cfg.plugins?.installs && Object.keys(cfg.plugins.installs).length > 0,
+  );
+  if (shouldMovePluginInstalls) {
+    const committed = await commitConfigWithPendingPluginInstalls({
+      nextConfig: cfg,
+      baseHash: params.baseHash,
+    });
+    await refreshPluginRegistryAfterConfigMutation({
+      config: committed.config,
+      reason: "source-changed",
+      installRecords: committed.installRecords,
+      logger: { warn: (message) => params.runtime.log(message) },
+    });
+    return committed.config;
+  }
+
+  await replaceConfigFile({
+    nextConfig: cfg,
+    baseHash: params.baseHash,
+  });
+  if (params.resolved.pluginInstalled) {
+    await refreshPluginRegistryAfterConfigMutation({
+      config: cfg,
+      reason: "source-changed",
+      logger: { warn: (message) => params.runtime.log(message) },
+    });
+  }
+  return cfg;
+}

--- a/src/commands/channels/resolve.ts
+++ b/src/commands/channels/resolve.ts
@@ -13,17 +13,12 @@ import { resolveCommandConfigWithSecrets } from "../../cli/command-config-resolu
 import { formatCliCommand } from "../../cli/command-format.js";
 import { getChannelsCommandSecretTargetIds } from "../../cli/command-secret-targets.js";
 import { formatUnsupportedChannelActionMessage } from "../../cli/error-format.js";
-import { commitConfigWithPendingPluginInstalls } from "../../cli/plugins-install-record-commit.js";
-import { refreshPluginRegistryAfterConfigMutation } from "../../cli/plugins-registry-refresh.js";
-import {
-  getRuntimeConfig,
-  readConfigFileSnapshot,
-  replaceConfigFile,
-} from "../../config/config.js";
+import { getRuntimeConfig, readConfigFileSnapshot } from "../../config/config.js";
 import { danger } from "../../globals.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { resolveInstallableChannelPlugin } from "../channel-setup/channel-plugin-resolution.js";
+import { persistResolvedChannelPluginConfig } from "./plugin-config-persistence.js";
 
 export type ChannelsResolveOptions = {
   channel?: string;
@@ -156,35 +151,11 @@ export async function channelsResolveCommand(opts: ChannelsResolveOptions, runti
     );
   }
   if (resolvedExplicit?.configChanged) {
-    cfg = resolvedExplicit.cfg;
-    const shouldMovePluginInstalls = Boolean(
-      cfg.plugins?.installs && Object.keys(cfg.plugins.installs).length > 0,
-    );
-    if (shouldMovePluginInstalls) {
-      const committed = await commitConfigWithPendingPluginInstalls({
-        nextConfig: cfg,
-        baseHash: (await sourceSnapshotPromise)?.hash,
-      });
-      cfg = committed.config;
-      await refreshPluginRegistryAfterConfigMutation({
-        config: cfg,
-        reason: "source-changed",
-        installRecords: committed.installRecords,
-        logger: { warn: (message) => runtime.log(message) },
-      });
-    } else {
-      await replaceConfigFile({
-        nextConfig: cfg,
-        baseHash: (await sourceSnapshotPromise)?.hash,
-      });
-      if (resolvedExplicit.pluginInstalled) {
-        await refreshPluginRegistryAfterConfigMutation({
-          config: cfg,
-          reason: "source-changed",
-          logger: { warn: (message) => runtime.log(message) },
-        });
-      }
-    }
+    cfg = await persistResolvedChannelPluginConfig({
+      resolved: resolvedExplicit,
+      baseHash: (await sourceSnapshotPromise)?.hash,
+      runtime,
+    });
   }
 
   const selection = explicitChannel

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -245,16 +245,16 @@ describe("maybeRepairGatewayDaemon", () => {
     });
   }
 
-  async function runAutoRepair() {
+  async function runAutoRepair(options: { repair?: boolean; yes?: boolean } = { repair: true }) {
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
     await maybeRepairGatewayDaemon({
       cfg: { gateway: {} },
       runtime,
       prompter: createDoctorPrompter({
         runtime,
-        options: { repair: true },
+        options,
       }),
-      options: { deep: false, repair: true },
+      options: { deep: false, ...options },
       gatewayDetailsMessage: "details",
       healthOk: false,
     });
@@ -540,6 +540,39 @@ describe("maybeRepairGatewayDaemon", () => {
     await runNonInteractiveUpdateRepair();
 
     expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("skips running service restart during non-interactive repairs", async () => {
+    setPlatform("linux");
+
+    await runNonInteractiveRepair();
+
+    expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("starts stopped service during non-interactive repairs", async () => {
+    setPlatform("linux");
+    service.readRuntime.mockResolvedValue({ status: "stopped" });
+
+    await runNonInteractiveRepair();
+
+    expect(service.restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("restarts running service when repair is explicitly approved", async () => {
+    setPlatform("linux");
+
+    await runAutoRepair();
+
+    expect(service.restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("restarts running service when --yes explicitly approves repairs", async () => {
+    setPlatform("linux");
+
+    await runAutoRepair({ yes: true });
+
+    expect(service.restart).toHaveBeenCalledTimes(1);
   });
 
   it("skips gateway service install when service repair policy is external", async () => {

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -459,6 +459,10 @@ export async function maybeRepairGatewayDaemon(params: {
         // Health probe failed — fall through to the restart prompt below.
       }
     }
+    if (params.options.nonInteractive === true) {
+      // --fix auto-approves runtime repairs; do not let a headless doctor kill its live gateway.
+      return;
+    }
 
     const restart = await confirmDoctorServiceRepair(
       params.prompter,

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -51,6 +51,7 @@ const mocks = vi.hoisted(() => ({
   installPluginFromClawHub: vi.fn(),
   installPluginFromNpmSpec: vi.fn(),
   listChannelPluginCatalogEntries: vi.fn(),
+  listOfficialExternalChannelEnvVars: vi.fn(() => []),
   listOfficialExternalPluginCatalogEntries: vi.fn(),
   loadInstalledPluginIndex: vi.fn(),
   loadInstalledPluginIndexInstallRecords: vi.fn(),
@@ -160,6 +161,7 @@ vi.mock("../../../plugins/plugin-metadata-snapshot.js", () => ({
 
 vi.mock("../../../plugins/official-external-plugin-catalog.js", () => ({
   getOfficialExternalPluginCatalogManifest: mocks.getOfficialExternalPluginCatalogManifest,
+  listOfficialExternalChannelEnvVars: mocks.listOfficialExternalChannelEnvVars,
   listOfficialExternalPluginCatalogEntries: mocks.listOfficialExternalPluginCatalogEntries,
   resolveOfficialExternalPluginId: mocks.resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginInstall: mocks.resolveOfficialExternalPluginInstall,

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -983,6 +983,15 @@ describe("gateway-status command", () => {
     ]);
   });
 
+  it("passes the full caller timeout through to active configured remote probes", async () => {
+    const { runtime } = createRuntimeCapture();
+    probeGateway.mockClear();
+
+    await runGatewayStatus(runtime, { timeout: "15000", json: true });
+
+    expect(requireProbeCall("wss://remote.example:18789").timeoutMs).toBe(15_000);
+  });
+
   it("uses configured handshake timeout as the default local probe budget", async () => {
     const { runtime } = createRuntimeCapture();
     probeGateway.mockClear();

--- a/src/commands/gateway-status/helpers.test.ts
+++ b/src/commands/gateway-status/helpers.test.ts
@@ -436,18 +436,28 @@ describe("resolveProbeBudgetMs", () => {
     ).toBe(2_500);
   });
 
-  it("keeps non-local probe caps unchanged", () => {
+  it("lets active remote probes use the full caller budget", () => {
     expect(
       resolveProbeBudgetMs(15_000, {
         kind: "configRemote",
         active: true,
         url: "wss://gateway.example/ws",
       }),
-    ).toBe(1500);
+    ).toBe(15_000);
     expect(
       resolveProbeBudgetMs(15_000, {
         kind: "explicit",
         active: true,
+        url: "wss://gateway.example/ws",
+      }),
+    ).toBe(15_000);
+  });
+
+  it("keeps inactive remote and SSH tunnel probes on the short cap", () => {
+    expect(
+      resolveProbeBudgetMs(15_000, {
+        kind: "configRemote",
+        active: false,
         url: "wss://gateway.example/ws",
       }),
     ).toBe(1500);

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -150,15 +150,15 @@ export function resolveProbeBudgetMs(
   if (target.kind === "sshTunnel") {
     return Math.min(2000, overallMs);
   }
+  if (target.active) {
+    return overallMs;
+  }
+  if (target.kind === "localLoopback") {
+    return Math.min(800, overallMs);
+  }
   if (!isLoopbackProbeTarget(target)) {
     return Math.min(1500, overallMs);
   }
-  if (target.kind === "localLoopback" && !target.active) {
-    return Math.min(800, overallMs);
-  }
-  // Active/discovered loopback probes and explicit loopback URLs should honor
-  // the caller budget because healthy local detail RPCs can legitimately take
-  // longer than the legacy short caps.
   return overallMs;
 }
 

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -9,6 +9,7 @@ import {
   upsertApiKeyProfile,
   writeOAuthCredentials,
 } from "../plugins/provider-auth-helpers.js";
+import { setTestEnvValue } from "../test-utils/env.js";
 import {
   createAuthTestLifecycle,
   readAuthProfilesForAgent,
@@ -162,7 +163,8 @@ describe("writeOAuthCredentials", () => {
 
   it("writes OAuth credentials to all sibling agent dirs when syncSiblingAgents=true", async () => {
     tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-oauth-sync-"));
-    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+    lifecycle.setStateDir(tempStateDir);
+    setTestEnvValue("OPENCLAW_STATE_DIR", tempStateDir);
 
     const mainAgentDir = path.join(tempStateDir, "agents", "main", "agent");
     const kidAgentDir = path.join(tempStateDir, "agents", "kid", "agent");
@@ -171,7 +173,7 @@ describe("writeOAuthCredentials", () => {
     await fs.mkdir(kidAgentDir, { recursive: true });
     await fs.mkdir(workerAgentDir, { recursive: true });
 
-    process.env.OPENCLAW_AGENT_DIR = kidAgentDir;
+    setTestEnvValue("OPENCLAW_AGENT_DIR", kidAgentDir);
 
     const creds = {
       refresh: "refresh-sync",
@@ -198,14 +200,15 @@ describe("writeOAuthCredentials", () => {
 
   it("writes OAuth credentials only to target dir by default", async () => {
     tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-oauth-nosync-"));
-    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+    lifecycle.setStateDir(tempStateDir);
+    setTestEnvValue("OPENCLAW_STATE_DIR", tempStateDir);
 
     const mainAgentDir = path.join(tempStateDir, "agents", "main", "agent");
     const kidAgentDir = path.join(tempStateDir, "agents", "kid", "agent");
     await fs.mkdir(mainAgentDir, { recursive: true });
     await fs.mkdir(kidAgentDir, { recursive: true });
 
-    process.env.OPENCLAW_AGENT_DIR = kidAgentDir;
+    setTestEnvValue("OPENCLAW_AGENT_DIR", kidAgentDir);
 
     const creds = {
       refresh: "refresh-kid",
@@ -229,7 +232,8 @@ describe("writeOAuthCredentials", () => {
 
   it("syncs siblings from explicit agentDir outside OPENCLAW_STATE_DIR", async () => {
     tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-oauth-external-"));
-    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+    lifecycle.setStateDir(tempStateDir);
+    setTestEnvValue("OPENCLAW_STATE_DIR", tempStateDir);
 
     // Create standard-layout agents tree *outside* OPENCLAW_STATE_DIR
     const externalRoot = path.join(tempStateDir, "external", "agents");

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -6,7 +6,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { MigrationApplyResult, MigrationPlan } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
-import { captureEnv } from "../test-utils/env.js";
+import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { createThrowingRuntime } from "./onboard-non-interactive.test-helpers.js";
 import type { installGatewayDaemonNonInteractive } from "./onboard-non-interactive/local/daemon-install.js";
 
@@ -336,8 +336,8 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       throw new Error("temp home not initialized");
     }
     const stateDir = await fs.mkdtemp(path.join(tempHome, prefix));
-    process.env.OPENCLAW_STATE_DIR = stateDir;
-    delete process.env.OPENCLAW_CONFIG_PATH;
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    deleteTestEnvValue("OPENCLAW_CONFIG_PATH");
     return stateDir;
   };
   const withStateDir = async (
@@ -364,16 +364,16 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       "OPENCLAW_GATEWAY_TOKEN",
       "OPENCLAW_GATEWAY_PASSWORD",
     ]);
-    process.env.OPENCLAW_SKIP_CHANNELS = "1";
-    process.env.OPENCLAW_SKIP_GMAIL_WATCHER = "1";
-    process.env.OPENCLAW_SKIP_CRON = "1";
-    process.env.OPENCLAW_SKIP_CANVAS_HOST = "1";
-    process.env.OPENCLAW_SKIP_BROWSER_CONTROL_SERVER = "1";
-    delete process.env.OPENCLAW_GATEWAY_TOKEN;
-    delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+    setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
+    setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
+    setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
+    setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
+    setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
+    deleteTestEnvValue("OPENCLAW_GATEWAY_TOKEN");
+    deleteTestEnvValue("OPENCLAW_GATEWAY_PASSWORD");
 
     tempHome = await makeTempWorkspace("openclaw-onboard-");
-    process.env.HOME = tempHome;
+    setTestEnvValue("HOME", tempHome);
 
     await loadGatewayOnboardModules();
   });
@@ -969,8 +969,8 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       return;
     }
     await withStateDir("state-lan-", async (stateDir) => {
-      process.env.OPENCLAW_STATE_DIR = stateDir;
-      process.env.OPENCLAW_CONFIG_PATH = path.join(stateDir, "openclaw.json");
+      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
 
       const port = getPseudoPort(40_000);
       const workspace = path.join(stateDir, "openclaw");

--- a/src/config/mcp-config.ts
+++ b/src/config/mcp-config.ts
@@ -67,9 +67,10 @@ export async function listConfiguredMcpServers(): Promise<ConfigMcpReadResult> {
   };
 }
 
-export async function updateConfiguredMcpServerTools(params: {
+async function updateConfiguredMcpServerConfig(params: {
   name: string;
-  tools: McpServerToolSelection | null;
+  update: (server: Record<string, unknown>) => Record<string, unknown>;
+  errorLabel: string;
 }): Promise<ConfigMcpWriteResult> {
   const name = params.name.trim();
   if (!name) {
@@ -92,22 +93,7 @@ export async function updateConfiguredMcpServerTools(params: {
 
   const next = structuredClone(loaded.config);
   const servers = normalizeConfiguredMcpServers(next.mcp?.servers);
-  const server = { ...servers[name] };
-  if (params.tools === null) {
-    delete server.toolFilter;
-  } else {
-    const include = normalizeToolSelectionList(params.tools.include);
-    const exclude = normalizeToolSelectionList(params.tools.exclude);
-    if (include || exclude) {
-      server.toolFilter = {
-        ...(include ? { include } : {}),
-        ...(exclude ? { exclude } : {}),
-      };
-    } else {
-      delete server.toolFilter;
-    }
-  }
-  servers[name] = server;
+  servers[name] = params.update({ ...servers[name] });
   next.mcp = {
     ...next.mcp,
     servers,
@@ -119,7 +105,7 @@ export async function updateConfiguredMcpServerTools(params: {
     return {
       ok: false,
       path: loaded.path,
-      error: `Config invalid after MCP tool selection update (${issue.path}: ${issue.message}).`,
+      error: `Config invalid after MCP ${params.errorLabel} (${issue.path}: ${issue.message}).`,
     };
   }
   await replaceConfigFile({
@@ -135,57 +121,42 @@ export async function updateConfiguredMcpServerTools(params: {
   };
 }
 
+export async function updateConfiguredMcpServerTools(params: {
+  name: string;
+  tools: McpServerToolSelection | null;
+}): Promise<ConfigMcpWriteResult> {
+  return updateConfiguredMcpServerConfig({
+    name: params.name,
+    errorLabel: "tool selection update",
+    update: (server) => {
+      if (params.tools === null) {
+        delete server.toolFilter;
+      } else {
+        const include = normalizeToolSelectionList(params.tools.include);
+        const exclude = normalizeToolSelectionList(params.tools.exclude);
+        if (include || exclude) {
+          server.toolFilter = {
+            ...(include ? { include } : {}),
+            ...(exclude ? { exclude } : {}),
+          };
+        } else {
+          delete server.toolFilter;
+        }
+      }
+      return server;
+    },
+  });
+}
+
 export async function updateConfiguredMcpServer(params: {
   name: string;
   update: (server: Record<string, unknown>) => Record<string, unknown>;
 }): Promise<ConfigMcpWriteResult> {
-  const name = params.name.trim();
-  if (!name) {
-    return { ok: false, path: "", error: "MCP server name is required." };
-  }
-
-  const loaded = await listConfiguredMcpServers();
-  if (!loaded.ok) {
-    return loaded;
-  }
-  if (!Object.hasOwn(loaded.mcpServers, name)) {
-    return {
-      ok: true,
-      path: loaded.path,
-      config: loaded.config,
-      mcpServers: loaded.mcpServers,
-      updated: false,
-    };
-  }
-
-  const next = structuredClone(loaded.config);
-  const servers = normalizeConfiguredMcpServers(next.mcp?.servers);
-  servers[name] = canonicalizeConfiguredMcpServer(params.update({ ...servers[name] }));
-  next.mcp = {
-    ...next.mcp,
-    servers,
-  };
-
-  const validated = validateConfigObjectWithPlugins(next);
-  if (!validated.ok) {
-    const issue = validated.issues[0];
-    return {
-      ok: false,
-      path: loaded.path,
-      error: `Config invalid after MCP configure (${issue.path}: ${issue.message}).`,
-    };
-  }
-  await replaceConfigFile({
-    nextConfig: validated.config,
-    baseHash: loaded.baseHash,
+  return updateConfiguredMcpServerConfig({
+    name: params.name,
+    errorLabel: "configure",
+    update: (server) => canonicalizeConfiguredMcpServer(params.update(server)),
   });
-  return {
-    ok: true,
-    path: loaded.path,
-    config: validated.config,
-    mcpServers: servers,
-    updated: true,
-  };
 }
 
 export async function setConfiguredMcpServer(params: {

--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -28,6 +28,9 @@ vi.mock("../channels/plugins/configured-state.js", async (importOriginal) => {
       cfg: OpenClawConfig;
       env?: NodeJS.ProcessEnv;
     }) => {
+      if (params.channelId === "cache-channel") {
+        return Boolean(params.env?.CACHE_CHANNEL_TOKEN?.trim());
+      }
       if (params.channelId === "irc") {
         return Boolean(params.env?.IRC_HOST?.trim() && params.env?.IRC_NICK?.trim());
       }
@@ -1198,10 +1201,11 @@ describe("applyPluginAutoEnable core", () => {
   it("does not reuse same-turn auto-enable results after discovery mutates in place", () => {
     const config: OpenClawConfig = {};
     const mutableDiscovery: PluginDiscoveryResult = { candidates: [], diagnostics: [] };
-    const manifestRegistry = makeRegistry([{ id: "irc-plugin", channels: ["irc"] }]);
+    const manifestRegistry = makeRegistry([
+      { id: "cache-channel-plugin", channels: ["cache-channel"] },
+    ]);
     const configuredEnv = makeIsolatedEnv({
-      IRC_HOST: "irc.libera.chat",
-      IRC_NICK: "openclaw-bot",
+      CACHE_CHANNEL_TOKEN: "configured",
     });
 
     const first = applyPluginAutoEnable({
@@ -1211,7 +1215,10 @@ describe("applyPluginAutoEnable core", () => {
       manifestRegistry,
     });
     mutableDiscovery.candidates.push(
-      makeBundledChannelCandidate({ pluginId: "irc-plugin", channelId: "irc" }),
+      makeBundledChannelCandidate({
+        pluginId: "cache-channel-plugin",
+        channelId: "cache-channel",
+      }),
     );
     const second = applyPluginAutoEnable({
       config,
@@ -1220,8 +1227,8 @@ describe("applyPluginAutoEnable core", () => {
       manifestRegistry,
     });
 
-    expect(first.config.plugins?.entries?.["irc-plugin"]).toBeUndefined();
-    expect(second.config.plugins?.entries?.["irc-plugin"]?.enabled).toBe(true);
+    expect(first.config.plugins?.entries?.["cache-channel-plugin"]).toBeUndefined();
+    expect(second.config.plugins?.entries?.["cache-channel-plugin"]?.enabled).toBe(true);
     expect(second).not.toBe(first);
   });
 

--- a/src/gateway/agent-event-assistant-text.ts
+++ b/src/gateway/agent-event-assistant-text.ts
@@ -11,3 +11,15 @@ export function resolveAssistantStreamDeltaText(evt: AgentEventPayload): string 
   const text = evt.data.text;
   return typeof delta === "string" ? delta : typeof text === "string" ? text : "";
 }
+
+export function isReplaceableAssistantStreamEvent(evt: AgentEventPayload): boolean {
+  return evt.data.replaceable === true;
+}
+
+export function resolveAssistantStreamSnapshotText(evt: AgentEventPayload): string {
+  const text = evt.data.text;
+  if (typeof text === "string") {
+    return text;
+  }
+  return resolveAssistantStreamDeltaText(evt);
+}

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2313,6 +2313,81 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     },
   );
 
+  it("buffers replaceable assistant events for streaming chat completions", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "final answer", delta: "", replace: true, replaceable: true },
+      });
+      emitAgentEvent({ runId, stream: "assistant", data: { text: "final answer" } });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+      return { payloads: [{ text: "final answer" }] };
+    }) as never);
+
+    const res = await postChatCompletions(port, {
+      stream: true,
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(res.status).toBe(200);
+    const data = parseSseDataLines(await res.text());
+    const chunks = data
+      .filter((d) => d !== "[DONE]")
+      .map((d) => JSON.parse(d) as Record<string, unknown>);
+    const allContent = chunks
+      .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
+      .map((choice) => (choice.delta as Record<string, unknown> | undefined)?.content)
+      .filter((content): content is string => typeof content === "string")
+      .join("");
+
+    expect(allContent).toBe("final answer");
+    expect(allContent).not.toContain("coordination draft");
+  });
+
+  it("prefers final result text over buffered replaceable chat drafts", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+      });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+      return { payloads: [{ text: "final answer" }] };
+    }) as never);
+
+    const res = await postChatCompletions(port, {
+      stream: true,
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(res.status).toBe(200);
+    const data = parseSseDataLines(await res.text());
+    const chunks = data
+      .filter((d) => d !== "[DONE]")
+      .map((d) => JSON.parse(d) as Record<string, unknown>);
+    const allContent = chunks
+      .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
+      .map((choice) => (choice.delta as Record<string, unknown> | undefined)?.content)
+      .filter((content): content is string => typeof content === "string")
+      .join("");
+
+    expect(allContent).toBe("final answer");
+  });
+
   it("includes usage in final stream chunk when stream_options.include_usage=true", async () => {
     const port = enabledPort;
     agentCommand.mockClear();

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -35,7 +35,11 @@ import {
   type InputImageSource,
 } from "../media/input-files.js";
 import { defaultRuntime } from "../runtime.js";
-import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
+import {
+  isReplaceableAssistantStreamEvent,
+  resolveAssistantStreamDeltaText,
+  resolveAssistantStreamSnapshotText,
+} from "./agent-event-assistant-text.js";
 import {
   buildAgentMessageFromConversationEntries,
   type ConversationEntry,
@@ -1180,6 +1184,7 @@ export async function handleOpenAiHttpRequest(
   let wroteStopChunk = false;
   let sawAssistantDelta = false;
   let bufferedAssistantContent = "";
+  let bufferedReplaceableAssistantContent = "";
   let finalUsage: OpenAiChatCompletionsUsage | undefined;
   let finalizeRequested = false;
   let finalizeFinishReason: "stop" | "tool_calls" = "stop";
@@ -1226,6 +1231,20 @@ export async function handleOpenAiHttpRequest(
     }
 
     if (evt.stream === "assistant") {
+      const text = evt.data?.text;
+      const replace = evt.data?.replace === true;
+      if (replace && typeof text === "string") {
+        bufferedReplaceableAssistantContent = text;
+      }
+
+      if (isReplaceableAssistantStreamEvent(evt)) {
+        const snapshot = resolveAssistantStreamSnapshotText(evt);
+        if (snapshot) {
+          bufferedReplaceableAssistantContent = snapshot;
+        }
+        return;
+      }
+
       const content = resolveAssistantStreamDeltaText(evt) ?? "";
       if (!content) {
         return;
@@ -1313,7 +1332,10 @@ export async function handleOpenAiHttpRequest(
           writeAssistantRoleChunk(res, { runId, model });
         }
         if (!sawAssistantDelta) {
-          const commentary = bufferedAssistantContent || resolveAgentResponseCommentary(result);
+          const commentary =
+            bufferedAssistantContent ||
+            resolveAgentResponseCommentary(result) ||
+            bufferedReplaceableAssistantContent;
           if (commentary) {
             sawAssistantDelta = true;
             writeAssistantContentChunk(res, {
@@ -1339,7 +1361,11 @@ export async function handleOpenAiHttpRequest(
           writeAssistantRoleChunk(res, { runId, model });
         }
 
-        const content = resolveAgentResponseText(result);
+        const content =
+          resolveAgentResponseCommentary(result) ||
+          bufferedReplaceableAssistantContent ||
+          resolveAgentResponseText(result) ||
+          "No response from OpenClaw.";
 
         sawAssistantDelta = true;
         writeAssistantContentChunk(res, {

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1372,6 +1372,83 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(response?.output?.[1]?.name).toBe("get_weather");
   });
 
+  it("buffers replaceable assistant events for streaming responses", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "final answer", delta: "", replace: true, replaceable: true },
+      });
+      emitAgentEvent({ runId, stream: "assistant", data: { text: "final answer" } });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+      return { payloads: [{ text: "final answer" }] };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const events = parseSseEvents(await res.text());
+    const deltas = events
+      .filter((event) => event.event === "response.output_text.delta")
+      .map((event) => {
+        const parsed = JSON.parse(event.data) as { delta?: string };
+        return parsed.delta ?? "";
+      })
+      .join("");
+    const completed = JSON.parse(findSseEvent(events, "response.completed").data) as {
+      response?: { output?: Array<{ content?: Array<{ text?: string }> }> };
+    };
+
+    expect(deltas).toBe("final answer");
+    expect(completed.response?.output?.[0]?.content?.[0]?.text).toBe("final answer");
+    expect(deltas).not.toContain("coordination draft");
+  });
+
+  it("prefers final result text over buffered replaceable response drafts", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+      });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+      return { payloads: [{ text: "final answer" }] };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const events = parseSseEvents(await res.text());
+    const deltas = events
+      .filter((event) => event.event === "response.output_text.delta")
+      .map((event) => {
+        const parsed = JSON.parse(event.data) as { delta?: string };
+        return parsed.delta ?? "";
+      })
+      .join("");
+
+    expect(deltas).toBe("final answer");
+  });
+
   it("falls back to payload text for streamed function_call responses", async () => {
     const port = enabledPort;
     agentCommand.mockClear();

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -33,7 +33,11 @@ import {
   type InputImageSource,
 } from "../media/input-files.js";
 import { defaultRuntime } from "../runtime.js";
-import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
+import {
+  isReplaceableAssistantStreamEvent,
+  resolveAssistantStreamDeltaText,
+  resolveAssistantStreamSnapshotText,
+} from "./agent-event-assistant-text.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import {
@@ -912,11 +916,13 @@ export async function handleOpenResponsesHttpRequest(
   setSseHeaders(res);
 
   let accumulatedText = "";
+  let bufferedReplaceableAssistantContent = "";
   let sawAssistantDelta = false;
   let closed = false;
   let unsubscribe = () => {};
   let stopWatchingDisconnect = () => {};
   let finalUsage: Usage | undefined;
+  let finalizeStatus: ResponseResource["status"] | null = null;
   let finalizeRequested: { status: ResponseResource["status"]; text: string } | null = null;
 
   const maybeFinalize = () => {
@@ -982,6 +988,7 @@ export async function handleOpenResponsesHttpRequest(
     if (finalizeRequested) {
       return;
     }
+    finalizeStatus = status;
     finalizeRequested = { status, text };
     maybeFinalize();
   };
@@ -1028,13 +1035,39 @@ export async function handleOpenResponsesHttpRequest(
     }
 
     if (evt.stream === "assistant") {
+      if (isReplaceableAssistantStreamEvent(evt)) {
+        const snapshot = resolveAssistantStreamSnapshotText(evt);
+        if (snapshot) {
+          bufferedReplaceableAssistantContent = snapshot;
+        }
+        return;
+      }
+
       const text = evt.data?.text;
       const replace = evt.data?.replace === true;
+      const hadAssistantDelta = sawAssistantDelta;
       if (replace && typeof text === "string") {
         accumulatedText = text;
       }
+
       const content = resolveAssistantStreamDeltaText(evt);
       if (!content) {
+        if (
+          replace &&
+          typeof text === "string" &&
+          text &&
+          !toolChoiceConstraint &&
+          !hadAssistantDelta
+        ) {
+          sawAssistantDelta = true;
+          writeSseEvent(res, {
+            type: "response.output_text.delta",
+            item_id: outputItemId,
+            output_index: 0,
+            content_index: 0,
+            delta: text,
+          });
+        }
         return;
       }
 
@@ -1064,7 +1097,8 @@ export async function handleOpenResponsesHttpRequest(
     if (evt.stream === "lifecycle") {
       const phase = evt.data?.phase;
       if (phase === "end" || phase === "error") {
-        const finalText = accumulatedText || "No response from OpenClaw.";
+        const finalText =
+          accumulatedText || bufferedReplaceableAssistantContent || "No response from OpenClaw.";
         const finalStatus = phase === "error" ? "failed" : "completed";
         requestFinalize(finalStatus, finalText);
       }
@@ -1097,6 +1131,12 @@ export async function handleOpenResponsesHttpRequest(
       // Check for pending client tool calls BEFORE maybeFinalize() because the
       // lifecycle:end event may already have requested finalization.
       const resultAny = result as { payloads?: Array<{ text?: string }>; meta?: unknown };
+      const resultPayloadText = Array.isArray(resultAny.payloads)
+        ? resultAny.payloads
+            .map((p) => (typeof p.text === "string" ? p.text : ""))
+            .filter(Boolean)
+            .join("\n\n")
+        : "";
       const meta = resultAny.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 
@@ -1137,22 +1177,16 @@ export async function handleOpenResponsesHttpRequest(
       ) {
         const usage = finalUsage ?? createEmptyUsage();
         const finalText =
-          accumulatedText ||
-          (Array.isArray(resultAny.payloads)
-            ? resultAny.payloads
-                .map((p) => (typeof p.text === "string" ? p.text : ""))
-                .filter(Boolean)
-                .join("\n\n")
-            : "");
+          accumulatedText || resultPayloadText || bufferedReplaceableAssistantContent;
 
-        if (toolChoiceConstraint && accumulatedText) {
+        if (toolChoiceConstraint && finalText && !sawAssistantDelta) {
           sawAssistantDelta = true;
           writeSseEvent(res, {
             type: "response.output_text.delta",
             item_id: outputItemId,
             output_index: 0,
             content_index: 0,
-            delta: accumulatedText,
+            delta: finalText,
           });
         }
         writeSseEvent(res, {
@@ -1237,25 +1271,16 @@ export async function handleOpenResponsesHttpRequest(
         return;
       }
 
-      maybeFinalize();
-
-      if (closed) {
-        return;
-      }
-
       // Fallback: if no streaming deltas were received, send the full response as text
       if (!sawAssistantDelta) {
-        const payloads = resultAny.payloads;
         const content =
-          Array.isArray(payloads) && payloads.length > 0
-            ? payloads
-                .map((p) => (typeof p.text === "string" ? p.text : ""))
-                .filter(Boolean)
-                .join("\n\n")
-            : "No response from OpenClaw.";
+          resultPayloadText || bufferedReplaceableAssistantContent || "No response from OpenClaw.";
 
         accumulatedText = content;
         sawAssistantDelta = true;
+        if (finalizeStatus !== null) {
+          finalizeRequested = { status: finalizeStatus, text: content };
+        }
 
         writeSseEvent(res, {
           type: "response.output_text.delta",
@@ -1265,6 +1290,8 @@ export async function handleOpenResponsesHttpRequest(
           delta: content,
         });
       }
+
+      maybeFinalize();
     } catch (err) {
       if (closed || abortController.signal.aborted) {
         return;

--- a/src/gateway/server-chat.stream-text-merge.test.ts
+++ b/src/gateway/server-chat.stream-text-merge.test.ts
@@ -60,6 +60,29 @@ describe("server chat stream text merge", () => {
     ).toBe("Before tool call\nAfter tool call");
   });
 
+  it("replaces prior live text when Codex assistant item switches with empty delta", () => {
+    const prior = "coordination draft";
+    const replacement = resolveMergedAssistantText({
+      previousText: prior,
+      nextText: "final answer",
+      nextDelta: "",
+    });
+
+    expect(replacement).toBe("final answer");
+    expect(replacement).not.toContain(prior);
+  });
+
+  it("would concatenate superseded text if replacement incorrectly included delta", () => {
+    const prior = "coordination draft";
+    const buggy = resolveMergedAssistantText({
+      previousText: prior,
+      nextText: "final ",
+      nextDelta: "final ",
+    });
+
+    expect(buggy).toBe("coordination draftfinal ");
+  });
+
   it("caps merged live text while preserving the newest assistant output", () => {
     const result = resolveMergedAssistantText({
       previousText: "a".repeat(MAX_LIVE_CHAT_BUFFER_CHARS - 2),

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -149,7 +149,6 @@ import {
 import { reactivateCompletedSubagentSession } from "../session-subagent-reactivation.js";
 import {
   canonicalizeSpawnedByForAgent,
-  loadGatewaySessionRow,
   loadSessionEntry,
   migrateAndPruneGatewaySessionStoreKey,
   resolveGatewaySessionStoreTarget,
@@ -166,6 +165,7 @@ import {
   waitForTerminalGatewayDedupe,
 } from "./agent-wait-dedupe.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
+import { emitSessionsChanged } from "./session-change-event.js";
 import type {
   GatewayRequestContext,
   GatewayRequestHandlerOptions,
@@ -569,92 +569,6 @@ function requestGroupMatchesTrusted(params: {
     return true;
   }
   return Boolean(params.trustedGroupId && requestGroupId === params.trustedGroupId);
-}
-
-function emitSessionsChanged(
-  context: Pick<
-    GatewayRequestHandlerOptions["context"],
-    "broadcastToConnIds" | "getSessionEventSubscriberConnIds"
-  >,
-  payload: { sessionKey?: string; agentId?: string; reason: string },
-) {
-  const connIds = context.getSessionEventSubscriberConnIds();
-  if (connIds.size === 0) {
-    return;
-  }
-  const sessionRow = payload.sessionKey
-    ? loadGatewaySessionRow(
-        payload.sessionKey,
-        payload.sessionKey === "global" && payload.agentId
-          ? { agentId: payload.agentId }
-          : undefined,
-      )
-    : null;
-  // Unscoped global updates must not leak one agent's goal into another agent's UI row.
-  const omitUnscopedGlobalGoal = payload.sessionKey === "global" && !payload.agentId;
-  context.broadcastToConnIds(
-    "sessions.changed",
-    {
-      ...payload,
-      ts: Date.now(),
-      ...(sessionRow
-        ? {
-            updatedAt: sessionRow.updatedAt ?? undefined,
-            sessionId: sessionRow.sessionId,
-            kind: sessionRow.kind,
-            channel: sessionRow.channel,
-            subject: sessionRow.subject,
-            groupChannel: sessionRow.groupChannel,
-            space: sessionRow.space,
-            chatType: sessionRow.chatType,
-            origin: sessionRow.origin,
-            spawnedBy: sessionRow.spawnedBy,
-            spawnedWorkspaceDir: sessionRow.spawnedWorkspaceDir,
-            spawnedCwd: sessionRow.spawnedCwd,
-            forkedFromParent: sessionRow.forkedFromParent,
-            spawnDepth: sessionRow.spawnDepth,
-            subagentRole: sessionRow.subagentRole,
-            subagentControlScope: sessionRow.subagentControlScope,
-            label: sessionRow.label,
-            displayName: sessionRow.displayName,
-            deliveryContext: sessionRow.deliveryContext,
-            parentSessionKey: sessionRow.parentSessionKey,
-            childSessions: sessionRow.childSessions,
-            thinkingLevel: sessionRow.thinkingLevel,
-            fastMode: sessionRow.fastMode,
-            verboseLevel: sessionRow.verboseLevel,
-            traceLevel: sessionRow.traceLevel,
-            reasoningLevel: sessionRow.reasoningLevel,
-            elevatedLevel: sessionRow.elevatedLevel,
-            sendPolicy: sessionRow.sendPolicy,
-            systemSent: sessionRow.systemSent,
-            abortedLastRun: sessionRow.abortedLastRun,
-            inputTokens: sessionRow.inputTokens,
-            outputTokens: sessionRow.outputTokens,
-            lastChannel: sessionRow.lastChannel,
-            lastTo: sessionRow.lastTo,
-            lastAccountId: sessionRow.lastAccountId,
-            lastThreadId: sessionRow.lastThreadId,
-            totalTokens: sessionRow.totalTokens,
-            totalTokensFresh: sessionRow.totalTokensFresh,
-            ...(omitUnscopedGlobalGoal ? {} : { goal: sessionRow.goal ?? null }),
-            contextTokens: sessionRow.contextTokens,
-            estimatedCostUsd: sessionRow.estimatedCostUsd,
-            responseUsage: sessionRow.responseUsage,
-            modelProvider: sessionRow.modelProvider,
-            model: sessionRow.model,
-            status: sessionRow.status,
-            startedAt: sessionRow.startedAt,
-            endedAt: sessionRow.endedAt,
-            runtimeMs: sessionRow.runtimeMs,
-            compactionCheckpointCount: sessionRow.compactionCheckpointCount,
-            latestCompactionCheckpoint: sessionRow.latestCompactionCheckpoint,
-          }
-        : {}),
-    },
-    connIds,
-    { dropIfSlow: true },
-  );
 }
 
 type GatewayAgentTaskTerminalStatus = Extract<

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -53,7 +53,7 @@ import {
   pinActivePluginSessionExtensionRegistry,
 } from "../plugins/runtime.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
-import { getTotalQueueSize } from "../process/command-queue.js";
+import { getTotalQueueSize, isGatewayDraining } from "../process/command-queue.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   clearSecretsRuntimeSnapshot,
@@ -876,6 +876,7 @@ export async function startGatewayServer(
     startedAt: serverStartedAt,
     getStartupPending: isGatewayStartupPending,
     getStartupPendingReason: () => startupPendingReason,
+    getGatewayDraining: isGatewayDraining,
     getEventLoopHealth: readinessEventLoopHealth.snapshot,
     shouldSkipChannelReadiness: () =>
       isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -68,6 +68,7 @@ function createReadinessHarness(params: {
   accounts?: Record<string, Partial<ChannelAccountSnapshot>>;
   getStartupPending?: () => boolean;
   getStartupPendingReason?: Parameters<typeof createReadinessChecker>[0]["getStartupPendingReason"];
+  getGatewayDraining?: Parameters<typeof createReadinessChecker>[0]["getGatewayDraining"];
   getEventLoopHealth?: Parameters<typeof createReadinessChecker>[0]["getEventLoopHealth"];
   shouldSkipChannelReadiness?: Parameters<
     typeof createReadinessChecker
@@ -83,6 +84,7 @@ function createReadinessHarness(params: {
       startedAt,
       getStartupPending: params.getStartupPending,
       getStartupPendingReason: params.getStartupPendingReason,
+      getGatewayDraining: params.getGatewayDraining,
       getEventLoopHealth: params.getEventLoopHealth,
       shouldSkipChannelReadiness: params.shouldSkipChannelReadiness,
       cacheTtlMs: params.cacheTtlMs,
@@ -173,6 +175,35 @@ describe("createReadinessChecker", () => {
       expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
 
       startupPending = false;
+      expect(readiness()).toEqual(readySnapshot());
+      expect(manager.getRuntimeSnapshot).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("reports not ready while the gateway command queue is draining for restart", () => {
+    withReadinessClock(() => {
+      const { manager, readiness } = createReadinessHarness({
+        getGatewayDraining: () => true,
+        cacheTtlMs: 1_000,
+      });
+
+      expect(readiness()).toEqual(failingSnapshot(["gateway-draining"]));
+      expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not cache gateway-draining readiness", () => {
+    withReadinessClock(() => {
+      let gatewayDraining = true;
+      const { manager, readiness } = createReadinessHarness({
+        getGatewayDraining: () => gatewayDraining,
+        cacheTtlMs: 1_000,
+      });
+
+      expect(readiness()).toEqual(failingSnapshot(["gateway-draining"]));
+      expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
+
+      gatewayDraining = false;
       expect(readiness()).toEqual(readySnapshot());
       expect(manager.getRuntimeSnapshot).toHaveBeenCalledTimes(1);
     });

--- a/src/gateway/server/readiness.ts
+++ b/src/gateway/server/readiness.ts
@@ -42,6 +42,7 @@ export function createReadinessChecker(deps: {
   startedAt: number;
   getStartupPending?: () => boolean;
   getStartupPendingReason?: () => string | undefined;
+  getGatewayDraining?: () => boolean;
   getEventLoopHealth?: () => GatewayEventLoopHealth | undefined;
   shouldSkipChannelReadiness?: () => boolean;
   cacheTtlMs?: number;
@@ -58,6 +59,12 @@ export function createReadinessChecker(deps: {
       const reason = deps.getStartupPendingReason?.() ?? "startup-sidecars";
       return withEventLoopHealth(
         { ready: false, failing: [reason], uptimeMs },
+        deps.getEventLoopHealth,
+      );
+    }
+    if (deps.getGatewayDraining?.()) {
+      return withEventLoopHealth(
+        { ready: false, failing: ["gateway-draining"], uptimeMs },
         deps.getEventLoopHealth,
       );
     }

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1691,6 +1691,45 @@ describe("gateway session utils", () => {
   });
 
   test("listAgentsForGateway reports per-agent thinking defaults from the agent model", () => {
+    const resolveDeepSeekThinkingProfile = vi.fn(() => ({
+      levels: [
+        { id: "off" as const },
+        { id: "minimal" as const },
+        { id: "low" as const },
+        { id: "medium" as const },
+        { id: "high" as const },
+        { id: "xhigh" as const },
+      ],
+      defaultLevel: "medium" as const,
+    }));
+    const registry = createEmptyPluginRegistry();
+    registry.providers.push(
+      {
+        pluginId: "test-minimax",
+        source: "test",
+        provider: {
+          id: "minimax",
+          label: "MiniMax",
+          auth: [],
+          resolveThinkingProfile: () => ({
+            levels: [{ id: "off" }],
+            defaultLevel: "off",
+          }),
+        },
+      },
+      {
+        pluginId: "test-deepseek",
+        source: "test",
+        provider: {
+          id: "deepseek",
+          label: "DeepSeek",
+          auth: [],
+          resolveThinkingProfile: resolveDeepSeekThinkingProfile,
+        },
+      },
+    );
+    setActivePluginRegistry(registry);
+
     const cfg = {
       session: { mainKey: "main" },
       agents: {
@@ -1713,6 +1752,12 @@ describe("gateway session utils", () => {
     const agent = result.agents.find((row) => row.id === "investment-master");
 
     expect(agent?.model).toEqual({ primary: "deepseek/deepseek-v4-flash" });
+    expect(resolveDeepSeekThinkingProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "deepseek",
+        modelId: "deepseek-v4-flash",
+      }),
+    );
     expect(agent?.thinkingDefault).toBe("xhigh");
     expect(agent?.thinkingLevels?.map((level) => level.id)).toEqual(
       expect.arrayContaining(["off", "minimal", "low", "medium", "high", "xhigh"]),

--- a/src/plugins/activation-planner.test.ts
+++ b/src/plugins/activation-planner.test.ts
@@ -69,6 +69,30 @@ describe("activation planner", () => {
           origin: "bundled",
         },
         {
+          id: "custom-harness-plugin",
+          providers: [],
+          channels: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+          activation: {
+            onAgentHarnesses: ["custom-harness"],
+          },
+          origin: "workspace",
+        },
+        {
+          id: "load-path-harness-plugin",
+          providers: [],
+          channels: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+          activation: {
+            onAgentHarnesses: ["load-path-harness"],
+          },
+          origin: "config",
+        },
+        {
           id: "demo-channel",
           channels: ["telegram"],
           providers: [],
@@ -141,6 +165,92 @@ describe("activation planner", () => {
           kind: "command",
           command: "memory",
         },
+      }),
+    ).toEqual([]);
+  });
+
+  it("plans manifest-owned custom harnesses and respects their activation policy", () => {
+    expect(
+      resolveManifestActivationPluginIds({
+        trigger: {
+          kind: "agentHarness",
+          runtime: "custom-harness",
+        },
+      }),
+    ).toEqual(["custom-harness-plugin"]);
+
+    expect(
+      resolveManifestActivationPluginIds({
+        config: {
+          plugins: {
+            entries: {
+              "custom-harness-plugin": { enabled: false },
+            },
+          },
+        },
+        trigger: {
+          kind: "agentHarness",
+          runtime: "custom-harness",
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("requires canonical ids for explicit manifest owner trust", () => {
+    expect(
+      resolveManifestActivationPluginIds({
+        config: {
+          plugins: {
+            allow: ["legacy-custom-harness-plugin"],
+          },
+        },
+        trigger: {
+          kind: "agentHarness",
+          runtime: "custom-harness",
+        },
+        requireExplicitManifestOwnerTrust: true,
+      }),
+    ).toEqual([]);
+
+    expect(
+      resolveManifestActivationPluginIds({
+        config: {
+          plugins: {
+            allow: ["custom-harness-plugin"],
+          },
+        },
+        trigger: {
+          kind: "agentHarness",
+          runtime: "custom-harness",
+        },
+        requireExplicitManifestOwnerTrust: true,
+      }),
+    ).toEqual(["custom-harness-plugin"]);
+  });
+
+  it("treats load-path manifest owners as explicitly trusted for activation planning", () => {
+    expect(
+      resolveManifestActivationPluginIds({
+        trigger: {
+          kind: "agentHarness",
+          runtime: "load-path-harness",
+        },
+        requireExplicitManifestOwnerTrust: true,
+      }),
+    ).toEqual(["load-path-harness-plugin"]);
+
+    expect(
+      resolveManifestActivationPluginIds({
+        config: {
+          plugins: {
+            deny: ["load-path-harness-plugin"],
+          },
+        },
+        trigger: {
+          kind: "agentHarness",
+          runtime: "load-path-harness",
+        },
+        requireExplicitManifestOwnerTrust: true,
       }),
     ).toEqual([]);
   });

--- a/src/plugins/activation-planner.ts
+++ b/src/plugins/activation-planner.ts
@@ -4,7 +4,11 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.js";
 import { normalizePluginsConfig } from "./config-state.js";
-import { passesManifestOwnerBasePolicy } from "./manifest-owner-policy.js";
+import {
+  hasExplicitManifestOwnerTrust,
+  isBundledManifestOwner,
+  passesManifestOwnerBasePolicy,
+} from "./manifest-owner-policy.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
 import type { PluginManifestActivationCapability } from "./manifest.js";
@@ -63,6 +67,7 @@ type ResolveManifestActivationPlanParams = {
   onlyPluginIds?: readonly string[];
   manifestRecords?: readonly PluginManifestRecord[];
   allowRestrictiveAllowlistBypass?: boolean;
+  requireExplicitManifestOwnerTrust?: boolean;
 };
 
 /** Returns a deterministic activation plan without importing plugin runtime modules. */
@@ -70,7 +75,6 @@ export function resolveManifestActivationPlan(
   params: ResolveManifestActivationPlanParams,
 ): PluginActivationPlan {
   const onlyPluginIdSet = createPluginIdScopeSet(normalizePluginIdScope(params.onlyPluginIds));
-  const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
   const registry = params.manifestRecords
     ? { plugins: params.manifestRecords, diagnostics: [] }
     : loadPluginManifestRegistryForPluginRegistry({
@@ -79,6 +83,7 @@ export function resolveManifestActivationPlan(
         env: params.env,
         includeDisabled: true,
       });
+  const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
   const entries = registry.plugins
     .flatMap((plugin) => {
       if (params.origin && plugin.origin !== params.origin) {
@@ -92,6 +97,15 @@ export function resolveManifestActivationPlan(
           plugin,
           normalizedConfig,
           allowRestrictiveAllowlistBypass: params.allowRestrictiveAllowlistBypass,
+        })
+      ) {
+        return [];
+      }
+      if (
+        params.requireExplicitManifestOwnerTrust &&
+        !hasExplicitActivationPlannerManifestOwnerTrust({
+          plugin,
+          normalizedConfig,
         })
       ) {
         return [];
@@ -123,6 +137,23 @@ export function resolveManifestActivationPluginIds(
   params: ResolveManifestActivationPlanParams,
 ): string[] {
   return [...resolveManifestActivationPlan(params).pluginIds];
+}
+
+function hasExplicitActivationPlannerManifestOwnerTrust(params: {
+  plugin: Pick<PluginManifestRecord, "id" | "origin">;
+  normalizedConfig: ReturnType<typeof normalizePluginsConfig>;
+}): boolean {
+  // plugins.load.paths is already an operator-selected trust boundary. Keep
+  // the trust local to planner callers so setup-only channel imports retain
+  // their stricter scoped-import policy.
+  return (
+    isBundledManifestOwner(params.plugin) ||
+    params.plugin.origin === "config" ||
+    hasExplicitManifestOwnerTrust({
+      plugin: params.plugin,
+      normalizedConfig: params.normalizedConfig,
+    })
+  );
 }
 
 function listManifestActivationTriggerReasons(

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -150,6 +150,38 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
     );
   });
 
+  it("compacts pull-request shards into isolated groups inside fewer jobs", () => {
+    const base = createNodeTestShards({ includeReleaseOnlyPluginShards: false });
+    const compact = createNodeTestShardBundles({
+      includeReleaseOnlyPluginShards: false,
+      compact: true,
+    });
+
+    expect(compact.length).toBeLessThan(40);
+    expect(compact.every((shard) => Array.isArray(shard.groups))).toBe(true);
+    expect(compact.some((shard) => shard.requiresDist)).toBe(true);
+    expect(
+      compact.every((shard) =>
+        shard.groups.every((group) => group.requiresDist === shard.requiresDist),
+      ),
+    ).toBe(true);
+    expect(
+      compact
+        .flatMap((shard) => shard.groups.flatMap((group) => group.includePatterns ?? []))
+        .toSorted((a, b) => a.localeCompare(b)),
+    ).toEqual(
+      base.flatMap((shard) => shard.includePatterns ?? []).toSorted((a, b) => a.localeCompare(b)),
+    );
+    expect(compact.every((shard) => shard.groups.every((group) => group.configs.length > 0))).toBe(
+      true,
+    );
+    expect(
+      compact
+        .filter((shard) => shard.groups.some((group) => !group.includePatterns))
+        .every((shard) => shard.timeoutMinutes === 120),
+    ).toBe(true);
+  });
+
   it("splits the slow core unit shards while keeping paired source/security coverage", () => {
     const coreUnitShards = createNodeTestShards()
       .filter((shard) => shard.shardName.startsWith("core-unit-"))

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -108,14 +108,30 @@ describe("ci workflow guards", () => {
     expect(workflow.concurrency["cancel-in-progress"]).toContain(
       "github.event_name == 'pull_request'",
     );
-    expect(workflow.jobs["checks-fast-core"].strategy["max-parallel"]).toBe(4);
-    expect(workflow.jobs["checks-node-core-test-nondist-shard"].strategy["max-parallel"]).toBe(6);
-    expect(workflow.jobs["checks-fast-plugin-contracts-shard"].strategy["max-parallel"]).toBe(4);
-    expect(workflow.jobs["checks-fast-channel-contracts-shard"].strategy["max-parallel"]).toBe(4);
-    expect(workflow.jobs["check-shard"].strategy["max-parallel"]).toBe(4);
-    expect(workflow.jobs["check-additional-shard"].strategy["max-parallel"]).toBe(4);
+    expect(workflow.jobs["checks-fast-core"].strategy["max-parallel"]).toBe(8);
+    expect(workflow.jobs["checks-node-core-test-nondist-shard"].strategy["max-parallel"]).toBe(12);
+    expect(workflow.jobs["checks-fast-plugin-contracts-shard"].strategy["max-parallel"]).toBe(8);
+    expect(workflow.jobs["checks-fast-channel-contracts-shard"].strategy["max-parallel"]).toBe(8);
+    expect(workflow.jobs["check-shard"].strategy["max-parallel"]).toBe(8);
+    expect(workflow.jobs["check-additional-shard"].strategy["max-parallel"]).toBe(8);
     expect(workflow.jobs["checks-windows"].strategy["max-parallel"]).toBe(2);
     expect(workflow.jobs.android.strategy["max-parallel"]).toBe(2);
+  });
+
+  it("debounces canonical main pushes before Blacksmith admission", () => {
+    const workflow = readCiWorkflow();
+    const source = readFileSync(".github/workflows/ci.yml", "utf8");
+    const admission = workflow.jobs["runner-admission"];
+
+    expect(admission["runs-on"]).toBe("ubuntu-24.04");
+    expect(admission.steps[0].if).toContain("github.ref == 'refs/heads/main'");
+    expect(admission.steps[0].run).toContain('sleep "${OPENCLAW_MAIN_CI_DEBOUNCE_SECONDS}"');
+    expect(admission.env.OPENCLAW_MAIN_CI_DEBOUNCE_SECONDS).toBe("90");
+    expect(workflow.jobs.preflight.needs).toContain("runner-admission");
+    expect(workflow.jobs["security-fast"].needs).toContain("runner-admission");
+    expect(source).toContain(
+      "cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'openclaw/openclaw' && github.ref == 'refs/heads/main') }}",
+    );
   });
 
   it("uses bundled Node shards and telemetry-backed runner sizes", () => {
@@ -440,10 +456,12 @@ describe("ci workflow guards", () => {
 
   it("fails and retries quiet Node test shard stalls quickly", () => {
     const workflow = readCiWorkflow();
+    const preflightJob = workflow.jobs.preflight;
     const nodeTestJob = workflow.jobs["checks-node-core-test-nondist-shard"];
     const runStep = nodeTestJob.steps.find((step) => step.name === "Run Node test shard");
 
-    expect(nodeTestJob["timeout-minutes"]).toBe(60);
+    expect(JSON.stringify(preflightJob.steps)).toContain("timeout_minutes: shard.timeoutMinutes");
+    expect(nodeTestJob["timeout-minutes"]).toBe("${{ matrix.timeout_minutes || 60 }}");
     expect(runStep.env.OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS).toBe("300000");
     expect(runStep.env.OPENCLAW_VITEST_NO_OUTPUT_RETRY).toBe("1");
     expect(runStep.env.OPENCLAW_TEST_PROJECTS_PARALLEL).toBe("2");

--- a/test/scripts/kitchen-sink-plugin-assertions.test.ts
+++ b/test/scripts/kitchen-sink-plugin-assertions.test.ts
@@ -14,6 +14,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const ASSERTIONS_SCRIPT = "scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs";
+const BASH_BIN = process.platform === "win32" ? "bash" : "/bin/bash";
 const SWEEP_SCRIPT = "scripts/e2e/lib/kitchen-sink-plugin/sweep.sh";
 const REQUIRED_FULL_DIAGNOSTIC_CANARIES = [
   "agent tool result middleware must be a function",
@@ -225,11 +226,40 @@ function runScanLogs({
 }
 
 function runSweepShell(script: string, env: NodeJS.ProcessEnv = {}) {
-  return spawnSync("/bin/bash", ["-c", script], {
+  return spawnSync(BASH_BIN, ["-c", toBashScript(script)], {
     cwd: process.cwd(),
     encoding: "utf8",
-    env: { ...process.env, ...env },
+    env: { ...process.env, ...toBashEnv(env) },
   });
+}
+
+function toBashScript(script: string) {
+  if (process.platform === "win32") {
+    return `export PATH="/usr/bin:/bin:$PATH"\n${script}`;
+  }
+  return script;
+}
+
+function toBashEnv(env: NodeJS.ProcessEnv) {
+  if (process.platform !== "win32") {
+    return env;
+  }
+
+  return Object.fromEntries(
+    Object.entries(env).map(([key, value]) => [
+      key,
+      typeof value === "string" ? toGitBashPath(value) : value,
+    ]),
+  );
+}
+
+function toGitBashPath(value: string) {
+  const match = /^([A-Za-z]):[\\/](.*)$/u.exec(value);
+  if (!match) {
+    return value;
+  }
+
+  return `/${match[1].toLowerCase()}/${match[2].replaceAll("\\", "/")}`;
 }
 
 describe("kitchen-sink plugin assertions", () => {

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -1370,7 +1370,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
           cwd: process.cwd(),
           env: {
             ...process.env,
-            OPENCLAW_CROSS_OS_PROCESS_TREE_KILL_AFTER_MS: "25",
+            OPENCLAW_CROSS_OS_PROCESS_TREE_KILL_AFTER_MS: "200",
             OPENCLAW_TEST_CHILD_PID: childPidPath,
           },
           stdio: ["ignore", "ignore", "pipe"],
@@ -1384,7 +1384,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       const result = await waitForExit(runner, 5_000);
 
       expect(result).toEqual({ signal: null, status: 143 });
-      await waitForDead(childPid, 2_000);
+      await waitForDead(childPid, 10_000);
     } finally {
       if (runnerPid !== undefined && isProcessAlive(runnerPid)) {
         process.kill(runnerPid, "SIGKILL");

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -120,6 +120,12 @@ describe("package acceptance workflow", () => {
     const existingCloseoutEvidenceMatchIndex = workflow.indexOf(
       'if [[ -n "$existing_closeout_full_release_validation_run_id" &&',
     );
+    const rollbackDrillGateIndex = workflow.indexOf(
+      'if [[ -z "$ROLLBACK_DRILL_ID" || -z "$ROLLBACK_DRILL_DATE" ]]; then',
+    );
+    const rollbackDrillPushSkipIndex = workflow.indexOf(
+      "Stable closeout skipped: rollback drill repository variables are missing",
+    );
 
     expect(workflow).toContain('evidence_checksum_asset="${evidence_asset}.sha256"');
     expect(workflow).toContain('--pattern "$evidence_checksum_asset"');
@@ -169,6 +175,9 @@ describe("package acceptance workflow", () => {
       "Stable closeout manifest for $tag does not match immutable postpublish evidence; refusing to accept it.",
     );
     expect(workflow).toContain(
+      "Stable closeout requires repository variables RELEASE_ROLLBACK_DRILL_ID and RELEASE_ROLLBACK_DRILL_DATE, or explicit manual overrides.",
+    );
+    expect(workflow).toContain(
       "REPAIR_PARTIAL_CLOSEOUT: ${{ needs.resolve.outputs.repair_partial_closeout }}",
     );
     expect(workflow).toContain('--allow-stale-rollback-drill "$REPAIR_PARTIAL_CLOSEOUT"');
@@ -186,6 +195,8 @@ describe("package acceptance workflow", () => {
     expect(partialRepairIndex).toBeGreaterThan(-1);
     expect(partialRepairIndex).toBeLessThan(releaseVersionGateIndex);
     expect(evidenceDownloadIndex).toBeGreaterThan(releaseVersionGateIndex);
+    expect(rollbackDrillGateIndex).toBeGreaterThan(existingCloseoutEvidenceMatchIndex);
+    expect(rollbackDrillPushSkipIndex).toBeGreaterThan(rollbackDrillGateIndex);
   });
 
   it("keeps pnpm version selection sourced from packageManager", () => {

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,7 @@
     "@noble/ed25519": "3.1.0",
     "@openclaw/media-core": "workspace:*",
     "@openclaw/normalization-core": "workspace:*",
-    "dompurify": "3.4.9",
+    "dompurify": "3.4.11",
     "highlight.js": "11.11.1",
     "json5": "2.2.3",
     "lit": "3.3.3",


### PR DESCRIPTION
## What Problem This Solves

CLI model selection can discover a Vercel AI Gateway model from its live catalog, but the embedded runner cannot resolve that selected model when it is not in the bundled static catalog. The picker and runtime therefore disagree about which models are selectable.

OpenRouter already has the provider-owned dynamic resolution hook; Vercel AI Gateway was missing the equivalent hook.

## Why This Change Was Made

- Add Vercel AI Gateway dynamic model metadata for live-only model ids.
- Attach the provider transport (`anthropic-messages`) and gateway base URL at the provider boundary.
- Register the hook so `resolveModelAsync` can resolve selected live catalog rows.
- Add regression coverage for both provider-level and runtime-facing resolution.

## User Impact

Models returned by the Vercel AI Gateway catalog can now be selected and used through the CLI model picker, including model ids absent from the bundled fallback list. Existing static model metadata remains unchanged.

## Evidence

- `./node_modules/.bin/vitest run extensions/vercel-ai-gateway/index.test.ts extensions/vercel-ai-gateway/provider-catalog.test.ts --config test/vitest/vitest.full-extensions.config.ts`
  - 2 test files passed, 8 tests passed.
- `./node_modules/.bin/vitest run extensions/openrouter/index.test.ts --config test/vitest/vitest.full-extensions.config.ts`
  - 1 test file passed, 42 tests passed.
- `./node_modules/.bin/oxfmt --check ...`
  - passed.
- `git diff --check`
  - passed.
- Autoreview: clean; one unrelated finding in an existing Canvas diff was ignored as outside this branch.

The full `pnpm check:changed` lane was attempted through Testbox but was blocked by the nested Crabbox binary sanity check (`selected binary failed basic --version/--help sanity checks`).
