### PR TITLE
fix: compact Codex OAuth OpenAI sessions without API keys

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1846,7 +1846,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     });
   });
 
-  it("keeps selected Codex harness queued compaction on canonical OpenAI context", async () => {
+  it("runs selected Codex harness queued compaction on canonical OpenAI context", async () => {
     resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "codex" });
     maybeCompactAgentHarnessSessionMock.mockResolvedValueOnce({
       ok: true,
@@ -1874,7 +1874,16 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     );
 
     expect(result.ok).toBe(true);
-    expect(maybeCompactAgentHarnessSessionMock).not.toHaveBeenCalled();
+    expect(contextEngineCompactMock).toHaveBeenCalledTimes(1);
+    expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledTimes(1);
+    expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5.5",
+        agentHarnessId: "codex",
+      }),
+      { nativeCompactionRequest: "after_context_engine" },
+    );
     const compactArg = mockCallArg(contextEngineCompactMock) as {
       runtimeContext?: Record<string, unknown>;
     };
@@ -1915,7 +1924,15 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     );
 
     expect(result.ok).toBe(true);
-    expect(maybeCompactAgentHarnessSessionMock).not.toHaveBeenCalled();
+    expect(contextEngineCompactMock).toHaveBeenCalledTimes(1);
+    expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledTimes(1);
+    expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5.5",
+      }),
+      { nativeCompactionRequest: "after_context_engine" },
+    );
     const compactArg = mockCallArg(contextEngineCompactMock) as {
       runtimeContext?: Record<string, unknown>;
     };
@@ -1968,7 +1985,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     });
   });
 
-  it("keeps concrete Codex pins on canonical OpenAI for queued compaction", async () => {
+  it("uses concrete Codex pins on canonical OpenAI for queued compaction", async () => {
     resolveAgentHarnessPolicyMock.mockReturnValue({
       runtime: "auto",
       runtimeSource: "model",
@@ -1999,7 +2016,16 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     );
 
     expect(result.ok).toBe(true);
-    expect(maybeCompactAgentHarnessSessionMock).not.toHaveBeenCalled();
+    expect(contextEngineCompactMock).toHaveBeenCalledTimes(1);
+    expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledTimes(1);
+    expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5.5",
+        agentHarnessId: "codex",
+      }),
+      { nativeCompactionRequest: "after_context_engine" },
+    );
     const compactArg = mockCallArg(contextEngineCompactMock) as {
       runtimeContext?: Record<string, unknown>;
     };
@@ -2068,7 +2094,10 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
         config: {
           models: {
             providers: {
-              openai: { models: [{ id: "gpt-5.5", contextWindow: 350_000 }] },
+              openai: {
+                baseUrl: "https://example.test/v1",
+                models: [{ id: "gpt-5.5", contextWindow: 350_000 }],
+              },
             },
           },
         },
@@ -2125,7 +2154,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     expect(contextEngineCompactMock).not.toHaveBeenCalled();
   });
 
-  it("uses context-engine compaction when no Codex native binding is selected", async () => {
+  it("keeps context-engine compaction successful when Codex native binding is missing", async () => {
     resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "codex" });
     maybeCompactAgentHarnessSessionMock.mockResolvedValueOnce({
       ok: false,
@@ -2146,8 +2175,25 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(true);
     expect(result.result?.summary).toBe("engine-summary");
-    expect(maybeCompactAgentHarnessSessionMock).not.toHaveBeenCalled();
     expect(contextEngineCompactMock).toHaveBeenCalledTimes(1);
+    expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledTimes(1);
+    expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5.4",
+        agentHarnessId: "codex",
+      }),
+      { nativeCompactionRequest: "after_context_engine" },
+    );
+    const details = result.result?.details as
+      | { codexNativeCompaction?: Record<string, unknown> }
+      | undefined;
+    expect(details?.codexNativeCompaction).toMatchObject({
+      ok: false,
+      compacted: false,
+      reason: "no codex app-server thread binding",
+      failure: { reason: "missing_thread_binding" },
+    });
   });
 
   it("keeps owning context-engine compaction primary for legacy Codex native sessions", async () => {

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -252,7 +252,7 @@ export async function compactEmbeddedAgentSession(
   const ceModelId = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
   const attemptNativeHarnessCompaction = shouldAttemptNativeHarnessCompaction({
     provider: ceProvider,
-    contextProvider: resolvedCompactionTarget.contextProvider,
+    nativeHarnessCompaction: resolvedCompactionTarget.nativeHarnessCompaction,
     selectedHarnessRuntime,
   });
   if (attemptNativeHarnessCompaction) {
@@ -630,14 +630,14 @@ export async function compactEmbeddedAgentSession(
 
 function shouldAttemptNativeHarnessCompaction(params: {
   provider: string;
-  contextProvider?: string;
+  nativeHarnessCompaction?: boolean;
   selectedHarnessRuntime?: string | null;
 }): boolean {
   const selectedRuntime = normalizeOptionalAgentRuntimeId(params.selectedHarnessRuntime);
   if (!selectedRuntime || selectedRuntime === "auto" || selectedRuntime === "openclaw") {
     return false;
   }
-  return isOpenAIProvider(params.provider) ? params.contextProvider !== undefined : true;
+  return isOpenAIProvider(params.provider) ? params.nativeHarnessCompaction === true : true;
 }
 
 function buildCompactionContextEngineRuntimeContext(params: {

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -271,6 +271,7 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     expect(result.provider).toBe("openai");
     expect(result.runtimeProvider).toBeUndefined();
     expect(result.contextProvider).toBeUndefined();
+    expect(result.nativeHarnessCompaction).toBe(true);
     expect(result.model).toBe("gpt-5.5");
     expect(result.authProfileId).toBeUndefined();
   });
@@ -315,7 +316,10 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
       config: {
         models: {
           providers: {
-            openai: { models: [{ id: "gpt-5.5" }] },
+            openai: {
+              baseUrl: "https://example.test/v1",
+              models: [{ id: "gpt-5.5" }],
+            },
           },
         },
       } as unknown as OpenClawConfig,
@@ -328,6 +332,7 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     expect(result.provider).toBe("openai");
     expect(result.runtimeProvider).toBeUndefined();
     expect(result.contextProvider).toBeUndefined();
+    expect(result.nativeHarnessCompaction).toBeUndefined();
     expect(result.model).toBe("gpt-5.5");
     expect(result.authProfileId).toBeUndefined();
   });
@@ -387,6 +392,7 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     expect(result.provider).toBe("openai");
     expect(result.runtimeProvider).toBeUndefined();
     expect(result.contextProvider).toBeUndefined();
+    expect(result.nativeHarnessCompaction).toBe(true);
     expect(result.model).toBe("gpt-5.4-mini");
     expect(result.authProfileId).toBeUndefined();
   });

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.ts
@@ -70,6 +70,7 @@ export function resolveEmbeddedCompactionTarget(params: {
   provider: string | undefined;
   runtimeProvider?: string;
   contextProvider?: string;
+  nativeHarnessCompaction?: boolean;
   model: string | undefined;
   authProfileId: string | undefined;
 } {
@@ -99,6 +100,7 @@ export function resolveEmbeddedCompactionTarget(params: {
     return {
       runtimeProvider: routedRuntimeProvider,
       contextProvider: useCodexHarnessRuntime ? routedRuntimeProvider : undefined,
+      ...(useCodexHarnessRuntime ? { nativeHarnessCompaction: true } : {}),
     };
   };
   if (!override) {


### PR DESCRIPTION
Fixes #95693

## What Problem This Solves

Fixes an issue where users running canonical OpenAI models through the Codex OAuth runtime could see manual `/compact` or budget-triggered compaction fail with a missing OpenAI API key error, even though normal agent turns used the Codex OAuth runtime successfully.

## Why This Change Was Made

The compaction target resolver now carries an internal `nativeHarnessCompaction` fact when the active OpenAI model should compact through the Codex native harness. Queued compaction uses that fact instead of treating `contextProvider` as the behavior sentinel, so canonical OpenAI + Codex runtime sessions can use native Codex compaction while custom OpenAI-compatible base URL providers continue using the direct OpenClaw compaction path.

## User Impact

Codex/OAuth-only OpenAI sessions can compact without requiring a separate `OPENAI_API_KEY` or API-key-backed profile. This is an internal bug fix only: no new API, SDK, config, CLI flag, or persisted state surface is added, and custom OpenAI-compatible base URL behavior is preserved.

## Evidence

- Behavior addressed: Codex OAuth OpenAI sessions no longer fall through to the direct API-key-backed OpenAI compaction path when manual `sessions.compact` or `/compact` runs against canonical `openai/gpt-5.5` with `agentRuntime.id = "codex"`.
- Real environment tested: Local Podman Crabbox (`provider=local-container`, `runtime=podman`, image `ubuntu_26.04`), lease `cbx_24b511b75d4d` / `silver-barnacle`, Node `v24.18.0`, OpenClaw source checkout `2026.6.9`, using real local Codex OAuth credentials forwarded as a secret env profile. No direct OpenAI API-key credential was used for the migrated OpenAI profile.
- Exact steps or command run after this patch: local Podman Crabbox proof hydrated an isolated `HOME`, imported Codex OAuth with `node --import tsx src/entry.ts migrate apply codex --from "$HOME/.codex" --include-secrets --yes --no-backup --force --json`, verified OpenAI config and persisted auth profiles were OAuth-only, ran a live `openai/gpt-5.5` Codex-harness agent turn, then called `sessions.compact` for that session. Also ran `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compaction-runtime-context.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts --maxWorkers=1`, `git diff --check origin/main...HEAD`, and `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex` after rebasing onto latest `origin/main`.
- Observed result after fix: migration created only an OpenAI OAuth profile (`mode/type: oauth`), the live turn returned the expected token (`ISSUE-95693-F7E8A0`), and `sessions.compact` returned `ok:true`, `compacted:false`, `details.backend:"codex-app-server"`, `details.signal:"thread/compact/start"`, and `details.pending:true`; no OpenAI API key was required. Focused Vitest passed, diff check passed, and autoreview reported no accepted/actionable findings.
