### PR TITLE
fix(control-ui): exclude disabled cron jobs from Overview failed count

### DIFF
--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -64,7 +64,7 @@ import {
   stopWorkboardLifecycleRefresh,
   stopWorkboardPolling,
 } from "./controllers/workboard.ts";
-import { resolveCronJobLastRunStatus } from "./cron-status.ts";
+import { isCronJobActiveFailure } from "./cron-status.ts";
 import { syncCustomThemeStyleTag } from "./custom-theme.ts";
 import { isMonitoredAuthProvider } from "./model-auth-helpers.ts";
 import {
@@ -941,7 +941,7 @@ function buildAttentionItems(host: SettingsAppHost) {
   }
 
   const cronJobs = host.cronJobs ?? [];
-  const failedCron = cronJobs.filter((j) => resolveCronJobLastRunStatus(j) === "error");
+  const failedCron = cronJobs.filter(isCronJobActiveFailure);
   if (failedCron.length > 0) {
     items.push({
       severity: "error",

--- a/ui/src/ui/cron-status.test.ts
+++ b/ui/src/ui/cron-status.test.ts
@@ -1,0 +1,40 @@
+// Control UI tests cover cron status derivation behavior.
+import { describe, expect, it } from "vitest";
+import { isCronJobActiveFailure, resolveCronJobLastRunStatus } from "./cron-status.ts";
+import type { CronJob } from "./types.ts";
+
+function job(overrides: Partial<CronJob> = {}): CronJob {
+  return {
+    id: "job",
+    name: "Job",
+    enabled: true,
+    createdAtMs: 0,
+    updatedAtMs: 0,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: "test" },
+    ...overrides,
+  };
+}
+
+describe("isCronJobActiveFailure", () => {
+  it("counts an enabled job whose last run errored", () => {
+    expect(isCronJobActiveFailure(job({ state: { lastRunStatus: "error" } }))).toBe(true);
+  });
+
+  it("ignores a disabled job that retains historical error state", () => {
+    const disabled = job({
+      enabled: false,
+      state: { lastRunStatus: "error", consecutiveErrors: 6, nextRunAtMs: undefined },
+    });
+    // Historical status is still preserved for detail views.
+    expect(resolveCronJobLastRunStatus(disabled)).toBe("error");
+    expect(isCronJobActiveFailure(disabled)).toBe(false);
+  });
+
+  it("does not count enabled jobs whose last run succeeded or is unknown", () => {
+    expect(isCronJobActiveFailure(job({ state: { lastRunStatus: "ok" } }))).toBe(false);
+    expect(isCronJobActiveFailure(job())).toBe(false);
+  });
+});

--- a/ui/src/ui/cron-status.ts
+++ b/ui/src/ui/cron-status.ts
@@ -6,3 +6,11 @@ export type CronJobLastRunStatus = CronRunStatus | "unknown";
 export function resolveCronJobLastRunStatus(job: CronJob): CronJobLastRunStatus {
   return job.state?.lastRunStatus ?? job.state?.lastStatus ?? "unknown";
 }
+
+// Overview "failed cron" surfaces track current actionability, so a failure only
+// counts while the job is still enabled. Disabled jobs keep their historical
+// `lastRunStatus: "error"` for detail views, but a retired job must not be
+// reported as an active operational problem.
+export function isCronJobActiveFailure(job: CronJob): boolean {
+  return job.enabled && resolveCronJobLastRunStatus(job) === "error";
+}

--- a/ui/src/ui/views/overview-cards.ts
+++ b/ui/src/ui/views/overview-cards.ts
@@ -3,7 +3,7 @@ import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion"
 import { html, nothing, type TemplateResult } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { t } from "../../i18n/index.ts";
-import { resolveCronJobLastRunStatus } from "../cron-status.ts";
+import { isCronJobActiveFailure } from "../cron-status.ts";
 import { formatCost, formatTokens, formatRelativeTimestamp } from "../format.ts";
 import { isMonitoredAuthProvider } from "../model-auth-helpers.ts";
 import { formatNextRun } from "../presenter.ts";
@@ -134,9 +134,7 @@ export function renderOverviewCards(props: OverviewCardsProps) {
   const cronEnabled = props.cronStatus?.enabled ?? null;
   const cronNext = props.cronStatus?.nextWakeAtMs ?? null;
   const cronJobCount = props.cronJobs.length;
-  const failedCronCount = props.cronJobs.filter(
-    (j) => resolveCronJobLastRunStatus(j) === "error",
-  ).length;
+  const failedCronCount = props.cronJobs.filter(isCronJobActiveFailure).length;
   const authLoading = props.modelAuthStatus === null;
   const authProviders = props.modelAuthStatus?.providers ?? [];
   const monitoredProviders = authProviders.filter(isMonitoredAuthProvider);


### PR DESCRIPTION
## What Problem This Solves

The Control UI Overview counted a cron job as a *current* failure whenever its
`state.lastRunStatus === "error"`, with no check on whether the job is still
active. Both the Overview "failed cron" card hint and the attention-items list
shared this gap. As a result, a job that previously failed and was then
**intentionally disabled** (`enabled: false`, `nextRunAtMs: null`) kept being
reported as an active operational problem purely because of its retained
historical error state. This makes a retired job look like a live incident and
erodes trust in Overview as a current-actionability surface. Fixes #95716.

## Why This Change Was Made

Overview health is about *current* actionability. A disabled job cannot run
again, so a stale `lastRunStatus: "error"` on it is history, not an active
failure. The adjacent "overdue jobs" computation already gates on `j.enabled`;
the failed-cron count was the inconsistent one. Rather than duplicate the
`enabled && status === "error"` check across the two surfaces (which previously
each inlined the predicate), this adds one shared `isCronJobActiveFailure`
helper in `cron-status.ts` so both surfaces stay in sync. Per-job detail views
keep showing the historical status through `resolveCronJobLastRunStatus`, which
is left unchanged.

## User Impact

- Disabled cron jobs that previously errored no longer inflate the Overview
  "N failed" badge or raise an "N cron jobs failed" attention callout.
- Enabled jobs whose last run errored are still counted, unchanged.
- Per-job views still display the historical `error` status, so no information
  is lost.
- Control UI only; no config, schema, gateway protocol, or scheduler behavior
  changes.

## Evidence

New colocated unit test `ui/src/ui/cron-status.test.ts` (3 cases) passing via the
repo runner:

```text
$ node scripts/run-vitest.mjs ui/src/ui/cron-status.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Before/after on a harness driving the real exported functions with the exact
job state from the issue (one disabled-after-failure job + one active failing
job):

```text
disabled job historical status: error
OLD failed-count: 2 -> [ '81fc999f-0cf1-4cfe-aabb-8326f673d575', 'active' ]
NEW failed-count: 1 -> [ 'active' ]
```

The disabled job is dropped from the count while its historical `error` status
is still reported for detail views; the active failing job is unchanged.

Formatting (`oxfmt --check`) and `oxlint` clean on all four touched files.

---
AI-assisted.
