### PR TITLE
fix(#95840): contextPruning (mode: cache-ttl) never fires on OpenAI models: isCacheTtlEligibleProvider excludes OpenAI, so the idle-gap tool-result firebreak is dead for the highest-volume provider

### DIFF
--- a/src/agents/embedded-agent-runner/cache-ttl.test.ts
+++ b/src/agents/embedded-agent-runner/cache-ttl.test.ts
@@ -53,8 +53,12 @@ describe("isCacheTtlEligibleProvider", () => {
     expect(isCacheTtlEligibleProvider("openrouter", "zai/glm-5")).toBe(true);
   });
 
+  it("allows OpenAI providers", () => {
+    expect(isCacheTtlEligibleProvider("openai", "gpt-4o")).toBe(true);
+    expect(isCacheTtlEligibleProvider("openai", "gpt-5.5")).toBe(true);
+  });
+
   it("rejects unsupported providers and models", () => {
-    expect(isCacheTtlEligibleProvider("openai", "gpt-4o")).toBe(false);
     expect(isCacheTtlEligibleProvider("openrouter", "openai/gpt-4o")).toBe(false);
   });
 

--- a/src/agents/embedded-agent-runner/cache-ttl.ts
+++ b/src/agents/embedded-agent-runner/cache-ttl.ts
@@ -53,7 +53,8 @@ export function isCacheTtlEligibleProvider(
       modelApi,
     }) ||
     (normalizedProvider === "kilocode" && isAnthropicModelRef(normalizedModelId)) ||
-    isGooglePromptCacheEligible({ modelApi, modelId: normalizedModelId })
+    isGooglePromptCacheEligible({ modelApi, modelId: normalizedModelId }) ||
+    normalizedProvider === "openai"
   );
 }
 


### PR DESCRIPTION
## Summary

What problem does this PR solve?

The `contextPruning` `mode: "cache-ttl"` firebreak — which prunes stale tool-results after an idle gap so post-idle requests don't re-cache oversized history — never executed for OpenAI models. The eligibility gate `isCacheTtlEligibleProvider()` in `cache-ttl.ts` only returned `true` for Anthropic, kilocode+Anthropic, and Google providers. OpenAI was excluded with no config override, leaving read-heavy agents on `openai/gpt-5.5` with no idle-gap firebreak at all.

Why does this matter now?

OpenAI is the highest-volume provider. Without this firebreak, idle-gap turns (gap > 5-min cache TTL) re-cache the full grown tool-result history cold. Over a 7-day window the idle-gap cold-input bucket was ~2.9M tokens. The `[Old tool result content cleared]` marker had never appeared in any agent session log — the firebreak was dead code for the most common provider.

What is the intended outcome?

OpenAI providers (`normalizedProvider === "openai"`) are now eligible for cache-ttl context pruning. The TTL-based idle-gap pruning tracks timestamps, not cache breakpoints, so it works correctly with OpenAI's automatic prefix cache (unlike Anthropic's explicit cache breakpoints).

What is intentionally out of scope?

- Kilocode+OpenAI remains ineligible (only `normalizedProvider === "openai"` is added, not the kilocode variant).
- OpenRouter-routed OpenAI models remain ineligible (the provider normalizes to `"openrouter"`, not `"openai"`).
- No new pruning modes or config overrides — this is a targeted eligibility fix, not a provider-agnostic pruning redesign.

What does success look like?

- `isCacheTtlEligibleProvider("openai", "gpt-4o")` returns `true`.
- Read-heavy agents on OpenAI models get stale tool-result pruning after idle gaps.
- All 14 tests in `cache-ttl.test.ts` and `attempt.spawn-workspace.cache-ttl.test.ts` pass.

What should reviewers focus on?

- The single-line addition to `isCacheTtlEligibleProvider` in `src/agents/embedded-agent-runner/cache-ttl.ts` (appending `|| normalizedProvider === "openai"`).
- The test update in `cache-ttl.test.ts`: removed the `expect(false)` for OpenAI and added a dedicated `"allows OpenAI providers"` test case.
- Verify that kilocode+OpenAI and OpenRouter-routed OpenAI correctly remain ineligible.

## Linked context

Which issue does this close?

Closes #95840

Which issues, PRs, or discussions are related?

Related #95610 — same root cause (OpenClaw's context optimizations assume Anthropic-style explicit cache breakpoints and silently no-op on OpenAI's automatic prefix cache). #95610 covers the prefix-stability half (within-TTL cold re-sends); this PR covers the idle-gap firebreak half (post-TTL re-cache size).

Was this requested by a maintainer or owner?

No — filed as a community bug report with empirical evidence from production agent session logs.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `isCacheTtlEligibleProvider` returned `false` for all OpenAI models, so the `contextPruning` cache-ttl firebreak never fired for the highest-volume provider.
- Real environment tested: Unit test suite (Vitest v4.1.8) against the `cache-ttl.ts` module and its integration with `attempt.spawn-workspace`.
- Exact steps or command run after this patch: `vitest` via `test/vitest/vitest.agents.config.ts` targeting `cache-ttl.test.ts` and `attempt.spawn-workspace.cache-ttl.test.ts`.
- Evidence after fix (console output):
  ```
  Test Files  2 passed (2)
       Tests  14 passed (14)
  Start at  20:48:52
  Duration  4.97s (transform 2.47s, setup 385ms, import 4.15s, tests 147ms, environment 0ms)
  ```
- Observed result after fix: All 14 tests pass — 12 in `cache-ttl.test.ts` (including the new `"allows OpenAI providers"` case) and 2 in `attempt.spawn-workspace.cache-ttl.test.ts`.
- What was not tested: End-to-end agent session with actual OpenAI model calls and idle-gap pruning. The fix is a provider eligibility flag change; the pruning logic itself is unchanged and already tested for Anthropic/Google paths.
- Proof limitations or environment constraints: This is a unit-level fix; full integration proof requires running a read-heavy agent on `openai/gpt-5.5` through an idle gap and verifying the `[Old tool result content cleared]` marker appears in session logs. That requires live API access and is deferred to post-merge monitoring.
- Before evidence (optional but encouraged): Production grep across all agent session logs on 2026.6.6 returned 0 matches for `[Old tool result content cleared]` — confirming the firebreak had never fired for any agent, including Anthropic-eligible ones (which simply weren't read-heavy enough to trigger it).

## Tests and validation

Which commands did you run?

Ran the Vitest agent test shard via `test/vitest/vitest.agents.config.ts`, which executed:
- `src/agents/embedded-agent-runner/cache-ttl.test.ts` (12 tests)
- `src/agents/embedded-agent-runner/run/attempt.spawn-workspace.cache-ttl.test.ts` (2 tests)

What regression coverage was added or updated?

- Added new test case `"allows OpenAI providers"` in `cache-ttl.test.ts` that asserts `isCacheTtlEligibleProvider("openai", "gpt-4o")` and `isCacheTtlEligibleProvider("openai", "gpt-5.5")` both return `true`.
- Updated `"rejects unsupported providers and models"` test: removed the `expect(isCacheTtlEligibleProvider("openai", "gpt-4o")).toBe(false)` assertion that previously encoded the bug.

What failed before this fix, if known?

The `"rejects unsupported providers and models"` test expected OpenAI to be rejected (`toBe(false)`). After the fix, that assertion was removed and replaced with the new positive test case. Without updating the test, the old assertion would have failed.

If no test was added, why not?

Tests were added and updated — see above.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes — agents using OpenAI models with `contextPruning.mode: "cache-ttl"` will now have stale tool-results pruned after idle gaps, reducing cold-cache input token counts.

Did config, environment, or migration behavior change? (`Yes/No`)

No — no new config keys, environment variables, or migrations. The existing `contextPruning.mode: "cache-ttl"` setting now applies to OpenAI providers.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No — this change only affects which providers are eligible for context pruning; no auth, secrets, or network behavior is modified.

What is the highest-risk area?

OpenAI's automatic prefix cache differs from Anthropic's explicit cache breakpoints. The TTL-based idle-gap pruning only tracks timestamps (via `readLastCacheTtlTimestamp`), not cache breakpoints, so it should work correctly. However, if OpenAI's prefix cache interacts unexpectedly with the pruning timestamps, it could cause unnecessary re-caching or missed pruning.

How is that risk mitigated?

- The pruning logic itself is unchanged — only the provider eligibility gate is widened.
- The TTL mechanism tracks idle gaps via timestamps, independent of how the provider implements caching.
- The change is narrowly scoped to `normalizedProvider === "openai"`; kilocode+OpenAI and OpenRouter-routed OpenAI remain excluded.
- All 14 existing tests pass, including integration tests in `attempt.spawn-workspace.cache-ttl.test.ts`.