### PR TITLE
docs: add Clawcks install option

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -44,6 +44,10 @@
     "target": "ClawHub"
   },
   {
+    "source": "Clawcks",
+    "target": "Clawcks"
+  },
+  {
     "source": "OpenAI",
     "target": "OpenAI"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1066,6 +1066,7 @@
                 "group": "Hosting",
                 "pages": [
                   "install/azure",
+                  "install/clawcks",
                   "install/digitalocean",
                   "install/docker-vm-runtime",
                   "install/exe-dev",

--- a/docs/install/clawcks.md
+++ b/docs/install/clawcks.md
@@ -1,0 +1,50 @@
+---
+summary: "Run OpenClaw on Clawcks managed hosting"
+read_when:
+  - You want hosted OpenClaw without managing a server
+  - You want browser-based setup and CLI access
+title: "Clawcks"
+---
+
+# Clawcks
+
+Run OpenClaw on Clawcks.
+
+Clawcks hosts OpenClaw for you. It is an opinionated hosting option focused on ease of use. You do not need to set up a server, Docker, Kubernetes, networking, storage, or a process manager.
+
+## Credential trust
+
+Clawcks is independent and not affiliated with OpenClaw. Because Clawcks runs the Gateway for you, the credentials you enter during onboarding are handled by Clawcks.
+
+Use Clawcks only if you are comfortable trusting Clawcks with your OpenAI API key, Telegram bot token, hosted Gateway state, and any data handled by that Gateway. Use another install option if you want those credentials and data to stay on infrastructure you control.
+
+The onboarding flow guides you through setup. You need an OpenAI API key and a Telegram bot token. Clawcks shows you how to create the Telegram bot during onboarding.
+
+Clawcks also provides a web-based CLI, so you can control the agent from the browser.
+
+## What you need
+
+- An OpenAI API key
+- A Telegram bot token
+
+The OpenAI API key is needed for onboarding. After setup, you can switch OpenClaw to any supported model provider and any supported agent harness, including Codex.
+
+## Deploy
+
+Go to [clawcks.com](https://clawcks.com) and follow the onboarding steps.
+
+When setup finishes, Clawcks keeps the OpenClaw Gateway running for you.
+
+## When to use Clawcks
+
+Use Clawcks if you want to run OpenClaw without managing hosting yourself.
+
+Use another install option if you want to control the server, container image, network, filesystem, and deployment process.
+
+## Notes
+
+- Clawcks runs a hosted OpenClaw Gateway.
+- Your local machine does not need to stay on.
+- The Telegram setup is part of onboarding.
+- The web-based CLI gives direct control over the agent from the browser.
+- Clawcks is opinionated and focuses on ease of use.

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -192,6 +192,9 @@ Deploy OpenClaw on a cloud server or VPS:
   <Card title="Azure" href="/install/azure">
     Azure deployment.
   </Card>
+  <Card title="Clawcks" href="/install/clawcks">
+    Opinionated OpenClaw hosting focused on ease of use.
+  </Card>
   <Card title="Railway" href="/install/railway">
     Railway deployment.
   </Card>


### PR DESCRIPTION
﻿## Summary
- Add a Clawcks install page.
- Add Clawcks to the install hosting list.
- Add the new page to docs navigation.
- Keep the hosted-service boundary clear in the page text.

## What Problem This Solves
The install docs already list several hosting and deployment options, but they do not include Clawcks. That leaves out a hosted OpenClaw provider that can help users who want a simpler setup path.

## Why This Change Was Made
Clawcks is a legitimate OpenClaw hosting option for users who want OpenClaw running without managing a server, Docker, Kubernetes, networking, storage, or a process manager themselves.

Adding Clawcks to the same install area as the other hosting providers makes that option discoverable where users already compare deployment paths. The docs stay practical: they explain what Clawcks handles, what the user needs for onboarding, when Clawcks is a good fit, and when another install option is better.

The change is limited to install docs, docs navigation, and the i18n glossary entry for the Clawcks brand name. It does not change runtime behavior, installer behavior, or config.

## User Impact
Users looking for the easiest hosted path can now find Clawcks from the install overview and decide whether it fits their needs.

Users who want full control over the server, container image, network, filesystem, and deployment process are pointed back to the other install options.

## Evidence
The new page appears in the docs index, internal links resolve, and the touched docs pass formatting and whitespace checks. The page also states that Clawcks is independent from OpenClaw and explains the hosted-service trust boundary before the deploy handoff.

CI is green on the latest PR commit, including `check-docs` and `Real behavior proof`.

## Verification
- `pnpm docs:list`
- `pnpm docs:check-mdx`
- `pnpm docs:check-links`
- `pnpm docs:check-i18n-glossary`
- `oxfmt --check` on touched docs
- `git diff --check`
