### PR TITLE
fix(git-hooks): skip sequencer pre-commit formatting

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -20,6 +20,7 @@ GIT_DIR="$(git rev-parse --git-dir 2>/dev/null || true)"
 if [[ -n "$GIT_DIR" ]] && \
   { [[ -f "$GIT_DIR/MERGE_HEAD" ]] || \
     [[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ]] || \
+    [[ -f "$GIT_DIR/REVERT_HEAD" ]] || \
     [[ -f "$GIT_DIR/REBASE_HEAD" ]] || \
     [[ -d "$GIT_DIR/rebase-merge" ]] || \
     [[ -d "$GIT_DIR/rebase-apply" ]]; }; then

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -16,6 +16,17 @@ if [[ ! -f "$FILTER_FILES" ]]; then
   exit 1
 fi
 
+GIT_DIR="$(git rev-parse --git-dir 2>/dev/null || true)"
+if [[ -n "$GIT_DIR" ]] && \
+  { [[ -f "$GIT_DIR/MERGE_HEAD" ]] || \
+    [[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ]] || \
+    [[ -f "$GIT_DIR/REBASE_HEAD" ]] || \
+    [[ -d "$GIT_DIR/rebase-merge" ]] || \
+    [[ -d "$GIT_DIR/rebase-apply" ]]; }; then
+  # Sequencer commits stage the operation result, not just the user's local edits.
+  exit 0
+fi
+
 # Security: avoid option-injection from malicious file names (e.g. "--all", "--force").
 # Robustness: NUL-delimited file list handles spaces/newlines safely.
 # Compatibility: use read loops instead of `mapfile` so this runs on macOS Bash 3.x.

--- a/test/git-hooks-pre-commit.test.ts
+++ b/test/git-hooks-pre-commit.test.ts
@@ -216,6 +216,7 @@ describe("git-hooks/pre-commit (integration)", () => {
 
   it.each([
     ["cherry-pick", "CHERRY_PICK_HEAD", "file"],
+    ["revert", "REVERT_HEAD", "file"],
     ["rebase head", "REBASE_HEAD", "file"],
     ["merge rebase state", "rebase-merge", "dir"],
     ["apply rebase state", "rebase-apply", "dir"],

--- a/test/git-hooks-pre-commit.test.ts
+++ b/test/git-hooks-pre-commit.test.ts
@@ -1,6 +1,6 @@
 // Git hook tests validate pre-commit hook behavior and scripts.
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempRepoRoot } from "./helpers/temp-repo.js";
@@ -39,8 +39,8 @@ const runFailure = (
       const failure = error as Error & { status?: number; stderr?: string; stdout?: string };
       return {
         status: failure.status ?? 1,
-        stderr: String(failure.stderr ?? ""),
-        stdout: String(failure.stdout ?? ""),
+        stderr: failure.stderr ?? "",
+        stdout: failure.stdout ?? "",
       };
     }
     throw error;
@@ -83,6 +83,34 @@ function installPreCommitFixture(dir: string): string {
   return fakeBinDir;
 }
 
+function installFormattingRecorder(dir: string): string {
+  const logPath = path.join(dir, "hook-tool.log");
+  writeFileSync(
+    path.join(dir, "scripts", "pre-commit", "filter-staged-files.mjs"),
+    `const files = process.argv.slice(3).filter((arg) => arg !== "--");
+for (const file of files) {
+  if (file.endsWith(".ts")) {
+    process.stdout.write(file);
+    process.stdout.write("\0");
+  }
+}
+`,
+    "utf8",
+  );
+  writeFileSync(
+    path.join(dir, "scripts", "pre-commit", "run-node-tool.sh"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> ${JSON.stringify(logPath)}
+`,
+    {
+      encoding: "utf8",
+      mode: 0o755,
+    },
+  );
+  return logPath;
+}
+
 function installRunNodeToolFixture(dir: string): void {
   mkdirSync(path.join(dir, "scripts", "pre-commit"), { recursive: true });
   symlinkSync(
@@ -99,6 +127,13 @@ function splitNonEmptyLines(output: string): string[] {
     }
   }
   return lines;
+}
+
+function readFormatterLog(logPath: string): string[] {
+  if (!existsSync(logPath)) {
+    return [];
+  }
+  return splitNonEmptyLines(readFileSync(logPath, "utf8"));
 }
 
 afterEach(() => {
@@ -126,6 +161,99 @@ describe("git-hooks/pre-commit (integration)", () => {
 
     const staged = splitNonEmptyLines(run(dir, "git", ["diff", "--cached", "--name-only"]));
     expect(staged).toEqual(["--all"]);
+  });
+
+  it("skips formatting staged files while a merge commit is in progress", () => {
+    const dir = makeTempRepoRoot(tempDirs, "openclaw-pre-commit-merge-");
+    run(dir, "git", ["init", "-q", "--initial-branch=main"]);
+    installPreCommitFixture(dir);
+    const logPath = installFormattingRecorder(dir);
+
+    writeFileSync(path.join(dir, "changed.ts"), "export const value = 1;\n", "utf8");
+    run(dir, "git", ["add", "--", "changed.ts"]);
+    run(dir, "git", [
+      "-c",
+      "user.name=Test User",
+      "-c",
+      "user.email=test@example.invalid",
+      "commit",
+      "-q",
+      "-m",
+      "initial",
+    ]);
+    run(dir, "git", ["checkout", "-q", "-b", "side"]);
+    writeFileSync(path.join(dir, "changed.ts"), "export const value = 2;\n", "utf8");
+    run(dir, "git", ["add", "--", "changed.ts"]);
+    run(dir, "git", [
+      "-c",
+      "user.name=Test User",
+      "-c",
+      "user.email=test@example.invalid",
+      "commit",
+      "-q",
+      "-m",
+      "side change",
+    ]);
+    run(dir, "git", ["checkout", "-q", "main"]);
+    run(dir, "git", [
+      "-c",
+      "user.name=Test User",
+      "-c",
+      "user.email=test@example.invalid",
+      "merge",
+      "--no-commit",
+      "--no-ff",
+      "side",
+    ]);
+
+    expect(existsSync(path.join(dir, ".git", "MERGE_HEAD"))).toBe(true);
+    expect(run(dir, "git", ["diff", "--cached", "--name-only"])).toBe("changed.ts");
+
+    run(dir, "bash", ["git-hooks/pre-commit"]);
+
+    expect(readFormatterLog(logPath)).toEqual([]);
+  });
+
+  it.each([
+    ["cherry-pick", "CHERRY_PICK_HEAD", "file"],
+    ["rebase head", "REBASE_HEAD", "file"],
+    ["merge rebase state", "rebase-merge", "dir"],
+    ["apply rebase state", "rebase-apply", "dir"],
+  ])("skips formatting staged files while %s metadata is present", (_label, gitPath, kind) => {
+    const dir = makeTempRepoRoot(tempDirs, "openclaw-pre-commit-sequencer-");
+    run(dir, "git", ["init", "-q", "--initial-branch=main"]);
+    installPreCommitFixture(dir);
+    const logPath = installFormattingRecorder(dir);
+
+    writeFileSync(path.join(dir, "changed.ts"), "export const value = 1;\n", "utf8");
+    run(dir, "git", ["add", "--", "changed.ts"]);
+
+    const metadataPath = path.join(dir, ".git", gitPath);
+    if (kind === "dir") {
+      mkdirSync(metadataPath, { recursive: true });
+    } else {
+      writeFileSync(metadataPath, "sequencer state\n", "utf8");
+    }
+
+    run(dir, "bash", ["git-hooks/pre-commit"]);
+
+    expect(readFormatterLog(logPath)).toEqual([]);
+  });
+
+  it("still formats staged files during a normal commit", () => {
+    const dir = makeTempRepoRoot(tempDirs, "openclaw-pre-commit-normal-");
+    run(dir, "git", ["init", "-q", "--initial-branch=main"]);
+    installPreCommitFixture(dir);
+    const logPath = installFormattingRecorder(dir);
+
+    writeFileSync(path.join(dir, "changed.ts"), "export const value = 1;\n", "utf8");
+    run(dir, "git", ["add", "--", "changed.ts"]);
+
+    run(dir, "bash", ["git-hooks/pre-commit"]);
+
+    expect(readFormatterLog(logPath)).toEqual([
+      "oxfmt --write --no-error-on-unmatched-pattern changed.ts",
+    ]);
   });
 
   it("does not run the changed-scope check for non-doc staged changes", () => {


### PR DESCRIPTION
## Summary

- Stop `git-hooks/pre-commit` from formatting sequencer-staged files while merge, rebase, or cherry-pick commits are in progress.
- Keep normal pre-commit formatting behavior unchanged for ordinary staged files.
- Add hook integration coverage for merge metadata, rebase/cherry-pick metadata, and the normal commit path.

What problem does this PR solve?

`git-hooks/pre-commit` currently treats the sequencer-created staged index like ordinary local edits, so a merge/rebase/cherry-pick commit can run `oxfmt --write` over files staged by the operation.

Why does this matter now?

The hook was changed to format staged files directly; during sequencer commits that staged set can include unrelated upstream files.

What is the intended outcome?

Sequencer commits exit the hook successfully before formatter selection, while normal commits still run the formatter on staged format-able files.

What is intentionally out of scope?

No formatter selection rules, helper scripts, package manager behavior, or non-sequencer hook behavior are changed.

What does success look like?

Merge, rebase, and cherry-pick commit states do not invoke the formatter; a normal commit still does.

What should reviewers focus on?

The early Git metadata guard in `git-hooks/pre-commit` and the regression coverage in `test/git-hooks-pre-commit.test.ts`.

## Linked context

Which issue does this close?

Closes #95841

Which issues, PRs, or discussions are related?

Related: none found in open/closed issue and PR searches for this hook behavior.

Was this requested by a maintainer or owner?

No.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `git-hooks/pre-commit` should skip formatter invocation while merge/rebase/cherry-pick sequencer metadata is present, and should still format normal staged files.
- Real environment tested: Linux source checkout, branch head `ca8140e300caea46af70858a7f28a709eff81d22`, with temp Git repos invoking the real `git-hooks/pre-commit` from this branch.
- Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs test/git-hooks-pre-commit.test.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
node scripts/run-oxlint.mjs test/git-hooks-pre-commit.test.ts
node_modules/.bin/oxfmt --check --threads=1 git-hooks/pre-commit test/git-hooks-pre-commit.test.ts
```

A separate temp-repo shell repro invoked this branch's real `git-hooks/pre-commit` in merge, cherry-pick, rebase, and normal commit states while stubbing only the downstream formatter runner to record whether it was called.

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

Terminal capture from the temp-repo hook repro after this patch:

```text
merge MERGE_HEAD: staged=changed.ts formatter_invoked=no expected=no log=(none)
cherry-pick CHERRY_PICK_HEAD: staged=conflict.ts formatter_invoked=no expected=no log=(none)
rebase metadata: staged=conflict.ts formatter_invoked=no expected=no log=(none)
normal commit: staged=changed.ts formatter_invoked=yes expected=yes log=oxfmt --write --no-error-on-unmatched-pattern changed.ts
```

Focused test output after this patch:

```text
test/git-hooks-pre-commit.test.ts (12 tests)
12 passed
```

- Observed result after fix: merge, cherry-pick, and rebase states exited without invoking the formatter; the normal commit state still invoked `oxfmt --write --no-error-on-unmatched-pattern changed.ts`. The focused hook test file passed all 12 tests.
- What was not tested: Full `pnpm check` and the full hosted CI matrix were not run locally.
- Proof limitations or environment constraints: The temp-repo proof stubs the downstream formatter runner to record invocations instead of executing `oxfmt`; the hook script under test is the real branch file.
- Before evidence (optional but encouraged):

Terminal capture from current `upstream/main` before this patch:

```text
upstream_main=0529281430dbf55924a521ecea19578abc9f11c0
merge MERGE_HEAD: staged=changed.ts formatter_invoked=yes log=oxfmt --write --no-error-on-unmatched-pattern changed.ts
```

## Tests and validation

Which commands did you run?

```bash
node scripts/run-vitest.mjs test/git-hooks-pre-commit.test.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
node scripts/run-oxlint.mjs test/git-hooks-pre-commit.test.ts
node_modules/.bin/oxfmt --check --threads=1 git-hooks/pre-commit test/git-hooks-pre-commit.test.ts
git diff --check
```

What regression coverage was added or updated?

Added coverage that the hook skips formatter invocation for real merge metadata and for cherry-pick/rebase metadata paths, plus a non-regression test proving normal staged files still reach the formatter.

What failed before this fix, if known?

The new skip tests failed before the hook guard because the formatter runner was called with `oxfmt --write --no-error-on-unmatched-pattern changed.ts`.

If no test was added, why not?

N/A; regression tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, for contributor Git hook behavior during merge/rebase/cherry-pick commits.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No new execution surface. The change reduces formatter execution in sequencer commit states only.

What is the highest-risk area?

Accidentally disabling normal pre-commit formatting.

How is that risk mitigated?

The normal commit regression test and temp-repo proof both show a staged `.ts` file still invokes the formatter when no sequencer metadata is present.

## Current review state

What is the next action?

Ready for maintainer review after PR CI starts.

What is still waiting on author, maintainer, CI, or external proof?

Hosted PR CI and maintainer review.

Which bot or reviewer comments were addressed?

None yet.

Disclosure: AI-assisted; contributor manually reviewed and is responsible for the change.
