### PR TITLE
fix(compaction): trim prefix when transcript ends in an oversized tool result

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "../../types.js";
+import type { SessionTreeEntry } from "../types.js";
+import { estimateTokens, findCutPoint } from "./compaction.js";
+
+const KEEP_RECENT_TOKENS = 20000;
+const LARGE_TOOL_OUTPUT = "x".repeat(120000);
+
+function userText(text: string, timestamp: number): AgentMessage {
+  return { role: "user", content: [{ type: "text", text }], timestamp };
+}
+
+function assistantText(text: string, timestamp: number): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "claude-fable-5",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp,
+  };
+}
+
+function toolResultText(text: string, timestamp: number): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call-1",
+    toolName: "bash",
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp,
+  };
+}
+
+function messageEntry(message: AgentMessage, index: number): SessionTreeEntry {
+  return {
+    type: "message",
+    id: `entry-${index}`,
+    parentId: index === 0 ? null : `entry-${index - 1}`,
+    timestamp: new Date(message.timestamp).toISOString(),
+    message,
+  };
+}
+
+function buildTranscript(): SessionTreeEntry[] {
+  const messages: AgentMessage[] = [
+    userText("start of the conversation", 1),
+    assistantText("first reply", 2),
+    userText("please run the command", 3),
+    assistantText("running it now", 4),
+    toolResultText(LARGE_TOOL_OUTPUT, 5),
+  ];
+  return messages.map((message, index) => messageEntry(message, index));
+}
+
+describe("findCutPoint with a trailing oversized tool result", () => {
+  it("counts the final tool result as larger than the keep budget", () => {
+    const trailing = toolResultText(LARGE_TOOL_OUTPUT, 5);
+
+    expect(estimateTokens(trailing)).toBeGreaterThanOrEqual(KEEP_RECENT_TOKENS);
+  });
+
+  it("trims the prefix instead of keeping the whole transcript", () => {
+    const entries = buildTranscript();
+
+    const result = findCutPoint(entries, 0, entries.length, KEEP_RECENT_TOKENS);
+
+    expect(result.firstKeptEntryIndex).toBeGreaterThan(0);
+    expect(result.firstKeptEntryIndex).toBe(3);
+  });
+});

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -407,6 +407,7 @@ export function findCutPoint(
     const messageTokens = estimateTokens(entry.message);
     accumulatedTokens += messageTokens;
     if (accumulatedTokens >= keepRecentTokens) {
+      cutIndex = cutPoints[cutPoints.length - 1];
       for (const cutPoint of cutPoints) {
         if (cutPoint >= i) {
           cutIndex = cutPoint;


### PR DESCRIPTION
## Summary
Auto and preflight compaction silently no-ops when the transcript ends in an oversized tool result. The compaction pass runs but keeps the entire transcript and summarizes zero messages, so context never shrinks. Under a context-overflow trigger the session re-enters the same oversized state and the workflow stalls or loops on a context it cannot reduce.

The trigger is extremely common in agentic and coding sessions: a transcript whose final entry is a tool result whose own estimate is at least `keepRecentTokens` (default 20000, about 80k chars) such as a large read, grep, or bash output, evaluated at preemptive compaction right before the next assistant turn.

## Root cause
`packages/agent-core/src/harness/compaction/compaction.ts` (`findCutPoint`, the single canonical path; the `src/agents/sessions/compaction` module only re-exports it).

`toolResult` entries are excluded from `findValidCutPoints`, but the backward token-accumulation loop still counts them. When `accumulatedTokens >= keepRecentTokens` is crossed at the trailing `toolResult` index `i`, the forward search for a cut point at or after `i` finds none (no valid cut point sits at or after the last entry), so `cutIndex` keeps its initial default `cutPoints[0]`, the earliest cut, which means keep everything.

```ts
let cutIndex = cutPoints[0];

for (let i = endIndex - 1; i >= startIndex; i--) {
  const entry = entries[i];
  if (entry.type !== "message") {
    continue;
  }
  const messageTokens = estimateTokens(entry.message);
  accumulatedTokens += messageTokens;
  if (accumulatedTokens >= keepRecentTokens) {
    for (const cutPoint of cutPoints) {
      if (cutPoint >= i) {
        cutIndex = cutPoint;
        break;
      }
    }
    break;
  }
}
```

Downstream that yields `firstKeptEntryIndex = 0`, which means an empty summarization range and a true no-op.

## Fix
Default `cutIndex` to the most recent valid cut before the forward search, mirroring the existing `cutPoints[0]` idiom two lines above.

```ts
  if (accumulatedTokens >= keepRecentTokens) {
    cutIndex = cutPoints[cutPoints.length - 1];
    for (const cutPoint of cutPoints) {
      if (cutPoint >= i) {
        cutIndex = cutPoint;
        break;
      }
    }
    break;
  }
```

When a valid cut point exists at or after `i`, the forward search still finds it and behavior is unchanged. Only the previously-broken trailing-tool-result case now keeps the minimal recent tail instead of the whole transcript.

## Why this is the right boundary
`findCutPoint` owns cut-point selection for compaction and is the single canonical path; the `src/agents/sessions/compaction` module re-exports it, so there is no sibling selector to patch. The change touches only the fallback that was unreachable-by-design for the trailing-tool-result shape and leaves every case that already resolved a cut point at or after `i` byte-for-byte identical, confirmed by the existing `compaction.test.ts` and `compaction-image-tokens.test.ts` still passing.

This is distinct from closed #78478 and #78300, which describe a transcript with no valid cut point at all (tool-call dominated, empty fallback summaries). Here there are plenty of valid cut points; the selector simply defaulted to the wrong end.

## Verification
- `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts packages/agent-core/src/harness/compaction/compaction.test.ts packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts` - 3 files, 6 passing.
- New `compaction-trailing-toolresult.test.ts` fails on pristine `origin/main` (firstKeptEntryIndex 0) and passes with the patch (firstKeptEntryIndex 3).
- `node scripts/run-oxlint.mjs` and `oxfmt --check` clean on both changed files.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` clean.

## Real behavior proof
Behavior addressed: preemptive compaction no-ops (keeps the whole transcript, summarizes nothing) when the transcript ends in a tool result whose estimate is at least the keep-recent budget.
Real environment tested: drove the real `findCutPoint` cut-point selector (the canonical compaction decision function, with its real `estimateTokens` estimator and `findValidCutPoints` collector) on pristine `origin/main` 5dfbb9d1e0 and on the patched tree, with an identical 5-entry transcript ending in a 120k-char tool result and a 20000 keep-recent budget; nothing mocked.
Exact steps or command run after this patch: invoked `findCutPoint(entries, 0, entries.length, 20000)` through a small Node driver and recorded the returned `firstKeptEntryIndex` and the resulting summarization range on each tree.
Evidence after fix:
```
# BEFORE (pristine main 5dfbb9d1e0)
transcript entries           : 5 (last = toolResult)
keepRecentTokens budget      : 20000
trailing toolResult estimate : 30000 tokens
firstKeptEntryIndex          : 0
entries summarized (prefix)  : 0 of 5
outcome                      : NO-OP (whole transcript kept, nothing summarized)
# AFTER (this patch, identical inputs)
transcript entries           : 5 (last = toolResult)
keepRecentTokens budget      : 20000
trailing toolResult estimate : 30000 tokens
firstKeptEntryIndex          : 3
entries summarized (prefix)  : 3 of 5
outcome                      : trimmed prefix, kept recent tail
```
Observed result after fix: on identical input the selector moves from keeping all 5 entries and summarizing nothing to keeping the recent tail and summarizing the 3-entry prefix, so compaction actually reduces the context instead of no-opping.
What was not tested: no live provider request or full end-to-end gateway run; the full repo build was not run (out of scope for this change, which is confined to the pure cut-point selector).
