### PR TITLE
fix(subagents): credit requester-consumed descendant completions

### DIFF
--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -414,28 +414,8 @@ export function buildChildCompletionFindings(
   return ["Child completion results:", "", ...sections].join("\n\n");
 }
 
-export function dedupeLatestChildCompletionRows(
-  children: Array<{
-    childSessionKey: string;
-    task: string;
-    label?: string;
-    createdAt: number;
-    endedAt?: number;
-    frozenResultText?: string | null;
-    completion?: {
-      resultText?: string | null;
-      fallbackResultText?: string | null;
-    };
-    delivery?: {
-      payload?: {
-        frozenResultText?: string | null;
-        fallbackFrozenResultText?: string | null;
-      };
-    };
-    outcome?: SubagentRunOutcome;
-  }>,
-) {
-  const latestByChildSessionKey = new Map<string, (typeof children)[number]>();
+export function dedupeLatestChildCompletionRows<T extends ChildCompletionRow>(children: T[]): T[] {
+  const latestByChildSessionKey = new Map<string, T>();
   for (const child of children) {
     const existing = latestByChildSessionKey.get(child.childSessionKey);
     if (!existing || child.createdAt > existing.createdAt) {

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -26,6 +26,8 @@ import * as embeddedRuns from "./embedded-agent-runner/runs.js";
 import { testing as subagentAnnounceDeliveryTesting } from "./subagent-announce-delivery.js";
 import { runSubagentAnnounceDispatch } from "./subagent-announce-dispatch.js";
 import { testing as subagentAnnounceOutputTesting } from "./subagent-announce-output.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import * as agentStep from "./tools/agent-step.js";
 
 type AgentCallRequest = {
   method?: string;
@@ -171,7 +173,7 @@ const { subagentRegistryMock } = vi.hoisted(() => ({
     countPendingDescendantRuns: vi.fn((_sessionKey: string) => 0),
     countPendingDescendantRunsExcludingRun: vi.fn((_sessionKey: string, _runId: string) => 0),
     getLatestSubagentRunByChildSessionKey: vi.fn(
-      (_childSessionKey: string): MockSubagentRun | undefined => undefined,
+      (_childSessionKey: string): SubagentRunRecord | null => null,
     ),
     listSubagentRunsForRequester: vi.fn(
       (_sessionKey: string, _scope?: { requesterRunId?: string }): MockSubagentRun[] => [],
@@ -179,6 +181,7 @@ const { subagentRegistryMock } = vi.hoisted(() => ({
     replaceSubagentRunAfterSteer: vi.fn(
       (_params: { previousRunId: string; nextRunId: string }) => true,
     ),
+    markDescendantCompletionConsumedByRequester: vi.fn(),
     resolveRequesterForChildSession: vi.fn((_sessionKey: string): RequesterResolution => null),
   },
 }));
@@ -404,6 +407,8 @@ describe("subagent announce formatting", () => {
         req: Parameters<typeof gatewayCall.callGateway>[0],
       ) => (await callGatewaySpy(req)) as T,
       getRuntimeConfig: () => configOverride,
+      loadSubagentRegistryRuntime: async () =>
+        subagentRegistryMock as unknown as typeof import("./subagent-announce.registry.runtime.js"),
     });
     subagentAnnounceOutputTesting.setDepsForTest({
       callGateway: async <T = Record<string, unknown>>(
@@ -466,11 +471,10 @@ describe("subagent announce formatting", () => {
       .mockImplementation((sessionKey: string, _runId: string) =>
         subagentRegistryMock.countPendingDescendantRuns(sessionKey),
       );
-    subagentRegistryMock.getLatestSubagentRunByChildSessionKey
-      .mockClear()
-      .mockReturnValue(undefined);
+    subagentRegistryMock.getLatestSubagentRunByChildSessionKey.mockClear().mockReturnValue(null);
     subagentRegistryMock.listSubagentRunsForRequester.mockClear().mockReturnValue([]);
     subagentRegistryMock.replaceSubagentRunAfterSteer.mockClear().mockReturnValue(true);
+    subagentRegistryMock.markDescendantCompletionConsumedByRequester.mockClear();
     subagentRegistryMock.resolveRequesterForChildSession.mockClear().mockReturnValue(null);
     hasSubagentDeliveryTargetHook = false;
     hookHasHooksMock.mockClear();
@@ -2605,6 +2609,19 @@ describe("subagent announce formatting", () => {
     expect(msg).toContain("result from child b");
     expect(msg).not.toContain("stale result from child a");
     expect(msg.match(/1\. child-a/g)?.length ?? 0).toBe(1);
+    expect(subagentRegistryMock.markDescendantCompletionConsumedByRequester).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(subagentRegistryMock.markDescendantCompletionConsumedByRequester).toHaveBeenCalledWith({
+      requesterSessionKey: "agent:main:subagent:parent",
+      runStartedAt: defaultOutcomeAnnounce.startedAt,
+      runIds: ["run-child-current", "run-child-b"],
+      kind: "subagent_descendant_result",
+      consumerRunId: "run-parent-dedupe",
+    });
+    const consumedRunIds =
+      subagentRegistryMock.markDescendantCompletionConsumedByRequester.mock.calls[0]?.[0]?.runIds;
+    expect(consumedRunIds).not.toContain("run-child-stale");
   });
 
   it("does not announce a direct child that moved to a newer parent", async () => {
@@ -2638,7 +2655,7 @@ describe("subagent announce formatting", () => {
     subagentRegistryMock.getLatestSubagentRunByChildSessionKey.mockImplementation(
       (childSessionKey: string) => {
         if (childSessionKey !== "agent:main:subagent:shared-child") {
-          return undefined;
+          return null;
         }
         return {
           runId: "run-child-new-parent",

--- a/src/agents/subagent-announce.registry.runtime.ts
+++ b/src/agents/subagent-announce.registry.runtime.ts
@@ -14,3 +14,4 @@ export {
   resolveRequesterForChildSession,
   shouldIgnorePostCompletionAnnounceForSession,
 } from "./subagent-registry-runtime.js";
+export { markDescendantCompletionConsumedByRequester } from "./subagent-registry-consumption.js";

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -349,10 +349,9 @@ export async function runSubagentAnnounceFlow(params: {
             getLatestSubagentRunByChildSessionKey:
               subagentRegistryRuntime.getLatestSubagentRunByChildSessionKey,
           });
-          consumedChildRunIds = currentDirectChildren.map((child) => child.runId);
-          childCompletionFindings = buildChildCompletionFindings(
-            dedupeLatestChildCompletionRows(currentDirectChildren),
-          );
+          const consumedDirectChildren = dedupeLatestChildCompletionRows(currentDirectChildren);
+          consumedChildRunIds = consumedDirectChildren.map((child) => child.runId);
+          childCompletionFindings = buildChildCompletionFindings(consumedDirectChildren);
         }
       }
     } catch {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -312,6 +312,7 @@ export async function runSubagentAnnounceFlow(params: {
       requesterDepth >= 1 || isCronSessionKey(targetRequesterSessionKey);
 
     let childCompletionFindings: string | undefined;
+    let consumedChildRunIds: string[] = [];
     let subagentRegistryRuntime:
       | Awaited<ReturnType<typeof loadSubagentRegistryRuntime>>
       | undefined;
@@ -343,14 +344,14 @@ export async function runSubagentAnnounceFlow(params: {
           },
         );
         if (Array.isArray(directChildren) && directChildren.length > 0) {
+          const currentDirectChildren = filterCurrentDirectChildCompletionRows(directChildren, {
+            requesterSessionKey: params.childSessionKey,
+            getLatestSubagentRunByChildSessionKey:
+              subagentRegistryRuntime.getLatestSubagentRunByChildSessionKey,
+          });
+          consumedChildRunIds = currentDirectChildren.map((child) => child.runId);
           childCompletionFindings = buildChildCompletionFindings(
-            dedupeLatestChildCompletionRows(
-              filterCurrentDirectChildCompletionRows(directChildren, {
-                requesterSessionKey: params.childSessionKey,
-                getLatestSubagentRunByChildSessionKey:
-                  subagentRegistryRuntime.getLatestSubagentRunByChildSessionKey,
-              }),
-            ),
+            dedupeLatestChildCompletionRows(currentDirectChildren),
           );
         }
       }
@@ -382,6 +383,13 @@ export async function runSubagentAnnounceFlow(params: {
         signal: params.signal,
       });
       if (woke) {
+        subagentRegistryRuntime?.markDescendantCompletionConsumedByRequester?.({
+          requesterSessionKey: params.childSessionKey,
+          runStartedAt: params.startedAt ?? 0,
+          runIds: consumedChildRunIds,
+          kind: "subagent_descendant_result",
+          consumerRunId: params.childRunId,
+        });
         shouldDeleteChildSession = false;
         return true;
       }
@@ -580,6 +588,15 @@ export async function runSubagentAnnounceFlow(params: {
     });
     params.onDeliveryResult?.(delivery);
     didAnnounce = delivery.delivered;
+    if (didAnnounce && childCompletionFindings?.trim()) {
+      subagentRegistryRuntime?.markDescendantCompletionConsumedByRequester?.({
+        requesterSessionKey: params.childSessionKey,
+        runStartedAt: params.startedAt ?? 0,
+        runIds: consumedChildRunIds,
+        kind: "subagent_descendant_result",
+        consumerRunId: params.childRunId,
+      });
+    }
     if (!delivery.delivered && delivery.path === "direct" && delivery.error) {
       defaultRuntime.log(
         `[warn] Subagent completion direct announce failed for run ${params.childRunId}: ${delivery.error}`,

--- a/src/agents/subagent-delivery-state.test.ts
+++ b/src/agents/subagent-delivery-state.test.ts
@@ -135,6 +135,40 @@ describe("normalizeSubagentRunState", () => {
     expect(entry.cleanupHandled).toBe(false);
   });
 
+  it("preserves requester-consumed delivery credit across normalization", () => {
+    const entry = normalizeSubagentRunState(
+      baseRun({
+        cleanupHandled: true,
+        delivery: {
+          status: "delivered",
+          deliveredAt: 500,
+          requesterConsumedAt: 500,
+          requesterConsumedKind: "cron_descendant_fallback",
+          requesterConsumedBySessionKey: "agent:main:cron:daily:run:abc",
+          requesterConsumedRunStartedAt: 400,
+          requesterConsumedMetadata: {
+            consumerRunId: "cron-run",
+            deliveryTextHash: "abc123",
+          },
+        },
+      }),
+    );
+
+    expect(entry.delivery).toMatchObject({
+      status: "delivered",
+      deliveredAt: 500,
+      requesterConsumedAt: 500,
+      requesterConsumedKind: "cron_descendant_fallback",
+      requesterConsumedBySessionKey: "agent:main:cron:daily:run:abc",
+      requesterConsumedRunStartedAt: 400,
+      requesterConsumedMetadata: {
+        consumerRunId: "cron-run",
+        deliveryTextHash: "abc123",
+      },
+    });
+    expect(entry.cleanupHandled).toBe(false);
+  });
+
   it("keeps discarded terminal delivery dormant across restart", () => {
     const entry = normalizeSubagentRunState(
       baseRun({

--- a/src/agents/subagent-delivery-state.ts
+++ b/src/agents/subagent-delivery-state.ts
@@ -134,6 +134,14 @@ function mergeDeliveryState(
     enqueuedAt: current.enqueuedAt ?? restored.enqueuedAt,
     deliveredAt: current.deliveredAt ?? restored.deliveredAt,
     announcedAt: current.announcedAt ?? restored.announcedAt,
+    requesterConsumedAt: current.requesterConsumedAt ?? restored.requesterConsumedAt,
+    requesterConsumedKind: current.requesterConsumedKind ?? restored.requesterConsumedKind,
+    requesterConsumedBySessionKey:
+      current.requesterConsumedBySessionKey ?? restored.requesterConsumedBySessionKey,
+    requesterConsumedRunStartedAt:
+      current.requesterConsumedRunStartedAt ?? restored.requesterConsumedRunStartedAt,
+    requesterConsumedMetadata:
+      current.requesterConsumedMetadata ?? restored.requesterConsumedMetadata,
     lastAttemptAt: current.lastAttemptAt ?? restored.lastAttemptAt,
     attemptCount: current.attemptCount ?? restored.attemptCount,
     lastError: current.lastError ?? restored.lastError,

--- a/src/agents/subagent-registry-completion.test.ts
+++ b/src/agents/subagent-registry-completion.test.ts
@@ -8,17 +8,36 @@ import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const lifecycleMocks = vi.hoisted(() => ({
   getGlobalHookRunner: vi.fn(),
+  getChannelPlugin: vi.fn(),
+  handleProgressEnded: vi.fn(async (): Promise<boolean | void> => {}),
   runSubagentEnded: vi.fn(async () => {}),
 }));
 
 vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: lifecycleMocks.getGlobalHookRunner,
 }));
+vi.mock("../channels/plugins/index.js", () => ({
+  getChannelPlugin: lifecycleMocks.getChannelPlugin,
+}));
+
+function firstSubagentEndedEvent(): unknown {
+  return (
+    lifecycleMocks.runSubagentEnded.mock.calls as unknown as Array<[event: unknown, ctx: unknown]>
+  )[0]?.[0];
+}
+
 function createRunEntry(): SubagentRunRecord {
   return {
     runId: "run-1",
     childSessionKey: "agent:main:subagent:child-1",
     requesterSessionKey: "agent:main:main",
+    requesterOrigin: {
+      channel: "discord",
+      accountId: "work",
+      to: "channel:123",
+      threadId: "456",
+      messageId: "msg-1",
+    },
     requesterDisplayKey: "main",
     task: "task",
     cleanup: "keep",
@@ -50,20 +69,44 @@ describe("emitSubagentEndedHookOnce", () => {
 
   beforeEach(() => {
     lifecycleMocks.getGlobalHookRunner.mockClear();
+    lifecycleMocks.getChannelPlugin.mockReset();
+    lifecycleMocks.handleProgressEnded.mockClear();
     lifecycleMocks.runSubagentEnded.mockClear();
   });
 
   it("treats timing differences as different only after both outcomes have timing", () => {
     expect(
       mod.shouldUpdateRunOutcome(
-        { status: "timeout", startedAt: 1_000, endedAt: 2_000, elapsedMs: 1_000 },
-        { status: "timeout", startedAt: 1_000, endedAt: 2_500, elapsedMs: 1_500 },
+        {
+          status: "timeout",
+          startedAt: 1_000,
+          endedAt: 2_000,
+          elapsedMs: 1_000,
+        },
+        {
+          status: "timeout",
+          startedAt: 1_000,
+          endedAt: 2_500,
+          elapsedMs: 1_500,
+        },
       ),
     ).toBe(true);
     expect(
       mod.shouldUpdateRunOutcome(
-        { status: "error", error: "boom", startedAt: 1_000, endedAt: 2_000, elapsedMs: 1_000 },
-        { status: "error", error: "boom", startedAt: 1_000, endedAt: 2_000, elapsedMs: 1_000 },
+        {
+          status: "error",
+          error: "boom",
+          startedAt: 1_000,
+          endedAt: 2_000,
+          elapsedMs: 1_000,
+        },
+        {
+          status: "error",
+          error: "boom",
+          startedAt: 1_000,
+          endedAt: 2_000,
+          elapsedMs: 1_000,
+        },
       ),
     ).toBe(false);
     expect(
@@ -84,6 +127,17 @@ describe("emitSubagentEndedHookOnce", () => {
         { status: "ok" },
       ),
     ).toBe(false);
+  });
+
+  it("clears progress-ended marker before replacing a completed outcome", () => {
+    const entry = createRunEntry();
+    entry.endedHookEmittedAt = 1_000;
+    entry.progressEndedHookEmittedAt = 1_100;
+
+    mod.resetSubagentRunProgressEndedHookMarker(entry);
+
+    expect(entry.endedHookEmittedAt).toBe(1_000);
+    expect(entry.progressEndedHookEmittedAt).toBeUndefined();
   });
 
   it("records ended hook marker even when no subagent_ended hooks are registered", async () => {
@@ -112,8 +166,57 @@ describe("emitSubagentEndedHookOnce", () => {
 
     expect(emitted).toBe(true);
     expect(lifecycleMocks.runSubagentEnded).toHaveBeenCalledTimes(1);
+    expect(firstSubagentEndedEvent()).toMatchObject({
+      requester: {
+        channel: "discord",
+        accountId: "work",
+        to: "channel:123",
+        threadId: "456",
+        messageId: "msg-1",
+      },
+    });
     expect(typeof params.entry.endedHookEmittedAt).toBe("number");
     expect(params.persist).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs internal progress-ended hooks without marking subagent_ended emitted", async () => {
+    lifecycleMocks.getChannelPlugin.mockReturnValue({
+      subagentProgress: { handleEnded: lifecycleMocks.handleProgressEnded },
+    });
+    const params = createEmitParams();
+    params.config = { channels: { discord: { enabled: true } } };
+    const emitted = await mod.emitSubagentProgressEndedHookOnce(params);
+
+    expect(emitted).toBe(true);
+    expect(lifecycleMocks.getChannelPlugin).toHaveBeenCalledWith("discord");
+    expect(lifecycleMocks.handleProgressEnded).toHaveBeenCalledWith({
+      config: params.config,
+      event: expect.objectContaining({
+        runId: "run-1",
+        requester: expect.objectContaining({
+          channel: "discord",
+          messageId: "msg-1",
+        }),
+      }),
+    });
+    expect(typeof params.entry.progressEndedHookEmittedAt).toBe("number");
+    expect(params.entry.endedHookEmittedAt).toBeUndefined();
+    expect(params.persist).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps progress-ended cleanup retryable when the channel reports it was not handled", async () => {
+    lifecycleMocks.handleProgressEnded.mockResolvedValueOnce(false);
+    lifecycleMocks.getChannelPlugin.mockReturnValue({
+      subagentProgress: { handleEnded: lifecycleMocks.handleProgressEnded },
+    });
+    const params = createEmitParams();
+    params.config = { channels: { discord: { enabled: true } } };
+    const emitted = await mod.emitSubagentProgressEndedHookOnce(params);
+
+    expect(emitted).toBe(false);
+    expect(lifecycleMocks.handleProgressEnded).toHaveBeenCalledTimes(1);
+    expect(params.entry.progressEndedHookEmittedAt).toBeUndefined();
+    expect(params.persist).not.toHaveBeenCalled();
   });
 
   it("returns false when the global hook runner is not initialized yet", async () => {

--- a/src/agents/subagent-registry-completion.test.ts
+++ b/src/agents/subagent-registry-completion.test.ts
@@ -8,36 +8,17 @@ import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const lifecycleMocks = vi.hoisted(() => ({
   getGlobalHookRunner: vi.fn(),
-  getChannelPlugin: vi.fn(),
-  handleProgressEnded: vi.fn(async (): Promise<boolean | void> => {}),
   runSubagentEnded: vi.fn(async () => {}),
 }));
 
 vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: lifecycleMocks.getGlobalHookRunner,
 }));
-vi.mock("../channels/plugins/index.js", () => ({
-  getChannelPlugin: lifecycleMocks.getChannelPlugin,
-}));
-
-function firstSubagentEndedEvent(): unknown {
-  return (
-    lifecycleMocks.runSubagentEnded.mock.calls as unknown as Array<[event: unknown, ctx: unknown]>
-  )[0]?.[0];
-}
-
 function createRunEntry(): SubagentRunRecord {
   return {
     runId: "run-1",
     childSessionKey: "agent:main:subagent:child-1",
     requesterSessionKey: "agent:main:main",
-    requesterOrigin: {
-      channel: "discord",
-      accountId: "work",
-      to: "channel:123",
-      threadId: "456",
-      messageId: "msg-1",
-    },
     requesterDisplayKey: "main",
     task: "task",
     cleanup: "keep",
@@ -69,44 +50,20 @@ describe("emitSubagentEndedHookOnce", () => {
 
   beforeEach(() => {
     lifecycleMocks.getGlobalHookRunner.mockClear();
-    lifecycleMocks.getChannelPlugin.mockReset();
-    lifecycleMocks.handleProgressEnded.mockClear();
     lifecycleMocks.runSubagentEnded.mockClear();
   });
 
   it("treats timing differences as different only after both outcomes have timing", () => {
     expect(
       mod.shouldUpdateRunOutcome(
-        {
-          status: "timeout",
-          startedAt: 1_000,
-          endedAt: 2_000,
-          elapsedMs: 1_000,
-        },
-        {
-          status: "timeout",
-          startedAt: 1_000,
-          endedAt: 2_500,
-          elapsedMs: 1_500,
-        },
+        { status: "timeout", startedAt: 1_000, endedAt: 2_000, elapsedMs: 1_000 },
+        { status: "timeout", startedAt: 1_000, endedAt: 2_500, elapsedMs: 1_500 },
       ),
     ).toBe(true);
     expect(
       mod.shouldUpdateRunOutcome(
-        {
-          status: "error",
-          error: "boom",
-          startedAt: 1_000,
-          endedAt: 2_000,
-          elapsedMs: 1_000,
-        },
-        {
-          status: "error",
-          error: "boom",
-          startedAt: 1_000,
-          endedAt: 2_000,
-          elapsedMs: 1_000,
-        },
+        { status: "error", error: "boom", startedAt: 1_000, endedAt: 2_000, elapsedMs: 1_000 },
+        { status: "error", error: "boom", startedAt: 1_000, endedAt: 2_000, elapsedMs: 1_000 },
       ),
     ).toBe(false);
     expect(
@@ -127,17 +84,6 @@ describe("emitSubagentEndedHookOnce", () => {
         { status: "ok" },
       ),
     ).toBe(false);
-  });
-
-  it("clears progress-ended marker before replacing a completed outcome", () => {
-    const entry = createRunEntry();
-    entry.endedHookEmittedAt = 1_000;
-    entry.progressEndedHookEmittedAt = 1_100;
-
-    mod.resetSubagentRunProgressEndedHookMarker(entry);
-
-    expect(entry.endedHookEmittedAt).toBe(1_000);
-    expect(entry.progressEndedHookEmittedAt).toBeUndefined();
   });
 
   it("records ended hook marker even when no subagent_ended hooks are registered", async () => {
@@ -166,57 +112,8 @@ describe("emitSubagentEndedHookOnce", () => {
 
     expect(emitted).toBe(true);
     expect(lifecycleMocks.runSubagentEnded).toHaveBeenCalledTimes(1);
-    expect(firstSubagentEndedEvent()).toMatchObject({
-      requester: {
-        channel: "discord",
-        accountId: "work",
-        to: "channel:123",
-        threadId: "456",
-        messageId: "msg-1",
-      },
-    });
     expect(typeof params.entry.endedHookEmittedAt).toBe("number");
     expect(params.persist).toHaveBeenCalledTimes(1);
-  });
-
-  it("runs internal progress-ended hooks without marking subagent_ended emitted", async () => {
-    lifecycleMocks.getChannelPlugin.mockReturnValue({
-      subagentProgress: { handleEnded: lifecycleMocks.handleProgressEnded },
-    });
-    const params = createEmitParams();
-    params.config = { channels: { discord: { enabled: true } } };
-    const emitted = await mod.emitSubagentProgressEndedHookOnce(params);
-
-    expect(emitted).toBe(true);
-    expect(lifecycleMocks.getChannelPlugin).toHaveBeenCalledWith("discord");
-    expect(lifecycleMocks.handleProgressEnded).toHaveBeenCalledWith({
-      config: params.config,
-      event: expect.objectContaining({
-        runId: "run-1",
-        requester: expect.objectContaining({
-          channel: "discord",
-          messageId: "msg-1",
-        }),
-      }),
-    });
-    expect(typeof params.entry.progressEndedHookEmittedAt).toBe("number");
-    expect(params.entry.endedHookEmittedAt).toBeUndefined();
-    expect(params.persist).toHaveBeenCalledTimes(1);
-  });
-
-  it("keeps progress-ended cleanup retryable when the channel reports it was not handled", async () => {
-    lifecycleMocks.handleProgressEnded.mockResolvedValueOnce(false);
-    lifecycleMocks.getChannelPlugin.mockReturnValue({
-      subagentProgress: { handleEnded: lifecycleMocks.handleProgressEnded },
-    });
-    const params = createEmitParams();
-    params.config = { channels: { discord: { enabled: true } } };
-    const emitted = await mod.emitSubagentProgressEndedHookOnce(params);
-
-    expect(emitted).toBe(false);
-    expect(lifecycleMocks.handleProgressEnded).toHaveBeenCalledTimes(1);
-    expect(params.entry.progressEndedHookEmittedAt).toBeUndefined();
-    expect(params.persist).not.toHaveBeenCalled();
   });
 
   it("returns false when the global hook runner is not initialized yet", async () => {

--- a/src/agents/subagent-registry-consumption.test.ts
+++ b/src/agents/subagent-registry-consumption.test.ts
@@ -1,0 +1,106 @@
+// Subagent registry consumption tests cover requester-owned orchestration credit.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { markDescendantCompletionConsumedByRequester } from "./subagent-registry-consumption.js";
+import { subagentRuns } from "./subagent-registry-memory.js";
+
+const persistSubagentRunsToDiskMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./subagent-registry-state.js", () => ({
+  persistSubagentRunsToDisk: persistSubagentRunsToDiskMock,
+}));
+
+describe("markDescendantCompletionConsumedByRequester", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    subagentRuns.clear();
+    persistSubagentRunsToDiskMock.mockClear();
+  });
+
+  afterEach(() => {
+    subagentRuns.clear();
+    vi.useRealTimers();
+  });
+
+  it("credits requester-consumed descendant completion as delivered", () => {
+    const now = Date.now();
+    subagentRuns.set("run-consumed-child", {
+      runId: "run-consumed-child",
+      childSessionKey: "agent:main:subagent:consumed-child",
+      requesterSessionKey: "agent:main:cron:daily:run:abc",
+      requesterDisplayKey: "cron run",
+      task: "child task",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+      createdAt: now - 100,
+      startedAt: now - 90,
+      endedAt: now - 10,
+      outcome: { status: "ok" },
+      completion: { required: true, resultText: "child result" },
+      delivery: { status: "pending", lastError: "announce deferred" },
+    });
+
+    const updated = markDescendantCompletionConsumedByRequester({
+      requesterSessionKey: "agent:main:cron:daily:run:abc",
+      runStartedAt: now - 200,
+      runIds: ["run-consumed-child"],
+      kind: "cron_descendant_fallback",
+      deliveryTextHash: "abc123",
+      consumerRunId: "cron-run",
+    });
+
+    const run = subagentRuns.get("run-consumed-child");
+    expect(updated).toBe(1);
+    expect(run?.delivery).toMatchObject({
+      status: "delivered",
+      requesterConsumedKind: "cron_descendant_fallback",
+      requesterConsumedBySessionKey: "agent:main:cron:daily:run:abc",
+      requesterConsumedRunStartedAt: now - 200,
+      requesterConsumedMetadata: {
+        consumerRunId: "cron-run",
+        deliveryTextHash: "abc123",
+      },
+    });
+    expect(run?.delivery?.lastError).toBeUndefined();
+    expect(persistSubagentRunsToDiskMock).toHaveBeenCalledWith(subagentRuns);
+  });
+
+  it("does not credit unrelated requester consumption", () => {
+    const now = Date.now();
+    subagentRuns.set("run-unrelated-child", {
+      runId: "run-unrelated-child",
+      childSessionKey: "agent:main:subagent:unrelated-child",
+      requesterSessionKey: "agent:main:cron:daily:run:abc",
+      requesterDisplayKey: "cron run",
+      task: "child task",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+      createdAt: now - 100,
+      startedAt: now - 90,
+      endedAt: now - 10,
+      outcome: { status: "ok" },
+      completion: { required: true, resultText: "child result" },
+      delivery: { status: "pending" },
+    });
+
+    const wrongRequester = markDescendantCompletionConsumedByRequester({
+      requesterSessionKey: "agent:main:cron:other:run:def",
+      runStartedAt: now - 200,
+      runIds: ["run-unrelated-child"],
+      kind: "cron_descendant_fallback",
+    });
+    const staleWindow = markDescendantCompletionConsumedByRequester({
+      requesterSessionKey: "agent:main:cron:daily:run:abc",
+      runStartedAt: now,
+      runIds: ["run-unrelated-child"],
+      kind: "cron_descendant_fallback",
+    });
+
+    const run = subagentRuns.get("run-unrelated-child");
+    expect(wrongRequester).toBe(0);
+    expect(staleWindow).toBe(0);
+    expect(run?.delivery?.status).toBe("pending");
+    expect(run?.delivery?.requesterConsumedAt).toBeUndefined();
+    expect(persistSubagentRunsToDiskMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/subagent-registry-consumption.ts
+++ b/src/agents/subagent-registry-consumption.ts
@@ -1,0 +1,70 @@
+/**
+ * Marks subagent completions consumed by requester-owned orchestration paths.
+ */
+import { setDetachedTaskDeliveryStatusByRunId } from "../tasks/detached-task-runtime.js";
+import { ensureDeliveryState } from "./subagent-delivery-state.js";
+import { subagentRuns } from "./subagent-registry-memory.js";
+import { persistSubagentRunsToDisk } from "./subagent-registry-state.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+export function markDescendantCompletionConsumedByRequester(params: {
+  requesterSessionKey: string;
+  runStartedAt: number;
+  runIds: readonly string[];
+  kind: NonNullable<SubagentRunRecord["delivery"]>["requesterConsumedKind"];
+  deliveryTextHash?: string;
+  consumerRunId?: string;
+}): number {
+  const requesterSessionKey = params.requesterSessionKey.trim();
+  const runIds = new Set(params.runIds.map((runId) => runId.trim()).filter(Boolean));
+  if (!requesterSessionKey || runIds.size === 0) {
+    return 0;
+  }
+
+  const now = Date.now();
+  let updated = 0;
+  for (const [runId, entry] of subagentRuns.entries()) {
+    if (!runIds.has(runId) || entry.requesterSessionKey !== requesterSessionKey) {
+      continue;
+    }
+    const descendantStartedAt = entry.startedAt ?? entry.createdAt;
+    if (typeof descendantStartedAt === "number" && descendantStartedAt < params.runStartedAt) {
+      continue;
+    }
+    if (typeof entry.endedAt !== "number" || entry.expectsCompletionMessage !== true) {
+      continue;
+    }
+    const delivery = ensureDeliveryState(entry);
+    delivery.status = "delivered";
+    delivery.deliveredAt ??= now;
+    delivery.requesterConsumedAt ??= now;
+    delivery.requesterConsumedKind = params.kind;
+    delivery.requesterConsumedBySessionKey = requesterSessionKey;
+    delivery.requesterConsumedRunStartedAt = params.runStartedAt;
+    delivery.requesterConsumedMetadata = {
+      ...(params.consumerRunId ? { consumerRunId: params.consumerRunId } : {}),
+      ...(params.deliveryTextHash ? { deliveryTextHash: params.deliveryTextHash } : {}),
+    };
+    delivery.suspendedAt = undefined;
+    delivery.suspendedReason = undefined;
+    delivery.lastError = undefined;
+    delivery.lastDropReason = undefined;
+    entry.wakeOnDescendantSettle = undefined;
+    try {
+      setDetachedTaskDeliveryStatusByRunId({
+        runId: entry.runId,
+        runtime: "subagent",
+        sessionKey: entry.childSessionKey,
+        deliveryStatus: "delivered",
+      });
+    } catch {
+      // The registry credit is the durable source of truth; task rows can be
+      // absent in tests or after pruning and should not block cleanup.
+    }
+    updated += 1;
+  }
+  if (updated > 0) {
+    persistSubagentRunsToDisk(subagentRuns);
+  }
+  return updated;
+}

--- a/src/agents/subagent-registry-runtime.ts
+++ b/src/agents/subagent-registry-runtime.ts
@@ -17,3 +17,4 @@ export {
   shouldIgnorePostCompletionAnnounceForSession,
 } from "./subagent-registry-announce-read.js";
 export { replaceSubagentRunAfterSteer } from "./subagent-registry-steer-runtime.js";
+export { markDescendantCompletionConsumedByRequester } from "./subagent-registry-consumption.js";

--- a/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -164,6 +164,7 @@ describe("subagent registry lifecycle error grace", () => {
       getRuntimeConfig: loadConfigMock as typeof import("../config/config.js").getRuntimeConfig,
       onAgentEvent:
         onAgentEventMock as unknown as typeof import("../infra/agent-events.js").onAgentEvent,
+      ensureRuntimePluginsLoaded: vi.fn(),
     });
     subagentAnnounceTesting.setDepsForTest({
       callGateway: callGatewayMock as typeof import("../gateway/call.js").callGateway,
@@ -179,6 +180,8 @@ describe("subagent registry lifecycle error grace", () => {
         resolveRequesterForChildSession: mod.resolveRequesterForChildSession,
         shouldIgnorePostCompletionAnnounceForSession:
           mod.shouldIgnorePostCompletionAnnounceForSession,
+        markDescendantCompletionConsumedByRequester:
+          mod.markDescendantCompletionConsumedByRequester,
       }),
     });
     subagentAnnounceDeliveryTesting.setDepsForTest({

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1540,3 +1540,5 @@ export function initSubagentRegistry() {
 // provider as a side effect (see subagent-registry-maintenance.ts).
 export { listSessionMaintenanceProtectedSubagentSessionKeys } from "./subagent-registry-maintenance.js";
 export { testing as __testing };
+
+export { markDescendantCompletionConsumedByRequester } from "./subagent-registry-consumption.js";

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -58,6 +58,14 @@ export type SubagentCompletionDeliveryState = {
   enqueuedAt?: number;
   deliveredAt?: number;
   announcedAt?: number;
+  requesterConsumedAt?: number;
+  requesterConsumedKind?: "cron_descendant_fallback" | "subagent_descendant_result";
+  requesterConsumedBySessionKey?: string;
+  requesterConsumedRunStartedAt?: number;
+  requesterConsumedMetadata?: {
+    consumerRunId?: string;
+    deliveryTextHash?: string;
+  };
   lastAttemptAt?: number;
   attemptCount?: number;
   lastError?: string | null;

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -21,6 +21,7 @@ const {
   deliverOutboundPayloadsMock,
   ensureOutboundSessionEntryMock,
   maybeApplyTtsToPayloadMock,
+  markDescendantCompletionConsumedByRequesterMock,
   retireSessionMcpRuntimeMock,
   resolveOutboundSessionRouteMock,
 } = vi.hoisted(() => ({
@@ -33,6 +34,7 @@ const {
   deliverOutboundPayloadsMock: vi.fn().mockResolvedValue([{ ok: true }]),
   ensureOutboundSessionEntryMock: vi.fn().mockResolvedValue(undefined),
   maybeApplyTtsToPayloadMock: vi.fn(async (params: { payload: unknown }) => params.payload),
+  markDescendantCompletionConsumedByRequesterMock: vi.fn().mockReturnValue(0),
   retireSessionMcpRuntimeMock: vi.fn().mockResolvedValue(true),
   resolveOutboundSessionRouteMock: vi.fn().mockResolvedValue(null),
 }));
@@ -82,6 +84,7 @@ vi.mock("../../agents/agent-bundle-mcp-tools.js", () => ({
 
 vi.mock("./delivery-subagent-registry.runtime.js", () => ({
   countActiveDescendantRuns: countActiveDescendantRunsMock,
+  markDescendantCompletionConsumedByRequester: markDescendantCompletionConsumedByRequesterMock,
 }));
 
 vi.mock("../../infra/outbound/deliver.js", () => ({
@@ -134,6 +137,7 @@ vi.mock("./subagent-followup-hints.js", () => ({
 
 vi.mock("./subagent-followup.runtime.js", () => ({
   readDescendantSubagentFallbackReply: vi.fn().mockResolvedValue(undefined),
+  readDescendantSubagentFallbackReplyWithRuns: vi.fn().mockResolvedValue(undefined),
   waitForDescendantSubagentSummary: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -160,6 +164,7 @@ import type { RunCronAgentTurnResult } from "./run.js";
 import { expectsSubagentFollowup, isLikelyInterimCronMessage } from "./subagent-followup-hints.js";
 import {
   readDescendantSubagentFallbackReply,
+  readDescendantSubagentFallbackReplyWithRuns,
   waitForDescendantSubagentSummary,
 } from "./subagent-followup.runtime.js";
 
@@ -308,6 +313,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     vi.mocked(expectsSubagentFollowup).mockReturnValue(false);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
     vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
+    vi.mocked(readDescendantSubagentFallbackReplyWithRuns).mockResolvedValue(undefined);
     vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
     vi.mocked(retireSessionMcpRuntime).mockResolvedValue(true);
     vi.mocked(resolveOutboundSessionRoute).mockResolvedValue(null);
@@ -331,6 +337,8 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(2);
     vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
     vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
+    vi.mocked(readDescendantSubagentFallbackReplyWithRuns).mockResolvedValue(undefined);
+    vi.mocked(readDescendantSubagentFallbackReplyWithRuns).mockResolvedValue(undefined);
 
     const params = makeBaseParams({ synthesizedText: "on it" });
     const state = await dispatchCronDelivery(params);
@@ -346,7 +354,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
   it("bestEffort delivery skips active subagent wait and sends the cron reply", async () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(2);
     vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
-    vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
+    vi.mocked(readDescendantSubagentFallbackReplyWithRuns).mockResolvedValue(undefined);
 
     const params = makeBaseParams({
       synthesizedText: "Parent cron summary is ready.",
@@ -823,14 +831,43 @@ describe("dispatchCronDelivery — double-announce guard", () => {
 
     // No direct delivery should have been sent (stale interim suppressed)
     expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    expect(markDescendantCompletionConsumedByRequesterMock).not.toHaveBeenCalled();
+  });
+
+  it("credits descendant fallback after active descendants drain and direct delivery succeeds", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValueOnce(2).mockReturnValueOnce(0);
+    vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
+    vi.mocked(readDescendantSubagentFallbackReplyWithRuns).mockResolvedValue({
+      text: "Child finished after drain.",
+      consumedRunIds: ["run-drained-child"],
+    });
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(true);
+
+    const params = makeBaseParams({ synthesizedText: "on it" });
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+    expectDeliveryCall(0, {
+      payloads: [{ text: "Child finished after drain." }],
+    });
+    expect(markDescendantCompletionConsumedByRequesterMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requesterSessionKey: params.runSessionKey,
+        runStartedAt: params.runStartedAt,
+        runIds: ["run-drained-child"],
+        kind: "cron_descendant_fallback",
+      }),
+    );
   });
 
   it("consolidates descendant output into the final direct delivery", async () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(true);
-    vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(
-      "Detailed child result, everything finished successfully.",
-    );
+    vi.mocked(readDescendantSubagentFallbackReplyWithRuns).mockResolvedValue({
+      text: "Detailed child result, everything finished successfully.",
+      consumedRunIds: ["run-child"],
+    });
 
     const params = makeBaseParams({ synthesizedText: "on it" });
     const state = await dispatchCronDelivery(params);
@@ -838,6 +875,14 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.deliveryAttempted).toBe(true);
     expect(state.delivered).toBe(true);
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expect(markDescendantCompletionConsumedByRequesterMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requesterSessionKey: params.runSessionKey,
+        runStartedAt: params.runStartedAt,
+        runIds: ["run-child"],
+        kind: "cron_descendant_fallback",
+      }),
+    );
     expectDeliveryCall(0, {
       channel: "telegram",
       to: "123456",
@@ -852,9 +897,12 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     const runSessionKey = "agent:main:cron:daily-monitor:run:test-session-id";
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(true);
-    vi.mocked(readDescendantSubagentFallbackReply).mockImplementation(async (params) =>
+    vi.mocked(readDescendantSubagentFallbackReplyWithRuns).mockImplementation(async (params) =>
       params.sessionKey === runSessionKey
-        ? "Run-scoped child result, everything finished successfully."
+        ? {
+            text: "Run-scoped child result, everything finished successfully.",
+            consumedRunIds: ["run-run-scoped-child"],
+          }
         : undefined,
     );
 
@@ -869,10 +917,17 @@ describe("dispatchCronDelivery — double-announce guard", () => {
 
     expect(countActiveDescendantRuns).toHaveBeenCalledWith(runSessionKey);
     expect(countActiveDescendantRuns).not.toHaveBeenCalledWith(agentSessionKey);
-    expect(readDescendantSubagentFallbackReply).toHaveBeenCalledWith({
+    expect(readDescendantSubagentFallbackReplyWithRuns).toHaveBeenCalledWith({
       sessionKey: runSessionKey,
       runStartedAt,
     });
+    expect(markDescendantCompletionConsumedByRequesterMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requesterSessionKey: runSessionKey,
+        runStartedAt,
+        runIds: ["run-run-scoped-child"],
+      }),
+    );
     expect(state.deliveryAttempted).toBe(true);
     expect(state.delivered).toBe(true);
     expectDeliveryCall(0, {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -57,6 +57,14 @@ function normalizeDeliveryTarget(channel: string, to: string): string {
   return normalizeTargetForProvider(channel, toTrimmed) ?? toTrimmed;
 }
 
+function hashDeliveredText(text: string): string {
+  let hash = 5381;
+  for (let index = 0; index < text.length; index += 1) {
+    hash = (hash * 33) ^ text.charCodeAt(index);
+  }
+  return (hash >>> 0).toString(16);
+}
+
 type NormalizedSilentReplyText = {
   text: string | undefined;
   strippedTrailingSilentToken: boolean;
@@ -913,6 +921,16 @@ export async function dispatchCronDelivery(
   let outputText = params.outputText;
   let synthesizedText = params.synthesizedText;
   let deliveryPayloads = params.deliveryPayloads;
+  let pendingRequesterConsumedCredit:
+    | {
+        requesterSessionKey: string;
+        runStartedAt: number;
+        runIds: string[];
+        kind: "cron_descendant_fallback";
+        deliveryTextHash: string;
+        consumerRunId: string;
+      }
+    | undefined;
 
   let delivered = verifiedMessageToolDelivery;
   let deliveryAttempted = verifiedMessageToolDelivery;
@@ -1168,6 +1186,13 @@ export async function dispatchCronDelivery(
       }
       // Only mark delivered when ALL payloads succeeded (no partial failure).
       delivered = deliveryResults.length > 0 && !hadPartialFailure;
+      if (delivered && pendingRequesterConsumedCredit) {
+        const subagentRegistryRuntime = await loadDeliverySubagentRegistryRuntime();
+        subagentRegistryRuntime.markDescendantCompletionConsumedByRequester(
+          pendingRequesterConsumedCredit,
+        );
+        pendingRequesterConsumedCredit = undefined;
+      }
       // Intentionally leave partial success uncached: replay may duplicate the
       // successful subset, but caching it here would permanently drop the
       // failed payloads by converting the replay into delivered=true.
@@ -1308,7 +1333,7 @@ export async function dispatchCronDelivery(
     // doesn't match the narrow hint list). We still need to use the
     // descendant's output instead of the interim cron text.
     const completedDescendantReply = shouldCheckCompletedDescendants
-      ? await subagentFollowupRuntime?.readDescendantSubagentFallbackReply({
+      ? await subagentFollowupRuntime?.readDescendantSubagentFallbackReplyWithRuns({
           sessionKey: subagentFollowupSessionKey,
           runStartedAt: params.runStartedAt,
         })
@@ -1325,10 +1350,22 @@ export async function dispatchCronDelivery(
         subagentFollowupSessionKey,
       );
       if (!finalReply && activeSubagentRuns === 0) {
-        finalReply = await subagentFollowupRuntime?.readDescendantSubagentFallbackReply({
-          sessionKey: subagentFollowupSessionKey,
-          runStartedAt: params.runStartedAt,
-        });
+        const fallbackReply =
+          await subagentFollowupRuntime?.readDescendantSubagentFallbackReplyWithRuns({
+            sessionKey: subagentFollowupSessionKey,
+            runStartedAt: params.runStartedAt,
+          });
+        if (fallbackReply) {
+          finalReply = fallbackReply.text;
+          pendingRequesterConsumedCredit = {
+            requesterSessionKey: subagentFollowupSessionKey,
+            runStartedAt: params.runStartedAt,
+            runIds: fallbackReply.consumedRunIds,
+            kind: "cron_descendant_fallback",
+            deliveryTextHash: hashDeliveredText(fallbackReply.text),
+            consumerRunId: createCronExecutionId(params.job.id, params.runStartedAt),
+          };
+        }
       }
       if (finalReply && activeSubagentRuns === 0) {
         outputText = finalReply;
@@ -1339,10 +1376,18 @@ export async function dispatchCronDelivery(
     } else if (completedDescendantReply) {
       // Descendants already finished before we got here. Use their output
       // directly instead of the cron agent's interim text.
-      outputText = completedDescendantReply;
-      summary = pickSummaryFromOutput(completedDescendantReply) ?? summary;
-      synthesizedText = completedDescendantReply;
-      deliveryPayloads = [{ text: completedDescendantReply }];
+      outputText = completedDescendantReply.text;
+      summary = pickSummaryFromOutput(completedDescendantReply.text) ?? summary;
+      synthesizedText = completedDescendantReply.text;
+      deliveryPayloads = [{ text: completedDescendantReply.text }];
+      pendingRequesterConsumedCredit = {
+        requesterSessionKey: subagentFollowupSessionKey,
+        runStartedAt: params.runStartedAt,
+        runIds: completedDescendantReply.consumedRunIds,
+        kind: "cron_descendant_fallback",
+        deliveryTextHash: hashDeliveredText(completedDescendantReply.text),
+        consumerRunId: createCronExecutionId(params.job.id, params.runStartedAt),
+      };
     }
     if (!params.deliveryBestEffort && activeSubagentRuns > 0) {
       // Parent orchestration is still in progress; avoid announcing a partial

--- a/src/cron/isolated-agent/delivery-subagent-registry.runtime.ts
+++ b/src/cron/isolated-agent/delivery-subagent-registry.runtime.ts
@@ -1,2 +1,3 @@
 // Runtime subagent registry seam for isolated-agent delivery gating.
 export { countActiveDescendantRuns } from "../../agents/subagent-registry-read.js";
+export { markDescendantCompletionConsumedByRequester } from "../../agents/subagent-registry-consumption.js";

--- a/src/cron/isolated-agent/subagent-followup.runtime.ts
+++ b/src/cron/isolated-agent/subagent-followup.runtime.ts
@@ -1,5 +1,6 @@
 // Runtime subagent follow-up seam for isolated cron agent completion handling.
 export {
   readDescendantSubagentFallbackReply,
+  readDescendantSubagentFallbackReplyWithRuns,
   waitForDescendantSubagentSummary,
 } from "./subagent-followup.js";

--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -9,6 +9,7 @@ vi.hoisted(() => {
 import { expectsSubagentFollowup, isLikelyInterimCronMessage } from "./subagent-followup-hints.js";
 import {
   readDescendantSubagentFallbackReply,
+  readDescendantSubagentFallbackReplyWithRuns,
   waitForDescendantSubagentSummary,
 } from "./subagent-followup.js";
 
@@ -209,6 +210,30 @@ describe("readDescendantSubagentFallbackReply", () => {
       runStartedAt,
     });
     expect(result).toBe("first child output\n\nsecond child output");
+  });
+
+  it("returns consumed run ids with fallback reply details", async () => {
+    vi.mocked(listDescendantRunsForRequester).mockReturnValue([
+      createDescendantRun({ runId: "run-1", resultText: "first child output" }),
+      createDescendantRun({
+        runId: "run-2",
+        childSessionKey: "child-2",
+        task: "task-2",
+        endedAt: 3000,
+        resultText: "second child output",
+      }),
+    ]);
+    vi.mocked(readLatestAssistantReply).mockResolvedValue(undefined);
+
+    const result = await readDescendantSubagentFallbackReplyWithRuns({
+      sessionKey: "test-session",
+      runStartedAt,
+    });
+
+    expect(result).toEqual({
+      text: "first child output\n\nsecond child output",
+      consumedRunIds: ["run-1", "run-2"],
+    });
   });
 
   it("skips SILENT_REPLY_TOKEN descendants", async () => {

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -4,6 +4,11 @@ import { listDescendantRunsForRequester } from "../../agents/subagent-registry-r
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { isLikelyInterimCronMessage } from "./subagent-followup-hints.js";
 
+export type DescendantSubagentFallbackReply = {
+  text: string;
+  consumedRunIds: string[];
+};
+
 function resolveCronSubagentTimings() {
   const fastTestMode = process.env.OPENCLAW_TEST_FAST === "1";
   return {
@@ -14,10 +19,10 @@ function resolveCronSubagentTimings() {
 }
 
 /** Reads completed descendant subagent replies when the orchestrator only emitted interim text. */
-export async function readDescendantSubagentFallbackReply(params: {
+export async function readDescendantSubagentFallbackReplyWithRuns(params: {
   sessionKey: string;
   runStartedAt: number;
-}): Promise<string | undefined> {
+}): Promise<DescendantSubagentFallbackReply | undefined> {
   const descendants = listDescendantRunsForRequester(params.sessionKey)
     .filter(
       (entry) =>
@@ -43,6 +48,7 @@ export async function readDescendantSubagentFallbackReply(params: {
   }
 
   const replies: string[] = [];
+  const consumedRunIds: string[] = [];
   // Limit fallback synthesis to the latest few children so a noisy run does not
   // flood the cron announce with stale descendant output.
   const latestRuns = [...latestByChild.values()]
@@ -69,14 +75,23 @@ export async function readDescendantSubagentFallbackReply(params: {
       continue;
     }
     replies.push(reply);
+    consumedRunIds.push(entry.runId);
   }
   if (replies.length === 0) {
     return undefined;
   }
   if (replies.length === 1) {
-    return replies[0];
+    return { text: replies[0], consumedRunIds };
   }
-  return replies.join("\n\n");
+  return { text: replies.join("\n\n"), consumedRunIds };
+}
+
+/** Reads completed descendant subagent reply text for older callers that do not need run credit. */
+export async function readDescendantSubagentFallbackReply(params: {
+  sessionKey: string;
+  runStartedAt: number;
+}): Promise<string | undefined> {
+  return (await readDescendantSubagentFallbackReplyWithRuns(params))?.text;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes a subagent lifecycle/delivery accounting gap for requester-owned background and cron subagent trees.

When a requester consumes completed descendant subagent output as part of its own result, the descendant run can now be durably credited as delivered. This prevents later cleanup/finalization from treating an already-consumed descendant completion as failed, suspended, or otherwise undelivered solely because there was no separate descendant-visible delivery event.

The new credit path is intentionally narrow: requester consumption counts as delivery evidence only for explicit consumed descendant run IDs, under the matching requester session/run-start window, and only after the requester path has successfully delivered its own result where applicable.

## What Problem This Solves

Requester-owned subagent trees can legitimately consume descendant output without sending a separate visible message for each descendant completion. This is common in cron/background flows where a requester gathers frozen descendant output, composes its own final result, and then delivers that requester result outward.

Without durable requester-consumption accounting, the registry/finalizer can see a descendant completion as delivery-unproven even though the requester already consumed that output. That leaves final delivery state inconsistent with real behavior and can produce misleading failed/suspended cleanup state.

This PR gives the registry an explicit durable signal for that case while preserving the normal delivery contract for everything else:

- visible delivery remains required when no requester consumption is proven;
- requester-consumption credit only applies to explicitly consumed descendant run IDs;
- matching is scoped by requester session and requester run-start timing;
- cron fallback credit is gated behind successful outbound requester delivery;
- nested/direct child credit only covers child output actually included in the requester-consumed result.

## Linked Context

I searched open and closed issues/PRs in `openclaw/openclaw` for related subagent delivery, requester-consumption, descendant-output, registry, and cron-fallback work. Relevant context:

- Related issue: #92433 — subagent completion can be silently dropped when an announce handoff reaches a requester transcript but the requester run ends before consuming it. This PR addresses the adjacent durable-accounting case for completions that are explicitly consumed by a requester.
- Related issue: #67777 — subagent completion delivery can be lost on direct-announce timeout, drain, or orphan prune. This PR does not implement the full durable inbox/spool requested there, but it narrows one delivery-accounting gap by recording proven requester consumption.
- Related issue: #86537 — suspended final delivery can expire and discard a pending subagent completion. This PR keeps requester-consumed completions from remaining indistinguishable from undelivered completions in finalization state.
- Related issue: #90299 — subagent lifecycle state can report lost active execution context while still surfacing child output. This PR improves lifecycle/state consistency when descendant output is actually consumed.
- Related PR: #92934 — requires assistant acknowledgement for completion wake handoffs so transcript commit alone is not treated as requester consumption. This PR complements that by adding durable credit for explicit consumed descendant run IDs.
- Related PR: #35080 — adds deterministic subagent announce delivery with descendant gating. This PR continues the same direction by making consumed descendant accounting durable.
- Related PR: #44205 — suppresses stale descendant cron fallback summaries. This PR keeps stale-vs-current discipline for requester-consumed descendant credit.
- Related PR: #95604 — Discord subagent progress feedback. This PR is not a Discord UI change, but accurate delivered/failed lifecycle state is useful to progress/failure-marker consumers.

No exact existing issue/PR was found for `markDescendantCompletionConsumedByRequester` or this exact requester-consumed credit mechanism, so this PR is the focused implementation thread for that behavior.

## Behavior Change

When OpenClaw can prove that a requester consumed descendant subagent output, the matching descendant run receives durable delivery credit:

- `delivery.status` is set to `"delivered"` for the matched descendant completion;
- requester-consumption metadata is persisted with the run/delivery state;
- cleanup/finalize treats `delivery.status === "delivered"` as completed delivery proof;
- normal visible-delivery paths remain required for completions that were not consumed by a requester.

Credit is only applied when the consumed run IDs are explicit and the requester/session timing constraints match. The PR does not add any broad “assume delivered” fallback.

## Implementation Notes

Core registry/runtime changes:

- `src/agents/subagent-registry-consumption.ts`
  - Implements durable requester-consumption credit.
  - Matches by requester session key, explicit consumed run IDs, and requester run-start window.
  - Records requester-consumption metadata and persists the updated run state.
- `src/agents/subagent-registry.types.ts`
  - Adds requester-consumption delivery state fields.
- `src/agents/subagent-delivery-state.ts`
  - Persists/restores the new delivery fields as optional additive state.
- `src/agents/subagent-registry.ts`
- `src/agents/subagent-registry-runtime.ts`
- `src/agents/subagent-announce.registry.runtime.ts`
- `src/cron/isolated-agent/delivery-subagent-registry.runtime.ts`
  - Wire the new registry operation through existing runtime boundaries.

Requester-consumption paths:

- `src/cron/isolated-agent/subagent-followup.ts`
  - Reads completed descendant fallback replies and returns both formatted fallback text and consumed descendant run IDs.
- `src/cron/isolated-agent/delivery-dispatch.ts`
  - Applies cron fallback consumption credit only after successful outbound requester delivery.
- `src/agents/subagent-announce.ts`
  - Credits nested/direct child completions when their output is included in the requester-consumed announcement/wake result.
  - Uses the same latest-child dedupe input for rendering and consumed-run credit so stale child rows are not credited.
- `src/agents/subagent-announce-output.ts`
  - Keeps latest-child dedupe reusable while preserving caller-specific fields such as `runId`.

## Tests Added/Updated

Coverage includes:

- positive requester-consumed descendant credit;
- no credit for mismatched requester session;
- no credit outside the requester run-start window;
- no credit without explicit consumed run IDs;
- persisted/restored requester-consumption delivery fields;
- cron fallback credit only after successful outbound requester delivery;
- cleanup/finalize treating `delivery.status === "delivered"` as proof;
- nested/direct child announcement credit;
- stale-vs-current child dedupe, including a negative assertion that stale child run IDs are not credited when stale output is not rendered.

Primary test files:

- `src/agents/subagent-registry-consumption.test.ts`
- `src/agents/subagent-delivery-state.test.ts`
- `src/agents/subagent-registry-completion.test.ts`
- `src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts`
- `src/agents/subagent-announce.format.e2e.test.ts`
- `src/cron/isolated-agent/subagent-followup.test.ts`
- `src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`

## Real Behavior Proof

The proof target for this branch is lifecycle behavior in registry/finalizer paths rather than a UI screenshot. The focused validation exercises the runtime-facing cases that require explicit requester-consumption accounting:

- requester-consumed descendant completions are durably marked delivered;
- mismatched requester sessions do not receive credit;
- out-of-window requester runs do not receive credit;
- completions without explicit consumed run IDs do not receive credit;
- cron fallback consumption is credited only after successful outbound requester delivery;
- nested subagent announcement credit only includes direct child run IDs whose output was actually consumed/rendered;
- stale child rows are excluded after latest-child dedupe;
- delivery state persistence/restore preserves requester-consumption metadata.

Validation evidence from the final branch state (`a6f065ba83a0`):

```bash
pnpm tsgo:core:test --pretty false
pnpm tsgo:extensions:test --pretty false
node scripts/run-vitest.mjs \
  src/agents/subagent-announce.format.e2e.test.ts \
  src/agents/subagent-registry-consumption.test.ts \
  src/agents/subagent-delivery-state.test.ts \
  src/cron/isolated-agent/subagent-followup.test.ts \
  src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
git diff --check
```

Result:

- type checks passed;
- focused Vitest validation passed across 4 shards;
- 201 focused tests passed;
- `git diff --check` passed.

## Expected Semantics

This PR keeps delivery accounting explicit:

- if a descendant result was visibly delivered, it is delivered;
- if a requester consumed the descendant output and then successfully delivered its own result, the descendant is delivered by requester consumption;
- if neither happened, failure/suspension handling still applies.

## Risk and Compatibility

Risk is moderate because this touches subagent lifecycle/delivery finalization, but the implementation is deliberately constrained:

- no broad “assume delivered” fallback was added;
- no delivery status is credited without explicit consumed run IDs;
- matching is scoped to requester session and requester run-start timing;
- cron fallback credit is gated behind successful outbound requester delivery;
- stale nested child rows are excluded after latest-child dedupe;
- persisted state changes are additive and optional on restore.

Existing delivery state can simply lack the new requester-consumption fields. Restore logic treats those fields as optional.

## PR/Commit Surface Breakdown

Diff surface against `origin/main...HEAD`:

- Source: 81 files, +3,026 / -791
- Tests: 52 files, +4,119 / -127
- Docs: 15 files, +245 / -113
- Scripts: 3 files, +120 / -17
- Config/Deps: 133 files, +279 / -279
- Other: 67 files, +171 / -184

Total: 351 files, +7,960 / -1,511.

Notes on the surface:

- The high file count comes from this branch being stacked on prior work relative to `origin/main`.
- The requester-consumed completion-credit implementation is concentrated in the subagent registry/delivery code, cron isolated-agent delivery path, subagent announce path, and focused regression tests.
- The final dedupe/credit alignment commit itself is 3 files, +26 / -31:
  - Source: 2 files, +5 / -26
  - Tests: 1 file, +21 / -5

## Reviewer Checklist

Recommended review focus:

- `src/agents/subagent-registry-consumption.ts`
  - Verify matching is narrow enough: explicit consumed run IDs, requester session key, and requester run-start window.
- `src/cron/isolated-agent/delivery-dispatch.ts`
  - Verify cron fallback credit is only applied after successful requester outbound delivery.
- `src/agents/subagent-announce.ts`
  - Verify nested/direct child credit only uses deduped, actually-consumed child rows.
- `src/agents/subagent-delivery-state.ts`
  - Verify persistence/restore behavior is additive and safe for older state.
- Tests listed above, especially negative cases around mismatched requester, stale child rows, and no explicit consumed run IDs.
