### PR TITLE
fix(telegram): sanitize outbound tool traces

### DIFF
--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -2,6 +2,7 @@
 import type { OutboundDeliveryFormattingOptions } from "openclaw/plugin-sdk/channel-outbound";
 import {
   resolveOutboundSendDep,
+  sanitizeForPlainText,
   type OutboundSendDeps,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
@@ -19,6 +20,7 @@ import {
   sendPayloadMediaSequenceOrFallback,
 } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { resolveTelegramInlineButtons } from "./button-types.js";
 import { splitTelegramHtmlChunks } from "./format.js";
@@ -198,6 +200,7 @@ export function createTelegramOutboundAdapter(
     chunkerMode: "markdown",
     extractMarkdownImages: true,
     textChunkLimit: TELEGRAM_TEXT_CHUNK_LIMIT,
+    sanitizeText: ({ text }) => sanitizeForPlainText(sanitizeAssistantVisibleText(text)),
     shouldSuppressLocalPayloadPrompt: options.shouldSuppressLocalPayloadPrompt,
     beforeDeliverPayload: options.beforeDeliverPayload,
     shouldTreatDeliveredTextAsVisible: options.shouldTreatDeliveredTextAsVisible,

--- a/extensions/telegram/src/telegram-outbound.test.ts
+++ b/extensions/telegram/src/telegram-outbound.test.ts
@@ -36,14 +36,14 @@ describe("telegramPlugin outbound", () => {
     clearTelegramRuntime();
     const text = 'Done.\n⚠️ 🛠️ `search "Pipeline" in ~/.openclaw/workspace-* (agent)` failed';
 
-    expect(telegramOutbound.sanitizeText?.({ text })).toBe("Done.");
+    expect(telegramOutbound.sanitizeText?.({ text, payload: { text } })).toBe("Done.");
   });
 
   it("preserves ordinary outbound text while sanitizing", () => {
     clearTelegramRuntime();
     const text = "The pipeline has 3 deals.";
 
-    expect(telegramOutbound.sanitizeText?.({ text })).toBe(text);
+    expect(telegramOutbound.sanitizeText?.({ text, payload: { text } })).toBe(text);
   });
 
   it("preserves explicit HTML parse mode before chunking", () => {

--- a/extensions/telegram/src/telegram-outbound.test.ts
+++ b/extensions/telegram/src/telegram-outbound.test.ts
@@ -29,8 +29,21 @@ describe("telegramPlugin outbound", () => {
     expect(telegramOutbound.presentationCapabilities?.limits?.text?.markdownDialect).toBe(
       "markdown",
     );
-    expect(telegramOutbound.sanitizeText).toBeUndefined();
     expect(telegramOutbound.pollMaxOptions).toBe(10);
+  });
+
+  it("strips assistant-visible tool traces before outbound delivery", () => {
+    clearTelegramRuntime();
+    const text = 'Done.\n⚠️ 🛠️ `search "Pipeline" in ~/.openclaw/workspace-* (agent)` failed';
+
+    expect(telegramOutbound.sanitizeText?.({ text })).toBe("Done.");
+  });
+
+  it("preserves ordinary outbound text while sanitizing", () => {
+    clearTelegramRuntime();
+    const text = "The pipeline has 3 deals.";
+
+    expect(telegramOutbound.sanitizeText?.({ text })).toBe(text);
   });
 
   it("preserves explicit HTML parse mode before chunking", () => {


### PR DESCRIPTION
## Summary

- **Problem:** Follow-up to #95084: Google Chat now strips assistant-visible internal tool-trace failure lines before outbound delivery, but Telegram still exposed no outbound `sanitizeText` hook for the shared delivery pipeline to invoke.
- **Solution:** Add Telegram's adapter-level sanitizer hook with the same SDK sanitizer chain used by the sibling Google Chat fix: `sanitizeForPlainText(sanitizeAssistantVisibleText(text))`.
- **What changed:** `extensions/telegram/src/outbound-adapter.ts` now declares `sanitizeText`, and `extensions/telegram/src/telegram-outbound.test.ts` locks in both stripping an internal tool-trace failure line and preserving ordinary assistant prose. The follow-up commit also passes the required `payload` argument in those test calls so `check-test-types` matches the adapter contract.
- **What did NOT change:** Out of scope / not changed: this only changes Telegram outbound text sanitization; it does not change Telegram target parsing, send routing, media handling, poll handling, chunking limits, config, protocol, public plugin metadata, compatibility/default behavior, or Bot API request construction.
- **Why it matters / User impact:** Telegram users should see the assistant-visible answer rather than internal tool execution failure scaffolding such as `⚠️ 🛠️ ... failed` appended to a final reply.
- **Fixes:** No direct issue; this is a sibling-gap follow-up to #95084.

## Origin / follow-up

- **Follows / completes:** #95084, merged on 2026-06-22, fixed Google Chat for the same internal tool-trace leak pattern.
- **Gap this fills:** Telegram was outside #95084's fixed surface and still had no outbound sanitizer hook, so the shared channel delivery sanitizer step had nothing Telegram-specific to call.
- **Consistency:** This uses the same public SDK sanitizer composition as the merged Google Chat patch while keeping the change at Telegram's source-of-truth outbound adapter boundary.

## Competition / linked PR analysis

- **Linked PR(s):** Related open PR scan: no direct linked open PR for this Telegram sanitizer hook. A current open PR search for Telegram sanitizer/tool-trace follow-ups returned broad outbound or unrelated Telegram work, not this focused adapter hook gap.
- **Gap in linked PR(s):** The merged anchor #95084 covered Google Chat only; it did not add or test `telegramOutbound.sanitizeText`.
- **Why this patch is better/canonical:** The source-of-truth owner for Telegram channel delivery behavior is the Telegram outbound adapter, and this patch wires the existing canonical sanitizer hook there instead of adding downstream string filtering or send-path special cases.
- **Local real behavior proof advantage:** The proof imports the production Telegram outbound adapter module and calls its real sanitizer hook directly, showing the exact text transformation that the shared delivery path will apply before send.

## Real behavior proof

- **Behavior or issue addressed:** Telegram outbound text removes assistant-visible internal tool-trace failure lines before delivery while preserving ordinary assistant text.
- **Real environment tested:** Local OpenClaw source checkout on Linux, Node v22.22.0, pnpm 11.2.2, commit `f85bb708b6`. The command imports the actual Telegram outbound adapter production module through `tsx` and calls its channel sanitizer hook with the required payload shape.
- **Exact steps or command run after this patch:**

```bash
node --import tsx -e 'import { telegramOutbound } from "./extensions/telegram/src/outbound-adapter.ts"; const trace = "Done.\n⚠️ 🛠️ `search \"Pipeline\" in /tmp/openclaw-workspace-* (agent)` failed"; console.log(JSON.stringify({ sanitizedTrace: telegramOutbound.sanitizeText?.({ text: trace, payload: { text: trace } }), ordinary: telegramOutbound.sanitizeText?.({ text: "The pipeline has 3 deals.", payload: { text: "The pipeline has 3 deals." } }) }, null, 2));'
```

- **Evidence after fix:**

```json
{
  "sanitizedTrace": "Done.",
  "ordinary": "The pipeline has 3 deals."
}
```

- **Observed result after fix:** The production Telegram outbound adapter sanitizer drops the internal tool-trace failure line and returns the expected assistant-visible text. A normal outbound reply remains unchanged.
- **What was not tested:** Outside this proof: native client rendering and Bot API round-trip. Credentials, chat identifiers, and message content are kept out of this PR. The exercised boundary is the adapter sanitizer hook immediately before send.
- **Fix classification:** Root cause fix.

## Regression Test Plan

- **Target test file:** `extensions/telegram/src/telegram-outbound.test.ts`, with dependency guard coverage from `src/infra/outbound/sanitize-text.test.ts` and `src/shared/text/assistant-visible-text.test.ts`.
- **Scenario locked in:** A Telegram outbound reply containing `Done.` plus an assistant-visible tool-trace failure line sanitizes to `Done.`, while ordinary text like `The pipeline has 3 deals.` is preserved exactly.
- **Why this is the smallest reliable guardrail:** The regression test exercises the Telegram adapter contract that the shared delivery path reads, so it catches the missing hook without requiring network delivery or a mocked Telegram API.

## CI failure attribution

- **Current-head failing check:** `check-test-types` on the initial PR head `20ea432337`.
- **Attribution:** Current PR directly introduced the failure. CI ran `pnpm check:test-types`, which failed only in the two newly added `extensions/telegram/src/telegram-outbound.test.ts` sanitizer assertions because the test calls omitted the required `payload` property for `ChannelOutboundAdapter.sanitizeText`.
- **Fix:** The follow-up commit updates both test calls to pass `payload: { text }`.
- **Verification:** The failing extensions test typecheck shard now passes locally:

```text
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo

Passed with no TypeScript errors.
```

## Additional validation

```text
node scripts/run-vitest.mjs extensions/telegram/src/telegram-outbound.test.ts

[test] passed 1 Vitest shard
- extensions/telegram/src/telegram-outbound.test.ts passed: 12 tests
```

```text
corepack pnpm format:check -- extensions/telegram/src/outbound-adapter.ts extensions/telegram/src/telegram-outbound.test.ts

All matched files use the correct format.
```

```text
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/outbound-adapter.ts extensions/telegram/src/telegram-outbound.test.ts

Completed without lint findings.
```

```text
git diff --check

Completed without whitespace errors.
```

## Merge risk

- **Risk labels considered:** `message-delivery` and `compatibility`; not `auth-provider`, `session-state`, `security-boundary`, or `availability`.
- **Risk explanation:** This touches a message-delivery adapter hook, but it uses existing SDK sanitizer exports and does not add config, protocol, schema, dependency, target resolution, chunking, or Bot API request behavior.
- **Why acceptable:** The diff is two Telegram files, the source change is one adapter property, and focused proof covers both the stripping behavior and preservation of ordinary outbound text.

## Root Cause

- **Root cause:** Telegram's outbound adapter lacked the `sanitizeText` contract hook, so `src/infra/outbound/deliver.ts` could not run the canonical assistant-visible delivery sanitizer for Telegram before normalized payload delivery. That missing source-of-truth mapping caused internal tool-trace failure text to remain in outbound Telegram text.
- **Why this is root-cause fix:** The shared delivery pipeline already owns when channel sanitizer hooks run; Telegram only needed to expose the correct adapter hook. Adding `sanitizeText` at `extensions/telegram/src/outbound-adapter.ts` fixes the missing source mapping before send instead of masking the symptom later in Telegram send code.
- **Maintainer-ready confidence:** High — the patch is limited to the Telegram outbound adapter contract and its colocated regression test, with focused production-function proof plus sanitizer dependency tests.
- **Patch quality notes:** No fallback, broad catch, default-return shim, config compatibility branch, or downstream string special case was added. The current PR diff remains only the two Telegram files; the CI follow-up only corrects the test call shape for the existing adapter contract.
- **Architecture / source-of-truth check:** Source-of-truth boundary is the `ChannelOutboundAdapter.sanitizeText` contract as implemented by the Telegram plugin adapter; the shared delivery path already consumes that contract before downstream send/payload handling.
