### PR TITLE
fix(harness): include updatedInput in native hook PermissionRequest allow decisions

### DIFF
--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -878,6 +878,7 @@ function handleClaudeLiveControlRequest(
       response: allowed
         ? {
             behavior: "allow",
+            updatedInput: isRecord(request.input) ? request.input : {},
             ...(toolUseId ? { toolUseID: toolUseId } : {}),
           }
         : {

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -462,7 +462,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(duplicateApproval.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { behavior: "allow", updatedInput: { command: "browserforce tabs" } },
       },
     });
 
@@ -483,7 +483,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(primaryApproval.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { behavior: "allow", updatedInput: { command: "browserforce tabs" } },
       },
     });
 
@@ -2473,7 +2473,10 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(response.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: {
+          behavior: "allow",
+          updatedInput: { owner: "openclaw", repo: "openclaw", title: "Test issue" },
+        },
       },
     });
     const request = getMockCallArg(approvalRequester, 0, 0, "approval request");
@@ -2633,7 +2636,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(allow.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { behavior: "allow", updatedInput: { command: "git push" } },
       },
     });
     expect(JSON.parse(deny.stdout)).toEqual({
@@ -2703,13 +2706,13 @@ describe("native hook relay registry", () => {
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { behavior: "allow", updatedInput: { command: "browserforce tabs" } },
         },
       },
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { behavior: "allow", updatedInput: { command: "browserforce tabs" } },
         },
       },
     ]);
@@ -2883,13 +2886,13 @@ describe("native hook relay registry", () => {
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { behavior: "allow", updatedInput: { command: "git push" } },
         },
       },
       {
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
-          decision: { behavior: "allow" },
+          decision: { behavior: "allow", updatedInput: { command: "git push" } },
         },
       },
     ]);
@@ -3015,7 +3018,7 @@ describe("native hook relay registry", () => {
     expect(JSON.parse(firstResponse.stdout)).toEqual({
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
-        decision: { behavior: "allow" },
+        decision: { behavior: "allow", updatedInput: { command: "git status" } },
       },
     });
   });

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -188,6 +188,7 @@ type NativeHookRelayProviderAdapter = {
   renderPermissionDecisionResponse: (
     decision: NativeHookRelayPermissionDecision,
     message?: string,
+    updatedInput?: Record<string, JsonValue>,
   ) => NativeHookRelayProcessResponse;
 };
 
@@ -387,13 +388,13 @@ const nativeHookRelayProviderAdapters: Record<
       stderr: "",
       exitCode: 0,
     }),
-    renderPermissionDecisionResponse: (decision, message) => ({
+    renderPermissionDecisionResponse: (decision, message, updatedInput) => ({
       stdout: `${JSON.stringify({
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
           decision:
             decision === "allow"
-              ? { behavior: "allow" }
+              ? { behavior: "allow", updatedInput: updatedInput ?? {} }
               : {
                   behavior: "deny",
                   message: message?.trim() || "Denied by OpenClaw",
@@ -1484,7 +1485,7 @@ async function runNativeHookRelayPermissionRequest(params: {
     request,
   });
   if (hasNativeHookRelayPermissionAllowAlways(allowAlwaysKey)) {
-    return params.adapter.renderPermissionDecisionResponse("allow");
+    return params.adapter.renderPermissionDecisionResponse("allow", undefined, request.toolInput);
   }
   const pendingApproval = pendingPermissionApprovals.get(approvalKey);
   try {
@@ -1495,11 +1496,11 @@ async function runNativeHookRelayPermissionRequest(params: {
         request,
       }));
     if (decision === "allow") {
-      return params.adapter.renderPermissionDecisionResponse("allow");
+      return params.adapter.renderPermissionDecisionResponse("allow", undefined, request.toolInput);
     }
     if (decision === "allow-always") {
       rememberNativeHookRelayPermissionAllowAlways(allowAlwaysKey);
-      return params.adapter.renderPermissionDecisionResponse("allow");
+      return params.adapter.renderPermissionDecisionResponse("allow", undefined, request.toolInput);
     }
     if (decision === "deny") {
       return params.adapter.renderPermissionDecisionResponse("deny", "Denied by user");


### PR DESCRIPTION
## Problem

The native hook relay renders the `allow` permission decision as `{ behavior: "allow" }` with no `updatedInput` (`src/agents/harness/native-hook-relay.ts`). Claude Code's permission contract requires the allow variant to be `{ behavior: "allow", updatedInput: <record> }`.

Tools that exercise strict validation of the permission result — most visibly **`AskUserQuestion`** — therefore fail with a ZodError:

```
expected record, path ["updatedInput"], received undefined
```

Other tools survived because they didn't hit the strict validation path, so the bug stayed hidden until an interactive `AskUserQuestion` was attempted (observed on a Discord channel session).

## Fix

Echo the original tool input back as `updatedInput` on every allow path:

- `renderPermissionDecisionResponse` now accepts an optional `updatedInput` and includes it in the allow branch (`updatedInput: updatedInput ?? {}`).
- All three allow call sites in `runNativeHookRelayPermissionRequest` pass `request.toolInput` (direct allow, allow-always, and cached allow-always reuse).

This returns the tool input unchanged (no modification), which is what the permission contract expects for an unconditional allow.

## Tests

- Updated the 6 assertions in `native-hook-relay.test.ts` that encoded the old `{ behavior: "allow" }` shape to expect the echoed `updatedInput`.
- `native-hook-relay.test.ts`: **75/75 passing**.
- oxlint clean on both changed files.

## Notes

Draft — opening for review/discussion. Deny path is unchanged.