### PR TITLE
fix(agents): idle-timeout retry duplicates the user's message

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts
@@ -36,7 +36,9 @@ vi.mock("../../music-generation-task-status.js", () => musicGenerationTaskStatus
 vi.mock("../../video-generation-task-status.js", () => videoGenerationTaskStatusMocks);
 vi.mock("../../../plugins/host-hook-state.js", () => hostHookStateMocks);
 
+import { SessionManager } from "../../sessions/index.js";
 import {
+  dropReplayableAbortedAssistantLeaf,
   forgetPromptBuildDrainCacheForRun,
   resolvePromptSubmissionSkipReason,
   resolveAttemptMediaTaskSystemPromptAddition,
@@ -277,5 +279,138 @@ describe("resolvePromptBuildHookResult drain cache", () => {
     });
 
     expect(hostHookStateMocks.drainPluginNextTurnInjectionContext).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("dropReplayableAbortedAssistantLeaf (SessionManager integration)", () => {
+  const appendRaw = (sm: SessionManager, message: unknown): string =>
+    sm.appendMessage(message as Parameters<SessionManager["appendMessage"]>[0]);
+
+  it("drops an empty aborted-assistant leaf back to its user parent", () => {
+    // Mirrors the idle-timeout retry transcript: the user turn was persisted, then an
+    // empty aborted-assistant leaf. The replay must resume from the user turn so the
+    // trailing-user repair can run instead of stacking a second user turn.
+    const sm = SessionManager.inMemory();
+    const userLeafId = appendRaw(sm, { role: "user", content: "hello", timestamp: Date.now() });
+    appendRaw(sm, {
+      role: "assistant",
+      content: [{ type: "text", text: "" }],
+      stopReason: "aborted",
+      timestamp: Date.now(),
+    });
+
+    expect(dropReplayableAbortedAssistantLeaf(sm, sm.getLeafEntry())).toBe(true);
+    expect(sm.getLeafId()).toBe(userLeafId);
+    const userTurns = sm
+      .buildSessionContext()
+      .messages.filter((message) => message.role === "user");
+    expect(userTurns).toHaveLength(1);
+  });
+
+  it("keeps a completed assistant leaf untouched", () => {
+    const sm = SessionManager.inMemory();
+    appendRaw(sm, { role: "user", content: "hello", timestamp: Date.now() });
+    const assistantLeafId = appendRaw(sm, {
+      role: "assistant",
+      content: [{ type: "text", text: "hi" }],
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+
+    expect(dropReplayableAbortedAssistantLeaf(sm, sm.getLeafEntry())).toBe(false);
+    expect(sm.getLeafId()).toBe(assistantLeafId);
+  });
+
+  it("keeps an aborted assistant leaf that emitted a tool call", () => {
+    // A leaf carrying tool calls must stay so tool-call/result pairing is not broken.
+    const sm = SessionManager.inMemory();
+    appendRaw(sm, { role: "user", content: "hello", timestamp: Date.now() });
+    const toolCallLeafId = appendRaw(sm, {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      stopReason: "aborted",
+      timestamp: Date.now(),
+    });
+
+    expect(dropReplayableAbortedAssistantLeaf(sm, sm.getLeafEntry())).toBe(false);
+    expect(sm.getLeafId()).toBe(toolCallLeafId);
+  });
+
+  it("keeps an empty aborted leaf whose parent is not a user turn", () => {
+    // Only an aborted leaf directly after a user turn is dropped; a parent that is itself
+    // an assistant means the user turn already had a reply we must not strip.
+    const sm = SessionManager.inMemory();
+    appendRaw(sm, { role: "user", content: "hello", timestamp: Date.now() });
+    appendRaw(sm, {
+      role: "assistant",
+      content: [{ type: "text", text: "partial answer" }],
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+    const abortedLeafId = appendRaw(sm, {
+      role: "assistant",
+      content: [{ type: "text", text: "" }],
+      stopReason: "aborted",
+      timestamp: Date.now(),
+    });
+
+    expect(dropReplayableAbortedAssistantLeaf(sm, sm.getLeafEntry())).toBe(false);
+    expect(sm.getLeafId()).toBe(abortedLeafId);
+  });
+
+  it("keeps an empty errored-assistant leaf (real provider/model error, not a local abort)", () => {
+    // An error leaf is a real provider/model outcome and must survive for the normal
+    // failover/orphan paths rather than be dropped like a local interruption.
+    const sm = SessionManager.inMemory();
+    appendRaw(sm, { role: "user", content: "hello", timestamp: Date.now() });
+    const errorLeafId = appendRaw(sm, {
+      role: "assistant",
+      content: [],
+      stopReason: "error",
+      timestamp: Date.now(),
+    });
+
+    expect(dropReplayableAbortedAssistantLeaf(sm, sm.getLeafEntry())).toBe(false);
+    expect(sm.getLeafId()).toBe(errorLeafId);
+  });
+
+  it("drops an aborted leaf that produced only thinking (no visible text)", () => {
+    const sm = SessionManager.inMemory();
+    const userLeafId = appendRaw(sm, { role: "user", content: "hello", timestamp: Date.now() });
+    appendRaw(sm, {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "partial reasoning" }],
+      stopReason: "aborted",
+      timestamp: Date.now(),
+    });
+
+    expect(dropReplayableAbortedAssistantLeaf(sm, sm.getLeafEntry())).toBe(true);
+    expect(sm.getLeafId()).toBe(userLeafId);
+  });
+
+  it("keeps an aborted leaf that produced visible text", () => {
+    // A partial reply must survive even though the turn aborted; dropping it would
+    // discard real assistant output.
+    const sm = SessionManager.inMemory();
+    appendRaw(sm, { role: "user", content: "hello", timestamp: Date.now() });
+    const partialLeafId = appendRaw(sm, {
+      role: "assistant",
+      content: [{ type: "text", text: "partial answer" }],
+      stopReason: "aborted",
+      timestamp: Date.now(),
+    });
+
+    expect(dropReplayableAbortedAssistantLeaf(sm, sm.getLeafEntry())).toBe(false);
+    expect(sm.getLeafId()).toBe(partialLeafId);
+  });
+
+  it("leaves a trailing user leaf for the normal orphan repair", () => {
+    // A plain trailing user leaf is the existing orphan repair's job, not this helper's;
+    // only an aborted-assistant leaf whose parent is a user turn is dropped here.
+    const sm = SessionManager.inMemory();
+    const userLeafId = appendRaw(sm, { role: "user", content: "hello", timestamp: Date.now() });
+
+    expect(dropReplayableAbortedAssistantLeaf(sm, sm.getLeafEntry())).toBe(false);
+    expect(sm.getLeafId()).toBe(userLeafId);
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
@@ -23,6 +23,8 @@ import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-pr
 import { wrapPluginSystemContextSection } from "../../hook-system-context-boundary.js";
 import { buildActiveImageGenerationTaskPromptContextForSession } from "../../image-generation-task-status.js";
 import { buildActiveMusicGenerationTaskPromptContextForSession } from "../../music-generation-task-status.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import type { SessionManager } from "../../sessions/index.js";
 import { prependSystemPromptAdditionAfterCacheBoundary } from "../../system-prompt-cache-boundary.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../tool-fs-policy.js";
 import { derivePromptTokens, type NormalizedUsage } from "../../usage.js";
@@ -507,6 +509,67 @@ export function mergeOrphanedTrailingUserPrompt(params: {
     merged: true,
     removeLeaf: true,
   };
+}
+
+/**
+ * True when a transcript leaf is an empty *aborted* assistant turn that a same-model
+ * retry left behind: stopReason "aborted" (a local interruption — the idle-timeout
+ * watchdog, run timeout, or user abort; see createLoopFailureMessage in agent-core) with
+ * no tool calls and no visible text. transformMessages already drops these before the
+ * model call, but on the transcript such a leaf sits between the persisted user turn and
+ * the replayed prompt, hiding the user leaf from the trailing-user orphan repair. Callers
+ * drop it back to its user parent so the replay merges instead of persisting a duplicate
+ * user turn and surfacing consecutive user turns to providers that reject them.
+ *
+ * Scope is deliberately limited to "aborted". An "error" leaf is a real provider/model
+ * outcome (rate limit, auth, overload, refusal, transport failure — usually carrying an
+ * errorMessage) and is preserved for the normal failover / suppressAssistantErrorPersistence
+ * / orphan paths rather than silently dropped here. Leaves with tool calls or visible text
+ * are likewise kept: dropping them would lose a real reply or break tool-call/result pairing.
+ */
+function isReplayableAbortedAssistantLeaf(message: AgentMessage): boolean {
+  if (message.role !== "assistant" || message.stopReason !== "aborted") {
+    return false;
+  }
+  return !message.content.some((block) => {
+    if (block.type === "toolCall") {
+      return true;
+    }
+    if (block.type === "text") {
+      return block.text.trim().length > 0;
+    }
+    return false;
+  });
+}
+
+/**
+ * Drops an empty aborted-assistant transcript leaf (see isReplayableAbortedAssistantLeaf)
+ * back to its user parent so a same-model retry replays the user turn through the normal
+ * trailing-user orphan repair instead of stacking a second user turn. Returns true when a
+ * leaf was dropped — the caller must rebuild the agent context and re-read the leaf; false
+ * leaves the transcript untouched. The caller passes the already-resolved leaf entry so this
+ * does not re-read it (the trailing-user repair reuses the same leaf). Only an aborted leaf
+ * whose immediate parent is a user turn is dropped; error leaves (real provider/model
+ * responses), tool-call scaffolding, or a leaf with visible text are preserved so we never
+ * discard a real response/reply or break tool-call/result pairing.
+ */
+export function dropReplayableAbortedAssistantLeaf(
+  session: Pick<SessionManager, "getEntry" | "branch">,
+  leafEntry: ReturnType<SessionManager["getLeafEntry"]> | null,
+): boolean {
+  if (
+    leafEntry?.type !== "message" ||
+    !isReplayableAbortedAssistantLeaf(leafEntry.message) ||
+    !leafEntry.parentId
+  ) {
+    return false;
+  }
+  const parentEntry = session.getEntry(leafEntry.parentId);
+  if (parentEntry?.type !== "message" || parentEntry.message.role !== "user") {
+    return false;
+  }
+  session.branch(parentEntry.id);
+  return true;
 }
 
 export function resolveAttemptFsWorkspaceOnly(params: {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -394,6 +394,7 @@ import { wrapStreamFnWithDiagnosticModelCallEvents } from "./attempt.model-diagn
 import {
   buildAfterTurnRuntimeContext,
   buildAfterTurnRuntimeContextFromUsage,
+  dropReplayableAbortedAssistantLeaf,
   prependSystemPromptAddition,
   resolveAttemptFsWorkspaceOnly,
   resolveAttemptMediaTaskSystemPromptAddition,
@@ -4045,7 +4046,31 @@ export async function runEmbeddedAttempt(
         let transcriptPromptForRuntimeSplit = effectiveTranscriptPrompt;
         let promptForRuntimeContextSplit = promptBeforePromptBuildHooks;
         // Repair orphaned trailing user messages so new prompts don't violate role ordering.
-        const leafEntry = isRawModelRun ? null : sessionManager.getLeafEntry();
+        // First drop any empty aborted-assistant leaf: a same-model idle-timeout retry persists
+        // one (a local interruption that produced no model output) between the user turn and this
+        // replay. transformMessages drops it before the model call, but on the transcript it hides
+        // the user leaf from the trailing-user repair below, so the replay would persist a
+        // duplicate user turn (and surface consecutive user turns to providers that reject them).
+        // Scope this to non-suppressed replays of the original prompt: suppress-mode retries
+        // (mid-turn continuation, compaction, codex recovery, before-finalize) drive their own
+        // continuation prompt and already skip the user re-append, so dropping the leaf there
+        // would let the orphan removeLeaf and the suppression both strip the user turn from the
+        // active branch. Error leaves (real provider/model responses) are intentionally not
+        // dropped here — they flow through the normal failover/orphan paths.
+        let leafEntry = isRawModelRun ? null : sessionManager.getLeafEntry();
+        if (
+          !isRawModelRun &&
+          !params.suppressNextUserMessagePersistence &&
+          dropReplayableAbortedAssistantLeaf(sessionManager, leafEntry)
+        ) {
+          const sessionContext = sessionManager.buildSessionContext();
+          activeSession.agent.state.messages = sessionContext.messages;
+          leafEntry = sessionManager.getLeafEntry();
+          log.debug(
+            `Dropped empty aborted-assistant leaf before trailing-user repair. ` +
+              `runId=${params.runId} sessionId=${params.sessionId} trigger=${params.trigger}`,
+          );
+        }
         if (leafEntry?.type === "message" && leafEntry.message.role === "user") {
           const messageMergeStrategy = resolveMessageMergeStrategy();
           const orphanPromptMerge = messageMergeStrategy.mergeOrphanedTrailingUserPrompt({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users would see their message duplicated in a conversation after the assistant fell silent and the turn was retried. When a model produces no output and the idle-timeout watchdog aborts the turn, the automatic same-model retry replayed the original prompt and persisted a second copy of the user's message: in the Control UI the message appeared twice, and the retry also sent consecutive user turns to providers that reject them (for example Anthropic and Gemini), which surfaced as a failed retry.

## Why This Change Was Made

The idle-timeout abort leaves an empty assistant turn on the transcript (stop reason `aborted`, with no text and no tool calls). That empty turn sat between the user message and the replay, hiding the user message from the existing trailing-user repair, so the replay appended a duplicate user turn instead of merging into it. This change drops that empty aborted turn back to its user parent before the trailing-user repair runs, so the replay merges normally and the conversation keeps a single user turn.

The fix is intentionally narrow:

- It only drops `aborted` turns (local interruptions — the idle-timeout watchdog, run timeout, or user abort). `error` turns are real provider/model responses (rate limit, auth, overload, refusal) and are left in place for the normal failover path; provider stop-reason mappings never produce `aborted`, so this stays limited to local interruptions.
- It only applies to non-suppressed replays of the original prompt, so the existing mid-turn continuation, compaction, and recovery retries (which drive their own continuation prompt and message persistence) are untouched.
- Turns that produced any visible text or a tool call are always preserved, so a real reply is never discarded and tool-call/result pairing is never broken.

## User Impact

After an idle-timeout retry the conversation keeps exactly one copy of the user's message, both in the Control UI and in the context sent to the model. The duplicated message and the consecutive-user-turn retry failures are gone. No configuration change is needed.

## Evidence

- **Behavior addressed:** same-model idle-timeout retry persisted a duplicate user message and sent consecutive user turns to the provider on the retry.
- **Real environment tested:** repo unit/integration lanes on Windows with Node, driving the real components of the affected path end to end — the real idle-timeout watchdog (`streamWithIdleTimeout`) firing a real abort against a silent stream, a real `SessionManager` persisting the transcript to a JSONL file, and the real repair helpers (`dropReplayableAbortedAssistantLeaf` + `mergeOrphanedTrailingUserPrompt`).
- **Exact steps or command run after this patch:**
  - `pnpm test src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts`
  - `pnpm test src/agents/embedded-agent-runner/run/attempt.test.ts`
  - Idle-timeout retry reproduction (script below): `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-embedded-agent.config.ts src/agents/embedded-agent-runner/run/idle-timeout-retry.repro.test.ts`
  - `pnpm exec oxfmt --check --threads=1 src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts`
- **Evidence after fix:**
  - `attempt.prompt-helpers.test.ts` — 20 passed. Includes an integration case that builds `user → empty aborted-assistant` on a real `SessionManager`, asserts the empty aborted turn is dropped back to its user parent, and that `buildSessionContext().messages` then contains exactly one user turn. Sibling cases assert that `error` turns, tool-call turns, visible-text turns, non-user parents, and plain trailing user turns are all preserved.
  - `attempt.test.ts` — 116 passed (full embedded-attempt runner; the existing trailing-user orphan repair still passes, with no regression).
  - Idle-timeout retry reproduction — 1 passed. The real idle watchdog fires, seeding `user → empty aborted-assistant` on a real `SessionManager`; from that identical starting transcript the same-model retry yields **2 user turns without the fix** vs **1 user turn with the fix**:

    ```text
    ==================== idle-timeout retry reproduction ====================
    [1] real idle watchdog fired: LLM idle timeout (1s): no response from model
        -> the aborted stream persists an empty assistant leaf (stopReason=aborted)

    [2] WITHOUT fix (current behavior)
        persisted JSONL:  user, assistant(aborted), user
        model context:    user, assistant(aborted), user
        >>> user turns in model context: 2  (duplicate; providers reject consecutive user turns)

    [3] WITH fix
        droppedAbortedLeaf=true  orphanRepair.merged=false  orphanRepair.removeLeaf=true
        model context:    user
        >>> user turns in model context: 1  (single turn; replay merged)
    =========================================================================
    ```

  - `oxfmt --check` — all three touched files correctly formatted; no lint or type errors.
- **Observed result after fix:** the replay merges into the existing user turn instead of stacking a second one; the active transcript and the model context keep a single user turn. (`orphanRepair.merged=false` here is expected: the replayed prompt text equals the interrupted user turn, so the repair recognizes it as already-included and sets `removeLeaf=true` rather than re-queuing it — exactly the de-duplication path.)
- **What was not tested:** a full gateway end-to-end run against a live remote provider. The idle-timeout watchdog itself is exercised for real in the reproduction above; only the remote provider round-trip is replaced by a deterministic silent stream. Provider stop-reason mappings were inspected to confirm `aborted` only originates from the local abort signal, never from a remote finish reason.

<details>
<summary>Idle-timeout retry reproduction script</summary>

Standalone reproduction (not part of the committed suite). Drop it into `src/agents/embedded-agent-runner/run/idle-timeout-retry.repro.test.ts` and run the command listed above. It mocks none of the pieces under test: the idle watchdog, the `SessionManager` transcript, and the two repair helpers are all the real implementations.

```ts
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";
import { describe, expect, it } from "vitest";
import { SessionManager } from "../../sessions/index.js";
import {
  dropReplayableAbortedAssistantLeaf,
  mergeOrphanedTrailingUserPrompt,
} from "./attempt.prompt-helpers.js";
import { streamWithIdleTimeout } from "./llm-idle-timeout.js";

const USER_PROMPT = "Summarize the Q3 planning notes.";
const IDLE_TIMEOUT_MS = 1200;

// A provider stream that never yields a chunk — the network-silence hang the
// idle watchdog guards against.
function createHangingStreamFn(): Parameters<typeof streamWithIdleTimeout>[0] {
  return (() => ({
    [Symbol.asyncIterator]() {
      return {
        next: () => new Promise<IteratorResult<unknown>>(() => {}),
        return: () => Promise.resolve({ done: true, value: undefined }),
      };
    },
  })) as unknown as Parameters<typeof streamWithIdleTimeout>[0];
}

async function triggerRealIdleTimeout(): Promise<Error> {
  let idleError: Error | undefined;
  const wrapped = streamWithIdleTimeout(createHangingStreamFn(), IDLE_TIMEOUT_MS, (error) => {
    idleError = error;
  });
  const stream = await wrapped({} as never, { messages: [] } as never, {} as never);
  try {
    for await (const _event of stream as AsyncIterable<unknown>) {
      void _event;
    }
  } catch (error) {
    idleError ??= error as Error;
  }
  if (!idleError) {
    throw new Error("expected the idle watchdog to fire");
  }
  return idleError;
}

function appendRaw(sm: SessionManager, message: unknown): string {
  return sm.appendMessage(message as Parameters<SessionManager["appendMessage"]>[0]);
}

// The real post-abort transcript: the user turn was persisted, then the
// idle-timeout abort left an empty assistant leaf with stopReason "aborted".
async function seedIdleTimeoutTranscript(file: string): Promise<SessionManager> {
  await fs.writeFile(file, "", "utf8");
  const sm = SessionManager.open(file);
  appendRaw(sm, { role: "user", content: USER_PROMPT, timestamp: Date.now() });
  appendRaw(sm, {
    role: "assistant",
    content: [{ type: "text", text: "" }],
    stopReason: "aborted",
    timestamp: Date.now(),
  });
  return sm;
}

function contextRoles(sm: SessionManager): string {
  return sm
    .buildSessionContext()
    .messages.map((message) => {
      const stopReason = (message as { stopReason?: string }).stopReason;
      return message.role === "assistant" && stopReason
        ? `${message.role}(${stopReason})`
        : message.role;
    })
    .join(", ");
}

function userTurnCount(sm: SessionManager): number {
  return sm.buildSessionContext().messages.filter((message) => message.role === "user").length;
}

async function persistedMessageRoles(file: string): Promise<string> {
  const raw = await fs.readFile(file, "utf8");
  const roles: string[] = [];
  for (const line of raw.split("\n")) {
    if (!line.trim()) {
      continue;
    }
    const entry = JSON.parse(line) as {
      type?: string;
      message?: { role?: string; stopReason?: string };
    };
    if (entry.type === "message" && entry.message?.role) {
      roles.push(
        entry.message.stopReason
          ? `${entry.message.role}(${entry.message.stopReason})`
          : entry.message.role,
      );
    }
  }
  return roles.join(", ");
}

describe("idle-timeout retry reproduction (real idle watchdog + real SessionManager)", () => {
  it("does not duplicate the user turn on a same-model idle-timeout retry", async () => {
    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "idle-retry-repro-"));
    const withoutFixFile = path.join(tmp, "without-fix.jsonl");
    const withFixFile = path.join(tmp, "with-fix.jsonl");
    const out: string[] = [];
    try {
      // [1] Fire the REAL idle watchdog against a silent stream.
      const idleError = await triggerRealIdleTimeout();

      // Both transcripts start from the identical real post-abort state.
      const withoutFix = await seedIdleTimeoutTranscript(withoutFixFile);
      const withFix = await seedIdleTimeoutTranscript(withFixFile);

      // [2] WITHOUT the fix (current main): the leaf is the aborted assistant, so the
      // trailing-user orphan repair (which only runs for a user leaf) never fires and
      // the same-model retry re-persists the user turn.
      appendRaw(withoutFix, { role: "user", content: USER_PROMPT, timestamp: Date.now() });

      // [3] WITH the fix: drop the empty aborted leaf back to its user parent so the
      // trailing-user repair runs and merges the replay instead of stacking a 2nd user.
      const dropped = dropReplayableAbortedAssistantLeaf(withFix, withFix.getLeafEntry());
      const repairedLeaf = withFix.getLeafEntry();
      const merge =
        repairedLeaf?.type === "message" && repairedLeaf.message.role === "user"
          ? mergeOrphanedTrailingUserPrompt({
              prompt: USER_PROMPT,
              trigger: "user",
              leafMessage: repairedLeaf.message,
            })
          : undefined;

      out.push("==================== idle-timeout retry reproduction ====================");
      out.push(`[1] real idle watchdog fired: ${idleError.message}`);
      out.push(`    -> the aborted stream persists an empty assistant leaf (stopReason=aborted)`);
      out.push("");
      out.push(`[2] WITHOUT fix (current behavior)`);
      out.push(`    persisted JSONL:  ${await persistedMessageRoles(withoutFixFile)}`);
      out.push(`    model context:    ${contextRoles(withoutFix)}`);
      out.push(
        `    >>> user turns in model context: ${userTurnCount(withoutFix)}  (duplicate; providers reject consecutive user turns)`,
      );
      out.push("");
      out.push(`[3] WITH fix`);
      out.push(
        `    droppedAbortedLeaf=${dropped}  orphanRepair.merged=${merge?.merged}  orphanRepair.removeLeaf=${merge?.removeLeaf}`,
      );
      out.push(`    model context:    ${contextRoles(withFix)}`);
      out.push(
        `    >>> user turns in model context: ${userTurnCount(withFix)}  (single turn; replay merged)`,
      );
      out.push("=========================================================================");
      // eslint-disable-next-line no-console
      console.log(`\n${out.join("\n")}\n`);

      expect(idleError.message).toContain("idle timeout");
      expect(userTurnCount(withoutFix)).toBe(2);
      expect(dropped).toBe(true);
      expect(userTurnCount(withFix)).toBe(1);
    } finally {
      await fs.rm(tmp, { recursive: true, force: true });
    }
  });
});
```

</details>
