### PR TITLE
fix(cron): redact command output in delivery

### DIFF
--- a/src/cron/delivery-redaction.ts
+++ b/src/cron/delivery-redaction.ts
@@ -1,0 +1,30 @@
+import { redactToolPayloadText } from "../logging/redact.js";
+
+const CRON_DEVICE_AUTH_REDACTION = "[redacted device authorization output]";
+const DEVICE_AUTH_URL_RE =
+  /\bhttps?:\/\/[^\s<>"']*(?:microsoft\.com\/devicelogin|aka\.ms\/devicelogin|\/oauth2?\/device|\/device(?:code|login)?\b|device[-_]?code|device[-_]?login)[^\s<>"']*/iu;
+const DEVICE_AUTH_CODE_LINE_RE =
+  /\b(?:user[-_\s]?code|device[-_\s]?code|verification[-_\s]?(?:uri|url)|enter\s+(?:the\s+)?code)\b.*\b[A-Z0-9]{4,12}(?:-[A-Z0-9]{2,12}){0,4}\b/iu;
+
+function redactActionRequiredLine(line: string): string {
+  if (!line.trim()) {
+    return line;
+  }
+  if (DEVICE_AUTH_URL_RE.test(line) || DEVICE_AUTH_CODE_LINE_RE.test(line)) {
+    return CRON_DEVICE_AUTH_REDACTION;
+  }
+  return line;
+}
+
+function redactActionRequiredLines(text: string): string {
+  return text
+    .split(/(\r\n|\r|\n)/u)
+    .map((part) => (/^(?:\r\n|\r|\n)$/u.test(part) ? part : redactActionRequiredLine(part)))
+    .join("");
+}
+
+/** Redacts command output before it leaves cron's non-interactive delivery boundary. */
+export function redactCronDeliveryText(text: string): string {
+  const secretRedacted = redactToolPayloadText(text);
+  return redactActionRequiredLines(secretRedacted);
+}

--- a/src/cron/delivery.failure-notify.test.ts
+++ b/src/cron/delivery.failure-notify.test.ts
@@ -37,7 +37,8 @@ vi.mock("../logging.js", () => ({
   })),
 }));
 
-const { sendFailureNotificationAnnounce } = await import("./delivery.js");
+const { sendCronAnnouncePayloadStrict, sendFailureNotificationAnnounce } =
+  await import("./delivery.js");
 
 type DeliveryRequest = {
   abortSignal?: unknown;
@@ -123,6 +124,35 @@ describe("sendFailureNotificationAnnounce", () => {
     expect(deliveryRequest.bestEffort).toBe(false);
     expect(deliveryRequest.deps).toEqual({ kind: "deps" });
     expect(deliveryRequest.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("redacts secrets and device authorization prompts before primary announce delivery", async () => {
+    await sendCronAnnouncePayloadStrict({
+      deps: {} as never,
+      cfg: {} as never,
+      agentId: "main",
+      jobId: "job-1",
+      target: { channel: "telegram", to: "123" },
+      message: [
+        "stdout:",
+        "Open https://microsoft.com/devicelogin and enter code ABCD-EFGH",
+        "OPENAI_API_KEY=sk-1234567890abcdef",
+        "ordinary status",
+      ].join("\n"),
+      abortSignal: new AbortController().signal,
+    });
+
+    const deliveryRequest = firstDeliveryRequest();
+    expect(deliveryRequest.payloads).toEqual([
+      {
+        text: [
+          "stdout:",
+          "[redacted device authorization output]",
+          "OPENAI_API_KEY=sk-123…cdef",
+          "ordinary status",
+        ].join("\n"),
+      },
+    ]);
   });
 
   it("uses sessionKey for delivery-target resolution and outbound context", async () => {

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -14,6 +14,7 @@ import {
   type CronDeliveryPlan,
   resolveCronDeliveryPlan,
 } from "./delivery-plan.js";
+import { redactCronDeliveryText } from "./delivery-redaction.js";
 import {
   resolveDeliveryTarget,
   type DeliveryTargetResolution,
@@ -114,7 +115,7 @@ async function deliverCronAnnouncePayload(params: {
     to: params.delivery.resolvedTarget.to,
     accountId: params.delivery.resolvedTarget.accountId,
     threadId: params.delivery.resolvedTarget.threadId,
-    payloads: [{ text: params.message }],
+    payloads: [{ text: redactCronDeliveryText(params.message) }],
     session: params.delivery.session,
     identity: params.delivery.identity,
     bestEffort: false,

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -7,6 +7,7 @@ import {
 import type { CliDeps } from "../cli/deps.types.js";
 import type { CronFailureDestinationConfig } from "../config/types.cron.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { redactCronDeliveryText } from "../cron/delivery-redaction.js";
 import {
   resolveCronDeliveryPlan,
   resolveFailureDestination,
@@ -89,6 +90,12 @@ function buildCronWebhookHeaders(webhookToken?: string): Record<string, string> 
     headers.Authorization = `Bearer ${webhookToken}`;
   }
   return headers;
+}
+
+function buildCronDeliveryWebhookPayload(evt: CronEvent): CronEvent {
+  return typeof evt.summary === "string"
+    ? { ...evt, summary: redactCronDeliveryText(evt.summary) }
+    : evt;
 }
 
 /** Posts a cron webhook without throwing back into scheduler completion flow. */
@@ -267,7 +274,7 @@ export function dispatchGatewayCronFinishedNotifications(params: {
         await postCronWebhook({
           webhookUrl: webhookTarget.url,
           webhookToken,
-          payload: params.evt,
+          payload: buildCronDeliveryWebhookPayload(params.evt),
           logContext: { jobId: params.evt.jobId, source: webhookTarget.source },
           blockedLog: "cron: webhook delivery blocked by SSRF guard",
           failedLog: "cron: webhook delivery failed",

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -584,6 +584,60 @@ describe("buildGatewayCronService", () => {
     }
   });
 
+  it("redacts command cron summaries before webhook delivery without changing stored run state", async () => {
+    const cfg = createCronConfig("server-cron-command-webhook-redaction");
+    loadConfigMock.mockReturnValue(cfg);
+    fetchWithSsrFGuardMock.mockResolvedValue({ release: vi.fn(async () => {}) });
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "redacted-command-webhook",
+        enabled: true,
+        deleteAfterRun: false,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: {
+          kind: "command",
+          argv: [
+            process.execPath,
+            "-e",
+            [
+              "process.stdout.write('Open https://microsoft.com/devicelogin and enter code ABCD-EFGH\\n')",
+              "process.stdout.write('OPENAI_API_KEY=sk-1234567890abcdef\\n')",
+            ].join(";"),
+          ],
+        },
+        delivery: {
+          mode: "webhook",
+          to: "https://example.invalid/cron-finished",
+        },
+      });
+
+      await state.cron.run(job.id, "force");
+
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
+      const request = requireRecord(
+        callArg(fetchWithSsrFGuardMock, 0, 0, "webhook request"),
+        "webhook request",
+      );
+      const init = requireRecord(request.init, "webhook init");
+      const payload = JSON.parse(String(init.body)) as { summary?: string };
+      expect(payload.summary).toContain("[redacted device authorization output]");
+      expect(payload.summary).toContain("OPENAI_API_KEY=sk-123…cdef");
+      expect(payload.summary).not.toContain("ABCD-EFGH");
+      expect(payload.summary).not.toContain("sk-1234567890abcdef");
+      expect(state.cron.getJob(job.id)?.state.lastDiagnosticSummary).toContain("ABCD-EFGH");
+    } finally {
+      state.cron.stop();
+    }
+  });
+
   it("routes global-scope main cron jobs through the global queue for queued wakes", async () => {
     const cfg = {
       ...createCronConfig("server-cron-global-queued"),


### PR DESCRIPTION
## Summary

Redacts sensitive and action-required command output before cron sends non-interactive announce or webhook delivery messages.

## Changes

- Added a cron delivery sanitizer that reuses the existing tool-output secret redactor and masks device-authorization prompt lines.
- Applied the sanitizer at cron announce delivery and cron completion webhook payload boundaries.
- Preserved stored cron run summaries/diagnostics for authorized inspection instead of changing command execution or run-log semantics.
- Added announce and webhook regression tests with fake token/device-code examples.

## Validation

- `node scripts/run-vitest.mjs src/cron/delivery.failure-notify.test.ts src/gateway/server-cron.test.ts src/cron/command-runner.test.ts src/cron/run-diagnostics.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 src/cron/delivery-redaction.ts src/cron/delivery.failure-notify.test.ts src/cron/delivery.ts src/gateway/server-cron-notifications.ts src/gateway/server-cron.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Notes

- AI-assisted change.
- No config, protocol, or changelog changes.
- `corepack pnpm tsgo:core` was attempted but is blocked by an unrelated existing unused variable in `src/config/sessions/session-accessor.ts:1545`.
- `corepack pnpm format:check` was attempted but is blocked by unrelated pre-existing formatting issues; scoped formatting for touched files passes.
