### PR TITLE
Hooks: chain global pre-commit guard

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -3,8 +3,13 @@
 set -euo pipefail
 
 ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+GLOBAL_HOOKS_PATH="$(git config --global --get core.hooksPath 2>/dev/null || true)"
 RUN_NODE_TOOL="$ROOT_DIR/scripts/pre-commit/run-node-tool.sh"
 FILTER_FILES="$ROOT_DIR/scripts/pre-commit/filter-staged-files.mjs"
+
+if [[ -n "$GLOBAL_HOOKS_PATH" && -x "$GLOBAL_HOOKS_PATH/pre-commit" ]]; then
+  "$GLOBAL_HOOKS_PATH/pre-commit" "$@"
+fi
 
 if [[ ! -x "$RUN_NODE_TOOL" ]]; then
   echo "Missing helper: $RUN_NODE_TOOL" >&2


### PR DESCRIPTION
## What Problem This Solves

OpenClaw can use the repo-local `git-hooks/pre-commit` through `core.hooksPath=git-hooks`. In that setup, user-level machine-wide Git guards configured via global `core.hooksPath` do not run. That is a local defense gap for checks such as secret scanning and AI-context loss protection.

This PR makes the repo-local pre-commit hook chain the configured global `pre-commit` hook first when it exists and is executable, then continues with the existing OpenClaw staged-file lint/format flow.

Validation evidence:

- `bash -n git-hooks/pre-commit` passed.
- `git-hooks/pre-commit` passed with no staged files.
- `git diff --check origin/main..HEAD` passed.
- `git diff --name-status origin/main..HEAD` shows only `git-hooks/pre-commit`.

## Summary

- Problem: this repo can use `core.hooksPath=git-hooks`, which means the machine-wide Git pre-commit guard is bypassed.
- Why it matters: local security and AI-context guards should still run before project-specific formatting hooks.
- What changed: `git-hooks/pre-commit` now invokes the configured global `pre-commit` hook first when present, then continues with the existing staged-file lint/format flow.
- What did NOT change (scope boundary): no lint/format behavior, dependency, CI, runtime, or product code changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related: none

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any Yes, explain risk + mitigation: the project pre-commit hook now runs the already-configured global pre-commit guard before its existing project checks. The call is conditional on the global hook being present and executable, and it preserves the existing hook behavior afterward.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local shell
- Model/provider: n/a
- Integration/channel (if any): Git hooks
- Relevant config (redacted): global `core.hooksPath` points to a user-level hook directory

### Steps

1. Configure this repository with `core.hooksPath=git-hooks`.
2. Run `bash -n git-hooks/pre-commit`.
3. Run `git-hooks/pre-commit` with no staged files.
4. Compare the PR diff against `origin/main`.

### Expected

- The hook remains syntactically valid.
- With no staged files, the hook exits successfully.
- The PR changes only `git-hooks/pre-commit`.

### Actual

- `bash -n git-hooks/pre-commit` passed.
- `git-hooks/pre-commit` passed.
- `git diff --name-status origin/main..HEAD` shows only `git-hooks/pre-commit`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before this PR, a repo-local `core.hooksPath=git-hooks` setup ran the project hook without first invoking the global guard. After this PR, the project hook conditionally invokes the global guard first.

Verification commands run locally:

```bash
bash -n git-hooks/pre-commit
git-hooks/pre-commit
git diff --check origin/main..HEAD
git diff --name-status origin/main..HEAD
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: global pre-commit guard path is called conditionally before the existing project hook logic; no-staged-files path exits successfully.
- Edge cases checked: global hook missing or non-executable remains a no-op because the condition checks both non-empty path and executable file.
- What you did not verify: full `pnpm check` / full test suite, because this only changes a shell pre-commit wrapper.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: n/a

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or remove the global hook invocation block from `git-hooks/pre-commit`.
- Files/config to restore: `git-hooks/pre-commit`.
- Known bad symptoms reviewers should watch for: pre-commit exits before running project lint/format if a user-level global hook fails.

## Risks and Mitigations

- Risk: a failing user-level global pre-commit hook blocks OpenClaw's project hook.
  - Mitigation: that is intentional for security guard failures; the project hook only chains an executable configured global hook and otherwise preserves existing behavior.
