### PR TITLE
fix(cron): preserve no-config delivery validation

### DIFF
--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -34,7 +34,10 @@ import {
 } from "../../infra/outbound/channel-target-prefix.js";
 import { isSubagentSessionKey } from "../../routing/session-key.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
-import { normalizeMessageChannel } from "../../utils/message-channel.js";
+import {
+  isDeliverableMessageChannel,
+  normalizeMessageChannel,
+} from "../../utils/message-channel.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 
 type CronJobIdParams = { id?: string; jobId?: string };
@@ -111,6 +114,9 @@ async function assertConfiguredAnnounceChannel(params: {
 
   if (configuredChannels.length === 0) {
     if (!hasExplicitChannelConfigEntry(params.cfg)) {
+      if (!isDeliverableMessageChannel(normalizedChannel)) {
+        throw new Error(`${params.field} is not a known channel: ${normalizedChannel}`);
+      }
       return;
     }
     throw new Error(`${params.field} is not configured: ${normalizedChannel}`);

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -82,11 +82,7 @@ function hasExplicitChannelConfigEntry(cfg: OpenClawConfig): boolean {
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
       return false;
     }
-    const record = entry as { enabled?: unknown };
-    if (record.enabled === false) {
-      return false;
-    }
-    return record.enabled === true || Object.keys(entry).some((key) => key !== "enabled");
+    return Object.keys(entry).length > 0;
   });
 }
 

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -67,6 +67,26 @@ async function listConfiguredAnnounceChannelIds(cfg: OpenClawConfig): Promise<st
   return await listConfiguredMessageChannels(cfg);
 }
 
+function hasExplicitChannelConfigEntry(cfg: OpenClawConfig): boolean {
+  const channels = cfg.channels;
+  if (!channels || typeof channels !== "object" || Array.isArray(channels)) {
+    return false;
+  }
+  return Object.entries(channels).some(([channelId, entry]) => {
+    if (channelId === "defaults" || channelId === "modelByChannel") {
+      return false;
+    }
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return false;
+    }
+    const record = entry as { enabled?: unknown };
+    if (record.enabled === false) {
+      return false;
+    }
+    return record.enabled === true || Object.keys(entry).some((key) => key !== "enabled");
+  });
+}
+
 async function assertConfiguredAnnounceChannel(params: {
   cfg: OpenClawConfig;
   channel?: string;
@@ -90,6 +110,9 @@ async function assertConfiguredAnnounceChannel(params: {
   }
 
   if (configuredChannels.length === 0) {
+    if (!hasExplicitChannelConfigEntry(params.cfg)) {
+      return;
+    }
     throw new Error(`${params.field} is not configured: ${normalizedChannel}`);
   }
 


### PR DESCRIPTION
## What Problem This Solves

The channel validation refactor made cron.add/cron.update reject announce destinations whenever no configured channel entries were present. Gateway cron tests and no-config/runtime setups intentionally rely on known channel ids resolved by the outbound path, so three cron tests failed deterministically on current main.

## Why This Change Was Made

Keep the new fail-closed behavior for explicit channel config, including stale ownerless and disabled entries. When there is no channel config at all, retain the existing behavior but still reject unknown channel ids.

## User Impact

Cron announce destinations continue to reject disabled, stale, or unknown channels while preserving no-config setups that use a known built-in or registered channel id.

## Evidence

- Before: current main `f40071cc0f` failed 3/18 tests in `src/gateway/server.cron.test.ts`.
- After: `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server.cron.test.ts src/gateway/server-methods/cron.validation.test.ts` -> 106/106 passed.
- Fresh autoreview: clean, no accepted/actionable findings.
- Fixes the baseline failure blocking PR #95485.