### PR TITLE
Fix Codex message-tool-only reply latency

### DIFF
--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -579,7 +579,7 @@ When `imsg launch` is running and `openclaw channels status --probe` reports `pr
   </Accordion>
 
   <Accordion title="Read receipts and typing">
-    When the private API bridge is up, accepted inbound chats are marked read before dispatch and a typing bubble is shown to the sender while the agent generates. Disable read-marking with:
+    When the private API bridge is up, accepted inbound chats are marked read and direct chats show a typing bubble as soon as the turn is accepted, while the agent prepares context and generates. Disable read-marking with:
 
     ```json5
     {

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -1102,6 +1102,40 @@ describe("createCodexDynamicToolBridge", () => {
     ]);
   });
 
+  it("marks delivered message-tool-only source replies as terminal", async () => {
+    const bridge = createBridgeWithToolResult(
+      "message",
+      textToolResult("Sent.", { messageId: "imessage-6264" }),
+      { sourceReplyDeliveryMode: "message_tool_only" },
+    );
+
+    const result = await handleMessageToolCall(bridge, {
+      action: "send",
+      message: "visible reply",
+    });
+
+    expect(result).toEqual(expectInputText("Sent."));
+    expect(result.terminate).toBe(true);
+    expect(Object.keys(result)).not.toContain("terminate");
+  });
+
+  it("does not mark explicit message-tool sends as terminal source replies", async () => {
+    const bridge = createBridgeWithToolResult(
+      "message",
+      textToolResult("Sent.", { messageId: "other-chat-message" }),
+      { sourceReplyDeliveryMode: "message_tool_only" },
+    );
+
+    const result = await handleMessageToolCall(bridge, {
+      action: "send",
+      target: "channel:other",
+      message: "cross-channel reply",
+    });
+
+    expect(result).toEqual(expectInputText("Sent."));
+    expect(result.terminate).toBeUndefined();
+  });
+
   it("does not record messaging side effects when the send fails", async () => {
     const tool = createTool({
       name: "message",

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -18,6 +18,7 @@ import {
   getChannelAgentToolMeta,
   getPluginToolMeta,
   type EmbeddedRunAttemptParams,
+  isDeliveredMessageToolOnlySourceReplyResult,
   isReplaySafeToolCall,
   isToolWrappedWithBeforeToolCallHook,
   isToolResultError,
@@ -66,6 +67,7 @@ type CodexDynamicToolHookContext = {
   currentThreadId?: string;
   replyToMode?: "off" | "first" | "all" | "batched";
   hasRepliedRef?: { value: boolean };
+  sourceReplyDeliveryMode?: EmbeddedRunAttemptParams["sourceReplyDeliveryMode"];
   onToolOutcome?: EmbeddedRunAttemptParams["onToolOutcome"];
   allocateToolOutcomeOrdinal?: EmbeddedRunAttemptParams["allocateToolOutcomeOrdinal"];
 };
@@ -358,12 +360,20 @@ export function createCodexDynamicToolBridge(params: {
           },
           terminalType,
         );
+        const deliveredSourceReply = isDeliveredMessageToolOnlySourceReplyResult({
+          sourceReplyDeliveryMode: params.hookContext?.sourceReplyDeliveryMode,
+          toolName,
+          args: executedArgs,
+          result,
+          isError: resultIsError,
+        });
         withDynamicToolTermination(
           response,
           rawResult.terminate === true ||
             result.terminate === true ||
             isToolResultYield(rawResult) ||
-            isToolResultYield(result),
+            isToolResultYield(result) ||
+            deliveredSourceReply,
         );
         const asyncStarted =
           isAsyncStartedToolResult(rawResult) || isAsyncStartedToolResult(result);

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -844,6 +844,7 @@ export async function runCodexAppServerAttempt(
       currentThreadId: params.currentThreadTs,
       replyToMode: params.replyToMode,
       hasRepliedRef: params.hasRepliedRef,
+      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
       onToolOutcome: onCodexToolOutcome,
       allocateToolOutcomeOrdinal: allocateCodexToolOutcomeOrdinal,
     },

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -346,6 +346,13 @@ describe("iMessage monitor last-route updates", () => {
       expect.objectContaining({ typing: true }),
       expect.anything(),
     );
+    await vi.waitFor(() => {
+      expect(earlyTypingClient.request).toHaveBeenCalledWith(
+        "typing",
+        expect.objectContaining({ typing: false, to: "+15550001111" }),
+        expect.any(Object),
+      );
+    });
   });
 
   it.each(["never", "message", "thinking"] as const)(

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -256,6 +256,98 @@ describe("iMessage monitor last-route updates", () => {
     });
   });
 
+  it("starts direct typing before dispatching the inbound turn", async () => {
+    setCachedIMessagePrivateApiStatus("imsg", {
+      available: true,
+      v2Ready: true,
+      selectors: {},
+      rpcMethods: ["watch.subscribe", "send", "typing"],
+    });
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const earlyTypingClient = {
+      request: vi.fn(async (method: string) => {
+        if (method === "typing") {
+          return { ok: true };
+        }
+        throw new Error(`unexpected imsg typing-client method ${method}`);
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    const watchClient = {
+      request: vi.fn(async (method: string) => {
+        if (method === "watch.subscribe") {
+          return { subscription: 1 };
+        }
+        if (method === "typing") {
+          return { ok: true };
+        }
+        throw new Error(`unexpected imsg watch-client method ${method}`);
+      }),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: {
+            message: {
+              id: 12,
+              chat_id: 123,
+              sender: "+15550001111",
+              is_from_me: false,
+              text: "respond after a slow context build",
+              is_group: false,
+              created_at: new Date().toISOString(),
+            },
+          },
+        });
+        await vi.waitFor(() => {
+          expect(earlyTypingClient.request).toHaveBeenCalledWith(
+            "typing",
+            expect.objectContaining({ typing: true, to: "+15550001111" }),
+            expect.any(Object),
+          );
+          expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+        });
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (params?.onNotification) {
+        onNotification = params.onNotification;
+        return watchClient as never;
+      }
+      return earlyTypingClient as never;
+    });
+    dispatchInboundMessageMock.mockImplementationOnce(async () => {
+      expect(earlyTypingClient.request).toHaveBeenCalledWith(
+        "typing",
+        expect.objectContaining({ typing: true, to: "+15550001111" }),
+        expect.any(Object),
+      );
+      return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550001111"],
+            sendReadReceipts: false,
+          },
+        },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    expect(watchClient.request).not.toHaveBeenCalledWith(
+      "typing",
+      expect.objectContaining({ typing: true }),
+      expect.anything(),
+    );
+  });
+
   it.each(["never", "message", "thinking"] as const)(
     "does not start direct tool typing when typingMode is %s",
     async (typingMode) => {
@@ -418,6 +510,87 @@ describe("iMessage monitor last-route updates", () => {
       expect.objectContaining({ typing: true }),
       expect.anything(),
     );
+  });
+
+  it("does not wait for read receipts before dispatching the inbound turn", async () => {
+    setCachedIMessagePrivateApiStatus("imsg", {
+      available: true,
+      v2Ready: true,
+      selectors: {},
+      rpcMethods: ["watch.subscribe", "read"],
+    });
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const readClient = {
+      request: vi.fn((method: string) => {
+        if (method === "read") {
+          return new Promise(() => {});
+        }
+        return Promise.reject(new Error(`unexpected imsg read-client method ${method}`));
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    const watchClient = {
+      request: vi.fn((method: string) => {
+        if (method === "watch.subscribe") {
+          return Promise.resolve({ subscription: 1 });
+        }
+        return Promise.reject(new Error(`unexpected imsg watch-client method ${method}`));
+      }),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: {
+            message: {
+              id: 11,
+              chat_id: 123,
+              sender: "+15550001111",
+              is_from_me: false,
+              text: "respond without waiting for read receipt",
+              is_group: false,
+              created_at: new Date().toISOString(),
+            },
+          },
+        });
+        await vi.waitFor(() => {
+          expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+        });
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (params?.onNotification) {
+        onNotification = params.onNotification;
+        return watchClient as never;
+      }
+      return readClient as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550001111"],
+          },
+        },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    expect(readClient.request).toHaveBeenCalledWith(
+      "read",
+      expect.objectContaining({ to: "+15550001111" }),
+      expect.any(Object),
+    );
+    expect(watchClient.request).not.toHaveBeenCalledWith(
+      "read",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
   });
 
   it.each([

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -1087,7 +1087,7 @@ function buildIMessageEchoScope(params: {
   return scopes;
 }
 
-function buildDirectIMessageReplyTarget(params: {
+export function buildDirectIMessageReplyTarget(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
   sender: string;

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -1072,22 +1072,54 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           sender: decision.sender,
         })
       : undefined;
+    let stopEarlyDirectTyping: (() => void) | undefined;
     if (earlyDirectTypingTarget) {
       // Start channel-native feedback before the expensive history/context/model
       // path. Use a short-lived client so a slow typing RPC cannot block the
-      // monitor client's watch stream or later dispatcher typing teardown.
-      void sendIMessageTyping(earlyDirectTypingTarget, true, {
+      // monitor client's watch stream. Stop is sequenced after start so fast
+      // command replies cannot leave a late true after typing:false.
+      const earlyDirectTypingStarted = sendIMessageTyping(earlyDirectTypingTarget, true, {
         cfg,
         accountId: accountInfo.accountId,
-      }).catch((err) => {
-        logTypingFailure({
-          log: (msg) => logVerbose(msg),
-          channel: "imessage",
-          action: "start",
-          target: earlyDirectTypingTarget,
-          error: err,
-        });
-      });
+      }).then(
+        () => true,
+        (err) => {
+          logTypingFailure({
+            log: (msg) => logVerbose(msg),
+            channel: "imessage",
+            action: "start",
+            target: earlyDirectTypingTarget,
+            error: err,
+          });
+          return false;
+        },
+      );
+      let earlyTypingStopQueued = false;
+      stopEarlyDirectTyping = () => {
+        if (earlyTypingStopQueued) {
+          return;
+        }
+        earlyTypingStopQueued = true;
+        void earlyDirectTypingStarted
+          .then(async (started) => {
+            if (!started) {
+              return;
+            }
+            await sendIMessageTyping(earlyDirectTypingTarget, false, {
+              cfg,
+              accountId: accountInfo.accountId,
+            });
+          })
+          .catch((err) => {
+            logTypingFailure({
+              log: (msg) => logVerbose(msg),
+              channel: "imessage",
+              action: "stop",
+              target: earlyDirectTypingTarget,
+              error: err,
+            });
+          });
+      };
     }
     const stagedAttachments = remoteHost
       ? []
@@ -1352,11 +1384,13 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
             historyMap: groupHistories,
             limit: historyLimit,
           },
-          onPreDispatchFailure: () =>
+          onPreDispatchFailure: () => {
+            stopEarlyDirectTyping?.();
             settleReplyDispatcher({
               dispatcher,
               onSettled: () => markDispatchIdle(),
-            }),
+            });
+          },
           runDispatch: async () => {
             try {
               return await dispatchInboundMessage({
@@ -1375,6 +1409,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
               });
             } finally {
               markDispatchIdle();
+              stopEarlyDirectTyping?.();
             }
           },
         }),

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -94,6 +94,7 @@ import {
   releaseIMessageInboundReplay,
 } from "./inbound-dedupe.js";
 import {
+  buildDirectIMessageReplyTarget,
   buildIMessageInboundContext,
   rememberIMessageSkippedFromMeForSelfChatDedupe,
   resolveIMessageReactionContext,
@@ -1039,6 +1040,55 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     const storePath = resolveStorePath(cfg.session?.store, {
       agentId: decision.route.agentId,
     });
+    const privateApiStatus = getCachedIMessagePrivateApiStatus(cliPath);
+    const supportsTyping = imessageRpcSupportsMethod(privateApiStatus, "typing");
+    const supportsRead = imessageRpcSupportsMethod(privateApiStatus, "read");
+    if (privateApiStatus?.available === true) {
+      // Surface a single warning per restart when the bridge is up but we
+      // had to gate off typing/read because the imsg build pre-dates the
+      // capability list. Otherwise the user sees no typing bubble / no
+      // "Read" receipt with no visible reason.
+      if (!supportsTyping || !supportsRead) {
+        warnIfImsgUpgradeNeeded.fireOnce(privateApiStatus.rpcMethods, runtime);
+      }
+    }
+    const configuredTypingMode = resolveConfiguredIMessageTypingMode(cfg);
+    const sendPolicy = resolveSendPolicy({
+      cfg,
+      entry: getSessionEntry({ storePath, sessionKey: decision.route.sessionKey }),
+      sessionKey: decision.route.sessionKey,
+      channel: "imessage",
+      chatType: decision.isGroup ? "group" : "direct",
+    });
+    const shouldStartDirectTyping =
+      supportsTyping &&
+      !decision.isGroup &&
+      sendPolicy !== "deny" &&
+      (configuredTypingMode === undefined || configuredTypingMode === "instant");
+    const earlyDirectTypingTarget = shouldStartDirectTyping
+      ? buildDirectIMessageReplyTarget({
+          cfg,
+          accountId: decision.route.accountId,
+          sender: decision.sender,
+        })
+      : undefined;
+    if (earlyDirectTypingTarget) {
+      // Start channel-native feedback before the expensive history/context/model
+      // path. Use a short-lived client so a slow typing RPC cannot block the
+      // monitor client's watch stream or later dispatcher typing teardown.
+      void sendIMessageTyping(earlyDirectTypingTarget, true, {
+        cfg,
+        accountId: accountInfo.accountId,
+      }).catch((err) => {
+        logTypingFailure({
+          log: (msg) => logVerbose(msg),
+          channel: "imessage",
+          action: "start",
+          target: earlyDirectTypingTarget,
+          error: err,
+        });
+      });
+    }
     const stagedAttachments = remoteHost
       ? []
       : await stageIMessageAttachments(validAttachments, {
@@ -1107,31 +1157,20 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       );
     }
 
-    const privateApiStatus = getCachedIMessagePrivateApiStatus(cliPath);
-    const supportsTyping = imessageRpcSupportsMethod(privateApiStatus, "typing");
-    const supportsRead = imessageRpcSupportsMethod(privateApiStatus, "read");
-    if (privateApiStatus?.available === true) {
-      // Surface a single warning per restart when the bridge is up but we
-      // had to gate off typing/read because the imsg build pre-dates the
-      // capability list. Otherwise the user sees no typing bubble / no
-      // "Read" receipt with no visible reason.
-      if (!supportsTyping || !supportsRead) {
-        warnIfImsgUpgradeNeeded.fireOnce(privateApiStatus.rpcMethods, runtime);
-      }
-    }
     const sendReadReceipts = imessageCfg.sendReadReceipts !== false;
     const typingTarget = ctxPayload.To;
 
     if (supportsRead && sendReadReceipts && typingTarget) {
-      try {
-        await markIMessageChatRead(typingTarget, {
-          cfg,
-          accountId: accountInfo.accountId,
-          client: getActiveClient(),
-        });
-      } catch (err) {
+      // Read receipts are best-effort channel UI. Do not put them on the
+      // critical path before model dispatch; slow private-API reads otherwise
+      // make accepted iMessage turns feel stuck before the agent starts. Use
+      // a short-lived client so a stuck read cannot block monitor-client typing.
+      void markIMessageChatRead(typingTarget, {
+        cfg,
+        accountId: accountInfo.accountId,
+      }).catch((err) => {
         runtime.error?.(`imessage: mark read failed: ${String(err)}`);
-      }
+      });
     }
 
     const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
@@ -1234,19 +1273,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       },
     });
     let directTypingController: IMessageTypingController | undefined;
-    const configuredTypingMode = resolveConfiguredIMessageTypingMode(cfg);
-    const sendPolicy = resolveSendPolicy({
-      cfg,
-      entry: getSessionEntry({ storePath, sessionKey: decision.route.sessionKey }),
-      sessionKey: decision.route.sessionKey,
-      channel: "imessage",
-      chatType: decision.isGroup ? "group" : "direct",
-    });
-    const shouldStartToolTyping =
-      !decision.isGroup &&
-      sendPolicy !== "deny" &&
-      (configuredTypingMode === undefined || configuredTypingMode === "instant");
-    const directToolTypingOptions = shouldStartToolTyping
+    const directToolTypingOptions = shouldStartDirectTyping
       ? ({
           // iMessage's native typing bubble is channel-owned UI, not a
           // visible tool-progress message. The suppress flag is what lets

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -28,6 +28,7 @@ import { truncateUtf16Safe } from "../utils.js";
 export const TOOL_PROGRESS_OUTPUT_MAX_CHARS = 8_000;
 
 export { FAST_MODE_AUTO_PROGRESS_KIND } from "../auto-reply/reply-payload.js";
+export { isDeliveredMessageToolOnlySourceReplyResult } from "../agents/embedded-agent-message-tool-source-reply.js";
 export { formatFastModeAutoProgressText, resolveFastModeForElapsed } from "../shared/fast-mode.js";
 export type { AgentMessage } from "../agents/runtime/index.js";
 export type { FastModeAutoProgressState } from "../shared/fast-mode.js";


### PR DESCRIPTION
## What Problem This Solves

In `message_tool_only` source-reply mode, Codex could successfully send the visible iMessage reply through the `message` dynamic tool but still leave the turn waiting for assistant synthesis. That produced the slow post-send tail we saw in logs, ending in an incomplete-turn path even though the user-visible reply had already been delivered.

## Why This Change Was Made

The core embedded-agent path already knows when a message-tool-only source reply is delivered and should be treated as terminal. The Codex app-server dynamic tool bridge was not carrying that source-reply mode into its dynamic-tool termination decision, so delivered implicit source replies were not marked terminal for Codex runs.

This PR exports the existing delivery detector through the harness runtime barrel, passes `sourceReplyDeliveryMode` into the Codex dynamic tool hook context, and marks delivered implicit message-tool-only replies as terminal. Explicit cross-channel message sends are intentionally not treated as terminal source replies.

## User Impact

This benefits setups that use the Codex app-server harness with a channel configured for `sourceReplyDeliveryMode: message_tool_only`, including iMessage-style flows where the model replies through the `message` tool instead of an assistant final message.

Expected benefit: removes the avoidable post-send wait/incomplete-turn tail after a successful visible message send. It does not address the separate cold plugin/provider discovery cost or the upstream model latency before the first tool call.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts -- --reporter=verbose -t "message-tool-only source replies|explicit message-tool sends"`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts -- --reporter=verbose`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts -- --reporter=verbose`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.turn-watches.test.ts -- --reporter=verbose -t "visible message call"`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
