### PR TITLE
fix(heartbeat): remember silent task results for the next user turn

### DIFF
--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -84,6 +84,7 @@ If you want a heartbeat to do something very specific (e.g. "check Gmail PubSub 
 
 - If nothing needs attention, reply with **`HEARTBEAT_OK`**.
 - Heartbeat runs may instead call `heartbeat_respond` with `notify: false` for no visible update, or `notify: true` plus `notificationText` for an alert. When present, the structured tool response takes precedence over the text fallback.
+- A meaningful `heartbeat_respond` result with `notify: false` remains silent but is remembered as bounded internal context for the next user turn in that session. `no_change` acknowledgments and visible notifications are not stored this way.
 - During heartbeat runs, OpenClaw treats `HEARTBEAT_OK` as an ack when it appears at the **start or end** of the reply. The token is stripped and the reply is dropped if the remaining content is **≤ `ackMaxChars`** (default: 300).
 - If `HEARTBEAT_OK` appears in the **middle** of a reply, it is not treated specially.
 - For alerts, **do not** include `HEARTBEAT_OK`; return only the alert text.

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
@@ -173,6 +173,21 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     expect(result.llmBoundaryPromptForPrecheck).toContain("Visible request");
   });
 
+  it("injects the latest heartbeat outcome only as hidden runtime context", () => {
+    const fixture = createInput();
+    const result = prepareEmbeddedAttemptPromptContext({
+      ...fixture.input,
+      heartbeatOutcomeContext: "Latest silent heartbeat outcome: deployment finished",
+    });
+
+    expect(result.promptForSession).toBe("Visible request");
+    expect(result.promptForModel).toBe("Visible request");
+    expect(result.runtimeContextMessageForCurrentTurn?.content).toContain(
+      "Latest silent heartbeat outcome: deployment finished",
+    );
+    expect(result.llmBoundaryPromptForPrecheck).not.toContain("deployment finished");
+  });
+
   it("reports aggregate tool-result pressure for compact-then-truncate routing", () => {
     hoisted.truncateOversizedToolResultsInMessages.mockImplementation((inputMessages) => ({
       messages: [...inputMessages],

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-context.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-context.ts
@@ -85,6 +85,7 @@ export function prepareEmbeddedAttemptPromptContext(input: {
   isRawModelRun: boolean;
   messages: AgentMessage[];
   preparedUserTurnMessage?: AgentMessage;
+  heartbeatOutcomeContext?: string;
   prompt: PromptAssemblyContext;
   replaceSessionMessages: (messages: AgentMessage[]) => void;
   sessionAgentId: string;
@@ -209,7 +210,11 @@ export function prepareEmbeddedAttemptPromptContext(input: {
   }
   const runtimeContextForHook = isRuntimeOnlyTurn
     ? undefined
-    : [currentInboundContextText, promptSubmission.runtimeContext?.trim()]
+    : [
+        currentInboundContextText,
+        promptSubmission.runtimeContext?.trim(),
+        input.heartbeatOutcomeContext?.trim(),
+      ]
         .filter((value): value is string => Boolean(value))
         .join("\n\n") || undefined;
   const runtimeContextMessageForCurrentTurn =

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -1,5 +1,9 @@
 /** Runs prompt assembly, admission, submission, and prompt-local recovery. */
 import { formatErrorMessage } from "../../../infra/errors.js";
+import {
+  buildHeartbeatOutcomeContext,
+  claimHeartbeatOutcomeForRun,
+} from "../../../infra/heartbeat-outcome-store.js";
 import { releasePendingAgentSteeringItems } from "../../subagent-registry.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { log } from "../logger.js";
@@ -156,8 +160,19 @@ export async function runEmbeddedAttemptPromptPhase(input: {
   input.lifecycle.setPromptCacheChangesForTurn(promptAssembly.promptCacheChangesForTurn);
 
   try {
+    const heartbeatOutcomeContext =
+      attempt.trigger === "user" && attempt.sessionKey
+        ? buildHeartbeatOutcomeContext(
+            claimHeartbeatOutcomeForRun({
+              agentId: input.context.sessionAgentId,
+              sessionKey: attempt.sessionKey,
+              runId: attempt.runId,
+            }),
+          )
+        : undefined;
     const promptContext = prepareEmbeddedAttemptPromptContext({
       attempt,
+      ...(heartbeatOutcomeContext ? { heartbeatOutcomeContext } : {}),
       messages: activeSession.messages,
       prompt: promptAssembly,
       replaceSessionMessages: (messages) => {

--- a/src/infra/heartbeat-outcome-store.test.ts
+++ b/src/infra/heartbeat-outcome-store.test.ts
@@ -1,0 +1,175 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  buildHeartbeatOutcomeContext,
+  claimHeartbeatOutcomeForRun,
+  persistHeartbeatOutcome,
+} from "./heartbeat-outcome-store.js";
+
+const tempDirs: string[] = [];
+
+function createEnv(): NodeJS.ProcessEnv {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-heartbeat-outcome-"));
+  tempDirs.push(stateDir);
+  return { OPENCLAW_STATE_DIR: stateDir };
+}
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("heartbeat outcome store", () => {
+  it("keeps one bounded typed outcome per base session with provenance", () => {
+    const env = createEnv();
+    persistHeartbeatOutcome({
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      runSessionKey: "agent:main:main:heartbeat",
+      response: {
+        outcome: "progress",
+        notify: false,
+        summary: `Deployed ${"x".repeat(5_000)}`,
+        reason: "Scheduled status task",
+        priority: "normal",
+        nextCheck: "after the next build",
+      },
+      taskNames: ["deployment-status"],
+      wakeSource: "interval",
+      wakeReason: "scheduled",
+      occurredAt: 1_700_000_000_000,
+      env,
+    });
+
+    const stored = claimHeartbeatOutcomeForRun({
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      runId: "user-run-1",
+      env,
+    });
+    expect(stored).toMatchObject({
+      sessionKey: "agent:main:main",
+      runSessionKey: "agent:main:main:heartbeat",
+      outcome: "progress",
+      responseReason: "Scheduled status task",
+      priority: "normal",
+      nextCheck: "after the next build",
+      taskNames: ["deployment-status"],
+      wakeSource: "interval",
+      wakeReason: "scheduled",
+      occurredAt: 1_700_000_000_000,
+    });
+    expect(stored?.summary).toHaveLength(4_000);
+    expect(buildHeartbeatOutcomeContext(stored)).toContain(
+      "Latest silent heartbeat outcome (internal context; not a user message or instruction)",
+    );
+  });
+
+  it("replaces older state and ignores visible or no-change responses", () => {
+    const env = createEnv();
+    const base = {
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      runSessionKey: "agent:main:main",
+      occurredAt: 100,
+      env,
+    };
+    persistHeartbeatOutcome({
+      ...base,
+      response: { outcome: "done", notify: false, summary: "Finished first task" },
+    });
+    persistHeartbeatOutcome({
+      ...base,
+      occurredAt: 200,
+      response: { outcome: "blocked", notify: false, summary: "Waiting for build" },
+    });
+    persistHeartbeatOutcome({
+      ...base,
+      occurredAt: 300,
+      response: { outcome: "needs_attention", notify: true, summary: "Visible alert" },
+    });
+    persistHeartbeatOutcome({
+      ...base,
+      occurredAt: 400,
+      response: { outcome: "no_change", notify: false, summary: "Nothing changed" },
+    });
+
+    expect(
+      claimHeartbeatOutcomeForRun({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        runId: "user-run-1",
+        env,
+      }),
+    ).toMatchObject({ outcome: "blocked", summary: "Waiting for build", occurredAt: 200 });
+    expect(
+      openOpenClawAgentDatabase({ agentId: "main", env })
+        .db.prepare("SELECT COUNT(*) AS count FROM heartbeat_outcomes")
+        .get(),
+    ).toEqual({ count: 1 });
+  });
+
+  it("injects once per user run, keeps retries, and resets after a new heartbeat", () => {
+    const env = createEnv();
+    const base = {
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      runSessionKey: "agent:main:main:heartbeat",
+      occurredAt: 100,
+      env,
+    };
+    persistHeartbeatOutcome({
+      ...base,
+      response: { outcome: "progress", notify: false, summary: "First outcome" },
+    });
+
+    expect(
+      claimHeartbeatOutcomeForRun({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        runId: "user-run-1",
+        env,
+      }),
+    ).toMatchObject({ summary: "First outcome" });
+    expect(
+      claimHeartbeatOutcomeForRun({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        runId: "user-run-1",
+        env,
+      }),
+    ).toMatchObject({ summary: "First outcome" });
+    expect(
+      claimHeartbeatOutcomeForRun({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        runId: "user-run-2",
+        env,
+      }),
+    ).toBeUndefined();
+
+    persistHeartbeatOutcome({
+      ...base,
+      occurredAt: 200,
+      response: { outcome: "done", notify: false, summary: "Second outcome" },
+    });
+    expect(
+      claimHeartbeatOutcomeForRun({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        runId: "user-run-2",
+        env,
+      }),
+    ).toMatchObject({ summary: "Second outcome" });
+  });
+});

--- a/src/infra/heartbeat-outcome-store.ts
+++ b/src/infra/heartbeat-outcome-store.ts
@@ -1,0 +1,220 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { Insertable, Selectable } from "kysely";
+import type { HeartbeatToolResponse } from "../auto-reply/heartbeat-tool-response.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
+import { runOpenClawAgentWriteTransaction } from "../state/openclaw-agent-db.js";
+import type { HeartbeatWakeSource } from "./heartbeat-wake.js";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "./kysely-sync.js";
+
+const HEARTBEAT_OUTCOME_SUMMARY_MAX_CHARS = 4_000;
+const HEARTBEAT_OUTCOME_REASON_MAX_CHARS = 1_000;
+const HEARTBEAT_OUTCOME_NEXT_CHECK_MAX_CHARS = 500;
+const HEARTBEAT_OUTCOME_WAKE_REASON_MAX_CHARS = 1_000;
+const HEARTBEAT_OUTCOME_TASK_NAME_MAX_CHARS = 200;
+const HEARTBEAT_OUTCOME_MAX_TASKS = 32;
+
+type HeartbeatOutcomeTable = OpenClawAgentKyselyDatabase["heartbeat_outcomes"];
+type HeartbeatOutcomeDatabase = Pick<OpenClawAgentKyselyDatabase, "heartbeat_outcomes">;
+type HeartbeatOutcomeRow = Selectable<HeartbeatOutcomeTable>;
+type HeartbeatOutcomeInsert = Insertable<HeartbeatOutcomeTable>;
+
+export type PersistedHeartbeatOutcome = {
+  sessionKey: string;
+  runSessionKey: string;
+  outcome: Exclude<HeartbeatToolResponse["outcome"], "no_change">;
+  summary: string;
+  responseReason?: string;
+  priority?: NonNullable<HeartbeatToolResponse["priority"]>;
+  nextCheck?: string;
+  taskNames: string[];
+  wakeSource?: HeartbeatWakeSource;
+  wakeReason?: string;
+  occurredAt: number;
+};
+
+function boundedText(value: string | undefined, maxChars: number): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? truncateUtf16Safe(normalized, maxChars) : undefined;
+}
+
+function normalizeTaskNames(taskNames: readonly string[]): string[] {
+  return taskNames
+    .map((name) => boundedText(name, HEARTBEAT_OUTCOME_TASK_NAME_MAX_CHARS))
+    .filter((name): name is string => Boolean(name))
+    .slice(0, HEARTBEAT_OUTCOME_MAX_TASKS);
+}
+
+function parseTaskNames(value: string | null): string[] {
+  if (!value) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed)
+      ? normalizeTaskNames(parsed.filter((item): item is string => typeof item === "string"))
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function rowToOutcome(row: HeartbeatOutcomeRow): PersistedHeartbeatOutcome | undefined {
+  if (
+    row.outcome !== "progress" &&
+    row.outcome !== "done" &&
+    row.outcome !== "blocked" &&
+    row.outcome !== "needs_attention"
+  ) {
+    return undefined;
+  }
+  return {
+    sessionKey: row.session_key,
+    runSessionKey: row.run_session_key,
+    outcome: row.outcome,
+    summary: row.summary,
+    ...(row.response_reason ? { responseReason: row.response_reason } : {}),
+    ...(row.priority === "low" || row.priority === "normal" || row.priority === "high"
+      ? { priority: row.priority }
+      : {}),
+    ...(row.next_check ? { nextCheck: row.next_check } : {}),
+    taskNames: parseTaskNames(row.task_names_json),
+    ...(row.wake_source ? { wakeSource: row.wake_source as HeartbeatWakeSource } : {}),
+    ...(row.wake_reason ? { wakeReason: row.wake_reason } : {}),
+    occurredAt: row.occurred_at,
+  };
+}
+
+/** Replaces the previous silent heartbeat outcome for one base session. */
+export function persistHeartbeatOutcome(params: {
+  agentId: string;
+  sessionKey: string;
+  runSessionKey: string;
+  response: HeartbeatToolResponse;
+  taskNames?: readonly string[];
+  wakeSource?: HeartbeatWakeSource;
+  wakeReason?: string;
+  occurredAt: number;
+  env?: NodeJS.ProcessEnv;
+}): void {
+  if (params.response.notify || params.response.outcome === "no_change") {
+    return;
+  }
+  const taskNames = normalizeTaskNames(params.taskNames ?? []);
+  const values: HeartbeatOutcomeInsert = {
+    session_key: params.sessionKey,
+    run_session_key: params.runSessionKey,
+    outcome: params.response.outcome,
+    summary:
+      boundedText(params.response.summary, HEARTBEAT_OUTCOME_SUMMARY_MAX_CHARS) ??
+      params.response.outcome,
+    response_reason:
+      boundedText(params.response.reason, HEARTBEAT_OUTCOME_REASON_MAX_CHARS) ?? null,
+    priority: params.response.priority ?? null,
+    next_check:
+      boundedText(params.response.nextCheck, HEARTBEAT_OUTCOME_NEXT_CHECK_MAX_CHARS) ?? null,
+    task_names_json: taskNames.length > 0 ? JSON.stringify(taskNames) : null,
+    wake_source: params.wakeSource ?? null,
+    wake_reason: boundedText(params.wakeReason, HEARTBEAT_OUTCOME_WAKE_REASON_MAX_CHARS) ?? null,
+    occurred_at: params.occurredAt,
+    context_run_id: null,
+    context_claimed_at: null,
+    updated_at: Date.now(),
+  };
+  runOpenClawAgentWriteTransaction(
+    ({ db }) => {
+      const agentDb = getNodeSqliteKysely<HeartbeatOutcomeDatabase>(db);
+      executeSqliteQuerySync(
+        db,
+        agentDb
+          .insertInto("heartbeat_outcomes")
+          .values(values)
+          .onConflict((conflict) =>
+            conflict.column("session_key").doUpdateSet({
+              run_session_key: values.run_session_key,
+              outcome: values.outcome,
+              summary: values.summary,
+              response_reason: values.response_reason,
+              priority: values.priority,
+              next_check: values.next_check,
+              task_names_json: values.task_names_json,
+              wake_source: values.wake_source,
+              wake_reason: values.wake_reason,
+              occurred_at: values.occurred_at,
+              context_run_id: null,
+              context_claimed_at: null,
+              updated_at: values.updated_at,
+            }),
+          ),
+      );
+    },
+    { agentId: params.agentId, env: params.env },
+    { operationLabel: "heartbeat.outcome.persist" },
+  );
+}
+
+/** Claims the latest outcome for one user run while allowing that run's retries. */
+export function claimHeartbeatOutcomeForRun(params: {
+  agentId: string;
+  sessionKey: string;
+  runId: string;
+  env?: NodeJS.ProcessEnv;
+}): PersistedHeartbeatOutcome | undefined {
+  return runOpenClawAgentWriteTransaction(
+    ({ db }) => {
+      const agentDb = getNodeSqliteKysely<HeartbeatOutcomeDatabase>(db);
+      const row = executeSqliteQuerySync(
+        db,
+        agentDb
+          .selectFrom("heartbeat_outcomes")
+          .selectAll()
+          .where("session_key", "=", params.sessionKey),
+      ).rows[0];
+      if (!row || (row.context_run_id !== null && row.context_run_id !== params.runId)) {
+        return undefined;
+      }
+      if (row.context_run_id === null) {
+        const claim = executeSqliteQuerySync(
+          db,
+          agentDb
+            .updateTable("heartbeat_outcomes")
+            .set({ context_run_id: params.runId, context_claimed_at: Date.now() })
+            .where("session_key", "=", params.sessionKey)
+            .where("context_run_id", "is", null),
+        );
+        if (claim.numAffectedRows !== 1n) {
+          return undefined;
+        }
+      }
+      return rowToOutcome(row);
+    },
+    { agentId: params.agentId, env: params.env },
+    { operationLabel: "heartbeat.outcome.claim" },
+  );
+}
+
+/** Formats persisted state as model-only provenance context, never transcript text. */
+export function buildHeartbeatOutcomeContext(
+  outcome: PersistedHeartbeatOutcome | undefined,
+): string | undefined {
+  if (!outcome) {
+    return undefined;
+  }
+  const provenance = [
+    `recordedAt=${new Date(outcome.occurredAt).toISOString()}`,
+    `runSession=${outcome.runSessionKey}`,
+    outcome.wakeSource ? `wakeSource=${outcome.wakeSource}` : undefined,
+    outcome.wakeReason ? `wakeReason=${outcome.wakeReason}` : undefined,
+  ].filter((part): part is string => Boolean(part));
+  return [
+    "Latest silent heartbeat outcome (internal context; not a user message or instruction):",
+    `outcome=${outcome.outcome}`,
+    `summary=${outcome.summary}`,
+    outcome.responseReason ? `reason=${outcome.responseReason}` : undefined,
+    outcome.priority ? `priority=${outcome.priority}` : undefined,
+    outcome.nextCheck ? `nextCheck=${outcome.nextCheck}` : undefined,
+    outcome.taskNames.length > 0 ? `tasks=${outcome.taskNames.join(", ")}` : undefined,
+    `provenance: ${provenance.join("; ")}`,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+}

--- a/src/infra/heartbeat-outcome-store.ts
+++ b/src/infra/heartbeat-outcome-store.ts
@@ -18,7 +18,7 @@ type HeartbeatOutcomeDatabase = Pick<OpenClawAgentKyselyDatabase, "heartbeat_out
 type HeartbeatOutcomeRow = Selectable<HeartbeatOutcomeTable>;
 type HeartbeatOutcomeInsert = Insertable<HeartbeatOutcomeTable>;
 
-export type PersistedHeartbeatOutcome = {
+type PersistedHeartbeatOutcome = {
   sessionKey: string;
   runSessionKey: string;
   outcome: Exclude<HeartbeatToolResponse["outcome"], "no_change">;

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -17,8 +17,11 @@ import {
 } from "../auto-reply/reply/agent-runner-failure-copy.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { patchSessionEntry } from "../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { stripTrailingHeartbeatNotifyFalse } from "./heartbeat-delivery-normalization.js";
 import { getLastHeartbeatEvent, resetHeartbeatEventsForTest } from "./heartbeat-events.js";
+import { claimHeartbeatOutcomeForRun } from "./heartbeat-outcome-store.js";
 import { runHeartbeatOnce, testing, type HeartbeatDeps } from "./heartbeat-runner.js";
 import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
 import {
@@ -282,6 +285,44 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
 
     expect(result.status).toBe("ran");
     expect(sendTelegram).not.toHaveBeenCalled();
+  });
+
+  it("persists a meaningful quiet outcome for the base session", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      vi.stubEnv("OPENCLAW_STATE_DIR", tmpDir);
+      const cfg = createConfig({ tmpDir, storePath });
+      const sessionKey = await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      replySpy.mockResolvedValue(
+        createHeartbeatToolResponsePayload({
+          outcome: "progress",
+          notify: false,
+          summary: "Deployment completed; smoke test pending.",
+          nextCheck: "next scheduled heartbeat",
+        }),
+      );
+
+      await runHeartbeatOnce({
+        cfg,
+        source: "manual",
+        reason: "operator check",
+        deps: createDeps({ sendTelegram: vi.fn(), getReplyFromConfig: replySpy }),
+      });
+
+      expect(
+        claimHeartbeatOutcomeForRun({ agentId: "main", sessionKey, runId: "user-run" }),
+      ).toMatchObject({
+        outcome: "progress",
+        summary: "Deployment completed; smoke test pending.",
+        wakeSource: "manual",
+        wakeReason: "operator check",
+      });
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+    });
   });
 
   it("delivers notificationText when notify=true", async () => {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -130,6 +130,7 @@ import {
   isRelayableExecCompletionEvent,
 } from "./heartbeat-events-filter.js";
 import { emitHeartbeatEvent, resolveIndicatorType } from "./heartbeat-events.js";
+import { persistHeartbeatOutcome } from "./heartbeat-outcome-store.js";
 import { HEARTBEAT_RUN_SCOPE, type HeartbeatRunScope } from "./heartbeat-run-scope.js";
 import {
   computeNextHeartbeatPhaseDueMs,
@@ -1922,6 +1923,16 @@ export async function runHeartbeatOnce(opts: {
     const responsePrefix = resolveHeartbeatResponsePrefix();
 
     if (heartbeatToolResponse && !heartbeatToolResponse.notify && !heartbeatTerminalToolFailure) {
+      persistHeartbeatOutcome({
+        agentId,
+        sessionKey,
+        runSessionKey,
+        response: heartbeatToolResponse,
+        taskNames: dueHeartbeatTasks.map((task) => task.name),
+        wakeSource: opts.source,
+        wakeReason: opts.reason,
+        occurredAt: startedAt,
+      });
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,

--- a/src/state/openclaw-agent-db.generated.d.ts
+++ b/src/state/openclaw-agent-db.generated.d.ts
@@ -68,6 +68,23 @@ export interface Conversations {
   updated_at: number;
 }
 
+export interface HeartbeatOutcomes {
+  context_claimed_at: number | null;
+  context_run_id: string | null;
+  next_check: string | null;
+  occurred_at: number;
+  outcome: string;
+  priority: string | null;
+  response_reason: string | null;
+  run_session_key: string;
+  session_key: string;
+  summary: string;
+  task_names_json: string | null;
+  updated_at: number;
+  wake_reason: string | null;
+  wake_source: string | null;
+}
+
 export interface MemoryEmbeddingCache {
   dims: number | null;
   embedding: string;
@@ -266,6 +283,7 @@ export interface DB {
   cache_entries: CacheEntries;
   conversation_deliveries: ConversationDeliveries;
   conversations: Conversations;
+  heartbeat_outcomes: HeartbeatOutcomes;
   memory_embedding_cache: MemoryEmbeddingCache;
   memory_index_chunks: MemoryIndexChunks;
   memory_index_meta: MemoryIndexMeta;

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -72,6 +72,7 @@ export { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
  * per pathname, protected with private file modes, and registered in the shared
  * OpenClaw state database for discovery and maintenance.
  */
+// v12 = bounded per-session heartbeat outcome context.
 // v11 = agent-scoped runtime leases, durable delivery operations, and canonical
 // external conversation addresses.
 // v10 = materialized active transcript paths.
@@ -82,7 +83,7 @@ export { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
 // The v4 session/transcript flip and main's v2 memory-identity
 // change is folded in structure-gated (migrateMemoryIndexSourcesIdentity), so
 // v2 main DBs and pre-merge v4 flip DBs both converge on this schema.
-export const OPENCLAW_AGENT_SCHEMA_VERSION = 11;
+export const OPENCLAW_AGENT_SCHEMA_VERSION = 12;
 const OPENCLAW_AGENT_DB_DIR_MODE = 0o700;
 const OPENCLAW_AGENT_DB_FILE_MODE = 0o600;
 const OPENCLAW_AGENT_DB_SLOW_OPEN_MS = 1_000;

--- a/src/state/openclaw-agent-schema.generated.ts
+++ b/src/state/openclaw-agent-schema.generated.ts
@@ -182,6 +182,23 @@ CREATE INDEX IF NOT EXISTS idx_agent_session_entries_status
   ON session_entries(status, session_key)
   WHERE status IS NOT NULL;
 
+CREATE TABLE IF NOT EXISTS heartbeat_outcomes (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  run_session_key TEXT NOT NULL,
+  outcome TEXT NOT NULL CHECK (outcome IN ('progress', 'done', 'blocked', 'needs_attention')),
+  summary TEXT NOT NULL,
+  response_reason TEXT,
+  priority TEXT CHECK (priority IS NULL OR priority IN ('low', 'normal', 'high')),
+  next_check TEXT,
+  task_names_json TEXT,
+  wake_source TEXT,
+  wake_reason TEXT,
+  occurred_at INTEGER NOT NULL,
+  context_run_id TEXT,
+  context_claimed_at INTEGER,
+  updated_at INTEGER NOT NULL
+) STRICT;
+
 CREATE TABLE IF NOT EXISTS transcript_events (
   session_id TEXT NOT NULL,
   seq INTEGER NOT NULL,

--- a/src/state/openclaw-agent-schema.sql
+++ b/src/state/openclaw-agent-schema.sql
@@ -177,6 +177,23 @@ CREATE INDEX IF NOT EXISTS idx_agent_session_entries_status
   ON session_entries(status, session_key)
   WHERE status IS NOT NULL;
 
+CREATE TABLE IF NOT EXISTS heartbeat_outcomes (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  run_session_key TEXT NOT NULL,
+  outcome TEXT NOT NULL CHECK (outcome IN ('progress', 'done', 'blocked', 'needs_attention')),
+  summary TEXT NOT NULL,
+  response_reason TEXT,
+  priority TEXT CHECK (priority IS NULL OR priority IN ('low', 'normal', 'high')),
+  next_check TEXT,
+  task_names_json TEXT,
+  wake_source TEXT,
+  wake_reason TEXT,
+  occurred_at INTEGER NOT NULL,
+  context_run_id TEXT,
+  context_claimed_at INTEGER,
+  updated_at INTEGER NOT NULL
+) STRICT;
+
 CREATE TABLE IF NOT EXISTS transcript_events (
   session_id TEXT NOT NULL,
   seq INTEGER NOT NULL,


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->
Closes #95811

## What Problem This Solves

Fixes an issue where a useful silent heartbeat task result vanished from the agent's usable context. Users could suppress an unimportant heartbeat notification, but the next user turn could not ask about the work that had just completed.

## Why This Change Was Made

Meaningful structured heartbeat outcomes with `notify: false` now replace one bounded typed row in the owning agent's SQLite database. The next user run atomically claims that outcome and receives it as hidden runtime context; retries of that same run retain it, while later user runs cannot replay stale status. The row records the base and run session, due task names, wake source/reason, outcome metadata, and timestamp.

This deliberately adds no public config and does not preserve heartbeat prompts, tool calls, or transcript messages. `no_change` acknowledgments and visible notifications are not stored in this internal handoff.

## User Impact

After a silent heartbeat makes progress, finishes work, or records a blocker, the next user message can use that result without receiving an unsolicited heartbeat message. The artifact is bounded and one-turn-only, so old task status does not keep influencing unrelated replies.

## Evidence

Contributor's original behavior proof:

<img width="734" height="164" alt="User asks about an earlier heartbeat result and the agent recalls the result" src="https://github.com/user-attachments/assets/abc7b5ef-77ff-4449-af21-b26e29a343c9" />

Maintainer rework proof:

- `node scripts/run-vitest.mjs src/infra/heartbeat-outcome-store.test.ts src/infra/heartbeat-runner.tool-response.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts src/state/openclaw-agent-db.test.ts` — 77 passed, 1 skipped across 3 shards.
- `node scripts/generate-kysely-types.mjs --verify` — generated schema and Kysely types current.
- `node scripts/check-changed.mjs -- <12 touched files>` — full hosted core/typecheck/lint/database gates passed: https://github.com/openclaw/openclaw/actions/runs/29577963401
- Structured maintainer autoreview — clean after one accepted stale-context finding was fixed with the run-claim lifecycle.
