### PR TITLE
fix(sessions): honor configured store for outbound transcript mirrors

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -5269,6 +5269,7 @@ describe("dispatchReplyFromConfig", () => {
       Provider: "whatsapp",
       OriginatingChannel: "whatsapp",
       OriginatingTo: "whatsapp:+15555550123",
+      AccountId: "default",
       MessageSid: "msg-1",
     });
     const replyResolver = vi.fn(async () => ({ text: "hi" }) as ReplyPayload);
@@ -5689,6 +5690,7 @@ describe("dispatchReplyFromConfig", () => {
       CommandBody: "hello",
       RawBody: "hello",
       Body: "hello",
+      AccountId: "default",
       MessageSid: "wa-msg-1",
       SessionKey: "agent:main:whatsapp:+15555550123",
       SuppressMessageReceivedHooks: true,
@@ -7038,6 +7040,7 @@ describe("dispatchReplyFromConfig", () => {
       Provider: "whatsapp",
       OriginatingChannel: "whatsapp",
       OriginatingTo: "whatsapp:+15555550123",
+      AccountId: "default",
       MessageSid: "msg-dup",
     });
     const replyResolver = vi.fn(async () => ({ text: "hi" }) as ReplyPayload);
@@ -7063,6 +7066,7 @@ describe("dispatchReplyFromConfig", () => {
       Provider: "whatsapp",
       OriginatingChannel: "whatsapp",
       OriginatingTo: "whatsapp:+15555550123",
+      AccountId: "default",
       MessageSid: "msg-dup-trace",
     });
     const replyResolver = vi.fn(async () => ({ text: "hi" }) as ReplyPayload);

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -118,6 +118,115 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     return event;
   }
 
+  it("uses configured session.store when storePath is omitted", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "transcript-config-store-"));
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    try {
+      process.env.OPENCLAW_STATE_DIR = path.join(tempDir, "default-state");
+      const sessionsDir = path.join(tempDir, "configured", "sessions");
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      const storePath = path.join(sessionsDir, "sessions.json");
+      const configuredSessionKey = "agent:main:configured-store";
+      fs.writeFileSync(
+        storePath,
+        JSON.stringify({
+          [configuredSessionKey]: {
+            sessionId: "configured-session-id",
+            chatType: "direct",
+          },
+        }),
+        "utf-8",
+      );
+
+      const result = await appendAssistantMessageToSessionTranscript({
+        agentId: "main",
+        sessionKey: configuredSessionKey,
+        text: "mirrored configured store reply",
+        config: { session: { store: storePath } },
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      expect(path.basename(result.sessionFile)).toBe("configured-session-id.jsonl");
+      expect(fs.realpathSync.native(path.dirname(result.sessionFile))).toBe(
+        fs.realpathSync.native(sessionsDir),
+      );
+      await expect(fs.promises.readFile(result.sessionFile, "utf-8")).resolves.toContain(
+        "mirrored configured store reply",
+      );
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the session key agent for configured session.store templates", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "transcript-agent-store-"));
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const emitSpy = vi.spyOn(transcriptEvents, "emitSessionTranscriptUpdate");
+    try {
+      process.env.OPENCLAW_STATE_DIR = path.join(tempDir, "default-state");
+      const storeTemplate = path.join(tempDir, "agents", "{agentId}", "sessions", "sessions.json");
+      const sessionsDir = path.join(tempDir, "agents", "worker", "sessions");
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      const storePath = path.join(sessionsDir, "sessions.json");
+      const configuredSessionKey = "agent:worker:configured-store";
+      fs.writeFileSync(
+        storePath,
+        JSON.stringify({
+          [configuredSessionKey]: {
+            sessionId: "worker-session-id",
+            chatType: "direct",
+          },
+        }),
+        "utf-8",
+      );
+      const beforeMessageWrite = vi.fn(({ message }: BeforeMessageWriteParams) => message);
+
+      const result = await appendAssistantMessageToSessionTranscript({
+        sessionKey: configuredSessionKey,
+        text: "mirrored worker store reply",
+        config: { session: { store: storeTemplate } },
+        beforeMessageWrite,
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      expect(path.basename(result.sessionFile)).toBe("worker-session-id.jsonl");
+      expect(fs.realpathSync.native(path.dirname(result.sessionFile))).toBe(
+        fs.realpathSync.native(sessionsDir),
+      );
+      await expect(fs.promises.readFile(result.sessionFile, "utf-8")).resolves.toContain(
+        "mirrored worker store reply",
+      );
+      expect(beforeMessageWrite).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: "worker",
+          sessionKey: configuredSessionKey,
+        }),
+      );
+      const event = requireTranscriptUpdateCall(emitSpy);
+      expect(event.agentId).toBe("worker");
+      expect(event.sessionKey).toBe(configuredSessionKey);
+    } finally {
+      emitSpy.mockRestore();
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("creates transcript file and appends message for valid session", async () => {
     writeTranscriptStore();
 

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -4,13 +4,18 @@ import type { AgentMessage } from "../../agents/runtime/index.js";
 import type { SessionManager } from "../../agents/sessions/session-manager.js";
 import { redactTranscriptMessage } from "../../agents/transcript-redact.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import {
   extractAssistantVisibleText,
   extractFirstTextBlock,
 } from "../../shared/chat-message-content.js";
 import { isTranscriptOnlyOpenClawAssistantModel } from "../../shared/transcript-only-openclaw-assistant.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
-import { resolveDefaultSessionStorePath, resolveSessionFilePath } from "./paths.js";
+import {
+  resolveDefaultSessionStorePath,
+  resolveSessionFilePath,
+  resolveStorePath,
+} from "./paths.js";
 import { persistSessionTranscriptTurn } from "./session-accessor.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import { loadSessionStore, resolveSessionStoreEntry } from "./store.js";
@@ -396,7 +401,12 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
     return { ok: false, reason: "message role must be assistant" };
   }
 
-  const storePath = params.storePath ?? resolveDefaultSessionStorePath(params.agentId);
+  const explicitAgentId = params.agentId?.trim() || undefined;
+  const sessionAgentId = parseAgentSessionKey(sessionKey)?.agentId;
+  const transcriptAgentId = explicitAgentId ?? sessionAgentId;
+  const storeAgentId = transcriptAgentId ?? resolveAgentIdFromSessionKey(sessionKey);
+  const storePath =
+    params.storePath ?? resolveStorePath(params.config?.session?.store, { agentId: storeAgentId });
   const store = loadSessionStore(storePath, { skipCache: true });
   const resolved = resolveSessionStoreEntry({ store, sessionKey });
   const entry = resolved.existing;
@@ -427,7 +437,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
         ? applyBeforeMessageWriteToAssistant({
             message,
             beforeMessageWrite: params.beforeMessageWrite,
-            agentId: params.agentId,
+            agentId: transcriptAgentId,
             sessionKey: resolved.normalizedKey,
           })
         : message;
@@ -449,7 +459,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
         sessionKey: resolved.normalizedKey,
         storePath,
         ...(sessionFile ? { sessionFile } : {}),
-        ...(params.agentId ? { agentId: params.agentId } : {}),
+        ...(transcriptAgentId ? { agentId: transcriptAgentId } : {}),
       },
       {
         cwd: currentEntry.spawnedCwd,
@@ -468,7 +478,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
                       message: candidate as Parameters<SessionManager["appendMessage"]>[0],
                       beforeMessageWrite: params.beforeMessageWrite,
                       explicitIdempotencyKey,
-                      agentId: params.agentId,
+                      agentId: transcriptAgentId,
                       sessionKey: resolved.normalizedKey,
                     }),
                 }
@@ -522,7 +532,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
         sessionStore: store,
         storePath,
         sessionEntry: entry,
-        agentId: params.agentId,
+        agentId: transcriptAgentId,
         sessionsDir: path.dirname(storePath),
       });
       sessionFile = resolvedSessionFile.sessionFile;


### PR DESCRIPTION
Closes #95781

## What Problem This Solves

Fixes an issue where users who configure `session.store` away from the default per-agent store could have outbound transcript mirrors skip or misplace mirrored assistant replies. The affected channel/plugin delivery path could still send the reply successfully, but the mirrored assistant turn would not reliably land in the configured session transcript store.

This matters for operators who use custom session stores for multi-agent layouts, isolated state directories, or store templates such as `agents/{agentId}/sessions/sessions.json`. Without this fix, the transcript can silently diverge from what was actually delivered.

## Why This Change Was Made

The outbound mirror call sites already pass runtime `config` into transcript append. The missing piece was inside the transcript append fallback: when callers omitted an explicit `storePath`, `appendExactAssistantMessageToSessionTranscript` still resolved the default session store instead of honoring `config.session.store`.

This PR keeps the existing priority order conservative:

1. preserve explicit `storePath` when a caller provides one
2. otherwise resolve through `config.session.store`
3. fall back to the existing default session store behavior when no configured store is available

For `{agentId}` store templates, the fallback store agent is taken from the explicit `agentId` when present, or derived from the canonical `agent:<id>:...` session key when `agentId` is omitted. That lets mirror appends find the same store where outbound session metadata was written, without adding store-path plumbing to each outbound caller.

The resolved owner agent is also threaded into transcript-file persistence, transcript-turn append metadata, and `beforeMessageWrite` hook context when the owner is explicit or encoded by a canonical `agent:<id>:...` session key. Legacy aliases and unscoped `global` keys are not force-labeled as `main`, so existing unscoped/global transcript update semantics stay intact.

## User Impact

Outbound mirrored replies now land in the intended configured session transcript store. Users and operators get more reliable session history, transcript auditability, and context continuity when they use custom or per-agent templated session stores.

Channel delivery behavior is unchanged. This PR does not add a new config option, change provider routing, or alter transport semantics.

## Scope

Changed files:

- `src/config/sessions/transcript.ts` - resolves transcript append fallback stores through `config.session.store`, derives the store agent from the session key when needed, and threads confirmed owner-agent metadata into transcript persistence and hook context.
- `src/config/sessions/transcript.test.ts` - adds regression coverage for fixed custom store paths, `{agentId}` templated stores, owner-agent transcript update metadata, and hook context.
- `src/auto-reply/reply/dispatch-from-config.test.ts` - fills in dispatch fixture `AccountId` values so inbound dedupe, hook-suppression, and duplicate-diagnostic paths exercise the intended default-account route key.

PR size: +129/-6 across 3 files.

## Risk and Compatibility

Risk is limited to the fallback store resolution used when transcript append callers omit `storePath`. Explicit `storePath` remains the highest-priority input, so existing direct callers that already pin a store path keep their behavior.

The compatibility-sensitive part is session state: custom `session.store` users should now get the behavior their config already implies. Default-store users should continue through the same default fallback.

The owner-agent follow-up is intentionally bounded. Confirmed owner ids from explicit `agentId` or canonical `agent:<id>:...` keys now flow to transcript events and hooks, but legacy aliases and unscoped `global` keys do not get a synthesized `agentId: "main"`. That avoids changing selected-global routing or older unscoped update payloads while still making canonical multi-agent transcript mirrors internally consistent.

## Evidence

Root-cause evidence on `upstream/main`:

- `src/config/sessions/transcript.ts:399` used `resolveDefaultSessionStorePath(params.agentId)` in the exact assistant append path.
- `src/infra/outbound/source-reply-mirror.ts:232`, `src/infra/outbound/outbound-send-service.ts:309`, and `src/infra/outbound/deliver.ts:1979` passed `config` to `appendAssistantMessageToSessionTranscript` without passing `storePath`.
- Live GitHub search found no duplicate issue/PR for `session.store transcript mirror outbound`.

Focused validation on the current head:

- `node scripts/run-vitest.mjs src/config/sessions/transcript.test.ts -- --reporter=dot` -> 49 passed.
- `node scripts/run-vitest.mjs src/config/sessions/transcript.test.ts src/config/sessions/transcript-append-redact.test.ts -- --reporter=dot` -> 63 passed.
- `node_modules/.bin/oxfmt --check --threads=1 src/config/sessions/transcript.ts src/config/sessions/transcript.test.ts`
- `git diff --check`

Earlier focused validation also run on the branch:

- `pnpm test src/infra/outbound/outbound-session.test.ts src/infra/outbound/outbound-send-service.test.ts src/infra/outbound/deliver.test.ts -- --reporter=dot` -> 152 passed.
- `pnpm test src/gateway/server-methods/send.test.ts -- --reporter=dot -t "mirror|mirrors|mirroring"` -> 118 passed.
- `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts -- --reporter=dot` -> 215 + 82 passed.
- `git diff --check upstream/main...HEAD`
- `node scripts/changed-lanes.mjs --base upstream/main --json` -> `core` and `coreTests` only.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --engine codex` -> clean; no accepted/actionable findings.

Known proof gap: no real outbound channel E2E was attached to this PR body. The branch has focused unit/path coverage for the session-store resolution behavior, plus outbound/gateway mirror-adjacent tests.

## Triage Notes

Suggested labels for maintainers: `P2`, `proof: supplied`, `merge-risk: 🚨 session-state`. Current automated labeling applied `size: S`.

