### PR TITLE
fix(heartbeat): allow reasoning/thinking blocks in heartbeat ack filt…

### DIFF
--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -135,6 +135,51 @@ describe("isHeartbeatOkResponse", () => {
       ),
     ).toBe(false);
   });
+
+  it("matches heartbeat acks that include reasoning blocks", () => {
+    // Model-internal reasoning blocks should not prevent heartbeat filtering.
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Checking for new tasks..." },
+          { type: "text", text: "HEARTBEAT_OK" },
+        ],
+      }),
+    ).toBe(true);
+
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: [
+          { type: "reasoning", reasoning: "Nothing to do" },
+          { type: "text", text: "HEARTBEAT_OK" },
+        ],
+      }),
+    ).toBe(true);
+
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", data: "redacted..." },
+          { type: "text", text: "HEARTBEAT_OK" },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not match heartbeat when reasoning is mixed with non-text content", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Checking..." },
+          { type: "tool_use", id: "tool-1", name: "search", input: {} },
+        ],
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("filterHeartbeatTranscriptArtifacts", () => {
@@ -187,6 +232,30 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
         },
       ]);
     }
+  });
+
+  it("removes heartbeat pairs where the assistant response includes reasoning blocks", () => {
+    const messages = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there!" },
+      { role: "user", content: HEARTBEAT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Checking for due tasks..." },
+          { type: "text", text: "HEARTBEAT_OK" },
+        ],
+      },
+      { role: "user", content: "What time is it?" },
+      { role: "assistant", content: "It is 3pm." },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there!" },
+      { role: "user", content: "What time is it?" },
+      { role: "assistant", content: "It is 3pm." },
+    ]);
   });
 
   it("removes prompt-only interrupted heartbeat spans", () => {

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -269,6 +269,18 @@ function resolveMessageText(content: unknown): { text: string; hasNonTextContent
       continue;
     }
     if (block.type !== "text" && block.type !== "input_text" && block.type !== "output_text") {
+      // Model-internal reasoning/thinking blocks are invisible to the user and should
+      // not prevent heartbeat filtering. They are ephemeral model artifacts, not
+      // content that the user sees or responds to. Skipping them here lets
+      // isHeartbeatOkResponse correctly classify short HEARTBEAT_OK acks even when
+      // the model emits reasoning alongside the text response.
+      if (
+        block.type === "reasoning" ||
+        block.type === "thinking" ||
+        block.type === "redacted_thinking"
+      ) {
+        continue;
+      }
       hasNonTextContent = true;
       continue;
     }


### PR DESCRIPTION
Fixes #95796

### Summary

Problem: Heartbeat transcript filtering inconsistently preserved or removed suppressed HEARTBEAT_OK turns from model request history depending on whether the final assistant message contained non-text reasoning/thinking content. When the assistant's heartbeat acknowledgement included a `thinking`, `reasoning`, or `redacted_thinking` block, the entire heartbeat prompt/ack pair was left in the context, wasting tokens and polluting the model prompt.

Solution: Treat model-internal reasoning/thinking blocks as invisible to the heartbeat filter. `resolveMessageText` now skips `thinking`/`reasoning`/`redacted_thinking` block types when computing `hasNonTextContent`, allowing `isHeartbeatOkResponse` to correctly recognize short HEARTBEAT_OK acks even when the model emits reasoning alongside the text response.

What changed: 
- Updated `resolveMessageText` in `heartbeat-filter.ts` to ignore reasoning blocks; added regression tests in `heartbeat-filter.test.ts` for `isHeartbeatOkResponse` and `filterHeartbeatTranscriptArtifacts` with reasoning/thinking blocks.
- Added `redacted_thinking` to the skipped reasoning block types (was missing in the original fix).
- Improved inline comment in `resolveMessageText` to explain WHY reasoning blocks are skipped (ephemeral model artifacts, not user-visible content).
- Added boundary test for reasoning mixed with non-text content (e.g., `tool_use`) to ensure it correctly returns `false`.

What did NOT change: Heartbeat token detection logic, maxAckChars enforcement, tool-call handling in heartbeat filtering, user-message heartbeat prompt detection, or the `stripHeartbeatToken` contract.



### Real behavior proof

Behavior addressed: Assistant messages containing both a reasoning block and a short HEARTBEAT_OK text block were incorrectly classified as non-heartbeat content, causing the heartbeat span to remain in the transcript.

Real environment tested: Linux, Node v22.23.0, OpenClaw worktree SHA 034787c9a8

Exact steps or command run after this patch:

```bash
# Test: Verify heartbeat ack with reasoning blocks is correctly identified
node -e "
const { isHeartbeatOkResponse } = require('./src/auto-reply/heartbeat-filter.ts');
const result = isHeartbeatOkResponse({
  role: 'assistant',
  content: [
    { type: 'thinking', thinking: 'Checking for new tasks...' },
    { type: 'text', text: 'HEARTBEAT_OK' },
  ],
});
console.log('isHeartbeatOkResponse:', result);
"
```

Evidence after fix:
```
isHeartbeatOkResponse: true
```

Before evidence (Negative control — old code):
```bash
node -e "
const { isHeartbeatOkResponse } = require('./src/auto-reply/heartbeat-filter.ts');
const result = isHeartbeatOkResponse({
  role: 'assistant',
  content: [
    { type: 'thinking', thinking: 'Checking for new tasks...' },
    { type: 'text', text: 'HEARTBEAT_OK' },
  ],
});
console.log('isHeartbeatOkResponse:', result);
"
```

Output:
```
isHeartbeatOkResponse: false
```

Test suite results:
```bash
pnpm test src/auto-reply/heartbeat-filter.test.ts --run
```

Output:
```
[test] starting test/vitest/vitest.unit-fast.config.ts

 ✓ |unit-fast| src/auto-reply/heartbeat-filter.test.ts (37 tests) 19ms

 Test Files  1 passed (1)
      Tests  37 passed (37)
```

All 37 tests pass. Key regression assertions:
- `matches heartbeat acks that include reasoning blocks` — verifies `isHeartbeatOkResponse` returns `true` for assistant messages with `thinking`/`reasoning`/`redacted_thinking` blocks + `HEARTBEAT_OK` text
- `removes heartbeat pairs where the assistant response includes reasoning blocks` — verifies `filterHeartbeatTranscriptArtifacts` strips the full heartbeat span from the transcript when the assistant ack includes reasoning blocks
- `does not match heartbeat when reasoning is mixed with non-text content` — verifies `isHeartbeatOkResponse` returns `false` when reasoning is mixed with tool calls or other non-text content

Observed result after fix: Messages like `[{ type: "thinking", thinking: "Checking..." }, { type: "text", text: "HEARTBEAT_OK" }]` are now correctly recognized as heartbeat acks and removed from the transcript.

What was not tested: Live model streaming with actual heartbeat reasoning blocks; the fix is verified through unit tests and the logic path is deterministic.

### Regression Test Plan

Coverage level: Unit-fast regression tests

Target test file: `src/auto-reply/heartbeat-filter.test.ts`

Scenario locked in:
1. `isHeartbeatOkResponse` returns `true` for assistant messages containing `thinking`/`reasoning`/`redacted_thinking` blocks alongside a short HEARTBEAT_OK text block.
2. `filterHeartbeatTranscriptArtifacts` removes the full heartbeat span (user prompt + assistant ack) when the assistant ack includes reasoning blocks.
3. `isHeartbeatOkResponse` returns `false` when reasoning blocks are mixed with other non-text content (e.g., `tool_use`), ensuring we don't over-match.

Why this is the smallest reliable guardrail: The three new tests cover the exact boundary that was broken (`resolveMessageText` flagging reasoning blocks as non-text), the end-to-end behavior (`filterHeartbeatTranscriptArtifacts` span removal), and a safety boundary (reasoning + non-text returns false), without touching other heartbeat logic paths.

### Root Cause

Root cause: `resolveMessageText` iterated over every block in the message content array and set `hasNonTextContent = true` for any block type other than `text`/`input_text`/`output_text`. This included model-internal reasoning blocks (`thinking`, `reasoning`, `redacted_thinking`), which are not user-visible and should not disqualify a message from being a heartbeat ack.

Missing detection / guardrail: Existing tests covered heartbeat filtering with plain text, tool calls, and tool results, but did not test the case where a heartbeat ack message contained reasoning blocks. The `hasNonTextContent` check was too broad and lacked a carve-out for reasoning content.

### Risk checklist

- **Did user-visible behavior change?** No — reasoning blocks are already hidden from users; this fix only affects internal transcript filtering.
- **Did config/environment/migration behavior change?** No — no new config keys.
- **Did security/auth behavior change?** No — the change is purely in message classification logic.

AI-assisted.
