### PR TITLE
fix(msteams): thread fresh channel mentions under the inbound message (#38629)

### DIFF
--- a/extensions/msteams/src/channel.message-adapter.test.ts
+++ b/extensions/msteams/src/channel.message-adapter.test.ts
@@ -226,3 +226,44 @@ describe("msteams channel message adapter", () => {
     });
   });
 });
+
+describe("msteams threading buildToolContext", () => {
+  const buildToolContext = msteamsPlugin.threading?.buildToolContext;
+  const channelRoute = "19:team-id/channel-id@thread.tacv2";
+
+  it("threads fresh channel @-mentions under the inbound message when ReplyToId is absent (#38629)", () => {
+    expect(buildToolContext).toBeDefined();
+    const toolContext = buildToolContext?.({
+      cfg,
+      accountId: "default",
+      context: {
+        To: "conversation:team-1",
+        NativeChannelId: channelRoute,
+        CurrentMessageId: "1700000000000",
+      },
+    });
+    expect(toolContext?.currentThreadTs).toBe("1700000000000");
+  });
+
+  it("keeps an explicit ReplyToId as the thread anchor", () => {
+    const toolContext = buildToolContext?.({
+      cfg,
+      accountId: "default",
+      context: {
+        NativeChannelId: channelRoute,
+        CurrentMessageId: "1700000000000",
+        ReplyToId: "reply-99",
+      },
+    });
+    expect(toolContext?.currentThreadTs).toBe("reply-99");
+  });
+
+  it("does not anchor on the inbound id for non-channel (DM) routes", () => {
+    const toolContext = buildToolContext?.({
+      cfg,
+      accountId: "default",
+      context: { CurrentMessageId: "1700000000000" },
+    });
+    expect(toolContext?.currentThreadTs).toBeUndefined();
+  });
+});

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -1193,10 +1193,16 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
       buildToolContext: ({ context, hasRepliedRef }) => {
         const nativeChannelId = context.NativeChannelId?.trim();
         const hasChannelRoute = Boolean(nativeChannelId && nativeChannelId.includes("/"));
+        const inboundMessageId =
+          context.CurrentMessageId != null ? String(context.CurrentMessageId) : undefined;
         return {
           currentChannelId: normalizeOptionalString(context.To),
           currentGraphChannelId: hasChannelRoute ? nativeChannelId : undefined,
-          currentThreadTs: context.ReplyToId,
+          // Fresh channel @-mentions arrive without ReplyToId, so the reply would
+          // post at the channel root instead of threading under the user's message.
+          // Fall back to the inbound message id as the thread anchor for channel
+          // routes. See #38629 / #52954 (the native close never covered this path).
+          currentThreadTs: context.ReplyToId ?? (hasChannelRoute ? inboundMessageId : undefined),
           hasRepliedRef,
         };
       },


### PR DESCRIPTION
## What Problem This Solves

When a user @-mentions the bot in an MS Teams **channel** with a fresh message (not a reply), the inbound activity has no `ReplyToId`. The threading adapter's `buildToolContext` sets `currentThreadTs: context.ReplyToId`, so with `ReplyToId` undefined the bot replies at the **channel root** instead of threading under the user's message. In a busy channel the reply detaches from the question and reads as an unrelated top-level post.

`extensions/msteams/src/channel.ts` (`buildToolContext`) currently has no fallback thread anchor for this case. This is the same class as #38629 ("replyToId unreliable, conversation.id/threadRootId not used as fallback") and #52954 ("channel thread replies post as top-level"), whose closures never added a fallback to this path — current `main` still does `currentThreadTs: context.ReplyToId`.

Related: #38629, #52954.

## Why This Change Was Made

Fall back to the inbound message id (`context.CurrentMessageId`, which the kernel populates from the inbound `MessageSid`/`activityId`) as the thread anchor when `ReplyToId` is absent **and** the message is a channel route (`hasChannelRoute`). This makes a fresh channel @-mention reply in a new thread rooted at the user's message, instead of at the channel root. DMs and explicit replies are unchanged (the fallback only applies to channel routes; an explicit `ReplyToId` still wins).

`CurrentMessageId` is `string | number`, so it is coerced to `string` for `currentThreadTs`.

## User Impact

In MS Teams channels, the bot's reply to a fresh @-mention now threads under the user's message instead of posting at the channel root. DM behavior and explicit thread replies are unaffected. No config, auth, secrets, network, or tool-execution changes.

## Evidence

This is a pure threading-context logic change. The new unit tests exercise the patched `msteamsPlugin.threading.buildToolContext` directly:

`pnpm vitest run extensions/msteams/src/channel.message-adapter.test.ts -t "buildToolContext"` → **3 passed**:
- fresh channel @-mention (no `ReplyToId`, channel route, `CurrentMessageId: "1700000000000"`) → `currentThreadTs === "1700000000000"` (threads under the inbound message);
- explicit `ReplyToId: "reply-99"` → `currentThreadTs === "reply-99"` (explicit reply still wins);
- non-channel (DM) route, no `ReplyToId` → `currentThreadTs === undefined` (no spurious anchor).

Production confirmation: an equivalent inbound-message-id fallback has been running on a live MS Teams gateway and resolved exactly this bug — fresh channel @-mentions that previously posted at the channel root now thread under the user's message. **Proof limitation:** that deployment runs `2026.5.28`, where the runtime exposed the inbound id under a different field name than the typed `CurrentMessageId` used here; the fix shape and user-facing outcome are identical, but I do not have a live MS Teams replay on current `main`. No MS Teams client screenshot; private tenant/channel details omitted.

## Risk

Low. The fallback is gated to channel routes and only applies when `ReplyToId` is absent, so DMs and explicit replies are untouched. Worst case is an invalid thread anchor, which MS Teams already tolerates by falling back to a new thread. Covered by the new unit tests.

AI-assisted change.
