### PR TITLE
test(plugin-sdk): refresh callable export budget expectation

### DIFF
--- a/test/scripts/plugin-sdk-surface-report.test.ts
+++ b/test/scripts/plugin-sdk-surface-report.test.ts
@@ -55,7 +55,7 @@ describe("plugin SDK surface report", () => {
     });
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("public callable exports 5184 > 5183");
+    expect(result.stderr).toContain("public callable exports 5185 > 5183");
   });
 
   it("rejects deprecated export growth by public entrypoint", () => {


### PR DESCRIPTION
## What Problem This Solves

The plugin SDK surface report now counts 5,185 public callable exports, but its regression test still expected the previous 5,184 diagnostic.

## Why This Change Was Made

Refresh the single assertion to match the current report output without changing the budget or runtime behavior.

## User Impact

None. This is a test expectation refresh for the existing SDK surface guard.

## Evidence

- `OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS=5183 node scripts/plugin-sdk-surface-report.mjs --check` reports `public callable exports 5185 > 5183`.
- Focused Vitest: 5 tests passed.
- Autoreview: clean, no accepted/actionable findings.
