### PR TITLE
fix: preserve exec policy layer base

### DIFF
--- a/src/infra/exec-policy.test.ts
+++ b/src/infra/exec-policy.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { applyExecPolicyLayer, type ExecPolicyLayer } from "./exec-policy.js";
+
+describe("applyExecPolicyLayer", () => {
+  it("preserves base fields when applying a normalized mode", () => {
+    const base = {
+      host: "gateway",
+      security: "deny",
+      ask: "always",
+    } satisfies ExecPolicyLayer & { host: string };
+
+    expect(applyExecPolicyLayer(base, { mode: "full" })).toMatchObject({
+      host: "gateway",
+      mode: "full",
+      security: "full",
+      ask: "off",
+    });
+  });
+
+  it("preserves base fields when applying legacy security and ask overrides", () => {
+    const base = {
+      timeoutSec: 30,
+      security: "deny",
+      ask: "always",
+    } satisfies ExecPolicyLayer & { timeoutSec: number };
+
+    expect(applyExecPolicyLayer(base, { security: "allowlist" })).toEqual({
+      timeoutSec: 30,
+      security: "allowlist",
+      ask: "always",
+    });
+  });
+
+  it("clears inherited normalized mode when legacy policy fields override it", () => {
+    const base = applyExecPolicyLayer(
+      {
+        host: "gateway",
+        security: "deny",
+        ask: "always",
+      } satisfies ExecPolicyLayer & { host: string },
+      { mode: "full" },
+    );
+
+    expect(applyExecPolicyLayer(base, { security: "deny" })).toEqual({
+      host: "gateway",
+      security: "deny",
+      ask: "off",
+    });
+  });
+});

--- a/src/infra/exec-policy.ts
+++ b/src/infra/exec-policy.ts
@@ -7,7 +7,6 @@ export type ExecPolicyLayer = {
   ask?: ExecAsk;
 };
 
-// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Preserve each caller's required policy fields.
 export function applyExecPolicyLayer<TBase extends ExecPolicyLayer>(
   base: TBase,
   layer?: ExecPolicyLayer,
@@ -17,12 +16,16 @@ export function applyExecPolicyLayer<TBase extends ExecPolicyLayer>(
   }
   if (layer.mode) {
     return {
+      ...base,
       mode: layer.mode,
       ...resolveExecPolicyForMode(layer.mode),
-    } as TBase & ExecPolicyLayer;
+    };
   }
   if (layer.security !== undefined || layer.ask !== undefined) {
     return {
+      ...base,
+      mode: undefined,
+      autoReview: undefined,
       security: layer.security ?? base.security,
       ask: layer.ask ?? base.ask,
     } as TBase & ExecPolicyLayer;


### PR DESCRIPTION
## Summary

- Preserve non-policy fields when `applyExecPolicyLayer` applies normalized exec modes or legacy `security` / `ask` overrides.
- Clear inherited normalized `mode` / `autoReview` state when a lower legacy override supplies `security` or `ask`, so narrower per-agent/session policy still wins.
- Add focused regression coverage for preserving caller fields and for legacy overrides clearing inherited normalized mode.

## Verification

- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p tsconfig.plugin-sdk.dts.json --declaration true`
- `node scripts/run-vitest.mjs src/infra/exec-policy.test.ts -- --reporter=verbose`
- `../openclaw/node_modules/.bin/oxfmt --check src/infra/exec-policy.ts src/infra/exec-policy.test.ts`
- `git diff --check origin/main...HEAD`

Note: this was validated from an isolated worktree using the main checkout's installed dependencies because the isolated worktree intentionally had no local `node_modules`.
