### PR TITLE
fix: treat feishu bind conversation ids as peers

### DIFF
--- a/src/commands/agents.bind.feishu.integration.test.ts
+++ b/src/commands/agents.bind.feishu.integration.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  createBindingResolverTestPlugin,
+  createTestRegistry,
+} from "../test-utils/channel-plugins.js";
+import { parseBindingSpecs } from "./agents.bindings.js";
+
+const feishuBindingPlugin = createBindingResolverTestPlugin({
+  id: "feishu",
+  resolveBindingAccountId: () => undefined,
+});
+
+describe("agents bind feishu integration", () => {
+  it("parses feishu group chat bindings into peer matches", () => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "feishu", plugin: feishuBindingPlugin, source: "test" }]),
+    );
+
+    const parsed = parseBindingSpecs({ agentId: "main", specs: ["feishu:oc_test"], config: {} });
+
+    expect(parsed.errors).toStrictEqual([]);
+    expect(parsed.bindings).toEqual([
+      {
+        type: "route",
+        agentId: "main",
+        match: { channel: "feishu", peer: { kind: "group", id: "oc_test" } },
+      },
+    ]);
+  });
+
+  it("preserves full feishu topic conversation ids after the channel separator", () => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "feishu", plugin: feishuBindingPlugin, source: "test" }]),
+    );
+
+    const parsed = parseBindingSpecs({
+      agentId: "main",
+      specs: ["feishu:oc_group_chat:topic:om_topic_root"],
+      config: {},
+    });
+
+    expect(parsed.errors).toStrictEqual([]);
+    expect(parsed.bindings).toEqual([
+      {
+        type: "route",
+        agentId: "main",
+        match: {
+          channel: "feishu",
+          peer: { kind: "group", id: "oc_group_chat:topic:om_topic_root" },
+        },
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry());
+  });
+});

--- a/src/commands/agents.bindings.ts
+++ b/src/commands/agents.bindings.ts
@@ -247,6 +247,36 @@ function getBindingChannelPlugin(channel: ChannelId) {
   return getLoadedChannelPlugin(channel) ?? getBundledChannelSetupPlugin(channel);
 }
 
+function resolveFeishuConversationBindingPeer(
+  raw: string,
+): { kind: "direct" | "group"; id: string } | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const lowered = trimmed.toLowerCase();
+  if (
+    lowered.startsWith("user:") ||
+    lowered.startsWith("dm:") ||
+    lowered.startsWith("open_id:") ||
+    lowered.startsWith("ou_") ||
+    lowered.startsWith("on_")
+  ) {
+    const id = trimmed.replace(/^(user|dm|open_id):/i, "").trim();
+    return id ? { kind: "direct", id } : undefined;
+  }
+  if (
+    lowered.startsWith("chat:") ||
+    lowered.startsWith("group:") ||
+    lowered.startsWith("channel:") ||
+    lowered.startsWith("oc_")
+  ) {
+    const id = trimmed.replace(/^(chat|group|channel):/i, "").trim();
+    return id ? { kind: "group", id } : undefined;
+  }
+  return undefined;
+}
+
 function resolveBindingAccountId(params: {
   channel: ChannelId;
   config: OpenClawConfig;
@@ -316,7 +346,9 @@ export function parseBindingSpecs(params: {
     if (!trimmed) {
       continue;
     }
-    const [channelRaw, accountRaw] = trimmed.split(":", 2);
+    const separatorIndex = trimmed.indexOf(":");
+    const channelRaw = separatorIndex >= 0 ? trimmed.slice(0, separatorIndex) : trimmed;
+    const accountRaw = separatorIndex >= 0 ? trimmed.slice(separatorIndex + 1) : undefined;
     const channel = normalizeBindingChannelId(channelRaw, params.config);
     if (!channel) {
       errors.push(formatUnknownChannelMessage({ channel: channelRaw }));
@@ -329,15 +361,22 @@ export function parseBindingSpecs(params: {
       );
       continue;
     }
+    const feishuPeer =
+      channel === "feishu" && accountId
+        ? resolveFeishuConversationBindingPeer(accountId)
+        : undefined;
     accountId = resolveBindingAccountId({
       channel,
       config: params.config,
       agentId,
-      explicitAccountId: accountId,
+      explicitAccountId: feishuPeer ? undefined : accountId,
     });
     const match: AgentRouteBinding["match"] = { channel };
     if (accountId) {
       match.accountId = accountId;
+    }
+    if (feishuPeer) {
+      match.peer = feishuPeer;
     }
     bindings.push({ type: "route", agentId, match });
   }


### PR DESCRIPTION
## Summary

Make `openclaw agents add --bind ...` generate routeable Feishu conversation bindings when the bind target is a chat or user conversation id instead of a channel account name.

## Changes

- split `--bind` specs on the first channel separator so Feishu topic ids keep their full `:topic:` suffix
- map Feishu conversation-like ids such as `oc_...`, `ou_...`, `on_...`, `chat:...`, and `user:...` into `match.peer` bindings
- add integration coverage for group chat and topic conversation ids

## Testing

- `pnpm test -- --run src/commands/agents.bind.feishu.integration.test.ts src/commands/agents.bind.matrix.integration.test.ts`

Fixes openclaw/openclaw#95734