### PR TITLE
fix(#95734): [Bug]: agents add --bind generates accountId format, but router only matches peer format

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -57,17 +57,25 @@ You can also add bindings when creating an agent:
 openclaw agents add work --workspace ~/.openclaw/workspace-work --bind telegram:* --bind discord:*
 ```
 
+Bind to a specific conversation (group, channel, or direct message) using the 3-segment format:
+
+```bash
+openclaw agents add feishu-bot --workspace ~/.openclaw/workspace-feishu --bind 'feishu:group:oc_test'
+openclaw agents bind --agent feishu-bot --bind 'matrix:dm:user123'
+```
+
 If you omit `accountId` (`--bind <channel>`), OpenClaw resolves it from plugin setup hooks, forced account binding, or the channel's configured account count.
 
 If you omit `--agent` for `bind` or `unbind`, OpenClaw targets the current default agent.
 
 ### `--bind` format
 
-| Format                       | Meaning                                                                                           |
-| ---------------------------- | ------------------------------------------------------------------------------------------------- |
-| `--bind <channel>:*`         | Match all accounts on the channel.                                                                |
-| `--bind <channel>:<account>` | Match one account.                                                                                |
-| `--bind <channel>`           | Match the default account only unless the CLI can safely resolve a plugin-specific account scope. |
+| Format                         | Meaning                                                                                           |
+| ------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `--bind <channel>:*`           | Match all accounts on the channel.                                                                |
+| `--bind <channel>:<account>`   | Match one account.                                                                                |
+| `--bind <channel>`             | Match the default account only unless the CLI can safely resolve a plugin-specific account scope. |
+| `--bind <channel>:<kind>:<id>` | Match a specific conversation by peer kind (`direct`, `group`, or `channel`) and peer ID.         |
 
 ### Binding scope behavior
 
@@ -122,7 +130,7 @@ Options:
 - `--workspace <dir>`
 - `--model <id>`
 - `--agent-dir <dir>`
-- `--bind <channel[:accountId]>` (repeatable)
+- `--bind <format>` (repeatable) — see [`--bind` format](#--bind-format)
 - `--non-interactive`
 - `--json`
 
@@ -149,7 +157,7 @@ Options:
 Options:
 
 - `--agent <id>` (defaults to the current default agent)
-- `--bind <channel[:accountId]>` (repeatable)
+- `--bind <format>` (repeatable) — see [`--bind` format](#--bind-format)
 - `--json`
 
 ### `agents unbind`
@@ -157,7 +165,7 @@ Options:
 Options:
 
 - `--agent <id>` (defaults to the current default agent)
-- `--bind <channel[:accountId]>` (repeatable)
+- `--bind <format>` (repeatable) — see [`--bind` format](#--bind-format)
 - `--all`
 - `--json`
 

--- a/src/commands/agents.bind.matrix.integration.test.ts
+++ b/src/commands/agents.bind.matrix.integration.test.ts
@@ -33,16 +33,134 @@ describe("agents bind matrix integration", () => {
     ]);
   });
 
-  it("rejects a binding spec with extra colon segments instead of silently truncating", () => {
+  it("accepts a three-segment peer binding spec (channel:peer_kind:peer_id)", () => {
     setActivePluginRegistry(
       createTestRegistry([{ pluginId: "matrix", plugin: matrixBindingPlugin, source: "test" }]),
     );
 
-    const parsed = parseBindingSpecs({ agentId: "main", specs: ["matrix:work:extra"], config: {} });
+    const parsed = parseBindingSpecs({
+      agentId: "main",
+      specs: ["matrix:group:oc_test"],
+      config: {},
+    });
+
+    expect(parsed.errors).toStrictEqual([]);
+    expect(parsed.bindings).toEqual([
+      {
+        type: "route",
+        agentId: "main",
+        match: { channel: "matrix", peer: { kind: "group", id: "oc_test" } },
+      },
+    ]);
+  });
+
+  it("rejects a binding spec with more than three colon segments", () => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "matrix", plugin: matrixBindingPlugin, source: "test" }]),
+    );
+
+    const parsed = parseBindingSpecs({
+      agentId: "main",
+      specs: ["matrix:work:extra:too_many"],
+      config: {},
+    });
 
     expect(parsed.bindings).toEqual([]);
     expect(parsed.errors).toEqual([
-      'Invalid binding "matrix:work:extra". Account id cannot contain ":". Use <channel>:<account>, for example telegram:default.',
+      'Invalid binding "matrix:work:extra:too_many". Too many segments. Use <channel>:<account> (e.g., telegram:default) or <channel>:<peer_kind>:<peer_id> (e.g., feishu:group:oc_test).',
+    ]);
+  });
+
+  it("rejects peer binding with invalid peer kind", () => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "matrix", plugin: matrixBindingPlugin, source: "test" }]),
+    );
+
+    const parsed = parseBindingSpecs({
+      agentId: "main",
+      specs: ["matrix:invalid:oc_test"],
+      config: {},
+    });
+
+    expect(parsed.bindings).toEqual([]);
+    expect(parsed.errors).toEqual([
+      'Invalid binding "matrix:invalid:oc_test". Peer kind "invalid" is not valid. Use one of: direct, group, channel. For example feishu:group:oc_test.',
+    ]);
+  });
+
+  it("rejects peer binding with empty peer kind", () => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "matrix", plugin: matrixBindingPlugin, source: "test" }]),
+    );
+
+    const parsed = parseBindingSpecs({
+      agentId: "main",
+      specs: ["matrix::oc_test"],
+      config: {},
+    });
+
+    expect(parsed.bindings).toEqual([]);
+    expect(parsed.errors).toEqual([
+      'Invalid binding "matrix::oc_test". Peer kind is empty. Use <channel>:<peer_kind>:<peer_id>, for example feishu:group:oc_test.',
+    ]);
+  });
+
+  it("rejects peer binding with empty peer id", () => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "matrix", plugin: matrixBindingPlugin, source: "test" }]),
+    );
+
+    const parsed = parseBindingSpecs({
+      agentId: "main",
+      specs: ["matrix:group:"],
+      config: {},
+    });
+
+    expect(parsed.bindings).toEqual([]);
+    expect(parsed.errors).toEqual([
+      'Invalid binding "matrix:group:". Peer id is empty. Use <channel>:<peer_kind>:<peer_id>, for example feishu:group:oc_test.',
+    ]);
+  });
+
+  it("normalizes peer kind aliases (dm -> direct)", () => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "matrix", plugin: matrixBindingPlugin, source: "test" }]),
+    );
+
+    const parsed = parseBindingSpecs({
+      agentId: "main",
+      specs: ["matrix:dm:user123"],
+      config: {},
+    });
+
+    expect(parsed.errors).toStrictEqual([]);
+    expect(parsed.bindings).toEqual([
+      {
+        type: "route",
+        agentId: "main",
+        match: { channel: "matrix", peer: { kind: "direct", id: "user123" } },
+      },
+    ]);
+  });
+
+  it("accepts peer binding with channel kind", () => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "matrix", plugin: matrixBindingPlugin, source: "test" }]),
+    );
+
+    const parsed = parseBindingSpecs({
+      agentId: "main",
+      specs: ["matrix:channel:news"],
+      config: {},
+    });
+
+    expect(parsed.errors).toStrictEqual([]);
+    expect(parsed.bindings).toEqual([
+      {
+        type: "route",
+        agentId: "main",
+        match: { channel: "matrix", peer: { kind: "channel", id: "news" } },
+      },
     ]);
   });
 

--- a/src/commands/agents.bindings.ts
+++ b/src/commands/agents.bindings.ts
@@ -1,6 +1,7 @@
 // Pure helpers for parsing, adding, removing, and generating agent route bindings.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeSortedUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { normalizeChatType } from "../channels/chat-type.js";
 import { getBundledChannelSetupPlugin } from "../channels/plugins/bundled.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { getLoadedChannelPlugin } from "../channels/plugins/index.js";
@@ -316,37 +317,76 @@ export function parseBindingSpecs(params: {
     if (!trimmed) {
       continue;
     }
-    // Bind specs are exactly <channel> or <channel>:<account>; extra colon
-    // segments would silently change the requested account if truncated.
-    const [channelRaw, accountRaw, ...extraSegments] = trimmed.split(":");
-    if (extraSegments.length > 0) {
-      errors.push(
-        `Invalid binding "${trimmed}". Account id cannot contain ":". Use <channel>:<account>, for example telegram:default.`,
-      );
-      continue;
-    }
+    const segments = trimmed.split(":");
+    const channelRaw = segments[0];
     const channel = normalizeBindingChannelId(channelRaw, params.config);
     if (!channel) {
       errors.push(formatUnknownChannelMessage({ channel: channelRaw }));
       continue;
     }
-    let accountId: string | undefined = accountRaw?.trim();
-    if (accountRaw !== undefined && !accountId) {
+
+    const match: AgentRouteBinding["match"] = { channel };
+
+    if (segments.length === 1) {
+      // <channel> only — resolve default accountId from plugin
+      const accountId = resolveBindingAccountId({
+        channel,
+        config: params.config,
+        agentId,
+        explicitAccountId: undefined,
+      });
+      if (accountId) {
+        match.accountId = accountId;
+      }
+    } else if (segments.length === 2) {
+      // <channel>:<account> — accountId binding
+      let accountId: string | undefined = segments[1]?.trim();
+      if (!accountId) {
+        errors.push(
+          `Invalid binding "${trimmed}". Account id is empty. Use <channel>:<account>, for example telegram:default.`,
+        );
+        continue;
+      }
+      accountId = resolveBindingAccountId({
+        channel,
+        config: params.config,
+        agentId,
+        explicitAccountId: accountId,
+      });
+      if (accountId) {
+        match.accountId = accountId;
+      }
+    } else if (segments.length === 3) {
+      // <channel>:<peer_kind>:<peer_id> — peer binding
+      const peerKindRaw = segments[1]?.trim();
+      const peerIdRaw = segments[2]?.trim();
+      if (!peerKindRaw) {
+        errors.push(
+          `Invalid binding "${trimmed}". Peer kind is empty. Use <channel>:<peer_kind>:<peer_id>, for example feishu:group:oc_test.`,
+        );
+        continue;
+      }
+      if (!peerIdRaw) {
+        errors.push(
+          `Invalid binding "${trimmed}". Peer id is empty. Use <channel>:<peer_kind>:<peer_id>, for example feishu:group:oc_test.`,
+        );
+        continue;
+      }
+      const peerKind = normalizeChatType(peerKindRaw);
+      if (!peerKind) {
+        errors.push(
+          `Invalid binding "${trimmed}". Peer kind "${peerKindRaw}" is not valid. Use one of: direct, group, channel. For example feishu:group:oc_test.`,
+        );
+        continue;
+      }
+      match.peer = { kind: peerKind, id: peerIdRaw };
+    } else {
       errors.push(
-        `Invalid binding "${trimmed}". Account id is empty. Use <channel>:<account>, for example telegram:default.`,
+        `Invalid binding "${trimmed}". Too many segments. Use <channel>:<account> (e.g., telegram:default) or <channel>:<peer_kind>:<peer_id> (e.g., feishu:group:oc_test).`,
       );
       continue;
     }
-    accountId = resolveBindingAccountId({
-      channel,
-      config: params.config,
-      agentId,
-      explicitAccountId: accountId,
-    });
-    const match: AgentRouteBinding["match"] = { channel };
-    if (accountId) {
-      match.accountId = accountId;
-    }
+
     bindings.push({ type: "route", agentId, match });
   }
   return { bindings, errors };


### PR DESCRIPTION
Closes #95734

## What Problem This Solves

Fixes an issue where `openclaw agents add --bind "feishu:oc_test"` generates bindings using the `accountId` field, but the routing engine matches conversations using the `peer` field. Messages in Feishu groups fall through to the default agent instead of the bound agent.

Users creating channel-specific agents (e.g., Feishu group bindings) had to manually edit `openclaw.json` after every `agents add` command to convert `accountId` to `peer` format — otherwise group messages were silently routed to the default agent.

## Why This Change Was Made

The `parseBindingSpecs` function in `src/commands/agents.bindings.ts` only recognized a 2-segment format `<channel>:<account>` which maps to `match.accountId`. However, route resolution (`src/routing/resolve-route.ts`) uses `match.peer` as the conversation-specific routing tier (checked at priority 1), while `match.accountId` is a lower-priority tier (priority 7). This means `accountId`-based bindings were ignored for group chat routing.

The fix introduces a new 3-segment binding format `<channel>:<peer_kind>:<peer_id>` (e.g., `feishu:group:oc_test`) that creates a `match.peer = { kind, id }` binding, which the router matches at the highest conversation-specific tier.

Key design decisions:
- `peer_kind` is validated against the `ChatType` enum (`direct`, `group`, `channel`) via `normalizeChatType()` with `dm` → `direct` alias support
- Empty or invalid peer segments produce explicit error messages
- Specs with more than 3 segments are rejected with a clear error documenting both valid formats
- The existing 2-segment format `<channel>:<account>` is preserved unchanged for backward compatibility

Non-goals:
- Migrating existing `accountId`-format bindings in `openclaw.json` to `peer` format (users must update manually or re-run `agents add`)
- Changes to the routing engine itself — this fix is in the CLI binding parser only

## User Impact

Users can now run `openclaw agents add --bind 'feishu:group:oc_test'` and the generated binding will use `match.peer = { kind: "group", id: "oc_test" }`, which the routing engine correctly matches for Feishu group messages.

## Evidence

### CLI command output

```
$ pnpm openclaw agents add test-agent --bind 'feishu:group:oc_test' --non-interactive --workspace /tmp/oc-evidence

Updated config: ~/.openclaw/openclaw.json
  Backup: ~/.openclaw/openclaw.json.bak
Workspace OK: /tmp/oc-evidence
Sessions OK: ~/.openclaw/agents/test-agent/sessions
Agent: test-agent
Workspace: /tmp/oc-evidence
Agent dir: ~/.openclaw/agents/test-agent/agent
```

### Generated binding in openclaw.json

```json
{
  "bindings": [
    {
      "type": "route",
      "agentId": "test-agent",
      "match": {
        "channel": "feishu",
        "peer": {
          "kind": "group",
          "id": "oc_test"
        }
      }
    }
  ]
}
```

### Parser-level proof (all edge cases)

```
// 3-segment peer binding — NEW
parseBindingSpecs({ specs: ["feishu:group:oc_test"] })
// → { bindings: [{ match: { channel: "feishu", peer: { kind: "group", id: "oc_test" } } }] }

// 2-segment account binding — backward compatible
parseBindingSpecs({ specs: ["telegram:default"] })
// → { bindings: [{ match: { channel: "telegram", accountId: "default" } }] }

// 1-segment channel-only — backward compatible
parseBindingSpecs({ specs: ["telegram"] })
// → { bindings: [{ match: { channel: "telegram" } }] }

// dm alias → direct
parseBindingSpecs({ specs: ["matrix:dm:user123"] })
// → { bindings: [{ match: { channel: "matrix", peer: { kind: "direct", id: "user123" } } }] }

// Invalid peer kind → error
parseBindingSpecs({ specs: ["matrix:room:oc_test"] })
// → { errors: ['Peer kind "room" is not valid. Use one of: direct, group, channel.'] }

// Empty peer kind → error
parseBindingSpecs({ specs: ["matrix::oc_test"] })
// → { errors: ['Peer kind is empty.'] }

// Empty peer id → error
parseBindingSpecs({ specs: ["matrix:group:"] })
// → { errors: ['Peer id is empty.'] }

// Too many segments → error
parseBindingSpecs({ specs: ["matrix:a:b:c"] })
// → { errors: ['Too many segments.'] }
```

### Test results

```
$ pnpm test src/commands/agents.bind.matrix.integration.test.ts
Test Files  1 passed (1)
     Tests  9 passed (9)
```

### Proof limitations

- No live Feishu environment available; validation is limited to the binding parser and test suite.
- End-to-end Feishu message routing requires an active Feishu bot token and group setup.