### PR TITLE
fix(ci): require QA live evidence artifacts

### DIFF
--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -226,7 +226,7 @@ jobs:
           name: qa-parity-${{ github.run_id }}-${{ github.run_attempt }}
           path: .artifacts/qa-e2e/
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
   run_live_runtime_token_efficiency:
     name: Run live runtime token-efficiency lane
@@ -315,7 +315,7 @@ jobs:
           name: qa-live-runtime-token-efficiency-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.run_lane.outputs.output_dir }}
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
   run_live_matrix:
     name: Run Matrix live QA lane
@@ -391,7 +391,7 @@ jobs:
           name: qa-live-matrix-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.run_lane.outputs.output_dir }}
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
   run_live_matrix_sharded:
     name: Run Matrix live QA lane (${{ matrix.profile }})
@@ -475,7 +475,7 @@ jobs:
           name: qa-live-matrix-${{ matrix.profile }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.run_lane.outputs.output_dir }}
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
   run_live_telegram:
     name: Run Telegram live QA lane with Convex leases
@@ -570,7 +570,7 @@ jobs:
           name: qa-live-telegram-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.run_lane.outputs.output_dir }}
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
   run_live_discord:
     name: Run Discord live QA lane with Convex leases
@@ -665,7 +665,7 @@ jobs:
           name: qa-live-discord-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.run_lane.outputs.output_dir }}
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
   run_live_whatsapp:
     name: Run WhatsApp live QA lane with Convex leases
@@ -763,7 +763,7 @@ jobs:
           name: qa-live-whatsapp-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.run_lane.outputs.output_dir }}
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
   run_live_slack:
     name: Run Slack live QA lane with Convex leases
@@ -859,4 +859,4 @@ jobs:
           name: qa-live-slack-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.run_lane.outputs.output_dir }}
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1419,6 +1419,26 @@ describe("package artifact reuse", () => {
     }
   });
 
+  it("requires QA live evidence artifacts when lanes run", () => {
+    const cases = [
+      ["run_mock_parity", "Upload parity artifacts"],
+      ["run_live_runtime_token_efficiency", "Upload live runtime token-efficiency artifacts"],
+      ["run_live_matrix", "Upload Matrix QA artifacts"],
+      ["run_live_matrix_sharded", "Upload Matrix QA shard artifacts"],
+      ["run_live_telegram", "Upload Telegram QA artifacts"],
+      ["run_live_discord", "Upload Discord QA artifacts"],
+      ["run_live_whatsapp", "Upload WhatsApp QA artifacts"],
+      ["run_live_slack", "Upload Slack QA artifacts"],
+    ];
+
+    for (const [jobName, stepName] of cases) {
+      const uploadStep = workflowStep(workflowJob(QA_LIVE_TRANSPORTS_WORKFLOW, jobName), stepName);
+
+      expect(uploadStep.if, jobName).toBe("always()");
+      expect(uploadStep.with?.["if-no-files-found"], jobName).toBe("error");
+    }
+  });
+
   it("fails Docker E2E release lanes when summary artifacts are missing", () => {
     const cases = [
       {


### PR DESCRIPTION
## What Problem This Solves

QA live transport workflows are evidence-producing gates, but their artifact uploads used `if-no-files-found: warn`. That means a lane could report success without durable QA evidence if the expected output directory was empty or not written.

## Why This Change Was Made

- require artifact presence for parity, runtime token-efficiency, Matrix, Telegram, Discord, WhatsApp, and Slack QA live uploads
- add a workflow guard so every QA live evidence upload keeps `if-no-files-found: error`

## User Impact

Nightly and manual QA live runs fail loudly when their evidence bundle is missing instead of producing a green run with no useful artifacts.

## Evidence

- inspected `.github/workflows/qa-live-transports-convex.yml`: all QA live upload steps ran with `if: always()` but accepted missing files with `warn`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/qa-live-transports-convex.yml`
- `git diff --check`
- `node scripts/crabbox-wrapper.mjs job run testbox-changed` for `473986a0d959df3ef8dcb82c23b9df2ac977ba70` (`tbx_01kvs9wtzg1zv4arkfytc3a8cr`; wrapper command exited 0; https://github.com/openclaw/openclaw/actions/runs/28001043651)
- `codex review --base origin/main`: no actionable regressions after the guard job-id fix

## Known proof gap

- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` could not run locally because this sparse Codex worktree has no `node_modules`; the Testbox changed gate covered the touched test lane remotely.
