### PR TITLE
fix(channels): prevent draft text loss when send returns false

### DIFF
--- a/src/channels/draft-stream-loop.ts
+++ b/src/channels/draft-stream-loop.ts
@@ -64,7 +64,7 @@ export function createDraftStreamLoop(params: {
         throw err;
       }
       if (sent === false) {
-        pendingText = text;
+        pendingText ||= text;
         return;
       }
       lastSentAt = Date.now();


### PR DESCRIPTION
## What Problem This Solves

When a channel streaming draft edit returns `false` (e.g. due to throttling or missing message ID), any streaming text that arrived via `update()` during the failed send attempt is silently discarded. This causes visible gaps in the user-visible streaming output.

## Root Cause

In `createDraftStreamLoop.flush()`, three text-restore paths use different operators:
- Line 55 (synchronous send error): `pendingText ||= text` — CORRECT
- Line 63 (async send rejection): `pendingText ||= text` — CORRECT
- Line 67 (send returns false): `pendingText = text` — INCORRECT, unconditionally overwrites newer text

## Fix

Change `=` to `||=` on line 67, matching the other two restore paths.

## Evidence

- 6 existing draft-stream-loop tests pass
- The `||=` operator preserves pendingText if it was set by a concurrent `update()` during the async send, while `=` unconditionally overwrites