### PR TITLE
fix(tavily): use inspect mode in normalizeConfiguredSecret to allow env fallback

### DIFF
--- a/extensions/tavily/src/config.test.ts
+++ b/extensions/tavily/src/config.test.ts
@@ -1,0 +1,106 @@
+// Tavily config tests cover SecretRef resolution and env fallback behavior.
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveTavilyApiKey } from "./config.js";
+
+describe("resolveTavilyApiKey", () => {
+  const originalEnv = process.env.TAVILY_API_KEY;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.TAVILY_API_KEY;
+    } else {
+      process.env.TAVILY_API_KEY = originalEnv;
+    }
+  });
+
+  it("returns a plain string apiKey as-is", () => {
+    expect(
+      resolveTavilyApiKey({
+        plugins: {
+          entries: {
+            tavily: { config: { webSearch: { apiKey: "tvly-abc123" } } },
+          },
+        },
+      } as never),
+    ).toBe("tvly-abc123");
+  });
+
+  it("falls back to process.env when no apiKey is configured", () => {
+    process.env.TAVILY_API_KEY = "env-fallback-key";
+    expect(resolveTavilyApiKey({} as never)).toBe("env-fallback-key");
+  });
+
+  it("returns undefined when no apiKey and no env var", () => {
+    delete process.env.TAVILY_API_KEY;
+    expect(resolveTavilyApiKey({} as never)).toBeUndefined();
+  });
+
+  it("allows env fallback when an env-source SecretRef is unresolvable", () => {
+    process.env.TAVILY_API_KEY = "runtime-env-key";
+    expect(
+      resolveTavilyApiKey({
+        plugins: {
+          entries: {
+            tavily: {
+              config: {
+                webSearch: {
+                  apiKey: {
+                    source: "env",
+                    provider: "default",
+                    id: "TAVILY_API_KEY",
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as never),
+    ).toBe("runtime-env-key");
+  });
+
+  it("blocks env fallback when a file-source SecretRef is configured", () => {
+    process.env.TAVILY_API_KEY = "ambient-key";
+    expect(
+      resolveTavilyApiKey({
+        plugins: {
+          entries: {
+            tavily: {
+              config: {
+                webSearch: {
+                  apiKey: {
+                    source: "file",
+                    provider: "default",
+                    id: "/etc/secrets/tavily",
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as never),
+    ).toBeUndefined();
+  });
+
+  it("blocks env fallback when an exec-source SecretRef is configured", () => {
+    process.env.TAVILY_API_KEY = "ambient-key";
+    expect(
+      resolveTavilyApiKey({
+        plugins: {
+          entries: {
+            tavily: {
+              config: {
+                webSearch: {
+                  apiKey: {
+                    source: "exec",
+                    provider: "default",
+                    id: "get-tavily-key",
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as never),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/tavily/src/config.ts
+++ b/extensions/tavily/src/config.ts
@@ -34,28 +34,60 @@ export function resolveTavilySearchConfig(cfg?: OpenClawConfig): TavilySearchCon
   return undefined;
 }
 
-function normalizeConfiguredSecret(value: unknown, path: string): string | undefined {
-  // Resolve with inspect mode so unresolved SecretRef input returns
-  // configured_unavailable instead of throwing. This lets callers fall
-  // back to process.env (or other runtime sources) without a try/catch.
+type SecretResolution =
+  | { kind: "available"; value: string }
+  | { kind: "allow_env_fallback" }
+  | { kind: "blocked"; ref: NonNullable<ReturnType<typeof resolveSecretInputString>["ref"]> };
+
+/**
+ * Resolves the configured apiKey with inspect-mode SecretRef handling.
+ *
+ * - available: the secret resolved successfully → use it.
+ * - allow_env_fallback: no apiKey configured, or an env-source SecretRef
+ *   could not be resolved by the config snapshot (the runtime may still
+ *   have the variable in process.env) → caller should try process.env.
+ * - blocked: a non-env SecretRef (file, exec) is explicitly configured
+ *   but unavailable → caller should NOT fall back to process.env.
+ */
+function normalizeConfiguredSecret(
+  value: unknown,
+  path: string,
+): SecretResolution {
   const resolution = resolveSecretInputString({
     value,
     path,
     mode: "inspect",
   });
   if (resolution.status === "available") {
-    return normalizeSecretInput(resolution.value);
+    return { kind: "available", value: normalizeSecretInput(resolution.value) };
   }
-  return undefined;
+  if (resolution.status === "missing") {
+    return { kind: "allow_env_fallback" };
+  }
+  // configured_unavailable: a SecretRef exists but cannot be resolved.
+  if (resolution.ref?.source === "env") {
+    return { kind: "allow_env_fallback" };
+  }
+  return { kind: "blocked", ref: resolution.ref! };
 }
 
 export function resolveTavilyApiKey(cfg?: OpenClawConfig): string | undefined {
   const search = resolveTavilySearchConfig(cfg);
-  return (
-    normalizeConfiguredSecret(search?.apiKey, "plugins.entries.tavily.config.webSearch.apiKey") ||
-    normalizeSecretInput(process.env.TAVILY_API_KEY) ||
-    undefined
+  const resolved = normalizeConfiguredSecret(
+    search?.apiKey,
+    "plugins.entries.tavily.config.webSearch.apiKey",
   );
+  if (resolved.kind === "available") {
+    return resolved.value || undefined;
+  }
+  if (resolved.kind === "blocked") {
+    // A non-env SecretRef was explicitly configured but is unavailable.
+    // Do not fall back to process.env — this would silently replace an
+    // explicit operator configuration.
+    return undefined;
+  }
+  // allow_env_fallback: no apiKey configured, or env SecretRef unresolved
+  return normalizeSecretInput(process.env.TAVILY_API_KEY) || undefined;
 }
 
 export function resolveTavilyBaseUrl(cfg?: OpenClawConfig): string {

--- a/extensions/tavily/src/config.ts
+++ b/extensions/tavily/src/config.ts
@@ -2,8 +2,8 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolvePositiveTimeoutSeconds } from "openclaw/plugin-sdk/provider-web-search";
 import {
-  normalizeResolvedSecretInputString,
   normalizeSecretInput,
+  resolveSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 
@@ -35,12 +35,18 @@ export function resolveTavilySearchConfig(cfg?: OpenClawConfig): TavilySearchCon
 }
 
 function normalizeConfiguredSecret(value: unknown, path: string): string | undefined {
-  return normalizeSecretInput(
-    normalizeResolvedSecretInputString({
-      value,
-      path,
-    }),
-  );
+  // Resolve with inspect mode so unresolved SecretRef input returns
+  // configured_unavailable instead of throwing. This lets callers fall
+  // back to process.env (or other runtime sources) without a try/catch.
+  const resolution = resolveSecretInputString({
+    value,
+    path,
+    mode: "inspect",
+  });
+  if (resolution.status === "available") {
+    return normalizeSecretInput(resolution.value);
+  }
+  return undefined;
 }
 
 export function resolveTavilyApiKey(cfg?: OpenClawConfig): string | undefined {


### PR DESCRIPTION
## Summary

Fixes #95109: `tavily_search` and `tavily_extract` fail with `UnresolvedSecretInputError` when `TAVILY_API_KEY` is configured as an env SecretRef that cannot be inline-resolved, even when the variable is set in the gateway process environment.

## Root cause

`normalizeConfiguredSecret` called `resolveSecretInputString` in strict mode, which throws on unresolvable SecretRefs. The throw escaped before the `|| normalizeSecretInput(process.env.TAVILY_API_KEY)` fallback.

## Changes (v2 — guarded fallback)

In `extensions/tavily/src/config.ts`:

- `normalizeConfiguredSecret` now returns a **classified `SecretResolution`** with three outcomes:
  - `available` — secret resolved → use directly
  - `allow_env_fallback` — missing or env-source ref unresolved → try `process.env`
  - `blocked` — non-env ref (file/exec) explicitly configured but unavailable → do NOT fall back

- `resolveTavilyApiKey` dispatches on the classification instead of a blind `||` chain

```typescript
// v1 (simple inspect mode):
return normalizeConfiguredSecret(search?.apiKey, path) || normalizeSecretInput(process.env.TAVILY_API_KEY);

// v2 (guarded classification):
const resolved = normalizeConfiguredSecret(search?.apiKey, path);
if (resolved.kind === "available") return resolved.value;
if (resolved.kind === "blocked") return undefined;  // explicit non-env config must not be replaced
return normalizeSecretInput(process.env.TAVILY_API_KEY);  // allow_env_fallback
```

## Real behavior proof

- **Behavior addressed**: Tavily SecretRef resolution throws before `process.env` fallback; guarded fallback now respects non-env SecretRef boundaries.
- **Real environment tested**: Linux Node 24, full repository checkout, 6-scenario live proof
- **Exact steps or command run after this patch**:
  ```shell
  $ node /tmp/proof-95712-v2.mjs
  ```
- **Evidence after fix**: Terminal output:
  ```
  ======================================================================
  PR #95712 v2 Live Proof — guarded Tavily SecretRef env fallback
  ======================================================================

  Case 1: Plain string apiKey
    kind: available value=tvly-key
    PASS: true

  Case 2: No apiKey configured → allow env fallback
    kind: allow_env_fallback
    PASS: true

  Case 3: env SecretRef unresolved → allow env fallback
    kind: allow_env_fallback
    PASS: true

  Case 4: file SecretRef unresolved → BLOCKED (no fallback)
    kind: blocked ref.source=file
    PASS: true

  Case 5: exec SecretRef unresolved → BLOCKED (no fallback)
    kind: blocked
    PASS: true

  Case 6: End-to-end fallback chain
    plain string: tvly-key
    env ref: env-key-12345
    file ref: undefined
    PASS: true

  ======================================================================
  RESULTS: 6/6 pass — guarded fallback preserves non-env boundaries
  ======================================================================
  ```
  Existing tests: `extensions/tavily/src/tavily-tools.test.ts` — 14/14 passed ✓
- **Observed result after fix**: Env SecretRef unavailable → falls back to `process.env`. File/exec SecretRef unavailable → blocked (no silent replacement). Plain string apiKey → unchanged.
- **What was not tested**: Live Tavily API call with real SecretRef configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)