### PR TITLE
fix(ci): use workflow revision for proof checks

### DIFF
--- a/.github/workflows/real-behavior-proof.yml
+++ b/.github/workflows/real-behavior-proof.yml
@@ -24,7 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          # Old PR events can carry a stale base SHA that predates current
+          # trusted checker scripts. Use the workflow revision instead.
+          ref: ${{ github.workflow_sha }}
           persist-credentials: false
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -15,6 +15,10 @@ function readWorkflowSanityWorkflow() {
   return parse(readFileSync(".github/workflows/workflow-sanity.yml", "utf8"));
 }
 
+function readRealBehaviorProofWorkflow() {
+  return parse(readFileSync(".github/workflows/real-behavior-proof.yml", "utf8"));
+}
+
 function readCriticalQualityWorkflow() {
   return readFileSync(".github/workflows/codeql-critical-quality.yml", "utf8");
 }
@@ -82,6 +86,18 @@ describe("ci workflow guards", () => {
 
   it("pins every external GitHub Action reference to a full commit SHA", () => {
     expect(findUnpinnedExternalActions()).toEqual([]);
+  });
+
+  it("runs real behavior proof from the trusted workflow revision", () => {
+    const workflow = readRealBehaviorProofWorkflow();
+    const source = readFileSync(".github/workflows/real-behavior-proof.yml", "utf8");
+    const checkout = workflow.jobs["real-behavior-proof"].steps.find(
+      (step) => step.uses === CHECKOUT_V6,
+    );
+
+    expect(checkout.with.ref).toBe("${{ github.workflow_sha }}");
+    expect(checkout.with.ref).not.toBe("${{ github.event.pull_request.base.sha }}");
+    expect(source).toContain("Old PR events can carry a stale base SHA");
   });
 
   it("keeps docs-change detection fail-safe and fixture-aware", () => {
@@ -467,7 +483,7 @@ describe("ci workflow guards", () => {
     expect(runStep.env.OPENCLAW_TEST_PROJECTS_PARALLEL).toBe("2");
     expect(runStep.env.OPENCLAW_NODE_TEST_ENV_JSON).toBe("${{ toJson(matrix.env) }}");
     expect(runStep.run).toContain("env: JSON.parse(process.env.OPENCLAW_NODE_TEST_ENV_JSON");
-    expect(runStep.run).toContain("if (plan.env && typeof plan.env === \"object\"");
+    expect(runStep.run).toContain('if (plan.env && typeof plan.env === "object"');
     expect(runStep.run).toContain("childEnv[key] = value");
   });
 


### PR DESCRIPTION
## Summary
- fix `Real behavior proof` so old PR events do not checkout stale `pull_request.base.sha` revisions that predate the current trusted checker scripts
- checkout `github.workflow_sha` for the metadata-only `pull_request_target` proof gate
- add a workflow guard test to keep that trusted-revision invariant from regressing

## Provenance
- observed failure on PR #76614 / run `27988802067`: `Cannot find module ... scripts/github/real-behavior-proof-check.mjs`
- PR #76614 still reports an old base SHA (`4545a0e...`), so the workflow checked out a trusted but stale base revision instead of the revision whose workflow is running

## Verification
- `tbx_01kvrrqq6tnwee3r41p22sy0qk`: `corepack pnpm format:check .github/workflows/real-behavior-proof.yml test/scripts/ci-workflow-guards.test.ts` passed
- `tbx_01kvrrqq6tnwee3r41p22sy0qk`: `corepack pnpm test:serial test/scripts/ci-workflow-guards.test.ts` passed 26/26
- `tbx_01kvrrqq6tnwee3r41p22sy0qk`: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` passed for `tooling`