### PR TITLE
fix(memory): improve node:sqlite unavailable guidance

### DIFF
--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -113,17 +113,25 @@ export function buildMemorySearchUnavailableResult(
   },
 ) {
   const reason = (error ?? "memory search unavailable").trim() || "memory search unavailable";
-  const isQuotaError = /insufficient_quota|quota|429/.test(normalizeLowercaseStringOrEmpty(reason));
+  const normalizedReason = normalizeLowercaseStringOrEmpty(reason);
+  const isQuotaError = /insufficient_quota|quota|429/.test(normalizedReason);
+  const isMissingNodeSqlite = /missing node:sqlite|no such built-?in module: node:sqlite/.test(
+    normalizedReason,
+  );
   const warning =
     overrides?.warning ??
     (isQuotaError
       ? "Memory search is unavailable because the embedding provider quota is exhausted."
-      : "Memory search is unavailable due to an embedding/provider error.");
+      : isMissingNodeSqlite
+        ? "Memory search is unavailable because this OpenClaw Node runtime does not provide SQLite support."
+        : "Memory search is unavailable due to an embedding/provider error.");
   const action =
     overrides?.action ??
     (isQuotaError
       ? "Top up or switch embedding provider, then retry memory_search."
-      : "Check embedding provider configuration and retry memory_search.");
+      : isMissingNodeSqlite
+        ? "Run OpenClaw with a Node runtime that includes node:sqlite, then retry memory_search."
+        : "Check embedding provider configuration and retry memory_search.");
   return {
     results: [],
     disabled: true,

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -13,7 +13,11 @@ import {
   setMemorySearchManagerImpl,
 } from "./memory-tool-manager.test-mocks.js";
 import { createMemorySearchTool, testing as memoryToolsTesting } from "./tools.js";
-import { MemoryGetSchema, MemorySearchSchema } from "./tools.shared.js";
+import {
+  buildMemorySearchUnavailableResult,
+  MemoryGetSchema,
+  MemorySearchSchema,
+} from "./tools.shared.js";
 import {
   asOpenClawConfig,
   createMemorySearchToolOrThrow,
@@ -117,6 +121,37 @@ describe("memory_search unavailable payloads", () => {
       error: "openai embeddings failed: 429 insufficient_quota",
       warning: "Memory search is unavailable because the embedding provider quota is exhausted.",
       action: "Top up or switch embedding provider, then retry memory_search.",
+    });
+  });
+
+  it("returns explicit unavailable metadata for missing node:sqlite failures", async () => {
+    const error =
+      "SQLite support is unavailable in this Node runtime (missing node:sqlite). No such built-in module: node:sqlite";
+    setMemorySearchImpl(async () => {
+      throw new Error(error);
+    });
+
+    const tool = createMemorySearchToolOrThrow();
+    const result = await tool.execute("missing-node-sqlite", { query: "hello" });
+    expectUnavailableMemorySearchDetails(result.details, {
+      error,
+      warning:
+        "Memory search is unavailable because this OpenClaw Node runtime does not provide SQLite support.",
+      action:
+        "Run OpenClaw with a Node runtime that includes node:sqlite, then retry memory_search.",
+    });
+  });
+
+  it("keeps explicit unavailable metadata overrides for missing node:sqlite reasons", () => {
+    const result = buildMemorySearchUnavailableResult("missing node:sqlite", {
+      warning: "custom warning",
+      action: "custom action",
+    });
+
+    expectUnavailableMemorySearchDetails(result, {
+      error: "missing node:sqlite",
+      warning: "custom warning",
+      action: "custom action",
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

`memory_search` currently reports missing `node:sqlite` as a generic embedding/provider failure. That sends users toward provider configuration even though the actual remediation is to run OpenClaw on a Node runtime with SQLite support.

This replacement carries forward the narrow fix from @rrrrrredy's source PR https://github.com/openclaw/openclaw/pull/69199. Clownfish is replacing the branch because the source PR is not maintainer-editable, while preserving attribution for the original contribution.

## Why This Change Was Made

Current main still routes manager setup and search unavailable errors through `buildMemorySearchUnavailableResult`, which only distinguishes quota errors from the generic fallback. The replacement keeps that shape but adds a targeted missing-`node:sqlite` branch and normalizes the reason string once so the quota and sqlite checks use the same input.

## User Impact

When `node:sqlite` is unavailable, `memory_search` returns the existing unavailable result shape with a targeted warning/action that points to restoring SQLite-capable Node support, while quota, generic, and explicit override paths remain unchanged.

## Evidence

- Source PR: https://github.com/openclaw/openclaw/pull/69199 by @rrrrrredy.
- Greptile's P2 normalization comment is addressed by using one normalized reason for both checks.
- Focused validation: `pnpm test extensions/memory-core/src/tools.test.ts`.
- Changed gate: `pnpm check:changed`.

Clownfish 🐠 replacement reef notes:
- Cluster: repair-openclaw-openclaw-69199-20260623a
- Source PRs: https://github.com/openclaw/openclaw/pull/69199
- Credit: Credit @rrrrrredy for the original fix and source PR https://github.com/openclaw/openclaw/pull/69199.; Mention that Clownfish is replacing the branch only because maintainers cannot safely update it; preserve attribution in the PR body and release-note context.; Do not edit CHANGELOG.md directly; OpenClaw release generation owns CHANGELOG.md.
- Validation: pnpm test extensions/memory-core/src/tools.test.ts; pnpm check:changed

fish notes: model gpt-5.5, reasoning medium; reviewed against 3662b0765875.
