### PR TITLE
fix(media): retry direct delivery when wake returns false after successful generation

### DIFF
--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -185,6 +185,63 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
     expect(lifecycle.wakeTaskCompletion).toHaveBeenCalledTimes(1);
   });
 
+  it("recovers via direct fallback when wake returns false with deliverable requesterOrigin", async () => {
+    const scheduled: Array<() => Promise<void>> = [];
+    const lifecycle = {
+      createTaskRun: vi.fn(),
+      recordTaskProgress: vi.fn(),
+      completeTaskRun: vi.fn(),
+      failTaskRun: vi.fn(),
+      wakeTaskCompletion: vi.fn(async () => false),
+    };
+    taskRegistryDeliveryRuntimeMocks.sendMessage.mockResolvedValueOnce({});
+
+    scheduleMediaGenerationTaskCompletion({
+      lifecycle,
+      handle: {
+        taskId: "task-direct-wakefalse",
+        runId: "tool:image_generate:direct-wakefalse",
+        requesterSessionKey: "agent:main:discord:channel:123",
+        requesterOrigin: {
+          channel: "discord",
+          to: "channel:123",
+        },
+        taskLabel: "proof image",
+      },
+      scheduleBackgroundWork: (work) => {
+        scheduled.push(work);
+      },
+      progressSummary: "Generating image",
+      toolName: "Image generation",
+      onWakeFailure: vi.fn(),
+      run: async () => ({
+        provider: "openai",
+        model: "gpt-image-1",
+        count: 1,
+        paths: ["/tmp/proof.png"],
+        wakeResult: "generated",
+        mediaUrls: ["/tmp/proof.png"],
+      }),
+    });
+
+    await scheduled[0]?.();
+
+    // Direct fallback attempted and succeeded → terminalResult cleared.
+    expect(taskRegistryDeliveryRuntimeMocks.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        to: "channel:123",
+        content: "Image generation completed.",
+        idempotencyKey: expect.stringContaining("blocked") as unknown,
+      }),
+    );
+    expect(lifecycle.completeTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminalResult: undefined,
+      }),
+    );
+  });
+
   it("completes a generated media task when completion wake throws", async () => {
     const scheduled: Array<() => Promise<void>> = [];
     const wakeError = new Error("requester wake failed");

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -472,6 +472,30 @@ export function scheduleMediaGenerationTaskCompletion<
         terminalResult = resolveRequiredCompletionDeliveryFailureTerminalResult(
           "completion delivery was not confirmed after successful generation",
         );
+        if (params.handle) {
+          const mediaUrls = Array.from(
+            new Set([
+              ...(executed.mediaUrls ?? []),
+              ...mediaUrlsFromGeneratedAttachments(executed.attachments),
+            ]),
+          );
+          // The wake agent path returned false (not threw), so the in-wake
+          // direct fallback didn't fire or its allowlisted reasons didn't match.
+          // Try direct channel delivery here — same pattern as the catch branch
+          // below — so the user sees the result when a generated artifact is on
+          // disk but the announce path lost the handoff.
+          const delivered = await tryDeliverMediaGenerationDirect({
+            config: params.config,
+            handle: params.handle,
+            toolName: params.toolName,
+            content: `${params.toolName} completed.`,
+            mediaUrls,
+            idempotencySuffix: "blocked",
+          });
+          if (delivered) {
+            terminalResult = undefined;
+          }
+        }
         params.onWakeFailure(
           `${params.toolName} completion delivery was not confirmed after successful generation`,
           {


### PR DESCRIPTION
## Summary

When `wakeTaskCompletion` returns `false` (not throws) after media generation succeeds, the outer handler only sets `terminalResult=blocked` without trying direct channel delivery — so a generated artifact on disk can silently drop without the user ever seeing it.
- **Problem**: The catch branch (line 487-505) calls `tryDeliverMediaGenerationDirect` after a throw, but the return-false branch (line 470-481) does not. After #89949 backfilled `effectiveDirectOrigin.to`, the catch path works but the return-false path still drops the result when the announce delivery reason falls outside the three `MEDIA_DIRECT_FALLBACK_DELIVERY_REASONS`.
- **Solution**: Symmetrically call `tryDeliverMediaGenerationDirect` in the return-false branch — same guard (`params.handle`), same idempotency suffix (`"blocked"`), same `mediaUrls` assembly. If delivery succeeds, `terminalResult` is cleared and the task completes normally.
- **What changed**: `src/agents/tools/media-generate-background-shared.ts` — 19 lines added in the `!completionDelivered` block. `src/agents/tools/media-generate-background-shared.test.ts` — 57-line regression test.
- **What did NOT change**: `MEDIA_DIRECT_FALLBACK_DELIVERY_REASONS` set, `tryDeliverMediaGenerationDirect` implementation, `wakeMediaGenerationTaskCompletion` inner logic, the throw-path recovery block, the `run()`-failure path, `createMediaGenerationTaskLifecycle`, any config surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #95910
- [x] This PR fixes a bug or regression

## Motivation

#86034 reported generated media silently dropping (generated file on disk, no user message). #89949 (Hypothesis A, merged) backfilled `effectiveDirectOrigin.to` from the requester session entry, fixing the in-wake direct fallback. However, the outer handler in `scheduleMediaGenerationTaskCompletion` still had an asymmetry: the `catch` branch retried via `tryDeliverMediaGenerationDirect`, but the `return false` branch never did. When the announce path loses the handoff for a reason outside the three allowlisted codes, the generated result is silently dropped.

This is a follow-up to #89949 (Hypothesis B).

## Real behavior proof

- **Behavior addressed**: After `wakeTaskCompletion` returns `false` with a deliverable `requesterOrigin`, direct channel delivery is attempted before marking the task as terminally blocked.

- **Real environment tested**: Linux 4.19.112 (x86_64), Node v24.13.1, branch `fix/media-wake-false-direct-fallback-95910` rebased on `origin/main` (`aa0bdb901f4`).

- **Exact steps or command run after this patch**:

  ```text
  node scripts/run-vitest.mjs run src/agents/tools/media-generate-background-shared.test.ts --maxWorkers=1
  node scripts/run-vitest.mjs run src/agents/subagent-announce-delivery.test.ts --maxWorkers=1
  npx oxlint --tsconfig config/tsconfig/oxlint.core.json src/agents/tools/media-generate-background-shared.ts src/agents/tools/media-generate-background-shared.test.ts
  ```

- **Evidence after fix**:

  ```console
  $ node scripts/run-vitest.mjs run src/agents/tools/media-generate-background-shared.test.ts --maxWorkers=1
   Test Files  1 passed (1)
        Tests  18 passed (18)

  $ node scripts/run-vitest.mjs run src/agents/subagent-announce-delivery.test.ts --maxWorkers=1
   Test Files  1 passed (1)
        Tests  102 passed (102)

  $ npx oxlint --tsconfig config/tsconfig/oxlint.core.json src/agents/tools/media-generate-background-shared.ts src/agents/tools/media-generate-background-shared.test.ts
  $ echo "lint exit=$?"
  lint exit=0
  ```

  **Behavior matrix**:

  | wakeTaskCompletion result | Before | After |
  |---------------------------|--------|-------|
  | return `true` | terminalResult=undefined ✅ | unchanged ✅ |
  | return `false` + no handle | terminalResult=blocked | unchanged |
  | return `false` + handle + no origin | terminalResult=blocked | unchanged (guard inside `tryDeliverMediaGenerationDirect` returns false) |
  | return `false` + handle + deliverable origin | ❌ terminalResult=blocked (silent drop) | ✅ direct delivery attempted → if success, terminalResult=undefined |
  | throw + handle + deliverable origin | ✅ direct delivery attempted | unchanged ✅ |

- **Observed result after fix**:
  1. New test `recovers via direct fallback when wake returns false with deliverable requesterOrigin` passes: `sendMessage` called with correct channel+to, `completeTaskRun` called with `terminalResult: undefined`.
  2. Existing `completes a generated media task when completion delivery cannot be confirmed` test still passes (no `requesterOrigin` → direct fallback guard returns false → terminalResult stays blocked).
  3. All 18 tests in the target file pass; all 102 tests in `subagent-announce-delivery.test.ts` pass.
  4. Lint clean.

- **What was not tested**: A real live multi-tool media generation→wake→fallback chain against the actual OpenClaw gateway with real channels (the regression test exercises the exact `scheduleMediaGenerationTaskCompletion` composition with the same mocked boundaries as all existing tests). The `requester_abandoned` reason specifically — while that's the canonical example of a reason outside the allowlist, the fix covers all such reasons uniformly.

## Root Cause

`scheduleMediaGenerationTaskCompletion` at `src/agents/tools/media-generate-background-shared.ts:459-515` has asymmetric recovery: the `catch` branch (line 483-505) calls `tryDeliverMediaGenerationDirect`, but the `!completionDelivered` branch (line 470-481) only sets `terminalResult` and calls `onWakeFailure`. When the inner wake path returns `false` for a reason outside `MEDIA_DIRECT_FALLBACK_DELIVERY_REASONS` (line 46-50), no direct delivery is attempted.

**Provenance**: introduced by `c88178d9b64` (2026-05-30, Ayaan Zaidi) — "fix(agent): recover media completion delivery". The catch-path direct fallback was there from the initial implementation; the return-false path was never symmetrized. Made visible by `e5f3df65381` (#89949) which backfilled `effectiveDirectOrigin.to`, making the throw-path fallback viable but leaving the return-false path unprotected. Confidence: clear.

## Regression Test Plan

**Scenarios locked in**:
1. Wake-return-false with deliverable `requesterOrigin` → direct fallback attempted and succeeds → `terminalResult: undefined`.
2. Existing return-false test without `requesterOrigin` still works (direct fallback guard returns false → `terminalResult` stays blocked).
3. Existing throw-path test with deliverable origin still works (no regression in the catch branch).

## User-visible / Behavior Changes

When media generation succeeds but the announce-to-requester handoff is lost for a non-allowlisted reason (e.g. `requester_abandoned`), the generated result is now direct-delivered to the channel instead of silently dropped. No behavior change when delivery actually fails (direct delivery returns false → terminalResult stays blocked, as before).

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No — same `sendMessage` call as the existing throw-path recovery
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Human Verification

- **Verified scenarios**: wake-return-false → direct fallback success, wake-return-false → direct fallback skipped when no origin, throw-path recovery unchanged.
- **Edge cases checked**: `params.handle` is null → direct fallback guard skips (same as catch branch).
- **What you did NOT verify**: Live multi-channel gateway session driving real media generation with wake delivery failure.

## Compatibility / Migration

- [x] Backward compatible? Yes — additive recovery path only
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes. This is the narrowest change: reuse the existing `tryDeliverMediaGenerationDirect` call with the same parameters and guard as the catch branch, so the return-false path behaves identically to the throw path for delivery recovery.
- **Refactor needed**: No. A broader refactor to unify the two branches (throw and return-false) into one post-wake recovery block could reduce duplication, but the current approach is the lowest-risk change for a targeted fix.
- **Alternative considered**: Expand `MEDIA_DIRECT_FALLBACK_DELIVERY_REASONS` to include `requester_abandoned`. Rejected — that's a delivery-contract surface change affecting all inner wake paths, while the outer handler fix covers all reasons uniformly.

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes

## Risks and Mitigations

**Highest risk**: The return-false branch fires `tryDeliverMediaGenerationDirect` before `onWakeFailure`, which is the reverse order of the throw branch (where `onWakeFailure` comes after). This is intentional — in the return-false path, `onWakeFailure` is informational logging after the delivery attempt, while in the throw path it includes the error. No functional difference.

**Compatibility**: Additive only. Direct delivery already exists on the throw path and uses the same `directIdempotencyKey` scheme. No duplicate delivery risk.

---

Fixes #95910
