### PR TITLE
fix: /status is too verbose for pinned model sessions

### DIFF
--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -1470,7 +1470,7 @@ describe("buildStatusReply subagent summary", () => {
     });
 
     const normalized = normalizeTestText(text);
-    expect(normalized).toContain("Session selected: anthropic/claude-opus-4-7");
+    expect(normalized).toContain("Model: anthropic/claude-opus-4-7");
     expect(normalized).toContain("oauth (claude-cli)");
     expect(normalized).not.toContain("api-key (env: ANTHROPIC_API_KEY)");
     expect(normalized).not.toContain("Usage:");

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -1732,7 +1732,7 @@ describe("buildStatusMessage", () => {
     });
 
     const normalized = normalizeTestText(text);
-    expect(normalized).toContain("Session selected: google/gemini-3.1-flash-lite");
+    expect(normalized).toContain("Model: google/gemini-3.1-flash-lite");
     expect(normalized).not.toContain("Fallbacks:");
   });
 
@@ -1765,7 +1765,7 @@ describe("buildStatusMessage", () => {
     expect(normalizeTestText(text)).toContain("Model: google-antigravity/claude-sonnet-4-6");
   });
 
-  it("warns when the session-selected model differs from the configured default", () => {
+  it("renders session-selected model overrides compactly", () => {
     const text = buildStatusMessage({
       agent: {
         model: "zhipu/glm-4.5-air",
@@ -1785,14 +1785,14 @@ describe("buildStatusMessage", () => {
     });
 
     const normalized = normalizeTestText(text);
-    expect(normalized).toContain("Configured default: zhipu/glm-4.5-air");
-    expect(normalized).toContain("Session selected: deepseek/deepseek-v4-flash");
-    expect(normalized).toContain("Reason: session override");
-    expect(normalized).toContain(
-      "This session is pinned to deepseek/deepseek-v4-flash; config primary zhipu/glm-4.5-air will apply to new/unpinned sessions.",
-    );
-    expect(normalized).toContain("Clear with: /model default");
-    expect(normalized).toContain(
+    expect(normalized).toContain("Model: deepseek/deepseek-v4-flash");
+    expect(normalized).toContain("session override, default zhipu/glm-4.5-air");
+    expect(normalized).toContain("clear /model default");
+    expect(normalized).not.toContain("Configured default:");
+    expect(normalized).not.toContain("Session selected:");
+    expect(normalized).not.toContain("Reason: session override");
+    expect(normalized).not.toContain("This session is pinned");
+    expect(normalized).not.toContain(
       "Docs: https://docs.openclaw.ai/concepts/models#selection-source-and-fallback-behavior",
     );
   });

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -1786,7 +1786,7 @@ describe("buildStatusMessage", () => {
 
     const normalized = normalizeTestText(text);
     expect(normalized).toContain("Model: deepseek/deepseek-v4-flash");
-    expect(normalized).toContain("session override, default zhipu/glm-4.5-air");
+    expect(normalized).toContain("pinned session; config primary zhipu/glm-4.5-air");
     expect(normalized).toContain("clear /model default");
     expect(normalized).not.toContain("Configured default:");
     expect(normalized).not.toContain("Session selected:");

--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -60,7 +60,8 @@ describe("buildStatusMessage context window", () => {
       modelAuth: "api-key",
     });
 
-    expect(text).toContain("Session selected: ollama-cloud/glm-5.1");
+    expect(text).toContain("Model: ollama-cloud/glm-5.1");
+    expect(text).toContain("session override, default ollama-cloud/deepseek-v4-pro");
     expect(text).toContain("Context: 128k/200k");
     expect(text).not.toContain("Context: 128k/1.0m");
   });
@@ -127,5 +128,4 @@ describe("buildStatusMessage context window", () => {
     expect(text).toContain("Context: 36k/1.0m");
     expect(text).not.toContain("Context: 36k/200k");
   });
-
 });

--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -61,7 +61,7 @@ describe("buildStatusMessage context window", () => {
     });
 
     expect(text).toContain("Model: ollama-cloud/glm-5.1");
-    expect(text).toContain("session override, default ollama-cloud/deepseek-v4-pro");
+    expect(text).toContain("pinned session; config primary ollama-cloud/deepseek-v4-pro");
     expect(text).toContain("Context: 128k/200k");
     expect(text).not.toContain("Context: 128k/1.0m");
   });

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -1070,16 +1070,12 @@ export function buildStatusMessage(args: StatusArgs): string {
     !areRuntimeModelRefsEquivalent(selectedModelLabel, configuredDefaultModelLabel, {
       config: args.config,
     });
-  const modelLines = configDefaultDiffersFromSession
-    ? [
-        `🧠 Configured default: ${configuredDefaultModelLabel}`,
-        `📌 Session selected: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`,
-        "⚠️ Reason: session override",
-        `⚠️ This session is pinned to ${selectedModelLabel}; config primary ${configuredDefaultModelLabel} will apply to new/unpinned sessions.`,
-        "↩️ Clear with: /model default",
-        "📖 Docs: https://docs.openclaw.ai/concepts/models#selection-source-and-fallback-behavior",
-      ]
-    : [`🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`];
+  const overrideLabel = configDefaultDiffersFromSession
+    ? ` · session override, default ${configuredDefaultModelLabel} · clear /model default`
+    : "";
+  const modelLines = [
+    `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}${overrideLabel}`,
+  ];
 
   // Show configured fallback models (from agent model config)
   const configuredFallbacks = (() => {

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -1071,7 +1071,7 @@ export function buildStatusMessage(args: StatusArgs): string {
       config: args.config,
     });
   const overrideLabel = configDefaultDiffersFromSession
-    ? ` · session override, default ${configuredDefaultModelLabel} · clear /model default`
+    ? ` · pinned session; config primary ${configuredDefaultModelLabel} · clear /model default`
     : "";
   const modelLines = [
     `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}${overrideLabel}`,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users checking `/status` would see a long model-selection explanation when the current session was pinned to a non-default model.

The affected workflow is chat `/status` in channels such as Discord. In the pinned-session case, the default response expanded into multiple lines for configured default, selected model, override reason, clear command, and docs, which made the status response harder to scan.

AI-assisted: yes, prepared with Codex and reviewed locally against the focused status formatter diff.

## Why This Change Was Made

Chat `/status` now keeps the active model, auth label, pinned-session marker, config primary, and clear command on the single model line. The detailed CLI status report remains the verbose diagnostic surface; this PR only compacts the chat status renderer.

## User Impact

Users with a non-default or session-pinned model still see which model is active and how to clear the override, but `/status` is shorter and closer to the previous compact design.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/status.test.ts src/status/status-message.test.ts src/auto-reply/reply/commands-status.test.ts`
- `git diff --check origin/main...HEAD`
- Local after-proof: installed the patched package into the active local gateway, restarted the gateway, and confirmed Discord `/status` shows one compact model override line instead of the previous multi-line default/session/docs block.

![After proof: compact Discord /status model override output](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw/pr-95797/status-after-compact-redacted.png)

Proof asset: https://github.com/Solvely-Colin/pr-proof-assets/blob/main/openclaw/pr-95797/status-after-compact-redacted.png
