### PR TITLE
[codex] Document Kubernetes observability wiring

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -70,6 +70,39 @@ openclaw plugins enable diagnostics-otel
 `protocol` currently supports `http/protobuf` only. `grpc` is ignored.
 </Note>
 
+## Kubernetes collectors
+
+In Kubernetes, point `diagnostics.otel.endpoint` at a collector service that is
+reachable from the Gateway pod. Use the collector's OTLP/HTTP port, commonly
+`4318`:
+
+```json5
+{
+  diagnostics: {
+    enabled: true,
+    otel: {
+      enabled: true,
+      endpoint: "http://otel-collector.observability.svc.cluster.local:4318",
+      protocol: "http/protobuf",
+      serviceName: "openclaw-gateway",
+      metrics: true,
+      traces: true,
+      logs: true,
+      captureContent: { enabled: false },
+    },
+  },
+}
+```
+
+Some cluster collectors expose OTLP/gRPC on port `4317` but do not expose
+OTLP/HTTP. OpenClaw does not export over gRPC today, so those deployments need
+an OTLP/HTTP receiver, a collector sidecar, or a cluster collector route that
+accepts HTTP protobuf.
+
+Container stdout/stderr logs are separate from `diagnostics-otel` log export.
+Use your platform log collector for process logs. Enable `diagnostics.otel.logs`
+when you also want structured diagnostic log records with trace context.
+
 ## Signals exported
 
 | Signal      | What goes in it                                                                                                                                                                                                    |

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -105,6 +105,52 @@ Edit the `AGENTS.md` in `scripts/k8s/manifests/configmap.yaml` and redeploy:
 
 Edit `openclaw.json` in `scripts/k8s/manifests/configmap.yaml`. See [Gateway configuration](/gateway/configuration) for the full reference.
 
+### Observability
+
+Kubernetes deployments usually have two separate observability paths:
+
+- Container stdout/stderr logs, collected by your cluster log pipeline.
+- OpenClaw diagnostics, exported by plugins as OpenTelemetry or Prometheus data.
+
+For OpenTelemetry push export, install and enable `diagnostics-otel`, then point
+the Gateway at an OTLP/HTTP collector that is reachable from the pod:
+
+```json5
+{
+  plugins: {
+    allow: ["diagnostics-otel"],
+    entries: {
+      "diagnostics-otel": { enabled: true },
+    },
+  },
+  diagnostics: {
+    enabled: true,
+    otel: {
+      enabled: true,
+      endpoint: "http://otel-collector.observability.svc.cluster.local:4318",
+      protocol: "http/protobuf",
+      serviceName: "openclaw-gateway",
+      metrics: true,
+      traces: true,
+      logs: true,
+      captureContent: { enabled: false },
+    },
+  },
+}
+```
+
+OpenClaw currently emits OTLP/HTTP protobuf. If your cluster collector exposes
+only OTLP/gRPC, add an OTLP/HTTP receiver or route OpenClaw through a collector
+that accepts HTTP on port `4318`.
+
+For Prometheus pull export, enable `diagnostics-prometheus` and scrape
+`/api/diagnostics/prometheus` through Gateway auth. Do not expose a public
+unauthenticated `/metrics` path.
+
+See [OpenTelemetry export](/gateway/opentelemetry) and
+[Prometheus metrics](/gateway/prometheus) for the full signal catalog and
+privacy model.
+
 ### Add providers
 
 Re-run with additional keys exported:


### PR DESCRIPTION
## Summary
- Document Kubernetes observability paths for container logs and OpenClaw diagnostics.
- Add OTLP/HTTP collector examples and the current gRPC export caveat.
- Link the Kubernetes install guide to the OpenTelemetry and Prometheus diagnostics docs.

## Validation
- `git diff --check`
- `node scripts/docs-list.js`
- `pnpm docs:list` could not complete in this checkout because dependency install was blocked by local npm auth, so I ran the docs index script directly.
- Not run: unit tests (docs-only change).