### PR TITLE
fix(cron):cron-every-error-backoff-unresolved

### DIFF
--- a/src/cron/service.issue-66019-unresolved-next-run.test.ts
+++ b/src/cron/service.issue-66019-unresolved-next-run.test.ts
@@ -68,7 +68,8 @@ async function expectJobDoesNotRefireWhenNextRunIsUnresolved(params: {
 function createEveryUnresolvedFixture(params: {
   id: string;
   scheduledAt: number;
-  everyMs?: number | unknown;
+  everyMs?: number;
+  invalidEveryMs?: boolean;
   consecutiveErrors?: number;
 }): CronJob {
   return {
@@ -77,7 +78,10 @@ function createEveryUnresolvedFixture(params: {
     enabled: true,
     createdAtMs: params.scheduledAt - 86_400_000,
     updatedAtMs: params.scheduledAt - 86_400_000,
-    schedule: { kind: "every", everyMs: params.everyMs ?? 60_000 },
+    schedule: {
+      kind: "every",
+      everyMs: params.invalidEveryMs ? ("abc" as unknown as number) : (params.everyMs ?? 60_000),
+    },
     sessionTarget: "isolated",
     wakeMode: "next-heartbeat",
     payload: { kind: "agentTurn", message: "ping" },
@@ -198,7 +202,7 @@ describe("#66019 unresolved next-run repro", () => {
       name: "error retry with non-finite everyMs",
       id: "cron-66019-every-error-invalid-interval",
       scheduledAt: Date.parse("2026-04-13T16:05:00.000Z"),
-      everyMs: "abc" as unknown as number,
+      invalidEveryMs: true,
       consecutiveErrors: 1,
       status: "error" as const,
       mockNextRun: false,
@@ -217,18 +221,28 @@ describe("#66019 unresolved next-run repro", () => {
       name: "successful completion with non-finite everyMs",
       id: "cron-66019-every-success-invalid-interval",
       scheduledAt: Date.parse("2026-04-13T16:15:00.000Z"),
-      everyMs: "abc" as unknown as number,
+      invalidEveryMs: true,
       status: "ok" as const,
       mockNextRun: false,
       expectedMsg: "cron: next run unresolved after successful completion; clearing schedule",
     },
   ])(
     "warns and clears every unresolved next run: $name",
-    async ({ id, scheduledAt, everyMs, consecutiveErrors, status, mockNextRun, expectedMsg }) => {
+    async ({
+      id,
+      scheduledAt,
+      everyMs,
+      invalidEveryMs,
+      consecutiveErrors,
+      status,
+      mockNextRun,
+      expectedMsg,
+    }) => {
       const everyJob = createEveryUnresolvedFixture({
         id,
         scheduledAt,
         everyMs,
+        invalidEveryMs,
         consecutiveErrors,
       });
       const { state, warnLogs } = createWarnCapturingState(scheduledAt);

--- a/src/cron/service.issue-66019-unresolved-next-run.test.ts
+++ b/src/cron/service.issue-66019-unresolved-next-run.test.ts
@@ -7,9 +7,11 @@ import {
   setupCronRegressionFixtures,
 } from "../../test/helpers/cron/service-regression-fixtures.js";
 import * as schedule from "./schedule.js";
+import * as jobs from "./service/jobs.js";
 import { createCronServiceState } from "./service/state.js";
-import { onTimer } from "./service/timer.js";
+import { applyJobResult, onTimer } from "./service/timer.js";
 import { saveCronStore } from "./store.js";
+import type { CronJob } from "./types.js";
 
 const issue66019Fixtures = setupCronRegressionFixtures({ prefix: "cron-66019-" });
 
@@ -61,6 +63,50 @@ async function expectJobDoesNotRefireWhenNextRunIsUnresolved(params: {
 
   expect(params.runIsolatedAgentJob).toHaveBeenCalledTimes(1);
   expect(params.state.store?.jobs[0]?.state.nextRunAtMs).toBeUndefined();
+}
+
+function createEveryUnresolvedFixture(params: {
+  id: string;
+  scheduledAt: number;
+  everyMs?: number | unknown;
+  consecutiveErrors?: number;
+}): CronJob {
+  return {
+    id: params.id,
+    name: params.id,
+    enabled: true,
+    createdAtMs: params.scheduledAt - 86_400_000,
+    updatedAtMs: params.scheduledAt - 86_400_000,
+    schedule: { kind: "every", everyMs: params.everyMs ?? 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "ping" },
+    delivery: { mode: "announce" },
+    state: {
+      nextRunAtMs: params.scheduledAt - 1_000,
+      lastRunAtMs: params.scheduledAt - 60_000,
+      ...(params.consecutiveErrors !== undefined
+        ? { consecutiveErrors: params.consecutiveErrors }
+        : {}),
+    },
+  };
+}
+
+function createWarnCapturingState(scheduledAt: number) {
+  const warnLogs: Array<{ obj: unknown; msg?: string }> = [];
+  const state = createCronServiceState({
+    cronEnabled: true,
+    storePath: "/dev/null",
+    log: {
+      ...noopLogger,
+      warn: (obj: unknown, msg?: string) => warnLogs.push({ obj, msg }),
+    },
+    nowMs: () => scheduledAt,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeat: vi.fn(),
+    runIsolatedAgentJob: createDefaultIsolatedRunner(),
+  });
+  return { state, warnLogs };
 }
 
 describe("#66019 unresolved next-run repro", () => {
@@ -136,6 +182,84 @@ describe("#66019 unresolved next-run repro", () => {
       clearCronTimer(state);
     }
   });
+
+  it.each([
+    {
+      name: "error retry with mocked unresolved next run",
+      id: "cron-66019-every-error-unresolved",
+      scheduledAt: Date.parse("2026-04-13T16:00:00.000Z"),
+      everyMs: 60_000,
+      consecutiveErrors: 1,
+      status: "error" as const,
+      mockNextRun: true,
+      expectedMsg: "cron: next run unresolved during transient error retry; clearing schedule",
+    },
+    {
+      name: "error retry with non-finite everyMs",
+      id: "cron-66019-every-error-invalid-interval",
+      scheduledAt: Date.parse("2026-04-13T16:05:00.000Z"),
+      everyMs: "abc" as unknown as number,
+      consecutiveErrors: 1,
+      status: "error" as const,
+      mockNextRun: false,
+      expectedMsg: "cron: next run unresolved during transient error retry; clearing schedule",
+    },
+    {
+      name: "successful completion with mocked unresolved next run",
+      id: "cron-66019-every-unresolved",
+      scheduledAt: Date.parse("2026-04-13T16:10:00.000Z"),
+      everyMs: 60_000,
+      status: "ok" as const,
+      mockNextRun: true,
+      expectedMsg: "cron: next run unresolved after successful completion; clearing schedule",
+    },
+    {
+      name: "successful completion with non-finite everyMs",
+      id: "cron-66019-every-success-invalid-interval",
+      scheduledAt: Date.parse("2026-04-13T16:15:00.000Z"),
+      everyMs: "abc" as unknown as number,
+      status: "ok" as const,
+      mockNextRun: false,
+      expectedMsg: "cron: next run unresolved after successful completion; clearing schedule",
+    },
+  ])(
+    "warns and clears every unresolved next run: $name",
+    async ({ id, scheduledAt, everyMs, consecutiveErrors, status, mockNextRun, expectedMsg }) => {
+      const everyJob = createEveryUnresolvedFixture({
+        id,
+        scheduledAt,
+        everyMs,
+        consecutiveErrors,
+      });
+      const { state, warnLogs } = createWarnCapturingState(scheduledAt);
+      state.store = { version: 1, jobs: [everyJob] };
+
+      const scheduleSpy = mockNextRun
+        ? vi.spyOn(schedule, "computeNextRunAtMs").mockReturnValue(undefined)
+        : undefined;
+      const jobSpy =
+        status === "ok" && mockNextRun
+          ? vi.spyOn(jobs, "computeJobNextRunAtMs").mockReturnValue(undefined)
+          : undefined;
+      try {
+        applyJobResult(state, everyJob, {
+          status,
+          ...(status === "error" ? { error: "429 rate limit exceeded" } : {}),
+          startedAt: scheduledAt,
+          endedAt: scheduledAt + 1_000,
+        });
+
+        expect(everyJob.state.nextRunAtMs).toBeUndefined();
+        expect(warnLogs).toContainEqual({
+          obj: { jobId: id, jobName: id, scheduleKind: "every" },
+          msg: expectedMsg,
+        });
+      } finally {
+        scheduleSpy?.mockRestore();
+        jobSpy?.mockRestore();
+      }
+    },
+  );
 
   it("preserves the active error backoff floor when maintenance repair later finds a natural next run", async () => {
     const store = issue66019Fixtures.makeStorePath();

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -428,6 +428,34 @@ function resolveCronNextRunWithLowerBound(params: {
   return Math.max(params.naturalNext, params.lowerBoundMs);
 }
 
+function resolveEveryNextRunAtMs(params: {
+  state: CronServiceState;
+  job: CronJob;
+  naturalNext: number | undefined;
+  lowerBoundMs?: number;
+  context: "completion" | "error_backoff";
+}): number | undefined {
+  if (params.naturalNext === undefined) {
+    const message =
+      params.context === "completion"
+        ? "cron: next run unresolved after successful completion; clearing schedule"
+        : "cron: next run unresolved during transient error retry; clearing schedule";
+    params.state.deps.log.warn(
+      {
+        jobId: params.job.id,
+        jobName: params.job.name,
+        scheduleKind: params.job.schedule.kind,
+      },
+      message,
+    );
+    return undefined;
+  }
+  if (params.lowerBoundMs !== undefined) {
+    return Math.max(params.naturalNext, params.lowerBoundMs);
+  }
+  return params.naturalNext;
+}
+
 function resolveRetryConfig(cronConfig?: CronConfig) {
   const retry = cronConfig?.retry;
   return {
@@ -909,9 +937,17 @@ export function applyJobResult(
               lowerBoundMs: backoffNext,
               context: "error_backoff",
             })
-          : normalNext !== undefined
-            ? Math.max(normalNext, backoffNext)
-            : backoffNext;
+          : job.schedule.kind === "every"
+            ? resolveEveryNextRunAtMs({
+                state,
+                job,
+                naturalNext: normalNext,
+                lowerBoundMs: backoffNext,
+                context: "error_backoff",
+              })
+            : normalNext !== undefined
+              ? Math.max(normalNext, backoffNext)
+              : backoffNext;
       state.deps.log.info(
         {
           jobId: job.id,
@@ -947,6 +983,13 @@ export function applyJobResult(
           job,
           naturalNext,
           lowerBoundMs: minNext,
+          context: "completion",
+        });
+      } else if (job.schedule.kind === "every") {
+        job.state.nextRunAtMs = resolveEveryNextRunAtMs({
+          state,
+          job,
+          naturalNext,
           context: "completion",
         });
       } else {


### PR DESCRIPTION
## What Problem This Solves

This consolidates the closed #95801 follow-up into one focused cron hardening PR.

For `every` schedules, `applyJobResult` now matches the existing unresolved-next-run
guard used by `cron` schedules (#66083): when next-run resolution returns
`undefined`, OpenClaw logs a warning and clears `nextRunAtMs` instead of either
silently clearing (successful completion) or falling back to a pure backoff-only
timestamp (transient error retry).

This is **defensive consistency for malformed schedule state**, not a fix for a
normal timeout/retry failure on a valid recurring schedule.

## Why This Change Was Made

On current `main`, the sibling `cron` path already warns and clears through
`resolveCronNextRunWithLowerBound()`. The corresponding `every` paths did not:

- successful completion cleared `nextRunAtMs` with no warning
- transient error retry used `backoffNext` when `normalNext` was `undefined`

That left `every` jobs with inconsistent diagnostics and, on the error path, a
retry cadence detached from the configured recurring schedule when schedule state
was already invalid.

## User Impact

**No behavior change for healthy `every` jobs with a finite `everyMs`.**

When persisted or in-memory job state already has an invalid/non-finite
`everyMs`, or next-run computation otherwise returns `undefined`, operators now
get an explicit warning before the schedule is cleared instead of silent schedule
loss or backoff-only retrying.

Per maintainer review on this PR: this branch is not reachable from a normal
valid-every timeout/retry path, so live scheduler proof is intentionally waived
for merge.

## Runtime reachability

For a valid schedule such as `{ kind: "every", everyMs: 60000 }`, a transient
execution error or successful completion still computes a finite `normalNext`.
`computeNextRunAtMs()` only returns `undefined` for `every` when
`coerceFiniteScheduleNumber(schedule.everyMs)` fails, and
`computeJobNextRunAtMs()` has the same guard.

The concrete real-runtime path is malformed persisted/in-memory schedule state,
for example `{ "kind": "every", "everyMs": "abc" }`. The regression suite
exercises that path directly through `applyJobResult()` without mocking the
scheduler.

## Compatibility note

The only behavior change is for **already-invalid `every` schedule state** that
previously continued on a pure backoff timestamp during error retry. Valid
schedules are unaffected. This aligns with the existing cron unresolved guard
rather than introducing a new user-facing scheduling contract.

## Evidence

Commands run:

```text
git diff --check
node scripts/run-vitest.mjs src/cron/service.issue-66019-unresolved-next-run.test.ts
```

Observed output:

```text
Test Files  1 passed (1)
Tests  7 passed (7)
```

Tests covered:

- existing cron unresolved refire-loop regressions
- every error/success unresolved paths (mocked contract + non-mock invalid `everyMs`)
- maintenance repair still preserves the active error backoff floor

What was not tested: broader cron suites beyond the focused unresolved-next-run
regression file. Live scheduler proof waived per maintainer review because the
changed branch is malformed-state hardening only.
