### PR TITLE
Persist hosted catalog snapshots in state

### DIFF
--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -1,6 +1,12 @@
 /** Persists hosted official external plugin catalog snapshots in OpenClaw state. */
 import { existsSync } from "node:fs";
 import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
@@ -27,6 +33,11 @@ type HostedCatalogSnapshotRow = {
   checksum: string;
   saved_at: string;
 };
+
+type HostedCatalogSnapshotDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "official_external_plugin_catalog_snapshots"
+>;
 
 function resolveStoreEnv(
   options: HostedOfficialExternalPluginCatalogSnapshotStoreOptions,
@@ -90,46 +101,46 @@ export function createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(
         return null;
       }
       const database = openOpenClawStateDatabase(resolveStateDatabaseOptions(options));
-      const row = database.db
-        .prepare(
-          `
-            SELECT feed_url, body, status, etag, last_modified, checksum, saved_at
-              FROM official_external_plugin_catalog_snapshots
-             WHERE feed_url = ?
-          `,
-        )
-        .get(url) as HostedCatalogSnapshotRow | undefined;
+      const stateDb = getNodeSqliteKysely<HostedCatalogSnapshotDatabase>(database.db);
+      const row = executeSqliteQueryTakeFirstSync(
+        database.db,
+        stateDb
+          .selectFrom("official_external_plugin_catalog_snapshots")
+          .select(["feed_url", "body", "status", "etag", "last_modified", "checksum", "saved_at"])
+          .where("feed_url", "=", url),
+      ) as HostedCatalogSnapshotRow | undefined;
       return rowToSnapshot(row);
     },
     async write(snapshot) {
       const now = Date.now();
-      runOpenClawStateWriteTransaction(({ db }) => {
-        db.prepare(
-          `
-            INSERT INTO official_external_plugin_catalog_snapshots (
-              feed_url, body, status, etag, last_modified, checksum, saved_at, updated_at_ms
-            ) VALUES (
-              @feed_url, @body, @status, @etag, @last_modified, @checksum, @saved_at, @updated_at_ms
-            )
-            ON CONFLICT(feed_url) DO UPDATE SET
-              body = excluded.body,
-              status = excluded.status,
-              etag = excluded.etag,
-              last_modified = excluded.last_modified,
-              checksum = excluded.checksum,
-              saved_at = excluded.saved_at,
-              updated_at_ms = excluded.updated_at_ms
-          `,
-        ).run({
-          feed_url: snapshot.metadata.url,
-          body: snapshot.body,
-          status: snapshot.metadata.status,
-          etag: snapshot.metadata.etag ?? null,
-          last_modified: snapshot.metadata.lastModified ?? null,
-          checksum: snapshot.metadata.checksum,
-          saved_at: snapshot.savedAt,
-          updated_at_ms: now,
-        });
+      runOpenClawStateWriteTransaction((database) => {
+        const stateDb = getNodeSqliteKysely<HostedCatalogSnapshotDatabase>(database.db);
+        executeSqliteQuerySync(
+          database.db,
+          stateDb
+            .insertInto("official_external_plugin_catalog_snapshots")
+            .values({
+              feed_url: snapshot.metadata.url,
+              body: snapshot.body,
+              status: snapshot.metadata.status,
+              etag: snapshot.metadata.etag ?? null,
+              last_modified: snapshot.metadata.lastModified ?? null,
+              checksum: snapshot.metadata.checksum,
+              saved_at: snapshot.savedAt,
+              updated_at_ms: now,
+            })
+            .onConflict((conflict) =>
+              conflict.column("feed_url").doUpdateSet({
+                body: snapshot.body,
+                status: snapshot.metadata.status,
+                etag: snapshot.metadata.etag ?? null,
+                last_modified: snapshot.metadata.lastModified ?? null,
+                checksum: snapshot.metadata.checksum,
+                saved_at: snapshot.savedAt,
+                updated_at_ms: now,
+              }),
+            ),
+        );
       }, resolveStateDatabaseOptions(options));
     },
   };

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -1,0 +1,136 @@
+/** Persists hosted official external plugin catalog snapshots in OpenClaw state. */
+import { existsSync } from "node:fs";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import type {
+  HostedOfficialExternalPluginCatalogMetadata,
+  HostedOfficialExternalPluginCatalogSnapshot,
+  HostedOfficialExternalPluginCatalogSnapshotStore,
+} from "./official-external-plugin-catalog.js";
+
+export type HostedOfficialExternalPluginCatalogSnapshotStoreOptions = {
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+  stateDatabasePath?: string;
+};
+
+type HostedCatalogSnapshotRow = {
+  feed_url: string;
+  body: string;
+  status: number | bigint;
+  etag: string | null;
+  last_modified: string | null;
+  checksum: string;
+  saved_at: string;
+};
+
+function resolveStoreEnv(
+  options: HostedOfficialExternalPluginCatalogSnapshotStoreOptions,
+): NodeJS.ProcessEnv | undefined {
+  if (!options.stateDir) {
+    return options.env;
+  }
+  return {
+    ...(options.env ?? process.env),
+    OPENCLAW_STATE_DIR: options.stateDir,
+  };
+}
+
+function resolveStateDatabaseOptions(
+  options: HostedOfficialExternalPluginCatalogSnapshotStoreOptions,
+): OpenClawStateDatabaseOptions {
+  const env = resolveStoreEnv(options);
+  return {
+    ...(env ? { env } : {}),
+    ...(options.stateDatabasePath ? { path: options.stateDatabasePath } : {}),
+  };
+}
+
+function resolveStateDatabasePath(
+  options: HostedOfficialExternalPluginCatalogSnapshotStoreOptions,
+): string {
+  if (options.stateDatabasePath) {
+    return options.stateDatabasePath;
+  }
+  return resolveOpenClawStateSqlitePath(resolveStoreEnv(options) ?? process.env);
+}
+
+function rowToSnapshot(
+  row: HostedCatalogSnapshotRow | undefined,
+): HostedOfficialExternalPluginCatalogSnapshot | null {
+  if (!row) {
+    return null;
+  }
+  const metadata: HostedOfficialExternalPluginCatalogMetadata = {
+    url: row.feed_url,
+    status: Number(row.status),
+    checksum: row.checksum,
+    ...(row.etag ? { etag: row.etag } : {}),
+    ...(row.last_modified ? { lastModified: row.last_modified } : {}),
+  };
+  return {
+    body: row.body,
+    metadata,
+    savedAt: row.saved_at,
+  };
+}
+
+/** Creates a snapshot store backed by the shared `state/openclaw.sqlite` database. */
+export function createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(
+  options: HostedOfficialExternalPluginCatalogSnapshotStoreOptions = {},
+): HostedOfficialExternalPluginCatalogSnapshotStore {
+  return {
+    async read(url) {
+      const pathname = resolveStateDatabasePath(options);
+      if (!existsSync(pathname)) {
+        return null;
+      }
+      const database = openOpenClawStateDatabase(resolveStateDatabaseOptions(options));
+      const row = database.db
+        .prepare(
+          `
+            SELECT feed_url, body, status, etag, last_modified, checksum, saved_at
+              FROM official_external_plugin_catalog_snapshots
+             WHERE feed_url = ?
+          `,
+        )
+        .get(url) as HostedCatalogSnapshotRow | undefined;
+      return rowToSnapshot(row);
+    },
+    async write(snapshot) {
+      const now = Date.now();
+      runOpenClawStateWriteTransaction(({ db }) => {
+        db.prepare(
+          `
+            INSERT INTO official_external_plugin_catalog_snapshots (
+              feed_url, body, status, etag, last_modified, checksum, saved_at, updated_at_ms
+            ) VALUES (
+              @feed_url, @body, @status, @etag, @last_modified, @checksum, @saved_at, @updated_at_ms
+            )
+            ON CONFLICT(feed_url) DO UPDATE SET
+              body = excluded.body,
+              status = excluded.status,
+              etag = excluded.etag,
+              last_modified = excluded.last_modified,
+              checksum = excluded.checksum,
+              saved_at = excluded.saved_at,
+              updated_at_ms = excluded.updated_at_ms
+          `,
+        ).run({
+          feed_url: snapshot.metadata.url,
+          body: snapshot.body,
+          status: snapshot.metadata.status,
+          etag: snapshot.metadata.etag ?? null,
+          last_modified: snapshot.metadata.lastModified ?? null,
+          checksum: snapshot.metadata.checksum,
+          saved_at: snapshot.savedAt,
+          updated_at_ms: now,
+        });
+      }, resolveStateDatabaseOptions(options));
+    },
+  };
+}

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1,6 +1,10 @@
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } from "./official-external-plugin-catalog-snapshot-store.js";
 import {
   type OfficialExternalPluginCatalogEntry,
   DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL,
@@ -245,6 +249,7 @@ describe("official external plugin catalog", () => {
       fetchImpl,
       ifNoneMatch: '"old"',
       ifModifiedSince: "Mon, 22 Jun 2026 00:00:00 GMT",
+      snapshotStore: null,
     });
 
     expect(result.source).toBe("hosted");
@@ -315,6 +320,7 @@ describe("official external plugin catalog", () => {
 
   it("falls back to the bundled catalog when hosted feed validation fails", async () => {
     const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore: null,
       fetchImpl: vi.fn(
         async () =>
           new Response(JSON.stringify({ schemaVersion: 1, id: " ", entries: [] }), {
@@ -333,6 +339,7 @@ describe("official external plugin catalog", () => {
 
   it("falls back to the bundled catalog on HTTP 304 until a snapshot cache exists", async () => {
     const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore: null,
       fetchImpl: vi.fn(
         async () =>
           new Response(null, {
@@ -393,6 +400,108 @@ describe("official external plugin catalog", () => {
       metadata: { etag: '"fresh"' },
     });
     expect(snapshot?.metadata.checksum).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it("persists hosted feed snapshots in OpenClaw state for HTTP 304 reuse", async () => {
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-hosted-catalog-"));
+    try {
+      const body = JSON.stringify({
+        schemaVersion: 1,
+        id: "openclaw-official-external-plugins",
+        generatedAt: "2026-06-22T00:00:00.000Z",
+        sequence: 7,
+        entries: [
+          {
+            name: "@openclaw/sqlite-snapshot-proof",
+            kind: "plugin",
+            openclaw: { plugin: { id: "sqlite-snapshot-proof" } },
+          },
+        ],
+      });
+
+      const seeded = await loadHostedOfficialExternalPluginCatalogEntries({
+        stateDir,
+        now: () => new Date("2026-06-22T02:03:04.000Z"),
+        fetchImpl: vi.fn(
+          async () =>
+            new Response(body, {
+              status: 200,
+              headers: {
+                etag: '"sqlite"',
+                "last-modified": "Mon, 22 Jun 2026 02:00:00 GMT",
+              },
+            }),
+        ),
+      });
+      if (seeded.source !== "hosted") {
+        throw new Error("expected seeded hosted feed");
+      }
+      closeOpenClawStateDatabaseForTest();
+
+      const result = await loadHostedOfficialExternalPluginCatalogEntries({
+        stateDir,
+        fetchImpl: vi.fn(async () => new Response(null, { status: 304 })),
+      });
+
+      expect(result.source).toBe("hosted-snapshot");
+      expect(result.entries.map((entry) => entry.name)).toEqual([
+        "@openclaw/sqlite-snapshot-proof",
+      ]);
+      if (result.source === "hosted-snapshot") {
+        expect(result.snapshot.savedAt).toBe("2026-06-22T02:03:04.000Z");
+        expect(result.metadata.checksum).toBe(seeded.metadata.checksum);
+      }
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads and updates hosted catalog snapshots in the SQLite store", async () => {
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-hosted-store-"));
+    try {
+      const store = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({ stateDir });
+      const url = "https://register.openclaw.ai/official-external-plugin-catalog.json";
+
+      const firstBody = JSON.stringify({ entries: [] });
+      const secondBody = JSON.stringify({ entries: [{}] });
+
+      await expect(store.read(url)).resolves.toBeNull();
+      await store.write({
+        body: firstBody,
+        metadata: {
+          url,
+          status: 200,
+          etag: '"first"',
+          checksum: "sha256:first",
+        },
+        savedAt: "2026-06-22T02:03:04.000Z",
+      });
+      await store.write({
+        body: secondBody,
+        metadata: {
+          url,
+          status: 200,
+          lastModified: "Mon, 22 Jun 2026 03:00:00 GMT",
+          checksum: "sha256:second",
+        },
+        savedAt: "2026-06-22T03:04:05.000Z",
+      });
+
+      await expect(store.read(url)).resolves.toMatchObject({
+        body: secondBody,
+        metadata: {
+          url,
+          status: 200,
+          lastModified: "Mon, 22 Jun 2026 03:00:00 GMT",
+          checksum: "sha256:second",
+        },
+        savedAt: "2026-06-22T03:04:05.000Z",
+      });
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("uses the last known good snapshot when the hosted feed returns HTTP 304", async () => {
@@ -655,6 +764,7 @@ describe("official external plugin catalog", () => {
 
   it("falls back to the bundled catalog on checksum mismatch and oversized bodies", async () => {
     const mismatch = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore: null,
       expectedSha256: "sha256:not-current",
       fetchImpl: vi.fn(
         async () =>
@@ -677,6 +787,7 @@ describe("official external plugin catalog", () => {
     }
 
     const oversized = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore: null,
       maxBytes: 4,
       fetchImpl: vi.fn(async () => new Response("12345", { status: 200 })),
     });

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -504,6 +504,24 @@ export function createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore(
   };
 }
 
+async function resolveHostedCatalogSnapshotStore(params: {
+  snapshotStore?: HostedOfficialExternalPluginCatalogSnapshotStore | null;
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+  stateDatabasePath?: string;
+}): Promise<HostedOfficialExternalPluginCatalogSnapshotStore | undefined> {
+  if (params.snapshotStore !== undefined) {
+    return params.snapshotStore ?? undefined;
+  }
+  const { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } =
+    await import("./official-external-plugin-catalog-snapshot-store.js");
+  return createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
+    ...(params.env ? { env: params.env } : {}),
+    ...(params.stateDir ? { stateDir: params.stateDir } : {}),
+    ...(params.stateDatabasePath ? { stateDatabasePath: params.stateDatabasePath } : {}),
+  });
+}
+
 export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   feedUrl?: string;
   fetchImpl?: FetchLike;
@@ -513,7 +531,10 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   ifNoneMatch?: string;
   ifModifiedSince?: string;
   expectedSha256?: string;
-  snapshotStore?: HostedOfficialExternalPluginCatalogSnapshotStore;
+  snapshotStore?: HostedOfficialExternalPluginCatalogSnapshotStore | null;
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+  stateDatabasePath?: string;
   now?: () => Date;
 }): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
   let url: URL;
@@ -522,6 +543,12 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   } catch (err) {
     return bundledFallbackResult(err);
   }
+  const snapshotStore = await resolveHostedCatalogSnapshotStore({
+    snapshotStore: params?.snapshotStore,
+    env: params?.env,
+    stateDir: params?.stateDir,
+    stateDatabasePath: params?.stateDatabasePath,
+  });
   const headers = new Headers();
   const ifNoneMatch = normalizeOptionalString(params?.ifNoneMatch);
   const ifModifiedSince = normalizeOptionalString(params?.ifModifiedSince);
@@ -562,7 +589,7 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     if (response.status === 304) {
       return await snapshotOrBundledFallbackResult({
         error: "hosted catalog feed returned HTTP 304",
-        snapshotStore: params?.snapshotStore,
+        snapshotStore,
         url: url.href,
         metadata: base,
         expectedSha256,
@@ -573,7 +600,7 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     if (!response.ok) {
       return await snapshotOrBundledFallbackResult({
         error: `hosted catalog feed returned HTTP ${response.status}`,
-        snapshotStore: params?.snapshotStore,
+        snapshotStore,
         url: url.href,
         metadata: base,
         expectedSha256,
@@ -592,7 +619,7 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     if (expectedSha256 && expectedSha256 !== checksum) {
       return await snapshotOrBundledFallbackResult({
         error: `hosted catalog feed checksum mismatch: expected ${expectedSha256}`,
-        snapshotStore: params?.snapshotStore,
+        snapshotStore,
         url: url.href,
         metadata,
         expectedSha256,
@@ -604,7 +631,7 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     if (!isOfficialExternalPluginCatalogFeed(raw)) {
       return await snapshotOrBundledFallbackResult({
         error: "hosted catalog feed did not match a supported schema version",
-        snapshotStore: params?.snapshotStore,
+        snapshotStore,
         url: url.href,
         metadata,
         expectedSha256,
@@ -612,11 +639,11 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         ifModifiedSince,
       });
     }
-    await params?.snapshotStore
+    await snapshotStore
       ?.write({
         body,
         metadata,
-        savedAt: (params.now?.() ?? new Date()).toISOString(),
+        savedAt: (params?.now?.() ?? new Date()).toISOString(),
       })
       .catch(() => undefined);
     return {
@@ -630,7 +657,7 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   } catch (err) {
     return await snapshotOrBundledFallbackResult({
       error: err,
-      snapshotStore: params?.snapshotStore,
+      snapshotStore,
       url: url.href,
       expectedSha256,
       ifNoneMatch,

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -698,6 +698,17 @@ export interface NodePairingPending {
   version: string | null;
 }
 
+export interface OfficialExternalPluginCatalogSnapshots {
+  body: string;
+  checksum: string;
+  etag: string | null;
+  feed_url: string;
+  last_modified: string | null;
+  saved_at: string;
+  status: number;
+  updated_at_ms: number;
+}
+
 export interface PluginBindingApprovals {
   account_id: string;
   approved_at: number;
@@ -989,6 +1000,7 @@ export interface DB {
   node_host_config: NodeHostConfig;
   node_pairing_paired: NodePairingPaired;
   node_pairing_pending: NodePairingPending;
+  official_external_plugin_catalog_snapshots: OfficialExternalPluginCatalogSnapshots;
   plugin_binding_approvals: PluginBindingApprovals;
   plugin_blob_entries: PluginBlobEntries;
   plugin_state_entries: PluginStateEntries;

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -475,6 +475,20 @@ CREATE TABLE IF NOT EXISTS installed_plugin_index (
 CREATE INDEX IF NOT EXISTS idx_installed_plugin_index_generated
   ON installed_plugin_index(generated_at_ms DESC, index_key);
 
+CREATE TABLE IF NOT EXISTS official_external_plugin_catalog_snapshots (
+  feed_url TEXT NOT NULL PRIMARY KEY,
+  body TEXT NOT NULL,
+  status INTEGER NOT NULL,
+  etag TEXT,
+  last_modified TEXT,
+  checksum TEXT NOT NULL,
+  saved_at TEXT NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_official_external_plugin_catalog_snapshots_updated
+  ON official_external_plugin_catalog_snapshots(updated_at_ms DESC, feed_url);
+
 CREATE TABLE IF NOT EXISTS gateway_restart_sentinel (
   sentinel_key TEXT NOT NULL PRIMARY KEY,
   version INTEGER NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -470,6 +470,20 @@ CREATE TABLE IF NOT EXISTS installed_plugin_index (
 CREATE INDEX IF NOT EXISTS idx_installed_plugin_index_generated
   ON installed_plugin_index(generated_at_ms DESC, index_key);
 
+CREATE TABLE IF NOT EXISTS official_external_plugin_catalog_snapshots (
+  feed_url TEXT NOT NULL PRIMARY KEY,
+  body TEXT NOT NULL,
+  status INTEGER NOT NULL,
+  etag TEXT,
+  last_modified TEXT,
+  checksum TEXT NOT NULL,
+  saved_at TEXT NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_official_external_plugin_catalog_snapshots_updated
+  ON official_external_plugin_catalog_snapshots(updated_at_ms DESC, feed_url);
+
 CREATE TABLE IF NOT EXISTS gateway_restart_sentinel (
   sentinel_key TEXT NOT NULL PRIMARY KEY,
   version INTEGER NOT NULL,


### PR DESCRIPTION
<!-- hosted-feed-stack:start -->
## Hosted Marketplace Feed Stack

This is PR4 in the hosted marketplace feed stack. The stack should land in order, with maintainer review at each step before the later PRs wire hosted marketplace data into broader user flows.

1. #95846: refactor the bundled external plugin catalog toward the feed-shaped data model. Merged.
2. #95868: add the lazy hosted marketplace feed loader for the configured public feed URL, with guarded HTTPS fetch, checksum, schema, size, timeout, and bundled fallback behavior. Merged.
3. #95877: add accepted hosted snapshot fallback so a failed or unchanged hosted fetch can reuse the last valid feed payload. Merged.
4. #95964: persist hosted marketplace feed snapshots in OpenClaw state. This PR.
5. #95969: add marketplace source profile validation for hosted feed install candidates.
6. #95981: add configurable `marketplaces.feeds` and `marketplaces.sources` profiles.
7. #96155: add `openclaw plugins marketplace refresh` as the explicit manual snapshot refresh path.
8. #96158: add `openclaw plugins marketplace entries` as the explicit manual read path over hosted, snapshot, or bundled fallback entries.
9. #96194: add marketplace feed telemetry.

The broader follow-up after this stack is to decide whether and how marketplace entries should feed install/search/startup behavior, add automatic conditional refresh using `ETag` / `Last-Modified`, or move to ClawHub producer-side validation for `/v1/feeds/plugins` and `/v1/feeds/skills`.
<!-- hosted-feed-stack:end -->

## Stack Context

This is step 4 in the hosted feed rollout. It has been restacked directly on current `main` after #95846, #95868, and #95877 merged, so the diff is limited to the persistent snapshot storage layer and its tests.

## RFC Alignment

This PR is the persistent snapshot plumbing for the hosted catalog loader. It implements the SQLite storage part of RFC #19 rollout item 6: store the latest accepted hosted feed snapshot in OpenClaw state so the client can keep using a last-known-good catalog during HTTP 304 responses or transient hosted-feed failures.

It intentionally does not claim the full lifecycle refresh implementation. Named feed/source profiles, source-ref validation, signed envelopes, scheduled refresh, `maxStale`, and feed freshness reporting are still follow-up PRs.

## Maintainer Boundary Decision

Maintainer review accepts this PR as the durable cache layer only: persisted hosted feed bodies are inert snapshot material, not trusted install, search, startup, or source authority. Later stack PRs must explicitly validate source profiles and feed trust rules before consuming persisted entries for marketplace behavior.

The default shared-state SQLite store is intentional for hosted loader resilience after HTTP 304 or transient feed failures. `snapshotStore: null` remains the explicit opt-out for callers and tests that must avoid persistence.

## Summary
- Adds a SQLite-backed snapshot store for hosted official external plugin catalog responses in OpenClaw state.
- Makes the hosted feed loader use that state-backed store by default while preserving `snapshotStore: null` for callers and tests that need persistence disabled.
- Persists the feed body plus URL, status, ETag, Last-Modified, locally computed checksum, save time, and update time.
- Lets HTTP 304 and transient hosted feed failures use the last known good state snapshot before falling back to the bundled catalog.
- Keeps snapshots keyed by the resolved feed URL, which leaves room for later named feed/source profile work without mixing feeds.

## Deliberately Not Included

- Named local feed/source profile configuration.
- `sourceRef` validation against configured source profiles.
- Authenticated feed URLs or secret-reference resolution.
- Signed feed envelopes or trust-key configuration.
- Background refresh scheduling, `maxStale`, or stale-catalog status reporting.
- Search, install UX, skills, or telemetry.

Those remain follow-up steps after the core fallback storage path is reviewable.

## Validation

- `pnpm exec oxlint --deny-warnings src/plugins/official-external-plugin-catalog.ts src/plugins/official-external-plugin-catalog.test.ts src/plugins/official-external-plugin-catalog-snapshot-store.ts src/state/openclaw-state-schema.generated.ts`
- `pnpm exec oxfmt --check src/plugins/official-external-plugin-catalog.ts src/plugins/official-external-plugin-catalog.test.ts src/plugins/official-external-plugin-catalog-snapshot-store.ts src/state/openclaw-state-schema.generated.ts src/state/openclaw-state-db.generated.d.ts`
- `pnpm db:kysely:check`
- `pnpm lint:kysely`
- `pnpm check:database-first-legacy-stores`
- `pnpm check:architecture`
- `pnpm tsgo:core`
- `git diff --check`
- `CI=1 node scripts/test-projects.mjs src/plugins/official-external-plugin-catalog.test.ts` - 35 tests passed
- `codex review --base origin/main` - no actionable correctness issues found

## Real behavior proof

Behavior or issue addressed:
This PR persists accepted hosted marketplace feed snapshots in OpenClaw SQLite state so the hosted catalog loader can reuse a last-known-good payload after live HTTP 304 responses or transient hosted-feed failures.

Real environment tested:
Windows host, `C:\src\openclaw-prflow\.worktrees\pr-95964`, source harness on commit `372ec63c99`, Node with `tsx`, isolated state directory `C:\\tmp\\openclaw-feeds-proof\\pr95964-live-snapshot-kysely`, and the live ClawHub feed endpoint `https://clawhub.ai/v1/feeds/plugins`.

Exact steps or command run after this patch:
1. Removed the isolated state directory.
2. Ran a source harness that called `loadHostedOfficialExternalPluginCatalogEntries({ stateDir, timeoutMs: 30000, chunkTimeoutMs: 30000 })` against the live ClawHub feed.
3. Re-ran the same loader with `ifNoneMatch` set to the live ETag returned by step 2.
4. Read the persisted snapshot through `createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({ stateDir })` and checked `state/openclaw.sqlite` on disk.

Evidence after fix:
The live harness printed:

```json
{
  "repoHead": "372ec63c99",
  "stateDir": "C:/tmp/openclaw-feeds-proof/pr95964-live-snapshot-kysely",
  "sqlitePath": "C:\\\\tmp\\\\openclaw-feeds-proof\\\\pr95964-live-snapshot-kysely\\\\state\\\\openclaw.sqlite",
  "sqliteBytes": 4096,
  "firstLoad": {
    "source": "hosted",
    "feedId": "clawhub-official",
    "schemaVersion": 1,
    "sequence": 16,
    "entries": 59,
    "etag": "\"sha256:cf3d85c1d6ede1907ca265e9b214ac6ff1c715c90c30ec65e8017addb590e32d-gzip\"",
    "lastModified": "Sat, 27 Jun 2026 18:43:36 GMT",
    "checksum": "sha256:cf3d85c1d6ede1907ca265e9b214ac6ff1c715c90c30ec65e8017addb590e32d"
  },
  "persistedSnapshot": {
    "feedUrl": "https://clawhub.ai/v1/feeds/plugins",
    "status": 200,
    "checksum": "sha256:cf3d85c1d6ede1907ca265e9b214ac6ff1c715c90c30ec65e8017addb590e32d",
    "savedAt": "2026-06-28T00:08:40.573Z",
    "bodyBytes": 21942
  },
  "secondConditionalLoad": {
    "source": "hosted-snapshot",
    "entries": 59,
    "feedId": "clawhub-official",
    "sequence": 16,
    "error": "hosted catalog feed returned HTTP 304",
    "status": 200,
    "etag": "\"sha256:cf3d85c1d6ede1907ca265e9b214ac6ff1c715c90c30ec65e8017addb590e32d-gzip\""
  }
}
```

Observed result after fix:
The first live load fetched the hosted feed and created the SQLite state database. The second conditional load received HTTP 304 from ClawHub and returned `source: "hosted-snapshot"` with the same 59 entries from the persisted SQLite snapshot.

What was not tested:
This proof did not exercise a packaged OpenClaw binary or CLI command path. The source harness covered the hosted loader's default persistent store wiring, and the focused tests cover snapshot validation, opt-out behavior, schema shape, and transient failure fallback.



