### PR TITLE
fix(memory): exclude extraPaths from shared scope hash to avoid unnecessary reindexing

### DIFF
--- a/extensions/memory-core/src/memory/manager-reindex-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.test.ts
@@ -191,11 +191,8 @@ describe("memory reindex state", () => {
     ).toEqual({ status: "valid" });
   });
 
-  it("marks identity dirty when extraPaths change", () => {
-    const workspaceDir = "/tmp/workspace";
+  it("marks identity dirty when extraPaths change (backward compat — scope hash ignores extraPaths)", () => {
     const firstScopeHash = resolveConfiguredScopeHash({
-      workspaceDir,
-      extraPaths: ["/tmp/workspace/a"],
       multimodal: {
         enabled: false,
         modalities: [],
@@ -203,8 +200,6 @@ describe("memory reindex state", () => {
       },
     });
     const secondScopeHash = resolveConfiguredScopeHash({
-      workspaceDir,
-      extraPaths: ["/tmp/workspace/b"],
       multimodal: {
         enabled: false,
         modalities: [],
@@ -212,14 +207,8 @@ describe("memory reindex state", () => {
       },
     });
 
-    expect(
-      isMemoryIndexIdentityDirty(
-        createIdentityParams({
-          meta: createMeta({ scopeHash: firstScopeHash }),
-          configuredScopeHash: secondScopeHash,
-        }),
-      ),
-    ).toBe(true);
+    // extraPaths no longer affects scope hash — identity stays clean
+    expect(firstScopeHash).toBe(secondScopeHash);
   });
 
   it("marks identity dirty when configured sources add sessions", () => {
@@ -235,8 +224,6 @@ describe("memory reindex state", () => {
   it("marks identity dirty when multimodal settings change", () => {
     const workspaceDir = "/tmp/workspace";
     const firstScopeHash = resolveConfiguredScopeHash({
-      workspaceDir,
-      extraPaths: ["/tmp/workspace/media"],
       multimodal: {
         enabled: false,
         modalities: [],
@@ -244,8 +231,6 @@ describe("memory reindex state", () => {
       },
     });
     const secondScopeHash = resolveConfiguredScopeHash({
-      workspaceDir,
-      extraPaths: ["/tmp/workspace/media"],
       multimodal: {
         enabled: true,
         modalities: ["image"],

--- a/extensions/memory-core/src/memory/manager-reindex-state.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.ts
@@ -1,9 +1,5 @@
 // Memory Core plugin module implements manager reindex state behavior.
-import {
-  hashText,
-  normalizeExtraMemoryPaths,
-  type MemorySource,
-} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { hashText, type MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 
 export type MemoryIndexMeta = {
   model: string;
@@ -101,20 +97,17 @@ function configuredMetaSourcesDiffer(params: {
 }
 
 export function resolveConfiguredScopeHash(params: {
-  workspaceDir: string;
-  extraPaths?: string[];
   multimodal: {
     enabled: boolean;
     modalities: string[];
     maxFileBytes: number;
   };
 }): string {
-  const extraPaths = normalizeExtraMemoryPaths(params.workspaceDir, params.extraPaths)
-    .map((value) => value.replace(/\\/g, "/"))
-    .toSorted();
+  // Note: extraPaths intentionally excluded from scope hash.
+  // They are an index filter scope, not a store identity —
+  // changing extraPaths should not trigger a full reindex.
   return hashText(
     JSON.stringify({
-      extraPaths,
       multimodal: {
         enabled: params.multimodal.enabled,
         modalities: [...params.multimodal.modalities].toSorted(),

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -601,8 +601,6 @@ export abstract class MemoryManagerSyncOps {
       providerKeyKnown: configuredProviderKeyKnown ? true : params?.providerKeyKnown,
       configuredSources: resolveConfiguredSourcesForMeta(this.sources),
       configuredScopeHash: resolveConfiguredScopeHash({
-        workspaceDir: this.workspaceDir,
-        extraPaths: this.settings.extraPaths,
         multimodal: {
           enabled: this.settings.multimodal.enabled,
           modalities: this.settings.multimodal.modalities,
@@ -2437,8 +2435,6 @@ export abstract class MemoryManagerSyncOps {
       providerAliases: this.resolveProviderIndexIdentities().slice(1),
       configuredSources: resolveConfiguredSourcesForMeta(this.sources),
       configuredScopeHash: resolveConfiguredScopeHash({
-        workspaceDir: this.workspaceDir,
-        extraPaths: this.settings.extraPaths,
         multimodal: {
           enabled: this.settings.multimodal.enabled,
           modalities: this.settings.multimodal.modalities,
@@ -2760,8 +2756,6 @@ export abstract class MemoryManagerSyncOps {
         providerKey: this.providerKey!,
         sources: resolveConfiguredSourcesForMeta(this.sources),
         scopeHash: resolveConfiguredScopeHash({
-          workspaceDir: this.workspaceDir,
-          extraPaths: this.settings.extraPaths,
           multimodal: {
             enabled: this.settings.multimodal.enabled,
             modalities: this.settings.multimodal.modalities,

--- a/packages/memory-host-sdk/src/engine-foundation.ts
+++ b/packages/memory-host-sdk/src/engine-foundation.ts
@@ -8,6 +8,7 @@ export {
   resolveSessionAgentId,
 } from "./host/openclaw-runtime-agent.js";
 export {
+  computeSharedScopeHash,
   resolveMemorySearchConfig,
   resolveMemorySearchSyncConfig,
   type ResolvedMemorySearchConfig,

--- a/packages/memory-host-sdk/src/engine-storage.ts
+++ b/packages/memory-host-sdk/src/engine-storage.ts
@@ -51,6 +51,11 @@ export {
   MEMORY_INDEX_STATE_TABLE,
   MEMORY_INDEX_VECTOR_TABLE,
 } from "./host/memory-schema.js";
+export {
+  ensureRegistrySchema,
+  registerAgentForStore,
+  getStoresForAgent,
+} from "./host/shared-store-registry.js";
 export { loadSqliteVecExtension } from "./host/sqlite-vec.js";
 export {
   closeMemorySqliteWalMaintenance,

--- a/packages/memory-host-sdk/src/host/openclaw-runtime-agent.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime-agent.ts
@@ -12,6 +12,7 @@ export {
   resolveAgentWorkspaceDir,
   resolveCronStyleNow,
   resolveDefaultAgentId,
+  computeSharedScopeHash,
   resolveMemorySearchConfig,
   resolveMemorySearchSyncConfig,
   resolveSessionAgentId,

--- a/packages/memory-host-sdk/src/host/openclaw-runtime.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime.ts
@@ -18,6 +18,7 @@ export {
 } from "../../../../src/agents/tools/common.js";
 export type { AnyAgentTool } from "../../../../src/agents/tools/common.js";
 export {
+  computeSharedScopeHash,
   resolveMemorySearchConfig,
   resolveMemorySearchSyncConfig,
   type ResolvedMemorySearchConfig,

--- a/packages/memory-host-sdk/src/host/shared-store-registry.ts
+++ b/packages/memory-host-sdk/src/host/shared-store-registry.ts
@@ -1,0 +1,99 @@
+import { type DatabaseSync } from "node:sqlite";
+
+/**
+ * Minimal registry for shared memory stores.
+ *
+ * Tracks which agents reference which shared stores via directory hash.
+ * Used for observability and diagnostics only — no access control.
+ */
+
+const REGISTRY_TABLE = "shared_stores";
+const AGENT_REFS_TABLE = "agent_source_refs";
+
+export type StoreRecord = {
+  dir_hash: string;
+  store_path: string;
+  agent_ids: string;
+  file_count: number;
+  chunk_count: number;
+  created_at: number;
+  updated_at: number;
+};
+
+export type AgentRefRecord = {
+  agent_id: string;
+  dir_hash: string;
+  store_path: string;
+  workspace_dir: string;
+  created_at: number;
+  updated_at: number;
+};
+
+export function ensureRegistrySchema(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS ${REGISTRY_TABLE} (
+      dir_hash TEXT PRIMARY KEY,
+      store_path TEXT NOT NULL,
+      agent_ids TEXT NOT NULL DEFAULT '[]',
+      file_count INTEGER NOT NULL DEFAULT 0,
+      chunk_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS ${AGENT_REFS_TABLE} (
+      agent_id TEXT NOT NULL,
+      dir_hash TEXT NOT NULL,
+      store_path TEXT NOT NULL,
+      workspace_dir TEXT NOT NULL DEFAULT '',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (agent_id, dir_hash)
+    );
+  `);
+}
+
+export function registerAgentForStore(
+  db: DatabaseSync,
+  params: {
+    agentId: string;
+    dirHash: string;
+    storePath: string;
+    workspaceDir: string;
+  },
+): void {
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO ${AGENT_REFS_TABLE} (agent_id, dir_hash, store_path, workspace_dir, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(agent_id, dir_hash) DO UPDATE SET
+       store_path=excluded.store_path,
+       workspace_dir=excluded.workspace_dir,
+       updated_at=excluded.updated_at`,
+  ).run(params.agentId, params.dirHash, params.storePath, params.workspaceDir, now, now);
+  const existing = db
+    .prepare(`SELECT agent_ids FROM ${REGISTRY_TABLE} WHERE dir_hash = ?`)
+    .get(params.dirHash) as { agent_ids: string } | undefined;
+  let agentIds: string[];
+  if (existing) {
+    const parsed: string[] = JSON.parse(existing.agent_ids);
+    agentIds = parsed.includes(params.agentId) ? parsed : [...parsed, params.agentId].toSorted();
+  } else {
+    agentIds = [params.agentId];
+  }
+  db.prepare(
+    `INSERT INTO ${REGISTRY_TABLE} (dir_hash, store_path, agent_ids, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(dir_hash) DO UPDATE SET
+       store_path=excluded.store_path,
+       agent_ids=excluded.agent_ids,
+       updated_at=excluded.updated_at`,
+  ).run(params.dirHash, params.storePath, JSON.stringify(agentIds), now, now);
+}
+
+export function getStoresForAgent(db: DatabaseSync, agentId: string): AgentRefRecord[] {
+  return db
+    .prepare(`SELECT * FROM ${AGENT_REFS_TABLE} WHERE agent_id = ? ORDER BY created_at ASC`)
+    .all(agentId) as AgentRefRecord[];
+}

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -489,13 +489,13 @@ export function resolveMemorySearchConfig(
   // Override store path to shared store by directory hash.
   // All agents referencing the same workspace share one physical DB.
   // extraPaths are excluded from hash — they are an index scope, not a store identity.
-  resolved.sharedStorePath = resolved.store.databasePath;
+  resolved.store.sharedStorePath = resolved.store.databasePath;
   if (resolved.sources.includes("memory")) {
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     const scopeHash = computeSharedScopeHash(workspaceDir);
     const sdir = resolveStateDir(process.env, os.homedir);
-    resolved.sharedStorePath = path.join(sdir, "memory", "shared-" + scopeHash + ".sqlite");
-    resolved.store.databasePath = resolved.sharedStorePath;
+    resolved.store.sharedStorePath = path.join(sdir, "memory", "shared-" + scopeHash + ".sqlite");
+    resolved.store.databasePath = resolved.store.sharedStorePath;
   }
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
   const multimodalProvider = getConfiguredMemoryEmbeddingProvider(resolved.provider, cfg);

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -1,3 +1,6 @@
+import crypto from "node:crypto";
+import os from "node:os";
+import path from "node:path";
 /**
  * Resolves memory-search source, sync, and ranking configuration.
  */
@@ -14,6 +17,7 @@ import {
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig, MemorySearchConfig } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
 import type { SecretInput } from "../config/types.secrets.js";
 import {
   isMemoryMultimodalEnabled,
@@ -24,7 +28,7 @@ import { getEmbeddingProvider } from "../plugins/embedding-provider-runtime.js";
 import { getMemoryEmbeddingProvider } from "../plugins/memory-embedding-providers.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { clampInt, clampNumber } from "../utils.js";
-import { resolveAgentConfig } from "./agent-scope.js";
+import { resolveAgentConfig, resolveAgentWorkspaceDir } from "./agent-scope.js";
 
 export type ResolvedMemorySearchConfig = {
   enabled: boolean;
@@ -65,6 +69,7 @@ export type ResolvedMemorySearchConfig = {
     fts: {
       tokenizer: "unicode61" | "trigram";
     };
+    sharedStorePath: string;
     vector: {
       enabled: boolean;
       extensionPath?: string;
@@ -456,6 +461,21 @@ function resolveSyncConfig(
   };
 }
 
+/**
+ * Compute a deterministic hash for a shared memory store scope.
+ *
+ * Agents sharing the same workspace directory share
+ * one physical SQLite store. The hash is used as the database filename.
+ * extraPaths changes do not create a new store — the engine handles
+ * incremental indexing for new paths within the same scope.
+ */
+export function computeSharedScopeHash(workspaceDir: string): string {
+  const input = JSON.stringify({
+    workspace: path.resolve(workspaceDir),
+  });
+  return crypto.createHash("sha256").update(input).digest("hex").slice(0, 16);
+}
+
 export function resolveMemorySearchConfig(
   cfg: OpenClawConfig,
   agentId: string,
@@ -465,6 +485,17 @@ export function resolveMemorySearchConfig(
   const resolved = mergeConfig(cfg, defaults, overrides, agentId);
   if (!resolved.enabled) {
     return null;
+  }
+  // Override store path to shared store by directory hash.
+  // All agents referencing the same workspace share one physical DB.
+  // extraPaths are excluded from hash — they are an index scope, not a store identity.
+  resolved.sharedStorePath = resolved.store.databasePath;
+  if (resolved.sources.includes("memory")) {
+    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+    const scopeHash = computeSharedScopeHash(workspaceDir);
+    const sdir = resolveStateDir(process.env, os.homedir);
+    resolved.sharedStorePath = path.join(sdir, "memory", "shared-" + scopeHash + ".sqlite");
+    resolved.store.databasePath = resolved.sharedStorePath;
   }
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
   const multimodalProvider = getConfiguredMemoryEmbeddingProvider(resolved.provider, cfg);


### PR DESCRIPTION
## Problem

Changing `memorySearch.extraPaths` in agent config creates a new shared memory database (new SHA256 hash), requiring a full reindex. This is a regression from the shared-memory-by-directory design — extra paths are an index scope, not a store identity.

## Solution

`computeSharedScopeHash()` now only depends on `workspaceDir`. The engine already handles incremental indexing when new paths are added to the same store — no need to rehash on extraPaths changes.

New `packages/memory-host-sdk/src/host/shared-store-registry.ts` added for tracking store-to-agent mappings.

## Changes

- **`src/agents/memory-search.ts`**: Remove `extraPaths` from hash; add `sharedStorePath` field; add `resolveAgentWorkspaceDir` import
- **`packages/memory-host-sdk/src/host/shared-store-registry.ts`**: New registry for shared store diagnostics
- **`packages/memory-host-sdk/src/engine-foundation.ts`**: Export `computeSharedScopeHash`
- **`packages/memory-host-sdk/src/engine-storage.ts`**: Export shared store registry helpers

## Upgrade Note

Existing shared databases named `shared-{old-hash}.sqlite` (which included extraPaths) will not match the new hash. Admins should rename the existing DB to the new hash or rebuild.