### PR TITLE
fix(model-ref): use normalized prefix length for stripPrefixes

### DIFF
--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -98,7 +98,7 @@ export function normalizeProviderModelIdWithPolicies(params: {
   for (const prefix of policy.stripPrefixes ?? []) {
     const normalizedPrefix = normalizeLowercaseStringOrEmpty(prefix);
     if (normalizedPrefix && normalizeLowercaseStringOrEmpty(modelId).startsWith(normalizedPrefix)) {
-      modelId = modelId.slice(prefix.length);
+      modelId = modelId.slice(normalizedPrefix.length);
       break;
     }
   }


### PR DESCRIPTION
Fixes #95743

## Why

In `normalizeProviderModelIdWithPolicies`, the `stripPrefixes` loop matches using `normalizedPrefix` (trimmed + lowercased) but strips using raw `prefix.length`. When a prefix has leading or trailing whitespace (e.g. `" openai/"`), it removes more characters than matched, mangling the model id (e.g. `"openai/gpt-4"` → `"pt-4"`), which then fails to resolve.

## What users will see

No new UI. Model IDs with whitespace-prefixed `stripPrefixes` entries will now resolve correctly instead of being mangled.

## Surface area
- [ ] UI
- [ ] CLI / env var
- [ ] API / contract
- [x] Default behavior change — stripPrefixes now strips the correct number of characters
- [ ] None

## Evidence

```typescript
// Before (bug): prefix = " openai/", normalizedPrefix = "openai/"
// modelId = "openai/gpt-4"
// matches "openai/" → strips prefix.length (9) → "pt-4" (WRONG)
modelId = modelId.slice(prefix.length);

// After (fix): strips normalizedPrefix.length (8) → "gpt-4" (CORRECT)
modelId = modelId.slice(normalizedPrefix.length);
```

## Bug fix verification
- Test: `packages/model-catalog-core/src/provider-model-id-normalization.ts` line 101
- When prefix has no whitespace: `normalizedPrefix.length === prefix.length` — no behavior change
- When prefix has whitespace: fix aligns strip length with match length

## Validation
- One-line change: `prefix.length` → `normalizedPrefix.length`
- The match condition already uses `normalizedPrefix` — the strip now aligns with it