### PR TITLE
fix(feishu): keep full streamed answer when final payload is only the last block

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -643,6 +643,37 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("keeps the full streamed answer when the final payload is only the last block", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "auto",
+        streaming: true,
+        blockStreaming: true,
+      },
+    });
+
+    const { options } = createDispatcherHarness();
+
+    // Multi-message turn (e.g. a CLI backend that emits one assistant message
+    // per tool round): the streamed blocks accumulate on the card...
+    await options.deliver({ text: "part1 " }, { kind: "block" });
+    await options.deliver({ text: "part2" }, { kind: "block" });
+    // ...but the final payload carries only the LAST block. It must be merged
+    // into the accumulated text, not replace it (otherwise the card collapses
+    // to just the last block).
+    await options.deliver({ text: "part2" }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("part1 part2", {
+      note: "Agent: agent",
+    });
+  });
+
   it("does not prepend automatic mentions to streaming card closes", async () => {
     const overrides = {
       runtime: createRuntimeLogger(),

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -735,12 +735,19 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               queueStreamingUpdate(text, { mode: "delta", dedupeWithLastPartial: true });
             }
             if (info?.kind === "final") {
-              // Final payloads can be cumulative snapshots or independent
-              // notices. Preserve both when the latter arrives after an answer.
-              streamText = text;
+              // Final payloads are normally the complete reply (a cumulative
+              // snapshot, or an answer already concatenated with a trailing
+              // notice), so we replace the streamed text with them. But some
+              // backends emit one assistant message per tool round, so the final
+              // payload can be just the LAST block — i.e. content we already
+              // streamed. Replacing in that case would collapse the card to the
+              // last block and drop everything before it. When the final is
+              // already contained in the streamed text, keep the richer
+              // accumulated text instead.
+              streamText = text && streamText.includes(text) ? streamText : text;
               hasStreamingFinalText = true;
               snapshotBaseText = "";
-              lastSnapshotTextLength = text.length;
+              lastSnapshotTextLength = streamText.length;
               flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
             }
             // Send media even when streaming handled the text


### PR DESCRIPTION
## Problem

With a streaming card enabled (`channels.feishu.*.streaming: true`), multi-message replies render correctly **while streaming**, but the **final message overwrites the whole streamed answer** — the card ends up showing only the last block.

Repro: a reply that emits one assistant message per tool round (e.g. a CLI/agent backend streaming "step 1/10 ✅ … step 10/10 ✅ done" across sleeps/tool calls). The card builds up the full answer live, then collapses to just `step 10/10 ✅ done` at finalization.

## Root cause

In `extensions/feishu/src/reply-dispatcher.ts`, the `info.kind === "final"` branch did `streamText = text` unconditionally. Normally `text` is the complete reply (a cumulative snapshot, or an answer already concatenated with a trailing notice), so replacing is correct. But when a backend emits one assistant message per tool round, the final payload is only the **last block** — already a subset of what was streamed — so replacing collapses the card to that block and drops everything before it.

## Fix

Keep the accumulated streamed text when the final payload is already contained in it; otherwise preserve the existing replace behavior:

```ts
streamText = text && streamText.includes(text) ? streamText : text;
```

## Validation

- New regression test in `reply-dispatcher.test.ts`: when the final payload is only the last block, the streaming card keeps the full accumulated answer.
- All existing `reply-dispatcher` tests pass (covers cumulative-final coalescing, answer+error finals, and error-final-replaces-transient-preview), so the replace behavior for those cases is unchanged.
- Verified end-to-end on a live Feishu deployment: a 10-step "report progress every interval" streaming reply now keeps the full content at finalization instead of collapsing to the last step.

Related to the Feishu streaming-card content-loss reports (#10078 final shows only the tail; #38824 / #38943 streaming-card content issues).
