### PR TITLE
feat(qa): expose active memory toggles to scenarios

### DIFF
--- a/extensions/qa-lab/src/scenario-runtime-api.test.ts
+++ b/extensions/qa-lab/src/scenario-runtime-api.test.ts
@@ -74,6 +74,8 @@ function createDeps(overrides?: Partial<QaScenarioRuntimeDeps>): QaScenarioRunti
     extractQaToolPayload: fn,
     formatMemoryDreamingDay: fn,
     resolveSessionTranscriptsDirForAgent: fn,
+    activeMemoryToggleKey: fn,
+    setActiveMemorySessionDisabled: fn,
     buildAgentSessionKey: fn,
     normalizeLowercaseStringOrEmpty: fn,
     formatErrorMessage: fn,

--- a/extensions/qa-lab/src/scenario-runtime-api.ts
+++ b/extensions/qa-lab/src/scenario-runtime-api.ts
@@ -86,6 +86,8 @@ export type QaScenarioRuntimeDeps = {
   extractQaToolPayload: QaScenarioRuntimeFunction;
   formatMemoryDreamingDay: QaScenarioRuntimeFunction;
   resolveSessionTranscriptsDirForAgent: QaScenarioRuntimeFunction;
+  activeMemoryToggleKey: QaScenarioRuntimeFunction;
+  setActiveMemorySessionDisabled: QaScenarioRuntimeFunction;
   buildAgentSessionKey: QaScenarioRuntimeFunction;
   normalizeLowercaseStringOrEmpty: QaScenarioRuntimeFunction;
   formatErrorMessage: QaScenarioRuntimeFunction;
@@ -177,6 +179,8 @@ type QaScenarioRuntimeApi<
   extractQaToolPayload: TDeps["extractQaToolPayload"];
   formatMemoryDreamingDay: TDeps["formatMemoryDreamingDay"];
   resolveSessionTranscriptsDirForAgent: TDeps["resolveSessionTranscriptsDirForAgent"];
+  activeMemoryToggleKey: TDeps["activeMemoryToggleKey"];
+  setActiveMemorySessionDisabled: TDeps["setActiveMemorySessionDisabled"];
   buildAgentSessionKey: TDeps["buildAgentSessionKey"];
   normalizeLowercaseStringOrEmpty: TDeps["normalizeLowercaseStringOrEmpty"];
   formatErrorMessage: TDeps["formatErrorMessage"];
@@ -283,6 +287,8 @@ export function createQaScenarioRuntimeApi<
     extractQaToolPayload: params.deps.extractQaToolPayload,
     formatMemoryDreamingDay: params.deps.formatMemoryDreamingDay,
     resolveSessionTranscriptsDirForAgent: params.deps.resolveSessionTranscriptsDirForAgent,
+    activeMemoryToggleKey: params.deps.activeMemoryToggleKey,
+    setActiveMemorySessionDisabled: params.deps.setActiveMemorySessionDisabled,
     buildAgentSessionKey: params.deps.buildAgentSessionKey,
     normalizeLowercaseStringOrEmpty: params.deps.normalizeLowercaseStringOrEmpty,
     formatErrorMessage: params.deps.formatErrorMessage,

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -1,11 +1,12 @@
 // Qa Lab plugin module implements suite runtime flow behavior.
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { formatMemoryDreamingDay } from "openclaw/plugin-sdk/memory-core-host-status";
 import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-host-core";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
+import { createPluginStateSyncKeyedStore } from "openclaw/plugin-sdk/runtime-doctor";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   callQaBrowserRequest,
@@ -84,6 +85,39 @@ type QaSuiteScenarioFlowEnv = {
   webSessionIds: Set<string>;
   transport: QaSuiteRuntimeEnv["transport"] & QaScenarioRuntimeEnv["transport"];
 } & Omit<QaSuiteRuntimeEnv, "transport">;
+
+function activeMemoryToggleKey(sessionKey: string) {
+  return createHash("sha256").update(sessionKey, "utf8").digest("hex");
+}
+
+function setActiveMemorySessionDisabled(
+  env: QaSuiteScenarioFlowEnv,
+  sessionKey: string,
+  disabled: boolean,
+) {
+  const store = createPluginStateSyncKeyedStore<{
+    sessionKey: string;
+    disabled: true;
+    updatedAt: number;
+  }>("active-memory", {
+    namespace: "session-toggles",
+    maxEntries: 10_000,
+    env: {
+      ...process.env,
+      OPENCLAW_STATE_DIR: path.join(env.gateway.tempRoot, "state"),
+    },
+  });
+  const key = activeMemoryToggleKey(sessionKey);
+  if (disabled) {
+    store.register(key, {
+      sessionKey,
+      disabled: true,
+      updatedAt: Date.now(),
+    });
+    return;
+  }
+  store.delete(key);
+}
 
 type QaSuiteStep = {
   name: string;
@@ -204,6 +238,8 @@ function createQaSuiteScenarioDeps(params: QaSuiteScenarioDepsParams) {
     extractQaToolPayload,
     formatMemoryDreamingDay,
     resolveSessionTranscriptsDirForAgent,
+    activeMemoryToggleKey,
+    setActiveMemorySessionDisabled,
     buildAgentSessionKey,
     normalizeLowercaseStringOrEmpty,
     formatErrorMessage: params.formatErrorMessage,


### PR DESCRIPTION
## Summary

- Exposes active-memory session toggle helpers through the QA scenario runtime API.
- Adds the QA suite runtime implementation that writes active-memory session disable toggles into the plugin state store.

## Why

Some QA scenarios need to exercise flows where Active Memory is deliberately disabled for a specific agent session, without mutating global config or relying on test-only process state. The production Active Memory extension keys its per-session toggle records by the hashed session key, so QA Lab needs a matching helper to set and clear that same plugin-state record before running a scenario.

This keeps the behavior scenario-scoped: a scenario can disable Active Memory for the exact session under test, then later re-enable it by deleting the same session-toggle record. That makes Active Memory coverage deterministic and keeps this unrelated toggle plumbing out of the Crabline channel-driver PR.

## Validation

- `pnpm exec vitest run extensions/qa-lab/src/scenario-runtime-api.test.ts`
- `git diff --check`
