### PR TITLE
fix(subagents): credit requester-consumed descendant completions

### DIFF
--- a/src/agents/subagent-registry-consumption.test.ts
+++ b/src/agents/subagent-registry-consumption.test.ts
@@ -1,0 +1,140 @@
+// Subagent registry consumption tests cover requester-owned orchestration credit.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { markDescendantCompletionConsumedByRequester } from "./subagent-registry-consumption.js";
+import { subagentRuns } from "./subagent-registry-memory.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+const restoreSubagentRunsFromDiskMock = vi.hoisted(() => vi.fn(() => 0));
+const persistSubagentRunsToDiskMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./subagent-registry-state.js", () => ({
+  persistSubagentRunsToDisk: persistSubagentRunsToDiskMock,
+  restoreSubagentRunsFromDisk: restoreSubagentRunsFromDiskMock,
+}));
+
+function makeCompletedRun(
+  overrides: Partial<SubagentRunRecord> & Pick<SubagentRunRecord, "runId">,
+): SubagentRunRecord {
+  const now = Date.now();
+  const { runId, ...rest } = overrides;
+  return {
+    runId,
+    childSessionKey: `agent:main:subagent:${runId}`,
+    requesterSessionKey: "agent:main:cron:daily:run:abc",
+    requesterDisplayKey: "cron run",
+    task: "child task",
+    cleanup: "keep",
+    expectsCompletionMessage: true,
+    createdAt: now - 100,
+    execution: {
+      status: "terminal",
+      startedAt: now - 90,
+      endedAt: now - 10,
+      outcome: { status: "ok" },
+    },
+    completion: { required: true, resultText: "child result" },
+    delivery: { status: "pending" },
+    ...rest,
+  };
+}
+
+describe("markDescendantCompletionConsumedByRequester", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    subagentRuns.clear();
+    restoreSubagentRunsFromDiskMock.mockClear();
+    restoreSubagentRunsFromDiskMock.mockReturnValue(0);
+    persistSubagentRunsToDiskMock.mockClear();
+  });
+
+  afterEach(() => {
+    subagentRuns.clear();
+    vi.useRealTimers();
+  });
+
+  it("credits requester-consumed descendant completion as delivered", () => {
+    const now = Date.now();
+    subagentRuns.set(
+      "run-consumed-child",
+      makeCompletedRun({
+        runId: "run-consumed-child",
+        childSessionKey: "agent:main:subagent:consumed-child",
+        delivery: { status: "pending", lastError: "announce deferred" },
+      }),
+    );
+
+    const updated = markDescendantCompletionConsumedByRequester({
+      requesterSessionKey: "agent:main:cron:daily:run:abc",
+      runStartedAt: now - 200,
+      runIds: ["run-consumed-child"],
+    });
+
+    const run = subagentRuns.get("run-consumed-child");
+    expect(updated).toBe(1);
+    expect(run?.delivery).toMatchObject({
+      status: "delivered",
+      requesterConsumedAt: now,
+    });
+    expect(run?.delivery?.lastError).toBeUndefined();
+    expect(persistSubagentRunsToDiskMock).toHaveBeenCalledWith(subagentRuns);
+  });
+
+  it("uses the requested run ids directly instead of scanning unrelated rows", () => {
+    const now = Date.now();
+    const unrelatedEntry = makeCompletedRun({
+      runId: "run-unrelated",
+      childSessionKey: "agent:main:subagent:unrelated",
+      task: "unrelated task",
+      completion: { required: true, resultText: "unrelated result" },
+    });
+    subagentRuns.set("run-unrelated", unrelatedEntry);
+
+    const updated = markDescendantCompletionConsumedByRequester({
+      requesterSessionKey: "agent:main:cron:daily:run:abc",
+      runStartedAt: now - 200,
+      runIds: ["missing-run-id"],
+    });
+
+    expect(updated).toBe(0);
+    expect(subagentRuns.get("run-unrelated")?.delivery?.status).toBe("pending");
+    expect(persistSubagentRunsToDiskMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "wrong requester",
+      params: (now: number) => ({
+        requesterSessionKey: "agent:main:cron:other:run:def",
+        runStartedAt: now - 200,
+      }),
+    },
+    {
+      name: "stale window",
+      params: (now: number) => ({
+        requesterSessionKey: "agent:main:cron:daily:run:abc",
+        runStartedAt: now,
+      }),
+    },
+  ])("does not credit unrelated requester consumption: $name", ({ params: buildParams }) => {
+    const now = Date.now();
+    subagentRuns.set(
+      "run-unrelated-child",
+      makeCompletedRun({
+        runId: "run-unrelated-child",
+        childSessionKey: "agent:main:subagent:unrelated-child",
+      }),
+    );
+
+    const updated = markDescendantCompletionConsumedByRequester({
+      ...buildParams(now),
+      runIds: ["run-unrelated-child"],
+    });
+
+    const run = subagentRuns.get("run-unrelated-child");
+    expect(updated).toBe(0);
+    expect(run?.delivery?.status).toBe("pending");
+    expect(run?.delivery?.requesterConsumedAt).toBeUndefined();
+    expect(persistSubagentRunsToDiskMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/subagent-registry-consumption.ts
+++ b/src/agents/subagent-registry-consumption.ts
@@ -1,0 +1,66 @@
+/**
+ * Marks subagent completions consumed by requester-owned orchestration paths.
+ */
+import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { setDetachedTaskDeliveryStatusByRunId } from "../tasks/detached-task-runtime.js";
+import { ensureDeliveryState } from "./subagent-delivery-state.js";
+import { subagentRuns } from "./subagent-registry-memory.js";
+import {
+  persistSubagentRunsToDisk,
+  restoreSubagentRunsFromDisk,
+} from "./subagent-registry-state.js";
+
+export function markDescendantCompletionConsumedByRequester(params: {
+  requesterSessionKey: string;
+  runStartedAt: number;
+  runIds: readonly string[];
+}): number {
+  const requesterSessionKey = params.requesterSessionKey.trim();
+  const runIds = normalizeUniqueStringEntries(params.runIds);
+  if (!requesterSessionKey || runIds.length === 0) {
+    return 0;
+  }
+
+  restoreSubagentRunsFromDisk({ runs: subagentRuns, mergeOnly: true });
+
+  const now = Date.now();
+  let updated = 0;
+  for (const runId of runIds) {
+    const entry = subagentRuns.get(runId);
+    if (!entry || entry.requesterSessionKey !== requesterSessionKey) {
+      continue;
+    }
+    const descendantStartedAt = entry.execution.startedAt ?? entry.createdAt;
+    if (typeof descendantStartedAt === "number" && descendantStartedAt < params.runStartedAt) {
+      continue;
+    }
+    if (typeof entry.execution.endedAt !== "number" || entry.expectsCompletionMessage !== true) {
+      continue;
+    }
+    const delivery = ensureDeliveryState(entry);
+    delivery.status = "delivered";
+    delivery.deliveredAt ??= now;
+    delivery.requesterConsumedAt ??= now;
+    delivery.suspendedAt = undefined;
+    delivery.suspendedReason = undefined;
+    delivery.lastError = undefined;
+    delivery.lastDropReason = undefined;
+    entry.wakeOnDescendantSettle = undefined;
+    try {
+      setDetachedTaskDeliveryStatusByRunId({
+        runId: entry.runId,
+        runtime: "subagent",
+        sessionKey: entry.childSessionKey,
+        deliveryStatus: "delivered",
+      });
+    } catch {
+      // The registry credit is the durable source of truth; task rows can be
+      // absent in tests or after pruning and should not block cleanup.
+    }
+    updated += 1;
+  }
+  if (updated > 0) {
+    persistSubagentRunsToDisk(subagentRuns);
+  }
+  return updated;
+}

--- a/src/agents/subagent-registry-runtime.ts
+++ b/src/agents/subagent-registry-runtime.ts
@@ -11,6 +11,7 @@ export {
   resolveRequesterForChildSession,
   shouldIgnorePostCompletionAnnounceForSession,
 } from "./subagent-registry-announce-read.js";
+export { markDescendantCompletionConsumedByRequester } from "./subagent-registry-consumption.js";
 
 export async function replaceSubagentRunAfterSteer(
   params: Parameters<typeof import("./subagent-registry.js").replaceSubagentRunAfterSteer>[0],

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -138,6 +138,8 @@ export type SubagentCompletionDeliveryState = {
   createdAt?: number;
   enqueuedAt?: number;
   deliveredAt?: number;
+  /** Completion was observed and incorporated by the requester turn itself. */
+  requesterConsumedAt?: number;
   announcedAt?: number;
   lastAttemptAt?: number;
   attemptCount?: number;

--- a/src/cron/isolated-agent/delivery-direct-payloads.ts
+++ b/src/cron/isolated-agent/delivery-direct-payloads.ts
@@ -1,0 +1,66 @@
+import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { hasReplyPayloadContent } from "../../interactive/payload.js";
+import {
+  resolveDirectCronFallbackSourceIndex,
+  resolveDirectCronSummaryFallbackText,
+  shouldAttachDirectCronFallbackText,
+} from "./delivery-dispatch-awareness.js";
+import { normalizeSilentReplyText } from "./delivery-dispatch-policy.js";
+
+export function buildNormalizedDirectCronPayloads(params: {
+  deliveryPayloads: ReplyPayload[];
+  outputText?: string;
+  summary?: string;
+  synthesizedText?: string;
+}): ReplyPayload[] {
+  const summaryFallbackText = resolveDirectCronSummaryFallbackText(params);
+  const normalizedSummaryFallback = summaryFallbackText
+    ? normalizeSilentReplyText(summaryFallbackText)
+    : undefined;
+  const normalizedSummaryFallbackText =
+    normalizedSummaryFallback?.strippedTrailingSilentToken === true
+      ? undefined
+      : normalizedSummaryFallback?.text;
+  const normalizedDeliveryPayloads = params.deliveryPayloads
+    .map((payload) => {
+      const normalized = payload.text ? normalizeSilentReplyText(payload.text) : undefined;
+      return normalized
+        ? {
+            ...payload,
+            text: normalized.strippedTrailingSilentToken ? undefined : normalized.text,
+          }
+        : payload;
+    })
+    .filter((payload) => hasReplyPayloadContent(payload, { trimText: true }));
+  const existingFallbackSourceIndex = resolveDirectCronFallbackSourceIndex(
+    normalizedDeliveryPayloads,
+    normalizedSummaryFallbackText,
+  );
+  const needsFallbackSource =
+    Boolean(normalizedSummaryFallbackText) &&
+    normalizedDeliveryPayloads.some(shouldAttachDirectCronFallbackText) &&
+    existingFallbackSourceIndex === undefined;
+  const fallbackSourceIndex = needsFallbackSource ? 0 : existingFallbackSourceIndex;
+  const directPayloads = needsFallbackSource
+    ? [{ text: normalizedSummaryFallbackText }, ...normalizedDeliveryPayloads]
+    : normalizedDeliveryPayloads;
+  const normalizedPayloads: ReplyPayload[] = [];
+  for (const payload of directPayloads) {
+    normalizedPayloads.push(
+      shouldAttachDirectCronFallbackText(payload) && normalizedSummaryFallbackText
+        ? {
+            ...payload,
+            fallbackText: {
+              text: normalizedSummaryFallbackText,
+              ...(fallbackSourceIndex !== undefined
+                ? { replacesPayloadIndex: fallbackSourceIndex }
+                : {}),
+            },
+          }
+        : payload,
+    );
+  }
+  return normalizedPayloads.length === 0 && normalizedSummaryFallbackText
+    ? [{ text: normalizedSummaryFallbackText }]
+    : normalizedPayloads;
+}

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1081,9 +1081,10 @@ describe("dispatchCronDelivery — double-announce guard", () => {
   it("consolidates descendant output into the final direct delivery", async () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(true);
-    vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(
-      "Detailed child result, everything finished successfully.",
-    );
+    vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue({
+      text: "Detailed child result, everything finished successfully.",
+      consumedRunIds: ["run-child"],
+    });
 
     const params = makeBaseParams({ synthesizedText: "on it" });
     const state = await dispatchCronDelivery(params);
@@ -1140,7 +1141,10 @@ describe("dispatchCronDelivery — double-announce guard", () => {
         vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
       }
       vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
-      vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(childReply);
+      vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue({
+        text: childReply,
+        consumedRunIds: ["run-child"],
+      });
 
       const params = makeBaseParams({
         spawnOnlyHandoff: true,
@@ -1270,7 +1274,10 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(true);
     vi.mocked(readDescendantSubagentFallbackReply).mockImplementation(async (params) =>
       params.sessionKey === runSessionKey
-        ? "Run-scoped child result, everything finished successfully."
+        ? {
+            text: "Run-scoped child result, everything finished successfully.",
+            consumedRunIds: ["run-child"],
+          }
         : undefined,
     );
 

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,5 +1,4 @@
 /** Dispatches isolated cron output to direct delivery, mirrors, and follow-up queues. */
-import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { resolveStorePath } from "../../config/sessions/inbound.runtime.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -15,6 +14,7 @@ import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { isCronSessionKey } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { buildNormalizedDirectCronPayloads } from "./delivery-direct-payloads.js";
 import {
   appendAdmittedDirectCronDeliveryTranscriptMirror,
   buildDirectCronTranscriptMirrorPayloads,
@@ -26,10 +26,7 @@ import {
   resolveCronAwarenessMainSessionKey,
   resolveCronAwarenessText,
   resolveDirectCronDeliverySessionKey,
-  resolveDirectCronFallbackSourceIndex,
-  resolveDirectCronSummaryFallbackText,
   resolveDirectCronTranscriptMirrorText,
-  shouldAttachDirectCronFallbackText,
   isSameSessionKey,
   shouldQueueCronAwareness,
 } from "./delivery-dispatch-awareness.js";
@@ -204,61 +201,12 @@ export async function dispatchCronDelivery(
     } = await loadDeliveryOutboundRuntime();
     const identity = resolveAgentOutboundIdentity(params.cfgWithAgentDefaults, params.agentId);
     try {
-      const summaryFallbackText = resolveDirectCronSummaryFallbackText({
+      const normalizedPayloads = buildNormalizedDirectCronPayloads({
+        deliveryPayloads,
         outputText,
         summary,
         synthesizedText,
       });
-      const normalizedSummaryFallback = summaryFallbackText
-        ? normalizeSilentReplyText(summaryFallbackText)
-        : undefined;
-      const normalizedSummaryFallbackText =
-        normalizedSummaryFallback?.strippedTrailingSilentToken === true
-          ? undefined
-          : normalizedSummaryFallback?.text;
-      const normalizeDirectPayload = (payload: ReplyPayload): ReplyPayload => {
-        const normalized = payload.text ? normalizeSilentReplyText(payload.text) : undefined;
-        return normalized
-          ? {
-              ...payload,
-              text: normalized.strippedTrailingSilentToken ? undefined : normalized.text,
-            }
-          : payload;
-      };
-      const normalizedDeliveryPayloads = deliveryPayloads
-        .map(normalizeDirectPayload)
-        .filter((payload) => hasReplyPayloadContent(payload, { trimText: true }));
-      const existingFallbackSourceIndex = resolveDirectCronFallbackSourceIndex(
-        normalizedDeliveryPayloads,
-        normalizedSummaryFallbackText,
-      );
-      const needsFallbackSource =
-        Boolean(normalizedSummaryFallbackText) &&
-        normalizedDeliveryPayloads.some(shouldAttachDirectCronFallbackText) &&
-        existingFallbackSourceIndex === undefined;
-      const fallbackSourceIndex = needsFallbackSource ? 0 : existingFallbackSourceIndex;
-      const directPayloads = needsFallbackSource
-        ? [{ text: normalizedSummaryFallbackText }, ...normalizedDeliveryPayloads]
-        : normalizedDeliveryPayloads;
-      let normalizedPayloads: ReplyPayload[] = [];
-      for (const payload of directPayloads) {
-        normalizedPayloads.push(
-          shouldAttachDirectCronFallbackText(payload) && normalizedSummaryFallbackText
-            ? {
-                ...payload,
-                fallbackText: {
-                  text: normalizedSummaryFallbackText,
-                  ...(fallbackSourceIndex !== undefined
-                    ? { replacesPayloadIndex: fallbackSourceIndex }
-                    : {}),
-                },
-              }
-            : payload,
-        );
-      }
-      if (normalizedPayloads.length === 0 && normalizedSummaryFallbackText) {
-        normalizedPayloads = [{ text: normalizedSummaryFallbackText }];
-      }
       if (normalizedPayloads.length === 0) {
         return await finishSilentReplyDelivery();
       }
@@ -580,6 +528,22 @@ export async function dispatchCronDelivery(
     const spawnOnlyHandoff = params.spawnOnlyHandoff;
     const expectedSubagentFollowup = expectsSubagentFollowup(initialSynthesizedText);
     const subagentRegistryRuntime = await loadDeliverySubagentRegistryRuntime();
+    const creditRequesterConsumedDescendants = async (runIds: readonly string[]) => {
+      if (runIds.length === 0) {
+        return;
+      }
+      try {
+        subagentRegistryRuntime.markDescendantCompletionConsumedByRequester({
+          requesterSessionKey: params.runSessionKey,
+          runStartedAt: params.runStartedAt,
+          runIds,
+        });
+      } catch (err) {
+        await logCronDeliveryWarn(
+          `[cron:${params.job.id}] failed to credit requester-consumed descendant completions (bestEffort): ${formatErrorMessage(err)}`,
+        );
+      }
+    };
     const subagentFollowupSessionKey = params.runSessionKey;
     let activeSubagentRuns = subagentRegistryRuntime.countActiveDescendantRuns(
       subagentFollowupSessionKey,
@@ -618,10 +582,16 @@ export async function dispatchCronDelivery(
         subagentFollowupSessionKey,
       );
       if (!finalReply && activeSubagentRuns === 0) {
-        finalReply = await subagentFollowupRuntime?.readDescendantSubagentFallbackReply({
+        const fallbackReply = await subagentFollowupRuntime?.readDescendantSubagentFallbackReply({
           sessionKey: subagentFollowupSessionKey,
           runStartedAt: params.runStartedAt,
         });
+        if (fallbackReply) {
+          finalReply = typeof fallbackReply === "string" ? fallbackReply : fallbackReply.text;
+          await creditRequesterConsumedDescendants(
+            typeof fallbackReply === "string" ? [] : fallbackReply.consumedRunIds,
+          );
+        }
       }
       if (finalReply && activeSubagentRuns === 0) {
         outputText = finalReply;
@@ -632,10 +602,17 @@ export async function dispatchCronDelivery(
     } else if (completedDescendantReply) {
       // Descendants already finished before we got here. Use their output
       // directly instead of the cron agent's interim text.
-      outputText = completedDescendantReply;
-      summary = pickSummaryFromOutput(completedDescendantReply) ?? summary;
-      synthesizedText = completedDescendantReply;
-      deliveryPayloads = [{ text: completedDescendantReply }];
+      const completedText =
+        typeof completedDescendantReply === "string"
+          ? completedDescendantReply
+          : completedDescendantReply.text;
+      outputText = completedText;
+      summary = pickSummaryFromOutput(completedText) ?? summary;
+      synthesizedText = completedText;
+      deliveryPayloads = [{ text: completedText }];
+      await creditRequesterConsumedDescendants(
+        typeof completedDescendantReply === "string" ? [] : completedDescendantReply.consumedRunIds,
+      );
     }
     if (spawnOnlyHandoff && !synthesizedText?.trim()) {
       // An accepted spawn is the turn's only completion; retiring it without

--- a/src/cron/isolated-agent/delivery-subagent-registry.runtime.ts
+++ b/src/cron/isolated-agent/delivery-subagent-registry.runtime.ts
@@ -1,2 +1,3 @@
 // Runtime subagent registry seam for isolated-agent delivery gating.
 export { countActiveDescendantRuns } from "../../agents/subagent-registry-read.js";
+export { markDescendantCompletionConsumedByRequester } from "../../agents/subagent-registry-consumption.js";

--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -137,7 +137,7 @@ describe("readDescendantSubagentFallbackReply", () => {
       sessionKey: "test-session",
       runStartedAt,
     });
-    expect(result).toBe("child output text");
+    expect(result?.text).toBe("child output text");
   });
 
   it("falls back to frozenResultText when session transcript unavailable", async () => {
@@ -152,7 +152,7 @@ describe("readDescendantSubagentFallbackReply", () => {
       sessionKey: "test-session",
       runStartedAt,
     });
-    expect(result).toBe("frozen child output");
+    expect(result?.text).toBe("frozen child output");
   });
 
   it("prefers session transcript over frozenResultText", async () => {
@@ -164,7 +164,7 @@ describe("readDescendantSubagentFallbackReply", () => {
       sessionKey: "test-session",
       runStartedAt,
     });
-    expect(result).toBe("live transcript text");
+    expect(result?.text).toBe("live transcript text");
   });
 
   it("prefers captured completion for internally resumed descendants", async () => {
@@ -179,7 +179,7 @@ describe("readDescendantSubagentFallbackReply", () => {
       sessionKey: "test-session",
       runStartedAt,
     });
-    expect(result).toBe("fresh recovered output");
+    expect(result?.text).toBe("fresh recovered output");
   });
 
   it("does not fall back to visible transcript for internally resumed descendants without captured output", async () => {
@@ -215,7 +215,7 @@ describe("readDescendantSubagentFallbackReply", () => {
       sessionKey: "test-session",
       runStartedAt,
     });
-    expect(result).toBe("first child output\n\nsecond child output");
+    expect(result?.text).toBe("first child output\n\nsecond child output");
   });
 
   it("skips SILENT_REPLY_TOKEN descendants", async () => {
@@ -239,7 +239,7 @@ describe("readDescendantSubagentFallbackReply", () => {
       sessionKey: "test-session",
       runStartedAt,
     });
-    expect(result).toBe("useful output");
+    expect(result?.text).toBe("useful output");
   });
 
   it("returns undefined when completion result is null", async () => {

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -10,6 +10,11 @@ import {
 import { isFastTestRuntimeEnv } from "../../infra/env.js";
 import { isLikelyInterimCronMessage } from "./subagent-followup-hints.js";
 
+type DescendantSubagentFallbackReply = {
+  text: string;
+  consumedRunIds: string[];
+};
+
 function resolveCronSubagentTimings() {
   const fastTestMode = isFastTestRuntimeEnv();
   return {
@@ -23,7 +28,7 @@ function resolveCronSubagentTimings() {
 export async function readDescendantSubagentFallbackReply(params: {
   sessionKey: string;
   runStartedAt: number;
-}): Promise<string | undefined> {
+}): Promise<DescendantSubagentFallbackReply | undefined> {
   const descendants = listDescendantRunsForRequester(params.sessionKey)
     .filter(
       (entry) =>
@@ -49,6 +54,7 @@ export async function readDescendantSubagentFallbackReply(params: {
   }
 
   const replies: string[] = [];
+  const consumedRunIds: string[] = [];
   // Limit fallback synthesis to the latest few children so a noisy run does not
   // flood the cron announce with stale descendant output.
   const latestRuns = [...latestByChild.values()]
@@ -75,14 +81,15 @@ export async function readDescendantSubagentFallbackReply(params: {
       continue;
     }
     replies.push(reply);
+    consumedRunIds.push(entry.runId);
   }
   if (replies.length === 0) {
     return undefined;
   }
   if (replies.length === 1) {
-    return replies[0];
+    return { text: replies[0] ?? "", consumedRunIds };
   }
-  return replies.join("\n\n");
+  return { text: replies.join("\n\n"), consumedRunIds };
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes a lifecycle/delivery accounting gap for background and cron-owned subagent trees: when a requester actually consumes completed descendant subagent output, the descendant run is now durably credited as delivered instead of later being finalized as failed/suspended solely because no separate visible delivery event occurred.

## What Problem This Solves

Requester-owned subagent trees can legitimately consume descendant output without sending a separate descendant-visible delivery event. This is common for cron/background flows where a parent/requester gathers frozen child output, composes its own result, and then delivers that requester result outward. Before this PR, the descendant completion could remain delivery-unproven even though its output had already been consumed by the requester. Later cleanup/finalization could then classify that descendant as failed or suspended, producing delivery state that did not match real behavior. This PR gives the registry an explicit durable signal for that case: requester consumption is delivery evidence only for the exact descendant runs that were consumed, under the matching requester session/run-start window, when the requester path adopts descendant fallback output, so the consumed descendant rows do not later announce or finalize as pending just because the final outward send fails.

## User Impact / Intended Outcome

When OpenClaw can prove that a requester consumed descendant subagent output, the matching descendant run receives durable delivery credit:
- `delivery.status` is set to `"delivered"` for the matched descendant completion;
- requester-consumption metadata is persisted with the run/delivery state;
- cleanup/finalize treats `delivery.status === "delivered"` as completed delivery proof;
- normal visible-delivery paths remain required for completions that were not consumed by a requester.
The matching is intentionally narrow. Credit is only applied when all of these are true:
- the consumed run IDs are explicit;
- the requester session key matches;
- the requester run-start window matches the consuming requester run;
- the consumption kind is known;
- cron fallback credit happens when cron adopts explicit descendant fallback output for the requester result;
- nested subagent announcement credit only covers direct child run IDs that were actually included in the requester-consumed output.

This PR keeps the delivery model explicit:
- if a descendant result was visibly delivered, it is delivered;
- if a requester consumed the descendant output because cron adopted it as the requester result, the descendant is delivered by requester consumption;
- if neither happened, failure/suspension handling still applies.

## Linked Context

- Related issue: #92433 — subagent completion can be silently dropped when an announce handoff reaches a requester transcript but the requester run ends before consuming it. This PR addresses the adjacent durable-accounting problem for completions that *are* consumed by a requester.
- Related issue: #67777 — subagent completion delivery can be lost on direct-announce timeout, drain, or orphan prune. This PR does not implement the full durable inbox/spool requested there, but it narrows one delivery-accounting gap by recording proven requester consumption.
- Related issue: #86537 — suspended final delivery can expire and discard a pending subagent completion. This PR keeps requester-consumed completions from remaining indistinguishable from undelivered completions in finalization state.
- Related issue: #90299 — subagent lifecycle state can report lost active execution context while still surfacing child output. This PR contributes to lifecycle/state consistency when descendant output is actually consumed.
- Related PR: #92934 — required assistant acknowledgement for completion wake handoffs, so transcript commit alone is not treated as requester consumption. This PR complements that by adding durable credit for explicit consumed descendant run IDs.
- Related PR: #35080 — deterministic subagent announce delivery with descendant gating. This PR builds on that direction by making consumed descendant accounting durable.
- Related PR: #44205 — stale descendant cron fallback summaries. This PR keeps the same stale-vs-current discipline for requester-consumed descendant credit.
- Related PR: #95604 — Discord subagent progress feedback. This PR is not a Discord UI change, but accurate delivered/failed lifecycle state is useful to progress/failure-marker consumers.
No exact existing issue/PR was found for `markDescendantCompletionConsumedByRequester` or this exact requester-consumed credit mechanism, so this PR should stand as the focused implementation thread for that behavior.

## What Changes

When OpenClaw can prove that a requester consumed descendant subagent output, the matching descendant run receives durable delivery credit:
- `delivery.status` is set to `"delivered"` for the matched descendant completion;
- requester-consumption metadata is persisted with the run/delivery state;
- cleanup/finalize treats `delivery.status === "delivered"` as completed delivery proof;
- normal visible-delivery paths remain required for completions that were not consumed by a requester.
The matching is intentionally narrow. Credit is only applied when all of these are true:
- the consumed run IDs are explicit;
- the requester session key matches;
- the requester run-start window matches the consuming requester run;
- the consumption kind is known;
- cron fallback credit happens when cron adopts explicit descendant fallback output for the requester result;
- nested subagent announcement credit only covers direct child run IDs that were actually included in the requester-consumed output.

## Implementation Notes

Core registry/runtime changes:
- Adds requester-consumed delivery metadata to subagent registry/delivery state.
- Adds a registry operation for marking descendant completions consumed by requester.
- Persists/restores the new delivery fields.
- Exposes the new runtime operation through the existing registry runtime shims.
Main files:
- `src/agents/subagent-registry-consumption.ts`
  - Implements durable requester-consumption credit.
  - Matches by requester session, explicit run IDs, and run-start window.
  - Records requester-consumption metadata and persists the updated run state.
- `src/agents/subagent-registry.types.ts`
  - Adds delivery/requester-consumption state fields.
- `src/agents/subagent-delivery-state.ts`
  - Persists and restores the new delivery fields.
- `src/agents/subagent-registry.ts`
- `src/agents/subagent-registry-runtime.ts`
- `src/agents/subagent-announce.registry.runtime.ts`
- `src/cron/isolated-agent/delivery-subagent-registry.runtime.ts`
  - Wires the new registry operation through runtime boundaries.
Requester-consumption paths:
- `src/cron/isolated-agent/subagent-followup.ts`
  - Reads completed descendant fallback replies and returns both formatted fallback text and the consumed descendant run IDs.
- `src/cron/isolated-agent/delivery-dispatch.ts`
  - Applies cron fallback consumption credit when cron adopts explicit descendant fallback output, before the final outbound send.
- `src/agents/subagent-announce.ts`
  - Credits nested/direct child completions when their output is included in the requester-consumed announcement/wake result.
  - Uses the same latest-child dedupe input for rendering and consumed-run credit so stale child rows are not credited.
- `src/agents/subagent-announce-output.ts`
  - Keeps latest-child dedupe reusable while preserving caller-specific fields such as `runId`.

## Tests / Verification

Coverage added or extended for:
- positive requester-consumed descendant credit;
- no credit for mismatched requester session;
- no credit outside the requester run-start window;
- no credit without explicit consumed run IDs;
- persisted/restored requester-consumption delivery fields;
- cron fallback credit only after successful outbound delivery;
- cleanup/finalize treating `delivery.status === "delivered"` as proof;
- nested/direct child announcement credit;
- stale-vs-current child dedupe, including a negative assertion that stale child run IDs are not credited when stale output is not rendered.
Primary test files:
- `src/agents/subagent-registry-consumption.test.ts`
- `src/agents/subagent-delivery-state.test.ts`
- `src/agents/subagent-registry-completion.test.ts`
- `src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts`
- `src/agents/subagent-announce.format.e2e.test.ts`
- `src/cron/isolated-agent/subagent-followup.test.ts`
- `src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`

## Evidence

### Rebase/Squash/Proof

- Common pinned upstream base: `65717fd3be89c8208fd1ee6753aa4f74e2d4e224` (`upstream/main`, `feat: add native multi-agent team coordination (#126106)`).
- Previous PR head: `fb0458d875912973d8c047fe51b09824ba7de88c`.
- Current rebased/squashed PR head: `fda9328e4d4185e5c99a45b27fa8fc8746881359`.
- Commit count over the pinned base: `1`.
- Conflict resolution preserved the PR's requester-consumed delivery accounting while keeping current-main cron direct-delivery extraction in `delivery-dispatch-direct.ts`.
- Exact-head semantic hardening ensures truncated child-completion findings credit only run IDs whose sections are actually visible to the requester; silent or budget-omitted completions are not credited.

### Real / Live Behavior Proof

Current-head deterministic evidence:

```text
head=fda9328e4d4185e5c99a45b27fa8fc8746881359
branch=p1/requester-consumed-completion-credit-clean
comparison_base=65717fd3be89c8208fd1ee6753aa4f74e2d4e224
commit_count_over_base=1
diff=28 files +1404/-502
diff_check=passed
focused_announce_output=40 passed
focused_requester_consumption=passed in 3 shards, 174 tests
oxlint_announce_output=passed (0 warnings/errors)
tsgo_core_test=passed
tsgo_root_test=passed
```

Behavior covered at the current head includes:

- explicit requester session, requester run-start window, and consumed-run-ID matching;
- durable requester-consumption delivery metadata and SQLite restore semantics;
- cron fallback credit before final outbound delivery, so already-consumed descendants do not remain pending when that final send fails;
- latest-child dedupe before rendering and crediting;
- direct child completion credit limited to sections actually rendered inside the findings budget;
- actionable failures prioritized and credited while omitted oversized successes remain uncredited;
- silent completion output remains uncredited.

## Compatibility and Risk

Risk is moderate because this touches subagent lifecycle/delivery finalization, but the implementation is deliberately constrained:
- no broad “assume delivered” fallback was added;
- no delivery status is credited without explicit consumed run IDs;
- matching is scoped to requester session and requester run-start timing;
- cron fallback credit is gated behind explicit adopted descendant fallback output;
- stale nested child rows are explicitly excluded after latest-child dedupe;
- persisted state changes are additive.
The main compatibility consideration is that existing delivery state can simply lack the new requester-consumption fields; restore logic treats those fields as optional.

## PR/Commit Surface Breakdown

Diff surface against `origin/main...HEAD` after the clean rebase:
Source: 12 files, +192 / -44
Tests: 6 files, +251 / -12
Total: 18 files, +443 / -56

## Reviewer Checklist

Recommended review focus:
- `src/agents/subagent-registry-consumption.ts`
  - Verify matching is narrow enough: run IDs, requester session key, and run-start window.
- `src/cron/isolated-agent/delivery-dispatch.ts`
  - Verify cron fallback credit is only applied after successful requester outbound delivery.
- `src/agents/subagent-announce.ts`
  - Verify nested/direct child credit only uses deduped, actually-consumed child rows.
- `src/agents/subagent-delivery-state.ts`
  - Verify persistence/restore behavior is additive and safe for older state.
- Tests listed above, especially negative cases around mismatched requester, stale child rows, and no explicit consumed run IDs.

---
Maintenance update: squashed to `6f24d892e13ae42b7c1647a90e8ff050bd4a83d6` after test-surface optimization only; behavior coverage and focused validation were preserved.

---

Non-test surface optimization (2026-06-25): squashed cleanup head e569f3aa7389e6151f18ffe241254a7292623a9c (was 6f24d892e13ae42b7c1647a90e8ff050bd4a83d6); removed duplicated requester-consumed fallback credit construction in delivery dispatch while preserving behavior. Validation: pnpm test -- src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts src/cron/isolated-agent/subagent-followup.test.ts -- --maxWorkers=1 --maxConcurrency=1; git diff --check; pnpm exec oxlint src/cron/isolated-agent/delivery-dispatch.ts.

---

Lint remediation (2026-06-26): squashed cleanup head 379d437e8c8fc86c0991db67987ef3a43d60f778 (was e569f3aa7389e6151f18ffe241254a7292623a9c); fixed CI `check-lint` failure in `src/agents/subagent-registry-consumption.test.ts` by removing an unnecessary empty spread fallback flagged by `unicorn(no-useless-fallback-in-spread)`. Validation: `TASK=lint OPENCLAW_LOCAL_CHECK=1 node scripts/run-oxlint-shards.mjs --threads=8`; `git diff HEAD^..HEAD --check`; `pnpm exec vitest run src/agents/subagent-registry-consumption.test.ts src/agents/subagent-announcement-consumption.test.ts`.

