### PR TITLE
fix(model-catalog): strip manifest model-id prefixes by the matched length

### DIFF
--- a/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
@@ -89,3 +89,34 @@ describe("provider model id policy normalization", () => {
     );
   });
 });
+
+describe("manifest stripPrefixes matches and slices on the same normalized value", () => {
+  function stripWith(stripPrefixes: string[], modelId: string): string {
+    const policies = collectManifestModelIdNormalizationPolicies([
+      {
+        modelIdNormalization: {
+          providers: {
+            openai: { stripPrefixes },
+          },
+        },
+      },
+    ]);
+    return normalizeStaticProviderModelIdWithPolicies("openai", modelId, policies);
+  }
+
+  it("strips a whitespace-free prefix exactly (control: no regression)", () => {
+    expect(stripWith(["openai/"], "openai/gpt-4")).toBe("gpt-4");
+  });
+
+  it("strips by the matched length when the manifest prefix has a leading space", () => {
+    expect(stripWith([" openai/"], "openai/gpt-4")).toBe("gpt-4");
+  });
+
+  it("strips by the matched length when the manifest prefix has a trailing space", () => {
+    expect(stripWith(["openai/ "], "openai/gpt-4")).toBe("gpt-4");
+  });
+
+  it("strips by the matched length when the manifest prefix differs in case and spacing", () => {
+    expect(stripWith([" OpenAI/ "], "openai/gpt-4")).toBe("gpt-4");
+  });
+});

--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -98,7 +98,7 @@ export function normalizeProviderModelIdWithPolicies(params: {
   for (const prefix of policy.stripPrefixes ?? []) {
     const normalizedPrefix = normalizeLowercaseStringOrEmpty(prefix);
     if (normalizedPrefix && normalizeLowercaseStringOrEmpty(modelId).startsWith(normalizedPrefix)) {
-      modelId = modelId.slice(prefix.length);
+      modelId = modelId.slice(normalizedPrefix.length);
       break;
     }
   }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Closes: #95743

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Fixes an issue where an operator whose plugin manifest declares a `stripPrefixes` entry with incidental surrounding
whitespace (or different casing) has the resolved model id silently **over-stripped**; for example
`openai/gpt-4` resolves to `pt-4`. The configured model then no longer matches any real provider model, so model
resolution produces a broken id and requests fail to route. This affects model-id normalization for any
manifest-defined provider that uses `stripPrefixes`.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

In the `stripPrefixes` loop the prefix is **matched** against the model id using the normalized value
(`normalizeLowercaseStringOrEmpty` = `trim().toLowerCase()`), but the model id is then **sliced** by the raw,
untrimmed prefix length:

```ts
const normalizedPrefix = normalizeLowercaseStringOrEmpty(prefix);
if (normalizedPrefix && normalizeLowercaseStringOrEmpty(modelId).startsWith(normalizedPrefix)) {
  modelId = modelId.slice(prefix.length); // raw length — does not match the value we matched on
  break;
}
```

So when the manifest prefix is `" openai/"` (length 8) the match succeeds on the trimmed `"openai/"` (length 7) but
the slice removes 8 characters. The fix slices by the same value the match was made on:

```ts
modelId = modelId.slice(normalizedPrefix.length);
```

This is exact for whitespace-free, already-lowercase prefixes
(`"openai/".length === normalizeLowercaseStringOrEmpty("openai/").length`), so existing manifests are unaffected.
One operand changes; no API, signature, or control-flow change.

The two sibling `slice(prefix.length)` uses in this file are unaffected by construction and are left as-is:
`stripSelfProviderModelPrefix` (L76) builds its `prefix` from the already-normalized value
(`normalizeLowercaseStringOrEmpty(provider) + "/"`), and the HuggingFace branch (L163) uses the hard-coded literal
`"huggingface/"` — in both, `prefix.length` already equals the matched length, so no whitespace/case mismatch is
possible.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

Operators can include incidental whitespace or casing in a manifest `stripPrefixes` entry and still get the correct
model id. Whitespace-free manifests behave exactly as before.

## Evidence
<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
**Real run.** I invoked the production normalization entry points exported by `packages/model-catalog-core`
(`collectManifestModelIdNormalizationPolicies` → `normalizeStaticProviderModelIdWithPolicies`) directly under Node
v24.16.0 in a clean `node:24-bookworm` Docker container — the same path the gateway uses to resolve a configured
provider/model id from a plugin manifest — before vs. after this patch:

```bash
docker run --rm -v "$PWD":/work -w /work node:24-bookworm \
  bash -lc 'node -v && npx -y tsx demo.mts ./src/provider-model-id-normalization.ts'
# demo.mts builds a manifest-shaped policy and resolves it:
#   collectManifestModelIdNormalizationPolicies([{ modelIdNormalization:
#     { providers: { openai: { stripPrefixes } } } }])
#   normalizeStaticProviderModelIdWithPolicies("openai", "openai/gpt-4", policies)
```

Captured stdout (real, unedited):

```
v24.16.0
===== BEFORE FIX (upstream main source) =====
source: ./buggy/provider-model-id-normalization.ts
  stripPrefixes=["openai/"]   "openai/gpt-4" -> "gpt-4"  [ok]
  stripPrefixes=[" openai/"]  "openai/gpt-4" -> "pt-4"  [OVER-STRIPPED]
  stripPrefixes=["openai/ "]  "openai/gpt-4" -> "pt-4"  [OVER-STRIPPED]
  stripPrefixes=[" OpenAI/ "] "openai/gpt-4" -> "t-4"  [OVER-STRIPPED]

===== AFTER FIX (this PR) =====
source: ./fixed/provider-model-id-normalization.ts
  stripPrefixes=["openai/"]   "openai/gpt-4" -> "gpt-4"  [ok]
  stripPrefixes=[" openai/"]  "openai/gpt-4" -> "gpt-4"  [ok]
  stripPrefixes=["openai/ "]  "openai/gpt-4" -> "gpt-4"  [ok]
  stripPrefixes=[" OpenAI/ "] "openai/gpt-4" -> "gpt-4"  [ok]
```

After the fix every padded/cased prefix resolves to `gpt-4`, matching the whitespace-free control case; the control
case is unchanged, confirming no regression.

**Regression tests.** Added 4 colocated cases in `provider-model-id-normalization.test.ts` (one control + three
whitespace/case variants), driven through the public manifest path. Against the patched source: `9 passed (9)`.
Against the unpatched source (to confirm the cases are real): `3 failed | 6 passed` — the three padded/cased cases
fail with `"pt-4"`/`"t-4"`, the control passes.

**Format / lint.** `oxfmt 0.52.0 --check`: clean. `oxlint 1.67.0` with the repo config:
`Found 0 warnings and 0 errors`.

**Scope of the run:** the production normalization path (manifest policy →
`normalizeStaticProviderModelIdWithPolicies`) was exercised directly under Node in Docker with the exact policy
object the gateway builds from a manifest. A full gateway boot loading an on-disk manifest file was outside this run
and is not needed to prove a one-operand `slice` change.
