### PR TITLE
feat(qa): wire Crabline WhatsApp transport

### DIFF
--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -16,7 +16,7 @@
     "@openclaw/plugin-sdk": "workspace:*",
     "@openclaw/slack": "workspace:*",
     "@openclaw/whatsapp": "workspace:*",
-    "@openclaw/crabline": "0.1.3",
+    "@openclaw/crabline": "0.1.4",
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {

--- a/extensions/qa-lab/src/crabline-transport.test.ts
+++ b/extensions/qa-lab/src/crabline-transport.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import { createQaCrablineTransportAdapter } from "./crabline-transport.js";
 
-function createSelection(channel: "slack" | "telegram" = "telegram") {
+function createSelection(channel: "slack" | "telegram" | "whatsapp" = "telegram") {
   return {
     capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
     channel,
@@ -153,6 +153,91 @@ describe("crabline transport", () => {
           },
           direction: "outbound",
           text: "assistant via fake slack",
+        });
+      } finally {
+        await transport.cleanup?.();
+      }
+    });
+  });
+
+  it("configures OpenClaw's WhatsApp plugin against a Crabline Baileys WebSocket server", async () => {
+    await withTempDir("qa-crabline-transport-", async (outputDir) => {
+      const transport = await createQaCrablineTransportAdapter({
+        outputDir,
+        selection: createSelection("whatsapp"),
+        state: createQaBusState(),
+      });
+
+      try {
+        expect(transport.id).toBe("crabline");
+        expect(transport.requiredPluginIds).toEqual(["whatsapp"]);
+        expect(transport.createGatewayConfig({ baseUrl: "http://127.0.0.1:1" })).toMatchObject({
+          channels: {
+            whatsapp: {
+              allowFrom: ["*"],
+              dmPolicy: "open",
+              enabled: true,
+              groupAllowFrom: ["*"],
+              groupPolicy: "open",
+            },
+          },
+        });
+        expect(transport.buildAgentDelivery({ target: "15551234567@s.whatsapp.net" })).toEqual({
+          channel: "whatsapp",
+          to: "15551234567@s.whatsapp.net",
+          replyChannel: "whatsapp",
+          replyTo: "15551234567@s.whatsapp.net",
+        });
+        const env = transport.createRuntimeEnvPatch?.() ?? {};
+        expect(env).toMatchObject({
+          CRABLINE_WHATSAPP_ADMIN_TOKEN: expect.any(String),
+          CRABLINE_WHATSAPP_RECORDER_PATH: expect.stringMatching(/whatsapp-fake-provider\.jsonl$/u),
+          CRABLINE_WHATSAPP_SELF_JID: "15550000000@s.whatsapp.net",
+          OPENCLAW_WHATSAPP_WEB_SOCKET_URL: expect.stringMatching(
+            /^ws:\/\/127\.0\.0\.1:\d+\/crabline\/whatsapp\/ws\/chat\?access_token=/u,
+          ),
+        });
+        expect(env.CRABLINE_WHATSAPP_ACCESS_TOKEN).toBeUndefined();
+        expect(env.CRABLINE_WHATSAPP_API_ROOT).toBeUndefined();
+
+        const manifest = JSON.parse(
+          await fs.readFile(path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH), "utf8"),
+        ) as {
+          provider?: string;
+        };
+        expect(manifest.provider).toBe("whatsapp");
+      } finally {
+        await transport.cleanup?.();
+      }
+    });
+  });
+
+  it("injects WhatsApp inbound messages through Crabline into normalized state", async () => {
+    await withTempDir("qa-crabline-transport-", async (outputDir) => {
+      const transport = await createQaCrablineTransportAdapter({
+        outputDir,
+        selection: createSelection("whatsapp"),
+        state: createQaBusState(),
+      });
+
+      try {
+        const message = await transport.state.addInboundMessage({
+          conversation: {
+            id: "15551234567@s.whatsapp.net",
+            kind: "direct",
+          },
+          senderId: "15557654321@s.whatsapp.net",
+          senderName: "Alice",
+          text: "WhatsApp baseline marker check.",
+        });
+        expect(message).toMatchObject({
+          conversation: {
+            id: "15551234567@s.whatsapp.net",
+            kind: "direct",
+          },
+          direction: "inbound",
+          senderId: "15557654321@s.whatsapp.net",
+          text: "WhatsApp baseline marker check.",
         });
       } finally {
         await transport.cleanup?.();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1346,8 +1346,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@openclaw/crabline':
-        specifier: 0.1.3
-        version: 0.1.3
+        specifier: 0.1.4
+        version: 0.1.4
       '@openclaw/discord':
         specifier: workspace:*
         version: link:../discord
@@ -3182,8 +3182,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@openclaw/crabline@0.1.3':
-    resolution: {integrity: sha512-ZbwAnR8k/gFWBPgJyGdJlHdZ4prEm3upMpchKpbogIR9NclOzSyzQ8+ScOotdjWLBnMBldsiemECc50goA5YxQ==}
+  '@openclaw/crabline@0.1.4':
+    resolution: {integrity: sha512-93WlCaqhppzdBKwRps7hP9mNgu6KHI1IATcQrRX+egaIhNTsfEFfZ5SJJUag8+WIHr982y4Fy5SQRQLWEs5WvA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -9269,10 +9269,12 @@ snapshots:
   '@openai/codex@0.139.0-win32-x64':
     optional: true
 
-  '@openclaw/crabline@0.1.3':
+  '@openclaw/crabline@0.1.4':
     dependencies:
       commander: 14.0.3
+      curve25519-js: 0.0.4
       picocolors: 1.1.1
+      ws: 8.21.0
       yaml: 2.9.0
       zod: 4.4.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
 minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:
-  - "@openclaw/crabline@0.1.3"
+  - "@openclaw/crabline@0.1.4"
   - "@openclaw/fs-safe@0.3.0"
   - "@openclaw/proxyline@0.3.3"
   - "acpx"


### PR DESCRIPTION
## What Problem This Solves

Keeps #95920 as the WhatsApp-only follow-up stacked on #97891. QA Lab can consume the published Crabline WhatsApp Baileys WebSocket server without Slack wiring or old runtime hook code in this PR.

## Why This Change Was Made

Crabline `0.1.4` now publishes the WhatsApp WebSocket endpoint and returns `OPENCLAW_WHATSAPP_WEB_SOCKET_URL` from its OpenClaw smoke env binding. OpenClaw only needs the package bump and focused QA Lab contract coverage on top of the shared transport env forwarding from #97891.

## User Impact

Maintainers can run Crabline-backed WhatsApp QA through the normal WhatsApp channel path without live WhatsApp credentials. Production WhatsApp behavior is unchanged unless QA explicitly supplies the WebSocket URL env.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-qa.config.ts qa-lab/src/crabline-transport.test.ts`
- `pnpm tsgo:extensions:test`