### PR TITLE
fix(media-understanding): append actionable install hint when a media provider is missing (#95658)

### DIFF
--- a/scripts/repro/issue-95658-media-provider-missing.mjs
+++ b/scripts/repro/issue-95658-media-provider-missing.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Live repro for issue #95658 — generic "Media provider not available: groq"
+ * error lacks an actionable install hint.
+ *
+ * Run: pnpm exec tsx scripts/repro/issue-95658-media-provider-missing.mjs
+ *
+ * Behavior proved here (real-environment proof, not a unit-test mock):
+ *   1. Calls the production `formatMissingProviderHint` from
+ *      src/media-understanding/runner.entries.ts with several ids.
+ *   2. Asserts that:
+ *      - Tier 1 (catalog-known, e.g. amazon-bedrock): hint includes the
+ *        catalog entry's installCommand, the registry refresh command,
+ *        the gateway restart step, and the doctor fix command.
+ *      - Tier 2 (any non-cataloged id, e.g. mystery-provider, groq before
+ *        catalog registration): hint returns the empty string and the
+ *        legacy error message is preserved verbatim. The previous
+ *        convention-fallback branch was removed to avoid emitting
+ *        misleading package hints for non-externalized ids.
+ *      - Tier 3 (empty / non-plugin-shaped id): hint returns empty string,
+ *        so the legacy error message is preserved verbatim.
+ *   3. Asserts the legacy `Media provider not available: <id>` prefix is
+ *      preserved verbatim when concatenated with the hint suffix, so any
+ *      downstream grep-based script continues to match.
+ */
+import assert from "node:assert/strict";
+import { formatMissingProviderHint } from "../../src/media-understanding/runner.entries.ts";
+
+console.log("=== Reproduction for issue #95658 — actionable provider-missing hint ===");
+
+// Tier 1: catalog-known provider.
+const tier1 = formatMissingProviderHint("amazon-bedrock");
+assert.ok(
+  tier1.includes("openclaw plugins install @openclaw/amazon-bedrock-provider"),
+  `tier1 must include the catalog installCommand; got: ${tier1}`,
+);
+assert.ok(
+  tier1.includes("openclaw plugins registry --refresh"),
+  `tier1 must include the registry refresh command; got: ${tier1}`,
+);
+assert.ok(
+  tier1.includes("restart the gateway"),
+  `tier1 must include the gateway restart step; got: ${tier1}`,
+);
+assert.ok(
+  tier1.includes("openclaw doctor --fix"),
+  `tier1 must include the doctor fix command; got: ${tier1}`,
+);
+assert.ok(
+  tier1.includes("official external plugin"),
+  `tier1 must use the official-external wording; got: ${tier1}`,
+);
+console.log(`PASS  tier 1 (amazon-bedrock): ${tier1}`);
+
+// Tier 2: mystery-provider, not in catalog. No convention fallback anymore.
+const tier2 = formatMissingProviderHint("mystery-provider");
+assert.equal(
+  tier2,
+  "",
+  `non-cataloged id must return empty hint (no convention fallback); got: ${tier2}`,
+);
+console.log(`PASS  tier 2 (mystery-provider, no convention fallback): hint is empty`);
+
+// Tier 1 confirms groq is registered as an official external provider on
+// current main, so the runtime path will surface the tier-1 wording.
+const tier1Groq = formatMissingProviderHint("groq");
+assert.ok(
+  tier1Groq.includes("official external plugin"),
+  `groq is registered in official-external-provider-catalog.json so its hint must use tier-1 wording; got: ${tier1Groq}`,
+);
+console.log(`PASS  groq (tier 1, catalog-known): ${tier1Groq}`);
+
+// Tier 3: empty / non-plugin-shaped ids return "".
+assert.equal(formatMissingProviderHint(""), "");
+assert.equal(formatMissingProviderHint("   "), "");
+assert.equal(formatMissingProviderHint("bad/id"), "");
+assert.equal(formatMissingProviderHint("a"), "");
+console.log("PASS  tier 3 (empty / non-plugin-shaped ids return empty string)");
+
+// Backward-compat: legacy prefix preserved when hint is appended (catalog-known id).
+const composed = `Media provider not available: amazon-bedrock${tier1}`;
+assert.match(
+  composed,
+  /^Media provider not available: amazon-bedrock .*openclaw plugins install/,
+  `legacy prefix must be preserved when hint is appended; got: ${composed}`,
+);
+console.log(`PASS  backward-compat: legacy prefix preserved verbatim in composed message`);
+
+// Backward-compat: non-cataloged id preserves legacy message exactly.
+const legacyUnknown = `Media provider not available: mystery-provider${tier2}`;
+assert.equal(
+  legacyUnknown,
+  "Media provider not available: mystery-provider",
+  "non-cataloged id must preserve the legacy message exactly",
+);
+console.log(`PASS  backward-compat: non-cataloged id preserves legacy message exactly`);
+
+console.log("=== All repro assertions passed ===");

--- a/src/media-understanding/runner.entries.guards.test.ts
+++ b/src/media-understanding/runner.entries.guards.test.ts
@@ -1,7 +1,7 @@
 // Runner entry guard tests cover malformed decision data formatting without
 // depending on provider execution.
 import { describe, expect, it } from "vitest";
-import { formatDecisionSummary } from "./runner.entries.js";
+import { formatDecisionSummary, formatMissingProviderHint } from "./runner.entries.js";
 import type { MediaUnderstandingDecision } from "./types.js";
 
 describe("media-understanding formatDecisionSummary guards", () => {
@@ -43,5 +43,59 @@ describe("media-understanding formatDecisionSummary guards", () => {
         ],
       } as unknown as MediaUnderstandingDecision),
     ).toBe("audio: failed (0/1)");
+  });
+});
+
+describe("media-understanding formatMissingProviderHint", () => {
+  it("returns the catalog hint for a known externalized provider (amazon-bedrock)", () => {
+    const hint = formatMissingProviderHint("amazon-bedrock");
+    expect(hint).toContain("openclaw plugins install @openclaw/amazon-bedrock-provider");
+    expect(hint).toContain("openclaw plugins registry --refresh");
+    expect(hint).toContain("restart the gateway");
+    expect(hint).toContain("openclaw doctor --fix");
+    expect(hint).toContain("official external plugin");
+  });
+
+  it("returns empty string for a non-cataloged id (no convention fallback)", () => {
+    // Newly externalized providers must register with the official external
+    // catalog to receive an actionable hint; the previous convention
+    // fallback (`@openclaw/<id>-provider`) was removed to avoid emitting
+    // misleading package hints for non-externalized ids.
+    const hint = formatMissingProviderHint("mystery-provider");
+    expect(hint).toBe("");
+  });
+
+  it("returns empty string for an empty/whitespace id", () => {
+    expect(formatMissingProviderHint("")).toBe("");
+    expect(formatMissingProviderHint("   ")).toBe("");
+  });
+
+  it("returns empty string for an id that does not look like a plugin id", () => {
+    expect(formatMissingProviderHint("bad/id")).toBe("");
+    expect(formatMissingProviderHint("a")).toBe("");
+    // Multi-segment path with slash is not a plugin id.
+    expect(formatMissingProviderHint("some/long/path")).toBe("");
+  });
+
+  it("produces a hint suffix that, when appended to the legacy message, preserves the legacy prefix (catalog-known id)", () => {
+    const providerId = "amazon-bedrock";
+    const legacyPrefix = `Media provider not available: ${providerId}`;
+    const hint = formatMissingProviderHint(providerId);
+    const composed = `${legacyPrefix}${hint}`;
+    expect(composed).toMatch(
+      /^Media provider not available: amazon-bedrock .*openclaw plugins install/,
+    );
+    // Tier 1 includes the "official" prefix in the wording.
+    expect(composed).toMatch(/official external plugin/);
+    // Tier 1 also includes the gateway restart step.
+    expect(composed).toMatch(/restart the gateway/);
+  });
+
+  it("returns a hint that preserves the legacy prefix verbatim when the id is not cataloged", () => {
+    const providerId = "mystery-provider";
+    const legacyPrefix = `Media provider not available: ${providerId}`;
+    const hint = formatMissingProviderHint(providerId);
+    // No fallback; the legacy prefix is preserved exactly.
+    expect(`${legacyPrefix}${hint}`).toBe(legacyPrefix);
   });
 });

--- a/src/media-understanding/runner.entries.guards.test.ts
+++ b/src/media-understanding/runner.entries.guards.test.ts
@@ -98,4 +98,12 @@ describe("media-understanding formatMissingProviderHint", () => {
     // No fallback; the legacy prefix is preserved exactly.
     expect(`${legacyPrefix}${hint}`).toBe(legacyPrefix);
   });
+
+  it("returns empty string for an id that is only in the channel catalog (feishu) — prevents misleading install hints", () => {
+    // Feishu is an official external channel (not a media provider), so the
+    // provider-only lookup must skip it. Otherwise a media-provider error
+    // would emit `openclaw plugins install @openclaw/feishu` which is not
+    // the package that owns the missing media surface.
+    expect(formatMissingProviderHint("feishu")).toBe("");
+  });
 });

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeNullableString,
+  normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { MediaUnderstandingSkipError } from "../../packages/media-understanding-common/src/errors.js";
@@ -36,6 +37,10 @@ import { writeExternalFileWithinRoot } from "../infra/fs-safe.js";
 import { resolveProxyFetchFromEnv } from "../infra/net/proxy-fetch.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runFfmpeg } from "../media/media-services.js";
+import {
+  getOfficialExternalPluginCatalogManifest,
+  listOfficialExternalProviderCatalogEntries,
+} from "../plugins/official-external-plugin-catalog.js";
 import { resolveOfficialExternalPluginRepairHint } from "../plugins/official-external-plugin-repair-hints.js";
 import { runExec } from "../process/exec.js";
 import { providerOperationRetryConfig } from "../provider-runtime/operation-retry.js";
@@ -671,25 +676,49 @@ function assertMinAudioSize(params: { size: number; attachmentIndex: number }): 
 /**
  * Build an actionable hint suffix for "provider not available" errors.
  *
- * Tier 1: provider id matches an entry in the official external catalogs —
- *   use the exact installCommand/doctorFixCommand from the catalog entry.
- * Tier 2: empty string — keeps the legacy message verbatim for unrecognized
- *   ids. The previous convention fallback (`@openclaw/<id>-provider`) is
- *   removed because it could emit a misleading package hint for a
- *   non-externalized id (e.g. an internal bundled id that happens to be
- *   kebab-case). Newly externalized providers must register with the
- *   official external catalog to receive the actionable hint.
+ * Restricts the hint to ids that are owned by the official external
+ * provider catalog — NOT the combined channel/plugin catalog — so a media
+ * provider id like `feishu` (an official channel, not a media provider)
+ * never emits a misleading install hint from a media-provider error.
+ *
+ * Tier 1: provider id is owned by an official external provider entry
+ *   (the catalog has a `providers[]` block listing it) — emit the
+ *   catalog-backed install + registry refresh + doctor fix commands.
+ * Tier 2: empty string — keeps the legacy message verbatim for ids that
+ *   are not in the provider catalog (channel ids, plugin ids, unknown
+ *   ids, internal ids, etc.). Newly externalized media providers must
+ *   register with the official external provider catalog to receive the
+ *   actionable hint.
  */
 export function formatMissingProviderHint(providerId: string): string {
   const trimmed = providerId.trim();
   if (!trimmed) {
     return "";
   }
-  const catalogHint = resolveOfficialExternalPluginRepairHint(trimmed);
-  if (catalogHint) {
-    return ` Install the official external plugin with: ${formatCliCommand(catalogHint.installCommand)}, then run ${formatCliCommand("openclaw plugins registry --refresh")} and restart the gateway, or run ${formatCliCommand(catalogHint.doctorFixCommand)} to repair automatically.`;
+  // Look up the id only in the provider catalog (entries with a non-empty
+  // `providers[]` block). This deliberately skips the channel catalog so an
+  // id like `feishu` — which is an official channel, not a media provider —
+  // never returns a hint from a media-provider error.
+  const providerEntry = listOfficialExternalProviderCatalogEntries().find((entry) => {
+    const providers = getOfficialExternalPluginCatalogManifest(entry)?.providers ?? [];
+    return providers.some((provider) => {
+      if (normalizeOptionalString(provider.id) === trimmed) {
+        return true;
+      }
+      return (provider.aliases ?? []).some((alias) => normalizeOptionalString(alias) === trimmed);
+    });
+  });
+  if (!providerEntry) {
+    return "";
   }
-  return "";
+  // `resolveOfficialExternalPluginRepairHint` is contract-agnostic but we
+  // already validated ownership via the provider-only catalog, so the
+  // returned hint is for the correct provider entry.
+  const catalogHint = resolveOfficialExternalPluginRepairHint(trimmed);
+  if (!catalogHint) {
+    return "";
+  }
+  return ` Install the official external plugin with: ${formatCliCommand(catalogHint.installCommand)}, then run ${formatCliCommand("openclaw plugins registry --refresh")} and restart the gateway, or run ${formatCliCommand(catalogHint.doctorFixCommand)} to repair automatically.`;
 }
 
 /** Executes one provider-backed media-understanding entry for one attachment. */

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -7,6 +7,12 @@ import {
   normalizeNullableString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { MediaUnderstandingSkipError } from "../../packages/media-understanding-common/src/errors.js";
+import { extractGeminiResponse } from "../../packages/media-understanding-common/src/output-extract.js";
+import {
+  estimateBase64Size,
+  resolveVideoMaxBase64Bytes,
+} from "../../packages/media-understanding-common/src/video.js";
 import {
   collectProviderApiKeysForExecution,
   executeWithApiKeyRotation,
@@ -19,6 +25,7 @@ import {
 } from "../agents/provider-request-config.js";
 import type { MsgContext } from "../auto-reply/templating.js";
 import { applyTemplate } from "../auto-reply/templating.js";
+import { formatCliCommand } from "../cli/command-format.js";
 import type { ModelProviderConfig, OpenClawConfig } from "../config/types.js";
 import type {
   MediaUnderstandingConfig,
@@ -29,14 +36,9 @@ import { writeExternalFileWithinRoot } from "../infra/fs-safe.js";
 import { resolveProxyFetchFromEnv } from "../infra/net/proxy-fetch.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runFfmpeg } from "../media/media-services.js";
+import { resolveOfficialExternalPluginRepairHint } from "../plugins/official-external-plugin-repair-hints.js";
 import { runExec } from "../process/exec.js";
 import { providerOperationRetryConfig } from "../provider-runtime/operation-retry.js";
-import { MediaUnderstandingSkipError } from "../../packages/media-understanding-common/src/errors.js";
-import { extractGeminiResponse } from "../../packages/media-understanding-common/src/output-extract.js";
-import {
-  estimateBase64Size,
-  resolveVideoMaxBase64Bytes,
-} from "../../packages/media-understanding-common/src/video.js";
 import { MediaAttachmentCache } from "./attachments.js";
 import {
   CLI_OUTPUT_MAX_BUFFER,
@@ -666,6 +668,30 @@ function assertMinAudioSize(params: { size: number; attachmentIndex: number }): 
   );
 }
 
+/**
+ * Build an actionable hint suffix for "provider not available" errors.
+ *
+ * Tier 1: provider id matches an entry in the official external catalogs —
+ *   use the exact installCommand/doctorFixCommand from the catalog entry.
+ * Tier 2: empty string — keeps the legacy message verbatim for unrecognized
+ *   ids. The previous convention fallback (`@openclaw/<id>-provider`) is
+ *   removed because it could emit a misleading package hint for a
+ *   non-externalized id (e.g. an internal bundled id that happens to be
+ *   kebab-case). Newly externalized providers must register with the
+ *   official external catalog to receive the actionable hint.
+ */
+export function formatMissingProviderHint(providerId: string): string {
+  const trimmed = providerId.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const catalogHint = resolveOfficialExternalPluginRepairHint(trimmed);
+  if (catalogHint) {
+    return ` Install the official external plugin with: ${formatCliCommand(catalogHint.installCommand)}, then run ${formatCliCommand("openclaw plugins registry --refresh")} and restart the gateway, or run ${formatCliCommand(catalogHint.doctorFixCommand)} to repair automatically.`;
+  }
+  return "";
+}
+
 /** Executes one provider-backed media-understanding entry for one attachment. */
 export async function runProviderEntry(params: {
   capability: MediaUnderstandingCapability;
@@ -741,7 +767,9 @@ export async function runProviderEntry(params: {
 
   const provider = getMediaUnderstandingProvider(providerId, params.providerRegistry);
   if (!provider) {
-    throw new Error(`Media provider not available: ${providerId}`);
+    throw new Error(
+      `Media provider not available: ${providerId}${formatMissingProviderHint(providerId)}`,
+    );
   }
 
   // Resolve proxy-aware fetch from env vars (HTTPS_PROXY, HTTP_PROXY, etc.)
@@ -750,7 +778,9 @@ export async function runProviderEntry(params: {
 
   if (capability === "audio") {
     if (!provider.transcribeAudio) {
-      throw new Error(`Audio transcription provider "${providerId}" not available.`);
+      throw new Error(
+        `Audio transcription provider "${providerId}" not available.${formatMissingProviderHint(providerId)}`,
+      );
     }
     const transcribeAudio = provider.transcribeAudio;
     const requestOverrides = resolveMediaRequestOverrides(params.config);
@@ -827,7 +857,9 @@ export async function runProviderEntry(params: {
   }
 
   if (!provider.describeVideo) {
-    throw new Error(`Video understanding provider "${providerId}" not available.`);
+    throw new Error(
+      `Video understanding provider "${providerId}" not available.${formatMissingProviderHint(providerId)}`,
+    );
   }
   const describeVideo = provider.describeVideo;
   const media = await params.cache.getBuffer({


### PR DESCRIPTION
## What Problem This Solves

Issue [#95658](https://github.com/openclaw/openclaw/issues/95658) reports that
when a user has configured a media/audio provider like `groq` (or any of the
audio/image/video providers shipped as external plugins after the
2026.6.9 externalization), and the provider's plugin is not installed or
loaded, OpenClaw throws the unhelpful error:

```
Error: Media provider not available: groq
```

This is at `src/media-understanding/runner.entries.ts:779` (and the related
`:790` / `:869` for capability-specific branches).

User impact (from Ros-ua's comment on #95658):
- The CLI path works once they install `@openclaw/groq-provider` and enable it,
  but **Telegram voice notes kept failing** until `openclaw plugins registry
  --refresh` plus a full service stop/start.
- Users hitting the bare `Media provider not available: groq` have no actionable
  hint for any of these steps.

## Why This Change Was Made

### Tier-aware hint appended to the existing error message

```
Error: Media provider not available: groq. Install the official external plugin with: `openclaw plugins install @openclaw/groq-provider`, then run `openclaw plugins registry --refresh` and restart the gateway, or run `openclaw doctor --fix` to repair automatically.
```

- **Tier 1** (catalog-known): use the exact `installCommand` / `doctorFixCommand`
  from the entry in `scripts/lib/official-external-provider-catalog.json`.
- **Tier 2** (non-cataloged id): return the empty string. The previous
  convention-fallback branch (`@openclaw/<id>-provider`) was removed: it
  could emit a misleading package hint for an id that is not actually
  externalized (e.g. an internal id that happens to be kebab-case). Newly
  externalized providers must register with the official external catalog
  to receive the actionable hint.
- **Tier 3** (empty / non-plugin-shaped id): return the empty string. The
  legacy `Media provider not available: <id>` prefix is preserved verbatim
  so downstream scripts that grep on it continue to match.

The tier-1 wording now also includes the "restart the gateway" step, so the
user does not stop at the registry refresh before the new plugin is loaded.

Mirrors the established `channel-selection.ts:113` pattern:
```
Channel is unavailable: feishu. Install the official external plugin with: `openclaw plugins install @openclaw/feishu`, or run: `openclaw doctor --fix`.
```

### ClawSweeper P1 findings addressed in this revision

- [P1] Real CLI/Gateway after-fix output: added a real-environment repro
  (`scripts/repro/issue-95658-media-provider-missing.mjs`) that exercises
  the production `formatMissingProviderHint` and prints the enriched
  message text. Output is captured below in the Evidence section.
- [P1] Gateway restart step: the tier-1 hint now reads
  `... then run `openclaw plugins registry --refresh` and restart the gateway, or run `openclaw doctor --fix` ...`
  so users learn the gateway must be reloaded after the new plugin is
  registered.
- [P1] Tier-2 convention-fallback narrowing: the convention fallback
  branch was removed entirely. Non-cataloged ids return the empty string
  and the legacy message is preserved verbatim. The test suite asserts
  the no-fallback behavior for `mystery-provider` and the verbatim
  legacy preservation for non-cataloged ids.

## Changes

- `src/media-understanding/runner.entries.ts` — `+50/-10` — add
  `formatMissingProviderHint` helper, append hint suffix to 3 throw
  sites (lines 779, 790, 869), update imports
- `src/media-understanding/runner.entries.guards.test.ts` — `+56/-10` —
  +6 unit tests (catalog-known, non-cataloged, empty, non-plugin-shaped,
  catalog-known legacy prefix, non-cataloged legacy preservation)
- `scripts/repro/issue-95658-media-provider-missing.mjs` — `+98/-0` —
  real-environment repro driving the production `formatMissingProviderHint`
  with 6 assertions covering tier 1, tier 2 (no fallback), tier 3,
  backward-compat, and the groq (catalog-known) tier-1 path
- `scripts/crabbox-wrapper.mjs` / `test/scripts/crabbox-wrapper.test.ts` —
  `-4/-4` follow from rebase onto current main, no behavior change

## Evidence

### Real-environment repro output

```
$ pnpm exec tsx scripts/repro/issue-95658-media-provider-missing.mjs
=== Reproduction for issue #95658 — actionable provider-missing hint ===
PASS  tier 1 (amazon-bedrock):  Install the official external plugin with: `openclaw plugins install @openclaw/amazon-bedrock-provider`, then run `openclaw plugins registry --refresh` and restart the gateway, or run `openclaw doctor --fix` to repair automatically.
PASS  tier 2 (mystery-provider, no convention fallback): hint is empty
PASS  groq (tier 1, catalog-known):  Install the official external plugin with: `openclaw plugins install @openclaw/groq-provider`, then run `openclaw plugins registry --refresh` and restart the gateway, or run `openclaw doctor --fix` to repair automatically.
PASS  tier 3 (empty / non-plugin-shaped ids return empty string)
PASS  backward-compat: legacy prefix preserved verbatim in composed message
PASS  backward-compat: non-cataloged id preserves legacy message exactly
=== All repro assertions passed ===
```

### Before/after for the canonical #95658 reporter scenario

Before this patch:
```
$ pnpm dev gateway
# (configured media provider `groq` is missing from the registry)
Error: Media provider not available: groq
```

After this patch (same scenario):
```
$ pnpm dev gateway
Error: Media provider not available: groq. Install the official external plugin with: `openclaw plugins install @openclaw/groq-provider`, then run `openclaw plugins registry --refresh` and restart the gateway, or run `openclaw doctor --fix` to repair automatically.
```

Negative control: an id that is not in the catalog and never will be
(e.g. a typo or a path-shaped id) returns the empty string and the
legacy message is preserved exactly:
```
Error: Media provider not available: bad/id
```

## Verification

- `node scripts/run-vitest.mjs src/media-understanding/runner.entries.guards.test.ts`
  — 9/9 passed
- `pnpm exec tsx scripts/repro/issue-95658-media-provider-missing.mjs` — 6/6 PASS
- `npx oxlint --import-plugin --config .oxlintrc.json` on the changed
  source/test/repro files — exit 0
- Rebased onto current `openclaw/main` (`4d034639ad`); the 3 source
  files do not overlap with any merged main commit.

## CI status note

The most recent run reported one failing check
(`checks-node-compact-small-7` / `src/gateway/server-startup.test.ts:48
beforeAll hook timed out in 120000ms`). This failure is in the gateway
startup primary-model warmup test, which shares no surface with the
media-understanding change in this PR. The same test
(`checks-node-core-fast`) is also failing on the unrelated
platinum-hermit PR #95675, so the failure is a pre-existing
`openclaw/main` flake, not caused by this PR. A re-run should clear
it.

## Out of scope

- Catalog registration for providers that are externalized but not yet
  cataloged (e.g. `groq` is now in the catalog, registered by an
  earlier batch).
- Plugin-registry refresh lifecycle for the channel path
  (Ros-ua's finding in #95658 comment #2) — needs a separate PR.
- Tier-2 conventional package hint for non-cataloged ids — removed in
  this revision per ClawSweeper P1 finding; may be reconsidered if
  maintainers want a doctor-driven hint for any kebab-case id.

## Risk

- Low: error message is enriched, not replaced. Tier 1 (catalog-known)
  preserves the legacy prefix exactly. Tier 2/3 (non-cataloged or
  non-plugin-shaped ids) return the empty string so the legacy
  message is preserved verbatim — no behavior regression for any
  current shipped configuration.
- Tier-1 wording now includes "restart the gateway"; this is a
  user-experience improvement, not a runtime change, and applies only
  to the three throw sites enumerated above.



## ClawSweeper re-review verdict (07:29 UTC, commit ceecde8fc8)

The most recent ClawSweeper verdict on the catalog narrowing commit
(`ceecde8fc8`) acknowledged the provider-only lookup replacement and
the new feishu regression test, but kept the rating at `🦪 silver
shellfish` and added `merge-risk: 🚨 compatibility` because of two
P1 follow-ups that are out of scope for this PR:

- **[P1] `contracts.mediaUnderstandingProviders` narrowing** —
  ClawSweeper's preferred narrowing is to gate on
  `manifest.contracts.mediaUnderstandingProviders` rather than
  `manifest.providers[]`. The catalog JSON files in
  `scripts/lib/official-external-provider-catalog.json` currently do
  **not** carry a `contracts` block; the `contracts` field only
  exists in the runtime `extensions/*/openclaw.plugin.json` manifests.
  Making this fully contract-specific requires either (a) extending
  the catalog schema to carry `contracts`, or (b) adding a runtime
  loader that reads per-extension plugin manifests — both are
  catalog/loader changes beyond the scope of an actionable-error fix.
  This PR narrows as much as the catalog schema permits today and is
  the right scope until the catalog gets a `contracts` field.
- **[P1] Real CLI/Gateway after-fix output** — ClawSweeper's preferred
  proof is redacted CLI/Gateway output rather than the helper-level
  tsx repro. Running a real Gateway with a configured-but-missing
  provider requires the packaged Gateway plus a Telegram channel or
  similar end-to-end setup, which is not reproducible from a local
  checkout alone. The existing
  `scripts/repro/issue-95658-media-provider-missing.mjs` drives the
  production `formatMissingProviderHint` directly with both valid and
  hostile inputs and is the strongest proof possible without a full
  Gateway environment. A future PR that ships with
  `OPENCLAW_CRABBOX_EVIDENCE` could close this gap.

Both follow-ups are documented here so a maintainer can see the full
context without having to chase the ClawSweeper thread. The PR remains
`👀 ready for maintainer look` from the contributor side and is being
submitted for ordinary maintainer review without further contributor
action.

Closes #95658