### PR TITLE
Fix SQLite user version guardrail allowlist

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -39,6 +39,7 @@ const rawSqliteAllowPathGroups = {
     "src/infra/sqlite-integrity.ts",
     "src/infra/sqlite-pragma.test-support.ts",
     "src/infra/sqlite-transaction.ts",
+    "src/infra/sqlite-user-version.ts",
     "src/infra/sqlite-wal.ts",
     "src/state/openclaw-agent-db.ts",
     "src/state/openclaw-state-db.ts",


### PR DESCRIPTION
## Summary
- Allowlist `src/infra/sqlite-user-version.ts` under the existing raw SQLite lifecycle, schema, transactions, and pragmas guardrail group.
- Unblock the main-branch `pnpm check:architecture` failure by documenting the shared `PRAGMA user_version` helper's direct `DatabaseSync` boundary.

## Verification
- `pnpm check:architecture`
- `git diff --check`

## Real behavior proof
Behavior addressed: `pnpm check:architecture` no longer fails on `src/infra/sqlite-user-version.ts` raw `node:sqlite` access.
Real environment tested: Local macOS checkout after rebasing `codex/fix-sqlite-user-version-guard` onto `origin/main`.
Exact steps or command run after this patch: `pnpm check:architecture`; `git diff --check`.
Evidence after fix: `scripts/check-kysely-guardrails.mjs` reports `Kysely guardrails OK`; the architecture lane exits successfully.
Observed result after fix: Both requested checks passed.
What was not tested: No runtime scenario; this is a guardrail allowlist-only CI unblocker.
