### PR TITLE
docs: document Docker Claude CLI persistence

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -202,6 +202,17 @@ openclaw models auth login --provider anthropic --method cli --set-default
 Use `agents.defaults.cliBackends.claude-cli.command` only when the `claude`
 binary is not already on `PATH`.
 
+## Docker gateways
+
+The OpenClaw Docker image does not include Claude Code. For Docker installs,
+install Claude Code in the container as the `node` user, persist `/home/node` so
+`~/.local/bin/claude` and `~/.claude` survive container replacement, and set
+`agents.defaults.cliBackends.claude-cli.command` if that binary is not on the
+container `PATH`. See [Docker - Claude Code CLI persistence](/install/docker#claude-code-cli-persistence).
+
+If you do not want to manage Claude Code inside Docker, use Anthropic API-key
+auth instead; API keys persist through OpenClaw's Docker config/auth mounts.
+
 ## Sessions
 
 - If the CLI supports sessions, set `sessionArg` (e.g. `--session-id`) or

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -316,6 +316,69 @@ Installed downloadable plugins store their package state under the mounted
 OpenClaw home, so plugin install records and package roots survive container
 replacement. Gateway startup does not generate bundled-plugin dependency trees.
 
+### Claude Code CLI persistence
+
+The Docker image does not preinstall Claude Code. If you want to use the
+Anthropic `claude-cli` backend from a Docker gateway, install Claude Code inside
+the container user environment and persist both the binary and Claude's user
+state:
+
+```bash
+# Persist /home/node so ~/.local/bin, ~/.claude, and Claude caches survive.
+export OPENCLAW_HOME_VOLUME="openclaw_home"
+./scripts/docker/setup.sh
+
+# Install Claude Code as the node user inside the persisted home.
+docker compose run --rm openclaw-cli sh -lc \
+  'curl -fsSL https://claude.ai/install.sh | bash'
+
+# Log in and verify credentials in the same persisted container home.
+docker compose run --rm openclaw-cli sh -lc \
+  '$HOME/.local/bin/claude auth login && $HOME/.local/bin/claude auth status --text'
+```
+
+If the installer asks to change shell startup files, skip that step and use the
+explicit `command` override below instead.
+
+Claude Code keeps user settings, auth, plugins, and project transcripts under
+`~/.claude`. Persisting `/home/node` with `OPENCLAW_HOME_VOLUME` is the simplest
+way to keep that directory together with the default native install location
+(`~/.local/bin/claude`). If you prefer bind mounts, mount both the installed
+binary location and `/home/node/.claude` with `OPENCLAW_EXTRA_MOUNTS`.
+
+If `claude` is not on the container `PATH`, point OpenClaw at the persisted
+binary:
+
+```json5
+{
+  agents: {
+    defaults: {
+      cliBackends: {
+        "claude-cli": {
+          command: "/home/node/.local/bin/claude",
+        },
+      },
+    },
+  },
+}
+```
+
+Verify the backend from the running Docker environment:
+
+```bash
+docker compose run --rm openclaw-cli sh -lc \
+  '$HOME/.local/bin/claude --version && $HOME/.local/bin/claude auth status --text'
+docker compose run --rm openclaw-cli models list --provider anthropic
+```
+
+If you do not want to persist Claude Code in Docker, or you need predictable
+production billing, use an Anthropic API key instead during onboarding. API-key
+auth uses OpenClaw's mounted config and auth-profile storage, so it does not
+require `~/.claude` persistence.
+
+See [CLI backends](/gateway/cli-backends#docker-gateways) and
+[Anthropic](/providers/anthropic#claude-cli) for Claude CLI runtime details.
+
 For full persistence details on VM deployments, see
 [Docker VM Runtime - What persists where](/install/docker-vm-runtime#what-persists-where).
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -329,11 +329,11 @@ export OPENCLAW_HOME_VOLUME="openclaw_home"
 ./scripts/docker/setup.sh
 
 # Install Claude Code as the node user inside the persisted home.
-docker compose run --rm openclaw-cli sh -lc \
+docker compose run --rm --entrypoint sh openclaw-cli -lc \
   'curl -fsSL https://claude.ai/install.sh | bash'
 
 # Log in and verify credentials in the same persisted container home.
-docker compose run --rm openclaw-cli sh -lc \
+docker compose run --rm --entrypoint sh openclaw-cli -lc \
   '$HOME/.local/bin/claude auth login && $HOME/.local/bin/claude auth status --text'
 ```
 
@@ -366,7 +366,7 @@ binary:
 Verify the backend from the running Docker environment:
 
 ```bash
-docker compose run --rm openclaw-cli sh -lc \
+docker compose run --rm --entrypoint sh openclaw-cli -lc \
   '$HOME/.local/bin/claude --version && $HOME/.local/bin/claude auth status --text'
 docker compose run --rm openclaw-cli models list --provider anthropic
 ```


### PR DESCRIPTION
## What Problem This Solves
Docker gateways currently document persistence for OpenClaw config and plugins, but not the extra state that Anthropic's Claude Code CLI needs.
Users who select the `claude-cli` backend can lose the installed `claude` binary or `~/.claude` auth/session state when the container is replaced unless they persist the container user's home directory or configure an explicit command path.

Fixes #66874.

## Summary
- document that the Docker image does not preinstall Claude Code
- explain how to persist `/home/node` so `~/.local/bin/claude`, `~/.claude`, and caches survive container replacement
- add a Docker-specific `claude-cli.command` example, verification commands, and Anthropic API-key fallback guidance

## Evidence
Validated locally from the PR branch:

```text
git diff --check HEAD~1..HEAD
node scripts/check-docs-mdx.mjs docs/install/docker.md docs/gateway/cli-backends.md
Docs MDX check passed (2 files, 106ms).
node scripts/docs-list.js >/tmp/oc-66874-docs-list-postcommit.out
```

`pnpm` package-script validation was not available in this local checkout because the environment does not currently have a working `pnpm` binary; the equivalent Node docs commands above were run directly.
