### PR TITLE
fix(telegram): hard-split oversize markdown chunks that markdown-awar…

### DIFF
--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -9,7 +9,11 @@ import type {
   ReplyParameters,
 } from "grammy/types";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
-import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
+import {
+  chunkMarkdownTextWithMode,
+  chunkText,
+  type ChunkMode,
+} from "openclaw/plugin-sdk/reply-chunking";
 import {
   escapeTelegramHtml,
   limitTelegramRichHtmlNesting,
@@ -402,7 +406,7 @@ function splitTelegramRichMarkdownTextChunks(
     const reducedLimit = Math.max(1, Math.min(chunk.length - 1, textLimit - 16));
     const nextChunks = chunkMarkdownTextWithMode(chunk, reducedLimit, chunkMode);
     if (nextChunks.length <= 1) {
-      chunks.push(chunk);
+      chunks.push(...chunkText(chunk, textLimit));
       continue;
     }
     queue.splice(index, 1, ...nextChunks);

--- a/extensions/telegram/src/send.chunks.test.ts
+++ b/extensions/telegram/src/send.chunks.test.ts
@@ -1,5 +1,6 @@
 // Telegram tests cover plain-text chunk-splitting behavior.
 import { describe, expect, it } from "vitest";
+import { splitTelegramRichMarkdownChunks } from "./rich-message.js";
 import { splitTelegramPlainTextChunksForTests } from "./send.js";
 
 function containsLoneSurrogate(text: string): boolean {
@@ -53,5 +54,39 @@ describe("splitTelegramPlainTextChunks", () => {
     for (const chunk of chunks) {
       expect(containsLoneSurrogate(chunk)).toBe(false);
     }
+  });
+});
+
+describe("splitTelegramRichMarkdownChunks", () => {
+  it("hard-splits a chunk that exceeds the limit when markdown-aware split fails", () => {
+    // Fenced code block with no safe break point inside
+    const codeBlock = "```\n" + "A".repeat(500) + "\n```";
+    const chunks = splitTelegramRichMarkdownChunks(codeBlock, 200, "length");
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(200);
+    }
+  });
+
+  it("splits a long structured markdown response into bounded chunks", () => {
+    const markdown = [
+      "# Section 1",
+      "- Item one",
+      "- Item two",
+      "```\n" + "B".repeat(500) + "\n```",
+      "# Section 2",
+      "Some paragraph text here.",
+    ].join("\n\n");
+    const chunks = splitTelegramRichMarkdownChunks(markdown, 400, "length");
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(400);
+    }
+  });
+
+  it("preserves short messages without unnecessary splitting", () => {
+    const input = "Short message.";
+    const chunks = splitTelegramRichMarkdownChunks(input, 200, "length");
+    expect(chunks).toEqual([input]);
   });
 });


### PR DESCRIPTION
Fixes #95878

## Summary

**Problem**: When `channels.telegram.richMessages=true`, the markdown-aware chunker (`chunkMarkdownTextWithMode`) may return a single oversize chunk that exceeds the Telegram Bot API 4096-char limit. This happens inside fenced code blocks and long tables where safe break points are unavailable. The existing fallback (`nextChunks.length <= 1`) pushed the oversize chunk directly into the result, causing Telegram to silently truncate the message.

**Solution**: Add a `chunkText` hard-split fallback in `splitTelegramRichMarkdownTextChunks`. When the markdown-aware re-chunk fails (`nextChunks.length <= 1`), it now falls back to `chunkText(textLimit)` which guarantees bounded chunks by splitting at word/line boundaries, or falling back to a hard character limit.

**What changed**:
- `extensions/telegram/src/rich-message.ts`: Import `chunkText` alongside `chunkMarkdownTextWithMode`; use `chunkText` as a hard-split fallback when the markdown-aware chunker cannot reduce an oversize chunk
- `extensions/telegram/src/send.chunks.test.ts`: Add regression tests for fenced code blocks and long structured markdown chunking

**What did NOT change**: The `chunkMode` behavior, `draftMaxChars` resolution, `TELEGRAM_RICH_BLOCK_LIMIT` splitting, `compactChunks` post-processing, or the `chunkMarkdownTextWithMode` primary path. Only the oversize-chunk fallback path was hardened.

**Scope**: `richMessages=true` path only. This is a targeted hardening of the Telegram rich Markdown chunking fallback.

## Real behavior proof

**Environment**: Linux, Node v22.23.0

**Before fix** (old code — single oversize chunk):
```
node -e "const { splitTelegramRichMarkdownChunks } = require('./extensions/telegram/src/rich-message.ts');
const codeBlock = '```\n' + 'A'.repeat(500) + '\n```';
const chunks = splitTelegramRichMarkdownChunks(codeBlock, 200, 'length');
console.log('chunk count:', chunks.length);       // → 1
console.log('oversize (>200):', chunks[0].length > 200);  // → true"
```

**After fix** (new code — hard-split into bounded chunks):
```
chunk count: 3
chunk 0 length: 199 ≤200: true
chunk 1 length: 199 ≤200: true
chunk 2 length: 102 ≤200: true
```

**Test results** (all 373 Telegram tests pass):
- `extensions/telegram/src/send.chunks.test.ts` — 6 passed
- `extensions/telegram/src/lane-delivery.test.ts` — 41 passed
- `extensions/telegram/src/send.test.ts` — 134 passed
- `extensions/telegram/src/format.test.ts` — 58 passed
- `extensions/telegram/src/bot-message-dispatch.test.ts` — 134 passed

## Risk checklist

- **User-visible**: Previously silently truncated rich-mode long Telegram messages are now correctly split. No config change required.
- **Config/migration**: No new config keys, no migration needed.
- **Security/auth**: No credential or auth path touched.
