### PR TITLE
fix(commitments): use single-char ellipsis in truncate to keep padEnd…

### DIFF
--- a/src/commands/commitments.test.ts
+++ b/src/commands/commitments.test.ts
@@ -125,6 +125,36 @@ describe("commitments command", () => {
     });
   });
 
+  it("keeps table columns aligned when an id or scope exceeds its column width", async () => {
+    mocks.listCommitments.mockResolvedValue([
+      commitment({
+        id: "cm_abcdefghijklmnopqrstuvwxyz",
+        scope: "main/telegram/+1555123456789012345678901234567890",
+      }),
+    ]);
+    const { runtime, logs } = createRuntime();
+
+    await commitmentsListCommand({}, runtime);
+
+    const output = logs.map(stripAnsi).join("\n");
+    // Verify the truncated row does not overflow its column width
+    // The id column is 16 chars wide; the scope column is 28 chars wide.
+    // With the single-char ellipsis, the truncated cell should be exactly
+    // maxChars wide, so padEnd holds the column and every row stays aligned.
+    const lines = output.split("\n");
+    const headerLine = lines.find((line) => line.startsWith("ID"));
+    const dataLine = lines.find((line) => line.startsWith("cm_"));
+    expect(headerLine).toBeDefined();
+    expect(dataLine).toBeDefined();
+    // Find the "Status" column position in the header
+    const statusIndex = headerLine?.indexOf("Status") ?? -1;
+    expect(statusIndex).toBeGreaterThan(-1);
+    // The "Status" column should start at the same position in the data line
+    expect(dataLine?.indexOf("pending")).toBe(statusIndex);
+    // Verify the truncated id ends with a single ellipsis character
+    expect(dataLine).toContain("cm_abcdefghijkl…");
+  });
+
   it("writes dismiss JSON to runtime stdout instead of log output", async () => {
     const { runtime, logs, stdout } = createRuntime();
 

--- a/src/commands/commitments.ts
+++ b/src/commands/commitments.ts
@@ -24,7 +24,7 @@ const STATUS_VALUES = new Set<CommitmentStatus>([
 ]);
 
 function truncate(value: string, maxChars: number): string {
-  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}...`;
+  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}…`;
 }
 
 function safe(value: string): string {


### PR DESCRIPTION
Fixes #95921

## What Problem This Solves

Fixes an issue where users running `openclaw commitments list` would see misaligned table columns when a commitment ID or scope exceeded its designated column width. The `truncate` helper in `src/commands/commitments.ts` reserved a single character for an ellipsis (`slice(0, maxChars - 1)`) but then appended the three-character ASCII `"..."`, so any truncated value ends up `maxChars + 2` characters wide. Because those values feed `padEnd` columns (ID via `truncate(id, 16).padEnd(16)`, Scope via `truncate(scope, 28).padEnd(28)`), a commitment whose id or scope is long enough to truncate overflows its column and pushes `Status`, `Kind`, `Due`, and every following column two characters to the right on that row. Commitment ids are uuid-ish and routinely exceed 16 chars, so this is a routine misalignment.

## Why This Change Was Made

`commitments.ts` was the lone outlier: every other truncation helper in the CLI (`flows.ts`, `tasks.ts`, `onboard-skills.ts`) already appends the single-character `…` (U+2026). With one reserved char plus a one-char ellipsis, a truncated value is exactly `maxChars` wide, so `padEnd` holds its column. Matching the established in-repo convention is the clean fix and keeps the helper a one-liner.

## User Impact

Operators running `openclaw commitments` now get a correctly aligned fixed-width table even when an id or scope is long enough to be truncated. Cosmetic only — no data, schema, or behavior change; non-truncated rows are byte-identical to before.

## Evidence

**Behavior or issue addressed:** A commitment ID of 27 characters (`cm_abcdefghijklmnopqrstuvwxyz`) exceeds the 16-character ID column and should be truncated. With the old three-char `"..."` suffix, the truncated string is 18 characters wide, so `padEnd(16)` cannot hold the column and every following column shifts.

**Real environment tested:** Linux, Node v22.23.0, local source checkout, worktree SHA `d94c1a9`.

**Exact steps or command run after this patch:**

```bash
# Reproduce the exact truncate + padEnd path used by the commitments table
node -e "
const truncate = (v, m) => v.length <= m ? v : v.slice(0, m - 1) + '…';
const id = 'cm_abcdefghijklmnopqrstuvwxyz';
const truncated = truncate(id, 16);
const padded = truncated.padEnd(16);
console.log('truncated:', JSON.stringify(truncated), 'length:', truncated.length);
console.log('padded + Status:', padded + 'Status');
console.log('column aligned:', padded.length === 16);
"
```

**Evidence after fix:**

```
truncated: "cm_abcdefghijkl…" length: 16
padded + Status: cm_abcdefghijkl…Status
column aligned: true
```

**Negative control — the old three-char `"..."` helper produces the misalignment:**

```bash
node -e "
const truncateOld = (v, m) => v.length <= m ? v : v.slice(0, m - 1) + '...';
const id = 'cm_abcdefghijklmnopqrstuvwxyz';
const truncated = truncateOld(id, 16);
const padded = truncated.padEnd(16);
console.log('truncated:', JSON.stringify(truncated), 'length:', truncated.length);
console.log('padded + Status:', padded + 'Status');
console.log('column aligned:', padded.length === 16);
"
```

Output:
```
truncated: "cm_abcdefghijkl..." length: 18
padded + Status: cm_abcdefghijkl...Status
column aligned: false
```

**Observed result after fix:** The truncated cell is exactly 16 characters wide, `padEnd` holds the column, and `Status` starts at the correct position in both header and data rows. The old helper produces 18 characters and breaks alignment.

**What was not tested:** Full terminal rendering across different terminal emulators (this is a pure string-length calculation issue, covered by unit tests). Tables in other commands (`flows`, `tasks`), which already have correct implementations.

---

## Summary

- Problem: `commitments.ts` `truncate` used `...` (3 chars) but only reserved 1 char, causing `padEnd` columns to misalign.
- Solution: Change suffix to `…` (1 char) to match `flows.ts`, `tasks.ts`, and `onboard-skills.ts`.
- What changed: `src/commands/commitments.ts:27` and regression test in `commitments.test.ts`.
- What did NOT change: Any other table logic, CLI flags, or business logic.

## Real Behavior Proof

See Evidence section above. The terminal output demonstrates the exact `truncate` + `padEnd` path used by the commitments table, showing the old helper produces 18 characters (misaligned) and the new helper produces 16 characters (aligned).

## Regression Test Plan

- Coverage level: Unit test + regression test
- Target test file: `src/commands/commitments.test.ts`
- Scenario locked in: When a commitment ID exceeds 16 characters, the truncated string is exactly 16 characters wide, and `padEnd` keeps the `Status` column aligned with the header.
- Why this is the smallest reliable guardrail: The test asserts the character position of the `Status` column in both header and data rows, not just the return value of `truncate`.

## Root Cause

- Root cause: `commitments.ts` was the only CLI truncation helper using `"..."` (3 chars); all others use `"…"` (1 char). `slice(0, maxChars - 1)` only reserves 1 position for the suffix.
- Missing detection / guardrail: Previous tests verified content presence but not column alignment, so `padEnd` failure was not caught.

**AI-assisted.**
