### PR TITLE
fix: preserve user model override during compaction

### DIFF
--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -286,7 +286,7 @@ export async function createModelSelectionState(params: {
       directStoredOverride.model,
     );
     const key = modelKey(normalizedOverride.provider, normalizedOverride.model);
-    if (staleDirectStoredOverride || !visibilityPolicy.allowsKey(key)) {
+    if (staleDirectStoredOverride || (!visibilityPolicy.allowsKey(key) && sessionEntry?.modelOverrideSource !== "user")) {
       const { updated } = applyModelOverrideToSessionEntry({
         entry: sessionEntry,
         selection: { provider: primaryProvider, model: primaryModel, isDefault: true },


### PR DESCRIPTION
## Summary

fix: preserve user-initiated model override during compaction

Fixes #95696

### Changed Files

| File | Change |
|------|--------|
| `src/auto-reply/reply/model-selection.ts` | +1, -1 |

## Real behavior proof (required for external PRs)

**Behavior or issue addressed**: Fix compaction resetting user's model override. When a user switches models via `/model` command and compaction triggers, the session reverts to a different model instead of preserving the user's choice.

**Real environment tested**: Linux x86_64, Node 24, OpenClaw local dev instance

**Exact steps or command run after this patch**:

```bash
node --max-old-space-size=4096 node_modules/.bin/vitest run src/auto-reply/reply/model-selection.test.ts --reporter=verbose
```

**Evidence after fix**:

```
 Test Files  1 passed (1)
      Tests  57 passed (57)
   Duration  19.86s
```

**Observed result after fix**: All 57 tests pass, including "preserves a user-selected override across turns" and "still clears disallowed auto-failover overrides through allowlist validation". Auto-fallback overrides are still properly managed while user-initiated overrides are preserved.

**What was not tested**: End-to-end compaction with live model switching in a full runtime environment

## Root cause

In `createModelSelectionState` (`src/auto-reply/reply/model-selection.ts:289`), the function clears the session's model override when `!visibilityPolicy.allowsKey(key)` is true — meaning the selected model is not in the configured visibility allowlist.

However, this check is too broad: it also catches **user-initiated** model overrides (set via `/model` command). When a user switches to a custom model that isn't in the default visibility allowlist (e.g., a local Ollama model or a custom API endpoint), the override is incorrectly deleted during the next `createModelSelectionState` call, such as when compaction triggers.

The flow:
1. User switches from default (Qwen) to DeepSeek via `/model` → `modelOverride = DeepSeek`, `modelOverrideSource = "user"`
2. User switches back to Qwen via `/model` → `modelOverride = Qwen`, `modelOverrideSource = "user"`
3. Compaction triggers → `createModelSelectionState` runs
4. Qwen's model key is not in the visibility allowlist → **override is deleted**
5. Next run falls back to stale `entry.model`/`entry.modelProvider` which points to DeepSeek

## Fix

```diff
- if (staleDirectStoredOverride || !visibilityPolicy.allowsKey(key)) {
+ if (staleDirectStoredOverride || (!visibilityPolicy.allowsKey(key) && sessionEntry?.modelOverrideSource !== "user")) {
```

The `modelOverrideSource !== "user"` guard ensures:
- **User-initiated overrides** (set via `/model`) are preserved even when the model is not in the visibility allowlist
- **Auto-fallback overrides** (`modelOverrideSource === "auto"` or undefined with provenance) are still cleared when stale or disallowed
- The existing behavior for stale heartbeats, Codex auto-pins, and legacy auto-fallback overrides is unchanged

## Testing

- `model-selection.test.ts`: 57/57 passed (including existing coverage for both user and auto-fallback overrides)
- `plugin-auto-enable.core.test.ts`: 51/51 passed locally (a failing CI shard `checks-node-compact-small-whole-2` is a pre-existing flaky test in an unrelated module — confirmed by running the same test file against unmodified `main`)

## Risk checklist

Did user-visible behavior change? (`Yes` — but only to fix a regression where compaction lost the user's model choice)

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area? Session model override resolution during compaction

How is that risk mitigated? The change is a single-line guard that only affects the specific code path where a user-initiated override would be incorrectly cleared. All existing tests pass, including the auto-fallback override tests that verify stale overrides are still properly managed.