### PR TITLE
Prevent repeated byte-triggered compactions

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -10,6 +10,7 @@ import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   loadSessionEntry,
+  readSessionTranscriptActiveStats,
   readTranscriptStatsSync,
   upsertSessionEntry,
 } from "../../config/sessions/session-accessor.js";
@@ -349,6 +350,9 @@ describe("runMemoryFlushIfNeeded", () => {
       };
       if (typeof params.newSessionId === "string" && params.newSessionId) {
         nextEntry.sessionId = params.newSessionId;
+      }
+      if (params.transcriptBytesCompaction) {
+        nextEntry.transcriptBytesCompaction = params.transcriptBytesCompaction;
       }
       params.sessionStore[sessionKey] = nextEntry;
       if (typeof params.storePath === "string") {
@@ -2801,6 +2805,154 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.trigger).toBe("budget");
     expect(compactCall.currentTokenCount).toBe(12);
     expect(compactCall.sessionFile).toBe("main");
+    expect(entry).toMatchObject({
+      transcriptBytesCompaction: {
+        bytes: expect.any(Number),
+        threshold: 10,
+        sessionId: "session",
+      },
+    });
+  });
+
+  it("suppresses repeated byte compaction until the active SQLite transcript grows", async () => {
+    const storePath = path.join(rootDir, "sqlite-byte-retry.json");
+    const sessionKey = "agent:main:main";
+    const scope = { agentId: "main", sessionId: "session", sessionKey, storePath };
+    await upsertSessionEntry(scope, { sessionId: "session", updatedAt: 10 });
+    await replaceSqliteTranscriptEvents(scope, [
+      { message: { role: "user", content: "x".repeat(256) }, type: "message" },
+    ]);
+    const byteSize = readSessionTranscriptActiveStats(scope).sizeBytes;
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 10,
+      totalTokensFresh: true,
+      compactionCount: 1,
+      transcriptBytesCompaction: { bytes: byteSize, threshold: 10, sessionId: "session" },
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { maxActiveTranscriptBytes: "10b" } } } },
+      followupRun: createTestFollowupRun({ sessionId: "session", sessionKey }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath,
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("retries byte compaction after any active SQLite transcript growth", async () => {
+    const storePath = path.join(rootDir, "sqlite-byte-growth-retry.json");
+    const sessionKey = "agent:main:main";
+    const scope = { agentId: "main", sessionId: "session", sessionKey, storePath };
+    await upsertSessionEntry(scope, { sessionId: "session", updatedAt: 10 });
+    await replaceSqliteTranscriptEvents(scope, [
+      { message: { role: "user", content: "x".repeat(256) }, type: "message" },
+    ]);
+    const previousBytes = readSessionTranscriptActiveStats(scope).sizeBytes;
+    await replaceSqliteTranscriptEvents(scope, [
+      { message: { role: "user", content: "x".repeat(257) }, type: "message" },
+    ]);
+    expect(readSessionTranscriptActiveStats(scope).sizeBytes).toBeGreaterThan(previousBytes);
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 10,
+      totalTokensFresh: true,
+      compactionCount: 1,
+      transcriptBytesCompaction: { bytes: previousBytes, threshold: 10, sessionId: "session" },
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { maxActiveTranscriptBytes: "10b" } } } },
+      followupRun: createTestFollowupRun({ sessionId: "session", sessionKey }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath,
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry?.compactionCount).toBe(2);
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledOnce();
+  });
+
+  it("records the rotated SQLite successor size instead of the predecessor size", async () => {
+    const storePath = path.join(rootDir, "sqlite-byte-successor.json");
+    const sessionKey = "agent:main:main";
+    const predecessorScope = {
+      agentId: "main",
+      sessionId: "session",
+      sessionKey,
+      storePath,
+    };
+    const successorScope = {
+      agentId: "main",
+      sessionId: "session-rotated",
+      sessionKey,
+      storePath,
+    };
+    await upsertSessionEntry(predecessorScope, { sessionId: "session", updatedAt: 10 });
+    await replaceSqliteTranscriptEvents(predecessorScope, [
+      { message: { role: "user", content: "x".repeat(4096) }, type: "message" },
+    ]);
+    const predecessorBytes = readTranscriptStatsSync(predecessorScope).sizeBytes;
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 10,
+      totalTokensFresh: true,
+      compactionCount: 0,
+    };
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    compactEmbeddedAgentSessionMock.mockImplementationOnce(async () => {
+      await upsertSessionEntry(successorScope, { sessionId: "session-rotated", updatedAt: 20 });
+      await replaceSqliteTranscriptEvents(successorScope, [
+        { message: { role: "user", content: "successor" }, type: "message" },
+      ]);
+      return {
+        ok: true,
+        compacted: true,
+        result: { tokensAfter: 42, sessionId: "session-rotated" },
+      };
+    });
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { maxActiveTranscriptBytes: "10b" } } } },
+      followupRun: createTestFollowupRun({ sessionId: "session", sessionKey }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    const successorBytes = readSessionTranscriptActiveStats(successorScope).sizeBytes;
+    expect(successorBytes).not.toBe(predecessorBytes);
+    expect(entry).toMatchObject({
+      sessionId: "session-rotated",
+      transcriptBytesCompaction: {
+        bytes: successorBytes,
+        threshold: 10,
+        sessionId: "session-rotated",
+      },
+    });
   });
 
   it("byte-guards a Codex runtime session through SQLite semantic compaction", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -365,6 +365,39 @@ type SessionTranscriptUsageSnapshot = {
 const TRANSCRIPT_OUTPUT_READ_BUFFER_TOKENS = 8192;
 const SQLITE_USAGE_TAIL_MAX_EVENTS = 512;
 const FALLBACK_TRANSCRIPT_BYTES_PER_TOKEN = 4;
+// A byte-triggered compaction can leave the successor transcript above the
+// configured threshold. Suppress only an identical no-growth retry; any later
+// transcript growth must preserve the configured threshold semantics.
+
+function shouldSuppressTranscriptBytesCompactionRetry(params: {
+  entry: SessionEntry;
+  activeTranscriptBytes?: number;
+  maxActiveTranscriptBytes?: number;
+  activeTranscriptSessionId?: string;
+}): boolean {
+  const previous = params.entry.transcriptBytesCompaction;
+  if (
+    typeof params.activeTranscriptBytes !== "number" ||
+    !Number.isFinite(params.activeTranscriptBytes) ||
+    typeof params.maxActiveTranscriptBytes !== "number" ||
+    !Number.isFinite(params.maxActiveTranscriptBytes) ||
+    typeof previous?.bytes !== "number" ||
+    !Number.isFinite(previous.bytes) ||
+    typeof previous.threshold !== "number" ||
+    !Number.isFinite(previous.threshold) ||
+    previous.threshold !== params.maxActiveTranscriptBytes
+  ) {
+    return false;
+  }
+
+  const previousSessionId = normalizeOptionalString(previous.sessionId);
+  const currentSessionId = normalizeOptionalString(params.activeTranscriptSessionId);
+  if (!previousSessionId || !currentSessionId || previousSessionId !== currentSessionId) {
+    return false;
+  }
+
+  return params.activeTranscriptBytes <= previous.bytes;
+}
 
 function deriveTranscriptUsageSnapshot(
   snapshot:
@@ -763,10 +796,21 @@ export async function runPreflightCompactionIfNeeded(params: {
       : undefined;
   const activeTranscriptBytes =
     transcriptUsageTokens?.transcriptByteSize ?? transcriptSizeSnapshot?.byteSize;
-  const shouldCompactByTranscriptBytes =
+  const activeTranscriptSessionId = normalizeOptionalString(entry.sessionId);
+  const rawShouldCompactByTranscriptBytes =
     typeof activeTranscriptBytes === "number" &&
     typeof maxActiveTranscriptBytes === "number" &&
     activeTranscriptBytes >= maxActiveTranscriptBytes;
+  const suppressTranscriptBytesCompaction =
+    rawShouldCompactByTranscriptBytes &&
+    shouldSuppressTranscriptBytesCompactionRetry({
+      entry,
+      activeTranscriptBytes,
+      maxActiveTranscriptBytes,
+      activeTranscriptSessionId,
+    });
+  const shouldCompactByTranscriptBytes =
+    rawShouldCompactByTranscriptBytes && !suppressTranscriptBytesCompaction;
   if (isCodexRuntime && !shouldCompactByTranscriptBytes) {
     // Codex owns native-thread token pressure; OpenClaw owns the host transcript byte fuse
     // that bounds fresh-thread bootstrap seeds.
@@ -821,7 +865,8 @@ export async function runPreflightCompactionIfNeeded(params: {
       `promptTokensEst=${promptTokenEstimate ?? "undefined"} ` +
       `activeTranscriptBytes=${activeTranscriptBytes ?? "undefined"} ` +
       `maxActiveTranscriptBytes=${maxActiveTranscriptBytes ?? "undefined"} ` +
-      `sizeTrigger=${shouldCompactByTranscriptBytes}`,
+      `sizeTrigger=${shouldCompactByTranscriptBytes} ` +
+      `sizeRetrySuppressed=${suppressTranscriptBytesCompaction}`,
   );
 
   const shouldCompactByTokens = shouldRunPreflightCompaction({
@@ -833,6 +878,15 @@ export async function runPreflightCompactionIfNeeded(params: {
     minimumThresholdTokens: serverCompactionThreshold,
   });
   const shouldCompact = shouldCompactByTokens || shouldCompactByTranscriptBytes;
+  if (suppressTranscriptBytesCompaction) {
+    logVerbose(
+      `preflightCompaction byte trigger suppressed: sessionKey=${params.sessionKey} ` +
+        `activeTranscriptBytes=${activeTranscriptBytes ?? "undefined"} ` +
+        `maxActiveTranscriptBytes=${maxActiveTranscriptBytes ?? "undefined"} ` +
+        `previousActiveTranscriptBytes=${entry.transcriptBytesCompaction?.bytes ?? "undefined"} ` +
+        `sessionId=${activeTranscriptSessionId ?? "undefined"}`,
+    );
+  }
   if (!shouldCompact) {
     return entry ?? params.sessionEntry;
   }
@@ -942,6 +996,22 @@ export async function runPreflightCompactionIfNeeded(params: {
       throw new Error(`Preflight compaction required but failed: ${reason}`);
     }
 
+    const postCompactionSessionId =
+      compactionTrigger === "transcript_bytes"
+        ? (normalizeOptionalString(result.result?.sessionId) ?? activeTranscriptSessionId)
+        : undefined;
+    const postCompactionTranscriptBytes =
+      compactionTrigger === "transcript_bytes" && postCompactionSessionId
+        ? readSessionLogSnapshot({
+            agentId: compactionAgentId,
+            sessionId: postCompactionSessionId,
+            sessionKey: compactionSessionKey,
+            storePath: compactionStorePath,
+            includeByteSize: true,
+            includeUsage: false,
+          }).byteSize
+        : undefined;
+
     await deps.incrementCompactionCount({
       agentId: compactionAgentId,
       cfg: params.cfg,
@@ -951,7 +1021,27 @@ export async function runPreflightCompactionIfNeeded(params: {
       storePath: compactionStorePath,
       tokensAfter: result.result?.tokensAfter,
       newSessionId: result.result?.sessionId,
+      transcriptBytesCompaction:
+        compactionTrigger === "transcript_bytes" &&
+        typeof postCompactionTranscriptBytes === "number" &&
+        typeof maxActiveTranscriptBytes === "number" &&
+        postCompactionSessionId
+          ? {
+              bytes: postCompactionTranscriptBytes,
+              threshold: maxActiveTranscriptBytes,
+              sessionId: postCompactionSessionId,
+            }
+          : undefined,
     });
+    if (compactionTrigger === "transcript_bytes") {
+      logVerbose(
+        `preflightCompaction transcript byte result: sessionKey=${params.sessionKey} ` +
+          `activeTranscriptBytesBefore=${activeTranscriptBytes ?? "undefined"} ` +
+          `activeTranscriptBytesAfter=${postCompactionTranscriptBytes ?? "undefined"} ` +
+          `maxActiveTranscriptBytes=${maxActiveTranscriptBytes ?? "undefined"} ` +
+          `sessionId=${postCompactionSessionId ?? "undefined"}`,
+      );
+    }
     await appendPostCompactionRefreshPrompt({
       cfg: params.cfg,
       followupRun: params.followupRun,

--- a/src/auto-reply/reply/agent-runner-session-reset.test.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.test.ts
@@ -112,6 +112,11 @@ describe("resetReplyRunSession", () => {
       },
       compactionCount: 4,
       memoryFlush: { kind: "failed", compactionCount: 3, failureCount: 2 },
+      transcriptBytesCompaction: {
+        sessionId: "session",
+        threshold: 1_000,
+        bytes: 2_000,
+      },
       systemPromptReport: {
         source: "run",
         generatedAt: 1,
@@ -162,6 +167,7 @@ describe("resetReplyRunSession", () => {
     expect(activeSessionEntry?.fallbackNotice).toBeUndefined();
     expect(activeSessionEntry?.compactionCount).toBe(0);
     expect(activeSessionEntry?.memoryFlush).toBeUndefined();
+    expect(activeSessionEntry?.transcriptBytesCompaction).toBeUndefined();
     expect(activeSessionEntry?.systemPromptReport).toBeUndefined();
     expect(activeSessionEntry?.compactionCount).toBe(0);
     expect(activeSessionEntry?.memoryFlush).toBeUndefined();
@@ -186,6 +192,7 @@ describe("resetReplyRunSession", () => {
     expect(persisted?.fallbackNotice).toBeUndefined();
     expect(persisted?.compactionCount).toBe(0);
     expect(persisted?.memoryFlush).toBeUndefined();
+    expect(persisted?.transcriptBytesCompaction).toBeUndefined();
   });
 
   it("rejects automatic recovery rotation for a model-locked session", async () => {

--- a/src/auto-reply/reply/agent-runner-session-reset.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.ts
@@ -95,6 +95,7 @@ export async function resetReplyRunSession(params: {
     fallbackNotice: undefined,
     compactionCount: 0,
     memoryFlush: undefined,
+    transcriptBytesCompaction: undefined,
   };
   clearAllCliSessions(nextEntry);
   nextEntry.agentHarnessId = undefined;

--- a/src/auto-reply/reply/session-updates.test.ts
+++ b/src/auto-reply/reply/session-updates.test.ts
@@ -80,7 +80,7 @@ vi.mock("../../routing/session-key.js", () => ({
   resolveAgentIdFromSessionKey: resolveAgentIdFromSessionKeyMock,
 }));
 
-const { ensureSkillSnapshot } = await import("./session-updates.js");
+const { ensureSkillSnapshot, incrementCompactionCount } = await import("./session-updates.js");
 
 describe("ensureSkillSnapshot", () => {
   beforeEach(() => {
@@ -308,5 +308,66 @@ describe("ensureSkillSnapshot", () => {
     });
     expect(result.sessionEntry?.pinnedAt).toBeUndefined();
     expect(sessionStore[sessionKey]).toEqual(result.sessionEntry);
+  });
+});
+
+describe("incrementCompactionCount", () => {
+  it("persists byte-triggered compaction metadata in the session entry", async () => {
+    const sessionEntry = {
+      sessionId: "session",
+      sessionFile: "/tmp/session.jsonl",
+      updatedAt: 1,
+      compactionCount: 0,
+    };
+    const sessionStore = { main: sessionEntry };
+
+    const nextCount = await incrementCompactionCount({
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      now: 123,
+      tokensAfter: 42,
+      transcriptBytesCompaction: {
+        bytes: 1234.9,
+        threshold: 100,
+        sessionId: "session-after-compaction",
+      },
+    });
+
+    expect(nextCount).toBe(1);
+    expect(sessionStore.main).toMatchObject({
+      compactionCount: 1,
+      totalTokens: 42,
+      totalTokensFresh: true,
+      transcriptBytesCompaction: {
+        bytes: 1234,
+        threshold: 100,
+        sessionId: "session-after-compaction",
+      },
+    });
+  });
+
+  it("clears stale byte-triggered metadata for ordinary token compactions", async () => {
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: 1,
+      compactionCount: 0,
+      transcriptBytesCompaction: {
+        bytes: 1234,
+        threshold: 100,
+        sessionId: "session",
+      },
+    };
+    const sessionStore = { main: sessionEntry };
+
+    await incrementCompactionCount({
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      now: 123,
+      tokensAfter: 42,
+    });
+
+    expect(sessionStore.main.transcriptBytesCompaction).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -1,5 +1,6 @@
 /** Session update helpers for skill snapshots, compaction, and lifecycle hooks. */
 import crypto from "node:crypto";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import {
   type ExecPolicyOverrides,
@@ -322,6 +323,8 @@ export async function incrementCompactionCount(params: {
   tokensAfter?: number;
   /** Session id after compaction when a context engine changed identity. */
   newSessionId?: string;
+  /** State recorded after a byte-triggered preflight compaction. */
+  transcriptBytesCompaction?: SessionEntry["transcriptBytesCompaction"];
 }): Promise<number | undefined> {
   const {
     agentId,
@@ -334,6 +337,7 @@ export async function incrementCompactionCount(params: {
     amount = 1,
     tokensAfter,
     newSessionId,
+    transcriptBytesCompaction,
   } = params;
   if (!sessionStore || !sessionKey) {
     return undefined;
@@ -369,6 +373,34 @@ export async function incrementCompactionCount(params: {
     updates.cacheWrite = undefined;
   } else if (incrementBy > 0) {
     updates.totalTokensFresh = false;
+  }
+  const normalizedTranscriptBytesCompactionBytes =
+    typeof transcriptBytesCompaction?.bytes === "number" &&
+    Number.isFinite(transcriptBytesCompaction.bytes) &&
+    transcriptBytesCompaction.bytes >= 0
+      ? Math.floor(transcriptBytesCompaction.bytes)
+      : undefined;
+  const normalizedTranscriptBytesCompactionThreshold =
+    typeof transcriptBytesCompaction?.threshold === "number" &&
+    Number.isFinite(transcriptBytesCompaction.threshold) &&
+    transcriptBytesCompaction.threshold > 0
+      ? Math.floor(transcriptBytesCompaction.threshold)
+      : undefined;
+  const normalizedTranscriptBytesCompactionSessionId = normalizeOptionalString(
+    transcriptBytesCompaction?.sessionId,
+  );
+  if (
+    normalizedTranscriptBytesCompactionBytes !== undefined &&
+    normalizedTranscriptBytesCompactionThreshold !== undefined &&
+    normalizedTranscriptBytesCompactionSessionId
+  ) {
+    updates.transcriptBytesCompaction = {
+      bytes: normalizedTranscriptBytesCompactionBytes,
+      threshold: normalizedTranscriptBytesCompactionThreshold,
+      sessionId: normalizedTranscriptBytesCompactionSessionId,
+    };
+  } else {
+    updates.transcriptBytesCompaction = undefined;
   }
   const nextEntry = projectCanonicalSessionEntryShape({ ...entry, ...updates });
   sessionStore[sessionKey] = nextEntry;

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1197,6 +1197,7 @@ describe("initSessionState RawBody", () => {
         },
         compactionCount: 3,
         memoryFlush: { kind: "failed", compactionCount: 2, failureCount: 3 },
+        transcriptBytesCompaction: { lastAttemptBytes: 42_000, blockedAtBytes: 42_000 },
         skillsSnapshot: {
           prompt: "<available_skills><skill><name>stale</name></skill></available_skills>",
           skills: [{ name: "stale" }],
@@ -1231,6 +1232,7 @@ describe("initSessionState RawBody", () => {
     expect(result.sessionEntry.contextBudgetStatus).toBeUndefined();
     expect(result.sessionEntry.compactionCount).toBe(0);
     expect(result.sessionEntry.memoryFlush).toBeUndefined();
+    expect(result.sessionEntry.transcriptBytesCompaction).toBeUndefined();
 
     const store = readSessionStoreFast(storePath) as Record<
       string,
@@ -1242,6 +1244,7 @@ describe("initSessionState RawBody", () => {
         contextBudgetStatus?: unknown;
         compactionCount?: number;
         memoryFlush?: unknown;
+        transcriptBytesCompaction?: unknown;
       }
     >;
     expect(store[sessionKey]?.skillsSnapshot).toBeUndefined();
@@ -1251,6 +1254,7 @@ describe("initSessionState RawBody", () => {
     expect(store[sessionKey]?.contextBudgetStatus).toBeUndefined();
     expect(store[sessionKey]?.compactionCount).toBe(0);
     expect(store[sessionKey]?.memoryFlush).toBeUndefined();
+    expect(store[sessionKey]?.transcriptBytesCompaction).toBeUndefined();
   });
 
   it("drains stale system events when /new rotates an existing session", async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -937,6 +937,7 @@ async function initSessionStateAttemptLocked(
   if (isNewSession) {
     sessionEntry.compactionCount = 0;
     sessionEntry.memoryFlush = undefined;
+    sessionEntry.transcriptBytesCompaction = undefined;
     // Runtime model fields are persisted last-run cache, not user selection.
     // Reset must drop them so the next turn resolves current defaults or the
     // explicit providerOverride/modelOverride values preserved above.

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -555,6 +555,12 @@ type SessionEntryCore = SessionRestartRecoveryState &
     contextTokens?: number;
     contextBudgetStatus?: SessionContextBudgetStatus;
     compactionCount?: number;
+    /** State recorded after the last byte-triggered preflight compaction. */
+    transcriptBytesCompaction?: {
+      bytes: number;
+      threshold: number;
+      sessionId: string;
+    };
     compactionCheckpoints?: SessionCompactionCheckpoint[];
     memoryFlush?: MemoryFlushState;
     cliSessionIds?: Record<string, string>;

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -141,6 +141,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "contextTokens",
   "contextBudgetStatus",
   "compactionCount",
+  "transcriptBytesCompaction",
   "compactionCheckpoints",
   "memoryFlush",
   "cliSessionIds",


### PR DESCRIPTION
## What Problem This Solves

Prevent repeated byte-triggered preflight compaction when the active SQLite transcript has not grown since the prior byte-triggered compaction.

Any positive transcript growth re-enables the configured byte threshold. Token-triggered compaction is unchanged.

## Behavior

- First crossing of `maxActiveTranscriptBytes`: compact.
- Same session, threshold, and active byte count: suppress the duplicate retry.
- Any positive active-transcript growth: allow the next byte-triggered retry.
- Logical session reset: clear the byte-compaction marker, including same-ID reset.
- Successful non-byte compaction: clear stale byte-retry metadata.

## Evidence

Exact head: `6567a1e2ace9608da31aac9d8c93ce7c569e0869`

- 78 focused memory/session tests passed.
- Exact-head GitHub Actions: 8/8 workflows passed.
- `mergeable=true` against current `main`.

### Exact-head real behavior proof

An isolated temporary SQLite transcript exercised the real `runPreflightCompactionIfNeeded` path and logical `/new` session initialization. Only the compactor boundary was substituted.

- Initial active bytes: `314`; first threshold crossing compacted once.
- Unchanged transcript: compaction count remained `1`.
- Growth to `315` bytes: compaction count advanced to `2`.
- Same-ID logical reset: `isNewSession=true`, `resetTriggered=true`, marker cleared.
- No live Gateway, real credential, or production state was used.
