### PR TITLE
fix(cron): warn when nextRunAtMs becomes undefined in silent code paths

### DIFF
--- a/src/cron/service.issue-66019-unresolved-next-run.test.ts
+++ b/src/cron/service.issue-66019-unresolved-next-run.test.ts
@@ -7,9 +7,11 @@ import {
   setupCronRegressionFixtures,
 } from "../../test/helpers/cron/service-regression-fixtures.js";
 import * as schedule from "./schedule.js";
+import * as jobs from "./service/jobs.js";
 import { createCronServiceState } from "./service/state.js";
-import { onTimer } from "./service/timer.js";
+import { applyJobResult, onTimer } from "./service/timer.js";
 import { saveCronStore } from "./store.js";
+import type { CronJob } from "./types.js";
 
 const issue66019Fixtures = setupCronRegressionFixtures({ prefix: "cron-66019-" });
 
@@ -137,6 +139,111 @@ describe("#66019 unresolved next-run repro", () => {
     }
   });
 
+  it("warns when an every-type job completes but naturalNext is undefined", async () => {
+    const scheduledAt = Date.parse("2026-04-13T16:00:00.000Z");
+
+    // Create an every-type job in memory with a valid everyMs.
+    const everyJob: CronJob = {
+      id: "cron-66019-every-unresolved",
+      name: "cron-66019-every-unresolved",
+      enabled: true,
+      createdAtMs: scheduledAt - 86_400_000,
+      updatedAtMs: scheduledAt - 86_400_000,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "ping" },
+      delivery: { mode: "announce" },
+      state: { nextRunAtMs: scheduledAt - 1_000, lastRunAtMs: scheduledAt - 60_000 },
+    };
+
+    const warnLogs: unknown[] = [];
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/dev/null",
+      log: {
+        ...noopLogger,
+        warn: (obj: unknown, msg?: string) => warnLogs.push({ obj, msg }),
+      },
+      nowMs: () => scheduledAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    state.store = { version: 1, jobs: [everyJob] };
+
+    // Mock computeJobNextRunAtMs to return undefined, simulating an every
+    // schedule that cannot compute its next run after completion.
+    const nextRunSpy = vi.spyOn(jobs, "computeJobNextRunAtMs").mockReturnValue(undefined);
+    try {
+      applyJobResult(state, everyJob, {
+        status: "ok",
+        startedAt: scheduledAt,
+        endedAt: scheduledAt + 1_000,
+      });
+
+      expect(everyJob.state.nextRunAtMs).toBeUndefined();
+
+      const unresolvedWarn = warnLogs.find(
+        (entry: any) =>
+          typeof entry.msg === "string" &&
+          entry.msg.includes("next run unresolved after successful completion"),
+      );
+      expect(unresolvedWarn).toBeDefined();
+      expect(unresolvedWarn).toHaveProperty("obj.jobId", "cron-66019-every-unresolved");
+      expect(unresolvedWarn).toHaveProperty("obj.scheduleKind", "every");
+    } finally {
+      nextRunSpy.mockRestore();
+    }
+  });
+
+  it("warns when transient error retry finds normalNext undefined", async () => {
+    const scheduledAt = Date.parse("2026-04-13T16:05:00.000Z");
+
+    const cronJob = createIssue66019Job({
+      id: "cron-66019-error-retry-unresolved",
+      scheduledAt,
+    });
+
+    const warnLogs: unknown[] = [];
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/dev/null",
+      log: {
+        ...noopLogger,
+        warn: (obj: unknown, msg?: string) => warnLogs.push({ obj, msg }),
+      },
+      nowMs: () => scheduledAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    state.store = { version: 1, jobs: [cronJob] };
+
+    // Mock computeJobNextRunAtMs to return undefined, simulating a cron
+    // schedule that cannot resolve the next run during transient error retry.
+    const nextRunSpy = vi.spyOn(jobs, "computeJobNextRunAtMs").mockReturnValue(undefined);
+
+    try {
+      applyJobResult(state, cronJob, {
+        status: "error",
+        error: "timeout: synthetic timeout failure",
+        startedAt: scheduledAt,
+        endedAt: scheduledAt + 1_000,
+      });
+
+      const retryWarn = warnLogs.find(
+        (entry: any) =>
+          typeof entry.msg === "string" &&
+          entry.msg.includes("next run unresolved during transient error retry"),
+      );
+      expect(retryWarn).toBeDefined();
+      expect(retryWarn).toHaveProperty("obj.jobId", "cron-66019-error-retry-unresolved");
+    } finally {
+      nextRunSpy.mockRestore();
+    }
+  });
+
   it("preserves the active error backoff floor when maintenance repair later finds a natural next run", async () => {
     const store = issue66019Fixtures.makeStorePath();
     const scheduledAt = Date.parse("2026-04-13T15:50:00.000Z");
@@ -179,6 +286,61 @@ describe("#66019 unresolved next-run repro", () => {
       expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
     } finally {
       nextRunSpy.mockRestore();
+      clearCronTimer(state);
+    }
+  });
+
+  it("warns when maintenance recompute clears a previously scheduled nextRunAtMs", async () => {
+    const scheduledAt = Date.parse("2026-04-13T16:10:00.000Z");
+
+    // Use an unsatisfiable cron expression (Feb 31 doesn't exist) so
+    // computeJobNextRunAtMs naturally returns undefined.
+    const cronJob: CronJob = {
+      id: "cron-66019-recompute-unresolved",
+      name: "cron-66019-recompute-unresolved",
+      enabled: true,
+      createdAtMs: scheduledAt - 86_400_000,
+      updatedAtMs: scheduledAt - 86_400_000,
+      schedule: { kind: "cron", expr: "0 0 31 2 *", tz: "UTC" },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "ping" },
+      delivery: { mode: "announce" },
+      state: {
+        nextRunAtMs: scheduledAt - 60_000, // past-due
+        lastRunAtMs: scheduledAt - 30_000, // after the expired slot
+        lastRunStatus: "ok",
+      },
+    };
+
+    const warnLogs: unknown[] = [];
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/dev/null",
+      log: {
+        ...noopLogger,
+        warn: (obj: unknown, msg?: string) => warnLogs.push({ obj, msg }),
+      },
+      nowMs: () => scheduledAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    state.store = { version: 1, jobs: [cronJob] };
+
+    try {
+      const { recomputeNextRunsForMaintenance } = await import("./service/jobs.js");
+      recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+
+      const recomputeWarn = warnLogs.find(
+        (entry: any) =>
+          typeof entry.msg === "string" &&
+          entry.msg.includes("next run unresolved during maintenance recompute"),
+      );
+      expect(recomputeWarn).toBeDefined();
+      expect(recomputeWarn).toHaveProperty("obj.jobId", "cron-66019-recompute-unresolved");
+      expect(recomputeWarn).toHaveProperty("obj.scheduleKind", "cron");
+    } finally {
       clearCronTimer(state);
     }
   });

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -626,6 +626,21 @@ function recomputeJobNextRunAtMs(params: { state: CronServiceState; job: CronJob
       }
     }
     if (params.job.state.nextRunAtMs !== newNext) {
+      if (
+        newNext === undefined &&
+        hasScheduledNextRunAtMs(params.job.state.nextRunAtMs) &&
+        isJobEnabled(params.job)
+      ) {
+        params.state.deps.log.warn(
+          {
+            jobId: params.job.id,
+            jobName: params.job.name,
+            scheduleKind: params.job.schedule.kind,
+            previousNextRunAtMs: params.job.state.nextRunAtMs,
+          },
+          "cron: next run unresolved during maintenance recompute; job will not reschedule",
+        );
+      }
       params.job.state.nextRunAtMs = newNext;
       changed = true;
     }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -875,6 +875,15 @@ export function applyJobResult(
         if (normalNext === undefined) {
           // Preserve the unresolved-cron guard (#66019): do not synthesize a
           // retry when the schedule cannot produce a next scheduled slot.
+          state.deps.log.warn(
+            {
+              jobId: job.id,
+              jobName: job.name,
+              consecutiveErrors: retryDecision.consecutiveErrors,
+              retryCategory: retryDecision.retryCategory,
+            },
+            "cron: next run unresolved during transient error retry; falling back to error backoff",
+          );
         } else if (retryNextRunAtMs < normalNext) {
           job.state.nextRunAtMs = retryNextRunAtMs;
           state.deps.log.info(
@@ -950,6 +959,16 @@ export function applyJobResult(
           context: "completion",
         });
       } else {
+        if (naturalNext === undefined) {
+          state.deps.log.warn(
+            {
+              jobId: job.id,
+              jobName: job.name,
+              scheduleKind: job.schedule.kind,
+            },
+            "cron: next run unresolved after successful completion; job will not reschedule",
+          );
+        }
         job.state.nextRunAtMs = naturalNext;
       }
     } else {


### PR DESCRIPTION
## Summary

- Add `log.warn` when `applyJobResult` sets `nextRunAtMs` to `undefined` for non-cron schedule types (every/at) after a successful completion. Previously this path was silent — only the cron branch had a warn via `resolveCronNextRunWithLowerBound`.
- Add `log.warn` when a transient error retry finds `normalNext === undefined` and falls back to error backoff. Previously the `#66019` guard comment was the only signal; no log was emitted.
- Add `log.warn` when `recomputeJobNextRunAtMs` clears a previously-scheduled `nextRunAtMs` to `undefined` for an enabled job during maintenance recompute. Previously this degradation was completely silent.
- All three warn messages include structured fields (`jobId`, `jobName`, `scheduleKind`) consistent with the existing `resolveCronNextRunWithLowerBound` warn pattern.
- No scheduling behavior changes — only observability improvements.

## Linked context

Related #66019

## Real behavior proof

- Behavior addressed: When `computeNextRunAtMs` / `computeJobNextRunAtMs` returns `undefined`, the cron scheduler silently stops executing the job. Users see "cron job stopped running" with no indication in logs. Three code paths that set `nextRunAtMs = undefined` without any warn are now instrumented.
- Real environment tested: OpenClaw source checkout on Linux, with focused Vitest coverage for all three new warn paths plus the two existing #66019 regression tests.
- Exact steps or command run after this patch:

```text
node_modules/.pnpm/vitest@4.0.18_…/vitest.mjs run \
  --config test/vitest/vitest.cron-standalone.config.ts \
  src/cron/service.issue-66019-unresolved-next-run.test.ts
```

(Standalone config bypasses the custom `OpenClawNonIsolatedRunner` which fails in this checkout due to a vitest `TestRunner` module-resolution issue with pnpm hoisted layout.)

- Evidence after fix:

```text
✓ does not refire a recurring cron job 2s later when next-run resolution returns undefined
✓ does not refire a recurring errored cron job after the first backoff window when next-run resolution returns undefined
✓ warns when an every-type job completes but naturalNext is undefined
✓ warns when transient error retry finds normalNext undefined
✓ preserves the active error backoff floor when maintenance repair later finds a natural next run
✓ warns when maintenance recompute clears a previously scheduled nextRunAtMs

Test Files  1 passed (1)
Tests       6 passed (6)
```

- Observed result after fix: All three previously-silent `nextRunAtMs = undefined` paths now emit a `log.warn` with the job id, name, and schedule kind. The existing #66019 regression tests continue to pass, confirming no behavioral change.
- What was not tested: Full `onTimer` end-to-end test for the maintenance recompute warn (the `recomputeNextRunsForMaintenance` path was tested directly due to vitest spy limitations with module-internal calls in pnpm hoisted mode). The cron-config test suite (`test/vitest/vitest.cron.config.ts`) could not run due to the `OpenClawNonIsolatedRunner` environment issue — this is a pre-existing checkout-level problem, not introduced by this PR.
- Negative control / before evidence: Current `main` has only one warn for unresolved next-run (in `resolveCronNextRunWithLowerBound`, line ~424 of timer.ts). The `every` completion branch, the transient-retry `normalNext === undefined` guard, and the `recomputeJobNextRunAtMs` degradation path all silently set `nextRunAtMs = undefined` with no log output.

## Tests and validation

- Targeted Vitest: 6 tests passed (3 existing #66019 regression + 3 new warn-path tests)
- `git diff --check` passed
- No scheduling behavior changes — all three additions are warn-only

## Risk checklist

- Did user-visible behavior change? No (log output only; scheduling logic unchanged)
- Did config, environment, or migration behavior change? No
- Did security, auth, secrets, network, or tool execution behavior change? No
- Highest-risk area: `applyJobResult` and `recomputeJobNextRunAtMs` are on the critical path for every cron tick
- Mitigation: All changes are additive (warn log calls inserted before existing assignments). No control flow altered. Existing regression tests for #66019 refire-loop and backoff-floor behavior continue to pass.

## Current review state

- AI-assisted: Yes, Claude Code
- Next action: Awaiting maintainer review
- Bot comments addressed: None yet
