### PR TITLE
fix(telegram): keep OAuth emails out of rich entity detection

### DIFF
--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1246,11 +1246,11 @@ describe("deliverReplies", () => {
       chat: { id: "123" },
     });
     const bot = createBot({ sendMessage });
+    const oauthProfileText =
+      "OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)";
 
     await deliverWith({
-      replies: [
-        { text: "OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)" },
-      ],
+      replies: [{ text: oauthProfileText }],
       runtime,
       bot,
       richMessages: true,
@@ -1261,7 +1261,7 @@ describe("deliverReplies", () => {
     };
     const richMessage = raw.sendRichMessage.mock.calls[0]?.[0]?.rich_message;
     expect(richMessage).toEqual({
-      html: "OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)",
+      html: oauthProfileText,
       skip_entity_detection: true,
     });
   });

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1239,6 +1239,33 @@ describe("deliverReplies", () => {
     expect(mockCallArg(sendRichMessage, 1, 0)).not.toHaveProperty("reply_to_message_id");
   });
 
+  it("skips rich entity detection for reply text with provider-prefixed email addresses", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 11,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      replies: [
+        { text: "OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)" },
+      ],
+      runtime,
+      bot,
+      richMessages: true,
+    });
+
+    const raw = bot.api.raw as unknown as {
+      sendRichMessage: ReturnType<typeof vi.fn>;
+    };
+    const richMessage = raw.sendRichMessage.mock.calls[0]?.[0]?.rich_message;
+    expect(richMessage).toEqual({
+      html: "OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)",
+      skip_entity_detection: true,
+    });
+  });
+
   it("uses legacy reply id when selected reply target differs from quote source", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -690,6 +690,22 @@ describe("createTelegramDraftStream", () => {
     expect(api.editMessageText).not.toHaveBeenCalled();
   });
 
+  it("skips rich entity detection for draft text with provider-prefixed email addresses", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, { richMessages: true });
+
+    stream.update("OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)");
+    await stream.flush();
+
+    expect(api.raw.sendRichMessage).toHaveBeenCalledWith({
+      chat_id: 123,
+      rich_message: {
+        html: "OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)",
+        skip_entity_detection: true,
+      },
+    });
+  });
+
   it("keeps rich preview html out of plain preview gating", async () => {
     const api = createMockDraftApi();
     const stream = createDraftStream(api, { richMessages: true, minInitialChars: 10 });

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -693,14 +693,16 @@ describe("createTelegramDraftStream", () => {
   it("skips rich entity detection for draft text with provider-prefixed email addresses", async () => {
     const api = createMockDraftApi();
     const stream = createDraftStream(api, { richMessages: true });
+    const oauthProfileText =
+      "OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)";
 
-    stream.update("OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)");
+    stream.update(oauthProfileText);
     await stream.flush();
 
     expect(api.raw.sendRichMessage).toHaveBeenCalledWith({
       chat_id: 123,
       rich_message: {
-        html: "OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)",
+        html: oauthProfileText,
         skip_entity_detection: true,
       },
     });

--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -174,17 +174,11 @@ export function buildTelegramRichMarkdown(
   markdown: string,
   options?: TelegramRichMessageOptions,
 ): TelegramInputRichMessage {
-  const skipEntityDetection = shouldSkipTelegramRichEntityDetection(markdown, options);
-  return buildTelegramRichHtml(
-    markdownToTelegramRichHtml(markdown, {
-      ...options,
-      skipEntityDetection,
-    }),
-    {
-      ...options,
-      skipEntityDetection,
-    },
-  );
+  const richOptions = {
+    ...options,
+    skipEntityDetection: shouldSkipTelegramRichEntityDetection(markdown, options),
+  };
+  return buildTelegramRichHtml(markdownToTelegramRichHtml(markdown, richOptions), richOptions);
 }
 
 export function buildTelegramRichHtml(
@@ -438,16 +432,14 @@ export function splitTelegramRichMessageTextChunks(params: {
   tableMode?: MarkdownTableMode;
   skipEntityDetection?: boolean;
 }): TelegramRichTextChunk[] {
-  const skipEntityDetection = shouldSkipTelegramRichEntityDetection(params.text, {
-    skipEntityDetection: params.skipEntityDetection,
-  });
+  const markdownOptions = {
+    tableMode: params.tableMode,
+    skipEntityDetection: shouldSkipTelegramRichEntityDetection(params.text, {
+      skipEntityDetection: params.skipEntityDetection,
+    }),
+  };
   const renderMarkdownChunk = (chunk: string) =>
-    prepareTelegramRichHtml(
-      markdownToTelegramRichHtml(chunk, {
-        tableMode: params.tableMode,
-        skipEntityDetection,
-      }),
-    );
+    prepareTelegramRichHtml(markdownToTelegramRichHtml(chunk, markdownOptions));
   const htmlChunks =
     params.textMode === "html"
       ? splitPreparedTelegramRichHtml({

--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -96,6 +96,16 @@ type TelegramApiWithRichRaw = Bot["api"] & {
   raw?: TelegramRichRawApi;
 };
 
+const TELEGRAM_RICH_EMAIL_TOKEN_RE =
+  /[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)+/iu;
+
+function shouldSkipTelegramRichEntityDetection(
+  text: string,
+  options?: Pick<TelegramRichMessageOptions, "skipEntityDetection">,
+): boolean {
+  return options?.skipEntityDetection === true || TELEGRAM_RICH_EMAIL_TOKEN_RE.test(text);
+}
+
 export function getTelegramRichRawApi(api: Bot["api"]): TelegramRichRawApi {
   const raw = (api as TelegramApiWithRichRaw).raw;
   if (raw) {
@@ -164,7 +174,17 @@ export function buildTelegramRichMarkdown(
   markdown: string,
   options?: TelegramRichMessageOptions,
 ): TelegramInputRichMessage {
-  return buildTelegramRichHtml(markdownToTelegramRichHtml(markdown, options), options);
+  const skipEntityDetection = shouldSkipTelegramRichEntityDetection(markdown, options);
+  return buildTelegramRichHtml(
+    markdownToTelegramRichHtml(markdown, {
+      ...options,
+      skipEntityDetection,
+    }),
+    {
+      ...options,
+      skipEntityDetection,
+    },
+  );
 }
 
 export function buildTelegramRichHtml(
@@ -172,7 +192,7 @@ export function buildTelegramRichHtml(
   options?: TelegramRichMessageOptions,
 ): TelegramInputRichMessage {
   const safeHtml = prepareTelegramRichHtml(html);
-  return options?.skipEntityDetection === true
+  return shouldSkipTelegramRichEntityDetection(safeHtml, options)
     ? { html: safeHtml, skip_entity_detection: true }
     : { html: safeHtml };
 }
@@ -418,11 +438,14 @@ export function splitTelegramRichMessageTextChunks(params: {
   tableMode?: MarkdownTableMode;
   skipEntityDetection?: boolean;
 }): TelegramRichTextChunk[] {
+  const skipEntityDetection = shouldSkipTelegramRichEntityDetection(params.text, {
+    skipEntityDetection: params.skipEntityDetection,
+  });
   const renderMarkdownChunk = (chunk: string) =>
     prepareTelegramRichHtml(
       markdownToTelegramRichHtml(chunk, {
         tableMode: params.tableMode,
-        skipEntityDetection: params.skipEntityDetection,
+        skipEntityDetection,
       }),
     );
   const htmlChunks =

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -958,26 +958,24 @@ describe("sendMessageTelegram", () => {
 
   it("skips rich entity detection for provider-prefixed email text", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 45, chat: { id: "123" } });
+    const oauthProfileText =
+      "OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)";
 
-    await sendMessageTelegram(
-      "123",
-      "OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)",
-      {
-        cfg: {
-          channels: {
-            telegram: {
-              richMessages: true,
-            },
+    await sendMessageTelegram("123", oauthProfileText, {
+      cfg: {
+        channels: {
+          telegram: {
+            richMessages: true,
           },
         },
-        token: "tok",
       },
-    );
+      token: "tok",
+    });
 
     expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
     const richMessage = botRawApi.sendRichMessage.mock.calls[0]?.[0]?.rich_message;
     expect(richMessage).toEqual({
-      html: "OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)",
+      html: oauthProfileText,
       skip_entity_detection: true,
     });
     expect(richMessage?.html).not.toContain("mailto:");

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -956,6 +956,33 @@ describe("sendMessageTelegram", () => {
     expect(richMessage?.html).toContain("<table>");
   });
 
+  it("skips rich entity detection for provider-prefixed email text", async () => {
+    botApi.sendMessage.mockResolvedValue({ message_id: 45, chat: { id: "123" } });
+
+    await sendMessageTelegram(
+      "123",
+      "OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)",
+      {
+        cfg: {
+          channels: {
+            telegram: {
+              richMessages: true,
+            },
+          },
+        },
+        token: "tok",
+      },
+    );
+
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+    const richMessage = botRawApi.sendRichMessage.mock.calls[0]?.[0]?.rich_message;
+    expect(richMessage).toEqual({
+      html: "OAuth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)",
+      skip_entity_detection: true,
+    });
+    expect(richMessage?.html).not.toContain("mailto:");
+  });
+
   it.each([
     {
       name: "list",


### PR DESCRIPTION
## What Problem This Solves

Telegram rich messages were rejected with `400: RICH_MESSAGE_EMAIL_INVALID` when runtime text included OAuth profile labels such as `openai:<redacted-email> (<redacted-email>)`. Plain text sends worked, but rich final/progress payloads could pass through Markdown linkification first and produce an invalid rich e-mail link like `mailto:openai:<redacted-email>`.

## Why This Change Was Made

The shared Telegram rich-message builder now disables Telegram rich entity detection whenever the source or prepared rich HTML contains an email-like token. That prevents Markdown auto-linkification from turning provider-prefixed OAuth labels into invalid `mailto:` links, while preserving explicit Markdown links and existing caller-requested `skip_entity_detection` behavior.

The fix is centralized in `extensions/telegram/src/rich-message.ts`, so durable rich sends, draft/progress sends, and reply delivery helpers share the same behavior.

## User Impact

Telegram rich messages can be re-enabled for runtime status/final/progress replies that include OAuth account emails without those replies being rejected. Users should see the email text normally instead of losing the rich Telegram reply.

## Evidence

- Reproduced the exact Bot API failure live: rich HTML containing a provider-prefixed `mailto:` email link returned `400 Bad Request: RICH_MESSAGE_EMAIL_INVALID`.
- Verified the fixed live payload succeeds with `skip_entity_detection: true` and deleted the probe message after send.
- `pnpm test -- --run extensions/telegram/src/send.test.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot/delivery.test.ts` passed: 3 files, 243 tests.
- `pnpm exec oxfmt --check extensions/telegram/src/rich-message.ts extensions/telegram/src/send.test.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot/delivery.test.ts` passed.
- `pnpm tsgo:extensions:test` passed.
- `NODE_OPTIONS=--max-old-space-size=12288 pnpm build` passed. A normal `pnpm build` hit a Node heap OOM in `tsdown`, so the successful build used a larger heap.
