### PR TITLE
Use shared Claude auth state

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1578,6 +1578,7 @@
                     "pages": [
                       "gateway/gateway-lock",
                       "gateway/background-process",
+                      "gateway/agent-runtime-boundary",
                       "gateway/multiple-gateways"
                     ]
                   },

--- a/docs/gateway/agent-runtime-boundary.md
+++ b/docs/gateway/agent-runtime-boundary.md
@@ -1,0 +1,104 @@
+---
+summary: "Keep privileged coding agents inside the managed Gateway runtime"
+read_when:
+  - Installing or removing host-level coding agent CLIs
+  - Auditing a Gateway host after bootstrap or recovery work
+  - Moving temporary rescue agents back into the managed runtime
+title: "Agent Runtime Boundary"
+---
+
+# Agent Runtime Boundary
+
+OpenClaw should run coding agents from the managed Gateway runtime by default. Avoid keeping a second host-level agent CLI available on the same Gateway host unless it has a current bootstrap or recovery purpose.
+
+## Decision
+
+Use the managed Gateway runtime as the normal execution boundary for Codex, Claude, and similar coding agents.
+
+Host-level agent CLIs are allowed only as temporary rescue tools. They must have an owner, a reason, and a removal window. When the rescue window ends, disable the host CLI and remove its live authentication material.
+
+## Why this boundary exists
+
+A host-level coding agent can see host files, host process state, network credentials, and container controls that the managed runtime may intentionally isolate. Even when the agent is trusted, leaving an extra authenticated CLI on the host expands the recovery surface and makes orphaned sessions harder to reason about.
+
+The safer default is:
+
+- one managed runtime for normal agent work
+- no long-lived host-level authenticated agent CLI
+- explicit session archival before removal
+- documented changes outside the host being changed
+
+## Temporary host-agent checklist
+
+Before installing a host-level agent CLI:
+
+1. Record the reason and owner.
+2. Prefer a dedicated profile, state directory, or temporary home.
+3. Avoid sharing credentials with the managed runtime.
+4. Set an expiry date for the host-level install.
+5. Document the planned removal path before using it for production recovery.
+
+Before disabling a host-level agent CLI:
+
+1. Archive session state to an operator-controlled location.
+2. Do not commit raw session logs, auth files, shell snapshots, or credentials.
+3. Remove or move live auth material out of the default agent home.
+4. Replace the host CLI with a refusal wrapper or remove it from `PATH`.
+5. Verify the host CLI fails closed.
+6. Verify the managed runtime still starts agents normally.
+7. Commit the decision or runbook update to GitHub.
+
+## What to archive
+
+Archive enough thread state to reconstruct the operational history:
+
+- session JSONL files
+- local history or state indexes when needed for lookup
+- a checksum for the archive
+- the timestamp and operator who created it
+
+Do not archive live auth tokens into GitHub. If raw session logs may contain secrets or private user data, keep the archive in an operator-controlled backup location and document only the checksum and storage owner in GitHub.
+
+## Disable pattern
+
+The safest host-level disable pattern is fail-closed:
+
+```bash
+command -v codex
+codex_path="$(command -v codex)"
+codex_dir="$(dirname "$codex_path")"
+mv "$codex_path" "$codex_dir/codex.host-disabled-$(date -u +%Y%m%dT%H%M%SZ)"
+install -m 0755 ./host-agent-disabled-wrapper "$codex_dir/codex"
+codex --version
+```
+
+The replacement command should exit non-zero and explain that operators must use the managed Gateway runtime instead.
+
+If the host-level agent has a separate real binary or symlink such as `codex-real`, disable that entrypoint too. Removing only the outer wrapper is not enough when other scripts can call the inner binary directly.
+
+## Verification
+
+After disabling the host-level CLI:
+
+```bash
+codex --version
+openclaw agents list
+openclaw status --deep
+```
+
+Expected result:
+
+- the host-level CLI refuses to run
+- the Gateway can still list and start managed agents
+- no host-level agent processes remain unless they are explicitly attached to an active rescue session
+
+## Recurring cleanup
+
+Use conservative cleanup jobs for agent hosts:
+
+- daily cleanup for clearly orphaned coding-agent processes
+- less frequent cleanup for detached terminal multiplexers
+- no automatic removal of attached sessions
+- no deletion of raw session archives
+
+Detached terminal sessions should be killed only after an idle threshold long enough for real recovery use. A 48 hour threshold is a reasonable starting point for `tmux` sessions that are detached and named for temporary agent access.

--- a/scripts/auth-monitor.sh
+++ b/scripts/auth-monitor.sh
@@ -13,8 +13,54 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CLAUDE_CREDS="$HOME/.claude/.credentials.json"
+SHARED_CLAUDE_HOME="${OPENCLAW_SHARED_CLAUDE_HOME:-/data/agent-state/claude-home}"
 STATE_FILE="$HOME/.openclaw/auth-monitor-state"
+
+resolve_claude_creds() {
+    if [ -n "${CLAUDE_CREDS:-}" ]; then
+        printf '%s\n' "$CLAUDE_CREDS"
+        return
+    fi
+    for candidate in \
+        "${CLAUDE_CONFIG_DIR:-}/.credentials.json" \
+        "${CLAUDE_CONFIG_DIR:-}/.claude/.credentials.json" \
+        "$SHARED_CLAUDE_HOME/.credentials.json" \
+        "$SHARED_CLAUDE_HOME/.claude/.credentials.json" \
+        "$HOME/.claude/.credentials.json" \
+        "$HOME/.credentials.json"
+    do
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return
+        fi
+    done
+    printf '%s\n' "$SHARED_CLAUDE_HOME/.credentials.json"
+}
+
+CLAUDE_CREDS="$(resolve_claude_creds)"
+
+claude_creds_value() {
+    local field="$1"
+    local default_value="$2"
+    python3 - "$CLAUDE_CREDS" "$field" "$default_value" <<'PY'
+import json
+import sys
+
+path, field, default = sys.argv[1:4]
+try:
+    with open(path, "r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    for part in field.split("."):
+        value = value[part]
+except Exception:
+    print(default)
+else:
+    if value is None or isinstance(value, (dict, list)):
+        print(default)
+    else:
+        print(value)
+PY
+}
 
 # Configuration
 WARN_HOURS="${WARN_HOURS:-2}"
@@ -71,15 +117,26 @@ if [ ! -f "$CLAUDE_CREDS" ]; then
     exit 1
 fi
 
-EXPIRES_AT=$(jq -r '.claudeAiOauth.expiresAt // 0' "$CLAUDE_CREDS")
+EXPIRES_AT=$(claude_creds_value "claudeAiOauth.expiresAt" "0")
+REFRESH_TOKEN=$(claude_creds_value "claudeAiOauth.refreshToken" "")
+HAS_REFRESH=0
+if [ -n "$REFRESH_TOKEN" ]; then
+    HAS_REFRESH=1
+fi
 NOW_MS=$((NOW * 1000))
 DIFF_MS=$((EXPIRES_AT - NOW_MS))
 HOURS_LEFT=$((DIFF_MS / 3600000))
 MINS_LEFT=$(((DIFF_MS % 3600000) / 60000))
 
-if [ "$DIFF_MS" -lt 0 ]; then
+if [ "$DIFF_MS" -lt 0 ] && [ "$HAS_REFRESH" = "1" ]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - Auth refreshable: access token expired but refresh token is present"
+    exit 0
+elif [ "$DIFF_MS" -lt 0 ]; then
     send_notification "Claude Code auth EXPIRED! OpenClaw is down. Run on the OpenClaw host: ${SCRIPT_DIR}/mobile-reauth.sh" "urgent"
     exit 1
+elif [ "$HOURS_LEFT" -lt "$WARN_HOURS" ] && [ "$HAS_REFRESH" = "1" ]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - Auth refreshable: access token expires in ${HOURS_LEFT}h ${MINS_LEFT}m and refresh token is present"
+    exit 0
 elif [ "$HOURS_LEFT" -lt "$WARN_HOURS" ]; then
     send_notification "Claude Code auth expires in ${HOURS_LEFT}h ${MINS_LEFT}m. Consider re-auth soon." "high"
     exit 0

--- a/scripts/claude-auth-status.sh
+++ b/scripts/claude-auth-status.sh
@@ -4,8 +4,194 @@
 
 set -euo pipefail
 
-CLAUDE_CREDS="$HOME/.claude/.credentials.json"
-OPENCLAW_AUTH="$HOME/.openclaw/agents/main/agent/auth-profiles.json"
+SHARED_CLAUDE_HOME="${OPENCLAW_SHARED_CLAUDE_HOME:-/data/agent-state/claude-home}"
+OPENCLAW_AUTH="${OPENCLAW_AUTH:-$HOME/.openclaw/agents/main/agent/auth-profiles.json}"
+
+resolve_claude_creds() {
+    if [ -n "${CLAUDE_CREDS:-}" ]; then
+        printf '%s\n' "$CLAUDE_CREDS"
+        return
+    fi
+    for candidate in \
+        "${CLAUDE_CONFIG_DIR:-}/.credentials.json" \
+        "${CLAUDE_CONFIG_DIR:-}/.claude/.credentials.json" \
+        "$SHARED_CLAUDE_HOME/.credentials.json" \
+        "$SHARED_CLAUDE_HOME/.claude/.credentials.json" \
+        "$HOME/.claude/.credentials.json" \
+        "$HOME/.credentials.json"
+    do
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return
+        fi
+    done
+    printf '%s\n' "$SHARED_CLAUDE_HOME/.credentials.json"
+}
+
+CLAUDE_CREDS="$(resolve_claude_creds)"
+
+claude_creds_value() {
+    local field="$1"
+    local default_value="$2"
+    python3 - "$CLAUDE_CREDS" "$field" "$default_value" <<'PY'
+import json
+import sys
+
+path, field, default = sys.argv[1:4]
+try:
+    with open(path, "r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    for part in field.split("."):
+        value = value[part]
+except Exception:
+    print(default)
+else:
+    if value is None or isinstance(value, (dict, list)):
+        print(default)
+    else:
+        print(value)
+PY
+}
+
+status_json_value() {
+    local kind="$1"
+    STATUS_JSON_PAYLOAD="$STATUS_JSON" python3 - "$kind" <<'PY'
+import json
+import os
+import sys
+
+kind = sys.argv[1]
+try:
+    data = json.loads(os.environ.get("STATUS_JSON_PAYLOAD") or "{}")
+except json.JSONDecodeError:
+    data = {}
+
+profiles = (((data.get("auth") or {}).get("oauth") or {}).get("profiles") or [])
+providers = ((data.get("auth") or {}).get("providers") or [])
+
+if kind == "claude_expires":
+    values = [
+        int(item.get("expiresAt") or 0)
+        for item in profiles
+        if item.get("provider") == "anthropic" and item.get("type") in {"oauth", "token"}
+    ]
+    print(max(values) if values else 0)
+elif kind == "anthropic_any_expires":
+    values = [
+        int(item.get("expiresAt") or 0)
+        for item in profiles
+        if item.get("provider") == "anthropic" and item.get("type") == "oauth"
+    ]
+    print(max(values) if values else 0)
+elif kind == "best_profile":
+    values = [
+        (int(item.get("expiresAt") or 0), str(item.get("profileId") or "none"))
+        for item in profiles
+        if item.get("provider") == "anthropic" and item.get("type") == "oauth"
+    ]
+    print(max(values)[1] if values else "none")
+elif kind == "api_key_count":
+    values = []
+    for item in providers:
+        if item.get("provider") != "anthropic":
+            continue
+        raw_value = (item.get("profiles") or {}).get("apiKey") or 0
+        try:
+            values.append(int(raw_value))
+        except (TypeError, ValueError):
+            pass
+    print(max(values) if values else 0)
+elif kind == "anthropic_oauth_count":
+    values = [
+        item
+        for item in profiles
+        if item.get("provider") == "anthropic" and item.get("type") == "oauth"
+    ]
+    print(len(values))
+else:
+    print(0)
+PY
+}
+
+openclaw_auth_value() {
+    local kind="$1"
+    python3 - "$OPENCLAW_AUTH" "$kind" <<'PY'
+import json
+import sys
+
+path, kind = sys.argv[1:3]
+try:
+    with open(path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+except Exception:
+    data = {}
+
+profiles = data.get("profiles") or {}
+anthropic = [
+    (profile_id, value)
+    for profile_id, value in profiles.items()
+    if isinstance(value, dict) and value.get("provider") == "anthropic"
+]
+
+if kind == "default_expires":
+    print(int((profiles.get("anthropic:default") or {}).get("expires") or 0))
+elif kind == "max_expires":
+    values = []
+    for _, value in anthropic:
+        try:
+            values.append(int(value.get("expires") or 0))
+        except (TypeError, ValueError):
+            pass
+    print(max(values) if values else 0)
+elif kind == "best_profile":
+    values = []
+    for profile_id, value in anthropic:
+        try:
+            values.append((int(value.get("expires") or 0), profile_id))
+        except (TypeError, ValueError):
+            pass
+    print(max(values)[1] if values else "none")
+elif kind == "anthropic_count":
+    print(len(anthropic))
+else:
+    print(0)
+PY
+}
+
+emit_status_json() {
+    local claude_status="$1"
+    local claude_expires="$2"
+    local openclaw_status="$3"
+    local openclaw_expires="$4"
+    python3 - "$claude_status" "$claude_expires" "$openclaw_status" "$openclaw_expires" <<'PY'
+import json
+import sys
+
+claude_status, claude_expires, openclaw_status, openclaw_expires = sys.argv[1:5]
+needs_reauth = any(
+    status.startswith(("EXPIRED", "EXPIRING", "MISSING"))
+    for status in (claude_status, openclaw_status)
+)
+
+def as_int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+print(json.dumps({
+    "claude_code": {
+        "status": claude_status,
+        "expires_at_ms": as_int(claude_expires),
+    },
+    "openclaw": {
+        "status": openclaw_status,
+        "expires_at_ms": as_int(openclaw_expires),
+    },
+    "needs_reauth": needs_reauth,
+}, indent=2))
+PY
+}
 
 # Colors for terminal output
 RED='\033[0;31m'
@@ -56,56 +242,71 @@ format_epoch_seconds() {
     date -r "$epoch_seconds" 2>/dev/null || date -d "@$epoch_seconds"
 }
 
+claude_code_expires_at() {
+    if [ -f "$CLAUDE_CREDS" ]; then
+        claude_creds_value "claudeAiOauth.expiresAt" "0"
+        return
+    fi
+    if [ "$USE_JSON" -eq 1 ]; then
+        json_expires_for_claude_cli
+        return
+    fi
+    echo "0"
+}
+
+claude_code_refresh_present() {
+    if [ ! -f "$CLAUDE_CREDS" ]; then
+        return 1
+    fi
+    local has_refresh
+    has_refresh=$(claude_creds_value "claudeAiOauth.refreshToken" "")
+    [ -n "$has_refresh" ]
+}
+
+calc_claude_code_status() {
+    local expires_at="$1"
+    local status
+    local rc=0
+    status=$(calc_status_from_expires "$expires_at") || rc=$?
+    if [ "$rc" -ne 0 ] && claude_code_refresh_present; then
+        echo "OK:refreshable"
+        return 0
+    fi
+    echo "$status"
+    return "$rc"
+}
+
 json_expires_for_claude_cli() {
-    echo "$STATUS_JSON" | jq -r '
-        [.auth.oauth.profiles[]
-          | select(.provider == "anthropic" and (.type == "oauth" or .type == "token"))
-          | .expiresAt // 0]
-        | max // 0
-    ' 2>/dev/null || echo "0"
+    status_json_value "claude_expires"
 }
 
 json_expires_for_anthropic_any() {
-    echo "$STATUS_JSON" | jq -r '
-        [.auth.oauth.profiles[]
-          | select(.provider == "anthropic" and .type == "oauth")
-          | .expiresAt // 0]
-        | max // 0
-    ' 2>/dev/null || echo "0"
+    status_json_value "anthropic_any_expires"
 }
 
 json_best_anthropic_profile() {
-    echo "$STATUS_JSON" | jq -r '
-        [.auth.oauth.profiles[]
-          | select(.provider == "anthropic" and .type == "oauth")
-          | {id: .profileId, exp: (.expiresAt // 0)}]
-        | sort_by(.exp) | reverse | .[0].id // "none"
-    ' 2>/dev/null || echo "none"
+    status_json_value "best_profile"
 }
 
 json_anthropic_api_key_count() {
-    echo "$STATUS_JSON" | jq -r '
-        [.auth.providers[] | select(.provider == "anthropic") | .profiles.apiKey]
-        | max // 0
-    ' 2>/dev/null || echo "0"
+    status_json_value "api_key_count"
 }
 
 check_claude_code_auth() {
-    if [ "$USE_JSON" -eq 1 ]; then
-        local expires_at
-        expires_at=$(json_expires_for_claude_cli)
-        calc_status_from_expires "$expires_at"
-        return $?
-    fi
-
     if [ ! -f "$CLAUDE_CREDS" ]; then
+        if [ "$USE_JSON" -eq 1 ]; then
+            local json_expires_at
+            json_expires_at=$(json_expires_for_claude_cli)
+            calc_status_from_expires "$json_expires_at"
+            return $?
+        fi
         echo "MISSING"
         return 1
     fi
 
     local expires_at
-    expires_at=$(jq -r '.claudeAiOauth.expiresAt // 0' "$CLAUDE_CREDS" 2>/dev/null || echo "0")
-    calc_status_from_expires "$expires_at"
+    expires_at=$(claude_code_expires_at)
+    calc_claude_code_status "$expires_at"
 }
 
 check_openclaw_auth() {
@@ -115,8 +316,18 @@ check_openclaw_auth() {
         if ! [[ "$api_keys" =~ ^[0-9]+$ ]]; then
             api_keys=0
         fi
+        local oauth_count
+        oauth_count=$(status_json_value "anthropic_oauth_count")
+        if ! [[ "$oauth_count" =~ ^[0-9]+$ ]]; then
+            oauth_count=0
+        fi
         local expires_at
         expires_at=$(json_expires_for_anthropic_any)
+
+        if [ "$expires_at" -le 0 ] && [ "$api_keys" -eq 0 ] && [ "$oauth_count" -eq 0 ]; then
+            echo "SKIPPED:no-anthropic"
+            return 0
+        fi
 
         if [ "$expires_at" -le 0 ] && [ "$api_keys" -gt 0 ]; then
             echo "OK:static"
@@ -132,11 +343,18 @@ check_openclaw_auth() {
         return 1
     fi
 
+    local anthropic_count
+    anthropic_count=$(openclaw_auth_value "anthropic_count")
+    if ! [[ "$anthropic_count" =~ ^[0-9]+$ ]]; then
+        anthropic_count=0
+    fi
+    if [ "$anthropic_count" -eq 0 ]; then
+        echo "SKIPPED:no-anthropic"
+        return 0
+    fi
+
     local expires
-    expires=$(jq -r '
-        [.profiles | to_entries[] | select(.value.provider == "anthropic") | .value.expires]
-        | max // 0
-    ' "$OPENCLAW_AUTH" 2>/dev/null || echo "0")
+    expires=$(openclaw_auth_value "max_expires")
 
     calc_status_from_expires "$expires"
 }
@@ -149,23 +367,14 @@ if [ "$OUTPUT_MODE" = "json" ]; then
     claude_expires=0
     openclaw_expires=0
     if [ "$USE_JSON" -eq 1 ]; then
-        claude_expires=$(json_expires_for_claude_cli)
+        claude_expires=$(claude_code_expires_at)
         openclaw_expires=$(json_expires_for_anthropic_any)
     else
-        claude_expires=$(jq -r '.claudeAiOauth.expiresAt // 0' "$CLAUDE_CREDS" 2>/dev/null || echo "0")
-        openclaw_expires=$(jq -r '.profiles["anthropic:default"].expires // 0' "$OPENCLAW_AUTH" 2>/dev/null || echo "0")
+        claude_expires=$(claude_code_expires_at)
+        openclaw_expires=$(openclaw_auth_value "default_expires")
     fi
 
-    jq -n \
-        --arg cs "$claude_status" \
-        --arg ce "$claude_expires" \
-        --arg bs "$openclaw_status" \
-        --arg be "$openclaw_expires" \
-        '{
-            claude_code: {status: $cs, expires_at_ms: ($ce | tonumber)},
-            openclaw: {status: $bs, expires_at_ms: ($be | tonumber)},
-            needs_reauth: (($cs | startswith("EXPIRED") or startswith("EXPIRING") or startswith("MISSING")) or ($bs | startswith("EXPIRED") or startswith("EXPIRING") or startswith("MISSING")))
-        }'
+    emit_status_json "$claude_status" "$claude_expires" "$openclaw_status" "$openclaw_expires"
     exit 0
 fi
 
@@ -197,21 +406,24 @@ echo "=== Claude Code Auth Status ==="
 echo ""
 
 # Claude Code credentials
-echo "Claude Code (~/.claude/.credentials.json):"
-if [ "$USE_JSON" -eq 1 ]; then
-    expires_at=$(json_expires_for_claude_cli)
-else
-    expires_at=$(jq -r '.claudeAiOauth.expiresAt // 0' "$CLAUDE_CREDS" 2>/dev/null || echo "0")
+echo "Claude Code ($CLAUDE_CREDS):"
+expires_at=$(claude_code_expires_at)
+has_refresh=0
+if claude_code_refresh_present; then
+    has_refresh=1
 fi
 
 if [ -f "$CLAUDE_CREDS" ]; then
-    sub_type=$(jq -r '.claudeAiOauth.subscriptionType // "unknown"' "$CLAUDE_CREDS" 2>/dev/null || echo "unknown")
-    rate_tier=$(jq -r '.claudeAiOauth.rateLimitTier // "unknown"' "$CLAUDE_CREDS" 2>/dev/null || echo "unknown")
+    sub_type=$(claude_creds_value "claudeAiOauth.subscriptionType" "unknown")
+    rate_tier=$(claude_creds_value "claudeAiOauth.rateLimitTier" "unknown")
     echo "  Subscription: $sub_type"
     echo "  Rate tier: $rate_tier"
 fi
 
-if [ "$expires_at" -le 0 ]; then
+if [ "$expires_at" -le 0 ] && [ "$has_refresh" -eq 1 ]; then
+    echo -e "  Status: ${GREEN}OK${NC} (refreshable)"
+    echo "  Note: Access-token expiry is missing, but a refresh token is present."
+elif [ "$expires_at" -le 0 ]; then
     echo -e "  Status: ${RED}NOT FOUND${NC}"
     echo "  Action needed: Run 'claude setup-token'"
 else
@@ -220,9 +432,15 @@ else
     hours=$((diff_ms / 3600000))
     mins=$(((diff_ms % 3600000) / 60000))
 
-    if [ "$diff_ms" -lt 0 ]; then
+    if [ "$diff_ms" -lt 0 ] && [ "$has_refresh" -eq 1 ]; then
+        echo -e "  Status: ${GREEN}OK${NC} (refreshable)"
+        echo "  Note: Access token expired; refresh token is present and Claude should refresh it on next run."
+    elif [ "$diff_ms" -lt 0 ]; then
         echo -e "  Status: ${RED}EXPIRED${NC}"
         echo "  Action needed: Run 'claude setup-token' or re-authenticate"
+    elif [ "$diff_ms" -lt 3600000 ] && [ "$has_refresh" -eq 1 ]; then
+        echo -e "  Status: ${GREEN}OK${NC} (refreshable)"
+        echo "  Access token expires in ${mins}m; refresh token is present."
     elif [ "$diff_ms" -lt 3600000 ]; then
         echo -e "  Status: ${YELLOW}EXPIRING SOON (${mins}m remaining)${NC}"
         echo "  Consider running: claude setup-token"
@@ -234,27 +452,22 @@ fi
 
 echo ""
 echo "OpenClaw Auth (~/.openclaw/agents/main/agent/auth-profiles.json):"
+openclaw_status_display=$(check_openclaw_auth 2>/dev/null || true)
 if [ "$USE_JSON" -eq 1 ]; then
     best_profile=$(json_best_anthropic_profile)
     expires=$(json_expires_for_anthropic_any)
     api_keys=$(json_anthropic_api_key_count)
 else
-    best_profile=$(jq -r '
-        .profiles | to_entries
-        | map(select(.value.provider == "anthropic"))
-        | sort_by(.value.expires) | reverse
-        | .[0].key // "none"
-    ' "$OPENCLAW_AUTH" 2>/dev/null || echo "none")
-    expires=$(jq -r '
-        [.profiles | to_entries[] | select(.value.provider == "anthropic") | .value.expires]
-        | max // 0
-    ' "$OPENCLAW_AUTH" 2>/dev/null || echo "0")
+    best_profile=$(openclaw_auth_value "best_profile")
+    expires=$(openclaw_auth_value "max_expires")
     api_keys=0
 fi
 
 echo "  Profile: $best_profile"
 
-if [ "$expires" -le 0 ] && [ "$api_keys" -gt 0 ]; then
+if [[ "$openclaw_status_display" == SKIPPED* ]]; then
+    echo -e "  Status: ${GREEN}SKIPPED${NC} (no Anthropic OpenClaw profile configured)"
+elif [ "$expires" -le 0 ] && [ "$api_keys" -gt 0 ]; then
     echo -e "  Status: ${GREEN}OK${NC} (API key)"
 elif [ "$expires" -le 0 ]; then
     echo -e "  Status: ${RED}NOT FOUND${NC}"


### PR DESCRIPTION
## Summary
- document the managed Gateway runtime boundary for host-level coding agents
- make Claude auth monitor/status scripts read the shared Claude home at `/data/agent-state/claude-home`
- remove the jq dependency in those host scripts and treat refresh-token-backed Claude credentials as refreshable
- skip Anthropic OpenClaw auth failures when no Anthropic profile is configured

## Validation
- `bash -n scripts/auth-monitor.sh`
- `bash -n scripts/claude-auth-status.sh`
- `python3 -m json.tool docs/docs.json`
