### PR TITLE
feat(voice-call): support Twilio calls in IE1 and AU1

### DIFF
--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -121,6 +121,7 @@ Voice-call credentials accept SecretRefs. `plugins.entries.voice-call.config.twi
           twilio: {
             accountSid: "ACxxxxxxxx",
             authToken: "...",
+            // region: "ie1", // optional: us1 | ie1 | au1; defaults to us1
           },
           telnyx: {
             apiKey: "...",
@@ -186,6 +187,11 @@ Top-level keys under `plugins.entries.voice-call.config` not shown above:
 | `responseModel`                 | unset        | Overrides the default model for classic (non-realtime) responses.                      |
 | `responseSystemPrompt`          | generated    | Custom system prompt for classic responses.                                            |
 | `responseTimeoutMs`             | `30000`      | Timeout for classic response generation (ms).                                          |
+
+Twilio defaults to its US1 REST endpoint. To process calls in a supported
+non-US Region, set `twilio.region` to `ie1` or `au1` and use credentials from
+that Region. See
+[Twilio's non-US REST API guide](https://www.twilio.com/docs/global-infrastructure/using-the-twilio-rest-api-in-a-non-us-region).
 
 <AccordionGroup>
   <Accordion title="Provider exposure and security notes">

--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -98,6 +98,7 @@ Put under `plugins.entries.voice-call.config`:
 Notes:
 
 - Twilio/Telnyx/Plivo require a **publicly reachable** webhook URL.
+- Twilio defaults to US1. For a non-US Region, set `twilio.region` to `ie1` or `au1` and use credentials created in that Region; see [Twilio's regional REST API guide](https://www.twilio.com/docs/global-infrastructure/using-the-twilio-rest-api-in-a-non-us-region).
 - `mock` is a local dev provider (no network calls).
 - Telnyx requires `telnyx.publicKey` (or `TELNYX_PUBLIC_KEY`) unless `skipSignatureVerification` is true.
 - If older configs still use `provider: "log"`, `twilio.from`, or legacy `streaming.*` OpenAI keys, run `openclaw doctor --fix` to rewrite them.

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -59,6 +59,7 @@ const voiceCallConfigSchema = {
     "telnyx.publicKey": { label: "Telnyx Public Key", sensitive: true },
     "twilio.accountSid": { label: "Twilio Account SID" },
     "twilio.authToken": { label: "Twilio Auth Token", sensitive: true },
+    "twilio.region": { label: "Twilio Region", advanced: true },
     "outbound.defaultMode": { label: "Default Call Mode" },
     "outbound.notifyHangupDelaySec": {
       label: "Notify Hangup Delay (sec)",

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -71,6 +71,10 @@
       "label": "Twilio Auth Token",
       "sensitive": true
     },
+    "twilio.region": {
+      "label": "Twilio Region",
+      "advanced": true
+    },
     "outbound.defaultMode": {
       "label": "Default Call Mode"
     },
@@ -286,6 +290,10 @@
           },
           "authToken": {
             "type": ["string", "object"]
+          },
+          "region": {
+            "type": "string",
+            "enum": ["us1", "ie1", "au1"]
           }
         }
       },

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -92,6 +92,30 @@ describe("validateProviderConfig", () => {
   });
 
   describe("twilio provider", () => {
+    it("accepts supported Twilio Regions and rejects unknown ones", () => {
+      const baseConfig = {
+        enabled: true,
+        provider: "twilio",
+        fromNumber: "+15550001234",
+        twilio: {
+          accountSid: "AC123",
+          authToken: "secret",
+        },
+      } as const;
+
+      const regional = VoiceCallConfigSchema.parse({
+        ...baseConfig,
+        twilio: { ...baseConfig.twilio, region: "ie1" },
+      });
+      expect(regional.twilio?.region).toBe("ie1");
+      expect(
+        VoiceCallConfigSchema.safeParse({
+          ...baseConfig,
+          twilio: { ...baseConfig.twilio, region: "de1" },
+        }).success,
+      ).toBe(false);
+    });
+
     it("accepts SecretRef-backed auth tokens before runtime resolution", () => {
       const config = VoiceCallConfigSchema.parse({
         enabled: true,

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -15,6 +15,7 @@ import { normalizeWebhookPath } from "openclaw/plugin-sdk/webhook-ingress";
 import { z } from "zod";
 import { TtsConfigSchema } from "../api.js";
 import { deepMergeDefined } from "./deep-merge.js";
+import { TWILIO_REGIONS } from "./providers/twilio-region.js";
 import { DEFAULT_VOICE_CALL_REALTIME_INSTRUCTIONS } from "./realtime-defaults.js";
 
 // -----------------------------------------------------------------------------
@@ -66,6 +67,8 @@ const TwilioConfigSchema = z
     accountSid: z.string().min(1).optional(),
     /** Twilio Auth Token */
     authToken: SecretInputSchema.optional(),
+    /** Twilio processing Region (for example, ie1) */
+    region: z.enum(TWILIO_REGIONS).optional(),
   })
   .strict();
 

--- a/extensions/voice-call/src/providers/twilio-region.ts
+++ b/extensions/voice-call/src/providers/twilio-region.ts
@@ -1,0 +1,17 @@
+// Keep config validation and REST routing on the same closed set of supported Regions.
+export const TWILIO_REGIONS = ["us1", "ie1", "au1"] as const;
+export type TwilioRegion = (typeof TWILIO_REGIONS)[number];
+
+const TWILIO_API_HOSTNAME_BY_REGION = {
+  us1: "api.twilio.com",
+  ie1: "api.dublin.ie1.twilio.com",
+  au1: "api.sydney.au1.twilio.com",
+} satisfies Record<TwilioRegion, string>;
+
+export function resolveTwilioApiBaseUrl(params: {
+  accountSid: string;
+  region?: TwilioRegion;
+}): string {
+  const hostname = TWILIO_API_HOSTNAME_BY_REGION[params.region ?? "us1"];
+  return `https://${hostname}/2010-04-01/Accounts/${params.accountSid}`;
+}

--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -1,5 +1,14 @@
 // Voice Call tests cover twilio plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { guardedJsonApiRequestMock } = vi.hoisted(() => ({
+  guardedJsonApiRequestMock: vi.fn(),
+}));
+
+vi.mock("./shared/guarded-json-api.js", () => ({
+  guardedJsonApiRequest: guardedJsonApiRequestMock,
+}));
+
 import type { WebhookContext } from "../types.js";
 import { TwilioProvider } from "./twilio.js";
 import { TwilioApiError } from "./twilio/api.js";
@@ -8,6 +17,7 @@ const STREAM_URL = "wss://example.ngrok.app/voice/stream";
 
 beforeEach(() => {
   vi.useRealTimers();
+  guardedJsonApiRequestMock.mockReset();
 });
 
 function createProvider(): TwilioProvider {
@@ -113,6 +123,26 @@ function configureTelephonyTwiMlFallback(params: { providerCallId: string; strea
 }
 
 describe("TwilioProvider", () => {
+  it("uses the derived regional hostname for call status", async () => {
+    guardedJsonApiRequestMock.mockResolvedValue({ status: "completed" });
+    const provider = new TwilioProvider({
+      accountSid: "AC123",
+      authToken: "secret",
+      region: "ie1",
+    });
+
+    await expect(provider.getCallStatus({ providerCallId: "CA123" })).resolves.toEqual({
+      status: "completed",
+      isTerminal: true,
+    });
+    expect(guardedJsonApiRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.dublin.ie1.twilio.com/2010-04-01/Accounts/AC123/Calls/CA123.json",
+        allowedHostnames: ["api.dublin.ie1.twilio.com"],
+      }),
+    );
+  });
+
   it("sends direct initial TwiML for notify-mode outbound calls", async () => {
     const provider = createProvider();
     const apiRequest = createApiRequestMock(async () => ({ sid: "CA123", status: "queued" }));

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -31,6 +31,7 @@ import {
   normalizeProviderStatus,
 } from "./shared/call-status.js";
 import { guardedJsonApiRequest } from "./shared/guarded-json-api.js";
+import { resolveTwilioApiBaseUrl, type TwilioRegion } from "./twilio-region.js";
 import type { TwilioProviderOptions } from "./twilio.types.js";
 import { TwilioApiError, twilioApiRequest } from "./twilio/api.js";
 import { decideTwimlResponse, readTwimlRequestView } from "./twilio/twiml-policy.js";
@@ -72,6 +73,7 @@ type StreamSendResult = {
 type TwilioProviderConfig = {
   accountSid?: string;
   authToken?: string;
+  region?: TwilioRegion;
 };
 
 export class TwilioProvider implements VoiceCallProvider {
@@ -144,7 +146,10 @@ export class TwilioProvider implements VoiceCallProvider {
 
     this.accountSid = config.accountSid;
     this.authToken = config.authToken;
-    this.baseUrl = `https://api.twilio.com/2010-04-01/Accounts/${this.accountSid}`;
+    this.baseUrl = resolveTwilioApiBaseUrl({
+      accountSid: this.accountSid,
+      region: config.region,
+    });
     this.options = options;
 
     if (options.publicUrl) {
@@ -830,7 +835,7 @@ export class TwilioProvider implements VoiceCallProvider {
           Authorization: `Basic ${Buffer.from(`${this.accountSid}:${this.authToken}`).toString("base64")}`,
         },
         allowNotFound: true,
-        allowedHostnames: ["api.twilio.com"],
+        allowedHostnames: [new URL(this.baseUrl).hostname],
         auditContext: "twilio-get-call-status",
         errorPrefix: "Twilio get call status error",
       });

--- a/extensions/voice-call/src/providers/twilio/api.test.ts
+++ b/extensions/voice-call/src/providers/twilio/api.test.ts
@@ -9,7 +9,10 @@ vi.mock("../../../api.js", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
+import { resolveTwilioApiBaseUrl } from "../twilio-region.js";
 import { TwilioApiError, twilioApiRequest } from "./api.js";
+
+const DEFAULT_BASE_URL = resolveTwilioApiBaseUrl({ accountSid: "AC123" });
 
 type FetchGuardRequest = {
   url?: string;
@@ -67,7 +70,7 @@ describe("twilioApiRequest", () => {
 
     await expect(
       twilioApiRequest({
-        baseUrl: "https://api.twilio.com",
+        baseUrl: DEFAULT_BASE_URL,
         accountSid: "AC123",
         authToken: "secret",
         endpoint: "/Calls.json",
@@ -79,7 +82,7 @@ describe("twilioApiRequest", () => {
     ).resolves.toEqual({ sid: "CA123" });
 
     const { url, init, auditContext, policy, timeoutMs } = requireFirstFetchGuardRequest();
-    expect(url).toBe("https://api.twilio.com/Calls.json");
+    expect(url).toBe("https://api.twilio.com/2010-04-01/Accounts/AC123/Calls.json");
     expect(auditContext).toBe("voice-call.twilio.api");
     expect(policy).toEqual({ allowedHostnames: ["api.twilio.com"] });
     expect(timeoutMs).toBe(30_000);
@@ -98,6 +101,37 @@ describe("twilioApiRequest", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("derives the regional hostname for the request and SSRF policy", async () => {
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(JSON.stringify({ sid: "CA123" }), { status: 200 }),
+      release,
+    });
+    const baseUrl = resolveTwilioApiBaseUrl({
+      accountSid: "AC123",
+      region: "ie1",
+    });
+
+    await twilioApiRequest({
+      baseUrl,
+      accountSid: "AC123",
+      authToken: "secret",
+      endpoint: "/Calls.json",
+      body: {},
+    });
+
+    const { url, policy } = requireFirstFetchGuardRequest();
+    expect(url).toBe("https://api.dublin.ie1.twilio.com/2010-04-01/Accounts/AC123/Calls.json");
+    expect(policy).toEqual({ allowedHostnames: ["api.dublin.ie1.twilio.com"] });
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps AU1 to Twilio's Sydney regional hostname", () => {
+    expect(resolveTwilioApiBaseUrl({ accountSid: "AC123", region: "au1" })).toBe(
+      "https://api.sydney.au1.twilio.com/2010-04-01/Accounts/AC123",
+    );
+  });
+
   it("passes through URLSearchParams, allows 404s, and returns undefined for empty bodies", async () => {
     const missing = cancelTrackedTextResponse("missing", { status: 404 });
     const responses = [new Response(null, { status: 204 }), missing.response];
@@ -109,7 +143,7 @@ describe("twilioApiRequest", () => {
 
     await expect(
       twilioApiRequest({
-        baseUrl: "https://api.twilio.com",
+        baseUrl: DEFAULT_BASE_URL,
         accountSid: "AC123",
         authToken: "secret",
         endpoint: "/Calls.json",
@@ -119,7 +153,7 @@ describe("twilioApiRequest", () => {
 
     await expect(
       twilioApiRequest({
-        baseUrl: "https://api.twilio.com",
+        baseUrl: DEFAULT_BASE_URL,
         accountSid: "AC123",
         authToken: "secret",
         endpoint: "/Calls/missing.json",
@@ -140,7 +174,7 @@ describe("twilioApiRequest", () => {
 
     await expect(
       twilioApiRequest({
-        baseUrl: "https://api.twilio.com",
+        baseUrl: DEFAULT_BASE_URL,
         accountSid: "AC123",
         authToken: "secret",
         endpoint: "/Calls.json",
@@ -160,7 +194,7 @@ describe("twilioApiRequest", () => {
 
     try {
       await twilioApiRequest({
-        baseUrl: "https://api.twilio.com",
+        baseUrl: DEFAULT_BASE_URL,
         accountSid: "AC123",
         authToken: "secret",
         endpoint: "/Calls.json",
@@ -187,7 +221,7 @@ describe("twilioApiRequest", () => {
 
     await expect(
       twilioApiRequest({
-        baseUrl: "https://api.twilio.com",
+        baseUrl: DEFAULT_BASE_URL,
         accountSid: "AC123",
         authToken: "secret",
         endpoint: "/Calls.json",
@@ -212,7 +246,7 @@ describe("twilioApiRequest", () => {
 
     try {
       await twilioApiRequest({
-        baseUrl: "https://api.twilio.com",
+        baseUrl: DEFAULT_BASE_URL,
         accountSid: "AC123",
         authToken: "secret",
         endpoint: "/Calls/CA123.json",

--- a/extensions/voice-call/src/providers/twilio/api.ts
+++ b/extensions/voice-call/src/providers/twilio/api.ts
@@ -84,7 +84,7 @@ export async function twilioApiRequest<T = unknown>(params: {
       },
       body: bodyParams,
     },
-    policy: { allowedHostnames: ["api.twilio.com"] },
+    policy: { allowedHostnames: [new URL(requestUrl).hostname] },
     timeoutMs: TWILIO_API_TIMEOUT_MS,
     auditContext: "voice-call.twilio.api",
   });

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -187,6 +187,7 @@ async function resolveProvider(config: VoiceCallConfig): Promise<VoiceCallProvid
         {
           accountSid: config.twilio?.accountSid,
           authToken: resolveTwilioAuthToken(config),
+          region: config.twilio?.region,
         },
         {
           allowNgrokFreeTierLoopbackBypass,


### PR DESCRIPTION
AI-assisted: Codex.

## What Problem This Solves

The voice-call plugin sends every Twilio Calls API request to US1. Calls and call records are region-specific, so IE1 and AU1 deployments cannot create, update, hang up, or inspect their calls through the US1 endpoint.

Closes #95828.

## Why This Change Was Made

This adds one optional closed config field: `twilio.region` accepts `us1`, `ie1`, or `au1`. OpenClaw derives Twilio's documented REST hostname internally:

- absent or `us1` → `api.twilio.com`
- `ie1` → `api.dublin.ie1.twilio.com`
- `au1` → `api.sydney.au1.twilio.com`

The account-scoped base URL is prepared once and reused for mutations and status reads. Each path derives its SSRF allowlist from the actual request/base URL, so request routing and hostname policy cannot drift. No arbitrary base URL or user-selectable edge is exposed.

Config/default metric: one optional config surface added, zero defaults changed, zero config surfaces removed. Existing configs keep the shipped US1 behavior.

## User Impact

Twilio voice-call users can target IE1 or AU1 with the Auth Token created in that Region. Existing US1 users see no behavior change. Unsupported region values fail config validation.

## Evidence

- Blacksmith Testbox `tbx_01kwxddkwq631x975x00zmd94t`: full voice-call extension suite passed — 50 files, 506 tests.
- Same Testbox: changed-surface extension production/test typechecks, lint, import-cycle check, docs lane, and repository guards passed.
- Same Testbox: `pnpm docs:list` passed; full docs check passed across 684 formatting/lint files, 700 MDX files, and 5,753 internal links with zero broken links.
- Independent live probes returned HTTP 401 from `api.twilio.com`, `api.dublin.ie1.twilio.com`, and `api.sydney.au1.twilio.com`, confirming all three current HTTPS endpoints are active and enforce authentication.
- Contributor credentialed proof: IE1 `TwilioProvider.getCallStatus` reached `api.dublin.ie1.twilio.com` with regional credentials and returned `not-found` for a deliberately nonexistent Call SID, without creating or modifying a call.
- Fresh autoreview: no actionable findings, 0.93 confidence.
- Current main and shipped v2026.6.11 both hardcode `api.twilio.com`; Twilio's current regional REST, edge, and regional-credential documentation were checked directly.

Known gap: no second maintainer-owned regional Twilio credential set was available. The contributor's credentialed IE1 provider proof covers the authenticated path; the maintainer pass independently verified all three live endpoints and the full test/docs surface.
