### PR TITLE
fix(agents): normalize hallucinated Office file extensions

### DIFF
--- a/src/agents/agent-tools.params.test.ts
+++ b/src/agents/agent-tools.params.test.ts
@@ -7,6 +7,8 @@ import {
   assertRequiredParams,
   REQUIRED_PARAM_GROUPS,
   getToolParamsRecord,
+  normalizeFileToolPathParam,
+  normalizeHallucinatedOfficePathExtension,
   stripMalformedXmlArgValueSuffix,
   wrapToolParamValidation,
 } from "./agent-tools.params.js";
@@ -23,6 +25,30 @@ describe("assertRequiredParams", () => {
     expect(stripMalformedXmlArgValueSuffix("echo test</arg_value>")).toBe("echo test</arg_value>");
     expect(stripMalformedXmlArgValueSuffix("echo </arg_value>> test")).toBe(
       "echo </arg_value>> test",
+    );
+  });
+
+  it("normalizes known hallucinated Office/codex path extensions", () => {
+    expect(normalizeHallucinatedOfficePathExtension("reports/final.docodex")).toBe(
+      "reports/final.docx",
+    );
+    expect(normalizeHallucinatedOfficePathExtension("slides/plan.pptxodex")).toBe(
+      "slides/plan.pptx",
+    );
+    expect(normalizeHallucinatedOfficePathExtension("sheets/budget.XLSCODEX")).toBe(
+      "sheets/budget.xlsx",
+    );
+    expect(normalizeHallucinatedOfficePathExtension("notes/codex-report.txt")).toBe(
+      "notes/codex-report.txt",
+    );
+    expect(normalizeHallucinatedOfficePathExtension("archive.docodex/notes.txt")).toBe(
+      "archive.docodex/notes.txt",
+    );
+  });
+
+  it("normalizes file-tool paths after malformed XML suffix cleanup", () => {
+    expect(normalizeFileToolPathParam("reports/final.docodex</arg_value>>")).toBe(
+      "reports/final.docx",
     );
   });
 
@@ -49,6 +75,35 @@ describe("assertRequiredParams", () => {
       {
         path: "notes.txt",
         content: "keep literal payload</arg_value>>",
+      },
+      undefined,
+      undefined,
+    );
+  });
+
+  it("normalizes Office/codex path extensions without touching payload text", async () => {
+    const execute = vi.fn(async (_id, args) => args);
+    const tool = wrapToolParamValidation(
+      {
+        name: "write",
+        label: "write",
+        description: "write a file",
+        parameters: {},
+        execute,
+      },
+      REQUIRED_PARAM_GROUPS.write,
+    );
+
+    await tool.execute("id", {
+      path: "reports/final.docodex",
+      content: "keep literal payload.docodex",
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      "id",
+      {
+        path: "reports/final.docx",
+        content: "keep literal payload.docodex",
       },
       undefined,
       undefined,
@@ -93,9 +148,9 @@ describe("assertRequiredParams", () => {
         newText: "literal new</arg_value>>",
       },
     ];
-    await tool.execute("id", { path: "notes.txt</arg_value>>>", edits });
+    await tool.execute("id", { path: "notes.docxodex</arg_value>>>", edits });
 
-    expect(execute).toHaveBeenCalledWith("id", { path: "notes.txt", edits }, undefined, undefined);
+    expect(execute).toHaveBeenCalledWith("id", { path: "notes.docx", edits }, undefined, undefined);
   });
 
   it("includes received keys in error when some params are present but content is missing", () => {

--- a/src/agents/agent-tools.params.ts
+++ b/src/agents/agent-tools.params.ts
@@ -1,7 +1,7 @@
 /**
  * Shared validation for model-supplied tool parameters.
  * Converts malformed file-tool arguments into retryable errors and fixes the
- * specific XML suffix corruption seen in path arguments.
+ * specific XML suffix and Office-extension corruption seen in path arguments.
  */
 import type { AnyAgentTool } from "./agent-tools.types.js";
 
@@ -14,7 +14,13 @@ export type RequiredParamGroup = {
 
 const RETRY_GUIDANCE_SUFFIX = " Supply correct parameters before retrying.";
 const XML_ARG_VALUE_SUFFIX_RE = /<\/arg_value>>+$/;
-const XML_ARG_VALUE_PATH_PARAM_KEYS = new Set(["path"]);
+const FILE_TOOL_PATH_PARAM_KEYS = new Set(["path"]);
+const HALLUCINATED_OFFICE_PATH_EXTENSION_RE = /\.(doc|ppt|xls)(?:odex|codex|xodex|xcodex)$/i;
+const OFFICE_EXTENSION_BY_FAMILY: Record<string, string> = {
+  doc: ".docx",
+  ppt: ".pptx",
+  xls: ".xlsx",
+};
 
 function parameterValidationError(message: string): Error {
   return new Error(`${message}.${RETRY_GUIDANCE_SUFFIX}`);
@@ -110,6 +116,18 @@ export function stripMalformedXmlArgValueSuffix(value: string): string {
   return value.includes("</arg_value>") ? value.replace(XML_ARG_VALUE_SUFFIX_RE, "") : value;
 }
 
+/** Normalize known model-hallucinated Office/codex path extensions. */
+export function normalizeHallucinatedOfficePathExtension(value: string): string {
+  return value.replace(HALLUCINATED_OFFICE_PATH_EXTENSION_RE, (_match, family: string) => {
+    return OFFICE_EXTENSION_BY_FAMILY[family.toLowerCase()] ?? _match;
+  });
+}
+
+/** Normalize model-supplied file-tool path params without touching payload text. */
+export function normalizeFileToolPathParam(value: string): string {
+  return normalizeHallucinatedOfficePathExtension(stripMalformedXmlArgValueSuffix(value));
+}
+
 /** Strip malformed XML suffixes from selected string fields without mutating input. */
 export function stripMalformedXmlArgValueSuffixFromKeys<T extends Record<string, unknown>>(
   record: T,
@@ -130,13 +148,31 @@ export function stripMalformedXmlArgValueSuffixFromKeys<T extends Record<string,
   return normalized ?? record;
 }
 
-function resolveMalformedXmlArgValuePathKeys(
-  groups: readonly RequiredParamGroup[] | undefined,
-): string[] {
+/** Normalize selected file-tool path fields without mutating input. */
+export function normalizeFileToolPathParamsFromKeys<T extends Record<string, unknown>>(
+  record: T,
+  keys: readonly string[],
+): T {
+  let normalized: T | undefined;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value !== "string") {
+      continue;
+    }
+    const normalizedValue = normalizeFileToolPathParam(value);
+    if (normalizedValue !== value) {
+      normalized ??= { ...record };
+      normalized[key as keyof T] = normalizedValue as T[keyof T];
+    }
+  }
+  return normalized ?? record;
+}
+
+function resolveFileToolPathParamKeys(groups: readonly RequiredParamGroup[] | undefined): string[] {
   const keys = new Set<string>();
   for (const group of groups ?? []) {
     for (const key of group.keys) {
-      if (XML_ARG_VALUE_PATH_PARAM_KEYS.has(key)) {
+      if (FILE_TOOL_PATH_PARAM_KEYS.has(key)) {
         keys.add(key);
       }
     }
@@ -195,10 +231,10 @@ export function wrapToolParamValidation(
     ...tool,
     execute: async (toolCallId, params, signal, onUpdate) => {
       const record = getToolParamsRecord(params);
-      const pathKeys = resolveMalformedXmlArgValuePathKeys(requiredParamGroups);
+      const pathKeys = resolveFileToolPathParamKeys(requiredParamGroups);
       const normalizedParams =
         record && pathKeys.length > 0
-          ? stripMalformedXmlArgValueSuffixFromKeys(record, pathKeys)
+          ? normalizeFileToolPathParamsFromKeys(record, pathKeys)
           : params;
       if (requiredParamGroups?.length) {
         assertRequiredParams(getToolParamsRecord(normalizedParams), requiredParamGroups, tool.name);

--- a/src/agents/agent-tools.read.arg-value-suffix.test.ts
+++ b/src/agents/agent-tools.read.arg-value-suffix.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests malformed XML arg_value suffix cleanup for read paths.
+ * Tests malformed XML arg_value suffix cleanup and path normalization for read paths.
  * The wrapper should repair path params without touching unrelated payloads.
  */
 import { describe, expect, it, vi } from "vitest";
@@ -24,6 +24,29 @@ describe("createOpenClawReadTool malformed XML arg-value suffix handling", () =>
       "read-1",
       {
         path: "notes.txt",
+        offset: 1,
+      },
+      undefined,
+    );
+  });
+
+  it("normalizes hallucinated Office/codex read path extensions", async () => {
+    const execute = vi.fn(async () => ({ content: [{ type: "text" as const, text: "ok" }] }));
+    const base = {
+      name: "read",
+      label: "read",
+      description: "read a file",
+      parameters: {},
+      execute,
+    } as unknown as AnyAgentTool;
+    const tool = createOpenClawReadTool(base);
+
+    await tool.execute("read-1", { path: "reports/final.docodex" });
+
+    expect(execute).toHaveBeenCalledWith(
+      "read-1",
+      {
+        path: "reports/final.docx",
         offset: 1,
       },
       undefined,

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -26,8 +26,8 @@ import {
   REQUIRED_PARAM_GROUPS,
   assertRequiredParams,
   getToolParamsRecord,
-  stripMalformedXmlArgValueSuffix,
-  stripMalformedXmlArgValueSuffixFromKeys,
+  normalizeFileToolPathParam,
+  normalizeFileToolPathParamsFromKeys,
   wrapToolParamValidation,
 } from "./agent-tools.params.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
@@ -652,7 +652,7 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
     execute: async (toolCallId, args, signal, onUpdate) => {
       const record = getToolParamsRecord(args);
       const normalizedRecord = record
-        ? stripMalformedXmlArgValueSuffixFromKeys(record, ["path"])
+        ? normalizeFileToolPathParamsFromKeys(record, ["path"])
         : undefined;
       assertRequiredParams(normalizedRecord, REQUIRED_PARAM_GROUPS.write, tool.name);
       const filePath =
@@ -770,7 +770,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
         if (typeof rawFilePath !== "string" || !rawFilePath.trim()) {
           continue;
         }
-        const filePath = stripMalformedXmlArgValueSuffix(rawFilePath);
+        const filePath = normalizeFileToolPathParam(rawFilePath);
         if (!filePath.trim()) {
           throw malformedXmlArgValuePathError(key);
         }
@@ -886,7 +886,7 @@ export function createOpenClawReadTool(
     execute: async (toolCallId, params, signal) => {
       const record = getToolParamsRecord(params);
       const normalizedRecord = record
-        ? stripMalformedXmlArgValueSuffixFromKeys(record, ["path"])
+        ? normalizeFileToolPathParamsFromKeys(record, ["path"])
         : undefined;
       assertRequiredParams(normalizedRecord, REQUIRED_PARAM_GROUPS.read, base.name);
       const result = await executeReadWithAdaptivePaging({

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1542,8 +1542,7 @@ export async function resolveSessionTranscriptRuntimeTarget(
 export async function resolveSessionTranscriptRuntimeReadTarget(
   scope: SessionTranscriptRuntimeScope,
 ): Promise<SessionTranscriptRuntimeTarget> {
-  const { agentId, sessionEntry, sessionKey, sessionStore } =
-    resolveSessionTranscriptRuntimeContext(scope);
+  const { agentId, sessionEntry, sessionKey } = resolveSessionTranscriptRuntimeContext(scope);
   if (scope.sessionFile?.trim()) {
     return {
       agentId,


### PR DESCRIPTION
## What Problem This Solves

Fixes #93326. Model-supplied file-tool paths can hallucinate Office-like extensions such as `.docodex`, `.pptxodex`, or `.xlscodex`, causing file operations to target bogus paths instead of the intended `.docx`, `.pptx`, or `.xlsx` artifact.

## Why This Change Was Made

The existing file-tool parameter normalization already repaired malformed terminal `</arg_value>>` suffixes for path parameters. This extends that same path-only normalization to known Office/codex extension corruptions, without touching payload text such as file contents or edit replacement strings.

This is a replacement Clownfish fix for the closed prior attempts #93531 and #93599, preserving contributor credit in the commit trailers.

## User Impact

Agents are less likely to fail DOCX/PPTX/XLSX reads and writes because a hallucinated codex-flavored extension is corrected at the file-tool boundary before execution. Non-path payload text remains unchanged.

## Evidence

- `git diff --check origin/main..HEAD`
- `node scripts/run-vitest.mjs src/agents/agent-tools.params.test.ts src/agents/agent-tools.read.arg-value-suffix.test.ts --reporter=verbose` passed: 2 files, 20 tests.

Known proof gap: core tsgo could not run from the sparse worktree because tracked `ui/config` inputs are missing. Full CI should cover the rebased branch.
