### PR TITLE
feat(minimax): opt M3 into MiniMax priority lane via fastMode

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-616cb3c441affa908d2934f69ea668024dafdb976040bdfbda30b07ad17cd103  plugin-sdk-api-baseline.json
-5c7e7c393dfee5c8387fd634eefabac4ad854bfd5e9a24cadfe33a5cd8bef091  plugin-sdk-api-baseline.jsonl
+3cc34efcd90e6e36c61c876a96043102859800624aebf2eb6200a94ed9d64bd2  plugin-sdk-api-baseline.json
+3c765a8ac2ec69bdeb167c013c1b3149e931ebeec10d81f950ecd66eb80fe1de  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-1a66a755b98a7d4ff29fe7ccd19cd525c41677eccf1d954b0dc7ed71902e66bf  plugin-sdk-api-baseline.json
-93efacdebaa86153a980ea0c1db713548aeed91ad6e76b914b899746896b1b32  plugin-sdk-api-baseline.jsonl
+616cb3c441affa908d2934f69ea668024dafdb976040bdfbda30b07ad17cd103  plugin-sdk-api-baseline.json
+5c7e7c393dfee5c8387fd634eefabac4ad854bfd5e9a24cadfe33a5cd8bef091  plugin-sdk-api-baseline.jsonl

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -510,7 +510,7 @@ MiniMax is configured via `models.providers` because it uses custom endpoints:
 See [/providers/minimax](/providers/minimax) for setup details, model options, and config snippets.
 
 <Note>
-On MiniMax's Anthropic-compatible streaming path, OpenClaw disables thinking by default for the M2.x family unless you explicitly set it; MiniMax-M3 (and M3.x) stays on the provider's omitted/adaptive thinking path by default. `/fast on` rewrites `MiniMax-M2.7` to `MiniMax-M2.7-highspeed`.
+On MiniMax's Anthropic-compatible streaming path, OpenClaw disables thinking by default for the M2.x family unless you explicitly set it; MiniMax-M3 (and M3.x) stays on the provider's omitted/adaptive thinking path by default. Fast mode (`/fast on`, `/fast auto`, or `params.fastMode`) rewrites `MiniMax-M2.7` to `MiniMax-M2.7-highspeed`, and opts `MiniMax-M3` (and M3.x) into MiniMax's paid priority lane via `service_tier=priority` (billed at 1.5x standard) for both `minimax/*` and `minimax-portal/*`.
 </Note>
 
 Plugin-owned capability split:

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -681,7 +681,7 @@ Interactive custom-provider onboarding infers image input for common vision mode
     }
     ```
 
-    Set `MINIMAX_API_KEY`. Shortcuts: `openclaw onboard --auth-choice minimax-global-api` or `openclaw onboard --auth-choice minimax-cn-api`. The model catalog defaults to M3 and also includes the M2.7 variants. On the Anthropic-compatible streaming path, OpenClaw disables MiniMax M2.x thinking by default unless you explicitly set `thinking` yourself; MiniMax-M3 (and M3.x) stays on the provider's omitted/adaptive thinking path by default. `/fast on` or `params.fastMode: true` rewrites `MiniMax-M2.7` to `MiniMax-M2.7-highspeed`.
+    Set `MINIMAX_API_KEY`. Shortcuts: `openclaw onboard --auth-choice minimax-global-api` or `openclaw onboard --auth-choice minimax-cn-api`. The model catalog defaults to M3 and also includes the M2.7 variants. On the Anthropic-compatible streaming path, OpenClaw disables MiniMax M2.x thinking by default unless you explicitly set `thinking` yourself; MiniMax-M3 (and M3.x) stays on the provider's omitted/adaptive thinking path by default. Fast mode (`/fast on`, `/fast auto`, or `params.fastMode: true`) rewrites `MiniMax-M2.7` to `MiniMax-M2.7-highspeed`, and opts `MiniMax-M3` (and M3.x) into MiniMax's paid priority lane via `service_tier=priority` (billed at 1.5x standard); an explicit `service_tier` is preserved.
 
   </Accordion>
   <Accordion title="Moonshot AI (Kimi)">

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -505,7 +505,7 @@ API key auth, and dynamic model resolution.
     | `google-thinking` | Gemini thinking payload normalization on the shared stream path | `google`, `google-gemini-cli` |
     | `kilocode-thinking` | Kilo reasoning wrapper on the shared proxy stream path, with `kilo/auto` and unsupported proxy reasoning ids skipping injected thinking | `kilocode` |
     | `moonshot-thinking` | Moonshot binary native-thinking payload mapping from config + `/think` level | `moonshot` |
-    | `minimax-fast-mode` | MiniMax fast-mode model rewrite on the shared stream path | `minimax`, `minimax-portal` |
+    | `minimax-fast-mode` | MiniMax fast-mode handling on the shared stream path: `MiniMax-M2.7` -> `MiniMax-M2.7-highspeed` rewrite and `MiniMax-M3` `service_tier=priority` injection (the bundled MiniMax plugin wraps `createMinimaxFastModeWrapper` directly to also bill the highspeed/priority rate) | `minimax`, `minimax-portal` |
     | `openai-responses-defaults` | Shared native OpenAI/Codex Responses wrappers: attribution headers, `/fast`/`serviceTier`, text verbosity, native Codex web search, reasoning-compat payload shaping, and Responses context management | `openai` |
     | `openrouter-thinking` | OpenRouter reasoning wrapper for proxy routes, with unsupported-model/`auto` skips handled centrally | `openrouter` |
     | `tool-stream-default-on` | Default-on `tool_stream` wrapper for providers like Z.AI that want tool streaming unless explicitly disabled | `zai` |

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -505,7 +505,6 @@ API key auth, and dynamic model resolution.
     | `google-thinking` | Gemini thinking payload normalization on the shared stream path | `google`, `google-gemini-cli` |
     | `kilocode-thinking` | Kilo reasoning wrapper on the shared proxy stream path, with `kilo/auto` and unsupported proxy reasoning ids skipping injected thinking | `kilocode` |
     | `moonshot-thinking` | Moonshot binary native-thinking payload mapping from config + `/think` level | `moonshot` |
-    | `minimax-fast-mode` | MiniMax fast-mode handling on the shared stream path: `MiniMax-M2.7` -> `MiniMax-M2.7-highspeed` rewrite and `MiniMax-M3` `service_tier=priority` injection (the bundled MiniMax plugin wraps `createMinimaxFastModeWrapper` directly to also bill the highspeed/priority rate) | `minimax`, `minimax-portal` |
     | `openai-responses-defaults` | Shared native OpenAI/Codex Responses wrappers: attribution headers, `/fast`/`serviceTier`, text verbosity, native Codex web search, reasoning-compat payload shaping, and Responses context management | `openai` |
     | `openrouter-thinking` | OpenRouter reasoning wrapper for proxy routes, with unsupported-model/`auto` skips handled centrally | `openrouter` |
     | `tool-stream-default-on` | Default-on `tool_stream` wrapper for providers like Z.AI that want tool streaming unless explicitly disabled | `zai` |

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -409,7 +409,13 @@ See [MiniMax Search](/tools/minimax-search) for full web search configuration an
   </Accordion>
 
   <Accordion title="Fast mode">
-    `/fast on` or `params.fastMode: true` rewrites `MiniMax-M2.7` to `MiniMax-M2.7-highspeed` on the Anthropic-compatible stream path.
+    On the Anthropic-compatible stream path, fast mode (`/fast on`, `/fast auto`, or `params.fastMode: true`) speeds up MiniMax requests for both `minimax/*` (API key) and `minimax-portal/*` (OAuth):
+
+    - **`MiniMax-M2.7`** is rewritten to the faster `MiniMax-M2.7-highspeed` variant, billed at that variant's higher rate (2x input/output).
+    - **`MiniMax-M3`** (and M3.x) has no highspeed variant, so it is opted into MiniMax's paid priority lane via `service_tier=priority`, billed at 1.5x the standard M3 rate.
+
+    An explicit `service_tier` already on the request is preserved, and other MiniMax models gain no priority benefit. `/fast auto` resolves per model call.
+
   </Accordion>
 
   <Accordion title="Fallback example">

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -213,7 +213,7 @@ plugins.
         - `/verbose` is for debugging — keep it **off** in normal use.
         - `/trace` reveals only plugin-owned trace/debug lines; normal verbose chatter stays off.
         - `/fast auto|on|off` persists a session override; use the Sessions UI `inherit` option to clear it.
-        - `/fast` is provider-specific: OpenAI/Codex map it to `service_tier=priority`; direct Anthropic requests map it to `service_tier=auto` or `standard_only`.
+        - `/fast` is provider-specific: OpenAI/Codex map it to `service_tier=priority`; direct Anthropic requests map it to `service_tier=auto` or `standard_only`; MiniMax rewrites `MiniMax-M2.7` to `MiniMax-M2.7-highspeed` and opts `MiniMax-M3` into `service_tier=priority` (billed at 1.5x standard).
         - `/reasoning`, `/verbose`, and `/trace` are risky in group settings — they may reveal internal reasoning or plugin diagnostics. Keep them off in group chats.
 
       </Accordion>

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -73,7 +73,7 @@ title: "Thinking levels"
 - For `openai/*`, fast mode maps to OpenAI priority processing by sending `service_tier=priority` on supported Responses requests.
 - For Codex-backed `openai/*` / `openai-codex/*` models, fast mode sends the same `service_tier=priority` flag on Codex Responses. Native Codex app-server turns receive the tier only on `turn/start` or thread start/resume, so `auto` cannot retier one already-running app-server turn; it applies to the next model turn OpenClaw starts.
 - For direct public `anthropic/*` requests, including OAuth-authenticated traffic sent to `api.anthropic.com`, fast mode maps to Anthropic service tiers: `/fast on` sets `service_tier=auto`, `/fast off` sets `service_tier=standard_only`.
-- For `minimax/*` on the Anthropic-compatible path, `/fast on` (or `params.fastMode: true`) rewrites `MiniMax-M2.7` to `MiniMax-M2.7-highspeed`.
+- For `minimax/*` on the Anthropic-compatible path, fast mode (`/fast on`, `/fast auto`, or `params.fastMode: true`) rewrites `MiniMax-M2.7` to `MiniMax-M2.7-highspeed`, and opts `MiniMax-M3` (and M3.x) into MiniMax's paid priority lane by sending `service_tier=priority`. An explicit `service_tier` already on the request is preserved; M2.x models gain no priority benefit.
 - Explicit Anthropic `serviceTier` / `service_tier` model params override the fast-mode default when both are set. OpenClaw still skips Anthropic service-tier injection for non-Anthropic proxy base URLs.
 - `/status` shows `Fast` when fast mode is enabled and `Fast:auto` when the configured mode is auto.
 

--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -328,6 +328,57 @@ describe("minimax provider hooks", () => {
     expect(resolvedPortalModelId).toBe("MiniMax-M2.7-highspeed");
   });
 
+  it("opts MiniMax-M3 into the priority service_tier and 1.5x cost for both provider IDs", async () => {
+    const { providers } = await registerProviderPlugin({
+      plugin: minimaxProviderPlugin,
+      id: "minimax",
+      name: "MiniMax Provider",
+    });
+
+    // M3 has no highspeed variant: fast mode must inject service_tier=priority
+    // and bill 1.5x the standard M3 rate ({0.6,2.4,0.12,0} -> {0.9,3.6,0.18,0}).
+    const driveM3 = (providerId: "minimax" | "minimax-portal") => {
+      const provider = requireRegisteredProvider(providers, providerId);
+      let capturedPayload: Record<string, unknown> = {};
+      let capturedCost: Model<"anthropic-messages">["cost"] | undefined;
+      const capture: StreamFn = (model, _context, options) => {
+        capturedCost = model.cost;
+        const payload: Record<string, unknown> = {};
+        options?.onPayload?.(payload, model);
+        capturedPayload = payload;
+        return {} as ReturnType<StreamFn>;
+      };
+      const wrapped = provider.wrapStreamFn?.({
+        provider: providerId,
+        modelId: "MiniMax-M3",
+        extraParams: { fastMode: true },
+        streamFn: capture,
+      } as never);
+      void wrapped?.(
+        {
+          api: "anthropic-messages",
+          provider: providerId,
+          id: "MiniMax-M3",
+          cost: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: 0 },
+        } as Model<"anthropic-messages">,
+        { messages: [] } as Context,
+        {},
+      );
+      return { capturedPayload, capturedCost };
+    };
+
+    for (const providerId of ["minimax", "minimax-portal"] as const) {
+      const { capturedPayload, capturedCost } = driveM3(providerId);
+      expect(capturedPayload.service_tier).toBe("priority");
+      // 1.5x scaling carries float artifacts (2.4 * 1.5 -> 3.5999…); assert the
+      // billed intent per field rather than exact equality.
+      expect(capturedCost?.input).toBeCloseTo(0.9, 10);
+      expect(capturedCost?.output).toBeCloseTo(3.6, 10);
+      expect(capturedCost?.cacheRead).toBeCloseTo(0.18, 10);
+      expect(capturedCost?.cacheWrite).toBe(0);
+    }
+  });
+
   it("shares the provider hook bundle across MiniMax variants", async () => {
     const { providers } = await registerProviderPlugin({
       plugin: minimaxProviderPlugin,

--- a/extensions/minimax/model-definitions.ts
+++ b/extensions/minimax/model-definitions.ts
@@ -55,6 +55,24 @@ export const MINIMAX_LM_STUDIO_COST = {
 
 type MinimaxCatalogId = keyof typeof MINIMAX_TEXT_MODEL_CATALOG;
 
+// MiniMax bills the `service_tier: "priority"` lane at 1.5x the standard rate
+// (e.g. M3 $0.30/$1.20 -> $0.45/$1.80 at <=512k input).
+// https://platform.minimax.io/docs/guides/pricing-paygo
+export const MINIMAX_PRIORITY_COST_MULTIPLIER = 1.5;
+
+/** Scales every per-million cost field so OpenClaw estimates match a paid MiniMax lane. */
+export function scaleMinimaxCost(
+  cost: ModelDefinitionConfig["cost"],
+  multiplier: number,
+): ModelDefinitionConfig["cost"] {
+  return {
+    input: cost.input * multiplier,
+    output: cost.output * multiplier,
+    cacheRead: cost.cacheRead * multiplier,
+    cacheWrite: cost.cacheWrite * multiplier,
+  };
+}
+
 export function resolveMinimaxApiCost(modelId: string): ModelDefinitionConfig["cost"] {
   if (modelId === "MiniMax-M2.7") {
     return MINIMAX_M27_API_COST;

--- a/extensions/minimax/model-definitions.ts
+++ b/extensions/minimax/model-definitions.ts
@@ -56,8 +56,8 @@ export const MINIMAX_LM_STUDIO_COST = {
 type MinimaxCatalogId = keyof typeof MINIMAX_TEXT_MODEL_CATALOG;
 
 // MiniMax bills the `service_tier: "priority"` lane at 1.5x the standard rate
-// (e.g. M3 $0.30/$1.20 -> $0.45/$1.80 at <=512k input).
-// https://platform.minimax.io/docs/guides/pricing-paygo
+// (https://platform.minimax.io/docs/guides/pricing-paygo). Applied to the base
+// per-model rate OpenClaw already bills, e.g. M3 $0.60/$2.40 -> $0.90/$3.60.
 export const MINIMAX_PRIORITY_COST_MULTIPLIER = 1.5;
 
 /** Scales every per-million cost field so OpenClaw estimates match a paid MiniMax lane. */

--- a/extensions/minimax/provider-registration.ts
+++ b/extensions/minimax/provider-registration.ts
@@ -8,6 +8,7 @@ import type {
   ProviderCatalogContext,
   ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
+  ProviderWrapStreamFnContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import {
   MINIMAX_OAUTH_MARKER,
@@ -21,7 +22,11 @@ import {
   buildProviderReplayFamilyHooks,
   normalizeModelCompat,
 } from "openclaw/plugin-sdk/provider-model-shared";
-import { MINIMAX_FAST_MODE_STREAM_HOOKS } from "openclaw/plugin-sdk/provider-stream-family";
+import {
+  createMinimaxFastModeWrapper,
+  resolveBooleanFastMode,
+  type ResolveMinimaxFastLaneCost,
+} from "openclaw/plugin-sdk/provider-stream-family";
 import { fetchMinimaxUsage } from "openclaw/plugin-sdk/provider-usage";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
@@ -30,7 +35,12 @@ import {
   MINIMAX_TEXT_MODEL_CATALOG,
   MINIMAX_TEXT_MODEL_ORDER,
 } from "./api.js";
-import { DEFAULT_MINIMAX_MAX_TOKENS, resolveMinimaxApiCost } from "./model-definitions.js";
+import {
+  DEFAULT_MINIMAX_MAX_TOKENS,
+  MINIMAX_PRIORITY_COST_MULTIPLIER,
+  resolveMinimaxApiCost,
+  scaleMinimaxCost,
+} from "./model-definitions.js";
 import type { MiniMaxRegion } from "./oauth.js";
 import { applyMinimaxApiConfig, applyMinimaxApiConfigCn } from "./onboard.js";
 import {
@@ -61,9 +71,26 @@ const HYBRID_ANTHROPIC_OPENAI_REPLAY_HOOKS = buildProviderReplayFamilyHooks({
   family: "hybrid-anthropic-openai",
   anthropicModelDropThinkingBlocks: true,
 });
+// MiniMax owns its fast-lane pricing: highspeed (M2.x) bills the dedicated
+// variant's rate; the M3 priority `service_tier` bills 1.5x standard. The core
+// wrapper picks the lane and asks back here so core stays provider-pricing free.
+const resolveMinimaxFastLaneCost: ResolveMinimaxFastLaneCost = ({ requestModelId, priority }) => {
+  const cost = resolveMinimaxApiCost(requestModelId);
+  return priority ? scaleMinimaxCost(cost, MINIMAX_PRIORITY_COST_MULTIPLIER) : cost;
+};
+
+const MINIMAX_FAST_MODE_HOOKS = {
+  wrapStreamFn: (ctx: ProviderWrapStreamFnContext) =>
+    createMinimaxFastModeWrapper(
+      ctx.streamFn,
+      () => resolveBooleanFastMode(ctx.extraParams),
+      resolveMinimaxFastLaneCost,
+    ),
+};
+
 const MINIMAX_PROVIDER_HOOKS = {
   ...HYBRID_ANTHROPIC_OPENAI_REPLAY_HOOKS,
-  ...MINIMAX_FAST_MODE_STREAM_HOOKS,
+  ...MINIMAX_FAST_MODE_HOOKS,
   resolveReasoningOutputMode: () => "native" as const,
   resolveThinkingProfile: ({ modelId }: { modelId: string }) =>
     resolveMinimaxThinkingProfile(modelId),

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -202,8 +202,8 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 323),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10408),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5224),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10410),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5226),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
       3261,

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -877,7 +877,13 @@ function applyPostPluginStreamWrappers(
   // MiniMax's Anthropic-compatible stream can leak reasoning_content into the
   // visible reply path because it does not emit native Anthropic thinking
   // blocks. Disable thinking unless an earlier wrapper already set it.
-  ctx.agent.streamFn = createMinimaxThinkingDisabledWrapper(ctx.agent.streamFn, ctx.thinkingLevel);
+  // fastMode for M3 opts it into MiniMax's paid priority lane
+  const minimaxFastMode = ctx.effectiveExtraParams?.fastMode === true;
+  ctx.agent.streamFn = createMinimaxThinkingDisabledWrapper(
+    ctx.agent.streamFn,
+    ctx.thinkingLevel,
+    minimaxFastMode,
+  );
 
   const rawChatTemplateKwargs = resolveAliasedParamValue(
     [ctx.effectiveExtraParams, ctx.override],

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -877,13 +877,7 @@ function applyPostPluginStreamWrappers(
   // MiniMax's Anthropic-compatible stream can leak reasoning_content into the
   // visible reply path because it does not emit native Anthropic thinking
   // blocks. Disable thinking unless an earlier wrapper already set it.
-  // fastMode for M3 opts it into MiniMax's paid priority lane
-  const minimaxFastMode = ctx.effectiveExtraParams?.fastMode === true;
-  ctx.agent.streamFn = createMinimaxThinkingDisabledWrapper(
-    ctx.agent.streamFn,
-    ctx.thinkingLevel,
-    minimaxFastMode,
-  );
+  ctx.agent.streamFn = createMinimaxThinkingDisabledWrapper(ctx.agent.streamFn, ctx.thinkingLevel);
 
   const rawChatTemplateKwargs = resolveAliasedParamValue(
     [ctx.effectiveExtraParams, ctx.override],

--- a/src/llm/providers/stream-wrappers/minimax.test.ts
+++ b/src/llm/providers/stream-wrappers/minimax.test.ts
@@ -302,10 +302,10 @@ describe("createMinimaxFastModeWrapper", () => {
   });
 });
 
-describe("createMinimaxThinkingDisabledWrapper service_tier", () => {
+describe("createMinimaxFastModeWrapper service_tier", () => {
   function capturePayload(params: {
     modelId: string;
-    serviceTierPriority?: boolean;
+    fastMode: boolean | (() => boolean | undefined);
     initialPayload?: Record<string, unknown>;
   }): Record<string, unknown> {
     let captured: Record<string, unknown> = {};
@@ -315,11 +315,7 @@ describe("createMinimaxThinkingDisabledWrapper service_tier", () => {
       captured = payload;
       return {} as ReturnType<StreamFn>;
     };
-    const wrapped = createMinimaxThinkingDisabledWrapper(
-      baseStreamFn,
-      "adaptive",
-      params.serviceTierPriority,
-    );
+    const wrapped = createMinimaxFastModeWrapper(baseStreamFn, params.fastMode);
     void wrapped(
       {
         api: "anthropic-messages",
@@ -332,21 +328,30 @@ describe("createMinimaxThinkingDisabledWrapper service_tier", () => {
     return captured;
   }
 
-  it("injects service_tier priority for MiniMax-M3 when enabled", () => {
-    expect(capturePayload({ modelId: "MiniMax-M3", serviceTierPriority: true }).service_tier).toBe(
-      "priority",
-    );
+  it("injects service_tier priority for MiniMax-M3 when fast mode is on", () => {
+    expect(capturePayload({ modelId: "MiniMax-M3", fastMode: true }).service_tier).toBe("priority");
   });
 
-  it("does not inject service_tier for MiniMax-M3 when disabled", () => {
+  it("resolves function-based fast mode (e.g. /fast auto) for M3 priority", () => {
+    // Auto fast mode passes fastMode as a resolver function; the wrapper must
+    // call it per stream rather than only honoring a literal `true`.
+    expect(capturePayload({ modelId: "MiniMax-M3", fastMode: () => true }).service_tier).toBe(
+      "priority",
+    );
     expect(
-      capturePayload({ modelId: "MiniMax-M3", serviceTierPriority: false }).service_tier,
+      capturePayload({ modelId: "MiniMax-M3", fastMode: () => false }).service_tier,
     ).toBeUndefined();
   });
 
-  it("does not inject service_tier for M2.x even when enabled (no priority benefit)", () => {
+  it("does not inject service_tier for MiniMax-M3 when fast mode is off", () => {
+    expect(capturePayload({ modelId: "MiniMax-M3", fastMode: false }).service_tier).toBeUndefined();
+  });
+
+  it("does not inject service_tier for M2.x even in fast mode (no priority benefit)", () => {
+    // M2.7 routes to the highspeed model variant instead, so the captured
+    // payload carries no service_tier.
     expect(
-      capturePayload({ modelId: "MiniMax-M2.7", serviceTierPriority: true }).service_tier,
+      capturePayload({ modelId: "MiniMax-M2.7", fastMode: true }).service_tier,
     ).toBeUndefined();
   });
 
@@ -354,7 +359,7 @@ describe("createMinimaxThinkingDisabledWrapper service_tier", () => {
     expect(
       capturePayload({
         modelId: "MiniMax-M3",
-        serviceTierPriority: true,
+        fastMode: true,
         initialPayload: { service_tier: "standard_only" },
       }).service_tier,
     ).toBe("standard_only");

--- a/src/llm/providers/stream-wrappers/minimax.test.ts
+++ b/src/llm/providers/stream-wrappers/minimax.test.ts
@@ -2,7 +2,11 @@ import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { Context, Model } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
-import { createMinimaxFastModeWrapper, createMinimaxThinkingDisabledWrapper } from "./minimax.js";
+import {
+  createMinimaxFastModeWrapper,
+  createMinimaxThinkingDisabledWrapper,
+  type ResolveMinimaxFastLaneCost,
+} from "./minimax.js";
 
 function captureThinkingPayload(params: {
   provider: string;
@@ -356,12 +360,77 @@ describe("createMinimaxFastModeWrapper service_tier", () => {
   });
 
   it("preserves an already-set service_tier", () => {
+    // "standard" is MiniMax's own tier value; the wrapper must not clobber a
+    // service_tier an earlier wrapper/caller already chose.
     expect(
       capturePayload({
         modelId: "MiniMax-M3",
         fastMode: true,
-        initialPayload: { service_tier: "standard_only" },
+        initialPayload: { service_tier: "standard" },
       }).service_tier,
-    ).toBe("standard_only");
+    ).toBe("standard");
+  });
+});
+
+describe("createMinimaxFastModeWrapper fast-lane cost", () => {
+  const M27_STANDARD_COST = { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 };
+  const M3_STANDARD_COST = { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: 0 };
+
+  function captureModel(params: {
+    modelId: string;
+    baseCost: Model<"anthropic-messages">["cost"];
+    resolveFastLaneCost?: ResolveMinimaxFastLaneCost;
+  }): Model<"anthropic-messages"> {
+    let captured = {} as Model<"anthropic-messages">;
+    const baseStreamFn: StreamFn = (model) => {
+      captured = model as Model<"anthropic-messages">;
+      return {} as ReturnType<StreamFn>;
+    };
+    const wrapped = createMinimaxFastModeWrapper(baseStreamFn, true, params.resolveFastLaneCost);
+    void wrapped(
+      {
+        api: "anthropic-messages",
+        provider: "minimax",
+        id: params.modelId,
+        cost: params.baseCost,
+      } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    );
+    return captured;
+  }
+
+  it("bills the highspeed variant's cost for M2.7 fast mode", () => {
+    const captured = captureModel({
+      modelId: "MiniMax-M2.7",
+      baseCost: M27_STANDARD_COST,
+      // Stand-in for the plugin resolver: highspeed variant id -> its own rate.
+      resolveFastLaneCost: ({ requestModelId, priority }) => {
+        expect(requestModelId).toBe("MiniMax-M2.7-highspeed");
+        expect(priority).toBe(false);
+        return { input: 0.6, output: 2.4, cacheRead: 0.06, cacheWrite: 0.375 };
+      },
+    });
+    expect(captured.id).toBe("MiniMax-M2.7-highspeed");
+    expect(captured.cost).toEqual({ input: 0.6, output: 2.4, cacheRead: 0.06, cacheWrite: 0.375 });
+  });
+
+  it("bills the 1.5x priority cost for M3 fast mode", () => {
+    const captured = captureModel({
+      modelId: "MiniMax-M3",
+      baseCost: M3_STANDARD_COST,
+      resolveFastLaneCost: ({ requestModelId, priority }) => {
+        expect(requestModelId).toBe("MiniMax-M3");
+        expect(priority).toBe(true);
+        return { input: 0.9, output: 3.6, cacheRead: 0.18, cacheWrite: 0 };
+      },
+    });
+    expect(captured.id).toBe("MiniMax-M3");
+    expect(captured.cost).toEqual({ input: 0.9, output: 3.6, cacheRead: 0.18, cacheWrite: 0 });
+  });
+
+  it("leaves the base cost untouched when no resolver is supplied", () => {
+    const captured = captureModel({ modelId: "MiniMax-M3", baseCost: M3_STANDARD_COST });
+    expect(captured.cost).toEqual(M3_STANDARD_COST);
   });
 });

--- a/src/llm/providers/stream-wrappers/minimax.test.ts
+++ b/src/llm/providers/stream-wrappers/minimax.test.ts
@@ -301,3 +301,62 @@ describe("createMinimaxFastModeWrapper", () => {
     expect(capturedIds).toEqual(["MiniMax-M2.7-highspeed", "MiniMax-M2.7"]);
   });
 });
+
+describe("createMinimaxThinkingDisabledWrapper service_tier", () => {
+  function capturePayload(params: {
+    modelId: string;
+    serviceTierPriority?: boolean;
+    initialPayload?: Record<string, unknown>;
+  }): Record<string, unknown> {
+    let captured: Record<string, unknown> = {};
+    const baseStreamFn: StreamFn = (model, context, options) => {
+      const payload: Record<string, unknown> = { ...params.initialPayload };
+      options?.onPayload?.(payload, model);
+      captured = payload;
+      return {} as ReturnType<StreamFn>;
+    };
+    const wrapped = createMinimaxThinkingDisabledWrapper(
+      baseStreamFn,
+      "adaptive",
+      params.serviceTierPriority,
+    );
+    void wrapped(
+      {
+        api: "anthropic-messages",
+        provider: "minimax",
+        id: params.modelId,
+      } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    );
+    return captured;
+  }
+
+  it("injects service_tier priority for MiniMax-M3 when enabled", () => {
+    expect(capturePayload({ modelId: "MiniMax-M3", serviceTierPriority: true }).service_tier).toBe(
+      "priority",
+    );
+  });
+
+  it("does not inject service_tier for MiniMax-M3 when disabled", () => {
+    expect(
+      capturePayload({ modelId: "MiniMax-M3", serviceTierPriority: false }).service_tier,
+    ).toBeUndefined();
+  });
+
+  it("does not inject service_tier for M2.x even when enabled (no priority benefit)", () => {
+    expect(
+      capturePayload({ modelId: "MiniMax-M2.7", serviceTierPriority: true }).service_tier,
+    ).toBeUndefined();
+  });
+
+  it("preserves an already-set service_tier", () => {
+    expect(
+      capturePayload({
+        modelId: "MiniMax-M3",
+        serviceTierPriority: true,
+        initialPayload: { service_tier: "standard_only" },
+      }).service_tier,
+    ).toBe("standard_only");
+  });
+});

--- a/src/llm/providers/stream-wrappers/minimax.ts
+++ b/src/llm/providers/stream-wrappers/minimax.ts
@@ -78,11 +78,30 @@ export function createMinimaxFastModeWrapper(
     }
 
     const fastModelId = resolveMinimaxFastModelId(model.id);
-    if (!fastModelId) {
-      return underlying(model, context, options);
+    if (fastModelId) {
+      // M2.x: route to the dedicated highspeed model variant.
+      return underlying({ ...model, id: fastModelId }, context, options);
     }
 
-    return underlying({ ...model, id: fastModelId }, context, options);
+    // M3.x has no highspeed model variant; opt its requests into MiniMax's paid
+    // priority lane via `service_tier`. Other MiniMax models get no fast-mode
+    // change. Preserve a service_tier an earlier wrapper/caller already set.
+    if (!isMinimaxModelRequiringThinking(model)) {
+      return underlying(model, context, options);
+    }
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          const payloadObj = payload as Record<string, unknown>;
+          if (payloadObj.service_tier === undefined) {
+            payloadObj.service_tier = "priority";
+          }
+        }
+        return originalOnPayload?.(payload, model);
+      },
+    });
   };
 }
 
@@ -104,7 +123,6 @@ export function createMinimaxFastModeWrapper(
 export function createMinimaxThinkingDisabledWrapper(
   baseStreamFn: StreamFn | undefined,
   thinkingLevel?: ThinkLevel,
-  serviceTierPriority?: boolean,
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
@@ -119,9 +137,6 @@ export function createMinimaxThinkingDisabledWrapper(
       onPayload: (payload) => {
         if (payload && typeof payload === "object") {
           const payloadObj = payload as Record<string, unknown>;
-          if (requiresThinking && serviceTierPriority && payloadObj.service_tier === undefined) {
-            payloadObj.service_tier = "priority";
-          }
           if (requiresThinking) {
             if (thinkingLevel === undefined && isDisabledThinkingPayload(payloadObj.thinking)) {
               delete payloadObj.thinking;

--- a/src/llm/providers/stream-wrappers/minimax.ts
+++ b/src/llm/providers/stream-wrappers/minimax.ts
@@ -104,6 +104,7 @@ export function createMinimaxFastModeWrapper(
 export function createMinimaxThinkingDisabledWrapper(
   baseStreamFn: StreamFn | undefined,
   thinkingLevel?: ThinkLevel,
+  serviceTierPriority?: boolean,
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
@@ -118,6 +119,9 @@ export function createMinimaxThinkingDisabledWrapper(
       onPayload: (payload) => {
         if (payload && typeof payload === "object") {
           const payloadObj = payload as Record<string, unknown>;
+          if (requiresThinking && serviceTierPriority && payloadObj.service_tier === undefined) {
+            payloadObj.service_tier = "priority";
+          }
           if (requiresThinking) {
             if (thinkingLevel === undefined && isDisabledThinkingPayload(payloadObj.thinking)) {
               delete payloadObj.thinking;

--- a/src/llm/providers/stream-wrappers/minimax.ts
+++ b/src/llm/providers/stream-wrappers/minimax.ts
@@ -7,6 +7,27 @@ const MINIMAX_FAST_MODEL_IDS = new Map<string, string>([
 ]);
 type DynamicFastMode = boolean | (() => boolean | undefined);
 
+type MinimaxModelCost = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+};
+
+/**
+ * Resolves the per-million cost OpenClaw should bill for a MiniMax fast-mode
+ * lane. MiniMax pricing is owned by the MiniMax plugin, so the wrapper decides
+ * the lane and asks the plugin for the matching cost rather than hard-coding
+ * provider pricing in core. Returning `undefined` leaves the base model cost in
+ * place (the caller opted out of cost correction).
+ */
+export type ResolveMinimaxFastLaneCost = (params: {
+  /** Model id the request is actually sent as (highspeed variant, or the base M3 id). */
+  requestModelId: string;
+  /** True when the request opts into the paid `service_tier: "priority"` lane (M3.x). */
+  priority: boolean;
+}) => MinimaxModelCost | undefined;
+
 function resolveMinimaxFastModelId(modelId: unknown): string | undefined {
   if (typeof modelId !== "string") {
     return undefined;
@@ -66,6 +87,7 @@ function resolvePositiveMaxTokens(value: unknown): number | undefined {
 export function createMinimaxFastModeWrapper(
   baseStreamFn: StreamFn | undefined,
   fastMode: DynamicFastMode,
+  resolveFastLaneCost?: ResolveMinimaxFastLaneCost,
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
@@ -79,18 +101,24 @@ export function createMinimaxFastModeWrapper(
 
     const fastModelId = resolveMinimaxFastModelId(model.id);
     if (fastModelId) {
-      // M2.x: route to the dedicated highspeed model variant.
-      return underlying({ ...model, id: fastModelId }, context, options);
+      // M2.x: route to the dedicated highspeed model variant and bill at its
+      // higher rate so cost estimates match the variant MiniMax actually runs.
+      const cost = resolveFastLaneCost?.({ requestModelId: fastModelId, priority: false });
+      return underlying({ ...model, id: fastModelId, ...(cost ? { cost } : {}) }, context, options);
     }
 
     // M3.x has no highspeed model variant; opt its requests into MiniMax's paid
-    // priority lane via `service_tier`. Other MiniMax models get no fast-mode
-    // change. Preserve a service_tier an earlier wrapper/caller already set.
+    // priority lane via `service_tier` and bill at the priority rate. Other
+    // MiniMax models get no fast-mode change. Preserve a service_tier an earlier
+    // wrapper/caller already set.
     if (!isMinimaxModelRequiringThinking(model)) {
       return underlying(model, context, options);
     }
+    const modelId = typeof model.id === "string" ? model.id.trim() : "";
+    const priorityCost = resolveFastLaneCost?.({ requestModelId: modelId, priority: true });
+    const priorityModel = priorityCost ? { ...model, cost: priorityCost } : model;
     const originalOnPayload = options?.onPayload;
-    return underlying(model, context, {
+    return underlying(priorityModel, context, {
       ...options,
       onPayload: (payload) => {
         if (payload && typeof payload === "object") {

--- a/src/plugin-sdk/provider-stream.test.ts
+++ b/src/plugin-sdk/provider-stream.test.ts
@@ -17,7 +17,6 @@ import {
   createToolStreamWrapper,
   GOOGLE_THINKING_STREAM_HOOKS,
   KILOCODE_THINKING_STREAM_HOOKS,
-  MINIMAX_FAST_MODE_STREAM_HOOKS,
   MOONSHOT_THINKING_STREAM_HOOKS,
   OPENAI_RESPONSES_STREAM_HOOKS,
   OPENROUTER_THINKING_STREAM_HOOKS,
@@ -139,14 +138,12 @@ describe("composeProviderStreamWrappers", () => {
 describe("buildProviderStreamFamilyHooks", () => {
   it("covers the stream family matrix", async () => {
     let capturedPayload: Record<string, unknown> | undefined;
-    let capturedModelId: string | undefined;
     let capturedModelReasoning: boolean | undefined;
     let capturedHeaders: Record<string, string> | undefined;
     let capturedReasoning: string | undefined;
     let payloadSeed: Record<string, unknown> | undefined;
 
     const baseStreamFn: StreamFn = (model, _context, options) => {
-      capturedModelId = model.id;
       capturedModelReasoning = model.reasoning;
       capturedReasoning = options?.reasoning;
       const payload = {
@@ -181,24 +178,6 @@ describe("buildProviderStreamFamilyHooks", () => {
     );
     expect(googleThinkingConfig.thinkingLevel).toBe("HIGH");
     expect(googleThinkingConfig).not.toHaveProperty("thinkingBudget");
-
-    const minimaxHooks = MINIMAX_FAST_MODE_STREAM_HOOKS;
-    const minimaxStream = requireStreamFn(
-      requireWrapStreamFn(minimaxHooks.wrapStreamFn)({
-        streamFn: baseStreamFn,
-        extraParams: { fastMode: true },
-      } as never),
-    );
-    await minimaxStream(
-      {
-        api: "anthropic-messages",
-        provider: "minimax",
-        id: "MiniMax-M2.7",
-      } as never,
-      {} as never,
-      {},
-    );
-    expect(capturedModelId).toBe("MiniMax-M2.7-highspeed");
 
     const kilocodeHooks = KILOCODE_THINKING_STREAM_HOOKS;
     void requireStreamFn(
@@ -399,7 +378,6 @@ describe("buildProviderStreamFamilyHooks", () => {
   it("exposes canonical stream hook constants for reused families", () => {
     expect(GOOGLE_THINKING_STREAM_HOOKS.wrapStreamFn).toBeTypeOf("function");
     expect(KILOCODE_THINKING_STREAM_HOOKS.wrapStreamFn).toBeTypeOf("function");
-    expect(MINIMAX_FAST_MODE_STREAM_HOOKS.wrapStreamFn).toBeTypeOf("function");
     expect(MOONSHOT_THINKING_STREAM_HOOKS.wrapStreamFn).toBeTypeOf("function");
     expect(OPENAI_RESPONSES_STREAM_HOOKS.wrapStreamFn).toBeTypeOf("function");
     expect(OPENROUTER_THINKING_STREAM_HOOKS.wrapStreamFn).toBeTypeOf("function");

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -72,7 +72,8 @@ function hasFastModeParam(extraParams: Record<string, unknown> | undefined): boo
   );
 }
 
-function resolveBooleanFastMode(
+/** Resolves a provider-agnostic `fastMode`/`fast_mode` extra-param (incl. the `/fast auto` function form) to a boolean. */
+export function resolveBooleanFastMode(
   extraParams: Record<string, unknown> | undefined,
 ): boolean | undefined {
   const raw = extraParams?.fastMode ?? extraParams?.fast_mode;
@@ -216,7 +217,10 @@ export {
   createOpenRouterWrapper,
   isProxyReasoningUnsupported,
 } from "../llm/providers/stream-wrappers/proxy.js";
-export { createMinimaxFastModeWrapper } from "../llm/providers/stream-wrappers/minimax.js";
+export {
+  createMinimaxFastModeWrapper,
+  type ResolveMinimaxFastLaneCost,
+} from "../llm/providers/stream-wrappers/minimax.js";
 export {
   createOpenAIAttributionHeadersWrapper,
   createCodexNativeWebSearchWrapper,

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -1,6 +1,5 @@
 // Provider stream helpers expose shared wrapper families and payload transforms for provider plugins.
 import { createGoogleThinkingPayloadWrapper } from "../llm/providers/stream-wrappers/google.js";
-import { createMinimaxFastModeWrapper } from "../llm/providers/stream-wrappers/minimax.js";
 import { resolveMoonshotThinkingKeep } from "../llm/providers/stream-wrappers/moonshot-thinking.js";
 import {
   createCodexNativeWebSearchWrapper,
@@ -54,8 +53,6 @@ export type ProviderStreamFamily =
   | "kilocode-thinking"
   /** Applies Moonshot thinking type/keep normalization. */
   | "moonshot-thinking"
-  /** Enables MiniMax high-speed model routing when requested. */
-  | "minimax-fast-mode"
   /** Applies the default OpenAI Responses wrapper stack. */
   | "openai-responses-defaults"
   /** Applies OpenRouter proxy reasoning payload normalization. */
@@ -120,11 +117,6 @@ export function buildProviderStreamFamilyHooks(
           return createKilocodeWrapper(ctx.streamFn, thinkingLevel);
         },
       };
-    case "minimax-fast-mode":
-      return {
-        wrapStreamFn: (ctx: ProviderWrapStreamFnContext) =>
-          createMinimaxFastModeWrapper(ctx.streamFn, () => resolveBooleanFastMode(ctx.extraParams)),
-      };
     case "openai-responses-defaults":
       return {
         wrapStreamFn: (ctx: ProviderWrapStreamFnContext) => {
@@ -188,8 +180,6 @@ export const GOOGLE_THINKING_STREAM_HOOKS = buildProviderStreamFamilyHooks("goog
 export const KILOCODE_THINKING_STREAM_HOOKS = buildProviderStreamFamilyHooks("kilocode-thinking");
 /** @deprecated Moonshot provider-owned stream hook shortcut; use local provider hooks instead. */
 export const MOONSHOT_THINKING_STREAM_HOOKS = buildProviderStreamFamilyHooks("moonshot-thinking");
-/** @deprecated MiniMax provider-owned stream hook shortcut; use local provider hooks instead. */
-export const MINIMAX_FAST_MODE_STREAM_HOOKS = buildProviderStreamFamilyHooks("minimax-fast-mode");
 /** @deprecated OpenAI provider-owned stream hook shortcut; use local provider hooks instead. */
 export const OPENAI_RESPONSES_STREAM_HOOKS = buildProviderStreamFamilyHooks(
   "openai-responses-defaults",


### PR DESCRIPTION
## What Problem This Solves

MiniMax-M3 exposes a paid low-latency `service_tier: "priority"` lane on its
Anthropic-compatible endpoint, but OpenClaw has no way to opt a model's
requests into it. Operators running latency-sensitive M3 workloads cannot
trade spend for the faster lane today.

## Why This Change Was Made

Gate the priority lane behind the existing per-model `fastMode` flag, in the
**MiniMax-owned fast-mode wrapper** (`createMinimaxFastModeWrapper`). That
wrapper is the canonical fast-mode path: it already receives `DynamicFastMode`
and resolves it per stream call (via `resolveBooleanFastMode`), so it handles
the function form `/fast auto` passes, not just a literal `true`. For M2.7 it
rewrites to the highspeed model variant; for M3 (which has no highspeed
variant) it now injects `service_tier: "priority"`.

The MiniMax plugin wires this wrapper itself, passing a **plugin-owned cost
resolver**, instead of the generic `minimax-fast-mode` stream-family shortcut.
Pricing therefore stays plugin-owned and core stays provider-pricing-free.
Because the bundled provider was that deprecated shortcut's only consumer, this
revision removes the now-orphaned `MINIMAX_FAST_MODE_STREAM_HOOKS` seam rather
than leave a divergent, billing-incomplete second path.

Scope and non-goals:

- Opt-in only. Default behavior is unchanged when `fastMode` is unset/false.
- M3 only. M2.x models route to the highspeed variant instead and gain no
  priority `service_tier`.
- A `service_tier` already set by an earlier wrapper or caller is preserved.

## User Impact

Operators can opt MiniMax-M3 requests into MiniMax's priority lane by setting
`fastMode` (`/fast on`, `/fast auto`, or `params.fastMode: true`) on the model,
reducing latency at higher cost, and OpenClaw's cost estimate now matches the
billed lane. No impact on any model or caller that does not enable fast mode.

## Evidence

This revision is **rebased onto latest `main`** and resolves the review
findings plus the follow-up cleanup:

- **[BLOCKER] Priority/highspeed cost is reflected in estimates.** Opting M3
  into `service_tier: priority` previously kept standard M3 pricing, and the
  M2.7 highspeed rewrite kept standard M2.7 pricing. The fast-mode wrapper now
  bills the lane it actually runs: `createMinimaxFastModeWrapper` gained an
  optional `resolveFastLaneCost`, the wrapper picks the lane and the **MiniMax
  plugin owns the pricing** (core stays provider-pricing free). M3 priority
  bills **1.5x** the standard rate per
  [MiniMax pricing](https://platform.minimax.io/docs/guides/pricing-paygo);
  M2.7 highspeed bills the highspeed variant's rate. Mirrors the OpenAI
  service-tier multiplier approach in `openai-responses.ts`.
- **[IMPORTANT] Docs.** `docs/providers/minimax.md`, `docs/gateway/config-tools.md`,
  `docs/concepts/model-providers.md`, `docs/tools/slash-commands.md`,
  `docs/tools/thinking.md`, and `docs/plugins/sdk-provider-plugins.md` now
  describe M3 priority processing, `/fast auto`, the 1.5x pricing, and the
  affected provider IDs.
- **[IMPORTANT] Registration coverage.** `extensions/minimax/index.test.ts`
  proves the M3 `service_tier: priority` + 1.5x cost path through the real
  registered provider hook for **both** `minimax` and `minimax-portal`.
- **[NIT] Tier value.** The preservation test uses MiniMax's own `standard`
  tier value instead of Anthropic's `standard_only`.
- **[cleanup] Dropped the orphaned `minimax-fast-mode` SDK family seam.** Since
  the plugin now wires its own hook, the deprecated `MINIMAX_FAST_MODE_STREAM_HOOKS`
  export, the `minimax-fast-mode` family member/case, its stream-matrix test
  coverage, and the families-table doc row are removed. Regenerated the plugin
  SDK API baseline and re-pinned the public surface budget for the net export
  change (`resolveBooleanFastMode` is now exported and the `ResolveMinimaxFastLaneCost`
  type added; `+2` public exports / `+2` callable after dropping the deprecated
  hook). Also corrected the M3 priority-cost comment so its example matches the
  billed rate (`$0.60/$2.40 -> $0.90/$3.60`).

**Validation** (all local, rebased onto latest `main`):

```
pnpm test src/llm/providers/stream-wrappers/minimax.test.ts   → 22 passed
pnpm test extensions/minimax/index.test.ts                    → 15 passed
pnpm test src/plugin-sdk/provider-stream.test.ts              →  8 passed
pnpm test test/scripts/plugin-sdk-surface-report.test.ts      →  8 passed
tsgo:core:test / tsgo:extensions:test                         → clean
pnpm build                                                    → clean (no INEFFECTIVE_DYNAMIC_IMPORT)
oxfmt --check / plugin-sdk:api:check / surface-report --check → clean
```

The registration test drives the exact hooks the MiniMax extension registers
for both provider IDs and captures the outgoing payload + billed cost:

- `MiniMax-M2.7` + fast mode → request model `MiniMax-M2.7-highspeed` (both
  `minimax` and `minimax-portal`)
- `MiniMax-M3` + fast mode → outgoing `service_tier: "priority"` and model cost
  scaled to 1.5x (`{0.6,2.4,0.12,0}` → `{0.9,3.6,0.18,0}`) for both
  `minimax` and `minimax-portal`

**Live endpoint proof.** Real MiniMax-M3 requests to
`https://api.minimax.io/anthropic/v1/messages` (API key redacted), showing the
served lane MiniMax echoes back in `usage.service_tier`:

```
# control — no service_tier
  request:  {"model":"MiniMax-M3","max_tokens":16,"messages":[{"role":"user","content":"ping"}]}
  HTTP 200  → usage.service_tier = "standard"

# with the flag this PR sets
  request:  {"model":"MiniMax-M3","max_tokens":16,"messages":[...],"service_tier":"priority"}
  HTTP 200  → usage.service_tier = "priority"
  response: {"type":"message","model":"MiniMax-M3","content":[{"type":"text","text":"🏓 Pong! ..."}],
             "usage":{"input_tokens":50,"output_tokens":12,"service_tier":"priority"},"stop_reason":"end_turn"}
```

The live endpoint accepts `service_tier: "priority"` for MiniMax-M3 and confirms
the request was served on the priority lane (`usage.service_tier: "priority"`),
versus `"standard"` with the flag off — the exact before/after this PR's
`fastMode` flag produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
