### PR TITLE
Clear pending tool media delivered via the messaging tool

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -709,3 +709,96 @@ describe("handleToolExecutionEnd media emission", () => {
     expect(ctx.state.pendingToolTrustedLocalMedia).toBe(true);
   });
 });
+
+describe("handleToolExecutionEnd messaging-tool media dedup", () => {
+  // Regression: in automatic visible-reply mode the model may both queue
+  // generated media for automatic delivery AND deliver it via the message
+  // tool, which sent the image twice. The message tool sees the sandbox
+  // container path while the queued copy is a host path, so dedup is by basename.
+  it("drops queued tool media already delivered via the message tool across host/container paths", async () => {
+    const ctx = createMockContext();
+    ctx.state.pendingToolMediaUrls = [
+      "/data/media/tool-image-generation/gen-019eacf1---0e9fdb2e.jpg",
+    ];
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "msg-1",
+      args: {
+        action: "send",
+        to: "135170423",
+        text: "Готово",
+        media: "/workspace/media/tool-image-generation/gen-019eacf1---0e9fdb2e.jpg",
+      },
+    });
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "msg-1",
+      isError: false,
+      result: { content: [{ type: "text", text: "sent" }] },
+    });
+
+    expect(ctx.state.pendingToolMediaUrls).toStrictEqual([]);
+    expect(ctx.state.messagingToolSentMediaUrls).toContain(
+      "/workspace/media/tool-image-generation/gen-019eacf1---0e9fdb2e.jpg",
+    );
+  });
+
+  it("keeps queued tool media the message tool did not deliver", async () => {
+    const ctx = createMockContext();
+    ctx.state.pendingToolMediaUrls = ["/data/media/tool-image-generation/gen-other.jpg"];
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "msg-1",
+      args: {
+        action: "send",
+        to: "135170423",
+        media: "/workspace/media/tool-image-generation/gen-sent.jpg",
+      },
+    });
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "msg-1",
+      isError: false,
+      result: { content: [{ type: "text", text: "sent" }] },
+    });
+
+    expect(ctx.state.pendingToolMediaUrls).toStrictEqual([
+      "/data/media/tool-image-generation/gen-other.jpg",
+    ]);
+  });
+
+  it("does not drop queued media on a failed message tool send", async () => {
+    const ctx = createMockContext();
+    ctx.state.pendingToolMediaUrls = [
+      "/data/media/tool-image-generation/gen-019eacf1---0e9fdb2e.jpg",
+    ];
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "msg-1",
+      args: {
+        action: "send",
+        to: "135170423",
+        media: "/workspace/media/tool-image-generation/gen-019eacf1---0e9fdb2e.jpg",
+      },
+    });
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "msg-1",
+      isError: true,
+      result: { content: [{ type: "text", text: "failed" }] },
+    });
+
+    expect(ctx.state.pendingToolMediaUrls).toStrictEqual([
+      "/data/media/tool-image-generation/gen-019eacf1---0e9fdb2e.jpg",
+    ]);
+  });
+});

--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -1,6 +1,7 @@
 // Tool media handler tests cover media extraction from tool results, trusted
 // local media flags, and quiet/verbose tool-output emission paths.
 import { describe, expect, it, vi } from "vitest";
+import { readPendingToolMediaReply } from "./embedded-agent-subscribe.handlers.messages.js";
 import {
   handleToolExecutionEnd,
   handleToolExecutionStart,
@@ -800,5 +801,73 @@ describe("handleToolExecutionEnd messaging-tool media dedup", () => {
     expect(ctx.state.pendingToolMediaUrls).toStrictEqual([
       "/data/media/tool-image-generation/gen-019eacf1---0e9fdb2e.jpg",
     ]);
+  });
+
+  // Audio/trusted flags are global, not per-URL. If the basename filter empties
+  // the queue but leaves a flag set, readPendingToolMediaReply still returns a
+  // metadata-only payload — a phantom fallback delivery after the message tool
+  // already sent the file. Clearing the queue must clear the flags too.
+  it("clears audio/trusted flags when the message tool drained the queued media", async () => {
+    const ctx = createMockContext();
+    ctx.state.pendingToolMediaUrls = ["/data/media/tool-tts/gen-019eacf1---0e9fdb2e.opus"];
+    ctx.state.pendingToolAudioAsVoice = true;
+    ctx.state.pendingToolTrustedLocalMedia = true;
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "msg-1",
+      args: {
+        action: "send",
+        to: "135170423",
+        media: "/workspace/media/tool-tts/gen-019eacf1---0e9fdb2e.opus",
+      },
+    });
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "msg-1",
+      isError: false,
+      result: { content: [{ type: "text", text: "sent" }] },
+    });
+
+    expect(ctx.state.pendingToolMediaUrls).toStrictEqual([]);
+    expect(ctx.state.pendingToolAudioAsVoice).toBe(false);
+    expect(ctx.state.pendingToolTrustedLocalMedia).toBe(false);
+    // No phantom metadata-only fallback reply remains.
+    expect(readPendingToolMediaReply(ctx.state)).toBeNull();
+  });
+
+  // Partial drain: flags must survive while any queued media still needs them.
+  it("keeps audio/trusted flags when some queued media remains undelivered", async () => {
+    const ctx = createMockContext();
+    ctx.state.pendingToolMediaUrls = [
+      "/data/media/tool-tts/gen-sent.opus",
+      "/data/media/tool-tts/gen-kept.opus",
+    ];
+    ctx.state.pendingToolAudioAsVoice = true;
+    ctx.state.pendingToolTrustedLocalMedia = true;
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "msg-1",
+      args: {
+        action: "send",
+        to: "135170423",
+        media: "/workspace/media/tool-tts/gen-sent.opus",
+      },
+    });
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "msg-1",
+      isError: false,
+      result: { content: [{ type: "text", text: "sent" }] },
+    });
+
+    expect(ctx.state.pendingToolMediaUrls).toStrictEqual(["/data/media/tool-tts/gen-kept.opus"]);
+    expect(ctx.state.pendingToolAudioAsVoice).toBe(true);
+    expect(ctx.state.pendingToolTrustedLocalMedia).toBe(true);
   });
 });

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1294,6 +1294,13 @@ export async function handleToolExecutionEnd(
         ctx.state.pendingToolMediaUrls = ctx.state.pendingToolMediaUrls.filter(
           (u) => !sentBasenames.has(u.slice(u.lastIndexOf("/") + 1)),
         );
+        // Audio/trusted flags are global, not per-URL: once the queue is empty
+        // they would otherwise make readPendingToolMediaReply emit a phantom
+        // metadata-only fallback reply after the message tool already delivered.
+        if (ctx.state.pendingToolMediaUrls.length === 0) {
+          ctx.state.pendingToolAudioAsVoice = false;
+          ctx.state.pendingToolTrustedLocalMedia = false;
+        }
       }
     }
     if (

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1284,6 +1284,17 @@ export async function handleToolExecutionEnd(
     if (committedMediaUrls.length > 0) {
       ctx.state.messagingToolSentMediaUrls.push(...committedMediaUrls);
       ctx.trimMessagingToolSent();
+      // Drop pending tool media already delivered via the messaging tool, else
+      // automatic source-reply delivery sends generated media a second time.
+      // Host vs sandbox-container paths differ, so match by basename.
+      if (ctx.state.pendingToolMediaUrls.length > 0) {
+        const sentBasenames = new Set(
+          committedMediaUrls.map((u) => u.slice(u.lastIndexOf("/") + 1)),
+        );
+        ctx.state.pendingToolMediaUrls = ctx.state.pendingToolMediaUrls.filter(
+          (u) => !sentBasenames.has(u.slice(u.lastIndexOf("/") + 1)),
+        );
+      }
     }
     if (
       isDeliveredMessageToolOnlySourceReplyResult({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users receive a generated image **twice** in chat. In automatic visible-reply mode, a media-producing tool (e.g. `image_generate`) queues its output for automatic source-reply delivery, and when the model *also* sends that same file explicitly via the `message` tool, both deliveries fire. Observed in production as two `sendPhoto` calls for a single `image_generate` completion run.

## Why This Change Was Made

The existing reply-payload dedup (`filterMessagingToolMediaDuplicates`) already filters reply media against `messagingToolSentMediaUrls`, but it compares **normalized full paths** (`normalizeMediaForDedupe` only strips `file://`). The same generated file is referenced by two different prefixes that never normalize to the same string:

- the pending queue holds the **host** path: `/data/media/tool-image-generation/gen-….jpg`
- the `message`-tool args carry the **sandbox-container** path: `/workspace/media/tool-image-generation/gen-….jpg`

So the duplicate slips past the full-path comparison. This change stops it at the source: when messaging-tool media is committed in `handleToolExecutionEnd`, it drops any `pendingToolMediaUrls` entry with the same **basename** (basename matching is what bridges the host/container prefix difference). The drop is gated on a non-error send, so a failed `message`-tool send keeps the pending media as the fallback delivery path. Non-goal: it does not change `filterMessagingToolMediaDuplicates` or other delivery paths.

`pendingToolAudioAsVoice` / `pendingToolTrustedLocalMedia` are **global** flags (set per queue, not per URL). When the basename filter empties `pendingToolMediaUrls`, those flags are now cleared too — otherwise `readPendingToolMediaReply` would still return a non-null **metadata-only payload** (its guard requires both an empty URL list *and* both flags false), producing a phantom fallback reply after the `message` tool already delivered the file. (Addresses the review's `[P2]`/`[P1]` correctness finding.)

## User Impact

Users no longer get the same generated image delivered twice when the assistant both auto-attaches tool media and sends it via the `message` tool. No change to single-delivery cases.

## Evidence

Rebased onto latest `main` (clean, no conflicts). `tsgo:core` clean; `pnpm db:kysely:check` / `check:architecture` pass on the rebased branch (the earlier CI architecture failure was pre-existing main drift in `src/infra/sqlite-user-version.ts`, not this diff).

Five regression tests in `embedded-agent-subscribe.handlers.tools.media.test.ts`, all driving the **real** `handleToolExecutionEnd` handler:

- drops queued tool media already delivered via the message tool across host/container paths
- keeps queued tool media the message tool did **not** deliver
- does **not** drop queued media on a failed message-tool send
- **clears audio/trusted flags when the message tool drained the queued media** — asserts `readPendingToolMediaReply` returns `null` afterward (no phantom fallback reply)
- **keeps audio/trusted flags when some queued media remains undelivered** (partial drain)

```
 Test Files  1 passed (1)
      Tests  33 passed (33)
```

Both new flag tests are load-bearing: with the source fix reverted, `clears audio/trusted flags …` fails (the queue empties but the flags stay `true`, so `readPendingToolMediaReply` returns a non-null metadata-only reply). The original host/container dedup test likewise fails on `main` without the source change.

Root cause confirmed in production: two `sendPhoto` calls logged for one `image_generate` run.

> **Live transport proof:** a real-Telegram Crabbox before/after recording is the one outstanding `[P1]`. The contributor environment for this branch does not have the Crabbox / Convex burner-account tooling provisioned, so it can't be captured here. A maintainer can capture it via Mantis with the suggested comment, or trigger the standard `telegram-crabbox-e2e-proof` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
