### PR TITLE
fix(ci): require live proof evidence artifacts

### DIFF
--- a/.github/workflows/mantis-discord-smoke.yml
+++ b/.github/workflows/mantis-discord-smoke.yml
@@ -171,4 +171,4 @@ jobs:
           name: mantis-discord-smoke-${{ github.run_id }}-${{ github.run_attempt }}
           path: .artifacts/qa-e2e/mantis/
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error

--- a/.github/workflows/mantis-discord-status-reactions.yml
+++ b/.github/workflows/mantis-discord-status-reactions.yml
@@ -540,7 +540,7 @@ jobs:
           name: mantis-discord-status-reactions-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.run_mantis.outputs.output_dir }}
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Create Mantis GitHub App token
         id: mantis_app_token

--- a/.github/workflows/mantis-discord-thread-attachment.yml
+++ b/.github/workflows/mantis-discord-thread-attachment.yml
@@ -547,7 +547,7 @@ jobs:
         with:
           name: mantis-discord-thread-attachment-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.run_mantis.outputs.output_dir }}
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 14
 
       - name: Create Mantis GitHub App token

--- a/.github/workflows/mantis-slack-desktop-smoke.yml
+++ b/.github/workflows/mantis-slack-desktop-smoke.yml
@@ -458,7 +458,7 @@ jobs:
           name: mantis-slack-desktop-smoke-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.run_mantis.outputs.output_dir }}
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Create Mantis GitHub App token
         id: mantis_app_token

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -556,7 +556,7 @@ jobs:
           name: mantis-telegram-desktop-proof-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.inspect.outputs.output_dir }}
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Create Mantis GitHub App token
         id: mantis_app_token

--- a/.github/workflows/mantis-telegram-live.yml
+++ b/.github/workflows/mantis-telegram-live.yml
@@ -506,7 +506,7 @@ jobs:
           name: mantis-telegram-live-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.run_mantis.outputs.output_dir }}
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Create Mantis GitHub App token
         id: mantis_app_token

--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -273,4 +273,4 @@ jobs:
           name: npm-telegram-beta-e2e-${{ github.run_id }}-${{ github.run_attempt }}
           path: .artifacts/qa-e2e/
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -496,7 +496,26 @@ const GITHUB_WORKFLOW_OWNER_TEST_TARGETS = new Map([
   [".github/workflows/macos-release.yml", ["test/scripts/package-acceptance-workflow.test.ts"]],
   [
     ".github/workflows/mantis-telegram-desktop-proof.yml",
-    ["test/scripts/mantis-telegram-desktop-proof-workflow.test.ts"],
+    [
+      "test/scripts/mantis-telegram-desktop-proof-workflow.test.ts",
+      "test/scripts/package-acceptance-workflow.test.ts",
+    ],
+  ],
+  [
+    ".github/workflows/mantis-discord-smoke.yml",
+    ["test/scripts/package-acceptance-workflow.test.ts"],
+  ],
+  [
+    ".github/workflows/mantis-discord-status-reactions.yml",
+    ["test/scripts/package-acceptance-workflow.test.ts"],
+  ],
+  [
+    ".github/workflows/mantis-discord-thread-attachment.yml",
+    ["test/scripts/package-acceptance-workflow.test.ts"],
+  ],
+  [
+    ".github/workflows/mantis-slack-desktop-smoke.yml",
+    ["test/scripts/package-acceptance-workflow.test.ts"],
   ],
   [
     ".github/workflows/mantis-telegram-live.yml",

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -9,6 +9,15 @@ const LIVE_MEDIA_RUNNER_DOCKERFILE = ".github/images/live-media-runner/Dockerfil
 const LIVE_MEDIA_RUNNER_IMAGE = "ghcr.io/openclaw/openclaw-live-media-runner:ubuntu-24.04";
 const LIVE_MEDIA_RUNNER_IMAGE_WORKFLOW = ".github/workflows/live-media-runner-image.yml";
 const NPM_TELEGRAM_WORKFLOW = ".github/workflows/npm-telegram-beta-e2e.yml";
+const MANTIS_DISCORD_SMOKE_WORKFLOW = ".github/workflows/mantis-discord-smoke.yml";
+const MANTIS_DISCORD_STATUS_REACTIONS_WORKFLOW =
+  ".github/workflows/mantis-discord-status-reactions.yml";
+const MANTIS_DISCORD_THREAD_ATTACHMENT_WORKFLOW =
+  ".github/workflows/mantis-discord-thread-attachment.yml";
+const MANTIS_SLACK_DESKTOP_SMOKE_WORKFLOW = ".github/workflows/mantis-slack-desktop-smoke.yml";
+const MANTIS_TELEGRAM_DESKTOP_PROOF_WORKFLOW =
+  ".github/workflows/mantis-telegram-desktop-proof.yml";
+const MANTIS_TELEGRAM_LIVE_WORKFLOW = ".github/workflows/mantis-telegram-live.yml";
 const PACKAGE_JSON = "package.json";
 const SETUP_PNPM_STORE_CACHE_ACTION = ".github/actions/setup-pnpm-store-cache/action.yml";
 const DOCKER_E2E_PLAN_ACTION = ".github/actions/docker-e2e-plan/action.yml";
@@ -1436,6 +1445,58 @@ describe("package artifact reuse", () => {
 
       expect(uploadStep.if, jobName).toBe("always()");
       expect(uploadStep.with?.["if-no-files-found"], jobName).toBe("error");
+    }
+  });
+
+  it("requires live proof evidence artifacts when proof jobs run", () => {
+    const cases = [
+      {
+        workflowPath: MANTIS_DISCORD_SMOKE_WORKFLOW,
+        jobName: "run_discord_smoke",
+        stepName: "Upload Mantis artifacts",
+      },
+      {
+        workflowPath: MANTIS_DISCORD_STATUS_REACTIONS_WORKFLOW,
+        jobName: "run_status_reactions",
+        stepName: "Upload Mantis status reaction artifacts",
+      },
+      {
+        workflowPath: MANTIS_DISCORD_THREAD_ATTACHMENT_WORKFLOW,
+        jobName: "run_thread_attachment",
+        stepName: "Upload Mantis thread attachment artifacts",
+      },
+      {
+        workflowPath: MANTIS_SLACK_DESKTOP_SMOKE_WORKFLOW,
+        jobName: "run_slack_desktop",
+        stepName: "Upload Mantis Slack desktop artifacts",
+      },
+      {
+        workflowPath: MANTIS_TELEGRAM_DESKTOP_PROOF_WORKFLOW,
+        jobName: "run_telegram_desktop_proof",
+        stepName: "Upload Mantis Telegram desktop artifacts",
+      },
+      {
+        workflowPath: MANTIS_TELEGRAM_LIVE_WORKFLOW,
+        jobName: "run_telegram_live",
+        stepName: "Upload Mantis Telegram artifacts",
+      },
+      {
+        workflowPath: NPM_TELEGRAM_WORKFLOW,
+        jobName: "run_package_telegram_e2e",
+        stepName: "Upload npm Telegram E2E artifacts",
+      },
+    ];
+
+    for (const item of cases) {
+      const label = `${item.workflowPath} ${item.jobName}`;
+      const uploadStep = workflowStep(
+        workflowJob(item.workflowPath, item.jobName),
+        item.stepName,
+      );
+
+      expect(uploadStep.if, label).toContain("always()");
+      expect(uploadStep.uses, label).toBe(UPLOAD_ARTIFACT_V7);
+      expect(uploadStep.with?.["if-no-files-found"], label).toBe("error");
     }
   });
 

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1282,6 +1282,34 @@ describe("scripts/test-projects changed-target routing", () => {
     }
   });
 
+  it("keeps Mantis proof workflow edits on workflow evidence regression tests", () => {
+    const packageAcceptanceTargets = [
+      "test/scripts/package-acceptance-workflow.test.ts",
+      "test/scripts/ci-workflow-guards.test.ts",
+    ];
+    const workflowTargets = new Map([
+      [".github/workflows/mantis-discord-smoke.yml", packageAcceptanceTargets],
+      [".github/workflows/mantis-discord-status-reactions.yml", packageAcceptanceTargets],
+      [".github/workflows/mantis-discord-thread-attachment.yml", packageAcceptanceTargets],
+      [".github/workflows/mantis-slack-desktop-smoke.yml", packageAcceptanceTargets],
+      [
+        ".github/workflows/mantis-telegram-desktop-proof.yml",
+        [
+          "test/scripts/mantis-telegram-desktop-proof-workflow.test.ts",
+          "test/scripts/package-acceptance-workflow.test.ts",
+          "test/scripts/ci-workflow-guards.test.ts",
+        ],
+      ],
+    ]);
+
+    for (const [workflowPath, targets] of workflowTargets) {
+      expect(resolveChangedTestTargetPlan([workflowPath])).toEqual({
+        mode: "targets",
+        targets,
+      });
+    }
+  });
+
   it("keeps release-check workflow edits on release workflow regression tests", () => {
     expect(resolveChangedTestTargetPlan([".github/workflows/openclaw-release-checks.yml"])).toEqual(
       {


### PR DESCRIPTION
## What Problem This Solves

Live Mantis and Telegram proof workflows were allowed to finish artifact upload steps with `if-no-files-found: warn`. These jobs use their artifacts as durable proof for live QA runs and PR comments, so a missing artifact should fail the workflow instead of looking like a soft warning.

## Why This Change Was Made

This tightens the evidence contract for:

- Mantis Discord smoke
- Mantis Discord status reactions
- Mantis Discord thread attachment
- Mantis Slack desktop smoke
- Mantis Telegram desktop proof
- Mantis Telegram live
- npm Telegram beta E2E

The changed-test router now sends those workflow edits to the package workflow guard tests, and the guard asserts each upload uses `actions/upload-artifact` with `if-no-files-found: error`.

## User Impact

Maintainers get a failing workflow when live proof evidence is missing, instead of a green or ambiguous run with no downloadable artifact. Successful runs are unchanged except for the stricter missing-artifact behavior.

## Evidence

- `git diff --check origin/main...HEAD`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/mantis-discord-smoke.yml .github/workflows/mantis-telegram-live.yml .github/workflows/mantis-discord-thread-attachment.yml .github/workflows/mantis-discord-status-reactions.yml .github/workflows/mantis-slack-desktop-smoke.yml .github/workflows/mantis-telegram-desktop-proof.yml .github/workflows/npm-telegram-beta-e2e.yml`
- `node scripts/crabbox-wrapper.mjs run -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` (`run_9414cede7832`, `cbx_993d3d355d26`, exit 0)
- `codex review --base origin/main`: no actionable correctness issues

Known local gap: `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts test/scripts/test-projects.test.ts` cannot run in this sparse Codex worktree because `node_modules` is intentionally absent; the remote changed gate covered the touched test lanes.
