### PR TITLE
fix: force-release session .jsonl.lock on dispose when retained-lock user is stuck

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -237,6 +237,39 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(releases).toEqual(["held"]);
   });
 
+  it("force-releases on dispose when retained-lock user is stuck (#95833)", async () => {
+    // When a stuck subagent holds a retained lock and never releases, dispose
+    // must force-release the physical .jsonl.lock after a timeout instead of
+    // hanging indefinitely.
+    const release = vi.fn(async () => {});
+    const acquireLock = vi.fn(async () => ({ release }));
+
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireLock,
+      lockOptions,
+    });
+
+    // Start a write that will never complete — simulates a stuck operation
+    // that holds a retained lock.
+    const neverResolves = new Promise<void>(() => {});
+    const writePromise = controller.withSessionWriteLock(async () => {
+      await neverResolves;
+    });
+
+    // Give the write time to acquire the retained lock.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Dispose while the write is stuck. The bounded wait should time out
+    // and force-release rather than hanging.
+    await controller.dispose();
+
+    expect(release).toHaveBeenCalledTimes(1);
+
+    // Clean up: the stuck write will reject when the lock is released
+    // and the controller is disposed, but we don't care about that.
+    writePromise.catch(() => {});
+  });
+
   it("releases the eagerly-held lock when the fence read throws during prompt release", async () => {
     // A filesystem error can occur after the controller clears its in-memory
     // lock reference; the underlying lease still must be released.

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -257,7 +257,9 @@ describe("embedded attempt session lock lifecycle", () => {
     });
 
     // Give the write time to acquire the retained lock.
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise<void>((r) => {
+      setTimeout(r, 50);
+    });
 
     // Dispose while the write is stuck. The bounded wait should time out
     // and force-release rather than hanging.

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -135,6 +135,11 @@ const MAX_BENIGN_SESSION_FENCE_REWRITE_RESULT_BYTES =
 const MAX_BENIGN_SESSION_FENCE_CTIME_DIGEST_BYTES = 32 * 1024 * 1024;
 const MAX_SAFE_FILE_OFFSET = BigInt(Number.MAX_SAFE_INTEGER);
 
+// How long dispose waits for retained-lock users to become idle before
+// force-releasing the physical lock. Prevents indefinite hangs when a stuck
+// operation never releases its retained use (#95833).
+const DISPOSE_RETAINED_LOCK_IDLE_TIMEOUT_MS = 5_000;
+
 type SessionFileFenceSnapshot = {
   fingerprint: SessionFileFingerprint;
   digest?: string;
@@ -1321,6 +1326,34 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     return true;
   }
 
+  /**
+   * Bounded variant of {@link waitForRetainedLockIdle} for use in
+   * {@link disposeHeldLockAfterRetainedIdle}. Returns `false` when the caller
+   * is inside an active write-lock scope (same as the unbounded version) AND
+   * when retained-lock users do not become idle within the timeout. The
+   * timeout prevents dispose from hanging indefinitely when a stuck operation
+   * never releases its retained lock (#95833).
+   */
+  async function waitForRetainedLockIdleWithTimeout(): Promise<boolean> {
+    if (retainedLockUseCount === 0) {
+      return true;
+    }
+    if (activeWriteLock.getStore()?.scope.active === true) {
+      return false;
+    }
+    return new Promise<boolean>((resolve) => {
+      const timer = setTimeout(() => {
+        retainedLockIdleWaiters.delete(waiterResolve);
+        resolve(false);
+      }, DISPOSE_RETAINED_LOCK_IDLE_TIMEOUT_MS);
+      const waiterResolve = () => {
+        clearTimeout(timer);
+        resolve(true);
+      };
+      retainedLockIdleWaiters.add(waiterResolve);
+    });
+  }
+
   async function acquireWriteLock(): Promise<{
     lock: SessionLock;
     owned: boolean;
@@ -1659,7 +1692,16 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
     const drainOwner = await beginHeldLockDrain();
     try {
-      if (!(await waitForRetainedLockIdle())) {
+      const idle = await waitForRetainedLockIdleWithTimeout();
+      if (!idle && heldLock) {
+        // Dispose is the final cleanup path for the attempt. If retained-lock
+        // users did not become idle (caller inside an active write-lock scope,
+        // or the wait timed out because a stuck operation never released),
+        // force-release so the physical .jsonl.lock does not persist and
+        // permanently block the session (#95833).
+        const lock = heldLock;
+        heldLock = undefined;
+        await lock.release();
         return;
       }
       if (!heldLock) {


### PR DESCRIPTION
Closes #95833

## What Problem This Solves

Fixes an issue where sessions would permanently break with "Something went wrong" after a subagent abort-settle timeout, because the `.jsonl.lock` file was never released. Users had to manually delete the lock file to restore the session.

## Why This Change Was Made

`disposeHeldLockAfterRetainedIdle()` is the final lock cleanup path called from the attempt's outer `finally` block. Previously, when `waitForRetainedLockIdle()` returned `false` (caller inside an active write-lock scope) or waited indefinitely (a stuck operation never released its retained lock), dispose would return without releasing the physical lock — leaving a stale `.jsonl.lock` that blocked the session permanently.

The fix introduces a bounded variant `waitForRetainedLockIdleWithTimeout()` that adds a 5-second timeout to the retained-lock-idle wait. If the wait returns `false` (either because the caller is inside an active write-lock scope or the timeout fires), dispose now force-releases the lock anyway — since dispose is the final cleanup path and no more writes will happen.

## User Impact

Sessions that previously required manual `.jsonl.lock` removal after subagent abort-settle timeouts now recover automatically. The session lock is always released on every exit path of the attempt lifecycle.

## Evidence

**Test**: `pnpm test -- src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`

```
$ node node_modules/.bin/vitest run src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts --reporter=verbose
 ✓ force-releases on dispose when retained-lock user is stuck (#95833) 5082ms
 Test Files  1 passed (1)
      Tests  106 passed (106)
```

**Regression test**: The new test `force-releases on dispose when retained-lock user is stuck (#95833)` simulates a stuck `withSessionWriteLock` callback that never completes (like a hung model call). It verifies that `dispose()` force-releases the physical lock after the 5-second timeout instead of hanging indefinitely.

**All related tests pass**:

```
$ node node_modules/.bin/vitest run src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts src/agents/embedded-agent-runner/run/attempt-abort.test.ts src/agents/embedded-agent-runner/run/attempt.subscription-cleanup.test.ts src/agents/embedded-agent-runner/runs.test.ts --reporter=verbose
 Test Files  4 passed (4)
      Tests  140 passed (140)
```

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
