### PR TITLE
fix(cron): cron every unresolvedwarn

### DIFF
--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1542,8 +1542,7 @@ export async function resolveSessionTranscriptRuntimeTarget(
 export async function resolveSessionTranscriptRuntimeReadTarget(
   scope: SessionTranscriptRuntimeScope,
 ): Promise<SessionTranscriptRuntimeTarget> {
-  const { agentId, sessionEntry, sessionKey, sessionStore } =
-    resolveSessionTranscriptRuntimeContext(scope);
+  const { agentId, sessionEntry, sessionKey } = resolveSessionTranscriptRuntimeContext(scope);
   if (scope.sessionFile?.trim()) {
     return {
       agentId,

--- a/src/cron/service.issue-66019-unresolved-next-run.test.ts
+++ b/src/cron/service.issue-66019-unresolved-next-run.test.ts
@@ -7,9 +7,11 @@ import {
   setupCronRegressionFixtures,
 } from "../../test/helpers/cron/service-regression-fixtures.js";
 import * as schedule from "./schedule.js";
+import * as jobs from "./service/jobs.js";
 import { createCronServiceState } from "./service/state.js";
-import { onTimer } from "./service/timer.js";
+import { applyJobResult, onTimer } from "./service/timer.js";
 import { saveCronStore } from "./store.js";
+import type { CronJob } from "./types.js";
 
 const issue66019Fixtures = setupCronRegressionFixtures({ prefix: "cron-66019-" });
 
@@ -134,6 +136,59 @@ describe("#66019 unresolved next-run repro", () => {
     } finally {
       nextRunSpy.mockRestore();
       clearCronTimer(state);
+    }
+  });
+
+  it("warns when an every-type job completes but the next run is unresolved", () => {
+    const scheduledAt = Date.parse("2026-04-13T16:00:00.000Z");
+    const everyJob: CronJob = {
+      id: "cron-66019-every-unresolved",
+      name: "cron-66019-every-unresolved",
+      enabled: true,
+      createdAtMs: scheduledAt - 86_400_000,
+      updatedAtMs: scheduledAt - 86_400_000,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "ping" },
+      delivery: { mode: "announce" },
+      state: { nextRunAtMs: scheduledAt - 1_000, lastRunAtMs: scheduledAt - 60_000 },
+    };
+
+    const warnLogs: Array<{ obj: unknown; msg?: string }> = [];
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/dev/null",
+      log: {
+        ...noopLogger,
+        warn: (obj: unknown, msg?: string) => warnLogs.push({ obj, msg }),
+      },
+      nowMs: () => scheduledAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    state.store = { version: 1, jobs: [everyJob] };
+
+    const nextRunSpy = vi.spyOn(jobs, "computeJobNextRunAtMs").mockReturnValue(undefined);
+    try {
+      applyJobResult(state, everyJob, {
+        status: "ok",
+        startedAt: scheduledAt,
+        endedAt: scheduledAt + 1_000,
+      });
+
+      expect(everyJob.state.nextRunAtMs).toBeUndefined();
+      expect(warnLogs).toContainEqual({
+        obj: {
+          jobId: "cron-66019-every-unresolved",
+          jobName: "cron-66019-every-unresolved",
+          scheduleKind: "every",
+        },
+        msg: "cron: next run unresolved after successful completion; clearing schedule",
+      });
+    } finally {
+      nextRunSpy.mockRestore();
     }
   });
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -950,6 +950,16 @@ export function applyJobResult(
           context: "completion",
         });
       } else {
+        if (job.schedule.kind === "every" && naturalNext === undefined) {
+          state.deps.log.warn(
+            {
+              jobId: job.id,
+              jobName: job.name,
+              scheduleKind: job.schedule.kind,
+            },
+            "cron: next run unresolved after successful completion; clearing schedule",
+          );
+        }
         job.state.nextRunAtMs = naturalNext;
       }
     } else {


### PR DESCRIPTION
## What Problem This Solves

`every` cron jobs could silently lose `nextRunAtMs` after a successful run when
next-run resolution returned `undefined`.

In `src/cron/service/timer.ts`, the successful-completion path already guards
unresolved `cron` next runs through `resolveCronNextRunWithLowerBound()`, which
logs a warning before clearing the schedule. The corresponding `every` path
cleared `nextRunAtMs` with no warning, so recurring jobs could appear to stop
running without any diagnostic signal.

This patch adds a warning for unresolved successful `every` completions and adds
a focused regression test for that path.

## Evidence

Commands run:

```text
git diff --check
node scripts/run-vitest.mjs src/cron/service.issue-66019-unresolved-next-run.test.ts
```

Observed output:

```text
Test Files  1 passed (1)
Tests  4 passed (4)
```

Behavior addressed: successful `every` cron jobs now emit a warning instead of
silently clearing their schedule when next-run resolution returns `undefined`.

Evidence after fix:

```text
src/cron/service.issue-66019-unresolved-next-run.test.ts >
#66019 unresolved next-run repro >
does not refire a recurring cron job 2s later when next-run resolution returns undefined
src/cron/service.issue-66019-unresolved-next-run.test.ts >
#66019 unresolved next-run repro >
does not refire a recurring errored cron job after the first backoff window when next-run resolution returns undefined
src/cron/service.issue-66019-unresolved-next-run.test.ts >
#66019 unresolved next-run repro >
warns when an every-type job completes but the next run is unresolved
src/cron/service.issue-66019-unresolved-next-run.test.ts >
#66019 unresolved next-run repro >
preserves the active error backoff floor when maintenance repair later finds a natural next run

Test Files  1 passed (1)
Tests  4 passed (4)
```

Observed result after fix: when an `every` job completes successfully and
`computeJobNextRunAtMs` returns `undefined`, OpenClaw now logs a warning with
the job id, job name, and schedule kind before clearing `nextRunAtMs`. The
existing unresolved-next-run regression behavior remains green.

What was not tested: broader cron suites beyond the focused unresolved-next-run
regression file.
