### PR TITLE
fix(code-mode): surface QuickJS error name and message to the model

### DIFF
--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -1639,6 +1639,53 @@ describe("Code Mode", () => {
     expect(testing.activeRuns.size).toBe(beforeRunCount);
   });
 
+  it("surfaces the QuickJS error name and message for guest syntax errors", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const details = resultDetails(
+      await codeModeTools[0].execute("code-call-syntax", { code: "const x = ;" }),
+    );
+
+    expect(details.status).toBe("failed");
+    const error = String(details.error);
+    // Regression guard: QuickJS stacks are frames only, so the error used to
+    // collapse to a bare "at openclaw-code-mode:user.js:..." location with the
+    // actual cause dropped. The model now sees the name and message.
+    expect(error).toContain("SyntaxError");
+    expect(error).toContain("unexpected token");
+    expect(error.startsWith("at ")).toBe(false);
+  });
+
+  it("surfaces the QuickJS error name and message for guest runtime errors", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const details = resultDetails(
+      await codeModeTools[0].execute("code-call-runtime", { code: "return missingFn();" }),
+    );
+
+    expect(details.status).toBe("failed");
+    const error = String(details.error);
+    expect(error).toContain("ReferenceError");
+    expect(error).toContain("missingFn is not defined");
+    expect(error.startsWith("at ")).toBe(false);
+  });
+
   it("clamps omitted code-mode catalog search limits to maxSearchLimit", async () => {
     const catalogRef = createToolSearchCatalogRef();
     const config = {
@@ -1896,7 +1943,7 @@ describe("Code Mode", () => {
     );
 
     expect(details.status).toBe("failed");
-    expect(details.error).toBe("boom");
+    expect(String(details.error)).toContain("Error: boom");
     expect(details.output).toEqual([{ type: "text", text: "before" }]);
   });
 
@@ -2045,9 +2092,11 @@ describe("Code Mode", () => {
     );
 
     expect(result.status).toBe("failed");
-    expect(result).toMatchObject({
-      code: "internal_error",
-      error: "interrupted",
-    });
+    // A guest error whose message happens to be "interrupted" must stay
+    // internal_error and not be misclassified as a QuickJS interrupt/timeout.
+    expect(result).toMatchObject({ code: "internal_error" });
+    if (result.status === "failed") {
+      expect(result.error).toContain("interrupted");
+    }
   });
 });

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -1686,6 +1686,29 @@ describe("Code Mode", () => {
     expect(error.startsWith("at ")).toBe(false);
   });
 
+  it("does not duplicate host error headers or expose host stack frames", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const details = resultDetails(
+      await codeModeTools[0].execute("code-call-host-error", {
+        code: 'return globalThis.__openclawHostRequest("unsupported", "[]");',
+      }),
+    );
+
+    expect(details).toMatchObject({
+      status: "failed",
+      error: "Error: unsupported code mode bridge method",
+    });
+  });
+
   it("clamps omitted code-mode catalog search limits to maxSearchLimit", async () => {
     const catalogRef = createToolSearchCatalogRef();
     const config = {

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -131,6 +131,11 @@ function isQuickJsInterruptedError(error: unknown): boolean {
   if (error instanceof CodeModeGuestError) {
     return false;
   }
+  // Match on the raw QuickJS message, not the formatted errorMessage() string,
+  // which now leads with the error name and appends backtrace frames.
+  if (error instanceof JSException) {
+    return error.message === "interrupted";
+  }
   return errorMessage(error) === "interrupted";
 }
 
@@ -150,9 +155,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
+// QuickJS error stacks are backtrace frames only ("    at file:line:col"), with
+// no leading "Name: message" header like V8. Returning .stack alone therefore
+// dropped the actual cause, surfacing failures to the model as a bare location
+// (e.g. "at openclaw-code-mode:user.js:2:37"). Lead with name+message so the
+// model can self-correct, and keep the frames for location.
+function formatQuickJsError(name: string, message: string, stack: string | undefined): string {
+  const header = message ? `${name}: ${message}` : name;
+  return stack ? `${header}\n${stack}` : header;
+}
+
 function errorMessage(error: unknown): string {
   if (error instanceof JSException) {
-    return error.stack || error.message || String(error);
+    return formatQuickJsError(error.name, error.message, error.stack);
   }
   if (error instanceof Error) {
     return error.message || String(error);
@@ -575,7 +590,15 @@ async function readCompletedResult(vm: QuickJS, resultHandle: JSValueHandle): Pr
   const settled = await vm.resolvePromise(resultHandle);
   if ("error" in settled) {
     try {
-      throw new CodeModeGuestError(errorMessage(vm.dump(settled.error)));
+      // vm.dump rebuilds a host Error carrying the QuickJS name/message/stack;
+      // format it like the synchronous path so async rejections keep their cause
+      // and location instead of collapsing to the bare message.
+      const dumped = vm.dump(settled.error);
+      const text =
+        dumped instanceof Error
+          ? formatQuickJsError(dumped.name, dumped.message, dumped.stack)
+          : errorMessage(dumped);
+      throw new CodeModeGuestError(text);
     } finally {
       settled.error.dispose();
     }

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -162,7 +162,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 // model can self-correct, and keep the frames for location.
 function formatQuickJsError(name: string, message: string, stack: string | undefined): string {
   const header = message ? `${name}: ${message}` : name;
-  return stack ? `${header}\n${stack}` : header;
+  if (!stack || stack.split(/\r?\n/, 1)[0] === header) {
+    return header;
+  }
+  return `${header}\n${stack}`;
 }
 
 function errorMessage(error: unknown): string {


### PR DESCRIPTION
## Summary

- Fixes code-mode tool failures that surface to the model as a bare location like `at openclaw-code-mode:user.js:2:37` with `code: internal_error` and no actual cause.
- Formats QuickJS errors as `Name: message` followed by the backtrace frames, so a guest error (e.g. a syntax error in model-generated code) reports `SyntaxError: unexpected token ...` instead of dropping the cause.
- Applies the same formatting to both the synchronous eval path and the async rejected-promise path; leaves failure classification (`code`) and the timeout/interrupt handling unchanged.

## Linked context

Refs #95904

## Root cause

QuickJS error objects expose `.stack` as backtrace frames only (e.g. `    at openclaw-code-mode:user.js:2:37`) with no leading `Name: message` header like V8. The worker's `errorMessage()` returned `error.stack || error.message`, so for a `JSException` it returned the bare frames and dropped the error name and message entirely. The async path was similar: it surfaced only `.message`, dropping the name and location.

When a non-Codex fallback model (e.g. `deepseek/deepseek-v4-pro`, `openrouter/minimax/minimax-m3`) emits slightly-off code-mode JavaScript, the run fails but the model receives an uninformative `internal_error` with only a source location, so it cannot self-correct on the next turn.

## Real behavior proof

<!-- before(bug真实存在) → premise(成因主张为真) → after(修后好使) -->

- Behavior or issue addressed: code-mode guest errors surface to the model without the error name/message.
- Real environment tested: actual code-mode worker (`testing.runCodeModeWorker`) running real QuickJS-WASI in-process; no mocks, no external credentials needed (code-mode executes locally).
- Root cause / premise evidence: QuickJS `error.stack` is frames-only with no `Name: message` header — see `quickjs-wasi/dist/index.js` `JSException` (`get stack()` returns the raw QuickJS stack) and `_dump()` for errors (rebuilds a host `Error` whose `stack` is the QuickJS frames). The old `errorMessage()` returned `.stack` first.
- Before evidence (bug reproduced on main): driving the real worker with the reporter's pattern (a guest syntax error) on the unpatched worker:

```text
### guest SyntaxError (reporter repro)
status: failed  code: internal_error
error: "    at openclaw-code-mode:user.js:2:37\n"

### guest ReferenceError (runtime)
status: failed  code: internal_error
error: "exec is not defined"
```

- Exact steps or command run after this patch: same script, patched worker.
- Evidence after fix: console output from the real worker:

```text
### guest SyntaxError (reporter repro)
status: failed  code: internal_error
error: "SyntaxError: unexpected token in expression: ';'\n    at openclaw-code-mode:user.js:2:37\n"

### guest ReferenceError (runtime)
status: failed  code: internal_error
error: "ReferenceError: exec is not defined\n    at <anonymous> (openclaw-code-mode:user.js:1:31)\n    at <eval> (openclaw-code-mode:user.js:3:1)\n"
```

- Observed result after fix: the exact reporter symptom (`at openclaw-code-mode:user.js:2:37`) is preserved as the location but now prefixed with the real cause (`SyntaxError: unexpected token in expression: ';'`).
- What was not tested: live Telegram round-trip and the specific fallback models from the report (no credentials in my checkout); the fix is at the code-mode error-formatting layer, which is model/runtime agnostic.
- Proof limitations or environment constraints: the report's three product-level options (validate fallbacks, auto fall-through to another tool-capable model) are not addressed here — those are product/owner decisions. This PR fixes the concrete error-surfacing defect so the model gets an actionable diagnostic.

## Tests and validation

- `git diff --check`
- `node scripts/run-vitest.mjs src/agents/code-mode.test.ts` — 55 passed (includes two new tests for guest syntax/runtime error surfacing; updated two existing tests that asserted the old bare-message output).
- `oxfmt --check` on both changed files — clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` — no errors in the changed files (one pre-existing unrelated error in `src/infra/exec-policy.ts`).

## Risk checklist

Did user-visible behavior change? `Yes` — code-mode failure messages now include the error name/message; failure `code` values are unchanged.

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: the interrupt/timeout matcher (`isQuickJsInterruptedError`), which previously compared against `errorMessage()`.

How is that risk mitigated? It now matches on the raw QuickJS `.message` for `JSException`, decoupled from the human-facing formatting; timeout detection still relies primarily on the deadline check, and the existing "does not classify guest interrupted errors as timeouts" test still passes.

Current review state: maintainer review and CI.

AI-assisted. Proof above was run manually.