### PR TITLE
fix(cron): heal hallucinated everyMs schedule kind and every alias

### DIFF
--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -158,6 +158,41 @@ describe("normalizeCronJobCreate", () => {
     expectNormalizedAtSchedule({ kind: "at", at: "2026-01-12T18:00:00" });
   });
 
+  it("heals hallucinated kind=everyMs to canonical every", () => {
+    const normalized = normalizeMainSystemEventCreateJob({
+      name: "heal kind",
+      schedule: { kind: "everyMs", everyMs: 60_000 },
+    });
+
+    const schedule = normalized.schedule as Record<string, unknown>;
+    expect(schedule.kind).toBe("every");
+    expect(schedule.everyMs).toBe(60_000);
+  });
+
+  it("heals interval alias every to everyMs", () => {
+    const normalized = normalizeMainSystemEventCreateJob({
+      name: "heal interval",
+      schedule: { kind: "every", every: 90_000 },
+    });
+
+    const schedule = normalized.schedule as Record<string, unknown>;
+    expect(schedule.kind).toBe("every");
+    expect(schedule.everyMs).toBe(90_000);
+    expect("every" in schedule).toBe(false);
+  });
+
+  it("prefers explicit everyMs over the every alias", () => {
+    const normalized = normalizeMainSystemEventCreateJob({
+      name: "prefer everyMs",
+      schedule: { kind: "everyMs", everyMs: 60_000, every: 5_000 },
+    });
+
+    const schedule = normalized.schedule as Record<string, unknown>;
+    expect(schedule.kind).toBe("every");
+    expect(schedule.everyMs).toBe(60_000);
+    expect("every" in schedule).toBe(false);
+  });
+
   it("defaults cron stagger for recurring top-of-hour schedules", () => {
     const normalized = normalizeMainSystemEventCreateJob({
       name: "hourly",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -94,12 +94,18 @@ function hasAgentTurnOnlyPayloadHint(payload: UnknownRecord): boolean {
 function coerceSchedule(schedule: UnknownRecord) {
   const next: UnknownRecord = { ...schedule };
   const rawKind = normalizeLowercaseStringOrEmpty(schedule.kind);
-  const kind = rawKind === "at" || rawKind === "every" || rawKind === "cron" ? rawKind : undefined;
+  // Models frequently emit kind="everyMs" and the interval as "every"; heal both
+  // to the canonical kind="every"/everyMs shape instead of dropping the schedule.
+  const healedKind = rawKind === "everyms" ? "every" : rawKind;
+  const kind =
+    healedKind === "at" || healedKind === "every" || healedKind === "cron" ? healedKind : undefined;
   const exprRaw = normalizeOptionalString(schedule.expr) ?? "";
-  const everyMs = coerceFiniteScheduleNumber(schedule.everyMs);
+  const everyMs = coerceFiniteScheduleNumber(schedule.everyMs ?? schedule.every);
   const anchorMs = coerceFiniteScheduleNumber(schedule.anchorMs);
   const atString = normalizeOptionalString(schedule.at) ?? "";
   const parsedAtMs = atString ? parseAbsoluteTimeMs(atString) : null;
+
+  delete next.every;
 
   if (kind) {
     next.kind = kind;


### PR DESCRIPTION
## What

`coerceSchedule` now heals two shapes that models routinely hallucinate when creating recurring cron jobs:

- `kind: "everyMs"` → canonical `kind: "every"`
- interval in an `every` field → folded into `everyMs` (when `everyMs` is absent)

## Why

Recurring jobs are described by `kind: "every"` + `everyMs`. In practice models frequently emit `kind: "everyMs"` and/or put the interval in `every`. Previously:

- `kind: "everyMs"` was not one of `at | every | cron`, so `kind` fell through to `undefined`.
- `every` was ignored entirely, so the interval was dropped.

The result was an invalid schedule that failed validation, so the agent burned turns retrying the same malformed call.

## How

In `coerceSchedule`:

- Map `rawKind === "everyms"` to `"every"` before the kind whitelist check.
- Read the interval from `schedule.everyMs ?? schedule.every`, so the alias flows through the existing strict finite-number coercion (floored, range-checked) — explicit `everyMs` still wins over the alias.
- Drop the non-canonical `every` field from the normalized output.

No behavior change for already-canonical schedules.

## Tests

Added three cases to `src/cron/normalize.test.ts`:

- heals `kind: "everyMs"` → `"every"`
- heals `every` alias → `everyMs` and drops `every`
- explicit `everyMs` wins over `every`

`src/cron/normalize.test.ts` passes (57 tests); typecheck and oxlint clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)