### PR TITLE
perf(qa-lab): speed up unified QA suites

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -24,6 +24,20 @@ function listScenarioMarkdownPaths(dir = "qa/scenarios"): string[] {
     .toSorted();
 }
 
+function flowContainsCall(value: unknown, callName: string): boolean {
+  if (Array.isArray(value)) {
+    return value.some((entry) => flowContainsCall(entry, callName));
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    record.call === callName ||
+    Object.values(record).some((entry) => flowContainsCall(entry, callName))
+  );
+}
+
 describe("qa scenario catalog", () => {
   const dottedCoverageIdPattern = /^[a-z0-9][a-z0-9-]*(?:\.[a-z0-9][a-z0-9-]*)+$/;
 
@@ -142,6 +156,34 @@ describe("qa scenario catalog", () => {
     expect(bundledSkillConfig?.expectedSkillName).toBe("prose");
     expect(fanoutConfig?.expectedReplyGroups?.flat()).toContain("subagent-1: ok");
     expect(fanoutConfig?.expectedReplyGroups?.flat()).toContain("subagent-2: ok");
+  });
+
+  it("loads explicit suite isolation metadata from per-scenario YAML", () => {
+    const staleLinks = readQaScenarioById("subagent-stale-child-links");
+    const kitchenSink = readQaScenarioById("kitchen-sink-live-openai");
+
+    expect(staleLinks.execution.suiteIsolation).toBe("isolated");
+    expect(staleLinks.execution.isolationReason).toContain("gateway session");
+    expect(kitchenSink.execution.suiteIsolation).toBe("isolated");
+    expect(kitchenSink.execution.isolationReason).toContain("plugin/channel/tool config");
+  });
+
+  it("requires explicit suite isolation for gateway state restart scenarios", () => {
+    const scenarios = readQaScenarioPack().scenarios.filter(
+      (scenario) =>
+        scenario.execution.kind === "flow" &&
+        flowContainsCall(scenario.execution.flow, "env.gateway.restartAfterStateMutation"),
+    );
+
+    expect(scenarios.map((scenario) => scenario.id).toSorted()).toEqual([
+      "kitchen-sink-live-openai",
+      "subagent-stale-child-links",
+    ]);
+    expect(
+      scenarios
+        .filter((scenario) => scenario.execution.suiteIsolation !== "isolated")
+        .map((scenario) => scenario.id),
+    ).toEqual([]);
   });
 
   it("loads scenario-declared gateway runtime options from YAML", () => {

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -11,6 +11,11 @@ import {
   validateQaScenarioExecutionConfig,
 } from "./scenario-catalog.js";
 
+type CatalogScenario = ReturnType<typeof readQaScenarioPack>["scenarios"][number];
+type FlowCatalogScenario = CatalogScenario & {
+  execution: Extract<CatalogScenario["execution"], { kind: "flow" }>;
+};
+
 function listScenarioMarkdownPaths(dir = "qa/scenarios"): string[] {
   return fs
     .readdirSync(dir, { withFileTypes: true })
@@ -22,6 +27,18 @@ function listScenarioMarkdownPaths(dir = "qa/scenarios"): string[] {
       return entry.isFile() && entry.name.endsWith(".md") ? [entryPath] : [];
     })
     .toSorted();
+}
+
+function isFlowScenario(scenario: CatalogScenario): scenario is FlowCatalogScenario {
+  return scenario.execution.kind === "flow";
+}
+
+function requireFlowScenario(scenario: CatalogScenario): FlowCatalogScenario {
+  expect(scenario.execution.kind).toBe("flow");
+  if (!isFlowScenario(scenario)) {
+    throw new Error(`expected ${scenario.id} to be a flow scenario`);
+  }
+  return scenario;
 }
 
 function flowContainsCall(value: unknown, callName: string): boolean {
@@ -159,8 +176,8 @@ describe("qa scenario catalog", () => {
   });
 
   it("loads explicit suite isolation metadata from per-scenario YAML", () => {
-    const staleLinks = readQaScenarioById("subagent-stale-child-links");
-    const kitchenSink = readQaScenarioById("kitchen-sink-live-openai");
+    const staleLinks = requireFlowScenario(readQaScenarioById("subagent-stale-child-links"));
+    const kitchenSink = requireFlowScenario(readQaScenarioById("kitchen-sink-live-openai"));
 
     expect(staleLinks.execution.suiteIsolation).toBe("isolated");
     expect(staleLinks.execution.isolationReason).toContain("gateway session");
@@ -169,11 +186,11 @@ describe("qa scenario catalog", () => {
   });
 
   it("requires explicit suite isolation for gateway state restart scenarios", () => {
-    const scenarios = readQaScenarioPack().scenarios.filter(
-      (scenario) =>
-        scenario.execution.kind === "flow" &&
+    const scenarios = readQaScenarioPack()
+      .scenarios.filter(isFlowScenario)
+      .filter((scenario) =>
         flowContainsCall(scenario.execution.flow, "env.gateway.restartAfterStateMutation"),
-    );
+      );
 
     expect(scenarios.map((scenario) => scenario.id).toSorted()).toEqual([
       "kitchen-sink-live-openai",

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -70,6 +70,8 @@ const qaFlowScenarioExecutionSchema = z.object({
   kind: z.literal("flow").default("flow"),
   summary: z.string().trim().min(1).optional(),
   channel: qaScenarioChannelSchema.optional(),
+  suiteIsolation: z.literal("isolated").optional(),
+  isolationReason: z.string().trim().min(1).optional(),
   config: qaScenarioConfigSchema.optional(),
 });
 

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -333,6 +333,42 @@ describe("qa suite runtime launcher", () => {
     expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps multiple isolated flow scenarios in separate serial partitions", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-serial-isolated-");
+    await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/serial-isolated",
+      concurrency: 1,
+      scenarioIds: [
+        "group-visible-reply-tool",
+        "runtime-tool-image-generate",
+        "control-ui-chat-flow-playwright",
+      ],
+    });
+
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "serial-isolated");
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(2);
+    expect(runQaFlowSuite).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        outputDir: path.join(outputDir, "flow", "isolated-1"),
+        concurrency: 1,
+        workerStartStaggerMs: 0,
+        scenarioIds: ["group-visible-reply-tool"],
+      }),
+    );
+    expect(runQaFlowSuite).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        outputDir: path.join(outputDir, "flow", "isolated-2"),
+        concurrency: 1,
+        workerStartStaggerMs: 0,
+        scenarioIds: ["runtime-tool-image-generate"],
+      }),
+    );
+    expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
+  });
+
   it("accounts for isolated flow worker weight in unified suite concurrency", async () => {
     const repoRoot = await makeTempRepo("qa-suite-weighted-");
     let releaseShared!: () => void;

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -99,6 +99,7 @@ describe("qa suite runtime launcher", () => {
   });
 
   afterEach(async () => {
+    vi.unstubAllEnvs();
     await Promise.all(
       tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
     );
@@ -474,7 +475,7 @@ describe("qa suite runtime launcher", () => {
       expect.objectContaining({
         outputDir: path.join(outputDir, "flow", "isolated"),
         concurrency: 1,
-        workerStartStaggerMs: 500,
+        workerStartStaggerMs: 0,
         scenarioIds: ["group-visible-reply-tool"],
       }),
     );
@@ -563,6 +564,67 @@ describe("qa suite runtime launcher", () => {
         outputDir: path.join(outputDir, "flow", "isolated"),
         concurrency: 3,
         workerStartStaggerMs: 500,
+        scenarioIds: [
+          "runtime-tool-image-generate",
+          "runtime-inventory-drift-check",
+          "session-memory-ranking",
+        ],
+      }),
+    );
+  });
+
+  it("isolates flow scenarios that restart after state mutations", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-gateway-state-");
+    await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/gateway-state",
+      concurrency: 8,
+      scenarioIds: [
+        "channel-chat-baseline",
+        "subagent-stale-child-links",
+        "control-ui-chat-flow-playwright",
+      ],
+    });
+
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "gateway-state");
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(2);
+    expect(runQaFlowSuite).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        outputDir: path.join(outputDir, "flow", "shared"),
+        scenarioIds: ["channel-chat-baseline"],
+      }),
+    );
+    expect(runQaFlowSuite).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        outputDir: path.join(outputDir, "flow", "isolated"),
+        scenarioIds: ["subagent-stale-child-links"],
+      }),
+    );
+  });
+
+  it("preserves configured isolated worker start stagger overrides", async () => {
+    vi.stubEnv("OPENCLAW_QA_SUITE_WORKER_START_STAGGER_MS", "2500");
+    const repoRoot = await makeTempRepo("qa-suite-stagger-env-");
+    await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/stagger-env",
+      concurrency: 8,
+      scenarioIds: [
+        "runtime-tool-image-generate",
+        "runtime-inventory-drift-check",
+        "session-memory-ranking",
+        "control-ui-chat-flow-playwright",
+      ],
+    });
+
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "stagger-env");
+    expect(runQaFlowSuite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outputDir: path.join(outputDir, "flow"),
+        concurrency: 3,
+        workerStartStaggerMs: 2500,
         scenarioIds: [
           "runtime-tool-image-generate",
           "runtime-inventory-drift-check",

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -191,9 +191,13 @@ describe("qa suite runtime launcher", () => {
         await vitestBlocked;
         const evidencePath = path.join(params.outputDir, "qa-evidence.json");
         await writeEvidence(evidencePath);
+        const scenario = params.scenarios[0];
+        if (!scenario) {
+          throw new Error("expected scenario");
+        }
         return {
           outputDir: params.outputDir,
-          executionKind: params.scenarios[0]!.execution.kind,
+          executionKind: scenario.execution.kind,
           evidencePath,
           results: params.scenarios.map((scenarioItem) => ({
             durationMs: 1,

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -51,26 +51,27 @@ describe("qa suite runtime launcher", () => {
   beforeEach(() => {
     runQaFlowSuite.mockReset();
     runQaTestFileScenarios.mockReset();
-    runQaFlowSuite.mockImplementation(async (params: { outputDir?: string } | undefined) => {
-      const outputDir = params?.outputDir ?? "/tmp/qa-flow";
-      const evidencePath = path.join(outputDir, "qa-evidence.json");
-      await writeEvidence(evidencePath);
-      return {
-        outputDir,
-        evidencePath,
-        reportPath: path.join(outputDir, "qa-suite-report.md"),
-        summaryPath: path.join(outputDir, "qa-suite-summary.json"),
-        report: "# QA Suite Report\n",
-        scenarios: [
-          {
-            name: "channel-chat-baseline",
+    runQaFlowSuite.mockImplementation(
+      async (params: { outputDir?: string; scenarioIds?: string[] } | undefined) => {
+        const outputDir = params?.outputDir ?? "/tmp/qa-flow";
+        const evidencePath = path.join(outputDir, "qa-evidence.json");
+        await writeEvidence(evidencePath);
+        const scenarioIds = params?.scenarioIds ?? ["channel-chat-baseline"];
+        return {
+          outputDir,
+          evidencePath,
+          reportPath: path.join(outputDir, "qa-suite-report.md"),
+          summaryPath: path.join(outputDir, "qa-suite-summary.json"),
+          report: "# QA Suite Report\n",
+          scenarios: scenarioIds.map((scenarioId) => ({
+            name: scenarioId,
             status: "pass",
             steps: [],
-          },
-        ],
-        watchUrl: "http://127.0.0.1:43124",
-      };
-    });
+          })),
+          watchUrl: "http://127.0.0.1:43124",
+        };
+      },
+    );
     runQaTestFileScenarios.mockImplementation(
       async (params: {
         outputDir: string;
@@ -171,6 +172,56 @@ describe("qa suite runtime launcher", () => {
     ).toEqual([{ id: "control-ui-chat-flow-playwright", kind: "playwright" }]);
   });
 
+  it("serializes test-file runner partitions in one checkout", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-test-file-serial-");
+    let releaseVitest!: () => void;
+    let markVitestStarted!: () => void;
+    const vitestStarted = new Promise<void>((resolve) => {
+      markVitestStarted = resolve;
+    });
+    const vitestBlocked = new Promise<void>((resolve) => {
+      releaseVitest = resolve;
+    });
+    runQaTestFileScenarios.mockImplementationOnce(
+      async (params: {
+        outputDir: string;
+        scenarios: Array<{ id: string; execution: { kind: "script" | "vitest" | "playwright" } }>;
+      }) => {
+        markVitestStarted();
+        await vitestBlocked;
+        const evidencePath = path.join(params.outputDir, "qa-evidence.json");
+        await writeEvidence(evidencePath);
+        return {
+          outputDir: params.outputDir,
+          executionKind: params.scenarios[0]!.execution.kind,
+          evidencePath,
+          results: params.scenarios.map((scenarioItem) => ({
+            durationMs: 1,
+            logPath: path.join(params.outputDir, `${scenarioItem.id}.log`),
+            scenario: scenarioItem,
+            status: "pass",
+          })),
+        };
+      },
+    );
+
+    const runPromise = runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/test-file-serial",
+      concurrency: 8,
+      scenarioIds: ["gateway-smoke", "control-ui-chat-flow-playwright"],
+    });
+    await vitestStarted;
+    await Promise.resolve();
+
+    expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
+
+    releaseVitest();
+    await runPromise;
+
+    expect(runQaTestFileScenarios).toHaveBeenCalledTimes(2);
+  });
+
   it("runs mixed flow and Vitest/Playwright scenarios as one suite", async () => {
     const repoRoot = await makeTempRepo("qa-suite-mixed-");
     const result = await runQaSuite({
@@ -217,6 +268,247 @@ describe("qa suite runtime launcher", () => {
     expect(JSON.stringify(summary)).not.toContain(repoRoot);
     expect(summary.scenarios?.[1]?.details).toContain(
       "log=.artifacts/qa-e2e/mixed/playwright/control-ui-chat-flow-playwright.log",
+    );
+  });
+
+  it("respects serial concurrency across unified suite partitions", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-serial-");
+    let releaseFlow!: () => void;
+    let markFlowStarted!: () => void;
+    const flowStarted = new Promise<void>((resolve) => {
+      markFlowStarted = resolve;
+    });
+    const flowBlocked = new Promise<void>((resolve) => {
+      releaseFlow = resolve;
+    });
+    runQaFlowSuite.mockImplementationOnce(
+      async (params: { outputDir?: string; scenarioIds?: string[] } | undefined) => {
+        markFlowStarted();
+        await flowBlocked;
+        const outputDir = params?.outputDir ?? "/tmp/qa-flow";
+        const evidencePath = path.join(outputDir, "qa-evidence.json");
+        await writeEvidence(evidencePath);
+        const scenarioIds = params?.scenarioIds ?? ["channel-chat-baseline"];
+        return {
+          outputDir,
+          evidencePath,
+          reportPath: path.join(outputDir, "qa-suite-report.md"),
+          summaryPath: path.join(outputDir, "qa-suite-summary.json"),
+          report: "# QA Suite Report\n",
+          scenarios: scenarioIds.map((scenarioId) => ({
+            name: scenarioId,
+            status: "pass",
+            steps: [],
+          })),
+          watchUrl: "http://127.0.0.1:43124",
+        };
+      },
+    );
+
+    const runPromise = runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/serial",
+      concurrency: 1,
+      scenarioIds: [
+        "channel-chat-baseline",
+        "group-visible-reply-tool",
+        "control-ui-chat-flow-playwright",
+      ],
+    });
+    await flowStarted;
+    await Promise.resolve();
+
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    expect(runQaTestFileScenarios).not.toHaveBeenCalled();
+
+    releaseFlow();
+    await runPromise;
+
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(2);
+    expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
+  });
+
+  it("accounts for isolated flow worker weight in unified suite concurrency", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-weighted-");
+    let releaseShared!: () => void;
+    let markSharedStarted!: () => void;
+    const sharedStarted = new Promise<void>((resolve) => {
+      markSharedStarted = resolve;
+    });
+    const sharedBlocked = new Promise<void>((resolve) => {
+      releaseShared = resolve;
+    });
+    runQaFlowSuite.mockImplementationOnce(
+      async (params: { outputDir?: string; scenarioIds?: string[] } | undefined) => {
+        markSharedStarted();
+        await sharedBlocked;
+        const outputDir = params?.outputDir ?? "/tmp/qa-flow";
+        const evidencePath = path.join(outputDir, "qa-evidence.json");
+        await writeEvidence(evidencePath);
+        const scenarioIds = params?.scenarioIds ?? ["channel-chat-baseline"];
+        return {
+          outputDir,
+          evidencePath,
+          reportPath: path.join(outputDir, "qa-suite-report.md"),
+          summaryPath: path.join(outputDir, "qa-suite-summary.json"),
+          report: "# QA Suite Report\n",
+          scenarios: scenarioIds.map((scenarioId) => ({
+            name: scenarioId,
+            status: "pass",
+            steps: [],
+          })),
+          watchUrl: "http://127.0.0.1:43124",
+        };
+      },
+    );
+
+    const runPromise = runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/weighted",
+      concurrency: 2,
+      scenarioIds: [
+        "channel-chat-baseline",
+        "group-visible-reply-tool",
+        "control-ui-chat-flow-playwright",
+      ],
+    });
+    await sharedStarted;
+    await Promise.resolve();
+
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    expect(runQaTestFileScenarios).not.toHaveBeenCalled();
+
+    releaseShared();
+    await runPromise;
+
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(2);
+    expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares ordinary flow scenarios and isolates flow scenarios with config patches", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-partition-");
+    const result = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/smoke",
+      concurrency: 8,
+      scenarioIds: [
+        "channel-chat-baseline",
+        "group-visible-reply-tool",
+        "control-ui-chat-flow-playwright",
+      ],
+    });
+
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "smoke");
+    expect(result.executionKind).toBe("suite");
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(2);
+    expect(runQaFlowSuite).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        outputDir: path.join(outputDir, "flow", "shared"),
+        concurrency: 1,
+        scenarioIds: ["channel-chat-baseline"],
+      }),
+    );
+    expect(runQaFlowSuite).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        outputDir: path.join(outputDir, "flow", "isolated"),
+        concurrency: 3,
+        workerStartStaggerMs: 500,
+        scenarioIds: ["group-visible-reply-tool"],
+      }),
+    );
+    const summary = JSON.parse(
+      await fs.readFile(path.join(outputDir, "qa-suite-summary.json"), "utf8"),
+    ) as {
+      scenarios?: Array<{ name?: unknown; status?: unknown }>;
+    };
+    expect(summary.scenarios).toMatchObject([
+      { name: "channel-chat-baseline", status: "pass" },
+      { name: "group-visible-reply-tool", status: "pass" },
+      { name: "Control UI chat flow Playwright coverage", status: "pass" },
+    ]);
+  });
+
+  it("spreads ordinary flow scenarios across bounded shared batches", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-shared-batches-");
+    await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/smoke",
+      concurrency: 8,
+      scenarioIds: [
+        "channel-chat-baseline",
+        "dm-chat-baseline",
+        "thread-follow-up",
+        "control-ui-chat-flow-playwright",
+      ],
+    });
+
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "smoke");
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(3);
+    expect(runQaFlowSuite).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        outputDir: path.join(outputDir, "flow", "shared-1"),
+        concurrency: 1,
+        scenarioIds: ["channel-chat-baseline"],
+      }),
+    );
+    expect(runQaFlowSuite).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        outputDir: path.join(outputDir, "flow", "shared-2"),
+        concurrency: 1,
+        scenarioIds: ["dm-chat-baseline"],
+      }),
+    );
+    expect(runQaFlowSuite).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        outputDir: path.join(outputDir, "flow", "shared-3"),
+        concurrency: 1,
+        scenarioIds: ["thread-follow-up"],
+      }),
+    );
+  });
+
+  it("isolates flow scenarios that mutate shared runtime state", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-shared-state-");
+    await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/smoke",
+      concurrency: 8,
+      scenarioIds: [
+        "channel-chat-baseline",
+        "runtime-tool-image-generate",
+        "runtime-inventory-drift-check",
+        "session-memory-ranking",
+        "control-ui-chat-flow-playwright",
+      ],
+    });
+
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "smoke");
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(2);
+    expect(runQaFlowSuite).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        outputDir: path.join(outputDir, "flow", "shared"),
+        concurrency: 1,
+        scenarioIds: ["channel-chat-baseline"],
+      }),
+    );
+    expect(runQaFlowSuite).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        outputDir: path.join(outputDir, "flow", "isolated"),
+        concurrency: 5,
+        workerStartStaggerMs: 500,
+        scenarioIds: [
+          "runtime-tool-image-generate",
+          "runtime-inventory-drift-check",
+          "session-memory-ranking",
+        ],
+      }),
     );
   });
 

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -276,6 +276,32 @@ describe("qa suite runtime launcher", () => {
     );
   });
 
+  it("keeps channel-driver unified flow partitions serial by default", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-crabline-serial-");
+    await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/crabline-serial",
+      channelDriverSelection: {
+        capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+        channel: "telegram",
+        channelDriver: "crabline",
+        smokeArtifactPath: "crabline-fake-provider-smoke.json",
+      },
+      scenarioIds: ["channel-chat-baseline", "dm-chat-baseline", "control-ui-chat-flow-playwright"],
+    });
+
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "crabline-serial");
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    expect(runQaFlowSuite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outputDir: path.join(outputDir, "flow"),
+        concurrency: 1,
+        scenarioIds: ["channel-chat-baseline", "dm-chat-baseline"],
+      }),
+    );
+    expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
+  });
+
   it("respects serial concurrency across unified suite partitions", async () => {
     const repoRoot = await makeTempRepo("qa-suite-serial-");
     let releaseFlow!: () => void;

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -369,7 +369,7 @@ describe("qa suite runtime launcher", () => {
     const runPromise = runQaSuite({
       repoRoot,
       outputDir: ".artifacts/qa-e2e/weighted",
-      concurrency: 2,
+      concurrency: 3,
       scenarioIds: [
         "channel-chat-baseline",
         "group-visible-reply-tool",
@@ -379,14 +379,70 @@ describe("qa suite runtime launcher", () => {
     await sharedStarted;
     await Promise.resolve();
 
-    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
-    expect(runQaTestFileScenarios).not.toHaveBeenCalled();
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => {
+      expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
+    });
 
     releaseShared();
     await runPromise;
 
     expect(runQaFlowSuite).toHaveBeenCalledTimes(2);
     expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for already-started partitions before rejecting a unified suite", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-reject-settle-");
+    let releaseTestFile!: () => void;
+    let markTestFileStarted!: () => void;
+    const testFileStarted = new Promise<void>((resolve) => {
+      markTestFileStarted = resolve;
+    });
+    const testFileBlocked = new Promise<void>((resolve) => {
+      releaseTestFile = resolve;
+    });
+    runQaFlowSuite.mockRejectedValueOnce(new Error("flow partition failed"));
+    runQaTestFileScenarios.mockImplementationOnce(
+      async (params: {
+        outputDir: string;
+        scenarios: Array<{ id: string; execution: { kind: "script" | "vitest" | "playwright" } }>;
+      }) => {
+        markTestFileStarted();
+        await testFileBlocked;
+        const evidencePath = path.join(params.outputDir, "qa-evidence.json");
+        await writeEvidence(evidencePath);
+        return {
+          outputDir: params.outputDir,
+          executionKind: params.scenarios[0]?.execution.kind ?? "playwright",
+          evidencePath,
+          results: params.scenarios.map((scenarioItem) => ({
+            durationMs: 1,
+            logPath: path.join(params.outputDir, `${scenarioItem.id}.log`),
+            scenario: scenarioItem,
+            status: "pass",
+          })),
+        };
+      },
+    );
+
+    const runPromise = runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/reject-settle",
+      concurrency: 2,
+      scenarioIds: ["channel-chat-baseline", "control-ui-chat-flow-playwright"],
+    });
+    let rejected = false;
+    void runPromise.catch(() => {
+      rejected = true;
+    });
+    await testFileStarted;
+    await Promise.resolve();
+
+    expect(rejected).toBe(false);
+
+    releaseTestFile();
+    await expect(runPromise).rejects.toThrow("flow partition failed");
+    expect(rejected).toBe(true);
   });
 
   it("shares ordinary flow scenarios and isolates flow scenarios with config patches", async () => {
@@ -417,7 +473,7 @@ describe("qa suite runtime launcher", () => {
       2,
       expect.objectContaining({
         outputDir: path.join(outputDir, "flow", "isolated"),
-        concurrency: 3,
+        concurrency: 1,
         workerStartStaggerMs: 500,
         scenarioIds: ["group-visible-reply-tool"],
       }),
@@ -505,7 +561,7 @@ describe("qa suite runtime launcher", () => {
       2,
       expect.objectContaining({
         outputDir: path.join(outputDir, "flow", "isolated"),
-        concurrency: 5,
+        concurrency: 3,
         workerStartStaggerMs: 500,
         scenarioIds: [
           "runtime-tool-image-generate",

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -223,10 +223,27 @@ async function runWeightedUnifiedPartitionTasks(
   const limit = Math.max(1, Math.floor(maxWeight));
   const results: QaUnifiedPartitionResult[] = [];
   let activeWeight = 0;
-  let completed = 0;
+  let settled = 0;
   let nextIndex = 0;
   return await new Promise<QaUnifiedPartitionResult[]>((resolve, reject) => {
+    let firstError: Error | undefined;
+    let finished = false;
+    const finishIfSettled = () => {
+      if (finished || activeWeight > 0) {
+        return;
+      }
+      finished = true;
+      if (firstError) {
+        reject(firstError);
+        return;
+      }
+      resolve(results);
+    };
     const launch = () => {
+      if (firstError) {
+        finishIfSettled();
+        return;
+      }
       while (nextIndex < tasks.length) {
         const task = tasks[nextIndex];
         if (!task) {
@@ -243,17 +260,23 @@ async function runWeightedUnifiedPartitionTasks(
           (result) => {
             results[index] = result;
             activeWeight -= taskWeight;
-            completed += 1;
-            if (completed === tasks.length) {
-              resolve(results);
+            settled += 1;
+            if (settled === tasks.length) {
+              finishIfSettled();
               return;
             }
             launch();
           },
           (error: unknown) => {
-            reject(error instanceof Error ? error : new Error(String(error)));
+            firstError = error instanceof Error ? error : new Error(String(error));
+            activeWeight -= taskWeight;
+            settled += 1;
+            finishIfSettled();
           },
         );
+      }
+      if (settled === tasks.length) {
+        finishIfSettled();
       }
     };
     launch();
@@ -425,7 +448,11 @@ async function runUnifiedQaSuite(params: {
       {
         kind: "isolated",
         scenarios: isolatedFlowScenarios,
-        concurrency: Math.min(concurrency, MAX_ISOLATED_FLOW_CONCURRENCY),
+        concurrency: Math.min(
+          concurrency,
+          MAX_ISOLATED_FLOW_CONCURRENCY,
+          isolatedFlowScenarios.length,
+        ),
       },
     ].filter((partition) => partition.scenarios.length > 0);
     const runFlowSuite = await loadQaFlowSuiteRuntime();

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -12,6 +12,10 @@ import {
 } from "./evidence-summary.js";
 import { isQaFastModeEnabled } from "./model-selection.js";
 import { DEFAULT_QA_PROVIDER_MODE } from "./providers/index.js";
+import {
+  defaultQaSuiteConcurrencyForTransport,
+  normalizeQaTransportId,
+} from "./qa-transport-registry.js";
 import { defaultQaModelForMode, normalizeQaProviderMode } from "./run-config.js";
 import {
   readQaBootstrapScenarioCatalog,
@@ -425,9 +429,14 @@ async function runUnifiedQaSuite(params: {
     typeof params.runParams?.fastMode === "boolean"
       ? params.runParams.fastMode
       : isQaFastModeEnabled({ primaryModel, alternateModel });
+  const transportId = normalizeQaTransportId(params.runParams?.transportId);
+  const defaultConcurrency = params.runParams?.channelDriverSelection
+    ? 1
+    : defaultQaSuiteConcurrencyForTransport(transportId);
   const concurrency = normalizeQaSuiteConcurrency(
     params.runParams?.concurrency,
     params.plan.scenarios.length,
+    defaultConcurrency,
   );
   const evidenceSummaries: QaEvidenceSummaryJson[] = [];
   const scenarioResultsById = new Map<string, QaSuiteScenarioResult>();
@@ -485,15 +494,14 @@ async function runUnifiedQaSuite(params: {
             alternateModel,
             fastMode,
             concurrency: partition.concurrency,
-            workerStartStaggerMs:
-              isolatedPartition
-                ? (params.runParams?.workerStartStaggerMs ??
-                  resolveQaSuiteWorkerStartStaggerMs(
-                    partition.concurrency,
-                    process.env,
-                    ISOLATED_FLOW_WORKER_START_STAGGER_MS,
-                  ))
-                : params.runParams?.workerStartStaggerMs,
+            workerStartStaggerMs: isolatedPartition
+              ? (params.runParams?.workerStartStaggerMs ??
+                resolveQaSuiteWorkerStartStaggerMs(
+                  partition.concurrency,
+                  process.env,
+                  ISOLATED_FLOW_WORKER_START_STAGGER_MS,
+                ))
+              : params.runParams?.workerStartStaggerMs,
             scenarioIds: partition.scenarios.map((scenario) => scenario.id),
           });
           const scenarioResults: QaUnifiedPartitionResult["scenarioResults"] = [];

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -17,7 +17,11 @@ import {
   readQaBootstrapScenarioCatalog,
   type QaSeedScenarioWithSource,
 } from "./scenario-catalog.js";
-import { normalizeQaSuiteConcurrency, resolveQaSuiteOutputDir } from "./suite-planning.js";
+import {
+  normalizeQaSuiteConcurrency,
+  resolveQaSuiteOutputDir,
+  scenarioRequiresIsolatedQaSuiteWorker,
+} from "./suite-planning.js";
 import {
   buildQaSuiteSummaryJson,
   type QaSuiteResult,
@@ -63,9 +67,38 @@ type QaSuiteExecutionPlan =
       testFileScenariosByKind: Map<QaTestFileExecutionKind, QaTestFileScenario[]>;
     };
 
+const MAX_SHARED_FLOW_PARTITIONS = 4;
+const MAX_ISOLATED_FLOW_CONCURRENCY = 8;
+const ISOLATED_FLOW_WORKER_START_STAGGER_MS = 500;
+
+type QaUnifiedPartitionResult = {
+  evidenceSummaries: QaEvidenceSummaryJson[];
+  scenarioResults: Array<{
+    result: QaSuiteScenarioResult;
+    scenarioId: string;
+  }>;
+};
+
+type QaUnifiedPartitionTask = {
+  run: () => Promise<QaUnifiedPartitionResult>;
+  weight: number;
+};
+
 async function loadQaLabServerRuntime() {
   const { startQaLabServer } = await import("./lab-server.js");
   return startQaLabServer;
+}
+
+async function loadQaFlowSuiteRuntime() {
+  const [{ runQaFlowSuite }, startLab] = await Promise.all([
+    import("./suite.js"),
+    loadQaLabServerRuntime(),
+  ]);
+  return async (params: QaSuiteRunParams | undefined) =>
+    await runQaFlowSuite({
+      ...params,
+      startLab: params?.startLab ?? startLab,
+    });
 }
 
 function resolveRequestedScenarios(params: {
@@ -154,6 +187,70 @@ function rejectFlowOnlySuiteOptionsForUnifiedRun(runParams: QaSuiteRunParams | u
 
 function suitePartitionOutputDir(outputDir: string, kind: "flow" | QaTestFileExecutionKind) {
   return path.join(outputDir, kind);
+}
+
+function flowSuitePartitionOutputDir(outputDir: string, partition: string) {
+  return path.join(suitePartitionOutputDir(outputDir, "flow"), partition);
+}
+
+function partitionSharedFlowScenarios(
+  scenarios: readonly QaSeedScenarioWithSource[],
+  concurrency: number,
+) {
+  const partitionCount = Math.min(
+    Math.max(1, Math.floor(concurrency)),
+    MAX_SHARED_FLOW_PARTITIONS,
+    scenarios.length,
+  );
+  const partitions = Array.from({ length: partitionCount }, () => [] as QaSeedScenarioWithSource[]);
+  for (const [index, scenario] of scenarios.entries()) {
+    partitions[index % partitionCount]!.push(scenario);
+  }
+  return partitions.filter((partition) => partition.length > 0);
+}
+
+async function runWeightedUnifiedPartitionTasks(
+  tasks: readonly QaUnifiedPartitionTask[],
+  maxWeight: number,
+) {
+  if (tasks.length === 0) {
+    return [];
+  }
+  const limit = Math.max(1, Math.floor(maxWeight));
+  const results = new Array<QaUnifiedPartitionResult>(tasks.length);
+  let activeWeight = 0;
+  let completed = 0;
+  let nextIndex = 0;
+  return await new Promise<QaUnifiedPartitionResult[]>((resolve, reject) => {
+    const launch = () => {
+      while (nextIndex < tasks.length) {
+        const task = tasks[nextIndex]!;
+        const taskWeight = Math.max(1, Math.min(limit, Math.floor(task.weight)));
+        if (activeWeight > 0 && activeWeight + taskWeight > limit) {
+          return;
+        }
+        const index = nextIndex;
+        nextIndex += 1;
+        activeWeight += taskWeight;
+        task.run().then(
+          (result) => {
+            results[index] = result;
+            activeWeight -= taskWeight;
+            completed += 1;
+            if (completed === tasks.length) {
+              resolve(results);
+              return;
+            }
+            launch();
+          },
+          (error: unknown) => {
+            reject(error);
+          },
+        );
+      }
+    };
+    launch();
+  });
 }
 
 async function readQaSuiteEvidenceSummary(evidencePath: string) {
@@ -303,42 +400,102 @@ async function runUnifiedQaSuite(params: {
   );
   const evidenceSummaries: QaEvidenceSummaryJson[] = [];
   const scenarioResultsById = new Map<string, QaSuiteScenarioResult>();
+  const partitionTasks: QaUnifiedPartitionTask[] = [];
   if (params.plan.flowScenarios.length > 0) {
-    const flowResult = await runQaFlowSuiteFromRuntime({
-      ...params.runParams,
-      outputDir: suitePartitionOutputDir(outputDir, "flow"),
-      providerMode,
-      primaryModel,
-      alternateModel,
-      fastMode,
-      scenarioIds: params.plan.flowScenarios.map((scenario) => scenario.id),
-    });
-    for (const [index, scenario] of params.plan.flowScenarios.entries()) {
-      const result = flowResult.scenarios[index];
-      if (result) {
-        scenarioResultsById.set(scenario.id, result);
-      }
-    }
-    evidenceSummaries.push(await readQaSuiteEvidenceSummary(flowResult.evidencePath));
-  }
-  for (const [kind, testFileScenarios] of params.plan.testFileScenariosByKind) {
-    const result = await runQaTestFileSuiteFromRuntime({
-      runParams: {
-        ...params.runParams,
-        outputDir: suitePartitionOutputDir(outputDir, kind),
-        providerMode,
-        primaryModel,
-        scenarioIds: testFileScenarios.map((scenario) => scenario.id),
+    const sharedFlowScenarios = params.plan.flowScenarios.filter(
+      (scenario) => !scenarioRequiresIsolatedQaSuiteWorker(scenario),
+    );
+    const isolatedFlowScenarios = params.plan.flowScenarios.filter(
+      scenarioRequiresIsolatedQaSuiteWorker,
+    );
+    const sharedFlowPartitions = partitionSharedFlowScenarios(sharedFlowScenarios, concurrency);
+    const flowPartitions = [
+      ...sharedFlowPartitions.map((scenarios, index) => ({
+        kind: sharedFlowPartitions.length === 1 ? "shared" : `shared-${index + 1}`,
+        scenarios,
+        concurrency: 1,
+      })),
+      {
+        kind: "isolated",
+        scenarios: isolatedFlowScenarios,
+        concurrency: Math.min(concurrency, MAX_ISOLATED_FLOW_CONCURRENCY),
       },
-      scenarios: testFileScenarios,
-    });
-    for (const scenarioResult of result.results) {
-      scenarioResultsById.set(
-        scenarioResult.scenario.id,
-        testFileScenarioResultToSuiteScenario(scenarioResult, repoRoot),
-      );
+    ].filter((partition) => partition.scenarios.length > 0);
+    const runFlowSuite = await loadQaFlowSuiteRuntime();
+    for (const partition of flowPartitions) {
+      partitionTasks.push({
+        weight: partition.concurrency,
+        run: async () => {
+          const result = await runFlowSuite({
+            ...params.runParams,
+            outputDir:
+              flowPartitions.length === 1
+                ? suitePartitionOutputDir(outputDir, "flow")
+                : flowSuitePartitionOutputDir(outputDir, partition.kind),
+            providerMode,
+            primaryModel,
+            alternateModel,
+            fastMode,
+            concurrency: partition.concurrency,
+            workerStartStaggerMs:
+              partition.kind === "isolated"
+                ? ISOLATED_FLOW_WORKER_START_STAGGER_MS
+                : params.runParams?.workerStartStaggerMs,
+            scenarioIds: partition.scenarios.map((scenario) => scenario.id),
+          });
+          const scenarioResults: QaUnifiedPartitionResult["scenarioResults"] = [];
+          for (const [index, scenario] of partition.scenarios.entries()) {
+            const scenarioResult = result.scenarios[index];
+            if (scenarioResult) {
+              scenarioResults.push({ scenarioId: scenario.id, result: scenarioResult });
+            }
+          }
+          return {
+            evidenceSummaries: [await readQaSuiteEvidenceSummary(result.evidencePath)],
+            scenarioResults,
+          };
+        },
+      });
     }
-    evidenceSummaries.push(await readQaSuiteEvidenceSummary(result.evidencePath));
+  }
+  if (params.plan.testFileScenariosByKind.size > 0) {
+    partitionTasks.push({
+      weight: 1,
+      run: async () => {
+        const testFileEvidenceSummaries: QaEvidenceSummaryJson[] = [];
+        const testFileScenarioResults: QaUnifiedPartitionResult["scenarioResults"] = [];
+        for (const [kind, testFileScenarios] of params.plan.testFileScenariosByKind) {
+          const result = await runQaTestFileSuiteFromRuntime({
+            runParams: {
+              ...params.runParams,
+              outputDir: suitePartitionOutputDir(outputDir, kind),
+              providerMode,
+              primaryModel,
+              scenarioIds: testFileScenarios.map((scenario) => scenario.id),
+            },
+            scenarios: testFileScenarios,
+          });
+          testFileEvidenceSummaries.push(await readQaSuiteEvidenceSummary(result.evidencePath));
+          testFileScenarioResults.push(
+            ...result.results.map((scenarioResult) => ({
+              scenarioId: scenarioResult.scenario.id,
+              result: testFileScenarioResultToSuiteScenario(scenarioResult, repoRoot),
+            })),
+          );
+        }
+        return {
+          evidenceSummaries: testFileEvidenceSummaries,
+          scenarioResults: testFileScenarioResults,
+        };
+      },
+    });
+  }
+  const partitionResults = await runWeightedUnifiedPartitionTasks(partitionTasks, concurrency);
+  for (const partitionResult of partitionResults) {
+    for (const scenarioResult of partitionResult.scenarioResults) {
+      scenarioResultsById.set(scenarioResult.scenarioId, scenarioResult.result);
+    }
+    evidenceSummaries.push(...partitionResult.evidenceSummaries);
   }
   const finishedAt = new Date();
   const evidence = mergeQaEvidenceSummaries({
@@ -400,10 +557,7 @@ export async function runQaSuite(...args: [QaSuiteRunParams?]): Promise<QaSuiteR
 export async function runQaFlowSuiteFromRuntime(
   ...args: [QaSuiteRunParams?]
 ): Promise<QaSuiteResult> {
-  const { runQaFlowSuite } = await import("./suite.js");
-  const params = args[0];
-  return await runQaFlowSuite({
-    ...params,
-    startLab: params?.startLab ?? (await loadQaLabServerRuntime()),
-  });
+  return await (
+    await loadQaFlowSuiteRuntime()
+  )(args[0]);
 }

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -202,9 +202,13 @@ function partitionSharedFlowScenarios(
     MAX_SHARED_FLOW_PARTITIONS,
     scenarios.length,
   );
-  const partitions = Array.from({ length: partitionCount }, () => [] as QaSeedScenarioWithSource[]);
+  const partitions = Array.from({ length: partitionCount }, (): QaSeedScenarioWithSource[] => []);
   for (const [index, scenario] of scenarios.entries()) {
-    partitions[index % partitionCount]!.push(scenario);
+    const partition = partitions[index % partitionCount];
+    if (!partition) {
+      throw new Error("failed to partition shared QA flow scenarios");
+    }
+    partition.push(scenario);
   }
   return partitions.filter((partition) => partition.length > 0);
 }
@@ -217,14 +221,17 @@ async function runWeightedUnifiedPartitionTasks(
     return [];
   }
   const limit = Math.max(1, Math.floor(maxWeight));
-  const results = new Array<QaUnifiedPartitionResult>(tasks.length);
+  const results: QaUnifiedPartitionResult[] = [];
   let activeWeight = 0;
   let completed = 0;
   let nextIndex = 0;
   return await new Promise<QaUnifiedPartitionResult[]>((resolve, reject) => {
     const launch = () => {
       while (nextIndex < tasks.length) {
-        const task = tasks[nextIndex]!;
+        const task = tasks[nextIndex];
+        if (!task) {
+          return;
+        }
         const taskWeight = Math.max(1, Math.min(limit, Math.floor(task.weight)));
         if (activeWeight > 0 && activeWeight + taskWeight > limit) {
           return;
@@ -244,7 +251,7 @@ async function runWeightedUnifiedPartitionTasks(
             launch();
           },
           (error: unknown) => {
-            reject(error);
+            reject(error instanceof Error ? error : new Error(String(error)));
           },
         );
       }

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -440,24 +440,37 @@ async function runUnifiedQaSuite(params: {
       scenarioRequiresIsolatedQaSuiteWorker,
     );
     const sharedFlowPartitions = partitionSharedFlowScenarios(sharedFlowScenarios, concurrency);
+    const isolatedFlowConcurrency = Math.min(
+      concurrency,
+      MAX_ISOLATED_FLOW_CONCURRENCY,
+      isolatedFlowScenarios.length,
+    );
+    const isolatedFlowPartitions =
+      isolatedFlowConcurrency === 1 && isolatedFlowScenarios.length > 1
+        ? isolatedFlowScenarios.map((scenario, index) => ({
+            kind: `isolated-${index + 1}`,
+            scenarios: [scenario],
+            concurrency: 1,
+          }))
+        : [
+            {
+              kind: "isolated",
+              scenarios: isolatedFlowScenarios,
+              concurrency: isolatedFlowConcurrency,
+            },
+          ];
     const flowPartitions = [
       ...sharedFlowPartitions.map((scenarios, index) => ({
         kind: sharedFlowPartitions.length === 1 ? "shared" : `shared-${index + 1}`,
         scenarios,
         concurrency: 1,
       })),
-      {
-        kind: "isolated",
-        scenarios: isolatedFlowScenarios,
-        concurrency: Math.min(
-          concurrency,
-          MAX_ISOLATED_FLOW_CONCURRENCY,
-          isolatedFlowScenarios.length,
-        ),
-      },
+      ...isolatedFlowPartitions,
     ].filter((partition) => partition.scenarios.length > 0);
     const runFlowSuite = await loadQaFlowSuiteRuntime();
     for (const partition of flowPartitions) {
+      const isolatedPartition =
+        partition.kind === "isolated" || partition.kind.startsWith("isolated-");
       partitionTasks.push({
         weight: partition.concurrency,
         run: async () => {
@@ -473,7 +486,7 @@ async function runUnifiedQaSuite(params: {
             fastMode,
             concurrency: partition.concurrency,
             workerStartStaggerMs:
-              partition.kind === "isolated"
+              isolatedPartition
                 ? (params.runParams?.workerStartStaggerMs ??
                   resolveQaSuiteWorkerStartStaggerMs(
                     partition.concurrency,

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -20,6 +20,7 @@ import {
 import {
   normalizeQaSuiteConcurrency,
   resolveQaSuiteOutputDir,
+  resolveQaSuiteWorkerStartStaggerMs,
   scenarioRequiresIsolatedQaSuiteWorker,
 } from "./suite-planning.js";
 import {
@@ -473,7 +474,12 @@ async function runUnifiedQaSuite(params: {
             concurrency: partition.concurrency,
             workerStartStaggerMs:
               partition.kind === "isolated"
-                ? ISOLATED_FLOW_WORKER_START_STAGGER_MS
+                ? (params.runParams?.workerStartStaggerMs ??
+                  resolveQaSuiteWorkerStartStaggerMs(
+                    partition.concurrency,
+                    process.env,
+                    ISOLATED_FLOW_WORKER_START_STAGGER_MS,
+                  ))
                 : params.runParams?.workerStartStaggerMs,
             scenarioIds: partition.scenarios.map((scenario) => scenario.id),
           });

--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -14,6 +14,7 @@ import {
   resolveQaSuiteWorkerStartStaggerMs,
   resolveQaSuiteOutputDir,
   scenarioRequiresControlUi,
+  scenarioRequiresIsolatedQaSuiteWorker,
   selectQaFlowSuiteScenarios,
   shouldUseIsolatedQaSuiteScenarioWorkers,
 } from "./suite-planning.js";
@@ -291,6 +292,15 @@ describe("qa suite planning helpers", () => {
         ],
       }),
     ).toThrow("Selected QA scenarios require multiple channels");
+  });
+
+  it("isolates flow scenarios with explicit suite isolation metadata", () => {
+    expect(
+      scenarioRequiresIsolatedQaSuiteWorker(
+        makeQaSuiteTestScenario("explicit-isolated", { suiteIsolation: "isolated" }),
+      ),
+    ).toBe(true);
+    expect(scenarioRequiresIsolatedQaSuiteWorker(makeQaSuiteTestScenario("plain"))).toBe(false);
   });
 
   it("collects unique scenario-declared bundled plugins in encounter order", () => {

--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -202,6 +202,16 @@ describe("qa suite planning helpers", () => {
         }),
       ).toBe(1500);
     }
+    expect(resolveQaSuiteWorkerStartStaggerMs(4, {}, 500)).toBe(500);
+    expect(
+      resolveQaSuiteWorkerStartStaggerMs(
+        4,
+        {
+          OPENCLAW_QA_SUITE_WORKER_START_STAGGER_MS: "25",
+        },
+        500,
+      ),
+    ).toBe(25);
   });
 
   it("keeps explicitly requested provider-specific scenarios", () => {

--- a/extensions/qa-lab/src/suite-planning.ts
+++ b/extensions/qa-lab/src/suite-planning.ts
@@ -12,6 +12,12 @@ import { applyQaMergePatch, isQaMergePatchObject } from "./suite-merge-patch.js"
 
 const DEFAULT_QA_SUITE_CONCURRENCY = 64;
 const DEFAULT_QA_SUITE_WORKER_START_STAGGER_MS = 1_500;
+const QA_SHARED_STATE_MUTATION_FLOW_CALLS = new Set([
+  "ensureImageGenerationConfigured",
+  "forceMemoryIndex",
+  "patchConfig",
+  "writeWorkspaceSkill",
+]);
 
 type QaSeedScenario = ReturnType<typeof readQaBootstrapScenarioCatalog>["scenarios"][number];
 
@@ -209,6 +215,31 @@ function shouldUseIsolatedQaSuiteScenarioWorkers(params: {
   );
 }
 
+function scenarioRequiresIsolatedQaSuiteWorker(scenario: QaSeedScenario) {
+  return (
+    isQaMergePatchObject(scenario.gatewayConfigPatch) ||
+    scenario.gatewayRuntime !== undefined ||
+    (Array.isArray(scenario.plugins) && scenario.plugins.length > 0) ||
+    normalizeLowercaseStringOrEmpty(scenario.surface) === "memory" ||
+    scenario.execution.config?.ensureImageGeneration === true ||
+    flowContainsSharedStateMutation(scenario.execution.flow)
+  );
+}
+
+function flowContainsSharedStateMutation(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some(flowContainsSharedStateMutation);
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.call === "string" && QA_SHARED_STATE_MUTATION_FLOW_CALLS.has(record.call)) {
+    return true;
+  }
+  return Object.values(record).some(flowContainsSharedStateMutation);
+}
+
 function scenarioRequiresControlUi(scenario: QaSeedScenario) {
   return normalizeLowercaseStringOrEmpty(scenario.surface) === "control-ui";
 }
@@ -329,6 +360,7 @@ export {
   resolveQaSuiteWorkerStartStaggerMs,
   resolveQaSuiteOutputDir,
   scenarioRequiresControlUi,
+  scenarioRequiresIsolatedQaSuiteWorker,
   scenarioMatchesQaProviderLane,
   selectQaFlowSuiteScenarios,
   shouldUseIsolatedQaSuiteScenarioWorkers,

--- a/extensions/qa-lab/src/suite-planning.ts
+++ b/extensions/qa-lab/src/suite-planning.ts
@@ -216,6 +216,9 @@ function shouldUseIsolatedQaSuiteScenarioWorkers(params: {
 }
 
 function scenarioRequiresIsolatedQaSuiteWorker(scenario: QaSeedScenario) {
+  if (scenario.execution.kind !== "flow") {
+    return false;
+  }
   return (
     scenario.execution.suiteIsolation === "isolated" ||
     isQaMergePatchObject(scenario.gatewayConfigPatch) ||

--- a/extensions/qa-lab/src/suite-planning.ts
+++ b/extensions/qa-lab/src/suite-planning.ts
@@ -14,6 +14,7 @@ const DEFAULT_QA_SUITE_CONCURRENCY = 64;
 const DEFAULT_QA_SUITE_WORKER_START_STAGGER_MS = 1_500;
 const QA_SHARED_STATE_MUTATION_FLOW_CALLS = new Set([
   "ensureImageGenerationConfigured",
+  "env.gateway.restartAfterStateMutation",
   "forceMemoryIndex",
   "patchConfig",
   "writeWorkspaceSkill",
@@ -262,17 +263,18 @@ function normalizeQaSuiteConcurrency(
 function resolveQaSuiteWorkerStartStaggerMs(
   concurrency: number,
   env: NodeJS.ProcessEnv = process.env,
+  defaultStaggerMs = DEFAULT_QA_SUITE_WORKER_START_STAGGER_MS,
 ) {
   if (concurrency <= 1) {
     return 0;
   }
   const raw = env.OPENCLAW_QA_SUITE_WORKER_START_STAGGER_MS;
   if (raw === undefined) {
-    return DEFAULT_QA_SUITE_WORKER_START_STAGGER_MS;
+    return defaultStaggerMs;
   }
   const parsed = parseStrictNonNegativeInteger(raw);
   if (parsed === undefined) {
-    return DEFAULT_QA_SUITE_WORKER_START_STAGGER_MS;
+    return defaultStaggerMs;
   }
   return parsed;
 }

--- a/extensions/qa-lab/src/suite-planning.ts
+++ b/extensions/qa-lab/src/suite-planning.ts
@@ -12,9 +12,8 @@ import { applyQaMergePatch, isQaMergePatchObject } from "./suite-merge-patch.js"
 
 const DEFAULT_QA_SUITE_CONCURRENCY = 64;
 const DEFAULT_QA_SUITE_WORKER_START_STAGGER_MS = 1_500;
-const QA_SHARED_STATE_MUTATION_FLOW_CALLS = new Set([
+const QA_IMPLICIT_ISOLATION_FLOW_CALLS = new Set([
   "ensureImageGenerationConfigured",
-  "env.gateway.restartAfterStateMutation",
   "forceMemoryIndex",
   "patchConfig",
   "writeWorkspaceSkill",
@@ -218,27 +217,28 @@ function shouldUseIsolatedQaSuiteScenarioWorkers(params: {
 
 function scenarioRequiresIsolatedQaSuiteWorker(scenario: QaSeedScenario) {
   return (
+    scenario.execution.suiteIsolation === "isolated" ||
     isQaMergePatchObject(scenario.gatewayConfigPatch) ||
     scenario.gatewayRuntime !== undefined ||
     (Array.isArray(scenario.plugins) && scenario.plugins.length > 0) ||
     normalizeLowercaseStringOrEmpty(scenario.surface) === "memory" ||
     scenario.execution.config?.ensureImageGeneration === true ||
-    flowContainsSharedStateMutation(scenario.execution.flow)
+    flowContainsImplicitIsolationCall(scenario.execution.flow)
   );
 }
 
-function flowContainsSharedStateMutation(value: unknown): boolean {
+function flowContainsImplicitIsolationCall(value: unknown): boolean {
   if (Array.isArray(value)) {
-    return value.some(flowContainsSharedStateMutation);
+    return value.some(flowContainsImplicitIsolationCall);
   }
   if (!value || typeof value !== "object") {
     return false;
   }
   const record = value as Record<string, unknown>;
-  if (typeof record.call === "string" && QA_SHARED_STATE_MUTATION_FLOW_CALLS.has(record.call)) {
+  if (typeof record.call === "string" && QA_IMPLICIT_ISOLATION_FLOW_CALLS.has(record.call)) {
     return true;
   }
-  return Object.values(record).some(flowContainsSharedStateMutation);
+  return Object.values(record).some(flowContainsImplicitIsolationCall);
 }
 
 function scenarioRequiresControlUi(scenario: QaSeedScenario) {

--- a/extensions/qa-lab/src/suite-test-helpers.ts
+++ b/extensions/qa-lab/src/suite-test-helpers.ts
@@ -12,6 +12,7 @@ export function makeQaSuiteTestScenario(
     gatewayConfigPatch?: Record<string, unknown>;
     gatewayRuntime?: { forwardHostHome?: boolean; preserveDebugArtifacts?: boolean };
     runtimeParityTier?: QaSuiteTestScenario["runtimeParityTier"];
+    suiteIsolation?: "isolated";
     surface?: string;
   } = {},
 ): QaSuiteTestScenario {
@@ -29,6 +30,7 @@ export function makeQaSuiteTestScenario(
     execution: {
       kind: "flow",
       ...(params.channel ? { channel: params.channel } : {}),
+      ...(params.suiteIsolation ? { suiteIsolation: params.suiteIsolation } : {}),
       ...(params.config ? { config: params.config } : {}),
       flow: { steps: [{ name: "noop", actions: [{ assert: "true" }] }] },
     },

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -150,6 +150,7 @@ export type QaSuiteRunParams = {
   enabledPluginIds?: string[];
   controlUiEnabled?: boolean;
   transportReadyTimeoutMs?: number;
+  workerStartStaggerMs?: number;
   forcedRuntime?: RuntimeId;
   runtimePair?: [RuntimeId, RuntimeId];
   captureRuntimeParityCell?: boolean;
@@ -467,6 +468,7 @@ function buildQaIsolatedScenarioWorkerParams(params: {
     startLab: params.startLab,
     controlUiEnabled: scenarioRequiresControlUi(params.scenario),
     transportReadyTimeoutMs: params.input?.transportReadyTimeoutMs,
+    workerStartStaggerMs: params.input?.workerStartStaggerMs,
     forcedRuntime: params.input?.forcedRuntime,
   };
 }
@@ -1287,7 +1289,8 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
 
     try {
       updateScenarioRun();
-      const workerStartStaggerMs = resolveQaSuiteWorkerStartStaggerMs(concurrency);
+      const workerStartStaggerMs =
+        params?.workerStartStaggerMs ?? resolveQaSuiteWorkerStartStaggerMs(concurrency);
       writeQaSuiteProgress(progressEnabled, `scenario start stagger=${workerStartStaggerMs}ms`);
       const scenarios: QaSuiteScenarioResult[] = await mapQaSuiteWithConcurrency(
         selectedScenarios,

--- a/qa/scenarios/agents/subagent-stale-child-links.yaml
+++ b/qa/scenarios/agents/subagent-stale-child-links.yaml
@@ -24,6 +24,8 @@ scenario:
     - extensions/qa-lab/src/gateway-child.ts
   execution:
     kind: flow
+    suiteIsolation: isolated
+    isolationReason: Seeds persisted gateway session/subagent state and restarts the gateway.
     summary: Seed stale subagent session state on disk, restart the real gateway, then assert sessions.list filters only the stale child links.
 
 flow:

--- a/qa/scenarios/index.yaml
+++ b/qa/scenarios/index.yaml
@@ -29,6 +29,9 @@ title: OpenClaw QA Scenario Pack
 # - use `scenario.execution.kind: vitest`, `playwright`, or `script`
 #   plus `scenario.execution.path` for native tests or evidence producers that
 #   provide evidence without a top-level `flow`
+# - use `scenario.execution.suiteIsolation: isolated` for flow scenarios that
+#   mutate gateway/runtime state in non-obvious ways; add `isolationReason`
+#   so reviewers know why the suite scheduler must not share the worker
 # - use `runtimeParityTier` for runtime-pair gate membership: `standard`,
 #   `optional`, `live-only`, or `soak`
 # - treat the old `coverage: ["id"]` / `coverage: - id` list shape as invalid

--- a/qa/scenarios/plugins/kitchen-sink-live-openai.yaml
+++ b/qa/scenarios/plugins/kitchen-sink-live-openai.yaml
@@ -29,6 +29,8 @@ scenario:
     - scripts/e2e/kitchen-sink-plugin-docker.sh
   execution:
     kind: flow
+    suiteIsolation: isolated
+    isolationReason: Mutates gateway plugin/channel/tool config across gateway restarts.
     summary: Install @openclaw/kitchen-sink, restart the gateway, exercise command inventory/tool/channel/OpenAI-or-block paths, and record CPU/RSS/log evidence.
     config:
       requiredProviderMode: live-frontier


### PR DESCRIPTION
## What Problem This Solves

The `smoke-ci` QA profile was taking long enough to block PR 94291. Local profiling showed the slow path was not a single test file: the profile selects 108 scenarios, including 100 flow scenarios, and the unified suite was paying too much serialized lab/provider/gateway time.

This is not smoke-only. The change applies to unified QA suite runs that select both flow scenarios and test-file scenarios, including profile-driven suite runs. Pure flow-only runs keep the existing flow-suite path.

## Why This Change Was Made

This keeps all selected scenarios but makes the unified QA launcher run safe work in parallel inside the same CI job:

- ordinary flow scenarios are split across up to four shared gateway batches
- scenarios that mutate config/runtime/plugin/memory/image-generation/gateway-state stay isolated
- scenarios that restart after mutating gateway state now declare `execution.suiteIsolation: isolated` in YAML instead of depending on a hardcoded call-name list
- isolated flow scenarios are capped at eight workers and reserve only the workers they can actually use
- serial unified runs keep multiple isolated flow scenarios in separate flow-suite invocations so they do not share one worker
- Crabline channel-driver unified runs preserve the existing serial default unless concurrency is explicitly overridden
- the faster mixed-suite isolated default start stagger is 500ms, while explicit `workerStartStaggerMs` and `OPENCLAW_QA_SUITE_WORKER_START_STAGGER_MS` still win
- Vitest/Playwright/script test-file groups stay serialized in one checkout to avoid local test-runner cache races
- that serialized test-file group can overlap with flow work when the suite concurrency budget allows it
- partition scheduling is weighted so `--concurrency 1` and other low-resource caps still behave as caps
- on partition failure, already-started partitions are allowed to settle before the suite rejects, avoiding overlap with retry attempts

Tradeoffs made:

- This does not add CI shards or new runners; it uses more of the existing job's local concurrency budget.
- It deliberately leaves known shared-state scenarios isolated, so it is not the theoretical fastest possible schedule.
- The state-mutation classifier is conservative and structural. New QA scenarios that mutate shared state need to either use explicit `execution.suiteIsolation: isolated` metadata or an already-classified structural operation.
- Release-profile runs should benefit where they use the same unified mixed-suite launcher, but release has more live/provider categories and should get its own timing pass before claiming complete release coverage.

## User Impact

Unified QA suite profiles should finish materially faster without removing tests and without adding CI shards. Low-resource local runs still have a serial escape hatch through `--concurrency 1`.

## Evidence

Before:

- `node scripts/build-all.mjs qaRuntime`: completed successfully; warm runtime build was about 6s locally.
- Local equivalent unoptimized smoke run: `pnpm openclaw qa run --repo-root . --qa-profile smoke-ci ...` was interrupted after `486.07s` while still incomplete.

After:

- Full smoke proof before the final concurrency-contract fixes: `pnpm openclaw qa run --repo-root . --qa-profile smoke-ci --output-dir .artifacts/qa-e2e/smoke-ci-500-stagger-parallel-nonflow-local-20260622195639` passed `108/108`.
- Raw local command time: `321.27s`.
- Suite timestamps: `2026-06-23T02:56:49.984Z` to `2026-06-23T03:02:00.516Z`.
- Focused proof after the final rebase/scheduler/isolation/channel-driver fixes: `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/suite-planning.test.ts extensions/qa-lab/src/suite-launch.runtime.test.ts extensions/qa-lab/src/suite.test.ts -- --reporter=verbose` passed `89/89`.
- Focused lint: `node scripts/run-oxlint.mjs extensions/qa-lab/src/scenario-catalog.ts extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/suite-planning.ts extensions/qa-lab/src/suite-planning.test.ts extensions/qa-lab/src/suite-test-helpers.ts extensions/qa-lab/src/suite-launch.runtime.ts extensions/qa-lab/src/suite-launch.runtime.test.ts` passed.
- `git diff --check origin/main...HEAD` passed.
- Autoreview found one post-rebase channel-driver serialization issue; fixed in `10dc5e5` with a regression test. The final autoreview rerun was interrupted by the explicit push request.

Known proof gap: the full 108-scenario smoke run should be rerun on this final commit/CI because the last fixes preserved concurrency contracts, test-file serialization, explicit isolation metadata, and Crabline channel-driver serialization after the full local pass.
