### PR TITLE
fix(commitments): use single-char ellipsis in truncate to fix column alignment (fixes #95921)

### DIFF
--- a/src/commands/commitments.test.ts
+++ b/src/commands/commitments.test.ts
@@ -109,6 +109,27 @@ describe("commitments command", () => {
     );
   });
 
+  it("keeps column alignment when id or scope is truncated", async () => {
+    mocks.listCommitments.mockResolvedValue([commitment({ id: "cm_abcdefghijklmnopqrstuvwxyz" })]);
+    const { runtime, logs } = createRuntime();
+
+    await commitmentsListCommand({}, runtime);
+
+    const header = logs.map(stripAnsi).find((line) => line.startsWith("ID"));
+    const dataRow = logs.map(stripAnsi).find((line) => line.startsWith("cm_"));
+    expect(header).toBeDefined();
+    expect(dataRow).toBeDefined();
+    // The truncated id cell must be exactly 16 chars (padded),
+    // so Status column starts at the same offset in both lines.
+    const headerStatusIdx = header!.indexOf("Status");
+    const dataStatusIdx = dataRow!.indexOf("pending");
+    expect(dataStatusIdx).toBe(headerStatusIdx);
+    // The truncated id must end with the single-char ellipsis …
+    const idCell = dataRow!.slice(0, 16);
+    expect(idCell).toContain("…");
+    expect(idCell.length).toBe(16);
+  });
+
   it("writes list JSON to runtime stdout instead of log output", async () => {
     const { runtime, logs, stdout } = createRuntime();
 

--- a/src/commands/commitments.ts
+++ b/src/commands/commitments.ts
@@ -24,7 +24,7 @@ const STATUS_VALUES = new Set<CommitmentStatus>([
 ]);
 
 function truncate(value: string, maxChars: number): string {
-  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}...`;
+  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}…`;
 }
 
 function safe(value: string): string {


### PR DESCRIPTION
## What Problem This Solves

The `truncate()` helper in `src/commands/commitments.ts` reserves 1 character for the ellipsis (`slice(0, maxChars - 1)`) but appends the 3-character ASCII `"..."`, producing cells that are `maxChars + 2` characters wide. These overflow their `.padEnd()` columns, shifting `Status`, `Kind`, `Due`, and `Scope` two characters to the right on any row with a truncated ID or scope.

Every other truncation helper in the CLI (`flows.ts`, `tasks.ts`, `onboard-skills.ts`) already uses the single-character `…` (U+2026). `commitments.ts` was the lone outlier.

## Why This Change Was Made

- **Root cause:** `"..."` is 3 ASCII characters; the function only reserved 1 character, creating a 2-char overflow.
- **Fix:** Replace `"..."` with `"…"` (U+2026, 1 character), matching the pattern used by all sibling CLI commands.
- **Scope:** 1 source character changed, 1 regression test added.

## User Impact

The `openclaw commitments` table columns will now align correctly for commitments with long IDs or scope strings. No behavioral change for short values.

## Evidence

- **Behavior addressed:** `truncate()` in `src/commands/commitments.ts` produces cells wider than `maxChars`, breaking fixed-width column alignment in `openclaw commitments` table output.
- **Environment tested:** macOS 26.4.1, Node 22.22.3, OpenClaw repo checkout at `aa0bdb90` (upstream/main).
- **Steps run after the patch:**
  1. Applied 1-character fix: `"..."` → `"…"` in `src/commands/commitments.ts:27`.
  2. Ran `node scripts/run-vitest.mjs run src/commands/commitments.test.ts` — 5/5 tests pass including the new alignment regression test.
  3. Ran `pnpm build` to compile the fix.
  4. Seeded a test commitment with long ID (`cm_abcdefghijklmnopqrstuvwxyz_long_id_for_truncation_test`) and ran `pnpm openclaw commitments --all`.
- **Evidence after fix:**
  ```
  $ pnpm openclaw commitments --all
  Commitments: 1
  Store: /Users/liuhao/.openclaw/commitments/commitments.json
  ID               Status     Kind             Due                      Scope                        Suggested text
  cm_abcdefghijkl… expired    event_check_in   2025-06-23T17:40:00.000Z main/telegram/+155****4567   How did your interview go?
  ```
  ```
  $ node scripts/run-vitest.mjs run src/commands/commitments.test.ts
  ✓  commands  src/commands/commitments.test.ts (5 tests) 64ms
  Test Files  1 passed (1)
       Tests  5 passed (5)
  ```
- **Observed result after fix:** The truncated ID cell is `cm_abcdefghijkl…` (exactly 16 characters including the single-char `…`). The `expired` status column aligns with the `Status` header at the same column offset. The table is properly aligned.
- **What was not tested:** The fix is a single Unicode character change validated by unit tests and real CLI output. All commitment statuses, kinds, and due formats were exercised indirectly through existing tests.

## Real behavior proof

- **Behavior addressed:** The `truncate()` function in `src/commands/commitments.ts` produced cells that overflowed their `padEnd` column width by 2 characters due to using 3-char ASCII `"..."` instead of 1-char `…`.
- **Environment tested:** macOS 26.4.1, Node 22.22.3, OpenClaw repo at commit `aa0bdb90`.
- **Steps run after the patch:**
  1. Changed `"..."` to `"…"` in `src/commands/commitments.ts` line 27.
  2. Added regression test verifying column alignment with long commitment IDs.
  3. Ran `node scripts/run-vitest.mjs run src/commands/commitments.test.ts` — all 5 tests pass.
  4. Ran `pnpm build` to compile the fix into dist/.
  5. Seeded test commitment with long ID, ran `pnpm openclaw commitments --all`.
- **Evidence after fix:**
  ```
  $ pnpm openclaw commitments --all
  Commitments: 1
  Store: /Users/liuhao/.openclaw/commitments/commitments.json
  ID               Status     Kind             Due                      Scope                        Suggested text
  cm_abcdefghijkl… expired    event_check_in   2025-06-23T17:40:00.000Z main/telegram/+155****4567   How did your interview go?
  ```
  ```
  $ node scripts/run-vitest.mjs run src/commands/commitments.test.ts
  [test] starting test/vitest/vitest.commands.config.ts
   ✓  commands  src/commands/commitments.test.ts (5 tests) 64ms
   Test Files  1 passed (1)
        Tests  5 passed (5)
    Duration  446ms
  [test] passed 1 Vitest shard in 4.35s
  ```
- **Observed result after fix:** The truncated ID `cm_abcdefghijkl…` is exactly 16 characters. Column alignment is correct: `expired` starts at the same column position as `Status` in the header row. The single-char `…` replaces the 3-char `...`, eliminating the 2-character overflow.
- **What was not tested:** All commitment field types (status, kind, due, scope) were covered by existing unit tests. The CLI proof demonstrates the specific truncation alignment fix with a long commitment ID.
