### PR TITLE
Deny same-provider cross-context message sends by default

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1548,13 +1548,14 @@ Model Q&A - defaults, selection, aliases, switching, failover, auth profiles - l
   </Accordion>
 
   <Accordion title='How do I send a Discord message from Telegram? ("Cross-context messaging denied")'>
-    OpenClaw blocks **cross-provider** messaging by default. If a tool call is bound to Telegram, it will not send to Discord unless you explicitly allow it - and this takes effect immediately, no gateway restart needed:
+    OpenClaw blocks cross-context messaging by default. If a tool call is bound to one conversation, it will not send to another conversation unless you explicitly allow it. Same-provider sends use `allowWithinProvider`; cross-provider sends also require `allowAcrossProviders`. Changes take effect immediately, with no gateway restart needed:
 
     ```json5
     {
       tools: {
         message: {
           crossContext: {
+            allowWithinProvider: true,
             allowAcrossProviders: true,
             marker: { enabled: true, prefix: "[from {channel}] " },
           },

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -94,7 +94,7 @@ import {
 import { withTelegramStartupProbeSlot } from "./startup-probe-limiter.js";
 import { detectTelegramLegacyStateMigrations } from "./state-migrations.js";
 import { collectTelegramStatusIssues } from "./status-issues.js";
-import { parseTelegramTarget } from "./targets.js";
+import { parseTelegramTarget, telegramContextTargetsMatch } from "./targets.js";
 import {
   createTelegramThreadBindingManager,
   setTelegramThreadBindingIdleTimeoutBySessionKey,
@@ -1218,12 +1218,10 @@ export const telegramPlugin = createChatChannelPlugin({
     topLevelReplyToMode: "telegram",
     buildToolContext: (params) => buildTelegramThreadingToolContext(params),
     resolveAutoThreadId: ({ to, toolContext }) => resolveTelegramAutoThreadId({ to, toolContext }),
-    resolveCurrentChannelId: ({ to, threadId }) => {
-      if (threadId == null) {
-        return to;
-      }
-      return to.includes(":topic:") ? to : `${to}:topic:${threadId}`;
-    },
+    matchesToolContextTarget: ({ target, toolContext }) =>
+      telegramContextTargetsMatch(target, toolContext),
+    resolveCurrentChannelId: ({ to, threadId }) =>
+      threadId == null || to.includes(":topic:") ? to : `${to}:topic:${threadId}`,
   },
   outbound: telegramChannelOutbound,
 });

--- a/extensions/telegram/src/targets.test.ts
+++ b/extensions/telegram/src/targets.test.ts
@@ -19,6 +19,7 @@ import {
   normalizeTelegramOutboundTarget,
   parseTelegramTarget,
   stripTelegramInternalPrefixes,
+  telegramContextTargetsMatch,
 } from "./targets.js";
 
 const numericTelegramTargetNormalizers = [
@@ -308,6 +309,76 @@ describe("telegram target normalization", () => {
     expect(looksLikeTelegramTargetId("telegram:123456")).toBe(true);
     expect(looksLikeTelegramTargetId("tg:group:-100123")).toBe(true);
     expect(looksLikeTelegramTargetId("hello world")).toBe(false);
+  });
+});
+
+describe("telegramContextTargetsMatch", () => {
+  it("matches a bare chat target against a topic-bound context", () => {
+    expect(
+      telegramContextTargetsMatch("477789300", {
+        currentMessagingTarget: "477789300:topic:340799",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches a bare chat target against a bare context", () => {
+    expect(
+      telegramContextTargetsMatch("477789300", {
+        currentMessagingTarget: "477789300",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects an explicit topic target against a bare context", () => {
+    expect(
+      telegramContextTargetsMatch("477789300:topic:340799", {
+        currentMessagingTarget: "477789300",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a different explicit topic in the same chat", () => {
+    expect(
+      telegramContextTargetsMatch("477789300:topic:340800", {
+        currentMessagingTarget: "477789300:topic:340799",
+      }),
+    ).toBe(false);
+  });
+
+  it("matches the same explicit topic in the same chat", () => {
+    expect(
+      telegramContextTargetsMatch("477789300:topic:340799", {
+        currentMessagingTarget: "477789300:topic:340799",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches via currentChannelId when currentMessagingTarget is absent", () => {
+    expect(
+      telegramContextTargetsMatch("477789300", {
+        currentChannelId: "477789300:topic:340799",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a different chat", () => {
+    expect(
+      telegramContextTargetsMatch("999999999", {
+        currentMessagingTarget: "477789300:topic:340799",
+      }),
+    ).toBe(false);
+  });
+
+  it("strips Telegram prefixes before comparison", () => {
+    expect(
+      telegramContextTargetsMatch("telegram:477789300", {
+        currentMessagingTarget: "telegram:477789300:topic:340799",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false without any context targets", () => {
+    expect(telegramContextTargetsMatch("477789300", {})).toBe(false);
   });
 });
 

--- a/extensions/telegram/src/targets.ts
+++ b/extensions/telegram/src/targets.ts
@@ -154,3 +154,27 @@ export function parseTelegramTarget(to: string): TelegramTarget {
 export function resolveTelegramTargetChatType(target: string): "direct" | "group" | "unknown" {
   return parseTelegramTarget(target).chatType;
 }
+
+// A bare Telegram chat target may bind to the active topic for that chat, but
+// an explicit topic target must match the active topic exactly. This keeps
+// bare sends ergonomic while preserving explicit topic boundaries.
+export function telegramContextTargetsMatch(
+  target: string,
+  context: { currentChannelId?: string; currentMessagingTarget?: string },
+): boolean {
+  const parsedTarget = parseTelegramTarget(target);
+  const targetChatId = parsedTarget.chatId.toLowerCase();
+  const candidates = [context.currentMessagingTarget, context.currentChannelId].filter(
+    (value): value is string => Boolean(value),
+  );
+  return candidates.some((candidate) => {
+    const parsedCandidate = parseTelegramTarget(candidate);
+    if (parsedCandidate.chatId.toLowerCase() !== targetChatId) {
+      return false;
+    }
+    if (parsedTarget.messageThreadId === undefined) {
+      return true;
+    }
+    return parsedCandidate.messageThreadId === parsedTarget.messageThreadId;
+  });
+}

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -874,7 +874,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.list[].tools.byProvider":
     "Per-agent provider-specific tool policy overrides for channel-scoped capability control. Use this when a single agent needs tighter restrictions on one provider than others.",
   "agents.list[].tools.message.crossContext.allowWithinProvider":
-    "Per-agent message guard for sending to other conversations on the same provider. Set false for current-conversation-only public agents.",
+    "Per-agent opt-in for sending to other conversations on the same provider (default: false). Keep false for current-conversation-only public agents.",
   "agents.list[].tools.message.crossContext.allowAcrossProviders":
     "Per-agent message guard for sending across providers. Keep false for public or sandboxed agents.",
   "agents.list[].tools.message.actions.allow":
@@ -989,7 +989,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.allowCrossContextSend":
     "Legacy override: allow cross-context sends across all providers.",
   "tools.message.crossContext.allowWithinProvider":
-    "Allow sends to other channels within the same provider (default: true).",
+    "Allow sends to other channels within the same provider (default: false).",
   "tools.message.crossContext.allowAcrossProviders":
     "Allow sends across different providers (default: false).",
   "tools.message.crossContext.marker.enabled":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -759,7 +759,7 @@ export type MessageToolsConfig = {
    */
   allowCrossContextSend?: boolean;
   crossContext?: {
-    /** Allow sends to other channels within the same provider (default: true). */
+    /** Allow sends to other channels within the same provider (default: false). */
     allowWithinProvider?: boolean;
     /** Allow sends across different providers (default: false). */
     allowAcrossProviders?: boolean;

--- a/src/infra/outbound/message-action-preflight.ts
+++ b/src/infra/outbound/message-action-preflight.ts
@@ -1,0 +1,89 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { normalizeOutboundLocation } from "../../channels/location.js";
+import type {
+  ChannelMessageActionName,
+  ChannelThreadingToolContext,
+} from "../../channels/plugins/types.public.js";
+import {
+  hasInteractiveReplyBlocks,
+  hasMessagePresentationBlocks,
+} from "../../interactive/payload.js";
+
+type MessageActionPolicyContextInput = {
+  toolContext?: ChannelThreadingToolContext;
+  messageActionAuthorization?: {
+    toolContext?: ChannelThreadingToolContext;
+  };
+};
+
+const SEND_TEXT_KEYS = ["message", "SendMessage", "content", "text", "caption"] as const;
+const SEND_MEDIA_KEYS = ["media", "mediaUrl", "path", "filePath", "fileUrl", "image"] as const;
+
+export function resolvePolicyToolContext(
+  input: MessageActionPolicyContextInput,
+): ChannelThreadingToolContext | undefined {
+  return input.messageActionAuthorization === undefined
+    ? input.toolContext
+    : input.messageActionAuthorization.toolContext;
+}
+
+export function collectMessageAttachmentMediaHints(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const mediaUrls: string[] = [];
+  const seen = new Set<string>();
+  const pushMedia = (entry: unknown) => {
+    const normalized = normalizeOptionalString(entry);
+    if (!normalized || seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    mediaUrls.push(normalized);
+  };
+  for (const attachment of value) {
+    if (!attachment || typeof attachment !== "object" || Array.isArray(attachment)) {
+      continue;
+    }
+    const record = attachment as Record<string, unknown>;
+    pushMedia(record.media);
+    pushMedia(record.mediaUrl);
+    pushMedia(record.path);
+    pushMedia(record.filePath);
+    pushMedia(record.fileUrl);
+    pushMedia(record.url);
+  }
+  return mediaUrls;
+}
+
+export function assertLocationSendCanStandAlone(
+  location: ReturnType<typeof normalizeOutboundLocation>,
+  hasConflictingContent: boolean,
+): void {
+  if (location && hasConflictingContent) {
+    throw new Error("Location sends cannot be combined with message text or media.");
+  }
+}
+
+export function assertMessageActionPayloadBeforePolicy(
+  action: ChannelMessageActionName,
+  args: Record<string, unknown>,
+): void {
+  if (action !== "send") {
+    return;
+  }
+  const location = normalizeOutboundLocation(args.location);
+  const hasText = SEND_TEXT_KEYS.some((key) => Boolean(normalizeOptionalString(args[key])));
+  const hasMedia =
+    SEND_MEDIA_KEYS.some((key) => Boolean(normalizeOptionalString(args[key]))) ||
+    (Array.isArray(args.mediaUrls) &&
+      args.mediaUrls.some((entry) => Boolean(normalizeOptionalString(entry)))) ||
+    collectMessageAttachmentMediaHints(args.attachments).length > 0;
+  assertLocationSendCanStandAlone(
+    location,
+    hasText ||
+      hasMedia ||
+      hasMessagePresentationBlocks(args.presentation) ||
+      hasInteractiveReplyBlocks(args.interactive),
+  );
+}

--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -219,7 +219,6 @@ describe("runMessageAction context isolation", () => {
           },
           toolContext: { currentChannelId: "C12345678", currentChannelProvider: "workspace" },
         }),
-      expectedKind: "send",
     },
     {
       name: "thread-reply when channelId differs from current workspace channel",
@@ -234,11 +233,9 @@ describe("runMessageAction context isolation", () => {
           },
           toolContext: { currentChannelId: "C12345678", currentChannelProvider: "workspace" },
         }),
-      expectedKind: "action",
     },
-  ])("blocks cross-context UI handoff for $name", async ({ run, expectedKind }) => {
-    const result = await run();
-    expect(result.kind).toBe(expectedKind);
+  ])("blocks cross-context UI handoff for $name", async ({ run }) => {
+    await expect(run()).rejects.toThrow("Cross-context messaging denied");
   });
 
   it.each([
@@ -247,12 +244,14 @@ describe("runMessageAction context isolation", () => {
       channel: "directchat",
       target: "123@g.us",
       currentChannelId: "123@g.us",
+      shouldDeny: false,
     },
     {
       name: "local chat match",
       channel: "localchat",
       target: "localchat:+15551234567",
       currentChannelId: "localchat:+15551234567",
+      shouldDeny: false,
     },
     {
       name: "direct chat mismatch",
@@ -260,6 +259,7 @@ describe("runMessageAction context isolation", () => {
       target: "456@g.us",
       currentChannelId: "123@g.us",
       currentChannelProvider: "directchat",
+      shouldDeny: true,
     },
     {
       name: "local chat mismatch",
@@ -267,23 +267,31 @@ describe("runMessageAction context isolation", () => {
       target: "localchat:+15551230000",
       currentChannelId: "localchat:+15551234567",
       currentChannelProvider: "localchat",
+      shouldDeny: true,
     },
   ] as const)("$name", async (testCase) => {
-    const result = await runDrySend({
-      cfg: directChatConfig,
-      actionParams: {
-        channel: testCase.channel,
-        target: testCase.target,
-        message: "hi",
-      },
-      toolContext: {
-        currentChannelId: testCase.currentChannelId,
-        ...(testCase.currentChannelProvider
-          ? { currentChannelProvider: testCase.currentChannelProvider }
-          : {}),
-      },
-    });
+    const run = () =>
+      runDrySend({
+        cfg: directChatConfig,
+        actionParams: {
+          channel: testCase.channel,
+          target: testCase.target,
+          message: "hi",
+        },
+        toolContext: {
+          currentChannelId: testCase.currentChannelId,
+          ...(testCase.currentChannelProvider
+            ? { currentChannelProvider: testCase.currentChannelProvider }
+            : {}),
+        },
+      });
 
+    if (testCase.shouldDeny) {
+      await expect(run()).rejects.toThrow("Cross-context messaging denied");
+      return;
+    }
+
+    const result = await run();
     expect(result.kind).toBe("send");
   });
 

--- a/src/infra/outbound/message-action-runner.core-send.test.ts
+++ b/src/infra/outbound/message-action-runner.core-send.test.ts
@@ -510,12 +510,45 @@ describe("runMessageAction core send routing", () => {
     expect(result.to).toBe("channel:C123");
   });
 
-  it("preserves required delivery when message-tool-only sends target another conversation", async () => {
+  it("blocks same-provider cross-context message-tool-only sends by default", async () => {
     const sendText = registerSlackTextPlugin();
 
     await expect(
       runMessageAction({
         cfg: slackConfig,
+        action: "send",
+        params: {
+          target: "channel:C999",
+          message: "blocked cross-context send",
+          bestEffort: false,
+        },
+        toolContext: {
+          currentChannelProvider: "slack",
+          currentChannelId: "channel:C123",
+        },
+        sessionKey: "agent:main:slack:channel:C123",
+        sourceReplyDeliveryMode: "message_tool_only",
+        dryRun: false,
+      }),
+    ).rejects.toThrow("Cross-context messaging denied");
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
+  it("preserves required delivery for explicitly allowed same-provider cross-context sends", async () => {
+    const sendText = registerSlackTextPlugin();
+
+    await expect(
+      runMessageAction({
+        cfg: {
+          ...slackConfig,
+          tools: {
+            message: {
+              crossContext: {
+                allowWithinProvider: true,
+              },
+            },
+          },
+        } as OpenClawConfig,
         action: "send",
         params: {
           target: "channel:C999",

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -79,6 +79,12 @@ import {
   resolveAttachmentMediaPolicy,
   resolveExtraActionMediaSourceParamKeys,
 } from "./message-action-params.js";
+import {
+  assertLocationSendCanStandAlone,
+  assertMessageActionPayloadBeforePolicy,
+  collectMessageAttachmentMediaHints,
+  resolvePolicyToolContext,
+} from "./message-action-preflight.js";
 import { actionRequiresTarget } from "./message-action-spec.js";
 import {
   prepareOutboundMirrorRoute,
@@ -573,35 +579,6 @@ function applySendPayloadPartsToActionParams(
   actionParams.location = parts.payload.location;
 }
 
-function collectMessageAttachmentMediaHints(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  const mediaUrls: string[] = [];
-  const seen = new Set<string>();
-  const pushMedia = (entry: unknown) => {
-    const normalized = normalizeOptionalString(entry);
-    if (!normalized || seen.has(normalized)) {
-      return;
-    }
-    seen.add(normalized);
-    mediaUrls.push(normalized);
-  };
-  for (const attachment of value) {
-    if (!attachment || typeof attachment !== "object" || Array.isArray(attachment)) {
-      continue;
-    }
-    const record = attachment as Record<string, unknown>;
-    pushMedia(record.media);
-    pushMedia(record.mediaUrl);
-    pushMedia(record.path);
-    pushMedia(record.filePath);
-    pushMedia(record.fileUrl);
-    pushMedia(record.url);
-  }
-  return mediaUrls;
-}
-
 function hasExplicitSingularTargetParam(params: Record<string, unknown>): boolean {
   return readTrimmedStringAlias(params, ["target", "to", "channelId"]) !== undefined;
 }
@@ -1047,12 +1024,10 @@ async function buildSendPayloadParts(params: {
   }
   actionParams.mediaUrls = mergedMediaUrls.length > 0 ? [...mergedMediaUrls] : undefined;
 
-  if (
-    location &&
-    (message.trim() || mergedMediaUrls.length > 0 || hasPresentation || hasInteractive)
-  ) {
-    throw new Error("Location sends cannot be combined with message text or media.");
-  }
+  assertLocationSendCanStandAlone(
+    location,
+    Boolean(message.trim()) || mergedMediaUrls.length > 0 || hasPresentation || hasInteractive,
+  );
 
   if (params.channel && params.target) {
     message = await maybeApplyCrossContextMarker({
@@ -1730,11 +1705,12 @@ export async function runMessageAction(
     accountId,
   });
 
+  assertMessageActionPayloadBeforePolicy(action, params);
   enforceCrossContextPolicy({
     channel,
     action,
     args: params,
-    toolContext: input.toolContext,
+    toolContext: resolvePolicyToolContext(input),
     cfg,
     agentId: resolvedAgentId,
   });

--- a/src/infra/outbound/outbound-policy.test.ts
+++ b/src/infra/outbound/outbound-policy.test.ts
@@ -35,6 +35,38 @@ const mocks = vi.hoisted(() => ({
         },
       };
     }
+    if (channel === "telegram") {
+      return {
+        threading: {
+          matchesToolContextTarget: ({
+            target,
+            toolContext,
+          }: {
+            target: string;
+            toolContext: { currentMessagingTarget?: string; currentChannelId?: string };
+          }) => {
+            const parse = (value: string) => {
+              const topicMatch = /^(.*):topic:(\d+)$/.exec(value);
+              return topicMatch
+                ? { chatId: topicMatch[1] ?? "", threadId: Number(topicMatch[2]) }
+                : { chatId: value, threadId: undefined };
+            };
+            const parsedTarget = parse(target);
+            const candidates = [toolContext.currentMessagingTarget, toolContext.currentChannelId]
+              .filter((value): value is string => Boolean(value))
+              .map(parse);
+            return candidates.some((candidate) => {
+              if (candidate.chatId !== parsedTarget.chatId) {
+                return false;
+              }
+              return (
+                parsedTarget.threadId === undefined || parsedTarget.threadId === candidate.threadId
+              );
+            });
+          },
+        },
+      };
+    }
     if (channel === "richchat") {
       return {
         messaging: {
@@ -172,12 +204,7 @@ describe("outbound policy helpers", () => {
       expected: /target provider "forum" while bound to "workspace"/,
     },
     {
-      cfg: {
-        ...workspaceConfig,
-        tools: {
-          message: { crossContext: { allowWithinProvider: false } },
-        },
-      } as OpenClawConfig,
+      cfg: workspaceConfig,
       channel: "workspace",
       action: "send" as const,
       to: "C999",
@@ -189,9 +216,18 @@ describe("outbound policy helpers", () => {
       cfg: {
         ...workspaceConfig,
         tools: {
-          message: { crossContext: { allowWithinProvider: false } },
+          message: { crossContext: { allowWithinProvider: true } },
         },
       } as OpenClawConfig,
+      channel: "workspace",
+      action: "send" as const,
+      to: "C999",
+      currentChannelId: "C123",
+      currentChannelProvider: "workspace",
+      expected: "allow" as const,
+    },
+    {
+      cfg: workspaceConfig,
       channel: "workspace",
       action: "upload-file" as const,
       to: "C999",
@@ -293,6 +329,74 @@ describe("outbound policy helpers", () => {
         cfg: {
           tools: {
             message: { crossContext: { allowWithinProvider: false } },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows a bare Telegram chat target when bound to its active topic", () => {
+    expect(() =>
+      enforceCrossContextPolicy({
+        channel: "telegram",
+        action: "send",
+        args: { to: "477789300" },
+        toolContext: {
+          currentChannelId: "477789300:topic:340799",
+          currentMessagingTarget: "477789300:topic:340799",
+          currentChannelProvider: "telegram",
+        },
+        cfg: {},
+      }),
+    ).not.toThrow();
+  });
+
+  it("denies a different Telegram chat by default", () => {
+    expect(() =>
+      enforceCrossContextPolicy({
+        channel: "telegram",
+        action: "send",
+        args: { to: "999999999" },
+        toolContext: {
+          currentChannelId: "477789300:topic:340799",
+          currentMessagingTarget: "477789300:topic:340799",
+          currentChannelProvider: "telegram",
+        },
+        cfg: {},
+      }),
+    ).toThrow(/Cross-context messaging denied/);
+  });
+
+  it("denies a different explicit Telegram topic by default", () => {
+    expect(() =>
+      enforceCrossContextPolicy({
+        channel: "telegram",
+        action: "send",
+        args: { to: "477789300:topic:340800" },
+        toolContext: {
+          currentChannelId: "477789300:topic:340799",
+          currentMessagingTarget: "477789300:topic:340799",
+          currentChannelProvider: "telegram",
+        },
+        cfg: {},
+      }),
+    ).toThrow(/Cross-context messaging denied/);
+  });
+
+  it("allows a different Telegram chat when explicitly opted in", () => {
+    expect(() =>
+      enforceCrossContextPolicy({
+        channel: "telegram",
+        action: "send",
+        args: { to: "999999999" },
+        toolContext: {
+          currentChannelId: "477789300:topic:340799",
+          currentMessagingTarget: "477789300:topic:340799",
+          currentChannelProvider: "telegram",
+        },
+        cfg: {
+          tools: {
+            message: { crossContext: { allowWithinProvider: true } },
           },
         },
       }),

--- a/src/infra/outbound/outbound-policy.ts
+++ b/src/infra/outbound/outbound-policy.ts
@@ -238,7 +238,7 @@ export function enforceCrossContextPolicy(params: {
   }
 
   const currentProvider = params.toolContext?.currentChannelProvider;
-  const allowWithinProvider = messageConfig?.crossContext?.allowWithinProvider !== false;
+  const allowWithinProvider = messageConfig?.crossContext?.allowWithinProvider === true;
   const allowAcrossProviders = messageConfig?.crossContext?.allowAcrossProviders === true;
 
   // Provider mismatch is stronger than target mismatch; normalize targets only within one provider.


### PR DESCRIPTION
## Summary

Deny same-provider cross-context `message` tool sends by default. A tool call bound to one conversation can still reply to its current conversation, but sending or uploading into another conversation on the same provider now requires explicit opt-in:

```json5
{
  tools: {
    message: {
      crossContext: {
        allowWithinProvider: true,
      },
    },
  },
}
```

The legacy broad `tools.message.allowCrossContextSend=true` escape hatch remains supported.

## What Problem This Solves

Cross-provider sends are denied by default, but current `main` still permits same-provider cross-context sends unless `allowWithinProvider` is explicitly `false`. That permissive default lets authorization or work in one conversation drive an externally visible send into another conversation on the same provider.

This PR makes current-conversation delivery the safe default while preserving an explicit compatibility opt-in for intentional bridge workflows.

## Changes

- Change `allowWithinProvider` from opt-out (`!== false`) to explicit opt-in (`=== true`).
- Keep ordinary current-conversation sends allowed.
- Add Telegram-owned context matching:
  - a bare chat target matches the active topic in that chat;
  - an explicit topic target must match the active topic exactly;
  - a different chat or explicit topic remains cross-context.
- Update focused policy, message-action, Telegram-target, config-help, and documentation coverage.
- Preserve action validation ordering and use host-issued capability context for cross-context authorization.

## Compatibility

This intentionally tightens an existing default. Deployments that send to other conversations on the same provider must set `tools.message.crossContext.allowWithinProvider=true` or use the existing legacy broad override.

## Validation

Candidate head: `4934f2bc348ee7e51ad17bf2c967bd4671801bab`.

Executed in an isolated source checkout:

```bash
node scripts/run-vitest.mjs run \
  extensions/telegram/src/targets.test.ts \
  src/infra/outbound/outbound-policy.test.ts \
  src/infra/outbound/message-action-runner.context.test.ts \
  src/infra/outbound/message-action-runner.core-send.test.ts \
  src/infra/outbound/message-action-runner.plugin-dispatch.test.ts \
  src/infra/outbound/message-action-runner.send-validation.test.ts \
  --reporter=dot

node scripts/run-vitest.mjs run src/config/schema.help.quality.test.ts --reporter=dot
node scripts/run-vitest.mjs run test/scripts/lint-suppressions.test.ts --reporter=dot
pnpm protocol:check
node --import tsx scripts/check-ts-max-loc.ts --base origin/main --head HEAD
pnpm tsgo:core
pnpm tsgo:core:test
pnpm tsgo:extensions:test
pnpm tsgo:test:root
node scripts/run-oxlint.mjs <changed TypeScript files>
pnpm exec oxfmt --check <changed files>
git diff --check
```

Observed results:

- Telegram/outbound/message-action tests: 188 passed.
- Schema-help and lint-suppression tests: 25 passed.
- Protocol and TypeScript LOC-ratchet gates: passed.
- Core, core-test, extensions-test, and root-test type gates: passed.
- Targeted lint, format, and whitespace gates: passed.
- Two unrelated CI timing failures were reproduced as isolated exact-test reruns and both passed; the current head is a no-code CI retrigger of the validated implementation.

## Native Telegram Proof Plan

The remaining proof must run against the exact current PR head through the trusted Telegram Desktop proof workflow. The workflow should record the resolved base SHA `B` and candidate SHA `H`; `H` must equal the current PR head above when proof starts.

Using approved disposable Telegram contexts, verify:

1. With default configuration, a send from one chat to a different chat is denied. Capture the deterministic policy denial and the absence of delivery.
2. With default configuration, an explicit send from one topic to a different topic in the same chat is denied.
3. With default configuration, a bare same-chat target succeeds in the active topic.
4. With `allowWithinProvider=true`, the controlled cross-context send succeeds.

Evidence should include exact `B`/`H` SHAs, unique stimuli, native Telegram before/after media, the workflow run and artifact links, and the proof bot comment. A missing Telegram delivery without deterministic policy output is not sufficient denial evidence.

Stop rule: do not run or accept proof if the PR head changes, the candidate is not mergeable/green, the workflow resolves a different candidate SHA, or the stimulus does not discriminate the four cases.

## What Was Not Tested

No production Gateway or private conversation was used. Native Telegram Desktop proof and maintainer acceptance of the fail-closed rollout remain the final external gates.
