### PR TITLE
fix(matrix): prevent double bootstrapCrossSigning reset in forced reset

### DIFF
--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -389,7 +389,7 @@ If the homeserver requires UIA to upload cross-signing keys, OpenClaw tries no-a
 Useful flags:
 
 - `--recovery-key-stdin` (pair with `printf '%s\n' "$MATRIX_RECOVERY_KEY" | …`) or `--recovery-key <key>`
-- `--force-reset-cross-signing` to discard the current cross-signing identity (intentional only)
+- `--force-reset-cross-signing` to discard the current cross-signing identity (intentional only; requires the active recovery key to be stored or supplied with `--recovery-key-stdin`)
 
 ### Room-key backup
 

--- a/extensions/matrix/src/cli.ts
+++ b/extensions/matrix/src/cli.ts
@@ -1647,7 +1647,10 @@ export function registerMatrixCli(params: { program: Command }): void {
     .description("Enable Matrix E2EE, bootstrap verification, and print next steps")
     .option("--account <id>", "Account ID (for multi-account setups)")
     .option("--recovery-key <key>", "Recovery key to apply before bootstrap")
-    .option("--force-reset-cross-signing", "Force reset cross-signing identity before bootstrap")
+    .option(
+      "--force-reset-cross-signing",
+      "Force reset cross-signing identity before bootstrap (requires active recovery key)",
+    )
     .option("--verbose", "Show detailed diagnostics")
     .option("--json", "Output as JSON")
     .action(
@@ -2121,7 +2124,10 @@ export function registerMatrixCli(params: { program: Command }): void {
       "Recovery key to apply before bootstrap (prefer --recovery-key-stdin)",
     )
     .option("--recovery-key-stdin", "Read the Matrix recovery key from stdin")
-    .option("--force-reset-cross-signing", "Force reset cross-signing identity before bootstrap")
+    .option(
+      "--force-reset-cross-signing",
+      "Force reset cross-signing identity before bootstrap (requires active recovery key)",
+    )
     .option("--verbose", "Show detailed diagnostics")
     .option("--json", "Output as JSON")
     .action(

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1645,6 +1645,54 @@ describe("MatrixClient crypto bootstrapping", () => {
     expect(bootstrapSpy).toHaveBeenCalledTimes(2);
   });
 
+  it("rejects recovery keys when secret-storage metadata cannot authenticate them", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-sdk-test-"));
+    const recoveryKeyPath = path.join(tmpDir, "recovery-key.json");
+    fs.writeFileSync(
+      recoveryKeyPath,
+      JSON.stringify({
+        version: 1,
+        createdAt: new Date().toISOString(),
+        keyId: "SSSSKEY",
+        privateKeyBase64: Buffer.from([1, 2, 3, 4]).toString("base64"),
+      }),
+      "utf8",
+    );
+    const checkKey = vi.fn(async () => true);
+    Object.assign(matrixJsClient, {
+      secretStorage: {
+        getDefaultKeyId: vi.fn(async () => "SSSSKEY"),
+        getKey: vi.fn(async () => [
+          "SSSSKEY",
+          {
+            algorithm: "m.secret_storage.v1.aes-hmac-sha2",
+            iv: "authenticated-iv",
+          },
+        ]),
+        checkKey,
+      },
+    });
+    const client = new MatrixClient("https://matrix.example.org", "token", {
+      encryption: true,
+      recoveryKeyPath,
+    });
+    await (
+      client as unknown as {
+        ensureCryptoSupportInitialized: () => Promise<void>;
+      }
+    ).ensureCryptoSupportInitialized();
+    const bootstrapper = (
+      client as unknown as {
+        cryptoBootstrapper: {
+          deps: { canUnlockSecretStorage: () => Promise<boolean> };
+        };
+      }
+    ).cryptoBootstrapper;
+
+    await expect(bootstrapper.deps.canUnlockSecretStorage()).resolves.toBe(false);
+    expect(checkKey).not.toHaveBeenCalled();
+  });
+
   it("provides secret storage callbacks and resolves stored recovery key", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-sdk-test-"));
     const recoveryKeyPath = path.join(tmpDir, "recovery-key.json");

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -45,7 +45,6 @@ import {
 import { createMatrixGuardedFetch, type HttpMethod, type QueryParams } from "./sdk/transport.js";
 import type {
   MatrixClientEventMap,
-  MatrixAuthDict,
   MatrixCryptoBootstrapApi,
   MatrixDeviceVerificationStatusLike,
   MatrixRelationsPage,
@@ -485,8 +484,6 @@ export class MatrixClient {
     this.cryptoBootstrapper ??= new runtime.MatrixCryptoBootstrapper<MatrixRawEvent>({
       getUserId: () => this.getUserId(),
       getPassword: () => this.password,
-      preflightCrossSigningUiAuth: (authData: MatrixAuthDict | null) =>
-        this.client.uploadDeviceSigningKeys(authData ?? undefined),
       getDeviceId: () => this.client.getDeviceId(),
       verificationManager: this.verificationManager,
       recoveryKeyStore: this.recoveryKeyStore,

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -45,6 +45,7 @@ import {
 import { createMatrixGuardedFetch, type HttpMethod, type QueryParams } from "./sdk/transport.js";
 import type {
   MatrixClientEventMap,
+  MatrixAuthDict,
   MatrixCryptoBootstrapApi,
   MatrixDeviceVerificationStatusLike,
   MatrixRelationsPage,
@@ -484,6 +485,8 @@ export class MatrixClient {
     this.cryptoBootstrapper ??= new runtime.MatrixCryptoBootstrapper<MatrixRawEvent>({
       getUserId: () => this.getUserId(),
       getPassword: () => this.password,
+      preflightCrossSigningUiAuth: (authData: MatrixAuthDict | null) =>
+        this.client.uploadDeviceSigningKeys(authData ?? undefined),
       getDeviceId: () => this.client.getDeviceId(),
       verificationManager: this.verificationManager,
       recoveryKeyStore: this.recoveryKeyStore,

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -484,6 +484,18 @@ export class MatrixClient {
     this.cryptoBootstrapper ??= new runtime.MatrixCryptoBootstrapper<MatrixRawEvent>({
       getUserId: () => this.getUserId(),
       getPassword: () => this.password,
+      canUnlockSecretStorage: async () => {
+        const defaultKeyId = await this.client.secretStorage.getDefaultKeyId();
+        if (!defaultKeyId) {
+          return false;
+        }
+        const keyTuple = await this.client.secretStorage.getKey(defaultKeyId);
+        const key = this.recoveryKeyStore.getSecretStorageKeyCandidate(defaultKeyId);
+        if (!keyTuple || !key) {
+          return false;
+        }
+        return await this.client.secretStorage.checkKey(key, keyTuple[1]);
+      },
       getDeviceId: () => this.client.getDeviceId(),
       verificationManager: this.verificationManager,
       recoveryKeyStore: this.recoveryKeyStore,
@@ -747,13 +759,9 @@ export class MatrixClient {
           "Cross-signing/bootstrap is incomplete for an already owner-signed device; skipping automatic reset and preserving the current identity. Restore the recovery key or run an explicit verification bootstrap if repair is needed.",
         );
       } else {
-        // No password guard: passwordless token-auth bots should still attempt repair.
-        // UIA failures inside bootstrap() are caught below and logged as warnings.
+        // Forced reset validates the active SSSS recovery key before rotating local keys.
+        // Missing or stale recovery material fails without mutating crypto state.
         try {
-          // The repair path already force-resets cross-signing; allow secret storage
-          // recreation so the new keys can be persisted. Without this, a device that
-          // lost its recovery key enters a permanent failure loop because the new
-          // cross-signing keys have nowhere to be stored.
           const repaired = await cryptoBootstrapper.bootstrap(
             crypto,
             MATRIX_AUTOMATIC_REPAIR_BOOTSTRAP_OPTIONS,

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -494,7 +494,11 @@ export class MatrixClient {
         if (!keyTuple || !key) {
           return false;
         }
-        return await this.client.secretStorage.checkKey(key, keyTuple[1]);
+        const keyInfo = keyTuple[1];
+        if (!keyInfo.iv?.trim() || !keyInfo.mac?.trim()) {
+          return false;
+        }
+        return await this.client.secretStorage.checkKey(key, keyInfo);
       },
       getDeviceId: () => this.client.getDeviceId(),
       verificationManager: this.verificationManager,

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -40,6 +40,7 @@ function createBootstrapperDeps() {
   return {
     getUserId: vi.fn(async () => "@bot:example.org"),
     getPassword: vi.fn<() => string | undefined>(() => "super-secret-password"),
+    preflightCrossSigningUiAuth: vi.fn(async () => {}),
     getDeviceId: vi.fn(() => "DEVICE123"),
     verificationManager: {
       trackVerificationRequest: vi.fn(),
@@ -360,25 +361,13 @@ describe("MatrixCryptoBootstrapper", () => {
   it("does not mutate secret storage before forced repair fails on password UIA without a password", async () => {
     const deps = createBootstrapperDeps();
     deps.getPassword = vi.fn<() => string | undefined>(() => undefined);
-    const bootstrapCrossSigning = vi.fn<
-      ({
-        authUploadDeviceSigningKeys,
-      }: {
-        authUploadDeviceSigningKeys?: <T>(
-          makeRequest: (authData: Record<string, unknown> | null) => Promise<T>,
-        ) => Promise<T>;
-      }) => Promise<void>
-    >(async ({ authUploadDeviceSigningKeys }) => {
-      await authUploadDeviceSigningKeys?.(async (authData) => {
-        if (authData === null) {
-          throw new Error("need auth");
-        }
-        if (authData.type === "m.login.dummy") {
-          throw new Error("dummy rejected");
-        }
-        return undefined;
-      });
+    deps.preflightCrossSigningUiAuth = vi.fn(async (authData) => {
+      if (authData === null) {
+        throw new Error("need auth");
+      }
+      throw new Error("dummy rejected");
     });
+    const bootstrapCrossSigning = vi.fn(async () => {});
     const crypto = createCryptoApi({
       bootstrapCrossSigning,
       getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
@@ -397,21 +386,19 @@ describe("MatrixCryptoBootstrapper", () => {
       "Matrix cross-signing key upload requires UIA; provide matrix.password for m.login.password fallback",
     );
 
-    // SSSS bootstrap is deferred for passwordless forced reset to avoid mutating secret storage
-    // before UIA succeeds (gh-78396).
     expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
-    // Only one cross-signing attempt — the forced reset's internal repair path is blocked for
-    // all forced reset modes including passwordless (gh-78396).
-    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
+    expect(bootstrapCrossSigning).not.toHaveBeenCalled();
   });
 
-  it("repairs stale SSSS and retries an unpublished passwordless forced reset", async () => {
+  it("validates dummy UIA before passwordless forced reset mutates secret storage", async () => {
     const deps = createBootstrapperDeps();
     deps.getPassword = vi.fn<() => string | undefined>(() => undefined);
-    const bootstrapCrossSigning = vi
-      .fn<() => Promise<void>>()
-      .mockRejectedValueOnce(new Error("getSecretStorageKey callback returned falsey"))
-      .mockResolvedValueOnce(undefined);
+    deps.preflightCrossSigningUiAuth = vi.fn(async (authData) => {
+      if (authData === null) {
+        throw new Error("need auth");
+      }
+    });
+    const bootstrapCrossSigning = vi.fn(async () => {});
     const crypto = createCryptoApi({
       bootstrapCrossSigning,
       isCrossSigningReady: vi.fn(async () => true),
@@ -431,11 +418,12 @@ describe("MatrixCryptoBootstrapper", () => {
     expect(result.crossSigningReady).toBe(true);
     expect(result.crossSigningPublished).toBe(true);
 
-    // The first reset generated local keys but failed during SSSS export, before publication.
-    // matrix-js-sdk cannot resume that reset, so passwordless recovery recreates SSSS and retries.
-    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(2);
+    expect(deps.preflightCrossSigningUiAuth).toHaveBeenNthCalledWith(1, null);
+    expect(deps.preflightCrossSigningUiAuth).toHaveBeenNthCalledWith(2, {
+      type: "m.login.dummy",
+    });
+    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
     expectBootstrapCrossSigningCall(bootstrapCrossSigning, 1, { setupNewCrossSigning: true });
-    expectBootstrapCrossSigningCall(bootstrapCrossSigning, 2, { setupNewCrossSigning: true });
     expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledWith(
       crypto,
       {
@@ -443,6 +431,44 @@ describe("MatrixCryptoBootstrapper", () => {
         forceNewSecretStorage: true,
       },
     );
+    expect(deps.preflightCrossSigningUiAuth.mock.invocationCallOrder[1]).toBeLessThan(
+      deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey.mock.invocationCallOrder[0],
+    );
+    expect(
+      deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey.mock.invocationCallOrder[0],
+    ).toBeLessThan(bootstrapCrossSigning.mock.invocationCallOrder[0]);
+  });
+
+  it("does not recreate secret storage when configured password UIA is rejected", async () => {
+    const deps = createBootstrapperDeps();
+    deps.getPassword = vi.fn(() => "stale-password");
+    deps.preflightCrossSigningUiAuth = vi.fn(async (authData) => {
+      if (authData?.type === "m.login.password") {
+        throw new Error("password rejected");
+      }
+      throw new Error("need password");
+    });
+    const bootstrapCrossSigning = vi.fn(async () => {});
+    const crypto = createCryptoApi({ bootstrapCrossSigning });
+    const bootstrapper = new MatrixCryptoBootstrapper(
+      deps as unknown as MatrixCryptoBootstrapperDeps<MatrixRawEvent>,
+    );
+
+    await expect(
+      bootstrapper.bootstrap(crypto, {
+        strict: true,
+        forceResetCrossSigning: true,
+        allowSecretStorageRecreateWithoutRecoveryKey: true,
+      }),
+    ).rejects.toThrow("password rejected");
+
+    expect(deps.preflightCrossSigningUiAuth).toHaveBeenLastCalledWith({
+      type: "m.login.password",
+      identifier: { type: "m.id.user", user: "@bot:example.org" },
+      password: "stale-password",
+    });
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
+    expect(bootstrapCrossSigning).not.toHaveBeenCalled();
   });
 
   it("recreates secret storage upfront and does a single forced cross-signing reset", async () => {

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -422,6 +422,27 @@ describe("MatrixCryptoBootstrapper", () => {
     expectBootstrapCrossSigningCall(bootstrapCrossSigning, 1, { setupNewCrossSigning: true });
   });
 
+  it("does not repair SSSS after a non-strict forced reset failure", async () => {
+    const bootstrapCrossSigning = vi.fn(async () => {
+      throw new Error("getSecretStorageKey callback returned falsey");
+    });
+    const { deps, crypto, bootstrapper } = createForcedResetHarness(bootstrapCrossSigning);
+
+    const result = await bootstrapper.bootstrap(crypto, {
+      strict: false,
+      forceResetCrossSigning: true,
+      allowSecretStorageRecreateWithoutRecoveryKey: true,
+    });
+
+    expect(result).toEqual({
+      crossSigningReady: false,
+      crossSigningPublished: false,
+      ownDeviceVerified: null,
+    });
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
+    expect(bootstrapCrossSigning).toHaveBeenCalledOnce();
+  });
+
   it("re-exports cross-signing keys after forced reset creates secret storage", async () => {
     const bootstrapCrossSigning = vi.fn(async () => {});
     const { deps, crypto, bootstrapper } = createForcedResetHarness(bootstrapCrossSigning);

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -394,14 +394,12 @@ describe("MatrixCryptoBootstrapper", () => {
       "Matrix cross-signing key upload requires UIA; provide matrix.password for m.login.password fallback",
     );
 
-    // SSSS is bootstrapped upfront before cross-signing, even for forced reset. This is safe
-    // because SSSS recreation only happens when the existing SSSS is broken; if SSSS is healthy
-    // the upfront bootstrap is a no-op. When UIA then fails, the operator fixes the password
-    // config and retries with a working SSSS, which is strictly better than the previous behavior
-    // of a double cross-signing reset that could destroy E2EE state (gh-78396).
-    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalled();
-    // Only one cross-signing attempt — the upfront SSSS fix prevents the repair block from
-    // triggering a second resetCrossSigning.
+    // SSSS bootstrap is deferred for passwordless forced reset to avoid mutating secret storage
+    // before UIA succeeds. The old double-reset path (second bootstrapCrossSigning after SSSS)
+    // is removed entirely (gh-78396).
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
+    // Only one cross-signing attempt — the forced reset's internal repair path is still allowed
+    // for passwordless bots (gh-78396).
     expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -40,7 +40,6 @@ function createBootstrapperDeps() {
   return {
     getUserId: vi.fn(async () => "@bot:example.org"),
     getPassword: vi.fn<() => string | undefined>(() => "super-secret-password"),
-    preflightCrossSigningUiAuth: vi.fn(async () => {}),
     getDeviceId: vi.fn(() => "DEVICE123"),
     verificationManager: {
       trackVerificationRequest: vi.fn(),
@@ -361,13 +360,25 @@ describe("MatrixCryptoBootstrapper", () => {
   it("does not mutate secret storage before forced repair fails on password UIA without a password", async () => {
     const deps = createBootstrapperDeps();
     deps.getPassword = vi.fn<() => string | undefined>(() => undefined);
-    deps.preflightCrossSigningUiAuth = vi.fn(async (authData) => {
-      if (authData === null) {
-        throw new Error("need auth");
-      }
-      throw new Error("dummy rejected");
+    const bootstrapCrossSigning = vi.fn<
+      ({
+        authUploadDeviceSigningKeys,
+      }: {
+        authUploadDeviceSigningKeys?: <T>(
+          makeRequest: (authData: Record<string, unknown> | null) => Promise<T>,
+        ) => Promise<T>;
+      }) => Promise<void>
+    >(async ({ authUploadDeviceSigningKeys }) => {
+      await authUploadDeviceSigningKeys?.(async (authData) => {
+        if (authData === null) {
+          throw new Error("need auth");
+        }
+        if (authData.type === "m.login.dummy") {
+          throw new Error("dummy rejected");
+        }
+        return undefined;
+      });
     });
-    const bootstrapCrossSigning = vi.fn(async () => {});
     const crypto = createCryptoApi({
       bootstrapCrossSigning,
       getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
@@ -387,72 +398,14 @@ describe("MatrixCryptoBootstrapper", () => {
     );
 
     expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
-    expect(bootstrapCrossSigning).not.toHaveBeenCalled();
-  });
-
-  it("validates dummy UIA before passwordless forced reset mutates secret storage", async () => {
-    const deps = createBootstrapperDeps();
-    deps.getPassword = vi.fn<() => string | undefined>(() => undefined);
-    deps.preflightCrossSigningUiAuth = vi.fn(async (authData) => {
-      if (authData === null) {
-        throw new Error("need auth");
-      }
-    });
-    const bootstrapCrossSigning = vi.fn(async () => {});
-    const crypto = createCryptoApi({
-      bootstrapCrossSigning,
-      isCrossSigningReady: vi.fn(async () => true),
-      userHasCrossSigningKeys: vi.fn(async () => true),
-      getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
-    });
-    const bootstrapper = new MatrixCryptoBootstrapper(
-      deps as unknown as MatrixCryptoBootstrapperDeps<MatrixRawEvent>,
-    );
-
-    const result = await bootstrapper.bootstrap(crypto, {
-      strict: true,
-      forceResetCrossSigning: true,
-      allowSecretStorageRecreateWithoutRecoveryKey: true,
-    });
-
-    expect(result.crossSigningReady).toBe(true);
-    expect(result.crossSigningPublished).toBe(true);
-
-    expect(deps.preflightCrossSigningUiAuth).toHaveBeenNthCalledWith(1, null);
-    expect(deps.preflightCrossSigningUiAuth).toHaveBeenNthCalledWith(2, {
-      type: "m.login.dummy",
-    });
     expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
-    expectBootstrapCrossSigningCall(bootstrapCrossSigning, 1, { setupNewCrossSigning: true });
-    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledWith(
-      crypto,
-      {
-        allowSecretStorageRecreateWithoutRecoveryKey: true,
-        forceNewSecretStorage: true,
-      },
-    );
-    expect(deps.preflightCrossSigningUiAuth.mock.invocationCallOrder[1]).toBeLessThan(
-      deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey.mock.invocationCallOrder[0],
-    );
-    expect(
-      deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey.mock.invocationCallOrder[0],
-    ).toBeLessThan(bootstrapCrossSigning.mock.invocationCallOrder[0]);
   });
 
-  it("does not recreate secret storage when configured password UIA is rejected", async () => {
-    const deps = createBootstrapperDeps();
-    deps.getPassword = vi.fn(() => "stale-password");
-    deps.preflightCrossSigningUiAuth = vi.fn(async (authData) => {
-      if (authData?.type === "m.login.password") {
-        throw new Error("password rejected");
-      }
-      throw new Error("need password");
-    });
-    const bootstrapCrossSigning = vi.fn(async () => {});
-    const crypto = createCryptoApi({ bootstrapCrossSigning });
-    const bootstrapper = new MatrixCryptoBootstrapper(
-      deps as unknown as MatrixCryptoBootstrapperDeps<MatrixRawEvent>,
-    );
+  it("fails closed without recreating SSSS when forced reset cannot unlock it", async () => {
+    const bootstrapCrossSigning = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("getSecretStorageKey callback returned falsey"));
+    const { deps, crypto, bootstrapper } = createForcedResetHarness(bootstrapCrossSigning);
 
     await expect(
       bootstrapper.bootstrap(crypto, {
@@ -460,40 +413,11 @@ describe("MatrixCryptoBootstrapper", () => {
         forceResetCrossSigning: true,
         allowSecretStorageRecreateWithoutRecoveryKey: true,
       }),
-    ).rejects.toThrow("password rejected");
-
-    expect(deps.preflightCrossSigningUiAuth).toHaveBeenLastCalledWith({
-      type: "m.login.password",
-      identifier: { type: "m.id.user", user: "@bot:example.org" },
-      password: "stale-password",
-    });
-    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
-    expect(bootstrapCrossSigning).not.toHaveBeenCalled();
-  });
-
-  it("recreates secret storage upfront and does a single forced cross-signing reset", async () => {
-    const bootstrapCrossSigning = vi.fn<() => Promise<void>>(async () => {});
-    const { deps, crypto, bootstrapper } = createForcedResetHarness(bootstrapCrossSigning);
-
-    await bootstrapper.bootstrap(crypto, {
-      strict: true,
-      forceResetCrossSigning: true,
-      allowSecretStorageRecreateWithoutRecoveryKey: true,
-    });
-
-    // SSSS is bootstrapped upfront before cross-signing, with recreation allowed so broken
-    // SSSS is repaired before the destructive reset. No repair-block retry needed.
-    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledWith(
-      crypto,
-      expect.objectContaining({
-        allowSecretStorageRecreateWithoutRecoveryKey: true,
-        forceNewSecretStorage: true,
-      }),
+    ).rejects.toThrow(
+      "Forced cross-signing reset cannot access secret storage; restore the Matrix recovery key before retrying",
     );
-    // SSSS is bootstrapped again after cross-signing to pick up the newly published keys.
-    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledTimes(2);
-    // Only one forced cross-signing reset — the upfront SSSS fix prevents the repair block
-    // from triggering a second resetCrossSigning (gh-78396).
+
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
     expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
     expectBootstrapCrossSigningCall(bootstrapCrossSigning, 1, { setupNewCrossSigning: true });
   });
@@ -508,18 +432,8 @@ describe("MatrixCryptoBootstrapper", () => {
       allowSecretStorageRecreateWithoutRecoveryKey: true,
     });
 
-    // SSSS bootstrapped upfront (before cross-signing) and after (to pick up keys).
-    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledTimes(2);
-    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenNthCalledWith(
-      1,
-      crypto,
-      expect.objectContaining({
-        allowSecretStorageRecreateWithoutRecoveryKey: true,
-        forceNewSecretStorage: true,
-      }),
-    );
-    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenNthCalledWith(
-      2,
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledOnce();
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledWith(
       crypto,
       expect.objectContaining({
         allowSecretStorageRecreateWithoutRecoveryKey: true,

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -132,17 +132,6 @@ function createForcedResetHarness(bootstrapCrossSigning: BootstrapCrossSigningMo
   });
 }
 
-function expectForcedResetCrossSigningCalls(
-  bootstrapCrossSigning: BootstrapCrossSigningMock,
-  params: { setupNewCall: number; totalCalls: number },
-) {
-  expect(bootstrapCrossSigning).toHaveBeenCalledTimes(params.totalCalls);
-  expectBootstrapCrossSigningCall(bootstrapCrossSigning, params.setupNewCall, {
-    setupNewCrossSigning: true,
-  });
-  expectBootstrapCrossSigningCall(bootstrapCrossSigning, params.totalCalls);
-}
-
 async function bootstrapWithVerificationRequestListener(overrides?: {
   deps?: Partial<ReturnType<typeof createBootstrapperDeps>>;
   crypto?: Partial<MatrixCryptoBootstrapApi>;
@@ -405,14 +394,19 @@ describe("MatrixCryptoBootstrapper", () => {
       "Matrix cross-signing key upload requires UIA; provide matrix.password for m.login.password fallback",
     );
 
-    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
+    // SSSS is bootstrapped upfront before cross-signing, even for forced reset. This is safe
+    // because SSSS recreation only happens when the existing SSSS is broken; if SSSS is healthy
+    // the upfront bootstrap is a no-op. When UIA then fails, the operator fixes the password
+    // config and retries with a working SSSS, which is strictly better than the previous behavior
+    // of a double cross-signing reset that could destroy E2EE state (gh-78396).
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalled();
+    // Only one cross-signing attempt — the upfront SSSS fix prevents the repair block from
+    // triggering a second resetCrossSigning.
+    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
   });
 
-  it("recreates secret storage and retries a forced reset when stale server SSSS blocks it", async () => {
-    const bootstrapCrossSigning = vi
-      .fn<() => Promise<void>>()
-      .mockRejectedValueOnce(new Error("getSecretStorageKey callback returned falsey"))
-      .mockResolvedValueOnce(undefined);
+  it("recreates secret storage upfront and does a single forced cross-signing reset", async () => {
+    const bootstrapCrossSigning = vi.fn<() => Promise<void>>(async () => {});
     const { deps, crypto, bootstrapper } = createForcedResetHarness(bootstrapCrossSigning);
 
     await bootstrapper.bootstrap(crypto, {
@@ -421,17 +415,20 @@ describe("MatrixCryptoBootstrapper", () => {
       allowSecretStorageRecreateWithoutRecoveryKey: true,
     });
 
+    // SSSS is bootstrapped upfront before cross-signing, with recreation allowed so broken
+    // SSSS is repaired before the destructive reset. No repair-block retry needed.
     expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledWith(
       crypto,
-      {
+      expect.objectContaining({
         allowSecretStorageRecreateWithoutRecoveryKey: true,
-        forceNewSecretStorage: true,
-      },
+      }),
     );
-    expectForcedResetCrossSigningCalls(bootstrapCrossSigning, {
-      setupNewCall: 2,
-      totalCalls: 3,
-    });
+    // SSSS is bootstrapped again after cross-signing to pick up the newly published keys.
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledTimes(2);
+    // Only one forced cross-signing reset — the upfront SSSS fix prevents the repair block
+    // from triggering a second resetCrossSigning (gh-78396).
+    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
+    expectBootstrapCrossSigningCall(bootstrapCrossSigning, 1, { setupNewCrossSigning: true });
   });
 
   it("re-exports cross-signing keys after forced reset creates secret storage", async () => {
@@ -444,16 +441,25 @@ describe("MatrixCryptoBootstrapper", () => {
       allowSecretStorageRecreateWithoutRecoveryKey: true,
     });
 
-    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledWith(
+    // SSSS bootstrapped upfront (before cross-signing) and after (to pick up keys).
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledTimes(2);
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenNthCalledWith(
+      1,
       crypto,
-      {
+      expect.objectContaining({
         allowSecretStorageRecreateWithoutRecoveryKey: true,
-      },
+      }),
     );
-    expectForcedResetCrossSigningCalls(bootstrapCrossSigning, {
-      setupNewCall: 1,
-      totalCalls: 2,
-    });
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenNthCalledWith(
+      2,
+      crypto,
+      expect.objectContaining({
+        allowSecretStorageRecreateWithoutRecoveryKey: true,
+      }),
+    );
+    // No redundant second bootstrapCrossSigning call — no double reset (gh-78396).
+    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
+    expectBootstrapCrossSigningCall(bootstrapCrossSigning, 1, { setupNewCrossSigning: true });
   });
 
   it("trusts the fresh own identity after a forced cross-signing reset", async () => {

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -44,7 +44,7 @@ function createBootstrapperDeps() {
       trackVerificationRequest: vi.fn(),
     },
     recoveryKeyStore: {
-      bootstrapSecretStorageWithRecoveryKey: vi.fn(async () => {}),
+      bootstrapSecretStorageWithRecoveryKey: vi.fn<any>(async () => {}),
     },
     decryptBridge: {
       bindCryptoRetrySignals: vi.fn(),
@@ -395,12 +395,50 @@ describe("MatrixCryptoBootstrapper", () => {
     );
 
     // SSSS bootstrap is deferred for passwordless forced reset to avoid mutating secret storage
-    // before UIA succeeds. The old double-reset path (second bootstrapCrossSigning after SSSS)
-    // is removed entirely (gh-78396).
+    // before UIA succeeds (gh-78396).
     expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
-    // Only one cross-signing attempt — the forced reset's internal repair path is still allowed
-    // for passwordless bots (gh-78396).
+    // Only one cross-signing attempt — the forced reset's internal repair path is blocked for
+    // all forced reset modes including passwordless (gh-78396).
     expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry cross-signing when passwordless forced reset hits stale SSSS", async () => {
+    const deps = createBootstrapperDeps();
+    deps.getPassword = vi.fn<() => string | undefined>(() => undefined);
+    const bootstrapCrossSigning = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("getSecretStorageKey callback returned falsey"));
+    const crypto = createCryptoApi({
+      bootstrapCrossSigning,
+      isCrossSigningReady: vi.fn(async () => false),
+      userHasCrossSigningKeys: vi.fn(async () => false),
+      getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
+    });
+    const bootstrapper = new MatrixCryptoBootstrapper(
+      deps as unknown as MatrixCryptoBootstrapperDeps<MatrixRawEvent>,
+    );
+
+    const result = await bootstrapper.bootstrap(crypto, {
+      strict: false,
+      forceResetCrossSigning: true,
+      allowSecretStorageRecreateWithoutRecoveryKey: true,
+    });
+
+    // Forced reset failed without repair, so cross-signing is not ready.
+    expect(result.crossSigningReady).toBe(false);
+
+    // SSSS was deferred (passwordless), so no upfront SSSS. Only the cross-signing
+    // reset was attempted — once. The repair retry block is blocked for all forced
+    // reset modes, so no second bootstrapCrossSigning call (gh-78396, gh-93328).
+    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
+    expectBootstrapCrossSigningCall(bootstrapCrossSigning, 1, { setupNewCrossSigning: true });
+    // The repair block was not entered: bootstrapSecretStorageWithRecoveryKey was
+    // called only for the post-cross-signing second pass, not with forceNewSecretStorage.
+    expect(
+      deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey.mock.calls.some(
+        ([, opts]: [unknown, Record<string, unknown>]) => opts.forceNewSecretStorage === true,
+      ),
+    ).toBe(false);
   });
 
   it("recreates secret storage upfront and does a single forced cross-signing reset", async () => {

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -1,6 +1,7 @@
 // Matrix tests cover crypto bootstrap plugin behavior.
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { MatrixCryptoBootstrapper, type MatrixCryptoBootstrapperDeps } from "./crypto-bootstrap.js";
+import type { MatrixRecoveryKeyStore } from "./recovery-key-store.js";
 import type { MatrixCryptoBootstrapApi, MatrixRawEvent } from "./types.js";
 
 type BootstrapCrossSigningMock = Mock<MatrixCryptoBootstrapApi["bootstrapCrossSigning"]>;
@@ -44,7 +45,9 @@ function createBootstrapperDeps() {
       trackVerificationRequest: vi.fn(),
     },
     recoveryKeyStore: {
-      bootstrapSecretStorageWithRecoveryKey: vi.fn<any>(async () => {}),
+      bootstrapSecretStorageWithRecoveryKey: vi.fn<
+        MatrixRecoveryKeyStore["bootstrapSecretStorageWithRecoveryKey"]
+      >(async () => {}),
     },
     decryptBridge: {
       bindCryptoRetrySignals: vi.fn(),
@@ -402,16 +405,17 @@ describe("MatrixCryptoBootstrapper", () => {
     expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
   });
 
-  it("does not retry cross-signing when passwordless forced reset hits stale SSSS", async () => {
+  it("repairs stale SSSS and retries an unpublished passwordless forced reset", async () => {
     const deps = createBootstrapperDeps();
     deps.getPassword = vi.fn<() => string | undefined>(() => undefined);
     const bootstrapCrossSigning = vi
       .fn<() => Promise<void>>()
-      .mockRejectedValueOnce(new Error("getSecretStorageKey callback returned falsey"));
+      .mockRejectedValueOnce(new Error("getSecretStorageKey callback returned falsey"))
+      .mockResolvedValueOnce(undefined);
     const crypto = createCryptoApi({
       bootstrapCrossSigning,
-      isCrossSigningReady: vi.fn(async () => false),
-      userHasCrossSigningKeys: vi.fn(async () => false),
+      isCrossSigningReady: vi.fn(async () => true),
+      userHasCrossSigningKeys: vi.fn(async () => true),
       getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
     });
     const bootstrapper = new MatrixCryptoBootstrapper(
@@ -419,27 +423,26 @@ describe("MatrixCryptoBootstrapper", () => {
     );
 
     const result = await bootstrapper.bootstrap(crypto, {
-      strict: false,
+      strict: true,
       forceResetCrossSigning: true,
       allowSecretStorageRecreateWithoutRecoveryKey: true,
     });
 
-    // Forced reset failed without repair, so cross-signing is not ready.
-    expect(result.crossSigningReady).toBe(false);
+    expect(result.crossSigningReady).toBe(true);
+    expect(result.crossSigningPublished).toBe(true);
 
-    // SSSS was deferred (passwordless), so no upfront SSSS. Only the cross-signing
-    // reset was attempted — once. The repair retry block is blocked for all forced
-    // reset modes, so no second bootstrapCrossSigning call (gh-78396, gh-93328).
-    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
+    // The first reset generated local keys but failed during SSSS export, before publication.
+    // matrix-js-sdk cannot resume that reset, so passwordless recovery recreates SSSS and retries.
+    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(2);
     expectBootstrapCrossSigningCall(bootstrapCrossSigning, 1, { setupNewCrossSigning: true });
-    // The repair block was not entered: bootstrapSecretStorageWithRecoveryKey was
-    // called only for the post-cross-signing second pass, not with forceNewSecretStorage.
-    expect(
-      deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey.mock.calls.some(
-        (call: unknown[]) =>
-          (call as [unknown, Record<string, unknown>])[1]?.forceNewSecretStorage === true,
-      ),
-    ).toBe(false);
+    expectBootstrapCrossSigningCall(bootstrapCrossSigning, 2, { setupNewCrossSigning: true });
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenCalledWith(
+      crypto,
+      {
+        allowSecretStorageRecreateWithoutRecoveryKey: true,
+        forceNewSecretStorage: true,
+      },
+    );
   });
 
   it("recreates secret storage upfront and does a single forced cross-signing reset", async () => {

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -461,6 +461,7 @@ describe("MatrixCryptoBootstrapper", () => {
       crypto,
       expect.objectContaining({
         allowSecretStorageRecreateWithoutRecoveryKey: true,
+        forceNewSecretStorage: true,
       }),
     );
     // SSSS is bootstrapped again after cross-signing to pick up the newly published keys.
@@ -488,6 +489,7 @@ describe("MatrixCryptoBootstrapper", () => {
       crypto,
       expect.objectContaining({
         allowSecretStorageRecreateWithoutRecoveryKey: true,
+        forceNewSecretStorage: true,
       }),
     );
     expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).toHaveBeenNthCalledWith(

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -40,6 +40,7 @@ function createBootstrapperDeps() {
   return {
     getUserId: vi.fn(async () => "@bot:example.org"),
     getPassword: vi.fn<() => string | undefined>(() => "super-secret-password"),
+    canUnlockSecretStorage: vi.fn(async () => true),
     getDeviceId: vi.fn(() => "DEVICE123"),
     verificationManager: {
       trackVerificationRequest: vi.fn(),
@@ -399,6 +400,29 @@ describe("MatrixCryptoBootstrapper", () => {
 
     expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
     expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects forced reset before mutation when the active recovery key is unavailable", async () => {
+    const deps = createBootstrapperDeps();
+    deps.canUnlockSecretStorage = vi.fn(async () => false);
+    const bootstrapCrossSigning = vi.fn(async () => {});
+    const crypto = createCryptoApi({ bootstrapCrossSigning });
+    const bootstrapper = new MatrixCryptoBootstrapper(
+      deps as unknown as MatrixCryptoBootstrapperDeps<MatrixRawEvent>,
+    );
+
+    await expect(
+      bootstrapper.bootstrap(crypto, {
+        strict: true,
+        forceResetCrossSigning: true,
+        allowSecretStorageRecreateWithoutRecoveryKey: true,
+      }),
+    ).rejects.toThrow(
+      "Forced cross-signing reset requires the active Matrix recovery key; provide it with --recovery-key-stdin before retrying",
+    );
+
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
+    expect(bootstrapCrossSigning).not.toHaveBeenCalled();
   });
 
   it("fails closed without recreating SSSS when forced reset cannot unlock it", async () => {

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -436,7 +436,8 @@ describe("MatrixCryptoBootstrapper", () => {
     // called only for the post-cross-signing second pass, not with forceNewSecretStorage.
     expect(
       deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey.mock.calls.some(
-        ([, opts]: [unknown, Record<string, unknown>]) => opts.forceNewSecretStorage === true,
+        (call: unknown[]) =>
+          (call as [unknown, Record<string, unknown>])[1]?.forceNewSecretStorage === true,
       ),
     ).toBe(false);
   });

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -418,7 +418,7 @@ describe("MatrixCryptoBootstrapper", () => {
         allowSecretStorageRecreateWithoutRecoveryKey: true,
       }),
     ).rejects.toThrow(
-      "Forced cross-signing reset requires the active Matrix recovery key; provide it with --recovery-key-stdin before retrying",
+      "Forced cross-signing reset requires the active Matrix recovery key; supply it before retrying",
     );
 
     expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -51,42 +51,36 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
     options: MatrixCryptoBootstrapOptions = {},
   ): Promise<MatrixCryptoBootstrapResult> {
     const strict = options.strict === true;
-    const deferSecretStorageBootstrapUntilAfterCrossSigning =
-      options.forceResetCrossSigning === true;
+    const forceReset = options.forceResetCrossSigning === true;
     // Register verification listeners before expensive bootstrap work so incoming requests
     // are not missed during startup.
     this.registerVerificationRequestHandler(crypto);
-    if (!deferSecretStorageBootstrapUntilAfterCrossSigning) {
-      await this.bootstrapSecretStorage(crypto, {
-        strict,
-        allowSecretStorageRecreateWithoutRecoveryKey:
-          options.allowSecretStorageRecreateWithoutRecoveryKey === true,
-      });
-    }
-    let crossSigning = await this.bootstrapCrossSigning(crypto, {
-      forceResetCrossSigning: options.forceResetCrossSigning === true,
-      allowAutomaticCrossSigningReset: options.allowAutomaticCrossSigningReset !== false,
+
+    // Always bootstrap SSSS before cross-signing. For forced reset, run non-strict with
+    // recreation allowed so broken SSSS is repaired before the destructive reset.
+    await this.bootstrapSecretStorage(crypto, {
+      strict: forceReset ? false : strict,
       allowSecretStorageRecreateWithoutRecoveryKey:
-        options.allowSecretStorageRecreateWithoutRecoveryKey === true,
+        forceReset ? true : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
+    });
+
+    const crossSigning = await this.bootstrapCrossSigning(crypto, {
+      forceResetCrossSigning: forceReset,
+      allowAutomaticCrossSigningReset: options.allowAutomaticCrossSigningReset !== false,
+      // SSSS was already fixed above, so prevent the repair block from doing a second cross-signing
+      // reset after recreating secret storage (https://github.com/openclaw/openclaw/issues/78396).
+      allowSecretStorageRecreateWithoutRecoveryKey:
+        forceReset ? false : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
       strict,
     });
-    // Forced repair may need password UIA to upload new cross-signing keys. Delay any
-    // secret-storage repair/recreation until after that step succeeds so passwordless bots do
-    // not partially mutate SSSS on homeservers that require password-based UIA.
+
+    // Second SSSS pass to pick up cross-signing keys published during bootstrap.
     await this.bootstrapSecretStorage(crypto, {
       strict,
       allowSecretStorageRecreateWithoutRecoveryKey:
         options.allowSecretStorageRecreateWithoutRecoveryKey === true,
     });
-    if (deferSecretStorageBootstrapUntilAfterCrossSigning) {
-      crossSigning = await this.bootstrapCrossSigning(crypto, {
-        forceResetCrossSigning: false,
-        allowAutomaticCrossSigningReset: false,
-        allowSecretStorageRecreateWithoutRecoveryKey:
-          options.allowSecretStorageRecreateWithoutRecoveryKey === true,
-        strict,
-      });
-    }
+
     const ownDeviceVerified = await this.ensureOwnDeviceTrust(crypto, {
       strict,
     });

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -20,6 +20,7 @@ import { isMatrixDeviceOwnerVerified } from "./verification-status.js";
 export type MatrixCryptoBootstrapperDeps<TRawEvent extends MatrixRawEvent> = {
   getUserId: () => Promise<string>;
   getPassword?: () => string | undefined;
+  preflightCrossSigningUiAuth: (authData: MatrixAuthDict | null) => Promise<void>;
   getDeviceId: () => string | null | undefined;
   verificationManager: MatrixVerificationManager;
   recoveryKeyStore: MatrixRecoveryKeyStore;
@@ -52,33 +53,29 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
   ): Promise<MatrixCryptoBootstrapResult> {
     const strict = options.strict === true;
     const forceReset = options.forceResetCrossSigning === true;
-    const hasPassword = Boolean(this.deps.getPassword?.());
-    // Forced reset with a password: bootstrap SSSS upfront (non-strict, recreation allowed)
-    // so broken SSSS is repaired before the destructive reset. For passwordless bots, defer
-    // SSSS to avoid mutating it before UIA succeeds (passwordless-bot guard).
-    const deferSecretStorageBootstrapUntilAfterCrossSigning = forceReset && !hasPassword;
     // Register verification listeners before expensive bootstrap work so incoming requests
     // are not missed during startup.
     this.registerVerificationRequestHandler(crypto);
 
-    if (!deferSecretStorageBootstrapUntilAfterCrossSigning) {
-      await this.bootstrapSecretStorage(crypto, {
-        strict: forceReset ? false : strict,
-        allowSecretStorageRecreateWithoutRecoveryKey: forceReset
-          ? true
-          : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
-        forceNewSecretStorage: forceReset,
-      });
+    if (forceReset) {
+      // The auth-only upload is side-effect free: all signing-key fields are optional.
+      // Prove UIA before replacing SSSS or generating a new local identity.
+      await this.preflightCrossSigningUiAuth();
     }
+    await this.bootstrapSecretStorage(crypto, {
+      strict: forceReset ? true : strict,
+      allowSecretStorageRecreateWithoutRecoveryKey: forceReset
+        ? true
+        : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
+      forceNewSecretStorage: forceReset,
+    });
 
     const crossSigning = await this.bootstrapCrossSigning(crypto, {
       forceResetCrossSigning: forceReset,
       allowAutomaticCrossSigningReset: options.allowAutomaticCrossSigningReset !== false,
-      // Password-backed resets repair SSSS before generating keys, so never reset twice.
-      // Passwordless resets must repair after the first unpublished reset fails during SSSS export;
-      // matrix-js-sdk cannot resume that reset, so one retry is the only recovery path.
+      // Forced reset already authenticated and recreated SSSS, so never generate a second identity.
       allowSecretStorageRecreateWithoutRecoveryKey: forceReset
-        ? deferSecretStorageBootstrapUntilAfterCrossSigning
+        ? false
         : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
       strict,
     });
@@ -125,6 +122,17 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
         }
       }
     };
+  }
+
+  private async preflightCrossSigningUiAuth(): Promise<void> {
+    const userId = await this.deps.getUserId();
+    const authUploadDeviceSigningKeys = this.createSigningKeysUiAuthCallback({
+      userId,
+      password: this.deps.getPassword?.(),
+    });
+    await authUploadDeviceSigningKeys((authData) =>
+      this.deps.preflightCrossSigningUiAuth(authData),
+    );
   }
 
   private async bootstrapCrossSigning(

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -64,20 +64,21 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
     if (!deferSecretStorageBootstrapUntilAfterCrossSigning) {
       await this.bootstrapSecretStorage(crypto, {
         strict: forceReset ? false : strict,
-        allowSecretStorageRecreateWithoutRecoveryKey:
-          forceReset ? true : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
+        allowSecretStorageRecreateWithoutRecoveryKey: forceReset
+          ? true
+          : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
       });
     }
 
     const crossSigning = await this.bootstrapCrossSigning(crypto, {
       forceResetCrossSigning: forceReset,
       allowAutomaticCrossSigningReset: options.allowAutomaticCrossSigningReset !== false,
-      // Prevent the repair block from doing a second reset after recreating secret storage
-      // for all forced reset modes, including passwordless with stale SSSS (gh-78396).
-      allowSecretStorageRecreateWithoutRecoveryKey:
-        forceReset
-          ? false
-          : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
+      // Password-backed resets repair SSSS before generating keys, so never reset twice.
+      // Passwordless resets must repair after the first unpublished reset fails during SSSS export;
+      // matrix-js-sdk cannot resume that reset, so one retry is the only recovery path.
+      allowSecretStorageRecreateWithoutRecoveryKey: forceReset
+        ? deferSecretStorageBootstrapUntilAfterCrossSigning
+        : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
       strict,
     });
 

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -20,7 +20,6 @@ import { isMatrixDeviceOwnerVerified } from "./verification-status.js";
 export type MatrixCryptoBootstrapperDeps<TRawEvent extends MatrixRawEvent> = {
   getUserId: () => Promise<string>;
   getPassword?: () => string | undefined;
-  preflightCrossSigningUiAuth: (authData: MatrixAuthDict | null) => Promise<void>;
   getDeviceId: () => string | null | undefined;
   verificationManager: MatrixVerificationManager;
   recoveryKeyStore: MatrixRecoveryKeyStore;
@@ -53,27 +52,24 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
   ): Promise<MatrixCryptoBootstrapResult> {
     const strict = options.strict === true;
     const forceReset = options.forceResetCrossSigning === true;
+    const deferSecretStorageBootstrapUntilAfterCrossSigning = forceReset;
     // Register verification listeners before expensive bootstrap work so incoming requests
     // are not missed during startup.
     this.registerVerificationRequestHandler(crypto);
 
-    if (forceReset) {
-      // The auth-only upload is side-effect free: all signing-key fields are optional.
-      // Prove UIA before replacing SSSS or generating a new local identity.
-      await this.preflightCrossSigningUiAuth();
+    if (!deferSecretStorageBootstrapUntilAfterCrossSigning) {
+      await this.bootstrapSecretStorage(crypto, {
+        strict,
+        allowSecretStorageRecreateWithoutRecoveryKey:
+          options.allowSecretStorageRecreateWithoutRecoveryKey === true,
+      });
     }
-    await this.bootstrapSecretStorage(crypto, {
-      strict: forceReset ? true : strict,
-      allowSecretStorageRecreateWithoutRecoveryKey: forceReset
-        ? true
-        : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
-      forceNewSecretStorage: forceReset,
-    });
 
     const crossSigning = await this.bootstrapCrossSigning(crypto, {
       forceResetCrossSigning: forceReset,
       allowAutomaticCrossSigningReset: options.allowAutomaticCrossSigningReset !== false,
-      // Forced reset already authenticated and recreated SSSS, so never generate a second identity.
+      // A repair retry would generate another identity after the SDK already rotated local keys.
+      // Fail closed instead; the server identity and existing recovery material remain authoritative.
       allowSecretStorageRecreateWithoutRecoveryKey: forceReset
         ? false
         : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
@@ -122,17 +118,6 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
         }
       }
     };
-  }
-
-  private async preflightCrossSigningUiAuth(): Promise<void> {
-    const userId = await this.deps.getUserId();
-    const authUploadDeviceSigningKeys = this.createSigningKeysUiAuthCallback({
-      userId,
-      password: this.deps.getPassword?.(),
-    });
-    await authUploadDeviceSigningKeys((authData) =>
-      this.deps.preflightCrossSigningUiAuth(authData),
-    );
   }
 
   private async bootstrapCrossSigning(
@@ -245,6 +230,12 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
         }
         LogService.warn("MatrixClientLite", "Forced cross-signing reset failed:", err);
         if (options.strict) {
+          if (isRepairableSecretStorageAccessError(err)) {
+            throw new Error(
+              "Forced cross-signing reset cannot access secret storage; restore the Matrix recovery key before retrying",
+              { cause: err },
+            );
+          }
           throw err instanceof Error ? err : new Error(String(err));
         }
         return { ready: false, published: false };
@@ -355,19 +346,13 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
     options: {
       strict: boolean;
       allowSecretStorageRecreateWithoutRecoveryKey: boolean;
-      forceNewSecretStorage?: boolean;
     },
   ): Promise<void> {
     try {
-      const secretStorageOptions = {
+      await this.deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey(crypto, {
         allowSecretStorageRecreateWithoutRecoveryKey:
           options.allowSecretStorageRecreateWithoutRecoveryKey,
-        ...(options.forceNewSecretStorage ? { forceNewSecretStorage: true } : {}),
-      };
-      await this.deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey(
-        crypto,
-        secretStorageOptions,
-      );
+      });
       LogService.info("MatrixClientLite", "Secret storage bootstrap complete");
     } catch (err) {
       LogService.warn("MatrixClientLite", "Failed to bootstrap secret storage:", err);

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -56,7 +56,7 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
     const deferSecretStorageBootstrapUntilAfterCrossSigning = forceReset;
     if (forceReset && !(await this.deps.canUnlockSecretStorage())) {
       throw new Error(
-        "Forced cross-signing reset requires the active Matrix recovery key; provide it with --recovery-key-stdin before retrying",
+        "Forced cross-signing reset requires the active Matrix recovery key; supply it before retrying",
       );
     }
     // Register verification listeners before expensive bootstrap work so incoming requests

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -67,6 +67,7 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
         allowSecretStorageRecreateWithoutRecoveryKey: forceReset
           ? true
           : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
+        forceNewSecretStorage: forceReset,
       });
     }
 
@@ -346,13 +347,19 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
     options: {
       strict: boolean;
       allowSecretStorageRecreateWithoutRecoveryKey: boolean;
+      forceNewSecretStorage?: boolean;
     },
   ): Promise<void> {
     try {
-      await this.deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey(crypto, {
+      const secretStorageOptions = {
         allowSecretStorageRecreateWithoutRecoveryKey:
           options.allowSecretStorageRecreateWithoutRecoveryKey,
-      });
+        ...(options.forceNewSecretStorage ? { forceNewSecretStorage: true } : {}),
+      };
+      await this.deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey(
+        crypto,
+        secretStorageOptions,
+      );
       LogService.info("MatrixClientLite", "Secret storage bootstrap complete");
     } catch (err) {
       LogService.warn("MatrixClientLite", "Failed to bootstrap secret storage:", err);

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -72,11 +72,10 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
     const crossSigning = await this.bootstrapCrossSigning(crypto, {
       forceResetCrossSigning: forceReset,
       allowAutomaticCrossSigningReset: options.allowAutomaticCrossSigningReset !== false,
-      // SSSS was already fixed upfront for forced reset with password, so prevent the repair
-      // block from doing a second reset after recreating secret storage (gh-78396). For
-      // passwordless forced reset, SSSS was deferred so allow the existing repair path.
+      // Prevent the repair block from doing a second reset after recreating secret storage
+      // for all forced reset modes, including passwordless with stale SSSS (gh-78396).
       allowSecretStorageRecreateWithoutRecoveryKey:
-        forceReset && hasPassword
+        forceReset
           ? false
           : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
       strict,

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -20,6 +20,7 @@ import { isMatrixDeviceOwnerVerified } from "./verification-status.js";
 export type MatrixCryptoBootstrapperDeps<TRawEvent extends MatrixRawEvent> = {
   getUserId: () => Promise<string>;
   getPassword?: () => string | undefined;
+  canUnlockSecretStorage: () => Promise<boolean>;
   getDeviceId: () => string | null | undefined;
   verificationManager: MatrixVerificationManager;
   recoveryKeyStore: MatrixRecoveryKeyStore;
@@ -53,6 +54,11 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
     const strict = options.strict === true;
     const forceReset = options.forceResetCrossSigning === true;
     const deferSecretStorageBootstrapUntilAfterCrossSigning = forceReset;
+    if (forceReset && !(await this.deps.canUnlockSecretStorage())) {
+      throw new Error(
+        "Forced cross-signing reset requires the active Matrix recovery key; provide it with --recovery-key-stdin before retrying",
+      );
+    }
     // Register verification listeners before expensive bootstrap work so incoming requests
     // are not missed during startup.
     this.registerVerificationRequestHandler(crypto);

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -52,25 +52,33 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
   ): Promise<MatrixCryptoBootstrapResult> {
     const strict = options.strict === true;
     const forceReset = options.forceResetCrossSigning === true;
+    const hasPassword = Boolean(this.deps.getPassword?.());
+    // Forced reset with a password: bootstrap SSSS upfront (non-strict, recreation allowed)
+    // so broken SSSS is repaired before the destructive reset. For passwordless bots, defer
+    // SSSS to avoid mutating it before UIA succeeds (passwordless-bot guard).
+    const deferSecretStorageBootstrapUntilAfterCrossSigning = forceReset && !hasPassword;
     // Register verification listeners before expensive bootstrap work so incoming requests
     // are not missed during startup.
     this.registerVerificationRequestHandler(crypto);
 
-    // Always bootstrap SSSS before cross-signing. For forced reset, run non-strict with
-    // recreation allowed so broken SSSS is repaired before the destructive reset.
-    await this.bootstrapSecretStorage(crypto, {
-      strict: forceReset ? false : strict,
-      allowSecretStorageRecreateWithoutRecoveryKey:
-        forceReset ? true : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
-    });
+    if (!deferSecretStorageBootstrapUntilAfterCrossSigning) {
+      await this.bootstrapSecretStorage(crypto, {
+        strict: forceReset ? false : strict,
+        allowSecretStorageRecreateWithoutRecoveryKey:
+          forceReset ? true : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
+      });
+    }
 
     const crossSigning = await this.bootstrapCrossSigning(crypto, {
       forceResetCrossSigning: forceReset,
       allowAutomaticCrossSigningReset: options.allowAutomaticCrossSigningReset !== false,
-      // SSSS was already fixed above, so prevent the repair block from doing a second cross-signing
-      // reset after recreating secret storage (https://github.com/openclaw/openclaw/issues/78396).
+      // SSSS was already fixed upfront for forced reset with password, so prevent the repair
+      // block from doing a second reset after recreating secret storage (gh-78396). For
+      // passwordless forced reset, SSSS was deferred so allow the existing repair path.
       allowSecretStorageRecreateWithoutRecoveryKey:
-        forceReset ? false : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
+        forceReset && hasPassword
+          ? false
+          : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
       strict,
     });
 

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -76,6 +76,14 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
       strict,
     });
 
+    if (forceReset && (!crossSigning.ready || !crossSigning.published)) {
+      return {
+        crossSigningReady: crossSigning.ready,
+        crossSigningPublished: crossSigning.published,
+        ownDeviceVerified: null,
+      };
+    }
+
     // Second SSSS pass to pick up cross-signing keys published during bootstrap.
     await this.bootstrapSecretStorage(crypto, {
       strict,

--- a/extensions/matrix/src/matrix/sdk/recovery-key-store.test.ts
+++ b/extensions/matrix/src/matrix/sdk/recovery-key-store.test.ts
@@ -156,6 +156,12 @@ describe("MatrixRecoveryKeyStore", () => {
 
     expect(resolved?.[0]).toBe("SSSS");
     expect(Array.from(resolved?.[1] ?? [])).toEqual([1, 2, 3, 4]);
+
+    const resolvedFromMultipleKeys = await callbacks.getSecretStorageKey?.(
+      { keys: { OLD: { name: "old" }, SSSS: { name: "active" } } },
+      "m.cross_signing.master",
+    );
+    expect(resolvedFromMultipleKeys?.[0]).toBe("SSSS");
   });
 
   it("keeps a readable legacy recovery key usable when SQLite migration fails", async () => {

--- a/extensions/matrix/src/matrix/sdk/recovery-key-store.test.ts
+++ b/extensions/matrix/src/matrix/sdk/recovery-key-store.test.ts
@@ -240,6 +240,15 @@ describe("MatrixRecoveryKeyStore", () => {
     expect(saved.privateKeyBase64).toBe(Buffer.from([9, 8, 7]).toString("base64"));
   });
 
+  it("does not authorize destructive reset from an ephemeral cached key", () => {
+    const store = new MatrixRecoveryKeyStore();
+    const callbacks = store.buildCryptoCallbacks();
+
+    callbacks.cacheSecretStorageKey?.("KEY123", { name: "openclaw" }, new Uint8Array([9, 8, 7]));
+
+    expect(store.getSecretStorageKeyCandidate("KEY123")).toBeNull();
+  });
+
   it("creates and persists a recovery key when secret storage is missing", async () => {
     const { store, createRecoveryKeyFromPassphrase, bootstrapSecretStorage } =
       await runSecretStorageBootstrapScenario({

--- a/extensions/matrix/src/matrix/sdk/recovery-key-store.test.ts
+++ b/extensions/matrix/src/matrix/sdk/recovery-key-store.test.ts
@@ -148,6 +148,7 @@ describe("MatrixRecoveryKeyStore", () => {
     expect(fs.existsSync(recoveryKeyPath)).toBe(false);
     expect(fs.existsSync(`${recoveryKeyPath}.migrated`)).toBe(true);
     const callbacks = store.buildCryptoCallbacks();
+    expect(store.getSecretStorageKeyCandidate("SSSS")).toEqual(new Uint8Array([1, 2, 3, 4]));
     const resolved = await callbacks.getSecretStorageKey?.(
       { keys: { SSSS: { name: "test" } } },
       "m.cross_signing.master",

--- a/extensions/matrix/src/matrix/sdk/recovery-key-store.ts
+++ b/extensions/matrix/src/matrix/sdk/recovery-key-store.ts
@@ -66,13 +66,39 @@ export class MatrixRecoveryKeyStore {
         if (requestedKeyIds.length === 0) {
           return null;
         }
+
+        const staged = this.resolveStagedSecretStorageKey(requestedKeyIds);
+        if (staged) {
+          return staged;
+        }
+
         for (const keyId of requestedKeyIds) {
-          const candidate = this.getSecretStorageKeyCandidate(keyId);
-          if (candidate) {
-            return [keyId, candidate];
+          const cached = this.secretStorageKeyCache.get(keyId);
+          if (cached) {
+            return [keyId, new Uint8Array(cached.key)];
           }
         }
-        return null;
+
+        const stored = this.loadStoredRecoveryKey();
+        if (!stored?.privateKeyBase64) {
+          return null;
+        }
+        const privateKey = new Uint8Array(Buffer.from(stored.privateKeyBase64, "base64"));
+        if (privateKey.length === 0) {
+          return null;
+        }
+
+        if (stored.keyId && requestedKeyIds.includes(stored.keyId)) {
+          this.rememberSecretStorageKey(stored.keyId, privateKey, stored.keyInfo);
+          return [stored.keyId, privateKey];
+        }
+
+        const firstRequestedKeyId = requestedKeyIds[0];
+        if (!firstRequestedKeyId) {
+          return null;
+        }
+        this.rememberSecretStorageKey(firstRequestedKeyId, privateKey, stored.keyInfo);
+        return [firstRequestedKeyId, privateKey];
       },
       cacheSecretStorageKey: (keyId, keyInfo, key) => {
         const privateKey = new Uint8Array(key);

--- a/extensions/matrix/src/matrix/sdk/recovery-key-store.ts
+++ b/extensions/matrix/src/matrix/sdk/recovery-key-store.ts
@@ -144,10 +144,6 @@ export class MatrixRecoveryKeyStore {
     if (staged) {
       return staged[1];
     }
-    const cached = this.secretStorageKeyCache.get(normalizedKeyId);
-    if (cached) {
-      return new Uint8Array(cached.key);
-    }
     const stored = this.loadStoredRecoveryKey();
     if (!stored?.privateKeyBase64) {
       return null;

--- a/extensions/matrix/src/matrix/sdk/recovery-key-store.ts
+++ b/extensions/matrix/src/matrix/sdk/recovery-key-store.ts
@@ -66,39 +66,13 @@ export class MatrixRecoveryKeyStore {
         if (requestedKeyIds.length === 0) {
           return null;
         }
-
-        const staged = this.resolveStagedSecretStorageKey(requestedKeyIds);
-        if (staged) {
-          return staged;
-        }
-
         for (const keyId of requestedKeyIds) {
-          const cached = this.secretStorageKeyCache.get(keyId);
-          if (cached) {
-            return [keyId, new Uint8Array(cached.key)];
+          const candidate = this.getSecretStorageKeyCandidate(keyId);
+          if (candidate) {
+            return [keyId, candidate];
           }
         }
-
-        const stored = this.loadStoredRecoveryKey();
-        if (!stored?.privateKeyBase64) {
-          return null;
-        }
-        const privateKey = new Uint8Array(Buffer.from(stored.privateKeyBase64, "base64"));
-        if (privateKey.length === 0) {
-          return null;
-        }
-
-        if (stored.keyId && requestedKeyIds.includes(stored.keyId)) {
-          this.rememberSecretStorageKey(stored.keyId, privateKey, stored.keyInfo);
-          return [stored.keyId, privateKey];
-        }
-
-        const firstRequestedKeyId = requestedKeyIds[0];
-        if (!firstRequestedKeyId) {
-          return null;
-        }
-        this.rememberSecretStorageKey(firstRequestedKeyId, privateKey, stored.keyInfo);
-        return [firstRequestedKeyId, privateKey];
+        return null;
       },
       cacheSecretStorageKey: (keyId, keyInfo, key) => {
         const privateKey = new Uint8Array(key);
@@ -133,6 +107,31 @@ export class MatrixRecoveryKeyStore {
       keyId: stored.keyId,
       createdAt: stored.createdAt,
     };
+  }
+
+  getSecretStorageKeyCandidate(keyId: string): Uint8Array | null {
+    const normalizedKeyId = keyId.trim();
+    if (!normalizedKeyId) {
+      return null;
+    }
+    const staged = this.resolveStagedSecretStorageKey([normalizedKeyId]);
+    if (staged) {
+      return staged[1];
+    }
+    const cached = this.secretStorageKeyCache.get(normalizedKeyId);
+    if (cached) {
+      return new Uint8Array(cached.key);
+    }
+    const stored = this.loadStoredRecoveryKey();
+    if (!stored?.privateKeyBase64) {
+      return null;
+    }
+    const privateKey = new Uint8Array(Buffer.from(stored.privateKeyBase64, "base64"));
+    if (privateKey.length === 0) {
+      return null;
+    }
+    this.rememberSecretStorageKey(normalizedKeyId, privateKey, stored.keyInfo);
+    return privateKey;
   }
 
   private resolveEncodedRecoveryKeyInput(params: {

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts
@@ -1536,6 +1536,8 @@ export async function runMatrixQaE2eeBootstrapSuccessScenario(
 ): Promise<MatrixQaScenarioExecution> {
   requireMatrixQaPassword(context, "driver");
   return await withMatrixQaE2eeDriver(context, "matrix-e2ee-bootstrap-success", async (client) => {
+    const initial = await client.bootstrapOwnDeviceVerification();
+    assertMatrixQaBootstrapSucceeded("driver initial", initial);
     const result = await client.bootstrapOwnDeviceVerification({
       forceResetCrossSigning: true,
     });
@@ -1550,7 +1552,7 @@ export async function runMatrixQaE2eeBootstrapSuccessScenario(
         recoveryKeyStored: result.verification.recoveryKeyStored,
       },
       details: [
-        "driver bootstrap succeeded through real Matrix crypto bootstrap",
+        "driver bootstrap and guarded cross-signing reset succeeded through real Matrix crypto bootstrap",
         `device verified: ${result.verification.verified ? "yes" : "no"}`,
         `cross-signing verified: ${result.verification.crossSigningVerified ? "yes" : "no"}`,
         `signed by owner: ${result.verification.signedByOwner ? "yes" : "no"}`,


### PR DESCRIPTION
## What Problem This Solves

Fixes #78396.

This restores the reviewed Matrix E2EE fix from #93328 after the contributor fork branch became unavailable during maintainer sync. `--force-reset-cross-signing` must not rotate cross-signing, fail on stale/broken SSSS, recreate secret storage, and then rotate again.

## Why This Change Was Made

Forced reset now fails closed unless the active Matrix secret-storage recovery key can authenticate the current SSSS key before destructive cross-signing reset work starts. The branch preserves the original reviewed diff and commit authors from #93328, rebased onto current `main`.

## User Impact

Matrix operators get a guarded forced-reset path that avoids destroying E2EE state when the active recovery material cannot unlock secret storage. Docs and Matrix QA messaging explain the active recovery-key requirement.

## Evidence

- Replaces #93328.
- Autoreview on the original reviewed diff: clean, no accepted/actionable findings.
- Blacksmith Testbox `tbx_01kvq31d9z1hc09q946wr8nj99`: `node scripts/run-vitest.mjs extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts extensions/matrix/src/matrix/sdk/recovery-key-store.test.ts extensions/matrix/src/matrix/sdk.test.ts` passed, 3 files / 121 tests.
- Exact-head GitHub CI pending for this maintainer branch.
