### PR TITLE
fix(model-catalog): use normalized prefix length in stripPrefixes instead of raw length

### DIFF
--- a/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   collectManifestModelIdNormalizationPolicies,
   normalizeConfiguredProviderCatalogModelId,
+  normalizeProviderModelIdWithPolicies,
   normalizeStaticProviderModelIdWithPolicies,
   stripSelfProviderModelPrefix,
 } from "./provider-model-id-normalization.js";
@@ -87,5 +88,37 @@ describe("provider model id policy normalization", () => {
     expect(stripSelfProviderModelPrefix("vercel-ai-gateway", "vercel-ai-gateway/opus-4.6")).toBe(
       "opus-4.6",
     );
+  });
+
+  describe("stripPrefixes whitespace handling", () => {
+    it("trims leading whitespace from stripPrefixes entry", () => {
+      const policies = new Map([["openai", { stripPrefixes: [" openai/"], aliases: undefined }]]);
+      const result = normalizeProviderModelIdWithPolicies({
+        provider: "openai",
+        policies,
+        context: { modelId: "openai/gpt-4" },
+      });
+      expect(result).toBe("gpt-4");
+    });
+
+    it("trims trailing whitespace from stripPrefixes entry", () => {
+      const policies = new Map([["openai", { stripPrefixes: ["openai/ "], aliases: undefined }]]);
+      const result = normalizeProviderModelIdWithPolicies({
+        provider: "openai",
+        policies,
+        context: { modelId: "openai/gpt-4" },
+      });
+      expect(result).toBe("gpt-4");
+    });
+
+    it("handles whitespace-free prefix without regression", () => {
+      const policies = new Map([["openai", { stripPrefixes: ["openai/"], aliases: undefined }]]);
+      const result = normalizeProviderModelIdWithPolicies({
+        provider: "openai",
+        policies,
+        context: { modelId: "openai/gpt-4" },
+      });
+      expect(result).toBe("gpt-4");
+    });
   });
 });

--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -98,7 +98,7 @@ export function normalizeProviderModelIdWithPolicies(params: {
   for (const prefix of policy.stripPrefixes ?? []) {
     const normalizedPrefix = normalizeLowercaseStringOrEmpty(prefix);
     if (normalizedPrefix && normalizeLowercaseStringOrEmpty(modelId).startsWith(normalizedPrefix)) {
-      modelId = modelId.slice(prefix.length);
+      modelId = modelId.slice(normalizedPrefix.length);
       break;
     }
   }


### PR DESCRIPTION
### What Problem This Solves

In `normalizeProviderModelIdWithPolicies`, the manifest `stripPrefixes` loop *matches* using the normalized prefix (trimmed + lowercased) but *strips* using the raw `prefix.length`. A `stripPrefixes` entry with leading or trailing whitespace therefore removes more characters than it matched, mangling the model id.

For example, `stripPrefixes: [" openai/"]` on `"openai/gpt-4"` produces `"pt-4"` instead of `"gpt-4"`.

### Evidence

**Fix:** Changed `modelId = modelId.slice(prefix.length)` to `modelId = modelId.slice(normalizedPrefix.length)` on the strip arm of the loop.

**Test matrix:**

| Input | stripPrefixes | Before (buggy) | After (fixed) |
|-------|--------------|----------------|----------------|
| `openai/gpt-4` | `[" openai/"]` (leading space) | `"pt-4"` ❌ | `"gpt-4"` ✅ |
| `openai/gpt-4` | `["openai/ "]` (trailing space) | `"pt-4"` ❌ | `"gpt-4"` ✅ |
| `openai/gpt-4` | `["openai/"]` (clean, control) | `"gpt-4"` ✅ | `"gpt-4"` ✅ (no regression) |

**Test results:** All 8 tests pass (5 existing + 3 new stripPrefixes cases).

```
 ✓ packages/model-catalog-core/src/provider-model-id-normalization.test.ts (8 tests)
```

**Format check:** All matched files use the correct format.

**Diff:** +34 lines (tests) / -1 line (fix) across 2 files only.