### PR TITLE
ci: add Codex maturity scorecard agent

### DIFF
--- a/.github/codex/prompts/maturity-scorecard-agent.md
+++ b/.github/codex/prompts/maturity-scorecard-agent.md
@@ -1,0 +1,23 @@
+# OpenClaw Maturity Scorecard Agent
+
+You are refreshing the OpenClaw maturity score source for a release scorecard.
+
+Goal: use the `$claw-score` skill to refresh `qa/maturity-scores.yaml` for every active surface in `taxonomy.yaml`, using the current repository and the release evidence artifacts in `.artifacts/maturity-evidence`.
+
+Allowed tracked paths:
+
+- `qa/maturity-scores.yaml`
+
+Hard limits:
+
+- Do not edit generated docs, taxonomy, workflows, scripts, package metadata, lockfiles, tests, or application code.
+- Do not render docs. The workflow renders docs after validating the score source.
+- Keep the score source schema valid for QA Lab maturity score validation.
+
+Required workflow:
+
+1. Use the `$claw-score` skill before editing.
+2. Read `taxonomy.yaml`, any existing maturity score file, and the release evidence artifacts.
+3. Refresh scores for every active surface in `taxonomy.yaml`.
+4. Run the QA Lab maturity score validation used by this repository.
+5. If no defensible score update is possible, leave a valid `qa/maturity-scores.yaml` and explain the uncertainty in the final message.

--- a/.github/workflows/maturity-scorecard.yml
+++ b/.github/workflows/maturity-scorecard.yml
@@ -218,6 +218,67 @@ jobs:
           }
           NODE
 
+      - name: Ensure maturity scorecard agent key exists
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENCLAW_MATURITY_SCORECARD_AGENT_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+            echo "Missing OPENCLAW_MATURITY_SCORECARD_AGENT_OPENAI_API_KEY or OPENAI_API_KEY secret." >&2
+            exit 1
+          fi
+
+      - name: Run Codex maturity scorecard agent
+        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1
+        env:
+          MATURITY_EVIDENCE_DIR: .artifacts/maturity-evidence
+          MATURITY_SCORES_PATH: qa/maturity-scores.yaml
+          MATURITY_TAXONOMY_PATH: taxonomy.yaml
+        with:
+          openai-api-key: ${{ secrets.OPENCLAW_MATURITY_SCORECARD_AGENT_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
+          prompt-file: .github/codex/prompts/maturity-scorecard-agent.md
+          model: ${{ vars.OPENCLAW_CI_OPENAI_MODEL_BARE }}
+          effort: high
+          sandbox: workspace-write
+          safety-strategy: drop-sudo
+
+      - name: Enforce focused maturity score patch
+        run: |
+          set -euo pipefail
+          git restore --staged :/
+
+          allowed='^qa/maturity-scores\.yaml$'
+          bad_tracked="$(
+            git diff --name-only HEAD -- | while IFS= read -r path; do
+              if [[ ! "$path" =~ $allowed ]]; then
+                printf '%s\n' "$path"
+              fi
+            done
+          )"
+          if [[ -n "$bad_tracked" ]]; then
+            echo "Maturity scorecard agent touched forbidden tracked paths:"
+            printf '%s\n' "$bad_tracked"
+            exit 1
+          fi
+
+          bad_untracked="$(
+            git ls-files --others --exclude-standard | while IFS= read -r path; do
+              if [[ "$path" != "qa/maturity-scores.yaml" ]]; then
+                printf '%s\n' "$path"
+              fi
+            done
+          )"
+          if [[ -n "$bad_untracked" ]]; then
+            echo "Maturity scorecard agent created forbidden untracked paths:"
+            printf '%s\n' "$bad_untracked"
+            exit 1
+          fi
+
+          if [[ ! -f qa/maturity-scores.yaml ]]; then
+            echo "Maturity scorecard agent must produce qa/maturity-scores.yaml." >&2
+            exit 1
+          fi
+
       - name: Validate maturity score sources
         run: |
           node --import tsx --input-type=module <<'NODE'
@@ -291,7 +352,7 @@ jobs:
             exit 1
           fi
 
-          if [[ -z "$(git status --porcelain -- qa/maturity-scores.yaml docs/maturity-scores.yaml docs/maturity/scorecard.md docs/maturity/taxonomy.md)" ]]; then
+          if [[ -z "$(git status --porcelain -- qa/maturity-scores.yaml docs/maturity/scorecard.md docs/maturity/taxonomy.md)" ]]; then
             {
               echo
               echo "- Pull request: skipped; generated scorecard matches selected ref"
@@ -311,9 +372,6 @@ jobs:
           git fetch --no-tags --depth=1 origin "refs/heads/${branch}:refs/remotes/origin/${branch}" || true
           git switch -C "$branch"
           git add qa/maturity-scores.yaml docs/maturity/scorecard.md docs/maturity/taxonomy.md
-          if git ls-files --error-unmatch docs/maturity-scores.yaml >/dev/null 2>&1 || [[ -e docs/maturity-scores.yaml ]]; then
-            git add docs/maturity-scores.yaml
-          fi
           git commit -m "docs: update maturity scorecard"
           git push --force-with-lease origin "$branch"
 


### PR DESCRIPTION
## Summary

Adds the optional Codex-backed maturity scorecard refresh layer as a stacked PR on top of #95898.

This keeps #95898 focused on the release QA evidence default path and puts the Codex agent prompt/action in its own diff. The agent runs after the release QA evidence artifact is validated, updates only `qa/maturity-scores.yaml` (with `docs/maturity-scores.yaml` deletion allowed for the migration), and the workflow enforces that focused patch before rendering docs.

## Stack

- Base PR: #95898 (`ci/maturity-scorecard-qa-evidence`)
- This PR: adds the Codex prompt plus `openai/codex-action` step

## Security / Behavior Notes

- Keeps `safety-strategy: drop-sudo` and `sandbox: workspace-write` for the Codex Action.
- Drops the redundant deprecated `--full-auto` extra arg; the action's sandbox input already maps to Codex sandbox selection.
- Codex contract checked in sibling source: `codex-rs/exec/src/cli.rs` for the `--full-auto` deprecation warning, `codex-rs/core/src/context/prompts/permissions/sandbox_mode/workspace_write.md` for workspace-write behavior, and `sdk/typescript/src/threadOptions.ts` for sandbox mode values.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/maturity-scorecard.yml`
- `git diff --check`
