### PR TITLE
fix(model-catalog): stripPrefixes over-strips when prefix has whitespace

### DIFF
--- a/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
@@ -88,4 +88,36 @@ describe("provider model id policy normalization", () => {
       "opus-4.6",
     );
   });
+
+  it("CONTROL: a whitespace-free lowercase prefix strips correctly (no regression)", () => {
+    const policies = new Map([
+      ["openai", { stripPrefixes: ["openai/"], aliases: undefined }],
+    ]);
+
+    expect(
+      normalizeStaticProviderModelIdWithPolicies("openai", "openai/gpt-4", policies),
+    ).toBe("gpt-4");
+  });
+
+  it("DESIRED behavior (currently FAILS): a leading-space prefix strips exactly the matched prefix", () => {
+    const policies = new Map([
+      ["openai", { stripPrefixes: [" openai/"], aliases: undefined }],
+    ]);
+
+    // A whitespace-containing prefix should still strip only the normalized prefix
+    expect(
+      normalizeStaticProviderModelIdWithPolicies("openai", "openai/gpt-4", policies),
+    ).toBe("gpt-4");
+  });
+
+  it("DESIRED behavior (currently FAILS): a trailing-space prefix strips exactly the matched prefix", () => {
+    const policies = new Map([
+      ["openai", { stripPrefixes: ["openai/ "], aliases: undefined }],
+    ]);
+
+    // Same as above: trailing whitespace in manifest should not affect stripping
+    expect(
+      normalizeStaticProviderModelIdWithPolicies("openai", "openai/gpt-4", policies),
+    ).toBe("gpt-4");
+  });
 });

--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -98,7 +98,7 @@ export function normalizeProviderModelIdWithPolicies(params: {
   for (const prefix of policy.stripPrefixes ?? []) {
     const normalizedPrefix = normalizeLowercaseStringOrEmpty(prefix);
     if (normalizedPrefix && normalizeLowercaseStringOrEmpty(modelId).startsWith(normalizedPrefix)) {
-      modelId = modelId.slice(prefix.length);
+      modelId = modelId.slice(normalizedPrefix.length);
       break;
     }
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes a bug in `normalizeProviderModelIdWithPolicies` where `stripPrefixes` entries containing leading or trailing whitespace would over-strip model ids, mangling them and causing model resolution failures.

For example, with a manifest prefix of `" openai/"` (note the leading space), the model id `"openai/gpt-4"` would be incorrectly transformed to `"pt-4"` instead of `"gpt-4"`.

## Why This Change Was Made

The bug occurred because the function matched prefixes using the normalized (trimmed/lowercased) version but stripped using the raw prefix length. This mismatch caused one extra character to be removed when the prefix contained whitespace.

## User Impact

- **Affected**: Any plugin/manifest provider whose `stripPrefixes` policy entry carries leading or trailing whitespace
- **Severity**: Medium - mangled model ids silently fail model resolution (model not found)
- **Fix**: The strip operation now uses the normalized prefix length, matching the length used for comparison

## Evidence

### Before Fix
```ts
const policies = new Map([
  ["openai", { stripPrefixes: [" openai/"], aliases: undefined }],
]);

normalizeStaticProviderModelIdWithPolicies("openai", "openai/gpt-4", policies);
// → "pt-4" ❌ (expected: "gpt-4")
```

### After Fix
```ts
normalizeStaticProviderModelIdWithPolicies("openai", "openai/gpt-4", policies);
// → "gpt-4" ✅
```

### Test Coverage
Added three new test cases:
1. CONTROL: Verifies whitespace-free prefixes still work correctly
2. DESIRED behavior: Leading-space prefix strips exactly the matched prefix
3. DESIRED behavior: Trailing-space prefix strips exactly the matched prefix

All tests pass after the fix.

## Files Changed

- `packages/model-catalog-core/src/provider-model-id-normalization.ts` - Fixed the strip logic
- `packages/model-catalog-core/src/provider-model-id-normalization.test.ts` - Added regression tests

Closes #95743