### PR TITLE
Add hosted catalog snapshot fallback

### DIFF
--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -411,7 +411,13 @@ describe("official external plugin catalog", () => {
     });
     const seeded = await loadHostedOfficialExternalPluginCatalogEntries({
       snapshotStore: createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore(),
-      fetchImpl: vi.fn(async () => new Response(body, { status: 200 })),
+      fetchImpl: vi.fn(
+        async () =>
+          new Response(body, {
+            status: 200,
+            headers: { etag: '"snapshot-v1"' },
+          }),
+      ),
     });
     if (seeded.source !== "hosted") {
       throw new Error("expected seeded hosted feed");
@@ -426,7 +432,14 @@ describe("official external plugin catalog", () => {
 
     const result = await loadHostedOfficialExternalPluginCatalogEntries({
       snapshotStore,
-      fetchImpl: vi.fn(async () => new Response(null, { status: 304 })),
+      ifNoneMatch: '"snapshot-v1"',
+      fetchImpl: vi.fn(
+        async () =>
+          new Response(null, {
+            status: 304,
+            headers: { etag: '"snapshot-v1"' },
+          }),
+      ),
     });
 
     expect(result.source).toBe("hosted-snapshot");
@@ -435,6 +448,60 @@ describe("official external plugin catalog", () => {
       expect(result.error).toContain("HTTP 304");
       expect(result.snapshot.savedAt).toBe("2026-06-22T01:02:03.000Z");
       expect(result.metadata.checksum).toBe(seeded.metadata.checksum);
+    }
+  });
+
+  it("does not use a stale snapshot when HTTP 304 validators do not match", async () => {
+    const body = JSON.stringify({
+      schemaVersion: 1,
+      id: "openclaw-official-external-plugins",
+      generatedAt: "2026-06-22T00:00:00.000Z",
+      sequence: 4,
+      entries: [
+        {
+          name: "@openclaw/stale-snapshot-proof",
+          kind: "plugin",
+          openclaw: { plugin: { id: "stale-snapshot-proof" } },
+        },
+      ],
+    });
+    const seeded = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore: createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore(),
+      fetchImpl: vi.fn(
+        async () =>
+          new Response(body, {
+            status: 200,
+            headers: { etag: '"snapshot-v1"' },
+          }),
+      ),
+    });
+    if (seeded.source !== "hosted") {
+      throw new Error("expected seeded hosted feed");
+    }
+    const snapshotStore = createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore([
+      {
+        body,
+        metadata: seeded.metadata,
+        savedAt: "2026-06-22T01:02:03.000Z",
+      },
+    ]);
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore,
+      ifNoneMatch: '"snapshot-v2"',
+      fetchImpl: vi.fn(
+        async () =>
+          new Response(null, {
+            status: 304,
+            headers: { etag: '"snapshot-v2"' },
+          }),
+      ),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("snapshot fallback failed");
+      expect(result.error).toContain("ETag");
     }
   });
 
@@ -474,6 +541,46 @@ describe("official external plugin catalog", () => {
     ]);
     if (result.source === "hosted-snapshot") {
       expect(result.error).toContain("JSON");
+    }
+  });
+
+  it("does not use a stale snapshot when hosted validation fails with unmatched validators", async () => {
+    const body = JSON.stringify({
+      schemaVersion: 1,
+      id: "openclaw-official-external-plugins",
+      generatedAt: "2026-06-22T00:00:00.000Z",
+      sequence: 5,
+      entries: [
+        {
+          name: "@openclaw/stale-validation-snapshot-proof",
+          kind: "plugin",
+          openclaw: { plugin: { id: "stale-validation-snapshot-proof" } },
+        },
+      ],
+    });
+    const seeded = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore: createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore(),
+      fetchImpl: vi.fn(
+        async () => new Response(body, { status: 200, headers: { etag: '"snapshot-v1"' } }),
+      ),
+    });
+    if (seeded.source !== "hosted") {
+      throw new Error("expected seeded hosted feed");
+    }
+    const snapshotStore = createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore([
+      { body, metadata: seeded.metadata, savedAt: "2026-06-22T01:02:03.000Z" },
+    ]);
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore,
+      ifNoneMatch: '"snapshot-v2"',
+      fetchImpl: vi.fn(async () => new Response("{ nope", { status: 200 })),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("snapshot fallback failed");
+      expect(result.error).toContain("ETag");
     }
   });
 

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import {
   type OfficialExternalPluginCatalogEntry,
+  DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL,
   createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore,
   getOfficialExternalPluginCatalogEntry,
   isOfficialExternalPluginCatalogFeed,
@@ -487,7 +488,7 @@ describe("official external plugin catalog", () => {
           entries: [],
         }),
         metadata: {
-          url: "https://register.openclaw.ai/official-external-plugin-catalog.json",
+          url: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL,
           status: 200,
           checksum: "sha256:not-current",
         },

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import {
   type OfficialExternalPluginCatalogEntry,
+  createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore,
   getOfficialExternalPluginCatalogEntry,
   isOfficialExternalPluginCatalogFeed,
   listOfficialExternalPluginCatalogEntries,
@@ -342,12 +343,205 @@ describe("official external plugin catalog", () => {
 
     expect(result.source).toBe("bundled-fallback");
     if (result.source === "bundled-fallback") {
-      expect(result.error).toContain("without a cached snapshot");
+      expect(result.error).toContain("HTTP 304");
       expect(result.metadata).toMatchObject({
         status: 304,
         etag: '"same"',
         lastModified: "Mon, 22 Jun 2026 01:00:00 GMT",
       });
+    }
+  });
+
+  it("writes a validated hosted feed snapshot after a successful fetch", async () => {
+    const snapshotStore = createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore();
+    const writeSpy = vi.spyOn(snapshotStore, "write");
+    const body = JSON.stringify({
+      schemaVersion: 1,
+      id: "openclaw-official-external-plugins",
+      generatedAt: "2026-06-22T00:00:00.000Z",
+      sequence: 3,
+      entries: [
+        {
+          name: "@openclaw/snapshot-write-proof",
+          kind: "plugin",
+          openclaw: { plugin: { id: "snapshot-write-proof" } },
+        },
+      ],
+    });
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore,
+      now: () => new Date("2026-06-22T01:02:03.000Z"),
+      fetchImpl: vi.fn(
+        async () =>
+          new Response(body, {
+            status: 200,
+            headers: { etag: '"fresh"' },
+          }),
+      ),
+    });
+
+    expect(result.source).toBe("hosted");
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    const snapshot = await snapshotStore.read(
+      result.source === "hosted" ? result.metadata.url : "",
+    );
+    expect(snapshot).toMatchObject({
+      body,
+      savedAt: "2026-06-22T01:02:03.000Z",
+      metadata: { etag: '"fresh"' },
+    });
+    expect(snapshot?.metadata.checksum).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it("uses the last known good snapshot when the hosted feed returns HTTP 304", async () => {
+    const body = JSON.stringify({
+      schemaVersion: 1,
+      id: "openclaw-official-external-plugins",
+      generatedAt: "2026-06-22T00:00:00.000Z",
+      sequence: 4,
+      entries: [
+        {
+          name: "@openclaw/snapshot-proof",
+          kind: "plugin",
+          openclaw: { plugin: { id: "snapshot-proof" } },
+        },
+      ],
+    });
+    const seeded = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore: createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore(),
+      fetchImpl: vi.fn(async () => new Response(body, { status: 200 })),
+    });
+    if (seeded.source !== "hosted") {
+      throw new Error("expected seeded hosted feed");
+    }
+    const snapshotStore = createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore([
+      {
+        body,
+        metadata: seeded.metadata,
+        savedAt: "2026-06-22T01:02:03.000Z",
+      },
+    ]);
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore,
+      fetchImpl: vi.fn(async () => new Response(null, { status: 304 })),
+    });
+
+    expect(result.source).toBe("hosted-snapshot");
+    expect(result.entries.map((entry) => entry.name)).toEqual(["@openclaw/snapshot-proof"]);
+    if (result.source === "hosted-snapshot") {
+      expect(result.error).toContain("HTTP 304");
+      expect(result.snapshot.savedAt).toBe("2026-06-22T01:02:03.000Z");
+      expect(result.metadata.checksum).toBe(seeded.metadata.checksum);
+    }
+  });
+
+  it("uses a valid snapshot before bundled fallback when hosted validation fails", async () => {
+    const body = JSON.stringify({
+      schemaVersion: 1,
+      id: "openclaw-official-external-plugins",
+      generatedAt: "2026-06-22T00:00:00.000Z",
+      sequence: 5,
+      entries: [
+        {
+          name: "@openclaw/snapshot-validation-proof",
+          kind: "plugin",
+          openclaw: { plugin: { id: "snapshot-validation-proof" } },
+        },
+      ],
+    });
+    const seeded = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore: createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore(),
+      fetchImpl: vi.fn(async () => new Response(body, { status: 200 })),
+    });
+    if (seeded.source !== "hosted") {
+      throw new Error("expected seeded hosted feed");
+    }
+    const snapshotStore = createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore([
+      { body, metadata: seeded.metadata, savedAt: "2026-06-22T01:02:03.000Z" },
+    ]);
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore,
+      fetchImpl: vi.fn(async () => new Response("{ nope", { status: 200 })),
+    });
+
+    expect(result.source).toBe("hosted-snapshot");
+    expect(result.entries.map((entry) => entry.name)).toEqual([
+      "@openclaw/snapshot-validation-proof",
+    ]);
+    if (result.source === "hosted-snapshot") {
+      expect(result.error).toContain("JSON");
+    }
+  });
+
+  it("falls back to bundled entries when the snapshot is invalid", async () => {
+    const snapshotStore = createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore([
+      {
+        body: JSON.stringify({
+          schemaVersion: 1,
+          id: "openclaw-official-external-plugins",
+          generatedAt: "2026-06-22T00:00:00.000Z",
+          sequence: 1,
+          entries: [],
+        }),
+        metadata: {
+          url: "https://register.openclaw.ai/official-external-plugin-catalog.json",
+          status: 200,
+          checksum: "sha256:not-current",
+        },
+        savedAt: "2026-06-22T01:02:03.000Z",
+      },
+    ]);
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore,
+      fetchImpl: vi.fn(async () => new Response(null, { status: 304 })),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("snapshot fallback failed");
+      expect(result.error).toContain("checksum mismatch");
+    }
+  });
+
+  it("does not use a snapshot that violates the expected checksum", async () => {
+    const body = JSON.stringify({
+      schemaVersion: 1,
+      id: "openclaw-official-external-plugins",
+      generatedAt: "2026-06-22T00:00:00.000Z",
+      sequence: 6,
+      entries: [
+        {
+          name: "@openclaw/snapshot-pin-proof",
+          kind: "plugin",
+          openclaw: { plugin: { id: "snapshot-pin-proof" } },
+        },
+      ],
+    });
+    const seeded = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore: createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore(),
+      fetchImpl: vi.fn(async () => new Response(body, { status: 200 })),
+    });
+    if (seeded.source !== "hosted") {
+      throw new Error("expected seeded hosted feed");
+    }
+    const snapshotStore = createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore([
+      { body, metadata: seeded.metadata, savedAt: "2026-06-22T01:02:03.000Z" },
+    ]);
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore,
+      expectedSha256: "sha256:not-current",
+      fetchImpl: vi.fn(async () => new Response(body, { status: 200 })),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("snapshot fallback failed");
+      expect(result.error).toContain("expected checksum");
     }
   });
 

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -121,12 +121,31 @@ export type HostedOfficialExternalPluginCatalogMetadata = {
   checksum: string;
 };
 
+export type HostedOfficialExternalPluginCatalogSnapshot = {
+  body: string;
+  metadata: HostedOfficialExternalPluginCatalogMetadata;
+  savedAt: string;
+};
+
+export type HostedOfficialExternalPluginCatalogSnapshotStore = {
+  read: (url: string) => Promise<HostedOfficialExternalPluginCatalogSnapshot | null | undefined>;
+  write: (snapshot: HostedOfficialExternalPluginCatalogSnapshot) => Promise<void>;
+};
+
 export type HostedOfficialExternalPluginCatalogLoadResult =
   | {
       source: "hosted";
       entries: OfficialExternalPluginCatalogEntry[];
       feed: OfficialExternalPluginCatalogFeed;
       metadata: HostedOfficialExternalPluginCatalogMetadata;
+    }
+  | {
+      source: "hosted-snapshot";
+      entries: OfficialExternalPluginCatalogEntry[];
+      feed: OfficialExternalPluginCatalogFeed;
+      metadata: HostedOfficialExternalPluginCatalogMetadata;
+      snapshot: HostedOfficialExternalPluginCatalogSnapshot;
+      error: string;
     }
   | {
       source: "bundled-fallback";
@@ -369,6 +388,10 @@ function resolveOfficialExternalPluginCatalogEntryKey(
   return undefined;
 }
 
+function formatHostedCatalogError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function bundledFallbackResult(
   error: unknown,
   metadata?: HostedOfficialExternalPluginCatalogLoadResult["metadata"],
@@ -376,8 +399,80 @@ function bundledFallbackResult(
   return {
     source: "bundled-fallback",
     entries: listOfficialExternalPluginCatalogEntries(),
-    error: error instanceof Error ? error.message : String(error),
+    error: formatHostedCatalogError(error),
     ...(metadata ? { metadata } : {}),
+  };
+}
+
+function loadHostedCatalogSnapshotResult(params: {
+  snapshot: HostedOfficialExternalPluginCatalogSnapshot;
+  error: unknown;
+  expectedSha256?: string;
+}): HostedOfficialExternalPluginCatalogLoadResult {
+  const checksum = sha256Hex(params.snapshot.body);
+  if (checksum !== params.snapshot.metadata.checksum) {
+    throw new Error("hosted catalog snapshot checksum mismatch");
+  }
+  if (params.expectedSha256 && params.expectedSha256 !== checksum) {
+    throw new Error("hosted catalog snapshot checksum did not match expected checksum");
+  }
+  const raw = JSON.parse(params.snapshot.body) as unknown;
+  if (!isOfficialExternalPluginCatalogFeed(raw)) {
+    throw new Error("hosted catalog snapshot did not match schema version 1");
+  }
+  return {
+    source: "hosted-snapshot",
+    entries: dedupeOfficialExternalPluginCatalogEntries(
+      parseOfficialExternalPluginCatalogEntries(raw),
+    ),
+    feed: raw,
+    metadata: params.snapshot.metadata,
+    snapshot: params.snapshot,
+    error: formatHostedCatalogError(params.error),
+  };
+}
+
+async function snapshotOrBundledFallbackResult(params: {
+  error: unknown;
+  snapshotStore?: HostedOfficialExternalPluginCatalogSnapshotStore;
+  url: string;
+  metadata?: HostedOfficialExternalPluginCatalogLoadResult["metadata"];
+  expectedSha256?: string;
+}): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
+  if (params.snapshotStore) {
+    try {
+      const snapshot = await params.snapshotStore.read(params.url);
+      if (snapshot) {
+        return loadHostedCatalogSnapshotResult({
+          snapshot,
+          error: params.error,
+          expectedSha256: params.expectedSha256,
+        });
+      }
+    } catch (snapshotErr) {
+      return bundledFallbackResult(
+        `${formatHostedCatalogError(params.error)}; snapshot fallback failed: ${formatHostedCatalogError(snapshotErr)}`,
+        params.metadata,
+      );
+    }
+  }
+  return bundledFallbackResult(params.error, params.metadata);
+}
+
+export function createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore(
+  initialSnapshots: HostedOfficialExternalPluginCatalogSnapshot[] = [],
+): HostedOfficialExternalPluginCatalogSnapshotStore {
+  const snapshots = new Map<string, HostedOfficialExternalPluginCatalogSnapshot>();
+  for (const snapshot of initialSnapshots) {
+    snapshots.set(snapshot.metadata.url, snapshot);
+  }
+  return {
+    async read(url) {
+      return snapshots.get(url) ?? null;
+    },
+    async write(snapshot) {
+      snapshots.set(snapshot.metadata.url, snapshot);
+    },
   };
 }
 
@@ -390,6 +485,8 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   ifNoneMatch?: string;
   ifModifiedSince?: string;
   expectedSha256?: string;
+  snapshotStore?: HostedOfficialExternalPluginCatalogSnapshotStore;
+  now?: () => Date;
 }): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
   let url: URL;
   try {
@@ -400,6 +497,7 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   const headers = new Headers();
   const ifNoneMatch = normalizeOptionalString(params?.ifNoneMatch);
   const ifModifiedSince = normalizeOptionalString(params?.ifModifiedSince);
+  const expectedSha256 = normalizeOptionalString(params?.expectedSha256);
   if (ifNoneMatch) {
     headers.set("if-none-match", ifNoneMatch);
   }
@@ -434,13 +532,22 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     release = guarded.release;
     const base = metadataBase(response);
     if (response.status === 304) {
-      return bundledFallbackResult(
-        "hosted catalog feed returned HTTP 304 without a cached snapshot",
-        base,
-      );
+      return await snapshotOrBundledFallbackResult({
+        error: "hosted catalog feed returned HTTP 304",
+        snapshotStore: params?.snapshotStore,
+        url: url.href,
+        metadata: base,
+        expectedSha256,
+      });
     }
     if (!response.ok) {
-      return bundledFallbackResult(`hosted catalog feed returned HTTP ${response.status}`, base);
+      return await snapshotOrBundledFallbackResult({
+        error: `hosted catalog feed returned HTTP ${response.status}`,
+        snapshotStore: params?.snapshotStore,
+        url: url.href,
+        metadata: base,
+        expectedSha256,
+      });
     }
     const body = await readHostedCatalogResponseText({
       response,
@@ -449,36 +556,48 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         params?.chunkTimeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS,
     });
     const checksum = sha256Hex(body);
-    const expectedSha256 = normalizeOptionalString(params?.expectedSha256);
+    const metadata = { ...base, checksum };
     if (expectedSha256 && expectedSha256 !== checksum) {
-      return bundledFallbackResult(
-        `hosted catalog feed checksum mismatch: expected ${expectedSha256}`,
-        {
-          ...base,
-          checksum,
-        },
-      );
+      return await snapshotOrBundledFallbackResult({
+        error: `hosted catalog feed checksum mismatch: expected ${expectedSha256}`,
+        snapshotStore: params?.snapshotStore,
+        url: url.href,
+        metadata,
+        expectedSha256,
+      });
     }
     const raw = JSON.parse(body) as unknown;
     if (!isOfficialExternalPluginCatalogFeed(raw)) {
-      return bundledFallbackResult("hosted catalog feed did not match a supported schema version", {
-        ...base,
-        checksum,
+      return await snapshotOrBundledFallbackResult({
+        error: "hosted catalog feed did not match a supported schema version",
+        snapshotStore: params?.snapshotStore,
+        url: url.href,
+        metadata,
+        expectedSha256,
       });
     }
+    await params?.snapshotStore
+      ?.write({
+        body,
+        metadata,
+        savedAt: (params.now?.() ?? new Date()).toISOString(),
+      })
+      .catch(() => undefined);
     return {
       source: "hosted",
       entries: dedupeOfficialExternalPluginCatalogEntries(
         parseOfficialExternalPluginCatalogEntries(raw),
       ),
       feed: raw,
-      metadata: {
-        ...base,
-        checksum,
-      },
+      metadata,
     };
   } catch (err) {
-    return bundledFallbackResult(err);
+    return await snapshotOrBundledFallbackResult({
+      error: err,
+      snapshotStore: params?.snapshotStore,
+      url: url.href,
+      expectedSha256,
+    });
   } finally {
     if (response?.bodyUsed !== true) {
       await response?.body?.cancel().catch(() => undefined);

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -408,7 +408,14 @@ function loadHostedCatalogSnapshotResult(params: {
   snapshot: HostedOfficialExternalPluginCatalogSnapshot;
   error: unknown;
   expectedSha256?: string;
+  ifNoneMatch?: string;
+  ifModifiedSince?: string;
 }): HostedOfficialExternalPluginCatalogLoadResult {
+  assertSnapshotMatchesRequestValidators({
+    snapshot: params.snapshot,
+    ifNoneMatch: params.ifNoneMatch,
+    ifModifiedSince: params.ifModifiedSince,
+  });
   const checksum = sha256Hex(params.snapshot.body);
   if (checksum !== params.snapshot.metadata.checksum) {
     throw new Error("hosted catalog snapshot checksum mismatch");
@@ -432,12 +439,31 @@ function loadHostedCatalogSnapshotResult(params: {
   };
 }
 
+function assertSnapshotMatchesRequestValidators(params: {
+  snapshot: HostedOfficialExternalPluginCatalogSnapshot;
+  ifNoneMatch?: string;
+  ifModifiedSince?: string;
+}): void {
+  if (params.ifNoneMatch && params.snapshot.metadata.etag !== params.ifNoneMatch) {
+    throw new Error("hosted catalog snapshot ETag did not match request validator");
+  }
+  if (
+    !params.ifNoneMatch &&
+    params.ifModifiedSince &&
+    params.snapshot.metadata.lastModified !== params.ifModifiedSince
+  ) {
+    throw new Error("hosted catalog snapshot Last-Modified did not match request validator");
+  }
+}
+
 async function snapshotOrBundledFallbackResult(params: {
   error: unknown;
   snapshotStore?: HostedOfficialExternalPluginCatalogSnapshotStore;
   url: string;
   metadata?: HostedOfficialExternalPluginCatalogLoadResult["metadata"];
   expectedSha256?: string;
+  ifNoneMatch?: string;
+  ifModifiedSince?: string;
 }): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
   if (params.snapshotStore) {
     try {
@@ -447,6 +473,8 @@ async function snapshotOrBundledFallbackResult(params: {
           snapshot,
           error: params.error,
           expectedSha256: params.expectedSha256,
+          ifNoneMatch: params.ifNoneMatch,
+          ifModifiedSince: params.ifModifiedSince,
         });
       }
     } catch (snapshotErr) {
@@ -538,6 +566,8 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         url: url.href,
         metadata: base,
         expectedSha256,
+        ifNoneMatch,
+        ifModifiedSince,
       });
     }
     if (!response.ok) {
@@ -547,6 +577,8 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         url: url.href,
         metadata: base,
         expectedSha256,
+        ifNoneMatch,
+        ifModifiedSince,
       });
     }
     const body = await readHostedCatalogResponseText({
@@ -564,6 +596,8 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         url: url.href,
         metadata,
         expectedSha256,
+        ifNoneMatch,
+        ifModifiedSince,
       });
     }
     const raw = JSON.parse(body) as unknown;
@@ -574,6 +608,8 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         url: url.href,
         metadata,
         expectedSha256,
+        ifNoneMatch,
+        ifModifiedSince,
       });
     }
     await params?.snapshotStore
@@ -597,6 +633,8 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       snapshotStore: params?.snapshotStore,
       url: url.href,
       expectedSha256,
+      ifNoneMatch,
+      ifModifiedSince,
     });
   } finally {
     if (response?.bodyUsed !== true) {


### PR DESCRIPTION
<!-- hosted-feed-stack:start -->
## Hosted Marketplace Feed Stack

This is PR3 in the hosted marketplace feed stack. The stack should land in order, with maintainer review at each step before the later PRs wire hosted marketplace data into broader user flows.

1. #95846: refactor the bundled external plugin catalog toward the feed-shaped data model.
2. #95868: add the lazy hosted marketplace feed loader for the configured public feed URL, with guarded HTTPS fetch, checksum, schema, size, timeout, and bundled fallback behavior.
3. #95877: add accepted hosted snapshot fallback so a failed or unchanged hosted fetch can reuse the last valid feed payload.
4. #95964: persist hosted marketplace feed snapshots in OpenClaw state.
5. #95969: add marketplace source profile validation for hosted feed install candidates.
6. #95981: add configurable `marketplaces.feeds` and `marketplaces.sources` profiles.
7. #96155: add `openclaw plugins marketplace refresh` as the explicit manual snapshot refresh path.
8. #96158: add `openclaw plugins marketplace entries` as the explicit manual read path over hosted, snapshot, or bundled fallback entries.
9. #96194: add marketplace feed telemetry.

The broader follow-up after this stack is to decide whether and how marketplace entries should feed install/search/startup behavior, add automatic conditional refresh using `ETag` / `Last-Modified`, or move to ClawHub producer-side validation for `/v1/feeds/plugins` and `/v1/feeds/skills`.
<!-- hosted-feed-stack:end -->

## Journey Context

This is step 3 of the hosted OpenClaw feed path from RFC 19. #95846 made the bundled catalog feed-shaped. #95868 added guarded hosted fetch. This PR adds the last-known-good snapshot contract that makes the hosted path safe when the register endpoint is unchanged or temporarily unhealthy.

Current head `5f71635bba` is restacked on main after #95868 merged.

## What This PR Does

- Adds a narrow `HostedOfficialExternalPluginCatalogSnapshotStore` interface.
- Adds an in-memory snapshot store for tests and future runtime binding.
- Writes the exact hosted response body plus hosted metadata and `savedAt` after a successful hosted load.
- Uses a cached snapshot on 304, non-OK hosted responses, invalid hosted JSON/schema, or fetch failures.
- Validates cached snapshot body checksum before use.
- Validates cached snapshot schema before use.
- Preserves `expectedSha256` pinning for snapshots, so a stale cached body cannot satisfy a caller-pinned checksum it does not match.
- Honors request validators when serving snapshots, so conditional callers do not reuse a stale URL-only snapshot after `ETag` / `Last-Modified` changes.
- Falls back to the bundled catalog when no valid snapshot exists.

## What This PR Intentionally Does Not Do

This PR does not choose a production persistence location, wire SQLite/runtime storage, enable the hosted loader by default, add source profiles, add auth, add signed envelopes, add regional feeds, or change search/install behavior. It defines the loader-level snapshot semantics that a later runtime-owned persistent store can bind to.

## How To Review

Review this as fallback semantics, not as the final storage implementation. The key behavior is: hosted feed first, validated last-known-good snapshot second, bundled catalog last. A snapshot write failure is intentionally non-fatal because a good hosted response should still be usable even if cache persistence fails.

## Validation

- `pnpm exec oxlint --deny-warnings src/plugins/official-external-plugin-catalog.ts src/plugins/official-external-plugin-catalog.test.ts`
- `pnpm exec oxfmt --check src/plugins/official-external-plugin-catalog.ts src/plugins/official-external-plugin-catalog.test.ts`
- `git diff --check`
- `CI=1 node scripts/test-projects.mjs src/plugins/official-external-plugin-catalog.test.ts` (33 tests)
- `codex review --base origin/main` reported no actionable correctness issues.
- Live guarded snapshot proof: `node --import tsx -` source harness against `https://clawhub.ai/v1/feeds/plugins` with a file-backed snapshot store under `C:\tmp\openclaw-feeds-proof\pr95877-live-snapshot`.

## Real Behavior Proof

Behavior or issue addressed:
The hosted loader reuses a last-known-good hosted snapshot when a later hosted fetch cannot provide an acceptable fresh payload, while refusing stale snapshots when the caller supplied request validators that no longer match the snapshot metadata.

Real environment tested:
Windows checkout `C:\src\openclaw-prflow\.worktrees\pr-95877` at head `5f71635bba`, live guarded HTTPS fetch to `https://clawhub.ai/v1/feeds/plugins`, and a file-backed `HostedOfficialExternalPluginCatalogSnapshotStore` writing the exact snapshot body and metadata to `C:\tmp\openclaw-feeds-proof\pr95877-live-snapshot\official-external-plugin-catalog.snapshot.json`.

Exact steps or command run after this patch:
1. `pnpm exec oxlint --deny-warnings src/plugins/official-external-plugin-catalog.ts src/plugins/official-external-plugin-catalog.test.ts`
2. `pnpm exec oxfmt --check src/plugins/official-external-plugin-catalog.ts src/plugins/official-external-plugin-catalog.test.ts`
3. `git diff --check`
4. `CI=1 node scripts/test-projects.mjs src/plugins/official-external-plugin-catalog.test.ts`
5. `codex review --base origin/main`
6. `node --import tsx -` with a source harness that:
   - calls `loadHostedOfficialExternalPluginCatalogEntries({ snapshotStore })` against the live default feed,
   - persists the successful hosted response through a file-backed snapshot store,
   - calls `loadHostedOfficialExternalPluginCatalogEntries({ snapshotStore, ifNoneMatch: first.metadata.etag })`, and
   - verifies the second conditional request returns `source: "hosted-snapshot"` with `error: "hosted catalog feed returned HTTP 304"`.

Evidence after fix:

```text
Test Files  1 passed (1)
Tests  33 passed (33)
[test] passed 1 Vitest shard in 27.60s

Codex review: No actionable correctness issues were found in the changed catalog snapshot logic or its adjacent tests.

Live guarded snapshot proof output:
{
  "repoHead": "5f71635bbafe75c8109248da66b297b8ee4f9657",
  "feedUrl": "https://clawhub.ai/v1/feeds/plugins",
  "snapshotPath": "C:\\tmp\\openclaw-feeds-proof\\pr95877-live-snapshot\\official-external-plugin-catalog.snapshot.json",
  "firstLoad": {
    "source": "hosted",
    "status": 200,
    "entries": 59,
    "feedId": "clawhub-official",
    "sequence": 16,
    "etag": "\"sha256:cf3d85c1d6ede1907ca265e9b214ac6ff1c715c90c30ec65e8017addb590e32d-gzip\"",
    "lastModified": "Sat, 27 Jun 2026 18:43:36 GMT",
    "checksum": "sha256:cf3d85c1d6ede1907ca265e9b214ac6ff1c715c90c30ec65e8017addb590e32d"
  },
  "secondConditionalLoad": {
    "requestIfNoneMatch": "\"sha256:cf3d85c1d6ede1907ca265e9b214ac6ff1c715c90c30ec65e8017addb590e32d-gzip\"",
    "source": "hosted-snapshot",
    "status": 200,
    "entries": 59,
    "feedId": "clawhub-official",
    "sequence": 16,
    "error": "hosted catalog feed returned HTTP 304",
    "snapshotSavedAt": "2026-06-27T20:54:47.927Z"
  },
  "persistedSnapshot": {
    "url": "https://clawhub.ai/v1/feeds/plugins",
    "savedAt": "2026-06-27T20:54:47.927Z",
    "etag": "\"sha256:cf3d85c1d6ede1907ca265e9b214ac6ff1c715c90c30ec65e8017addb590e32d-gzip\"",
    "checksum": "sha256:cf3d85c1d6ede1907ca265e9b214ac6ff1c715c90c30ec65e8017addb590e32d",
    "bytes": 21942
  }
}
```

Observed result after fix:
The live proof first loaded the ClawHub feed over the guarded hosted path and persisted a snapshot. The second load sent the returned live ETag as `If-None-Match`, received HTTP 304 from the live service, validated the persisted snapshot metadata/body, and returned `source: "hosted-snapshot"` with the same 59-entry `clawhub-official` sequence 16 feed.

What was not tested:
This PR still does not test production SQLite persistence because that is the next PR in the stack. This proof uses a file-backed implementation of the snapshot-store interface to exercise the loader contract with the live hosted feed.