### PR TITLE
Add hosted external catalog feed loader

### DIFF
--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import {
   type OfficialExternalPluginCatalogEntry,
   getOfficialExternalPluginCatalogEntry,
   isOfficialExternalPluginCatalogFeed,
   listOfficialExternalPluginCatalogEntries,
+  loadHostedOfficialExternalPluginCatalogEntries,
   parseOfficialExternalPluginCatalogEntries,
   resolveOfficialExternalProviderContractPluginIds,
   resolveOfficialExternalProviderPluginIds,
@@ -69,6 +70,129 @@ describe("official external plugin catalog", () => {
         entries: [{ name: "legacy-catalog-entry" }],
       }),
     ).toEqual([{ name: "legacy-catalog-entry" }]);
+  });
+
+  it("loads a hosted feed with conditional headers and checksum metadata", async () => {
+    const body = JSON.stringify({
+      schemaVersion: 1,
+      id: "openclaw-official-external-plugins",
+      generatedAt: "2026-06-22T00:00:00.000Z",
+      sequence: 2,
+      entries: [
+        {
+          name: "@openclaw/hosted-proof",
+          kind: "plugin",
+          openclaw: {
+            plugin: { id: "hosted-proof", label: "Hosted Proof" },
+            install: { npmSpec: "@openclaw/hosted-proof", defaultChoice: "npm" },
+          },
+        },
+      ],
+    });
+    const fetchImpl = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("if-none-match")).toBe('"old"');
+      expect(headers.get("if-modified-since")).toBe("Mon, 22 Jun 2026 00:00:00 GMT");
+      return new Response(body, {
+        status: 200,
+        headers: {
+          etag: '"next"',
+          "last-modified": "Mon, 22 Jun 2026 01:00:00 GMT",
+          "content-length": String(new TextEncoder().encode(body).byteLength),
+        },
+      });
+    });
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      fetchImpl,
+      ifNoneMatch: '"old"',
+      ifModifiedSince: "Mon, 22 Jun 2026 00:00:00 GMT",
+    });
+
+    expect(result.source).toBe("hosted");
+    expect(result.entries.map((entry) => entry.name)).toEqual(["@openclaw/hosted-proof"]);
+    if (result.source === "hosted") {
+      expect(result.feed.sequence).toBe(2);
+      expect(result.metadata).toMatchObject({
+        status: 200,
+        etag: '"next"',
+        lastModified: "Mon, 22 Jun 2026 01:00:00 GMT",
+      });
+      expect(result.metadata.checksum).toMatch(/^sha256:[0-9a-f]{64}$/);
+    }
+  });
+
+  it("falls back to the bundled catalog when hosted feed validation fails", async () => {
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      fetchImpl: vi.fn(
+        async () =>
+          new Response(JSON.stringify({ schemaVersion: 1, id: " ", entries: [] }), {
+            status: 200,
+          }),
+      ),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(result.entries.length).toBe(listOfficialExternalPluginCatalogEntries().length);
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("schema version 1");
+      expect(result.metadata?.checksum).toMatch(/^sha256:[0-9a-f]{64}$/);
+    }
+  });
+
+  it("falls back to the bundled catalog on HTTP 304 until a snapshot cache exists", async () => {
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      fetchImpl: vi.fn(
+        async () =>
+          new Response(null, {
+            status: 304,
+            headers: { etag: '"same"', "last-modified": "Mon, 22 Jun 2026 01:00:00 GMT" },
+          }),
+      ),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("without a cached snapshot");
+      expect(result.metadata).toMatchObject({
+        status: 304,
+        etag: '"same"',
+        lastModified: "Mon, 22 Jun 2026 01:00:00 GMT",
+      });
+    }
+  });
+
+  it("falls back to the bundled catalog on checksum mismatch and oversized bodies", async () => {
+    const mismatch = await loadHostedOfficialExternalPluginCatalogEntries({
+      expectedSha256: "sha256:not-current",
+      fetchImpl: vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              schemaVersion: 1,
+              id: "openclaw-official-external-plugins",
+              generatedAt: "2026-06-22T00:00:00.000Z",
+              sequence: 1,
+              entries: [],
+            }),
+            { status: 200 },
+          ),
+      ),
+    });
+    expect(mismatch.source).toBe("bundled-fallback");
+    if (mismatch.source === "bundled-fallback") {
+      expect(mismatch.error).toContain("checksum mismatch");
+      expect(mismatch.metadata?.checksum).toMatch(/^sha256:[0-9a-f]{64}$/);
+    }
+
+    const oversized = await loadHostedOfficialExternalPluginCatalogEntries({
+      maxBytes: 4,
+      fetchImpl: vi.fn(async () => new Response("12345", { status: 200 })),
+    });
+    expect(oversized.source).toBe("bundled-fallback");
+    if (oversized.source === "bundled-fallback") {
+      expect(oversized.error).toContain("exceeds 4 bytes");
+    }
   });
 
   it("lists the externalized provider and capability plugins with install metadata", () => {

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -258,6 +258,59 @@ describe("official external plugin catalog", () => {
     }
   });
 
+  it("keeps live ClawHub metadata-only entries after hosted feed loading", async () => {
+    const body = JSON.stringify({
+      schemaVersion: 2,
+      id: "clawhub-official",
+      generatedAt: "2026-06-25T01:19:39.629Z",
+      sequence: 11,
+      entries: [
+        {
+          type: "plugin",
+          id: "@expediagroup/expedia-openclaw",
+          title: "Expedia Travel",
+          version: "1.0.4",
+          state: "available",
+          publisher: {
+            id: "expediagroup",
+            trust: "official",
+          },
+          install: {
+            candidates: [
+              {
+                sourceRef: "public-clawhub",
+                package: "@expediagroup/expedia-openclaw",
+                version: "1.0.4",
+                integrity:
+                  "sha256:b355dda04403becaab8bbab069fd1e7b0578262e7459e598cc5b19615b5bdab9",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      fetchImpl: vi.fn(
+        async () =>
+          new Response(body, {
+            status: 200,
+            headers: {
+              "content-length": String(new TextEncoder().encode(body).byteLength),
+            },
+          }),
+      ),
+    });
+
+    expect(result.source).toBe("hosted");
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({
+      id: "@expediagroup/expedia-openclaw",
+      title: "Expedia Travel",
+      version: "1.0.4",
+    });
+  });
+
   it("falls back to the bundled catalog when hosted feed validation fails", async () => {
     const result = await loadHostedOfficialExternalPluginCatalogEntries({
       fetchImpl: vi.fn(

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -14,6 +14,7 @@ import {
   resolveOfficialExternalWebProviderContractPluginIdsForEnv,
   resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginInstall,
+  resolveOfficialExternalPluginLabel,
 } from "./official-external-plugin-catalog.js";
 
 function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
@@ -57,7 +58,7 @@ describe("official external plugin catalog", () => {
     ).toBe(false);
     expect(
       isOfficialExternalPluginCatalogFeed({
-        schemaVersion: 2,
+        schemaVersion: 3,
         id: "openclaw-official-external-plugins",
         generatedAt: "2026-06-22T00:00:00.000Z",
         sequence: 1,
@@ -66,10 +67,131 @@ describe("official external plugin catalog", () => {
     ).toBe(false);
   });
 
+  it("accepts the live ClawHub feed schema version", () => {
+    expect(
+      isOfficialExternalPluginCatalogFeed({
+        schemaVersion: 2,
+        id: "clawhub-official",
+        generatedAt: "2026-06-25T01:19:39.629Z",
+        sequence: 11,
+        entries: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps live ClawHub marketplace entries as metadata-only feed entries", () => {
+    const [entry] = parseOfficialExternalPluginCatalogEntries({
+      schemaVersion: 2,
+      id: "clawhub-official",
+      generatedAt: "2026-06-25T01:19:39.629Z",
+      sequence: 11,
+      entries: [
+        {
+          type: "plugin",
+          id: "@expediagroup/expedia-openclaw",
+          title: "Expedia Travel",
+          version: "1.0.4",
+          state: "available",
+          publisher: {
+            id: "expediagroup",
+            trust: "official",
+          },
+          install: {
+            candidates: [
+              {
+                sourceRef: "public-clawhub",
+                package: "@expediagroup/expedia-openclaw",
+                version: "1.0.4",
+                integrity:
+                  "sha256:b355dda04403becaab8bbab069fd1e7b0578262e7459e598cc5b19615b5bdab9",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(entry).toMatchObject({
+      id: "@expediagroup/expedia-openclaw",
+      title: "Expedia Travel",
+      version: "1.0.4",
+    });
+    expect(resolveOfficialExternalPluginId(entry!)).toBeUndefined();
+    expect(resolveOfficialExternalPluginInstall(entry!)).toBeNull();
+  });
+
+  it("does not synthesize trusted installs for unavailable or untrusted hosted entries", () => {
+    const entries = parseOfficialExternalPluginCatalogEntries({
+      schemaVersion: 2,
+      id: "clawhub-official",
+      generatedAt: "2026-06-25T01:19:39.629Z",
+      sequence: 11,
+      entries: [
+        {
+          type: "plugin",
+          id: "@example/unavailable",
+          title: "Unavailable",
+          version: "1.0.0",
+          state: "disabled",
+          publisher: { id: "example", trust: "official" },
+          install: {
+            candidates: [
+              {
+                sourceRef: "public-clawhub",
+                package: "@example/unavailable",
+                version: "1.0.0",
+              },
+            ],
+          },
+        },
+        {
+          type: "plugin",
+          id: "@example/community",
+          title: "Community",
+          version: "1.0.0",
+          state: "available",
+          publisher: { id: "example", trust: "community" },
+          install: {
+            candidates: [
+              {
+                sourceRef: "public-clawhub",
+                package: "@example/community",
+                version: "1.0.0",
+              },
+            ],
+          },
+        },
+        {
+          type: "plugin",
+          id: "@example/private-source",
+          title: "Private Source",
+          version: "1.0.0",
+          state: "available",
+          publisher: { id: "example", trust: "official" },
+          install: {
+            candidates: [
+              {
+                sourceRef: "private-feed",
+                package: "@example/private-source",
+                version: "1.0.0",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(entries).toHaveLength(3);
+    for (const entry of entries) {
+      expect(resolveOfficialExternalPluginId(entry)).toBeUndefined();
+      expect(resolveOfficialExternalPluginInstall(entry)).toBeNull();
+    }
+  });
+
   it("keeps unsupported versioned feed wrappers out of legacy catalog parsing", () => {
     expect(
       parseOfficialExternalPluginCatalogEntries({
-        schemaVersion: 2,
+        schemaVersion: 3,
         id: "future-feed",
         generatedAt: "2026-06-22T00:00:00.000Z",
         sequence: 1,
@@ -146,7 +268,7 @@ describe("official external plugin catalog", () => {
     expect(result.source).toBe("bundled-fallback");
     expect(result.entries.length).toBe(listOfficialExternalPluginCatalogEntries().length);
     if (result.source === "bundled-fallback") {
-      expect(result.error).toContain("schema version 1");
+      expect(result.error).toContain("supported schema version");
       expect(result.metadata?.checksum).toMatch(/^sha256:[0-9a-f]{64}$/);
     }
   });

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import {
@@ -24,6 +25,16 @@ function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
 }
 
 describe("official external plugin catalog", () => {
+  it("keeps hosted fetch guard loading lazy for bundled catalog import paths", () => {
+    const source = readFileSync(
+      new URL("./official-external-plugin-catalog.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).not.toMatch(/from ["']\.\.\/infra\/net\/fetch-guard\.js["']/);
+    expect(source).toContain('await import("../infra/net/fetch-guard.js")');
+  });
+
   it("ships the official plugin catalog as a feed-shaped bundled fallback", () => {
     expect(isOfficialExternalPluginCatalogFeed(officialExternalPluginCatalog)).toBe(true);
     expect(officialExternalPluginCatalog).toMatchObject({

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -14,7 +14,6 @@ import {
   resolveOfficialExternalWebProviderContractPluginIdsForEnv,
   resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginInstall,
-  resolveOfficialExternalPluginLabel,
 } from "./official-external-plugin-catalog.js";
 
 function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
@@ -111,13 +110,17 @@ describe("official external plugin catalog", () => {
       ],
     });
 
+    if (entry === undefined) {
+      throw new Error("Expected hosted ClawHub feed entry to parse");
+    }
+
     expect(entry).toMatchObject({
       id: "@expediagroup/expedia-openclaw",
       title: "Expedia Travel",
       version: "1.0.4",
     });
-    expect(resolveOfficialExternalPluginId(entry!)).toBeUndefined();
-    expect(resolveOfficialExternalPluginInstall(entry!)).toBeNull();
+    expect(resolveOfficialExternalPluginId(entry)).toBeUndefined();
+    expect(resolveOfficialExternalPluginInstall(entry)).toBeNull();
   });
 
   it("does not synthesize trusted installs for unavailable or untrusted hosted entries", () => {

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -1,10 +1,12 @@
 /** Reads official external plugin/channel/provider catalogs into manifest-like metadata. */
+import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import officialExternalChannelCatalog from "../../scripts/lib/official-external-channel-catalog.json" with { type: "json" };
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import officialExternalProviderCatalog from "../../scripts/lib/official-external-provider-catalog.json" with { type: "json" };
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
+import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { isRecord } from "../utils.js";
 import type {
   PluginManifestChannelConfig,
@@ -86,13 +88,39 @@ export type OfficialExternalPluginCatalogEntry = {
 
 /** Feed-shaped wrapper used by the bundled external plugin catalog fallback. */
 export type OfficialExternalPluginCatalogFeed = {
-  schemaVersion: number;
+  schemaVersion: 1;
   id: string;
   generatedAt: string;
   sequence: number;
   description?: string;
   entries: readonly OfficialExternalPluginCatalogEntry[];
 };
+
+export type HostedOfficialExternalPluginCatalogMetadata = {
+  url: string;
+  status: number;
+  etag?: string;
+  lastModified?: string;
+  checksum: string;
+};
+
+export type HostedOfficialExternalPluginCatalogLoadResult =
+  | {
+      source: "hosted";
+      entries: OfficialExternalPluginCatalogEntry[];
+      feed: OfficialExternalPluginCatalogFeed;
+      metadata: HostedOfficialExternalPluginCatalogMetadata;
+    }
+  | {
+      source: "bundled-fallback";
+      entries: OfficialExternalPluginCatalogEntry[];
+      error: string;
+      metadata?: Omit<HostedOfficialExternalPluginCatalogMetadata, "checksum"> & {
+        checksum?: string;
+      };
+    };
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
 type OfficialExternalProviderContract =
   | "embeddingProviders"
@@ -108,6 +136,12 @@ const OFFICIAL_CATALOG_SOURCES = [
 ] as const;
 
 const OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSION = 1;
+export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL =
+  "https://register.openclaw.ai/official-external-plugin-catalog.json";
+const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS = 5000;
+const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES = 1024 * 1024;
+const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS = 5000;
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST = ["register.openclaw.ai"];
 
 export function isOfficialExternalPluginCatalogFeed(
   raw: unknown,
@@ -116,6 +150,7 @@ export function isOfficialExternalPluginCatalogFeed(
     return false;
   }
   const sequence = raw.sequence;
+  const entries = raw.entries;
   return (
     raw.schemaVersion === OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSION &&
     typeof raw.id === "string" &&
@@ -125,7 +160,7 @@ export function isOfficialExternalPluginCatalogFeed(
     typeof sequence === "number" &&
     Number.isInteger(sequence) &&
     sequence >= 0 &&
-    Array.isArray(raw.entries)
+    Array.isArray(entries)
   );
 }
 
@@ -151,6 +186,270 @@ export function parseOfficialExternalPluginCatalogEntries(
     return [];
   }
   return list.filter((entry): entry is OfficialExternalPluginCatalogEntry => isRecord(entry));
+}
+
+function normalizeHostedCatalogHeader(value: string | null): string | undefined {
+  const normalized = normalizeOptionalString(value);
+  return normalized || undefined;
+}
+
+function sha256Hex(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function resolveHostedCatalogFeedUrl(feedUrl: string | undefined): URL {
+  const raw = feedUrl?.trim() || DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL;
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error("hosted catalog feed URL is invalid");
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error("hosted catalog feed URL must use HTTPS");
+  }
+  if (!OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST.includes(parsed.hostname)) {
+    throw new Error("hosted catalog feed URL hostname is not allowed");
+  }
+  return parsed;
+}
+
+function parseHostedCatalogContentLength(raw: string | null, maxBytes: number): void {
+  const normalized = normalizeOptionalString(raw);
+  if (!normalized) {
+    return;
+  }
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error("hosted catalog feed has invalid content-length");
+  }
+  const size = Number(normalized);
+  if (!Number.isSafeInteger(size) || size > maxBytes) {
+    throw new Error(`hosted catalog feed exceeds ${maxBytes} bytes`);
+  }
+}
+
+function hasStreamingResponseBody(
+  response: Response,
+): response is Response & { body: ReadableStream<Uint8Array> } {
+  return Boolean(
+    response.body && typeof (response.body as { getReader?: unknown }).getReader === "function",
+  );
+}
+
+async function readHostedCatalogChunkWithTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  chunkTimeoutMs: number,
+): Promise<Awaited<ReturnType<typeof reader.read>>> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  return await new Promise((resolve, reject) => {
+    const clear = () => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+    };
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      clear();
+      void reader.cancel().catch(() => undefined);
+      reject(new Error(`hosted catalog feed read timed out after ${chunkTimeoutMs}ms`));
+    }, chunkTimeoutMs);
+    void reader.read().then(
+      (result) => {
+        clear();
+        if (!timedOut) {
+          resolve(result);
+        }
+      },
+      (err: unknown) => {
+        clear();
+        if (!timedOut) {
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      },
+    );
+  });
+}
+
+async function readHostedCatalogResponseText(params: {
+  response: Response;
+  maxBytes: number;
+  chunkTimeoutMs: number;
+}): Promise<string> {
+  parseHostedCatalogContentLength(params.response.headers.get("content-length"), params.maxBytes);
+  if (!hasStreamingResponseBody(params.response)) {
+    const text = await params.response.text();
+    if (new TextEncoder().encode(text).byteLength > params.maxBytes) {
+      throw new Error(`hosted catalog feed exceeds ${params.maxBytes} bytes`);
+    }
+    return text;
+  }
+  const reader = params.response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const chunk = await readHostedCatalogChunkWithTimeout(reader, params.chunkTimeoutMs);
+      if (chunk.done) {
+        break;
+      }
+      totalBytes += chunk.value.byteLength;
+      if (totalBytes > params.maxBytes) {
+        throw new Error(`hosted catalog feed exceeds ${params.maxBytes} bytes`);
+      }
+      chunks.push(chunk.value);
+    }
+  } catch (err) {
+    await reader.cancel().catch(() => undefined);
+    throw err;
+  } finally {
+    reader.releaseLock();
+  }
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}
+
+function bundledOfficialExternalPluginCatalogEntries(): OfficialExternalPluginCatalogEntry[] {
+  return OFFICIAL_CATALOG_SOURCES.flatMap((source) =>
+    parseOfficialExternalPluginCatalogEntries(source),
+  );
+}
+
+function dedupeOfficialExternalPluginCatalogEntries(
+  entries: OfficialExternalPluginCatalogEntry[],
+): OfficialExternalPluginCatalogEntry[] {
+  const resolved = new Map<string, OfficialExternalPluginCatalogEntry>();
+  for (const entry of entries) {
+    const pluginId = resolveOfficialExternalPluginId(entry);
+    const key = pluginId ? `${entry.kind ?? "plugin"}:${pluginId}` : (entry.name ?? "");
+    if (key && !resolved.has(key)) {
+      resolved.set(key, entry);
+    }
+  }
+  return [...resolved.values()];
+}
+
+function bundledFallbackResult(
+  error: unknown,
+  metadata?: HostedOfficialExternalPluginCatalogLoadResult["metadata"],
+): HostedOfficialExternalPluginCatalogLoadResult {
+  return {
+    source: "bundled-fallback",
+    entries: listOfficialExternalPluginCatalogEntries(),
+    error: error instanceof Error ? error.message : String(error),
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
+  feedUrl?: string;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  maxBytes?: number;
+  chunkTimeoutMs?: number;
+  ifNoneMatch?: string;
+  ifModifiedSince?: string;
+  expectedSha256?: string;
+}): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
+  let url: URL;
+  try {
+    url = resolveHostedCatalogFeedUrl(params?.feedUrl);
+  } catch (err) {
+    return bundledFallbackResult(err);
+  }
+  const headers = new Headers();
+  const ifNoneMatch = normalizeOptionalString(params?.ifNoneMatch);
+  const ifModifiedSince = normalizeOptionalString(params?.ifModifiedSince);
+  if (ifNoneMatch) {
+    headers.set("if-none-match", ifNoneMatch);
+  }
+  if (ifModifiedSince) {
+    headers.set("if-modified-since", ifModifiedSince);
+  }
+  const metadataBase = (response: Response) => {
+    const etag = normalizeHostedCatalogHeader(response.headers.get("etag"));
+    const lastModified = normalizeHostedCatalogHeader(response.headers.get("last-modified"));
+    return {
+      url: url.href,
+      status: response.status,
+      ...(etag ? { etag } : {}),
+      ...(lastModified ? { lastModified } : {}),
+    };
+  };
+  let response: Response | undefined;
+  let release: (() => Promise<void>) | undefined;
+  try {
+    const guarded = await fetchWithSsrFGuard({
+      url: url.href,
+      fetchImpl: params?.fetchImpl,
+      init: { method: "GET", headers },
+      requireHttps: true,
+      maxRedirects: 2,
+      timeoutMs: params?.timeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS,
+      policy: { hostnameAllowlist: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST },
+      auditContext: "official-external-plugin-catalog-feed",
+    });
+    response = guarded.response;
+    release = guarded.release;
+    const base = metadataBase(response);
+    if (response.status === 304) {
+      return bundledFallbackResult(
+        "hosted catalog feed returned HTTP 304 without a cached snapshot",
+        base,
+      );
+    }
+    if (!response.ok) {
+      return bundledFallbackResult(`hosted catalog feed returned HTTP ${response.status}`, base);
+    }
+    const body = await readHostedCatalogResponseText({
+      response,
+      maxBytes: params?.maxBytes ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES,
+      chunkTimeoutMs:
+        params?.chunkTimeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS,
+    });
+    const checksum = sha256Hex(body);
+    const expectedSha256 = normalizeOptionalString(params?.expectedSha256);
+    if (expectedSha256 && expectedSha256 !== checksum) {
+      return bundledFallbackResult(
+        `hosted catalog feed checksum mismatch: expected ${expectedSha256}`,
+        {
+          ...base,
+          checksum,
+        },
+      );
+    }
+    const raw = JSON.parse(body) as unknown;
+    if (!isOfficialExternalPluginCatalogFeed(raw)) {
+      return bundledFallbackResult("hosted catalog feed did not match schema version 1", {
+        ...base,
+        checksum,
+      });
+    }
+    return {
+      source: "hosted",
+      entries: dedupeOfficialExternalPluginCatalogEntries(
+        parseOfficialExternalPluginCatalogEntries(raw),
+      ),
+      feed: raw,
+      metadata: {
+        ...base,
+        checksum,
+      },
+    };
+  } catch (err) {
+    return bundledFallbackResult(err);
+  } finally {
+    if (response?.bodyUsed !== true) {
+      await response?.body?.cancel().catch(() => undefined);
+    }
+    await release?.().catch(() => undefined);
+  }
 }
 
 function normalizeDefaultChoice(value: unknown): PluginPackageInstall["defaultChoice"] | undefined {
@@ -233,18 +532,7 @@ export function resolveOfficialExternalPluginInstall(
 }
 
 export function listOfficialExternalPluginCatalogEntries(): OfficialExternalPluginCatalogEntry[] {
-  const entries = OFFICIAL_CATALOG_SOURCES.flatMap((source) =>
-    parseOfficialExternalPluginCatalogEntries(source),
-  );
-  const resolved = new Map<string, OfficialExternalPluginCatalogEntry>();
-  for (const entry of entries) {
-    const pluginId = resolveOfficialExternalPluginId(entry);
-    const key = pluginId ? `${entry.kind ?? "plugin"}:${pluginId}` : (entry.name ?? "");
-    if (key && !resolved.has(key)) {
-      resolved.set(key, entry);
-    }
-  }
-  return [...resolved.values()];
+  return dedupeOfficialExternalPluginCatalogEntries(bundledOfficialExternalPluginCatalogEntries());
 }
 
 /** Resolves official external plugin owners for configured capability provider ids. */

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -78,16 +78,34 @@ export type OfficialExternalPluginCatalogManifest = {
 
 /** Raw official external catalog entry loaded from generated catalog JSON. */
 export type OfficialExternalPluginCatalogEntry = {
+  id?: string;
+  title?: string;
+  type?: string;
+  state?: string;
+  publisher?: {
+    id?: string;
+    trust?: string;
+  };
   name?: string;
   version?: string;
   description?: string;
   source?: string;
   kind?: string;
+  install?: {
+    candidates?: readonly OfficialExternalPluginCatalogInstallCandidate[];
+  };
 } & Partial<Record<ManifestKey, OfficialExternalPluginCatalogManifest>>;
+
+export type OfficialExternalPluginCatalogInstallCandidate = {
+  sourceRef?: string;
+  package?: string;
+  version?: string;
+  integrity?: string;
+};
 
 /** Feed-shaped wrapper used by the bundled external plugin catalog fallback. */
 export type OfficialExternalPluginCatalogFeed = {
-  schemaVersion: 1;
+  schemaVersion: 1 | 2;
   id: string;
   generatedAt: string;
   sequence: number;
@@ -134,13 +152,13 @@ const OFFICIAL_CATALOG_SOURCES = [
   officialExternalPluginCatalog,
 ] as const;
 
-const OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSION = 1;
+const OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSIONS = new Set<unknown>([1, 2]);
 export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL =
-  "https://register.openclaw.ai/official-marketplace.json";
+  "https://clawhub.ai/v1/feeds/plugins";
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS = 5000;
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES = 1024 * 1024;
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS = 5000;
-const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST = ["register.openclaw.ai"];
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST = ["clawhub.ai"];
 
 export function isOfficialExternalPluginCatalogFeed(
   raw: unknown,
@@ -151,7 +169,7 @@ export function isOfficialExternalPluginCatalogFeed(
   const sequence = raw.sequence;
   const entries = raw.entries;
   return (
-    raw.schemaVersion === OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSION &&
+    OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSIONS.has(raw.schemaVersion) &&
     typeof raw.id === "string" &&
     raw.id.trim().length > 0 &&
     typeof raw.generatedAt === "string" &&
@@ -426,7 +444,7 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     }
     const raw = JSON.parse(body) as unknown;
     if (!isOfficialExternalPluginCatalogFeed(raw)) {
-      return bundledFallbackResult("hosted catalog feed did not match schema version 1", {
+      return bundledFallbackResult("hosted catalog feed did not match a supported schema version", {
         ...base,
         checksum,
       });

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -343,13 +343,30 @@ function dedupeOfficialExternalPluginCatalogEntries(
 ): OfficialExternalPluginCatalogEntry[] {
   const resolved = new Map<string, OfficialExternalPluginCatalogEntry>();
   for (const entry of entries) {
-    const pluginId = resolveOfficialExternalPluginId(entry);
-    const key = pluginId ? `${entry.kind ?? "plugin"}:${pluginId}` : (entry.name ?? "");
+    const key = resolveOfficialExternalPluginCatalogEntryKey(entry);
     if (key && !resolved.has(key)) {
       resolved.set(key, entry);
     }
   }
   return [...resolved.values()];
+}
+
+function resolveOfficialExternalPluginCatalogEntryKey(
+  entry: OfficialExternalPluginCatalogEntry,
+): string | undefined {
+  const pluginId = resolveOfficialExternalPluginId(entry);
+  if (pluginId) {
+    return `${normalizeOptionalString(entry.kind) ?? "plugin"}:${pluginId}`;
+  }
+  const name = normalizeOptionalString(entry.name);
+  if (name) {
+    return name;
+  }
+  const id = normalizeOptionalString(entry.id);
+  if (id) {
+    return `${normalizeOptionalString(entry.kind) ?? normalizeOptionalString(entry.type) ?? "plugin"}:${id}`;
+  }
+  return undefined;
 }
 
 function bundledFallbackResult(

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -6,7 +6,6 @@ import officialExternalChannelCatalog from "../../scripts/lib/official-external-
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import officialExternalProviderCatalog from "../../scripts/lib/official-external-provider-catalog.json" with { type: "json" };
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
-import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { isRecord } from "../utils.js";
 import type {
   PluginManifestChannelConfig,
@@ -137,7 +136,7 @@ const OFFICIAL_CATALOG_SOURCES = [
 
 const OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSION = 1;
 export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL =
-  "https://register.openclaw.ai/official-external-plugin-catalog.json";
+  "https://register.openclaw.ai/official-marketplace.json";
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS = 5000;
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES = 1024 * 1024;
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS = 5000;
@@ -385,6 +384,7 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   let response: Response | undefined;
   let release: (() => Promise<void>) | undefined;
   try {
+    const { fetchWithSsrFGuard } = await import("../infra/net/fetch-guard.js");
     const guarded = await fetchWithSsrFGuard({
       url: url.href,
       fetchImpl: params?.fetchImpl,


### PR DESCRIPTION
<!-- hosted-feed-stack:start -->
## Hosted Marketplace Feed Stack

This is PR2 in the hosted marketplace feed stack. The stack should land in order, with maintainer review at each step before the later PRs wire hosted marketplace data into broader user flows.

1. #95846: refactor the bundled external plugin catalog toward the feed-shaped data model.
2. #95868: add the lazy hosted marketplace feed loader for the configured public feed URL, with guarded HTTPS fetch, checksum, schema, size, timeout, and bundled fallback behavior.
3. #95877: add accepted hosted snapshot fallback so a failed or unchanged hosted fetch can reuse the last valid feed payload.
4. #95964: persist hosted marketplace feed snapshots in OpenClaw state.
5. #95969: add marketplace source profile validation for hosted feed install candidates.
6. #95981: add configurable `marketplaces.feeds` and `marketplaces.sources` profiles.
7. #96155: add `openclaw plugins marketplace refresh` as the explicit manual snapshot refresh path.
8. #96158: add `openclaw plugins marketplace entries` as the explicit manual read path over hosted, snapshot, or bundled fallback entries.
9. #96194: add marketplace feed telemetry.

The broader follow-up after this stack is to decide whether and how marketplace entries should feed install/search/startup behavior, add automatic conditional refresh using `ETag` / `Last-Modified`, or move to ClawHub producer-side validation for `/v1/feeds/plugins` and `/v1/feeds/skills`.
<!-- hosted-feed-stack:end -->

## Journey Context

This is step 2 of the hosted OpenClaw feed path from RFC 19. #95846 made the bundled catalog feed-shaped. This PR adds the guarded hosted fetch path for that same marketplace feed, while leaving the existing synchronous bundled-catalog startup path unchanged.

## What This PR Does

- Adds an async hosted loader for the configured public marketplace feed URL.
- Routes hosted fetches through the existing SSRF guard with HTTPS required and the allowed public feed host constrained.
- Sends optional `If-None-Match` and `If-Modified-Since` headers so callers can perform freshness checks.
- Reads response bodies with byte and chunk-timeout limits.
- Keeps the network guard import lazy so bundled-catalog cold paths do not load the guarded network stack.
- Computes `sha256` metadata for the hosted response body.
- Validates the hosted document against the feed-shaped official external plugin catalog schema.
- Preserves live ClawHub metadata-only feed entries through hosted parsing and dedupe.
- Falls back to the bundled catalog on network, status, checksum, size, JSON, or schema failures.
- Leaves hosted candidate-to-install metadata synthesis out of this transport slice; #95969 owns source-profile validation and ClawHub candidate integrity semantics.

## What This PR Intentionally Does Not Do

This PR does not wire the hosted loader into startup, add persistent snapshots, add source-profile selection, interpret `install.candidates[].integrity`, add auth, add signed envelopes, add regional feeds, or change plugin install/search behavior. #95877 adds the loader-level last-known-good snapshot contract on top of this fetch path, and #95969 owns source-profile validation plus ClawHub checksum semantics.

## How To Review

Review this as the hosted transport and validation layer. The important contract is: a hosted marketplace feed can be tried safely, but any unsafe or unusable hosted result falls back to the bundled catalog instead of changing current behavior.

Maintainer acceptance requested: this slice establishes the default ClawHub feed URL, hostname allowlist, accepted feed schema versions, checksum metadata, and bundled-fallback transport contract. It deliberately keeps install interpretation, snapshot persistence, config, and search/startup wiring in follow-up PRs.

## Validation

- `pnpm exec oxfmt --check src/plugins/official-external-plugin-catalog.ts src/plugins/official-external-plugin-catalog.test.ts`
- `pnpm exec oxlint --deny-warnings src/plugins/official-external-plugin-catalog.ts src/plugins/official-external-plugin-catalog.test.ts`
- `git diff --check`
- `CI=1 node scripts/test-projects.mjs src/plugins/official-external-plugin-catalog.test.ts` (26 tests)
- `pnpm tsgo:core`
- `codex review --base origin/main` after the metadata-only dedupe fix: no actionable correctness issues
- Repeated `codex review --base origin/main` after pushing head `76da9328af8498b99f133f8f0fe3f10f42cbee3d`: no actionable correctness issues
- Maintainer wrapper: `scripts/pr review-validate-artifacts 95868`, `OPENCLAW_TESTBOX=1 scripts/pr prepare-gates 95868`, `OPENCLAW_TESTBOX=1 scripts/pr prepare-push 95868`

## Real Behavior Proof

Behavior or issue addressed:
The hosted catalog fetch path uses the live ClawHub plugin feed by default, accepts the live feed wrapper, preserves raw marketplace package metadata without synthesizing OpenClaw install metadata, and still falls back safely on invalid hosted responses.

Real environment tested:
Windows checkout `C:\src\openclaw-prflow\.worktrees\pr-95868` at pushed head `76da9328af8498b99f133f8f0fe3f10f42cbee3d`, source harness via `node --import tsx`, live HTTPS request to `https://clawhub.ai/v1/feeds/plugins`.

Exact steps or command run after this patch:

1. `node --import tsx -e "... loadHostedOfficialExternalPluginCatalogEntries({ snapshotStore: null }) ..."`
2. `pnpm exec oxlint --deny-warnings src/plugins/official-external-plugin-catalog.ts src/plugins/official-external-plugin-catalog.test.ts`
3. `pnpm exec oxfmt --check src/plugins/official-external-plugin-catalog.ts src/plugins/official-external-plugin-catalog.test.ts`
4. `git diff --check`
5. `CI=1 node scripts/test-projects.mjs src/plugins/official-external-plugin-catalog.test.ts`
6. `codex review --base origin/main`

Evidence after fix:

```json
{
  "head": "76da9328af8498b99f133f8f0fe3f10f42cbee3d",
  "defaultFeedUrl": "https://clawhub.ai/v1/feeds/plugins",
  "resultSource": "hosted",
  "metadata": {
    "url": "https://clawhub.ai/v1/feeds/plugins",
    "status": 200,
    "checksum": "sha256:cf3d85c1d6ede1907ca265e9b214ac6ff1c715c90c30ec65e8017addb590e32d",
    "etag": "\"sha256:cf3d85c1d6ede1907ca265e9b214ac6ff1c715c90c30ec65e8017addb590e32d-gzip\"",
    "lastModified": "Sat, 27 Jun 2026 18:43:36 GMT"
  },
  "entryCount": 59,
  "feed": {
    "id": "clawhub-official",
    "sequence": 16,
    "schemaVersion": 1
  },
  "firstEntries": [
    {
      "id": "@expediagroup/expedia-openclaw",
      "label": "plugin",
      "npmSpec": "@expediagroup/expedia-openclaw",
      "state": "available",
      "type": "plugin"
    },
    {
      "id": "@openclaw/acpx",
      "label": "plugin",
      "npmSpec": "@openclaw/acpx",
      "state": "available",
      "type": "plugin"
    },
    {
      "id": "@openclaw/amazon-bedrock-mantle-provider",
      "label": "plugin",
      "npmSpec": "@openclaw/amazon-bedrock-mantle-provider",
      "state": "available",
      "type": "plugin"
    }
  ]
}
```

Observed result after fix:
The default hosted fetch accepted the live ClawHub feed as `hosted`, returned 59 hosted entries, preserved response checksum/validators, and left marketplace candidates as raw feed metadata so #95969 owns source-profile install interpretation.

What was not tested:
Snapshot reuse and candidate-to-install interpretation are not part of this PR. Snapshot reuse is covered by #95877; source-profile install interpretation is covered by #95969. Maintainer acceptance is still needed for the default ClawHub feed URL, hostname allowlist, schema acceptance, checksum metadata, and bundled-fallback transport contract.