### PR TITLE
fix(ci): finalize Windows Testbox after setup failures

### DIFF
--- a/.github/workflows/windows-blacksmith-testbox.yml
+++ b/.github/workflows/windows-blacksmith-testbox.yml
@@ -150,6 +150,7 @@ jobs:
           git --version
 
       - name: Run Testbox
+        if: always()
         shell: bash
         run: |
           set -euo pipefail

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -22,6 +22,7 @@ const UPDATE_MIGRATION_WORKFLOW = ".github/workflows/update-migration.yml";
 const CI_CHECK_TESTBOX_WORKFLOW = ".github/workflows/ci-check-testbox.yml";
 const CI_CHECK_ARM_TESTBOX_WORKFLOW = ".github/workflows/ci-check-arm-testbox.yml";
 const CI_BUILD_ARTIFACTS_TESTBOX_WORKFLOW = ".github/workflows/ci-build-artifacts-testbox.yml";
+const WINDOWS_BLACKSMITH_TESTBOX_WORKFLOW = ".github/workflows/windows-blacksmith-testbox.yml";
 const CRABBOX_HYDRATE_WORKFLOW = ".github/workflows/crabbox-hydrate.yml";
 const CRABBOX_CONFIG = ".crabbox.yaml";
 const SCHEDULED_LIVE_CHECKS_WORKFLOW = ".github/workflows/openclaw-scheduled-live-checks.yml";
@@ -1266,6 +1267,10 @@ describe("package artifact reuse", () => {
       workflowJob(CI_BUILD_ARTIFACTS_TESTBOX_WORKFLOW, "build-artifacts"),
       "Run Testbox",
     );
+    const runWindowsTestboxStep = workflowStep(
+      workflowJob(WINDOWS_BLACKSMITH_TESTBOX_WORKFLOW, "windows"),
+      "Run Testbox",
+    );
 
     expect(workflow).toContain('PNPM_CONFIG_STORE_DIR: "/tmp/openclaw-pnpm-store"');
     expect(workflow).not.toContain("PNPM_CONFIG_MODULES_DIR");
@@ -1277,6 +1282,7 @@ describe("package artifact reuse", () => {
     expect(runTestboxStep.if).toBe("always()");
     expect(runArmTestboxStep.if).toBe("always()");
     expect(runBuildArtifactsTestboxStep.if).toBe("always()");
+    expect(runWindowsTestboxStep.if).toBe("always()");
     expect(runTestboxStep["continue-on-error"]).toBeUndefined();
   });
 


### PR DESCRIPTION
## What Problem This Solves

The Windows Blacksmith Testbox workflow manually phones home as `hydrating`, then only runs the ready/idle Testbox lifecycle loop after checkout and shell prep succeed. If checkout or prep fails, the workflow never reaches the run/finalizer step, leaving the backend session stuck in the setup lifecycle path.

## Why This Change Was Made

- run the Windows `Run Testbox` lifecycle step with `always()` so it still executes after setup failures
- extend the existing Testbox workflow guard to cover the Windows wrapper alongside the Linux/ARM/build-artifacts wrappers

## User Impact

Failed Windows Testbox setup is more likely to report and close cleanly instead of stranding a Testbox session before it becomes ready for SSH inspection.

## Evidence

- inspected `.github/workflows/windows-blacksmith-testbox.yml`: `Begin Testbox` records hydrating state before checkout; `Run Testbox` previously had no `if`, so normal Actions success gating skipped it after checkout/prep failures
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/windows-blacksmith-testbox.yml`
- `git diff --check`
- `node scripts/crabbox-wrapper.mjs job run testbox-changed` for `f0c70e4731443bc30305752966a55736543eb058` (`tbx_01kvs8gz57pwywbqdjbyfb6kf5`; wrapper command exited 0; https://github.com/openclaw/openclaw/actions/runs/28000210948)
- `codex review --base origin/main`: no actionable regressions

## Known proof gap

- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` could not run locally because this sparse Codex worktree has no `node_modules`; the Testbox changed gate covered the touched test lane remotely.
