### PR TITLE
fix(telegram): allow same-chat sends when bound to a topic

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -76,6 +76,7 @@ import { resolveTelegramReactionLevel } from "./reaction-level.js";
 import { resolveTelegramStartupProbeTimeoutMs } from "./request-timeouts.js";
 import { getTelegramRuntime } from "./runtime.js";
 import { telegramSecurityAdapter } from "./security.js";
+import { loadTelegramSendModule } from "./send-runtime.js";
 import {
   resolveTelegramSessionConversation,
   resolveTelegramSessionTarget,
@@ -91,8 +92,7 @@ import {
 import { withTelegramStartupProbeSlot } from "./startup-probe-limiter.js";
 import { detectTelegramLegacyStateMigrations } from "./state-migrations.js";
 import { collectTelegramStatusIssues } from "./status-issues.js";
-import { parseTelegramTarget } from "./targets.js";
-import { loadTelegramSendModule } from "./send-runtime.js";
+import { parseTelegramTarget, telegramContextTargetsMatch } from "./targets.js";
 import {
   createTelegramThreadBindingManager,
   setTelegramThreadBindingIdleTimeoutBySessionKey,
@@ -1184,6 +1184,8 @@ export const telegramPlugin = createChatChannelPlugin({
     topLevelReplyToMode: "telegram",
     buildToolContext: (params) => buildTelegramThreadingToolContext(params),
     resolveAutoThreadId: ({ to, toolContext }) => resolveTelegramAutoThreadId({ to, toolContext }),
+    matchesToolContextTarget: ({ target, toolContext }) =>
+      telegramContextTargetsMatch(target, toolContext),
     resolveCurrentChannelId: ({ to, threadId }) => {
       if (threadId == null) {
         return to;

--- a/extensions/telegram/src/targets.test.ts
+++ b/extensions/telegram/src/targets.test.ts
@@ -18,6 +18,7 @@ import {
   normalizeTelegramOutboundTarget,
   parseTelegramTarget,
   stripTelegramInternalPrefixes,
+  telegramContextTargetsMatch,
 } from "./targets.js";
 
 const numericTelegramTargetNormalizers = [
@@ -307,6 +308,76 @@ describe("telegram target normalization", () => {
     expect(looksLikeTelegramTargetId("telegram:123456")).toBe(true);
     expect(looksLikeTelegramTargetId("tg:group:-100123")).toBe(true);
     expect(looksLikeTelegramTargetId("hello world")).toBe(false);
+  });
+});
+
+describe("telegramContextTargetsMatch", () => {
+  it("matches bare user against topic-bound context", () => {
+    expect(
+      telegramContextTargetsMatch("477789300", {
+        currentMessagingTarget: "477789300:topic:340799",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches bare user against bare context", () => {
+    expect(
+      telegramContextTargetsMatch("477789300", {
+        currentMessagingTarget: "477789300",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches the same explicit topic in the same chat", () => {
+    expect(
+      telegramContextTargetsMatch("477789300:topic:340799", {
+        currentMessagingTarget: "477789300:topic:340799",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a different explicit topic in the same chat", () => {
+    expect(
+      telegramContextTargetsMatch("477789300:topic:340800", {
+        currentMessagingTarget: "477789300:topic:340799",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects an explicit topic target against a bare context", () => {
+    expect(
+      telegramContextTargetsMatch("477789300:topic:340799", {
+        currentMessagingTarget: "477789300",
+      }),
+    ).toBe(false);
+  });
+
+  it("matches via currentChannelId when currentMessagingTarget is absent", () => {
+    expect(
+      telegramContextTargetsMatch("477789300", {
+        currentChannelId: "477789300:topic:340799",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a different chat", () => {
+    expect(
+      telegramContextTargetsMatch("999999999", {
+        currentMessagingTarget: "477789300:topic:340799",
+      }),
+    ).toBe(false);
+  });
+
+  it("strips the telegram prefix before comparison", () => {
+    expect(
+      telegramContextTargetsMatch("telegram:477789300", {
+        currentMessagingTarget: "telegram:477789300:topic:340799",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false without any context targets", () => {
+    expect(telegramContextTargetsMatch("477789300", {})).toBe(false);
   });
 });
 

--- a/extensions/telegram/src/targets.ts
+++ b/extensions/telegram/src/targets.ts
@@ -144,3 +144,31 @@ export function parseTelegramTarget(to: string): TelegramTarget {
 export function resolveTelegramTargetChatType(target: string): "direct" | "group" | "unknown" {
   return parseTelegramTarget(target).chatType;
 }
+
+// Telegram cross-context matching is chat-scoped, but a topic is a conversation
+// key under allowWithinProvider:false, not a cosmetic thread. A bare target (no
+// explicit topic) auto-threads back into the bound topic, so it stays in the
+// current conversation and matches, e.g. "477789300" matches
+// "477789300:topic:340799". An explicit topic must match the bound topic
+// exactly; an explicit *different* topic in the same chat is a separate
+// conversation and stays cross-context so the guard can still deny it.
+export function telegramContextTargetsMatch(
+  target: string,
+  context: { currentChannelId?: string; currentMessagingTarget?: string },
+): boolean {
+  const parsedTarget = parseTelegramTarget(target);
+  const targetChatId = parsedTarget.chatId.toLowerCase();
+  const candidates = [context.currentMessagingTarget, context.currentChannelId].filter(
+    (value): value is string => Boolean(value),
+  );
+  return candidates.some((candidate) => {
+    const parsedCandidate = parseTelegramTarget(candidate);
+    if (parsedCandidate.chatId.toLowerCase() !== targetChatId) {
+      return false;
+    }
+    return (
+      parsedTarget.messageThreadId === undefined ||
+      parsedTarget.messageThreadId === parsedCandidate.messageThreadId
+    );
+  });
+}

--- a/src/infra/outbound/outbound-policy.test.ts
+++ b/src/infra/outbound/outbound-policy.test.ts
@@ -35,6 +35,40 @@ const mocks = vi.hoisted(() => ({
         },
       };
     }
+    if (channel === "telegram") {
+      return {
+        threading: {
+          matchesToolContextTarget: ({
+            target,
+            toolContext,
+          }: {
+            target: string;
+            toolContext: { currentMessagingTarget?: string; currentChannelId?: string };
+          }) => {
+            const parse = (value: string) => {
+              const match = /^(.+):topic:(\d+)$/.exec(value);
+              return match
+                ? { chatId: match[1], topic: match[2] }
+                : { chatId: value, topic: undefined };
+            };
+            const parsedTarget = parse(target);
+            const candidates = [
+              toolContext.currentMessagingTarget,
+              toolContext.currentChannelId,
+            ].filter((value): value is string => Boolean(value));
+            return candidates.some((candidate) => {
+              const parsedCandidate = parse(candidate);
+              if (parsedCandidate.chatId !== parsedTarget.chatId) {
+                return false;
+              }
+              return (
+                parsedTarget.topic === undefined || parsedTarget.topic === parsedCandidate.topic
+              );
+            });
+          },
+        },
+      };
+    }
     if (channel === "richchat") {
       return {
         messaging: {
@@ -297,6 +331,66 @@ describe("outbound policy helpers", () => {
         },
       }),
     ).not.toThrow();
+  });
+
+  it("allows a bare Telegram user target when bound to a topic context", () => {
+    expect(() =>
+      enforceCrossContextPolicy({
+        channel: "telegram",
+        action: "send",
+        args: { to: "477789300" },
+        toolContext: {
+          currentChannelId: "477789300:topic:340799",
+          currentMessagingTarget: "477789300:topic:340799",
+          currentChannelProvider: "telegram",
+        },
+        cfg: {
+          tools: {
+            message: { crossContext: { allowWithinProvider: false } },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("denies a different Telegram chat when within-provider sends are disabled", () => {
+    expect(() =>
+      enforceCrossContextPolicy({
+        channel: "telegram",
+        action: "send",
+        args: { to: "999999999" },
+        toolContext: {
+          currentChannelId: "477789300:topic:340799",
+          currentMessagingTarget: "477789300:topic:340799",
+          currentChannelProvider: "telegram",
+        },
+        cfg: {
+          tools: {
+            message: { crossContext: { allowWithinProvider: false } },
+          },
+        },
+      }),
+    ).toThrow(/Cross-context messaging denied/);
+  });
+
+  it("denies an explicit different Telegram topic when within-provider sends are disabled", () => {
+    expect(() =>
+      enforceCrossContextPolicy({
+        channel: "telegram",
+        action: "send",
+        args: { to: "477789300:topic:340800" },
+        toolContext: {
+          currentChannelId: "477789300:topic:340799",
+          currentMessagingTarget: "477789300:topic:340799",
+          currentChannelProvider: "telegram",
+        },
+        cfg: {
+          tools: {
+            message: { crossContext: { allowWithinProvider: false } },
+          },
+        },
+      }),
+    ).toThrow(/Cross-context messaging denied/);
   });
 
   it("uses presentation when available and preferred", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an agent or cron bound to a Telegram **forum topic** would hit `Cross-context messaging denied` when it tried to message the **same chat** by its bare id.

When a turn is bound to a topic, the bound context is recorded with a topic suffix (e.g. `477789300:topic:340799`). If the agent then sends to the same chat with the bare target `477789300` (which is what cron deliveries and "reply to the user" sends naturally produce), the cross-context guard compared the raw target string against the topic-suffixed context, saw a mismatch, and — with `tools.message.crossContext.allowWithinProvider: false` — threw, blocking a legitimate same-chat send.

## Why This Change Was Made

Telegram channels implemented the threading adapter but not the optional `matchesToolContextTarget` hook, so the guard fell back to exact string comparison and treated a topic suffix as a different context.

This change implements `matchesToolContextTarget` for Telegram. A **bare** target (no explicit topic) matches a topic-bound context for the same chat and auto-threads back into the bound topic, so it stays in the current conversation — exactly the case cron deliveries and "reply to the user" sends produce. An **explicit** topic must still match the bound topic exactly: a *different* topic in the same chat is a separate conversation and stays cross-context, so `allowWithinProvider: false` still denies it. Only the channel's own hook is filled in; no SDK contract or shared policy change.

## User Impact

Agents and crons bound to a Telegram topic can again message the user/chat they are bound to, even with `allowWithinProvider: false`. Explicit sends to a different topic or a different chat are still guarded as before. No configuration change required.

AI-assisted (Claude). Authored with the maintainer's review; "Allow edits by maintainers" is enabled.

## Evidence

Rebased onto current `main` (the branch was 424 commits behind). This clears the previously failing `check-additional-runtime-topology-architecture` check, which was an unrelated stale Kysely raw-SQLite allowlist entry (`src/infra/sqlite-user-version.ts` — identical on both refs; `main` already added it to the allowlist), not anything in this diff.

Matcher narrowed per the ClawSweeper [P1] finding so an explicit *different* topic in the same chat stays cross-context.

New unit + policy tests and the touched suites, green locally:

```
# matcher + policy
node scripts/run-vitest.mjs extensions/telegram/src/targets.test.ts     → 49 passed
node scripts/run-vitest.mjs src/infra/outbound/outbound-policy.test.ts   → 27 passed

# typecheck (incl. tests)
pnpm tsgo:extensions:test  → exit 0
pnpm tsgo:core:test        → exit 0

# architecture guard (was failing pre-rebase)
pnpm check:architecture    → all guards passed

# formatting
oxfmt --check <touched files> → all correctly formatted
```

Test coverage:
- `telegramContextTargetsMatch`: bare↔topic, bare↔bare, same explicit topic↔same chat (match); **different explicit topic↔same chat (no match)**, **explicit topic↔bare context (no match)**, `currentChannelId` fallback, `telegram:` prefix stripping, different-chat rejection, empty-context.
- `enforceCrossContextPolicy` (telegram): allows a bare user target bound to a topic context; **denies an explicit different topic** and denies a different chat when `allowWithinProvider: false`.

Live Telegram proof (same-chat bare delivery lands in the active topic; different-chat/different-topic denial) requires Telegram credentials + Mantis. A maintainer can capture it with `@openclaw-mantis telegram live: verify that a Telegram topic-bound agent can send to the same bare chat, stays in the active topic, and still denies another chat when allowWithinProvider is false.`
