### PR TITLE
fix: ignore reasoning-only heartbeat ack blocks

### DIFF
--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -108,6 +108,27 @@ describe("isHeartbeatOkResponse", () => {
       }),
     ).toBe(false);
 
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "internal draft" },
+          { type: "output_text", text: "HEARTBEAT_OK" },
+        ],
+      }),
+    ).toBe(true);
+
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal draft" },
+          { type: "output_text", text: "HEARTBEAT_OK" },
+          { type: "image", image_url: "https://example.com/a.png" },
+        ],
+      }),
+    ).toBe(false);
+
     const toolCallOnlyMessage = {
       role: "assistant",
       content: null,
@@ -187,6 +208,24 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
         },
       ]);
     }
+  });
+
+  it("removes heartbeat pairs when the ack also contains reasoning blocks", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "thinking..." },
+          { type: "output_text", text: "HEARTBEAT_OK" },
+        ],
+      },
+      { role: "user", content: "what model are you" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what model are you" },
+    ]);
   });
 
   it("removes prompt-only interrupted heartbeat spans", () => {

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -282,6 +282,28 @@ function resolveMessageText(content: unknown): { text: string; hasNonTextContent
   return { text, hasNonTextContent };
 }
 
+function hasOnlyIgnorableHeartbeatAckBlocks(content: unknown): boolean {
+  if (!Array.isArray(content) || content.length === 0) {
+    return false;
+  }
+  let sawTextBlock = false;
+  for (const block of content) {
+    if (!isRecord(block)) {
+      return false;
+    }
+    const type = readString(block.type) ?? "";
+    if (type === "text" || type === "input_text" || type === "output_text") {
+      sawTextBlock = true;
+      continue;
+    }
+    if (type === "reasoning" || type === "thinking") {
+      continue;
+    }
+    return false;
+  }
+  return sawTextBlock;
+}
+
 /** Return whether a user message is an internal heartbeat prompt. */
 export function isHeartbeatUserMessage(
   message: { role: string; content?: unknown },
@@ -337,7 +359,7 @@ export function isHeartbeatOkResponse(
     return false;
   }
   const { text, hasNonTextContent } = resolveMessageText(message.content);
-  if (hasNonTextContent) {
+  if (hasNonTextContent && !hasOnlyIgnorableHeartbeatAckBlocks(message.content)) {
     return false;
   }
   return stripHeartbeatToken(text, { mode: "heartbeat", maxAckChars: ackMaxChars }).shouldSkip;


### PR DESCRIPTION
## Summary

Allow heartbeat transcript pruning to keep working when an otherwise short `HEARTBEAT_OK` acknowledgement is wrapped with provider reasoning/thinking blocks.

## Changes

- treat `reasoning` and `thinking` blocks as ignorable metadata for heartbeat ACK detection
- keep rejecting heartbeat ACKs that also contain other non-text payloads like images or tools
- add regression coverage for direct ACK detection and transcript-span pruning

## Testing

- `pnpm test -- --run src/auto-reply/heartbeat-filter.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-injection.test.ts`

Fixes openclaw/openclaw#95796