### PR TITLE
Refactor external plugin catalog toward feeds

### DIFF
--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -1,4 +1,9 @@
 {
+  "schemaVersion": 1,
+  "id": "openclaw-official-external-plugins",
+  "generatedAt": "2026-06-22T00:00:00.000Z",
+  "sequence": 1,
+  "description": "Bundled fallback feed for official external OpenClaw plugins.",
   "entries": [
     {
       "name": "@openclaw/acpx",

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
+import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import {
   type OfficialExternalPluginCatalogEntry,
   getOfficialExternalPluginCatalogEntry,
+  isOfficialExternalPluginCatalogFeed,
   listOfficialExternalPluginCatalogEntries,
+  parseOfficialExternalPluginCatalogEntries,
   resolveOfficialExternalProviderContractPluginIds,
   resolveOfficialExternalProviderPluginIds,
   resolveOfficialExternalProviderPluginIdsForEnv,
@@ -20,6 +23,54 @@ function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
 }
 
 describe("official external plugin catalog", () => {
+  it("ships the official plugin catalog as a feed-shaped bundled fallback", () => {
+    expect(isOfficialExternalPluginCatalogFeed(officialExternalPluginCatalog)).toBe(true);
+    expect(officialExternalPluginCatalog).toMatchObject({
+      schemaVersion: 1,
+      id: "openclaw-official-external-plugins",
+      sequence: 1,
+    });
+    expect(officialExternalPluginCatalog.entries.length).toBeGreaterThan(0);
+  });
+
+  it("does not allow malformed feed wrappers to count as feed documents", () => {
+    expect(
+      isOfficialExternalPluginCatalogFeed({
+        schemaVersion: 1,
+        id: " ",
+        generatedAt: "2026-06-22T00:00:00.000Z",
+        sequence: 1,
+        entries: [],
+      }),
+    ).toBe(false);
+    expect(
+      isOfficialExternalPluginCatalogFeed({
+        schemaVersion: 2,
+        id: "openclaw-official-external-plugins",
+        generatedAt: "2026-06-22T00:00:00.000Z",
+        sequence: 1,
+        entries: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps unsupported versioned feed wrappers out of legacy catalog parsing", () => {
+    expect(
+      parseOfficialExternalPluginCatalogEntries({
+        schemaVersion: 2,
+        id: "future-feed",
+        generatedAt: "2026-06-22T00:00:00.000Z",
+        sequence: 1,
+        entries: [{ name: "should-not-load" }],
+      }),
+    ).toEqual([]);
+    expect(
+      parseOfficialExternalPluginCatalogEntries({
+        entries: [{ name: "legacy-catalog-entry" }],
+      }),
+    ).toEqual([{ name: "legacy-catalog-entry" }]);
+  });
+
   it("lists the externalized provider and capability plugins with install metadata", () => {
     const providers = [
       ["arcee", "@openclaw/arcee-provider"],

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -84,6 +84,16 @@ export type OfficialExternalPluginCatalogEntry = {
   kind?: string;
 } & Partial<Record<ManifestKey, OfficialExternalPluginCatalogManifest>>;
 
+/** Feed-shaped wrapper used by the bundled external plugin catalog fallback. */
+export type OfficialExternalPluginCatalogFeed = {
+  schemaVersion: number;
+  id: string;
+  generatedAt: string;
+  sequence: number;
+  description?: string;
+  entries: readonly OfficialExternalPluginCatalogEntry[];
+};
+
 type OfficialExternalProviderContract =
   | "embeddingProviders"
   | "mediaUnderstandingProviders"
@@ -97,11 +107,43 @@ const OFFICIAL_CATALOG_SOURCES = [
   officialExternalPluginCatalog,
 ] as const;
 
-function parseCatalogEntries(raw: unknown): OfficialExternalPluginCatalogEntry[] {
+const OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSION = 1;
+
+export function isOfficialExternalPluginCatalogFeed(
+  raw: unknown,
+): raw is OfficialExternalPluginCatalogFeed {
+  if (!isRecord(raw)) {
+    return false;
+  }
+  const sequence = raw.sequence;
+  return (
+    raw.schemaVersion === OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSION &&
+    typeof raw.id === "string" &&
+    raw.id.trim().length > 0 &&
+    typeof raw.generatedAt === "string" &&
+    raw.generatedAt.trim().length > 0 &&
+    typeof sequence === "number" &&
+    Number.isInteger(sequence) &&
+    sequence >= 0 &&
+    Array.isArray(raw.entries)
+  );
+}
+
+export function parseOfficialExternalPluginCatalogEntries(
+  raw: unknown,
+): OfficialExternalPluginCatalogEntry[] {
   if (Array.isArray(raw)) {
     return raw.filter((entry): entry is OfficialExternalPluginCatalogEntry => isRecord(entry));
   }
+  if (isOfficialExternalPluginCatalogFeed(raw)) {
+    return raw.entries.filter((entry): entry is OfficialExternalPluginCatalogEntry =>
+      isRecord(entry),
+    );
+  }
   if (!isRecord(raw)) {
+    return [];
+  }
+  if ("schemaVersion" in raw) {
     return [];
   }
   const list = raw.entries ?? raw.packages ?? raw.plugins;
@@ -191,7 +233,9 @@ export function resolveOfficialExternalPluginInstall(
 }
 
 export function listOfficialExternalPluginCatalogEntries(): OfficialExternalPluginCatalogEntry[] {
-  const entries = OFFICIAL_CATALOG_SOURCES.flatMap((source) => parseCatalogEntries(source));
+  const entries = OFFICIAL_CATALOG_SOURCES.flatMap((source) =>
+    parseOfficialExternalPluginCatalogEntries(source),
+  );
   const resolved = new Map<string, OfficialExternalPluginCatalogEntry>();
   for (const entry of entries) {
     const pluginId = resolveOfficialExternalPluginId(entry);


### PR DESCRIPTION
<!-- hosted-feed-stack:start -->
## Hosted Marketplace Feed Stack

This is the first PR in the hosted marketplace feed stack. The stack should land in order, with maintainer review at each step before the later PRs wire hosted marketplace data into broader user flows.

1. #95846: refactor the bundled external plugin catalog toward the feed-shaped data model.
2. #95868: add the lazy hosted marketplace feed loader for the configured public feed URL, with guarded HTTPS fetch, checksum, schema, size, timeout, and bundled fallback behavior.
3. #95877: add accepted hosted snapshot fallback so a failed or unchanged hosted fetch can reuse the last valid feed payload.
4. #95964: persist hosted marketplace feed snapshots in OpenClaw state.
5. #95969: add marketplace source profile validation for hosted feed install candidates.
6. #95981: add configurable `marketplaces.feeds` and `marketplaces.sources` profiles.
7. #96155: add `openclaw plugins marketplace refresh` as the explicit manual snapshot refresh path.
8. #96158: add `openclaw plugins marketplace entries` as the explicit manual read path over hosted, snapshot, or bundled fallback entries.
9. #96194: add marketplace feed telemetry.

The broader follow-up after this stack is to decide whether and how marketplace entries should feed install/search/startup behavior, add automatic conditional refresh using `ETag` / `Last-Modified`, or move to ClawHub producer-side validation for `/v1/feeds/plugins` and `/v1/feeds/skills`.
<!-- hosted-feed-stack:end -->

## Journey Context

This is step 1 of the hosted OpenClaw feed path from RFC 19. This PR does the smallest safe prep: it makes the bundled official external plugin catalog look like the feed document we want to host later, while preserving current local behavior.

## What This PR Does

- Adds feed metadata around `scripts/lib/official-external-plugin-catalog.json` without changing the existing `entries` payload.
- Adds parser/type support for the feed-shaped bundled catalog.
- Preserves legacy local catalog parsing for existing unversioned catalog shapes.
- Fails closed for unsupported versioned feed wrappers so future schema versions do not silently parse as legacy catalogs.

## What This PR Intentionally Does Not Do

This PR does not fetch from `register.openclaw.ai`, add auth, add source profiles, add signed envelopes, add regional selection, add snapshot persistence, change search behavior, or move skills into feeds. Those are separate reviewable slices.

## How To Review

Review this as a mechanical shape change plus compatibility guard. Existing callers should still get the same official external plugin entries from the bundled catalog, while the bundled file becomes ready to serve as the local fallback for a hosted feed.

## Validation

- `pnpm exec oxfmt --check src/plugins/official-external-plugin-catalog.ts src/plugins/official-external-plugin-catalog.test.ts`
- `pnpm exec oxlint --deny-warnings src/plugins/official-external-plugin-catalog.ts src/plugins/official-external-plugin-catalog.test.ts`
- JSON parse of `scripts/lib/official-external-plugin-catalog.json`
- `git diff --check`
- `CI=1 timeout 180s node scripts/test-projects.mjs src/plugins/official-external-plugin-catalog.test.ts` (17 tests at initial PR authoring)

## Real Behavior Proof

Behavior or issue addressed:
The feed-shaped bundled fallback is still loaded by existing runtime catalog consumers after the catalog wrapper refactor.

Real environment tested:
Windows checkout `C:\tmp\openclaw-feeds-proof\pr1` at `44c0884c3edc`, source harness via `node --import tsx`, no network services.

Exact steps or command run after this patch:

1. Imported `src/plugins/official-external-plugin-catalog.ts`.
2. Imported `src/plugins/web-search-install-catalog.ts`.
3. Listed official external catalog entries and web-search consumer candidates from the bundled fallback.

Evidence after fix:

```json
{
  "head": "44c0884c3edc",
  "bundledFeedAccepted": true,
  "officialEntryCount": 74,
  "firstOfficialIds": ["wecom-openclaw-plugin", "openclaw-plugin-yuanbao", "openclaw-weixin", "openclaw-zaloclawbot"],
  "webSearchConsumerCount": 9,
  "webSearchConsumerSample": [
    { "pluginId": "brave", "provider": "brave", "npmSpec": "@openclaw/brave-plugin" },
    { "pluginId": "exa", "provider": "exa", "npmSpec": "@openclaw/exa-plugin" },
    { "pluginId": "firecrawl", "provider": "firecrawl", "npmSpec": "@openclaw/firecrawl-plugin" }
  ]
}
```

Observed result after fix:
The bundled feed wrapper validates, the existing official catalog returns 74 entries, and a real catalog consumer still resolves web-search install candidates from that feed-shaped fallback.

What was not tested:
Hosted network fetching is intentionally not part of this PR. It is covered by the next hosted-fetch PR.
