### PR TITLE
test(telegram): align message adapter send mock

### DIFF
--- a/extensions/telegram/src/channel.message-adapter.test.ts
+++ b/extensions/telegram/src/channel.message-adapter.test.ts
@@ -8,9 +8,11 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMessageTelegramMock = vi.fn();
+const reactMessageTelegramMock = vi.fn();
 
 vi.mock("./send.js", () => ({
   sendMessageTelegram: (...args: unknown[]) => sendMessageTelegramMock(...args),
+  reactMessageTelegram: (...args: unknown[]) => reactMessageTelegramMock(...args),
 }));
 
 import { telegramPlugin } from "./channel.js";
@@ -27,6 +29,7 @@ function requireTelegramMessageAdapter(): TelegramMessageAdapter {
 describe("telegram channel message adapter", () => {
   beforeEach(() => {
     sendMessageTelegramMock.mockReset();
+    reactMessageTelegramMock.mockReset();
   });
 
   it("backs declared durable-final capabilities with native send proofs", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Telegram message-adapter test could not exercise payload sends after the adapter began loading the reaction helper from the send module.

## Why This Change Was Made

The test mock now exposes the same `sendMessageTelegram` and `reactMessageTelegram` exports used by the production adapter. Both mocks are reset between tests so payload and reaction assertions remain isolated.

## User Impact

No production behavior changes. Telegram adapter tests now cover the current send-module contract instead of failing during module loading.

## Evidence

- Focused regression: `channel.message-adapter.test.ts` 4/4 passed.
- Full Telegram extension shard: 2,195/2,198 passed; the remaining three failures are unrelated native-command session tests blocked by missing workspace package `@openclaw/llm-core`.
- `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings.
