### PR TITLE
fix(telegram): route poll answers into sessions

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -164,11 +164,19 @@ const sendDurableMessageBatch = vi.fn(
     } as const;
   },
 );
-const sendPollTelegram = vi.fn(async () => ({
-  messageId: "790",
-  chatId: "123",
-  pollId: "poll-1",
-}));
+const sendPollTelegram = vi.fn(
+  async (): Promise<{
+    messageId: string;
+    chatId: string;
+    pollId: string;
+    pollAnswerRouting?: "enabled" | "unavailable";
+    warning?: string;
+  }> => ({
+    messageId: "790",
+    chatId: "123",
+    pollId: "poll-1",
+  }),
+);
 const sendStickerTelegram = vi.fn(async () => ({
   messageId: "456",
   chatId: "123",
@@ -1353,6 +1361,60 @@ describe("handleTelegramAction", () => {
     expect(details.messageId).toBe("790");
     expect(details.chatId).toBe("123");
     expect(details.pollId).toBe("poll-1");
+  });
+
+  it("returns a model-visible warning when public poll routing is unavailable", async () => {
+    sendPollTelegram.mockResolvedValueOnce({
+      messageId: "790",
+      chatId: "123",
+      pollId: "poll-1",
+      pollAnswerRouting: "unavailable",
+      warning: "Poll answers cannot reach the agent. Ask the user to reply in text.",
+    });
+
+    const result = await handleTelegramAction(
+      {
+        action: "poll",
+        to: "@testchannel",
+        question: "Ready?",
+        answers: ["Yes", "No"],
+        isAnonymous: false,
+      },
+      telegramConfig(),
+    );
+
+    expect(resultDetails(result)).toMatchObject({
+      pollAnswerRouting: "unavailable",
+      warning: "Poll answers cannot reach the agent. Ask the user to reply in text.",
+    });
+  });
+
+  it("returns the public-poll opt-in for default anonymous polls", async () => {
+    sendPollTelegram.mockResolvedValueOnce({
+      messageId: "790",
+      chatId: "123",
+      pollId: "poll-1",
+      pollAnswerRouting: "unavailable",
+      warning:
+        "Poll sent anonymously, so Telegram does not identify voters and answers cannot reach the agent. Send a public poll to route votes into this conversation.",
+    });
+
+    const result = await handleTelegramAction(
+      {
+        action: "poll",
+        to: "@testchannel",
+        question: "Ready?",
+        answers: ["Yes", "No"],
+      },
+      telegramConfig(),
+    );
+
+    const options = requireRecord(mockCall(sendPollTelegram, 0, "anonymous poll")[2], "options");
+    expect(options.isAnonymous).toBeUndefined();
+    expect(resultDetails(result)).toMatchObject({
+      pollAnswerRouting: "unavailable",
+      warning: expect.stringContaining("Send a public poll"),
+    });
   });
 
   it("rejects fractional poll durations before sending", async () => {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -750,6 +750,8 @@ export async function handleTelegramAction(
       messageId: result.messageId,
       chatId: result.chatId,
       pollId: result.pollId,
+      ...(result.pollAnswerRouting ? { pollAnswerRouting: result.pollAnswerRouting } : {}),
+      ...(result.warning ? { warning: result.warning } : {}),
     });
   }
 

--- a/extensions/telegram/src/allowed-updates.ts
+++ b/extensions/telegram/src/allowed-updates.ts
@@ -6,6 +6,10 @@ type TelegramUpdateType = (typeof API_CONSTANTS.ALL_UPDATE_TYPES)[number];
 const DEFAULT_TELEGRAM_UPDATE_TYPES: ReadonlyArray<TelegramUpdateType> =
   API_CONSTANTS.DEFAULT_UPDATE_TYPES;
 
+// grammy's DEFAULT_UPDATE_TYPES omits message_reaction, so it must always be opted in.
+// channel_post and poll_answer are in the current defaults, but reaction/channel-post/poll-vote
+// routing all *depend* on receiving those updates; the idempotent guards below pin that
+// dependency so the features keep working if a future grammy/Telegram default ever drops them.
 export function resolveTelegramAllowedUpdates(): ReadonlyArray<TelegramUpdateType> {
   const updates = [...DEFAULT_TELEGRAM_UPDATE_TYPES] as TelegramUpdateType[];
   if (!updates.includes("message_reaction")) {
@@ -13,6 +17,9 @@ export function resolveTelegramAllowedUpdates(): ReadonlyArray<TelegramUpdateTyp
   }
   if (!updates.includes("channel_post")) {
     updates.push("channel_post");
+  }
+  if (!updates.includes("poll_answer")) {
+    updates.push("poll_answer");
   }
   return updates;
 }

--- a/extensions/telegram/src/allowed-updates.ts
+++ b/extensions/telegram/src/allowed-updates.ts
@@ -6,10 +6,6 @@ type TelegramUpdateType = (typeof API_CONSTANTS.ALL_UPDATE_TYPES)[number];
 const DEFAULT_TELEGRAM_UPDATE_TYPES: ReadonlyArray<TelegramUpdateType> =
   API_CONSTANTS.DEFAULT_UPDATE_TYPES;
 
-// grammy's DEFAULT_UPDATE_TYPES omits message_reaction, so it must always be opted in.
-// channel_post and poll_answer are in the current defaults, but reaction/channel-post/poll-vote
-// routing all *depend* on receiving those updates; the idempotent guards below pin that
-// dependency so the features keep working if a future grammy/Telegram default ever drops them.
 export function resolveTelegramAllowedUpdates(): ReadonlyArray<TelegramUpdateType> {
   const updates = [...DEFAULT_TELEGRAM_UPDATE_TYPES] as TelegramUpdateType[];
   if (!updates.includes("message_reaction")) {
@@ -17,9 +13,6 @@ export function resolveTelegramAllowedUpdates(): ReadonlyArray<TelegramUpdateTyp
   }
   if (!updates.includes("channel_post")) {
     updates.push("channel_post");
-  }
-  if (!updates.includes("poll_answer")) {
-    updates.push("poll_answer");
   }
   return updates;
 }

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -38,6 +38,7 @@ import {
   ensureTelegramMessageProcessingResult,
   getTelegramSpooledReplayDeferredParticipant,
   isTelegramSpooledReplayUpdate,
+  recordTelegramMessageProcessingResult,
   runWithTelegramUpdateProcessingFrame,
   TelegramSpooledReplayProcessingError,
 } from "./bot-processing-outcome.js";
@@ -63,6 +64,10 @@ import {
   recordTelegramGroupHistoryEntry,
 } from "./group-history-window.js";
 import { registerTelegramOutboundGroupHistoryRecorder } from "./outbound-message-context.js";
+import {
+  prepareTelegramPollAnswerContext,
+  settleTelegramPollAnswerContext,
+} from "./poll-answer-context.js";
 import { formatTelegramRawUpdateForLog } from "./raw-update-log.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 import { getTelegramSequentialConstraints } from "./sequential-key.js";
@@ -234,7 +239,29 @@ export function createTelegramBotCore(
     await next();
   });
 
+  // poll_answer omits its chat and topic. Resolve the send-time route before
+  // sequentialize so the vote shares the same lane as ordinary session turns.
+  bot.use(async (ctx, next) => {
+    try {
+      prepareTelegramPollAnswerContext({ update: ctx.update, accountId: account.accountId });
+    } catch (error) {
+      if (isTelegramSpooledReplayUpdate(ctx.update)) {
+        recordTelegramMessageProcessingResult({ kind: "failed-retryable", error });
+        return;
+      }
+      throw error;
+    }
+    await next();
+  });
+
   bot.use(botRuntime.sequentialize(getTelegramSequentialConstraints));
+
+  // A fast vote can know its route before outbound verification finishes. Hold
+  // only that route's sequential lane until registration succeeds or declines it.
+  bot.use(async (ctx, next) => {
+    await settleTelegramPollAnswerContext({ update: ctx.update, accountId: account.accountId });
+    await next();
+  });
 
   const rawUpdateLogger = createSubsystemLogger("gateway/channels/telegram/raw-update");
 

--- a/extensions/telegram/src/bot-handlers.message-lifecycle.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-lifecycle.runtime.ts
@@ -146,7 +146,7 @@ export function createTelegramMessageLifecycleRuntime({
     return { process: true, claims: claim.kind === "claimed" ? [claim.handle] : [] };
   };
   const buildSyntheticTextMessage = (params: {
-    base: Message;
+    base: Message.ServiceMessage;
     text: string;
     entities?: Message["entities"];
     date?: number;

--- a/extensions/telegram/src/bot-handlers.poll-answer.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.poll-answer.runtime.ts
@@ -1,0 +1,153 @@
+// Telegram public-poll answer handler registration.
+import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import type { TelegramHandlerAuthorizationRuntime } from "./bot-handlers.authorization.runtime.js";
+import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
+import {
+  isTelegramSpooledReplayUpdate,
+  recordTelegramMessageProcessingResult,
+} from "./bot-processing-outcome.js";
+import { resolveTelegramForumFlag } from "./bot/helpers.js";
+import { resolveTelegramConversationRoute } from "./conversation-route.js";
+import { findTelegramPollRegistryEntry } from "./poll-registry.js";
+
+export function registerTelegramPollAnswerHandler(
+  {
+    accountId,
+    bot,
+    runtime,
+    telegramDeps,
+    resolveTelegramGroupConfig,
+    shouldSkipUpdate,
+  }: RegisterTelegramHandlerParams,
+  authorizationRuntime: TelegramHandlerAuthorizationRuntime,
+) {
+  const { resolveTelegramEventAuthorizationContext, authorizeTelegramEventSender } =
+    authorizationRuntime;
+
+  // Telegram emits poll_answer only for non-anonymous polls, and the update omits
+  // chat/thread data. The send path records that origin in the keyed plugin store.
+  bot.on("poll_answer", async (ctx) => {
+    try {
+      const pollAnswer = ctx.pollAnswer;
+      if (!pollAnswer || shouldSkipUpdate(ctx)) {
+        return;
+      }
+      const optionIds = pollAnswer.option_ids ?? [];
+      const user = pollAnswer.user;
+      // Retractions have no selection to route. Bot voters and voter_chat-only
+      // answers have no user identity that can pass the sender authorization gate.
+      if (optionIds.length === 0 || !user || user.is_bot) {
+        return;
+      }
+
+      // A true miss is a safe no-op. Store failures throw so durable ingress can
+      // release the claim and replay instead of permanently dropping the vote.
+      const pollId = pollAnswer.poll_id;
+      const entry = await findTelegramPollRegistryEntry({ pollId, accountId });
+      if (!entry) {
+        logVerbose(`telegram: poll_answer for poll ${pollId} has no registry entry; skipping`);
+        return;
+      }
+
+      const chatId = Number(entry.chatId);
+      const isGroup = entry.chatId.startsWith("-");
+      const isForum = isGroup
+        ? await resolveTelegramForumFlag({
+            chatId,
+            chatType: "supergroup",
+            isGroup,
+            getChat: bot.api.getChat.bind(bot.api),
+          })
+        : false;
+      const senderId = user?.id != null ? String(user.id) : "";
+      const senderUsername = user?.username ?? "";
+      const authorizationCfg = telegramDeps.getRuntimeConfig();
+      const eventAuthContext = await resolveTelegramEventAuthorizationContext({
+        cfg: authorizationCfg,
+        chatId,
+        isGroup,
+        isForum,
+        senderId,
+        messageThreadId: entry.messageThreadId,
+      });
+      const senderAuthorization = await authorizeTelegramEventSender({
+        chatId,
+        isGroup,
+        senderId,
+        senderUsername,
+        // Poll votes and reactions are both user-originated updates attached to
+        // bot-created UI, so they share the reaction authorization boundary.
+        mode: "reaction",
+        context: eventAuthContext,
+      });
+      if (!senderAuthorization) {
+        return;
+      }
+
+      // poll_answer has no thread id. A DM poll without persisted topic context
+      // cannot satisfy requireTopic and must not wake the base DM session.
+      if (!isGroup) {
+        const requireTopic = (
+          eventAuthContext.groupConfig as { requireTopic?: boolean } | undefined
+        )?.requireTopic;
+        if (requireTopic === true && eventAuthContext.dmThreadId == null) {
+          logVerbose(
+            `Blocked telegram poll_answer in DM ${chatId}: requireTopic=true but topic unknown`,
+          );
+          return;
+        }
+      }
+
+      const senderName = user
+        ? [user.first_name, user.last_name].filter(Boolean).join(" ").trim() || user.username
+        : undefined;
+      const senderUsernameLabel = user?.username ? `@${user.username}` : undefined;
+      let senderLabel = senderName;
+      if (senderName && senderUsernameLabel) {
+        senderLabel = `${senderName} (${senderUsernameLabel})`;
+      } else if (!senderName && senderUsernameLabel) {
+        senderLabel = senderUsernameLabel;
+      }
+      if (!senderLabel && user?.id) {
+        senderLabel = `id:${user.id}`;
+      }
+      senderLabel = senderLabel || "unknown";
+
+      const optionLabels = optionIds.map((index) => entry.options[index] ?? `option ${index}`);
+      const text = `Telegram poll vote: "${entry.question}" — ${senderLabel} voted: ${optionLabels.join(
+        ", ",
+      )}`;
+      const resolvedThreadId = eventAuthContext.resolvedThreadId;
+      const routeThreadId =
+        resolvedThreadId ?? eventAuthContext.dmThreadId ?? entry.messageThreadId;
+      const { topicConfig } = resolveTelegramGroupConfig(
+        chatId,
+        routeThreadId,
+        eventAuthContext.cfg,
+      );
+      const { route } = resolveTelegramConversationRoute({
+        cfg: eventAuthContext.cfg,
+        accountId,
+        chatId,
+        isGroup,
+        resolvedThreadId,
+        replyThreadId: routeThreadId,
+        senderId,
+        topicAgentId: topicConfig?.agentId,
+      });
+
+      telegramDeps.enqueueSystemEvent(text, {
+        sessionKey: route.sessionKey,
+        contextKey: `telegram:poll_answer:${pollId}:${user?.id ?? "anon"}:${optionIds.join("-")}`,
+      });
+      logVerbose(`telegram: poll_answer event enqueued for poll ${pollId} by ${senderLabel}`);
+    } catch (err) {
+      runtime.error?.(danger(`telegram poll_answer handler failed: ${String(err)}`));
+      if (isTelegramSpooledReplayUpdate(ctx.update)) {
+        recordTelegramMessageProcessingResult({ kind: "failed-retryable", error: err });
+        return;
+      }
+      throw err;
+    }
+  });
+}

--- a/extensions/telegram/src/bot-handlers.poll-answer.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.poll-answer.runtime.ts
@@ -1,28 +1,51 @@
 // Telegram public-poll answer handler registration.
+import type { ChatMember } from "grammy/types";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { TelegramHandlerAuthorizationRuntime } from "./bot-handlers.authorization.runtime.js";
+import type { TelegramHandlerMessageRuntime } from "./bot-handlers.message.runtime.js";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import {
   isTelegramSpooledReplayUpdate,
   recordTelegramMessageProcessingResult,
 } from "./bot-processing-outcome.js";
-import { resolveTelegramForumFlag } from "./bot/helpers.js";
-import { resolveTelegramConversationRoute } from "./conversation-route.js";
-import { findTelegramPollRegistryEntry } from "./poll-registry.js";
+import { getPreparedTelegramPollAnswer } from "./poll-answer-context.js";
+import { findTelegramPollRegistryEntry, retireTelegramPollRegistryEntry } from "./poll-registry.js";
 
-export function registerTelegramPollAnswerHandler(
-  {
-    accountId,
-    bot,
-    runtime,
-    telegramDeps,
-    resolveTelegramGroupConfig,
-    shouldSkipUpdate,
-  }: RegisterTelegramHandlerParams,
+function isCurrentTelegramChatMember(member: ChatMember): boolean {
+  return (
+    member.status === "creator" ||
+    member.status === "administrator" ||
+    member.status === "member" ||
+    (member.status === "restricted" && member.is_member)
+  );
+}
+
+export function registerTelegramPollHandlers(
+  { accountId, bot, runtime, telegramDeps, shouldSkipUpdate }: RegisterTelegramHandlerParams,
+  messageRuntime: TelegramHandlerMessageRuntime,
   authorizationRuntime: TelegramHandlerAuthorizationRuntime,
 ) {
   const { resolveTelegramEventAuthorizationContext, authorizeTelegramEventSender } =
     authorizationRuntime;
+  const { buildSyntheticTextMessage, buildSyntheticContext, processMessageWithReplyChain } =
+    messageRuntime;
+
+  bot.on("poll", async (ctx) => {
+    try {
+      const poll = ctx.poll;
+      if (!poll?.is_closed || shouldSkipUpdate(ctx)) {
+        return;
+      }
+      await retireTelegramPollRegistryEntry({ accountId, pollId: poll.id });
+    } catch (err) {
+      runtime.error?.(danger(`telegram poll handler failed: ${String(err)}`));
+      if (isTelegramSpooledReplayUpdate(ctx.update)) {
+        recordTelegramMessageProcessingResult({ kind: "failed-retryable", error: err });
+        return;
+      }
+      throw err;
+    }
+  });
 
   // Telegram emits poll_answer only for non-anonymous polls, and the update omits
   // chat/thread data. The send path records that origin in the keyed plugin store.
@@ -43,24 +66,30 @@ export function registerTelegramPollAnswerHandler(
       // A true miss is a safe no-op. Store failures throw so durable ingress can
       // release the claim and replay instead of permanently dropping the vote.
       const pollId = pollAnswer.poll_id;
-      const entry = await findTelegramPollRegistryEntry({ pollId, accountId });
+      const prepared = getPreparedTelegramPollAnswer(ctx.update);
+      const entry = prepared
+        ? prepared.entry
+        : await findTelegramPollRegistryEntry({ pollId, accountId });
       if (!entry) {
         logVerbose(`telegram: poll_answer for poll ${pollId} has no registry entry; skipping`);
         return;
       }
 
-      const chatId = Number(entry.chatId);
-      const isGroup = entry.chatId.startsWith("-");
-      const isForum = isGroup
-        ? await resolveTelegramForumFlag({
-            chatId,
-            chatType: "supergroup",
-            isGroup,
-            getChat: bot.api.getChat.bind(bot.api),
-          })
-        : false;
+      const chatId = entry.chat.id;
+      const isGroup = entry.chat.type === "group" || entry.chat.type === "supergroup";
+      const isForum = entry.chat.type === "supergroup" && entry.chat.is_forum === true;
       const senderId = user?.id != null ? String(user.id) : "";
       const senderUsername = user?.username ?? "";
+      if (!isGroup && user.id !== chatId) {
+        logVerbose(`Blocked forwarded telegram poll_answer for DM ${chatId} from ${senderId}`);
+        return;
+      }
+      if (isGroup && !isCurrentTelegramChatMember(await bot.api.getChatMember(chatId, user.id))) {
+        logVerbose(
+          `Blocked forwarded telegram poll_answer for group ${chatId} from non-member ${senderId}`,
+        );
+        return;
+      }
       const authorizationCfg = telegramDeps.getRuntimeConfig();
       const eventAuthContext = await resolveTelegramEventAuthorizationContext({
         cfg: authorizationCfg,
@@ -72,6 +101,7 @@ export function registerTelegramPollAnswerHandler(
       });
       const senderAuthorization = await authorizeTelegramEventSender({
         chatId,
+        chatTitle: "title" in entry.chat ? entry.chat.title : undefined,
         isGroup,
         senderId,
         senderUsername,
@@ -98,49 +128,37 @@ export function registerTelegramPollAnswerHandler(
         }
       }
 
-      const senderName = user
-        ? [user.first_name, user.last_name].filter(Boolean).join(" ").trim() || user.username
-        : undefined;
-      const senderUsernameLabel = user?.username ? `@${user.username}` : undefined;
-      let senderLabel = senderName;
-      if (senderName && senderUsernameLabel) {
-        senderLabel = `${senderName} (${senderUsernameLabel})`;
-      } else if (!senderName && senderUsernameLabel) {
-        senderLabel = senderUsernameLabel;
-      }
-      if (!senderLabel && user?.id) {
-        senderLabel = `id:${user.id}`;
-      }
-      senderLabel = senderLabel || "unknown";
-
       const optionLabels = optionIds.map((index) => entry.options[index] ?? `option ${index}`);
-      const text = `Telegram poll vote: "${entry.question}" — ${senderLabel} voted: ${optionLabels.join(
-        ", ",
-      )}`;
-      const resolvedThreadId = eventAuthContext.resolvedThreadId;
-      const routeThreadId =
-        resolvedThreadId ?? eventAuthContext.dmThreadId ?? entry.messageThreadId;
-      const { topicConfig } = resolveTelegramGroupConfig(
-        chatId,
-        routeThreadId,
-        eventAuthContext.cfg,
-      );
-      const { route } = resolveTelegramConversationRoute({
-        cfg: eventAuthContext.cfg,
-        accountId,
-        chatId,
-        isGroup,
-        resolvedThreadId,
-        replyThreadId: routeThreadId,
-        senderId,
-        topicAgentId: topicConfig?.agentId,
+      const text = `Poll response to "${entry.question}": ${optionLabels.join(", ")}`;
+      const syntheticMessage = buildSyntheticTextMessage({
+        base: {
+          message_id: entry.messageId,
+          date: Math.floor(Date.now() / 1000),
+          chat: entry.chat,
+          ...(entry.messageThreadId == null
+            ? {}
+            : {
+                message_thread_id: entry.messageThreadId,
+              }),
+        },
+        from: user,
+        text,
       });
-
-      telegramDeps.enqueueSystemEvent(text, {
-        sessionKey: route.sessionKey,
-        contextKey: `telegram:poll_answer:${pollId}:${user?.id ?? "anon"}:${optionIds.join("-")}`,
+      const result = await processMessageWithReplyChain({
+        ctx: buildSyntheticContext(ctx, syntheticMessage),
+        msg: syntheticMessage,
+        allMedia: [],
+        storeAllowFrom: eventAuthContext.storeAllowFrom,
+        options: {
+          forceWasMentioned: true,
+          messageIdOverride:
+            typeof ctx.update.update_id === "number"
+              ? String(ctx.update.update_id)
+              : `poll:${pollId}:${user.id}:${optionIds.join("-")}`,
+        },
       });
-      logVerbose(`telegram: poll_answer event enqueued for poll ${pollId} by ${senderLabel}`);
+      recordTelegramMessageProcessingResult(result);
+      logVerbose(`telegram: poll_answer dispatched for poll ${pollId} by ${senderId}`);
     } catch (err) {
       runtime.error?.(danger(`telegram poll_answer handler failed: ${String(err)}`));
       if (isTelegramSpooledReplayUpdate(ctx.update)) {

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -5,7 +5,7 @@ import { createTelegramHandlerInboundRuntime } from "./bot-handlers.inbound.runt
 import { registerTelegramMessageHandlers } from "./bot-handlers.message-events.runtime.js";
 import { createTelegramHandlerMessageRuntime } from "./bot-handlers.message.runtime.js";
 import { registerTelegramMigrationHandler } from "./bot-handlers.migration.runtime.js";
-import { registerTelegramPollAnswerHandler } from "./bot-handlers.poll-answer.runtime.js";
+import { registerTelegramPollHandlers } from "./bot-handlers.poll-answer.runtime.js";
 import { registerTelegramReactionHandler } from "./bot-handlers.reaction.runtime.js";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 
@@ -15,7 +15,7 @@ export const registerTelegramHandlers = (params: RegisterTelegramHandlerParams) 
   const inboundRuntime = createTelegramHandlerInboundRuntime(params, messageRuntime);
 
   registerTelegramReactionHandler(params, messageRuntime, authorizationRuntime);
-  registerTelegramPollAnswerHandler(params, authorizationRuntime);
+  registerTelegramPollHandlers(params, messageRuntime, authorizationRuntime);
   registerTelegramCallbackQueryHandler(params, messageRuntime, authorizationRuntime);
   registerTelegramMigrationHandler(params);
   registerTelegramMessageHandlers(params, messageRuntime, authorizationRuntime, inboundRuntime);

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -5,6 +5,7 @@ import { createTelegramHandlerInboundRuntime } from "./bot-handlers.inbound.runt
 import { registerTelegramMessageHandlers } from "./bot-handlers.message-events.runtime.js";
 import { createTelegramHandlerMessageRuntime } from "./bot-handlers.message.runtime.js";
 import { registerTelegramMigrationHandler } from "./bot-handlers.migration.runtime.js";
+import { registerTelegramPollAnswerHandler } from "./bot-handlers.poll-answer.runtime.js";
 import { registerTelegramReactionHandler } from "./bot-handlers.reaction.runtime.js";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 
@@ -14,6 +15,7 @@ export const registerTelegramHandlers = (params: RegisterTelegramHandlerParams) 
   const inboundRuntime = createTelegramHandlerInboundRuntime(params, messageRuntime);
 
   registerTelegramReactionHandler(params, messageRuntime, authorizationRuntime);
+  registerTelegramPollAnswerHandler(params, authorizationRuntime);
   registerTelegramCallbackQueryHandler(params, messageRuntime, authorizationRuntime);
   registerTelegramMigrationHandler(params);
   registerTelegramMessageHandlers(params, messageRuntime, authorizationRuntime, inboundRuntime);

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -457,6 +457,7 @@ const telegramBotRuntimeForTest = {
       setMyCommands: grammySpies.setMyCommandsSpy,
       getMe: grammySpies.getMeSpy,
       getChat: grammySpies.getChatSpy,
+      getChatMember: grammySpies.getChatSpy,
       sendMessage: grammySpies.sendMessageSpy,
       sendAnimation: grammySpies.sendAnimationSpy,
       sendPhoto: grammySpies.sendPhotoSpy,

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -13,6 +13,10 @@ import {
   clearPluginInteractiveHandlers,
   registerPluginInteractiveHandler,
 } from "openclaw/plugin-sdk/plugin-runtime";
+import type {
+  PluginStateKeyedStore,
+  PluginStateSyncKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { sanitizeTerminalText } from "openclaw/plugin-sdk/test-fixtures";
@@ -30,6 +34,8 @@ import {
 import type { TelegramBotOptions } from "./bot.types.js";
 import type { TelegramGetChat } from "./bot/types.js";
 import { buildTelegramOpaqueCallbackData } from "./native-command-callback-data.js";
+import type { TelegramPollRegistryEntry } from "./poll-registry.js";
+import type { TelegramRuntime } from "./runtime.types.js";
 
 vi.mock("openclaw/plugin-sdk/conversation-runtime", { spy: true });
 
@@ -89,7 +95,9 @@ const {
 } = await import("./bot-processing-outcome.js");
 const { TELEGRAM_RICH_TEXT_LIMIT } = await import("./rich-message.js");
 const { resolveTelegramConversationRoute } = await import("./conversation-route.js");
-const { resetTelegramAccountThrottlersForTest } = await import("./runtime.test-support.js");
+const { clearTelegramRuntimeForTest, resetTelegramAccountThrottlersForTest } =
+  await import("./runtime.test-support.js");
+const { setTelegramRuntime } = await import("./runtime.js");
 const {
   buildTelegramGroupFrom,
   buildTelegramThreadParams,
@@ -594,6 +602,154 @@ describe("createTelegramBot", () => {
     expect(sequentializeSpy).toHaveBeenCalledTimes(1);
     expect(middlewareUseSpy).toHaveBeenCalledWith(sequentializeSpy.mock.results[0]?.value);
     expect(harness.sequentializeKey).toBe(getTelegramSequentialConstraints);
+  });
+
+  it("prepares the recorded poll topic before sequentialization", async () => {
+    const openKeyedStore: TelegramRuntime["state"]["openKeyedStore"] = <T>(
+      options: Parameters<TelegramRuntime["state"]["openKeyedStore"]>[0],
+    ) => pluginStateTestRuntime.createPluginStateKeyedStoreForTests<T>("telegram", options);
+    const openSyncKeyedStore: TelegramRuntime["state"]["openSyncKeyedStore"] = <T>(
+      options: Parameters<TelegramRuntime["state"]["openSyncKeyedStore"]>[0],
+    ) => pluginStateTestRuntime.createPluginStateSyncKeyedStoreForTests<T>("telegram", options);
+    const store = openKeyedStore<TelegramPollRegistryEntry>({
+      namespace: "telegram.poll-registry",
+      maxEntries: 10_000,
+      overflowPolicy: "reject-new",
+    });
+    await store.register("default:poll-topic", {
+      pollId: "poll-topic",
+      chat: { id: -1001, type: "supergroup", title: "Reviewers", is_forum: true },
+      messageId: 7,
+      messageThreadId: 9,
+      question: "Ready?",
+      options: ["Yes", "No"],
+    });
+    setTelegramRuntime({
+      state: { openKeyedStore, openSyncKeyedStore },
+      channel: {},
+    } as TelegramRuntime);
+    let sequentialKey: string | string[] | undefined;
+    sequentializeSpy.mockImplementationOnce(
+      () => async (ctx: TelegramMiddlewareTestContext, next: () => Promise<void>) => {
+        sequentialKey = harness.sequentializeKey?.(ctx);
+        await next();
+      },
+    );
+    createTelegramBot({ token: "tok" });
+    const update = {
+      update_id: 40,
+      poll_answer: {
+        poll_id: "poll-topic",
+        option_ids: [0],
+        user: { id: 9, first_name: "Ada" },
+      },
+    };
+
+    try {
+      await runTelegramTestMiddlewareChain(middlewareUseSpy, { update }, async () => {});
+      expect(sequentialKey).toBe("telegram:-1001:topic:9");
+    } finally {
+      clearTelegramRuntimeForTest();
+    }
+  });
+
+  it("keeps poll registry preparation failures retryable during durable replay", async () => {
+    const readError = new Error("poll registry unavailable");
+    const openKeyedStore: TelegramRuntime["state"]["openKeyedStore"] = <T>() => ({
+      register: async () => {},
+      registerIfAbsent: async () => false,
+      lookup: async (): Promise<T | undefined> => {
+        throw readError;
+      },
+      consume: async () => undefined,
+      delete: async () => false,
+      entries: async () => [],
+      clear: async () => {},
+    });
+    const openSyncKeyedStore: TelegramRuntime["state"]["openSyncKeyedStore"] = <
+      T,
+    >(): PluginStateSyncKeyedStore<T> => ({
+      register: () => {},
+      registerIfAbsent: () => false,
+      lookup: (): T | undefined => {
+        throw readError;
+      },
+      consume: () => undefined,
+      delete: () => false,
+      entries: () => [],
+      clear: () => {},
+    });
+    setTelegramRuntime({
+      state: { openKeyedStore, openSyncKeyedStore },
+      channel: {},
+    } as TelegramRuntime);
+    createTelegramBot({ token: "tok" });
+    const update = {
+      update_id: 41,
+      poll_answer: {
+        poll_id: "poll-retry",
+        option_ids: [0],
+        user: { id: 9, first_name: "Ada" },
+      },
+    };
+
+    try {
+      await expect(
+        runWithTelegramSpooledReplayUpdate(update, async () => {
+          await runTelegramTestMiddlewareChain(middlewareUseSpy, { update }, async () => {});
+        }),
+      ).rejects.toMatchObject({
+        name: TelegramSpooledReplayProcessingError.name,
+        cause: readError,
+      });
+    } finally {
+      clearTelegramRuntimeForTest();
+    }
+  });
+
+  it.each([
+    {
+      name: "bot voter",
+      pollAnswer: {
+        poll_id: "poll-skip",
+        option_ids: [0],
+        user: { id: 9, first_name: "Bot", is_bot: true },
+      },
+    },
+    {
+      name: "vote retraction",
+      pollAnswer: {
+        poll_id: "poll-skip",
+        option_ids: [],
+        user: { id: 9, first_name: "Ada" },
+      },
+    },
+    {
+      name: "voter chat without a user identity",
+      pollAnswer: {
+        poll_id: "poll-skip",
+        option_ids: [0],
+        voter_chat: { id: -100123, type: "supergroup", title: "Reviewers" },
+      },
+    },
+  ])("skips registry preparation for $name", async ({ pollAnswer }) => {
+    const lookup = vi.fn(async () => {
+      throw new Error("registry should not be read");
+    });
+    const openKeyedStore: TelegramRuntime["state"]["openKeyedStore"] = <T>() =>
+      ({ lookup }) as unknown as PluginStateKeyedStore<T>;
+    setTelegramRuntime({ state: { openKeyedStore }, channel: {} } as TelegramRuntime);
+    createTelegramBot({ token: "tok" });
+    const update = { update_id: 42, poll_answer: pollAnswer };
+    const reachedHandlers = vi.fn();
+
+    try {
+      await runTelegramTestMiddlewareChain(middlewareUseSpy, { update }, reachedHandlers);
+      expect(lookup).not.toHaveBeenCalled();
+      expect(reachedHandlers).toHaveBeenCalledOnce();
+    } finally {
+      clearTelegramRuntimeForTest();
+    }
   });
 
   it("answers callback queries before same-chat sequentialize delays handlers", async () => {

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -3,6 +3,7 @@ import {
   clearPluginInteractiveHandlers,
   registerPluginInteractiveHandler,
 } from "openclaw/plugin-sdk/plugin-runtime";
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   closeOpenClawStateDatabaseForTest,
   createPluginStateKeyedStoreForTests,
@@ -52,6 +53,7 @@ import {
   TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE,
 } from "./message-cache-persistence.js";
 import { buildTelegramOpaqueCallbackData } from "./native-command-callback-data.js";
+import { recordTelegramPollRegistryEntry } from "./poll-registry.js";
 import { setTelegramRuntime } from "./runtime.js";
 import { clearTelegramRuntimeForTest as clearTelegramRuntime } from "./runtime.test-support.js";
 import type { TelegramRuntime } from "./runtime.types.js";
@@ -128,7 +130,6 @@ const THUMBS_UP_EMOJI = "\u{1F44D}";
 const FIRE_EMOJI = "\u{1F525}";
 const PARTY_EMOJI = "\u{1F389}";
 const HEART_EMOJI = "\u{2764}\u{FE0F}";
-
 type TelegramChannelConfig = NonNullable<NonNullable<OpenClawConfig["channels"]>["telegram"]>;
 
 function mockTelegramConfig(
@@ -170,6 +171,13 @@ type TelegramReactionPolicyCase = {
   expectedEnqueueCalls: number;
   expectedEvent?: string;
 };
+const TELEGRAM_POLL_REGISTRY_NAMESPACE = "telegram.poll-registry";
+const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 100;
+
+type TelegramPollRegistryEntry = Omit<
+  Parameters<typeof recordTelegramPollRegistryEntry>[0],
+  "accountId" | "env"
+> & { createdAt: number };
 
 async function withTelegramSpooledReplayUpdate<T>(
   update: object,
@@ -285,6 +293,36 @@ let telegramTestStoreSequence = 0;
 function createTelegramTestStorePath(label: string): string {
   telegramTestStoreSequence += 1;
   return telegramTestState.path(`${label}-${telegramTestStoreSequence}.json`);
+}
+
+async function installTelegramPollRegistryForTests(
+  entry?: Omit<TelegramPollRegistryEntry, "createdAt">,
+) {
+  setTelegramPluginStateRuntimeForTests();
+  const store = createPluginStateKeyedStoreForTests<TelegramPollRegistryEntry>("telegram", {
+    namespace: TELEGRAM_POLL_REGISTRY_NAMESPACE,
+    maxEntries: TELEGRAM_POLL_REGISTRY_MAX_ENTRIES,
+  });
+  await store.clear();
+  if (entry) {
+    await recordTelegramPollRegistryEntry(entry);
+  }
+  return store;
+}
+
+function setTelegramPollRegistryRuntimeForTests(
+  store: PluginStateKeyedStore<TelegramPollRegistryEntry>,
+): void {
+  setTelegramRuntime({
+    state: {
+      openKeyedStore: (() => store) as TelegramRuntime["state"]["openKeyedStore"],
+    },
+    channel: {},
+  } as TelegramRuntime);
+}
+
+function getTelegramPollAnswerHandlerForTests() {
+  return getOnHandler("poll_answer") as (ctx: Record<string, unknown>) => Promise<void>;
 }
 
 async function loadEnvelopeTimestampHelpers() {
@@ -752,6 +790,201 @@ describe("createTelegramBot", () => {
     createTelegramBot({ token: "tok" });
 
     expect(getOnHandler("message")).toEqual(expect.any(Function));
+  });
+
+  it("routes poll answers through the originating configured topic agent", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    getChatSpy.mockResolvedValue({ id: -1001234567890, type: "supergroup", is_forum: true });
+    await installTelegramPollRegistryForTests({
+      pollId: "poll-topic-agent",
+      chatId: "-1001234567890",
+      messageThreadId: 99,
+      question: "Escalate?",
+      options: ["Yes", "No"],
+    });
+
+    try {
+      loadConfig.mockReturnValue({
+        channels: {
+          telegram: {
+            groupPolicy: "open",
+            groups: {
+              "-1001234567890": {
+                requireMention: false,
+                topics: { "99": { agentId: "forum-agent", requireMention: false } },
+              },
+            },
+          },
+        },
+      });
+      createTelegramBot({ token: "tok" });
+
+      await getTelegramPollAnswerHandlerForTests()({
+        pollAnswer: {
+          poll_id: "poll-topic-agent",
+          option_ids: [0],
+          user: { id: 9, first_name: "Ada", username: "ada" },
+        },
+      });
+
+      expect(enqueueSystemEventSpy).toHaveBeenCalledWith(
+        'Telegram poll vote: "Escalate?" — Ada (@ada) voted: Yes',
+        expect.objectContaining({
+          contextKey: "telegram:poll_answer:poll-topic-agent:9:0",
+          sessionKey: expect.stringContaining(
+            "agent:forum-agent:telegram:group:-1001234567890:topic:99",
+          ),
+        }),
+      );
+      expect(getChatSpy).toHaveBeenCalledWith(-1001234567890);
+    } finally {
+      clearTelegramRuntime();
+      resetPluginStateStoreForTests();
+    }
+  });
+
+  it("blocks direct poll answers when requireTopic has no persisted topic", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    getChatSpy.mockClear();
+    await installTelegramPollRegistryForTests({
+      pollId: "poll-dm-topic",
+      chatId: "9876",
+      question: "Ready?",
+      options: ["Yes", "No"],
+    });
+
+    try {
+      loadConfig.mockReturnValue({
+        channels: {
+          telegram: {
+            dmPolicy: "allowlist",
+            allowFrom: ["9876"],
+            direct: { "9876": { requireTopic: true } },
+          },
+        },
+      });
+      createTelegramBot({ token: "tok" });
+
+      await getTelegramPollAnswerHandlerForTests()({
+        pollAnswer: {
+          poll_id: "poll-dm-topic",
+          option_ids: [0],
+          user: { id: 9876, first_name: "Ada", username: "ada" },
+        },
+      });
+
+      expect(getChatSpy).not.toHaveBeenCalled();
+      expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+    } finally {
+      clearTelegramRuntime();
+      resetPluginStateStoreForTests();
+    }
+  });
+
+  it("ignores unknown poll ids without enqueueing", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    await installTelegramPollRegistryForTests();
+
+    try {
+      createTelegramBot({ token: "tok" });
+      await getTelegramPollAnswerHandlerForTests()({
+        pollAnswer: {
+          poll_id: "missing-poll",
+          option_ids: [0],
+          user: { id: 9, first_name: "Ada" },
+        },
+      });
+      expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+    } finally {
+      clearTelegramRuntime();
+      resetPluginStateStoreForTests();
+    }
+  });
+
+  it.each([
+    {
+      name: "bot voter",
+      pollAnswer: {
+        poll_id: "poll-skip",
+        option_ids: [0],
+        user: { id: 9, first_name: "Bot", is_bot: true },
+      },
+    },
+    {
+      name: "vote retraction",
+      pollAnswer: {
+        poll_id: "poll-skip",
+        option_ids: [],
+        user: { id: 9, first_name: "Ada" },
+      },
+    },
+    {
+      name: "voter chat without a user identity",
+      pollAnswer: {
+        poll_id: "poll-skip",
+        option_ids: [0],
+        voter_chat: { id: -100123, type: "supergroup", title: "Reviewers" },
+      },
+    },
+  ])("drops $name before registry I/O", async ({ pollAnswer }) => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    const lookup = vi.fn(async () => {
+      throw new Error("registry should not be read");
+    });
+    setTelegramPollRegistryRuntimeForTests({
+      lookup,
+    } as unknown as PluginStateKeyedStore<TelegramPollRegistryEntry>);
+
+    try {
+      createTelegramBot({ token: "tok" });
+      await getTelegramPollAnswerHandlerForTests()({ pollAnswer });
+      expect(lookup).not.toHaveBeenCalled();
+      expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+    } finally {
+      clearTelegramRuntime();
+      resetPluginStateStoreForTests();
+    }
+  });
+
+  it("marks spooled registry read failures retryable", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    const readError = new Error("registry db unavailable");
+    setTelegramPollRegistryRuntimeForTests({
+      lookup: async () => {
+        throw readError;
+      },
+    } as unknown as PluginStateKeyedStore<TelegramPollRegistryEntry>);
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const update = {
+        update_id: 98082,
+        poll_answer: {
+          poll_id: "poll-read-error",
+          option_ids: [0],
+          user: { id: 9, first_name: "Ada" },
+        },
+      };
+      const { result } = await runWithTelegramUpdateProcessingFrame(() =>
+        withTelegramSpooledReplayUpdate(update, () =>
+          getTelegramPollAnswerHandlerForTests()({
+            update,
+            pollAnswer: update.poll_answer,
+          }),
+        ),
+      );
+
+      expect(result).toEqual({ kind: "failed-retryable", error: readError });
+      expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+    } finally {
+      clearTelegramRuntime();
+      resetPluginStateStoreForTests();
+    }
   });
 
   it("dedupes outbound prompt-context sends with ambient group history", async () => {

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -172,7 +172,7 @@ type TelegramReactionPolicyCase = {
   expectedEvent?: string;
 };
 const TELEGRAM_POLL_REGISTRY_NAMESPACE = "telegram.poll-registry";
-const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 100;
+const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 10_000;
 
 type TelegramPollRegistryEntry = Omit<
   Parameters<typeof recordTelegramPollRegistryEntry>[0],
@@ -302,6 +302,7 @@ async function installTelegramPollRegistryForTests(
   const store = createPluginStateKeyedStoreForTests<TelegramPollRegistryEntry>("telegram", {
     namespace: TELEGRAM_POLL_REGISTRY_NAMESPACE,
     maxEntries: TELEGRAM_POLL_REGISTRY_MAX_ENTRIES,
+    overflowPolicy: "reject-new",
   });
   await store.clear();
   if (entry) {
@@ -323,6 +324,10 @@ function setTelegramPollRegistryRuntimeForTests(
 
 function getTelegramPollAnswerHandlerForTests() {
   return getOnHandler("poll_answer") as (ctx: Record<string, unknown>) => Promise<void>;
+}
+
+function getTelegramPollHandlerForTests() {
+  return getOnHandler("poll") as (ctx: Record<string, unknown>) => Promise<void>;
 }
 
 async function loadEnvelopeTimestampHelpers() {
@@ -792,13 +797,19 @@ describe("createTelegramBot", () => {
     expect(getOnHandler("message")).toEqual(expect.any(Function));
   });
 
-  it("routes poll answers through the originating configured topic agent", async () => {
+  it("routes poll answers through the recorded forum topic", async () => {
     onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
-    getChatSpy.mockResolvedValue({ id: -1001234567890, type: "supergroup", is_forum: true });
+    dispatchReplyWithBufferedBlockDispatcher.mockClear();
+    getChatSpy.mockResolvedValue({ status: "member" });
     await installTelegramPollRegistryForTests({
       pollId: "poll-topic-agent",
-      chatId: "-1001234567890",
+      chat: {
+        id: -1001234567890,
+        type: "supergroup",
+        title: "Reviewers",
+        is_forum: true,
+      },
+      messageId: 321,
       messageThreadId: 99,
       question: "Escalate?",
       options: ["Yes", "No"],
@@ -821,6 +832,9 @@ describe("createTelegramBot", () => {
       createTelegramBot({ token: "tok" });
 
       await getTelegramPollAnswerHandlerForTests()({
+        update: { update_id: 9001 },
+        me: { id: 999, username: "openclaw_bot" },
+        getFile: getEmptyTelegramFile,
         pollAnswer: {
           poll_id: "poll-topic-agent",
           option_ids: [0],
@@ -828,16 +842,90 @@ describe("createTelegramBot", () => {
         },
       });
 
-      expect(enqueueSystemEventSpy).toHaveBeenCalledWith(
-        'Telegram poll vote: "Escalate?" — Ada (@ada) voted: Yes',
-        expect.objectContaining({
-          contextKey: "telegram:poll_answer:poll-topic-agent:9:0",
-          sessionKey: expect.stringContaining(
-            "agent:forum-agent:telegram:group:-1001234567890:topic:99",
-          ),
-        }),
+      expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+      expect(dispatchReplyWithBufferedBlockDispatcher.mock.calls[0]?.[0].ctx.SessionKey).toContain(
+        "agent:forum-agent:telegram:group:-1001234567890:topic:99",
       );
-      expect(getChatSpy).toHaveBeenCalledWith(-1001234567890);
+      expect(dispatchReplyWithBufferedBlockDispatcher.mock.calls[0]?.[0].ctx.Body).toContain(
+        'Poll response to "Escalate?": Yes',
+      );
+      expect(getChatSpy).toHaveBeenCalledWith(-1001234567890, 9);
+    } finally {
+      clearTelegramRuntime();
+      resetPluginStateStoreForTests();
+    }
+  });
+
+  it("blocks forwarded group poll answers from allowlisted former members", async () => {
+    onSpy.mockClear();
+    dispatchReplyWithBufferedBlockDispatcher.mockClear();
+    getChatSpy.mockResolvedValueOnce({ status: "left" });
+    await installTelegramPollRegistryForTests({
+      pollId: "poll-forwarded-group",
+      chat: {
+        id: -1001234567890,
+        type: "supergroup",
+        title: "Reviewers",
+        is_forum: true,
+      },
+      messageId: 324,
+      messageThreadId: 99,
+      question: "Escalate?",
+      options: ["Yes", "No"],
+    });
+
+    try {
+      loadConfig.mockReturnValue({
+        channels: {
+          telegram: { groupPolicy: "allowlist", groupAllowFrom: ["10"] },
+        },
+      });
+      createTelegramBot({ token: "tok" });
+
+      await getTelegramPollAnswerHandlerForTests()({
+        update: { update_id: 9003 },
+        pollAnswer: {
+          poll_id: "poll-forwarded-group",
+          option_ids: [0],
+          user: { id: 10, first_name: "Mallory" },
+        },
+      });
+
+      expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+      expect(getChatSpy).toHaveBeenCalledWith(-1001234567890, 10);
+    } finally {
+      clearTelegramRuntime();
+      resetPluginStateStoreForTests();
+    }
+  });
+
+  it("blocks forwarded direct-message poll answers from another user", async () => {
+    onSpy.mockClear();
+    dispatchReplyWithBufferedBlockDispatcher.mockClear();
+    await installTelegramPollRegistryForTests({
+      pollId: "poll-forwarded-dm",
+      chat: { id: 9876, type: "private", first_name: "Ada" },
+      messageId: 325,
+      question: "Ready?",
+      options: ["Yes", "No"],
+    });
+
+    try {
+      loadConfig.mockReturnValue({
+        channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+      });
+      createTelegramBot({ token: "tok" });
+
+      await getTelegramPollAnswerHandlerForTests()({
+        update: { update_id: 9004 },
+        pollAnswer: {
+          poll_id: "poll-forwarded-dm",
+          option_ids: [0],
+          user: { id: 10, first_name: "Mallory" },
+        },
+      });
+
+      expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     } finally {
       clearTelegramRuntime();
       resetPluginStateStoreForTests();
@@ -846,11 +934,12 @@ describe("createTelegramBot", () => {
 
   it("blocks direct poll answers when requireTopic has no persisted topic", async () => {
     onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
+    dispatchReplyWithBufferedBlockDispatcher.mockClear();
     getChatSpy.mockClear();
     await installTelegramPollRegistryForTests({
       pollId: "poll-dm-topic",
-      chatId: "9876",
+      chat: { id: 9876, type: "private", first_name: "Ada" },
+      messageId: 322,
       question: "Ready?",
       options: ["Yes", "No"],
     });
@@ -876,16 +965,92 @@ describe("createTelegramBot", () => {
       });
 
       expect(getChatSpy).not.toHaveBeenCalled();
-      expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+      expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     } finally {
       clearTelegramRuntime();
       resetPluginStateStoreForTests();
     }
   });
 
-  it("ignores unknown poll ids without enqueueing", async () => {
+  it("routes poll answers to the recorded direct-message topic session", async () => {
     onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
+    dispatchReplyWithBufferedBlockDispatcher.mockClear();
+    await installTelegramPollRegistryForTests({
+      pollId: "poll-dm-topic",
+      chat: { id: 9876, type: "private", first_name: "Ada" },
+      messageId: 323,
+      messageThreadId: 42,
+      question: "Ready?",
+      options: ["Yes", "No"],
+    });
+
+    try {
+      createTelegramBot({ token: "tok" });
+
+      await getTelegramPollAnswerHandlerForTests()({
+        update: { update_id: 9002 },
+        me: { id: 999, username: "openclaw_bot", has_topics_enabled: true },
+        getFile: getEmptyTelegramFile,
+        pollAnswer: {
+          poll_id: "poll-dm-topic",
+          option_ids: [0],
+          user: { id: 9876, first_name: "Ada", username: "ada" },
+        },
+      });
+
+      expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+      expect(dispatchReplyWithBufferedBlockDispatcher.mock.calls[0]?.[0].ctx.SessionKey).toBe(
+        "agent:main:main:thread:9876:42",
+      );
+    } finally {
+      clearTelegramRuntime();
+      resetPluginStateStoreForTests();
+    }
+  });
+
+  it("preserves durable replay for synthetic poll-answer turns", async () => {
+    onSpy.mockClear();
+    dispatchReplyWithBufferedBlockDispatcher.mockClear();
+    await installTelegramPollRegistryForTests({
+      pollId: "poll-durable-replay",
+      chat: { id: 9876, type: "private", first_name: "Ada" },
+      messageId: 326,
+      question: "Ready?",
+      options: ["Yes", "No"],
+    });
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const update = {
+        update_id: 9005,
+        poll_answer: {
+          poll_id: "poll-durable-replay",
+          option_ids: [0],
+          user: { id: 9876, first_name: "Ada", username: "ada" },
+        },
+      };
+
+      const replay = await runWithTelegramSpooledReplayUpdate(update, async () => {
+        await getTelegramPollAnswerHandlerForTests()({
+          update,
+          me: { id: 999, username: "openclaw_bot" },
+          getFile: getEmptyTelegramFile,
+          pollAnswer: update.poll_answer,
+        });
+      });
+
+      expect(replay.deferredWork).toBeDefined();
+      await expect(replay.deferredWork?.task).resolves.toEqual({ kind: "completed" });
+      expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    } finally {
+      clearTelegramRuntime();
+      resetPluginStateStoreForTests();
+    }
+  });
+
+  it("ignores unknown poll ids without dispatching", async () => {
+    onSpy.mockClear();
+    dispatchReplyWithBufferedBlockDispatcher.mockClear();
     await installTelegramPollRegistryForTests();
 
     try {
@@ -897,7 +1062,39 @@ describe("createTelegramBot", () => {
           user: { id: 9, first_name: "Ada" },
         },
       });
-      expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+      expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    } finally {
+      clearTelegramRuntime();
+      resetPluginStateStoreForTests();
+    }
+  });
+
+  it("retires a closed poll route after the durable replay grace", async () => {
+    onSpy.mockClear();
+    const entry: Omit<TelegramPollRegistryEntry, "createdAt"> = {
+      pollId: "poll-closed",
+      chat: { id: 123, type: "private", first_name: "Ada" },
+      messageId: 44,
+      question: "Ready?",
+      options: ["Yes", "No"],
+    };
+    const register = vi.fn(async () => {});
+    setTelegramPollRegistryRuntimeForTests({
+      lookup: async () => entry,
+      register,
+    } as unknown as PluginStateKeyedStore<TelegramPollRegistryEntry>);
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const poll = { id: "poll-closed", is_closed: true };
+      await getTelegramPollHandlerForTests()({
+        update: { update_id: 9003, poll },
+        poll,
+      });
+
+      expect(register).toHaveBeenCalledWith("default:poll-closed", entry, {
+        ttlMs: 48 * 60 * 60 * 1_000,
+      });
     } finally {
       clearTelegramRuntime();
       resetPluginStateStoreForTests();
@@ -931,7 +1128,7 @@ describe("createTelegramBot", () => {
     },
   ])("drops $name before registry I/O", async ({ pollAnswer }) => {
     onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
+    dispatchReplyWithBufferedBlockDispatcher.mockClear();
     const lookup = vi.fn(async () => {
       throw new Error("registry should not be read");
     });
@@ -943,7 +1140,7 @@ describe("createTelegramBot", () => {
       createTelegramBot({ token: "tok" });
       await getTelegramPollAnswerHandlerForTests()({ pollAnswer });
       expect(lookup).not.toHaveBeenCalled();
-      expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+      expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     } finally {
       clearTelegramRuntime();
       resetPluginStateStoreForTests();
@@ -952,7 +1149,7 @@ describe("createTelegramBot", () => {
 
   it("marks spooled registry read failures retryable", async () => {
     onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
+    dispatchReplyWithBufferedBlockDispatcher.mockClear();
     const readError = new Error("registry db unavailable");
     setTelegramPollRegistryRuntimeForTests({
       lookup: async () => {
@@ -980,7 +1177,7 @@ describe("createTelegramBot", () => {
       );
 
       expect(result).toEqual({ kind: "failed-retryable", error: readError });
-      expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+      expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     } finally {
       clearTelegramRuntime();
       resetPluginStateStoreForTests();

--- a/extensions/telegram/src/channel-actions.test.ts
+++ b/extensions/telegram/src/channel-actions.test.ts
@@ -463,7 +463,7 @@ describe("telegramMessageActions", () => {
     expect(discovery?.actions).not.toContain("react");
   });
 
-  it("advertises poll duration as a positive integer in message tool schema", () => {
+  it("advertises poll duration and public vote routing in message tool schema", () => {
     const cfg = {
       channels: {
         telegram: {
@@ -479,6 +479,14 @@ describe("telegramMessageActions", () => {
     expect(schema?.properties.pollDurationSeconds).toMatchObject({
       type: "integer",
       minimum: 1,
+    });
+    expect(schema?.properties.pollAnonymous).toMatchObject({
+      type: "boolean",
+      description: expect.stringContaining("do not create agent turns"),
+    });
+    expect(schema?.properties.pollPublic).toMatchObject({
+      type: "boolean",
+      description: expect.stringContaining("route into the originating agent conversation"),
     });
   });
 

--- a/extensions/telegram/src/group-access.ts
+++ b/extensions/telegram/src/group-access.ts
@@ -117,6 +117,31 @@ export const resolveTelegramRuntimeGroupPolicy = (params: {
     defaultGroupPolicy: params.defaultGroupPolicy,
   });
 
+export const resolveTelegramEffectiveGroupPolicy = (params: {
+  cfg: OpenClawConfig;
+  telegramCfg: TelegramAccountConfig;
+  groupConfig?: TelegramGroupConfig;
+  topicConfig?: TelegramTopicConfig;
+  useTopicAndGroupOverrides: boolean;
+}) => {
+  const { groupPolicy: runtimeFallbackPolicy } = resolveTelegramRuntimeGroupPolicy({
+    providerConfigPresent: params.cfg.channels?.telegram !== undefined,
+    groupPolicy: params.telegramCfg.groupPolicy,
+    defaultGroupPolicy: params.cfg.channels?.defaults?.groupPolicy,
+  });
+  const fallbackPolicy =
+    firstDefined(params.telegramCfg.groupPolicy, params.cfg.channels?.defaults?.groupPolicy) ??
+    runtimeFallbackPolicy;
+  return params.useTopicAndGroupOverrides
+    ? (firstDefined(
+        params.topicConfig?.groupPolicy,
+        params.groupConfig?.groupPolicy,
+        params.telegramCfg.groupPolicy,
+        params.cfg.channels?.defaults?.groupPolicy,
+      ) ?? runtimeFallbackPolicy)
+    : fallbackPolicy;
+};
+
 export const evaluateTelegramGroupPolicyAccess = (params: {
   isGroup: boolean;
   chatId: string | number;
@@ -135,22 +160,7 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
   requireSenderForAllowlistAuthorization: boolean;
   checkChatAllowlist: boolean;
 }): TelegramGroupPolicyAccessResult => {
-  const { groupPolicy: runtimeFallbackPolicy } = resolveTelegramRuntimeGroupPolicy({
-    providerConfigPresent: params.cfg.channels?.telegram !== undefined,
-    groupPolicy: params.telegramCfg.groupPolicy,
-    defaultGroupPolicy: params.cfg.channels?.defaults?.groupPolicy,
-  });
-  const fallbackPolicy =
-    firstDefined(params.telegramCfg.groupPolicy, params.cfg.channels?.defaults?.groupPolicy) ??
-    runtimeFallbackPolicy;
-  const groupPolicy = params.useTopicAndGroupOverrides
-    ? (firstDefined(
-        params.topicConfig?.groupPolicy,
-        params.groupConfig?.groupPolicy,
-        params.telegramCfg.groupPolicy,
-        params.cfg.channels?.defaults?.groupPolicy,
-      ) ?? runtimeFallbackPolicy)
-    : fallbackPolicy;
+  const groupPolicy = resolveTelegramEffectiveGroupPolicy(params);
 
   if (!params.isGroup || !params.enforcePolicy) {
     return { allowed: true, groupPolicy };

--- a/extensions/telegram/src/message-tool-schema.ts
+++ b/extensions/telegram/src/message-tool-schema.ts
@@ -5,8 +5,18 @@ import { Type } from "typebox";
 export function createTelegramPollExtraToolSchemas() {
   return {
     pollDurationSeconds: optionalPositiveIntegerSchema(),
-    pollAnonymous: Type.Optional(Type.Boolean()),
-    pollPublic: Type.Optional(Type.Boolean()),
+    pollAnonymous: Type.Optional(
+      Type.Boolean({
+        description:
+          "Send a display-only anonymous poll. Anonymous votes do not create agent turns. This is the default unless pollPublic is true.",
+      }),
+    ),
+    pollPublic: Type.Optional(
+      Type.Boolean({
+        description:
+          "Send a public poll whose votes route into the originating agent conversation. Voter identities are visible.",
+      }),
+    ),
   };
 }
 

--- a/extensions/telegram/src/poll-answer-context.ts
+++ b/extensions/telegram/src/poll-answer-context.ts
@@ -1,0 +1,119 @@
+// Telegram public-poll answer context prepared before sequentialization.
+import {
+  findTelegramPollRegistryEntrySync,
+  telegramPollRegistryKey,
+  type TelegramPollRegistryEntry,
+} from "./poll-registry.js";
+
+type EligibleTelegramPollAnswerUpdate = object & {
+  poll_answer: {
+    poll_id: string;
+    option_ids: number[];
+    user: { is_bot?: boolean };
+  };
+};
+
+export type PreparedTelegramPollAnswer = {
+  entry: TelegramPollRegistryEntry | null;
+  registrationPending?: true;
+};
+
+const preparedPollAnswers = new WeakMap<object, PreparedTelegramPollAnswer>();
+const pendingPollRegistrations = new Map<
+  string,
+  {
+    entry: TelegramPollRegistryEntry;
+    completion: Promise<TelegramPollRegistryEntry | null>;
+  }
+>();
+
+export function beginTelegramPollRegistration(params: {
+  accountId?: string;
+  entry: TelegramPollRegistryEntry;
+}): {
+  complete: (entry: TelegramPollRegistryEntry | null) => void;
+} {
+  const key = telegramPollRegistryKey(params.accountId, params.entry.pollId);
+  let completeRegistration: (entry: TelegramPollRegistryEntry | null) => void = () => {};
+  const completion = new Promise<TelegramPollRegistryEntry | null>((resolve) => {
+    completeRegistration = resolve;
+  });
+  const registration = { entry: params.entry, completion };
+  pendingPollRegistrations.set(key, registration);
+  return {
+    complete: (entry) => {
+      completeRegistration(entry);
+      if (pendingPollRegistrations.get(key) === registration) {
+        pendingPollRegistrations.delete(key);
+      }
+    },
+  };
+}
+
+export function prepareTelegramPollAnswerContext(params: {
+  update: object;
+  accountId?: string;
+}): void {
+  if (!isEligibleTelegramPollAnswerUpdate(params.update)) {
+    return;
+  }
+  if (preparedPollAnswers.has(params.update)) {
+    return;
+  }
+  const pollId = params.update.poll_answer.poll_id;
+  const pending = pendingPollRegistrations.get(telegramPollRegistryKey(params.accountId, pollId));
+  const prepared: PreparedTelegramPollAnswer = pending
+    ? { entry: pending.entry, registrationPending: true }
+    : {
+        entry: findTelegramPollRegistryEntrySync({
+          pollId,
+          accountId: params.accountId,
+        }),
+      };
+  preparedPollAnswers.set(params.update, prepared);
+}
+
+export async function settleTelegramPollAnswerContext(params: {
+  update: object;
+  accountId?: string;
+}): Promise<void> {
+  const prepared = preparedPollAnswers.get(params.update);
+  if (!prepared?.registrationPending || !isEligibleTelegramPollAnswerUpdate(params.update)) {
+    return;
+  }
+  const pollId = params.update.poll_answer.poll_id;
+  const pending = pendingPollRegistrations.get(telegramPollRegistryKey(params.accountId, pollId));
+  const entry = pending
+    ? await pending.completion
+    : findTelegramPollRegistryEntrySync({ pollId, accountId: params.accountId });
+  preparedPollAnswers.set(params.update, { entry });
+}
+
+export function getPreparedTelegramPollAnswer(
+  update: object,
+): PreparedTelegramPollAnswer | undefined {
+  return preparedPollAnswers.get(update);
+}
+
+export function isEligibleTelegramPollAnswerUpdate(
+  update: unknown,
+): update is EligibleTelegramPollAnswerUpdate {
+  if (!update || typeof update !== "object") {
+    return false;
+  }
+  const pollAnswer = (update as { poll_answer?: EligibleTelegramPollAnswerUpdate["poll_answer"] })
+    .poll_answer;
+  return Boolean(
+    pollAnswer?.poll_id &&
+    pollAnswer.user &&
+    !pollAnswer.user.is_bot &&
+    pollAnswer.option_ids?.length,
+  );
+}
+
+export function recordPreparedTelegramPollAnswer(
+  update: object,
+  prepared: PreparedTelegramPollAnswer,
+): void {
+  preparedPollAnswers.set(update, prepared);
+}

--- a/extensions/telegram/src/poll-registry.test.ts
+++ b/extensions/telegram/src/poll-registry.test.ts
@@ -1,0 +1,127 @@
+// Telegram tests cover poll registry plugin behavior.
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { findTelegramPollRegistryEntry, recordTelegramPollRegistryEntry } from "./poll-registry.js";
+import { setTelegramRuntime } from "./runtime.js";
+import { clearTelegramRuntimeForTest } from "./runtime.test-support.js";
+import type { TelegramRuntime } from "./runtime.types.js";
+
+const TELEGRAM_POLL_REGISTRY_NAMESPACE = "telegram.poll-registry";
+const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 100;
+
+type TelegramPollRegistryEntry = {
+  pollId: string;
+  chatId: string;
+  messageThreadId?: number;
+  question: string;
+  options: string[];
+  createdAt: number;
+};
+
+function installTelegramStateRuntime(
+  openKeyedStore: TelegramRuntime["state"]["openKeyedStore"],
+): void {
+  setTelegramRuntime({
+    state: { openKeyedStore },
+    channel: {},
+  } as TelegramRuntime);
+}
+
+describe("telegram poll registry", () => {
+  let store: PluginStateKeyedStore<TelegramPollRegistryEntry>;
+
+  beforeEach(async () => {
+    store = createPluginStateKeyedStoreForTests<TelegramPollRegistryEntry>("telegram", {
+      namespace: TELEGRAM_POLL_REGISTRY_NAMESPACE,
+      maxEntries: TELEGRAM_POLL_REGISTRY_MAX_ENTRIES,
+    });
+    await store.clear();
+    installTelegramStateRuntime(((options) =>
+      createPluginStateKeyedStoreForTests(
+        "telegram",
+        options,
+      )) as TelegramRuntime["state"]["openKeyedStore"]);
+  });
+
+  afterEach(() => {
+    clearTelegramRuntimeForTest();
+    resetPluginStateStoreForTests();
+  });
+
+  it("stores and retrieves poll registry entries", async () => {
+    await recordTelegramPollRegistryEntry({
+      pollId: "poll-1",
+      chatId: "-100123",
+      messageThreadId: 77,
+      question: "Ready?",
+      options: ["Yes", "No"],
+    });
+
+    await expect(findTelegramPollRegistryEntry({ pollId: "poll-1" })).resolves.toEqual(
+      expect.objectContaining({
+        pollId: "poll-1",
+        chatId: "-100123",
+        messageThreadId: 77,
+        question: "Ready?",
+        options: ["Yes", "No"],
+      }),
+    );
+  });
+
+  it("returns null for an unknown poll id", async () => {
+    await expect(findTelegramPollRegistryEntry({ pollId: "missing" })).resolves.toBeNull();
+  });
+
+  it("rejects a malformed stored chat id", async () => {
+    installTelegramStateRuntime((() => ({
+      lookup: async () => ({
+        pollId: "poll-invalid-chat",
+        chatId: "not-a-chat",
+        question: "Ready?",
+        options: ["Yes", "No"],
+        createdAt: Date.now(),
+      }),
+    })) as unknown as TelegramRuntime["state"]["openKeyedStore"]);
+
+    await expect(
+      findTelegramPollRegistryEntry({ pollId: "poll-invalid-chat" }),
+    ).resolves.toBeNull();
+  });
+
+  it("propagates store lookup failures so durable ingress can retry", async () => {
+    const readError = new Error("registry db unavailable");
+    const failingStore = {
+      lookup: async () => {
+        throw readError;
+      },
+    } as unknown as PluginStateKeyedStore<TelegramPollRegistryEntry>;
+    installTelegramStateRuntime((() => failingStore) as TelegramRuntime["state"]["openKeyedStore"]);
+
+    await expect(findTelegramPollRegistryEntry({ pollId: "poll-read-error" })).rejects.toBe(
+      readError,
+    );
+  });
+
+  it("caps the registry at the configured maximum entries", async () => {
+    for (let index = 0; index < TELEGRAM_POLL_REGISTRY_MAX_ENTRIES + 1; index += 1) {
+      await recordTelegramPollRegistryEntry({
+        pollId: `poll-${index}`,
+        chatId: "123",
+        question: `Question ${index}`,
+        options: ["A", "B"],
+      });
+    }
+
+    const entries = await store.entries();
+    expect(entries.length).toBeLessThanOrEqual(TELEGRAM_POLL_REGISTRY_MAX_ENTRIES);
+    // Newest entry is retained; the oldest entry is evicted by the bounded keyed store.
+    await expect(
+      findTelegramPollRegistryEntry({ pollId: `poll-${TELEGRAM_POLL_REGISTRY_MAX_ENTRIES}` }),
+    ).resolves.not.toBeNull();
+    await expect(findTelegramPollRegistryEntry({ pollId: "poll-0" })).resolves.toBeNull();
+  });
+});

--- a/extensions/telegram/src/poll-registry.test.ts
+++ b/extensions/telegram/src/poll-registry.test.ts
@@ -4,22 +4,26 @@ import {
   createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { findTelegramPollRegistryEntry, recordTelegramPollRegistryEntry } from "./poll-registry.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  findTelegramPollRegistryEntry,
+  recordTelegramPollRegistryEntry,
+  retireTelegramPollRegistryEntry,
+} from "./poll-registry.js";
 import { setTelegramRuntime } from "./runtime.js";
 import { clearTelegramRuntimeForTest } from "./runtime.test-support.js";
 import type { TelegramRuntime } from "./runtime.types.js";
 
 const TELEGRAM_POLL_REGISTRY_NAMESPACE = "telegram.poll-registry";
-const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 100;
+const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 10_000;
 
 type TelegramPollRegistryEntry = {
   pollId: string;
-  chatId: string;
+  chat: { id: number; type: "private"; first_name: string };
+  messageId: number;
   messageThreadId?: number;
   question: string;
   options: string[];
-  createdAt: number;
 };
 
 function installTelegramStateRuntime(
@@ -32,12 +36,11 @@ function installTelegramStateRuntime(
 }
 
 describe("telegram poll registry", () => {
-  let store: PluginStateKeyedStore<TelegramPollRegistryEntry>;
-
   beforeEach(async () => {
-    store = createPluginStateKeyedStoreForTests<TelegramPollRegistryEntry>("telegram", {
+    const store = createPluginStateKeyedStoreForTests<TelegramPollRegistryEntry>("telegram", {
       namespace: TELEGRAM_POLL_REGISTRY_NAMESPACE,
       maxEntries: TELEGRAM_POLL_REGISTRY_MAX_ENTRIES,
+      overflowPolicy: "reject-new",
     });
     await store.clear();
     installTelegramStateRuntime(((options) =>
@@ -48,6 +51,7 @@ describe("telegram poll registry", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     clearTelegramRuntimeForTest();
     resetPluginStateStoreForTests();
   });
@@ -55,7 +59,8 @@ describe("telegram poll registry", () => {
   it("stores and retrieves poll registry entries", async () => {
     await recordTelegramPollRegistryEntry({
       pollId: "poll-1",
-      chatId: "-100123",
+      chat: { id: 123, type: "private", first_name: "Ada" },
+      messageId: 44,
       messageThreadId: 77,
       question: "Ready?",
       options: ["Yes", "No"],
@@ -64,7 +69,8 @@ describe("telegram poll registry", () => {
     await expect(findTelegramPollRegistryEntry({ pollId: "poll-1" })).resolves.toEqual(
       expect.objectContaining({
         pollId: "poll-1",
-        chatId: "-100123",
+        chat: { id: 123, type: "private", first_name: "Ada" },
+        messageId: 44,
         messageThreadId: 77,
         question: "Ready?",
         options: ["Yes", "No"],
@@ -76,14 +82,36 @@ describe("telegram poll registry", () => {
     await expect(findTelegramPollRegistryEntry({ pollId: "missing" })).resolves.toBeNull();
   });
 
-  it("rejects a malformed stored chat id", async () => {
+  it("reclaims a closed poll after the durable replay grace", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-05T00:00:00.000Z"));
+    await recordTelegramPollRegistryEntry({
+      pollId: "poll-closed",
+      chat: { id: 123, type: "private", first_name: "Ada" },
+      messageId: 44,
+      question: "Ready?",
+      options: ["Yes", "No"],
+    });
+
+    await retireTelegramPollRegistryEntry({ pollId: "poll-closed" });
+    vi.setSystemTime(new Date("2026-08-06T23:59:59.999Z"));
+    await expect(findTelegramPollRegistryEntry({ pollId: "poll-closed" })).resolves.not.toBeNull();
+    vi.setSystemTime(new Date("2026-08-07T00:00:00.001Z"));
+    await expect(findTelegramPollRegistryEntry({ pollId: "poll-closed" })).resolves.toBeNull();
+  });
+
+  it("leaves unknown closed polls alone", async () => {
+    await expect(retireTelegramPollRegistryEntry({ pollId: "missing" })).resolves.toBeUndefined();
+  });
+
+  it("rejects malformed stored origin data", async () => {
     installTelegramStateRuntime((() => ({
       lookup: async () => ({
         pollId: "poll-invalid-chat",
-        chatId: "not-a-chat",
+        chat: { id: "not-a-chat", type: "private", first_name: "Ada" },
+        messageId: 44,
         question: "Ready?",
         options: ["Yes", "No"],
-        createdAt: Date.now(),
       }),
     })) as unknown as TelegramRuntime["state"]["openKeyedStore"]);
 
@@ -104,24 +132,5 @@ describe("telegram poll registry", () => {
     await expect(findTelegramPollRegistryEntry({ pollId: "poll-read-error" })).rejects.toBe(
       readError,
     );
-  });
-
-  it("caps the registry at the configured maximum entries", async () => {
-    for (let index = 0; index < TELEGRAM_POLL_REGISTRY_MAX_ENTRIES + 1; index += 1) {
-      await recordTelegramPollRegistryEntry({
-        pollId: `poll-${index}`,
-        chatId: "123",
-        question: `Question ${index}`,
-        options: ["A", "B"],
-      });
-    }
-
-    const entries = await store.entries();
-    expect(entries.length).toBeLessThanOrEqual(TELEGRAM_POLL_REGISTRY_MAX_ENTRIES);
-    // Newest entry is retained; the oldest entry is evicted by the bounded keyed store.
-    await expect(
-      findTelegramPollRegistryEntry({ pollId: `poll-${TELEGRAM_POLL_REGISTRY_MAX_ENTRIES}` }),
-    ).resolves.not.toBeNull();
-    await expect(findTelegramPollRegistryEntry({ pollId: "poll-0" })).resolves.toBeNull();
   });
 });

--- a/extensions/telegram/src/poll-registry.ts
+++ b/extensions/telegram/src/poll-registry.ts
@@ -1,0 +1,117 @@
+// Telegram plugin module implements public-poll vote routing registry behavior.
+//
+// Telegram only emits `poll_answer` updates for non-anonymous (public) polls, and those
+// updates do not carry the originating chat/thread. We persist a small pollId -> origin
+// map when a public poll is sent so an inbound vote can be routed back into the right
+// session. Storage goes through the shared plugin runtime keyed-state store, the same
+// pattern as the other Telegram caches (update-offset, topic-name, bot-info). The cap is
+// intentionally small; if a very old poll falls out, the later vote is ignored safely.
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
+import { getTelegramRuntime } from "./runtime.js";
+
+const TELEGRAM_POLL_REGISTRY_NAMESPACE = "telegram.poll-registry";
+const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 100;
+
+type TelegramPollRegistryEntry = {
+  pollId: string;
+  chatId: string;
+  messageThreadId?: number;
+  question: string;
+  options: string[];
+  createdAt: number;
+};
+
+type TelegramPollRegistryStore = PluginStateKeyedStore<TelegramPollRegistryEntry>;
+
+function openPollRegistryStore(env?: NodeJS.ProcessEnv): TelegramPollRegistryStore {
+  return getTelegramRuntime().state.openKeyedStore<TelegramPollRegistryEntry>({
+    namespace: TELEGRAM_POLL_REGISTRY_NAMESPACE,
+    maxEntries: TELEGRAM_POLL_REGISTRY_MAX_ENTRIES,
+    ...(env ? { env } : {}),
+  });
+}
+
+// Public poll ids are globally unique, but keying by account keeps registries isolated
+// per bot account and mirrors the other Telegram keyed stores.
+function pollRegistryKey(accountId: string | undefined, pollId: string): string {
+  return `${normalizeAccountId(accountId)}:${pollId}`;
+}
+
+function normalizePollRegistryEntry(raw: unknown): TelegramPollRegistryEntry | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const entry = raw as {
+    pollId?: unknown;
+    chatId?: unknown;
+    messageThreadId?: unknown;
+    question?: unknown;
+    options?: unknown;
+    createdAt?: unknown;
+  };
+  const numericChatId = typeof entry.chatId === "string" ? Number(entry.chatId) : Number.NaN;
+  if (
+    typeof entry.pollId !== "string" ||
+    typeof entry.chatId !== "string" ||
+    !Number.isSafeInteger(numericChatId) ||
+    typeof entry.question !== "string" ||
+    !Array.isArray(entry.options) ||
+    !entry.options.every((option) => typeof option === "string") ||
+    typeof entry.createdAt !== "number" ||
+    !Number.isFinite(entry.createdAt) ||
+    (entry.messageThreadId != null &&
+      (typeof entry.messageThreadId !== "number" || !Number.isFinite(entry.messageThreadId)))
+  ) {
+    return null;
+  }
+  return {
+    pollId: entry.pollId,
+    chatId: entry.chatId,
+    messageThreadId:
+      typeof entry.messageThreadId === "number" ? Math.floor(entry.messageThreadId) : undefined,
+    question: entry.question,
+    options: entry.options,
+    createdAt: Math.floor(entry.createdAt),
+  };
+}
+
+export async function recordTelegramPollRegistryEntry(params: {
+  accountId?: string;
+  pollId: string;
+  chatId: string;
+  messageThreadId?: number;
+  question: string;
+  options: string[];
+  env?: NodeJS.ProcessEnv;
+}): Promise<void> {
+  // The keyed store persists JSON and rejects explicit `undefined`, so only include the
+  // optional thread id when it is actually present.
+  const entry: TelegramPollRegistryEntry = {
+    pollId: params.pollId,
+    chatId: params.chatId,
+    question: params.question,
+    options: [...params.options],
+    createdAt: Date.now(),
+    ...(typeof params.messageThreadId === "number"
+      ? { messageThreadId: Math.floor(params.messageThreadId) }
+      : {}),
+  };
+  await openPollRegistryStore(params.env).register(
+    pollRegistryKey(params.accountId, params.pollId),
+    entry,
+  );
+}
+
+export async function findTelegramPollRegistryEntry(params: {
+  accountId?: string;
+  pollId: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<TelegramPollRegistryEntry | null> {
+  // Missing entries resolve to `undefined`; real store failures must propagate so
+  // durable Telegram ingress can release the claim and retry the poll_answer.
+  const stored = await openPollRegistryStore(params.env).lookup(
+    pollRegistryKey(params.accountId, params.pollId),
+  );
+  return normalizePollRegistryEntry(stored);
+}

--- a/extensions/telegram/src/poll-registry.ts
+++ b/extensions/telegram/src/poll-registry.ts
@@ -1,25 +1,31 @@
 // Telegram plugin module implements public-poll vote routing registry behavior.
 //
 // Telegram only emits `poll_answer` updates for non-anonymous (public) polls, and those
-// updates do not carry the originating chat/thread. We persist a small pollId -> origin
-// map when a public poll is sent so an inbound vote can be routed back into the right
-// session. Storage goes through the shared plugin runtime keyed-state store, the same
-// pattern as the other Telegram caches (update-offset, topic-name, bot-info). The cap is
-// intentionally small; if a very old poll falls out, the later vote is ignored safely.
-import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+// updates do not carry the originating chat/thread. Persist the authoritative route
+// returned by sendPoll so a later vote can enter the normal inbound turn pipeline.
+import type { Chat } from "grammy/types";
+import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
+import type {
+  PluginStateKeyedStore,
+  PluginStateSyncKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getTelegramRuntime } from "./runtime.js";
 
 const TELEGRAM_POLL_REGISTRY_NAMESPACE = "telegram.poll-registry";
-const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 100;
+const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 10_000;
+const TELEGRAM_CLOSED_POLL_RETENTION_MS = 48 * 60 * 60 * 1_000;
 
-type TelegramPollRegistryEntry = {
+type TelegramPollRouteChat = Exclude<Chat, { type: "channel" }>;
+
+export type TelegramPollRegistryEntry = {
   pollId: string;
-  chatId: string;
+  chat: TelegramPollRouteChat;
+  messageId: number;
   messageThreadId?: number;
   question: string;
   options: string[];
-  createdAt: number;
 };
 
 type TelegramPollRegistryStore = PluginStateKeyedStore<TelegramPollRegistryEntry>;
@@ -28,79 +34,119 @@ function openPollRegistryStore(env?: NodeJS.ProcessEnv): TelegramPollRegistrySto
   return getTelegramRuntime().state.openKeyedStore<TelegramPollRegistryEntry>({
     namespace: TELEGRAM_POLL_REGISTRY_NAMESPACE,
     maxEntries: TELEGRAM_POLL_REGISTRY_MAX_ENTRIES,
+    overflowPolicy: "reject-new",
+    ...(env ? { env } : {}),
+  });
+}
+
+function openPollRegistrySyncStore(
+  env?: NodeJS.ProcessEnv,
+): PluginStateSyncKeyedStore<TelegramPollRegistryEntry> {
+  return getTelegramRuntime().state.openSyncKeyedStore<TelegramPollRegistryEntry>({
+    namespace: TELEGRAM_POLL_REGISTRY_NAMESPACE,
+    maxEntries: TELEGRAM_POLL_REGISTRY_MAX_ENTRIES,
+    overflowPolicy: "reject-new",
     ...(env ? { env } : {}),
   });
 }
 
 // Public poll ids are globally unique, but keying by account keeps registries isolated
 // per bot account and mirrors the other Telegram keyed stores.
-function pollRegistryKey(accountId: string | undefined, pollId: string): string {
+export function telegramPollRegistryKey(accountId: string | undefined, pollId: string): string {
   return `${normalizeAccountId(accountId)}:${pollId}`;
 }
 
-function normalizePollRegistryEntry(raw: unknown): TelegramPollRegistryEntry | null {
-  if (!raw || typeof raw !== "object") {
+function normalizePollChat(raw: unknown): TelegramPollRouteChat | null {
+  if (!isRecord(raw)) {
     return null;
   }
-  const entry = raw as {
-    pollId?: unknown;
-    chatId?: unknown;
-    messageThreadId?: unknown;
-    question?: unknown;
-    options?: unknown;
-    createdAt?: unknown;
-  };
-  const numericChatId = typeof entry.chatId === "string" ? Number(entry.chatId) : Number.NaN;
+  const id = parseStrictInteger(raw.id);
+  if (id === undefined) {
+    return null;
+  }
+  if (raw.type === "private" && typeof raw.first_name === "string") {
+    return { id, type: "private", first_name: raw.first_name };
+  }
+  if (raw.type === "group" && typeof raw.title === "string") {
+    return { id, type: "group", title: raw.title };
+  }
+  if (raw.type === "supergroup" && typeof raw.title === "string") {
+    return {
+      id,
+      type: "supergroup",
+      title: raw.title,
+      ...(raw.is_forum === true ? { is_forum: true } : {}),
+    };
+  }
+  return null;
+}
+
+function normalizePollRegistryEntry(raw: unknown): TelegramPollRegistryEntry | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const chat = normalizePollChat(raw.chat);
+  const messageId = parseStrictInteger(raw.messageId);
+  const messageThreadId = parseStrictInteger(raw.messageThreadId);
   if (
-    typeof entry.pollId !== "string" ||
-    typeof entry.chatId !== "string" ||
-    !Number.isSafeInteger(numericChatId) ||
-    typeof entry.question !== "string" ||
-    !Array.isArray(entry.options) ||
-    !entry.options.every((option) => typeof option === "string") ||
-    typeof entry.createdAt !== "number" ||
-    !Number.isFinite(entry.createdAt) ||
-    (entry.messageThreadId != null &&
-      (typeof entry.messageThreadId !== "number" || !Number.isFinite(entry.messageThreadId)))
+    typeof raw.pollId !== "string" ||
+    !chat ||
+    messageId === undefined ||
+    typeof raw.question !== "string" ||
+    !Array.isArray(raw.options) ||
+    !raw.options.every((option) => typeof option === "string") ||
+    (raw.messageThreadId != null && messageThreadId === undefined)
   ) {
     return null;
   }
   return {
-    pollId: entry.pollId,
-    chatId: entry.chatId,
-    messageThreadId:
-      typeof entry.messageThreadId === "number" ? Math.floor(entry.messageThreadId) : undefined,
-    question: entry.question,
-    options: entry.options,
-    createdAt: Math.floor(entry.createdAt),
+    pollId: raw.pollId,
+    chat,
+    messageId,
+    ...(messageThreadId === undefined ? {} : { messageThreadId }),
+    question: raw.question,
+    options: raw.options,
   };
 }
 
 export async function recordTelegramPollRegistryEntry(params: {
   accountId?: string;
   pollId: string;
-  chatId: string;
+  chat: TelegramPollRouteChat;
+  messageId: number;
   messageThreadId?: number;
   question: string;
   options: string[];
   env?: NodeJS.ProcessEnv;
-}): Promise<void> {
+}): Promise<TelegramPollRegistryEntry> {
+  const entry = createTelegramPollRegistryEntry(params);
+  await openPollRegistryStore(params.env).register(
+    telegramPollRegistryKey(params.accountId, params.pollId),
+    entry,
+  );
+  return entry;
+}
+
+export function createTelegramPollRegistryEntry(params: {
+  pollId: string;
+  chat: TelegramPollRouteChat;
+  messageId: number;
+  messageThreadId?: number;
+  question: string;
+  options: string[];
+}): TelegramPollRegistryEntry {
   // The keyed store persists JSON and rejects explicit `undefined`, so only include the
   // optional thread id when it is actually present.
-  const entry: TelegramPollRegistryEntry = {
+  return {
     pollId: params.pollId,
-    chatId: params.chatId,
+    chat: params.chat,
+    messageId: params.messageId,
     question: params.question,
     options: [...params.options],
-    createdAt: Date.now(),
     ...(typeof params.messageThreadId === "number"
       ? { messageThreadId: Math.floor(params.messageThreadId) }
       : {}),
   };
-  await openPollRegistryStore(params.env).register(
-    pollRegistryKey(params.accountId, params.pollId),
-    entry,
-  );
 }
 
 export async function findTelegramPollRegistryEntry(params: {
@@ -111,7 +157,34 @@ export async function findTelegramPollRegistryEntry(params: {
   // Missing entries resolve to `undefined`; real store failures must propagate so
   // durable Telegram ingress can release the claim and retry the poll_answer.
   const stored = await openPollRegistryStore(params.env).lookup(
-    pollRegistryKey(params.accountId, params.pollId),
+    telegramPollRegistryKey(params.accountId, params.pollId),
   );
   return normalizePollRegistryEntry(stored);
+}
+
+export function findTelegramPollRegistryEntrySync(params: {
+  accountId?: string;
+  pollId: string;
+  env?: NodeJS.ProcessEnv;
+}): TelegramPollRegistryEntry | null {
+  const stored = openPollRegistrySyncStore(params.env).lookup(
+    telegramPollRegistryKey(params.accountId, params.pollId),
+  );
+  return normalizePollRegistryEntry(stored);
+}
+
+export async function retireTelegramPollRegistryEntry(params: {
+  accountId?: string;
+  pollId: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<void> {
+  const store = openPollRegistryStore(params.env);
+  const key = telegramPollRegistryKey(params.accountId, params.pollId);
+  const entry = normalizePollRegistryEntry(await store.lookup(key));
+  if (!entry) {
+    return;
+  }
+  // Keep the route beyond Telegram's 24-hour update window so a durable replay
+  // that started before the close update can still deliver its vote.
+  await store.register(key, entry, { ttlMs: TELEGRAM_CLOSED_POLL_RETENTION_MS });
 }

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -120,7 +120,7 @@ let claimNextTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.test
 let listTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.test-support.js").listTelegramSpooledUpdateClaims;
 let listTelegramSpooledUpdates: typeof import("./telegram-ingress-spool.test-support.js").listTelegramSpooledUpdates;
 let recoverStaleTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.test-support.js").recoverStaleTelegramSpooledUpdateClaims;
-let writeTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.js").writeTelegramSpooledUpdate;
+let writeTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.test-support.js").writeTelegramSpooledUpdate;
 let createTelegramSpooledReplayDeferredParticipant: typeof import("./bot-processing-outcome.js").createTelegramSpooledReplayDeferredParticipant;
 type TelegramMessageProcessingResult =
   import("./bot-processing-outcome.js").TelegramMessageProcessingResult;
@@ -852,12 +852,12 @@ function startIsolatedIngressSession(params: {
 describe("TelegramPollingSession", () => {
   beforeAll(async () => {
     ({ TelegramPollingSession } = await import("./polling-session.js"));
-    ({ writeTelegramSpooledUpdate } = await import("./telegram-ingress-spool.js"));
     ({
       claimNextTelegramSpooledUpdate,
       listTelegramSpooledUpdateClaims,
       listTelegramSpooledUpdates,
       recoverStaleTelegramSpooledUpdateClaims,
+      writeTelegramSpooledUpdate,
     } = await import("./telegram-ingress-spool.test-support.js"));
     ({ createTelegramSpooledReplayDeferredParticipant } =
       await import("./bot-processing-outcome.js"));
@@ -1730,6 +1730,9 @@ describe("TelegramPollingSession", () => {
           update: { update_id: 2, message: { text: "during-drain" } },
           queued: 1,
         });
+        expect(worker.ackSpooledUpdate).not.toHaveBeenCalledWith("write-2", expect.anything());
+        releaseFirstClaim?.();
+        releaseFirstClaim = undefined;
         await waitForTelegramTestState(() =>
           expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("write-2", {
             ok: true,
@@ -1737,8 +1740,6 @@ describe("TelegramPollingSession", () => {
           }),
         );
         worker.emit({ type: "spooled", updateId: 2, queued: 1 });
-        releaseFirstClaim?.();
-        releaseFirstClaim = undefined;
 
         await waitForTelegramTestState(() =>
           expect(handleUpdate).toHaveBeenCalledWith({

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -27,8 +27,6 @@ import { resolveTelegramAdoptionStallTimeoutMs } from "./telegram-ingress-drain.
 import {
   resolveTelegramIngressSpoolDir,
   resolveTelegramUpdateId,
-  telegramSpooledUpdateLaneKey,
-  writeTelegramSpooledUpdate,
 } from "./telegram-ingress-spool.js";
 import {
   createTelegramIngressWorker,
@@ -533,13 +531,16 @@ export class TelegramPollingSession {
         // The committed spool enqueue is the ACK boundary; offset persistence is
         // monotonic catch-up and must not stall intake during a state-store outage.
         void (async () => {
-          let updateId: number;
-          try {
-            updateId = await writeTelegramSpooledUpdate({
-              spoolDir,
-              update: message.update,
-              laneKey: telegramSpooledUpdateLaneKey(message.update, botInfo),
+          const updateId = resolveTelegramUpdateId(message.update);
+          if (updateId === null) {
+            ackSpooledUpdate(message.requestId, {
+              ok: false,
+              message: "Telegram update missing numeric update_id.",
             });
+            return;
+          }
+          try {
+            await ingressMonitor.admit(message.update);
             this.opts.log(`[telegram][diag] isolated polling update spooled updateId=${updateId}`);
           } catch (err: unknown) {
             this.opts.log(
@@ -562,7 +563,6 @@ export class TelegramPollingSession {
           });
           this.opts.log(`[telegram][diag] isolated polling offset queued updateId=${updateId}`);
           ackSpooledUpdate(message.requestId, { ok: true, updateId });
-          requestImmediateDrain();
         })();
         return;
       }

--- a/extensions/telegram/src/send-special.ts
+++ b/extensions/telegram/src/send-special.ts
@@ -1,3 +1,5 @@
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { recordTelegramPollRegistryEntry } from "./poll-registry.js";
 import {
   resolveTelegramApiContext,
   withTelegramApiContextLease,
@@ -131,14 +133,36 @@ async function sendPollTelegramWithContext(
       api.sendPoll(prepared.chatId, normalizedPoll.question, normalizedPoll.options, pollParams),
     "poll",
   );
+  const finalized = await finalizeTelegramOutbound({
+    context,
+    prepared,
+    result,
+    resultContext: "poll send",
+  });
   const pollId = result?.poll?.id;
+  // Public poll answers omit chat/thread routing metadata. Record the origin at
+  // the central send boundary so every caller gets the same inbound route.
+  // This is best-effort because the poll already exists and retrying could duplicate it.
+  if (pollId && opts.isAnonymous === false) {
+    try {
+      await recordTelegramPollRegistryEntry({
+        accountId: context.account.accountId,
+        pollId,
+        chatId: finalized.chatId,
+        messageThreadId: prepared.threadParams.message_thread_id,
+        question: normalizedPoll.question,
+        options: normalizedPoll.options,
+      });
+    } catch (err) {
+      logVerbose(
+        `telegram: failed to record poll registry entry for poll ${pollId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
   return {
-    ...(await finalizeTelegramOutbound({
-      context,
-      prepared,
-      result,
-      resultContext: "poll send",
-    })),
+    ...finalized,
     pollId,
   };
 }

--- a/extensions/telegram/src/send-special.ts
+++ b/extensions/telegram/src/send-special.ts
@@ -1,5 +1,11 @@
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { recordTelegramPollRegistryEntry } from "./poll-registry.js";
+import { resolveTelegramEffectiveGroupPolicy } from "./group-access.js";
+import { resolveTelegramScopedGroupConfig } from "./group-config-helpers.js";
+import { beginTelegramPollRegistration } from "./poll-answer-context.js";
+import {
+  createTelegramPollRegistryEntry,
+  recordTelegramPollRegistryEntry,
+} from "./poll-registry.js";
 import {
   resolveTelegramApiContext,
   withTelegramApiContextLease,
@@ -12,8 +18,17 @@ import type {
 } from "./send-message-types.js";
 import { finalizeTelegramOutbound, prepareTelegramOutbound } from "./send-outbound.js";
 import { normalizePollInput, type PollInput } from "./send.runtime.js";
+import { resolveTelegramBotUserIdFromToken } from "./token.js";
 
 type TelegramSendPollParams = Parameters<TelegramApiContext["api"]["sendPoll"]>[3];
+
+type TelegramPollSendResult = {
+  messageId: string;
+  chatId: string;
+  pollId: string;
+  pollAnswerRouting?: "enabled" | "unavailable";
+  warning?: string;
+};
 
 /**
  * Send a sticker to a Telegram chat by file_id.
@@ -85,7 +100,7 @@ export async function sendPollTelegram(
   to: string,
   poll: PollInput,
   opts: TelegramPollOpts,
-): Promise<{ messageId: string; chatId: string; pollId?: string }> {
+): Promise<TelegramPollSendResult> {
   const context = resolveTelegramApiContext(opts);
   return withTelegramApiContextLease(context, sendPollTelegramWithContext(to, poll, opts, context));
 }
@@ -95,7 +110,7 @@ async function sendPollTelegramWithContext(
   poll: PollInput,
   opts: TelegramPollOpts,
   context: TelegramApiContext,
-): Promise<{ messageId: string; chatId: string; pollId?: string }> {
+): Promise<TelegramPollSendResult> {
   const { api } = context;
   const prepared = await prepareTelegramOutbound({
     to,
@@ -133,36 +148,125 @@ async function sendPollTelegramWithContext(
       api.sendPoll(prepared.chatId, normalizedPoll.question, normalizedPoll.options, pollParams),
     "poll",
   );
-  const finalized = await finalizeTelegramOutbound({
-    context,
-    prepared,
-    result,
-    resultContext: "poll send",
-  });
-  const pollId = result?.poll?.id;
-  // Public poll answers omit chat/thread routing metadata. Record the origin at
-  // the central send boundary so every caller gets the same inbound route.
-  // This is best-effort because the poll already exists and retrying could duplicate it.
-  if (pollId && opts.isAnonymous === false) {
-    try {
-      await recordTelegramPollRegistryEntry({
+  const pollId = result.poll.id;
+  const routeChat = result.chat.type === "channel" ? undefined : result.chat;
+  const messageThreadId = result.message_thread_id ?? prepared.threadSpec?.id;
+  const provisionalEntry =
+    opts.isAnonymous === false && routeChat
+      ? createTelegramPollRegistryEntry({
+          pollId,
+          chat: routeChat,
+          messageId: result.message_id,
+          messageThreadId,
+          question: normalizedPoll.question,
+          options: normalizedPoll.options,
+        })
+      : undefined;
+  const registration = provisionalEntry
+    ? beginTelegramPollRegistration({
         accountId: context.account.accountId,
-        pollId,
-        chatId: finalized.chatId,
-        messageThreadId: prepared.threadParams.message_thread_id,
-        question: normalizedPoll.question,
-        options: normalizedPoll.options,
-      });
-    } catch (err) {
-      logVerbose(
-        `telegram: failed to record poll registry entry for poll ${pollId}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
+        entry: provisionalEntry,
+      })
+    : undefined;
+  let registeredEntry: Awaited<ReturnType<typeof recordTelegramPollRegistryEntry>> | null = null;
+  let pollAnswerRouting: TelegramPollSendResult["pollAnswerRouting"];
+  let warning: string | undefined;
+  try {
+    const finalized = await finalizeTelegramOutbound({
+      context,
+      prepared,
+      result,
+      resultContext: "poll send",
+    });
+    // Public poll answers omit chat/thread routing metadata. Record the origin at
+    // the central send boundary so every caller gets the same inbound route.
+    // The poll already exists, so surface storage failure instead of retrying and duplicating it.
+    if (pollId && opts.isAnonymous !== false) {
+      pollAnswerRouting = "unavailable";
+      warning =
+        "Poll sent anonymously, so Telegram does not identify voters and answers cannot reach the agent. Send a public poll to route votes into this conversation.";
+    } else if (pollId) {
+      const isGroup = result.chat.type === "group" || result.chat.type === "supergroup";
+      const botUserId = resolveTelegramBotUserIdFromToken(opts.token || context.account.token);
+      let canVerifyVoters = result.chat.type === "private";
+      if (result.chat.type === "channel") {
+        pollAnswerRouting = "unavailable";
+        warning =
+          "Poll sent, but public poll answer routing is not supported for Telegram channels. Send the poll in a direct chat or group, or ask subscribers to reply in text.";
+      } else if (isGroup) {
+        const { groupConfig, topicConfig } = resolveTelegramScopedGroupConfig(
+          context.account.config,
+          result.chat.id,
+          messageThreadId,
+        );
+        const groupPolicyConfig =
+          groupConfig && "groupPolicy" in groupConfig ? groupConfig : undefined;
+        const groupIngressDisabled =
+          groupConfig?.enabled === false ||
+          topicConfig?.enabled === false ||
+          resolveTelegramEffectiveGroupPolicy({
+            cfg: opts.cfg,
+            telegramCfg: context.account.config,
+            groupConfig: groupPolicyConfig,
+            topicConfig,
+            useTopicAndGroupOverrides: true,
+          }) === "disabled";
+        if (groupIngressDisabled) {
+          pollAnswerRouting = "unavailable";
+          warning =
+            "Poll sent, but answers cannot reach the agent because inbound messages are disabled for this group or topic. Enable inbound messages for this target and send a new poll, or ask participants to reply in text.";
+        } else if (botUserId == null) {
+          pollAnswerRouting = "unavailable";
+          warning =
+            "Poll sent, but answers cannot reach the agent because the bot account could not be verified. Check the bot token and send a new poll, or ask the user to reply in text.";
+        } else {
+          try {
+            const botMember = await api.getChatMember(result.chat.id, botUserId);
+            canVerifyVoters =
+              botMember.status === "creator" || botMember.status === "administrator";
+            if (!canVerifyVoters) {
+              pollAnswerRouting = "unavailable";
+              warning =
+                "Poll sent, but answers cannot reach the agent because the bot is not an administrator in this group. Make the bot an administrator and send a new poll, or ask the user to reply in text.";
+            }
+          } catch (err) {
+            pollAnswerRouting = "unavailable";
+            warning =
+              "Poll sent, but answers cannot reach the agent because group membership verification failed. Make the bot an administrator and send a new poll, or ask the user to reply in text.";
+            logVerbose(
+              `telegram: failed to verify poll voter access for poll ${pollId}: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+            );
+          }
+        }
+      }
+      if (canVerifyVoters && provisionalEntry) {
+        try {
+          registeredEntry = await recordTelegramPollRegistryEntry({
+            accountId: context.account.accountId,
+            ...provisionalEntry,
+          });
+          pollAnswerRouting = "enabled";
+        } catch (err) {
+          pollAnswerRouting = "unavailable";
+          warning =
+            "Poll sent, but answers cannot reach the agent because routing state could not be saved. Ask the user to reply in text.";
+          logVerbose(
+            `telegram: failed to record poll registry entry for poll ${pollId}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      }
     }
+    return {
+      ...finalized,
+      pollId,
+      ...(pollAnswerRouting ? { pollAnswerRouting } : {}),
+      ...(warning ? { warning } : {}),
+    };
+  } finally {
+    registration?.complete(registeredEntry);
   }
-  return {
-    ...finalized,
-    pollId,
-  };
 }

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -35,6 +35,7 @@ const { botApi, botRawApi, botConfigUseSpy, botCtorSpy } = vi.hoisted(() => ({
     editMessageCaption: vi.fn(),
     editMessageText: vi.fn(),
     editMessageReplyMarkup: vi.fn(),
+    getChatMember: vi.fn(),
     pinChatMessage: vi.fn(),
     sendChatAction: vi.fn(),
     sendMessage: vi.fn(),

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -22,6 +22,7 @@ import {
   hasProviderObservedTelegramThreadBinding,
 } from "./message-cache.js";
 import { registerTelegramOutboundGroupHistoryRecorder } from "./outbound-message-context.js";
+import { recordTelegramPollRegistryEntry } from "./poll-registry.js";
 import { createTelegramPromptContextProjectionCursor } from "./prompt-context-projection.js";
 import { inputRichBlocksToPlainText, type InputRichBlock } from "./rich-block-model.js";
 import { setTelegramRuntime } from "./runtime.js";
@@ -151,6 +152,12 @@ const sendMessageTelegram: typeof sendMessageTelegramImpl = async (to, text, opt
   );
 
 const TELEGRAM_TEST_CFG = {};
+const TELEGRAM_POLL_REGISTRY_NAMESPACE = "telegram.poll-registry";
+const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 100;
+type TelegramPollRegistryEntry = Omit<
+  Parameters<typeof recordTelegramPollRegistryEntry>[0],
+  "accountId" | "env"
+> & { createdAt: number };
 type PersistedSentMessageForTest = {
   scopeKey: string;
   chatId: string;
@@ -5091,6 +5098,15 @@ describe("editMessageTelegram", () => {
 });
 
 describe("sendPollTelegram", () => {
+  async function installPollRegistryStore() {
+    const store = createPluginStateKeyedStoreForTests<TelegramPollRegistryEntry>("telegram", {
+      namespace: TELEGRAM_POLL_REGISTRY_NAMESPACE,
+      maxEntries: TELEGRAM_POLL_REGISTRY_MAX_ENTRIES,
+    });
+    await store.clear();
+    return store;
+  }
+
   it("sends polls with 12 options", async () => {
     const api = {
       sendPoll: vi.fn(async () => ({ message_id: 123, chat: { id: 555 }, poll: { id: "p1" } })),
@@ -5177,6 +5193,109 @@ describe("sendPollTelegram", () => {
     expect(sendPollCall[2]).toEqual(["A", "B"]);
     expect(requireRecord(sendPollCall[3], "send poll params").open_period).toBe(60);
     expect(wasSentByBot("123", 123)).toBe(true);
+  });
+
+  it("records a public poll origin with its resolved topic", async () => {
+    const store = await installPollRegistryStore();
+    const api = {
+      sendPoll: vi.fn(async () => ({
+        message_id: 123,
+        chat: { id: -1001234567890 },
+        poll: { id: "poll-public" },
+      })),
+    };
+
+    await sendPollTelegram(
+      "-1001234567890:topic:99",
+      { question: " Ready? ", options: [" Yes ", "No "] },
+      {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "t",
+        api: api as unknown as Bot["api"],
+        isAnonymous: false,
+      },
+    );
+
+    expect(await store.entries()).toEqual([
+      expect.objectContaining({
+        value: expect.objectContaining({
+          pollId: "poll-public",
+          chatId: "-1001234567890",
+          messageThreadId: 99,
+          question: "Ready?",
+          options: ["Yes", "No"],
+        }),
+      }),
+    ]);
+  });
+
+  it("does not register anonymous polls", async () => {
+    const store = await installPollRegistryStore();
+    const api = {
+      sendPoll: vi.fn(async () => ({
+        message_id: 123,
+        chat: { id: 555 },
+        poll: { id: "poll-anonymous" },
+      })),
+    };
+
+    await sendPollTelegram(
+      "555",
+      { question: "Ready?", options: ["Yes", "No"] },
+      {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "t",
+        api: api as unknown as Bot["api"],
+        isAnonymous: true,
+      },
+    );
+
+    expect(await store.entries()).toHaveLength(0);
+  });
+
+  it("does not retry an already-sent poll when origin storage fails", async () => {
+    const pollRegistryKey = "default:poll-write-error";
+    const register = vi.fn(async (key: string) => {
+      if (key === pollRegistryKey) {
+        throw new Error("registry db unavailable");
+      }
+    });
+    setTelegramRuntime({
+      state: {
+        openKeyedStore: (() => ({
+          register,
+        })) as unknown as TelegramRuntime["state"]["openKeyedStore"],
+        openSyncKeyedStore: (() =>
+          sentMessageStore) as TelegramRuntime["state"]["openSyncKeyedStore"],
+      },
+      channel: {},
+    } as TelegramRuntime);
+    const api = {
+      sendPoll: vi.fn(async () => ({
+        message_id: 123,
+        chat: { id: 555 },
+        poll: { id: "poll-write-error" },
+      })),
+    };
+
+    await expect(
+      sendPollTelegram(
+        "555",
+        { question: "Ready?", options: ["Yes", "No"] },
+        {
+          cfg: TELEGRAM_TEST_CFG,
+          token: "t",
+          api: api as unknown as Bot["api"],
+          isAnonymous: false,
+        },
+      ),
+    ).resolves.toEqual({
+      messageId: "123",
+      chatId: "555",
+      pollId: "poll-write-error",
+    });
+    expect(api.sendPoll).toHaveBeenCalledTimes(1);
+    expect(register.mock.calls.filter(([key]) => key === pollRegistryKey)).toHaveLength(1);
   });
 
   it("fails poll sends instead of retrying without message_thread_id", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -22,6 +22,12 @@ import {
   hasProviderObservedTelegramThreadBinding,
 } from "./message-cache.js";
 import { registerTelegramOutboundGroupHistoryRecorder } from "./outbound-message-context.js";
+import {
+  beginTelegramPollRegistration,
+  getPreparedTelegramPollAnswer,
+  prepareTelegramPollAnswerContext,
+  settleTelegramPollAnswerContext,
+} from "./poll-answer-context.js";
 import { recordTelegramPollRegistryEntry } from "./poll-registry.js";
 import { createTelegramPromptContextProjectionCursor } from "./prompt-context-projection.js";
 import { inputRichBlocksToPlainText, type InputRichBlock } from "./rich-block-model.js";
@@ -153,7 +159,7 @@ const sendMessageTelegram: typeof sendMessageTelegramImpl = async (to, text, opt
 
 const TELEGRAM_TEST_CFG = {};
 const TELEGRAM_POLL_REGISTRY_NAMESPACE = "telegram.poll-registry";
-const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 100;
+const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 10_000;
 type TelegramPollRegistryEntry = Omit<
   Parameters<typeof recordTelegramPollRegistryEntry>[0],
   "accountId" | "env"
@@ -201,7 +207,13 @@ function installTelegramStateRuntimeForTest(
           "telegram",
           options,
         )) as TelegramRuntime["state"]["openKeyedStore"],
-      openSyncKeyedStore: (() => syncStore) as TelegramRuntime["state"]["openSyncKeyedStore"],
+      openSyncKeyedStore: ((options) =>
+        options.namespace === TELEGRAM_SENT_MESSAGE_CACHE_NAMESPACE
+          ? syncStore
+          : createPluginStateSyncKeyedStoreForTests(
+              "telegram",
+              options,
+            )) as TelegramRuntime["state"]["openSyncKeyedStore"],
     },
     channel: {},
   } as TelegramRuntime);
@@ -5102,6 +5114,7 @@ describe("sendPollTelegram", () => {
     const store = createPluginStateKeyedStoreForTests<TelegramPollRegistryEntry>("telegram", {
       namespace: TELEGRAM_POLL_REGISTRY_NAMESPACE,
       maxEntries: TELEGRAM_POLL_REGISTRY_MAX_ENTRIES,
+      overflowPolicy: "reject-new",
     });
     await store.clear();
     return store;
@@ -5184,7 +5197,12 @@ describe("sendPollTelegram", () => {
       { cfg: TELEGRAM_TEST_CFG, token: "t", api: api as unknown as Bot["api"] },
     );
 
-    expect(res).toEqual({ messageId: "123", chatId: "555", pollId: "p1" });
+    expect(res).toMatchObject({
+      messageId: "123",
+      chatId: "555",
+      pollId: "p1",
+      pollAnswerRouting: "unavailable",
+    });
     expect(api.sendPoll).toHaveBeenCalledTimes(1);
     const sendPollMock = api.sendPoll as ReturnType<typeof vi.fn>;
     const sendPollCall = firstMockCall(sendPollMock, "send poll call");
@@ -5197,30 +5215,42 @@ describe("sendPollTelegram", () => {
 
   it("records a public poll origin with its resolved topic", async () => {
     const store = await installPollRegistryStore();
-    const api = {
-      sendPoll: vi.fn(async () => ({
-        message_id: 123,
-        chat: { id: -1001234567890 },
-        poll: { id: "poll-public" },
-      })),
-    };
+    botApi.getChatMember.mockResolvedValue({ status: "administrator" });
+    botApi.sendPoll.mockResolvedValue({
+      message_id: 123,
+      message_thread_id: 99,
+      chat: {
+        id: -1001234567890,
+        type: "supergroup",
+        title: "Reviewers",
+        is_forum: true,
+      },
+      poll: { id: "poll-public" },
+    });
 
-    await sendPollTelegram(
+    const result = await sendPollTelegram(
       "-1001234567890:topic:99",
       { question: " Ready? ", options: [" Yes ", "No "] },
       {
         cfg: TELEGRAM_TEST_CFG,
-        token: "t",
-        api: api as unknown as Bot["api"],
+        token: "999:token",
         isAnonymous: false,
       },
     );
 
+    expect(result.pollAnswerRouting).toBe("enabled");
+    expect(botApi.getChatMember).toHaveBeenCalledWith(-1001234567890, 999);
     expect(await store.entries()).toEqual([
       expect.objectContaining({
         value: expect.objectContaining({
           pollId: "poll-public",
-          chatId: "-1001234567890",
+          chat: {
+            id: -1001234567890,
+            type: "supergroup",
+            title: "Reviewers",
+            is_forum: true,
+          },
+          messageId: 123,
           messageThreadId: 99,
           question: "Ready?",
           options: ["Yes", "No"],
@@ -5229,26 +5259,251 @@ describe("sendPollTelegram", () => {
     ]);
   });
 
-  it("does not register anonymous polls", async () => {
+  it("reports unavailable routing when the bot cannot verify group voters", async () => {
+    const store = await installPollRegistryStore();
+    botApi.getChatMember.mockResolvedValue({ status: "member" });
+    botApi.sendPoll.mockResolvedValue({
+      message_id: 124,
+      chat: { id: -1001234567890, type: "supergroup", title: "Reviewers" },
+      poll: { id: "poll-non-admin" },
+    });
+
+    await expect(
+      sendPollTelegram(
+        "-1001234567890",
+        { question: "Ready?", options: ["Yes", "No"] },
+        {
+          cfg: TELEGRAM_TEST_CFG,
+          token: "999:token",
+          isAnonymous: false,
+        },
+      ),
+    ).resolves.toMatchObject({
+      pollAnswerRouting: "unavailable",
+      warning: expect.stringContaining("not an administrator"),
+    });
+    expect(await store.entries()).toHaveLength(0);
+  });
+
+  const disabledPollRouteCases: Array<{
+    name: string;
+    cfg: Parameters<typeof sendPollTelegram>[2]["cfg"];
+    messageThreadId?: number;
+    omitResultThreadId?: boolean;
+  }> = [
+    {
+      name: "account policy",
+      cfg: { channels: { telegram: { groupPolicy: "disabled" as const } } },
+      messageThreadId: undefined,
+    },
+    {
+      name: "group scope",
+      cfg: {
+        channels: {
+          telegram: {
+            groups: { "-1001234567890": { enabled: false } },
+          },
+        },
+      },
+      messageThreadId: undefined,
+    },
+    {
+      name: "topic policy",
+      cfg: {
+        channels: {
+          telegram: {
+            groupPolicy: "open" as const,
+            groups: {
+              "-1001234567890": {
+                topics: { "99": { groupPolicy: "disabled" as const } },
+              },
+            },
+          },
+        },
+      },
+      messageThreadId: 99,
+    },
+    {
+      name: "General topic policy without a returned thread id",
+      cfg: {
+        channels: {
+          telegram: {
+            groupPolicy: "open" as const,
+            groups: {
+              "-1001234567890": {
+                topics: { "1": { groupPolicy: "disabled" as const } },
+              },
+            },
+          },
+        },
+      },
+      messageThreadId: 1,
+      omitResultThreadId: true,
+    },
+    {
+      name: "topic scope",
+      cfg: {
+        channels: {
+          telegram: {
+            groups: {
+              "-1001234567890": { topics: { "99": { enabled: false } } },
+            },
+          },
+        },
+      },
+      messageThreadId: 99,
+    },
+  ];
+
+  it.each(disabledPollRouteCases)(
+    "reports unavailable routing for disabled $name",
+    async ({ cfg, messageThreadId, omitResultThreadId }) => {
+      const store = await installPollRegistryStore();
+      botApi.sendPoll.mockResolvedValue({
+        message_id: 125,
+        ...(messageThreadId === undefined || omitResultThreadId
+          ? {}
+          : { message_thread_id: messageThreadId }),
+        chat: { id: -1001234567890, type: "supergroup", title: "Reviewers" },
+        poll: { id: "poll-disabled" },
+      });
+
+      await expect(
+        sendPollTelegram(
+          "-1001234567890",
+          { question: "Ready?", options: ["Yes", "No"] },
+          {
+            cfg,
+            token: "999:token",
+            isAnonymous: false,
+            ...(messageThreadId === undefined ? {} : { messageThreadId }),
+          },
+        ),
+      ).resolves.toMatchObject({
+        pollAnswerRouting: "unavailable",
+        warning: expect.stringContaining("inbound messages are disabled"),
+      });
+      expect(botApi.getChatMember).not.toHaveBeenCalled();
+      expect(await store.entries()).toHaveLength(0);
+    },
+  );
+
+  it("reports unavailable routing for channel polls", async () => {
+    const store = await installPollRegistryStore();
+    botApi.sendPoll.mockResolvedValue({
+      message_id: 125,
+      chat: { id: -1001234567890, type: "channel", title: "Announcements" },
+      poll: { id: "poll-channel" },
+    });
+
+    await expect(
+      sendPollTelegram(
+        "-1001234567890",
+        { question: "Ready?", options: ["Yes", "No"] },
+        {
+          cfg: TELEGRAM_TEST_CFG,
+          token: "999:token",
+          isAnonymous: false,
+        },
+      ),
+    ).resolves.toMatchObject({
+      pollAnswerRouting: "unavailable",
+      warning: expect.stringContaining("not supported for Telegram channels"),
+    });
+    expect(botApi.getChatMember).not.toHaveBeenCalled();
+    expect(await store.entries()).toHaveLength(0);
+  });
+
+  it("prepares a fast poll route without waiting for registration", async () => {
+    const entry = {
+      pollId: "poll-fast-answer",
+      chat: { id: -1001234567890, type: "supergroup" as const, title: "Reviewers" },
+      messageId: 125,
+      question: "Ready?",
+      options: ["Yes", "No"],
+    };
+    const registration = beginTelegramPollRegistration({ entry });
+    const update = {
+      poll_answer: {
+        poll_id: "poll-fast-answer",
+        option_ids: [0],
+        user: { id: 9, first_name: "Ada", is_bot: false },
+      },
+    };
+    prepareTelegramPollAnswerContext({ update });
+    expect(getPreparedTelegramPollAnswer(update)).toMatchObject({
+      entry: { pollId: "poll-fast-answer", chat: { id: -1001234567890 } },
+      registrationPending: true,
+    });
+
+    let settlementFinished = false;
+    const settlement = settleTelegramPollAnswerContext({ update }).then(() => {
+      settlementFinished = true;
+    });
+    await Promise.resolve();
+    expect(settlementFinished).toBe(false);
+    registration.complete(entry);
+    await settlement;
+    expect(getPreparedTelegramPollAnswer(update)).toEqual({ entry });
+  });
+
+  it("does not reread or delay unknown poll answers", async () => {
+    const store = await installPollRegistryStore();
+    const syncStore = createPluginStateSyncKeyedStoreForTests<TelegramPollRegistryEntry>(
+      "telegram",
+      {
+        namespace: TELEGRAM_POLL_REGISTRY_NAMESPACE,
+        maxEntries: TELEGRAM_POLL_REGISTRY_MAX_ENTRIES,
+        overflowPolicy: "reject-new",
+      },
+    );
+    const lookup = vi.spyOn(syncStore, "lookup");
+    setTelegramRuntime({
+      state: {
+        openKeyedStore: (() => store) as TelegramRuntime["state"]["openKeyedStore"],
+        openSyncKeyedStore: (() => syncStore) as TelegramRuntime["state"]["openSyncKeyedStore"],
+      },
+      channel: {},
+    } as TelegramRuntime);
+    const update = {
+      update_id: 13,
+      poll_answer: {
+        poll_id: "poll-unknown",
+        user: { id: 10, is_bot: false, first_name: "Ada" },
+        option_ids: [0],
+      },
+    };
+
+    prepareTelegramPollAnswerContext({ update });
+
+    expect(getPreparedTelegramPollAnswer(update)?.entry).toBeNull();
+    expect(lookup).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports default anonymous polls as unavailable without registering them", async () => {
     const store = await installPollRegistryStore();
     const api = {
       sendPoll: vi.fn(async () => ({
         message_id: 123,
-        chat: { id: 555 },
+        chat: { id: 555, type: "private" },
         poll: { id: "poll-anonymous" },
       })),
     };
 
-    await sendPollTelegram(
-      "555",
-      { question: "Ready?", options: ["Yes", "No"] },
-      {
-        cfg: TELEGRAM_TEST_CFG,
-        token: "t",
-        api: api as unknown as Bot["api"],
-        isAnonymous: true,
-      },
-    );
+    await expect(
+      sendPollTelegram(
+        "555",
+        { question: "Ready?", options: ["Yes", "No"] },
+        {
+          cfg: TELEGRAM_TEST_CFG,
+          token: "t",
+          api: api as unknown as Bot["api"],
+        },
+      ),
+    ).resolves.toMatchObject({
+      pollAnswerRouting: "unavailable",
+      warning: expect.stringContaining("Send a public poll"),
+    });
 
     expect(await store.entries()).toHaveLength(0);
   });
@@ -5273,7 +5528,7 @@ describe("sendPollTelegram", () => {
     const api = {
       sendPoll: vi.fn(async () => ({
         message_id: 123,
-        chat: { id: 555 },
+        chat: { id: 555, type: "private" },
         poll: { id: "poll-write-error" },
       })),
     };
@@ -5293,6 +5548,9 @@ describe("sendPollTelegram", () => {
       messageId: "123",
       chatId: "555",
       pollId: "poll-write-error",
+      pollAnswerRouting: "unavailable",
+      warning:
+        "Poll sent, but answers cannot reach the agent because routing state could not be saved. Ask the user to reply in text.",
     });
     expect(api.sendPoll).toHaveBeenCalledTimes(1);
     expect(register.mock.calls.filter(([key]) => key === pollRegistryKey)).toHaveLength(1);

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -83,6 +83,7 @@ describe("getTelegramSequentialKey", () => {
       "telegram:123:topic:1",
     ],
     [{ update: { message: mockMessage({ chat: mockChat({ id: 555 }) }) } }, "telegram:555"],
+    [{ update: { poll_answer: { poll_id: "poll-123" } } }, "telegram:poll:poll-123"],
     [
       {
         channelPost: mockMessage({ chat: mockChat({ id: -100777111222, type: "channel" }) }),

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -17,6 +17,8 @@ import {
   resolveTelegramMessageForumFlagHint,
   shouldUseTelegramDmThreadSession,
 } from "./bot/helpers.js";
+import { getPreparedTelegramPollAnswer } from "./poll-answer-context.js";
+import type { TelegramPollRegistryEntry } from "./poll-registry.js";
 import { hasTelegramQuestionCallbackPrefix } from "./question-callback-data.js";
 
 const TELEGRAM_READ_ONLY_STATUS_COMMAND_KEYS = new Set([
@@ -187,10 +189,16 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   if (reaction?.chat?.id) {
     return `telegram:${reaction.chat.id}`;
   }
-  const pollId = ctx.update?.poll_answer?.poll_id;
+  const update = ctx.update;
+  const pollId = update?.poll_answer?.poll_id;
   if (pollId) {
-    // Poll answers do not include their originating chat. Serialize answers for
-    // the same poll without forcing unrelated polls through the global unknown lane.
+    const prepared = getPreparedTelegramPollAnswer(update);
+    const entry = prepared?.entry;
+    if (entry) {
+      return getTelegramPollAnswerSequentialKey(entry, ctx.me);
+    }
+    // Missing historical registry entries do no work, but keep duplicate answers
+    // for the same unknown poll together while the handler records the miss.
     return `telegram:poll:${pollId}`;
   }
   const msg =
@@ -257,6 +265,25 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
     return threadId != null ? `telegram:${chatId}:topic:${threadId}` : `telegram:${chatId}`;
   }
   return "telegram:unknown";
+}
+
+function getTelegramPollAnswerSequentialKey(
+  entry: TelegramPollRegistryEntry,
+  botUser?: UserFromGetMe,
+): string {
+  const isGroup = entry.chat.type === "group" || entry.chat.type === "supergroup";
+  const isForum = entry.chat.type === "supergroup" && entry.chat.is_forum === true;
+  const threadId = isGroup
+    ? resolveTelegramForumThreadId({ isForum, messageThreadId: entry.messageThreadId })
+    : shouldUseTelegramDmThreadSession({
+          dmThreadId: entry.messageThreadId,
+          botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(botUser),
+        })
+      ? entry.messageThreadId
+      : undefined;
+  return threadId == null
+    ? `telegram:${entry.chat.id}`
+    : `telegram:${entry.chat.id}:topic:${threadId}`;
 }
 
 export function getTelegramSequentialConstraints(

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -48,6 +48,7 @@ type TelegramSequentialKeyContext = {
       chat?: { id?: number; type?: string; is_forum?: boolean };
       message_id?: number;
     };
+    poll_answer?: { poll_id?: string };
   };
 };
 
@@ -185,6 +186,12 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   const reaction = ctx.update?.message_reaction;
   if (reaction?.chat?.id) {
     return `telegram:${reaction.chat.id}`;
+  }
+  const pollId = ctx.update?.poll_answer?.poll_id;
+  if (pollId) {
+    // Poll answers do not include their originating chat. Serialize answers for
+    // the same poll without forcing unrelated polls through the global unknown lane.
+    return `telegram:poll:${pollId}`;
   }
   const msg =
     ctx.message ??

--- a/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
+++ b/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
@@ -83,8 +83,9 @@ const { createTelegramTransportIngressMonitor } =
   await import("./telegram-ingress-drain-factory.js");
 const { setTelegramRuntime } = await import("./runtime.js");
 const { resetTelegramAccountThrottlersForTest } = await import("./runtime.test-support.js");
-const { openTelegramIngressQueue, telegramQueueEventId, writeTelegramSpooledUpdate } =
+const { openTelegramIngressQueue, telegramQueueEventId } =
   await import("./telegram-ingress-spool.js");
+const { writeTelegramSpooledUpdate } = await import("./telegram-ingress-spool.test-support.js");
 
 const cfg = {
   channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },

--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -12,11 +12,11 @@ import {
 } from "./bot-processing-outcome.js";
 import { createTelegramIngressMonitor } from "./telegram-ingress-drain.js";
 import { resolveTelegramIngressNonRetryableFailure } from "./telegram-ingress-non-retryable.js";
-import { telegramSpooledUpdateLaneKey } from "./telegram-ingress-spool.js";
 import {
   TelegramIngressPayloadError,
   type TelegramSpooledUpdatePayload,
 } from "./telegram-ingress-spool.payload.js";
+import { telegramSpooledUpdateLaneKey } from "./telegram-ingress-spool.test-support.js";
 
 async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-ingress-drain-"));

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -21,6 +21,13 @@ import {
   resolveTelegramForumThreadId,
   resolveTelegramMessageForumFlagHint,
 } from "./bot/helpers.js";
+import {
+  getPreparedTelegramPollAnswer,
+  isEligibleTelegramPollAnswerUpdate,
+  prepareTelegramPollAnswerContext,
+  recordPreparedTelegramPollAnswer,
+  settleTelegramPollAnswerContext,
+} from "./poll-answer-context.js";
 import { hasTelegramQuestionCallbackPrefix } from "./question-callback-data.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 import { normalizeTelegramStateAccountId } from "./state-account-id.js";
@@ -268,12 +275,21 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
     TelegramSpooledUpdatePayload
   >({
     queue: params.queue,
-    inspect: (update, context) =>
-      inspectTelegramSpooledUpdate(
+    inspect: (update, context) => {
+      if (
+        context.phase === "admission" &&
+        typeof update === "object" &&
+        update !== null &&
+        isEligibleTelegramPollAnswerUpdate(update)
+      ) {
+        prepareTelegramPollAnswerContext({ update, accountId: params.accountId });
+      }
+      return inspectTelegramSpooledUpdate(
         update,
         params.botInfo,
         context.phase === "claim" ? context.claimedLaneKey : undefined,
-      ),
+      );
+    },
     payload: {
       version: TELEGRAM_SPOOLED_UPDATE_PAYLOAD_VERSION,
       serialize: (update, { receivedAt }) => {
@@ -283,9 +299,25 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
             "Telegram spooled update is missing numeric update_id.",
           );
         }
-        return { version: TELEGRAM_SPOOLED_UPDATE_PAYLOAD_VERSION, updateId, receivedAt, update };
+        const preparedPollAnswer =
+          typeof update === "object" && update !== null
+            ? getPreparedTelegramPollAnswer(update)
+            : undefined;
+        return {
+          version: TELEGRAM_SPOOLED_UPDATE_PAYLOAD_VERSION,
+          updateId,
+          receivedAt,
+          update,
+          ...(preparedPollAnswer ? { preparedPollAnswer } : {}),
+        };
       },
-      deserialize: (payload) => payload.update,
+      deserialize: (payload) => {
+        const update = payload.update;
+        if (payload.preparedPollAnswer && typeof update === "object" && update !== null) {
+          recordPreparedTelegramPollAnswer(update, payload.preparedPollAnswer);
+        }
+        return update;
+      },
       encode: ({ body }) => body,
       decode: (payload) => ({ version: payload.version, body: payload }),
       createClaimError: (kind, claim) =>
@@ -302,7 +334,13 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
       try {
         const result = await runWithTelegramSpooledReplayUpdate(
           update as object,
-          async () => await params.dispatch(update, telegramLifecycle),
+          async () => {
+            await settleTelegramPollAnswerContext({
+              update: update as object,
+              accountId: params.accountId,
+            });
+            return await params.dispatch(update, telegramLifecycle);
+          },
           telegramLifecycle,
         );
         const outcome = result.value;

--- a/extensions/telegram/src/telegram-ingress-spool.payload.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.payload.ts
@@ -1,9 +1,12 @@
 // Telegram plugin module defines durable ingress queue payload shape.
+import type { PreparedTelegramPollAnswer } from "./poll-answer-context.js";
+
 export type TelegramSpooledUpdatePayload = {
   version: number;
   updateId: number;
   receivedAt: number;
   update: unknown;
+  preparedPollAnswer?: PreparedTelegramPollAnswer;
 };
 
 export const TELEGRAM_SPOOLED_UPDATE_PAYLOAD_VERSION = 1;

--- a/extensions/telegram/src/telegram-ingress-spool.test-support.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test-support.ts
@@ -10,10 +10,8 @@ import {
   type ChannelIngressQueueRecord,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { TelegramBotInfo } from "./bot-info.js";
-import {
-  openTelegramIngressQueue,
-  telegramSpooledUpdateLaneKey,
-} from "./telegram-ingress-spool.js";
+import { getTelegramSequentialKey } from "./sequential-key.js";
+import { openTelegramIngressQueue, resolveTelegramUpdateId } from "./telegram-ingress-spool.js";
 import {
   TELEGRAM_SPOOLED_UPDATE_PAYLOAD_VERSION,
   type TelegramSpooledUpdatePayload,
@@ -43,6 +41,40 @@ export type ClaimedTelegramSpooledUpdate = TelegramSpooledUpdate & {
 
 export function telegramQueueEventId(updateId: number): string {
   return String(updateId).padStart(16, "0");
+}
+
+export function telegramSpooledUpdateLaneKey(update: unknown, botInfo?: TelegramBotInfo): string {
+  return getTelegramSequentialKey({
+    update: update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
+    ...(botInfo ? { me: botInfo } : {}),
+  });
+}
+
+export async function writeTelegramSpooledUpdate(params: {
+  spoolDir: string;
+  update: unknown;
+  laneKey?: string;
+  now?: number;
+}): Promise<number> {
+  const updateId = resolveTelegramUpdateId(params.update);
+  if (updateId === null) {
+    throw new Error("Telegram update missing numeric update_id.");
+  }
+  const receivedAt = params.now ?? Date.now();
+  await openTelegramIngressQueue(params.spoolDir).enqueue(
+    telegramQueueEventId(updateId),
+    {
+      version: TELEGRAM_SPOOLED_UPDATE_PAYLOAD_VERSION,
+      updateId,
+      receivedAt,
+      update: params.update,
+    },
+    {
+      receivedAt,
+      laneKey: params.laneKey ?? telegramSpooledUpdateLaneKey(params.update),
+    },
+  );
+  return updateId;
 }
 
 function spoolFileName(updateId: number): string {

--- a/extensions/telegram/src/telegram-ingress-spool.test.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test.ts
@@ -2,22 +2,29 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests as createChannelIngressQueue,
+  createPluginStateKeyedStoreForTests,
+  createPluginStateSyncKeyedStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { beginTelegramPollRegistration } from "./poll-answer-context.js";
+import { recordTelegramPollRegistryEntry } from "./poll-registry.js";
 import { setTelegramRuntime } from "./runtime.js";
 import { clearTelegramRuntimeForTest } from "./runtime.test-support.js";
+import { createTelegramIngressMonitor } from "./telegram-ingress-drain.js";
 import {
   openTelegramIngressQueue,
   resolveTelegramIngressSpoolDir,
-  telegramSpooledUpdateLaneKey,
-  writeTelegramSpooledUpdate,
+  resolveTelegramUpdateId,
 } from "./telegram-ingress-spool.js";
 import {
   listTelegramSpooledUpdates,
   telegramQueueEventId,
+  telegramSpooledUpdateLaneKey,
+  writeTelegramSpooledUpdate,
 } from "./telegram-ingress-spool.test-support.js";
 
 async function withTempState<T>(
@@ -28,9 +35,16 @@ async function withTempState<T>(
     accountId: "acct",
     env: { OPENCLAW_STATE_DIR: stateDir } as NodeJS.ProcessEnv,
   });
+  const openKeyedStore = <StoreValue>(
+    options: Parameters<typeof createPluginStateKeyedStoreForTests<StoreValue>>[1],
+  ) => createPluginStateKeyedStoreForTests<StoreValue>("telegram", options);
   setTelegramRuntime({
     state: {
       resolveStateDir: () => stateDir,
+      openKeyedStore,
+      openSyncKeyedStore: <StoreValue>(
+        options: Parameters<typeof createPluginStateSyncKeyedStoreForTests<StoreValue>>[1],
+      ) => createPluginStateSyncKeyedStoreForTests<StoreValue>("telegram", options),
       openChannelIngressQueue: (
         options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
       ) => createChannelIngressQueue({ ...options, channelId: "telegram" }),
@@ -94,6 +108,184 @@ describe("telegram ingress spool mapping", () => {
       const rows = await queue.listPending({ limit: "all" });
       expect(rows[0]?.id).toBe(telegramQueueEventId(9));
       expect(rows[0]?.laneKey).toBeTruthy();
+    });
+  });
+
+  it("keeps a poll vote ahead of a later message from the same topic", async () => {
+    await withTempState(async (_stateDir, spoolDir) => {
+      await recordTelegramPollRegistryEntry({
+        accountId: "acct",
+        pollId: "poll-topic-order",
+        chat: { id: -100123, type: "supergroup", title: "Reviewers", is_forum: true },
+        messageId: 40,
+        messageThreadId: 99,
+        question: "Ready?",
+        options: ["Yes", "No"],
+      });
+      const voteUpdate = {
+        update_id: 9,
+        poll_answer: {
+          poll_id: "poll-topic-order",
+          option_ids: [0],
+          user: { id: 111, first_name: "Ada" },
+        },
+      };
+      const messageUpdate = {
+        update_id: 10,
+        message: {
+          chat: { id: -100123, type: "supergroup", title: "Reviewers", is_forum: true },
+          from: { id: 111, first_name: "Ada" },
+          is_topic_message: true,
+          message_id: 41,
+          message_thread_id: 99,
+          text: "after vote",
+        },
+      };
+
+      let releaseVote: (() => void) | undefined;
+      const voteReleased = new Promise<void>((resolve) => {
+        releaseVote = resolve;
+      });
+      if (!releaseVote) {
+        throw new Error("Expected vote release resolver");
+      }
+      const dispatchOrder: number[] = [];
+      const onError = vi.fn();
+      const queue = openTelegramIngressQueue(spoolDir);
+      const monitor = createTelegramIngressMonitor({
+        queue,
+        cfg: { channels: { telegram: { groupPolicy: "open" } } } as OpenClawConfig,
+        accountId: "acct",
+        onError,
+        dispatch: async (update) => {
+          const updateId = resolveTelegramUpdateId(update);
+          if (updateId === null) {
+            throw new Error("Expected update id");
+          }
+          dispatchOrder.push(updateId);
+          if (updateId === 9) {
+            await voteReleased;
+          }
+          return { kind: "completed" };
+        },
+      });
+
+      monitor.start();
+      await monitor.waitForIdle();
+      const admissions = await Promise.all([
+        monitor.admit(voteUpdate),
+        monitor.admit(messageUpdate),
+      ]);
+      expect(admissions.map((result) => result.kind)).toEqual(["durable", "durable"]);
+      expect(await queue.listPending({ limit: "all" })).toEqual([
+        expect.objectContaining({
+          id: telegramQueueEventId(9),
+          payload: expect.objectContaining({
+            preparedPollAnswer: {
+              entry: expect.objectContaining({ messageThreadId: 99 }),
+            },
+          }),
+        }),
+        expect.objectContaining({ id: telegramQueueEventId(10) }),
+      ]);
+      await monitor.waitForPumpIdle();
+      expect(onError).not.toHaveBeenCalled();
+      expect(dispatchOrder).toEqual([9]);
+      expect(await queue.listClaims()).toEqual([
+        expect.objectContaining({ laneKey: "telegram:-100123:topic:99" }),
+      ]);
+      expect(await queue.listPending({ limit: "all" })).toEqual([
+        expect.objectContaining({ laneKey: "telegram:-100123:topic:99" }),
+      ]);
+      releaseVote();
+      await monitor.waitForIdle();
+      expect(dispatchOrder).toEqual([9, 10]);
+      await monitor.stop();
+    });
+  });
+
+  it("fences a pending poll vote to its topic without blocking unrelated admission", async () => {
+    await withTempState(async (_stateDir, spoolDir) => {
+      const entry = {
+        pollId: "poll-pending-topic",
+        chat: {
+          id: -100123,
+          type: "supergroup" as const,
+          title: "Reviewers",
+          is_forum: true as const,
+        },
+        messageId: 40,
+        messageThreadId: 99,
+        question: "Ready?",
+        options: ["Yes", "No"],
+      };
+      const registration = beginTelegramPollRegistration({ accountId: "acct", entry });
+      const voteUpdate = {
+        update_id: 9,
+        poll_answer: {
+          poll_id: entry.pollId,
+          option_ids: [0],
+          user: { id: 111, first_name: "Ada" },
+        },
+      };
+      const unrelatedUpdate = {
+        update_id: 10,
+        message: {
+          chat: entry.chat,
+          from: { id: 111, first_name: "Ada" },
+          is_topic_message: true,
+          message_id: 41,
+          message_thread_id: 100,
+          text: "unrelated topic",
+        },
+      };
+      const sameTopicUpdate = {
+        update_id: 11,
+        message: {
+          chat: entry.chat,
+          from: { id: 111, first_name: "Ada" },
+          is_topic_message: true,
+          message_id: 42,
+          message_thread_id: 99,
+          text: "after vote",
+        },
+      };
+      const dispatchOrder: number[] = [];
+      const queue = openTelegramIngressQueue(spoolDir);
+      const monitor = createTelegramIngressMonitor({
+        queue,
+        cfg: { channels: { telegram: { groupPolicy: "open" } } } as OpenClawConfig,
+        accountId: "acct",
+        dispatch: (update) => {
+          const updateId = resolveTelegramUpdateId(update);
+          if (updateId === null) {
+            throw new Error("Expected update id");
+          }
+          dispatchOrder.push(updateId);
+          return { kind: "completed" };
+        },
+      });
+
+      monitor.start();
+      await monitor.waitForIdle();
+      await expect(
+        Promise.all([
+          monitor.admit(voteUpdate),
+          monitor.admit(unrelatedUpdate),
+          monitor.admit(sameTopicUpdate),
+        ]),
+      ).resolves.toMatchObject([{ kind: "durable" }, { kind: "durable" }, { kind: "durable" }]);
+      await vi.waitFor(() => expect(dispatchOrder).toContain(10));
+      expect(dispatchOrder).not.toContain(9);
+      expect(dispatchOrder).not.toContain(11);
+      expect(await queue.listClaims()).toEqual([
+        expect.objectContaining({ laneKey: "telegram:-100123:topic:99" }),
+      ]);
+
+      registration.complete(entry);
+      await monitor.waitForIdle();
+      expect(dispatchOrder.indexOf(9)).toBeLessThan(dispatchOrder.indexOf(11));
+      await monitor.stop();
     });
   });
 });

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -4,14 +4,9 @@ import path from "node:path";
 import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
 import { computeBackoff, type BackoffPolicy } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
-import type { TelegramBotInfo } from "./bot-info.js";
 import { getTelegramRuntime } from "./runtime.js";
-import { getTelegramSequentialKey } from "./sequential-key.js";
 import { normalizeTelegramStateAccountId } from "./state-account-id.js";
-import {
-  TELEGRAM_SPOOLED_UPDATE_PAYLOAD_VERSION,
-  type TelegramSpooledUpdatePayload,
-} from "./telegram-ingress-spool.payload.js";
+import type { TelegramSpooledUpdatePayload } from "./telegram-ingress-spool.payload.js";
 const TELEGRAM_INGRESS_SPOOL_PREFIX = "ingress-spool-";
 const TELEGRAM_SPOOLED_COMPLETION_RETRY_POLICY: BackoffPolicy = {
   initialMs: 250,
@@ -75,45 +70,6 @@ export function openTelegramIngressQueue(
     accountId: parts.accountId,
     stateDir: parts.stateDir,
   });
-}
-
-export function telegramSpooledUpdateLaneKey(update: unknown, botInfo?: TelegramBotInfo): string {
-  return getTelegramSequentialKey({
-    update: update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
-    ...(botInfo ? { me: botInfo } : {}),
-  });
-}
-
-/**
- * Durable-before-ack accept path: commit the update to the ingress queue.
- * Polling advances offset only after this returns; webhook returns 200 only after.
- */
-export async function writeTelegramSpooledUpdate(params: {
-  spoolDir: string;
-  update: unknown;
-  laneKey?: string;
-  now?: number;
-}): Promise<number> {
-  const updateId = resolveTelegramUpdateId(params.update);
-  if (updateId === null) {
-    throw new Error("Telegram update missing numeric update_id.");
-  }
-  const receivedAt = params.now ?? Date.now();
-  const queue = openTelegramIngressQueue(params.spoolDir);
-  await queue.enqueue(
-    telegramQueueEventId(updateId),
-    {
-      version: TELEGRAM_SPOOLED_UPDATE_PAYLOAD_VERSION,
-      updateId,
-      receivedAt,
-      update: params.update,
-    },
-    {
-      receivedAt,
-      laneKey: params.laneKey ?? telegramSpooledUpdateLaneKey(params.update),
-    },
-  );
-  return updateId;
 }
 
 /** Backoff for irrevocable-adoption completion retries (bot-message only). */

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -21,7 +21,8 @@ import {
 import { setTelegramRuntime } from "./runtime.js";
 import { clearTelegramRuntimeForTest as clearTelegramRuntime } from "./runtime.test-support.js";
 import type { TelegramRuntime } from "./runtime.types.js";
-import { openTelegramIngressQueue, writeTelegramSpooledUpdate } from "./telegram-ingress-spool.js";
+import { openTelegramIngressQueue } from "./telegram-ingress-spool.js";
+import { writeTelegramSpooledUpdate } from "./telegram-ingress-spool.test-support.js";
 import {
   listTelegramSpooledUpdateClaims,
   listTelegramSpooledUpdates,

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -37,11 +37,7 @@ import { createTelegramBot } from "./bot.js";
 import { resolveTelegramTransport } from "./fetch.js";
 import { isRetryableTelegramApiError, isTelegramAuthenticationError } from "./network-errors.js";
 import { createTelegramTransportIngressMonitor } from "./telegram-ingress-drain-factory.js";
-import {
-  resolveTelegramIngressSpoolDir,
-  telegramSpooledUpdateLaneKey,
-  writeTelegramSpooledUpdate,
-} from "./telegram-ingress-spool.js";
+import { resolveTelegramIngressSpoolDir } from "./telegram-ingress-spool.js";
 import { createTelegramWebhookStatusPublisher } from "./webhook-status.js";
 
 const TELEGRAM_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
@@ -395,7 +391,6 @@ export async function startTelegramWebhook(opts: {
 
   const log = (line: string) => runtime.log?.(line);
   let webhookIngressMonitor: ReturnType<typeof createTelegramTransportIngressMonitor> | undefined;
-  const requestWebhookSpoolDrain = () => webhookIngressMonitor?.requestDrain();
   const startWebhookSpoolDrain = () => {
     if (webhookIngressMonitor) {
       return;
@@ -489,17 +484,16 @@ export async function startTelegramWebhook(opts: {
 
       // Telegram sees 200 only after the update is durable. If SQLite rejects
       // the enqueue, this path returns non-200 so Telegram redelivers.
-      await writeTelegramSpooledUpdate({
-        spoolDir,
-        update: body.value,
-        laneKey: telegramSpooledUpdateLaneKey(body.value, botInfo),
-      });
+      const ingressMonitor = webhookIngressMonitor;
+      if (!ingressMonitor) {
+        throw new Error("Telegram webhook ingress is not ready.");
+      }
+      await ingressMonitor.admit(body.value);
       // Enqueue duplicate detection makes Telegram webhook retries idempotent:
       // re-posted update_ids map to the same spool row and still ack fast.
       res.setHeader(TELEGRAM_WEBHOOK_ACCEPTED_HEADER, TELEGRAM_WEBHOOK_ACCEPTED_VALUE);
       respondText(200);
       status.noteWebhookUpdateReceived();
-      requestWebhookSpoolDrain();
       if (diagnosticsEnabled) {
         logWebhookProcessed({
           channel: "telegram",

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -185,7 +185,6 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
   options: CreateChannelIngressMonitorOptions<TRaw, TBody, TStoredPayload, TMetadata>,
 ) {
   const now = options.now ?? Date.now;
-  const appendRetryDelaysMs = options.appendRetryDelaysMs ?? DEFAULT_APPEND_RETRY_DELAYS_MS;
   const waitForDeliveryIdleBeforeRepump = options.waitForDeliveryIdleBeforeRepump ?? false;
   const retention =
     options.retention === "standard"
@@ -583,7 +582,7 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
     receivedAt: number;
   }): Promise<Awaited<ReturnType<Queue["enqueue"]>>> => {
     let lastError: unknown;
-    for (const delayMs of appendRetryDelaysMs) {
+    for (const delayMs of options.appendRetryDelaysMs ?? DEFAULT_APPEND_RETRY_DELAYS_MS) {
       if (delayMs > 0) {
         await sleep(delayMs);
       }


### PR DESCRIPTION
Fixes #89573.

## What Problem This Solves

OpenClaw could send Telegram polls, but a vote on a public poll produced no agent turn. Telegram's `poll_answer` update contains the poll id and voter selection, but omits the originating chat and forum-topic route.

## Root Cause and Canonical Fix

The Telegram plugin discarded the send-time origin and treated poll answers outside the normal inbound message pipeline. The fix now:

- records the returned poll id, resolved chat, topic, question, and options at the public-poll send boundary;
- stores that bounded route in shared plugin-state SQLite under `telegram.poll-registry`;
- prepares the recovered or provisional route synchronously before Telegram sequentialization so votes share the normal chat/topic lane;
- authorizes the voter, then sends a synthetic service message through the canonical Telegram inbound turn pipeline;
- requires current origin-group membership even when the voter remains on an operator allowlist;
- treats channels as an unsupported poll-answer route instead of storing an unreadable route and claiming success;
- checks the target's effective group/topic inbound policy before claiming answer routing is enabled;
- records registry-read failures as retryable durable-ingress outcomes;
- persists the prepared route with the durable vote, so a later same-topic message cannot overtake it;
- fences an immediate vote inside only its recovered chat/topic lane while outbound verification and route persistence finish, leaving unrelated admission and delivery unblocked;
- returns unknown poll ids after one registry lookup, so they cannot hold unrelated Telegram updates in serialized admission;
- skips retractions and identity-less/bot voters before registry lookup;
- retires closed-poll routes after a 48-hour durable-replay grace, reclaiming registry capacity without expiring active polls.

Unknown polls, retractions, bot votes, identity-less `voter_chat` answers, and unauthorized forwarded-poll voters remain intentional non-outcomes. Polls remain anonymous by default; the tool schema and result now explain that public polls are the opt-in for agent-routed votes.

## Operator Behavior

Direct-chat public polls enable answer routing immediately. Telegram only guarantees `getChatMember` for other group members when the bot is an administrator, so group public-poll routing is enabled only after that prerequisite is confirmed. Each vote also proves that the voter is still a current member of the origin group. Disabled group/topic targets, channel poll routes, and anonymous polls return unavailable instead of promising an inbound turn that cannot occur. The poll still sends when routing cannot be enabled, but the message-tool result returns `pollAnswerRouting: "unavailable"` with a concrete operator action instead of failing silently or resending the poll.

This is the best owner-boundary fix: origin is recorded where Telegram still exposes it, authentication remains in Telegram ingress, and the resulting vote follows the same session, reply, delivery, and ordering path as a normal inbound message. The temporary public async admission hook was removed; no core policy, JSON sidecar, parallel session resolver, or new configuration surface was added.

## Evidence

- Exact head: `ef3ffac7337887ae6b83e4c2651b05a1b79e0031`; branch base: `a1d20ae31bc57e327747ed99493faaf86339ada9`.
- Focused Telegram lifecycle/middleware/handler tests: 5 files, 501 tests passed. Telegram transport/drain coverage passed 520/520, the durable coalescing harness passed 5/5, and the shared ingress monitor passed 23/23.
- Exact-head local CI shards passed: production `tsgo`, test `tsgo`, full Oxlint, all 125 plugin package-boundary compiles, formatting, plugin boundaries, SDK surface, dead exports, and `git diff --check`. The remote check runner was unavailable during the first changed-gate attempt, so the repository-mandated local fallback produced this evidence.
- Final authorization/routing pass: 234 focused tests passed, including five disabled account/group/topic cases and Telegram's omitted General-topic thread id; production/test `tsgo`, focused Oxlint, dead exports, and `git diff --check` passed.
- Final review-fix pass: 522 focused ingress/Telegram tests passed, including route-local pending registration, unrelated admission and delivery, same-topic order, one-lookup unknown answers, anonymous result guidance, message-tool schema guidance, and exact bot-creation state fixtures; production/test `tsgo`, focused Oxlint, and `git diff --check` passed.
- Maintainer review passes: structural simplification, performance/allocation audit, and independent correctness/security review rounds; final autoreview was clean at 0.99.
- Real Telegram userbot proof, direct chat: a real user received public poll Bot API message `497`, selected `Yes`, Telegram emitted the vote, the gateway created a new inbound agent request containing `Poll response to "Ready?": Yes`, and the bot replied `POLL_VOTE_RECEIVED` as message `499`.
- Real Telegram userbot proof, forum: in topic `48125`, the bot sent poll `48127`; the real user selected `Yes`; the vote-triggered reply `48130` remained in topic `48125`. The temporary topic was deleted after proof.
- Both runs observed exactly three provider requests: create poll, tool result, vote-triggered turn. No gateway error or retry occurred.
- Discord regression proof also passed on the same head: a leased QA driver received the exact `OPENCLAW_E2E_OK` reply from an ephemeral gateway built from this checkout.

The exact-head regression pass also resolves the prior review questions without production shims: synthetic poll turns inherit durable replay from the canonical AsyncLocalStorage frame and produce a completed deferred participant; grammY's pinned `sendPoll` contract uses `message_thread_id` for forum supergroups and private bot topics and explicitly disallows channel direct-message chats. The existing direct-topic session test and the new durable replay test cover those contracts.

```json
{
  "channel": "telegram",
  "head": "ef3ffac7337887ae6b83e4c2651b05a1b79e0031",
  "environment": "ephemeral gateway + mock provider + real Telegram Bot API + real TDLib user",
  "scenarios": [
    "direct-chat public poll -> real user vote -> originating agent turn",
    "forum-topic public poll -> real user vote -> same-topic agent turn"
  ],
  "directPollBotApiMessageId": 497,
  "directReplyBotApiMessageId": 499,
  "forumTopicId": 48125,
  "forumPollBotApiMessageId": 48127,
  "forumReplyBotApiMessageId": 48130,
  "selectedOption": "Yes",
  "agentObserved": "Poll response to \"Ready?\": Yes",
  "visibleReply": "POLL_VOTE_RECEIVED",
  "providerRequestCount": 3,
  "verdict": "pass"
}
```

## Scope Metrics

- Production: +783 / -100 lines. Net growth is the concrete transport capability, durable route owner/lifecycle, authorization boundary, route-local registration fence, and operator-visible failure contract; the old direct-spool production path, unknown-vote delay, and public async admission hook were deleted.
- Tests and test harnesses: +1423 / -24 lines. Coverage includes direct chat, current group membership, disabled target policy, channel rejection, group authorization, forum topics, forwarded polls, no-op filtering, route retirement, immediate-vote races, unrelated admission during registration, unknown-vote admission, durable retry/adoption, same-session ordering, transport admission, and tool-result warnings.
- Config/default surfaces: 0 added, 0 changed, 0 removed.
- Dependencies, schema versions, protocol versions, docs, generated files: unchanged.

## Redundancy

#89573 is the canonical issue. #95309 is the stale broader sidecar/migration alternative; #72501 is its closed predecessor. This PR uses the current plugin-state and compositional Telegram handler seams.

## AI Assistance

Implementation and review were assisted by AI tooling. Maintainer review verified the current send, authorization, session, durable-ingress, storage, and Telegram API contracts before publication.
