### PR TITLE
feat(infra): add OpenRouter provider usage/cost fetch

### DIFF
--- a/src/infra/provider-usage.auth.ts
+++ b/src/infra/provider-usage.auth.ts
@@ -93,6 +93,13 @@ function resolveXiaomiApiKey(): string | undefined {
   });
 }
 
+function resolveOpenRouterApiKey(): string | undefined {
+  return resolveProviderApiKeyFromConfigAndStore({
+    providerId: "openrouter",
+    envDirect: [process.env.OPENROUTER_API_KEY],
+  });
+}
+
 function resolveProviderApiKeyFromConfigAndStore(params: {
   providerId: UsageProviderId;
   envDirect: Array<string | undefined>;
@@ -246,6 +253,13 @@ export async function resolveProviderAuths(params: {
     }
     if (provider === "xiaomi") {
       const apiKey = resolveXiaomiApiKey();
+      if (apiKey) {
+        auths.push({ provider, token: apiKey });
+      }
+      continue;
+    }
+    if (provider === "openrouter") {
+      const apiKey = resolveOpenRouterApiKey();
       if (apiKey) {
         auths.push({ provider, token: apiKey });
       }

--- a/src/infra/provider-usage.fetch.openrouter.test.ts
+++ b/src/infra/provider-usage.fetch.openrouter.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { createProviderUsageFetch, makeResponse } from "../test-utils/provider-usage-fetch.js";
+import { fetchOpenRouterUsage } from "./provider-usage.fetch.openrouter.js";
+
+describe("fetchOpenRouterUsage", () => {
+  it("returns HTTP errors for failed requests", async () => {
+    const mockFetch = createProviderUsageFetch(async () => makeResponse(401, "unauthorized"));
+    const result = await fetchOpenRouterUsage("key", 5000, mockFetch);
+
+    expect(result.error).toBe("HTTP 401");
+    expect(result.windows).toHaveLength(0);
+  });
+
+  it("builds a credits window when a limit is set", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        data: { limit: 100, limit_remaining: 75, usage: 25 },
+      }),
+    );
+
+    const result = await fetchOpenRouterUsage("key", 5000, mockFetch);
+    expect(result.provider).toBe("openrouter");
+    expect(result.displayName).toBe("OpenRouter");
+    expect(result.windows).toHaveLength(1);
+    expect(result.windows[0]).toMatchObject({
+      label: "Credits",
+      usedPercent: 25,
+    });
+  });
+
+  it("returns no windows for pay-as-you-go keys (limit null)", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, { data: { limit: null, usage: 12.5 } }),
+    );
+
+    const result = await fetchOpenRouterUsage("key", 5000, mockFetch);
+    expect(result.windows).toHaveLength(0);
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/src/infra/provider-usage.fetch.openrouter.ts
+++ b/src/infra/provider-usage.fetch.openrouter.ts
@@ -1,0 +1,71 @@
+import { buildUsageHttpErrorSnapshot, fetchJson } from "./provider-usage.fetch.shared.js";
+import { clampPercent, PROVIDER_LABELS } from "./provider-usage.shared.js";
+import type { ProviderUsageSnapshot, UsageWindow } from "./provider-usage.types.js";
+
+// https://openrouter.ai/api/v1/key — returns credit usage/limit for the bearer key.
+// `limit`/`usage` are denominated in OpenRouter credits; `limit` is null for
+// pay-as-you-go keys (no cap), in which case a percentage window is not meaningful.
+type OpenRouterKeyResponse = {
+  data?: {
+    limit?: number | null;
+    limit_remaining?: number | null;
+    usage?: number;
+  };
+};
+
+export async function fetchOpenRouterUsage(
+  token: string,
+  timeoutMs: number,
+  fetchFn: typeof fetch,
+): Promise<ProviderUsageSnapshot> {
+  const res = await fetchJson(
+    "https://openrouter.ai/api/v1/key",
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+    },
+    timeoutMs,
+    fetchFn,
+  );
+
+  if (!res.ok) {
+    let message: string | undefined;
+    try {
+      const data = (await res.json()) as {
+        error?: { message?: unknown } | null;
+      };
+      const raw = data?.error?.message;
+      if (typeof raw === "string" && raw.trim()) {
+        message = raw.trim();
+      }
+    } catch {
+      // ignore parse errors
+    }
+    return buildUsageHttpErrorSnapshot({
+      provider: "openrouter",
+      status: res.status,
+      message,
+    });
+  }
+
+  const { data } = (await res.json()) as OpenRouterKeyResponse;
+  const windows: UsageWindow[] = [];
+  const limit = data?.limit;
+  const usage = data?.usage;
+  // Only a capped key yields a meaningful utilization percentage. Pay-as-you-go
+  // keys (limit === null) report spend but no denominator, so emit no window.
+  if (typeof limit === "number" && limit > 0 && typeof usage === "number") {
+    windows.push({
+      label: "Credits",
+      usedPercent: clampPercent((usage / limit) * 100),
+    });
+  }
+
+  return {
+    provider: "openrouter",
+    displayName: PROVIDER_LABELS.openrouter,
+    windows,
+  };
+}

--- a/src/infra/provider-usage.fetch.ts
+++ b/src/infra/provider-usage.fetch.ts
@@ -3,4 +3,5 @@ export { fetchCodexUsage } from "./provider-usage.fetch.codex.js";
 export { fetchCopilotUsage } from "./provider-usage.fetch.copilot.js";
 export { fetchGeminiUsage } from "./provider-usage.fetch.gemini.js";
 export { fetchMinimaxUsage } from "./provider-usage.fetch.minimax.js";
+export { fetchOpenRouterUsage } from "./provider-usage.fetch.openrouter.js";
 export { fetchZaiUsage } from "./provider-usage.fetch.zai.js";

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -6,6 +6,7 @@ import {
   fetchCopilotUsage,
   fetchGeminiUsage,
   fetchMinimaxUsage,
+  fetchOpenRouterUsage,
   fetchZaiUsage,
 } from "./provider-usage.fetch.js";
 import {
@@ -63,6 +64,8 @@ export async function loadProviderUsageSummary(
             return await fetchCodexUsage(auth.token, auth.accountId, timeoutMs, fetchFn);
           case "minimax":
             return await fetchMinimaxUsage(auth.token, timeoutMs, fetchFn);
+          case "openrouter":
+            return await fetchOpenRouterUsage(auth.token, timeoutMs, fetchFn);
           case "xiaomi":
             return {
               provider: "xiaomi",

--- a/src/infra/provider-usage.shared.ts
+++ b/src/infra/provider-usage.shared.ts
@@ -9,6 +9,7 @@ export const PROVIDER_LABELS: Record<UsageProviderId, string> = {
   "google-gemini-cli": "Gemini",
   minimax: "MiniMax",
   "openai-codex": "Codex",
+  openrouter: "OpenRouter",
   xiaomi: "Xiaomi",
   zai: "z.ai",
 };
@@ -19,6 +20,7 @@ export const usageProviders: UsageProviderId[] = [
   "google-gemini-cli",
   "minimax",
   "openai-codex",
+  "openrouter",
   "xiaomi",
   "zai",
 ];

--- a/src/infra/provider-usage.types.ts
+++ b/src/infra/provider-usage.types.ts
@@ -23,5 +23,6 @@ export type UsageProviderId =
   | "google-gemini-cli"
   | "minimax"
   | "openai-codex"
+  | "openrouter"
   | "xiaomi"
   | "zai";


### PR DESCRIPTION
## Summary

Adds OpenRouter to the provider-usage subsystem so usage/cost can be fetched for the OpenRouter provider, matching the existing pattern used by the other usage providers.

OpenRouter already has a model adapter in the codebase (`buildOpenrouterProvider`), but there was no usage/cost fetcher for it. This wires one in.

## What this does

- New `src/infra/provider-usage.fetch.openrouter.ts` — fetches credit/usage via OpenRouter's `GET /api/v1/key` (Bearer auth, credit-denominated; handles `limit: null`).
- Wires OpenRouter through the existing provider-usage seams:
  - `provider-usage.types.ts` — add `openrouter` to the provider id union
  - `provider-usage.shared.ts` — label + provider list entry
  - `provider-usage.fetch.ts` — export the new fetcher
  - `provider-usage.load.ts` — dispatch case
  - `provider-usage.auth.ts` — resolve the API key from config/store
- Unit test `provider-usage.fetch.openrouter.test.ts`.

## Notes

- Follows the repo conventions: ESM `.js` import specifiers, no `any`, mirrors the structure of the existing per-provider fetchers.
- Scope is intentionally minimal — usage/cost fetch only; no behavior change to existing providers.
- +132 lines across 7 files, test included.

## Test plan

- [ ] `pnpm tsgo` (type check)
- [ ] `pnpm check` (lint/format)
- [ ] `pnpm test` (the new `provider-usage.fetch.openrouter.test.ts` + existing provider-usage suite)

---

<sub>※ このファイルは PR 本文のドラフトです。提出前に上流の CONTRIBUTING / PR テンプレに合わせて調整してください。</sub>
