### PR TITLE
fix(plugin-sdk): bound live model catalog success body

### DIFF
--- a/src/plugin-sdk/provider-catalog-live-runtime.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.test.ts
@@ -126,6 +126,24 @@ describe("provider-catalog-live-runtime", () => {
     ).resolves.toEqual(["custom-a", "custom-b"]);
   });
 
+  it("accepts UTF-8 BOM-prefixed catalog responses", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi.fn(async () => ({
+      response: new Response("\uFEFF" + JSON.stringify({ data: [{ id: "model-a" }] })),
+      finalUrl: "https://provider.example.test/v1/models",
+      release,
+    }));
+
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+      }),
+    ).resolves.toEqual(["model-a"]);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("caches raw live model rows for provider-specific projection", async () => {
     const { fetchGuard, fetchGuardMock } = buildFetchGuard({
       models: [{ slug: "custom-a" }, { slug: "custom-b" }],
@@ -155,6 +173,91 @@ describe("provider-catalog-live-runtime", () => {
     expect(first).toEqual([{ slug: "custom-a" }, { slug: "custom-b" }]);
     expect(second).toEqual(first);
     expect(fetchGuardMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds an unbounded live catalog success stream and cancels the body", async () => {
+    const encoder = new TextEncoder();
+    let pullCount = 0;
+    let cancelled = false;
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi.fn(async () => ({
+      response: new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            pullCount += 1;
+            // Stream a JSON array prefix followed by an effectively endless run of
+            // padding so the body never terminates under its own power.
+            if (pullCount === 1) {
+              controller.enqueue(encoder.encode('[{"id":"model-a","object":"model"},'));
+              return;
+            }
+            controller.enqueue(encoder.encode("0".repeat(1024 * 1024)));
+          },
+          cancel() {
+            cancelled = true;
+          },
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+      finalUrl: "https://provider.example.test/v1/models",
+      release,
+    }));
+
+    const error = await fetchLiveProviderModelIds({
+      providerId: "provider",
+      endpoint: "https://provider.example.test/v1/models",
+      fetchGuard: fetchGuardMock,
+    }).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/Live model catalog response exceeded \d+ bytes/);
+    expect(cancelled).toBe(true);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts a stalled live catalog success stream", async () => {
+    vi.useFakeTimers();
+    try {
+      const encoder = new TextEncoder();
+      let cancelReason: unknown;
+      const release = vi.fn(async () => undefined);
+      const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi.fn(async () => ({
+        response: new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              // Emit a partial JSON prefix and then idle forever without closing.
+              controller.enqueue(encoder.encode('[{"id":"model-a",'));
+            },
+            cancel(reason) {
+              cancelReason = reason;
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+        finalUrl: "https://provider.example.test/v1/models",
+        release,
+      }));
+
+      const resultPromise = fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+        timeoutMs: 1234,
+      }).catch((err: unknown) => err);
+
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1234);
+      const error = await resultPromise;
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe(
+        "Live model catalog response stalled: no data received for 1234ms",
+      );
+      expect(cancelReason).toBeInstanceOf(Error);
+      expect(release).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("throws structured HTTP errors after releasing guarded fetches", async () => {

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -1,3 +1,4 @@
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { isNonSecretApiKeyMarker } from "../agents/model-auth-markers.js";
 import {
   clearLiveCatalogCacheForTests,
@@ -44,6 +45,15 @@ export type CachedLiveProviderModelRowsParams = FetchLiveProviderModelRowsParams
   cacheKeyParts?: readonly unknown[];
   shouldCacheRows?: (rows: readonly unknown[]) => boolean;
 };
+
+// Live model catalogs are fetched at runtime from provider-controlled endpoints,
+// so the success body is untrusted just like the error body. A faulty or hostile
+// provider can stream an unbounded JSON document; reading it without a ceiling
+// lets a single discovery call exhaust process memory. The cap is sized well
+// above the largest known catalog (OpenRouter's live catalog is already >100KB
+// and grows) while still bounding memory, matching the existing bounded reads
+// for provider error bodies.
+const LIVE_MODEL_CATALOG_BODY_MAX_BYTES = 4 * 1024 * 1024;
 
 export class LiveModelCatalogHttpError extends Error {
   readonly status: number;
@@ -133,17 +143,29 @@ async function cancelUnreadResponseBody(response: Response): Promise<void> {
   }
 }
 
+async function readLiveModelCatalogJson(response: Response, timeoutMs: number): Promise<unknown> {
+  const buffer = await readResponseWithLimit(response, LIVE_MODEL_CATALOG_BODY_MAX_BYTES, {
+    chunkTimeoutMs: timeoutMs,
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(`Live model catalog response exceeded ${maxBytes} bytes (${size} bytes received)`),
+    onIdleTimeout: ({ chunkTimeoutMs }) =>
+      new Error(`Live model catalog response stalled: no data received for ${chunkTimeoutMs}ms`),
+  });
+  return JSON.parse(new TextDecoder().decode(buffer));
+}
+
 export async function fetchLiveProviderModelRows(
   params: FetchLiveProviderModelRowsParams,
 ): Promise<readonly unknown[]> {
   const fetchGuard = params.fetchGuard ?? fetchWithSsrFGuard;
+  const timeoutMs = params.timeoutMs ?? 5_000;
   const { response, release } = await fetchGuard({
     url: params.endpoint,
     init: {
       headers: buildHeaders(params),
     },
     signal: params.signal,
-    timeoutMs: params.timeoutMs ?? 5_000,
+    timeoutMs,
     policy: params.policy ?? ssrfPolicyFromHttpBaseUrlAllowedHostname(params.endpoint),
     ...(params.lookupFn ? { lookupFn: params.lookupFn } : {}),
     ...(params.requireHttps !== undefined ? { requireHttps: params.requireHttps } : {}),
@@ -154,7 +176,9 @@ export async function fetchLiveProviderModelRows(
       await cancelUnreadResponseBody(response);
       throw new LiveModelCatalogHttpError(params.providerId, response.status);
     }
-    return (params.readRows ?? readDefaultLiveModelCatalogRows)(await response.json());
+    return (params.readRows ?? readDefaultLiveModelCatalogRows)(
+      await readLiveModelCatalogJson(response, timeoutMs),
+    );
   } finally {
     await release();
   }


### PR DESCRIPTION
## What Problem This Solves

Live provider model catalogs were read with unbounded `response.json()`. A provider-controlled success stream could consume unbounded memory or remain open indefinitely after headers.

Supersedes #95246 after its contributor fork branch became unpushable during required mainline synchronization.

## Why This Change Was Made

The shared catalog boundary now uses `readResponseWithLimit` with a 4 MiB cap and the existing request timeout as an idle-chunk deadline. Overflow and stalled streams are cancelled, guarded fetch resources are always released, and `TextDecoder` preserves the previous UTF-8 BOM behavior.

The fix is shared across all live catalog callers; no provider-specific configuration or fallback path is added.

## User Impact

Provider model discovery fails quickly with a descriptive error for oversized or stalled success bodies instead of consuming unbounded resources. Valid catalog responses, including BOM-prefixed JSON, continue to work.

## Evidence

- `node scripts/run-vitest.mjs run src/plugin-sdk/provider-catalog-live-runtime.test.ts` — 1 file, 10 tests passed.
- Official OpenRouter live catalog — 496,778 bytes / 339 models, below the 4 MiB cap.
- `oxfmt --check` on touched files and `git diff --check` — passed.
- Fresh Codex autoreview on the reviewed patch — no actionable findings.
- Original exact-head full CI run `27966792754` — success before branch-topology recovery.

## Real behavior proof

The official OpenRouter `/api/v1/models` endpoint returned a 496,778-byte JSON catalog with 339 models and parsed successfully through the same response shape. Regression tests cover bounded success, overflow cancellation, idle cancellation, structured HTTP errors, resource release, and UTF-8 BOM decoding.

Contributor credit is preserved with `Co-authored-by: Alix-007 <li.long15@xydigit.com>`.
