### PR TITLE
fix(ci): restore QA workflow gates

### DIFF
--- a/.github/workflows/ios-periphery-comment.yml
+++ b/.github/workflows/ios-periphery-comment.yml
@@ -27,10 +27,8 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
-            const fs = require("node:fs");
-            const os = require("node:os");
             const path = require("node:path");
-            const childProcess = require("node:child_process");
+            const zlib = require("node:zlib");
 
             const marker = "<!-- openclaw-ios-periphery-dead-code -->";
             const run = context.payload.workflow_run;
@@ -126,10 +124,7 @@ jobs:
                 archive_format: "zip",
               });
 
-              const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ios-periphery-"));
-              const archivePath = path.join(dir, "artifact.zip");
               const archiveBuffer = Buffer.from(archive.data);
-              fs.writeFileSync(archivePath, archiveBuffer);
 
               const allowedArtifactFiles = new Set([
                 "periphery.json",
@@ -240,19 +235,59 @@ jobs:
                   return;
                 }
 
-                entries.set(name, { uncompressedSize });
+                entries.set(name, {
+                  compressedSize,
+                  compressionMethod,
+                  localHeaderOffset: readUInt32(offset + 42),
+                  uncompressedSize,
+                });
                 offset = nextOffset;
               }
 
+              const readZipEntry = (name, entry) => {
+                const localHeaderOffset = entry.localHeaderOffset;
+                if (
+                  localHeaderOffset + 30 > archiveBuffer.length ||
+                  readUInt32(localHeaderOffset) !== 0x04034b50
+                ) {
+                  throw new Error(`${name} has an invalid local header.`);
+                }
+
+                const localNameLength = readUInt16(localHeaderOffset + 26);
+                const localExtraLength = readUInt16(localHeaderOffset + 28);
+                const dataStart = localHeaderOffset + 30 + localNameLength + localExtraLength;
+                const dataEnd = dataStart + entry.compressedSize;
+                if (dataEnd > archiveBuffer.length) {
+                  throw new Error(`${name} exceeds archive bounds.`);
+                }
+
+                const compressed = archiveBuffer.subarray(dataStart, dataEnd);
+                let contents;
+                if (entry.compressionMethod === 0) {
+                  contents = compressed;
+                } else {
+                  try {
+                    contents = zlib.inflateRawSync(compressed, { maxOutputLength: maxEntryBytes });
+                  } catch (error) {
+                    if (error && error.code === "ERR_BUFFER_TOO_LARGE") {
+                      throw new Error(`${name} exceeded the per-file size limit while reading.`);
+                    }
+                    throw error;
+                  }
+                }
+                if (contents.length !== entry.uncompressedSize || contents.length > maxEntryBytes) {
+                  throw new Error(`${name} exceeded the per-file size limit while reading.`);
+                }
+                return contents.toString("utf8");
+              };
+
               const files = new Map();
               for (const [name, entry] of entries) {
-                const contents = childProcess.execFileSync("unzip", ["-p", archivePath, name], {
-                  encoding: "utf8",
-                  maxBuffer: Math.max(1, entry.uncompressedSize + 1024),
-                  timeout: 5000,
-                });
-                if (Buffer.byteLength(contents, "utf8") > maxEntryBytes) {
-                  core.warning(`Skipping ${artifactName}; ${name} exceeded the per-file size limit while reading.`);
+                let contents;
+                try {
+                  contents = readZipEntry(name, entry);
+                } catch (error) {
+                  core.warning(`Skipping ${artifactName}; ${error instanceof Error ? error.message : String(error)}`);
                   return;
                 }
                 files.set(name, contents);

--- a/src/infra/exec-policy.test.ts
+++ b/src/infra/exec-policy.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { applyExecPolicyLayer } from "./exec-policy.js";
+
+describe("applyExecPolicyLayer", () => {
+  it("preserves caller fields when applying a mode layer", () => {
+    const result = applyExecPolicyLayer(
+      {
+        ask: "on-miss" as const,
+        host: "node",
+        security: "allowlist" as const,
+      },
+      { mode: "full" },
+    );
+
+    expect(result).toEqual({
+      ask: "off",
+      autoReview: false,
+      host: "node",
+      mode: "full",
+      security: "full",
+    });
+  });
+
+  it("preserves caller fields but clears stale mode when applying explicit policy fields", () => {
+    const result = applyExecPolicyLayer(
+      {
+        ask: "on-miss" as const,
+        host: "node",
+        mode: "auto" as const,
+        security: "allowlist" as const,
+      },
+      { security: "deny" },
+    );
+
+    expect(result).toEqual({
+      ask: "on-miss",
+      host: "node",
+      security: "deny",
+    });
+  });
+});

--- a/src/infra/exec-policy.ts
+++ b/src/infra/exec-policy.ts
@@ -7,7 +7,6 @@ export type ExecPolicyLayer = {
   ask?: ExecAsk;
 };
 
-// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Preserve each caller's required policy fields.
 export function applyExecPolicyLayer<TBase extends ExecPolicyLayer>(
   base: TBase,
   layer?: ExecPolicyLayer,
@@ -17,15 +16,18 @@ export function applyExecPolicyLayer<TBase extends ExecPolicyLayer>(
   }
   if (layer.mode) {
     return {
+      ...base,
       mode: layer.mode,
       ...resolveExecPolicyForMode(layer.mode),
-    } as TBase & ExecPolicyLayer;
+    } as unknown as TBase & ExecPolicyLayer;
   }
   if (layer.security !== undefined || layer.ask !== undefined) {
+    const { mode: _mode, ...baseWithoutMode } = base;
     return {
+      ...baseWithoutMode,
       security: layer.security ?? base.security,
       ask: layer.ask ?? base.ask,
-    } as TBase & ExecPolicyLayer;
+    } as unknown as TBase & ExecPolicyLayer;
   }
   return base;
 }

--- a/test/scripts/ios-periphery-comment-workflow.test.ts
+++ b/test/scripts/ios-periphery-comment-workflow.test.ts
@@ -2,6 +2,7 @@ import { Buffer } from "node:buffer";
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { compileFunction } from "node:vm";
+import { deflateRawSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { markdownToIR } from "../../packages/markdown-core/src/ir.js";
@@ -316,41 +317,47 @@ function u32(value: number): Buffer {
   return buffer;
 }
 
-function makeZip(files: Record<string, string>): Buffer {
+function makeZip(
+  files: Record<string, string>,
+  options: { compressionMethod?: 0 | 8 } = {},
+): Buffer {
   const localParts: Buffer[] = [];
   const centralParts: Buffer[] = [];
   let offset = 0;
+  const compressionMethod = options.compressionMethod ?? 0;
 
   for (const [name, contents] of Object.entries(files)) {
     const nameBuffer = Buffer.from(name, "utf8");
     const contentsBuffer = Buffer.from(contents, "utf8");
+    const compressedBuffer =
+      compressionMethod === 8 ? deflateRawSync(contentsBuffer) : contentsBuffer;
     const checksum = crc32(contentsBuffer);
     const localHeader = Buffer.concat([
       u32(0x04034b50),
       u16(20),
       u16(0),
-      u16(0),
+      u16(compressionMethod),
       u16(0),
       u16(0),
       u32(checksum),
-      u32(contentsBuffer.length),
+      u32(compressedBuffer.length),
       u32(contentsBuffer.length),
       u16(nameBuffer.length),
       u16(0),
       nameBuffer,
     ]);
-    localParts.push(localHeader, contentsBuffer);
+    localParts.push(localHeader, compressedBuffer);
     centralParts.push(
       Buffer.concat([
         u32(0x02014b50),
         u16(20),
         u16(20),
         u16(0),
-        u16(0),
+        u16(compressionMethod),
         u16(0),
         u16(0),
         u32(checksum),
-        u32(contentsBuffer.length),
+        u32(compressedBuffer.length),
         u32(contentsBuffer.length),
         u16(nameBuffer.length),
         u16(0),
@@ -362,7 +369,7 @@ function makeZip(files: Record<string, string>): Buffer {
         nameBuffer,
       ]),
     );
-    offset += localHeader.length + contentsBuffer.length;
+    offset += localHeader.length + compressedBuffer.length;
   }
 
   const localData = Buffer.concat(localParts);
@@ -391,11 +398,27 @@ function markFirstCentralDirectoryEntryEncrypted(archive: Buffer): Buffer {
   return result;
 }
 
+function setFirstEntryUncompressedSize(archive: Buffer, size: number): Buffer {
+  const result = Buffer.from(archive);
+  if (result.readUInt32LE(0) !== 0x04034b50) {
+    throw new Error("missing ZIP local file header");
+  }
+  result.writeUInt32LE(size, 22);
+  const centralOffset = result.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+  if (centralOffset < 0) {
+    throw new Error("missing ZIP central directory entry");
+  }
+  result.writeUInt32LE(size, centralOffset + 24);
+  return result;
+}
+
 describe("iOS Periphery comment workflow", () => {
   it("parses the workflow YAML and embedded github-script JavaScript", () => {
-    expect(() => commenterScript()).not.toThrow();
+    const script = commenterScript();
+    expect(script).not.toContain("node:child_process");
+    expect(script).not.toContain("execFileSync");
     expect(() =>
-      compileFunction(`return (async () => {\n${commenterScript()}\n})();`, [
+      compileFunction(`return (async () => {\n${script}\n})();`, [
         "require",
         "context",
         "core",
@@ -486,6 +509,55 @@ describe("iOS Periphery comment workflow", () => {
 
     expect(result.downloadCount).toBe(1);
     expect(result.core.warnings).toEqual([]);
+  });
+
+  it("accepts deflated Periphery artifacts", async () => {
+    const archive = makeZip(
+      {
+        "periphery.json": "[]\n",
+        "periphery.status": "0\n",
+      },
+      { compressionMethod: 8 },
+    );
+    const result = await runCommenter(
+      {
+        expired: false,
+        id: 77,
+        name: ARTIFACT_NAME,
+        size_in_bytes: archive.length,
+      },
+      archive,
+    );
+
+    expect(result.downloadCount).toBe(1);
+    expect(result.core.warnings).toEqual([]);
+  });
+
+  it("rejects deflated entries that inflate past the per-file limit", async () => {
+    const archive = setFirstEntryUncompressedSize(
+      makeZip(
+        {
+          "periphery.json": `${" ".repeat(2 * 1024 * 1024 + 1)}[]\n`,
+          "periphery.status": "0\n",
+        },
+        { compressionMethod: 8 },
+      ),
+      1,
+    );
+    const result = await runCommenter(
+      {
+        expired: false,
+        id: 77,
+        name: ARTIFACT_NAME,
+        size_in_bytes: archive.length,
+      },
+      archive,
+    );
+
+    expectUnavailableComment(result.createdBodies);
+    expect(result.core.warnings).toEqual([
+      `Skipping ${ARTIFACT_NAME}; periphery.json exceeded the per-file size limit while reading.`,
+    ]);
   });
 
   it("rejects oversized artifact metadata before download", async () => {

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -217,7 +217,7 @@ describe("production lint suppressions", () => {
         "src/plugins/hooks.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/host-hooks.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/lazy-service-module.ts|typescript/no-unnecessary-type-parameters|1",
-        "src/plugins/public-surface-loader.ts|typescript/no-unnecessary-type-parameters|1",
+        "src/plugins/public-surface-loader.ts|typescript/no-unnecessary-type-parameters|2",
         "src/plugins/runtime/runtime-plugin-boundary.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/runtime/types-channel.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/trusted-tool-policy.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
## Summary
- replace the iOS Periphery comment workflow's `unzip -p` shell-out with bounded in-memory ZIP entry reads
- add stored/deflated artifact coverage, a no-shell-out assertion, and dishonest deflate coverage for output-limit enforcement
- fix `applyExecPolicyLayer` so it preserves caller fields while clearing stale mode when explicit policy fields override it, restoring plugin-sdk boundary dts generation on current `main`
- refresh the production lint-suppression inventory for the current `main` suppression count

## Verification
- `git diff --check origin/main..HEAD`
- raw Crabbox AWS `run_256b65342ad6` / `cbx_c32146ff0f08`: `unzip-missing`; `CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/ios-periphery-comment-workflow.test.ts` passed 25 tests
- Blacksmith Testbox changed gate `tbx_01kvs09j9jz1zyq23ayedwsap4`: `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm check:changed` passed core, coreTests, and tooling lanes
- final pushed head is `4e82b623f01` on current `origin/main`

## Review
- review pass found an inflate output-cap regression; fixed with `maxOutputLength` and dishonest deflate coverage
- re-review found no remaining blockers

## Notes
- macOS Crabbox proof remains capacity-blocked: AWS macOS Dedicated Host attempts failed with unavailable/insufficient host capacity; Parallels needs a configured source/template; apple-container is Linux-only.
