### PR TITLE
fix(active-memory): exclude dreaming-narrative session keys from eligibility gate

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -844,6 +844,21 @@ describe("active-memory plugin", () => {
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });
 
+  it("does not run for dreaming-narrative cron session keys", async () => {
+    const result = await hooks.before_prompt_build(
+      { prompt: "what wings should i order?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:dreaming-narrative-light-abc123",
+        messageProvider: "webchat",
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(runEmbeddedAgent).not.toHaveBeenCalled();
+  });
+
   it("defaults to direct-style sessions only", async () => {
     const result = await hooks.before_prompt_build(
       { prompt: "what wings should we order?", messages: [] },

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -859,6 +859,25 @@ describe("active-memory plugin", () => {
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });
 
+  it("allows non-canonical session keys that merely contain the dreaming-narrative substring", async () => {
+    const result = await hooks.before_prompt_build(
+      { prompt: "what wings should i order?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:webchat:dreaming-narrative-room",
+        messageProvider: "webchat",
+      },
+    );
+
+    // Real session keys that happen to contain "dreaming-narrative" in a
+    // non-canonical way (not {light|rem|deep} phase suffix) must remain eligible.
+    // The session key "agent:main:webchat:dreaming-narrative-room" is a real chat
+    // whose topic happens to contain the string — not a dreaming cron key.
+    expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
+    expect(result).not.toBeUndefined();
+  });
+
   it("defaults to direct-style sessions only", async () => {
     const result = await hooks.before_prompt_build(
       { prompt: "what wings should we order?", messages: [] },

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -859,6 +859,26 @@ describe("active-memory plugin", () => {
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });
 
+  it("does not run when a session id resolves to a dreaming-narrative cron session key", async () => {
+    hoisted.sessionStore["agent:main:dreaming-narrative-light-abc123"] = {
+      sessionId: "dreaming-session",
+      updatedAt: 1,
+    };
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "what wings should i order?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionId: "dreaming-session",
+        messageProvider: "webchat",
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(runEmbeddedAgent).not.toHaveBeenCalled();
+  });
+
   it("allows non-canonical session keys that merely contain the dreaming-narrative substring", async () => {
     const result = await hooks.before_prompt_build(
       { prompt: "what wings should i order?", messages: [] },

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -878,6 +878,25 @@ describe("active-memory plugin", () => {
     expect(result).not.toBeUndefined();
   });
 
+  it("allows real webchat session keys whose peer id starts with a phased dreaming-narrative prefix", async () => {
+    const result = await hooks.before_prompt_build(
+      { prompt: "what wings should i order?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:webchat:dreaming-narrative-light-room",
+        messageProvider: "webchat",
+      },
+    );
+
+    // A real webchat session key whose peer id begins with a phased dreaming-narrative
+    // phrase must not be excluded. Only the canonical bare or agent-prefixed key
+    // shape (dreaming-narrative-<phase>-<hash> directly after agentId or bare) should
+    // be rejected — not the same phrase appearing deeper in the key as a peer id.
+    expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
+    expect(result).not.toBeUndefined();
+  });
+
   it("defaults to direct-style sessions only", async () => {
     const result = await hooks.before_prompt_build(
       { prompt: "what wings should we order?", messages: [] },

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -1156,9 +1156,16 @@ function isEligibleInteractiveSession(ctx: {
     return false;
   }
   // Exclude only canonical dreaming-narrative session keys (bare or agent-prefixed).
-  // Broad substring match would also exclude real chat session ids that happen to
-  // contain the phrase (e.g. telegram:group:dreaming-narrative-room).
-  if (/(?:^|:)dreaming-narrative-(?:light|rem|deep)-/i.test(ctx.sessionKey ?? "")) {
+  // Canonical forms: "dreaming-narrative-<phase>-<hash>" or
+  // "agent:<agentId>:dreaming-narrative-<phase>-<hash>".
+  // A colon-delimited match would also exclude real chat session ids whose peer id
+  // begins with a phased dreaming-narrative phrase (e.g.
+  // "agent:main:feishu:group:dreaming-narrative-light-room").
+  const sessionKey = ctx.sessionKey ?? "";
+  if (
+    /^dreaming-narrative-(light|rem|deep)-/i.test(sessionKey) ||
+    /^agent:[^:]+:dreaming-narrative-(light|rem|deep)-/i.test(sessionKey)
+  ) {
     return false;
   }
   if (!ctx.sessionKey && !ctx.sessionId) {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -1155,7 +1155,10 @@ function isEligibleInteractiveSession(ctx: {
   if (ctx.trigger !== "user") {
     return false;
   }
-  if (ctx.sessionKey?.toLowerCase().includes("dreaming-narrative")) {
+  // Exclude only canonical dreaming-narrative session keys (bare or agent-prefixed).
+  // Broad substring match would also exclude real chat session ids that happen to
+  // contain the phrase (e.g. telegram:group:dreaming-narrative-room).
+  if (/(?:^|:)dreaming-narrative-(?:light|rem|deep)-/i.test(ctx.sessionKey ?? "")) {
     return false;
   }
   if (!ctx.sessionKey && !ctx.sessionId) {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -3630,7 +3630,12 @@ export default definePluginEntry({
               });
               return undefined;
             }
-            if (!isEligibleInteractiveSession(ctx)) {
+            if (
+              !isEligibleInteractiveSession({
+                ...ctx,
+                sessionKey: resolvedSessionKey ?? ctx.sessionKey,
+              })
+            ) {
               await persistPluginStatusLines({
                 api,
                 agentId: effectiveAgentId,

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -1155,6 +1155,9 @@ function isEligibleInteractiveSession(ctx: {
   if (ctx.trigger !== "user") {
     return false;
   }
+  if (ctx.sessionKey?.toLowerCase().includes("dreaming-narrative")) {
+    return false;
+  }
   if (!ctx.sessionKey && !ctx.sessionId) {
     return false;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes #78500.

This restores the reviewed active-memory fix from #93168 after the contributor fork branch became unavailable during maintainer sync. Dreaming-narrative cron session keys should not be eligible for active-memory recall and consume the nightly cron lane budget.

## Why This Change Was Made

The eligibility guard now rejects canonical dreaming-narrative session keys while preserving real chat/session keys that only contain the same phrase as a substring. The branch preserves the original reviewed diff and commit authors from #93168, including the maintainer fix for sessionId-only contexts, rebased onto current `main`.

## User Impact

Nightly dreaming-narrative cron windows avoid active-memory cold-start work, reducing 45s lane timeout risk without suppressing unrelated interactive chats.

## Evidence

- Replaces #93168.
- Autoreview on the reviewed diff: clean after the sessionId-only fix, no accepted/actionable findings.
- Blacksmith Testbox `tbx_01kvq31d9z1hc09q946wr8nj99`: `node scripts/run-vitest.mjs extensions/active-memory/index.test.ts` passed, 1 file / 152 tests.
- Exact-head GitHub CI pending for this maintainer branch.
