### PR TITLE
fix(cron): preserve no-config delivery validation

### DIFF
--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -34,7 +34,10 @@ import {
 } from "../../infra/outbound/channel-target-prefix.js";
 import { isSubagentSessionKey } from "../../routing/session-key.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
-import { normalizeMessageChannel } from "../../utils/message-channel.js";
+import {
+  isDeliverableMessageChannel,
+  normalizeMessageChannel,
+} from "../../utils/message-channel.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 
 type CronJobIdParams = { id?: string; jobId?: string };
@@ -111,6 +114,9 @@ async function assertConfiguredAnnounceChannel(params: {
 
   if (configuredChannels.length === 0) {
     if (!hasExplicitChannelConfigEntry(params.cfg)) {
+      if (!isDeliverableMessageChannel(normalizedChannel)) {
+        throw new Error(`${params.field} is not a known channel: ${normalizedChannel}`);
+      }
       return;
     }
     throw new Error(`${params.field} is not configured: ${normalizedChannel}`);

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -82,11 +82,7 @@ function hasExplicitChannelConfigEntry(cfg: OpenClawConfig): boolean {
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
       return false;
     }
-    const record = entry as { enabled?: unknown };
-    if (record.enabled === false) {
-      return false;
-    }
-    return record.enabled === true || Object.keys(entry).some((key) => key !== "enabled");
+    return Object.keys(entry).length > 0;
   });
 }
 

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -67,6 +67,26 @@ async function listConfiguredAnnounceChannelIds(cfg: OpenClawConfig): Promise<st
   return await listConfiguredMessageChannels(cfg);
 }
 
+function hasExplicitChannelConfigEntry(cfg: OpenClawConfig): boolean {
+  const channels = cfg.channels;
+  if (!channels || typeof channels !== "object" || Array.isArray(channels)) {
+    return false;
+  }
+  return Object.entries(channels).some(([channelId, entry]) => {
+    if (channelId === "defaults" || channelId === "modelByChannel") {
+      return false;
+    }
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return false;
+    }
+    const record = entry as { enabled?: unknown };
+    if (record.enabled === false) {
+      return false;
+    }
+    return record.enabled === true || Object.keys(entry).some((key) => key !== "enabled");
+  });
+}
+
 async function assertConfiguredAnnounceChannel(params: {
   cfg: OpenClawConfig;
   channel?: string;
@@ -90,6 +110,9 @@ async function assertConfiguredAnnounceChannel(params: {
   }
 
   if (configuredChannels.length === 0) {
+    if (!hasExplicitChannelConfigEntry(params.cfg)) {
+      return;
+    }
     throw new Error(`${params.field} is not configured: ${normalizedChannel}`);
   }
 


### PR DESCRIPTION
## What Problem This Solves
Current main rejects cron delivery requests when no channel configuration exists at all. The gateway cron tests and the no-config operator path expect those requests to remain valid until a channel is explicitly configured.

## Why This Change Was Made
Preserve the existing no-config behavior while keeping strict validation once an explicit channel entry exists. The change is limited to the shared cron delivery validation boundary.

## User Impact
Cron add/update and failure-announcement flows remain usable on fresh installs without channel entries, while explicitly configured channel ids still receive validation.

## Evidence
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server.cron.test.ts` passed: 18/18.
- The failing CI cases reproduced as `response.ok === false`; the focused current-main test passes with this narrow fix.
