### PR TITLE
fix(gateway): show last error when status probe fails

### DIFF
--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -57,9 +57,9 @@ const inspectPortConnections = vi.fn<(port: number) => Promise<PortConnections>>
     connections: [],
   }),
 );
-const readLastGatewayErrorLine = vi.fn<(_env?: NodeJS.ProcessEnv) => Promise<string | null>>(
-  async (_env?: NodeJS.ProcessEnv) => null,
-);
+const readLastGatewayErrorLine = vi.fn<
+  (_env?: NodeJS.ProcessEnv, _options?: { requirePatternMatch?: boolean }) => Promise<string | null>
+>(async (_env?: NodeJS.ProcessEnv, _options?: { requirePatternMatch?: boolean }) => null);
 const loadInstalledPluginIndexInstallRecords = vi.fn<
   (params?: {
     env?: NodeJS.ProcessEnv;
@@ -177,7 +177,8 @@ vi.mock("../../config/config.js", () => ({
 }));
 
 vi.mock("../../daemon/diagnostics.js", () => ({
-  readLastGatewayErrorLine: (env: NodeJS.ProcessEnv) => readLastGatewayErrorLine(env),
+  readLastGatewayErrorLine: (env: NodeJS.ProcessEnv, options?: { requirePatternMatch?: boolean }) =>
+    readLastGatewayErrorLine(env, options),
 }));
 
 vi.mock("../../daemon/inspect.js", () => ({
@@ -1176,12 +1177,66 @@ describe("gatherDaemonStatus", () => {
         OPENCLAW_STATE_DIR: "/tmp/openclaw-daemon",
         OPENCLAW_CONFIG_PATH: "/tmp/openclaw-daemon/openclaw.json",
       }),
+      { requirePatternMatch: true },
     );
     expect(status.port?.status).toBe("busy");
     expect(status.rpc?.ok).toBe(false);
     expect(status.lastError).toBe(
       "parse/handle error: Error: ENOSPC: no space left on device, write",
     );
+  });
+
+  it("does not read local gateway errors for an explicit probe URL", async () => {
+    inspectPortUsage.mockResolvedValueOnce({
+      port: 19001,
+      status: "busy",
+      listeners: [{ pid: 8000, ppid: 1, commandLine: "openclaw gateway" }],
+      hints: [],
+    });
+    callGatewayStatusProbe.mockResolvedValueOnce({
+      ok: false,
+      url: "wss://remote.example:18790",
+      error: "gateway closed (1000): ",
+    });
+
+    const status = await gatherDaemonStatus({
+      rpc: { url: "wss://remote.example:18790" },
+      probe: true,
+      deep: false,
+    });
+
+    expect(readLastGatewayErrorLine).not.toHaveBeenCalled();
+    expect(status.lastError).toBeUndefined();
+  });
+
+  it("does not read local gateway errors in remote mode", async () => {
+    daemonLoadedConfig = {
+      gateway: {
+        mode: "remote",
+        remote: { url: "wss://remote.example:18790" },
+        auth: { token: "daemon-token" },
+      },
+    };
+    inspectPortUsage.mockResolvedValueOnce({
+      port: 19001,
+      status: "busy",
+      listeners: [{ pid: 8000, ppid: 1, commandLine: "openclaw gateway" }],
+      hints: [],
+    });
+    callGatewayStatusProbe.mockResolvedValueOnce({
+      ok: false,
+      url: "wss://remote.example:18790",
+      error: "gateway closed (1000): ",
+    });
+
+    const status = await gatherDaemonStatus({
+      rpc: {},
+      probe: true,
+      deep: false,
+    });
+
+    expect(readLastGatewayErrorLine).not.toHaveBeenCalled();
+    expect(status.lastError).toBeUndefined();
   });
 
   it("compares plugin drift against the running gateway version from the probe, not the CLI VERSION", async () => {

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { StaleOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import { createMockGatewayService } from "../../daemon/service.test-helpers.js";
-import type { PortConnections } from "../../infra/ports.js";
+import type { PortConnections, PortListener, PortUsageStatus } from "../../infra/ports.js";
 import type { GatewayRestartHandoff } from "../../infra/restart-handoff.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import { VERSION } from "../../version.js";
@@ -36,19 +36,30 @@ const findExtraGatewayServices = vi.fn(async (_env?: unknown, _opts?: unknown) =
 const findStaleOpenClawUpdateLaunchdJobs = vi.fn<
   (env?: NodeJS.ProcessEnv) => Promise<StaleOpenClawUpdateLaunchdJob[]>
 >(async () => []);
-const inspectPortUsage = vi.fn(async (port: number) => ({
-  port,
-  status: "free" as const,
-  listeners: [],
-  hints: [],
-}));
+type PortUsageTestSummary = {
+  port: number;
+  status: PortUsageStatus;
+  listeners: PortListener[];
+  hints: string[];
+};
+
+const inspectPortUsage = vi.fn<(port: number) => Promise<PortUsageTestSummary>>(
+  async (port: number) => ({
+    port,
+    status: "free",
+    listeners: [],
+    hints: [],
+  }),
+);
 const inspectPortConnections = vi.fn<(port: number) => Promise<PortConnections>>(
   async (port: number) => ({
     port,
     connections: [],
   }),
 );
-const readLastGatewayErrorLine = vi.fn(async (_env?: NodeJS.ProcessEnv) => null);
+const readLastGatewayErrorLine = vi.fn<(_env?: NodeJS.ProcessEnv) => Promise<string | null>>(
+  async (_env?: NodeJS.ProcessEnv) => null,
+);
 const loadInstalledPluginIndexInstallRecords = vi.fn<
   (params?: {
     env?: NodeJS.ProcessEnv;
@@ -291,6 +302,13 @@ describe("gatherDaemonStatus", () => {
     loadInstalledPluginIndexInstallRecords.mockResolvedValue({});
     loadGatewayTlsRuntime.mockClear();
     inspectGatewayRestart.mockClear();
+    inspectPortUsage.mockReset();
+    inspectPortUsage.mockImplementation(async (port: number) => ({
+      port,
+      status: "free" as const,
+      listeners: [],
+      hints: [],
+    }));
     inspectPortConnections.mockClear();
     inspectWindowsGatewayFirewall.mockClear();
     inspectWindowsGatewayFirewall.mockResolvedValue({
@@ -300,6 +318,8 @@ describe("gatherDaemonStatus", () => {
       message: "Windows LAN firewall diagnostics do not apply.",
       details: [],
     });
+    readLastGatewayErrorLine.mockReset();
+    readLastGatewayErrorLine.mockResolvedValue(null);
     readGatewayRestartHandoffSync.mockClear();
     readConfigFileSnapshotCalls.mockClear();
     loadConfigCalls.mockClear();
@@ -1127,6 +1147,41 @@ describe("gatherDaemonStatus", () => {
       healthy: false,
       staleGatewayPids: [9000],
     });
+  });
+
+  it("includes the last gateway error when the service is listening but the RPC probe fails", async () => {
+    inspectPortUsage.mockResolvedValueOnce({
+      port: 19001,
+      status: "busy",
+      listeners: [{ pid: 8000, ppid: 1, commandLine: "openclaw gateway" }],
+      hints: [],
+    });
+    callGatewayStatusProbe.mockResolvedValueOnce({
+      ok: false,
+      url: "wss://127.0.0.1:19001",
+      error: "gateway closed (1000): ",
+    });
+    readLastGatewayErrorLine.mockResolvedValueOnce(
+      "parse/handle error: Error: ENOSPC: no space left on device, write",
+    );
+
+    const status = await gatherDaemonStatus({
+      rpc: {},
+      probe: true,
+      deep: false,
+    });
+
+    expect(readLastGatewayErrorLine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        OPENCLAW_STATE_DIR: "/tmp/openclaw-daemon",
+        OPENCLAW_CONFIG_PATH: "/tmp/openclaw-daemon/openclaw.json",
+      }),
+    );
+    expect(status.port?.status).toBe("busy");
+    expect(status.rpc?.ok).toBe(false);
+    expect(status.lastError).toBe(
+      "parse/handle error: Error: ENOSPC: no space left on device, write",
+    );
   });
 
   it("compares plugin drift against the running gateway version from the probe, not the CLI VERSION", async () => {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -734,11 +734,16 @@ export async function gatherDaemonStatus(
 
   let lastError: string | undefined;
   if (
+    shouldInspectLocalGateway &&
     loaded &&
     runtime?.status === "running" &&
-    ((portStatus && portStatus.status !== "busy") || rpc?.ok === false)
+    portStatus &&
+    (portStatus.status !== "busy" || rpc?.ok === false)
   ) {
-    lastError = (await readLastGatewayErrorLine(mergedDaemonEnv as NodeJS.ProcessEnv)) ?? undefined;
+    lastError =
+      (await readLastGatewayErrorLine(mergedDaemonEnv as NodeJS.ProcessEnv, {
+        requirePatternMatch: portStatus.status === "busy",
+      })) ?? undefined;
   }
 
   // Plugin version drift detection.

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -733,7 +733,11 @@ export async function gatherDaemonStatus(
     : undefined;
 
   let lastError: string | undefined;
-  if (loaded && runtime?.status === "running" && portStatus && portStatus.status !== "busy") {
+  if (
+    loaded &&
+    runtime?.status === "running" &&
+    ((portStatus && portStatus.status !== "busy") || rpc?.ok === false)
+  ) {
     lastError = (await readLastGatewayErrorLine(mergedDaemonEnv as NodeJS.ProcessEnv)) ?? undefined;
   }
 

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -327,6 +327,14 @@ describe("printDaemonStatus", () => {
             listeners: [],
             hints: [],
           },
+          rpc: {
+            ok: false,
+            kind: "connect",
+            capability: "unknown",
+            error: "gateway closed (1000): ",
+            url: "ws://127.0.0.1:18789",
+          },
+          lastError: "failed to bind gateway socket EADDRINUSE",
           extraServices: [],
         },
         { json: false },
@@ -338,6 +346,8 @@ describe("printDaemonStatus", () => {
     expectMockLineContains(runtime.error, "Gateway port 18789 is not listening");
     expectMockLineContains(runtime.error, "/Users/test/Library/Logs/openclaw/gateway.log");
     expectMockLineContains(runtime.error, "Errors: suppressed");
+    const errors = runtime.error.mock.calls.map(([line]) => line).join("\n");
+    expect(errors.match(/Last gateway error:/g)).toHaveLength(1);
   });
 
   it("prints GUI-session wording before generic missing-supervision wording", () => {

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -397,6 +397,50 @@ describe("printDaemonStatus", () => {
     expectMockLineContains(runtime.log, "Capability: write-capable");
   });
 
+  it("prints the last gateway error when a running service fails the RPC probe", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "systemd user",
+          loaded: true,
+          loadedText: "enabled",
+          notLoadedText: "disabled",
+          runtime: { status: "running", pid: 8000 },
+        },
+        gateway: {
+          bindMode: "lan",
+          bindHost: "0.0.0.0",
+          port: 2345,
+          portSource: "service args",
+          probeUrl: "ws://127.0.0.1:2345",
+        },
+        port: {
+          port: 2345,
+          status: "busy",
+          listeners: [{ pid: 8000, ppid: 1, address: "*:2345" }],
+          hints: [],
+        },
+        rpc: {
+          ok: false,
+          kind: "connect",
+          capability: "unknown",
+          error: "gateway closed (1000): ",
+          url: "ws://127.0.0.1:2345",
+        },
+        lastError: "parse/handle error: Error: ENOSPC: no space left on device, write",
+        extraServices: [],
+      },
+      { json: false },
+    );
+
+    expectMockLineContains(runtime.error, "Connectivity probe: failed");
+    expectMockLineContains(runtime.error, "gateway closed (1000):");
+    expectMockLineContains(
+      runtime.error,
+      "Last gateway error: parse/handle error: Error: ENOSPC: no space left on device, write",
+    );
+  });
+
   it("prints CLI and gateway versions with readable guidance when they differ", () => {
     printDaemonStatus(
       {

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -305,7 +305,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
       for (const line of lines.slice(0, 12)) {
         defaultRuntime.error(`  ${errorText(line)}`);
       }
-      if (status.lastError) {
+      if (status.port?.status === "busy" && status.lastError) {
         defaultRuntime.error(`${errorText("Last gateway error:")} ${status.lastError}`);
       }
     }

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -305,6 +305,9 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
       for (const line of lines.slice(0, 12)) {
         defaultRuntime.error(`  ${errorText(line)}`);
       }
+      if (status.lastError) {
+        defaultRuntime.error(`${errorText("Last gateway error:")} ${status.lastError}`);
+      }
     }
     const capability = formatCapabilityLabel(rpc.capability);
     if (capability) {

--- a/src/daemon/diagnostics.test.ts
+++ b/src/daemon/diagnostics.test.ts
@@ -124,4 +124,22 @@ describe("readLastGatewayErrorLine", () => {
       "recent two",
     ]);
   });
+
+  it("surfaces ENOSPC from stdout ahead of a generic stderr tail on linux", async () => {
+    const stateDir = makeTempStateDir();
+    const homeDir = makeTempStateDir();
+    const env = { HOME: homeDir, OPENCLAW_STATE_DIR: stateDir };
+    const stateLogs = resolveGatewayLogPaths(env);
+    fs.mkdirSync(stateLogs.logDir, { recursive: true });
+    fs.writeFileSync(
+      stateLogs.stdoutPath,
+      "parse/handle error: Error: ENOSPC: no space left on device, write\n",
+      "utf8",
+    );
+    fs.writeFileSync(stateLogs.stderrPath, "gateway stderr tail without a known pattern\n", "utf8");
+
+    await expect(readLastGatewayErrorLine(env, { platform: "linux" })).resolves.toBe(
+      "parse/handle error: Error: ENOSPC: no space left on device, write",
+    );
+  });
 });

--- a/src/daemon/diagnostics.test.ts
+++ b/src/daemon/diagnostics.test.ts
@@ -142,4 +142,18 @@ describe("readLastGatewayErrorLine", () => {
       "parse/handle error: Error: ENOSPC: no space left on device, write",
     );
   });
+
+  it("does not return a generic log tail when a pattern match is required", async () => {
+    const stateDir = makeTempStateDir();
+    const homeDir = makeTempStateDir();
+    const env = { HOME: homeDir, OPENCLAW_STATE_DIR: stateDir };
+    const stateLogs = resolveGatewayLogPaths(env);
+    fs.mkdirSync(stateLogs.logDir, { recursive: true });
+    fs.writeFileSync(stateLogs.stdoutPath, "gateway stdout current\n", "utf8");
+    fs.writeFileSync(stateLogs.stderrPath, "routine gateway stderr\n", "utf8");
+
+    await expect(
+      readLastGatewayErrorLine(env, { platform: "linux", requirePatternMatch: true }),
+    ).resolves.toBeNull();
+  });
 });

--- a/src/daemon/diagnostics.ts
+++ b/src/daemon/diagnostics.ts
@@ -4,6 +4,8 @@ import { resolveGatewayLogPaths, resolveGatewaySupervisorLogPaths } from "./rest
 
 // Error patterns worth surfacing from gateway service logs after failed starts.
 const GATEWAY_LOG_ERROR_PATTERNS = [
+  /\bENOSPC\b/i,
+  /no space left on device/i,
   /refusing to bind gateway/i,
   /gateway auth mode/i,
   /gateway start blocked/i,

--- a/src/daemon/diagnostics.ts
+++ b/src/daemon/diagnostics.ts
@@ -85,7 +85,7 @@ function findLastNonEmptyLine(lines: string[]): string | null {
 
 export async function readLastGatewayErrorLine(
   env: NodeJS.ProcessEnv,
-  options?: { platform?: NodeJS.Platform },
+  options?: { platform?: NodeJS.Platform; requirePatternMatch?: boolean },
 ): Promise<string | null> {
   const platform = options?.platform ?? process.platform;
   const readStderr = platform !== "darwin";
@@ -109,6 +109,9 @@ export async function readLastGatewayErrorLine(
     if (GATEWAY_LOG_ERROR_PATTERNS.some((pattern) => pattern.test(line))) {
       return line;
     }
+  }
+  if (options?.requirePatternMatch) {
+    return null;
   }
   return readStderr
     ? (findLastNonEmptyLine(stderrLines) ?? findLastNonEmptyLine(stdoutLines))


### PR DESCRIPTION
## What Problem This Solves

`openclaw gateway status --deep` can currently show a running gateway service and a busy gateway port while the RPC probe only reports a generic close, for example `gateway closed (1000):`. In that state the actionable server-side error is already present in the gateway logs, but the status command does not surface it unless the port is not listening.

A real field case had the service active, port 2345 owned by the gateway process, and Feishu running, while `openclaw gateway status --deep --json` reported `rpc.ok=false` with only `gateway closed (1000):`. The gateway journal showed the actual cause: `parse/handle error: Error: ENOSPC: no space left on device, write`.

## Why This Change Was Made

This keeps the existing status diagnostic model and applies it to the missing case:

- read the latest gateway error when the managed service is running but the RPC probe fails, even if the port is listening
- print that `Last gateway error` next to the failed connectivity/read probe
- prioritize ENOSPC / `no space left on device` log lines when selecting the most useful recent gateway error

This does not change gateway auth, RPC behavior, service lifecycle, or log redaction. It only makes existing diagnostics more actionable.

## User Impact

Users who run `openclaw gateway status --deep` against a listening but internally failing gateway will see the likely root cause immediately instead of needing to know which service logs or journal entries to inspect. Disk-full failures become visible as a direct status hint rather than a misleading generic WebSocket close.

## Evidence

Field evidence from the affected host:

- `df -h /`: root filesystem was 100% full
- `openclaw gateway status --deep --json`: service runtime was `running`, port status was `busy`, listener PID owned `/usr/lib/node_modules/openclaw/dist/index.js gateway --port 2345`, but `rpc.ok=false` and `rpc.error="gateway closed (1000): "`
- gateway journal contained `parse/handle error: Error: ENOSPC: no space left on device, write`

Local validation:

- `corepack pnpm test src/daemon/diagnostics.test.ts`
- `corepack pnpm test src/cli/daemon-cli/status.gather.test.ts`
- `corepack pnpm test src/cli/daemon-cli/status.print.test.ts`
- `corepack pnpm test:changed`
- `corepack pnpm exec oxfmt --check --threads=1 src/daemon/diagnostics.ts src/daemon/diagnostics.test.ts src/cli/daemon-cli/status.gather.ts src/cli/daemon-cli/status.gather.test.ts src/cli/daemon-cli/status.print.ts src/cli/daemon-cli/status.print.test.ts`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 CI=1 corepack pnpm check:changed`

AI-assisted: investigated and implemented with Codex; changes and evidence were manually reviewed before submission.
