### PR TITLE
fix(runtime): protect active work during restarts

### DIFF
--- a/qa/scenarios/personal/share-safe-diagnostics-artifact.yaml
+++ b/qa/scenarios/personal/share-safe-diagnostics-artifact.yaml
@@ -31,7 +31,6 @@ scenario:
     kind: flow
     summary: Verify personal diagnostics handoffs produce useful redacted artifacts instead of raw transcript dumps.
     config:
-      sessionKey: agent:qa:personal-share-safe-diagnostics
       artifactName: personal-diagnostics-summary.txt
       safeMarker: PERSONAL-DIAGNOSTICS-SAFE-OK
       workspaceFiles:
@@ -109,11 +108,17 @@ flow:
         - set: requestCountBefore
           value:
             expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/requests`)).length : 0"
+        - set: sessionKey
+          value:
+            expr: "`agent:qa:personal-share-safe-diagnostics:${randomUUID().slice(0, 8)}`"
+        - set: beforeDiagnosticsCursor
+          value:
+            expr: state.getSnapshot().messages.length
         - call: runAgentPrompt
           args:
             - ref: env
             - sessionKey:
-                expr: config.sessionKey
+                ref: sessionKey
               message:
                 expr: config.prompt
               timeoutMs:
@@ -137,14 +142,11 @@ flow:
             expr: "!config.forbiddenNeedles.some((needle) => artifact.includes(needle))"
             message:
               expr: "`share-safe diagnostics artifact leaked unsafe source material: ${artifact}`"
-        - call: waitForAgentHistoryReply
+        - call: waitForCondition
           saveAs: outbound
           args:
-            - ref: env
-            - expr: config.sessionKey
             - lambda:
-                params: [text]
-                expr: "text.includes(config.safeMarker) && text.includes(config.artifactName)"
+                expr: "state.getSnapshot().messages.slice(beforeDiagnosticsCursor).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && candidate.text.includes(config.safeMarker) && candidate.text.includes(config.artifactName)).at(-1)"
             - expr: liveTurnTimeoutMs(env, 30000)
             - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
         - assert:

--- a/qa/scenarios/personal/tool-safety-followthrough.yaml
+++ b/qa/scenarios/personal/tool-safety-followthrough.yaml
@@ -58,6 +58,9 @@ flow:
         - set: requestCountBefore
           value:
             expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/requests`)).length : 0"
+        - set: beforePreActionCursor
+          value:
+            expr: state.getSnapshot().messages.length
         - call: runAgentPrompt
           args:
             - ref: env
@@ -67,14 +70,13 @@ flow:
                 expr: config.preActionPrompt
               timeoutMs:
                 expr: liveTurnTimeoutMs(env, 20000)
-        - call: waitForOutboundMessage
+        - call: waitForCondition
           saveAs: preActionOutbound
           args:
-            - ref: state
             - lambda:
-                params: [candidate]
-                expr: "candidate.conversation.id === 'qa-operator'"
+                expr: "state.getSnapshot().messages.slice(beforePreActionCursor).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && /^ready$/i.test(candidate.text.replace(/<[^>]*>/g, '').trim())).at(-1)"
             - expr: liveTurnTimeoutMs(env, 20000)
+            - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
         - assert:
             expr: "/\\bready\\b/i.test(preActionOutbound.text) && preActionOutbound.text.trim().split(/\\s+/).filter(Boolean).length <= 6"
             message:

--- a/qa/scenarios/workspace/long-running-release-audit.yaml
+++ b/qa/scenarios/workspace/long-running-release-audit.yaml
@@ -167,6 +167,9 @@ flow:
         - set: sessionKey
           value:
             expr: "`agent:qa:release-audit:${randomUUID().slice(0, 8)}`"
+        - set: beforeAuditCursor
+          value:
+            expr: state.getSnapshot().messages.length
         - call: runAgentPrompt
           args:
             - ref: env
@@ -227,15 +230,12 @@ flow:
             expr: "reportFindings.length > 0 && reportFindings.every((finding) => typeof finding?.verified === 'boolean')"
             message:
               expr: "`each report finding must include a boolean verified field: ${reportText}`"
-        - call: waitForAgentHistoryReply
+        - call: waitForCondition
           saveAs: outbound
           args:
-            - ref: env
-            - ref: sessionKey
             - lambda:
-                params: [text]
-                expr: "text.trim() === 'RELEASE-AUDIT-COMPLETE'"
-            - expr: liveTurnTimeoutMs(env, 45000)
+                expr: "state.getSnapshot().messages.slice(beforeAuditCursor).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && candidate.text.replace(/<[^>]*>/g, '').trim() === 'RELEASE-AUDIT-COMPLETE').at(-1)"
+            - expr: liveTurnTimeoutMs(env, 120000)
             - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
         - call: readRawQaSessionStore
           saveAs: store

--- a/src/acp/control-plane/manager.failover.test.ts
+++ b/src/acp/control-plane/manager.failover.test.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionAcpMeta } from "../../config/sessions/types.js";
 import {
   AcpRuntimeError,
-  AcpSessionManager,
+  createAcpSessionManagerWithMocks,
   baseCfg,
   createRuntime,
   hoisted,
@@ -101,7 +101,7 @@ describe("AcpSessionManager backend failover", () => {
   it("starts later failover turns on the configured primary backend", async () => {
     const harness = setupFailoverBackends({ initialBackend: "fallback-backend" });
 
-    const manager = new AcpSessionManager();
+    const manager = createAcpSessionManagerWithMocks();
     await manager.runTurn({
       cfg: harness.cfg,
       sessionKey: harness.sessionKey,
@@ -125,7 +125,7 @@ describe("AcpSessionManager backend failover", () => {
       throw new AcpRuntimeError("ACP_TURN_FAILED", "backend unavailable");
     });
 
-    const manager = new AcpSessionManager();
+    const manager = createAcpSessionManagerWithMocks();
     await manager.runTurn({
       cfg: harness.cfg,
       sessionKey: harness.sessionKey,
@@ -163,7 +163,7 @@ describe("AcpSessionManager backend failover", () => {
       throw new AcpRuntimeError("ACP_TURN_FAILED", "backend unavailable");
     });
 
-    const manager = new AcpSessionManager();
+    const manager = createAcpSessionManagerWithMocks();
     await expect(
       manager.runTurn({
         cfg: harness.cfg,
@@ -190,7 +190,7 @@ describe("AcpSessionManager backend failover", () => {
       ),
     });
 
-    const manager = new AcpSessionManager();
+    const manager = createAcpSessionManagerWithMocks();
     await expect(
       manager.runTurn({
         cfg: harness.cfg,
@@ -215,7 +215,7 @@ describe("AcpSessionManager backend failover", () => {
       throw new AcpRuntimeError("ACP_TURN_FAILED", "rate limit exceeded");
     });
 
-    const manager = new AcpSessionManager();
+    const manager = createAcpSessionManagerWithMocks();
     await expect(
       manager.runTurn({
         cfg: harness.cfg,
@@ -238,7 +238,7 @@ describe("AcpSessionManager backend failover", () => {
     });
     const events: unknown[] = [];
 
-    const manager = new AcpSessionManager();
+    const manager = createAcpSessionManagerWithMocks();
     await expect(
       manager.runTurn({
         cfg: harness.cfg,

--- a/src/acp/control-plane/manager.test-helpers.ts
+++ b/src/acp/control-plane/manager.test-helpers.ts
@@ -46,6 +46,16 @@ export const resetAcpSessionManagerForTests = () =>
   managerModule.testing.resetAcpSessionManagerForTests();
 export const { AcpRuntimeError } = await import("../runtime/errors.js");
 
+export function createAcpSessionManagerWithMocks(): InstanceType<typeof AcpSessionManager> {
+  return new AcpSessionManager({
+    listAcpSessions: (params) => hoistedMocks.listAcpSessionEntriesMock(params),
+    readSessionEntry: (params) => hoistedMocks.readAcpSessionEntryMock(params),
+    upsertSessionMeta: (params) => hoistedMocks.upsertAcpSessionMetaMock(params),
+    getRuntimeBackend: (backendId) => hoistedMocks.getAcpRuntimeBackendMock(backendId),
+    requireRuntimeBackend: (backendId) => hoistedMocks.requireAcpRuntimeBackendMock(backendId),
+  });
+}
+
 export const baseCfg = {
   acp: {
     enabled: true,
@@ -112,10 +122,7 @@ function mockCallArgs(mock: ReturnType<typeof vi.fn>): Array<Record<string, unkn
   return mock.mock.calls.map((call) => call[0] as Record<string, unknown>);
 }
 
-function findMockCallFields(
-  mock: ReturnType<typeof vi.fn>,
-  expected: Record<string, unknown>,
-) {
+function findMockCallFields(mock: ReturnType<typeof vi.fn>, expected: Record<string, unknown>) {
   return mockCallArgs(mock).find((actual) =>
     Object.entries(expected).every(([key, value]) => Object.is(actual[key], value)),
   );

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1538,6 +1538,34 @@ describe("spawnAcpDirect", () => {
     expectAcceptedSpawn(result);
   });
 
+  it("attaches plain duplicate ACP spawn intents to the existing active task", async () => {
+    hoisted.listTasksForOwnerKeyMock.mockReturnValueOnce([
+      {
+        taskId: "task-existing",
+        runtime: "acp",
+        status: "running",
+        agentId: "codex",
+        ownerKey: "agent:main:telegram:direct:6098642967",
+        childSessionKey: "agent:codex:acp:existing",
+        runId: "run-existing",
+        label: "Investigate flaky tests",
+        task: "Investigate   flaky tests",
+      },
+    ]);
+
+    const result = await spawnAcpDirect(
+      createSpawnRequest({ label: "Investigate flaky tests" }),
+      createRequesterContext(),
+    );
+
+    const accepted = expectAcceptedSpawn(result);
+    expect(accepted.childSessionKey).toBe("agent:codex:acp:existing");
+    expect(accepted.runId).toBe("run-existing");
+    expect(accepted.note).toContain("attached to existing active ACP task");
+    expect(findAgentGatewayCall()).toBeUndefined();
+    expect(hoisted.createRunningTaskRunMock).not.toHaveBeenCalled();
+  });
+
   it("does not double-count ACP task rows for active registry-tracked ACP children", async () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1566,6 +1566,37 @@ describe("spawnAcpDirect", () => {
     expect(hoisted.createRunningTaskRunMock).not.toHaveBeenCalled();
   });
 
+  it("starts a new ACP spawn when a duplicate intent requests a timeout override", async () => {
+    hoisted.listTasksForOwnerKeyMock.mockReturnValueOnce([
+      {
+        taskId: "task-existing",
+        runtime: "acp",
+        status: "running",
+        agentId: "codex",
+        ownerKey: "agent:main:telegram:direct:6098642967",
+        childSessionKey: "agent:codex:acp:existing",
+        runId: "run-existing",
+        label: "Investigate flaky tests",
+        task: "Investigate flaky tests",
+      },
+    ]);
+
+    const result = await spawnAcpDirect(
+      createSpawnRequest({
+        label: "Investigate flaky tests",
+        runTimeoutSeconds: 45,
+      }),
+      createRequesterContext(),
+    );
+
+    const accepted = expectAcceptedSpawn(result);
+    expect(accepted.childSessionKey).not.toBe("agent:codex:acp:existing");
+    expect(accepted.runId).not.toBe("run-existing");
+    expect(accepted.runTimeoutSeconds).toBe(45);
+    expect(findAgentGatewayCall()?.params?.timeout).toBe(45);
+    expect(hoisted.createRunningTaskRunMock).toHaveBeenCalled();
+  });
+
   it("does not double-count ACP task rows for active registry-tracked ACP children", async () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -342,6 +342,7 @@ function canAttachToExistingAcpSpawnIntent(params: SpawnAcpParams & { threadRequ
     !normalizeOptionalString(params.cwd) &&
     !normalizeOptionalString(params.model) &&
     !normalizeOptionalString(params.thinking) &&
+    params.runTimeoutSeconds === undefined &&
     (!params.attachments || params.attachments.length === 0)
   );
 }

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -302,6 +302,50 @@ function isActiveTaskStatus(status: string | undefined): boolean {
   return status === "queued" || status === "running";
 }
 
+function normalizeTaskIntentText(value: string | undefined): string {
+  return value?.replace(/\s+/g, " ").trim().toLowerCase() ?? "";
+}
+
+function findActiveAcpSpawnIntentTask(params: {
+  ownerKey: string | undefined;
+  targetAgentId: string;
+  task: string;
+  label?: string;
+}) {
+  const ownerKey = normalizeOptionalString(params.ownerKey);
+  if (!ownerKey) {
+    return undefined;
+  }
+  const taskText = normalizeTaskIntentText(params.task);
+  const labelText = normalizeTaskIntentText(params.label);
+  if (!taskText) {
+    return undefined;
+  }
+  return listTasksForOwnerKey(ownerKey).find(
+    (task) =>
+      task.runtime === "acp" &&
+      isActiveTaskStatus(task.status) &&
+      task.agentId === params.targetAgentId &&
+      normalizeTaskIntentText(task.task) === taskText &&
+      normalizeTaskIntentText(task.label) === labelText &&
+      Boolean(normalizeOptionalString(task.childSessionKey)) &&
+      Boolean(normalizeOptionalString(task.runId)),
+  );
+}
+
+function canAttachToExistingAcpSpawnIntent(params: SpawnAcpParams & { threadRequested: boolean }) {
+  return (
+    params.mode !== "session" &&
+    params.streamTo === undefined &&
+    !params.threadRequested &&
+    !normalizeOptionalString(params.resumeSessionId) &&
+    !normalizeOptionalString(params.cwd) &&
+    !normalizeOptionalString(params.model) &&
+    !normalizeOptionalString(params.thinking) &&
+    (!params.attachments || params.attachments.length === 0)
+  );
+}
+
 function countUntrackedActiveAcpRunsForOwner(ownerKey: string | undefined): number {
   const normalizedOwnerKey = normalizeOptionalString(ownerKey);
   if (!normalizedOwnerKey) {
@@ -1366,6 +1410,32 @@ export async function spawnAcpDirect(
       errorCode: "agent_forbidden",
       error: agentPolicyError.message,
     });
+  }
+  if (canAttachToExistingAcpSpawnIntent({ ...params, threadRequested: requestThreadBinding })) {
+    const existing = findActiveAcpSpawnIntentTask({
+      ownerKey: requesterInternalKey,
+      targetAgentId,
+      task: params.task,
+      label: params.label,
+    });
+    const childSessionKey = normalizeOptionalString(existing?.childSessionKey);
+    const runId = normalizeOptionalString(existing?.runId);
+    if (existing && childSessionKey && runId) {
+      log.info("ACP spawn attached to existing active task intent", {
+        ownerKey: requesterInternalKey,
+        targetAgentId,
+        taskId: existing.taskId,
+        runId,
+      });
+      return {
+        status: "accepted",
+        childSessionKey,
+        runId,
+        mode: spawnMode,
+        runTimeoutSeconds,
+        note: "attached to existing active ACP task; follow-ups continue on the existing run.",
+      };
+    }
   }
   const subagentStore = resolveSubagentCapabilityStore(parentSessionKey, {
     cfg,

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -248,6 +248,8 @@ vi.mock("../config/runtime-snapshot.js", () => ({
 }));
 
 vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: () => state.sessionStoreMock ?? {},
+  resolveStorePath: () => state.storePathMock ?? "/tmp/sessions.json",
   resolveAgentIdFromSessionKey: () => "default",
   mergeSessionEntry: (a: unknown, b: unknown) => ({ ...(a as object), ...(b as object) }),
   updateSessionStore: vi.fn(
@@ -278,6 +280,7 @@ vi.mock("../infra/agent-events.js", () => ({
   captureAgentRunLifecycleGeneration: () => "test-generation",
   clearAgentRunContext: (...args: unknown[]) => state.clearAgentRunContextMock(...args),
   emitAgentEvent: (...args: unknown[]) => state.emitAgentEventMock(...args),
+  getAgentRunContext: vi.fn(() => null),
   getAgentEventLifecycleGeneration: () => "test-generation",
   onAgentEvent: vi.fn(),
   registerAgentRunContext: (...args: unknown[]) => state.registerAgentRunContextMock(...args),

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -135,11 +135,34 @@ import {
   isAgentRunRestartAbortReason,
   resolveAgentRunAbortLifecycleFields,
 } from "./run-termination.js";
+import { reconcilePersistedRunningSession } from "./session-running-reconciliation.js";
 import { normalizeSpawnedRunMetadata } from "./spawned-context.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 import { ensureAgentWorkspace } from "./workspace.js";
 
 const log = createSubsystemLogger("agents/agent-command");
+
+function resolveTerminalReconciliationReason(params: {
+  result: { meta?: unknown };
+  deliveryResult?: unknown;
+}): string | undefined {
+  const meta = params.result.meta;
+  const error = meta && typeof meta === "object" ? (meta as { error?: unknown }).error : undefined;
+  const kind = error && typeof error === "object" ? (error as { kind?: unknown }).kind : undefined;
+  if (kind === "incomplete_turn") {
+    return "incomplete_turn_fallback";
+  }
+  const delivery = params.deliveryResult as
+    | { deliveryStatus?: { reason?: unknown }; safeFallbackDelivered?: unknown }
+    | undefined;
+  if (
+    delivery?.safeFallbackDelivered === true ||
+    delivery?.deliveryStatus?.reason === "safety_hook_blocked_fallback_delivered"
+  ) {
+    return "safety_hook_blocked_final_fallback";
+  }
+  return undefined;
+}
 
 function hasExactConfiguredProviderModel(params: {
   cfg: OpenClawConfig;
@@ -2332,6 +2355,29 @@ async function agentCommandInternal(
             }
           : deliveryParams,
       );
+      const terminalReconciliationReason = resolveTerminalReconciliationReason({
+        result,
+        deliveryResult,
+      });
+      if (
+        terminalReconciliationReason &&
+        sessionStore &&
+        sessionKey &&
+        !suppressVisibleSessionEffects &&
+        !sessionReboundDuringRun
+      ) {
+        await reconcilePersistedRunningSession({
+          storePath,
+          sessionKey,
+          activeRunPresent: false,
+          reason: terminalReconciliationReason,
+          safeFallbackDelivered:
+            terminalReconciliationReason === "incomplete_turn_fallback"
+              ? deliveryResult?.deliverySucceeded === true
+              : (deliveryResult as { safeFallbackDelivered?: boolean } | undefined)
+                  ?.safeFallbackDelivered === true,
+        });
+      }
 
       // Phase 2: Clear pending delivery payload after successful delivery.
       if (

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -138,6 +138,7 @@ type DeliveryStatusLike = {
   errorMessage?: unknown;
   resultCount?: unknown;
   sentBeforeError?: unknown;
+  safeFallbackDelivered?: unknown;
   payloadOutcomes?: Array<Record<string, unknown>>;
 };
 
@@ -877,6 +878,60 @@ describe("normalizeAgentCommandReplyPayloads", () => {
         hookEffect: { cancelReason: "owned-by-other-agent" },
       },
     ]);
+  });
+
+  it("delivers a safe fallback when a safety hook blocks the native final", async () => {
+    deliverOutboundPayloadsMock
+      .mockImplementationOnce(async (params: unknown) => {
+        (
+          params as {
+            onPayloadDeliveryOutcome?: (outcome: {
+              index: number;
+              status: "suppressed";
+              reason: "cancelled_by_message_sending_hook";
+              hookEffect: { cancelReason: string; metadata: Record<string, unknown> };
+            }) => void;
+          }
+        ).onPayloadDeliveryOutcome?.({
+          index: 0,
+          status: "suppressed",
+          reason: "cancelled_by_message_sending_hook",
+          hookEffect: {
+            cancelReason: "presend-telegram-guard internal filesystem/runtime leak",
+            metadata: { reason: "internal_path_leak" },
+          },
+        });
+        return [];
+      })
+      .mockImplementationOnce(async (params: unknown) => {
+        const payload = (params as { payloads: ReplyPayload[] }).payloads[0];
+        return [{ channel: "slack", messageId: `safe:${payload?.text ?? ""}` }];
+      });
+
+    const delivered = await deliverMediaReplyForTest({
+      key: "agent:tester:slack:direct:alice",
+      agentId: "tester",
+    } as never);
+
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(2);
+    const firstCall = deliverOutboundPayloadsMock.mock.calls[0];
+    const secondCall = deliverOutboundPayloadsMock.mock.calls[1];
+    expect(firstCall).toBeDefined();
+    expect(secondCall).toBeDefined();
+    const originalPayload = (firstCall[0] as { payloads: ReplyPayload[] }).payloads[0];
+    const fallbackPayload = (secondCall[0] as { payloads: ReplyPayload[] }).payloads[0];
+    expect(originalPayload?.text).toBe("here you go");
+    expect(fallbackPayload?.text).toBe("I couldn't send that reply safely. Please try again.");
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(delivered.safeFallbackDelivered).toBe(true);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: true,
+      status: "sent",
+      succeeded: true,
+      reason: "safety_hook_blocked_fallback_delivered",
+      safeFallbackDelivered: true,
+    });
   });
 
   it("surfaces durable partial failures without clearing delivery retry state", async () => {

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -94,6 +94,7 @@ type AgentCommandDeliveryStatus = {
   errorMessage?: string;
   /** Free-form lowercase_snake reason from durable delivery or preflight validation. */
   reason?: string;
+  safeFallbackDelivered?: boolean;
   resultCount?: number;
   sentBeforeError?: true;
   payloadOutcomes?: AgentCommandDeliveryPayloadOutcome[];
@@ -109,9 +110,11 @@ type AgentCommandDeliveryResult = {
   messagingToolSentTargets?: MessagingToolSend[];
   deliverySucceeded?: boolean;
   deliveryStatus?: AgentCommandDeliveryStatus;
+  safeFallbackDelivered?: boolean;
 };
 
 const NESTED_LOG_PREFIX = "[agent:nested]";
+const SAFETY_HOOK_BLOCKED_FALLBACK_TEXT = "I couldn't send that reply safely. Please try again.";
 
 type FreshSessionEntryForDeliveryResolver = () => Promise<SessionEntry | undefined>;
 
@@ -218,6 +221,7 @@ function buildDeliveryResult(params: {
   result: RunResult;
   deliverySucceeded?: boolean;
   deliveryStatus?: AgentCommandDeliveryStatus;
+  safeFallbackDelivered?: boolean;
 }): AgentCommandDeliveryResult {
   return {
     payloads: params.payloads,
@@ -236,7 +240,45 @@ function buildDeliveryResult(params: {
       ? { deliverySucceeded: params.deliverySucceeded }
       : {}),
     ...(params.deliveryStatus ? { deliveryStatus: params.deliveryStatus } : {}),
+    ...(params.safeFallbackDelivered !== undefined
+      ? { safeFallbackDelivered: params.safeFallbackDelivered }
+      : {}),
   };
+}
+
+function stringifyHookMetadata(value: unknown): string {
+  if (value == null) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function isSafetyHookSuppression(send: DurableSendResult): boolean {
+  if (send.status !== "suppressed" || send.reason !== "cancelled_by_message_sending_hook") {
+    return false;
+  }
+  const haystack = [
+    send.reason,
+    ...(send.payloadOutcomes ?? []).map((outcome) =>
+      [
+        outcome.status === "suppressed" ? outcome.reason : "",
+        outcome.status === "suppressed" ? outcome.hookEffect?.cancelReason : "",
+        outcome.status === "suppressed" ? stringifyHookMetadata(outcome.hookEffect?.metadata) : "",
+      ].join(" "),
+    ),
+  ]
+    .join(" ")
+    .toLowerCase();
+  return /\b(presend|guard|leak|secret|token|filesystem|runtime|unsafe|internal_path)\b/.test(
+    haystack,
+  );
 }
 
 function serializeDeliveryPayloadOutcomes(
@@ -720,6 +762,7 @@ export async function deliverAgentCommandResult(
   }
 
   let deliverySucceeded = false;
+  let safeFallbackDelivered = false;
   const logPayload = (payload: NormalizedOutboundPayload) => {
     if (opts.json) {
       return;
@@ -770,7 +813,60 @@ export async function deliverAgentCommandResult(
       if (restartAbort.signal?.aborted && send.status === "failed") {
         throw restartAbort.signal.reason;
       }
+      if (isSafetyHookSuppression(send)) {
+        const fallbackPlan = createOutboundPayloadPlan([
+          { text: SAFETY_HOOK_BLOCKED_FALLBACK_TEXT } as ReplyPayload,
+        ]);
+        const fallbackPayloads = projectOutboundPayloadPlanForOutbound(fallbackPlan);
+        if (fallbackPayloads.length > 0) {
+          params.assertDeliveryCurrent?.();
+          let fallbackSend: DurableSendResult;
+          try {
+            fallbackSend = await sendDurableMessageBatch({
+              cfg,
+              channel: deliveryChannel,
+              to: deliveryTarget,
+              accountId: resolvedAccountId,
+              payloads: fallbackPayloads,
+              session: outboundSession,
+              replyToId: resolvedReplyToId ?? null,
+              threadId: resolvedThreadTarget ?? null,
+              bestEffort: true,
+              durability: "best_effort",
+              signal: restartAbort.signal,
+              onDeliveryIntent: restartAbort.dispose,
+              onError: logDeliveryError,
+              onPayload: logPayload,
+              deps: createOutboundSendDeps(deps),
+            });
+          } catch (error) {
+            fallbackSend = {
+              status: "failed",
+              error,
+              stage: "platform_send",
+            };
+          }
+          safeFallbackDelivered = fallbackSend.status === "sent";
+          if (safeFallbackDelivered) {
+            send = fallbackSend;
+          } else if (send.status === "suppressed") {
+            send = {
+              status: "failed",
+              error: new Error("Safety hook blocked final reply and fallback was not delivered."),
+              stage: fallbackSend.status === "suppressed" ? "unknown" : "platform_send",
+              payloadOutcomes: fallbackSend.payloadOutcomes,
+            };
+          }
+        }
+      }
       deliveryStatus = deliveryStatusFromDurableSend(send);
+      if (safeFallbackDelivered && deliveryStatus) {
+        deliveryStatus = {
+          ...deliveryStatus,
+          reason: "safety_hook_blocked_fallback_delivered",
+          safeFallbackDelivered: true,
+        };
+      }
       if (!bestEffortDeliver && (send.status === "failed" || send.status === "partial_failed")) {
         emitJsonEnvelope(deliveryStatus);
         throw send.error;
@@ -800,5 +896,6 @@ export async function deliverAgentCommandResult(
     result,
     deliverySucceeded,
     deliveryStatus,
+    safeFallbackDelivered,
   });
 }

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -1610,7 +1610,7 @@ describe("runContextEngineMaintenance", () => {
         });
 
         await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(1));
-        const [runningTask] = listTasksForOwnerKey(sessionKey).filter(
+        const runningTask = listTasksForOwnerKey(sessionKey).find(
           (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
         );
         expect(runningTask?.status).toBe("running");
@@ -1619,7 +1619,7 @@ describe("runContextEngineMaintenance", () => {
         await flushAsyncWork();
         await waitForDeferredTurnMaintenanceForSession(sessionKey);
 
-        const [timedOutTask] = listTasksForOwnerKey(sessionKey).filter(
+        const timedOutTask = listTasksForOwnerKey(sessionKey).find(
           (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
         );
         expect(timedOutTask?.status).toBe("failed");

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -1549,7 +1549,7 @@ describe("runContextEngineMaintenance", () => {
         await waitForAssertion(() =>
           expectSystemEventContaining(
             sessionKey,
-            "Background task update: Context engine turn maintenance.",
+            "Background task update: Context engine turn maintenance (run ",
           ),
         );
 

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -1569,6 +1569,68 @@ describe("runContextEngineMaintenance", () => {
     });
   });
 
+  it("fails deferred maintenance that exceeds the stale timeout", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-timeout-", async () => {
+      vi.useFakeTimers();
+      try {
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+
+        const sessionKey = "agent:main:session-timeout";
+        const maintain = vi.fn(
+          async () =>
+            await new Promise<{
+              changed: false;
+              bytesFreed: 0;
+              rewrittenEntries: 0;
+            }>(() => {}),
+        );
+        const backgroundEngine = {
+          info: {
+            id: "test",
+            name: "Test Engine",
+            turnMaintenanceMode: "background" as const,
+          },
+          ingest: async () => ({ ingested: true }),
+          assemble: async ({ messages }: { messages: unknown[] }) => ({
+            messages,
+            estimatedTokens: 0,
+          }),
+          compact: async () => ({ ok: true, compacted: false }),
+          maintain,
+        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+
+        await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-timeout",
+          sessionKey,
+          sessionFile: "/tmp/session-timeout.jsonl",
+          reason: "turn",
+        });
+
+        await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(1));
+        const [runningTask] = listTasksForOwnerKey(sessionKey).filter(
+          (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        expect(runningTask?.status).toBe("running");
+
+        await vi.advanceTimersByTimeAsync(301_000);
+        await flushAsyncWork();
+        await waitForDeferredTurnMaintenanceForSession(sessionKey);
+
+        const [timedOutTask] = listTasksForOwnerKey(sessionKey).filter(
+          (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        expect(timedOutTask?.status).toBe("failed");
+        expect(timedOutTask?.error).toContain("timed out");
+        expect(timedOutTask?.terminalSummary).toContain("timed out");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   it("surfaces deferred maintenance failures even when they fail quickly", async () => {
     await withStateDirEnv("openclaw-turn-maintenance-", async () => {
       vi.useFakeTimers();

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -12,11 +12,13 @@ import type {
   ContextEngineRuntimeSettings,
 } from "../../context-engine/types.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { withTimeout } from "../../node-host/with-timeout.js";
 import {
   enqueueCommandInLane,
   GatewayDrainingError,
   isGatewayDraining,
 } from "../../process/command-queue.js";
+import { CONTEXT_ENGINE_TURN_MAINTENANCE_TASK_KIND } from "../../tasks/context-engine-maintenance-task.js";
 import {
   completeTaskRunByRunId,
   createQueuedTaskRun,
@@ -38,11 +40,12 @@ import {
   rewriteTranscriptEntriesInSessionManager,
 } from "./transcript-rewrite.js";
 
-const TURN_MAINTENANCE_TASK_KIND = "context_engine_turn_maintenance";
+const TURN_MAINTENANCE_TASK_KIND = CONTEXT_ENGINE_TURN_MAINTENANCE_TASK_KIND;
 const TURN_MAINTENANCE_TASK_LABEL = "Context engine turn maintenance";
 const TURN_MAINTENANCE_TASK_TASK = "Deferred context-engine maintenance after turn.";
 const TURN_MAINTENANCE_LANE_PREFIX = "context-engine-turn-maintenance:";
 const TURN_MAINTENANCE_LONG_WAIT_MS = 10_000;
+const TURN_MAINTENANCE_STALE_TIMEOUT_MS = 300_000;
 const DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY = Symbol.for(
   "openclaw.contextEngineTurnMaintenanceAbortState",
 );
@@ -401,6 +404,14 @@ async function executeContextEngineMaintenance(params: {
   return result;
 }
 
+async function runDeferredTurnMaintenanceWithTimeout<T>(work: () => Promise<T>): Promise<T> {
+  return await withTimeout(
+    async () => await work(),
+    TURN_MAINTENANCE_STALE_TIMEOUT_MS,
+    "Deferred context engine maintenance",
+  );
+}
+
 async function runDeferredTurnMaintenanceWorker(params: {
   contextEngine: ContextEngine;
   sessionId: string;
@@ -456,19 +467,21 @@ async function runDeferredTurnMaintenanceWorker(params: {
       }
     }, TURN_MAINTENANCE_LONG_WAIT_MS);
 
-    const result = await executeContextEngineMaintenance({
-      contextEngine: params.contextEngine,
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-      sessionFile: params.sessionFile,
-      reason: "turn",
-      sessionManager: params.sessionManager,
-      runtimeContext: params.runtimeContext,
-      runtimeSettings: params.runtimeSettings,
-      agentId: params.agentId,
-      config: params.config,
-      executionMode: "background",
-    });
+    const result = await runDeferredTurnMaintenanceWithTimeout(() =>
+      executeContextEngineMaintenance({
+        contextEngine: params.contextEngine,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        sessionFile: params.sessionFile,
+        reason: "turn",
+        sessionManager: params.sessionManager,
+        runtimeContext: params.runtimeContext,
+        runtimeSettings: params.runtimeSettings,
+        agentId: params.agentId,
+        config: params.config,
+        executionMode: "background",
+      }),
+    );
     if (longRunningTimer) {
       clearTimeout(longRunningTimer);
       longRunningTimer = null;

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -1279,6 +1279,41 @@ describe("main-session-restart-recovery", () => {
     const customStore = readSessionStoreForTest(customStorePath);
     expect(defaultStore["agent:main:main"]?.abortedLastRun).toBe(true);
     expect(customStore["agent:main:main"]?.abortedLastRun).toBe(false);
+    expect(customStore["agent:main:main"]?.status).toBe("running");
+    expect(customStore["agent:main:main"]?.recoveredFromStaleRunning).toBeUndefined();
+  });
+
+  it("reconciles startup stale running rows that are not resumable recovery targets", async () => {
+    const sessionsDir = await makeSessionsDir("openclaw");
+    const sessionKey = "agent:openclaw:telegram:group:-1003789377335:topic:25537";
+    await writeStore(sessionsDir, {
+      [sessionKey]: {
+        sessionId: "telegram-topic-stale-running",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        subagentRole: "leaf",
+      },
+    });
+
+    const result = await recoverStartupOrphanedMainSessions({
+      stateDir: tmpDir,
+      activeSessionIds: [],
+      activeSessionKeys: [],
+      updatedBeforeMs: Date.now(),
+    });
+
+    expect(result).toMatchObject({
+      marked: 0,
+      recovered: 0,
+      failed: 0,
+      reconciledStale: 1,
+    });
+    expect(callGateway).not.toHaveBeenCalled();
+    const store = readSessionStoreForTest(path.join(sessionsDir, "sessions.json"));
+    expect(store[sessionKey]?.status).toBe("failed");
+    expect(store[sessionKey]?.recoveredFromStaleRunning).toBe(true);
+    expect(store[sessionKey]?.staleRunningRecoveryReason).toBe("startup_stale_running_session");
   });
 
   it("fails marked sessions whose transcript tail cannot be resumed", async () => {

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -14,6 +14,7 @@ import {
   registerAgentRunContext,
   resetAgentRunContextForTest,
 } from "../infra/agent-events.js";
+import { createTaskRecord, resetTaskRegistryForTests } from "../tasks/runtime-internal.js";
 import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
@@ -40,6 +41,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  resetTaskRegistryForTests({ persist: false });
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -1314,6 +1316,86 @@ describe("main-session-restart-recovery", () => {
     expect(store[sessionKey]?.status).toBe("failed");
     expect(store[sessionKey]?.recoveredFromStaleRunning).toBe(true);
     expect(store[sessionKey]?.staleRunningRecoveryReason).toBe("startup_stale_running_session");
+  });
+
+  it("does not rewrite terminal stale session rows during startup reconciliation", async () => {
+    const sessionsDir = await makeSessionsDir("openclaw");
+    const killedKey = "agent:openclaw:telegram:group:-1003789377335:topic:terminal-killed";
+    const timeoutKey = "agent:openclaw:telegram:group:-1003789377335:topic:terminal-timeout";
+    await writeStore(sessionsDir, {
+      [killedKey]: {
+        sessionId: "terminal-killed-session",
+        updatedAt: Date.now() - 10_000,
+        status: "killed",
+        abortedLastRun: true,
+      },
+      [timeoutKey]: {
+        sessionId: "terminal-timeout-session",
+        updatedAt: Date.now() - 10_000,
+        status: "timeout",
+        abortedLastRun: true,
+      },
+    });
+
+    const result = await recoverStartupOrphanedMainSessions({
+      stateDir: tmpDir,
+      activeSessionIds: [],
+      activeSessionKeys: [],
+      updatedBeforeMs: Date.now(),
+    });
+
+    expect(result).toMatchObject({
+      marked: 0,
+      recovered: 0,
+      failed: 0,
+      reconciledStale: 0,
+    });
+    const store = readSessionStoreForTest(path.join(sessionsDir, "sessions.json"));
+    expect(store[killedKey]?.status).toBe("killed");
+    expect(store[killedKey]?.recoveredFromStaleRunning).toBeUndefined();
+    expect(store[timeoutKey]?.status).toBe("timeout");
+    expect(store[timeoutKey]?.recoveredFromStaleRunning).toBeUndefined();
+  });
+
+  it("does not reconcile stale running rows while queued requester work is active", async () => {
+    const sessionsDir = await makeSessionsDir("openclaw");
+    const sessionKey = "agent:openclaw:telegram:group:-1003789377335:topic:queued-work";
+    await writeStore(sessionsDir, {
+      [sessionKey]: {
+        sessionId: "queued-work-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        subagentRole: "leaf",
+      },
+    });
+    createTaskRecord({
+      runtime: "acp",
+      requesterSessionKey: sessionKey,
+      ownerKey: sessionKey,
+      scopeKind: "session",
+      task: "queued requester work",
+      status: "queued",
+      deliveryStatus: "pending",
+      notifyPolicy: "done_only",
+    });
+
+    const result = await recoverStartupOrphanedMainSessions({
+      stateDir: tmpDir,
+      activeSessionIds: [],
+      activeSessionKeys: [],
+      updatedBeforeMs: Date.now(),
+    });
+
+    expect(result).toMatchObject({
+      marked: 0,
+      recovered: 0,
+      failed: 0,
+      reconciledStale: 0,
+    });
+    const store = readSessionStoreForTest(path.join(sessionsDir, "sessions.json"));
+    expect(store[sessionKey]?.status).toBe("running");
+    expect(store[sessionKey]?.recoveredFromStaleRunning).toBeUndefined();
   });
 
   it("fails marked sessions whose transcript tail cannot be resumed", async () => {

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -45,6 +45,7 @@ import {
   listActiveEmbeddedRunSessionKeys,
 } from "./embedded-agent-runner/run-state.js";
 import { resolveAgentSessionDirs } from "./session-dirs.js";
+import { reconcilePersistedRunningSessionsInStore } from "./session-running-reconciliation.js";
 import type { SessionLockInspection } from "./session-write-lock.js";
 
 const log = createSubsystemLogger("main-session-restart-recovery");
@@ -916,27 +917,48 @@ export async function recoverStartupOrphanedMainSessions(
     updatedBeforeMs?: number;
     resumedSessionKeys?: Set<string>;
   } = {},
-): Promise<{ marked: number; recovered: number; failed: number; skipped: number }> {
+): Promise<{
+  marked: number;
+  recovered: number;
+  failed: number;
+  skipped: number;
+  reconciledStale: number;
+}> {
   const startupRecoveryCutoffMs = params.updatedBeforeMs ?? Date.now();
+  const activeSessionIds = [...(params.activeSessionIds ?? listActiveEmbeddedRunSessionIds())];
+  const activeSessionKeys = [...(params.activeSessionKeys ?? listActiveEmbeddedRunSessionKeys())];
   const marked = await markStartupOrphanedMainSessionsForRecovery({
     cfg: params.cfg,
     stateDir: params.stateDir,
-    activeSessionIds: params.activeSessionIds,
-    activeSessionKeys: params.activeSessionKeys,
+    activeSessionIds,
+    activeSessionKeys,
     updatedBeforeMs: startupRecoveryCutoffMs,
   });
   const recovered = await recoverRestartAbortedMainSessions({
     cfg: params.cfg,
     stateDir: params.stateDir,
     resumedSessionKeys: params.resumedSessionKeys,
-    activeSessionIds: params.activeSessionIds,
-    activeSessionKeys: params.activeSessionKeys,
+    activeSessionIds,
+    activeSessionKeys,
   });
+  let reconciledStale = 0;
+  for (const storePath of await resolveRestartRecoveryStorePaths(params)) {
+    const staleResult = await reconcilePersistedRunningSessionsInStore({
+      storePath,
+      activeSessionIds,
+      activeSessionKeys,
+      updatedBeforeMs: startupRecoveryCutoffMs,
+      reason: "startup_stale_running_session",
+      safeFallbackDelivered: false,
+    });
+    reconciledStale += staleResult.reconciled;
+  }
   return {
     marked: marked.marked,
     recovered: recovered.recovered,
     failed: recovered.failed,
     skipped: marked.skipped + recovered.skipped,
+    reconciledStale,
   };
 }
 

--- a/src/agents/session-running-reconciliation.ts
+++ b/src/agents/session-running-reconciliation.ts
@@ -3,15 +3,13 @@ import type { SessionEntry } from "../config/sessions.js";
 import { applyRestartRecoveryLifecycle } from "../config/sessions/session-accessor.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
-  listFreshTasksForOwnerKey,
-  listTasksForRelatedSessionKey,
-  listTasksForSessionKey,
-} from "../tasks/task-registry.js";
-import type { TaskRecord } from "../tasks/task-registry.types.js";
+  isActiveTaskStatusForStatus,
+  listTasksForSessionReconciliationForStatus,
+} from "../tasks/task-status-access.js";
 
 const log = createSubsystemLogger("session-running-reconciliation");
 
-const STALE_RUNNING_STATUSES = new Set(["running", "processing", "timeout", "killed"]);
+const STALE_RUNNING_STATUSES = new Set(["running", "processing"]);
 
 export type SessionRunningReconciliationResult = {
   changed: boolean;
@@ -26,25 +24,15 @@ export type SessionRunningReconciliationResult = {
 
 type MutableSessionEntry = SessionEntry & Record<string, unknown>;
 
-function uniqueTasks(tasks: TaskRecord[]): TaskRecord[] {
-  const byId = new Map<string, TaskRecord>();
-  for (const task of tasks) {
-    byId.set(task.taskId, task);
-  }
-  return [...byId.values()];
-}
-
 export function countRunningTasksForSessionKey(sessionKey: string | undefined): number {
   const key = sessionKey?.trim();
   if (!key) {
     return 0;
   }
   try {
-    return uniqueTasks([
-      ...listFreshTasksForOwnerKey(key),
-      ...listTasksForSessionKey(key),
-      ...listTasksForRelatedSessionKey(key),
-    ]).filter((task) => task.status === "running").length;
+    return listTasksForSessionReconciliationForStatus(key).filter((task) =>
+      isActiveTaskStatusForStatus(task.status),
+    ).length;
   } catch (error) {
     log.warn("failed to count running tasks for persisted session reconciliation", {
       sessionKey: key,

--- a/src/agents/session-running-reconciliation.ts
+++ b/src/agents/session-running-reconciliation.ts
@@ -1,0 +1,245 @@
+import type { SessionEntry } from "../config/sessions.js";
+// Reconciles persisted session lifecycle when runtime state has already ended.
+import { applyRestartRecoveryLifecycle } from "../config/sessions/session-accessor.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  listFreshTasksForOwnerKey,
+  listTasksForRelatedSessionKey,
+  listTasksForSessionKey,
+} from "../tasks/task-registry.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+
+const log = createSubsystemLogger("session-running-reconciliation");
+
+const STALE_RUNNING_STATUSES = new Set(["running", "processing", "timeout", "killed"]);
+
+export type SessionRunningReconciliationResult = {
+  changed: boolean;
+  sessionKey: string;
+  oldStatus?: string;
+  newStatus?: string;
+  activeRunPresent: boolean;
+  runningTaskCount: number;
+  reason: string;
+  safeFallbackDelivered: boolean;
+};
+
+type MutableSessionEntry = SessionEntry & Record<string, unknown>;
+
+function uniqueTasks(tasks: TaskRecord[]): TaskRecord[] {
+  const byId = new Map<string, TaskRecord>();
+  for (const task of tasks) {
+    byId.set(task.taskId, task);
+  }
+  return [...byId.values()];
+}
+
+export function countRunningTasksForSessionKey(sessionKey: string | undefined): number {
+  const key = sessionKey?.trim();
+  if (!key) {
+    return 0;
+  }
+  try {
+    return uniqueTasks([
+      ...listFreshTasksForOwnerKey(key),
+      ...listTasksForSessionKey(key),
+      ...listTasksForRelatedSessionKey(key),
+    ]).filter((task) => task.status === "running").length;
+  } catch (error) {
+    log.warn("failed to count running tasks for persisted session reconciliation", {
+      sessionKey: key,
+      error: String(error),
+    });
+    return 1;
+  }
+}
+
+function clearInterruptedDeliveryState(entry: MutableSessionEntry): void {
+  entry.pendingFinalDelivery = undefined;
+  entry.pendingFinalDeliveryText = undefined;
+  entry.pendingFinalDeliveryCreatedAt = undefined;
+  entry.pendingFinalDeliveryLastAttemptAt = undefined;
+  entry.pendingFinalDeliveryAttemptCount = undefined;
+  entry.pendingFinalDeliveryLastError = undefined;
+  entry.pendingFinalDeliveryContext = undefined;
+  entry.pendingFinalDeliveryIntentId = undefined;
+  entry.restartRecoveryDeliveryRunId = undefined;
+  entry.restartRecoveryDeliveryContext = undefined;
+}
+
+function markEntryTerminal(params: {
+  entry: MutableSessionEntry;
+  now: number;
+  newStatus: NonNullable<SessionEntry["status"]>;
+  reason: string;
+  safeFallbackDelivered: boolean;
+}): void {
+  params.entry.status = params.newStatus;
+  params.entry.abortedLastRun = true;
+  params.entry.endedAt = params.now;
+  params.entry.updatedAt = params.now;
+  if (typeof params.entry.startedAt === "number") {
+    params.entry.runtimeMs = Math.max(0, params.now - params.entry.startedAt);
+  }
+  params.entry.recoveredFromStaleRunning = true;
+  params.entry.staleRunningRecoveryReason = params.reason;
+  params.entry.staleRunningRecoveredAt = params.now;
+  params.entry.safeFallbackDelivered = params.safeFallbackDelivered;
+  clearInterruptedDeliveryState(params.entry);
+}
+
+function logReconciliation(result: SessionRunningReconciliationResult): void {
+  log.warn("reconciled persisted running session", {
+    sessionKey: result.sessionKey,
+    oldStatus: result.oldStatus ?? null,
+    newStatus: result.newStatus ?? null,
+    activeRunPresent: result.activeRunPresent,
+    runningTaskCount: result.runningTaskCount,
+    recoveryReason: result.reason,
+    safeFallbackDelivered: result.safeFallbackDelivered,
+  });
+}
+
+export async function reconcilePersistedRunningSession(params: {
+  storePath: string;
+  sessionKey: string;
+  candidateSessionKeys?: Iterable<string | undefined>;
+  activeRunPresent: boolean;
+  reason: string;
+  safeFallbackDelivered?: boolean;
+  newStatus?: "failed";
+}): Promise<SessionRunningReconciliationResult> {
+  const primarySessionKey = params.sessionKey.trim();
+  const candidateKeys = new Set(
+    [primarySessionKey, ...(params.candidateSessionKeys ?? [])]
+      .map((key) => key?.trim())
+      .filter((key): key is string => Boolean(key)),
+  );
+  const runningTaskCount = countRunningTasksForSessionKey(primarySessionKey);
+  const baseResult: SessionRunningReconciliationResult = {
+    changed: false,
+    sessionKey: primarySessionKey,
+    activeRunPresent: params.activeRunPresent,
+    runningTaskCount,
+    reason: params.reason,
+    safeFallbackDelivered: params.safeFallbackDelivered === true,
+  };
+  if (!params.storePath || !primarySessionKey || params.activeRunPresent || runningTaskCount > 0) {
+    return baseResult;
+  }
+
+  const newStatus: NonNullable<SessionEntry["status"]> = params.newStatus ?? "failed";
+  const now = Date.now();
+  let changedResult: SessionRunningReconciliationResult | undefined;
+  await applyRestartRecoveryLifecycle({
+    storePath: params.storePath,
+    requireWriteSuccess: true,
+    update: (entries) => {
+      const current = entries.find(({ sessionKey }) => candidateKeys.has(sessionKey));
+      const entry = current?.entry as MutableSessionEntry | undefined;
+      if (!current || !entry) {
+        return { result: undefined };
+      }
+      const oldStatus = typeof entry.status === "string" ? entry.status : undefined;
+      if (!oldStatus || !STALE_RUNNING_STATUSES.has(oldStatus)) {
+        return { result: undefined };
+      }
+      markEntryTerminal({
+        entry,
+        now,
+        newStatus,
+        reason: params.reason,
+        safeFallbackDelivered: params.safeFallbackDelivered === true,
+      });
+      changedResult = {
+        ...baseResult,
+        changed: true,
+        sessionKey: current.sessionKey,
+        oldStatus,
+        newStatus,
+      };
+      return {
+        result: undefined,
+        replacements: [{ sessionKey: current.sessionKey, entry }],
+      };
+    },
+  });
+  if (changedResult) {
+    logReconciliation(changedResult);
+    return changedResult;
+  }
+  return baseResult;
+}
+
+export async function reconcilePersistedRunningSessionsInStore(params: {
+  storePath: string;
+  activeSessionIds?: Iterable<string>;
+  activeSessionKeys?: Iterable<string>;
+  reason: string;
+  safeFallbackDelivered?: boolean;
+  updatedBeforeMs?: number;
+}): Promise<{ reconciled: number; skippedActive: number; skippedTask: number }> {
+  const activeSessionIds = new Set(
+    [...(params.activeSessionIds ?? [])].map((value) => value.trim()).filter(Boolean),
+  );
+  const activeSessionKeys = new Set(
+    [...(params.activeSessionKeys ?? [])].map((value) => value.trim()).filter(Boolean),
+  );
+  const result = { reconciled: 0, skippedActive: 0, skippedTask: 0 };
+  const now = Date.now();
+  await applyRestartRecoveryLifecycle({
+    storePath: params.storePath,
+    requireWriteSuccess: true,
+    update: (entries) => {
+      const replacements: Array<{ sessionKey: string; entry: SessionEntry }> = [];
+      for (const { sessionKey, entry } of entries) {
+        const mutable = entry as MutableSessionEntry;
+        const oldStatus = typeof mutable.status === "string" ? mutable.status : undefined;
+        if (!oldStatus || !STALE_RUNNING_STATUSES.has(oldStatus)) {
+          continue;
+        }
+        const updatedAt = typeof mutable.updatedAt === "number" ? mutable.updatedAt : undefined;
+        if (
+          params.updatedBeforeMs !== undefined &&
+          updatedAt !== undefined &&
+          updatedAt > params.updatedBeforeMs
+        ) {
+          continue;
+        }
+        const activeRunPresent =
+          activeSessionKeys.has(sessionKey) ||
+          (typeof mutable.sessionId === "string" && activeSessionIds.has(mutable.sessionId));
+        if (activeRunPresent) {
+          result.skippedActive++;
+          continue;
+        }
+        const runningTaskCount = countRunningTasksForSessionKey(sessionKey);
+        if (runningTaskCount > 0) {
+          result.skippedTask++;
+          continue;
+        }
+        markEntryTerminal({
+          entry: mutable,
+          now,
+          newStatus: "failed",
+          reason: params.reason,
+          safeFallbackDelivered: params.safeFallbackDelivered === true,
+        });
+        replacements.push({ sessionKey, entry: mutable });
+        result.reconciled++;
+        logReconciliation({
+          changed: true,
+          sessionKey,
+          oldStatus,
+          newStatus: "failed",
+          activeRunPresent,
+          runningTaskCount,
+          reason: params.reason,
+          safeFallbackDelivered: params.safeFallbackDelivered === true,
+        });
+      }
+      return { result, replacements };
+    },
+  });
+  return result;
+}

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -695,7 +695,13 @@ export function createSubagentRunManager(params: {
         agentId: registerParams.agentId,
         requesterAgentId: registerParams.requesterAgentId,
         deliveryStatus:
-          registerParams.expectsCompletionMessage === false ? "not_applicable" : "pending",
+          registerParams.expectsCompletionMessage === false && !requesterOrigin
+            ? "not_applicable"
+            : "pending",
+        notifyPolicy:
+          registerParams.expectsCompletionMessage === false && requesterOrigin
+            ? "state_changes"
+            : undefined,
         startedAt: now,
         lastEventAt: now,
       });

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -360,6 +360,36 @@ describe("subagent registry seam flow", () => {
     ]);
   });
 
+  it("keeps requester-origin subagent task state changes deliverable when terminal completion is suppressed", async () => {
+    const { findTaskByRunId, resetTaskRegistryForTests } =
+      await import("../tasks/task-registry.js");
+    resetTaskRegistryForTests();
+
+    mod.registerSubagentRun({
+      runId: "run-topic-start-ack",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:telegram:group:-1001234567890:topic:42",
+      requesterDisplayKey: "agent:main:telegram:group:-1001234567890:topic:42",
+      requesterOrigin: {
+        channel: "telegram",
+        to: "telegram:-1001234567890:topic:42",
+        threadId: 42,
+      },
+      task: "visible topic task",
+      cleanup: "keep",
+      expectsCompletionMessage: false,
+    });
+
+    expectRecordFields(
+      findTaskByRunId("run-topic-start-ack"),
+      {
+        deliveryStatus: "pending",
+        notifyPolicy: "state_changes",
+      },
+      "registered task",
+    );
+  });
+
   it("schedules orphan recovery instead of terminally failing on recoverable wait transport errors", async () => {
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -290,6 +290,7 @@ describe("gateway tool restart continuation", () => {
 
   it("reports continuationQueued=false when a coalesced restart belongs to another session (#86742)", async () => {
     requestSafeGatewayRestartMock.mockReturnValue({
+      ok: true,
       status: "coalesced",
       preflight: {
         safe: true,
@@ -302,6 +303,7 @@ describe("gateway tool restart continuation", () => {
           activeTasks: 0,
           totalActive: 0,
         },
+        blockers: [],
         taskBlockers: [],
       },
       restart: {
@@ -319,7 +321,7 @@ describe("gateway tool restart continuation", () => {
         activeWorkInterruptApproved: false,
         skipDeferralDowngraded: false,
       },
-    });
+    } as unknown as ReturnType<typeof requestSafeGatewayRestart> as never);
     const tool = createGatewayTool({
       agentSessionKey: "agent:main:main",
       config: {},

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -1,11 +1,11 @@
 // Gateway tool restart tests cover the sentinel handoff that lets an agent
 // resume private work after the gateway process restarts.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { requestSafeGatewayRestart } from "../../infra/restart-coordinator.js";
 import type { RestartSentinelPayload } from "../../infra/restart-sentinel.js";
-import type { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { createGatewayTool } from "./gateway-tool.js";
 
-type ScheduleGatewayRestartArgs = Parameters<typeof scheduleGatewaySigusr1Restart>[0];
+type SafeGatewayRestartArgs = Parameters<typeof requestSafeGatewayRestart>[0];
 
 const {
   extractDeliveryInfoMock,
@@ -13,7 +13,7 @@ const {
   isRestartEnabledMock,
   callGatewayToolMock,
   clearRestartSentinelMock,
-  scheduleGatewaySigusr1RestartMock,
+  requestSafeGatewayRestartMock,
   writeRestartSentinelMock,
 } = vi.hoisted(() => ({
   isRestartEnabledMock: vi.fn(() => true),
@@ -32,15 +32,36 @@ const {
   ),
   writeRestartSentinelMock: vi.fn(async (_payload: RestartSentinelPayload) => undefined),
   clearRestartSentinelMock: vi.fn(async () => undefined),
-  scheduleGatewaySigusr1RestartMock: vi.fn((_opts?: ScheduleGatewayRestartArgs) => ({
-    ok: true,
-    pid: 123,
-    signal: "SIGUSR1" as const,
-    delayMs: 250,
-    mode: "emit" as const,
-    coalesced: false,
-    cooldownMsApplied: 0,
-    emitHooksQueued: true,
+  requestSafeGatewayRestartMock: vi.fn((_opts?: SafeGatewayRestartArgs) => ({
+    status: "scheduled" as const,
+    preflight: {
+      safe: true,
+      summary: "no active work",
+      counts: {
+        queueSize: 0,
+        pendingReplies: 0,
+        embeddedRuns: 0,
+        cronRuns: 0,
+        activeTasks: 0,
+        totalActive: 0,
+      },
+      taskBlockers: [],
+    },
+    restart: {
+      ok: true,
+      pid: 123,
+      signal: "SIGUSR1" as const,
+      delayMs: 250,
+      mode: "emit" as const,
+      coalesced: false,
+      cooldownMsApplied: 0,
+      emitHooksQueued: true,
+    },
+    interruption: {
+      skipDeferralRequested: false,
+      activeWorkInterruptApproved: false,
+      skipDeferralDowngraded: false,
+    },
   })),
 }));
 
@@ -64,8 +85,8 @@ vi.mock("../../infra/restart-sentinel.js", async () => {
   };
 });
 
-vi.mock("../../infra/restart.js", () => ({
-  scheduleGatewaySigusr1Restart: scheduleGatewaySigusr1RestartMock,
+vi.mock("../../infra/restart-coordinator.js", () => ({
+  requestSafeGatewayRestart: requestSafeGatewayRestartMock,
 }));
 
 vi.mock("../../logging/subsystem.js", () => ({
@@ -88,11 +109,11 @@ function requireRestartSentinelPayload(): RestartSentinelPayload {
   return payload;
 }
 
-function requireScheduledRestartArgs(): NonNullable<ScheduleGatewayRestartArgs> {
-  const calls = scheduleGatewaySigusr1RestartMock.mock.calls;
+function requireSafeRestartArgs(): NonNullable<SafeGatewayRestartArgs> {
+  const calls = requestSafeGatewayRestartMock.mock.calls;
   const args = calls[calls.length - 1]?.[0];
   if (!args) {
-    throw new Error("expected scheduled restart args");
+    throw new Error("expected safe restart args");
   }
   return args;
 }
@@ -117,16 +138,37 @@ describe("gateway tool restart continuation", () => {
     writeRestartSentinelMock.mockReset();
     writeRestartSentinelMock.mockResolvedValue(undefined);
     clearRestartSentinelMock.mockClear();
-    scheduleGatewaySigusr1RestartMock.mockReset();
-    scheduleGatewaySigusr1RestartMock.mockReturnValue({
-      ok: true,
-      pid: 123,
-      signal: "SIGUSR1",
-      delayMs: 250,
-      mode: "emit",
-      coalesced: false,
-      cooldownMsApplied: 0,
-      emitHooksQueued: true,
+    requestSafeGatewayRestartMock.mockReset();
+    requestSafeGatewayRestartMock.mockReturnValue({
+      status: "scheduled",
+      preflight: {
+        safe: true,
+        summary: "no active work",
+        counts: {
+          queueSize: 0,
+          pendingReplies: 0,
+          embeddedRuns: 0,
+          cronRuns: 0,
+          activeTasks: 0,
+          totalActive: 0,
+        },
+        taskBlockers: [],
+      },
+      restart: {
+        ok: true,
+        pid: 123,
+        signal: "SIGUSR1",
+        delayMs: 250,
+        mode: "emit",
+        coalesced: false,
+        cooldownMsApplied: 0,
+        emitHooksQueued: true,
+      },
+      interruption: {
+        skipDeferralRequested: false,
+        activeWorkInterruptApproved: false,
+        skipDeferralDowngraded: false,
+      },
     });
     callGatewayToolMock.mockReset();
     callGatewayToolMock.mockResolvedValue({ ok: true });
@@ -192,7 +234,7 @@ describe("gateway tool restart continuation", () => {
     expect(writeRestartSentinelMock).not.toHaveBeenCalled();
     // The sentinel is emitted by the restart scheduler hook, so failed restart
     // delivery can still clean up a prepared file before the process exits.
-    await requireScheduledRestartArgs().emitHooks?.beforeEmit?.();
+    await requireSafeRestartArgs().emitHooks?.beforeEmit?.();
 
     const payload = requireRestartSentinelPayload();
     expect(payload.kind).toBe("restart");
@@ -209,9 +251,14 @@ describe("gateway tool restart continuation", () => {
       kind: "agentTurn",
       message: "Reply with exactly: Yay! I did it!",
     });
-    const restartArgs = requireScheduledRestartArgs();
+    const restartArgs = requireSafeRestartArgs();
     expect(restartArgs.delayMs).toBe(250);
     expect(restartArgs.reason).toBe("continue after reboot");
+    expect(restartArgs.requester).toBe("agent-tool session=agent:main:main");
+    expect(restartArgs.audit).toEqual({
+      actor: "agent-tool",
+      deviceId: "agent:main:main",
+    });
     expect(restartArgs.sessionKey).toBe("agent:main:main");
     expect(typeof restartArgs.emitHooks?.beforeEmit).toBe("function");
     expect(typeof restartArgs.emitHooks?.afterEmitRejected).toBe("function");
@@ -236,21 +283,42 @@ describe("gateway tool restart continuation", () => {
       continuationMessage: "Reply after restart",
     });
 
-    expect(requireScheduledRestartArgs().sessionKey).toBe("agent:main:session-A");
-    await requireScheduledRestartArgs().emitHooks?.beforeEmit?.();
+    expect(requireSafeRestartArgs().sessionKey).toBe("agent:main:session-A");
+    await requireSafeRestartArgs().emitHooks?.beforeEmit?.();
     expect(requireRestartSentinelPayload().sessionKey).toBe("agent:main:session-A");
   });
 
   it("reports continuationQueued=false when a coalesced restart belongs to another session (#86742)", async () => {
-    scheduleGatewaySigusr1RestartMock.mockReturnValue({
-      ok: true,
-      pid: 123,
-      signal: "SIGUSR1",
-      delayMs: 0,
-      mode: "emit",
-      coalesced: true,
-      cooldownMsApplied: 0,
-      emitHooksQueued: false,
+    requestSafeGatewayRestartMock.mockReturnValue({
+      status: "coalesced",
+      preflight: {
+        safe: true,
+        summary: "no active work",
+        counts: {
+          queueSize: 0,
+          pendingReplies: 0,
+          embeddedRuns: 0,
+          cronRuns: 0,
+          activeTasks: 0,
+          totalActive: 0,
+        },
+        taskBlockers: [],
+      },
+      restart: {
+        ok: true,
+        pid: 123,
+        signal: "SIGUSR1",
+        delayMs: 0,
+        mode: "emit",
+        coalesced: true,
+        cooldownMsApplied: 0,
+        emitHooksQueued: false,
+      },
+      interruption: {
+        skipDeferralRequested: false,
+        activeWorkInterruptApproved: false,
+        skipDeferralDowngraded: false,
+      },
     });
     const tool = createGatewayTool({
       agentSessionKey: "agent:main:main",
@@ -282,7 +350,7 @@ describe("gateway tool restart continuation", () => {
         delayMs,
       }),
     ).rejects.toThrow("delayMs must be a non-negative integer");
-    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(requestSafeGatewayRestartMock).not.toHaveBeenCalled();
   });
 
   it("accepts string restart delayMs values through the shared numeric reader", async () => {
@@ -296,7 +364,7 @@ describe("gateway tool restart continuation", () => {
       delayMs: "250",
     });
 
-    expect(requireScheduledRestartArgs().delayMs).toBe(250);
+    expect(requireSafeRestartArgs().delayMs).toBe(250);
   });
 
   it("coerces legacy continuationKind inputs to an agentTurn", async () => {
@@ -311,7 +379,7 @@ describe("gateway tool restart continuation", () => {
       continuationMessage: "Reply after restart",
     });
 
-    await requireScheduledRestartArgs().emitHooks?.beforeEmit?.();
+    await requireSafeRestartArgs().emitHooks?.beforeEmit?.();
 
     // Older model-facing arguments should not reintroduce system-event
     // continuations; visible replies still go through the message tool.
@@ -333,7 +401,7 @@ describe("gateway tool restart continuation", () => {
       reason: "restart requested",
     });
 
-    await requireScheduledRestartArgs().emitHooks?.beforeEmit?.();
+    await requireSafeRestartArgs().emitHooks?.beforeEmit?.();
 
     const payload = requireRestartSentinelPayload();
     expect(payload.sessionKey).toBe("agent:main:main");
@@ -350,7 +418,7 @@ describe("gateway tool restart continuation", () => {
       action: "restart",
     });
 
-    const scheduledArgs = requireScheduledRestartArgs();
+    const scheduledArgs = requireSafeRestartArgs();
     await scheduledArgs.emitHooks?.beforeEmit?.();
     await scheduledArgs.emitHooks?.afterEmitRejected?.();
 

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -17,6 +17,7 @@ import { normalizeConfigPatchReplacePaths } from "../../config/patch-replace-pat
 import { extractDeliveryInfo } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { GatewayClientRequestError } from "../../gateway/client.js";
+import { requestSafeGatewayRestart } from "../../infra/restart-coordinator.js";
 import {
   buildRestartSuccessContinuation,
   clearRestartSentinel,
@@ -24,7 +25,6 @@ import {
   type RestartSentinelPayload,
   writeRestartSentinel,
 } from "../../infra/restart-sentinel.js";
-import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { collectEnabledInsecureOrDangerousFlags } from "../../security/dangerous-config-flags.js";
 import { parseConfigPathArrayIndex } from "../../shared/path-array-index.js";
@@ -494,9 +494,14 @@ export function createGatewayTool(opts?: {
           `gateway tool: restart requested (delayMs=${delayMs ?? "default"}, reason=${reason ?? "none"})`,
         );
         let sentinelWritten = false;
-        const scheduled = scheduleGatewaySigusr1Restart({
+        const safeRestart = requestSafeGatewayRestart({
           delayMs,
-          reason,
+          reason: reason ?? "gateway.tool.restart",
+          requester: `agent-tool session=${sessionKey ?? "<none>"}`,
+          audit: {
+            actor: "agent-tool",
+            ...(sessionKey ? { deviceId: sessionKey } : {}),
+          },
           // Ownership and sentinel routing use the same trusted session identity,
           // so model-supplied params cannot queue work into another session.
           sessionKey,
@@ -513,8 +518,15 @@ export function createGatewayTool(opts?: {
           },
         });
         return jsonResult({
-          ...scheduled,
-          ...(payload.continuation ? { continuationQueued: scheduled.emitHooksQueued } : {}),
+          ...safeRestart.restart,
+          safeRestart: {
+            status: safeRestart.status,
+            preflight: safeRestart.preflight,
+            interruption: safeRestart.interruption,
+          },
+          ...(payload.continuation
+            ? { continuationQueued: safeRestart.restart.emitHooksQueued }
+            : {}),
         });
       }
 

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -278,6 +278,7 @@ vi.mock("../../infra/outbound/session-binding-service.js", () => ({
 }));
 vi.mock("../../infra/agent-events.js", () => ({
   emitAgentEvent: (params: unknown) => agentEventMocks.emitAgentEvent(params),
+  getAgentRunContext: vi.fn(() => null),
   onAgentEvent: (listener: unknown) => agentEventMocks.onAgentEvent(listener),
 }));
 vi.mock("../../plugins/runtime-plugins.runtime.js", () => ({

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -492,6 +492,7 @@ vi.mock("../../bindings/records.js", () => ({
 }));
 vi.mock("../../infra/agent-events.js", () => ({
   emitAgentEvent: (params: unknown) => agentEventMocks.emitAgentEvent(params),
+  getAgentRunContext: vi.fn(() => null),
   onAgentEvent: (listener: unknown) => agentEventMocks.onAgentEvent(listener),
 }));
 vi.mock("../../plugins/conversation-binding.js", () => ({

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -50,6 +50,7 @@ vi.mock("../../globals.js", () => ({
 
 vi.mock("../../process/command-queue.js", () => ({
   clearCommandLane: vi.fn().mockReturnValue(0),
+  getTotalQueueSize: vi.fn().mockReturnValue(0),
   getQueueSize: vi.fn().mockReturnValue(0),
 }));
 

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -26,6 +26,7 @@ const agentEventMocks = vi.hoisted(() => {
       }
     }),
     getAgentEventLifecycleGeneration: vi.fn(() => "test-generation"),
+    getAgentRunContext: vi.fn(() => null),
     onAgentEvent: vi.fn((handler: (event: AgentEvent) => void) => {
       handlers.add(handler);
       return () => handlers.delete(handler);

--- a/src/commands/flows.test.ts
+++ b/src/commands/flows.test.ts
@@ -134,7 +134,12 @@ describe("flows commands", () => {
         flows: [
           {
             ...jsonRoundTrip(flow),
-            tasks: [jsonRoundTrip(childTask)],
+            tasks: [
+              {
+                ...jsonRoundTrip(childTask),
+                lastEventAt: expect.any(Number),
+              },
+            ],
             taskSummary: {
               total: 1,
               active: 1,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -7,10 +7,7 @@ import type {
   SessionAcpIdentityState,
   SessionAcpMeta,
 } from "@openclaw/acp-core/types";
-import {
-  normalizeOptionalString,
-  type FastMode,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString, type FastMode } from "@openclaw/normalization-core/string-coerce";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { ChannelId } from "../../channels/plugins/channel-id.types.js";
 import type { ChannelRouteRef } from "../../plugin-sdk/channel-route.js";
@@ -259,6 +256,10 @@ export type SessionEntry = {
   pluginOwnerId?: string;
   systemSent?: boolean;
   abortedLastRun?: boolean;
+  /** True when a stale durable running row was reconciled after no active run/task remained. */
+  recoveredFromStaleRunning?: boolean;
+  /** Machine-readable reason for the stale running row reconciliation. */
+  staleRunningRecoveryReason?: string;
   /** Interrupted run generations whose late lifecycle events must be ignored. */
   restartRecoveryRuns?: RestartRecoveryRun[];
   /** Durable guard state for automatic subagent orphan recovery. */

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -260,6 +260,10 @@ export type SessionEntry = {
   recoveredFromStaleRunning?: boolean;
   /** Machine-readable reason for the stale running row reconciliation. */
   staleRunningRecoveryReason?: string;
+  /** Timestamp (ms) when the stale running row was reconciled. */
+  staleRunningRecoveredAt?: number;
+  /** True when the reconciliation path already emitted a safe fallback final. */
+  safeFallbackDelivered?: boolean;
   /** Interrupted run generations whose late lifecycle events must be ignored. */
   restartRecoveryRuns?: RestartRecoveryRun[];
   /** Durable guard state for automatic subagent orphan recovery. */

--- a/src/gateway/server-methods/agent.create-event.test.ts
+++ b/src/gateway/server-methods/agent.create-event.test.ts
@@ -28,6 +28,10 @@ const agentIngressMocks = vi.hoisted(() => ({
   agentCommandFromIngress: vi.fn(async () => ({ ok: true })),
 }));
 
+const taskRuntimeMocks = vi.hoisted(() => ({
+  createRunningTaskRun: vi.fn(),
+}));
+
 vi.mock("../../config/config.js", () => ({
   getRuntimeConfig: configMocks.getRuntimeConfig,
 }));
@@ -41,7 +45,7 @@ vi.mock("../../runtime.js", () => ({
 }));
 
 vi.mock("../../tasks/detached-task-runtime.js", () => ({
-  createRunningTaskRun: vi.fn(),
+  createRunningTaskRun: taskRuntimeMocks.createRunningTaskRun,
 }));
 
 import { agentHandlers } from "./agent.js";
@@ -62,6 +66,11 @@ describe("agent handler session create events", () => {
     configMocks.getRuntimeConfig.mockClear();
     agentIngressMocks.agentCommandFromIngress.mockClear();
     agentIngressMocks.agentCommandFromIngress.mockResolvedValue({ ok: true });
+    taskRuntimeMocks.createRunningTaskRun.mockReset().mockReturnValue({
+      taskId: "task-created",
+      runtime: "cli",
+      status: "running",
+    });
     await fs.writeFile(storePath, "{}\n", "utf8");
   });
 
@@ -123,6 +132,55 @@ describe("agent handler session create events", () => {
         expect(call?.[3]).toEqual({ dropIfSlow: true });
       },
       { timeout: 2_000, interval: 5 },
+    );
+  });
+
+  it("tracks Telegram topic agent turns with requester origin even when final delivery is off", async () => {
+    const respond = vi.fn();
+
+    await agentHandlers.agent({
+      params: {
+        message: "topic work",
+        agentId: "main",
+        sessionKey: "agent:main:telegram:group:-1001234567890:topic:42",
+        channel: "telegram",
+        to: "telegram:-1001234567890:topic:42",
+        threadId: "42",
+        deliver: false,
+        idempotencyKey: "idem-topic-start-ack",
+      },
+      respond,
+      context: {
+        dedupe: new Map(),
+        deps: {} as never,
+        logGateway: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() } as never,
+        chatAbortControllers: new Map(),
+        addChatRun: vi.fn(),
+        registerToolEventRecipient: vi.fn(),
+        getRuntimeConfig: configMocks.getRuntimeConfig,
+        getSessionEventSubscriberConnIds: () => new Set(),
+        broadcastToConnIds: vi.fn(),
+      } as never,
+      client: null,
+      isWebchatConnect: () => false,
+      req: { id: "req-topic-start-ack" } as never,
+    });
+
+    await vi.waitFor(() => {
+      expect(taskRuntimeMocks.createRunningTaskRun).toHaveBeenCalled();
+    });
+    expect(taskRuntimeMocks.createRunningTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtime: "cli",
+        sourceId: "idem-topic-start-ack",
+        ownerKey: "agent:main:telegram:group:-1001234567890:topic:42",
+        requesterOrigin: {
+          channel: "telegram",
+          to: "telegram:-1001234567890:topic:42",
+          threadId: "42",
+        },
+        deliveryStatus: "pending",
+      }),
     );
   });
 });

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -3342,7 +3342,7 @@ describe("gateway agent handler", () => {
           ownerKey: "agent:work:main",
           label: "plugin:memory-core",
           task: "background plugin subagent task",
-          deliveryStatus: "not_applicable",
+          deliveryStatus: "pending",
         });
         expect(task.runtime).not.toBe("cli");
       });

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -41,7 +41,12 @@ const mocks = vi.hoisted(() => ({
   agentCommand: vi.fn(),
   clearAgentRunContext: vi.fn(),
   registerAgentRunContext: vi.fn(),
-  emitAgentEvent: vi.fn(),
+  agentEventListeners: new Set<(event: unknown) => void>(),
+  emitAgentEvent: vi.fn((event: unknown) => {
+    for (const listener of mocks.agentEventListeners) {
+      listener(event);
+    }
+  }),
   performGatewaySessionReset: vi.fn(),
   emitGatewaySessionEndPluginHook: vi.fn(),
   emitGatewaySessionStartPluginHook: vi.fn(),
@@ -157,7 +162,10 @@ vi.mock("../../infra/agent-events.js", () => ({
   getAgentEventLifecycleGeneration: () => mocks.lifecycleGeneration,
   getAgentRunContext: vi.fn(),
   registerAgentRunContext: mocks.registerAgentRunContext,
-  onAgentEvent: vi.fn(),
+  onAgentEvent: vi.fn((listener: (event: unknown) => void) => {
+    mocks.agentEventListeners.add(listener);
+    return () => mocks.agentEventListeners.delete(listener);
+  }),
 }));
 
 vi.mock("../../agents/subagent-registry-read.js", () => ({
@@ -573,6 +581,7 @@ describe("gateway agent handler", () => {
     resetTaskRegistryForTests();
     resetSubagentRegistryForTests({ persist: false });
     subagentRegistryTesting.setDepsForTest();
+    mocks.agentEventListeners.clear();
     mocks.loadConfigReturn = {};
     mocks.emitGatewaySessionEndPluginHook.mockReset();
     mocks.emitGatewaySessionStartPluginHook.mockReset();
@@ -3312,6 +3321,16 @@ describe("gateway agent handler", () => {
           client: pluginClient,
         },
       );
+      mocks.emitAgentEvent({
+        runId,
+        sessionKey: childSessionKey,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: Date.now() - 100,
+          endedAt: Date.now(),
+        },
+      });
 
       await waitForAssertion(() => {
         const tasks = listTaskRecords().filter((task) => task.runId === runId);
@@ -5673,6 +5692,7 @@ describe("gateway agent handler chat.abort integration", () => {
     mocks.emitGatewaySessionStartPluginHook.mockReset();
     mocks.getLatestSubagentRunByChildSessionKey.mockReset();
     mocks.replaceSubagentRunAfterSteer.mockReset();
+    mocks.agentEventListeners.clear();
     mocks.resolveExplicitAgentSessionKey.mockReset().mockReturnValue(undefined);
     mocks.listAgentIds.mockReset().mockReturnValue(["main"]);
     mocks.getChannelPlugin.mockReset();

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -155,6 +155,7 @@ vi.mock("../../infra/agent-events.js", () => ({
   clearAgentRunContext: mocks.clearAgentRunContext,
   emitAgentEvent: mocks.emitAgentEvent,
   getAgentEventLifecycleGeneration: () => mocks.lifecycleGeneration,
+  getAgentRunContext: vi.fn(),
   registerAgentRunContext: mocks.registerAgentRunContext,
   onAgentEvent: vi.fn(),
 }));
@@ -4650,6 +4651,9 @@ describe("gateway agent handler", () => {
         {
           message: "background cli seam task",
           sessionKey: "agent:main:main",
+          channel: "telegram",
+          to: "telegram:-100",
+          threadId: "42",
           idempotencyKey: "task-registry-agent-seam",
         },
         { reqId: "task-registry-agent-seam" },
@@ -4661,6 +4665,7 @@ describe("gateway agent handler", () => {
         runId: "task-registry-agent-seam",
         childSessionKey: "agent:main:main",
         sourceId: "task-registry-agent-seam",
+        deliveryStatus: "pending",
       });
       expectStringFieldContains(
         mockCallArg(createRunningTaskRunSpy) as Record<string, unknown>,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -834,6 +834,7 @@ function deleteGatewayDedupeEntries(params: {
 function dispatchAgentRunFromGateway(params: {
   ingressOpts: Parameters<typeof agentCommandFromIngress>[0];
   runId: string;
+  trackingSessionKey?: string;
   dedupeKeys: readonly string[];
   /**
    * Controller whose signal is wired into `ingressOpts.abortSignal`. Used on
@@ -850,23 +851,27 @@ function dispatchAgentRunFromGateway(params: {
   let taskTracked = false;
   if (shouldTrackTask) {
     try {
+      const trackingSessionKey = params.trackingSessionKey?.trim() || params.ingressOpts.sessionKey;
+      const now = Date.now();
+      const requesterOrigin = normalizeDeliveryContext({
+        channel: params.ingressOpts.channel,
+        to: params.ingressOpts.to,
+        accountId: params.ingressOpts.accountId,
+        threadId: params.ingressOpts.threadId,
+      });
       taskTracked = Boolean(
         createRunningTaskRun({
           runtime: "cli",
           sourceId: params.runId,
-          ownerKey: params.ingressOpts.sessionKey,
+          ownerKey: trackingSessionKey,
           scopeKind: "session",
-          requesterOrigin: normalizeDeliveryContext({
-            channel: params.ingressOpts.channel,
-            to: params.ingressOpts.to,
-            accountId: params.ingressOpts.accountId,
-            threadId: params.ingressOpts.threadId,
-          }),
-          childSessionKey: params.ingressOpts.sessionKey,
+          requesterOrigin,
+          childSessionKey: trackingSessionKey,
           runId: params.runId,
           task: params.ingressOpts.message,
-          deliveryStatus: "not_applicable",
-          startedAt: Date.now(),
+          deliveryStatus: requesterOrigin?.channel ? "pending" : "not_applicable",
+          startedAt: now,
+          lastEventAt: now,
         }),
       );
     } catch (err) {
@@ -2725,6 +2730,7 @@ export const agentHandlers: GatewayRequestHandlers = {
               allowModelOverride,
             },
             runId,
+            trackingSessionKey: requestedSessionKeyRaw,
             dedupeKeys: agentDedupeKeys,
             abortController: activeRunAbort.controller,
             cleanupAbortController: activeRunAbort.cleanup,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -835,6 +835,7 @@ function dispatchAgentRunFromGateway(params: {
   ingressOpts: Parameters<typeof agentCommandFromIngress>[0];
   runId: string;
   trackingSessionKey?: string;
+  requesterOrigin?: DeliveryContext;
   dedupeKeys: readonly string[];
   /**
    * Controller whose signal is wired into `ingressOpts.abortSignal`. Used on
@@ -853,12 +854,14 @@ function dispatchAgentRunFromGateway(params: {
     try {
       const trackingSessionKey = params.trackingSessionKey?.trim() || params.ingressOpts.sessionKey;
       const now = Date.now();
-      const requesterOrigin = normalizeDeliveryContext({
-        channel: params.ingressOpts.channel,
-        to: params.ingressOpts.to,
-        accountId: params.ingressOpts.accountId,
-        threadId: params.ingressOpts.threadId,
-      });
+      const requesterOrigin =
+        normalizeDeliveryContext(params.requesterOrigin) ??
+        normalizeDeliveryContext({
+          channel: params.ingressOpts.channel,
+          to: params.ingressOpts.to,
+          accountId: params.ingressOpts.accountId,
+          threadId: params.ingressOpts.threadId,
+        });
       taskTracked = Boolean(
         createRunningTaskRun({
           runtime: "cli",
@@ -2643,6 +2646,12 @@ export const agentHandlers: GatewayRequestHandlers = {
           }
           const execApprovalFollowupElevatedDefaults =
             execApprovalFollowupRuntimeHandoff?.bashElevated;
+          const requesterOrigin = normalizeDeliveryContext({
+            channel: turnSourceChannel ?? resolvedChannel,
+            to: turnSourceTo ?? resolvedTo,
+            accountId: turnSourceAccountId ?? resolvedAccountId,
+            threadId: explicitThreadId ?? resolvedThreadId,
+          });
 
           dispatchAgentRunFromGateway({
             ingressOpts: {
@@ -2731,6 +2740,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             },
             runId,
             trackingSessionKey: requestedSessionKeyRaw,
+            requesterOrigin,
             dedupeKeys: agentDedupeKeys,
             abortController: activeRunAbort.controller,
             cleanupAbortController: activeRunAbort.cleanup,

--- a/src/gateway/server-methods/restart.test.ts
+++ b/src/gateway/server-methods/restart.test.ts
@@ -88,7 +88,7 @@ describe("gateway.restart.request handler", () => {
 
     await invokeRestartRequest({ reason: "operator", skipDeferral: true });
 
-    expectRestartRequest({ skipDeferral: true });
+    expectRestartRequest({ skipDeferral: true, activeWorkInterruptApproved: true });
   });
 
   it("forwards active-work interruption approval only when explicitly true", async () => {

--- a/src/gateway/server-methods/restart.test.ts
+++ b/src/gateway/server-methods/restart.test.ts
@@ -50,12 +50,24 @@ function mockScheduledRestart(preflight: { safe: boolean; summary: string }) {
   });
 }
 
-function expectRestartRequest(skipDeferral: boolean) {
-  expect(requestSafeGatewayRestart).toHaveBeenCalledWith({
-    reason: "operator",
-    delayMs: 0,
-    skipDeferral,
-  });
+function expectRestartRequest(params: {
+  skipDeferral: boolean;
+  activeWorkInterruptApproved?: boolean;
+}) {
+  expect(requestSafeGatewayRestart).toHaveBeenCalledWith(
+    expect.objectContaining({
+      reason: "operator",
+      delayMs: 0,
+      skipDeferral: params.skipDeferral,
+      activeWorkInterruptApproved: params.activeWorkInterruptApproved ?? false,
+      requester: "actor=unknown-actor device=unknown-device ip=unknown-ip conn=unknown-conn",
+      audit: {
+        actor: "unknown-actor",
+        deviceId: "unknown-device",
+        clientIp: "unknown-ip",
+      },
+    }),
+  );
 }
 
 describe("gateway.restart.request handler", () => {
@@ -68,7 +80,7 @@ describe("gateway.restart.request handler", () => {
 
     await invokeRestartRequest({ reason: "operator" });
 
-    expectRestartRequest(false);
+    expectRestartRequest({ skipDeferral: false });
   });
 
   it("forwards skipDeferral: true only when params.skipDeferral === true", async () => {
@@ -76,7 +88,22 @@ describe("gateway.restart.request handler", () => {
 
     await invokeRestartRequest({ reason: "operator", skipDeferral: true });
 
-    expectRestartRequest(true);
+    expectRestartRequest({ skipDeferral: true });
+  });
+
+  it("forwards active-work interruption approval only when explicitly true", async () => {
+    mockScheduledRestart({ safe: false, summary: "" });
+
+    await invokeRestartRequest({
+      reason: "operator",
+      skipDeferral: true,
+      interruptActiveWork: true,
+    });
+
+    expectRestartRequest({
+      skipDeferral: true,
+      activeWorkInterruptApproved: true,
+    });
   });
 
   it("normalizes truthy non-boolean skipDeferral values to false", async () => {
@@ -84,7 +111,7 @@ describe("gateway.restart.request handler", () => {
 
     await invokeRestartRequest({ reason: "operator", skipDeferral: "true" });
 
-    expectRestartRequest(false);
+    expectRestartRequest({ skipDeferral: false });
   });
 
   it("forwards skipDeferral: false explicitly when the param is sent as false", async () => {
@@ -92,7 +119,7 @@ describe("gateway.restart.request handler", () => {
 
     await invokeRestartRequest({ reason: "operator", skipDeferral: false });
 
-    expectRestartRequest(false);
+    expectRestartRequest({ skipDeferral: false });
   });
 
   it("rejects non-object params without scheduling a restart", async () => {

--- a/src/gateway/server-methods/restart.ts
+++ b/src/gateway/server-methods/restart.ts
@@ -35,11 +35,12 @@ export const restartHandlers: GatewayRequestHandlers = {
       return;
     }
     const actor = resolveControlPlaneActor(client);
+    const skipDeferral = normalizeSkipDeferral(params.skipDeferral);
     const result = requestSafeGatewayRestart({
       reason: normalizeReason(params.reason),
       delayMs: 0,
-      skipDeferral: normalizeSkipDeferral(params.skipDeferral),
-      activeWorkInterruptApproved: params.interruptActiveWork === true,
+      skipDeferral,
+      activeWorkInterruptApproved: skipDeferral || params.interruptActiveWork === true,
       requester: formatControlPlaneActor(actor),
       audit: {
         actor: actor.actor,

--- a/src/gateway/server-methods/restart.ts
+++ b/src/gateway/server-methods/restart.ts
@@ -4,6 +4,7 @@ import {
   createSafeGatewayRestartPreflight,
   requestSafeGatewayRestart,
 } from "../../infra/restart-coordinator.js";
+import { formatControlPlaneActor, resolveControlPlaneActor } from "../control-plane-audit.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 function isRestartRequestParams(value: unknown): value is Record<string, unknown> {
@@ -24,7 +25,7 @@ function normalizeSkipDeferral(value: unknown): boolean {
 
 /** Gateway request handlers for safe restart coordination. */
 export const restartHandlers: GatewayRequestHandlers = {
-  "gateway.restart.request": async ({ respond, params }) => {
+  "gateway.restart.request": async ({ respond, params, client }) => {
     if (!isRestartRequestParams(params)) {
       respond(
         false,
@@ -33,10 +34,18 @@ export const restartHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    const actor = resolveControlPlaneActor(client);
     const result = requestSafeGatewayRestart({
       reason: normalizeReason(params.reason),
       delayMs: 0,
       skipDeferral: normalizeSkipDeferral(params.skipDeferral),
+      activeWorkInterruptApproved: params.interruptActiveWork === true,
+      requester: formatControlPlaneActor(actor),
+      audit: {
+        actor: actor.actor,
+        deviceId: actor.deviceId,
+        clientIp: actor.clientIp,
+      },
     });
     respond(true, result);
   },

--- a/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
+++ b/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
@@ -14,6 +14,7 @@ const listSessionsFromStoreAsyncMock = vi.fn();
 const loadCombinedSessionStoreForGatewayMock = vi.fn();
 const loadSessionEntryMock = vi.fn((sessionKey: string, _opts?: { agentId?: string }) => ({
   canonicalKey: sessionKey,
+  storePath: undefined as string | undefined,
 }));
 
 vi.mock("../server-session-key.js", () => ({
@@ -420,7 +421,10 @@ describe("sessions.abort agent scope", () => {
   });
 
   it("infers selected-agent global aborts from agent-prefixed aliases", async () => {
-    loadSessionEntryMock.mockImplementationOnce(() => ({ canonicalKey: "global" }));
+    loadSessionEntryMock.mockImplementationOnce(() => ({
+      canonicalKey: "global",
+      storePath: undefined,
+    }));
     const context = createContext({ globalScope: true });
 
     await callSessions(
@@ -495,7 +499,10 @@ describe("sessions.abort agent scope", () => {
   });
 
   it("infers selected-agent global subscriptions from agent-prefixed aliases", async () => {
-    loadSessionEntryMock.mockImplementationOnce(() => ({ canonicalKey: "global" }));
+    loadSessionEntryMock.mockImplementationOnce(() => ({
+      canonicalKey: "global",
+      storePath: undefined,
+    }));
     const subscribeSessionMessageEvents = vi.fn();
     const context = createContext({
       globalScope: true,

--- a/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
+++ b/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
@@ -289,7 +289,7 @@ describe("sessions.abort agent scope", () => {
     );
   });
 
-  it("clears stale persisted session state when abort finds no active run", async () => {
+  it("reconciles stale persisted running state when abort finds no active run", async () => {
     const sessionKey = "agent:main:main";
     const originalUpdatedAt = Date.now() - 60_000;
     await withSessionStore(
@@ -337,10 +337,14 @@ describe("sessions.abort agent scope", () => {
           undefined,
         );
         const stored = loadSessionStore(storePath, { skipCache: true })[sessionKey];
-        expect(stored?.status).toBeUndefined();
+        expect(stored?.status).toBe("failed");
+        expect(stored?.abortedLastRun).toBe(true);
+        expect(stored?.recoveredFromStaleRunning).toBe(true);
+        expect(stored?.staleRunningRecoveryReason).toBe("sessions_abort_no_active_run");
         expect(stored?.restartRecoveryDeliveryRunId).toBeUndefined();
         expect(stored?.restartRecoveryDeliveryContext).toBeUndefined();
         expect(stored?.sessionId).toBe("session-stale-no-active-run");
+        expect(stored?.endedAt).toEqual(expect.any(Number));
         expect(stored?.updatedAt).toBeGreaterThan(originalUpdatedAt);
         expect(broadcastToConnIds).toHaveBeenCalledWith(
           "sessions.changed",

--- a/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
+++ b/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
@@ -1,7 +1,11 @@
 /**
  * Tests that session abort requests stay scoped to the targeted agent.
  */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { loadSessionStore, saveSessionStore, type SessionEntry } from "../../config/sessions.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
 const chatAbortMock = vi.fn();
@@ -77,6 +81,20 @@ function createContext(
 
 function createRespond(): RespondFn {
   return vi.fn() as unknown as RespondFn;
+}
+
+async function withSessionStore<T>(
+  entries: Record<string, SessionEntry>,
+  run: (storePath: string) => Promise<T>,
+): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), "openclaw-sessions-abort-"));
+  const storePath = join(dir, "sessions.json");
+  try {
+    await saveSessionStore(storePath, entries, { skipMaintenance: true });
+    return await run(storePath);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 function createBetaRunContext(activeRun: ActiveRun): GatewayRequestContext {
@@ -268,6 +286,125 @@ describe("sessions.abort agent scope", () => {
       new Set(["conn-1"]),
       { dropIfSlow: true },
     );
+  });
+
+  it("clears stale persisted session state when abort finds no active run", async () => {
+    const sessionKey = "agent:main:main";
+    const originalUpdatedAt = Date.now() - 60_000;
+    await withSessionStore(
+      {
+        [sessionKey]: {
+          sessionId: "session-stale-no-active-run",
+          updatedAt: originalUpdatedAt,
+          status: "running",
+          restartRecoveryDeliveryRunId: "run-stale",
+          restartRecoveryDeliveryContext: {
+            channel: "telegram",
+            to: "user-1",
+          },
+        },
+      },
+      async (storePath) => {
+        const broadcastToConnIds = vi.fn();
+        loadSessionEntryMock.mockReturnValueOnce({
+          canonicalKey: sessionKey,
+          storePath,
+        });
+        chatAbortMock.mockImplementationOnce(
+          async ({ respond: abortRespond }: { respond: RespondFn }) => {
+            abortRespond(true, { ok: true, aborted: false, runIds: [] });
+          },
+        );
+        const context = createContext({
+          extra: {
+            getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
+            broadcastToConnIds,
+            dedupe: new Map(),
+          },
+        });
+
+        const respond = await callSessions(
+          "sessions.abort",
+          { key: sessionKey },
+          { context, reqId: "req-stale-no-active-run" },
+        );
+
+        expect(respond).toHaveBeenCalledWith(
+          true,
+          { ok: true, abortedRunId: null, status: "no-active-run" },
+          undefined,
+          undefined,
+        );
+        const stored = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+        expect(stored?.status).toBeUndefined();
+        expect(stored?.restartRecoveryDeliveryRunId).toBeUndefined();
+        expect(stored?.restartRecoveryDeliveryContext).toBeUndefined();
+        expect(stored?.sessionId).toBe("session-stale-no-active-run");
+        expect(stored?.updatedAt).toBeGreaterThan(originalUpdatedAt);
+        expect(broadcastToConnIds).toHaveBeenCalledWith(
+          "sessions.changed",
+          expect.objectContaining({
+            sessionKey,
+            reason: "abort",
+          }),
+          new Set(["conn-1"]),
+          { dropIfSlow: true },
+        );
+      },
+    );
+  });
+
+  it("does not clear persisted session state when abort stops an active run", async () => {
+    const sessionKey = "agent:main:main";
+    const originalEntry: SessionEntry = {
+      sessionId: "session-active-abort",
+      updatedAt: Date.now() - 60_000,
+      status: "running",
+      restartRecoveryDeliveryRunId: "run-active",
+      restartRecoveryDeliveryContext: {
+        channel: "telegram",
+        to: "user-1",
+      },
+    };
+    await withSessionStore({ [sessionKey]: originalEntry }, async (storePath) => {
+      loadSessionEntryMock.mockReturnValueOnce({
+        canonicalKey: sessionKey,
+        storePath,
+      });
+      chatAbortMock.mockImplementationOnce(
+        async ({ respond: abortRespond }: { respond: RespondFn }) => {
+          abortRespond(true, { ok: true, aborted: true, runIds: ["run-active"] });
+        },
+      );
+      const context = createContext({
+        extra: {
+          getSessionEventSubscriberConnIds: () => new Set(),
+          broadcastToConnIds: vi.fn(),
+          dedupe: new Map(),
+        },
+      });
+
+      const respond = await callSessions(
+        "sessions.abort",
+        { key: sessionKey, runId: "run-active" },
+        { context, reqId: "req-active-abort" },
+      );
+
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        { ok: true, abortedRunId: "run-active", status: "aborted" },
+        undefined,
+        undefined,
+      );
+      const stored = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+      expect(stored?.status).toBe("running");
+      expect(stored?.restartRecoveryDeliveryRunId).toBe("run-active");
+      expect(stored?.restartRecoveryDeliveryContext).toEqual({
+        channel: "telegram",
+        to: "user-1",
+      });
+      expect(stored?.updatedAt).toBe(originalEntry.updatedAt);
+    });
   });
 
   it("forwards selected-agent scope for key-based global aborts", async () => {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -137,6 +137,67 @@ import { assertValidParams } from "./validation.js";
 
 const compactionCheckpointStore = createFileBackedCompactionCheckpointStore();
 
+const STALE_NO_ACTIVE_RUN_SESSION_STATUSES = new Set([
+  "running",
+  "processing",
+  "timeout",
+  "killed",
+]);
+
+async function clearPersistedNoActiveRunSessionState(params: {
+  cfg: OpenClawConfig;
+  key: string;
+  storePath: string;
+  agentId?: string;
+}): Promise<boolean> {
+  if (!params.storePath) {
+    return false;
+  }
+  const now = Date.now();
+  return await updateSessionStore(
+    params.storePath,
+    async (store) => {
+      const target = resolveGatewaySessionStoreTarget({
+        cfg: params.cfg,
+        key: params.key,
+        store,
+        agentId: params.agentId,
+      });
+      const targetEntry = resolveFreshestSessionEntryFromStoreKeys(store, target.storeKeys);
+      const entry = targetEntry as (SessionEntry & Record<string, unknown>) | undefined;
+      if (!entry) {
+        return false;
+      }
+      const status = typeof entry.status === "string" ? entry.status : undefined;
+      const hasBlockingStatus = Boolean(status && STALE_NO_ACTIVE_RUN_SESSION_STATUSES.has(status));
+      const hasRestartRecoveryState =
+        entry.restartRecoveryDeliveryRunId !== undefined ||
+        entry.restartRecoveryDeliveryContext !== undefined;
+      if (!hasBlockingStatus && !hasRestartRecoveryState) {
+        return false;
+      }
+      const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({
+        cfg: params.cfg,
+        key: params.key,
+        store,
+        agentId: params.agentId,
+      });
+      const writableEntry = store[primaryKey] as
+        | (SessionEntry & Record<string, unknown>)
+        | undefined;
+      if (!writableEntry) {
+        return false;
+      }
+      delete writableEntry.status;
+      delete writableEntry.restartRecoveryDeliveryRunId;
+      delete writableEntry.restartRecoveryDeliveryContext;
+      writableEntry.updatedAt = now;
+      return true;
+    },
+    { skipSaveWhenResult: (changed) => !changed },
+  );
+}
+
 function filterSessionStoreToConfiguredAgents(
   cfg: OpenClawConfig,
   store: Record<string, SessionEntry>,
@@ -1900,7 +1961,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     const requestedGlobalAgentId = requestedGlobalAgent.agentId;
-    const { canonicalKey } = loadSessionEntry(key, { agentId: requestedGlobalAgentId });
+    const { canonicalKey, storePath } = loadSessionEntry(key, { agentId: requestedGlobalAgentId });
     const requestedKeyAliases =
       requestedKey &&
       requestedKey !== key &&
@@ -1995,6 +2056,20 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         ...(canonicalKey === "global" && abortAgentId ? { agentId: abortAgentId } : {}),
         reason: "abort",
       });
+    } else {
+      const clearedStaleSessionState = await clearPersistedNoActiveRunSessionState({
+        cfg,
+        key: canonicalKey,
+        storePath,
+        agentId: requestedGlobalAgentId,
+      });
+      if (clearedStaleSessionState) {
+        emitSessionsChanged(context, {
+          sessionKey: canonicalKey,
+          ...(canonicalKey === "global" && abortAgentId ? { agentId: abortAgentId } : {}),
+          reason: "abort",
+        });
+      }
     }
   },
   "sessions.patch": async ({ params, respond, context, client, isWebchatConnect }) => {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -45,6 +45,7 @@ import {
   waitForEmbeddedAgentRunEnd,
 } from "../../agents/embedded-agent-runner/runs.js";
 import { compactEmbeddedAgentSession } from "../../agents/embedded-agent.js";
+import { reconcilePersistedRunningSession } from "../../agents/session-running-reconciliation.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
 import { normalizeReasoningLevel, normalizeThinkLevel } from "../../auto-reply/thinking.js";
 import {
@@ -137,13 +138,6 @@ import { assertValidParams } from "./validation.js";
 
 const compactionCheckpointStore = createFileBackedCompactionCheckpointStore();
 
-const STALE_NO_ACTIVE_RUN_SESSION_STATUSES = new Set([
-  "running",
-  "processing",
-  "timeout",
-  "killed",
-]);
-
 async function clearPersistedNoActiveRunSessionState(params: {
   cfg: OpenClawConfig;
   key: string;
@@ -153,28 +147,19 @@ async function clearPersistedNoActiveRunSessionState(params: {
   if (!params.storePath) {
     return false;
   }
-  const now = Date.now();
-  return await updateSessionStore(
+  let candidateSessionKeys: string[] = [];
+  const target = await updateSessionStore(
     params.storePath,
     async (store) => {
-      const target = resolveGatewaySessionStoreTarget({
+      const resolvedTarget = resolveGatewaySessionStoreTarget({
         cfg: params.cfg,
         key: params.key,
         store,
         agentId: params.agentId,
       });
-      const targetEntry = resolveFreshestSessionEntryFromStoreKeys(store, target.storeKeys);
-      const entry = targetEntry as (SessionEntry & Record<string, unknown>) | undefined;
-      if (!entry) {
-        return false;
-      }
-      const status = typeof entry.status === "string" ? entry.status : undefined;
-      const hasBlockingStatus = Boolean(status && STALE_NO_ACTIVE_RUN_SESSION_STATUSES.has(status));
-      const hasRestartRecoveryState =
-        entry.restartRecoveryDeliveryRunId !== undefined ||
-        entry.restartRecoveryDeliveryContext !== undefined;
-      if (!hasBlockingStatus && !hasRestartRecoveryState) {
-        return false;
+      const targetEntry = resolveFreshestSessionEntryFromStoreKeys(store, resolvedTarget.storeKeys);
+      if (!targetEntry) {
+        return undefined;
       }
       const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({
         cfg: params.cfg,
@@ -182,20 +167,23 @@ async function clearPersistedNoActiveRunSessionState(params: {
         store,
         agentId: params.agentId,
       });
-      const writableEntry = store[primaryKey] as
-        | (SessionEntry & Record<string, unknown>)
-        | undefined;
-      if (!writableEntry) {
-        return false;
-      }
-      delete writableEntry.status;
-      delete writableEntry.restartRecoveryDeliveryRunId;
-      delete writableEntry.restartRecoveryDeliveryContext;
-      writableEntry.updatedAt = now;
-      return true;
+      candidateSessionKeys = resolvedTarget.storeKeys;
+      return { primaryKey, storeKeys: resolvedTarget.storeKeys };
     },
-    { skipSaveWhenResult: (changed) => !changed },
+    { skipSaveWhenResult: (value) => value === undefined },
   );
+  if (!target?.primaryKey) {
+    return false;
+  }
+  const result = await reconcilePersistedRunningSession({
+    storePath: params.storePath,
+    sessionKey: target.primaryKey,
+    candidateSessionKeys,
+    activeRunPresent: false,
+    reason: "sessions_abort_no_active_run",
+    safeFallbackDelivered: false,
+  });
+  return result.changed;
 }
 
 function filterSessionStoreToConfiguredAgents(

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -34,7 +34,28 @@ const startManagedServiceUpdateHandoffMock = vi.fn(async () => ({
   logPath: "/tmp/openclaw-update-run-handoff/handoff.log",
 }));
 
-const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({ scheduled: true }));
+const requestSafeGatewayRestartMock = vi.fn(() => ({
+  status: "scheduled",
+  preflight: {
+    safe: true,
+    summary: "no active work",
+    counts: {
+      queueSize: 0,
+      pendingReplies: 0,
+      embeddedRuns: 0,
+      cronRuns: 0,
+      activeTasks: 0,
+      totalActive: 0,
+    },
+    taskBlockers: [],
+  },
+  restart: { scheduled: true },
+  interruption: {
+    skipDeferralRequested: false,
+    activeWorkInterruptApproved: false,
+    skipDeferralDowngraded: false,
+  },
+}));
 
 type PostCoreFinalizeOutcome = Awaited<
   ReturnType<
@@ -101,8 +122,8 @@ vi.mock("../../infra/restart-sentinel.js", async () => {
   };
 });
 
-vi.mock("../../infra/restart.js", () => ({
-  scheduleGatewaySigusr1Restart: scheduleGatewaySigusr1RestartMock,
+vi.mock("../../infra/restart-coordinator.js", () => ({
+  requestSafeGatewayRestart: requestSafeGatewayRestartMock,
 }));
 
 vi.mock("../../infra/package-json.js", () => ({
@@ -219,8 +240,29 @@ beforeEach(() => {
   refreshLatestUpdateRestartSentinelMock.mockResolvedValue(null);
   recordLatestUpdateRestartSentinelMock.mockClear();
   startManagedServiceUpdateHandoffMock.mockClear();
-  scheduleGatewaySigusr1RestartMock.mockClear();
-  scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true });
+  requestSafeGatewayRestartMock.mockClear();
+  requestSafeGatewayRestartMock.mockReturnValue({
+    status: "scheduled",
+    preflight: {
+      safe: true,
+      summary: "no active work",
+      counts: {
+        queueSize: 0,
+        pendingReplies: 0,
+        embeddedRuns: 0,
+        cronRuns: 0,
+        activeTasks: 0,
+        totalActive: 0,
+      },
+      taskBlockers: [],
+    },
+    restart: { scheduled: true },
+    interruption: {
+      skipDeferralRequested: false,
+      activeWorkInterruptApproved: false,
+      skipDeferralDowngraded: false,
+    },
+  });
   runPostCoreFinalizeAfterGatewayUpdateMock.mockClear();
   runPostCoreFinalizeAfterGatewayUpdateMock.mockResolvedValue({
     status: "skipped",
@@ -370,7 +412,7 @@ describe("update.run restart scheduling", () => {
   it("schedules restart when update succeeds", async () => {
     const payload = await captureUpdateRunPayload();
 
-    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    expect(requestSafeGatewayRestartMock).toHaveBeenCalledTimes(1);
     expect(payload?.ok).toBe(true);
     expect(payload?.restart).toEqual({ scheduled: true });
   });
@@ -389,7 +431,7 @@ describe("update.run restart scheduling", () => {
       continuationMessage: "This should not run after a failed update.",
     });
 
-    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(requestSafeGatewayRestartMock).not.toHaveBeenCalled();
     expect(payload?.ok).toBe(false);
     expect(payload?.restart).toBeNull();
     expect(capturedPayload?.continuation).toBeUndefined();
@@ -443,10 +485,10 @@ describe("update.run restart scheduling", () => {
       "managed handoff",
     ) as [{ handoffId?: string; meta?: { handoffId?: string } }];
     expect(handoffParams.meta?.handoffId).toBe(handoffParams.handoffId);
-    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    expect(requestSafeGatewayRestartMock).toHaveBeenCalledTimes(1);
     const [restartParams] = firstMockCall(
-      scheduleGatewaySigusr1RestartMock,
-      "gateway restart schedule",
+      requestSafeGatewayRestartMock,
+      "safe gateway restart request",
     ) as [{ delayMs?: number; reason?: string; skipCooldown?: boolean; skipDeferral?: boolean }];
     expect(restartParams?.reason).toBe("update.run");
     expect(restartParams?.skipCooldown).toBe(true);
@@ -496,7 +538,7 @@ describe("update.run restart scheduling", () => {
         restartDelayMs: 0,
       }),
     );
-    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledWith(
+    expect(requestSafeGatewayRestartMock).toHaveBeenCalledWith(
       expect.objectContaining({
         delayMs: 2000,
         reason: "update.run",
@@ -547,7 +589,7 @@ describe("update.run restart scheduling", () => {
         }),
       }),
     );
-    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    expect(requestSafeGatewayRestartMock).toHaveBeenCalledTimes(1);
     expect(payload?.ok).toBe(true);
     expect(payload?.result?.status).toBe("skipped");
     expect(payload?.result?.reason).toBe("managed-service-handoff-started");
@@ -641,7 +683,7 @@ describe("update.run restart scheduling", () => {
 
     expect(runGatewayUpdateMock).not.toHaveBeenCalled();
     expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
-    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(requestSafeGatewayRestartMock).not.toHaveBeenCalled();
     expect(payload?.ok).toBe(false);
     expect(payload?.restart).toBeNull();
     expect(payload?.result?.status).toBe("skipped");
@@ -657,7 +699,7 @@ describe("update.run restart scheduling", () => {
 
     expect(runGatewayUpdateMock).not.toHaveBeenCalled();
     expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
-    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(requestSafeGatewayRestartMock).not.toHaveBeenCalled();
     expect(payload?.ok).toBe(false);
     expect(payload?.restart).toBeNull();
     expect(payload?.result?.status).toBe("skipped");
@@ -679,7 +721,7 @@ describe("update.run restart scheduling", () => {
     const payload = await captureUpdateRunPayload();
 
     expect(runGatewayUpdateMock).not.toHaveBeenCalled();
-    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(requestSafeGatewayRestartMock).not.toHaveBeenCalled();
     expect(payload?.ok).toBe(false);
     expect(payload?.result?.status).toBe("skipped");
     expect(payload?.result?.reason).toBe("restart-unavailable");
@@ -717,7 +759,7 @@ describe("update.run post-core plugin finalize", () => {
     expect(finalizeParams.result?.mode).toBe("git");
     expect(finalizeParams.result?.status).toBe("ok");
     // Convergence succeeded, so the gateway is allowed to restart onto the new core.
-    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    expect(requestSafeGatewayRestartMock).toHaveBeenCalledTimes(1);
     expect(payload?.ok).toBe(true);
     expect(payload?.result?.status).toBe("ok");
   });
@@ -775,7 +817,7 @@ describe("update.run post-core plugin finalize", () => {
     const payload = await captureUpdateRunPayload();
 
     // Restarting onto the new core with unreconciled plugins is the bug we avoid.
-    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(requestSafeGatewayRestartMock).not.toHaveBeenCalled();
     expect(payload?.ok).toBe(false);
     expect(payload?.result?.status).toBe("error");
     expect(payload?.result?.reason).toBe("post-core-plugin-finalize-failed");

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -14,8 +14,8 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { GATEWAY_SERVICE_KIND, GATEWAY_SERVICE_MARKER } from "../../daemon/constants.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import { readPackageVersion } from "../../infra/package-json.js";
+import { requestSafeGatewayRestart } from "../../infra/restart-coordinator.js";
 import { type RestartSentinelPayload, writeRestartSentinel } from "../../infra/restart-sentinel.js";
-import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { detectRespawnSupervisor } from "../../infra/supervisor-markers.js";
 import { normalizeUpdateChannel } from "../../infra/update-channels.js";
 import { CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON } from "../../infra/update-control-plane-sentinel.js";
@@ -353,9 +353,9 @@ export const updateHandlers: GatewayRequestHandlers = {
     // Restarting after a failed update leaves the process in a broken state
     // (corrupted node_modules, partial builds) and causes a crash loop.
     const updateWasPackageSwap = result.status === "ok" && result.mode !== "git";
-    const restart =
+    const safeRestart =
       handoff?.status === "started" || result.status === "ok"
-        ? scheduleGatewaySigusr1Restart({
+        ? requestSafeGatewayRestart({
             delayMs:
               handoff?.status === "started"
                 ? resolveManagedServiceHandoffRestartDelayMs(restartDelayMs, supervisor)
@@ -364,9 +364,11 @@ export const updateHandlers: GatewayRequestHandlers = {
                   : restartDelayMs,
             reason: "update.run",
             // Package swaps and managed handoffs should restart without waiting
-            // for normal deferral/cooldown windows; the new code is already staged.
+            // for cooldown, but active user-visible work still requires the
+            // safe restart coordinator's deferral unless explicitly approved.
             skipDeferral: updateWasPackageSwap || handoff?.status === "started",
             skipCooldown: updateWasPackageSwap || handoff?.status === "started",
+            requester: formatControlPlaneActor(actor),
             audit: {
               actor: actor.actor,
               deviceId: actor.deviceId,
@@ -375,6 +377,7 @@ export const updateHandlers: GatewayRequestHandlers = {
             },
           })
         : null;
+    const restart = safeRestart?.restart ?? null;
     context?.logGateway?.info(
       `update.run completed ${formatControlPlaneActor(actor)} changedPaths=<n/a> restartReason=update.run status=${result.status}`,
     );

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -196,6 +196,8 @@ vi.mock("../infra/session-delivery-queue.js", () => ({
 }));
 
 vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => ({})),
+  resolveStorePath: vi.fn(() => "/tmp/sessions.json"),
   resolveMainSessionKeyFromConfig: mocks.resolveMainSessionKeyFromConfig,
 }));
 

--- a/src/infra/exec-approvals-analysis.test.ts
+++ b/src/infra/exec-approvals-analysis.test.ts
@@ -201,7 +201,7 @@ describe("Windows enforced shell command rendering", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(result.command).toMatch(/^& .+python3(?:\.\d+)? a\.py$/);
+    expect(result.command).toMatch(/^& (?:"[^"]+python3(?:\.\d+)?"|.+python3(?:\.\d+)?) a\.py$/);
   });
 
   it("rejects Windows commands with unsafe tokens", () => {

--- a/src/infra/restart-coordinator.test.ts
+++ b/src/infra/restart-coordinator.test.ts
@@ -124,7 +124,7 @@ describe("safe gateway restart coordinator", () => {
     expect(result.status).toBe("coalesced");
   });
 
-  it("forwards skipDeferral to scheduleGatewaySigusr1Restart and marks status scheduled", () => {
+  it("downgrades skipDeferral while active work exists without interruption approval", () => {
     scheduleGatewaySigusr1Restart.mockReturnValueOnce({
       ok: true,
       pid: 123,
@@ -148,12 +148,55 @@ describe("safe gateway restart coordinator", () => {
       },
     });
 
+    expect(result.status).toBe("deferred");
+    expect(result.preflight.safe).toBe(false);
+    expect(result.interruption).toEqual({
+      skipDeferralRequested: true,
+      activeWorkInterruptApproved: false,
+      skipDeferralDowngraded: true,
+    });
+    expect(scheduleGatewaySigusr1Restart).toHaveBeenCalledWith({
+      delayMs: 0,
+      reason: "test.skip-deferral",
+    });
+  });
+
+  it("forwards skipDeferral when active-work interruption is explicitly approved", () => {
+    scheduleGatewaySigusr1Restart.mockReturnValueOnce({
+      ok: true,
+      pid: 123,
+      signal: "SIGUSR1",
+      delayMs: 0,
+      mode: "emit",
+      coalesced: false,
+      cooldownMsApplied: 0,
+    });
+
+    const result = requestSafeGatewayRestart({
+      reason: "test.approved-interrupt",
+      skipDeferral: true,
+      activeWorkInterruptApproved: true,
+      inspect: {
+        getQueueSize: () => 1,
+        getPendingReplies: () => 0,
+        getEmbeddedRuns: () => 0,
+        getCronRuns: () => 0,
+        getActiveTasks: () => 0,
+        getTaskBlockers: () => [],
+      },
+    });
+
     expect(result.status).toBe("scheduled");
     expect(result.preflight.safe).toBe(false);
+    expect(result.interruption).toEqual({
+      skipDeferralRequested: true,
+      activeWorkInterruptApproved: true,
+      skipDeferralDowngraded: false,
+    });
     expect(scheduleGatewaySigusr1Restart).toHaveBeenCalledWith({
       delayMs: 0,
       preservePendingEmitHooksOnDeferralBypass: true,
-      reason: "test.skip-deferral",
+      reason: "test.approved-interrupt",
       skipDeferral: true,
     });
   });

--- a/src/infra/restart-coordinator.ts
+++ b/src/infra/restart-coordinator.ts
@@ -2,12 +2,18 @@
 import { getActiveEmbeddedRunCount } from "../agents/embedded-agent-runner/run-state.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import { getActiveCronJobCount } from "../cron/active-jobs.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
 import {
   getInspectableActiveTaskRestartBlockers,
   type ActiveTaskRestartBlocker,
 } from "../tasks/task-registry.maintenance.js";
-import { scheduleGatewaySigusr1Restart, type ScheduledRestart } from "./restart.js";
+import {
+  scheduleGatewaySigusr1Restart,
+  type RestartAuditInfo,
+  type RestartEmitHooks,
+  type ScheduledRestart,
+} from "./restart.js";
 
 // Safe restart coordination checks active local work before scheduling SIGUSR1
 // restarts, while still allowing explicit deferral bypasses for operators.
@@ -39,6 +45,11 @@ export type SafeGatewayRestartRequestResult = {
   status: "scheduled" | "deferred" | "coalesced";
   preflight: SafeGatewayRestartPreflight;
   restart: ScheduledRestart;
+  interruption: {
+    skipDeferralRequested: boolean;
+    activeWorkInterruptApproved: boolean;
+    skipDeferralDowngraded: boolean;
+  };
 };
 
 type SafeRestartInspectors = {
@@ -58,6 +69,7 @@ const defaultInspectors: SafeRestartInspectors = {
   getActiveTasks: () => getInspectableActiveTaskRestartBlockers().length,
   getTaskBlockers: getInspectableActiveTaskRestartBlockers,
 };
+const restartLog = createSubsystemLogger("restart");
 
 function normalizeCount(value: number): number {
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
@@ -172,15 +184,40 @@ export function requestSafeGatewayRestart(
     reason?: string;
     delayMs?: number;
     skipDeferral?: boolean;
+    activeWorkInterruptApproved?: boolean;
+    requester?: string;
+    audit?: RestartAuditInfo;
+    emitHooks?: RestartEmitHooks;
+    sessionKey?: string;
+    skipCooldown?: boolean;
     preservePendingEmitHooks?: boolean;
     inspect?: Partial<SafeRestartInspectors>;
   } = {},
 ): SafeGatewayRestartRequestResult {
   const preflight = createSafeGatewayRestartPreflight(opts.inspect);
-  const skipDeferral = opts.skipDeferral === true;
+  const skipDeferralRequested = opts.skipDeferral === true;
+  const activeWorkInterruptApproved = opts.activeWorkInterruptApproved === true;
+  const skipDeferral = skipDeferralRequested && (preflight.safe || activeWorkInterruptApproved);
+  const skipDeferralDowngraded = skipDeferralRequested && !skipDeferral;
+  const requester = opts.requester?.trim() || "requester=<unknown>";
+  const reason = opts.reason ?? "gateway.restart.safe";
+  restartLog.info(
+    `safe restart requested ${requester} reason=${reason} active=${preflight.counts.totalActive} queue=${preflight.counts.queueSize} replies=${preflight.counts.pendingReplies} embedded=${preflight.counts.embeddedRuns} cron=${preflight.counts.cronRuns} tasks=${preflight.counts.activeTasks} skipDeferral=${skipDeferralRequested} interruptApproved=${activeWorkInterruptApproved}`,
+  );
+  if (skipDeferralDowngraded) {
+    // Tool-accessible restarts must not interrupt visible work merely because a
+    // loose caller set skipDeferral; require an explicit interruption approval.
+    restartLog.warn(
+      `safe restart skipDeferral downgraded ${requester} reason=${reason} active=${preflight.counts.totalActive}`,
+    );
+  }
   const restart = scheduleGatewaySigusr1Restart({
     delayMs: opts.delayMs ?? 0,
-    reason: opts.reason ?? "gateway.restart.safe",
+    reason,
+    ...(opts.audit ? { audit: opts.audit } : {}),
+    ...(opts.emitHooks ? { emitHooks: opts.emitHooks } : {}),
+    ...(opts.sessionKey ? { sessionKey: opts.sessionKey } : {}),
+    ...(opts.skipCooldown === true ? { skipCooldown: true } : {}),
     ...(opts.preservePendingEmitHooks === true || skipDeferral
       ? { preservePendingEmitHooksOnDeferralBypass: true }
       : {}),
@@ -196,5 +233,10 @@ export function requestSafeGatewayRestart(
     status,
     preflight,
     restart,
+    interruption: {
+      skipDeferralRequested,
+      activeWorkInterruptApproved,
+      skipDeferralDowngraded,
+    },
   };
 }

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -665,8 +665,10 @@ describe("update-startup", () => {
     expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledWith({
       delayMs: 0,
       reason: "update.auto",
+      audit: { actor: "update.auto" },
       skipCooldown: true,
       skipDeferral: true,
+      preservePendingEmitHooksOnDeferralBypass: true,
     });
     expect(log.info).toHaveBeenCalledWith("auto-update handoff started", {
       channel: "beta",
@@ -702,8 +704,10 @@ describe("update-startup", () => {
     expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledWith({
       delayMs: 2000,
       reason: "update.auto",
+      audit: { actor: "update.auto" },
       skipCooldown: true,
       skipDeferral: true,
+      preservePendingEmitHooksOnDeferralBypass: true,
     });
   });
 

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -24,7 +24,7 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 import { resolveOpenClawPackageRoot } from "./openclaw-root.js";
-import { scheduleGatewaySigusr1Restart } from "./restart.js";
+import { requestSafeGatewayRestart } from "./restart-coordinator.js";
 import { detectRespawnSupervisor, type RespawnSupervisor } from "./supervisor-markers.js";
 import { normalizeUpdateChannel, DEFAULT_PACKAGE_CHANNEL } from "./update-channels.js";
 import { compareSemverStrings, resolveNpmChannelTag, checkUpdateStatus } from "./update-check.js";
@@ -660,9 +660,13 @@ export async function runGatewayUpdateCheck(params: {
 
   await writeState(nextState);
   if (pendingAutoUpdateRestartDelayMs !== null) {
-    scheduleGatewaySigusr1Restart({
+    requestSafeGatewayRestart({
       delayMs: pendingAutoUpdateRestartDelayMs,
       reason: "update.auto",
+      requester: "update.auto",
+      audit: {
+        actor: "update.auto",
+      },
       skipCooldown: true,
       skipDeferral: true,
     });

--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -1,4 +1,7 @@
 // Stuck session recovery integration tests cover end-to-end recovery diagnostics.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { resolveEmbeddedSessionLane } from "../agents/embedded-agent-runner/lanes.js";
 import {
@@ -10,6 +13,7 @@ import {
   testing as replyRunTesting,
   createReplyOperation,
 } from "../auto-reply/reply/reply-run-registry.js";
+import { loadSessionStore } from "../config/sessions.js";
 import {
   enqueueCommandInLane,
   getQueueSize,
@@ -203,6 +207,67 @@ describe("stuck session recovery integration", () => {
       warnAfterMs: Number.MAX_SAFE_INTEGER,
     });
     await expect(Promise.race([queued, delay(100)])).resolves.toBe("drained");
+  });
+
+  it("marks a recovered Telegram topic session non-running after aborting a stalled embedded run", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-stuck-session-"));
+    try {
+      const sessionKey = "agent:openclaw:telegram:group:-1003789377335:topic:25537";
+      const sessionId = "telegram-topic-stalled-session";
+      const sessionFile = path.join(tempDir, `${sessionId}.jsonl`);
+      const storePath = path.join(tempDir, "sessions.json");
+      fs.writeFileSync(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId,
+            sessionFile,
+            updatedAt: Date.now() - 60_000,
+            status: "running",
+            startedAt: Date.now() - 120_000,
+          },
+        }),
+      );
+
+      const lane = resolveEmbeddedSessionLane(sessionKey);
+      const operation = createReplyOperation({
+        sessionKey,
+        sessionId,
+        resetTriggered: false,
+      });
+      operation.setPhase("running");
+      operation.attachBackend({
+        kind: "embedded",
+        cancel: () => queueMicrotask(() => operation.complete()),
+        isStreaming: () => false,
+      });
+      void enqueueCommandInLane(lane, () => new Promise<never>(() => {}), {
+        warnAfterMs: Number.MAX_SAFE_INTEGER,
+      });
+
+      const outcome = await recoverStuckDiagnosticSession({
+        sessionId,
+        sessionKey,
+        sessionFile,
+        ageMs: 720_000,
+        queueDepth: 1,
+        allowActiveAbort: true,
+      });
+
+      expect(outcome.status).toBe("aborted");
+      expect(getQueueSize(lane)).toBe(0);
+      const stored = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+      expect(stored?.status).toBe("failed");
+      expect(stored?.recoveredFromStaleRunning).toBe(true);
+      expect(stored?.staleRunningRecoveryReason).toBe("stuck_recovery_abort_embedded_run");
+      expect(stored?.endedAt).toEqual(expect.any(Number));
+      const next = enqueueCommandInLane(lane, async () => "next-turn", {
+        warnAfterMs: Number.MAX_SAFE_INTEGER,
+      });
+      await expect(Promise.race([next, delay(100)])).resolves.toBe("next-turn");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("does not reset a lane that unwedged and started a queued turn during the abort (#91700)", async () => {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -1,4 +1,5 @@
 // Stuck session recovery runtime helpers inspect embedded sessions for recovery.
+import path from "node:path";
 import { resolveEmbeddedSessionLane } from "../agents/embedded-agent-runner/lanes.js";
 import {
   abortAndDrainEmbeddedAgentRun,
@@ -9,6 +10,7 @@ import {
   resolveActiveEmbeddedRunHandleSessionId,
   resolveActiveEmbeddedRunHandleSessionIdBySessionFile,
 } from "../agents/embedded-agent-runner/runs.js";
+import { reconcilePersistedRunningSession } from "../agents/session-running-reconciliation.js";
 import {
   getCommandLaneActiveTaskIds,
   getCommandLaneSnapshot,
@@ -83,6 +85,25 @@ function formatRecoveryContext(
     fields.push(`laneQueued=${extra.queuedCount}`);
   }
   return fields.join(" ");
+}
+
+async function reconcileRecoveredSession(params: {
+  request: StuckSessionRecoveryParams;
+  activeRunPresent: boolean;
+  reason: string;
+}) {
+  const sessionKey = params.request.sessionKey?.trim();
+  const sessionFile = params.request.sessionFile?.trim();
+  if (!sessionKey || !sessionFile) {
+    return;
+  }
+  await reconcilePersistedRunningSession({
+    storePath: path.join(path.dirname(path.resolve(sessionFile)), "sessions.json"),
+    sessionKey,
+    activeRunPresent: params.activeRunPresent,
+    reason: params.reason,
+    safeFallbackDelivered: false,
+  });
 }
 
 export async function recoverStuckDiagnosticSession(
@@ -306,6 +327,14 @@ export async function recoverStuckDiagnosticSession(
               released,
               lane: sessionLane ?? undefined,
             };
+      await reconcileRecoveredSession({
+        request: params,
+        activeRunPresent: false,
+        reason:
+          outcome.action === "abort_embedded_run"
+            ? "stuck_recovery_abort_embedded_run"
+            : "stuck_recovery_release_lane",
+      });
       diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
       return outcome;
     }

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -130,6 +130,8 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "quotaSuspension",
   "recoveredFromStaleRunning",
   "staleRunningRecoveryReason",
+  "staleRunningRecoveredAt",
+  "safeFallbackDelivered",
 ] as const satisfies ReadonlyArray<keyof SessionEntry | "__proto__" | "constructor" | "prototype">;
 
 type ReservedSessionEntrySlotKey = Extract<

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -128,6 +128,8 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "pluginDebugEntries",
   "acp",
   "quotaSuspension",
+  "recoveredFromStaleRunning",
+  "staleRunningRecoveryReason",
 ] as const satisfies ReadonlyArray<keyof SessionEntry | "__proto__" | "constructor" | "prototype">;
 
 type ReservedSessionEntrySlotKey = Extract<

--- a/src/tasks/context-engine-maintenance-task.ts
+++ b/src/tasks/context-engine-maintenance-task.ts
@@ -1,0 +1,16 @@
+// Defines the task-registry identity for core context-engine turn maintenance.
+import type { TaskRecord } from "./task-registry.types.js";
+
+export const CONTEXT_ENGINE_TURN_MAINTENANCE_TASK_KIND = "context_engine_turn_maintenance";
+
+export function isContextEngineTurnMaintenanceTask(
+  task: Pick<TaskRecord, "childSessionKey" | "runtime" | "scopeKind" | "sourceId" | "taskKind">,
+): boolean {
+  return (
+    task.runtime === "acp" &&
+    task.scopeKind === "session" &&
+    task.taskKind?.trim() === CONTEXT_ENGINE_TURN_MAINTENANCE_TASK_KIND &&
+    task.sourceId?.trim() === CONTEXT_ENGINE_TURN_MAINTENANCE_TASK_KIND &&
+    !task.childSessionKey?.trim()
+  );
+}

--- a/src/tasks/task-executor-policy.test.ts
+++ b/src/tasks/task-executor-policy.test.ts
@@ -72,7 +72,7 @@ describe("task-executor-policy", () => {
       "Task needs follow-up: ACP import (run run-1234). Needs login.",
     );
     expect(formatTaskStateChangeMessage(blockedTask, progressEvent)).toBe(
-      "Background task update: ACP import. No output for 60s.",
+      "Background task update: ACP import (run run-1234). No output for 60s.",
     );
   });
 

--- a/src/tasks/task-executor-policy.ts
+++ b/src/tasks/task-executor-policy.ts
@@ -99,12 +99,16 @@ export function formatTaskStateChangeMessage(
   event: TaskEventRecord,
 ): string | null {
   const title = resolveTaskDisplayTitle(task);
+  const runLabel = resolveTaskRunLabel(task);
+  if (event.kind === "queued") {
+    return `Background task accepted: ${title}${runLabel}.`;
+  }
   if (event.kind === "running") {
-    return `Background task started: ${title}.`;
+    return `Background task started: ${title}${runLabel}.`;
   }
   if (event.kind === "progress") {
     const summary = sanitizeTaskStatusText(event.summary);
-    return summary ? `Background task update: ${title}. ${summary}` : null;
+    return summary ? `Background task update: ${title}${runLabel}. ${summary}` : null;
   }
   return null;
 }

--- a/src/tasks/task-executor-policy.ts
+++ b/src/tasks/task-executor-policy.ts
@@ -101,10 +101,10 @@ export function formatTaskStateChangeMessage(
   const title = resolveTaskDisplayTitle(task);
   const runLabel = resolveTaskRunLabel(task);
   if (event.kind === "queued") {
-    return `Background task accepted: ${title}${runLabel}.`;
+    return `Queued in background: ${title}. I'll update you when it starts, if it runs long, fails, or finishes.`;
   }
   if (event.kind === "running") {
-    return `Background task started: ${title}${runLabel}.`;
+    return `Working in background: ${title}. I'll update you if it runs long, fails, or finishes.`;
   }
   if (event.kind === "progress") {
     const summary = sanitizeTaskStatusText(event.summary);

--- a/src/tasks/task-executor.test.ts
+++ b/src/tasks/task-executor.test.ts
@@ -344,7 +344,7 @@ describe("task-executor", () => {
       expect(runningFlow?.ownerKey).toBe("agent:main:main");
       expect(runningFlow?.status).toBe("running");
       expect(runningFlow?.goal).toBe("Write summary");
-      expect(runningFlow?.notifyPolicy).toBe("done_only");
+      expect(runningFlow?.notifyPolicy).toBe("state_changes");
 
       completeTaskRunByRunId({
         runId: "run-executor-flow",
@@ -358,7 +358,7 @@ describe("task-executor", () => {
       expect(succeededFlow?.status).toBe("succeeded");
       expect(succeededFlow?.endedAt).toBe(40);
       expect(succeededFlow?.goal).toBe("Write summary");
-      expect(succeededFlow?.notifyPolicy).toBe("done_only");
+      expect(succeededFlow?.notifyPolicy).toBe("state_changes");
     });
   });
 

--- a/src/tasks/task-executor.ts
+++ b/src/tasks/task-executor.ts
@@ -94,10 +94,23 @@ function ensureSingleTaskFlow(params: {
 type TaskRunCreateParams = DetachedTaskCreateParams;
 type RunningTaskRunCreateParams = DetachedRunningTaskCreateParams;
 
+function resolveDetachedTaskNotifyPolicy(
+  params: TaskRunCreateParams | RunningTaskRunCreateParams,
+): TaskNotifyPolicy | undefined {
+  if (params.notifyPolicy) {
+    return params.notifyPolicy;
+  }
+  if (params.scopeKind !== "session" || params.deliveryStatus === "not_applicable") {
+    return undefined;
+  }
+  return "state_changes";
+}
+
 export function createQueuedTaskRun(params: TaskRunCreateParams): TaskRecord | null {
   const task = createTaskRecord({
     ...params,
     status: "queued",
+    notifyPolicy: resolveDetachedTaskNotifyPolicy(params),
   });
   if (!task) {
     return null;
@@ -116,6 +129,7 @@ export function createRunningTaskRun(params: RunningTaskRunCreateParams): TaskRe
   const task = createTaskRecord({
     ...params,
     status: "running",
+    notifyPolicy: resolveDetachedTaskNotifyPolicy(params),
   });
   if (!task) {
     return null;

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -350,6 +350,81 @@ describe("task-registry maintenance issue #60299", () => {
     expect(getInspectableActiveTaskRestartBlockers()).toHaveLength(1);
   });
 
+  it("reclaims stale context-engine maintenance rows in the authoritative gateway", async () => {
+    const staleAt = Date.now() - 40 * 60_000;
+    const task = makeStaleTask({
+      taskId: "task-context-engine-maintenance-stale",
+      runtime: "acp",
+      taskKind: "context_engine_turn_maintenance",
+      sourceId: "context_engine_turn_maintenance",
+      ownerKey: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: undefined,
+      runId: "turn-maint:agent:main:main:old",
+      label: "Context engine turn maintenance",
+      task: "Deferred context-engine maintenance after turn.",
+      createdAt: staleAt,
+      startedAt: staleAt,
+      lastEventAt: staleAt,
+    });
+
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      runtimeAuthoritative: true,
+    });
+
+    expectMaintenanceCounts(previewTaskRegistryMaintenance(), { reconciled: 1 });
+    expect(getTaskRegistryMaintenanceDiagnostics().staleRunningTasks).toContainEqual(
+      expect.objectContaining({
+        taskId: task.taskId,
+        decision: "would_reconcile",
+      }),
+    );
+    expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 1 });
+    const storedTask = requireTaskRecord(currentTasks, task.taskId);
+    expect(storedTask.status).toBe("lost");
+    expect(storedTask.error).toBe("context engine maintenance worker no longer active");
+    expect(getInspectableActiveTaskRestartBlockers()).toHaveLength(0);
+  });
+
+  it("keeps stale context-engine maintenance rows in non-authoritative inspection", async () => {
+    const staleAt = Date.now() - 40 * 60_000;
+    const task = makeStaleTask({
+      taskId: "task-context-engine-maintenance-nonauthoritative",
+      runtime: "acp",
+      taskKind: "context_engine_turn_maintenance",
+      sourceId: "context_engine_turn_maintenance",
+      ownerKey: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: undefined,
+      runId: "turn-maint:agent:main:main:old",
+      label: "Context engine turn maintenance",
+      task: "Deferred context-engine maintenance after turn.",
+      createdAt: staleAt,
+      startedAt: staleAt,
+      lastEventAt: staleAt,
+    });
+
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      runtimeAuthoritative: false,
+    });
+
+    expectMaintenanceCounts(previewTaskRegistryMaintenance(), { reconciled: 0 });
+    expect(getTaskRegistryMaintenanceDiagnostics().staleRunningTasks).toContainEqual(
+      expect.objectContaining({
+        taskId: task.taskId,
+        decision: "retained",
+        reason: "acp_runtime_not_authoritative",
+      }),
+    );
+    expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 0 });
+    expectTaskStatus(currentTasks, task.taskId, "running");
+    expect(getInspectableActiveTaskRestartBlockers()).toHaveLength(1);
+  });
+
   it("only treats started non-ended running tasks as restart blockers", () => {
     const now = Date.now();
     const activeRunning = makeStaleTask({

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -36,6 +36,7 @@ import {
   type SessionKeyChatType,
 } from "../sessions/session-chat-type-shared.js";
 import { CODEX_NATIVE_SUBAGENT_STALE_ERROR } from "./codex-native-subagent-task.js";
+import { isContextEngineTurnMaintenanceTask } from "./context-engine-maintenance-task.js";
 import {
   getDetachedTaskLifecycleRuntime,
   tryRecoverTaskBeforeMarkLost,
@@ -497,6 +498,13 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
     return false;
   }
 
+  if (isContextEngineTurnMaintenanceTask(task)) {
+    // Deferred context-engine maintenance is owned by this Gateway process and
+    // has no child session to prove liveness after restart. Only the
+    // authoritative Gateway sweep may reclaim stale rows.
+    return !taskRegistryMaintenanceRuntime.isRuntimeAuthoritative();
+  }
+
   const childSessionKey = task.childSessionKey?.trim();
   if (!childSessionKey) {
     return !isChildlessNativeSubagentTask(task);
@@ -528,6 +536,9 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
 }
 
 function resolveTaskLostError(task: TaskRecord, context?: BackingSessionLookupContext): string {
+  if (isContextEngineTurnMaintenanceTask(task)) {
+    return "context engine maintenance worker no longer active";
+  }
   const nativeDefinition = resolveChildlessNativeSubagentTaskDefinition(task);
   if (nativeDefinition) {
     return nativeDefinition.taskKind === "codex-native"

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -28,7 +28,9 @@ import {
   listFreshTasksForOwnerKey,
   markTaskTerminalById,
   maybeDeliverTaskStateChangeUpdate,
+  resetTaskRegistryDeliveryRuntimeForTests,
   resetTaskRegistryForTests,
+  setTaskRegistryDeliveryRuntimeForTests,
   updateTaskNotifyPolicyById,
 } from "./task-registry.js";
 import {
@@ -110,6 +112,7 @@ function createStoredTask(): TaskRecord {
 describe("task-registry store runtime", () => {
   afterEach(() => {
     ORIGINAL_ENV.restore();
+    resetTaskRegistryDeliveryRuntimeForTests();
     resetTaskRegistryForTests();
     resetTaskFlowRegistryForTests({ persist: false });
   });
@@ -311,6 +314,14 @@ describe("task-registry store runtime", () => {
   it("uses atomic task-plus-delivery store methods when available", async () => {
     const upsertTaskWithDeliveryState = vi.fn();
     const deleteTaskWithDeliveryState = vi.fn();
+    const sendMessage = vi.fn(async () => ({
+      channel: "telegram",
+      to: "telegram:-1001:topic:42",
+      via: "direct" as const,
+      mediaUrl: null,
+      result: { messageId: "message-1" },
+    }));
+    setTaskRegistryDeliveryRuntimeForTests({ sendMessage });
     configureTaskRegistryRuntime({
       store: {
         loadSnapshot: () => ({
@@ -333,6 +344,12 @@ describe("task-registry store runtime", () => {
       status: "running",
       notifyPolicy: "state_changes",
       deliveryStatus: "pending",
+      requesterOrigin: {
+        channel: "telegram",
+        to: "telegram:-1001:topic:42",
+        accountId: "openclaw",
+        threadId: 42,
+      },
     });
 
     await maybeDeliverTaskStateChangeUpdate(created.taskId, {
@@ -354,7 +371,9 @@ describe("task-registry store runtime", () => {
         return params.deliveryState?.lastNotifiedEventAt === 200;
       }),
     ).toBe(true);
+    expect(sendMessage).toHaveBeenCalled();
     expect(deleteTaskWithDeliveryState).toHaveBeenCalledWith(created.taskId);
+    resetTaskRegistryDeliveryRuntimeForTests();
   });
 
   it("persists create requester origin with one projected snapshot when only separate upserts exist", () => {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1579,7 +1579,8 @@ describe("task-registry", () => {
         channel: "telegram",
         to: "telegram:-1001234567890:topic:42",
         threadId: 42,
-        content: "Background task started: ACP background task (run run-topi).",
+        content:
+          "Working in background: ACP background task. I'll update you if it runs long, fails, or finishes.",
       });
       expect(peekSystemEvents(ownerKey)).toStrictEqual([]);
 
@@ -3633,7 +3634,8 @@ describe("task-registry", () => {
 
       await waitForAssertion(() =>
         expectRecordFields(sentMessageCall(), {
-          content: "Background task started: ACP background task (run run-stat).",
+          content:
+            "Working in background: ACP background task. I'll update you if it runs long, fails, or finishes.",
         }),
       );
       hoisted.sendMessageMock.mockClear();

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -3415,7 +3415,7 @@ describe("task-registry", () => {
       await waitForAssertion(() =>
         expectRecordFields(sentMessageCall(), {
           content:
-            "Background task update: ACP background task. No output for 60s. It may be waiting for input.",
+            "Background task update: ACP background task (run run-stat). No output for 60s. It may be waiting for input.",
         }),
       );
       expectRecordFields(requireTaskByRunId("run-state-change"), {
@@ -3570,6 +3570,13 @@ describe("task-registry", () => {
         notifyPolicy: "state_changes",
       });
 
+      await waitForAssertion(() =>
+        expectRecordFields(sentMessageCall(), {
+          content: "Background task started: ACP background task (run run-stat).",
+        }),
+      );
+      hoisted.sendMessageMock.mockClear();
+
       const relay = startAcpSpawnParentStreamRelay({
         runId: "run-state-stream",
         parentSessionKey: "agent:main:main",
@@ -3584,7 +3591,7 @@ describe("task-registry", () => {
       relay.notifyStarted();
       await flushAsyncWork();
       expectRecordFields(sentMessageCall(), {
-        content: "Background task update: ACP background task. Started.",
+        content: "Background task update: ACP background task (run run-stat). Started.",
       });
 
       hoisted.sendMessageMock.mockClear();
@@ -3592,7 +3599,7 @@ describe("task-registry", () => {
       await flushAsyncWork();
       expectRecordFields(sentMessageCall(), {
         content:
-          "Background task update: ACP background task. No prompt submission observed for 1s after child start.",
+          "Background task update: ACP background task (run run-stat). No prompt submission observed for 1s after child start.",
       });
 
       expect(peekSystemEvents("agent:main:main")).toStrictEqual([]);

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -134,7 +134,10 @@ vi.mock("../agents/subagent-control.js", () => ({
 
 vi.mock("../utils/message-channel.js", () => ({
   isDeliverableMessageChannel: (channel: string) =>
-    channel === "notifychat" || channel === "guildchat" || channel === "discord",
+    channel === "notifychat" ||
+    channel === "guildchat" ||
+    channel === "discord" ||
+    channel === "telegram",
 }));
 
 function configureTaskRegistryMaintenanceRuntimeForTest(params: {
@@ -1541,6 +1544,64 @@ describe("task-registry", () => {
         expect.stringContaining("Background task ready for review: ACP background task"),
       ]);
       expect(hasPendingHeartbeatWake()).toBe(true);
+    });
+  });
+
+  it("delivers group topic task state changes directly while terminal completion stays parent-routed", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryForTests();
+      hoisted.sendMessageMock.mockResolvedValue({
+        channel: "telegram",
+        to: "telegram:-1001234567890:topic:42",
+        via: "direct",
+      });
+      const ownerKey = "agent:main:telegram:group:-1001234567890:topic:42";
+      const task = createTaskRecord({
+        runtime: "acp",
+        ownerKey,
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "telegram",
+          to: "telegram:-1001234567890:topic:42",
+          threadId: 42,
+        },
+        childSessionKey: "agent:main:acp:child",
+        runId: "run-topic-state-change",
+        task: "Investigate topic acknowledgement",
+        status: "running",
+        deliveryStatus: "pending",
+        notifyPolicy: "state_changes",
+        startedAt: 100,
+      });
+
+      await waitForAssertion(() => expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(1));
+      expectRecordFields(sentMessageCall(), {
+        channel: "telegram",
+        to: "telegram:-1001234567890:topic:42",
+        threadId: 42,
+        content: "Background task started: ACP background task (run run-topi).",
+      });
+      expect(peekSystemEvents(ownerKey)).toStrictEqual([]);
+
+      emitAgentEvent({
+        runId: task.runId!,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          endedAt: 250,
+        },
+      });
+
+      await waitForAssertion(() =>
+        expectRecordFields(requireTaskByRunId("run-topic-state-change"), {
+          status: "succeeded",
+          deliveryStatus: "session_queued",
+        }),
+      );
+      expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(1);
+      expect(peekSystemEvents(ownerKey)).toEqual([
+        expect.stringContaining("Background task ready for review: ACP background task"),
+      ]);
     });
   });
 

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1164,7 +1164,11 @@ export function reloadTaskRegistryFromStore(): void {
   restoreTaskRegistryOnce();
 }
 
-function updateTask(taskId: string, patch: Partial<TaskRecord>): TaskRecord | null {
+function updateTask(
+  taskId: string,
+  patch: Partial<TaskRecord>,
+  pendingDeliveryState?: TaskDeliveryState,
+): TaskRecord | null {
   const current = tasks.get(taskId);
   if (!current) {
     return null;
@@ -1183,10 +1187,13 @@ function updateTask(taskId: string, patch: Partial<TaskRecord>): TaskRecord | nu
   const parentFlowIndexChanged = current.parentFlowId?.trim() !== next.parentFlowId?.trim();
   // Persist before mutating memory. If the store rejects the write, keep the
   // in-memory mirror at the durable value and report that no mutation applied.
-  if (!tryPersistTaskUpsert(next, "update")) {
+  if (!tryPersistTaskUpsert(next, "update", pendingDeliveryState)) {
     return null;
   }
   tasks.set(taskId, next);
+  if (pendingDeliveryState) {
+    taskDeliveryStates.set(taskId, pendingDeliveryState);
+  }
   if (patch.runId && patch.runId !== current.runId) {
     rebuildRunIdIndex();
   }
@@ -1239,6 +1246,19 @@ function upsertTaskDeliveryState(state: TaskDeliveryState): TaskDeliveryState {
   }
   taskDeliveryStates.set(state.taskId, next);
   return cloneTaskDeliveryState(next);
+}
+
+function buildTaskDeliveryNotificationState(params: {
+  taskId: string;
+  requesterOrigin?: TaskDeliveryState["requesterOrigin"];
+  lastNotifiedEventAt: number;
+}): TaskDeliveryState {
+  const requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
+  return {
+    taskId: params.taskId,
+    ...(requesterOrigin ? { requesterOrigin } : {}),
+    lastNotifiedEventAt: params.lastNotifiedEventAt,
+  };
 }
 
 function getTaskDeliveryState(taskId: string): TaskDeliveryState | undefined {
@@ -1475,14 +1495,18 @@ export async function maybeDeliverTaskStateChangeUpdate(
     }
     if (!canDeliverTaskToRequesterOrigin(current)) {
       queueTaskSystemEvent(current, eventText);
-      upsertTaskDeliveryState({
+      const nextDeliveryState = buildTaskDeliveryNotificationState({
         taskId,
         requesterOrigin: deliveryState?.requesterOrigin,
         lastNotifiedEventAt: latestEvent.at,
       });
-      return updateTask(taskId, {
-        lastEventAt: Date.now(),
-      });
+      return updateTask(
+        taskId,
+        {
+          lastEventAt: Date.now(),
+        },
+        nextDeliveryState,
+      );
     }
     const { sendMessage } = await loadTaskRegistryDeliveryRuntime();
     const requesterAgentId = parseAgentSessionKey(ownerSessionKey)?.agentId;
@@ -1505,14 +1529,18 @@ export async function maybeDeliverTaskStateChangeUpdate(
         idempotencyKey,
       },
     });
-    upsertTaskDeliveryState({
+    const nextDeliveryState = buildTaskDeliveryNotificationState({
       taskId,
       requesterOrigin: deliveryState?.requesterOrigin,
       lastNotifiedEventAt: latestEvent.at,
     });
-    return updateTask(taskId, {
-      lastEventAt: Date.now(),
-    });
+    return updateTask(
+      taskId,
+      {
+        lastEventAt: Date.now(),
+      },
+      nextDeliveryState,
+    );
   } catch (error) {
     log.warn("Failed to deliver background task state change", {
       taskId,

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1274,6 +1274,10 @@ function canDeliverTaskToRequesterOrigin(task: TaskRecord): boolean {
   return canDeliverToRequesterOrigin(owner.requesterOrigin);
 }
 
+function canDeliverTaskStateChangeToRequesterOrigin(task: TaskRecord): boolean {
+  return canDeliverToRequesterOrigin(resolveTaskDeliveryOwner(task).requesterOrigin);
+}
+
 function canDeliverToRequesterOrigin(origin: TaskDeliveryState["requesterOrigin"]): boolean {
   const channel = origin?.channel?.trim();
   const to = origin?.to?.trim();
@@ -1493,7 +1497,7 @@ export async function maybeDeliverTaskStateChangeUpdate(
         lastEventAt: Date.now(),
       });
     }
-    if (!canDeliverTaskToRequesterOrigin(current)) {
+    if (!canDeliverTaskStateChangeToRequesterOrigin(current)) {
       queueTaskSystemEvent(current, eventText);
       const nextDeliveryState = buildTaskDeliveryNotificationState({
         taskId,

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1823,6 +1823,14 @@ export function createTaskRecord(params: {
   }));
   if (isTerminalTaskStatus(record.status)) {
     void maybeDeliverTaskTerminalUpdate(taskId);
+  } else if (record.status === "queued" || record.status === "running") {
+    void maybeDeliverTaskStateChangeUpdate(
+      taskId,
+      appendTaskEvent({
+        at: lastEventAt,
+        kind: record.status,
+      }),
+    );
   }
   return cloneTaskRecord(record);
 }

--- a/src/tasks/task-status-access.ts
+++ b/src/tasks/task-status-access.ts
@@ -2,11 +2,13 @@
 import {
   findTaskByRunId,
   getTaskById,
+  listFreshTasksForOwnerKey,
   listTaskRecords,
   listTasksForAgentId,
+  listTasksForRelatedSessionKey,
   listTasksForSessionKey,
 } from "./task-registry.js";
-import type { TaskRecord } from "./task-registry.types.js";
+import type { TaskRecord, TaskStatus } from "./task-registry.types.js";
 
 /** Returns only the session lookup fields needed by task status commands. */
 export function getTaskSessionLookupByIdForStatus(
@@ -34,6 +36,22 @@ export function listTasksForOwnerOrRequesterSessionKeyForStatus(sessionKey: stri
   return listTaskRecords().filter(
     (task) => task.requesterSessionKey === sessionKey || task.ownerKey === sessionKey,
   );
+}
+
+export function isActiveTaskStatusForStatus(status: TaskStatus): boolean {
+  return status === "queued" || status === "running";
+}
+
+export function listTasksForSessionReconciliationForStatus(sessionKey: string): TaskRecord[] {
+  const byId = new Map<string, TaskRecord>();
+  for (const task of [
+    ...listFreshTasksForOwnerKey(sessionKey),
+    ...listTasksForSessionKey(sessionKey),
+    ...listTasksForRelatedSessionKey(sessionKey),
+  ]) {
+    byId.set(task.taskId, task);
+  }
+  return [...byId.values()];
 }
 
 export function listTasksForAgentIdForStatus(agentId: string): TaskRecord[] {


### PR DESCRIPTION
## What Problem This Solves

Fixes the core runtime failure mode behind the 2026-06-22 topic UX incident: model/tool-triggered gateway restarts could bypass active-work deferral and interrupt live user-facing work, while delegated tasks could remain too quiet or duplicate-prone.

The incident evidence showed repeated controlled launchd-handoff gateway restarts around 16:24, 16:25, 16:29, 16:54, 17:07, and 17:15 while active work existed, including 4-6 active tasks and 2-3 embedded runs. Restart drain timeout was `0ms`, producing stale resumes, delayed/no finals, duplicate assistant finals, and repeated “are we done?” nudges rather than a crash loop.

## Changes

- Protect active work during safe restart requests by downgrading `skipDeferral` unless `interruptActiveWork` is explicitly approved.
- Add restart audit context with requester/reason and active-work counts.
- Route gateway tool/update restart paths through the safer restart coordination shape.
- Make user-facing delegated/session tasks default to visible `state_changes` while preserving silent/not-applicable handling for internal maintenance work.
- Attach duplicate ACP spawn intents to existing active work in the narrow safe case.
- Persist task progress delivery watermarks atomically with task updates so state-change delivery does not regress into repeated/progress-only noise.
- Add regression coverage across restart coordination, gateway restart/update methods, task registry/executor policy, ACP spawn, gateway tool, and context-engine maintenance.

## Evidence

Focused regression suite passed locally:

```bash
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs   src/infra/restart-coordinator.test.ts   src/gateway/server-methods/restart.test.ts   src/gateway/server-methods/update.test.ts   src/infra/update-startup.test.ts   src/agents/tools/gateway-tool.test.ts   src/tasks/task-registry.test.ts   src/tasks/task-executor.test.ts   src/tasks/task-executor-policy.test.ts   src/agents/acp-spawn.test.ts   src/agents/embedded-agent-runner/context-engine-maintenance.test.ts   src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts
```

Result: `5 Vitest shards passed`, `309 tests passed`.

Additional local verification after the follow-up progress-watermark fix:

```bash
git diff --check
pnpm lint
pnpm check:test-types
node scripts/run-vitest.mjs run --config test/vitest/vitest.tasks.config.ts --reporter=verbose
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts --reporter=verbose
node scripts/run-vitest.mjs run src/agents/tools/gateway-tool.test.ts --reporter=verbose
pnpm build
pnpm format:check -- src/tasks/task-registry.ts src/tasks/task-registry.store.test.ts src/agents/embedded-agent-runner/context-engine-maintenance.test.ts src/agents/tools/gateway-tool.test.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts
```

Results: local lint, type checks, focused task/gateway/tool tests, build, and formatting passed. Latest pushed commit: `0ea98d3eb6e`.

## Notes

This PR changes core runtime behavior. It is intentionally source-only and does not deploy or restart any live gateway.

## Additional verification after ClawSweeper/Mantis follow-up

Follow-up fix pushed for the two ClawSweeper findings:

- Preserved the documented `openclaw gateway restart --safe --skip-deferral` operator bypass by treating boolean `skipDeferral` as active-work interruption approval at the restart RPC boundary.
- Tightened duplicate ACP spawn attachment so requests with explicit `runTimeoutSeconds` start a new run instead of reusing an active run with different timeout intent.

Focused local proof after the follow-up fix:

```bash
node scripts/run-vitest.mjs src/cli/daemon-cli/lifecycle.test.ts src/infra/restart-coordinator.test.ts src/gateway/server-methods/restart.test.ts src/agents/acp-spawn.test.ts --reporter=verbose
pnpm format:check -- src/gateway/server-methods/restart.ts src/gateway/server-methods/restart.test.ts src/agents/acp-spawn.ts src/agents/acp-spawn.test.ts
git diff --check
```

Results: 4 Vitest shards passed, 114 tests passed; formatting and diff whitespace checks passed.

Mantis proof has also been attached in the PR thread:

- Native Telegram Desktop proof run: https://github.com/openclaw/openclaw/actions/runs/28079858909
- Raw QA files: https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-95812/run-28079858909-1/index.json

## Additional follow-up: stale Telegram topic session reconciliation

This update adds the source fix for a Telegram forum topic/session wedging as `status="running"` after stuck-session recovery had already aborted/drained the embedded run and the task DB had no running work.

### Added changes

- Reconciles persisted running session rows to a terminal non-running state when no active embedded run and no running task remain.
- Applies that reconciliation from stuck-session recovery, incomplete-turn fallback handling, `sessions.abort` no-active-run handling, and startup stale-running sweeps.
- Sends a neutral fallback when a safety/presend hook blocks a native final for internal filesystem/runtime leakage instead of treating invisible suppression as successful user delivery.
- Adds structured reconciliation logs for session key, old/new status, active-run presence, running task count, reason, and safe-fallback delivery.

### Added proof

```bash
npm test -- src/agents/command/delivery.test.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts src/agents/main-session-restart-recovery.test.ts
npm run build
```

Results: focused regression suite passed across gateway, logging, and agent shards; full build passed.

### Added regression coverage

- Stalled Telegram topic key recovery marks the session non-running, releases the lane, and allows the next queued turn to run without manual reset.
- `sessions.abort` reconciles a stale persisted `running` row when no active run exists.
- Safety-hook native final suppression sends a safe fallback and does not deliver the blocked/leaky content.
- Startup stale-running sweep does not mark a freshly resumed session as stale failed.

### Remaining gap

No live Telegram topic smoke was run for this follow-up commit. The test uses the concrete Telegram forum topic key shape and local session/lane/task machinery; live adapter proof can be added by Mantis or maintainer runtime proof if required.




Additional local verification after the persisted recovery metadata contract fix:

```bash
pnpm format:check src/config/sessions/types.ts src/plugins/session-entry-slot-keys.ts
pnpm check:test-types
```

Results: formatting and test type checks passed. Latest pushed commit: `8f3d904e85b`.
