### PR TITLE
feat(cron): add deliveryStreams filter for command payloads

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -145,9 +145,9 @@ openclaw cron create "*/15 * * * *" \
   --to "-1001234567890"
 ```
 
-`--command <shell>` stores `argv: ["sh", "-lc", <shell>]`. Use `--command-argv '["node","scripts/report.mjs"]'` when you want exact argv execution without shell parsing. Optional `--command-env KEY=VALUE`, `--command-input`, `--timeout-seconds`, `--no-output-timeout-seconds`, and `--output-max-bytes` fields control the process environment, stdin, and output bounds.
+`--command <shell>` stores `argv: ["sh", "-lc", <shell>]`. Use `--command-argv '["node","scripts/report.mjs"]'` when you want exact argv execution without shell parsing. Optional `--command-env KEY=VALUE`, `--command-input`, `--timeout-seconds`, `--no-output-timeout-seconds`, `--output-max-bytes`, and `--delivery-streams` fields control the process environment, stdin, output bounds, and delivery filtering.
 
-If stdout is non-empty, that text is the delivered result. If stdout is empty and stderr is non-empty, stderr is delivered. If both streams are present, cron delivers a small `stdout:` / `stderr:` block. A zero exit code records the run as `ok`; non-zero exit, signal, timeout, or no-output timeout records `error` and can trigger failure alerts. A command that prints only `NO_REPLY` uses the normal cron silent-token suppression and posts nothing back to chat.
+By default, if stdout is non-empty, that text is the delivered result. If stdout is empty and stderr is non-empty, stderr is delivered. If both streams are present, cron delivers a small `stdout:` / `stderr:` block. Use `--delivery-streams '["stdout"]'` to deliver only stdout (useful for long-running commands that write heartbeat markers to stderr), or `--delivery-streams '["stderr"]'` to deliver only stderr. The filtered delivery affects announce and webhook outputs; full stdout/stderr are always preserved in `lastDiagnostics` for debugging. A zero exit code records the run as `ok`; non-zero exit, signal, timeout, or no-output timeout records `error` and can trigger failure alerts. A command that prints only `NO_REPLY` uses the normal cron silent-token suppression and posts nothing back to chat.
 
 ### Payload options for isolated jobs
 

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -44,6 +44,12 @@ function cronCommandPayloadSchema(params: { argv: TSchema }) {
       timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
       noOutputTimeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
       outputMaxBytes: Type.Optional(Type.Integer({ minimum: 1 })),
+      deliveryStreams: Type.Optional(
+        Type.Array(Type.Union([Type.Literal("stdout"), Type.Literal("stderr")]), {
+          minItems: 1,
+          maxItems: 2,
+        }),
+      ),
     },
     { additionalProperties: false },
   );

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -30,6 +30,31 @@ import {
 } from "./shared.js";
 import { normalizeCronSessionTargetOption, parseCronThreadIdOption } from "./thread-id-shared.js";
 
+function parseDeliveryStreamsOption(
+  value: unknown,
+): readonly ("stdout" | "stderr")[] | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("--delivery-streams must be a JSON array of strings");
+  }
+  if (
+    !Array.isArray(parsed) ||
+    parsed.length === 0 ||
+    parsed.length > 2 ||
+    !parsed.every((item) => item === "stdout" || item === "stderr")
+  ) {
+    throw new Error(
+      "--delivery-streams must be a JSON array containing only \"stdout\" and/or \"stderr\"",
+    );
+  }
+  return parsed as ("stdout" | "stderr")[];
+}
+
 export function registerCronStatusCommand(cron: Command) {
   addGatewayClientOptions(
     cron
@@ -129,6 +154,10 @@ export function registerCronAddCommand(cron: Command) {
       .option("--timeout-seconds <n>", "Timeout seconds for agent or command jobs")
       .option("--no-output-timeout-seconds <n>", "No-output timeout seconds for command jobs")
       .option("--output-max-bytes <n>", "Maximum captured stdout/stderr bytes for command jobs")
+      .option(
+        "--delivery-streams <json>",
+        'Delivery stream filter for command jobs (e.g., \'["stdout"]\' or \'["stderr"]\')',
+      )
       .option("--light-context", "Use lightweight bootstrap context for agent jobs", false)
       .option("--tools <list>", "Tool allow-list (e.g. exec,read,write or exec read write)")
       .option("--announce", "Fallback-deliver final text to a chat", false)
@@ -236,6 +265,7 @@ export function registerCronAddCommand(cron: Command) {
                 const noOutputTimeoutSeconds =
                   parsePositiveIntOrUndefined(rawNoOutputTimeoutSeconds);
                 const outputMaxBytes = parsePositiveIntOrUndefined(opts.outputMaxBytes);
+                const deliveryStreams = parseDeliveryStreamsOption(opts.deliveryStreams);
                 return {
                   kind: "command" as const,
                   argv: commandArgv ?? ["sh", "-lc", commandShell ?? ""],
@@ -250,6 +280,7 @@ export function registerCronAddCommand(cron: Command) {
                       : undefined,
                   outputMaxBytes:
                     outputMaxBytes && Number.isFinite(outputMaxBytes) ? outputMaxBytes : undefined,
+                  deliveryStreams,
                 };
               }
               return {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -25,6 +25,31 @@ import {
 } from "./shared.js";
 import { normalizeCronSessionTargetOption, parseCronThreadIdOption } from "./thread-id-shared.js";
 
+function parseDeliveryStreamsOption(
+  value: unknown,
+): readonly ("stdout" | "stderr")[] | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("--delivery-streams must be a JSON array of strings");
+  }
+  if (
+    !Array.isArray(parsed) ||
+    parsed.length === 0 ||
+    parsed.length > 2 ||
+    !parsed.every((item) => item === "stdout" || item === "stderr")
+  ) {
+    throw new Error(
+      "--delivery-streams must be a JSON array containing only \"stdout\" and/or \"stderr\"",
+    );
+  }
+  return parsed as ("stdout" | "stderr")[];
+}
+
 const CRON_EDIT_LOOKUP_PAGE_SIZE = 200;
 const CRON_EDIT_LOOKUP_MAX_PAGES = 50;
 
@@ -123,6 +148,10 @@ export function registerCronEditCommand(cron: Command) {
       .option("--timeout-seconds <n>", "Timeout seconds for agent or command jobs")
       .option("--no-output-timeout-seconds <n>", "No-output timeout seconds for command jobs")
       .option("--output-max-bytes <n>", "Maximum captured stdout/stderr bytes for command jobs")
+      .option(
+        "--delivery-streams <json>",
+        'Delivery stream filter for command jobs (e.g., \'["stdout"]\' or \'["stderr"]\')',
+      )
       .option("--light-context", "Enable lightweight bootstrap context for agent jobs")
       .option("--no-light-context", "Disable lightweight bootstrap context for agent jobs")
       .option("--tools <list>", "Tool allow-list (e.g. exec,read,write or exec read write)")
@@ -457,6 +486,8 @@ export function registerCronEditCommand(cron: Command) {
               noOutputTimeoutSeconds !== undefined,
             );
             assignIf(payload, "outputMaxBytes", outputMaxBytes, outputMaxBytes !== undefined);
+            const deliveryStreams = parseDeliveryStreamsOption(opts.deliveryStreams);
+            assignIf(payload, "deliveryStreams", deliveryStreams, deliveryStreams !== undefined);
             patch.payload = payload;
           }
 

--- a/src/cron/command-runner.test.ts
+++ b/src/cron/command-runner.test.ts
@@ -154,4 +154,102 @@ describe("runCronCommandJob", () => {
     expect(result.error).toBe("command stopped");
     expect(result.summary).toBeUndefined();
   });
+
+  it("delivers only stdout when deliveryStreams is ['stdout']", async () => {
+    const result = await runCronCommandJob({
+      job: makeCommandJob({
+        kind: "command",
+        argv: [
+          process.execPath,
+          "-e",
+          "process.stdout.write('stdout only'); process.stderr.write('stderr hidden')",
+        ],
+        timeoutSeconds: 5,
+        deliveryStreams: ["stdout"],
+      }),
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toBe("stdout only");
+    expect(result.summary).not.toContain("stderr hidden");
+  });
+
+  it("delivers only stderr when deliveryStreams is ['stderr']", async () => {
+    const result = await runCronCommandJob({
+      job: makeCommandJob({
+        kind: "command",
+        argv: [
+          process.execPath,
+          "-e",
+          "process.stdout.write('stdout hidden'); process.stderr.write('stderr only')",
+        ],
+        timeoutSeconds: 5,
+        deliveryStreams: ["stderr"],
+      }),
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toBe("stderr only");
+    expect(result.summary).not.toContain("stdout hidden");
+  });
+
+  it("delivers both streams when deliveryStreams is ['stdout', 'stderr']", async () => {
+    const result = await runCronCommandJob({
+      job: makeCommandJob({
+        kind: "command",
+        argv: [
+          process.execPath,
+          "-e",
+          "process.stdout.write('stdout visible'); process.stderr.write('stderr visible')",
+        ],
+        timeoutSeconds: 5,
+        deliveryStreams: ["stdout", "stderr"],
+      }),
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toContain("stdout visible");
+    expect(result.summary).toContain("stderr visible");
+  });
+
+  it("defaults to delivering both streams when deliveryStreams is undefined", async () => {
+    const result = await runCronCommandJob({
+      job: makeCommandJob({
+        kind: "command",
+        argv: [
+          process.execPath,
+          "-e",
+          "process.stdout.write('stdout default'); process.stderr.write('stderr default')",
+        ],
+        timeoutSeconds: 5,
+      }),
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toContain("stdout default");
+    expect(result.summary).toContain("stderr default");
+  });
+
+  it("handles heartbeat markers in stderr with stdout-only delivery", async () => {
+    const result = await runCronCommandJob({
+      job: makeCommandJob({
+        kind: "command",
+        argv: [
+          process.execPath,
+          "-e",
+          [
+            "console.error('[heartbeat] still running...');",
+            "console.error('[heartbeat] still running...');",
+            "process.stdout.write('Final result summary');",
+          ].join(""),
+        ],
+        timeoutSeconds: 5,
+        deliveryStreams: ["stdout"],
+      }),
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toBe("Final result summary");
+    expect(result.summary).not.toContain("[heartbeat]");
+  });
 });

--- a/src/cron/command-runner.ts
+++ b/src/cron/command-runner.ts
@@ -24,13 +24,24 @@ function trimOutput(value: string): string | undefined {
   return normalizeOptionalString(value);
 }
 
-function buildCommandSummary(params: { stdout: string; stderr: string }): string | undefined {
+function buildCommandSummary(
+  params: { stdout: string; stderr: string },
+  deliveryStreams?: readonly ("stdout" | "stderr")[],
+): string | undefined {
   const stdout = trimOutput(params.stdout);
   const stderr = trimOutput(params.stderr);
-  if (stdout && stderr) {
-    return `stdout:\n${stdout}\n\nstderr:\n${stderr}`;
+
+  // Apply delivery stream filtering if specified
+  const includeStdout = !deliveryStreams || deliveryStreams.includes("stdout");
+  const includeStderr = !deliveryStreams || deliveryStreams.includes("stderr");
+
+  const filteredStdout = includeStdout ? stdout : undefined;
+  const filteredStderr = includeStderr ? stderr : undefined;
+
+  if (filteredStdout && filteredStderr) {
+    return `stdout:\n${filteredStdout}\n\nstderr:\n${filteredStderr}`;
   }
-  return stdout ?? stderr;
+  return filteredStdout ?? filteredStderr;
 }
 
 function commandErrorMessage(params: {
@@ -125,7 +136,10 @@ export async function runCronCommandJob(params: {
       result.termination !== "no-output-timeout" &&
       result.termination !== "signal";
     const status: CronRunStatus = ok ? "ok" : "error";
-    const summary = buildCommandSummary({ stdout: result.stdout, stderr: result.stderr });
+    const summary = buildCommandSummary(
+      { stdout: result.stdout, stderr: result.stderr },
+      payload.deliveryStreams,
+    );
     const error = ok
       ? undefined
       : commandErrorMessage({


### PR DESCRIPTION
Implement per-stream delivery filtering for cron command jobs to prevent stderr heartbeat markers from polluting announce/webhook outputs.

- Add deliveryStreams field to command payload schema with validation
- Update buildCommandSummary to filter stdout/stderr based on deliveryStreams
- Add CLI --delivery-streams option for cron add/edit commands
- Add comprehensive tests covering all delivery stream combinations
- Document the feature in cron-jobs.md with usage examples

Fixes GitHub issue #95941

<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
