### PR TITLE
fix(whatsapp): preserve durable reply target

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -11,6 +11,7 @@ type CapturedReplyPayload = {
   isError?: boolean;
   mediaUrl?: string;
   mediaUrls?: string[];
+  replyToId?: string | null;
 };
 
 type CapturedDispatchParams = {
@@ -720,6 +721,7 @@ describe("whatsapp inbound dispatch", () => {
       agentId: "main",
       to: "+1000",
       info: { kind: "final" },
+      replyToId: null,
     });
     expectRecordFields(requireRecord(durableParams.payload, "durable payload"), {
       text: "final payload",
@@ -732,6 +734,64 @@ describe("whatsapp inbound dispatch", () => {
       combinedBody: "incoming",
       combinedBodySessionKey: "agent:main:whatsapp:+15551234567",
     });
+  });
+
+  it.each([
+    {
+      name: "uses resolved final payload reply targets",
+      payload: { text: "final payload", replyToId: "trigger-message" },
+      expectedReplyToId: "trigger-message",
+    },
+    {
+      name: "blocks durable fallback without a final payload reply target",
+      payload: { text: "final payload" },
+      expectedReplyToId: null,
+    },
+  ] satisfies Array<{
+    name: string;
+    payload: CapturedReplyPayload;
+    expectedReplyToId: string | null;
+  }>)("$name while preserving quoted WhatsApp context", async ({ payload, expectedReplyToId }) => {
+    deliverInboundReplyWithMessageSendContextMock.mockResolvedValueOnce({
+      status: "handled_visible",
+      delivery: {
+        messageIds: ["wa-1"],
+        visibleReplySent: true,
+      },
+    });
+    const deliverReply = vi.fn(async () => acceptedDeliveryResult());
+
+    await dispatchBufferedReply({
+      context: {
+        Body: "incoming",
+        ReplyToId: "quoted-bot-message",
+        ReplyToBody: "Earlier bot reply",
+        ReplyToSender: "OpenClaw",
+      },
+      deliverReply,
+      msg: makeMsg({
+        event: { id: "trigger-message" },
+      }),
+    });
+
+    const deliver = getCapturedDeliver();
+    await deliver?.(payload, { kind: "final" });
+
+    const durableParams = requireMockArg(
+      deliverInboundReplyWithMessageSendContextMock,
+      0,
+      0,
+      "durable delivery params",
+    );
+    expectRecordFields(durableParams, {
+      replyToId: expectedReplyToId,
+    });
+    expectRecordFields(requireRecord(durableParams.ctxPayload, "durable context"), {
+      ReplyToId: "quoted-bot-message",
+      ReplyToBody: "Earlier bot reply",
+      ReplyToSender: "OpenClaw",
+    });
+    expect(deliverReply).not.toHaveBeenCalled();
   });
 
   it("does not fall back when durable WhatsApp delivery suppresses a send", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -691,6 +691,7 @@ export async function dispatchWhatsAppBufferedReply(params: {
               payload: normalizedDeliveryPayload,
               info,
               to: conversationId,
+              replyToId: normalizedDeliveryPayload.replyToId ?? null,
               formatting: {
                 textLimit,
                 tableMode,


### PR DESCRIPTION
## What Problem This Solves

WhatsApp reply-to-bot flows can preserve the earlier quoted bot message as agent context, then accidentally reuse that quoted message as the native outbound reply target for the final answer. In WhatsApp Web/Desktop this makes the bot appear to reply to the wrong native message even though the generated response text is correct.

## Why This Change Was Made

WhatsApp durable final delivery now passes an explicit reply target into the shared durable delivery path. When the normalized final payload has a resolved `replyToId`, durable delivery uses that target. When it does not, WhatsApp passes explicit `null` so shared durable delivery cannot fall back to the model-visible quoted context fields.

This keeps the earlier quoted message available in `ReplyToBody` / `ReplyToSender` for agent context while preventing it from becoming the native WhatsApp quote target.

## User Impact

Users in WhatsApp group reply-to-bot flows should see final bot replies quote the triggering user message when reply threading has resolved that target. If no final payload reply target exists, the bot no longer incorrectly quotes the earlier bot message.

## Evidence

- `node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts` — 52 passed
- `pnpm tsgo:extensions` — passed
- `git diff --check` — clean
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings
