### PR TITLE
fix(codex): terminate message-tool source replies

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -1102,6 +1102,39 @@ describe("createCodexDynamicToolBridge", () => {
     ]);
   });
 
+  it("marks delivered message-tool-only source replies as terminal", async () => {
+    const bridge = createBridgeWithToolResult(
+      "message",
+      textToolResult("Sent.", { messageId: "imessage-6264" }),
+      { sourceReplyDeliveryMode: "message_tool_only" },
+    );
+
+    const result = await handleMessageToolCall(bridge, {
+      action: "send",
+      message: "visible reply",
+    });
+
+    expect(result).toEqual(expectInputText("Sent."));
+    expect(result.terminate).toBe(true);
+  });
+
+  it("does not mark explicit message-tool sends as terminal source replies", async () => {
+    const bridge = createBridgeWithToolResult(
+      "message",
+      textToolResult("Sent.", { messageId: "other-chat-message" }),
+      { sourceReplyDeliveryMode: "message_tool_only" },
+    );
+
+    const result = await handleMessageToolCall(bridge, {
+      action: "send",
+      target: "channel:other",
+      message: "cross-channel reply",
+    });
+
+    expect(result).toEqual(expectInputText("Sent."));
+    expect(result.terminate).toBeUndefined();
+  });
+
   it("does not record messaging side effects when the send fails", async () => {
     const tool = createTool({
       name: "message",

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -18,6 +18,7 @@ import {
   getChannelAgentToolMeta,
   getPluginToolMeta,
   type EmbeddedRunAttemptParams,
+  isDeliveredMessageToolOnlySourceReplyResult,
   isReplaySafeToolCall,
   isToolWrappedWithBeforeToolCallHook,
   isToolResultError,
@@ -65,6 +66,7 @@ type CodexDynamicToolHookContext = {
   currentMessagingTarget?: string;
   currentThreadId?: string;
   replyToMode?: "off" | "first" | "all" | "batched";
+  sourceReplyDeliveryMode?: EmbeddedRunAttemptParams["sourceReplyDeliveryMode"];
   hasRepliedRef?: { value: boolean };
   onToolOutcome?: EmbeddedRunAttemptParams["onToolOutcome"];
   allocateToolOutcomeOrdinal?: EmbeddedRunAttemptParams["allocateToolOutcomeOrdinal"];
@@ -358,10 +360,18 @@ export function createCodexDynamicToolBridge(params: {
           },
           terminalType,
         );
+        const deliveredSourceReply = isDeliveredMessageToolOnlySourceReplyResult({
+          sourceReplyDeliveryMode: params.hookContext?.sourceReplyDeliveryMode,
+          toolName,
+          args: executedArgs,
+          result,
+          isError: resultIsError,
+        });
         withDynamicToolTermination(
           response,
           rawResult.terminate === true ||
             result.terminate === true ||
+            deliveredSourceReply ||
             isToolResultYield(rawResult) ||
             isToolResultYield(result),
         );

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -843,6 +843,7 @@ export async function runCodexAppServerAttempt(
       currentMessagingTarget: params.currentMessagingTarget,
       currentThreadId: params.currentThreadTs,
       replyToMode: params.replyToMode,
+      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
       hasRepliedRef: params.hasRepliedRef,
       onToolOutcome: onCodexToolOutcome,
       allocateToolOutcomeOrdinal: allocateCodexToolOutcomeOrdinal,

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -140,6 +140,7 @@ export {
   isToolResultError,
   sanitizeToolResult,
 } from "../agents/embedded-agent-subscribe.tools.js";
+export { isDeliveredMessageToolOnlySourceReplyResult } from "../agents/embedded-agent-message-tool-source-reply.js";
 export { normalizeUsage } from "../agents/usage.js";
 export { resolveOpenClawAgentDir } from "./agent-dir-compat.js";
 export {


### PR DESCRIPTION
## Summary

- Marks delivered implicit `message_tool_only` source replies as terminal for Codex dynamic-tool runs.
- Passes `sourceReplyDeliveryMode` into the Codex dynamic tool hook context.
- Adds regression coverage proving implicit source replies terminate while explicit cross-channel message sends do not.

This is a minimal alternative/companion to #95826. It keeps the fix scoped to the Codex dynamic-tool termination path and shared harness export without the additional iMessage/docs changes in that draft.

## Root Cause

The embedded-agent path already has shared logic for detecting when a `message.send` call delivered the visible source reply in `message_tool_only` mode. The Codex app-server dynamic-tool bridge was not receiving `sourceReplyDeliveryMode`, so those delivered source replies were not included in Codex's dynamic-tool termination decision. Codex could therefore keep waiting after the user-visible reply had already been sent.

## Test Plan

- [x] `node scripts/run-vitest.mjs run extensions/codex/src/app-server/dynamic-tools.test.ts`
- [x] `node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts src/agents/embedded-agent-message-tool-source-reply.test.ts`
- [x] `git diff --check origin/main...HEAD`
- [ ] `pnpm build` currently fails on current `origin/main` declaration generation in unrelated `src/commands/doctor/shared/preview-warnings.ts` type errors:
  - `ToolProfilePolicy | undefined` is not assignable to `ToolPolicyConfig` at lines 450, 501, and 637.
  - This PR does not touch that file.
