### PR TITLE
fix(install): pin node-domexception to resolvable 2.0.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ overrides:
   minimatch: 10.2.5
   path-to-regexp: 8.4.0
   qs: 6.15.2
-  node-domexception: npm:@nolyfill/domexception@1.0.28
+  node-domexception: 2.0.2
   typebox: 1.1.39
   tar: 7.5.16
   tough-cookie: 4.1.3
@@ -3116,9 +3116,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nolyfill/domexception@1.0.28':
-    resolution: {integrity: sha512-tlc/FcYIv5i8RYsl2iDil4A0gOihaas1R5jPcIC4Zw3GhjKsVilw90aHcVlhZPTBLGBzd379S+VcnsDjd9ChiA==}
-    engines: {node: '>=12.4.0'}
+  node-domexception@2.0.2:
+    resolution: {integrity: sha512-Qf9vHK9c5MGgUXj8SnucCIS4oEPuUstjRaMplLGeZpbWMfNV1rvEcXuwoXfN51dUfD1b4muPHPQtCx/5Dj/QAA==}
+    engines: {node: '>=16'}
 
   '@openai/codex@0.139.0':
     resolution: {integrity: sha512-wr2fRE+fzW0CjEbfFsLh1ftarVEcw0CMLWS7QyA0nyOz5qacQPVq3cq2+/U7oEbwm1TOqoi0Fm1nxniB5FkpmA==}
@@ -9208,7 +9208,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nolyfill/domexception@1.0.28': {}
+  node-domexception@2.0.2: {}
 
   '@openai/codex@0.139.0':
     optionalDependencies:
@@ -11363,7 +11363,7 @@ snapshots:
 
   fetch-blob@3.2.0:
     dependencies:
-      node-domexception: '@nolyfill/domexception@1.0.28'
+      node-domexception: 2.0.2
       web-streams-polyfill: 3.3.3
 
   file-type@22.0.1:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -114,7 +114,7 @@ overrides:
   minimatch: 10.2.5
   path-to-regexp: 8.4.0
   qs: 6.15.2
-  node-domexception: "npm:@nolyfill/domexception@1.0.28"
+  node-domexception: 2.0.2
   typebox: 1.1.39
   tar: 7.5.16
   tough-cookie: 4.1.3

--- a/test/scripts/root-package-overrides.test.ts
+++ b/test/scripts/root-package-overrides.test.ts
@@ -53,12 +53,12 @@ describe("root package override guardrails", () => {
     expect(pnpmWorkspace.overrides).not.toHaveProperty(packageName);
   });
 
-  it("pins the node-domexception alias exactly in pnpm override metadata", () => {
+  it("pins node-domexception to a resolvable version in pnpm override metadata", () => {
     const manifest = readRootManifest();
     const pnpmWorkspace = readPnpmWorkspaceConfig();
     const pnpmOverride = pnpmWorkspace.overrides?.["node-domexception"];
 
-    expect(pnpmOverride).toBe("npm:@nolyfill/domexception@1.0.28");
+    expect(pnpmOverride).toBe("2.0.2");
     expect(manifest.overrides).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary
- Problem: Fresh source installs fail with `No matching version found for node-domexception@1.0.28` because the workspace override resolves to an aliased package (`@nolyfill/domexception@1.0.28`) that is not available in all registry environments.
- Solution: Replace the alias override with the latest published `node-domexception` version (`2.0.2`), which is widely mirrored and functionally equivalent (it re-exports the native DOMException).
- What changed: `pnpm-workspace.yaml` override and the matching `pnpm-lock.yaml` entries; one contract test updated.
- What did NOT change: No runtime code, no API surface, no other dependency versions, no shrinkwrap files.

Fixes #95927

## Real behavior proof
- **Behavior or issue addressed:** `pnpm install` from a clean source checkout fails when the configured npm registry cannot resolve `@nolyfill/domexception@1.0.28`.
- **Real environment tested:** Linux Node 22.22.0, pnpm 11.2.2.
- **Exact steps or command run after this patch:**
  ```bash
  rm -rf node_modules
  pnpm install --frozen-lockfile
  ```
- **Evidence after fix:** `pnpm install --frozen-lockfile` completes without `ERR_PNPM_NO_MATCHING_VERSION` for `node-domexception`; lockfile is recognized as up to date and all workspace packages resolve successfully.
- **Observed result after fix:** Installation finishes with `Done in 3m 42.3s using pnpm v11.2.2` and no matching-version error.
- **What was not tested:** macOS/Windows install paths; runtime behavior is unchanged because the dependency only provides the same DOMException global.

## Regression Test Plan
- Coverage level: Unit test / contract test
- Target test file: `test/scripts/root-package-overrides.test.ts`
- Scenario locked in: Verify that `node-domexception` is pinned to a resolvable version in workspace overrides.
- Why this is the smallest reliable guardrail: The existing override contract test already guards against unversioned or broken overrides; updating it catches regressions of this specific pin.

## Root Cause
- Root cause: The workspace override used an npm alias (`npm:@nolyfill/domexception@1.0.28`) that depends on package availability in the user's registry mirror. When the mirror lacks the aliased package, pnpm cannot satisfy the transitive dependency from `fetch-blob@3.2.0`.
- Missing detection / guardrail: The override contract test did not verify that the aliased target is broadly resolvable; switching to the canonical package version removes the alias availability risk.
