### PR TITLE
fix(cron): default deleteAfterRun for isolated cron jobs

### DIFF
--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -194,6 +194,71 @@ describe("normalizeCronJobCreate", () => {
     expect(normalized.deleteAfterRun).toBe(true);
   });
 
+  it("defaults deleteAfterRun for recurring isolated agent jobs", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "recurring isolated",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        message: "hi",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.deleteAfterRun).toBe(true);
+  });
+
+  it("defaults deleteAfterRun for recurring isolated jobs from payload kind", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "recurring isolated default target",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      wakeMode: "now",
+      payload: {
+        kind: "command",
+        argv: ["echo", "hi"],
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.sessionTarget).toBe("isolated");
+    expect(normalized.deleteAfterRun).toBe(true);
+  });
+
+  it("preserves explicit deleteAfterRun=false for isolated jobs", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "keep isolated session",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      deleteAfterRun: false,
+      payload: {
+        kind: "agentTurn",
+        message: "hi",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.deleteAfterRun).toBe(false);
+  });
+
+  it("does not default deleteAfterRun for recurring main jobs", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "recurring main",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: {
+        kind: "systemEvent",
+        text: "hi",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.deleteAfterRun).toBeUndefined();
+  });
+
   it("normalizes delivery mode and channel", () => {
     const normalized = normalizeIsolatedAgentTurnCreateJob({
       name: "delivery",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -619,8 +619,8 @@ export function normalizeCronJobInput(
     if (
       "schedule" in next &&
       isRecord(next.schedule) &&
-      next.schedule.kind === "at" &&
-      !("deleteAfterRun" in next)
+      !("deleteAfterRun" in next) &&
+      (next.sessionTarget === "isolated" || next.schedule.kind === "at")
     ) {
       next.deleteAfterRun = true;
     }


### PR DESCRIPTION
## Summary
- Isolated cron sessions are intended as per-run scratch sessions, but periodic isolated jobs did not default to `deleteAfterRun=true`.
- Only one-shot (`schedule.kind === "at"`) jobs got the cleanup default, so recurring isolated runs left sessions alive and could keep consuming tokens after the run was marked ok.
- `normalizeCronJobCreate` now defaults `deleteAfterRun` to `true` whenever the resolved `sessionTarget` is `isolated`, while still preserving explicit `deleteAfterRun: false`.

Fixes #95907

## Real behavior proof
- **Behavior or issue addressed:** Periodic isolated cron jobs persisted their agent session after a run, allowing the session loop to keep consuming tokens.
- **Real environment tested:** Linux, Node 22.22.0, local source checkout.
- **Exact steps or command run after this patch:**
  ```bash
  node --import tsx -e "
    import { normalizeCronJobCreate } from './src/cron/normalize.ts';
    const job = normalizeCronJobCreate({
      name: 'recurring isolated',
      enabled: true,
      schedule: { kind: 'cron', expr: '* * * * *' },
      sessionTarget: 'isolated',
      wakeMode: 'now',
      payload: { kind: 'agentTurn', message: 'hi' }
    });
    console.log(JSON.stringify(job, null, 2));
  "
  ```
- **Evidence after fix:**
  ```json
  {
    "name": "recurring isolated",
    "enabled": true,
    "schedule": { "kind": "cron", "expr": "* * * * *" },
    "sessionTarget": "isolated",
    "wakeMode": "now",
    "payload": { "kind": "agentTurn", "message": "hi" },
    "deleteAfterRun": true,
    "delivery": { "mode": "announce" }
  }
  ```
- **Observed result after fix:** A newly created recurring isolated cron job now has `deleteAfterRun: true` without an explicit user override.
- **What was not tested:** Live token accounting against a real model provider; the change is in normalization defaults and is covered by unit tests.

## Regression Test Plan
- Coverage level: Unit test
- Target test file: `src/cron/normalize.test.ts`
- Scenario locked in: `defaults deleteAfterRun for recurring isolated agent jobs`, `defaults deleteAfterRun for recurring isolated jobs from payload kind`, `preserves explicit deleteAfterRun=false for isolated jobs`, and `does not default deleteAfterRun for recurring main jobs`.
- Why this is the smallest reliable guardrail: The fix lives entirely in normalization defaults, so asserting the normalized job shape covers the behavior and prevents regressions for both isolated and main targets.

## Root Cause
- Root cause: `normalizeCronJobInput` only defaulted `deleteAfterRun` for one-shot `schedule.kind === "at"` schedules. Recurring isolated jobs therefore fell through with `deleteAfterRun` undefined, so `cleanupCronRunSessionAfterRun` skipped session deletion and the isolated agent session stayed alive after the run.
- Missing detection / guardrail: No test asserted the default for recurring isolated jobs, and the default logic did not consider the `sessionTarget` ownership of the session.
