### PR TITLE
fix(agent): emit context_management for openai-chatgpt-responses when…

### DIFF
--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -4373,6 +4373,43 @@ describe("applyExtraParamsToAgent", () => {
       expect(run().store).toBe(false);
     },
   );
+  it("injects context_management for openai-chatgpt-responses when responsesServerCompaction is configured", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5.5",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": {
+                params: {
+                  responsesServerCompaction: true,
+                  responsesCompactThreshold: 360_000,
+                },
+              },
+            },
+          },
+        },
+      },
+      model: {
+        api: "openai-chatgpt-responses",
+        provider: "openai",
+        id: "gpt-5.5",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        contextWindow: 400_000,
+      } as Model<"openai-chatgpt-responses">,
+      payload: {
+        store: false,
+      },
+    });
+    expect(payload.store).toBe(false);
+    expect(payload.context_management).toEqual([
+      {
+        type: "compaction",
+        compact_threshold: 360_000,
+      },
+    ]);
+  });
 
   it("strips prompt cache fields for non-OpenAI openai-responses endpoints", () => {
     const payload = runResponsesPayloadMutationCase({

--- a/src/agents/openai-responses-payload-policy.test.ts
+++ b/src/agents/openai-responses-payload-policy.test.ts
@@ -247,4 +247,53 @@ describe("openai responses payload policy", () => {
     expect(policy.allowsServiceTier).toBe(true);
     expect(policy.shouldStripStore).toBe(false);
   });
+
+  it("auto-injects server compaction for openai-chatgpt-responses when enableServerCompaction is true", () => {
+    const payload = {} satisfies Record<string, unknown>;
+
+    applyOpenAIResponsesPayloadPolicy(
+      payload,
+      resolveOpenAIResponsesPayloadPolicy(
+        {
+          api: "openai-chatgpt-responses",
+          provider: "openai",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          contextWindow: 400_000,
+        },
+        {
+          enableServerCompaction: true,
+          storeMode: "provider-policy",
+        },
+      ),
+    );
+
+    expect(payload).toEqual({
+      context_management: [{ type: "compaction", compact_threshold: 280_000 }],
+    });
+  });
+
+  it("suppresses server compaction for openai-chatgpt-responses when store is explicitly disabled", () => {
+    const payload = {} satisfies Record<string, unknown>;
+
+    applyOpenAIResponsesPayloadPolicy(
+      payload,
+      resolveOpenAIResponsesPayloadPolicy(
+        {
+          api: "openai-chatgpt-responses",
+          provider: "openai",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          contextWindow: 400_000,
+        },
+        {
+          enableServerCompaction: true,
+          storeMode: "disable",
+        },
+      ),
+    );
+
+    expect(payload).toEqual({
+      store: false,
+    });
+    expect(payload).not.toHaveProperty("context_management");
+  });
 });

--- a/src/agents/openai-responses-payload-policy.ts
+++ b/src/agents/openai-responses-payload-policy.ts
@@ -298,7 +298,7 @@ function shouldEnableOpenAIResponsesServerCompaction(
   if (configured === false) {
     return false;
   }
-  if (explicitStore !== true) {
+  if (explicitStore === false) {
     return false;
   }
   if (configured === true) {


### PR DESCRIPTION
Fixes #95788

### Summary

**Problem:** For OpenAI Responses / Codex-backed `openai/gpt-5.5` sessions, `responsesServerCompaction` and `responsesCompactThreshold` are read from config/model params by the runner/preflight layer, but the live `openai-chatgpt-responses` request builder suppresses `context_management` before the outbound payload reaches the server. This causes premature server-side history reduction even when the local config intends a higher compaction threshold.

**Solution:** Relax the `explicitStore` gate in `shouldEnableOpenAIResponsesServerCompaction` from `explicitStore !== true` to `explicitStore === false`. For `openai-chatgpt-responses`, `allowsResponsesStore` is `false`, so `explicitStore` resolves to `undefined` under `provider-policy` mode; the old gate incorrectly treated `undefined` as a denial, while the new gate only blocks compaction when `store` is explicitly disabled.

**What changed:** Updated `shouldEnableOpenAIResponsesServerCompaction` in `openai-responses-payload-policy.ts`; added regression tests in `openai-responses-payload-policy.test.ts` and `embedded-agent-runner-extraparams.test.ts`.

**What did NOT change:** The `buildOpenAIResponsesParams` `storeMode: "disable"` call for the transport stream path, the `createOpenAIResponsesContextManagementWrapper` wrapper logic, Azure behavior, other provider routes, or the OpenAI Responses payload policy contract beyond the `explicitStore` gate.

**Fixes:** #95788

### Real behavior proof

**Behavior addressed:** Long-running GPT-5.5 Codex/OAuth sessions showed `224k/400k -> 116k/400k` reduction on the same session file with local `compactionCount: 0`, indicating server-side reduction happened before the configured `360000` threshold could govern behavior.

**Code finding:** `resolveOpenAIResponsesPayloadPolicy` with `storeMode: "provider-policy"` for `openai-chatgpt-responses` sets `explicitStore = undefined` (because `allowsResponsesStore` is `false` for this API). `shouldEnableOpenAIResponsesServerCompaction` then returned `false` at `explicitStore !== true`, so `useServerCompaction` was `false` and `context_management` was never emitted.

**Evidence after fix:**
- `resolveOpenAIResponsesPayloadPolicy({ api: "openai-chatgpt-responses", provider: "openai" }, { enableServerCompaction: true, storeMode: "provider-policy" })` now yields `useServerCompaction: true`.
- `applyOpenAIResponsesPayloadPolicy` then correctly injects `context_management: [{ type: "compaction", compact_threshold: <threshold> }]`.
- The runtime wrapper path (`createOpenAIResponsesContextManagementWrapper`) now routes `onPayload` for Codex models so the final payload carries the configured threshold.

### Regression Test Plan

**Coverage level:** Agent payload policy + embedded runner extra-params integration.

**Target test files:**
- `src/agents/openai-responses-payload-policy.test.ts`
- `src/agents/embedded-agent-runner-extraparams.test.ts`

**Scenarios locked in:**
1. `openai-chatgpt-responses` with `enableServerCompaction: true` and `provider-policy` store mode auto-injects `context_management`.
2. `openai-chatgpt-responses` with `storeMode: "disable"` suppresses `context_management` (store explicitly disabled).
3. `openai-chatgpt-responses` runtime wrapper path with `responsesServerCompaction: true` and `responsesCompactThreshold: 360000` emits `context_management` on the final payload while preserving `store: false`.

**Why this is the smallest reliable guardrail:** It covers the exact gate (`shouldEnableOpenAIResponsesServerCompaction`) and the two boundaries (policy resolution and runtime wrapper) that previously suppressed the config, without touching unrelated transport or provider paths.

### Root Cause

**Root cause:** `shouldEnableOpenAIResponsesServerCompaction` used `explicitStore !== true` as a blanket gate. This blocked any model whose `explicitStore` was `undefined`, including `openai-chatgpt-responses` where `allowsResponsesStore` is intentionally `false` (Codex does not support the `store` field). The config was read in the runner layer but never propagated to the outbound payload because the policy resolved `useServerCompaction: false`.

**Missing detection / guardrail:** Existing tests verified `openai-responses` and Azure payload policy, but no test asserted that `openai-chatgpt-responses` with `responsesServerCompaction: true` actually emitted `context_management` through the runtime wrapper path.

---