### PR TITLE
fix(commitments): keep table columns aligned when an id or scope is truncated

### DIFF
--- a/src/commands/commitments.test.ts
+++ b/src/commands/commitments.test.ts
@@ -109,6 +109,101 @@ describe("commitments command", () => {
     );
   });
 
+  it("keeps fixed-width columns aligned when an id or scope is truncated", async () => {
+    // An id longer than the 16-char ID column and a scope longer than the
+    // 28-char Scope column, so truncate() fires for both cells.
+    mocks.listCommitments.mockResolvedValue([
+      commitment({
+        id: "cm_abcdefghijklmnopqrstuvwxyz", // 29 chars > 16
+        agentId: "averylongagentidentifier",
+        channel: "telegram",
+        to: "+15551234567890", // agentId/channel/to joined > 28 chars
+      }),
+    ]);
+    const { runtime, logs } = createRuntime();
+
+    await commitmentsListCommand({}, runtime);
+
+    const lines = logs.map(stripAnsi);
+    const header = lines.find((line) => line.startsWith("ID"));
+    const row = lines.find((line) => line.startsWith("cm_"));
+    expect(header).toBeDefined();
+    expect(row).toBeDefined();
+
+    // The truncated ID cell must stay within its 16-char column: 15 chars of
+    // content plus a single-character ellipsis, not a 3-char "..." that overflows.
+    expect(row?.slice(0, 16)).toBe("cm_abcdefghijkl…");
+
+    // With each truncated cell at its intended width, the following columns line
+    // up with the header. A 3-char "..." pushes every column after a truncated
+    // cell 2 chars right of its header label.
+    expect(row?.indexOf("pending")).toBe(header?.indexOf("Status"));
+    expect(row?.indexOf("event_check_in")).toBe(header?.indexOf("Kind"));
+  });
+
+  it("keeps the Scope column aligned when only the scope is truncated", async () => {
+    // Short id (untouched) but a scope longer than its 28-char column, so only
+    // the scope cell is truncated. Isolates the second truncation site.
+    mocks.listCommitments.mockResolvedValue([
+      commitment({
+        id: "cm_short", // 8 chars, fits the ID column untouched
+        agentId: "averylongagentidentifier",
+        channel: "telegram",
+        to: "+15551234567890", // joined scope exceeds 28 chars
+      }),
+    ]);
+    const { runtime, logs } = createRuntime();
+
+    await commitmentsListCommand({}, runtime);
+
+    const lines = logs.map(stripAnsi);
+    const header = lines.find((line) => line.startsWith("ID"));
+    const row = lines.find((line) => line.startsWith("cm_"));
+    expect(header).toBeDefined();
+    expect(row).toBeDefined();
+
+    // The short id is rendered in full (no ellipsis).
+    expect(row?.slice(0, 16)).toBe("cm_short        ");
+
+    // The 28-char Scope cell ends in a single-char ellipsis and holds its width,
+    // so the trailing Suggested text column still begins under its header label.
+    const scopeCell = row?.slice(70, 98);
+    expect(scopeCell?.length).toBe(28);
+    expect(scopeCell?.endsWith("…")).toBe(true);
+    expect(row?.indexOf("How did it go?")).toBe(header?.indexOf("Suggested text"));
+  });
+
+  it("does not truncate an id that exactly fills the ID column", async () => {
+    // 16 chars == maxChars, so value.length <= maxChars and the id passes through
+    // whole with no ellipsis. Guards the boundary so we never over-truncate.
+    mocks.listCommitments.mockResolvedValue([commitment({ id: "cm_exactly16char" })]);
+    const { runtime, logs } = createRuntime();
+
+    await commitmentsListCommand({}, runtime);
+
+    const lines = logs.map(stripAnsi);
+    const header = lines.find((line) => line.startsWith("ID"));
+    const row = lines.find((line) => line.startsWith("cm_"));
+    expect(row?.slice(0, 16)).toBe("cm_exactly16char");
+    expect(row).not.toContain("…");
+    expect(row?.indexOf("pending")).toBe(header?.indexOf("Status"));
+  });
+
+  it("truncates an id one character past the column width to a single ellipsis", async () => {
+    // 17 chars == maxChars + 1, so truncate fires: 15 chars of content plus one
+    // ellipsis == 16, holding the column (the old "..." produced 18 and overflowed).
+    mocks.listCommitments.mockResolvedValue([commitment({ id: "cm_0123456789abcd" })]);
+    const { runtime, logs } = createRuntime();
+
+    await commitmentsListCommand({}, runtime);
+
+    const lines = logs.map(stripAnsi);
+    const header = lines.find((line) => line.startsWith("ID"));
+    const row = lines.find((line) => line.startsWith("cm_"));
+    expect(row?.slice(0, 16)).toBe("cm_0123456789ab…");
+    expect(row?.indexOf("pending")).toBe(header?.indexOf("Status"));
+  });
+
   it("writes list JSON to runtime stdout instead of log output", async () => {
     const { runtime, logs, stdout } = createRuntime();
 

--- a/src/commands/commitments.ts
+++ b/src/commands/commitments.ts
@@ -24,7 +24,7 @@ const STATUS_VALUES = new Set<CommitmentStatus>([
 ]);
 
 function truncate(value: string, maxChars: number): string {
-  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}...`;
+  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}…`;
 }
 
 function safe(value: string): string {


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->
Closes #95921

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Fixes an issue where operators running `openclaw commitments` see the table's
columns drift out of alignment whenever a commitment's **ID** or **Scope** is long
enough to be truncated. The header row and every short row line up, but a row with
a truncated cell pushes `Status`, `Kind`, `Due`, `Scope`, and `Suggested text` two
characters to the right, so the list no longer reads as a clean fixed-width table.

The columns are sized with `padEnd(16)` / `padEnd(28)` etc., which only hold their
width if each cell is at most that many characters. The `truncate()` helper breaks
that contract: it reserves one character for an ellipsis (`slice(0, maxChars - 1)`)
but then appends the **three-character** ASCII `"..."`, so a truncated value is
`maxChars + 2` characters wide and overflows its column by two.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

`truncate()` now appends the single-character ellipsis `…` (U+2026) instead of the
three-character `...`. With one reserved character and a one-character ellipsis, a
truncated value is exactly `maxChars` wide, so `padEnd` holds the column and the
table stays aligned.

This also brings `commitments.ts` in line with the rest of the CLI: every other
truncation helper in the codebase already uses the one-character `…`
(`src/commands/flows.ts`, `src/commands/tasks.ts`,
`src/commands/onboard-skills.ts`). `commitments.ts` was the lone outlier.

Scope is intentionally minimal: only truncated cells change (their tail goes from
`...` to `…`); untruncated output is byte-for-byte identical.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

`openclaw commitments` renders a correctly aligned table again, even when an ID or
scope is long enough to be shortened. Truncated cells end in `…` (matching the rest
of the CLI) instead of `...`. There is no behavior change for commitments whose
fields fit within their columns.

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
**Real `openclaw commitments` run (before → after).** Seeded a real commitment
store with two pending commitments - one short, one whose id (29 chars) and scope
(>28 chars) get truncated, and ran the actual CLI (`pnpm openclaw commitments`,
built from source) against it. Node 24 / pnpm 11.2.2.

Before (current `...`):
```
ID               Status     Kind             Due                      Scope                        Suggested text
cm_short         pending    event_check_in   2026-06-30T01:28:12.894Z main/telegram/+15551234567   How did it go?
cm_abcdefghijkl… pending    event_check_in   2026-06-30T01:28:12.894Z averylongagentidentifier/te… How did it go?
```

The truncated cell is exactly 16 chars and every column realigns.

**Regression tests** (`src/commands/commitments.test.ts`). Added four focused
cases that exercise the real `commitmentsListCommand` rendering path (the data
store and config are provided the same way the sibling tests in that file do):

- a truncated **id and scope** together - asserts the truncated id cell stays
  within its 16-char column and `Status`/`Kind` align with the header;
- a truncated **scope only** (short id) - asserts the 28-char Scope cell holds
  its width and the `Suggested text` column still starts under its header;
- the **exact-width boundary** -- a 16-char id is rendered in full with no
  ellipsis (guards against over-truncating at `length == maxChars`);
- the **one-past-boundary** - a 17-char id truncates to 15 chars plus one
  ellipsis (16 wide), where the old `...` produced 18 and overflowed.

- With the fix: `8 passed (8)` (5 pre-existing + 4 new).
- Reverting the one-character change to the old `...`: 3 of the new alignment
  cases fail (e.g. `expected 'cm_0123456789ab.' to be 'cm_0123456789ab…'`); the
  exact-width boundary case still passes (it never truncates), and the
  pre-existing tests still pass.

**Lint/format** on the two changed files: `oxfmt --check` → "All matched files
use the correct format"; `oxlint` → "Found 0 warnings and 0 errors."