### PR TITLE
fix(xiaomi): correct mimo-v2.5 and mimo-v2.5-pro max output tokens to 128K

### DIFF
--- a/docs/providers/xiaomi.md
+++ b/docs/providers/xiaomi.md
@@ -84,8 +84,8 @@ Choose the Token Plan auth choice that matches the regional base URL shown in Xi
 
 | Model ref                         | Input       | Context   | Max output | Reasoning | Notes         |
 | --------------------------------- | ----------- | --------- | ---------- | --------- | ------------- |
-| `xiaomi-token-plan/mimo-v2.5-pro` | text        | 1,048,576 | 32,000     | Yes       | Default model |
-| `xiaomi-token-plan/mimo-v2.5`     | text, image | 1,048,576 | 32,000     | Yes       | Multimodal    |
+| `xiaomi-token-plan/mimo-v2.5-pro` | text        | 1,048,576 | 131,072    | Yes       | Default model |
+| `xiaomi-token-plan/mimo-v2.5`     | text, image | 1,048,576 | 131,072    | Yes       | Multimodal    |
 
 <Tip>
 Token Plan onboarding validates the key shape and warns when a `tp-...` key is entered into the pay-as-you-go path, or an `sk-...` key is entered into the Token Plan path.
@@ -222,7 +222,7 @@ Token Plan:
             reasoning: true,
             input: ["text"],
             contextWindow: 1048576,
-            maxTokens: 32000,
+            maxTokens: 131072,
           },
           {
             id: "mimo-v2.5",
@@ -230,7 +230,7 @@ Token Plan:
             reasoning: true,
             input: ["text", "image"],
             contextWindow: 1048576,
-            maxTokens: 32000,
+            maxTokens: 131072,
           },
         ],
       },

--- a/extensions/xiaomi/openclaw.plugin.json
+++ b/extensions/xiaomi/openclaw.plugin.json
@@ -77,7 +77,7 @@
             "input": ["text"],
             "reasoning": true,
             "contextWindow": 1048576,
-            "maxTokens": 32000,
+            "maxTokens": 131072,
             "cost": {
               "input": 1,
               "output": 3,
@@ -95,7 +95,7 @@
             "input": ["text", "image"],
             "reasoning": true,
             "contextWindow": 1048576,
-            "maxTokens": 32000,
+            "maxTokens": 131072,
             "cost": {
               "input": 0.4,
               "output": 2,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting the `mimo-v2.5` or `mimo-v2.5-pro` models (Xiaomi Token Plan provider) would have their generations capped far below the models' real output limit. The bundled Xiaomi plugin declared `maxTokens: 32000` for both models, so the agent loop truncated/limited responses at ~32K output tokens even though the models support 128K.

## Why This Change Was Made

The real maximum completion (output) tokens for both `mimo-v2.5` and `mimo-v2.5-pro` is 131072 (128K), not 32000. This change updates the `maxTokens` field for both models in `extensions/xiaomi/openclaw.plugin.json` to the correct value. The `contextWindow` (1048576 / 1M) was already correct and is unchanged.

## User Impact

Users on the Xiaomi Token Plan provider can now request the full 128K output budget from `mimo-v2.5` and `mimo-v2.5-pro`, matching the providers' actual capability. No config migration required.

## Evidence

Verified against OpenRouter's model API (`https://openrouter.ai/api/v1/models`):

- `mimo-v2.5`: context_length `1048576`, max_completion_tokens `131072`
- `mimo-v2.5-pro`: context_length `1048576`, max_completion_tokens `131072`

Cross-referenced with the official model pages, which advertise the 1M context window:

- https://mimo.mi.com/models/mimo-v2.5
- https://mimo.mi.com/models/mimo-v2.5-pro

Diff:

```
-            "maxTokens": 32000,
+            "maxTokens": 131072,
```
(applied to both `mimo-v2.5-pro` and `mimo-v2.5`)
