### PR TITLE
fix(heartbeat-filter): preserve HEARTBEAT_OK detection with reasoning/thinking blocks

### DIFF
--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -135,6 +135,36 @@ describe("isHeartbeatOkResponse", () => {
       ),
     ).toBe(false);
   });
+
+  it("matches HEARTBEAT_OK even when the message contains reasoning/thinking blocks", () => {
+    // This tests the fix for issue #95796 where messages with reasoning blocks
+    // were incorrectly rejected by isHeartbeatOkResponse due to hasNonTextContent check.
+    const messageWithReasoning = {
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "Let me check the heartbeat status..." },
+        { type: "text", text: "HEARTBEAT_OK" },
+      ],
+    };
+    expect(isHeartbeatOkResponse(messageWithReasoning)).toBe(true);
+
+    // Also test with thinking block (another common non-text block type)
+    const messageWithThinking = {
+      role: "assistant",
+      content: [
+        { type: "thinking", text: "Processing heartbeat request" },
+        { type: "text", text: "**HEARTBEAT_OK**" },
+      ],
+    };
+    expect(isHeartbeatOkResponse(messageWithThinking)).toBe(true);
+
+    // Test with output_text (should still work as before)
+    const messageWithOutputText = {
+      role: "assistant",
+      content: [{ type: "output_text", text: "HEARTBEAT_OK" }],
+    };
+    expect(isHeartbeatOkResponse(messageWithOutputText)).toBe(true);
+  });
 });
 
 describe("filterHeartbeatTranscriptArtifacts", () => {

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -336,10 +336,7 @@ export function isHeartbeatOkResponse(
   if (hasAssistantToolCall(message)) {
     return false;
   }
-  const { text, hasNonTextContent } = resolveMessageText(message.content);
-  if (hasNonTextContent) {
-    return false;
-  }
+  const { text } = resolveMessageText(message.content);
   return stripHeartbeatToken(text, { mode: "heartbeat", maxAckChars: ackMaxChars }).shouldSkip;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes a bug where heartbeat transcript filtering incorrectly preserved heartbeat prompt/ack pairs when the assistant's HEARTBEAT_OK response contained non-text content blocks like `reasoning` or `thinking`.

This caused context inflation as heartbeat artifacts were not being pruned, leading to:
- Increased token usage
- Model confusion from stale tool call artifacts
- 100% reproduction rate when models use reasoning/thinking features

## Why This Change Was Made

The `isHeartbeatOkResponse` function in `src/auto-reply/heartbeat-filter.ts` was checking `hasNonTextContent` and rejecting any message with non-text blocks, even if the text content was a valid HEARTBEAT_OK acknowledgment.

The issue was in lines 339-342:
```ts
const { text, hasNonTextContent } = resolveMessageText(message.content);
if (hasNonTextContent) {
  return false;  // ❌ Rejects messages with reasoning/thinking blocks
}
```

This check was overly broad - it should only reject messages where the non-text content is meaningful (like tool calls), not auxiliary blocks like reasoning that don't affect the semantic meaning of the HEARTBEAT_OK acknowledgment.

## User Impact

- **Affected**: All users using HEARTBEAT.md with models that produce reasoning/thinking content
- **Severity**: High - causes major context size inflation and model confusion
- **Frequency**: 100% when heartbeat ACK contains reasoning/thinking blocks
- **Fix**: Removed the `hasNonTextContent` check, allowing HEARTBEAT_OK detection to focus on the actual text content

## Evidence

### Before Fix
```ts
const message = {
  role: "assistant",
  content: [
    { type: "reasoning", text: "Let me check the heartbeat status..." },
    { type: "text", text: "HEARTBEAT_OK" },
  ],
};
isHeartbeatOkResponse(message); // → false ❌
```

### After Fix
```ts
isHeartbeatOkResponse(message); // → true ✅
```

## Test Coverage

Added test case in `src/auto-reply/heartbeat-filter.test.ts` verifying:
- Messages with `reasoning` + `text` blocks containing HEARTBEAT_OK are detected
- Messages with `thinking` + `text` blocks containing HEARTBEAT_OK are detected  
- Existing behavior for `output_text` blocks is preserved

All 35 tests pass.

## Files Changed

- `src/auto-reply/heartbeat-filter.ts` - Removed overly broad `hasNonTextContent` check from `isHeartbeatOkResponse`
- `src/auto-reply/heartbeat-filter.test.ts` - Added regression tests for reasoning/thinking block scenarios

Closes #95796