### PR TITLE
fix: avoid false macOS update failures during gateway shutdown

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1112,6 +1112,32 @@ describe("launchd install", () => {
     expect(output).toContain("Stopped LaunchAgent");
   });
 
+  it("waits for the configured gateway port to finish releasing after bootout", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_GATEWAY_PORT: "19009",
+    };
+    inspectPortUsage
+      .mockResolvedValueOnce({
+        port: 19009,
+        status: "busy",
+        listeners: [],
+        hints: [],
+      })
+      .mockResolvedValueOnce({
+        port: 19009,
+        status: "free",
+        listeners: [],
+        hints: [],
+      });
+
+    await runStopLaunchAgentWithFakeTimers({ env, stdout: new PassThrough() });
+
+    expect(inspectPortUsage).toHaveBeenCalledTimes(2);
+    expect(inspectPortUsage).toHaveBeenNthCalledWith(1, 19009);
+    expect(inspectPortUsage).toHaveBeenNthCalledWith(2, 19009);
+  });
+
   it("resolves the stop postcondition port from the stored LaunchAgent environment", async () => {
     const env = createDefaultLaunchdEnv();
     await installLaunchAgent({
@@ -1146,7 +1172,7 @@ describe("launchd install", () => {
     });
     formatPortDiagnostics.mockReturnValue(["Port 19004 is held by pid 4242."]);
 
-    await expect(stopLaunchAgent({ env, stdout })).rejects.toThrow(
+    await expect(runStopLaunchAgentWithFakeTimers({ env, stdout })).rejects.toThrow(
       "gateway port 19004 is still busy after LaunchAgent stop\nPort 19004 is held by pid 4242.",
     );
 
@@ -1291,7 +1317,7 @@ describe("launchd install", () => {
     });
     formatPortDiagnostics.mockReturnValue(["Port 19008 is held by pid 4242."]);
 
-    await expect(stopLaunchAgent({ env, stdout, disable: true })).rejects.toThrow(
+    await expect(runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true })).rejects.toThrow(
       "gateway port 19008 is still busy after LaunchAgent stop\nPort 19008 is held by pid 4242.",
     );
 

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -65,6 +65,9 @@ const cleanStaleGatewayProcessesSync = vi.hoisted(() =>
 const inspectPortUsage = vi.hoisted(() =>
   vi.fn(async () => ({ port: 18789, status: "free", listeners: [], hints: [] })),
 );
+const probePortUsage = vi.hoisted(() =>
+  vi.fn<typeof import("../infra/ports-probe.js").probePortUsage>(async () => "free"),
+);
 const formatPortDiagnostics = vi.hoisted(() => vi.fn(() => ["Port 18789 is already in use."]));
 const defaultProgramArguments = ["node", "-e", "process.exit(0)"];
 
@@ -262,6 +265,10 @@ vi.mock("../infra/ports.js", () => ({
   formatPortDiagnostics,
 }));
 
+vi.mock("../infra/ports-probe.js", () => ({
+  probePortUsage,
+}));
+
 vi.mock("node:fs/promises", async () => {
   const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
   const wrapped = {
@@ -354,6 +361,8 @@ beforeEach(() => {
   cleanStaleGatewayProcessesSync.mockReturnValue([]);
   inspectPortUsage.mockReset();
   inspectPortUsage.mockResolvedValue({ port: 18789, status: "free", listeners: [], hints: [] });
+  probePortUsage.mockReset();
+  probePortUsage.mockResolvedValue("free");
   formatPortDiagnostics.mockReset();
   formatPortDiagnostics.mockReturnValue(["Port 18789 is already in use."]);
   launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff.mockReset();
@@ -1117,25 +1126,35 @@ describe("launchd install", () => {
       ...createDefaultLaunchdEnv(),
       OPENCLAW_GATEWAY_PORT: "19009",
     };
-    inspectPortUsage
-      .mockResolvedValueOnce({
-        port: 19009,
-        status: "busy",
-        listeners: [],
-        hints: [],
-      })
-      .mockResolvedValueOnce({
-        port: 19009,
-        status: "free",
-        listeners: [],
-        hints: [],
-      });
+    inspectPortUsage.mockResolvedValueOnce({
+      port: 19009,
+      status: "busy",
+      listeners: [],
+      hints: [],
+    });
 
     await runStopLaunchAgentWithFakeTimers({ env, stdout: new PassThrough() });
 
-    expect(inspectPortUsage).toHaveBeenCalledTimes(2);
-    expect(inspectPortUsage).toHaveBeenNthCalledWith(1, 19009);
-    expect(inspectPortUsage).toHaveBeenNthCalledWith(2, 19009);
+    expect(inspectPortUsage).toHaveBeenCalledTimes(1);
+    expect(probePortUsage).toHaveBeenCalledWith(19009);
+  });
+
+  it("keeps waiting until a bind probe explicitly confirms port release", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_GATEWAY_PORT: "19010",
+    };
+    inspectPortUsage.mockResolvedValueOnce({
+      port: 19010,
+      status: "busy",
+      listeners: [],
+      hints: [],
+    });
+    probePortUsage.mockResolvedValueOnce("busy").mockResolvedValueOnce("unknown");
+
+    await runStopLaunchAgentWithFakeTimers({ env, stdout: new PassThrough() });
+
+    expect(probePortUsage).toHaveBeenCalledTimes(3);
   });
 
   it("resolves the stop postcondition port from the stored LaunchAgent environment", async () => {
@@ -1170,6 +1189,7 @@ describe("launchd install", () => {
       listeners: [],
       hints: [],
     });
+    probePortUsage.mockResolvedValue("busy");
     formatPortDiagnostics.mockReturnValue(["Port 19004 is held by pid 4242."]);
 
     await expect(runStopLaunchAgentWithFakeTimers({ env, stdout })).rejects.toThrow(
@@ -1315,6 +1335,7 @@ describe("launchd install", () => {
       listeners: [],
       hints: [],
     });
+    probePortUsage.mockResolvedValue("busy");
     formatPortDiagnostics.mockReturnValue(["Port 19008 is held by pid 4242."]);
 
     await expect(runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true })).rejects.toThrow(

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -5,6 +5,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { normalizeEnvVarKey } from "../infra/host-env-security.js";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
+import { probePortUsage } from "../infra/ports-probe.js";
 import { formatPortDiagnostics, inspectPortUsage } from "../infra/ports.js";
 import { cleanStaleGatewayProcessesSync } from "../infra/restart-stale-pids.js";
 import { parseTcpPort } from "../infra/tcp-port.js";
@@ -49,7 +50,7 @@ const LAUNCH_AGENT_ENV_DIR_NAME = "service-env";
 const LAUNCH_AGENT_STDERR_PATH = "/dev/null";
 const OPENCLAW_UPDATE_LAUNCHD_LABEL_PREFIX = "ai.openclaw.update.";
 const OPENCLAW_MANUAL_UPDATE_LAUNCHD_LABEL_PATTERN = /^ai\.openclaw\.manual-update\.\d+$/;
-const LAUNCH_AGENT_STOP_PORT_RELEASE_ATTEMPTS = 20;
+const LAUNCH_AGENT_STOP_PORT_RELEASE_TIMEOUT_MS = 2_000;
 const LAUNCH_AGENT_STOP_PORT_RELEASE_POLL_MS = 100;
 
 export type StaleOpenClawUpdateLaunchdJob = {
@@ -773,22 +774,29 @@ async function waitForLaunchAgentStopped(serviceTarget: string): Promise<LaunchA
   return lastUnknown ?? { state: "running" };
 }
 
+async function waitForGatewayPortRelease(port: number): Promise<boolean> {
+  const deadline = Date.now() + LAUNCH_AGENT_STOP_PORT_RELEASE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await sleep(Math.min(LAUNCH_AGENT_STOP_PORT_RELEASE_POLL_MS, deadline - Date.now()));
+    const status = await probePortUsage(port);
+    if (status === "free") {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function assertGatewayPortReleasedAfterStop(env: GatewayServiceEnv): Promise<void> {
   const port = await resolveLaunchAgentGatewayPort(env);
   if (port === null) {
     return;
   }
   cleanStaleGatewayProcessesSync(port);
-  let diagnostics = await inspectPortUsage(port).catch(() => null);
-  for (
-    let attempt = 1;
-    diagnostics?.status === "busy" && attempt < LAUNCH_AGENT_STOP_PORT_RELEASE_ATTEMPTS;
-    attempt += 1
-  ) {
-    await sleep(LAUNCH_AGENT_STOP_PORT_RELEASE_POLL_MS);
-    diagnostics = await inspectPortUsage(port).catch(() => null);
-  }
+  const diagnostics = await inspectPortUsage(port).catch(() => null);
   if (diagnostics?.status !== "busy") {
+    return;
+  }
+  if (await waitForGatewayPortRelease(port)) {
     return;
   }
   throw new Error(

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -23,6 +23,7 @@ import { execFileUtf8 } from "./exec-file.js";
 import { isCurrentProcessLaunchdServiceLabel } from "./launchd-current-service.js";
 import {
   buildLaunchAgentPlist as buildLaunchAgentPlistImpl,
+  LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS,
   readLaunchAgentProgramArgumentsFromFile,
 } from "./launchd-plist.js";
 import { scheduleDetachedLaunchdRestartHandoff } from "./launchd-restart-handoff.js";
@@ -50,7 +51,7 @@ const LAUNCH_AGENT_ENV_DIR_NAME = "service-env";
 const LAUNCH_AGENT_STDERR_PATH = "/dev/null";
 const OPENCLAW_UPDATE_LAUNCHD_LABEL_PREFIX = "ai.openclaw.update.";
 const OPENCLAW_MANUAL_UPDATE_LAUNCHD_LABEL_PATTERN = /^ai\.openclaw\.manual-update\.\d+$/;
-const LAUNCH_AGENT_STOP_PORT_RELEASE_TIMEOUT_MS = 2_000;
+const LAUNCH_AGENT_STOP_PORT_RELEASE_TIMEOUT_MS = LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS * 1_000;
 const LAUNCH_AGENT_STOP_PORT_RELEASE_POLL_MS = 100;
 
 export type StaleOpenClawUpdateLaunchdJob = {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -9,6 +9,7 @@ import { formatPortDiagnostics, inspectPortUsage } from "../infra/ports.js";
 import { cleanStaleGatewayProcessesSync } from "../infra/restart-stale-pids.js";
 import { parseTcpPort } from "../infra/tcp-port.js";
 import { getWindowsCmdExePath } from "../infra/windows-install-roots.js";
+import { sleep } from "../utils.js";
 import {
   GATEWAY_LAUNCH_AGENT_LABEL,
   GATEWAY_SERVICE_KIND,
@@ -48,6 +49,8 @@ const LAUNCH_AGENT_ENV_DIR_NAME = "service-env";
 const LAUNCH_AGENT_STDERR_PATH = "/dev/null";
 const OPENCLAW_UPDATE_LAUNCHD_LABEL_PREFIX = "ai.openclaw.update.";
 const OPENCLAW_MANUAL_UPDATE_LAUNCHD_LABEL_PATTERN = /^ai\.openclaw\.manual-update\.\d+$/;
+const LAUNCH_AGENT_STOP_PORT_RELEASE_ATTEMPTS = 20;
+const LAUNCH_AGENT_STOP_PORT_RELEASE_POLL_MS = 100;
 
 export type StaleOpenClawUpdateLaunchdJob = {
   label: string;
@@ -776,7 +779,15 @@ async function assertGatewayPortReleasedAfterStop(env: GatewayServiceEnv): Promi
     return;
   }
   cleanStaleGatewayProcessesSync(port);
-  const diagnostics = await inspectPortUsage(port).catch(() => null);
+  let diagnostics = await inspectPortUsage(port).catch(() => null);
+  for (
+    let attempt = 1;
+    diagnostics?.status === "busy" && attempt < LAUNCH_AGENT_STOP_PORT_RELEASE_ATTEMPTS;
+    attempt += 1
+  ) {
+    await sleep(LAUNCH_AGENT_STOP_PORT_RELEASE_POLL_MS);
+    diagnostics = await inspectPortUsage(port).catch(() => null);
+  }
   if (diagnostics?.status !== "busy") {
     return;
   }

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -2,11 +2,10 @@
 import os from "node:os";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { runCommandWithTimeout } from "../process/exec.js";
-import { isErrno } from "./errors.js";
 import { parseStrictPositiveInteger } from "./parse-finite-number.js";
 import { buildPortHints } from "./ports-format.js";
 import { resolveLsofCommand } from "./ports-lsof.js";
-import { tryListenOnPort } from "./ports-probe.js";
+import { probePortUsage } from "./ports-probe.js";
 import type {
   PortConnection,
   PortConnectionDirection,
@@ -610,36 +609,6 @@ async function readWindowsEstablishedConnections(
   return { connections: result.entries, detail: result.detail, errors: result.errors };
 }
 
-async function tryListenOnHost(port: number, host: string): Promise<PortUsageStatus | "skip"> {
-  try {
-    await tryListenOnPort({ port, host, exclusive: true });
-    return "free";
-  } catch (err) {
-    if (isErrno(err) && err.code === "EADDRINUSE") {
-      return "busy";
-    }
-    if (isErrno(err) && (err.code === "EADDRNOTAVAIL" || err.code === "EAFNOSUPPORT")) {
-      return "skip";
-    }
-    return "unknown";
-  }
-}
-
-async function checkPortInUse(port: number): Promise<PortUsageStatus> {
-  const hosts = ["127.0.0.1", "0.0.0.0", "::1", "::"];
-  let sawUnknown = false;
-  for (const host of hosts) {
-    const result = await tryListenOnHost(port, host);
-    if (result === "busy") {
-      return "busy";
-    }
-    if (result === "unknown") {
-      sawUnknown = true;
-    }
-  }
-  return sawUnknown ? "unknown" : "free";
-}
-
 export async function inspectPortUsage(port: number): Promise<PortUsage> {
   const errors: string[] = [];
   const result =
@@ -648,7 +617,7 @@ export async function inspectPortUsage(port: number): Promise<PortUsage> {
   let listeners = result.listeners;
   let status: PortUsageStatus = listeners.length > 0 ? "busy" : "unknown";
   if (listeners.length === 0) {
-    status = await checkPortInUse(port);
+    status = await probePortUsage(port);
   }
   if (status !== "busy") {
     listeners = [];

--- a/src/infra/ports-probe.test.ts
+++ b/src/infra/ports-probe.test.ts
@@ -1,7 +1,7 @@
 // Tests local port probing and availability detection.
 import net from "node:net";
 import { describe, expect, it } from "vitest";
-import { tryListenOnPort } from "./ports-probe.js";
+import { probePortUsage, tryListenOnPort } from "./ports-probe.js";
 
 async function withListeningServer(cb: (address: net.AddressInfo) => Promise<void>): Promise<void> {
   const server = net.createServer();
@@ -62,6 +62,14 @@ describe("tryListenOnPort", () => {
       expect(listenError?.address).toBe("127.0.0.1");
       expect(listenError?.port).toBe(address.port);
       expect(rejection?.syscall).toBe("listen");
+    });
+  });
+});
+
+describe("probePortUsage", () => {
+  it("reports an IPv4-only loopback listener as busy", async () => {
+    await withListeningServer(async (address) => {
+      await expect(probePortUsage(address.port)).resolves.toBe("busy");
     });
   });
 });

--- a/src/infra/ports-probe.ts
+++ b/src/infra/ports-probe.ts
@@ -1,5 +1,9 @@
 // Probes local ports and reports listener availability.
 import net from "node:net";
+import { isErrno } from "./errors.js";
+import type { PortUsageStatus } from "./ports-types.js";
+
+const PORT_PROBE_HOSTS = ["127.0.0.1", "0.0.0.0", "::1", "::"];
 
 /** Opens and closes a temporary listener to verify that a port can be bound. */
 export async function tryListenOnPort(params: {
@@ -27,4 +31,34 @@ export async function tryListenOnPort(params: {
       })
       .listen(listenOptions);
   });
+}
+
+async function probePortOnHost(port: number, host: string): Promise<PortUsageStatus | "skip"> {
+  try {
+    await tryListenOnPort({ port, host, exclusive: true });
+    return "free";
+  } catch (err) {
+    if (isErrno(err) && err.code === "EADDRINUSE") {
+      return "busy";
+    }
+    if (isErrno(err) && (err.code === "EADDRNOTAVAIL" || err.code === "EAFNOSUPPORT")) {
+      return "skip";
+    }
+    return "unknown";
+  }
+}
+
+/** Checks all supported local address families without resolving listener diagnostics. */
+export async function probePortUsage(port: number): Promise<PortUsageStatus> {
+  let sawUnknown = false;
+  for (const host of PORT_PROBE_HOSTS) {
+    const result = await probePortOnHost(port, host);
+    if (result === "busy") {
+      return "busy";
+    }
+    if (result === "unknown") {
+      sawUnknown = true;
+    }
+  }
+  return sawUnknown ? "unknown" : "free";
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users stopping or updating a managed gateway could
receive a false failure when the gateway port was still releasing immediately
after `launchctl bootout`.

In an observed update, the updater reported that the gateway port was still
busy only 356 ms before the gateway completed its clean shutdown.

## Why This Change Was Made

The LaunchAgent stop postcondition now polls the configured gateway port for a
short bounded grace period after stale-process cleanup. It preserves the
existing fail-closed behavior and diagnostics when the port remains busy.

This is limited to stop verification after bootout. It does not change the
separate restart-before-kickstart behavior tracked in #88309 and #89096.

## User Impact

Managed macOS gateway stops and updates no longer fail spuriously while a
cleanly exiting gateway finishes releasing its port. A genuinely persistent
port conflict still fails with the existing diagnostics.

## Evidence

- Added a regression test where the first port inspection is busy and the next
  inspection is free.
- Existing persistent-busy stop and disable tests still require failure after
  the bounded wait.
- Passed:
  - `node scripts/run-vitest.mjs src/daemon/launchd.test.ts src/cli/daemon-cli/lifecycle.test.ts src/cli/daemon-cli/lifecycle-core.test.ts src/cli/daemon-cli/restart-health.test.ts`
  - focused `oxfmt --check`
  - `git diff --check`
  - changed-lane dry run (`core`, `coreTests`)
- Codex autoreview: clean, no accepted/actionable findings.
- Broad pre-push runner validation was unavailable because remote runner
  allocation failed before the check executed; PR CI remains the broad gate.
