### PR TITLE
fix(mattermost): channel prompts describe rooms as group chats

### DIFF
--- a/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
+++ b/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
@@ -95,13 +95,13 @@ export function registerGroupIntroPromptCases(): void {
         },
         expected: [
           "You are in a Mattermost channel.",
-          "Your text replies are automatically sent to this channel. For ordinary text, do not use the message tool to send to this same destination; just reply normally. Use message(action=send) only when you need to send files, images, or other attachments to this same channel/thread.",
-          groupParticipationNote,
+          "Your text replies are automatically sent to this channel. For ordinary text, do not use the message tool to send to this same channel; just reply normally. Use message(action=send) only when you need to send files, images, or other attachments to this same channel/thread.",
+          channelParticipationNote,
           groupSilentNote,
           groupSilentProseGuard,
           "Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). Address the specific sender noted in the message context.",
         ],
-        forbidden: ["Mattermost group chat"],
+        forbidden: ["Mattermost group chat", "this group chat"],
       },
       {
         name: "whatsapp-always-on",

--- a/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
+++ b/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
@@ -20,6 +20,8 @@ export function registerGroupIntroPromptCases(): void {
       "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \\n sequences; use real line breaks sparingly.";
     const telegramGroupParticipationNote =
       "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \\n sequences; use real line breaks sparingly.";
+    const channelParticipationNote =
+      "Be a good channel participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \\n sequences; use real line breaks sparingly.";
     const groupSilentNote =
       'If no response is needed, reply with exactly "NO_REPLY" (and nothing else) so OpenClaw stays silent.';
     const groupSilentProseGuard =
@@ -132,6 +134,26 @@ export function registerGroupIntroPromptCases(): void {
           "Never say that you are staying quiet, keeping channel noise low, making a context-only note, or sending no channel reply.",
           groupSilentProseGuard,
         ],
+        defaultActivation: "always",
+      },
+      {
+        name: "mattermost-channel-always-on",
+        message: {
+          Body: "hello channel",
+          From: "mattermost:channel:town-square",
+          To: "+2001",
+          ChatType: "channel",
+          Provider: "mattermost",
+          SenderE164: "+2001",
+          GroupSubject: "Town Square",
+          GroupMembers: "Alice, Bob",
+        },
+        expected: [
+          "You are in a Mattermost channel.",
+          channelParticipationNote,
+          "Activation: always-on (you receive every channel message).",
+        ],
+        forbidden: ["Mattermost group chat", "this group chat", "every group message"],
         defaultActivation: "always",
       },
     ];

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -97,7 +97,24 @@ describe("group runtime loading", () => {
     });
 
     expect(context).toContain("You are in a Mattermost channel.");
-    expect(context).not.toContain("You are in a Mattermost group chat.");
+    expect(context).toContain("Your text replies are automatically sent to this channel.");
+    expect(context).toContain("send to this same channel");
+    expect(context).toContain("Be a good channel participant");
+    expect(context).toContain("a directly requested channel task");
+    expect(context).not.toContain("Mattermost group chat");
+    expect(context).not.toContain("this group chat");
+    expect(context).not.toContain("same group");
+    expect(context).not.toContain("group-chat task");
+
+    const toolOnlyContext = groups.buildGroupChatContext({
+      sessionCtx: { ChatType: "channel", Provider: "mattermost" },
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+    expect(toolOnlyContext).toContain("not automatically sent to this channel");
+    expect(toolOnlyContext).toContain("target defaults to this channel");
+    expect(toolOnlyContext).toContain("If no visible channel response is needed");
+    expect(toolOnlyContext).not.toContain("group response");
+    expect(toolOnlyContext).not.toContain("this group chat");
   });
 
   it("builds direct chat context without silent-token guidance", () => {

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -201,7 +201,7 @@ describe("group runtime loading", () => {
 
     expect(context).toContain("You are in a Mattermost channel.");
     expect(context).toContain("Your text replies are automatically sent to this channel.");
-    expect(context).toContain("do not use the message tool to send to this same destination");
+    expect(context).toContain("do not use the message tool to send to this same channel");
     expect(context).toContain("attachments to this same channel/thread");
     expect(context).not.toContain("group chat");
   });

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -91,6 +91,15 @@ describe("group runtime loading", () => {
     vi.doUnmock("./groups.runtime.js");
   });
 
+  it("describes channel conversations as channels instead of group chats", () => {
+    const context = groups.buildGroupChatContext({
+      sessionCtx: { ChatType: "channel", Provider: "mattermost" },
+    });
+
+    expect(context).toContain("You are in a Mattermost channel.");
+    expect(context).not.toContain("You are in a Mattermost group chat.");
+  });
+
   it("builds direct chat context without silent-token guidance", () => {
     expect(
       groups.buildDirectChatContext({

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -348,7 +348,7 @@ export function resolveGroupSilentReplyBehavior(params: {
   };
 }
 
-/** Builds the channel-specific group intro injected into the system prompt. */
+/** Builds the group/channel intro injected into the system prompt. */
 export function buildGroupIntro(params: {
   cfg: OpenClawConfig;
   sessionCtx: TemplateContext;
@@ -358,9 +358,10 @@ export function buildGroupIntro(params: {
   silentReplyPolicy?: SilentReplyPolicy;
 }): string {
   const { activation } = resolveGroupSilentReplyBehavior(params);
+  const messageTypeLabel = params.sessionCtx.ChatType === "channel" ? "channel" : "group";
   const activationLine =
     activation === "always"
-      ? "Activation: always-on (you receive every group message)."
+      ? `Activation: always-on (you receive every ${messageTypeLabel} message).`
       : "Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included).";
   return `${activationLine} Address the specific sender noted in the message context.`;
 }

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -244,6 +244,12 @@ export function buildGroupChatContext(params: {
   const botUsername = normalizeOptionalString(params.sessionCtx.BotUsername);
   const sharedChatNoun = resolveSharedChatNoun(params.sessionCtx.ChatType);
   const destinationLabel = sharedChatNoun === "channel" ? "this channel" : "this group chat";
+  const participantLabel = sharedChatNoun === "channel" ? "channel" : "group";
+  const textReplyDestinationLabel =
+    sharedChatNoun === "channel" ? "this same channel" : "this same destination";
+  const attachmentDestinationLabel =
+    sharedChatNoun === "channel" ? "same channel/thread" : "same group/topic";
+  const taskLabel = sharedChatNoun === "channel" ? "channel task" : "group-chat task";
 
   const lines: string[] = [];
   lines.push(`You are in a ${providerLabel} ${sharedChatNoun}.`);
@@ -258,11 +264,11 @@ export function buildGroupChatContext(params: {
     );
   } else {
     lines.push(
-      `Your text replies are automatically sent to ${destinationLabel}. For ordinary text, do not use the message tool to send to this same destination; just reply normally. Use message(action=send) only when you need to send files, images, or other attachments to this same ${sharedChatNoun === "channel" ? "channel/thread" : "group/topic"}.`,
+      `Your text replies are automatically sent to ${destinationLabel}. For ordinary text, do not use the message tool to send to ${textReplyDestinationLabel}; just reply normally. Use message(action=send) only when you need to send files, images, or other attachments to this ${attachmentDestinationLabel}.`,
     );
   }
   lines.push(
-    "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available.",
+    `Be a good ${participantLabel} participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available.`,
   );
   const tableGuidance = provider === "telegram" ? "" : " Avoid Markdown tables.";
   lines.push(
@@ -273,13 +279,13 @@ export function buildGroupChatContext(params: {
     lines.push("Discord: wrap bare URLs like <https://example.com> to suppress embeds.");
   }
   lines.push(
-    "When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value.",
+    `When subagent or session-spawn tools are available and a directly requested ${taskLabel} will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise ${participantLabel}-visible updates when they add value.`,
   );
   const canUseSilentReply =
     !messageToolOnly && params.silentToken && params.silentReplyPolicy !== "disallow";
   if (messageToolOnly) {
     lines.push(
-      `If no visible ${sharedChatNoun === "channel" ? "channel" : "group"} response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to ${destinationLabel}.`,
+      `If no visible ${participantLabel} response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to ${destinationLabel}.`,
     );
   }
   if (canUseSilentReply) {


### PR DESCRIPTION
## Summary

Fixes Mattermost channel prompt guidance so channel conversations are described consistently as channels, not partially as group chats.

- Fix classification: Root-cause prompt builder invariant fix.
- Maintainer-ready confidence: High.
- Root cause: The shared group/channel prompt helpers receive trusted `ChatType: "channel"` for Mattermost channel rooms, but delivery, participant, task, tool-only, and first-turn activation guidance still had group-chat-only labels. That source prompt surface produced contradictory channel-vs-group instructions.
- Why this is root-cause fix: The fix changes the source prompt builder invariant so trusted `ChatType` selects one channel/group label set before any guidance is appended. Every trusted guidance fragment now consumes that source label set, so the prompt cannot mix `Mattermost channel` with `this group chat` for channel sessions.
- Patch quality notes: Small focused patch quality guardrail: one source file plus focused regression coverage, no catch-all fallback, no string-scrubbing downstream, and no schema/config/protocol changes.

## Linked context

Related: #95645

The issue reports that Mattermost public/private channels receive prompt intro wording that calls the conversation a group chat even though the authoritative metadata identifies the room as a channel.

Linked-open-PR scan note: external linked PRs were treated as advisory only; this change stays narrow and does not touch public API, config, schema, protocol, delivery routing, or Mattermost event ingestion.

## What Problem This Solves

Fixes an issue where users relying on Mattermost channel auto-reply behavior would get system prompt guidance that mixed channel wording with group-chat delivery instructions when the incoming room was a channel.

- Behavior or issue addressed: Mattermost channel prompts now consistently describe the visible destination as a channel, including normal text delivery, message-tool delivery, participant behavior, delegated task guidance, no-visible-response guidance, and first-turn activation guidance.
- Why it matters / User impact: The model receives a single trusted description of the conversation type, avoiding contradictory prompt context that could make a channel response sound or behave like a group-chat response.

## Why This Change Was Made

Group and channel conversations share the same helper. The safest boundary is to keep that routing unchanged and make the helper derive all destination labels from trusted `ChatType` once.

- What did NOT change: This does not change message delivery routing, Mattermost event handling, session state, permissions, provider adapters, public API, config, schema, protocol, defaults, direct conversation behavior, or the wording for existing group conversations.
- Architecture / source-of-truth check: `ChatType` remains the source of truth for channel-vs-group prompt wording. The PR does not add a second classifier or infer channel semantics from provider-specific strings.
- Rebase update: This branch has been synced with current `main`; conflict resolution kept the upstream `resolveSharedChatNoun(...)` helper and preserved the channel-specific delivery, participant, task, tool-only, and activation wording.

## User Impact

Mattermost channel replies now get consistent channel wording throughout the system prompt, including always-on activation text. Existing group conversations keep the previous group-chat wording.

## Real behavior proof

I ran a runtime prompt capture against the patched PR head using the same group/channel prompt builder and first-turn activation intro that feed the auto-reply system prompt.

- Runtime input: Mattermost `channel_type=O`.
- Runtime mapping observed: `ChatType: "channel"`.
- Runtime prompt path observed: `buildGroupChatContext(...) + buildGroupIntro(...)` for a Mattermost channel first turn.
- Observed result after fix: normal delivery, message-tool-only delivery, participant guidance, delegated task guidance, no-visible-response guidance, and always-on activation all describe the room as a channel. The runtime check also rejects the former group-specific fragments `Mattermost group chat`, `this group chat`, `same group`, `group-chat task`, `group response`, and `every group message` on the channel path.
- Proof limitation: I did not attach this run to a live Mattermost server transcript in this environment; the proof below is copied runtime prompt output for the same Mattermost channel prompt path ClawSweeper requested.

Evidence after fix: Validation `mattermost-channel-current-prompt` (pass, exit_code=0, 1011ms):

```text
Mattermost runtime input: channel_type=O
Mapped ChatType: channel
Combined normal first-turn prompt:
You are in a Mattermost channel. Your text replies are automatically sent to this channel. For ordinary text, do not use the message tool to send to this same channel; just reply normally. Use message(action=send) only when you need to send files, images, or other attachments to this same channel/thread. Be a good channel participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \n sequences; use real line breaks sparingly. If addressed to someone else, stay silent unless invited or correcting key facts. When subagent or session-spawn tools are available and a directly requested channel task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise channel-visible updates when they add value. If no response is needed, reply with exactly "NO_REPLY" (and nothing else) so OpenClaw stays silent. Be extremely selective: reply only when directly addressed or clearly helpful. Do not add any other words, punctuation, tags, markdown/code blocks, or explanations. If you only react or otherwise handle the message without a text reply, your final answer must still be exactly "NO_REPLY". Never say that you are staying quiet, keeping channel noise low, making a context-only note, or sending no channel reply. Any prose describing silence is wrong; the whole final answer must be only "NO_REPLY".

Activation: always-on (you receive every channel message). Address the specific sender noted in the message context.
Combined message-tool-only first-turn prompt:
You are in a Mattermost channel. Normal final replies are private and are not automatically sent to this channel. To post visible output here, use the message tool with action=send; the target defaults to this channel. Be a good channel participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \n sequences; use real line breaks sparingly. If addressed to someone else, stay silent unless invited or correcting key facts. When subagent or session-spawn tools are available and a directly requested channel task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise channel-visible updates when they add value. If no visible channel response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to this channel.

Activation: always-on (you receive every channel message). Address the specific sender noted in the message context.
Combined runtime prompt check: PASS
```

Additional focused validation on the rebased PR head:

Evidence after fix: Validation `prompt-regression-head` (pass, exit_code=0, 7013ms):

```text
RUN  v4.1.8

Test Files  1 passed (1)
     Tests  8 passed (8)
  Duration  1.35s
```

Evidence after fix: Validation `trigger-prompt-regression-head` (pass, exit_code=0, 15650ms):

```text
RUN  v4.1.8

Test Files  1 passed (1)
     Tests  6 passed | 16 skipped (22)
  Duration  15.65s
```

Evidence after fix: Validation `diff-check` (pass, exit_code=0).

## Evidence

The real behavior proof and validation output above are the maintainer-visible evidence for this source-repro prompt bug.

## Tests and validation

- Target test files: `src/auto-reply/reply/groups.test.ts` and `src/auto-reply/reply.triggers.group-intro-prompts.cases.ts`.
- Scenario locked in: A Mattermost channel event with trusted `ChatType: "channel"` builds the shared group/channel context and first-turn intro, and must receive channel-specific wording throughout the prompt.
- Why this is the smallest reliable guardrail: The test checks both positive channel wording and negative group-wording exclusions in normal and tool-only paths, directly guarding the source helper without adding brittle downstream prompt scrubbing.

Commands run on this rebased PR head:

- `pnpm install --frozen-lockfile`
- `node --import tsx --input-type=module -e '<combined Mattermost channel first-turn prompt capture>'`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/groups.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts -t "group intro prompts"`
- `git diff --check origin/main...HEAD`

## Risk checklist

- Risk labels considered: automation, message-delivery, security-boundary, session-state.
- Risk explanation: The changed strings describe whether replies are visible, private, or sent through the message tool, so they sit near delivery and automation guidance even though they are prompt text only.
- Why acceptable: The patch changes only prompt labels derived from the already-trusted `ChatType`; it does not alter routing, sending, session persistence, permissions, authentication, provider adapters, config, schema, protocol, or defaults.
- Compatibility/default behavior: Existing group conversations keep the previous group-chat wording, and non-channel chat types continue through the existing group path unchanged.
- Out of scope: No Mattermost event ingestion changes, no metadata shape changes, no public API/config/schema changes, no delivery semantics changes, and no prompt behavior changes for direct conversations.

## Official template answers

### What problem does this PR solve?

Mattermost channel prompts no longer mix channel wording with group-chat delivery guidance.

### Why does this matter now?

The issue is user-visible in the prompt context for Mattermost channel rooms and can give the model contradictory instructions about where replies are posted.

### What is the intended outcome?

Root-cause fix: the source prompt builder derives all group/channel wording from trusted `ChatType` before appending guidance.

### What is intentionally out of scope?

Changing Mattermost ingestion, delivery routing, session persistence, provider adapters, public API, config, schema, protocol, defaults, or direct-chat behavior is intentionally out of scope.

### Which commands did you run?

`pnpm install --frozen-lockfile`; `node --import tsx --input-type=module -e '<combined Mattermost channel first-turn prompt capture>'`; `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/groups.test.ts`; `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts -t "group intro prompts"`; `git diff --check origin/main...HEAD`.

### What regression coverage was added or updated?

Updated `src/auto-reply/reply/groups.test.ts` and the shared group-intro prompt cases to lock Mattermost `ChatType: "channel"` wording for normal, tool-only, and first-turn activation paths, including negative checks against the former group-specific fragments.

### What is the highest-risk area?

The highest-risk area is prompt text adjacent to automation and message-delivery guidance.

### How is that risk mitigated?

The patch changes only labels selected from trusted `ChatType`, preserves existing routing and delivery semantics, and includes focused positive/negative regression checks for both prompt helper output and first-turn activation intro.

### What is the next action?

Ready for maintainer review.

### Which bot or reviewer comments were addressed?

ClawSweeper requested real behavior proof beyond mock/test-only output; the updated body includes copied runtime prompt output for a Mattermost `channel_type=O` channel path plus the channel/group fragment checks. ClawSweeper's sibling-PR/canonical-choice note remains a maintainer-selection advisory; this update does not close, comment on, or mutate sibling PRs.

## Current review state

Ready for maintainer review.

Local validation is passing and maintainer-visible proof is included above.

- RF-001: Disclosed as a maintainer-selection advisory; several sibling PRs target the canonical prompt issue, and maintainers should choose the final canonical path.
- RF-002: Disclosed as a scope advisory; the source helper applies `ChatType: "channel"` wording to every trusted channel surface, not Mattermost-only downstream strings.
- RF-003: Disclosed as a maintainer-selection advisory; there is no narrow automated repair blocker left in this PR.
