### PR TITLE
Expose agent tool execution context

### DIFF
--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -145,6 +145,11 @@ local proof.
     Use `definePluginEntry` for non-channel plugins. Channel plugins use
     `defineChannelPluginEntry`.
 
+    Tool handlers may accept an optional fifth execution-context argument when
+    they need runtime-owned facts for the current call. The context includes the
+    active `runId`, effective `sessionKey`, ephemeral `sessionId`, owning
+    `agentId`, and ambient `deliveryContext` when those values are available.
+
   </Step>
 
   <Step title="Test the runtime">

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -238,9 +238,11 @@ releases.
     `api.runtime.config.writeConfigFile(...)` directly. Prefer config that was
     already passed into the active call path. Long-lived handlers that need the
     current process snapshot can use `api.runtime.config.current()`. Long-lived
-    agent tools should use the tool context's `ctx.getRuntimeConfig()` inside
-    `execute` so a tool created before a config write still sees the refreshed
-    runtime config.
+    factory-created agent tools should use the tool factory context's
+    `ctx.getRuntimeConfig()` inside `execute` so a tool created before a config
+    write still sees the refreshed runtime config. For per-call run, session, or
+    delivery facts, use the tool execution context rather than closing over the
+    factory context.
 
     Config writes must go through the transactional helpers and choose an
     after-write policy:

--- a/docs/plugins/tool-plugins.md
+++ b/docs/plugins/tool-plugins.md
@@ -151,6 +151,14 @@ Factories are still for fixed tool names. Use `definePluginEntry` directly when
 the plugin computes tool names dynamically or combines tools with hooks,
 services, providers, commands, or other runtime surfaces.
 
+Factory context is construction-time state. Use it to decide whether the tool
+exists for the run or to bind stable helpers. Per-call state belongs in the
+execution context: static tool-plugin `execute` handlers receive it as fields on
+their third `context` argument, and factory-created `AgentTool.execute`
+handlers receive it as the optional fifth argument. The execution context
+includes `runId`, effective `sessionKey`, `sessionId`, `agentId`, and
+`deliveryContext` when OpenClaw knows those values.
+
 ## Return values
 
 `defineToolPlugin` wraps plain return values into the OpenClaw tool-result

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -455,6 +455,32 @@ export interface AgentToolResult<T> {
 /** Callback used by tools to stream partial execution updates. */
 export type AgentToolUpdateCallback<T = unknown> = (partialResult: AgentToolResult<T>) => void;
 
+/** Normalized delivery target associated with the active tool call, when known. */
+export type AgentToolDeliveryContext = {
+  /** Channel/plugin id that owns the delivery target. */
+  channel?: string;
+  /** Channel-local destination id. */
+  to?: string;
+  /** Optional channel account/workspace id. */
+  accountId?: string;
+  /** Optional thread/topic id nested under `to`. */
+  threadId?: string | number;
+};
+
+/** Runtime-owned facts for one concrete tool execution. */
+export type AgentToolExecutionContext = object & {
+  /** Agent that owns the run. */
+  agentId?: string;
+  /** Effective session key used by the active run. */
+  sessionKey?: string;
+  /** Ephemeral session UUID, regenerated on /new and /reset. */
+  sessionId?: string;
+  /** Stable run identifier for this agent invocation. */
+  runId?: string;
+  /** Ambient delivery route for the current inbound/outbound conversation. */
+  deliveryContext?: AgentToolDeliveryContext;
+};
+
 /** Tool definition used by the agent runtime. */
 export interface AgentTool<
   TParameters extends TSchema = TSchema,
@@ -473,6 +499,7 @@ export interface AgentTool<
     params: Static<TParameters>,
     signal?: AbortSignal,
     onUpdate?: AgentToolUpdateCallback<TDetails>,
+    context?: AgentToolExecutionContext,
   ) => Promise<AgentToolResult<TDetails>>;
   /**
    * Per-tool execution mode override.

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -163,7 +163,7 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 321),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10311),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10313),
     publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5174),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",

--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -163,6 +163,57 @@ describe("agent tool definition adapter", () => {
     expect(prepareBeforeToolCallParams).toHaveBeenCalledOnce();
     expect(execute).toHaveBeenCalledOnce();
   });
+
+  it("passes run session and delivery context to runtime tool execution", async () => {
+    const execute = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "done" }],
+      details: {},
+    }));
+    const tool = {
+      name: "context_probe",
+      label: "Context Probe",
+      description: "observes runtime context",
+      parameters: Type.Object({}),
+      execute,
+    } satisfies AgentTool;
+    const hookContext = {
+      agentId: "agent-main",
+      sessionKey: "agent:main:rovoclaw:default:direct:cli",
+      sessionId: "session-123",
+      runId: "run-123",
+      deliveryContext: {
+        channel: "rovoclaw",
+        to: "direct:original",
+        accountId: "workspace-1",
+        threadId: "thread-1",
+      },
+    };
+    const [definition] = toToolDefinitions([tool], hookContext);
+    if (!definition) {
+      throw new Error("missing context probe definition");
+    }
+
+    await definition.execute("call-context", {}, undefined, undefined, extensionContext);
+
+    expect(execute).toHaveBeenCalledWith(
+      "call-context",
+      {},
+      undefined,
+      undefined,
+      expect.objectContaining({
+        agentId: "agent-main",
+        sessionKey: "agent:main:rovoclaw:default:direct:cli",
+        sessionId: "session-123",
+        runId: "run-123",
+        deliveryContext: {
+          channel: "rovoclaw",
+          to: "direct:original",
+          accountId: "workspace-1",
+          threadId: "thread-1",
+        },
+      }),
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -23,7 +23,12 @@ import {
 } from "./code-mode-control-tools.js";
 import { sanitizeForConsole } from "./console-sanitize.js";
 import type { ClientToolDefinition } from "./embedded-agent-runner/run/params.js";
-import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "./runtime/index.js";
+import type {
+  AgentTool,
+  AgentToolExecutionContext,
+  AgentToolResult,
+  AgentToolUpdateCallback,
+} from "./runtime/index.js";
 import type { ToolDefinition } from "./sessions/index.js";
 import { normalizeToolName } from "./tool-policy.js";
 import { jsonResult, payloadTextResult } from "./tools/common.js";
@@ -59,6 +64,21 @@ const TOOL_ERROR_PARAM_PREVIEW_MAX_CHARS = 600;
 const TOOL_ERROR_EXEC_COMMAND_HASH_CHARS = 16;
 const SENSITIVE_EXEC_ENV_VALUE = "[omitted exec env value]";
 const EXEC_COMMAND_PARAM_KEYS = new Set(["command", "cmd"]);
+
+function buildAgentToolExecutionContext(
+  hookContext?: HookContext,
+): AgentToolExecutionContext | undefined {
+  if (!hookContext) {
+    return undefined;
+  }
+  return {
+    ...(hookContext.agentId ? { agentId: hookContext.agentId } : {}),
+    ...(hookContext.sessionKey ? { sessionKey: hookContext.sessionKey } : {}),
+    ...(hookContext.sessionId ? { sessionId: hookContext.sessionId } : {}),
+    ...(hookContext.runId ? { runId: hookContext.runId } : {}),
+    ...(hookContext.deliveryContext ? { deliveryContext: hookContext.deliveryContext } : {}),
+  };
+}
 
 type ClientToolCallRecorder =
   | ((toolName: string, params: Record<string, unknown>) => void)
@@ -423,7 +443,13 @@ export function toToolDefinitions(
             });
             recordAdjustedParamsForToolCall(toolCallId, executeParams, hookContext?.runId);
           }
-          const rawResult = await tool.execute(toolCallId, executeParams, signal, onUpdate);
+          const rawResult = await tool.execute(
+            toolCallId,
+            executeParams,
+            signal,
+            onUpdate,
+            buildAgentToolExecutionContext(hookContext),
+          );
           const result = normalizeToolExecutionResult({
             toolName: normalizedName,
             result: rawResult,

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -60,6 +60,7 @@ import {
 import type { SkillSnapshot, SkillTelemetrySource } from "../skills/types.js";
 import { resolveSkillWorkshopToolApproval } from "../skills/workshop/policy.js";
 import { isPlainObject, truncateUtf16Safe } from "../utils.js";
+import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import {
   adjustedParamsByToolCallId,
   buildAdjustedParamsKey,
@@ -109,6 +110,8 @@ export type HookContext = {
   /** Ephemeral session UUID — regenerated on /new and /reset. */
   sessionId?: string;
   runId?: string;
+  /** Ambient delivery route associated with the active tool call. */
+  deliveryContext?: DeliveryContext;
   trace?: DiagnosticTraceContext;
   channelId?: string;
   /** Originating channel for approval delivery routing; mirrors exec approval turn-source fields. */

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -27,6 +27,7 @@ import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import type { SkillSnapshot } from "../skills/types.js";
+import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
@@ -1218,6 +1219,12 @@ export function createOpenClawCodingTools(options?: {
   options?.recordToolPrepStage?.("schema-normalization");
   const turnSourceChannel = options?.messageChannel ?? options?.messageProvider;
   const turnSourceTo = options?.currentMessagingTarget ?? options?.currentChannelId;
+  const toolDeliveryContext = normalizeDeliveryContext({
+    channel: resolveGatewayMessageChannel(turnSourceChannel),
+    to: options?.messageTo ?? turnSourceTo,
+    accountId: options?.agentAccountId,
+    threadId: options?.messageThreadId ?? options?.currentThreadTs,
+  });
   const hookContext = {
     agentId,
     ...(options?.config ? { config: options.config } : {}),
@@ -1230,6 +1237,7 @@ export function createOpenClawCodingTools(options?: {
     sessionKey: options?.sessionKey,
     sessionId: options?.sessionId,
     runId: options?.runId,
+    ...(toolDeliveryContext ? { deliveryContext: toolDeliveryContext } : {}),
     channelId: options?.hookChannelId ?? options?.currentChannelId,
     ...(turnSourceChannel ? { turnSourceChannel } : {}),
     ...(turnSourceTo ? { turnSourceTo } : {}),

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -16,6 +16,7 @@ import { readSnakeCaseParamRaw } from "../../param-key.js";
 import type { ImageSanitizationLimits } from "../image-sanitization.js";
 import type {
   AgentTool,
+  AgentToolExecutionContext,
   AgentToolProgress,
   AgentToolResult,
   AgentToolUpdateCallback,
@@ -41,6 +42,7 @@ type ErasedAgentToolExecute = {
     params: unknown,
     signal?: AbortSignal,
     onUpdate?: AgentToolUpdateCallback,
+    context?: AgentToolExecutionContext,
   ): Promise<AgentToolResult<unknown>>;
 };
 

--- a/src/plugin-sdk/tool-plugin.test.ts
+++ b/src/plugin-sdk/tool-plugin.test.ts
@@ -77,6 +77,48 @@ describe("defineToolPlugin", () => {
     });
   });
 
+  it("passes execution context to concrete tool handlers", async () => {
+    const observedContexts: unknown[] = [];
+    const entry = defineToolPlugin({
+      id: "context-tools",
+      name: "Context Tools",
+      description: "Observe execution context.",
+      tools: (tool) => [
+        tool({
+          name: "context_echo",
+          description: "Echo context.",
+          parameters: Type.Object({}),
+          execute(_params, _config, context) {
+            observedContexts.push(context);
+            return "ok";
+          },
+        }),
+      ],
+    });
+    const captured = createCapturedPluginRegistration({ id: "context-tools" });
+    const executionContext = {
+      agentId: "agent-main",
+      sessionKey: "agent:main:rovoclaw:default:direct:cli",
+      sessionId: "session-123",
+      runId: "run-123",
+      deliveryContext: {
+        channel: "rovoclaw",
+        to: "direct:original",
+      },
+    };
+
+    entry.register(captured.api);
+    await captured.tools[0].execute("call-1", {}, undefined, undefined, executionContext);
+
+    expect(observedContexts).toEqual([
+      expect.objectContaining({
+        ...executionContext,
+        api: captured.api,
+        toolCallId: "call-1",
+      }),
+    ]);
+  });
+
   it("passes optional tools through to runtime registration and metadata", () => {
     const entry = defineToolPlugin({
       id: "optional-tools",

--- a/src/plugin-sdk/tool-plugin.ts
+++ b/src/plugin-sdk/tool-plugin.ts
@@ -1,6 +1,10 @@
 // Tool plugin contracts describe plugin-provided tools, schemas, and invocation hooks.
 import { Type, type Static, type TSchema } from "typebox";
-import type { AgentToolResult, AgentToolUpdateCallback } from "../agents/runtime/index.js";
+import type {
+  AgentToolExecutionContext,
+  AgentToolResult,
+  AgentToolUpdateCallback,
+} from "../agents/runtime/index.js";
 import { jsonResult, textResult } from "../agents/tools/common.js";
 import type { PluginManifestActivation } from "../plugins/manifest.js";
 import type { JsonSchemaObject } from "../shared/json-schema.types.js";
@@ -18,7 +22,7 @@ const EMPTY_TOOL_PLUGIN_CONFIG_SCHEMA = Type.Object({}, { additionalProperties: 
 export const toolPluginMetadataSymbol = Symbol.for("openclaw.plugin-sdk.tool-plugin.metadata");
 
 /** Runtime context supplied to a concrete tool plugin execution handler. */
-export type ToolPluginExecutionContext = {
+export type ToolPluginExecutionContext = AgentToolExecutionContext & {
   /** Plugin runtime API for tool implementations that need OpenClaw services. */
   api: OpenClawPluginApi;
   /** Abort signal for the current tool call. */
@@ -218,9 +222,10 @@ export function defineToolPlugin<TConfigSchema extends TSchema | undefined = und
             label: tool.label,
             description: tool.description,
             parameters: tool.parameters,
-            execute: async (toolCallId, params, signal, onUpdate) =>
+            execute: async (toolCallId, params, signal, onUpdate, executionContext) =>
               wrapToolPluginResult(
                 await execute(params, config, {
+                  ...(executionContext ?? {}),
                   api,
                   signal,
                   toolCallId,

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -606,6 +606,46 @@ describe("resolvePluginTools optional tools", () => {
     ]);
   });
 
+  it("forwards execution context through plugin tool scope wrappers", async () => {
+    const execute = vi.fn(
+      async (
+        _toolCallId: string,
+        _params: unknown,
+        _signal?: AbortSignal,
+        _onUpdate?: unknown,
+        _context?: unknown,
+      ) => ({ content: [{ type: "text" as const, text: "ok" }] }),
+    );
+    setRegistry([
+      {
+        pluginId: "context-owner",
+        optional: false,
+        source: "/tmp/context-owner.js",
+        names: ["context_probe"],
+        factory: () => ({
+          ...makeTool("context_probe"),
+          execute,
+        }),
+      },
+    ]);
+    const [tool] = resolvePluginTools(createResolveToolsParams({ context: createContext() }));
+    const executionContext = {
+      runId: "run-context",
+      sessionKey: "agent:main:rovoclaw:default:direct:cli",
+      deliveryContext: { channel: "rovoclaw", to: "direct:original" },
+    };
+
+    await tool?.execute("call-context", {}, undefined, undefined, executionContext);
+
+    expect(execute).toHaveBeenCalledWith(
+      "call-context",
+      {},
+      undefined,
+      undefined,
+      executionContext,
+    );
+  });
+
   it("wraps every array tool callback and restores caller scope after errors", async () => {
     const context = createContext();
     const observed: Array<{ name: string; pluginId?: string; pluginSource?: string }> = [];
@@ -2023,11 +2063,19 @@ describe("resolvePluginTools optional tools", () => {
   });
 
   it("caches plugin tool descriptors and uses the runtime only on execution", async () => {
+    const observedExecutionContexts: unknown[] = [];
     const factory = vi.fn((rawCtx: unknown) => {
       const ctx = rawCtx as { sessionId?: string };
       return {
         ...makeTool("cached_tool"),
-        async execute() {
+        async execute(
+          _toolCallId: string,
+          _params: unknown,
+          _signal?: AbortSignal,
+          _onUpdate?: unknown,
+          executionContext?: unknown,
+        ) {
+          observedExecutionContexts.push(executionContext);
           return { content: [{ type: "text", text: ctx.sessionId ?? "missing" }] };
         },
       };
@@ -2059,9 +2107,17 @@ describe("resolvePluginTools optional tools", () => {
     expect(second[0]).not.toBe(first[0]);
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
 
-    await expect(second[0]?.execute("call", {}, undefined)).resolves.toEqual({
+    const executionContext = {
+      runId: "run-cached",
+      sessionKey: "agent:main:rovoclaw:default:direct:cli",
+      deliveryContext: { channel: "rovoclaw", to: "direct:original" },
+    };
+    await expect(
+      second[0]?.execute("call", {}, undefined, undefined, executionContext),
+    ).resolves.toEqual({
       content: [{ type: "text", text: "same" }],
     });
+    expect(observedExecutionContexts).toEqual([executionContext]);
     expect(factory).toHaveBeenCalledTimes(2);
   });
 

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -140,13 +140,18 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
     params: unknown,
     signal?: AbortSignal,
     onUpdate?: unknown,
+    context?: Parameters<AnyAgentTool["execute"]>[4],
   ) =>
     runWithPluginToolScope(
       entry,
       () =>
-        Reflect.apply(tool.execute, tool, [toolCallId, params, signal, onUpdate]) as ReturnType<
-          AnyAgentTool["execute"]
-        >,
+        Reflect.apply(tool.execute, tool, [
+          toolCallId,
+          params,
+          signal,
+          onUpdate,
+          context,
+        ]) as ReturnType<AnyAgentTool["execute"]>,
     );
   const wrapped = new Proxy<AnyAgentTool>(tool, {
     get(target, prop) {
@@ -682,7 +687,7 @@ function createCachedDescriptorPluginTool(params: {
     label: descriptor.title ?? descriptor.name,
     description: descriptor.description,
     parameters: descriptor.inputSchema as never,
-    async execute(toolCallId, executeParams, signal, onUpdate) {
+    async execute(toolCallId, executeParams, signal, onUpdate, context) {
       const loadOptions = buildPluginRuntimeLoadOptions(params.loadContext, {
         activate: false,
         toolDiscovery: true,
@@ -729,7 +734,7 @@ function createCachedDescriptorPluginTool(params: {
           continue;
         }
         if (matchedTool) {
-          return matchedTool.execute(toolCallId, executeParams, signal, onUpdate);
+          return matchedTool.execute(toolCallId, executeParams, signal, onUpdate, context);
         }
       }
       throw new Error(`plugin tool runtime missing (${pluginId}): ${toolName}`);


### PR DESCRIPTION
## What Problem This Solves

Plugin tools can need trusted run-scoped facts such as `runId`, effective `sessionKey`, `sessionId`, `agentId`, and the ambient `deliveryContext` at the moment a tool executes. Today plugin factory context is construction-time state, while the richer run context only exists later in the tool wrapper path. That forces plugins to infer active turns from session strings or rely on registration-shape-specific context behavior.

## Why This Change Was Made

This adds an optional `AgentToolExecutionContext` fifth argument to `AgentTool.execute` and threads it through the OpenClaw tool adapter, plugin scope wrappers, cached descriptor tools, and `defineToolPlugin` handlers. The context is built from the existing hook/run facts and preserves the canonical delivery route instead of adding fallback session guessing.

The change also documents the distinction between construction-time factory context and execution-time run/session/delivery context, and updates the plugin SDK surface budget for the two new public `agent-core` type exports.

## User Impact

Existing tools keep working because the new argument is optional. Plugin authors get a stable SDK-backed way to read current run/session/delivery identity during tool execution, including factory-created and descriptor-cached plugin tools.

## Evidence

- `node scripts/run-vitest.mjs src/agents/agent-tool-definition-adapter.test.ts src/plugins/tools.optional.test.ts src/plugin-sdk/tool-plugin.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts test/scripts/plugin-sdk-surface-report.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `node --max-old-space-size=8192 scripts/plugin-sdk-surface-report.mjs --check`
- `pnpm docs:check-mdx`
- `git diff --check`
