### PR TITLE
fix(diagnostics): redact debug payload secrets

### DIFF
--- a/src/agents/anthropic-payload-log.test.ts
+++ b/src/agents/anthropic-payload-log.test.ts
@@ -28,6 +28,10 @@ describe("createAnthropicPayloadLogger", () => {
           authorization: "Bearer sk-secret", // pragma: allowlist secret
           content: [
             {
+              type: "text",
+              text: "debug key sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWx", // pragma: allowlist secret
+            },
+            {
               type: "image",
               source: { type: "base64", media_type: "image/png", data: "QUJDRA==" },
             },
@@ -57,8 +61,9 @@ describe("createAnthropicPayloadLogger", () => {
     const message = ((sanitizedPayload.messages as unknown[] | undefined) ?? []) as Array<
       Record<string, unknown>
     >;
-    const source = (((message[0]?.content as Array<Record<string, unknown>> | undefined) ?? [])[0]
-      ?.source ?? {}) as Record<string, unknown>;
+    const content = (message[0]?.content as Array<Record<string, unknown>> | undefined) ?? [];
+    const imageContent = content.find((entry) => entry.type === "image") ?? {};
+    const source = (imageContent.source ?? {}) as Record<string, unknown>;
     const metadata = (sanitizedPayload.metadata ?? {}) as Record<string, unknown>;
     expect(message[0]).not.toHaveProperty("authorization");
     expect(metadata).not.toHaveProperty("api_key");
@@ -68,6 +73,7 @@ describe("createAnthropicPayloadLogger", () => {
     expect(source.bytes).toBe(4);
     expect(source.sha256).toBe(crypto.createHash("sha256").update("QUJDRA==").digest("hex"));
     expect(event.payloadDigest).toMatch(/^[a-f0-9]{64}$/u);
+    expect(JSON.stringify(event)).not.toContain("sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWx");
   });
 
   it("sanitizes usage and error fields before writing logs", () => {
@@ -88,15 +94,17 @@ describe("createAnthropicPayloadLogger", () => {
           content: "",
           usage: {
             input: 1,
+            output: "github token ghp_AbCdEfGhIjKlMnOpQrStUvWx1234", // pragma: allowlist secret
             authorization: "Bearer sk-secret", // pragma: allowlist secret
           },
         } as never,
       ],
-      new Error("failed with Bearer sk-secret"), // pragma: allowlist secret
+      new Error("failed with pplx-AbCdEfGhIjKlMnOpQrStUvWx"), // pragma: allowlist secret
     );
 
     const event = JSON.parse(lines[0]?.trim() ?? "{}") as Record<string, unknown>;
-    expect(event.error).toBe("failed with Bearer <redacted>");
-    expect(event.usage).toEqual({ input: 1 });
+    expect(event.error).not.toContain("pplx-AbCdEfGhIjKlMnOpQrStUvWx");
+    expect(JSON.stringify(event.usage)).not.toContain("ghp_AbCdEfGhIjKlMnOpQrStUvWx1234");
+    expect(event.usage).toMatchObject({ input: 1 });
   });
 });

--- a/src/agents/anthropic-payload-log.ts
+++ b/src/agents/anthropic-payload-log.ts
@@ -7,6 +7,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import type { Model } from "../llm/types.js";
+import { redactSecrets } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveUserPath } from "../utils.js";
 import { parseBooleanValue } from "../utils/boolean.js";
@@ -56,20 +57,24 @@ function getWriter(filePath: string): PayloadLogWriter {
   return getQueuedFileWriter(writers, filePath);
 }
 
+function redactDiagnosticPayload(value: unknown): unknown {
+  return redactSecrets(sanitizeDiagnosticPayload(value));
+}
+
 function formatError(error: unknown): string | undefined {
   if (error instanceof Error) {
-    const redacted = sanitizeDiagnosticPayload(error.message);
+    const redacted = redactDiagnosticPayload(error.message);
     return typeof redacted === "string" ? redacted : error.message;
   }
   if (typeof error === "string") {
-    const redacted = sanitizeDiagnosticPayload(error);
+    const redacted = redactDiagnosticPayload(error);
     return typeof redacted === "string" ? redacted : error;
   }
   if (typeof error === "number" || typeof error === "boolean" || typeof error === "bigint") {
     return String(error);
   }
   if (error && typeof error === "object") {
-    return safeJsonStringify(sanitizeDiagnosticPayload(error)) ?? "unknown error";
+    return safeJsonStringify(redactDiagnosticPayload(error)) ?? "unknown error";
   }
   return undefined;
 }
@@ -151,7 +156,7 @@ export function createAnthropicPayloadLogger(params: {
       const nextOnPayload = (payload: unknown) => {
         // Forward the original payload to the provider hook, but persist only
         // the redacted diagnostic copy.
-        const redactedPayload = sanitizeDiagnosticPayload(payload);
+        const redactedPayload = redactDiagnosticPayload(payload);
         record({
           ...base,
           ts: new Date().toISOString(),
@@ -187,7 +192,7 @@ export function createAnthropicPayloadLogger(params: {
       ...base,
       ts: new Date().toISOString(),
       stage: "usage",
-      usage: sanitizeDiagnosticPayload(usage) as Record<string, unknown>,
+      usage: redactDiagnosticPayload(usage) as Record<string, unknown>,
       error: errorMessage,
     });
     log.info("anthropic usage", {

--- a/src/agents/cache-trace.test.ts
+++ b/src/agents/cache-trace.test.ts
@@ -178,11 +178,14 @@ describe("createCacheTrace", () => {
     const { lines, trace } = createMemoryTraceForTest();
 
     trace?.recordStage("stream:context", {
+      prompt: "prompt key sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWx", // pragma: allowlist secret
       system: {
         provider: { apiKey: "sk-system-secret", baseUrl: "https://api.example.com" },
+        text: "aws key AKIAIOSFODNN7EXAMPLE", // pragma: allowlist secret
       },
       model: {
         id: "test-model",
+        label: "github token ghp_AbCdEfGhIjKlMnOpQrStUvWx1234", // pragma: allowlist secret
         apiKey: "sk-model-secret",
         tokenCount: 8192,
       },
@@ -202,6 +205,7 @@ describe("createCacheTrace", () => {
           metadata: {
             secretKey: "message-secret-key",
             label: "preserve-me",
+            detail: "perplexity token pplx-AbCdEfGhIjKlMnOpQrStUvWx", // pragma: allowlist secret
           },
           content: [
             {
@@ -211,6 +215,8 @@ describe("createCacheTrace", () => {
           ],
         },
       ] as unknown as [],
+      note: "google key AIzaSyA1bC2dE3fG4hI5jK6lM7nO8pQrStUvW", // pragma: allowlist secret
+      error: "xai key xai-1234567890AbCdEfGhIjKlMnOpQrStUvWx", // pragma: allowlist secret
     });
 
     const event = JSON.parse(lines[0]?.trim() ?? "{}") as Record<string, unknown>;
@@ -218,9 +224,11 @@ describe("createCacheTrace", () => {
       provider: {
         baseUrl: "https://api.example.com",
       },
+      text: expect.not.stringContaining("AKIAIOSFODNN7EXAMPLE"),
     });
     expect(event.model).toEqual({
       id: "test-model",
+      label: expect.not.stringContaining("ghp_AbCdEfGhIjKlMnOpQrStUvWx1234"),
       tokenCount: 8192,
     });
     expect(event.options).toEqual({
@@ -256,12 +264,17 @@ describe("createCacheTrace", () => {
     expect(firstMessage?.role).toBe("user");
     expect(firstMessage?.metadata).toEqual({
       label: "preserve-me",
+      detail: expect.not.stringContaining("pplx-AbCdEfGhIjKlMnOpQrStUvWx"),
     });
     const source = (((firstMessage?.content as Array<Record<string, unknown>> | undefined) ?? [])[0]
       ?.source ?? {}) as Record<string, unknown>;
     expect(source.data).toBe("<redacted>");
     expect(source.bytes).toBe(6);
     expect(source.sha256).toBe(crypto.createHash("sha256").update("U0VDUkVU").digest("hex"));
+    expect(event.prompt).not.toContain("sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWx");
+    expect(event.note).not.toContain("AIzaSyA1bC2dE3fG4hI5jK6lM7nO8pQrStUvW");
+    expect(event.error).not.toContain("xai-1234567890AbCdEfGhIjKlMnOpQrStUvWx");
+    expect(JSON.stringify(event)).not.toContain("AKIAIOSFODNN7EXAMPLE");
   });
 
   it("handles circular references in messages without stack overflow", () => {

--- a/src/agents/cache-trace.ts
+++ b/src/agents/cache-trace.ts
@@ -5,6 +5,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { redactSecrets } from "../logging/redact.js";
 import { resolveUserPath } from "../utils.js";
 import { parseBooleanValue } from "../utils/boolean.js";
 import { safeJsonStringify } from "../utils/safe-json.js";
@@ -113,6 +114,10 @@ function getWriter(filePath: string): CacheTraceWriter {
   return getQueuedFileWriter(writers, filePath);
 }
 
+function redactDiagnosticPayload(value: unknown): unknown {
+  return redactSecrets(sanitizeDiagnosticPayload(value));
+}
+
 function digest(value: unknown): string {
   const serialized = stableStringify(value);
   return crypto.createHash("sha256").update(serialized).digest("hex");
@@ -156,17 +161,17 @@ export function createCacheTrace(params: CacheTraceInit): CacheTrace | null {
     };
 
     if (payload.prompt !== undefined && cfg.includePrompt) {
-      event.prompt = payload.prompt;
+      event.prompt = redactDiagnosticPayload(payload.prompt) as string;
     }
     if (payload.system !== undefined && cfg.includeSystem) {
-      event.system = sanitizeDiagnosticPayload(payload.system);
+      event.system = redactDiagnosticPayload(payload.system);
       event.systemDigest = digest(payload.system);
     }
     if (payload.options) {
-      event.options = sanitizeDiagnosticPayload(payload.options) as Record<string, unknown>;
+      event.options = redactDiagnosticPayload(payload.options) as Record<string, unknown>;
     }
     if (payload.model) {
-      event.model = sanitizeDiagnosticPayload(payload.model) as Record<string, unknown>;
+      event.model = redactDiagnosticPayload(payload.model) as Record<string, unknown>;
     }
 
     const messages = payload.messages;
@@ -179,15 +184,15 @@ export function createCacheTrace(params: CacheTraceInit): CacheTrace | null {
       if (cfg.includeMessages) {
         // Full messages are optional; summaries/digests are always recorded when
         // message payloads are supplied.
-        event.messages = sanitizeDiagnosticPayload(messages) as AgentMessage[];
+        event.messages = redactDiagnosticPayload(messages) as AgentMessage[];
       }
     }
 
     if (payload.note) {
-      event.note = payload.note;
+      event.note = redactDiagnosticPayload(payload.note) as string;
     }
     if (payload.error) {
-      event.error = payload.error;
+      event.error = redactDiagnosticPayload(payload.error) as string;
     }
 
     const line = safeJsonStringify(event);


### PR DESCRIPTION
## Summary

- Harden opt-in agent diagnostic JSONL sinks so common bare vendor-token strings are redacted before persistence.
- Preserve existing diagnostic payload shaping for credential fields, auth strings, and image/base64 metadata.

## Changes

- Layer `redactSecrets(sanitizeDiagnosticPayload(...))` in the Anthropic payload logger for request payloads, usage records, and formatted errors.
- Apply the same layered redaction in cache tracing and redact previously raw `prompt`, `note`, and `error` fields before writing trace events.
- Extend focused tests with representative fake token-shaped strings across payloads, usage, prompt, note, and error fields.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs src/agents/anthropic-payload-log.test.ts src/agents/cache-trace.test.ts`
- `node scripts/run-oxlint.mjs src/agents/anthropic-payload-log.ts src/agents/cache-trace.ts src/agents/anthropic-payload-log.test.ts src/agents/cache-trace.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`

## Notes

- No `CHANGELOG.md` update.
- No agent transcript section included; adding sanitized transcript logs requires explicit approval.
