### PR TITLE
Improve model call telemetry

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -194,6 +194,12 @@ on the public diagnostic event bus.
   internal request trace scope. Logs and diagnostic events inside that scope
   inherit the request trace by default, while agent run and model-call spans are
   created as children so provider `traceparent` headers stay on the same trace.
+- **Model-call correlation:** `openclaw.model.call` spans include safe prompt
+  component sizes by default and include per-call token attributes when the
+  provider result exposes usage. `openclaw.model.usage` remains the run-level
+  accounting span for aggregate cost, context, and channel dashboards; it stays
+  on the same diagnostic trace when the emitting runtime has trusted trace
+  context.
 
 ## Exported metrics
 
@@ -333,6 +339,8 @@ Liveness warnings also emit:
   - `gen_ai.request.model`, `gen_ai.operation.name`, `openclaw.provider`, `openclaw.model`, `openclaw.api`, `openclaw.transport`
   - `openclaw.errorCategory` and optional `openclaw.failureKind` on errors
   - `openclaw.model_call.request_bytes`, `openclaw.model_call.response_bytes`, `openclaw.model_call.time_to_first_byte_ms`
+  - `openclaw.model_call.prompt.input_messages_count`, `openclaw.model_call.prompt.input_messages_chars`, `openclaw.model_call.prompt.system_prompt_chars`, `openclaw.model_call.prompt.tool_definitions_count`, `openclaw.model_call.prompt.tool_definitions_chars`, `openclaw.model_call.prompt.total_chars` (safe component sizes only, no prompt text)
+  - `openclaw.model_call.usage.*` and `gen_ai.usage.*` when the model-call result carries provider usage for that individual call
   - `openclaw.provider.request_id_hash` (bounded SHA-based hash of the upstream provider request id; raw ids are not exported)
   - With `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`, model-call spans use the latest GenAI inference span name `{gen_ai.operation.name} {gen_ai.request.model}` and `CLIENT` span kind instead of `openclaw.model.call`.
 - `openclaw.harness.run`

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -2284,6 +2284,23 @@ describe("diagnostics-otel service", () => {
       requestPayloadBytes: 1234,
       responseStreamBytes: 567,
       timeToFirstByteMs: 45,
+      promptStats: {
+        inputMessagesCount: 2,
+        inputMessagesChars: 3456,
+        systemPromptChars: 789,
+        toolDefinitionsCount: 4,
+        toolDefinitionsChars: 2345,
+        totalChars: 6590,
+      },
+      usage: {
+        input: 100,
+        output: 20,
+        cacheRead: 30,
+        cacheWrite: 5,
+        reasoningTokens: 8,
+        promptTokens: 135,
+        total: 155,
+      },
       trace: {
         traceId: TRACE_ID,
         spanId: CHILD_SPAN_ID,
@@ -2418,6 +2435,21 @@ describe("diagnostics-otel service", () => {
     expect(modelSpanAttributes["openclaw.model_call.request_bytes"]).toBe(1234);
     expect(modelSpanAttributes["openclaw.model_call.response_bytes"]).toBe(567);
     expect(modelSpanAttributes["openclaw.model_call.time_to_first_byte_ms"]).toBe(45);
+    expect(modelSpanAttributes["openclaw.model_call.prompt.input_messages_count"]).toBe(2);
+    expect(modelSpanAttributes["openclaw.model_call.prompt.input_messages_chars"]).toBe(3456);
+    expect(modelSpanAttributes["openclaw.model_call.prompt.system_prompt_chars"]).toBe(789);
+    expect(modelSpanAttributes["openclaw.model_call.prompt.tool_definitions_count"]).toBe(4);
+    expect(modelSpanAttributes["openclaw.model_call.prompt.tool_definitions_chars"]).toBe(2345);
+    expect(modelSpanAttributes["openclaw.model_call.prompt.total_chars"]).toBe(6590);
+    expect(modelSpanAttributes["openclaw.model_call.usage.input_tokens"]).toBe(100);
+    expect(modelSpanAttributes["openclaw.model_call.usage.output_tokens"]).toBe(20);
+    expect(modelSpanAttributes["openclaw.model_call.usage.cache_read_input_tokens"]).toBe(30);
+    expect(modelSpanAttributes["openclaw.model_call.usage.cache_creation_input_tokens"]).toBe(5);
+    expect(modelSpanAttributes["openclaw.model_call.usage.reasoning_output_tokens"]).toBe(8);
+    expect(modelSpanAttributes["openclaw.model_call.usage.prompt_tokens"]).toBe(135);
+    expect(modelSpanAttributes["openclaw.model_call.usage.total_tokens"]).toBe(155);
+    expect(modelSpanAttributes["gen_ai.usage.input_tokens"]).toBe(135);
+    expect(modelSpanAttributes["gen_ai.usage.output_tokens"]).toBe(20);
     const runDuration = lastHistogramRecord("openclaw.run.duration_ms");
     expect(runDuration?.[0]).toBe(100);
     expect(Object.hasOwn(runDuration?.[1] ?? {}, "openclaw.runId")).toBe(false);

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -458,6 +458,78 @@ function assignModelCallSizeTimingAttrs(
   );
 }
 
+function assignNumberAttr(
+  attrs: Record<string, string | number | boolean>,
+  key: string,
+  value: number | undefined,
+): void {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    attrs[key] = value;
+  }
+}
+
+function modelCallPromptTokens(usage: {
+  promptTokens?: number;
+  input?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+}): number | undefined {
+  if (typeof usage.promptTokens === "number" && Number.isFinite(usage.promptTokens)) {
+    return usage.promptTokens;
+  }
+  const input = usage.input ?? 0;
+  const cacheRead = usage.cacheRead ?? 0;
+  const cacheWrite = usage.cacheWrite ?? 0;
+  const total = input + cacheRead + cacheWrite;
+  return total > 0 ? total : undefined;
+}
+
+function assignModelCallPromptStatsAttrs(
+  attrs: Record<string, string | number | boolean>,
+  evt: Pick<Extract<DiagnosticEventPayload, { type: "model.call.started" }>, "promptStats">,
+): void {
+  const stats = evt.promptStats;
+  if (!stats) {
+    return;
+  }
+  for (const [key, value] of [
+    ["openclaw.model_call.prompt.input_messages_count", stats.inputMessagesCount],
+    ["openclaw.model_call.prompt.input_messages_chars", stats.inputMessagesChars],
+    ["openclaw.model_call.prompt.system_prompt_chars", stats.systemPromptChars],
+    ["openclaw.model_call.prompt.tool_definitions_count", stats.toolDefinitionsCount],
+    ["openclaw.model_call.prompt.tool_definitions_chars", stats.toolDefinitionsChars],
+    ["openclaw.model_call.prompt.total_chars", stats.totalChars],
+  ] as const) {
+    assignNumberAttr(attrs, key, value);
+  }
+}
+
+function assignModelCallUsageAttrs(
+  attrs: Record<string, string | number | boolean>,
+  evt: Pick<ModelCallLifecycleDiagnosticEvent, "usage">,
+): void {
+  const usage = evt.usage;
+  if (!usage) {
+    return;
+  }
+  const promptTokens = modelCallPromptTokens(usage);
+  for (const [key, value] of [
+    ["openclaw.model_call.usage.input_tokens", usage.input],
+    ["openclaw.model_call.usage.output_tokens", usage.output],
+    ["openclaw.model_call.usage.cache_read_input_tokens", usage.cacheRead],
+    ["openclaw.model_call.usage.cache_creation_input_tokens", usage.cacheWrite],
+    ["openclaw.model_call.usage.reasoning_output_tokens", usage.reasoningTokens],
+    ["openclaw.model_call.usage.prompt_tokens", promptTokens],
+    ["openclaw.model_call.usage.total_tokens", usage.total],
+    ["gen_ai.usage.input_tokens", promptTokens],
+    ["gen_ai.usage.output_tokens", usage.output],
+    ["gen_ai.usage.cache_read.input_tokens", usage.cacheRead],
+    ["gen_ai.usage.cache_creation.input_tokens", usage.cacheWrite],
+  ] as const) {
+    assignPositiveNumberAttr(attrs, key, value);
+  }
+}
+
 function assignGenAiSpanIdentityAttrs(
   attrs: Record<string, string | number | boolean>,
   input: { api?: string; model?: string; provider?: string },
@@ -3180,6 +3252,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         if (evt.transport) {
           spanAttrs["openclaw.transport"] = evt.transport;
         }
+        assignModelCallPromptStatsAttrs(spanAttrs, evt);
         trackTrustedSpan(
           evt,
           metadata,
@@ -3218,6 +3291,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           spanAttrs["openclaw.transport"] = evt.transport;
         }
         assignModelCallSizeTimingAttrs(spanAttrs, evt);
+        assignModelCallPromptStatsAttrs(spanAttrs, evt);
+        assignModelCallUsageAttrs(spanAttrs, evt);
         assignOtelModelContentAttributes(spanAttrs, modelContent, contentCapturePolicy);
         const span =
           takeTrackedTrustedSpan(evt, metadata) ??
@@ -3270,6 +3345,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           spanAttrs["openclaw.transport"] = evt.transport;
         }
         assignModelCallSizeTimingAttrs(spanAttrs, evt);
+        assignModelCallPromptStatsAttrs(spanAttrs, evt);
+        assignModelCallUsageAttrs(spanAttrs, evt);
         assignOtelModelContentAttributes(spanAttrs, modelContent, contentCapturePolicy);
         const span =
           takeTrackedTrustedSpan(evt, metadata) ??

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -593,6 +593,96 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
     expect(JSON.stringify(events)).not.toContain("private tool description");
   });
 
+  it("captures per-call usage from terminal error events", async () => {
+    // Aborted/error streams terminate with an `error` event carrying the final
+    // AssistantMessage and its usage. Iterating to completion without awaiting
+    // result() must still surface per-call usage, matching the `done` path and
+    // the usage field already emitted on model.call.error and its OTel span.
+    const assistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "partial reply" }],
+      usage: {
+        input: 11,
+        output: 7,
+        cacheRead: 3,
+        cacheWrite: 2,
+        reasoningTokens: 5,
+        totalTokens: 28,
+      },
+      stopReason: "aborted",
+      timestamp: 1,
+    };
+    async function* stream() {
+      yield { type: "error", reason: "aborted", error: assistant };
+    }
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => stream()) as unknown as StreamFn,
+      {
+        runId: "run-1",
+        provider: "openrouter",
+        model: "openrouter/auto",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-error-usage",
+      },
+    );
+
+    const events = await collectModelCallEvents(async () => {
+      await drain(wrapped({} as never, {} as never, {} as never) as AsyncIterable<unknown>);
+    });
+
+    // An in-band error event is data, not a throw, so iteration completes
+    // normally; the per-call usage rides on the terminal completion event.
+    const completedEvent = getEvent(events, 1);
+    expect(completedEvent.type).toBe("model.call.completed");
+    expect(completedEvent.usage).toEqual({
+      input: 11,
+      output: 7,
+      cacheRead: 3,
+      cacheWrite: 2,
+      reasoningTokens: 5,
+      total: 28,
+      promptTokens: 16,
+    });
+  });
+
+  it("skips prompt stat computation when diagnostics are disabled", async () => {
+    // Prompt stats are only attached to diagnostic events; when diagnostics are
+    // off those events are dropped, so the JSON.stringify of input messages and
+    // tool definitions must not run on the model-call hot path.
+    setDiagnosticsEnabledForProcess(false);
+    let promptInspected = false;
+    const streamContext = {
+      systemPrompt: "system",
+      get messages() {
+        promptInspected = true;
+        return [{ role: "user", content: "x", timestamp: 1 }];
+      },
+      get tools() {
+        promptInspected = true;
+        return [{ name: "lookup", description: "d", parameters: { type: "object" } }];
+      },
+    };
+    async function* stream() {
+      yield { type: "text_delta", delta: "ok" };
+    }
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => stream()) as unknown as StreamFn,
+      {
+        runId: "run-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-disabled-prompt-stats",
+      },
+    );
+
+    await drain(
+      wrapped({} as never, streamContext as never, {} as never) as AsyncIterable<unknown>,
+    );
+
+    expect(promptInspected).toBe(false);
+  });
+
   it("captures output and completes when callers only await stream.result()", async () => {
     const assistant = {
       role: "assistant",

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -520,6 +520,79 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
     expect(events[1]?.privateData.modelContent?.outputMessages).toEqual([assistant]);
   });
 
+  it("emits safe prompt stats and per-call usage without content capture", async () => {
+    const assistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "trace reply" }],
+      usage: {
+        input: 11,
+        output: 7,
+        cacheRead: 3,
+        cacheWrite: 2,
+        reasoningTokens: 5,
+        totalTokens: 28,
+      },
+      timestamp: 1,
+    };
+    async function* stream() {
+      yield { type: "done", reason: "stop", message: assistant };
+    }
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => stream()) as unknown as StreamFn,
+      {
+        runId: "run-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-stats",
+      },
+    );
+
+    const inputMessages = [{ role: "user", content: "private prompt text", timestamp: 1 }];
+    const tools = [
+      { name: "lookup", description: "private tool description", parameters: { type: "object" } },
+    ];
+    const systemPrompt = "private system prompt";
+    const events = await collectModelCallEvents(async () => {
+      const streamResult = wrapped(
+        {} as never,
+        {
+          systemPrompt,
+          messages: inputMessages,
+          tools,
+        } as never,
+        {},
+      );
+      await drain(streamResult as unknown as AsyncIterable<unknown>);
+    });
+
+    const startedEvent = getEvent(events, 0);
+    const completedEvent = getEvent(events, 1);
+    const expectedPromptStats = {
+      inputMessagesCount: inputMessages.length,
+      inputMessagesChars: JSON.stringify(inputMessages).length,
+      systemPromptChars: systemPrompt.length,
+      toolDefinitionsCount: tools.length,
+      toolDefinitionsChars: JSON.stringify(tools).length,
+      totalChars:
+        JSON.stringify(inputMessages).length + systemPrompt.length + JSON.stringify(tools).length,
+    };
+    expect(startedEvent.promptStats).toEqual(expectedPromptStats);
+    expect(completedEvent.promptStats).toEqual(expectedPromptStats);
+    expect(completedEvent.usage).toEqual({
+      input: 11,
+      output: 7,
+      cacheRead: 3,
+      cacheWrite: 2,
+      reasoningTokens: 5,
+      total: 28,
+      promptTokens: 16,
+    });
+    expect(JSON.stringify(events)).not.toContain("private prompt text");
+    expect(JSON.stringify(events)).not.toContain("private system prompt");
+    expect(JSON.stringify(events)).not.toContain("private tool description");
+  });
+
   it("captures output and completes when callers only await stream.result()", async () => {
     const assistant = {
       role: "assistant",

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -260,14 +260,15 @@ function observeOutputMessageContent(state: ModelCallObservationState, chunk: un
   } catch {
     return;
   }
-  if (type === "done") {
-    observeModelCallUsage(state, message);
-  }
-  if (!state.contentCapture?.outputMessages) {
-    return;
-  }
+  // Terminal events carry the final AssistantMessage with usage — `done` for
+  // success, `error` for aborted/error streams. Capture usage from either so
+  // iterated error-terminated calls still report the per-call usage that the
+  // model.call.error event and its OTel span already expose.
   if (message !== undefined) {
-    state.outputMessages = [cloneDiagnosticContentValue(message)];
+    observeModelCallUsage(state, message);
+    if (state.contentCapture?.outputMessages) {
+      state.outputMessages = [cloneDiagnosticContentValue(message)];
+    }
   }
 }
 
@@ -812,7 +813,13 @@ export function wrapStreamFnWithDiagnosticModelCallEvents(
   return ((model, streamContext, options) => {
     const callId = ctx.nextCallId();
     const trace = freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(ctx.trace));
-    const promptStats = streamContextModelPromptStats(streamContext);
+    // Prompt stats JSON-stringify the input messages and tool definitions; only
+    // the diagnostic events consume them (plugin hooks never receive prompt
+    // stats), so skip the work when diagnostics are disabled and those events
+    // would be dropped.
+    const promptStats = areDiagnosticsEnabledForProcess()
+      ? streamContextModelPromptStats(streamContext)
+      : undefined;
     const eventBase = baseModelCallEvent(ctx, callId, trace, promptStats);
     const modelContent = streamContextModelContentFields(ctx.contentCapture, streamContext);
     emitModelCallStarted(eventBase, modelContent);

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -35,6 +35,7 @@ import type {
   PluginHookModelCallStartedEvent,
 } from "../../../plugins/hook-types.js";
 import type { StreamFn } from "../../runtime/index.js";
+import { derivePromptTokens, normalizeUsage, type UsageLike } from "../../usage.js";
 
 type ModelCallDiagnosticContext = {
   runId: string;
@@ -76,12 +77,19 @@ type ModelCallSizeTimingFields = Pick<
   Extract<DiagnosticEventInput, { type: "model.call.completed" }>,
   "requestPayloadBytes" | "responseStreamBytes" | "timeToFirstByteMs"
 >;
+type ModelCallPromptStats = NonNullable<
+  Extract<DiagnosticEventInput, { type: "model.call.started" }>["promptStats"]
+>;
+type ModelCallUsage = NonNullable<
+  Extract<DiagnosticEventInput, { type: "model.call.completed" }>["usage"]
+>;
 type ModelCallObservationState = {
   requestPayloadBytes?: number;
   responseStreamBytes: number;
   timeToFirstByteMs?: number;
   modelContent?: DiagnosticModelCallContent;
   outputMessages?: unknown[];
+  usage?: ModelCallUsage;
   contentCapture?: DiagnosticModelContentCapturePolicy;
   lastStreamProgressAt?: number;
   terminalEventEmitted?: boolean;
@@ -110,6 +118,14 @@ function assignRequestPayloadBytes(state: ModelCallObservationState, payload: un
 
 function utf8StringByteLength(value: string): number {
   return Buffer.byteLength(value, "utf8");
+}
+
+function jsonCharLength(value: unknown): number | undefined {
+  try {
+    return JSON.stringify(value)?.length;
+  } catch {
+    return undefined;
+  }
 }
 
 function streamDeltaByteLength(chunk: Record<string, unknown>): number | undefined {
@@ -169,12 +185,87 @@ function streamContextModelContentFields(
   return Object.keys(content).length > 0 ? content : undefined;
 }
 
-function observeOutputMessageContent(state: ModelCallObservationState, chunk: unknown): void {
-  if (!state.contentCapture?.outputMessages || !isRecord(chunk)) {
+function streamContextModelPromptStats(streamContext: unknown): ModelCallPromptStats | undefined {
+  if (!isRecord(streamContext)) {
+    return undefined;
+  }
+  const messages = Array.isArray(streamContext.messages) ? streamContext.messages : undefined;
+  const tools = Array.isArray(streamContext.tools) ? streamContext.tools : undefined;
+  const systemPrompt =
+    typeof streamContext.systemPrompt === "string" ? streamContext.systemPrompt : undefined;
+  const inputMessagesChars = messages ? jsonCharLength(messages) : undefined;
+  const toolDefinitionsChars = tools ? jsonCharLength(tools) : undefined;
+  const systemPromptChars = systemPrompt?.length;
+  if (
+    messages === undefined &&
+    tools === undefined &&
+    systemPromptChars === undefined &&
+    inputMessagesChars === undefined &&
+    toolDefinitionsChars === undefined
+  ) {
+    return undefined;
+  }
+  const totalChars =
+    (inputMessagesChars ?? 0) + (systemPromptChars ?? 0) + (toolDefinitionsChars ?? 0);
+  return {
+    ...(messages ? { inputMessagesCount: messages.length } : {}),
+    ...(inputMessagesChars !== undefined ? { inputMessagesChars } : {}),
+    ...(systemPromptChars !== undefined ? { systemPromptChars } : {}),
+    ...(tools ? { toolDefinitionsCount: tools.length } : {}),
+    ...(toolDefinitionsChars !== undefined ? { toolDefinitionsChars } : {}),
+    totalChars,
+  };
+}
+
+function normalizedModelCallUsage(rawUsage: unknown): ModelCallUsage | undefined {
+  if (!isRecord(rawUsage)) {
+    return undefined;
+  }
+  const usage = normalizeUsage(rawUsage as UsageLike);
+  if (!usage) {
+    return undefined;
+  }
+  const promptTokens = derivePromptTokens(usage);
+  return {
+    ...usage,
+    ...(promptTokens !== undefined ? { promptTokens } : {}),
+  };
+}
+
+function observeModelCallUsage(state: ModelCallObservationState, value: unknown): void {
+  if (!isRecord(value)) {
     return;
   }
-  const message =
-    chunk.type === "done" ? chunk.message : chunk.type === "error" ? chunk.error : undefined;
+  let rawUsage: unknown;
+  try {
+    rawUsage = value.usage;
+  } catch {
+    return;
+  }
+  const usage = normalizedModelCallUsage(rawUsage);
+  if (usage) {
+    state.usage = usage;
+  }
+}
+
+function observeOutputMessageContent(state: ModelCallObservationState, chunk: unknown): void {
+  if (!isRecord(chunk)) {
+    return;
+  }
+  let type: unknown;
+  let message: unknown;
+  try {
+    type = chunk.type;
+    message = type === "done" ? chunk.message : type === "error" ? chunk.error : undefined;
+  } catch {
+    return;
+  }
+  if (type === "done") {
+    observeModelCallUsage(state, message);
+  }
+  if (!state.contentCapture?.outputMessages) {
+    return;
+  }
   if (message !== undefined) {
     state.outputMessages = [cloneDiagnosticContentValue(message)];
   }
@@ -186,6 +277,7 @@ function observeResultMessageContent(
   result: unknown,
 ): void {
   state.timeToFirstByteMs ??= Math.max(0, Date.now() - startedAt);
+  observeModelCallUsage(state, result);
   if (state.contentCapture?.outputMessages && state.outputMessages === undefined) {
     state.outputMessages = [cloneDiagnosticContentValue(result)];
   }
@@ -285,6 +377,7 @@ function baseModelCallEvent(
   ctx: ModelCallDiagnosticContext,
   callId: string,
   trace: DiagnosticTraceContext,
+  promptStats: ModelCallPromptStats | undefined,
 ): ModelCallEventBase {
   return {
     runId: ctx.runId,
@@ -300,6 +393,7 @@ function baseModelCallEvent(
     ...(ctx.contextWindowReferenceTokens
       ? { contextWindowReferenceTokens: ctx.contextWindowReferenceTokens }
       : {}),
+    ...(promptStats ? { promptStats } : {}),
     trace,
   };
 }
@@ -316,6 +410,10 @@ function modelCallCompletedContent(state: ModelCallObservationState) {
     ...state.modelContent,
     ...(state.outputMessages ? { outputMessages: state.outputMessages } : {}),
   };
+}
+
+function modelCallUsageField(state: ModelCallObservationState) {
+  return state.usage ? { usage: state.usage } : {};
 }
 
 function modelCallErrorFields(err: unknown): ModelCallErrorFields {
@@ -444,6 +542,7 @@ function emitModelCallCompleted(
       ...eventBase,
       durationMs,
       ...sizeTimingFields,
+      ...modelCallUsageField(state),
     },
     modelContentPrivateData(modelCallCompletedContent(state)),
   );
@@ -473,6 +572,7 @@ function emitModelCallError(
       durationMs,
       ...sizeTimingFields,
       ...fields,
+      ...modelCallUsageField(state),
     },
     modelContentPrivateData(modelCallCompletedContent(state)),
   );
@@ -712,7 +812,8 @@ export function wrapStreamFnWithDiagnosticModelCallEvents(
   return ((model, streamContext, options) => {
     const callId = ctx.nextCallId();
     const trace = freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(ctx.trace));
-    const eventBase = baseModelCallEvent(ctx, callId, trace);
+    const promptStats = streamContextModelPromptStats(streamContext);
+    const eventBase = baseModelCallEvent(ctx, callId, trace, promptStats);
     const modelContent = streamContextModelContentFields(ctx.contentCapture, streamContext);
     emitModelCallStarted(eventBase, modelContent);
     ctx.onStarted?.();

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -591,6 +591,7 @@ type DiagnosticModelCallBaseEvent = DiagnosticBaseEvent & {
   contextWindowSource?: "model" | "modelsConfig" | "agentContextTokens" | "default";
   contextWindowReferenceTokens?: number;
   upstreamRequestIdHash?: string;
+  promptStats?: DiagnosticModelCallPromptStats;
 };
 
 export type DiagnosticModelCallStartedEvent = DiagnosticModelCallBaseEvent & {
@@ -603,6 +604,7 @@ export type DiagnosticModelCallCompletedEvent = DiagnosticModelCallBaseEvent & {
   requestPayloadBytes?: number;
   responseStreamBytes?: number;
   timeToFirstByteMs?: number;
+  usage?: DiagnosticModelCallUsage;
 };
 
 export type DiagnosticModelCallErrorEvent = DiagnosticModelCallBaseEvent & {
@@ -614,7 +616,27 @@ export type DiagnosticModelCallErrorEvent = DiagnosticModelCallBaseEvent & {
   requestPayloadBytes?: number;
   responseStreamBytes?: number;
   timeToFirstByteMs?: number;
+  usage?: DiagnosticModelCallUsage;
 };
+
+export type DiagnosticModelCallPromptStats = Readonly<{
+  inputMessagesCount?: number;
+  inputMessagesChars?: number;
+  systemPromptChars?: number;
+  toolDefinitionsCount?: number;
+  toolDefinitionsChars?: number;
+  totalChars?: number;
+}>;
+
+export type DiagnosticModelCallUsage = Readonly<{
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  reasoningTokens?: number;
+  promptTokens?: number;
+  total?: number;
+}>;
 
 export type DiagnosticContextAssembledEvent = DiagnosticBaseEvent & {
   type: "context.assembled";

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -619,7 +619,7 @@ export type DiagnosticModelCallErrorEvent = DiagnosticModelCallBaseEvent & {
   usage?: DiagnosticModelCallUsage;
 };
 
-export type DiagnosticModelCallPromptStats = Readonly<{
+type DiagnosticModelCallPromptStats = Readonly<{
   inputMessagesCount?: number;
   inputMessagesChars?: number;
   systemPromptChars?: number;
@@ -628,7 +628,7 @@ export type DiagnosticModelCallPromptStats = Readonly<{
   totalChars?: number;
 }>;
 
-export type DiagnosticModelCallUsage = Readonly<{
+type DiagnosticModelCallUsage = Readonly<{
   input?: number;
   output?: number;
   cacheRead?: number;


### PR DESCRIPTION
## What Problem This Solves

OpenClaw model-call traces made the current-turn input easy to see, but the real prompt burden could be split across model input messages, system instructions, and tool definitions. Token usage also lived primarily on the separate run-level `openclaw.model.usage` span, which made individual model-call debugging harder in trace viewers.

## Why This Change Was Made

This adds safe model-call prompt metadata to diagnostic events and OTel spans:

- `openclaw.model_call.prompt.*` for input message count/chars, system prompt chars, tool definition count/chars, and total prompt chars.
- `openclaw.model_call.usage.*` and `gen_ai.usage.*` on model-call spans when the provider result exposes per-call usage.

Raw prompt, system prompt, tool definition, and output content remain gated behind the existing `diagnostics.otel.captureContent` policy.

## User Impact

Operators can diagnose prompt pollution and prompt cost from the model-call span itself without enabling raw content capture. Existing aggregate run accounting stays on `openclaw.model.usage`, and trusted trace correlation remains unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts extensions/diagnostics-otel/src/service.test.ts`
- `node scripts/format-docs.mjs --check docs/gateway/opentelemetry.md`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` with `AUTOREVIEW_AUTO_TESTS=0`: clean, no accepted/actionable findings
