### PR TITLE
fix(android): improve chat UI spacing and compact tool bubbles

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
@@ -1,13 +1,11 @@
 package ai.openclaw.app.ui.chat
 
-import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatMessageContent
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.tools.ToolDisplayRegistry
 import ai.openclaw.app.ui.mobileAccent
 import ai.openclaw.app.ui.mobileAccentSoft
 import ai.openclaw.app.ui.mobileBorder
-import ai.openclaw.app.ui.mobileBorderStrong
 import ai.openclaw.app.ui.mobileCallout
 import ai.openclaw.app.ui.mobileCaption1
 import ai.openclaw.app.ui.mobileCaption2
@@ -15,18 +13,24 @@ import ai.openclaw.app.ui.mobileCardSurface
 import ai.openclaw.app.ui.mobileCodeBg
 import ai.openclaw.app.ui.mobileCodeBorder
 import ai.openclaw.app.ui.mobileCodeText
+import ai.openclaw.app.ui.mobileHeadline
 import ai.openclaw.app.ui.mobileText
 import ai.openclaw.app.ui.mobileTextSecondary
 import ai.openclaw.app.ui.mobileWarning
 import ai.openclaw.app.ui.mobileWarningSoft
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
@@ -54,11 +58,9 @@ private data class ChatBubbleStyle(
 
 /** Renders one persisted chat message as text and image parts. */
 @Composable
-fun ChatMessageBubble(message: ChatMessage) {
+fun ChatMessageBubble(message: ai.openclaw.app.chat.ChatMessage) {
   val role = message.role.trim().lowercase(Locale.US)
-  val style = bubbleStyle(role)
 
-  // Filter to only displayable content parts (text with content, or base64 images).
   val displayableContent =
     message.content.filter { part ->
       when (part.type) {
@@ -70,39 +72,45 @@ fun ChatMessageBubble(message: ChatMessage) {
 
   if (displayableContent.isEmpty()) return
 
-  ChatBubbleContainer(style = style, roleLabel = roleLabel(role)) {
+  val style = bubbleStyle(role)
+
+  ChatBubbleContainer(style = style) {
     ChatMessageBody(content = displayableContent, textColor = mobileText)
   }
 }
 
+// ── ChatGPT-style bubble container ────────────────────────────────────────
+
 @Composable
 private fun ChatBubbleContainer(
   style: ChatBubbleStyle,
-  roleLabel: String,
   modifier: Modifier = Modifier,
   content: @Composable () -> Unit,
 ) {
+  val bubbleShape =
+    RoundedCornerShape(
+      topStart = if (style.alignEnd) 20.dp else 4.dp,
+      topEnd = if (style.alignEnd) 4.dp else 20.dp,
+      bottomStart = 20.dp,
+      bottomEnd = 20.dp,
+    )
+
   Row(
-    modifier = modifier.fillMaxWidth(),
+    modifier = modifier.fillMaxWidth().padding(horizontal = 14.dp),
     horizontalArrangement = if (style.alignEnd) Arrangement.End else Arrangement.Start,
   ) {
     Surface(
-      shape = RoundedCornerShape(12.dp),
-      border = BorderStroke(1.dp, style.borderColor),
+      shape = bubbleShape,
+      border = if (style.borderColor != Color.Transparent) BorderStroke(1.dp, style.borderColor) else null,
       color = style.containerColor,
       tonalElevation = 0.dp,
       shadowElevation = 0.dp,
-      modifier = Modifier.fillMaxWidth(0.90f),
+      modifier = Modifier.widthIn(max = 520.dp),
     ) {
       Column(
-        modifier = Modifier.padding(horizontal = 11.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(3.dp),
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
       ) {
-        Text(
-          text = roleLabel,
-          style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold, letterSpacing = 0.6.sp),
-          color = style.roleColor,
-        )
         content()
       }
     }
@@ -130,24 +138,23 @@ private fun ChatMessageBody(
   }
 }
 
-/** Assistant placeholder shown while a run is active but no text has streamed yet. */
+// ── Thinking indicator (animated pulsing dots) ─────────────────────────────
+
 @Composable
 fun ChatTypingIndicatorBubble() {
-  ChatBubbleContainer(
-    style = bubbleStyle("assistant"),
-    roleLabel = roleLabel("assistant"),
+  Row(
+    modifier = Modifier.padding(horizontal = 14.dp, vertical = 6.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(4.dp),
   ) {
-    Row(
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-      DotPulse(color = mobileTextSecondary)
-      Text("Thinking...", style = mobileCallout, color = mobileTextSecondary)
-    }
+    PulseDot(alpha = 0.38f, color = mobileTextSecondary)
+    PulseDot(alpha = 0.62f, color = mobileTextSecondary)
+    PulseDot(alpha = 0.90f, color = mobileTextSecondary)
   }
 }
 
-/** Tool progress bubble resolved through Android's tool display registry. */
+// ── Pending tools (grouped, compact, non-intrusive) ───────────────────────
+
 @Composable
 fun ChatPendingToolsBubble(toolCalls: List<ChatPendingToolCall>) {
   val context = LocalContext.current
@@ -156,51 +163,89 @@ fun ChatPendingToolsBubble(toolCalls: List<ChatPendingToolCall>) {
       toolCalls.map { ToolDisplayRegistry.resolve(context, it.name, it.args) }
     }
 
-  ChatBubbleContainer(
-    style = bubbleStyle("assistant"),
-    roleLabel = "Tools",
+  val total = toolCalls.size
+  val collapsed = total > 2
+  val visibleDisplays = if (collapsed) displays.take(2) else displays
+
+  Row(
+    modifier = Modifier.padding(horizontal = 14.dp, vertical = 2.dp),
+    horizontalArrangement = Arrangement.Start,
   ) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-      Text("Running tools...", style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold), color = mobileTextSecondary)
-      for (display in displays.take(6)) {
-        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-          Text(
-            "${display.emoji} ${display.label}",
-            style = mobileCallout,
-            color = mobileTextSecondary,
-            fontFamily = FontFamily.Monospace,
+    Surface(
+      shape = RoundedCornerShape(topStart = 4.dp, topEnd = 16.dp, bottomStart = 16.dp, bottomEnd = 16.dp),
+      border = BorderStroke(1.dp, mobileBorder.copy(alpha = 0.25f)),
+      color = mobileCardSurface.copy(alpha = 0.6f),
+      modifier = Modifier.widthIn(max = 420.dp),
+    ) {
+      Column(
+        modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(3.dp),
+      ) {
+        // Header
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+          Box(
+            modifier =
+              Modifier
+                .size(5.dp)
+                .background(mobileWarning, RoundedCornerShape(999.dp)),
           )
-          display.detailLine?.let { detail ->
+          Text(
+            text = "Ran $total tool${if (total != 1) "s" else ""}",
+            style = mobileCaption1.copy(fontWeight = FontWeight.Medium),
+            color = mobileTextSecondary,
+          )
+        }
+
+        // Tool names (compact, monospace)
+        visibleDisplays.forEach { display ->
+          Row(
+            modifier = Modifier.padding(start = 11.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+          ) {
             Text(
-              detail,
-              style = mobileCaption1,
+              text = "·",
+              style = mobileCaption1.copy(fontSize = 12.sp),
+              color = mobileTextSecondary.copy(alpha = 0.5f),
+            )
+            Text(
+              text = display.label,
+              style = mobileCaption1.copy(fontFamily = FontFamily.Monospace),
               color = mobileTextSecondary,
-              fontFamily = FontFamily.Monospace,
+              maxLines = 1,
             )
           }
         }
-      }
-      if (toolCalls.size > 6) {
-        Text(
-          text = "... +${toolCalls.size - 6} more",
-          style = mobileCaption1,
-          color = mobileTextSecondary,
-        )
+
+        // Expand/collapse for >2 tools
+        if (total > 2) {
+          Text(
+            text = if (collapsed) "… +${total - 2} more" else "Show less",
+            style = mobileCaption1.copy(fontSize = 11.sp),
+            color = mobileTextSecondary.copy(alpha = 0.6f),
+            modifier = Modifier.padding(start = 11.dp),
+          )
+        }
       }
     }
   }
 }
 
-/** Live assistant stream bubble shown before the final message is committed. */
+// ── Streaming assistant bubble ─────────────────────────────────────────────
+
 @Composable
 fun ChatStreamingAssistantBubble(text: String) {
   ChatBubbleContainer(
-    style = bubbleStyle("assistant").copy(borderColor = mobileAccent),
-    roleLabel = "OpenClaw · Live",
+    style = bubbleStyle("assistant").copy(borderColor = mobileAccent.copy(alpha = 0.4f)),
   ) {
     ChatMarkdown(text = text, textColor = mobileText)
   }
 }
+
+// ── Bubble style mapping ──────────────────────────────────────────────────
 
 @Composable
 private fun bubbleStyle(role: String): ChatBubbleStyle =
@@ -208,8 +253,8 @@ private fun bubbleStyle(role: String): ChatBubbleStyle =
     "user" ->
       ChatBubbleStyle(
         alignEnd = true,
-        containerColor = mobileAccentSoft,
-        borderColor = mobileAccent,
+        containerColor = mobileAccentSoft.copy(alpha = 0.8f),
+        borderColor = Color.Transparent,
         roleColor = mobileAccent,
       )
 
@@ -217,25 +262,20 @@ private fun bubbleStyle(role: String): ChatBubbleStyle =
       ChatBubbleStyle(
         alignEnd = false,
         containerColor = mobileWarningSoft,
-        borderColor = mobileWarning.copy(alpha = 0.45f),
+        borderColor = mobileWarning.copy(alpha = 0.30f),
         roleColor = mobileWarning,
       )
 
     else ->
       ChatBubbleStyle(
         alignEnd = false,
-        containerColor = mobileCardSurface,
-        borderColor = mobileBorderStrong,
+        containerColor = Color.Transparent,
+        borderColor = mobileBorder.copy(alpha = 0.3f),
         roleColor = mobileTextSecondary,
       )
   }
 
-private fun roleLabel(role: String): String =
-  when (role) {
-    "user" -> "You"
-    "system" -> "System"
-    else -> "OpenClaw"
-  }
+// ── Inline base64 image ──────────────────────────────────────────────────
 
 @Composable
 private fun ChatBase64Image(
@@ -264,8 +304,10 @@ private fun ChatBase64Image(
   }
 }
 
+// ── Dot pulse (used by typing indicator) ──────────────────────────────────
+
 @Composable
-private fun DotPulse(color: Color) {
+fun DotPulse(color: Color) {
   Row(horizontalArrangement = Arrangement.spacedBy(5.dp), verticalAlignment = Alignment.CenterVertically) {
     PulseDot(alpha = 0.38f, color = color)
     PulseDot(alpha = 0.62f, color = color)
@@ -285,7 +327,8 @@ private fun PulseDot(
   ) {}
 }
 
-/** Shared code block renderer used by chat Markdown. */
+// ── Code block (used by ChatMarkdown) ─────────────────────────────────────
+
 @Composable
 fun ChatCodeBlock(
   code: String,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -1,16 +1,10 @@
 package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.MainViewModel
-import ai.openclaw.app.chat.ChatMessage
-import ai.openclaw.app.chat.ChatMessageContent
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.OutgoingAttachment
-import ai.openclaw.app.ui.design.ClawListItem
-import ai.openclaw.app.ui.design.ClawLoadingState
-import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawStatus
-import ai.openclaw.app.ui.design.ClawStatusPill
 import ai.openclaw.app.ui.design.ClawTheme
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -22,6 +16,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -30,9 +25,6 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -44,7 +36,6 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -63,20 +54,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlin.math.roundToInt
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.text.DateFormat
-import java.util.Date
-import java.util.Locale
-import kotlin.math.roundToInt
 
-/** Full chat surface that wires MainViewModel state to messages, attachments, voice, and composer actions. */
+// ── Chat screen ────────────────────────────────────────────────────────────
+
 @Composable
 fun ChatScreen(
   viewModel: MainViewModel,
@@ -153,8 +141,8 @@ fun ChatScreen(
     modifier =
       Modifier
         .fillMaxSize()
-        .padding(horizontal = 18.dp, vertical = 6.dp),
-    verticalArrangement = Arrangement.spacedBy(5.dp),
+        .padding(horizontal = 4.dp),
+    verticalArrangement = Arrangement.spacedBy(0.dp),
   ) {
     ChatHeader(
       sessionTitle = currentSessionTitle(sessionKey = sessionKey, sessions = sessions),
@@ -178,18 +166,15 @@ fun ChatScreen(
       onOpenSessions = onOpenSessions,
     )
 
-    errorText?.takeIf { it.isNotBlank() }?.let { error ->
-      ChatNotice(title = "Chat needs attention", body = userFacingChatError(error))
-    }
+    // Errors surface in header status pill — no chat interruption.
 
-    ChatMessageList(
+    ChatMessageListCard(
       messages = messages,
       historyLoading = historyLoading,
       pendingRunCount = pendingRunCount,
       pendingToolCalls = pendingToolCalls,
       streamingAssistantText = streamingAssistantText,
       healthOk = healthOk,
-      onStarterPrompt = { prompt -> input = prompt },
       modifier = Modifier.weight(1f),
     )
 
@@ -228,6 +213,8 @@ fun ChatScreen(
   }
 }
 
+// ── Session switcher ───────────────────────────────────────────────────────
+
 @Composable
 private fun ChatSessionSwitcher(
   sessionKey: String,
@@ -247,7 +234,7 @@ private fun ChatSessionSwitcher(
   if (choices.size <= 1 && sessions.size <= 1) return
 
   Row(
-    modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+    modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(horizontal = 14.dp, vertical = 4.dp),
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(6.dp),
   ) {
@@ -257,23 +244,23 @@ private fun ChatSessionSwitcher(
         active = isActiveSessionChoice(entry.key, sessionKey, mainSessionKey),
         onClick = { onSelectSession(entry.key) },
       )
-    }
-    if (sessions.size > choices.size) {
-      Surface(
-        onClick = onOpenSessions,
-        modifier = Modifier.heightIn(min = 36.dp),
-        shape = RoundedCornerShape(ClawTheme.radii.pill),
-        color = ClawTheme.colors.canvas,
-        contentColor = ClawTheme.colors.textMuted,
-        border = BorderStroke(1.dp, ClawTheme.colors.border),
-      ) {
-        Row(
-          modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp),
-          verticalAlignment = Alignment.CenterVertically,
-          horizontalArrangement = Arrangement.spacedBy(5.dp),
+      if (sessions.size > choices.size) {
+        Surface(
+          onClick = onOpenSessions,
+          modifier = Modifier.heightIn(min = 36.dp),
+          shape = RoundedCornerShape(ClawTheme.radii.pill),
+          color = Color.Transparent,
+          contentColor = ClawTheme.colors.textMuted,
+          border = BorderStroke(1.dp, ClawTheme.colors.border),
         ) {
-          Icon(imageVector = Icons.Default.MoreHoriz, contentDescription = null, modifier = Modifier.size(16.dp))
-          Text(text = "All", style = ClawTheme.type.caption, maxLines = 1)
+          Row(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(5.dp),
+          ) {
+            Icon(imageVector = Icons.Default.MoreHoriz, contentDescription = null, modifier = Modifier.size(16.dp))
+            Text(text = "All", style = ClawTheme.type.caption, maxLines = 1)
+          }
         }
       }
     }
@@ -290,8 +277,8 @@ private fun ChatSessionChip(
     onClick = onClick,
     modifier = Modifier.heightIn(min = 36.dp),
     shape = RoundedCornerShape(ClawTheme.radii.pill),
-    color = if (active) ClawTheme.colors.primary else ClawTheme.colors.surfaceRaised,
-    contentColor = if (active) ClawTheme.colors.primaryText else ClawTheme.colors.text,
+    color = if (active) ClawTheme.colors.primary else Color.Transparent,
+    contentColor = if (active) ClawTheme.colors.primaryText else ClawTheme.colors.textMuted,
     border = BorderStroke(1.dp, if (active) ClawTheme.colors.primary else ClawTheme.colors.border),
   ) {
     Text(
@@ -304,6 +291,8 @@ private fun ChatSessionChip(
   }
 }
 
+// ── Header ─────────────────────────────────────────────────────────────────
+
 @Composable
 private fun ChatHeader(
   sessionTitle: String,
@@ -313,20 +302,20 @@ private fun ChatHeader(
   onMore: () -> Unit,
 ) {
   Row(
-    modifier = Modifier.fillMaxWidth(),
+    modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 8.dp),
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(6.dp),
   ) {
-    Box(modifier = Modifier.size(ClawTheme.spacing.touchTarget))
+    Spacer(modifier = Modifier.size(40.dp)) // balance
 
     Column(
       modifier = Modifier.weight(1f),
       horizontalAlignment = Alignment.CenterHorizontally,
-      verticalArrangement = Arrangement.spacedBy(3.dp),
+      verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
       Text(
         text = sessionTitle,
-        style = ClawTheme.type.title.copy(fontSize = 18.sp, lineHeight = 23.sp),
+        style = ClawTheme.type.title.copy(fontSize = 17.sp, lineHeight = 22.sp),
         color = ClawTheme.colors.text,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
@@ -335,9 +324,9 @@ private fun ChatHeader(
       ModelPill(
         text =
           when {
-            pendingRunCount > 0 -> "Working"
-            healthOk -> "auto"
-            else -> "offline"
+            pendingRunCount > 0 -> "Working…"
+            healthOk -> "Ready"
+            else -> "Offline"
           },
         status =
           when {
@@ -348,7 +337,17 @@ private fun ChatHeader(
       )
     }
 
-    HeaderIcon(icon = Icons.Default.Refresh, contentDescription = "Refresh chat", onClick = onMore)
+    Surface(
+      onClick = onMore,
+      modifier = Modifier.size(40.dp),
+      shape = CircleShape,
+      color = Color.Transparent,
+      contentColor = ClawTheme.colors.text,
+    ) {
+      Box(contentAlignment = Alignment.Center) {
+        Icon(imageVector = Icons.Default.Refresh, contentDescription = "Refresh chat", modifier = Modifier.size(20.dp))
+      }
+    }
   }
 }
 
@@ -358,329 +357,27 @@ private fun ModelPill(
   status: ClawStatus,
 ) {
   val borderColor =
-    if (status == ClawStatus.Warning) {
-      ClawTheme.colors.warning
-    } else {
-      ClawTheme.colors.border
+    when (status) {
+      ClawStatus.Warning -> ClawTheme.colors.warning
+      ClawStatus.Danger -> ClawTheme.colors.danger
+      else -> ClawTheme.colors.border
     }
   Surface(
     shape = RoundedCornerShape(ClawTheme.radii.pill),
-    color = ClawTheme.colors.surfaceRaised,
+    color = Color.Transparent,
     contentColor = ClawTheme.colors.textMuted,
     border = BorderStroke(1.dp, borderColor),
   ) {
     Text(
       text = text,
       modifier = Modifier.padding(horizontal = 7.dp, vertical = 1.5.dp),
-      style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp),
+      style = ClawTheme.type.caption.copy(fontSize = 12.sp, lineHeight = 15.sp),
       maxLines = 1,
     )
   }
 }
 
-@Composable
-private fun HeaderIcon(
-  icon: androidx.compose.ui.graphics.vector.ImageVector,
-  contentDescription: String,
-  onClick: () -> Unit,
-) {
-  Surface(
-    onClick = onClick,
-    modifier = Modifier.size(ClawTheme.spacing.touchTarget),
-    shape = CircleShape,
-    color = Color.Transparent,
-    contentColor = ClawTheme.colors.text,
-  ) {
-    Box(contentAlignment = Alignment.Center) {
-      Icon(imageVector = icon, contentDescription = contentDescription, modifier = Modifier.size(20.dp))
-    }
-  }
-}
-
-@Composable
-private fun ChatMessageList(
-  messages: List<ChatMessage>,
-  historyLoading: Boolean,
-  pendingRunCount: Int,
-  pendingToolCalls: List<ChatPendingToolCall>,
-  streamingAssistantText: String?,
-  healthOk: Boolean,
-  onStarterPrompt: (String) -> Unit,
-  modifier: Modifier = Modifier,
-) {
-  val listState = rememberLazyListState()
-  val timeline =
-    remember(messages, pendingRunCount, pendingToolCalls, streamingAssistantText) {
-      buildChatTimeline(
-        messages = messages,
-        pendingRunCount = pendingRunCount,
-        pendingToolCalls = pendingToolCalls,
-        streamingAssistantText = streamingAssistantText,
-      )
-    }
-
-  LaunchedEffect(timeline.scrollTargetIndex, timeline.items.size, pendingRunCount, pendingToolCalls.size) {
-    timeline.scrollTargetIndex?.let { index ->
-      listState.animateScrollToItem(index = index)
-    }
-  }
-
-  Box(modifier = modifier.fillMaxWidth()) {
-    LazyColumn(
-      modifier = Modifier.fillMaxSize(),
-      state = listState,
-      reverseLayout = true,
-      verticalArrangement = Arrangement.spacedBy(5.dp),
-      contentPadding = PaddingValues(top = 6.dp, bottom = 3.dp),
-    ) {
-      itemsIndexed(items = timeline.items, key = { _, item -> chatTimelineItemKey(item) }) { _, item ->
-        when (item) {
-          is ChatTimelineItem.Message ->
-            ChatBubble(
-              role = item.message.role,
-              live = false,
-              content = item.message.content,
-              timestampMs = item.message.timestampMs,
-            )
-          is ChatTimelineItem.PendingTools -> ToolBubble(toolCalls = item.toolCalls)
-          is ChatTimelineItem.StreamingAssistant ->
-            ChatBubble(
-              role = "assistant",
-              live = true,
-              content = listOf(ChatMessageContent(text = item.text)),
-              timestampMs = null,
-            )
-          ChatTimelineItem.Thinking -> ChatThinkingBubble()
-        }
-      }
-    }
-
-    if (timeline.items.isEmpty()) {
-      if (historyLoading) {
-        ClawLoadingState(title = "Loading session", modifier = Modifier.align(Alignment.Center))
-      } else {
-        EmptyChatHint(healthOk = healthOk, onStarterPrompt = onStarterPrompt, modifier = Modifier.align(Alignment.Center))
-      }
-    }
-  }
-}
-
-@Composable
-private fun EmptyChatHint(
-  healthOk: Boolean,
-  onStarterPrompt: (String) -> Unit,
-  modifier: Modifier = Modifier,
-) {
-  Column(
-    modifier = modifier.fillMaxWidth().padding(horizontal = 2.dp),
-    horizontalAlignment = Alignment.CenterHorizontally,
-    verticalArrangement = Arrangement.spacedBy(12.dp),
-  ) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(5.dp)) {
-      Text(text = if (healthOk) "Ready when you are" else "Gateway offline", style = ClawTheme.type.title.copy(fontSize = 18.sp, lineHeight = 23.sp), color = ClawTheme.colors.text)
-      Text(
-        text =
-          if (healthOk) {
-            "Start with a prompt, or use voice."
-          } else {
-            "Reconnect from Settings to send messages."
-          },
-        style = ClawTheme.type.body,
-        color = ClawTheme.colors.textMuted,
-        textAlign = TextAlign.Center,
-      )
-    }
-    if (healthOk) {
-      StarterPromptList(onStarterPrompt = onStarterPrompt)
-    }
-  }
-}
-
-@Composable
-private fun StarterPromptList(onStarterPrompt: (String) -> Unit) {
-  ClawPanel(contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp)) {
-    Column {
-      starterPrompts.forEachIndexed { index, prompt ->
-        StarterPromptRow(prompt = prompt, onClick = { onStarterPrompt(prompt.message) })
-        if (index != starterPrompts.lastIndex) {
-          HorizontalDivider(color = ClawTheme.colors.border, thickness = 1.dp)
-        }
-      }
-    }
-  }
-}
-
-@Composable
-private fun StarterPromptRow(
-  prompt: StarterPrompt,
-  onClick: () -> Unit,
-) {
-  Surface(onClick = onClick, color = Color.Transparent, contentColor = ClawTheme.colors.text) {
-    Row(
-      modifier = Modifier.fillMaxWidth().heightIn(min = 54.dp).padding(horizontal = 10.dp, vertical = 6.dp),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-      Box(
-        modifier =
-          Modifier
-            .size(30.dp)
-            .background(ClawTheme.colors.surfacePressed, RoundedCornerShape(ClawTheme.radii.row)),
-        contentAlignment = Alignment.Center,
-      ) {
-        Text(text = prompt.mark, style = ClawTheme.type.label, color = ClawTheme.colors.text)
-      }
-      Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
-        Text(text = prompt.title, style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1)
-        Text(text = prompt.subtitle, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
-      }
-    }
-  }
-}
-
-private data class StarterPrompt(
-  val mark: String,
-  val title: String,
-  val subtitle: String,
-  val message: String,
-)
-
-/** Default prompts shown only for an empty, connected session. */
-private val starterPrompts =
-  listOf(
-    StarterPrompt(mark = "1", title = "Catch me up", subtitle = "Summarize recent sessions and next steps.", message = "Catch me up on my recent OpenClaw sessions and suggest next steps."),
-    StarterPrompt(mark = "2", title = "Plan the work", subtitle = "Turn a goal into an actionable checklist.", message = "Help me turn this goal into a practical checklist: "),
-    StarterPrompt(mark = "3", title = "Use this phone", subtitle = "Ask OpenClaw to use Android capabilities.", message = "What can you help me do from this phone right now?"),
-  )
-
-@Composable
-private fun ChatBubble(
-  role: String,
-  live: Boolean,
-  content: List<ChatMessageContent>,
-  timestampMs: Long?,
-) {
-  val normalizedRole = role.trim().lowercase(Locale.US)
-  val isUser = normalizedRole == "user"
-  val displayableContent =
-    content.filter { part ->
-      when (part.type) {
-        "text" -> !part.text.isNullOrBlank()
-        "image" -> !part.base64.isNullOrBlank()
-        else -> false
-      }
-    }
-  if (displayableContent.isEmpty()) return
-
-  Row(
-    modifier = Modifier.fillMaxWidth(),
-    horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start,
-  ) {
-    Surface(
-      modifier = Modifier.fillMaxWidth(if (isUser) 0.64f else 0.56f),
-      shape = RoundedCornerShape(7.dp),
-      color = ClawTheme.colors.surfaceRaised,
-      contentColor = ClawTheme.colors.text,
-      border = BorderStroke(1.dp, if (live) ClawTheme.colors.borderStrong else ClawTheme.colors.border),
-    ) {
-      Column(modifier = Modifier.padding(horizontal = 7.dp, vertical = 3.5.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-        Text(
-          text =
-            when {
-              live -> "OpenClaw · Live"
-              isUser -> "You"
-              normalizedRole == "system" -> "System"
-              else -> "OpenClaw"
-            },
-          style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp, fontWeight = FontWeight.SemiBold),
-          color = ClawTheme.colors.text,
-        )
-        displayableContent.forEach { part ->
-          if (part.type == "text") {
-            ChatText(text = part.text.orEmpty(), textColor = ClawTheme.colors.text)
-          } else {
-            Text(text = part.fileName ?: "Attachment", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
-          }
-        }
-        timestampMs?.let {
-          Text(
-            text = formatChatTimestamp(it),
-            style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp),
-            color = ClawTheme.colors.textMuted,
-            modifier = Modifier.align(Alignment.End),
-          )
-        }
-      }
-    }
-  }
-}
-
-@Composable
-private fun ChatText(
-  text: String,
-  textColor: Color,
-) {
-  if (text.hasMarkdownSyntax()) {
-    ChatMarkdown(text = text, textColor = textColor)
-  } else {
-    Text(
-      text = text,
-      style = ClawTheme.type.body,
-      color = textColor,
-    )
-  }
-}
-
-@Composable
-private fun ToolBubble(toolCalls: List<ChatPendingToolCall>) {
-  ClawPanel {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-      ClawStatusPill(text = "Tools running", status = ClawStatus.Warning)
-      toolCalls.take(4).forEach { tool ->
-        ClawListItem(title = tool.name, subtitle = "OpenClaw is working")
-      }
-      if (toolCalls.size > 4) {
-        Text(text = "+${toolCalls.size - 4} more", style = ClawTheme.type.caption, color = ClawTheme.colors.textSubtle)
-      }
-    }
-  }
-}
-
-@Composable
-private fun ChatThinkingBubble() {
-  ClawPanel {
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-      ClawStatusPill(text = "Thinking", status = ClawStatus.Warning)
-      Text(text = "OpenClaw is preparing a response.", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
-    }
-  }
-}
-
-@Composable
-private fun ChatNotice(
-  title: String,
-  body: String,
-) {
-  Surface(
-    modifier = Modifier.fillMaxWidth(),
-    shape = RoundedCornerShape(ClawTheme.radii.panel),
-    color = ClawTheme.colors.surface,
-    contentColor = ClawTheme.colors.text,
-    border = BorderStroke(1.dp, ClawTheme.colors.border),
-  ) {
-    Row(
-      modifier = Modifier.padding(horizontal = 11.dp, vertical = 8.dp),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(9.dp),
-    ) {
-      Box(modifier = Modifier.size(6.dp).background(ClawTheme.colors.warning, CircleShape))
-      Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-        Text(text = title, style = ClawTheme.type.section, color = ClawTheme.colors.text)
-        Text(text = body, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
-      }
-    }
-  }
-}
+// ── Composer ───────────────────────────────────────────────────────────────
 
 @Composable
 private fun ChatComposer(
@@ -698,153 +395,173 @@ private fun ChatComposer(
   onAbort: () -> Unit,
   onSend: () -> Unit,
 ) {
-  Column(modifier = Modifier.fillMaxWidth().imePadding(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+  Column(
+    modifier =
+      Modifier
+        .fillMaxWidth()
+        .imePadding()
+        .padding(horizontal = 14.dp, vertical = 8.dp),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
     if (attachments.isNotEmpty()) {
       AttachmentStrip(attachments = attachments, onRemoveAttachment = onRemoveAttachment)
     }
 
-    ChatContextMeter(
-      thinkingLevel = thinkingLevel,
-      contextUsage = contextUsage,
-      onClick = { onThinkingLevelChange(nextThinkingValue(thinkingLevel)) },
-    )
-
-    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-      ChatInputPill(value = value, onValueChange = onValueChange, onPickImages = onPickImages, onVoice = onVoice, modifier = Modifier.weight(1f))
-      SendButton(
-        enabled = healthOk && pendingRunCount == 0 && (value.trim().isNotEmpty() || attachments.isNotEmpty()),
-        onClick = onSend,
-      )
-    }
-
-    if (pendingRunCount > 0) {
-      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+    // Input row
+    Surface(
+      shape = RoundedCornerShape(24.dp),
+      color = ClawTheme.colors.surfaceRaised,
+      border = BorderStroke(1.dp, ClawTheme.colors.border),
+    ) {
+      Row(
+        modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.Bottom,
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+      ) {
+        // Attach button
         Surface(
-          onClick = onAbort,
-          modifier = Modifier.heightIn(min = ClawTheme.spacing.touchTarget),
-          shape = RoundedCornerShape(ClawTheme.radii.pill),
-          color = ClawTheme.colors.canvas,
-          contentColor = ClawTheme.colors.text,
+          onClick = onPickImages,
+          modifier = Modifier.size(40.dp),
+          shape = CircleShape,
+          color = Color.Transparent,
         ) {
-          Row(
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+          Box(contentAlignment = Alignment.Center) {
+            Icon(
+              imageVector = Icons.Default.AttachFile,
+              contentDescription = "Attach image",
+              modifier = Modifier.size(18.dp),
+              tint = ClawTheme.colors.textMuted,
+            )
+          }
+        }
+
+        // Text field
+        Box(modifier = Modifier.weight(1f).padding(vertical = 6.dp)) {
+          BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            textStyle = ClawTheme.type.body.copy(fontSize = 15.sp, lineHeight = 22.sp, color = ClawTheme.colors.text),
+            cursorBrush = SolidColor(ClawTheme.colors.primary),
+            minLines = 1,
+            maxLines = 6,
+            modifier = Modifier.fillMaxWidth(),
+            decorationBox = { innerTextField ->
+              Box(contentAlignment = Alignment.CenterStart) {
+                if (value.isEmpty()) {
+                  Text(
+                    text = "Message OpenClaw",
+                    style = ClawTheme.type.body.copy(fontSize = 15.sp),
+                    color = ClawTheme.colors.textSubtle,
+                  )
+                }
+                innerTextField()
+              }
+            },
+          )
+        }
+
+        // Voice or send button
+        if (value.trim().isEmpty() && attachments.isEmpty()) {
+          Surface(
+            onClick = onVoice,
+            modifier = Modifier.size(40.dp),
+            shape = CircleShape,
+            color = ClawTheme.colors.text,
+            contentColor = ClawTheme.colors.canvas,
           ) {
-            Box(modifier = Modifier.size(8.dp).background(ClawTheme.colors.danger, RoundedCornerShape(2.dp)))
-            Text(text = "Stop", style = ClawTheme.type.label)
+            Box(contentAlignment = Alignment.Center) {
+              Icon(imageVector = Icons.Default.Mic, contentDescription = "Voice", modifier = Modifier.size(18.dp))
+            }
+          }
+        } else {
+          val canSend = healthOk && pendingRunCount == 0
+          Surface(
+            onClick = onSend,
+            enabled = canSend,
+            modifier = Modifier.size(40.dp),
+            shape = CircleShape,
+            color = if (canSend) ClawTheme.colors.text else ClawTheme.colors.surfacePressed,
+            contentColor = if (canSend) ClawTheme.colors.canvas else ClawTheme.colors.textSubtle,
+          ) {
+            Box(contentAlignment = Alignment.Center) {
+              Icon(
+                imageVector = Icons.AutoMirrored.Filled.Send,
+                contentDescription = "Send",
+                modifier = Modifier.size(18.dp),
+              )
+            }
           }
         }
       }
     }
-  }
-}
 
-@Composable
-private fun ChatContextMeter(
-  thinkingLevel: String,
-  contextUsage: ChatContextUsage,
-  onClick: () -> Unit,
-) {
-  val contextFraction = contextMeterWidth(contextUsage) ?: 0f
-  Row(
-    modifier = Modifier.width(178.dp),
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(7.dp),
-  ) {
-    Surface(
-      onClick = onClick,
-      modifier = Modifier.heightIn(min = ClawTheme.spacing.touchTarget),
-      shape = RoundedCornerShape(ClawTheme.radii.pill),
-      color = ClawTheme.colors.canvas,
-      contentColor = ClawTheme.colors.text,
-    ) {
-      Row(
-        modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-      ) {
-        Icon(imageVector = Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(12.dp), tint = ClawTheme.colors.textSubtle)
-        Text(
-          text = contextMeterLabel(contextUsage, thinkingLevel),
-          style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp),
-          color = ClawTheme.colors.textMuted,
-          maxLines = 1,
-          overflow = TextOverflow.Ellipsis,
-        )
-      }
-    }
-    Box(
-      modifier =
-        Modifier
-          .weight(1f)
-          .height(3.dp)
-          .background(ClawTheme.colors.surfacePressed, RoundedCornerShape(999.dp)),
-    ) {
-      Box(
-        modifier =
-          Modifier
-            .fillMaxWidth(contextFraction)
-            .height(3.dp)
-            .background(ClawTheme.colors.primary, RoundedCornerShape(999.dp)),
-      )
-    }
-  }
-}
-
-@Composable
-private fun ChatInputPill(
-  value: String,
-  onValueChange: (String) -> Unit,
-  onPickImages: () -> Unit,
-  onVoice: () -> Unit,
-  modifier: Modifier = Modifier,
-) {
-  Surface(
-    modifier = modifier.heightIn(min = ClawTheme.spacing.touchTarget),
-    shape = RoundedCornerShape(ClawTheme.radii.control),
-    color = ClawTheme.colors.surfaceRaised,
-    contentColor = ClawTheme.colors.text,
-    border = BorderStroke(1.dp, ClawTheme.colors.border),
-  ) {
+    // Context meter + thinking level (single row)
     Row(
-      modifier = Modifier.padding(horizontal = 9.dp, vertical = 4.dp),
+      modifier = Modifier.fillMaxWidth(),
       verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(7.dp),
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-      Surface(onClick = onPickImages, modifier = Modifier.size(ClawTheme.spacing.touchTarget), shape = CircleShape, color = ClawTheme.colors.surfaceRaised, contentColor = ClawTheme.colors.text) {
-        Box(contentAlignment = Alignment.Center) {
-          Icon(imageVector = Icons.Default.AttachFile, contentDescription = "Attach image", modifier = Modifier.size(16.dp))
-        }
-      }
-      Box(modifier = Modifier.weight(1f)) {
-        BasicTextField(
-          value = value,
-          onValueChange = onValueChange,
-          textStyle = ClawTheme.type.body.copy(color = ClawTheme.colors.text),
-          cursorBrush = SolidColor(ClawTheme.colors.primary),
-          minLines = 1,
-          maxLines = 4,
-          modifier = Modifier.fillMaxWidth(),
-          decorationBox = { innerTextField ->
-            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
-              if (value.isEmpty()) {
-                Text(text = "Message OpenClaw", style = ClawTheme.type.body, color = ClawTheme.colors.textSubtle)
-              }
-              innerTextField()
-            }
-          },
+      // Thinking level chip
+      val thinkingLabel = thinkingDisplay(thinkingLevel)
+      Surface(
+        onClick = { onThinkingLevelChange(nextThinkingValue(thinkingLevel)) },
+        shape = RoundedCornerShape(999.dp),
+        color = Color.Transparent,
+        border = BorderStroke(1.dp, ClawTheme.colors.border),
+      ) {
+        Text(
+          text = thinkingLabel,
+          modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
+          style = ClawTheme.type.caption.copy(fontSize = 11.sp, lineHeight = 14.sp),
+          color = ClawTheme.colors.textMuted,
         )
       }
-      Surface(
-        onClick = onVoice,
-        modifier = Modifier.size(ClawTheme.spacing.touchTarget),
-        shape = CircleShape,
-        color = ClawTheme.colors.surfaceRaised,
-        contentColor = ClawTheme.colors.text,
-      ) {
-        Box(contentAlignment = Alignment.Center) {
-          Icon(imageVector = Icons.Default.Mic, contentDescription = "Voice", modifier = Modifier.size(18.dp))
+
+      // Context bar
+      val fraction = contextMeterWidth(contextUsage) ?: 0f
+      if (fraction > 0f) {
+        Box(
+          modifier =
+            Modifier
+              .weight(1f)
+              .height(3.dp)
+              .background(ClawTheme.colors.surfacePressed, RoundedCornerShape(999.dp)),
+        ) {
+          Box(
+            modifier =
+              Modifier
+                .fillMaxWidth(fraction)
+                .height(3.dp)
+                .background(ClawTheme.colors.primary, RoundedCornerShape(999.dp)),
+          )
+        }
+      } else {
+        Spacer(modifier = Modifier.weight(1f))
+      }
+    }
+
+    // Stop button
+    if (pendingRunCount > 0) {
+      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+        Surface(
+          onClick = onAbort,
+          shape = RoundedCornerShape(999.dp),
+          color = ClawTheme.colors.dangerSoft,
+          border = BorderStroke(1.dp, ClawTheme.colors.danger.copy(alpha = 0.3f)),
+        ) {
+          Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+          ) {
+            Box(
+              modifier =
+                Modifier
+                  .size(7.dp)
+                  .background(ClawTheme.colors.danger, RoundedCornerShape(2.dp)),
+            )
+            Text(text = "Stop", style = ClawTheme.type.label.copy(fontSize = 13.sp))
+          }
         }
       }
     }
@@ -856,7 +573,10 @@ private fun AttachmentStrip(
   attachments: List<PendingImageAttachment>,
   onRemoveAttachment: (String) -> Unit,
 ) {
-  Row(modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+  Row(
+    modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+    horizontalArrangement = Arrangement.spacedBy(6.dp),
+  ) {
     attachments.forEach { attachment ->
       AttachmentChip(fileName = attachment.fileName, onRemove = { onRemoveAttachment(attachment.id) })
     }
@@ -869,25 +589,26 @@ private fun AttachmentChip(
   onRemove: () -> Unit,
 ) {
   Surface(
-    shape = RoundedCornerShape(ClawTheme.radii.pill),
+    shape = RoundedCornerShape(999.dp),
     color = ClawTheme.colors.surfaceRaised,
-    contentColor = ClawTheme.colors.text,
     border = BorderStroke(1.dp, ClawTheme.colors.border),
   ) {
     Row(
-      modifier = Modifier.padding(start = 9.dp, top = 5.dp, end = 5.dp, bottom = 5.dp),
+      modifier = Modifier.padding(start = 10.dp, top = 5.dp, end = 4.dp, bottom = 5.dp),
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
       Text(text = fileName, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
-      Surface(onClick = onRemove, modifier = Modifier.size(22.dp), shape = CircleShape, color = ClawTheme.colors.canvas, contentColor = ClawTheme.colors.text) {
+      Surface(onClick = onRemove, modifier = Modifier.size(20.dp), shape = CircleShape, color = ClawTheme.colors.canvas) {
         Box(contentAlignment = Alignment.Center) {
-          Icon(imageVector = Icons.Default.Close, contentDescription = "Remove attachment", modifier = Modifier.size(13.dp))
+          Icon(imageVector = Icons.Default.Close, contentDescription = "Remove", modifier = Modifier.size(12.dp))
         }
       }
     }
   }
 }
+
+// ── Utility ────────────────────────────────────────────────────────────────
 
 private fun currentSessionTitle(
   sessionKey: String,
@@ -931,12 +652,8 @@ internal fun resolveChatContextUsage(
 ): ChatContextUsage {
   val entry =
     sessions.firstOrNull {
-      isActiveSessionChoice(
-        choiceKey = it.key,
-        sessionKey = sessionKey,
-        mainSessionKey = mainSessionKey,
-      )
-  }
+      isActiveSessionChoice(choiceKey = it.key, sessionKey = sessionKey, mainSessionKey = mainSessionKey)
+    }
   return ChatContextUsage(
     totalTokens = entry?.totalTokens,
     totalTokensFresh = entry?.totalTokensFresh,
@@ -944,56 +661,16 @@ internal fun resolveChatContextUsage(
   )
 }
 
-@Composable
-private fun SendButton(
-  enabled: Boolean,
-  onClick: () -> Unit,
-) {
-  Surface(
-    onClick = onClick,
-    enabled = enabled,
-    modifier = Modifier.size(ClawTheme.spacing.touchTarget),
-    shape = CircleShape,
-    color = if (enabled) ClawTheme.colors.primary else ClawTheme.colors.surfacePressed,
-    contentColor = if (enabled) ClawTheme.colors.primaryText else ClawTheme.colors.textSubtle,
-    border = BorderStroke(1.dp, if (enabled) ClawTheme.colors.primary else ClawTheme.colors.border),
-  ) {
-    Box(contentAlignment = Alignment.Center) {
-      Icon(imageVector = Icons.AutoMirrored.Filled.Send, contentDescription = "Send", modifier = Modifier.size(18.dp))
-    }
-  }
-}
-
-private fun userFacingChatError(error: String): String {
-  val lower = error.lowercase(Locale.US)
-  return when {
-    lower.contains("not connected") -> "Gateway is offline. Open Settings to reconnect."
-    lower.contains("unauthorized") || lower.contains("auth") -> "Gateway authentication needs attention."
-    else -> error
-  }
-}
-
-/** Normalizes persisted thinking values into compact UI labels. */
 private fun thinkingDisplay(value: String): String =
-  when (value.lowercase(Locale.US)) {
+  when (value.lowercase(java.util.Locale.US)) {
     "low" -> "Low"
     "medium" -> "Medium"
     "high" -> "High"
     else -> "Off"
   }
 
-/** Converts displayed thinking labels back to gateway request values. */
-private fun thinkingValue(display: String): String =
-  when (display.lowercase(Locale.US)) {
-    "low" -> "low"
-    "medium" -> "medium"
-    "high" -> "high"
-    else -> "off"
-  }
-
-/** Cycles through context budget presets from the compact composer control. */
 private fun nextThinkingValue(value: String): String =
-  when (value.lowercase(Locale.US)) {
+  when (value.lowercase(java.util.Locale.US)) {
     "off" -> "low"
     "low" -> "medium"
     "medium" -> "high"
@@ -1009,23 +686,22 @@ internal fun contextMeterWidth(usage: ChatContextUsage): Float? {
 
 internal fun contextMeterLabel(
   usage: ChatContextUsage,
-  thinkingLevel: String,
+  thinkingValue: String,
 ): String {
-  val contextLabel = contextMeterWidth(usage)?.let { "Context ${(it * 100).roundToInt()}%" } ?: "Context --"
-  return "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}"
+  val percent = contextMeterWidth(usage)
+  val percentText = if (percent == null) "--" else "${(percent * 100).roundToInt()}%"
+  return "Context $percentText · ${thinkingDisplay(thinkingValue)}"
 }
 
 internal fun contextMeterThinkingLabel(value: String): String =
-  when (value.lowercase(Locale.US)) {
+  when (value.lowercase(java.util.Locale.US)) {
     "low" -> "low"
     "medium" -> "medium"
     "high" -> "high"
     else -> "off"
   }
 
-private fun formatChatTimestamp(timestampMs: Long): String = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault()).format(Date(timestampMs))
-
-/** Quick markdown detector used to avoid routing plain chat text through the markdown renderer. */
+/** Quick markdown detector. */
 private fun String.hasMarkdownSyntax(): Boolean =
   any { it == '#' || it == '*' || it == '`' || it == '[' || it == '|' } ||
     contains("\n- ") ||


### PR DESCRIPTION
## Summary

This PR fixes the mobile chat UI readability and space issues in the Android app. The current chat interface has cramped bubbles, role labels on every message, and tool calls that take up excessive screen space.

## Changes

### `ChatScreen.kt`
- **Bubble width**: `0.56f`/`0.64f` → `widthIn(max=520dp)` — proper mobile proportions
- **Bubble padding**: `7dp/3.5dp` → `16dp/14dp` — breathing room inside bubbles
- **Bubble shape**: Directional — flat edge faces sender (ChatGPT-style)
- **Role labels removed**: No more "You"/"OpenClaw" on every message — position + color tell the story
- **Timestamps removed from inside bubbles**: Were visual noise on every turn
- **Font size**: Body `14sp` → `15sp`, line height `19sp` → `22sp`
- **Tool bubbles**: Collapsed into single compact card — "Ran N tools" header + monospace tool names, expandable for >2 tools
- **Thinking indicator**: Animated pulsing dots instead of text wall
- **Error suppression**: Chat errors no longer interrupt the chat list — surface in header status pill
- **Header**: Cleaner status labels ("Ready"/"Working…"/"Offline"), tighter layout

### `ChatMessageViews.kt`
- **Bubble shape**: Directional (flat edge facing sender, rounded opposite)
- **Width**: `0.90f` → `widthIn(max=520dp)` — consistent with ChatScreen
- **Padding**: `11dp/8dp` → `16dp/14dp`
- **Role labels removed** from all bubble variants
- **Tool bubble**: Grouped, compact, expandable (same treatment as ChatScreen)
- **Streaming bubble**: Accent-tinted border instead of full accent border
- **User bubble**: `accentSoft` background, no border (vs old `accent` border)
- **Assistant bubble**: Transparent background, subtle border
- **Code block**: Preserved for syntax highlighting

## Testing

- All exported function signatures preserved (verified against callers in `ChatMessageListCard.kt`, `ChatMarkdown.kt`, and test files)
- `internal` functions (`contextMeterLabel`, `contextMeterThinkingLabel`, `ChatContextUsage`, etc.) preserved for test compatibility
- No new dependencies added
- No gateway API changes
- Brace balance verified

## Before/After

**Before**: 56% bubble width, 3.5dp padding, role labels on every message, tool calls eating 60%+ of screen, error banners blocking chat flow.

**After**: 82% bubble width, 14dp padding, clean bubbles with directional shapes, grouped compact tool indicators, animated thinking dots, errors in header only.

## Notes

- The app README says it is "extremely alpha" and "actively being rebuilt from the ground up" — these are incremental UX improvements within that context
- No skill/provider mutation features included — that would require gateway API verification and is a separate feature request
