### PR TITLE
Wake parent sessions on ACP task completion

### DIFF
--- a/src/agents/internal-event-contract.ts
+++ b/src/agents/internal-event-contract.ts
@@ -4,6 +4,7 @@ export const AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION = "task_completion" as co
 
 const AGENT_INTERNAL_EVENT_SOURCES = [
   "subagent",
+  "acp",
   "cron",
   "image_generation",
   "video_generation",

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -8,6 +8,8 @@ import {
   getOrCreateSessionMcpRuntime,
 } from "../../agents/agent-bundle-mcp-tools.js";
 import * as bootstrapCache from "../../agents/bootstrap-cache.js";
+import { AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION } from "../../agents/internal-event-contract.js";
+import { formatAgentInternalEventsForPlainPrompt } from "../../agents/internal-events.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.ts";
@@ -3720,6 +3722,48 @@ describe("drainFormattedSystemEvents", () => {
       });
 
       expect(result).toContain("Reminder: rotate API keys");
+      expect(peekSystemEvents("agent:main:main")).toEqual([]);
+    } finally {
+      resetSystemEventsForTest();
+    }
+  });
+
+  it("renders ACP continuation events without protected internal context delimiters", async () => {
+    try {
+      const eventText = formatAgentInternalEventsForPlainPrompt([
+        {
+          type: AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION,
+          source: "acp",
+          childSessionKey: "agent:codex:acp:child",
+          childSessionId: "child-session-id",
+          announceType: "ACP background task",
+          taskLabel: "Repair the PR",
+          status: "ok",
+          statusLabel: "succeeded",
+          result:
+            "No child output is embedded here.\nInspect the task/run/session records and artifacts before deciding what to do next.",
+          replyInstruction:
+            "Inspect and verify the child task/run/session artifacts before deciding whether the original request is done.",
+        },
+      ]);
+      enqueueSystemEvent(eventText, {
+        sessionKey: "agent:main:main",
+        contextKey: "task:task_123:acp-terminal-continuation:succeeded:succeeded",
+      });
+
+      const result = await drainFormattedSystemEvents({
+        cfg: {} as OpenClawConfig,
+        sessionKey: "agent:main:main",
+        isMainSession: true,
+        isNewSession: false,
+      });
+
+      expect(result).toContain("System:");
+      expect(result).toContain("source: acp");
+      expect(result).toContain("No child output is embedded here.");
+      expect(result).toContain("Inspect the task/run/session records and artifacts");
+      expect(result).not.toContain("<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>");
+      expect(result).not.toContain("OpenClaw runtime context (internal)");
       expect(peekSystemEvents("agent:main:main")).toEqual([]);
     } finally {
       resetSystemEventsForTest();

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -81,6 +81,27 @@ function createTaskRecord(params: Parameters<typeof createTaskRecordOrNull>[0]):
   return task;
 }
 
+function expectAcpContinuationEvent(value: string): void {
+  expect(value).toContain("A background task completed.");
+  expect(value).toContain("source: acp");
+  expect(value).toContain("type: ACP background task");
+  expect(value).toContain("No child output is embedded here.");
+  expect(value).toContain("Inspect the task/run/session records and artifacts");
+  expect(value).toContain("Instruction:");
+  expect(value).not.toContain("<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>");
+  expect(value).not.toContain("OpenClaw runtime context (internal)");
+}
+
+function expectAcpTerminalSessionEvents(events: string[], terminalMessage: string | RegExp): void {
+  expect(events).toHaveLength(2);
+  if (typeof terminalMessage === "string") {
+    expect(events[0]).toContain(terminalMessage);
+  } else {
+    expect(events[0]).toMatch(terminalMessage);
+  }
+  expectAcpContinuationEvent(events[1] ?? "");
+}
+
 function createManagedTaskFlow(
   params: Parameters<typeof createManagedTaskFlowOrNull>[0],
 ): TaskFlowRecord {
@@ -1210,9 +1231,10 @@ describe("task-registry", () => {
         }),
       );
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
-      expect(peekSystemEvents("agent:main:main")).toEqual([
-        expect.stringContaining("Background task ready for review: ACP background task"),
-      ]);
+      expectAcpTerminalSessionEvents(
+        peekSystemEvents("agent:main:main"),
+        "Background task ready for review: ACP background task",
+      );
     });
   });
 
@@ -1241,9 +1263,10 @@ describe("task-registry", () => {
         });
 
         await waitForAssertion(() =>
-          expect(peekSystemEvents("agent:main:main")).toEqual([
-            expect.stringContaining("Background task ready for review: ACP background task"),
-          ]),
+          expectAcpTerminalSessionEvents(
+            peekSystemEvents("agent:main:main"),
+            "Background task ready for review: ACP background task",
+          ),
         );
         expectRecordFields(requireTaskById(task.taskId), {
           deliveryStatus: "pending",
@@ -1256,9 +1279,10 @@ describe("task-registry", () => {
         expectRecordFields(requireTaskById(task.taskId), {
           deliveryStatus: "pending",
         });
-        expect(peekSystemEvents("agent:main:main")).toEqual([
-          expect.stringContaining("Background task ready for review: ACP background task"),
-        ]);
+        expectAcpTerminalSessionEvents(
+          peekSystemEvents("agent:main:main"),
+          "Background task ready for review: ACP background task",
+        );
         expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
       },
       { durableStore: true },
@@ -1380,8 +1404,8 @@ describe("task-registry", () => {
       expect(String(message.content)).toContain(
         "Next: parent will review/verify before calling it done.",
       );
-      expect(peekSystemEvents("agent:main:discord:guild-123:channel-parent-channel")).toStrictEqual(
-        [],
+      expectAcpContinuationEvent(
+        peekSystemEvents("agent:main:discord:guild-123:channel-parent-channel")[0] ?? "",
       );
     });
   });
@@ -1455,9 +1479,10 @@ describe("task-registry", () => {
           expect(task.deliveryStatus).toBe("session_queued");
         });
         expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
-        expect(peekSystemEvents("agent:main:discord:guild-123:channel-parent-channel")).toEqual([
-          expect.stringContaining("Background task ready for review: ACP background task"),
-        ]);
+        expectAcpTerminalSessionEvents(
+          peekSystemEvents("agent:main:discord:guild-123:channel-parent-channel"),
+          "Background task ready for review: ACP background task",
+        );
       });
     },
   );
@@ -1537,9 +1562,10 @@ describe("task-registry", () => {
         expect(task.deliveryStatus).toBe("session_queued");
       });
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
-      expect(peekSystemEvents(ownerKey)).toEqual([
-        expect.stringContaining("Background task ready for review: ACP background task"),
-      ]);
+      expectAcpTerminalSessionEvents(
+        peekSystemEvents(ownerKey),
+        "Background task ready for review: ACP background task",
+      );
       expect(hasPendingHeartbeatWake()).toBe(true);
     });
   });
@@ -1584,8 +1610,9 @@ describe("task-registry", () => {
       );
       await waitForAssertion(() => {
         const events = peekSystemEvents("agent:main:main");
-        expect(events).toHaveLength(1);
+        expect(events).toHaveLength(2);
         expect(events[0]).toContain("Background task failed: ACP background task");
+        expectAcpContinuationEvent(events[1] ?? "");
       });
     });
   });
@@ -1621,8 +1648,10 @@ describe("task-registry", () => {
       );
       expect(peekSystemEvents("agent:main:main")).toEqual([
         "Background task blocked: ACP background task (run run-deli). Writable session or apply_patch authorization required.",
+        expect.stringContaining("source: acp"),
         "Task needs follow-up: ACP background task (run run-deli). Writable session or apply_patch authorization required.",
       ]);
+      expectAcpContinuationEvent(peekSystemEvents("agent:main:main")[1] ?? "");
       expect(hasPendingHeartbeatWake()).toBe(true);
     });
   });
@@ -1659,8 +1688,9 @@ describe("task-registry", () => {
         }),
       );
       const events = peekSystemEvents("agent:main:main");
-      expect(events).toHaveLength(1);
+      expect(events).toHaveLength(2);
       expect(events[0]).toContain("Background task ready for review: ACP background task");
+      expectAcpContinuationEvent(events[1] ?? "");
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
     });
   });
@@ -1690,8 +1720,10 @@ describe("task-registry", () => {
       );
       expect(peekSystemEvents("agent:main:main")).toEqual([
         "Background task blocked: ACP background task (run run-sess). Writable session or apply_patch authorization required.",
+        expect.stringContaining("source: acp"),
         "Task needs follow-up: ACP background task (run run-sess). Writable session or apply_patch authorization required.",
       ]);
+      expectAcpContinuationEvent(peekSystemEvents("agent:main:main")[1] ?? "");
       expect(hasPendingHeartbeatWake()).toBe(true);
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
     });
@@ -1740,10 +1772,11 @@ describe("task-registry", () => {
 
       await waitForAssertion(() => {
         const events = peekSystemEvents("agent:main:main");
-        expect(events).toHaveLength(1);
+        expect(events).toHaveLength(2);
         expect(events[0]).toBe(
           "Background task ready for review: ACP background task (run run-deta). Next: parent will review/verify before calling it done.",
         );
+        expectAcpContinuationEvent(events[1] ?? "");
       });
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
     });
@@ -1782,8 +1815,10 @@ describe("task-registry", () => {
         }),
       );
       expect(peekSystemEvents("agent:main:main")).toEqual([
+        expect.stringContaining("source: acp"),
         "Task needs follow-up: ACP background task (run run-bloc). Writable session or apply_patch authorization required.",
       ]);
+      expectAcpContinuationEvent(peekSystemEvents("agent:main:main")[0] ?? "");
       expect(hasPendingHeartbeatWake()).toBe(true);
     });
   });
@@ -1816,10 +1851,11 @@ describe("task-registry", () => {
 
       await waitForAssertion(() => {
         const events = peekSystemEvents("agent:main:main");
-        expect(events).toHaveLength(1);
+        expect(events).toHaveLength(2);
         expect(events[0]).toBe(
           "Background task ready for review: ACP background task (run run-succ). Created /tmp/file.txt and verified contents. Next: parent will review/verify before calling it done.",
         );
+        expectAcpContinuationEvent(events[1] ?? "");
       });
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
       expect(hasPendingHeartbeatWake()).toBe(true);
@@ -1961,9 +1997,10 @@ describe("task-registry", () => {
         task: "Spawn ACP child",
         deliveryStatus: "pending",
       });
-      expect(peekSystemEvents("agent:main:main")).toEqual([
-        expect.stringContaining("Background task ready for review: ACP background task"),
-      ]);
+      expectAcpTerminalSessionEvents(
+        peekSystemEvents("agent:main:main"),
+        "Background task ready for review: ACP background task",
+      );
     });
   });
 
@@ -3423,9 +3460,10 @@ describe("task-registry", () => {
       await flushAsyncWork();
 
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
-      expect(peekSystemEvents("agent:main:main")).toEqual([
+      expectAcpTerminalSessionEvents(
+        peekSystemEvents("agent:main:main"),
         "Background task ready for review: ACP background task (run run-quie). Next: parent will review/verify before calling it done.",
-      ]);
+      );
       relay.dispose();
       vi.useRealTimers();
     });
@@ -3475,7 +3513,7 @@ describe("task-registry", () => {
         content:
           "Background task failed: ACP background task (run run-fail). Permission denied by ACP runtime",
       });
-      expect(peekSystemEvents("agent:main:main")).toStrictEqual([]);
+      expectAcpContinuationEvent(peekSystemEvents("agent:main:main")[0] ?? "");
     });
   });
 

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -7,6 +7,11 @@ import {
   buildAgentRunTerminalOutcome,
   type AgentRunTerminalOutcome,
 } from "../agents/agent-run-terminal-outcome.js";
+import {
+  AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION,
+  type AgentInternalEventStatus,
+} from "../agents/internal-event-contract.js";
+import { formatAgentInternalEventsForPlainPrompt } from "../agents/internal-events.js";
 import { shouldRouteCompletionThroughRequesterSession } from "../auto-reply/reply/completion-delivery-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { onAgentEvent } from "../infra/agent-events.js";
@@ -1303,6 +1308,91 @@ function queueTaskSystemEvent(task: TaskRecord, text: string) {
   return true;
 }
 
+function resolveAcpTaskInternalEventStatus(task: TaskRecord): AgentInternalEventStatus {
+  if (task.status === "succeeded" && task.terminalOutcome !== "blocked") {
+    return "ok";
+  }
+  if (task.status === "timed_out") {
+    return "timeout";
+  }
+  if (
+    task.status === "failed" ||
+    task.status === "cancelled" ||
+    task.status === "lost" ||
+    task.terminalOutcome === "blocked"
+  ) {
+    return "error";
+  }
+  return "unknown";
+}
+
+function formatAcpTerminalContinuationEvent(task: TaskRecord): string {
+  const label = "ACP background task";
+  const taskRef = [
+    task.runId ? `runId=${task.runId}` : "",
+    task.childSessionKey ? `childSessionKey=${task.childSessionKey}` : "",
+    task.runId ? "" : `taskId=${task.taskId}`,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const result = [
+    "No child output is embedded here.",
+    "Inspect the task/run/session records and artifacts before deciding what to do next.",
+    taskRef,
+  ]
+    .filter(Boolean)
+    .join("\n");
+  return formatAgentInternalEventsForPlainPrompt([
+    {
+      type: AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION,
+      source: "acp",
+      childSessionKey: task.childSessionKey ?? "",
+      childSessionId: task.sourceId,
+      announceType: "ACP background task",
+      taskLabel: label,
+      status: resolveAcpTaskInternalEventStatus(task),
+      statusLabel:
+        task.terminalOutcome === "blocked" ? "blocked" : task.status.replaceAll("_", " "),
+      result,
+      replyInstruction:
+        "A completed ACP task is ready for parent review. Inspect and verify the child task/run/session artifacts before deciding whether the original request is done. If additional action is required, continue the workflow and report a concise blocker only after checking those artifacts.",
+    },
+  ]);
+}
+
+function queueAcpTerminalContinuation(task: TaskRecord) {
+  if (task.runtime !== "acp") {
+    return false;
+  }
+  if (!task.childSessionKey?.trim()) {
+    return false;
+  }
+  const owner = resolveTaskDeliveryOwner(task);
+  const ownerKey = owner.sessionKey?.trim();
+  if (!ownerKey) {
+    return false;
+  }
+  const text = formatAcpTerminalContinuationEvent(task);
+  if (!text.trim()) {
+    return false;
+  }
+  const terminalOutcome =
+    task.terminalOutcome ?? (task.status === "succeeded" ? "succeeded" : "none");
+  const continuationKey = task.runId?.trim() || task.taskId;
+  enqueueSystemEvent(text, {
+    sessionKey: ownerKey,
+    contextKey: `task:${continuationKey}:acp-terminal-continuation:${task.status}:${terminalOutcome}`,
+    deliveryContext: owner.requesterOrigin,
+  });
+  requestHeartbeat({
+    source: "background-task",
+    intent: "immediate",
+    reason: "background-task-acp-terminal",
+    sessionKey: ownerKey,
+  });
+  return true;
+}
+
 function queueBlockedTaskFollowup(task: TaskRecord) {
   const followupText = formatTaskBlockedFollowupMessage(task);
   if (!followupText) {
@@ -1373,6 +1463,7 @@ export async function maybeDeliverTaskTerminalUpdate(taskId: string): Promise<Ta
     if ((shouldRouteParentReview && !shouldDeliverParentReviewDirect) || !canDeliverDirect) {
       try {
         queueTaskSystemEvent(latest, sessionEventText);
+        queueAcpTerminalContinuation(latest);
         if (latest.terminalOutcome === "blocked") {
           queueBlockedTaskFollowup(latest);
         }
@@ -1411,6 +1502,7 @@ export async function maybeDeliverTaskTerminalUpdate(taskId: string): Promise<Ta
           idempotencyKey,
         },
       });
+      queueAcpTerminalContinuation(latest);
       if (latest.terminalOutcome === "blocked") {
         queueBlockedTaskFollowup(latest);
       }
@@ -1427,6 +1519,7 @@ export async function maybeDeliverTaskTerminalUpdate(taskId: string): Promise<Ta
       });
       try {
         queueTaskSystemEvent(latest, sessionEventText);
+        queueAcpTerminalContinuation(latest);
         if (latest.terminalOutcome === "blocked") {
           queueBlockedTaskFollowup(latest);
         }

--- a/src/tasks/task-status.test.ts
+++ b/src/tasks/task-status.test.ts
@@ -144,4 +144,18 @@ describe("task status formatting", () => {
       ),
     ).toBe("");
   });
+
+  it("strips ACP internal completion events from task status text", () => {
+    expect(
+      sanitizeTaskStatusText(
+        [
+          "OpenClaw runtime context (internal):",
+          "This context is runtime-generated, not user-authored. Keep internal details private.",
+          "",
+          "[Internal task completion event]",
+          "source: acp",
+        ].join("\n"),
+      ),
+    ).toBe("");
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

ACP background task completion can stop at passive lifecycle telemetry such as `Background task done...` without re-entering the requester parent session. That leaves the user with a task-status marker instead of the parent agent continuing the workflow and summarizing the result.

This PR adds ACP terminal task completion as a parent-continuation event source. When a delegated ACP task reaches terminal delivery, OpenClaw queues an ACP-safe plain continuation prompt to the requester session and wakes it immediately, even if the passive channel lifecycle message was already delivered.

## Summary

- Rebased onto current `main` and switched to the current `requestHeartbeat({ source, intent, ... })` API.
- Add `acp` as an internal task-completion event source.
- Queue a parent-session ACP continuation event whenever a delegated ACP task reaches terminal delivery.
- Use `formatAgentInternalEventsForPlainPrompt`, not protected runtime-context envelopes, before queueing through generic system events.
- Keep child output out of the continuation event; the parent is instructed to inspect task/run/session artifacts before continuing.
- Preserve blocked-task follow-up behavior.
- Dedupe continuation events by ACP run/session so duplicate task records produce one parent continuation.
- Add drain/rendering regression coverage proving queued ACP continuations do not render raw internal context markers.

## Related Issues

Refs #52249. This PR is the narrow ACP task-terminal continuation slice of that broader yielded-parent completion issue.

Related to the closed narrower tracker #77251, which describes the exact symptom where group/channel ACP background work stops at `Background task done...` instead of waking the parent agent to send the useful reply.

This does not claim to close the entire native `sessions_spawn` / write-lock / fence cluster tracked in adjacent issues; it specifically fixes delegated ACP terminal task delivery from `src/tasks/task-registry.ts` into a parent-session continuation event.

## Example

For a delegated ACP task that reaches terminal delivery, the requester session now receives two queued session events:

```text
Background task ready for review: ACP background task (run run-succ). Created /tmp/file.txt and verified contents. Next: parent will review/verify before calling it done.

A background task completed. Use this result to reply to the user in your normal assistant voice.

source: acp
session_key: agent:main:acp:child
session_id: unknown
type: ACP background task
task: ACP background task
status: succeeded

Child result:
---
No child output is embedded here.
Inspect the task/run/session records and artifacts before deciding what to do next.
runId=run-succ childSessionKey=agent:main:acp:child
---

Instruction:
A completed ACP task is ready for parent review. Inspect and verify the child task/run/session artifacts before deciding whether the original request is done. If additional action is required, continue the workflow and report a concise blocker only after checking those artifacts.
```

Drain/rendering proof: when this continuation is drained through the generic system-event renderer, it is rendered as normal `System:` lines and does not contain `<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>` or `OpenClaw runtime context (internal)`.

## Evidence

Focused local validation on commit `c865725868033bc098d430708a0ffb1a6a718a61`:

- `node scripts/run-vitest.mjs src/tasks/task-registry.test.ts` - 81 passed
- `node scripts/run-vitest.mjs src/tasks/task-status.test.ts` - 9 passed
- `node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts` - 116 passed
- `node_modules/.bin/oxlint src/agents/internal-event-contract.ts src/tasks/task-registry.ts src/tasks/task-registry.test.ts src/tasks/task-status.test.ts src/auto-reply/reply/session.test.ts` - 0 errors
- `git diff --check` - clean

Regression coverage added/updated:

- `src/tasks/task-registry.test.ts` proves delegated ACP terminal completion queues a requester-session continuation, wakes the parent, preserves blocked follow-up behavior, avoids raw child-output instruction leakage, and dedupes shared-run task records to one parent continuation.
- `src/auto-reply/reply/session.test.ts` proves ACP continuation events drain/render without protected internal-context delimiters.
- `src/tasks/task-status.test.ts` covers ACP internal-event source sanitization for task status text.

## Note

Full `pnpm check` was not rerun for this repair. The prior full check failure was broad existing `tsgo` drift outside this patch; the focused behavior path and changed-file lint are green on the rebased branch.


## Contributor Proof After Mantis Request

Mantis visual proof was requested exactly as ClawSweeper suggested: https://github.com/openclaw/openclaw/pull/95776#issuecomment-4773435949

The upstream Mantis workflow accepted the event but did not produce a maintainer visual capture because the workflow requires write/maintain/admin access and reported `Actor armsteadj1 permission: read`: https://github.com/openclaw/openclaw/actions/runs/27986757945

Additional contributor proof on the exact PR SHA `c865725868033bc098d430708a0ffb1a6a718a61`:

```text
PR 95776 contributor proof
sha=c865725868033bc098d430708a0ffb1a6a718a61
started=2026-06-22T22:01:19Z

$ node scripts/run-vitest.mjs src/tasks/task-registry.test.ts
Test Files  1 passed (1)
Tests  81 passed (81)

$ node scripts/run-vitest.mjs src/tasks/task-status.test.ts
Test Files  1 passed (1)
Tests  9 passed (9)

$ node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts
Test Files  1 passed (1)
Tests  116 passed (116)

$ node_modules/.bin/oxlint src/agents/internal-event-contract.ts src/tasks/task-registry.ts src/tasks/task-registry.test.ts src/tasks/task-status.test.ts src/auto-reply/reply/session.test.ts
0 errors

$ git diff --check
clean
finished=2026-06-22T22:01:36Z
```

GitHub real-behavior proof gate also passed on the PR: https://github.com/openclaw/openclaw/actions/runs/27969078234
