### PR TITLE
fix(msteams): allow groupAllowFrom to match conversation IDs

### DIFF
--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -153,7 +153,7 @@ Disable with:
 **Group access**
 
 - Default: `channels.msteams.groupPolicy = "allowlist"` (blocked unless you add `groupAllowFrom`). Use `channels.defaults.groupPolicy` to override the default when unset.
-- `channels.msteams.groupAllowFrom` controls which senders or static sender access groups can trigger in group chats/channels (falls back to `channels.msteams.allowFrom`).
+- `channels.msteams.groupAllowFrom` controls which senders, static sender access groups, or group/channel conversation IDs can trigger in group chats/channels (falls back to `channels.msteams.allowFrom`). Conversation IDs may include the `19:...` form with either `@thread.tacv2` or `@thread.skype`; any `;messageid=...` runtime suffix is ignored.
 - Set `groupPolicy: "open"` to allow any member (still mention-gated by default).
 - To allow **no channels**, set `channels.msteams.groupPolicy: "disabled"`.
 

--- a/extensions/msteams/src/monitor-handler/access.ts
+++ b/extensions/msteams/src/monitor-handler/access.ts
@@ -18,6 +18,7 @@ import { getMSTeamsRuntime } from "../runtime.js";
 import type { MSTeamsTurnContext } from "../sdk-types.js";
 
 const MSTEAMS_SENDER_NAME_KIND = "plugin:msteams-sender-name" as const;
+const MSTEAMS_CONVERSATION_ID_KIND = "plugin:msteams-conversation-id" as const;
 const msteamsIngressIdentity = {
   key: "sender-id",
   normalize: normalizeIngressValue,
@@ -29,14 +30,28 @@ const msteamsIngressIdentity = {
       normalizeSubject: normalizeIngressValue,
       dangerous: true,
     },
+    {
+      key: "conversation-id",
+      kind: MSTEAMS_CONVERSATION_ID_KIND,
+      normalizeEntry: normalizeAllowlistConversationId,
+      normalizeSubject: normalizeAllowlistConversationId,
+    },
   ],
   isWildcardEntry: (entry) => normalizeIngressValue(entry) === "*",
   resolveEntryId: ({ entryIndex, fieldKey }) =>
-    `msteams-entry-${entryIndex + 1}:${fieldKey === "sender-name" ? "name" : "id"}`,
+    `msteams-entry-${entryIndex + 1}:${fieldKey === "sender-name" ? "name" : fieldKey === "conversation-id" ? "conversation-id" : "id"}`,
 } satisfies StableChannelIngressIdentityParams;
 
 function normalizeIngressValue(value?: string | null): string | null {
   return normalizeOptionalLowercaseString(value) ?? null;
+}
+
+function normalizeAllowlistConversationId(value?: string | null): string | null {
+  const trimmed = normalizeOptionalLowercaseString(value);
+  if (!trimmed) {
+    return null;
+  }
+  return normalizeMSTeamsConversationId(trimmed);
 }
 
 export async function resolveMSTeamsSenderAccess(params: {
@@ -84,7 +99,10 @@ export async function resolveMSTeamsSenderAccess(params: {
     readStoreAllowFrom: pairing.readAllowFromStore,
     subject: {
       stableId: senderId,
-      aliases: { "sender-name": senderName },
+      aliases: {
+        "sender-name": senderName,
+        ...(!isDirectMessage ? { "conversation-id": conversationId } : {}),
+      },
     },
     conversation: {
       kind: isDirectMessage ? "direct" : convType === "channel" ? "channel" : "group",

--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -954,4 +954,136 @@ describe("msteams monitor handler authz", () => {
     expect(ctx.SupplementalContext).toEqual({});
     expect(ctx.BodyForAgent).toBe("Current message");
   });
+
+  it("allows group chat messages when groupAllowFrom contains the conversation id", async () => {
+    resetThreadMocks();
+    const { conversationStore, deps } = createDeps({
+      channels: {
+        msteams: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["19:group@thread.tacv2"],
+          requireMention: false,
+        },
+      },
+    } as OpenClawConfig);
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler(createAttackerGroupActivity());
+
+    expect(conversationStore.upsert).toHaveBeenCalledTimes(1);
+    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it("allows channel messages when groupAllowFrom contains the channel conversation id", async () => {
+    resetThreadMocks();
+    const { conversationStore, deps } = createDeps({
+      channels: {
+        msteams: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["19:channel@thread.tacv2"],
+          requireMention: false,
+        },
+      },
+    } as OpenClawConfig);
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler(createChannelThreadActivity());
+
+    expect(conversationStore.upsert).toHaveBeenCalledTimes(1);
+    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it("strips the ;messageid= suffix before matching groupAllowFrom conversation ids", async () => {
+    resetThreadMocks();
+    const { conversationStore, deps } = createDeps({
+      channels: {
+        msteams: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["19:group@thread.tacv2"],
+          requireMention: false,
+        },
+      },
+    } as OpenClawConfig);
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler(
+      createMessageActivity({
+        id: "msg-suffix",
+        text: "hello",
+        from: {
+          id: "attacker-id",
+          aadObjectId: "attacker-aad",
+          name: "Attacker",
+        },
+        conversation: {
+          id: "19:group@thread.tacv2;messageid=1782122147084",
+          conversationType: "groupChat",
+        },
+      }),
+    );
+
+    expect(conversationStore.upsert).toHaveBeenCalledTimes(1);
+    expect(mockCallArg(conversationStore.upsert, 0, 0)).toBe("19:group@thread.tacv2");
+    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it("supports legacy @thread.skype conversation ids in groupAllowFrom", async () => {
+    resetThreadMocks();
+    const { conversationStore, deps } = createDeps({
+      channels: {
+        msteams: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["19:legacy@thread.skype"],
+          requireMention: false,
+        },
+      },
+    } as OpenClawConfig);
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler(
+      createMessageActivity({
+        id: "msg-skype",
+        text: "hello",
+        from: {
+          id: "attacker-id",
+          aadObjectId: "attacker-aad",
+          name: "Attacker",
+        },
+        conversation: {
+          id: "19:legacy@thread.skype;messageid=123456789",
+          conversationType: "groupChat",
+        },
+      }),
+    );
+
+    expect(conversationStore.upsert).toHaveBeenCalledTimes(1);
+    expect(mockCallArg(conversationStore.upsert, 0, 0)).toBe("19:legacy@thread.skype");
+    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it("does not allow DMs by conversation id in allowFrom", async () => {
+    resetThreadMocks();
+    const { conversationStore, deps } = createDeps({
+      channels: {
+        msteams: {
+          dmPolicy: "allowlist",
+          allowFrom: ["19:dm@thread.tacv2"],
+        },
+      },
+    } as OpenClawConfig);
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler(createAttackerPersonalActivity("msg-dm-conv"));
+
+    expect(conversationStore.upsert).not.toHaveBeenCalled();
+    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Problem: `channels.msteams.groupAllowFrom` was only matched against sender IDs and sender names, so allowlist entries containing a group/channel conversation ID never matched and messages were always dropped.
- Solution: Add a `conversation-id` alias to the MS Teams ingress identity so `groupAllowFrom` can match the normalized conversation ID for non-DM conversations.
- What changed:
  - `extensions/msteams/src/monitor-handler/access.ts` — added `conversation-id` alias with normalization that strips the runtime `;messageid=...` suffix and lowercases the value.
  - `extensions/msteams/src/monitor-handler/message-handler.authz.test.ts` — added regression tests for group chat, channel, suffix stripping, legacy `@thread.skype`, and DM guard.
  - `docs/channels/msteams.md` — documented that `groupAllowFrom` accepts senders, access groups, or group/channel conversation IDs.
- What did NOT change: DM (`allowFrom`) semantics; only non-DM conversations expose the `conversation-id` alias. Existing sender-id and sender-name matching is preserved.

Fixes #95737

## Real behavior proof
- **Behavior or issue addressed:** Group/channel allowlist entries using the MS Teams conversation ID were ignored, causing all inbound messages to be dropped.
- **Real environment tested:** Linux x86_64, Node 22.19+ (repo default), local source checkout.
- **Exact steps or command run after this patch:**
  ```bash
  pnpm test extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
  ```
- **Evidence after fix:**
  ```
  [test] starting test/vitest/vitest.extension-msteams.config.ts

   RUN  v4.1.7 /workspace/openclaw

   Test Files  1 passed (1)
        Tests  23 passed (23)
     Start at  20:19:09
     Duration  12.14s (transform 6.22s, setup 339ms, import 11.06s, tests 434ms, environment 0ms)

  [test] passed 1 Vitest shard in 22.88s
  ```
- **Observed result after fix:** All existing tests continue to pass and the five new regression tests confirm that messages are allowed when `groupAllowFrom` contains the matching conversation ID, with and without a `;messageid=...` suffix, for both `@thread.tacv2` and `@thread.skype` formats.
- **What was not tested:** A live Microsoft Teams Bot Framework tenant/end-to-end roundtrip was not exercised; validation uses the real access-resolution code path with the repo's Vitest harness.

## Regression Test Plan
- Coverage level: Unit test
- Target test file: `extensions/msteams/src/monitor-handler/message-handler.authz.test.ts`
- Scenario locked in: non-DM MS Teams conversations can be allowlisted by conversation ID; runtime `;messageid=...` suffix is stripped; legacy `@thread.skype` IDs work; DM `allowFrom` does not accidentally match conversation IDs.
- Why this is the smallest reliable guardrail: The tests exercise the actual `resolveMSTeamsSenderAccess` / message handler path and fail if any of the new matching rules regress, without requiring external Teams credentials.

## Root Cause
- Root cause: The stable channel ingress identity for MS Teams only exposed `sender-id` and `sender-name` aliases, so `groupAllowFrom` entries were interpreted as sender identifiers even when operators supplied conversation IDs.
- Missing detection / guardrail: There was no alias for the conversation ID and no normalization that stripped the runtime suffix before matching, so valid allowlist entries silently never matched.
