### PR TITLE
docs(copilot): refresh harness parity notes

### DIFF
--- a/docs/plugins/copilot.md
+++ b/docs/plugins/copilot.md
@@ -150,6 +150,12 @@ the same directory), or `~/.openclaw/agents/<agentId>/copilot` otherwise.
 Override with `copilotHome: <path>` on the attempt input when you need a
 custom location (for example, a shared mount for migration).
 
+Live harness tests use `OPENCLAW_COPILOT_AGENT_LIVE_TOKEN` when a direct token
+is needed. The shared live-test setup intentionally scrubs `COPILOT_GITHUB_TOKEN`,
+`GH_TOKEN`, and `GITHUB_TOKEN` after staging real auth profiles into the isolated
+test home, so passing a `gh auth token` value through the dedicated live-test
+variable avoids false skips without exposing the token to unrelated suites.
+
 ## Configuration surface
 
 The harness reads its config from per-attempt input
@@ -314,13 +320,19 @@ right scope, and `session_status: "current"` resolves to a stale
 sandbox key. The bridge builder is in
 `extensions/copilot/src/tool-bridge.ts` and mirrors the PI
 authoritative call at
-`src/agents/pi-embedded-runner/run/attempt.ts:1029-1117`. Two PI fields
-are intentionally **not** forwarded at MVP and tracked as follow-ups:
-`sandbox` (the harness does not yet route through `resolveSandboxContext`)
-and the PI tool-search/code-mode machinery
-(`toolSearchCatalogRef`, `includeCoreTools`,
-`includeToolSearchControls`, `toolSearchCatalogExecutor`,
-`toolConstructionPlan`), which has no analog at the SDK boundary.
+`src/agents/pi-embedded-runner/run/attempt.ts:1029-1117`. `runAttempt`
+already resolves sandbox context through the shared
+`resolveSandboxContext` seam, passes the SDK an effective working
+directory, and forwards `sandbox` plus the subagent-spawn workspace into
+the tool bridge. The bridge also forwards the bounded tool-construction
+controls it can enforce at the SDK boundary: `includeCoreTools`, the
+runtime tool allowlist, and `toolConstructionPlan`.
+
+The remaining PI tool-search/code-mode fields are intentionally **not**
+forwarded at MVP and tracked as follow-ups: `toolSearchCatalogRef`,
+`includeToolSearchControls`, and `toolSearchCatalogExecutor`. Those
+controls drive PI's native tool-search UI and have no direct Copilot SDK
+analog yet.
 
 ### Session-level GitHub token
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Copilot harness parity docs still described sandbox and bounded tool-construction forwarding as missing follow-up work, even though the runtime and tests now wire those fields through the generic bridge.

## Why This Change Was Made

The docs now match the current harness contract: `runAttempt` resolves sandbox context, the tool bridge forwards sandbox plus subagent workspace context, and the bridge carries the bounded tool-construction controls the SDK boundary can enforce. The remaining follow-up is narrowed to PI's native tool-search/code-mode controls, which still have no direct Copilot SDK analog.

## User Impact

Operators and reviewers can use the Copilot harness docs as a current parity map without chasing already-completed sandbox/tool-construction work. The auth section also documents the dedicated live-test token variable so live harness proof does not false-skip after shared test setup scrubs generic GitHub token env vars.

## Evidence

- `OPENCLAW_COPILOT_AGENT_LIVE_TOKEN=<gh auth token> OPENCLAW_LIVE_TEST=1 OPENCLAW_COPILOT_AGENT_LIVE_TEST=1 OPENCLAW_LIVE_TEST_QUIET=1 node_modules/.bin/vitest run --config test/vitest/vitest.live.config.ts extensions/copilot/src/attempt.live.test.ts --reporter=verbose` — passed; Copilot SDK session called `live_echo` with `phase-1-green`, returned assistant text, and reported usage.
- `node scripts/check-docs-mdx.mjs docs/plugins/copilot.md` — passed.
- `node scripts/format-docs.mjs --check docs/plugins/copilot.md` — passed.
- `git diff --check` — passed.
