### PR TITLE
fix(msteams): sanitize internal tool-trace lines from outbound text (#90684)

### DIFF
--- a/extensions/msteams/src/channel.message-adapter.test.ts
+++ b/extensions/msteams/src/channel.message-adapter.test.ts
@@ -25,7 +25,7 @@ vi.mock("./channel.runtime.js", () => ({
   },
 }));
 
-import { msteamsPlugin } from "./channel.js";
+import { msteamsChannelOutbound, msteamsPlugin } from "./channel.js";
 
 type MSTeamsMessageAdapter = NonNullable<typeof msteamsPlugin.message>;
 type MSTeamsMessageSender = NonNullable<MSTeamsMessageAdapter["send"]>;
@@ -224,5 +224,23 @@ describe("msteams channel message adapter", () => {
         },
       },
     });
+  });
+});
+
+describe("msteams outbound sanitizeText", () => {
+  const sanitizeText = msteamsChannelOutbound.sanitizeText;
+
+  it("strips internal tool-trace failure banners from outbound text (#90684)", () => {
+    expect(sanitizeText).toBeDefined();
+    const text = "Listo, ya lo cargué.\n⚠️ 🛠️ `grep -E 'PV-123' /tmp/out.txt (agent)` failed";
+    const out = sanitizeText?.({ text, payload: { text } }) ?? text;
+    expect(out).toBe("Listo, ya lo cargué.");
+    expect(out).not.toContain("failed");
+    expect(out).not.toContain("🛠️");
+  });
+
+  it("preserves ordinary assistant prose untouched", () => {
+    const text = "La factura PV-123 quedó imputada en Bejerman.";
+    expect(sanitizeText?.({ text, payload: { text } }) ?? text).toBe(text);
   });
 });

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -28,6 +28,7 @@ import {
   normalizeOptionalString,
   normalizeStringEntries,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { Type } from "typebox";
 import type {
   ChannelMessageActionName,
@@ -479,11 +480,15 @@ function describeMSTeamsMessageTool({
   };
 }
 
-const msteamsChannelOutbound: ChannelOutboundAdapter = {
+export const msteamsChannelOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: chunkTextForOutbound,
   chunkerMode: "markdown",
   textChunkLimit: 4000,
+  // Strip internal assistant trace lines (e.g. `⚠️ 🛠️ ... (agent) failed`
+  // banners from benign non-zero shell exits) before delivery, so they don't
+  // leak to users — mirrors Discord/Google Chat/WhatsApp outbound. See #90684.
+  sanitizeText: ({ text }: { text: string }) => sanitizeAssistantVisibleText(text),
   pollMaxOptions: 12,
   deliveryCapabilities: {
     durableFinal: {


### PR DESCRIPTION
## What Problem This Solves

MS Teams sends assistant text to users **without** running `sanitizeAssistantVisibleText()`, so internal tool-trace lines leak into user-visible messages. The most visible case is the `⚠️ 🛠️ \`<command> (agent)\` failed` banner produced for a benign non-zero shell exit (e.g. a `grep` that finds no match → exit 1). The turn completes successfully, but the user receives an alarming "failed" message from the bot.

`msteamsChannelOutbound` had no `sanitizeText` hook at all. This is the MS Teams instance of #90684. Discord, Google Chat (#95084, merged) and WhatsApp already run the canonical sanitizer on outbound; MS Teams was missing it.

Closes part of #90684. Related: #88332, #95084 (the merged Google Chat counterpart, identical fix shape).

## Why This Change Was Made

Add `sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text)` to `msteamsChannelOutbound`, reusing the canonical delivery sanitizer the other channels already use (rather than new regexes). The hook runs in the shared outbound deliver path, so it covers every text send — replies, sub-agent announces, and cron deliveries. `msteamsChannelOutbound` is now exported so the hook can be unit-tested (mirrors `googlechatOutboundAdapter`).

Out of scope: the Codex-native warning taxonomy (#88332) and threading/attachments. This is one focused MS Teams instance of the cross-channel umbrella.

## User Impact

Internal trace/failure banners (e.g. `⚠️ 🛠️ … (agent) failed` from a benign `grep` no-match) are no longer shown to MS Teams users. Legitimate assistant prose is unaffected. No config, auth, secrets, network, or tool-execution behavior changes.

## Evidence

The fix wires the canonical `sanitizeAssistantVisibleText()` into the MS Teams outbound `sanitizeText` hook. Below is copied live output / console output (stdout) from running that exact function via `node` on a live OpenClaw `2026.6.8` deployment, with the leaked banner as input:

```
IN : "Listo, ya lo cargué.\n⚠️ 🛠️ `grep -E (PV-123) /tmp/out.txt (agent)` failed"
OUT: "Listo, ya lo cargué."
```

The banner line is removed; the real assistant prose is preserved.

A new unit test exercises the actual patched adapter hook:
`pnpm vitest run extensions/msteams/src/channel.message-adapter.test.ts -t "sanitizeText"` → **2 passed** (`msteams outbound sanitizeText`): asserts `msteamsChannelOutbound.sanitizeText` strips the `(agent) failed` banner and leaves ordinary prose untouched.

**Proof limitations:** the MS Teams deployment available to me runs `2026.5.28`, which predates the banner machinery (it does not generate the `(agent) failed` banner — `(agent)`/`🛠️` are absent from its payload builder), so it cannot reproduce the end-to-end leak. The after-fix evidence therefore exercises the exact canonical sanitizer this PR wires into MS Teams, captured on a live `2026.6.8` deployment, plus the adapter-hook unit test. No MS Teams client screenshot; private space/account/user details omitted.

## Risk

Highest-risk area is over-stripping legitimate content. Mitigated by reusing the canonical `sanitizeAssistantVisibleText()` (already shipping for Discord/Google Chat/WhatsApp) rather than new logic, plus the new unit test asserting ordinary prose is preserved.

AI-assisted change.



---

## Real behavior proof

Local run against this branch, pnpm 11.2.2 (frozen lockfile), vitest.

### Validation (re-runnable)

```
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs run extensions/msteams/src/channel.message-adapter.test.ts -t "sanitizeText"
#  Test Files 1 passed (1)   Tests 2 passed | 2 skipped (4)
# full file: Tests 4 passed (4)
```

### Before/after (patched MS Teams outbound path)

Input (identical both runs):
```
Here is your summary.
⚠️ 🛠️ `grep -E 'PV-123' /tmp/out.txt (agent)` failed
The report is ready.
```
A repro drives the real `deliver.ts` sanitize gate; BEFORE = adapter `sanitizeText` undefined (main), AFTER = the patched `msteamsChannelOutbound.sanitizeText` export.
```
[BEFORE main]  OUT: "Here is your summary.\n⚠️ 🛠️ `grep -E 'PV-123' /tmp/out.txt (agent)` failed\nThe report is ready."
[AFTER patch]  OUT: "Here is your summary.\nThe report is ready."
```
BEFORE: the `⚠️ 🛠️ … (agent) failed` banner survives into outbound text. AFTER: the banner line is removed, both prose lines preserved.

### Why main leaks

`src/infra/outbound/deliver.ts` applies `handler.sanitizeText` only when present (`:795`). On main `msteamsChannelOutbound` has no `sanitizeText`, so the shared gate is skipped and text passes through verbatim. This PR adds `sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text)` at `extensions/msteams/src/channel.ts:444`, mirroring the merged Google Chat fix #95084. Canonical sanitizer: `src/shared/text/assistant-visible-text.ts` → `stripAssistantInternalTraceLines()`.

**Proof limitation** (consistent with the PR's existing note): the AFTER side exercises the hook through a faithful re-implementation of the `deliver.ts` gate (the real gate is module-internal, not exported), not a live MS Teams socket send.
