### PR TITLE
fix: classify provider code-only failover errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
+- **Provider-native failover codes:** classify documented Anthropic, Google, OpenAI, and owned-alias error codes through provider hooks so message-less SDK failures rotate to configured fallback models instead of surfacing as empty responses. (#95729) Thanks @Pick-cat.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.
 - **Control UI workspace avatars:** inline validated agent avatar files in bootstrap and identity responses so Personal card images render without unauthenticated avatar-route requests, while preserving configured emoji precedence. (#102892, #97602) Thanks @LZY3538.
 - **Exec safe-bin flags:** auto-approve curated read-only boolean flags for default stdin-only filters while keeping unknown flags, tail follow/retry modes, file operands, and custom profiles fail-closed. (#88953) Thanks @yetval.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
-- **Provider-native failover codes:** classify documented Anthropic, Google, OpenAI, and owned-alias error codes through provider hooks so message-less SDK failures rotate to configured fallback models instead of surfacing as empty responses. (#95729) Thanks @Pick-cat.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.
 - **Control UI workspace avatars:** inline validated agent avatar files in bootstrap and identity responses so Personal card images render without unauthenticated avatar-route requests, while preserving configured emoji precedence. (#102892, #97602) Thanks @LZY3538.
 - **Exec safe-bin flags:** auto-approve curated read-only boolean flags for default stdin-only filters while keeping unknown flags, tail follow/retry modes, file operands, and custom profiles fail-closed. (#88953) Thanks @yetval.

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -120,20 +120,22 @@ describe("anthropic provider replay hooks", () => {
   it("classifies Anthropic-native structured failover errors", async () => {
     const provider = await registerSingleProviderPlugin(anthropicPlugin);
 
-    expect(
-      provider.classifyFailoverReason?.({
-        provider: "anthropic",
-        errorMessage: "",
-        errorType: "rate_limit_error",
-      }),
-    ).toBe("rate_limit");
-    expect(
-      provider.classifyFailoverReason?.({
-        provider: "anthropic",
-        errorMessage: "",
-        errorType: "api_error",
-      }),
-    ).toBe("server_error");
+    for (const providerId of ["anthropic", "claude-cli"]) {
+      expect(
+        provider.classifyFailoverReason?.({
+          provider: providerId,
+          errorMessage: "",
+          errorType: "rate_limit_error",
+        }),
+      ).toBe("rate_limit");
+      expect(
+        provider.classifyFailoverReason?.({
+          provider: providerId,
+          errorMessage: "",
+          errorType: "api_error",
+        }),
+      ).toBe("server_error");
+    }
     expect(
       provider.classifyFailoverReason?.({
         provider: "anthropic",

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -133,7 +133,7 @@ describe("anthropic provider replay hooks", () => {
         errorMessage: "",
         errorType: "api_error",
       }),
-    ).toBe("timeout");
+    ).toBe("server_error");
     expect(
       provider.classifyFailoverReason?.({
         provider: "anthropic",
@@ -149,6 +149,13 @@ describe("anthropic provider replay hooks", () => {
         code: "RATE_LIMIT_ERROR",
       }),
     ).toBe("rate_limit");
+    expect(
+      provider.classifyFailoverReason?.({
+        provider: "anthropic",
+        errorMessage: "",
+        code: "API_ERROR",
+      }),
+    ).toBe("server_error");
     expect(
       provider.classifyFailoverReason?.({
         provider: "anthropic",

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -117,6 +117,48 @@ describe("anthropic provider replay hooks", () => {
     ).toBe("native");
   });
 
+  it("classifies Anthropic-native structured failover errors", async () => {
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+    expect(
+      provider.classifyFailoverReason?.({
+        provider: "anthropic",
+        errorMessage: "",
+        errorType: "rate_limit_error",
+      }),
+    ).toBe("rate_limit");
+    expect(
+      provider.classifyFailoverReason?.({
+        provider: "anthropic",
+        errorMessage: "",
+        errorType: "api_error",
+      }),
+    ).toBe("timeout");
+    expect(
+      provider.classifyFailoverReason?.({
+        provider: "anthropic",
+        errorMessage: "",
+        errorType: "rate_limit_error",
+        code: "API_ERROR",
+      }),
+    ).toBe("rate_limit");
+    expect(
+      provider.classifyFailoverReason?.({
+        provider: "anthropic",
+        errorMessage: "",
+        code: "RATE_LIMIT_ERROR",
+      }),
+    ).toBe("rate_limit");
+    expect(
+      provider.classifyFailoverReason?.({
+        provider: "anthropic",
+        errorMessage: "",
+        errorType: "UNKNOWN_ERROR",
+        code: "INSUFFICIENT_QUOTA",
+      }),
+    ).toBeUndefined();
+  });
+
   it("owns replay policy for Claude transports", async () => {
     const provider = await registerSingleProviderPlugin(anthropicPlugin);
 

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -907,8 +907,7 @@ export function buildAnthropicProvider(): ProviderPlugin {
         normalizeLowercaseStringOrEmpty(provider) === PROVIDER_ID),
     resolveReasoningOutputMode: () => "native",
     classifyFailoverReason: ({ code, errorType }) =>
-      classifyAnthropicFailoverDescriptor(errorType) ??
-      classifyAnthropicFailoverDescriptor(code),
+      classifyAnthropicFailoverDescriptor(errorType) ?? classifyAnthropicFailoverDescriptor(code),
     resolveThinkingProfile: ({ provider, modelId, params }) => {
       const contractModelId = resolveClaudeModelIdentity({ id: modelId, params });
       return isAnthropicMandatoryClaude5Model(contractModelId) &&

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -906,11 +906,9 @@ export function buildAnthropicProvider(): ProviderPlugin {
       (!isAnthropicMandatoryClaude5Model(modelId) ||
         normalizeLowercaseStringOrEmpty(provider) === PROVIDER_ID),
     resolveReasoningOutputMode: () => "native",
-    classifyFailoverReason: ({ provider, code, errorType }) =>
-      normalizeLowercaseStringOrEmpty(provider) === PROVIDER_ID
-        ? (classifyAnthropicFailoverDescriptor(errorType) ??
-          classifyAnthropicFailoverDescriptor(code))
-        : undefined,
+    classifyFailoverReason: ({ code, errorType }) =>
+      classifyAnthropicFailoverDescriptor(errorType) ??
+      classifyAnthropicFailoverDescriptor(code),
     resolveThinkingProfile: ({ provider, modelId, params }) => {
       const contractModelId = resolveClaudeModelIdentity({ id: modelId, params });
       return isAnthropicMandatoryClaude5Model(contractModelId) &&

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -65,7 +65,7 @@ function classifyAnthropicFailoverDescriptor(value: string | undefined) {
     case "RATE_LIMIT_ERROR":
       return "rate_limit" as const;
     case "API_ERROR":
-      return "timeout" as const;
+      return "server_error" as const;
     default:
       return undefined;
   }

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -58,6 +58,18 @@ import { wrapAnthropicProviderStream } from "./stream-wrappers.js";
 import { fetchAnthropicUsage, resolveAnthropicUsageAuth } from "./usage.js";
 
 const PROVIDER_ID = "anthropic";
+
+// Anthropic-native error descriptors stay with the Anthropic provider hook.
+function classifyAnthropicFailoverDescriptor(value: string | undefined) {
+  switch (value?.trim().toUpperCase()) {
+    case "RATE_LIMIT_ERROR":
+      return "rate_limit" as const;
+    case "API_ERROR":
+      return "timeout" as const;
+    default:
+      return undefined;
+  }
+}
 type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
 const DEFAULT_ANTHROPIC_MODEL = "anthropic/claude-opus-4-8";
 const ANTHROPIC_OPUS_48_MODEL_ID = "claude-opus-4-8";
@@ -894,6 +906,11 @@ export function buildAnthropicProvider(): ProviderPlugin {
       (!isAnthropicMandatoryClaude5Model(modelId) ||
         normalizeLowercaseStringOrEmpty(provider) === PROVIDER_ID),
     resolveReasoningOutputMode: () => "native",
+    classifyFailoverReason: ({ provider, code, errorType }) =>
+      normalizeLowercaseStringOrEmpty(provider) === PROVIDER_ID
+        ? (classifyAnthropicFailoverDescriptor(errorType) ??
+          classifyAnthropicFailoverDescriptor(code))
+        : undefined,
     resolveThinkingProfile: ({ provider, modelId, params }) => {
       const contractModelId = resolveClaudeModelIdentity({ id: modelId, params });
       return isAnthropicMandatoryClaude5Model(contractModelId) &&

--- a/extensions/google/provider-hooks.test.ts
+++ b/extensions/google/provider-hooks.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { GOOGLE_GEMINI_PROVIDER_HOOKS } from "./provider-hooks.js";
+
+describe("GOOGLE_GEMINI_PROVIDER_HOOKS.classifyFailoverReason", () => {
+  it.each([
+    { provider: "google", code: "UNAVAILABLE", expected: "overloaded" },
+    { provider: "google-vertex", code: "DEADLINE_EXCEEDED", expected: "timeout" },
+    { provider: "google-antigravity", code: "INTERNAL", expected: "server_error" },
+    { provider: "google-gemini-cli", code: "UNAVAILABLE", expected: "overloaded" },
+  ] as const)("classifies $provider $code as $expected", ({ provider, code, expected }) => {
+    expect(
+      GOOGLE_GEMINI_PROVIDER_HOOKS.classifyFailoverReason({
+        provider,
+        errorMessage: "",
+        code,
+      }),
+    ).toBe(expected);
+  });
+
+  it("leaves unknown codes for generic classification", () => {
+    expect(
+      GOOGLE_GEMINI_PROVIDER_HOOKS.classifyFailoverReason({
+        provider: "google-vertex",
+        errorMessage: "",
+        code: "INSUFFICIENT_QUOTA",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/google/provider-hooks.ts
+++ b/extensions/google/provider-hooks.ts
@@ -3,10 +3,25 @@ import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/core";
+import type { ProviderFailoverErrorContext } from "openclaw/plugin-sdk/plugin-entry";
 import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
 import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
 import { resolveGoogleThinkingProfile } from "./provider-policy.js";
 import { createGoogleThinkingStreamWrapper } from "./thinking-api.js";
+
+// Google-family gRPC status codes stay with the shared Gemini provider hook.
+function classifyGoogleFailoverCode(code: string | undefined) {
+  switch (code?.trim().toUpperCase()) {
+    case "UNAVAILABLE":
+      return "overloaded" as const;
+    case "DEADLINE_EXCEEDED":
+      return "timeout" as const;
+    case "INTERNAL":
+      return "server_error" as const;
+    default:
+      return undefined;
+  }
+}
 
 export const GOOGLE_GEMINI_PROVIDER_HOOKS = {
   ...buildProviderReplayFamilyHooks({
@@ -16,4 +31,6 @@ export const GOOGLE_GEMINI_PROVIDER_HOOKS = {
   resolveThinkingProfile: (context: ProviderDefaultThinkingPolicyContext) =>
     resolveGoogleThinkingProfile(context) satisfies ProviderThinkingProfile | undefined,
   wrapStreamFn: createGoogleThinkingStreamWrapper,
+  classifyFailoverReason: ({ code }: ProviderFailoverErrorContext) =>
+    classifyGoogleFailoverCode(code),
 };

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -207,20 +207,22 @@ describe("buildOpenAIProvider", () => {
   it("classifies OpenAI-native code-only failover errors", () => {
     const provider = buildOpenAIProvider();
 
-    expect(
-      provider.classifyFailoverReason?.({
-        provider: "openai",
-        errorMessage: "",
-        code: "SERVER_ERROR",
-      }),
-    ).toBe("server_error");
-    expect(
-      provider.classifyFailoverReason?.({
-        provider: "openai",
-        errorMessage: "",
-        code: "INSUFFICIENT_QUOTA",
-      }),
-    ).toBe("billing");
+    for (const providerId of ["openai", "azure-openai", "azure-openai-responses"]) {
+      expect(
+        provider.classifyFailoverReason?.({
+          provider: providerId,
+          errorMessage: "",
+          code: "SERVER_ERROR",
+        }),
+      ).toBe("server_error");
+      expect(
+        provider.classifyFailoverReason?.({
+          provider: providerId,
+          errorMessage: "",
+          code: "INSUFFICIENT_QUOTA",
+        }),
+      ).toBe("billing");
+    }
     // API_ERROR is an Anthropic-native code, not OpenAI's: fall through to generic.
     expect(
       provider.classifyFailoverReason?.({

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -204,6 +204,33 @@ describe("buildOpenAIProvider", () => {
     });
   });
 
+  it("classifies OpenAI-native code-only failover errors", () => {
+    const provider = buildOpenAIProvider();
+
+    expect(
+      provider.classifyFailoverReason?.({
+        provider: "openai",
+        errorMessage: "",
+        code: "SERVER_ERROR",
+      }),
+    ).toBe("server_error");
+    expect(
+      provider.classifyFailoverReason?.({
+        provider: "openai",
+        errorMessage: "",
+        code: "INSUFFICIENT_QUOTA",
+      }),
+    ).toBe("billing");
+    // API_ERROR is an Anthropic-native code, not OpenAI's: fall through to generic.
+    expect(
+      provider.classifyFailoverReason?.({
+        provider: "openai",
+        errorMessage: "",
+        code: "API_ERROR",
+      }),
+    ).toBeUndefined();
+  });
+
   it("marks the OpenAI manifest catalog as runtime-discovered", () => {
     expect(manifest.modelCatalog.discovery.openai).toBe("runtime");
   });

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -940,10 +940,7 @@ export function buildOpenAIProvider(): ProviderPlugin {
     },
     matchesContextOverflowError: ({ errorMessage }) =>
       /content_filter.*(?:prompt|input).*(?:too long|exceed)/i.test(errorMessage),
-    classifyFailoverReason: ({ provider, code }) =>
-      normalizeProviderId(provider ?? "") === PROVIDER_ID
-        ? classifyOpenAiFailoverCode(code)
-        : undefined,
+    classifyFailoverReason: ({ code }) => classifyOpenAiFailoverCode(code),
     resolveReasoningOutputMode: () => "native",
     resolveThinkingProfile: ({ provider, modelId, agentRuntime, compat }) =>
       normalizeProviderId(provider) === PROVIDER_ID

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -49,6 +49,18 @@ import {
 import { resolveUnifiedOpenAIThinkingProfile } from "./thinking-policy.js";
 
 const PROVIDER_ID = "openai";
+
+// OpenAI-native error codes stay with the OpenAI provider hook.
+function classifyOpenAiFailoverCode(code: string | undefined) {
+  switch (code?.trim().toUpperCase()) {
+    case "SERVER_ERROR":
+      return "server_error" as const;
+    case "INSUFFICIENT_QUOTA":
+      return "billing" as const;
+    default:
+      return undefined;
+  }
+}
 const OPENAI_MODELS_ENDPOINT = "https://api.openai.com/v1/models";
 const OPENAI_CODEX_MODELS_ENDPOINT = `${OPENAI_CODEX_RESPONSES_BASE_URL}/models?client_version=1.0.0`;
 const OPENAI_MODELS_CACHE_TTL_MS = 60_000;
@@ -928,6 +940,10 @@ export function buildOpenAIProvider(): ProviderPlugin {
     },
     matchesContextOverflowError: ({ errorMessage }) =>
       /content_filter.*(?:prompt|input).*(?:too long|exceed)/i.test(errorMessage),
+    classifyFailoverReason: ({ provider, code }) =>
+      normalizeProviderId(provider ?? "") === PROVIDER_ID
+        ? classifyOpenAiFailoverCode(code)
+        : undefined,
     resolveReasoningOutputMode: () => "native",
     resolveThinkingProfile: ({ provider, modelId, agentRuntime, compat }) =>
       normalizeProviderId(provider) === PROVIDER_ID

--- a/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
@@ -1499,6 +1499,28 @@ describe("classifyFailoverReason provider messages", () => {
 });
 
 describe("classifyProviderRuntimeFailureKind", () => {
+  it("classifies generic resource-exhausted codes as rate_limit", () => {
+    expect(
+      classifyProviderRuntimeFailureKind({
+        provider: "openai",
+        code: "RESOURCE_EXHAUSTED",
+        message: "",
+      }),
+    ).toBe("rate_limit");
+  });
+
+  it.each([
+    { provider: "openai", code: "SERVER_ERROR" },
+    { provider: "google", code: "UNAVAILABLE" },
+    { provider: "anthropic", code: "RATE_LIMIT_ERROR" },
+  ] as const)(
+    "does not report code-only $provider $code failures as empty responses",
+    ({ provider, code }) => {
+      expect(classifyProviderRuntimeFailureKind({ provider, code, message: "" })).not.toBe(
+        "empty_response",
+      );
+    },
+  );
   it("classifies missing scope failures", () => {
     expect(
       classifyProviderRuntimeFailureKind({

--- a/src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
+++ b/src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
@@ -118,7 +118,7 @@ describe("provider failover hook structured signals", () => {
 
   it.each([
     { errorType: "rate_limit_error", reason: "rate_limit", runtimeKind: "rate_limit" },
-    { errorType: "api_error", reason: "timeout", runtimeKind: "timeout" },
+    { errorType: "api_error", reason: "server_error", runtimeKind: "unclassified" },
   ] as const)(
     "classifies message-less Anthropic $errorType assistant failures",
     ({ errorType, reason, runtimeKind }) => {
@@ -129,7 +129,7 @@ describe("provider failover hook structured signals", () => {
         if (context.errorType === "rate_limit_error") {
           return "rate_limit";
         }
-        return context.errorType === "api_error" ? "timeout" : undefined;
+        return context.errorType === "api_error" ? "server_error" : undefined;
       });
 
       const message = makeAssistantMessageFixture({
@@ -147,6 +147,26 @@ describe("provider failover hook structured signals", () => {
           errorType,
         }),
       ).toBe(runtimeKind);
+    },
+  );
+
+  it.each([
+    { provider: "google", code: "SERVER_ERROR" },
+    { provider: "anthropic", code: "INSUFFICIENT_QUOTA" },
+    { provider: "openai", code: "INTERNAL" },
+    { provider: "openai", code: "DEADLINE_EXCEEDED" },
+    { provider: "anthropic", code: "UNAVAILABLE" },
+    { provider: "google", code: "API_ERROR" },
+    { provider: "google", code: "RATE_LIMIT_ERROR" },
+  ] as const)(
+    "does not apply provider-native $code semantics to non-owner $provider",
+    ({ provider, code }) => {
+      providerRuntimeMocks.classifyProviderPluginError.mockReturnValue(undefined);
+
+      expect(classifyFailoverSignal({ provider, code, message: "" })).toBeNull();
+      expect(classifyProviderRuntimeFailureKind({ provider, code, message: "" })).toBe(
+        "unclassified",
+      );
     },
   );
 

--- a/src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
+++ b/src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
@@ -1,7 +1,12 @@
 // Covers provider hook structured failover signals.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveFailoverReasonFromError } from "../failover-error.js";
-import { classifyFailoverSignal } from "./errors.js";
+import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
+import {
+  classifyAssistantFailoverReason,
+  classifyProviderRuntimeFailureKind,
+  classifyFailoverSignal,
+} from "./errors.js";
 
 const providerRuntimeMocks = vi.hoisted(() => ({
   classifyProviderPluginError: vi.fn(),
@@ -110,6 +115,40 @@ describe("provider failover hook structured signals", () => {
       }),
     ).toBe("billing");
   });
+
+  it.each([
+    { errorType: "rate_limit_error", reason: "rate_limit", runtimeKind: "rate_limit" },
+    { errorType: "api_error", reason: "timeout", runtimeKind: "timeout" },
+  ] as const)(
+    "classifies message-less Anthropic $errorType assistant failures",
+    ({ errorType, reason, runtimeKind }) => {
+      providerRuntimeMocks.classifyProviderPluginError.mockImplementation((context) => {
+        if (context.provider !== "anthropic") {
+          return undefined;
+        }
+        if (context.errorType === "rate_limit_error") {
+          return "rate_limit";
+        }
+        return context.errorType === "api_error" ? "timeout" : undefined;
+      });
+
+      const message = makeAssistantMessageFixture({
+        provider: "anthropic",
+        errorMessage: undefined,
+        errorType,
+        content: [],
+      });
+
+      expect(classifyAssistantFailoverReason(message)).toBe(reason);
+      expect(
+        classifyProviderRuntimeFailureKind({
+          provider: "anthropic",
+          message: "",
+          errorType,
+        }),
+      ).toBe(runtimeKind);
+    },
+  );
 
   it("does not promote generic SDK type strings as structured provider descriptors", () => {
     providerRuntimeMocks.classifyProviderPluginError.mockReturnValue("billing");

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -907,6 +907,8 @@ function classifyFailoverClassificationFromHttpStatus(
   return null;
 }
 
+// Only cross-provider structured codes classify in core; provider-native
+// mappings belong to provider hooks.
 function classifyFailoverReasonFromCode(raw: string | undefined): FailoverReason | null {
   const normalized = raw?.trim().toUpperCase();
   if (!normalized) {
@@ -917,14 +919,24 @@ function classifyFailoverReasonFromCode(raw: string | undefined): FailoverReason
     case "RATE_LIMIT":
     case "RATE_LIMITED":
     case "RATE_LIMIT_EXCEEDED":
+    case "RATE_LIMIT_ERROR":
     case "TOO_MANY_REQUESTS":
     case "THROTTLED":
     case "THROTTLING":
     case "THROTTLINGEXCEPTION":
     case "THROTTLING_EXCEPTION":
       return "rate_limit";
+    case "INSUFFICIENT_QUOTA":
+      return "billing";
     case "DEACTIVATED_WORKSPACE":
       return "auth_permanent";
+    case "INTERNAL":
+    case "SERVER_ERROR":
+      return "server_error";
+    case "API_ERROR":
+    case "DEADLINE_EXCEEDED":
+      return "timeout";
+    case "UNAVAILABLE":
     case "OVERLOADED":
     case "OVERLOADED_ERROR":
       return "overloaded";
@@ -1247,8 +1259,9 @@ export function classifyProviderRuntimeFailureKind(
   const normalizedSignal = typeof signal === "string" ? { message: signal } : signal;
   const message = normalizedSignal.message?.trim() ?? "";
   const status = inferSignalStatus(normalizedSignal);
+  const hasStructuredErrorSignal = Boolean(normalizedSignal.code || normalizedSignal.errorType);
 
-  if (!message && typeof status !== "number") {
+  if (!message && typeof status !== "number" && !hasStructuredErrorSignal) {
     return "empty_response";
   }
   if (normalizedSignal.code === "refresh_contention") {

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -919,24 +919,14 @@ function classifyFailoverReasonFromCode(raw: string | undefined): FailoverReason
     case "RATE_LIMIT":
     case "RATE_LIMITED":
     case "RATE_LIMIT_EXCEEDED":
-    case "RATE_LIMIT_ERROR":
     case "TOO_MANY_REQUESTS":
     case "THROTTLED":
     case "THROTTLING":
     case "THROTTLINGEXCEPTION":
     case "THROTTLING_EXCEPTION":
       return "rate_limit";
-    case "INSUFFICIENT_QUOTA":
-      return "billing";
     case "DEACTIVATED_WORKSPACE":
       return "auth_permanent";
-    case "INTERNAL":
-    case "SERVER_ERROR":
-      return "server_error";
-    case "API_ERROR":
-    case "DEADLINE_EXCEEDED":
-      return "timeout";
-    case "UNAVAILABLE":
     case "OVERLOADED":
     case "OVERLOADED_ERROR":
       return "overloaded";


### PR DESCRIPTION
## What Problem This Solves
Structured assistant errors that only carry an error `code` (no HTTP status, no body message) fell through to `null` in the failover reason classifier and were reported as `empty_response`, so model failover/cooldown never ran. Provider-native codes like OpenAI `SERVER_ERROR`/`INSUFFICIENT_QUOTA`, Google `UNAVAILABLE`/`DEADLINE_EXCEEDED`/`INTERNAL`, and Anthropic `RATE_LIMIT_ERROR`/`API_ERROR` were not recognized.

## Why This Change Was Made
Provider-native code→reason mappings now live in each provider plugin's `classifyFailoverReason` hook (OpenAI, the Google family covering `google`/`google-vertex`/`google-antigravity`, and Anthropic), keeping core `classifyFailoverReasonFromCode` generic (cross-provider codes only). `classifyFailoverSignal` already dispatches code-only structured signals to the matching provider hook, so the previous core `PROVIDER_CODE_REASON_MAP` was redundant duplication of plugin-owned policy that could drift from each provider as it evolves (`AGENTS.md` provider-boundary policy). The generic guard — message-less structured-code signals must not be reported as `empty_response` — stays in core where it belongs.

## User Impact
Code-only provider errors correctly trigger model failover. When the primary provider returns a structured code with no message (e.g. OpenAI `SERVER_ERROR`, Google `DEADLINE_EXCEEDED`, Anthropic `API_ERROR`), the classifier maps it to the right failover reason and attempts a fallback model instead of treating the turn as an empty response.

## Evidence

**Boundary fix:** removed the 13-entry `PROVIDER_CODE_REASON_MAP` from core `src/agents/embedded-agent-helpers/errors.ts` (now generic); added `classifyFailoverReason` hooks to `extensions/openai/openai-provider.ts`, `extensions/google/provider-hooks.ts` (shared `GOOGLE_GEMINI_PROVIDER_HOOKS`), and `extensions/anthropic/register.runtime.ts`. Provider-specific assertions moved to each plugin's test; the core test keeps the `empty_response` regression.

**Typecheck + lint (clean):**
```
$ pnpm tsgo:core          # exit 0
$ pnpm tsgo:extensions    # exit 0
$ node scripts/run-oxlint.mjs <touched files>   # exit 0
```

**Core + sibling failover tests:**
```
$ node scripts/run-vitest.mjs \
    src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts \
    src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts \
    src/agents/embedded-agent-helpers/provider-error-patterns.test.ts
 Tests  149 passed + 44 passed
```

**Provider hook tests (each plugin owns its codes):**
```
$ node scripts/run-vitest.mjs \
    extensions/openai/openai-provider.test.ts \
    extensions/anthropic/index.test.ts \
    extensions/google/provider-hooks.test.ts
 Tests  40 passed + 37 passed
```
- openai: `SERVER_ERROR`→server_error, `INSUFFICIENT_QUOTA`→billing, `API_ERROR`→undefined (not OpenAI's)
- google-family: `UNAVAILABLE`→overloaded, `DEADLINE_EXCEEDED`→timeout, `INTERNAL`→server_error
- anthropic: `RATE_LIMIT_ERROR`→rate_limit, `API_ERROR`→timeout, `INSUFFICIENT_QUOTA`→undefined

Rebased on latest `origin/main` before push.
