### PR TITLE
test: fix plugin auto-enable discovery cache test

### DIFF
--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -1196,33 +1196,39 @@ describe("applyPluginAutoEnable core", () => {
   });
 
   it("does not reuse same-turn auto-enable results after discovery mutates in place", () => {
-    const config: OpenClawConfig = {};
+    const config: OpenClawConfig = {
+      plugins: {
+        entries: {
+          browser: {
+            config: {},
+          },
+        },
+      },
+    };
     const mutableDiscovery: PluginDiscoveryResult = { candidates: [], diagnostics: [] };
-    const manifestRegistry = makeRegistry([{ id: "irc-plugin", channels: ["irc"] }]);
-    const configuredEnv = makeIsolatedEnv({
-      IRC_HOST: "irc.libera.chat",
-      IRC_NICK: "openclaw-bot",
-    });
+    const manifestRegistry = makeRegistry([{ id: "browser", channels: [] }]);
+    setupRegistryMock.resolvePluginSetupAutoEnableReasons.mockClear();
 
     const first = applyPluginAutoEnable({
       config,
       discovery: mutableDiscovery,
-      env: configuredEnv,
+      env,
       manifestRegistry,
     });
     mutableDiscovery.candidates.push(
-      makeBundledChannelCandidate({ pluginId: "irc-plugin", channelId: "irc" }),
+      makeBundledChannelCandidate({ pluginId: "unrelated-channel", channelId: "unrelated" }),
     );
     const second = applyPluginAutoEnable({
       config,
       discovery: mutableDiscovery,
-      env: configuredEnv,
+      env,
       manifestRegistry,
     });
 
-    expect(first.config.plugins?.entries?.["irc-plugin"]).toBeUndefined();
-    expect(second.config.plugins?.entries?.["irc-plugin"]?.enabled).toBe(true);
+    expect(first.config.plugins?.entries?.browser?.enabled).toBe(true);
+    expect(second).toEqual(first);
     expect(second).not.toBe(first);
+    expect(setupRegistryMock.resolvePluginSetupAutoEnableReasons).toHaveBeenCalledTimes(2);
   });
 
   it("does not reuse same-turn auto-enable results after env mutates in place", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes a `main` CI failure in `src/config/plugin-auto-enable.core.test.ts` where the discovery-mutation cache test expected the first call not to auto-enable `irc-plugin`, but the test also provided valid IRC env configuration. Current auto-enable behavior intentionally treats those env vars as configured channel state, so the first call already enabled the plugin.

## Why This Change Was Made

The test is meant to prove that same-turn `applyPluginAutoEnable` cache entries are invalidated when the discovery object mutates in place. It now uses the existing setup auto-enable path for `browser`, mutates discovery with an unrelated candidate, and asserts the resolver ran twice plus the second result is a fresh object.

## User Impact

No runtime behavior changes. This only repairs a stale test expectation on `main` so unrelated PRs are not blocked by the core runtime infra check.

## Evidence

- `node scripts/run-vitest.mjs src/config/plugin-auto-enable.core.test.ts` passes, 52/52.
- `git diff --check` passes.
- `.agents/skills/autoreview/scripts/autoreview --mode local` reported no accepted/actionable findings.
