### PR TITLE
fix(plugins): allowlist explicitly selected setup plugins

### DIFF
--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -440,11 +440,11 @@ describe("setupChannels workspace shadow exclusion", () => {
     });
   });
 
-  it("allowlists ClickClack when it is explicitly selected for setup", async () => {
+  it("allowlists a selected setup plugin when plugins.allow is restrictive", async () => {
     const setupWizard = {
-      channel: "clickclack",
+      channel: "weixin",
       getStatus: vi.fn(async () => ({
-        channel: "clickclack",
+        channel: "weixin",
         configured: false,
         statusLines: [],
       })),
@@ -453,25 +453,25 @@ describe("setupChannels workspace shadow exclusion", () => {
           ...cfg,
           channels: {
             ...cfg.channels,
-            clickclack: {
-              ...cfg.channels?.clickclack,
+            weixin: {
+              ...cfg.channels?.weixin,
               token: "secret",
             },
           },
         },
       })),
     };
-    const clickClackPlugin = makeSetupPlugin({
-      id: "clickclack",
-      label: "ClickClack",
+    const weixinPlugin = makeSetupPlugin({
+      id: "weixin",
+      label: "Weixin",
       setupWizard,
     });
     resolveChannelSetupEntries.mockReturnValue(
       makeChannelSetupEntries({
         entries: [
           {
-            id: "clickclack",
-            meta: makeMeta("clickclack", "ClickClack"),
+            id: "weixin",
+            meta: makeMeta("weixin", "Weixin"),
           },
         ],
       }),
@@ -480,15 +480,15 @@ describe("setupChannels workspace shadow exclusion", () => {
       makePluginRegistry({
         channelSetups: [
           {
-            pluginId: "clickclack",
+            pluginId: "weixin",
             source: "bundled",
             enabled: true,
-            plugin: clickClackPlugin,
+            plugin: weixinPlugin,
           },
         ],
       }),
     );
-    const select = vi.fn().mockResolvedValueOnce("clickclack").mockResolvedValueOnce("__done__");
+    const select = vi.fn().mockResolvedValueOnce("weixin").mockResolvedValueOnce("__done__");
 
     const next = await setupChannels(
       {
@@ -509,10 +509,9 @@ describe("setupChannels workspace shadow exclusion", () => {
       },
     );
 
-    expect(next.plugins?.allow).toEqual(["memory-core", "clickclack"]);
-    expect(next.plugins?.entries?.clickclack?.enabled).toBe(true);
-    expect(next.channels?.clickclack).toEqual({
-      enabled: true,
+    expect(next.plugins?.allow).toEqual(["memory-core", "weixin"]);
+    expect(next.plugins?.entries?.weixin?.enabled).toBe(true);
+    expect(next.channels?.weixin).toEqual({
       token: "secret",
     });
   });

--- a/src/plugins/enable.test.ts
+++ b/src/plugins/enable.test.ts
@@ -164,25 +164,25 @@ describe("enablePluginInConfig", () => {
 });
 
 describe("enableExplicitlySelectedPluginInConfig", () => {
-  it("appends ClickClack to a restrictive allowlist before enabling it", () => {
+  it("appends an explicitly selected plugin to a restrictive allowlist before enabling it", () => {
     const result = enableExplicitlySelectedPluginInConfig(
       {
         plugins: {
           allow: ["memory-core"],
         },
       } as OpenClawConfig,
-      "clickclack",
+      "weixin",
     );
 
     expect(result.enabled).toBe(true);
-    expect(result.config.plugins?.allow).toEqual(["memory-core", "clickclack"]);
-    expect(result.config.plugins?.entries?.clickclack?.enabled).toBe(true);
-    expect(result.config.channels?.clickclack?.enabled).toBe(true);
+    expect(result.config.plugins?.allow).toEqual(["memory-core", "weixin"]);
+    expect(result.config.plugins?.entries?.weixin?.enabled).toBe(true);
   });
 
-  it("keeps unrelated explicit plugin enables blocked by a restrictive allowlist", () => {
+  it("keeps globally disabled plugins blocked without changing the allowlist", () => {
     const cfg = {
       plugins: {
+        enabled: false,
         allow: ["memory-core"],
       },
     } as OpenClawConfig;
@@ -193,24 +193,24 @@ describe("enableExplicitlySelectedPluginInConfig", () => {
       config: cfg,
       enabled: false,
       pluginId: "google",
-      reason: "blocked by allowlist",
+      reason: "plugins disabled",
     });
   });
 
-  it("keeps ClickClack blocked by the denylist without changing the allowlist", () => {
+  it("keeps explicitly selected plugins blocked by the denylist without changing the allowlist", () => {
     const cfg = {
       plugins: {
         allow: ["memory-core"],
-        deny: ["clickclack"],
+        deny: ["weixin"],
       },
     } as OpenClawConfig;
 
-    const result = enableExplicitlySelectedPluginInConfig(cfg, "clickclack");
+    const result = enableExplicitlySelectedPluginInConfig(cfg, "weixin");
 
     expect(result).toEqual({
       config: cfg,
       enabled: false,
-      pluginId: "clickclack",
+      pluginId: "weixin",
       reason: "blocked by denylist",
     });
   });

--- a/src/plugins/enable.ts
+++ b/src/plugins/enable.ts
@@ -49,8 +49,8 @@ export function enablePluginInConfig(
 /**
  * Enables a plugin selected through an explicit user action.
  *
- * ClickClack is bundled without a separate install trust record, so selecting
- * it is the trust gesture that materializes its id in a restrictive allowlist.
+ * The setup/onboarding caller has already captured the user's trust gesture,
+ * so materialize the selected id in a restrictive allowlist before retrying.
  */
 export function enableExplicitlySelectedPluginInConfig(
   cfg: OpenClawConfig,
@@ -58,7 +58,7 @@ export function enableExplicitlySelectedPluginInConfig(
   options: PluginEnableOptions = {},
 ): PluginEnableResult {
   const result = enablePluginInConfig(cfg, pluginId, options);
-  if (result.reason !== "blocked by allowlist" || result.pluginId !== "clickclack") {
+  if (result.reason !== "blocked by allowlist") {
     return result;
   }
   return enablePluginInConfig(


### PR DESCRIPTION
## What Problem This Solves

Fixes #93568. When a user explicitly selects Weixin / WeChat through channel setup with a restrictive `plugins.allow`, OpenClaw installs or resolves the selected plugin but then fails enablement because only the older ClickClack path can append itself to the allowlist.

## Why This Change Was Made

Current main at `3d787b51812cf2883524fa8413acf09d647564ec` still special-cases `clickclack` in `enableExplicitlySelectedPluginInConfig`. Channel setup and onboarding both call that helper for explicit user selections, so the trust gesture is already known at the owner boundary. The narrow fix should generalize that helper for explicitly selected plugins while keeping `plugins.enabled=false` and `plugins.deny` authoritative.

This carries forward the non-security implementation direction from source PR https://github.com/openclaw/openclaw/pull/93593 by @ZOOWH and credits the #93568 report from @Kambrian plus the confirming setup-flow note from @neo-fusheng. The open overlapping PR is routed to central security handling by Clownfish and is not used or mutated by this replacement fix.

## User Impact

Users with restrictive `plugins.allow` can complete guided setup for explicitly selected channel plugins such as Weixin without manually editing config after the install/selection step. Denylisted plugins and globally disabled plugins remain blocked.

## Evidence

- Source inspection: `src/plugins/enable.ts` currently auto-appends only `clickclack` after `blocked by allowlist`.
- Caller inspection: `src/flows/channel-setup.ts` and `src/commands/onboarding-plugin-install.ts` both route explicit selections through that helper.
- Planned validation: `node scripts/run-vitest.mjs run src/plugins/enable.test.ts src/flows/channel-setup.test.ts src/commands/onboarding-plugin-install.test.ts` and `pnpm check:changed`.

Clownfish 🐠 replacement reef notes:
- Cluster: gitcrawl-1176-autonomous-drip-20260622c
- Source PRs: https://github.com/openclaw/openclaw/pull/93593
- Credit: Fixes #93568 reported by @Kambrian; note @neo-fusheng's confirming setup-flow comment in the PR body.; Credit @ZOOWH and source PR https://github.com/openclaw/openclaw/pull/93593 for the earlier non-security implementation direction and regression coverage.; Do not close, supersede, repair, or merge the security-routed overlapping PR in this lane; central security handling owns that exact ref and any separate contributor attribution there.
- Validation: node scripts/run-vitest.mjs run src/plugins/enable.test.ts src/flows/channel-setup.test.ts src/commands/onboarding-plugin-install.test.ts; pnpm check:changed

fish notes: model gpt-5.5, reasoning medium; reviewed against d17be2f7a1ea.
