### PR TITLE
fix(onboard): refresh provider plugin registry after setup installs

### DIFF
--- a/src/cli/plugins-registry-refresh.ts
+++ b/src/cli/plugins-registry-refresh.ts
@@ -52,7 +52,7 @@ export async function refreshPluginRegistryAfterConfigMutation(params: {
   }
 }
 
-async function invalidatePluginRuntimeDiscoveryAfterConfigMutation(params: {
+export async function invalidatePluginRuntimeDiscoveryAfterConfigMutation(params: {
   logger?: PluginRegistryRefreshLogger;
 }): Promise<void> {
   try {

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -408,6 +408,7 @@ describe("ensureOnboardingPluginInstalled", () => {
     expect(refreshPluginRegistryAfterConfigMutation).toHaveBeenCalledWith(
       expect.objectContaining({
         config: result.cfg,
+        installRecords: result.cfg.plugins?.installs,
         reason: "source-changed",
         policyPluginIds: ["demo-plugin"],
         traceCommand: "onboarding-plugin-install",

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -100,6 +100,11 @@ vi.mock("../plugins/installs.js", () => ({
   resolveNpmInstallRecordSpec,
 }));
 
+const clearPluginMetadataLifecycleCaches = vi.hoisted(() => vi.fn());
+vi.mock("../plugins/plugin-metadata-lifecycle.js", () => ({
+  clearPluginMetadataLifecycleCaches,
+}));
+
 const withTimeout = vi.hoisted(() => vi.fn(async <T>(promise: Promise<T>) => await promise));
 vi.mock("../utils/with-timeout.js", () => ({
   withTimeout,
@@ -398,6 +403,15 @@ describe("ensureOnboardingPluginInstalled", () => {
       npmTarballName: "demo-plugin-1.2.3.tgz",
     });
     expect(result.status).toBe("installed");
+    expect(clearPluginMetadataLifecycleCaches).toHaveBeenCalledOnce();
+    expect(refreshPluginRegistryAfterConfigMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: result.cfg,
+        reason: "source-changed",
+        policyPluginIds: ["demo-plugin"],
+        traceCommand: "onboarding-plugin-install",
+      }),
+    );
   });
 
   it("uses a guarded npm install override without official-trust flags", async () => {
@@ -635,7 +649,15 @@ describe("ensureOnboardingPluginInstalled", () => {
     expect(installed?.pluginId).toBe("demo-plugin");
     expect(installed?.source).toBe("npm");
     expect(installed?.spec).toBe("@wecom/wecom-openclaw-plugin@1.2.3");
-    expect(refreshPluginRegistryAfterConfigMutation).not.toHaveBeenCalled();
+    expect(clearPluginMetadataLifecycleCaches).toHaveBeenCalledOnce();
+    expect(refreshPluginRegistryAfterConfigMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: result.cfg,
+        reason: "source-changed",
+        policyPluginIds: ["demo-plugin"],
+        traceCommand: "onboarding-plugin-install",
+      }),
+    );
   });
 
   it("logs npm install warnings once while shortening the progress label", async () => {
@@ -708,6 +730,8 @@ describe("ensureOnboardingPluginInstalled", () => {
       pluginId: "demo-plugin",
       status: "timed_out",
     });
+    expect(clearPluginMetadataLifecycleCaches).not.toHaveBeenCalled();
+    expect(refreshPluginRegistryAfterConfigMutation).not.toHaveBeenCalled();
     expect(stop).toHaveBeenCalledWith("Install timed out: Demo Plugin");
     expect(note).toHaveBeenCalledWith(
       "Installing @demo/plugin@1.2.3 timed out after 5 minutes.\nReturning to selection.",
@@ -1070,6 +1094,7 @@ describe("ensureOnboardingPluginInstalled", () => {
       ]);
       expect(prompt.message).not.toContain("\x1b");
       expect(prompt.options[0]?.label).not.toContain("\x1b");
+      expect(clearPluginMetadataLifecycleCaches).not.toHaveBeenCalled();
     });
   });
 
@@ -1213,6 +1238,16 @@ describe("ensureOnboardingPluginInstalled", () => {
       });
       expect(result.installed).toBe(true);
       expect(result.status).toBe("installed");
+      expect(clearPluginMetadataLifecycleCaches).toHaveBeenCalledOnce();
+      expect(refreshPluginRegistryAfterConfigMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: result.cfg,
+          reason: "source-changed",
+          workspaceDir,
+          policyPluginIds: ["demo-plugin"],
+          traceCommand: "onboarding-plugin-install",
+        }),
+      );
       expect(result.cfg.plugins?.installs).toEqual({
         "demo-plugin": {
           pluginId: "demo-plugin",

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -23,9 +23,11 @@ vi.mock("../cli/plugin-install-plan.js", () => ({
   resolveBundledInstallPlanForCatalogEntry,
 }));
 
-const refreshPluginRegistryAfterConfigMutation = vi.hoisted(() => vi.fn(async () => undefined));
+const invalidatePluginRuntimeDiscoveryAfterConfigMutation = vi.hoisted(() =>
+  vi.fn(async () => undefined),
+);
 vi.mock("../cli/plugins-registry-refresh.js", () => ({
-  refreshPluginRegistryAfterConfigMutation,
+  invalidatePluginRuntimeDiscoveryAfterConfigMutation,
 }));
 
 const resolveBundledPluginSources = vi.hoisted(() => vi.fn(() => new Map()));
@@ -103,6 +105,10 @@ vi.mock("../plugins/installs.js", () => ({
 const clearPluginMetadataLifecycleCaches = vi.hoisted(() => vi.fn());
 vi.mock("../plugins/plugin-metadata-lifecycle.js", () => ({
   clearPluginMetadataLifecycleCaches,
+}));
+const clearLoadInstalledPluginIndexInstallRecordsCache = vi.hoisted(() => vi.fn());
+vi.mock("../plugins/installed-plugin-index-records.js", () => ({
+  clearLoadInstalledPluginIndexInstallRecordsCache,
 }));
 
 const withTimeout = vi.hoisted(() => vi.fn(async <T>(promise: Promise<T>) => await promise));
@@ -187,7 +193,7 @@ describe("ensureOnboardingPluginInstalled", () => {
     delete process.env.OPENCLAW_ALLOW_PLUGIN_INSTALL_OVERRIDES;
     delete process.env.OPENCLAW_PLUGIN_INSTALL_OVERRIDES;
     withTimeout.mockImplementation(async <T>(promise: Promise<T>) => await promise);
-    refreshPluginRegistryAfterConfigMutation.mockResolvedValue(undefined);
+    invalidatePluginRuntimeDiscoveryAfterConfigMutation.mockResolvedValue(undefined);
   });
 
   it("localizes plugin install choices", async () => {
@@ -404,15 +410,11 @@ describe("ensureOnboardingPluginInstalled", () => {
       npmTarballName: "demo-plugin-1.2.3.tgz",
     });
     expect(result.status).toBe("installed");
+    expect(clearLoadInstalledPluginIndexInstallRecordsCache).toHaveBeenCalledOnce();
     expect(clearPluginMetadataLifecycleCaches).toHaveBeenCalledOnce();
-    expect(refreshPluginRegistryAfterConfigMutation).toHaveBeenCalledWith(
+    expect(invalidatePluginRuntimeDiscoveryAfterConfigMutation).toHaveBeenCalledWith(
       expect.objectContaining({
-        config: result.cfg,
-        installRecords: result.cfg.plugins?.installs,
-        reason: "source-changed",
-        policyPluginIds: ["demo-plugin"],
-        traceCommand: "onboarding-plugin-install",
-        workspaceDir: "/tmp/workspace",
+        logger: expect.objectContaining({ warn: expect.any(Function) }),
       }),
     );
   });
@@ -652,13 +654,11 @@ describe("ensureOnboardingPluginInstalled", () => {
     expect(installed?.pluginId).toBe("demo-plugin");
     expect(installed?.source).toBe("npm");
     expect(installed?.spec).toBe("@wecom/wecom-openclaw-plugin@1.2.3");
+    expect(clearLoadInstalledPluginIndexInstallRecordsCache).toHaveBeenCalledOnce();
     expect(clearPluginMetadataLifecycleCaches).toHaveBeenCalledOnce();
-    expect(refreshPluginRegistryAfterConfigMutation).toHaveBeenCalledWith(
+    expect(invalidatePluginRuntimeDiscoveryAfterConfigMutation).toHaveBeenCalledWith(
       expect.objectContaining({
-        config: result.cfg,
-        reason: "source-changed",
-        policyPluginIds: ["demo-plugin"],
-        traceCommand: "onboarding-plugin-install",
+        logger: expect.objectContaining({ warn: expect.any(Function) }),
       }),
     );
   });
@@ -733,8 +733,9 @@ describe("ensureOnboardingPluginInstalled", () => {
       pluginId: "demo-plugin",
       status: "timed_out",
     });
+    expect(clearLoadInstalledPluginIndexInstallRecordsCache).not.toHaveBeenCalled();
     expect(clearPluginMetadataLifecycleCaches).not.toHaveBeenCalled();
-    expect(refreshPluginRegistryAfterConfigMutation).not.toHaveBeenCalled();
+    expect(invalidatePluginRuntimeDiscoveryAfterConfigMutation).not.toHaveBeenCalled();
     expect(stop).toHaveBeenCalledWith("Install timed out: Demo Plugin");
     expect(note).toHaveBeenCalledWith(
       "Installing @demo/plugin@1.2.3 timed out after 5 minutes.\nReturning to selection.",
@@ -1241,14 +1242,11 @@ describe("ensureOnboardingPluginInstalled", () => {
       });
       expect(result.installed).toBe(true);
       expect(result.status).toBe("installed");
+      expect(clearLoadInstalledPluginIndexInstallRecordsCache).toHaveBeenCalledOnce();
       expect(clearPluginMetadataLifecycleCaches).toHaveBeenCalledOnce();
-      expect(refreshPluginRegistryAfterConfigMutation).toHaveBeenCalledWith(
+      expect(invalidatePluginRuntimeDiscoveryAfterConfigMutation).toHaveBeenCalledWith(
         expect.objectContaining({
-          config: result.cfg,
-          reason: "source-changed",
-          workspaceDir,
-          policyPluginIds: ["demo-plugin"],
-          traceCommand: "onboarding-plugin-install",
+          logger: expect.objectContaining({ warn: expect.any(Function) }),
         }),
       );
       expect(result.cfg.plugins?.installs).toEqual({

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -373,6 +373,7 @@ describe("ensureOnboardingPluginInstalled", () => {
         progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
       } as never,
       runtime: { log: vi.fn() } as never,
+      workspaceDir: "/tmp/workspace",
     });
 
     expect(select).not.toHaveBeenCalled();
@@ -410,6 +411,7 @@ describe("ensureOnboardingPluginInstalled", () => {
         reason: "source-changed",
         policyPluginIds: ["demo-plugin"],
         traceCommand: "onboarding-plugin-install",
+        workspaceDir: "/tmp/workspace",
       }),
     );
   });

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -93,6 +93,7 @@ async function markOnboardingPluginInstalled(
   await refreshPluginRegistryAfterConfigMutation({
     config: result.cfg,
     reason: "source-changed",
+    installRecords: result.cfg.plugins?.installs ?? {},
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     policyPluginIds: [params.pluginId],
     traceCommand: "onboarding-plugin-install",

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { resolveBundledInstallPlanForCatalogEntry } from "../cli/plugin-install-plan.js";
+import { refreshPluginRegistryAfterConfigMutation } from "../cli/plugins-registry-refresh.js";
 import { assertConfigWriteAllowedInCurrentMode } from "../config/nix-mode-write-guard.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
@@ -46,6 +47,7 @@ import {
   resolveNpmInstallRecordSpec,
 } from "../plugins/installs.js";
 import type { PluginPackageInstall } from "../plugins/manifest.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withTimeout } from "../utils/with-timeout.js";
 import { VERSION } from "../version.js";
@@ -78,6 +80,25 @@ type OnboardingPluginInstallResult = {
   pluginId: string;
   status: OnboardingPluginInstallStatus;
 };
+
+async function markOnboardingPluginInstalled(
+  result: OnboardingPluginInstallResult & { installed: true },
+  params: {
+    runtime: RuntimeEnv;
+    workspaceDir?: string;
+    pluginId: string;
+  },
+): Promise<OnboardingPluginInstallResult & { installed: true }> {
+  clearPluginMetadataLifecycleCaches();
+  await refreshPluginRegistryAfterConfigMutation({
+    config: result.cfg,
+    reason: "source-changed",
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    policyPluginIds: [params.pluginId],
+    traceCommand: "onboarding-plugin-install",
+  });
+  return result;
+}
 
 function shouldFallbackClawHubToNpm(params: {
   result: { ok: false; code?: string };
@@ -915,12 +936,15 @@ async function installPluginFromOverride(params: {
           ...(result.version ? { version: result.version } : {}),
           ...buildNpmResolutionInstallFields(result.npmResolution),
         } as const);
-  return {
-    cfg: recordPluginInstall(enableResult.config, install),
-    installed: true,
-    pluginId: result.pluginId,
-    status: "installed",
-  };
+  return await markOnboardingPluginInstalled(
+    {
+      cfg: recordPluginInstall(enableResult.config, install),
+      installed: true,
+      pluginId: result.pluginId,
+      status: "installed",
+    },
+    { runtime: params.runtime, pluginId: result.pluginId },
+  );
 }
 
 async function installPluginFromClawHubSpecWithProgress(params: {
@@ -1104,21 +1128,27 @@ export async function ensureOnboardingPluginInstalled(params: {
       };
     }
     if (pathsReferToSameDirectory(localPath, bundledLocalPath)) {
-      return {
-        cfg: enableResult.config,
-        installed: true,
-        pluginId: entry.pluginId,
-        status: "installed",
-      };
+      return await markOnboardingPluginInstalled(
+        {
+          cfg: enableResult.config,
+          installed: true,
+          pluginId: entry.pluginId,
+          status: "installed",
+        },
+        { runtime, workspaceDir, pluginId: entry.pluginId },
+      );
     }
     next = addPluginLoadPath(enableResult.config, localPath);
     next = await recordLocalPluginInstall({ cfg: next, entry, localPath, npmSpec, workspaceDir });
-    return {
-      cfg: next,
-      installed: true,
-      pluginId: entry.pluginId,
-      status: "installed",
-    };
+    return await markOnboardingPluginInstalled(
+      {
+        cfg: next,
+        installed: true,
+        pluginId: entry.pluginId,
+        status: "installed",
+      },
+      { runtime, workspaceDir, pluginId: entry.pluginId },
+    );
   }
 
   let shouldTryNpm = choice === "npm";
@@ -1171,12 +1201,15 @@ export async function ensureOnboardingPluginInstalled(params: {
         spec: clawhubSpecs?.recordSpec ?? clawhubInstallSpec,
         installPath: result.targetDir,
       });
-      return {
-        cfg: next,
-        installed: true,
-        pluginId: result.pluginId,
-        status: "installed",
-      };
+      return await markOnboardingPluginInstalled(
+        {
+          cfg: next,
+          installed: true,
+          pluginId: result.pluginId,
+          status: "installed",
+        },
+        { runtime, workspaceDir, pluginId: result.pluginId },
+      );
     }
 
     await prompter.note(
@@ -1293,12 +1326,15 @@ export async function ensureOnboardingPluginInstalled(params: {
       ...buildNpmResolutionInstallFields(result.npmResolution),
     } as const;
     next = recordPluginInstall(next, install);
-    return {
-      cfg: next,
-      installed: true,
-      pluginId: result.pluginId,
-      status: "installed",
-    };
+    return await markOnboardingPluginInstalled(
+      {
+        cfg: next,
+        installed: true,
+        pluginId: result.pluginId,
+        status: "installed",
+      },
+      { runtime, workspaceDir, pluginId: result.pluginId },
+    );
   }
 
   await prompter.note(
@@ -1338,21 +1374,27 @@ export async function ensureOnboardingPluginInstalled(params: {
         };
       }
       if (pathsReferToSameDirectory(localPath, bundledLocalPath)) {
-        return {
-          cfg: enableResult.config,
-          installed: true,
-          pluginId: entry.pluginId,
-          status: "installed",
-        };
+        return await markOnboardingPluginInstalled(
+          {
+            cfg: enableResult.config,
+            installed: true,
+            pluginId: entry.pluginId,
+            status: "installed",
+          },
+          { runtime, workspaceDir, pluginId: entry.pluginId },
+        );
       }
       next = addPluginLoadPath(enableResult.config, localPath);
       next = await recordLocalPluginInstall({ cfg: next, entry, localPath, npmSpec, workspaceDir });
-      return {
-        cfg: next,
-        installed: true,
-        pluginId: entry.pluginId,
-        status: "installed",
-      };
+      return await markOnboardingPluginInstalled(
+        {
+          cfg: next,
+          installed: true,
+          pluginId: entry.pluginId,
+          status: "installed",
+        },
+        { runtime, workspaceDir, pluginId: entry.pluginId },
+      );
     }
   }
 

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -826,6 +826,7 @@ async function installPluginFromOverride(params: {
   override: PluginInstallOverride;
   prompter: WizardPrompter;
   runtime: RuntimeEnv;
+  workspaceDir?: string;
 }): Promise<OnboardingPluginInstallResult> {
   const { entry, prompter, runtime } = params;
   runtime.log?.(
@@ -944,7 +945,7 @@ async function installPluginFromOverride(params: {
       pluginId: result.pluginId,
       status: "installed",
     },
-    { runtime: params.runtime, pluginId: result.pluginId },
+    { runtime: params.runtime, workspaceDir: params.workspaceDir, pluginId: result.pluginId },
   );
 }
 
@@ -1043,6 +1044,7 @@ export async function ensureOnboardingPluginInstalled(params: {
       override: installOverride,
       prompter,
       runtime,
+      workspaceDir,
     });
   }
   const allowLocal = hasGitWorkspace(workspaceDir);

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -9,7 +9,7 @@ import path from "node:path";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { resolveBundledInstallPlanForCatalogEntry } from "../cli/plugin-install-plan.js";
-import { refreshPluginRegistryAfterConfigMutation } from "../cli/plugins-registry-refresh.js";
+import { invalidatePluginRuntimeDiscoveryAfterConfigMutation } from "../cli/plugins-registry-refresh.js";
 import { assertConfigWriteAllowedInCurrentMode } from "../config/nix-mode-write-guard.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
@@ -41,6 +41,7 @@ import {
   installPluginFromNpmPackArchive,
   type InstallPluginResult,
 } from "../plugins/install.js";
+import { clearLoadInstalledPluginIndexInstallRecordsCache } from "../plugins/installed-plugin-index-records.js";
 import {
   buildNpmResolutionInstallFields,
   recordPluginInstall,
@@ -85,18 +86,13 @@ async function markOnboardingPluginInstalled(
   result: OnboardingPluginInstallResult & { installed: true },
   params: {
     runtime: RuntimeEnv;
-    workspaceDir?: string;
-    pluginId: string;
   },
 ): Promise<OnboardingPluginInstallResult & { installed: true }> {
+  // Onboarding has not committed config yet, so invalidate only process-local
+  // discovery. The next lookup recovers the new package alongside persisted records.
+  clearLoadInstalledPluginIndexInstallRecordsCache();
   clearPluginMetadataLifecycleCaches();
-  await refreshPluginRegistryAfterConfigMutation({
-    config: result.cfg,
-    reason: "source-changed",
-    installRecords: result.cfg.plugins?.installs ?? {},
-    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-    policyPluginIds: [params.pluginId],
-    traceCommand: "onboarding-plugin-install",
+  await invalidatePluginRuntimeDiscoveryAfterConfigMutation({
     logger: { warn: (message) => params.runtime.log(message) },
   });
   return result;
@@ -827,7 +823,6 @@ async function installPluginFromOverride(params: {
   override: PluginInstallOverride;
   prompter: WizardPrompter;
   runtime: RuntimeEnv;
-  workspaceDir?: string;
 }): Promise<OnboardingPluginInstallResult> {
   const { entry, prompter, runtime } = params;
   runtime.log?.(
@@ -946,7 +941,7 @@ async function installPluginFromOverride(params: {
       pluginId: result.pluginId,
       status: "installed",
     },
-    { runtime: params.runtime, workspaceDir: params.workspaceDir, pluginId: result.pluginId },
+    { runtime: params.runtime },
   );
 }
 
@@ -1045,7 +1040,6 @@ export async function ensureOnboardingPluginInstalled(params: {
       override: installOverride,
       prompter,
       runtime,
-      workspaceDir,
     });
   }
   const allowLocal = hasGitWorkspace(workspaceDir);
@@ -1139,7 +1133,7 @@ export async function ensureOnboardingPluginInstalled(params: {
           pluginId: entry.pluginId,
           status: "installed",
         },
-        { runtime, workspaceDir, pluginId: entry.pluginId },
+        { runtime },
       );
     }
     next = addPluginLoadPath(enableResult.config, localPath);
@@ -1151,7 +1145,7 @@ export async function ensureOnboardingPluginInstalled(params: {
         pluginId: entry.pluginId,
         status: "installed",
       },
-      { runtime, workspaceDir, pluginId: entry.pluginId },
+      { runtime },
     );
   }
 
@@ -1212,7 +1206,7 @@ export async function ensureOnboardingPluginInstalled(params: {
           pluginId: result.pluginId,
           status: "installed",
         },
-        { runtime, workspaceDir, pluginId: result.pluginId },
+        { runtime },
       );
     }
 
@@ -1337,7 +1331,7 @@ export async function ensureOnboardingPluginInstalled(params: {
         pluginId: result.pluginId,
         status: "installed",
       },
-      { runtime, workspaceDir, pluginId: result.pluginId },
+      { runtime },
     );
   }
 
@@ -1385,7 +1379,7 @@ export async function ensureOnboardingPluginInstalled(params: {
             pluginId: entry.pluginId,
             status: "installed",
           },
-          { runtime, workspaceDir, pluginId: entry.pluginId },
+          { runtime },
         );
       }
       next = addPluginLoadPath(enableResult.config, localPath);
@@ -1397,7 +1391,7 @@ export async function ensureOnboardingPluginInstalled(params: {
           pluginId: entry.pluginId,
           status: "installed",
         },
-        { runtime, workspaceDir, pluginId: entry.pluginId },
+        { runtime },
       );
     }
   }

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -96,6 +96,7 @@ async function markOnboardingPluginInstalled(
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     policyPluginIds: [params.pluginId],
     traceCommand: "onboarding-plugin-install",
+    logger: { warn: (message) => params.runtime.log(message) },
   });
   return result;
 }


### PR DESCRIPTION
## Summary

Fixes #95765.

First-time onboarding can install an external provider plugin and then immediately continue with the originally selected provider auth flow in the same run.

## What Problem This Solves

External provider plugins selected during first-time onboarding, such as DeepSeek, Groq, Cerebras, DeepInfra, and Chutes, could install successfully but still fail to become visible to the same onboarding process. The auth-choice resolver would then keep using stale provider plugin metadata/index state, so onboarding re-entered the provider selection/install path and eventually skipped the selected provider credential prompt.

The user-facing symptom looked like a plugin install loop: install the provider plugin, see it install, then still fail to reach the API key/auth prompt.

## Changes

- After every successful onboarding plugin install path, invalidate install-record, plugin metadata, and runtime loader caches.
- Keep canonical registry persistence in the caller's existing atomic config/install-record commit.
- Cover successful npm/ClawHub/local install paths, including fallback/local paths.
- Keep skip/failure/timeout paths from refreshing metadata/registry.
- Add/extend regression assertions in onboarding plugin install tests.

## Evidence

- Controlled Linux PTY matrix: five external providers failed to reach their credential prompt before the fix; all five reached it after process-local discovery invalidation. Three built-in providers remained unchanged.
- Targeted suite: 3 files / 51 tests passed.
- Hydrated Azure Crabbox `run_c7d6c5f502c9`: `scripts/e2e/onboard-docker.sh` completed package build/integrity plus channels and skills wizard cases, exit 0.

## Real behavior proof

All behavior verification below ran on the requested controlled server, using the public beta installer and isolated fresh profiles per provider round.

### Baseline before fix

Installed with:

```bash
curl -fsSL https://openclaw.ai/install.sh | bash -s -- --beta
```

Environment:

- OpenClaw `2026.6.10-beta.2 (87b40c7)`
- Node `v24.17.0`
- npm `11.13.0`
- Linux VM

Baseline matrix from the original beta install:

| Provider | Auth choice | Install prompts | Credential prompt seen | Search before key | Outcome |
|---|---|---:|---:|---:|---|
| DeepSeek | `deepseek-api-key` | 2 | No | Yes | `skipped_auth_after_install` |
| Groq | `groq-api-key` | 2 | No | Yes | `skipped_auth_after_install` |
| Cerebras | `cerebras-api-key` | 2 | No | Yes | `skipped_auth_after_install` |
| DeepInfra | `deepinfra-api-key` | 2 | No | Yes | `skipped_auth_after_install` |
| Chutes | `chutes-api-key` | 2 | No | Yes | `skipped_auth_after_install` |

### Fixed behavior after patch

The fixed behavior was validated on the same server. For behavior proof, I applied an equivalent validation patch to the installed beta dist file, ran the matrix against the real installed `openclaw` command, and then restored the original dist file afterward. The source branch contains the actual TypeScript fix.

Fixed matrix:

| Provider | Auth choice | Install prompts | Credential prompt seen | Search before key | Outcome |
|---|---|---:|---:|---:|---|
| DeepSeek | `deepseek-api-key` | 2 | Yes | No | `api_key_prompt_seen` |
| Groq | `groq-api-key` | 2 | Yes | No | `api_key_prompt_seen` |
| Cerebras | `cerebras-api-key` | 2 | Yes | No | `api_key_prompt_seen` |
| DeepInfra | `deepinfra-api-key` | 2 | Yes | No | `api_key_prompt_seen` |
| Chutes | `chutes-api-key` | 2 | Yes | No | `api_key_prompt_seen` |
| Fireworks | `fireworks-api-key` | 0 | Yes | No | `api_key_prompt_seen` |
| Together | `together-api-key` | 0 | Yes | No | `api_key_prompt_seen` |
| OpenRouter | `openrouter-api-key` | 0 | Yes | No | `api_key_prompt_seen` |

Note: the automated install-prompt counter still records two install prompt matches for external plugins because the interactive UI redraws the prompt text while the install flow is active. The important fixed condition is that onboarding reaches the selected provider credential prompt before Web Search. The fixed matrix has `apiKeyPromptSeen: true` and `skippedToSearchBeforeApiKey: false` for all eight providers.

### Targeted tests on the same server

Command:

```bash
node scripts/run-vitest.mjs run \
  src/commands/onboarding-plugin-install.test.ts \
  src/commands/auth-choice.apply.plugin-provider.test.ts \
  src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.test.ts
```

Result:

- 3 files passed.
- 51 tests passed.

### Changed-file formatting on the same server

Command:

```bash
corepack pnpm exec oxfmt --check --threads=1 \
  src/commands/onboarding-plugin-install.ts \
  src/commands/onboarding-plugin-install.test.ts
```

Result: passed.

### Full build note

I also attempted `pnpm build:strict-smoke` on the same server. The server has about 3.6 GiB RAM and `tsdown` was killed by OOM even after adding temporary swap. This appears to be a server resource limit rather than a patch failure. Full build coverage should come from GitHub Actions.

Self-owned fork CI was also dispatched for the current head: https://github.com/snowzlmbot/openclaw/actions/runs/27960004165

### Exact implementation E2E

The final non-persisting implementation passed the full Docker onboarding E2E on a hydrated Azure Crabbox:

- Run: `run_c7d6c5f502c9`
- Provider / lease: Azure `cbx_3bf60a77cb0f` (`amber-hermit`)
- Command: `scripts/e2e/onboard-docker.sh`
- Result: both `channels` and `skills` wizard cases completed; exit 0.

## Risk

Low-to-moderate onboarding/plugin registry risk:

- Invalidation only runs after successful onboarding plugin install paths.
- Skip/failure/timeout paths do not invalidate discovery.
- No pending install record is persisted before the caller commits config.
- This makes newly installed provider plugins visible in the same process, matching what direct `models auth login --provider <provider>` could already do after onboarding.

## Cleanup / privacy

- Each real onboarding round used an isolated `loop49-*` profile and cleaned profile/workspace/systemd service afterward.
- Raw transcripts containing temporary local gateway URLs were not retained in the working evidence directory; only sanitized logs/status summaries were kept.
- Hostnames, IPs, tokens, and local-only identifiers are omitted from this PR body.


