### PR TITLE
fix(telegram): materialize block-boundary newlines in rich HTML for Bot API 10.1

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -119,16 +119,32 @@ describe("markdownToTelegramHtml", () => {
     );
   });
 
-  it("preserves structural newlines that only separate block tags", () => {
+  it("preserves structural newlines that only separate block tags with text content", () => {
     // Block tags already break; a stray <br> would add a blank line or land as an
     // invalid container child. Mixed text hugging a block keeps its boundary \n too.
-    const blocks = "<h2>Plan</h2>\n<table><tbody><tr><td>A</td></tr></tbody></table>";
-    expect(materializeTelegramRichHtmlLineBreaks(blocks)).toBe(blocks);
     expect(
       materializeTelegramRichHtmlLineBreaks(
         'A\n\n<figure><img src="https://x/a.jpg"/></figure>\n\nB',
       ),
     ).toBe('A\n\n<figure><img src="https://x/a.jpg"/></figure>\n\nB');
+  });
+
+  it("materializes pure-whitespace newlines between block tags outside containers", () => {
+    // Bot API 10.1 rich messages collapse bare newlines between block elements.
+    // When a segment between two block tags is purely whitespace newlines (no text),
+    // they must become <br> so block boundaries are visible (#95538).
+    expect(materializeTelegramRichHtmlLineBreaks("<h2>Plan</h2>\n<p>Details</p>")).toBe(
+      "<h2>Plan</h2><br><p>Details</p>",
+    );
+    expect(materializeTelegramRichHtmlLineBreaks("<h2>Plan</h2>\n\n<p>Details</p>")).toBe(
+      "<h2>Plan</h2><br><br><p>Details</p>",
+    );
+    // Newlines before a container tag (table/figure/details) are also materialized
+    // when the segment is purely whitespace, but container internals are preserved.
+    const beforeTable = "<h2>Plan</h2>\n<table><tbody><tr><td>A</td></tr></tbody></table>";
+    expect(materializeTelegramRichHtmlLineBreaks(beforeTable)).toBe(
+      "<h2>Plan</h2><br><table><tbody><tr><td>A</td></tr></tbody></table>",
+    );
   });
 
   it("does not let a self-closing literal tag swallow later line breaks", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -1020,6 +1020,7 @@ function convertTelegramRichSegmentNewlines(
   segment: string,
   prevStructural: boolean,
   nextStructural: boolean,
+  insideRichContainer: boolean,
 ): string {
   if (!segment.includes("\n")) {
     return segment;
@@ -1027,10 +1028,20 @@ function convertTelegramRichSegmentNewlines(
   // Keep newline runs that hug a structural tag: Telegram already starts a new
   // line there, so a stray <br> would add a blank line or land as an invalid
   // child inside a container (table/figure/details/list).
+  // However, Bot API 10.1 rich messages do not reliably render bare newlines
+  // between block-level elements — they collapse as insignificant whitespace.
+  // When the segment is purely whitespace newlines (no text content) and not
+  // inside a rich container (table/figure/details), the run must still be
+  // materialized as <br> so that block boundaries are visible (#95538: /status
+  // card loses field-per-line layout under richMessages).
+  const segmentIsPureNewlines = segment.trim() === "";
   return segment.replace(/\n+/g, (run: string, offset: number) => {
     const hugsPrev = offset === 0 && prevStructural;
     const hugsNext = offset + run.length === segment.length && nextStructural;
-    return hugsPrev || hugsNext ? run : "<br>".repeat(run.length);
+    if ((hugsPrev || hugsNext) && (!segmentIsPureNewlines || insideRichContainer)) {
+      return run;
+    }
+    return "<br>".repeat(run.length);
   });
 }
 
@@ -1064,6 +1075,15 @@ function isTelegramRichLineBreakStructuralTag(rawTag: string, tagName: string): 
   );
 }
 
+// Rich containers whose pretty-printed internal newlines must stay literal:
+// a <br> inside <table>/<figure>/<details> is either an invalid child or an
+// unwanted blank line between layout elements.
+const TELEGRAM_RICH_LINE_BREAK_CONTAINER_TAGS: ReadonlySet<string> = new Set([
+  "table",
+  "figure",
+  "details",
+]);
+
 // Bot API 10.1 rich messages parse structured HTML, so literal newlines are
 // insignificant whitespace — unlike the legacy HTML parse mode that renders them
 // as line breaks. Materialize inline newlines as <br> so multi-line prose and
@@ -1076,6 +1096,7 @@ export function materializeTelegramRichHtmlLineBreaks(html: string): string {
   let result = "";
   let lastIndex = 0;
   let literalDepth = 0;
+  let containerDepth = 0;
   let prevStructural = false;
 
   HTML_TAG_PATTERN.lastIndex = 0;
@@ -1091,15 +1112,19 @@ export function materializeTelegramRichHtmlLineBreaks(html: string): string {
     const tagIsStructural =
       tagName === "br" || isTelegramRichLineBreakStructuralTag(rawTag, tagName);
     const segment = html.slice(lastIndex, tagStart);
+    const insideRichContainer = containerDepth > 0;
     result +=
       literalDepth > 0
         ? segment
-        : convertTelegramRichSegmentNewlines(segment, prevStructural, tagIsStructural);
+        : convertTelegramRichSegmentNewlines(segment, prevStructural, tagIsStructural, insideRichContainer);
 
     // Self-closing literal tags (e.g. a stray <pre/>) must not open a region that
     // never closes and swallows every later line break.
     if (TELEGRAM_RICH_LITERAL_WHITESPACE_TAGS.has(tagName) && !rawTag.trimEnd().endsWith("/>")) {
       literalDepth = isClosing ? Math.max(0, literalDepth - 1) : literalDepth + 1;
+    }
+    if (TELEGRAM_RICH_LINE_BREAK_CONTAINER_TAGS.has(tagName) && !rawTag.trimEnd().endsWith("/>")) {
+      containerDepth = isClosing ? Math.max(0, containerDepth - 1) : containerDepth + 1;
     }
     result += rawTag;
     lastIndex = tagEnd;
@@ -1108,7 +1133,7 @@ export function materializeTelegramRichHtmlLineBreaks(html: string): string {
 
   const tail = html.slice(lastIndex);
   result +=
-    literalDepth > 0 ? tail : convertTelegramRichSegmentNewlines(tail, prevStructural, false);
+    literalDepth > 0 ? tail : convertTelegramRichSegmentNewlines(tail, prevStructural, false, containerDepth > 0);
   return result;
 }
 


### PR DESCRIPTION
## Summary

Bot API 10.1 rich messages treat literal newlines between block-level elements as insignificant whitespace, collapsing them instead of rendering line breaks. When the `/status` card (or any multi-line text built with single `\n` separators) is routed through the rich-message path, every field merges into a single run-on line.

The root cause is that `convertTelegramRichSegmentNewlines` skips pure-newline segments that hug a structural tag (prev/next block), assuming the block tag itself produces a visual break. This assumption holds in browsers but not in Bot API 10.1 rich messages.

Fix: when a segment between two block tags is purely whitespace newlines (no text content) and not inside a rich container (table/figure/details), materialize the newlines as `<br>` so block boundaries remain visible.

Fixes #95538

## Root Cause

In `extensions/telegram/src/format.ts`, `convertTelegramRichSegmentNewlines` (line ~1020) has `hugsPrev`/`hugsNext` logic that keeps bare `\n` runs literal when they hug a structural tag. This is correct for browsers (block tags produce their own line break) but incorrect for Bot API 10.1 rich messages, where bare newlines between block elements collapse as insignificant whitespace.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Real behavior proof

**Behavior addressed:** Telegram `/status` card delivered as a single run-on line when `richMessages: true`. Block-boundary newlines between fields collapse.

**Environment tested:** Node.js v24.13.1 on Linux, OpenClaw main branch and PR branch.

**Steps run after the patch:** Called `materializeTelegramRichHtmlLineBreaks` from source via `node --import tsx` for block-boundary HTML patterns, inspecting whether `\n` between block tags is preserved or materialized as `<br>`.

**Evidence before fix (upstream/main — bug present):**

```text
Input:  "<h2>Plan</h2>\n<p>Details</p>"
Output: "<h2>Plan</h2>\n<p>Details</p>"    ← bare \n preserved, collapses in rich messages

Input:  "<h2>Plan</h2>\n\n<p>Details</p>"
Output: "<h2>Plan</h2>\n\n<p>Details</p>"  ← bare \n\n preserved, collapses in rich messages
```

**Evidence after fix (PR branch — bug fixed):**

```text
Input:  "<h2>Plan</h2>\n<p>Details</p>"
Output: "<h2>Plan</h2><br><p>Details</p>"    ← \n materialized as <br>, visible in rich messages

Input:  "<h2>Plan</h2>\n\n<p>Details</p>"
Output: "<h2>Plan</h2><br><br><p>Details</p>"  ← \n\n materialized as <br><br>
```

**Container internals preserved (no regression):**

```text
Input:  "<table>\n<thead>\n<tr><th>H</th></tr>\n</thead>\n</table>"
Output: "<table>\n<thead>\n<tr><th>H</th></tr>\n</thead>\n</table>"  ← unchanged, no <br> injected
```

**Mixed text hugging a block preserved (no regression):**

```text
Input:  "A\n\n<figure><img src=\"https://x/a.jpg\"/></figure>\n\nB"
Output: "A\n\n<figure><img src=\"https://x/a.jpg\"/></figure>\n\nB"  ← unchanged
```

**Observed result after the fix:** Block-boundary newlines between `<h2>`, `<p>`, and other block elements are correctly materialized as `<br>` in Bot API 10.1 rich messages, restoring the field-per-line layout of `/status` and similar multi-line text. Container-internal pretty-printed newlines in `<table>`, `<figure>`, and `<details>` remain literal, avoiding invalid `<br>` children.

**What was not tested:** Live Telegram Bot API 10.1 sendRichMessage call (no Telegram bot token available in CI). The fix is verified at the `materializeTelegramRichHtmlLineBreaks` level which is the direct input to the rich message payload.