### PR TITLE
fix(bundle-mcp): always clean up MCP session on failure, not just for new connections

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -696,10 +696,12 @@ export function createSessionMcpRuntime(params: {
               launchSummary: resolved.description,
               message,
             });
-            if (!reusedSession) {
-              await disposeSession(session);
-              sessions.delete(serverName);
-            }
+            // Always clean up on failure — whether reused or new.
+            // A reused session that fails (e.g. server-side Streamable HTTP
+            // session expiry with "Session not found" -32600) must be disposed
+            // and recreated, not left to persist indefinitely.
+            await disposeSession(session);
+            sessions.delete(serverName);
             failIfDisposed();
           }
         }


### PR DESCRIPTION
## Problem

When a Streamable HTTP MCP server discards its session (e.g. \"Session not found\" -32600), OpenClaw reuses the dead session object without reconnecting. 

The code at  around line 1104 sets `reusedSession = true` when it finds an existing session. At lines 1189-1191, if `reusedSession == false`, it properly deletes and recreates the session. But if `reusedSession == true`, it only logs a warning and keeps using the dead session forever.

## Fix

Remove the `if (!reusedSession)` guard in the error handler so that **all** session failures — whether from reused or newly created sessions — trigger proper cleanup:

- `disposeSession(session)` is always called on failure
- `sessions.delete(serverName)` is always called, allowing a fresh session to be created on the next catalog refresh

This ensures that when a Streamable HTTP server-side session expires, OpenClaw detects the failure and reconnects with a new session instead of perpetually failing against a dead one.

## Changes

- `src/agents/agent-bundle-mcp-runtime.ts`: Removed the `if (!reusedSession)` conditional guard around `disposeSession()` and `sessions.delete()`, adding explanatory comments about the Streamable HTTP session expiry scenario.