### PR TITLE
fix(acpx): sessions_spawn fails for harnesses lacking model support

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -708,6 +708,81 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     });
   });
 
+  it("retries ensureSession without a model when the ACP harness never advertised model support (issue #95869)", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      agentRegistry: {
+        resolve: (agentName: string) => (agentName === "opencode" ? "opencode acp" : agentName),
+        list: () => ["opencode"],
+      },
+    });
+    const ensure = vi
+      .spyOn(delegate, "ensureSession")
+      .mockRejectedValueOnce(
+        new Error(
+          'Cannot apply --model "openrouter/owl-alpha": the ACP agent did not advertise model support. Generic model selection requires ACP models plus session/set_model support, or an adapter-specific startup model flag.',
+        ),
+      )
+      .mockResolvedValueOnce({
+        sessionKey: "agent:opencode:acp:test",
+        backend: "acpx",
+        runtimeSessionName: "opencode",
+      });
+
+    await runtime.ensureSession({
+      sessionKey: "agent:opencode:acp:test",
+      agent: "opencode",
+      mode: "persistent",
+      model: "openrouter/owl-alpha",
+    });
+
+    expect(ensure).toHaveBeenCalledTimes(2);
+    expect(readFirstEnsureSessionInput(ensure)).toMatchObject({
+      model: "openrouter/owl-alpha",
+      sessionOptions: { model: "openrouter/owl-alpha" },
+    });
+    const [, secondCall] = ensure.mock.calls;
+    if (!secondCall) {
+      throw new Error("Expected ensureSession to be retried");
+    }
+    expect(secondCall[0]).not.toHaveProperty("sessionOptions");
+    expect((secondCall[0] as { model?: string }).model).toBeUndefined();
+  });
+
+  it("does not retry ensureSession when the ACP harness rejects a specific unsupported model id", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      agentRegistry: {
+        resolve: (agentName: string) => (agentName === "opencode" ? "opencode acp" : agentName),
+        list: () => ["opencode"],
+      },
+    });
+    const ensure = vi
+      .spyOn(delegate, "ensureSession")
+      .mockRejectedValueOnce(
+        new Error(
+          'Cannot apply --model "unknown/model": the ACP agent did not advertise that model. Available models: none advertised.',
+        ),
+      );
+
+    await expect(
+      runtime.ensureSession({
+        sessionKey: "agent:opencode:acp:test",
+        agent: "opencode",
+        mode: "persistent",
+        model: "unknown/model",
+      }),
+    ).rejects.toThrow("did not advertise that model");
+
+    expect(ensure).toHaveBeenCalledTimes(1);
+  });
+
   it("injects Codex ACP startup config into the scoped registry", () => {
     expect(testing.isCodexAcpCommand(CODEX_ACP_COMMAND)).toBe(true);
     expect(testing.isCodexAcpCommand(CODEX_ACP_WRAPPER_COMMAND)).toBe(true);

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -586,6 +586,32 @@ function withAcpxSessionOptions(input: OpenClawRuntimeEnsureInput): AcpxDelegate
   } as AcpxDelegateEnsureInput;
 }
 
+// acpx@0.10.0 throws RequestedModelUnsupportedError out of ensureSession() when a
+// model is requested but the harness never advertised ACP `models`/`session/set_model`
+// support at all (e.g. opencode). That error class isn't exported from acpx's public
+// `runtime` entrypoint, so this matches the one phrase that is specific to "harness has
+// no model capability" rather than "harness rejected this model id" (which must still
+// surface). Drop this once acpx exposes a typed/opt-out way to skip model passthrough.
+const ACP_MODEL_SUPPORT_UNADVERTISED_MESSAGE = "did not advertise model support";
+
+function isAcpModelSupportUnadvertisedError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes(ACP_MODEL_SUPPORT_UNADVERTISED_MESSAGE);
+}
+
+async function ensureDelegateSessionWithModelFallback(
+  delegate: BaseAcpxRuntime,
+  input: OpenClawRuntimeEnsureInput,
+): Promise<AcpRuntimeHandle> {
+  try {
+    return await delegate.ensureSession(withAcpxSessionOptions(input));
+  } catch (error) {
+    if (!input.model || !isAcpModelSupportUnadvertisedError(error)) {
+      throw error;
+    }
+    return await delegate.ensureSession(withAcpxSessionOptions({ ...input, model: undefined }));
+  }
+}
+
 function quoteShellArg(value: string): string {
   if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) {
     return value;
@@ -989,7 +1015,7 @@ export class AcpxRuntime implements AcpRuntime {
           this.withCodexWrapperDiagnostics({
             command: stableLaunchCommand,
             fallbackCode: "ACP_SESSION_INIT_FAILED",
-            run: () => delegate.ensureSession(withAcpxSessionOptions(ensureInput)),
+            run: () => ensureDelegateSessionWithModelFallback(delegate, ensureInput),
           }),
       });
     }


### PR DESCRIPTION
Closes #95869

## What Problem This Solves

`sessions_spawn(runtime="acp")` fails for ACP harnesses that don't advertise model selection support (opencode, via the bundled `acpx` runtime). The gateway always forwards the configured/default model into `ensureSession`, so even though the agent works fine through `acpx <agent> exec` directly, spawning the same agent through OpenClaw throws a model-unsupported error before the session ever starts.

## Why This Change Was Made

`extensions/acpx/src/runtime.ts` now retries `ensureSession` once without the model when the delegate (bundled `acpx@0.10.0`) rejects specifically because the harness never advertised `models`/`session/set_model` capability at all. A harness that does advertise models but rejects a specific id still errors as before, since that case is a real, actionable mistake rather than a missing capability.

The validation that distinguishes those two cases lives inside the `acpx` package, and its error class isn't exported from `acpx`'s public `runtime` entrypoint, so this catches it by matching the one message that is specific to "no model capability at all." That's a local stopgap rather than the cleanest fix — ideally `acpx` exposes a typed error or an opt-out so callers don't have to match error text.

## User Impact

ACP harnesses without model support (opencode today, and any future harness in the same situation) can be spawned via `sessions_spawn` again. OpenClaw falls back to the harness's own configured model instead of failing the spawn outright.

## Evidence

- `node scripts/run-vitest.mjs extensions/acpx` — 141 passed, including new regression coverage for both the retry-without-model path and the unchanged "explicitly unsupported model id" path
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo` — clean
- `node scripts/run-oxlint.mjs extensions/acpx/src/runtime.ts extensions/acpx/src/runtime.test.ts` — clean