### PR TITLE
fix(openshell): pin local mirror mutations

### DIFF
--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -184,6 +184,22 @@ class OpenShellFsBridge implements SandboxFsBridge {
       );
     }
     if (path.resolve(from.mountHostRoot) === path.resolve(to.mountHostRoot)) {
+      const fromStats = await fromRoot.stat(fromRelativePath);
+      if (!fromStats.isDirectory && fromStats.nlink > 1) {
+        await moveBetweenRoots({
+          fromRoot,
+          fromRelativePath,
+          toRoot: fromRoot,
+          toRelativePath,
+          runRemoteRename: async () =>
+            await this.backend.renameRemotePath(
+              from.containerPath,
+              to.containerPath,
+              params.signal,
+            ),
+        });
+        return;
+      }
       await this.backend.renameRemotePath(from.containerPath, to.containerPath, params.signal);
       await mkdirRootRelative(fromRoot, path.dirname(toRelativePath));
       await fromRoot.move(fromRelativePath, toRelativePath, { overwrite: true });

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -1,4 +1,5 @@
 // Openshell plugin module implements fs bridge behavior.
+import { randomUUID } from "node:crypto";
 import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { root as fsRoot } from "openclaw/plugin-sdk/file-access-runtime";
@@ -10,13 +11,13 @@ import type {
 import { createWritableRenameTargetResolver } from "openclaw/plugin-sdk/sandbox";
 import { isPathInside } from "openclaw/plugin-sdk/security-runtime";
 import type { OpenShellFsBridgeContext, OpenShellSandboxBackend } from "./backend.types.js";
-import { movePathWithCopyFallback } from "./mirror.js";
 
 type ResolvedMountPath = SandboxResolvedPath & {
   mountHostRoot: string;
   writable: boolean;
   source: "workspace" | "agent" | "protectedSkill";
 };
+type FsRoot = Awaited<ReturnType<typeof fsRoot>>;
 
 const MATERIALIZED_SKILLS_CONTAINER_PARTS = [".openclaw", "sandbox-skills", "skills"] as const;
 
@@ -117,7 +118,8 @@ class OpenShellFsBridge implements SandboxFsBridge {
       allowFinalSymlinkForUnlink: false,
     });
     await this.backend.mkdirpRemotePath(target.containerPath, params.signal);
-    await fsPromises.mkdir(hostPath, { recursive: true });
+    const root = await fsRoot(target.mountHostRoot);
+    await mkdirRootRelative(root, path.relative(target.mountHostRoot, hostPath));
   }
 
   async remove(params: {
@@ -141,7 +143,8 @@ class OpenShellFsBridge implements SandboxFsBridge {
       signal: params.signal,
       ignoreMissing: params.force !== false,
     });
-    await fsPromises.rm(hostPath, {
+    const root = await fsRoot(target.mountHostRoot);
+    await removeRootRelative(root, path.relative(target.mountHostRoot, hostPath), {
       recursive: params.recursive ?? false,
       force: params.force !== false,
     });
@@ -168,9 +171,32 @@ class OpenShellFsBridge implements SandboxFsBridge {
       allowMissingLeaf: true,
       allowFinalSymlinkForUnlink: false,
     });
-    await this.backend.renameRemotePath(from.containerPath, to.containerPath, params.signal);
-    await fsPromises.mkdir(path.dirname(toHostPath), { recursive: true });
-    await movePathWithCopyFallback({ from: fromHostPath, to: toHostPath });
+    const fromRoot = await fsRoot(from.mountHostRoot);
+    const toRoot = await fsRoot(to.mountHostRoot);
+    const fromRelativePath = path.relative(from.mountHostRoot, fromHostPath);
+    const toRelativePath = path.relative(to.mountHostRoot, toHostPath);
+    if (
+      !normalizeRootRelativePath(fromRelativePath) ||
+      !normalizeRootRelativePath(toRelativePath)
+    ) {
+      throw new Error(
+        `OpenShell mirror bridge cannot rename mount roots: ${from.containerPath} -> ${to.containerPath}`,
+      );
+    }
+    if (path.resolve(from.mountHostRoot) === path.resolve(to.mountHostRoot)) {
+      await this.backend.renameRemotePath(from.containerPath, to.containerPath, params.signal);
+      await mkdirRootRelative(fromRoot, path.dirname(toRelativePath));
+      await fromRoot.move(fromRelativePath, toRelativePath, { overwrite: true });
+      return;
+    }
+    await moveBetweenRoots({
+      fromRoot,
+      fromRelativePath,
+      toRoot,
+      toRelativePath,
+      runRemoteRename: async () =>
+        await this.backend.renameRemotePath(from.containerPath, to.containerPath, params.signal),
+    });
   }
 
   async stat(params: {
@@ -341,6 +367,157 @@ class OpenShellFsBridge implements SandboxFsBridge {
 
     throw new Error(`Path escapes sandbox root (${workspaceRoot}): ${params.filePath}`);
   }
+}
+
+async function mkdirRootRelative(root: FsRoot, relativePath: string): Promise<void> {
+  const normalized = normalizeRootRelativePath(relativePath);
+  if (!normalized) {
+    await root.ensureRoot();
+    return;
+  }
+  await root.mkdir(normalized);
+}
+
+async function removeRootRelative(
+  root: FsRoot,
+  relativePath: string,
+  options: { recursive: boolean; force: boolean },
+): Promise<void> {
+  const normalized = normalizeRootRelativePath(relativePath);
+  const stats = await root.stat(normalized).catch((err: unknown) => {
+    if (options.force && getErrorCode(err) === "not-found") {
+      return null;
+    }
+    throw err;
+  });
+  if (!stats) {
+    return;
+  }
+  if (stats.isDirectory && options.recursive) {
+    const entries = await root.list(normalized, { withFileTypes: true });
+    for (const entry of entries) {
+      await removeRootRelative(root, path.join(normalized, entry.name), options);
+    }
+  }
+  await root.remove(normalized);
+}
+
+async function moveBetweenRoots(params: {
+  fromRoot: FsRoot;
+  fromRelativePath: string;
+  toRoot: FsRoot;
+  toRelativePath: string;
+  runRemoteRename: () => Promise<void>;
+}): Promise<void> {
+  const stagedToRelativePath = path.join(
+    path.dirname(params.toRelativePath),
+    `.openclaw-mirror-move-${process.pid}-${randomUUID()}`,
+  );
+  let stagedPathToRemove: string | undefined;
+  try {
+    stagedPathToRemove = stagedToRelativePath;
+    await copyBetweenRoots(
+      params.fromRoot,
+      params.fromRelativePath,
+      params.toRoot,
+      stagedToRelativePath,
+    );
+    await params.runRemoteRename();
+    await removeRootRelative(params.toRoot, params.toRelativePath, {
+      recursive: true,
+      force: true,
+    });
+    await mkdirRootRelative(params.toRoot, path.dirname(params.toRelativePath));
+    await params.toRoot.move(stagedToRelativePath, params.toRelativePath, { overwrite: true });
+    stagedPathToRemove = undefined;
+    await removeRootRelative(params.fromRoot, params.fromRelativePath, {
+      recursive: true,
+      force: false,
+    });
+  } finally {
+    if (stagedPathToRemove) {
+      await removeRootRelative(params.toRoot, stagedPathToRemove, {
+        recursive: true,
+        force: true,
+      }).catch(() => undefined);
+    }
+  }
+}
+
+async function copyBetweenRoots(
+  fromRoot: FsRoot,
+  fromRelativePath: string,
+  toRoot: FsRoot,
+  toRelativePath: string,
+): Promise<void> {
+  const normalizedFrom = normalizeRootRelativePath(fromRelativePath);
+  const normalizedTo = normalizeRootRelativePath(toRelativePath);
+  const stats = await fromRoot.stat(normalizedFrom);
+  if (stats.isDirectory) {
+    await mkdirRootRelative(toRoot, normalizedTo);
+    const entries = await fromRoot.list(normalizedFrom, { withFileTypes: true });
+    for (const entry of entries) {
+      await copyBetweenRoots(
+        fromRoot,
+        path.join(normalizedFrom, entry.name),
+        toRoot,
+        path.join(normalizedTo, entry.name),
+      );
+    }
+    return;
+  }
+
+  await copyFileBetweenRoots(fromRoot, normalizedFrom, toRoot, normalizedTo, stats.mode);
+}
+
+async function copyFileBetweenRoots(
+  fromRoot: FsRoot,
+  fromRelativePath: string,
+  toRoot: FsRoot,
+  toRelativePath: string,
+  mode: number,
+): Promise<void> {
+  await mkdirRootRelative(toRoot, path.dirname(toRelativePath));
+  const opened = await fromRoot.open(fromRelativePath, { hardlinks: "allow" });
+  let writable: Awaited<ReturnType<FsRoot["openWritable"]>> | undefined;
+  let committed = false;
+  try {
+    writable = await toRoot.openWritable(toRelativePath, { mkdir: true, mode: mode & 0o777 });
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    while (true) {
+      const { bytesRead } = await opened.handle.read(buffer, 0, buffer.length, null);
+      if (bytesRead === 0) {
+        break;
+      }
+      let written = 0;
+      while (written < bytesRead) {
+        const { bytesWritten } = await writable.handle.write(buffer, written, bytesRead - written);
+        if (bytesWritten === 0) {
+          throw new Error(`OpenShell mirror copy made no write progress: ${toRelativePath}`);
+        }
+        written += bytesWritten;
+      }
+    }
+    committed = true;
+  } finally {
+    await opened.handle.close();
+    await writable?.handle.close();
+    if (!committed) {
+      await removeRootRelative(toRoot, toRelativePath, { recursive: true, force: true }).catch(
+        () => undefined,
+      );
+    }
+  }
+}
+
+function normalizeRootRelativePath(relativePath: string): string {
+  return relativePath === "." ? "" : relativePath;
+}
+
+function getErrorCode(err: unknown): string | undefined {
+  return typeof err === "object" && err !== null && "code" in err
+    ? String((err as { code: unknown }).code)
+    : undefined;
 }
 
 function resolveProtectedSkillTarget(params: {

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -205,6 +205,11 @@ class OpenShellFsBridge implements SandboxFsBridge {
       await fromRoot.move(fromRelativePath, toRelativePath, { overwrite: true });
       return;
     }
+    if (fromHostPath === toHostPath || isPathInside(fromHostPath, toHostPath)) {
+      throw new Error(
+        `OpenShell mirror bridge cannot rename a path into itself: ${from.containerPath} -> ${to.containerPath}`,
+      );
+    }
     await moveBetweenRoots({
       fromRoot,
       fromRelativePath,

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
 import type { CreateSandboxBackendParams } from "openclaw/plugin-sdk/sandbox";
 import {
   createSandboxBrowserConfig,
@@ -544,7 +545,17 @@ async function expectPathMissing(targetPath: string): Promise<void> {
   expect((error as NodeJS.ErrnoException).code).toBe("ENOENT");
 }
 
+async function rebindDirectoryToSymlink(aliasPath: string, targetPath: string): Promise<void> {
+  const stats = await fs.lstat(aliasPath).catch(() => null);
+  if (stats?.isSymbolicLink()) {
+    return;
+  }
+  await fs.rm(aliasPath, { recursive: true, force: true });
+  await fs.symlink(targetPath, aliasPath, "dir");
+}
+
 afterEach(async () => {
+  __setFsSafeTestHooksForTest(undefined);
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -707,6 +718,128 @@ describe("openshell fs bridges", () => {
     expect(backend["runRemoteShellScript"]).not.toHaveBeenCalled();
   });
 
+  it("renames local mirror paths across writable mount roots", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
+    const agentWorkspaceDir = await makeTempDir("openclaw-openshell-agent-");
+    const sourcePath = path.join(workspaceDir, "source.txt");
+    await fs.writeFile(sourcePath, "payload", "utf8");
+    await fs.chmod(sourcePath, 0o755);
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir,
+        containerWorkdir: "/sandbox",
+        workspaceAccess: "rw",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+    await bridge.rename({ from: "/sandbox/source.txt", to: "/agent/nested/target.txt" });
+
+    await expectPathMissing(sourcePath);
+    await expect(
+      fs.readFile(path.join(agentWorkspaceDir, "nested", "target.txt"), "utf8"),
+    ).resolves.toBe("payload");
+    const targetStats = await fs.stat(path.join(agentWorkspaceDir, "nested", "target.txt"));
+    expect(targetStats.mode & 0o111).toBe(0o111);
+    expect(backend["renameRemotePath"]).toHaveBeenCalledWith(
+      "/sandbox/source.txt",
+      "/agent/nested/target.txt",
+      undefined,
+    );
+  });
+
+  it("replaces local mirror directories when renaming across writable mount roots", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
+    const agentWorkspaceDir = await makeTempDir("openclaw-openshell-agent-");
+    await fs.mkdir(path.join(workspaceDir, "source"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "source", "new.txt"), "new", "utf8");
+    await fs.mkdir(path.join(agentWorkspaceDir, "target"), { recursive: true });
+    await fs.writeFile(path.join(agentWorkspaceDir, "target", "old.txt"), "old", "utf8");
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir,
+        containerWorkdir: "/sandbox",
+        workspaceAccess: "rw",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+    await bridge.rename({ from: "/sandbox/source", to: "/agent/target" });
+
+    await expectPathMissing(path.join(workspaceDir, "source"));
+    await expect(fs.readdir(path.join(agentWorkspaceDir, "target"))).resolves.toEqual(["new.txt"]);
+    await expect(
+      fs.readFile(path.join(agentWorkspaceDir, "target", "new.txt"), "utf8"),
+    ).resolves.toBe("new");
+  });
+
+  it("renames hardlinked local mirror files across writable mount roots", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
+    const agentWorkspaceDir = await makeTempDir("openclaw-openshell-agent-");
+    const sourcePath = path.join(workspaceDir, "source.txt");
+    await fs.writeFile(sourcePath, "payload", "utf8");
+    try {
+      await fs.link(sourcePath, path.join(workspaceDir, "other-link.txt"));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+    await fs.writeFile(path.join(agentWorkspaceDir, "target.txt"), "keep", "utf8");
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir,
+        containerWorkdir: "/sandbox",
+        workspaceAccess: "rw",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+    await bridge.rename({ from: "/sandbox/source.txt", to: "/agent/target.txt" });
+    await expect(fs.readFile(path.join(agentWorkspaceDir, "target.txt"), "utf8")).resolves.toBe(
+      "payload",
+    );
+    await expectPathMissing(sourcePath);
+  });
+
+  it("rejects cross-root renames to a mount root before remote mutation", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
+    const agentWorkspaceDir = await makeTempDir("openclaw-openshell-agent-");
+    await fs.writeFile(path.join(workspaceDir, "source.txt"), "payload", "utf8");
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir,
+        containerWorkdir: "/sandbox",
+        workspaceAccess: "rw",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+    await expect(bridge.rename({ from: "/sandbox/source.txt", to: "/agent" })).rejects.toThrow(
+      "cannot rename mount roots",
+    );
+    expect(backend["renameRemotePath"]).not.toHaveBeenCalled();
+  });
+
   it("removes remote mirror paths through the pinned backend operation", async () => {
     const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
     await fs.writeFile(path.join(workspaceDir, "target.txt"), "payload", "utf8");
@@ -732,6 +865,122 @@ describe("openshell fs bridges", () => {
     });
     expect(backend["runRemoteShellScript"]).not.toHaveBeenCalled();
   });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects local mkdir parent rebinding during mirror mutation",
+    async () => {
+      const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+      const outsideDir = await makeTempDir("openclaw-openshell-outside-");
+      const aliasPath = path.join(workspaceDir, "alias");
+      await fs.mkdir(aliasPath, { recursive: true });
+      const backend = createMirrorBackendMock();
+      const sandbox = createSandboxTestContext({
+        overrides: {
+          backendId: "openshell",
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+          containerWorkdir: "/sandbox",
+        },
+      });
+      __setFsSafeTestHooksForTest({
+        beforeRootFallbackMutation: async (operation) => {
+          if (operation === "mkdir") {
+            await rebindDirectoryToSymlink(aliasPath, outsideDir);
+          }
+        },
+      });
+
+      const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+      const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+      await expect(bridge.mkdirp({ filePath: "alias/escaped" })).rejects.toThrow();
+      await expectPathMissing(path.join(outsideDir, "escaped"));
+      expect(backend["mkdirpRemotePath"]).toHaveBeenCalledWith("/sandbox/alias/escaped", undefined);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects local remove parent rebinding during mirror mutation",
+    async () => {
+      const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+      const outsideDir = await makeTempDir("openclaw-openshell-outside-");
+      const aliasPath = path.join(workspaceDir, "alias");
+      await fs.mkdir(aliasPath, { recursive: true });
+      await fs.writeFile(path.join(aliasPath, "victim.txt"), "inside", "utf8");
+      await fs.writeFile(path.join(outsideDir, "victim.txt"), "outside", "utf8");
+      const backend = createMirrorBackendMock();
+      const sandbox = createSandboxTestContext({
+        overrides: {
+          backendId: "openshell",
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+          containerWorkdir: "/sandbox",
+        },
+      });
+      __setFsSafeTestHooksForTest({
+        beforeRootFallbackMutation: async (operation) => {
+          if (operation === "remove") {
+            await rebindDirectoryToSymlink(aliasPath, outsideDir);
+          }
+        },
+      });
+
+      const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+      const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+      await expect(bridge.remove({ filePath: "alias/victim.txt", force: true })).rejects.toThrow();
+      await expect(fs.readFile(path.join(outsideDir, "victim.txt"), "utf8")).resolves.toBe(
+        "outside",
+      );
+      expect(backend["removeRemotePath"]).toHaveBeenCalledWith("/sandbox/alias/victim.txt", {
+        recursive: false,
+        signal: undefined,
+        ignoreMissing: true,
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects local rename target parent rebinding during mirror mutation",
+    async () => {
+      const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+      const outsideDir = await makeTempDir("openclaw-openshell-outside-");
+      const aliasPath = path.join(workspaceDir, "alias");
+      const sourcePath = path.join(workspaceDir, "source.txt");
+      await fs.mkdir(aliasPath, { recursive: true });
+      await fs.writeFile(sourcePath, "payload", "utf8");
+      const backend = createMirrorBackendMock();
+      const sandbox = createSandboxTestContext({
+        overrides: {
+          backendId: "openshell",
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+          containerWorkdir: "/sandbox",
+        },
+      });
+      __setFsSafeTestHooksForTest({
+        beforeRootFallbackMutation: async (operation) => {
+          if (operation === "move") {
+            await rebindDirectoryToSymlink(aliasPath, outsideDir);
+          }
+        },
+      });
+
+      const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+      const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+      await expect(
+        bridge.rename({ from: "source.txt", to: "alias/escaped.txt" }),
+      ).rejects.toThrow();
+      await expect(fs.readFile(sourcePath, "utf8")).resolves.toBe("payload");
+      await expectPathMissing(path.join(outsideDir, "escaped.txt"));
+      expect(backend["renameRemotePath"]).toHaveBeenCalledWith(
+        "/sandbox/source.txt",
+        "/sandbox/alias/escaped.txt",
+        undefined,
+      );
+    },
+  );
 
   it("keeps local mirror state unchanged when remote pinned mkdir is rejected", async () => {
     const workspaceDir = await makeTempDir("openclaw-openshell-fs-");

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -816,6 +816,47 @@ describe("openshell fs bridges", () => {
     await expectPathMissing(sourcePath);
   });
 
+  it("renames hardlinked local mirror files inside one writable mount root", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
+    const sourcePath = path.join(workspaceDir, "source.txt");
+    await fs.writeFile(sourcePath, "payload", "utf8");
+    try {
+      await fs.link(sourcePath, path.join(workspaceDir, "other-link.txt"));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+        workspaceAccess: "rw",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+    await bridge.rename({ from: "/sandbox/source.txt", to: "/sandbox/target.txt" });
+    await expect(fs.readFile(path.join(workspaceDir, "target.txt"), "utf8")).resolves.toBe(
+      "payload",
+    );
+    await expectPathMissing(sourcePath);
+    await expect(fs.readFile(path.join(workspaceDir, "other-link.txt"), "utf8")).resolves.toBe(
+      "payload",
+    );
+    expect(backend["renameRemotePath"]).toHaveBeenCalledWith(
+      "/sandbox/source.txt",
+      "/sandbox/target.txt",
+      undefined,
+    );
+  });
+
   it("rejects cross-root renames to a mount root before remote mutation", async () => {
     const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
     const agentWorkspaceDir = await makeTempDir("openclaw-openshell-agent-");

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -881,6 +881,33 @@ describe("openshell fs bridges", () => {
     expect(backend["renameRemotePath"]).not.toHaveBeenCalled();
   });
 
+  it("rejects cross-root renames into the source tree before remote mutation", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
+    const sourceDir = path.join(workspaceDir, "source");
+    const agentWorkspaceDir = path.join(sourceDir, "agent-root");
+    await fs.mkdir(agentWorkspaceDir, { recursive: true });
+    await fs.writeFile(path.join(sourceDir, "payload.txt"), "payload", "utf8");
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir,
+        containerWorkdir: "/sandbox",
+        workspaceAccess: "rw",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+    await expect(
+      bridge.rename({ from: "/sandbox/source", to: "/agent/nested/target" }),
+    ).rejects.toThrow("cannot rename a path into itself");
+    expect(backend["renameRemotePath"]).not.toHaveBeenCalled();
+    await expect(fs.readFile(path.join(sourceDir, "payload.txt"), "utf8")).resolves.toBe("payload");
+  });
+
   it("removes remote mirror paths through the pinned backend operation", async () => {
     const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
     await fs.writeFile(path.join(workspaceDir, "target.txt"), "payload", "utf8");


### PR DESCRIPTION
## Summary

Hardens OpenShell local mirror filesystem mutations so mkdir, remove, and rename stay confined to their resolved mount roots during local mirror updates.

## Changes

- Routes local mirror `mkdirp` and `remove` through `fsRoot()` root-confined operations instead of raw host-path `fsPromises` calls.
- Routes same-root local mirror renames through `Root.move()` and preserves cross-root mirror rename behavior with staged, streamed root-confined copies.
- Preserves recursive remove, overwrite behavior, hardlinked source compatibility, executable bits, and cross-root directory replacement semantics.
- Adds focused OpenShell regression coverage for local parent rebind races and cross-root rename compatibility cases.

## Validation

- `corepack pnpm test:extension openshell -- --reporter=verbose`
- `corepack pnpm tsgo:extensions:test`
- `corepack pnpm lint:extensions`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean

## Notes

- `corepack pnpm check:changed` could not dispatch because the Crabbox binary failed its sanity check before starting Testbox.
- `corepack pnpm tsgo:extensions` still fails on an unrelated existing unused `sessionStore` in `src/config/sessions/session-accessor.ts`.
- `CHANGELOG.md` was not updated.
