### PR TITLE
fix(cron): pass manifestPlugins through cron model selection for plugin provider resolution

### DIFF
--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -2,6 +2,7 @@
 import type { AgentConfig } from "../../config/types.agents.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronJob } from "../types.js";
+import type { ModelManifestNormalizationContext } from "../../agents/model-selection-normalize.js";
 import {
   DEFAULT_MODEL,
   DEFAULT_PROVIDER,
@@ -30,6 +31,7 @@ export type ResolveCronModelSelectionParams = {
   payload: CronJob["payload"];
   isGmailHook: boolean;
   agentId?: string;
+  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
 };
 
 /** Resolved provider/model pair plus the precedence source that selected it. */
@@ -74,6 +76,7 @@ export async function resolveCronModelSelection(
     cfg: params.cfgWithAgentDefaults,
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
+    manifestPlugins: params.manifestPlugins,
   });
   let provider = resolvedDefault.provider;
   let model = resolvedDefault.model;
@@ -104,6 +107,7 @@ export async function resolveCronModelSelection(
       raw: subagentModelRaw,
       defaultProvider: resolvedDefault.provider,
       defaultModel: resolvedDefault.model,
+      manifestPlugins: params.manifestPlugins,
     });
     if (!("error" in resolvedSubagent)) {
       provider = resolvedSubagent.ref.provider;
@@ -117,6 +121,7 @@ export async function resolveCronModelSelection(
     ? resolveHooksGmailModel({
         cfg: params.cfg,
         defaultProvider: DEFAULT_PROVIDER,
+        manifestPlugins: params.manifestPlugins,
       })
     : null;
   if (hooksGmailModelRef) {
@@ -128,6 +133,7 @@ export async function resolveCronModelSelection(
       ref: hooksGmailModelRef,
       defaultProvider: resolvedDefault.provider,
       defaultModel: resolvedDefault.model,
+      manifestPlugins: params.manifestPlugins,
     });
     if (status.allowed) {
       provider = hooksGmailModelRef.provider;
@@ -148,6 +154,7 @@ export async function resolveCronModelSelection(
       raw: modelOverride,
       defaultProvider: resolvedDefault.provider,
       defaultModel: resolvedDefault.model,
+      manifestPlugins: params.manifestPlugins,
     });
     if ("error" in resolvedOverride) {
       return {
@@ -177,6 +184,7 @@ export async function resolveCronModelSelection(
         raw: `${sessionProviderOverride}/${sessionModelOverride}`,
         defaultProvider: resolvedDefault.provider,
         defaultModel: resolvedDefault.model,
+        manifestPlugins: params.manifestPlugins,
       });
       if (!("error" in resolvedSessionOverride)) {
         provider = resolvedSessionOverride.ref.provider;

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -106,6 +106,8 @@ import {
   setSessionRuntimeModel,
 } from "./run.runtime.js";
 import type { RunCronAgentTurnResult } from "./run.types.js";
+import { normalizePluginsConfig } from "../../plugins/config-state.js";
+import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 import { resolveCronSession } from "./session.js";
 
@@ -658,6 +660,15 @@ async function prepareCronRunContext(params: {
     cronSession.sessionEntry.label = `Cron: ${labelSuffix}`;
   }
 
+  const pluginsEnabled = normalizePluginsConfig(cfgWithAgentDefaults.plugins).enabled;
+  const manifestMetadataSnapshot = pluginsEnabled
+    ? loadManifestMetadataSnapshot({
+        config: cfgWithAgentDefaults,
+        workspaceDir,
+        env: process.env,
+      })
+    : undefined;
+
   const resolvedModelSelection = await resolveCronModelSelection({
     cfg: input.cfg,
     cfgWithAgentDefaults,
@@ -666,6 +677,7 @@ async function prepareCronRunContext(params: {
     payload: input.job.payload,
     isGmailHook,
     agentId,
+    manifestPlugins: manifestMetadataSnapshot?.plugins ?? [],
   });
   if (!resolvedModelSelection.ok) {
     return {


### PR DESCRIPTION
## What Problem This Solves

Plugin model providers (e.g. OpenRouter plugins, custom provider plugins) cannot be resolved for isolated cron sessions. When a user configures `agents.defaults.model` to use a plugin-provided model, the cron agent fails to resolve it because `manifestPlugins` is never passed to model resolution in the cron path.

The interactive agent path (`agent-command.ts:760-761`) correctly computes `manifestPlugins` from `loadManifestMetadataSnapshot` and passes it through to `resolveConfiguredModelRef` and `buildConfiguredModelCatalog`. The cron path (`run.ts` → `model-selection.ts`) was missing this entirely.

## Why This Change Was Made

Root cause: `resolveCronModelSelection()` dispatches to `resolveConfiguredModelRef`, `resolveAllowedModelRef`, `getModelRefStatus`, and `resolveHooksGmailModel` — all of which accept `manifestPlugins` via `ModelManifestNormalizationContext`. But the cron path never supplied it, so plugin model ID normalization was always skipped, causing plugin-provided model refs to fail resolution.

## User Impact

- Cron jobs can now resolve plugin-provided model references, matching the interactive agent behavior
- Backward compatible: `manifestPlugins` is optional (defaults to `undefined`), so existing callers are unaffected

## Evidence

- 70 existing cron model-selection tests pass (model-formatting, hook-content-wrapping, model-overrides, model-preflight, cron-model-override, cron-model-override-forwarding)
- `manifestPlugins` is already consumed correctly by all the downstream function signatures — this change only closes the gap in the parameter plumbing
