### PR TITLE
fix(onboard): external provider plugin install skips selected auth flow

### DIFF
--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -105,6 +105,11 @@ vi.mock("../utils/with-timeout.js", () => ({
   withTimeout,
 }));
 
+const clearPluginMetadataLifecycleCaches = vi.hoisted(() => vi.fn());
+vi.mock("../plugins/plugin-metadata-lifecycle.js", () => ({
+  clearPluginMetadataLifecycleCaches,
+}));
+
 import { ensureOnboardingPluginInstalled } from "./onboarding-plugin-install.js";
 
 function requireCapturedPrompt<T>(captured: T | undefined): T {
@@ -636,6 +641,9 @@ describe("ensureOnboardingPluginInstalled", () => {
     expect(installed?.source).toBe("npm");
     expect(installed?.spec).toBe("@wecom/wecom-openclaw-plugin@1.2.3");
     expect(refreshPluginRegistryAfterConfigMutation).not.toHaveBeenCalled();
+    // A successful install must invalidate the process-stable plugin metadata snapshot
+    // so the same onboarding run can discover and resolve the freshly installed provider.
+    expect(clearPluginMetadataLifecycleCaches).toHaveBeenCalledOnce();
   });
 
   it("logs npm install warnings once while shortening the progress label", async () => {
@@ -708,6 +716,8 @@ describe("ensureOnboardingPluginInstalled", () => {
       pluginId: "demo-plugin",
       status: "timed_out",
     });
+    // No on-disk plugin landed, so the metadata snapshot must stay intact.
+    expect(clearPluginMetadataLifecycleCaches).not.toHaveBeenCalled();
     expect(stop).toHaveBeenCalledWith("Install timed out: Demo Plugin");
     expect(note).toHaveBeenCalledWith(
       "Installing @demo/plugin@1.2.3 timed out after 5 minutes.\nReturning to selection.",

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -46,6 +46,7 @@ import {
   resolveNpmInstallRecordSpec,
 } from "../plugins/installs.js";
 import type { PluginPackageInstall } from "../plugins/manifest.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withTimeout } from "../utils/with-timeout.js";
 import { VERSION } from "../version.js";
@@ -996,7 +997,7 @@ async function installPluginFromClawHubSpecWithProgress(params: {
 }
 
 /** Ensures an onboarding plugin is installed, enabled, and recorded in config. */
-export async function ensureOnboardingPluginInstalled(params: {
+async function runOnboardingPluginInstall(params: {
   cfg: OpenClawConfig;
   entry: OnboardingPluginInstallEntry;
   prompter: WizardPrompter;
@@ -1363,4 +1364,19 @@ export async function ensureOnboardingPluginInstalled(params: {
     pluginId: entry.pluginId,
     status: "failed",
   };
+}
+
+export async function ensureOnboardingPluginInstalled(
+  params: Parameters<typeof runOnboardingPluginInstall>[0],
+): Promise<OnboardingPluginInstallResult> {
+  const result = await runOnboardingPluginInstall(params);
+  if (result.installed) {
+    // A fresh on-disk plugin install adds a provider/manifest that the process-stable
+    // plugin metadata snapshot does not know about. Without invalidating it here, the
+    // same onboarding run keeps reusing the pre-install snapshot, so the just-installed
+    // provider stays undiscoverable and the selected auth flow is skipped. This mirrors
+    // the persisted index writer, which clears the same caches on install.
+    clearPluginMetadataLifecycleCaches();
+  }
+  return result;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes #95765. During first-time model setup, selecting an external provider that requires an on-demand provider plugin install (reproduced with DeepSeek) can install the plugin but never continue into the provider API-key/auth step. The plugin reports as installed, yet the selected auth flow is skipped and the final configured model/auth state stays on the default OpenAI path.

## Why This Change Was Made

Onboarding installs a provider plugin through `ensureOnboardingPluginInstalled`, which records the plugin into config (`plugins.entries.<id>.enabled`, install record) and lands the package on disk. The provider auth flow then immediately re-resolves providers in the same process to reach the auth method.

Plugin metadata is process-stable by design: the metadata snapshot used by provider discovery is memoized and reused until an install/reload explicitly clears it via `clearPluginMetadataLifecycleCaches()` (the persisted index writer already does this on write). The onboarding install path only wrote config install records and never cleared those caches, so the post-install re-resolution kept reusing the pre-install snapshot. The freshly installed provider stayed undiscoverable, `resolveProviderPluginChoice` returned no match, `applyAuthChoiceLoadedPluginProvider` returned `retrySelection`, and the wizard abandoned the selected auth choice. This matches the reported `loaded 35 plugin(s)` reload with no `loading deepseek` line, while a fresh process (`models auth login --provider deepseek`) loads the plugin and reaches the API-key prompt.

The fix clears the plugin metadata lifecycle caches once when an onboarding install lands a plugin on disk, mirroring the persisted index writer. The change wraps the shared install entry point, so every onboarding install caller (provider auth, channels, search, official plugins) benefits without per-caller changes. Failed/skipped/timed-out installs do not clear the caches.

## User Impact

First-time users selecting an external provider (e.g. DeepSeek) that needs an on-demand plugin install now continue straight into the provider's API-key/auth step in the same onboarding run, instead of silently falling back to the default OpenAI missing-auth state.

## Evidence

Root cause is the process-stable plugin metadata snapshot not being invalidated after an onboarding install. Existing contract tests already prove the snapshot stays stale until exactly this lifecycle clear is called:

- `src/plugins/plugin-metadata-snapshot.memo.test.ts` — "keeps persisted registry snapshots process-stable until lifecycle clear" and "clears the process memo at plugin metadata lifecycle boundaries".

New/updated coverage proves the onboarding install now triggers that clear on success and not on failure (`src/commands/onboarding-plugin-install.test.ts`).

Narrow tests run in the worktree-safe runner (`node scripts/run-vitest.mjs`):

```text
src/commands/onboarding-plugin-install.test.ts ......... 27 passed
src/plugins/plugin-metadata-snapshot.memo.test.ts ...... 32 passed
src/wizard/setup.official-plugins.test.ts ..............  6 passed
src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.test.ts ... 10 passed
src/flows/search-setup.test.ts ......................... 10 passed
src/commands/auth-choice.apply.plugin-provider.test.ts . 14 passed
```

`oxfmt --check` passes on both changed files.

AI-assisted.
