### PR TITLE
fix(heartbeat): recognize HEARTBEAT_OK through reasoning blocks (fixes #95796)

### DIFF
--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -124,6 +124,28 @@ describe("isHeartbeatOkResponse", () => {
     expect(isHeartbeatOkResponse(toolCallOnlyMessage)).toBe(false);
   });
 
+  it("recognizes heartbeat OK acknowledgements paired with reasoning blocks", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: [
+          { type: "reasoning", reasoning: "Checking system status..." },
+          { type: "text", text: "HEARTBEAT_OK" },
+        ],
+      }),
+    ).toBe(true);
+
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Let me verify." },
+          { type: "text", text: "HEARTBEAT_OK" },
+        ],
+      }),
+    ).toBe(true);
+  });
+
   it("respects ackMaxChars overrides", () => {
     expect(
       isHeartbeatOkResponse(

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -254,7 +254,12 @@ function matchesHeartbeatPromptText(text: string, prompt: string | undefined): b
   return Boolean(normalized) && (text === normalized || text.startsWith(`${normalized}\n`));
 }
 
-function resolveMessageText(content: unknown): { text: string; hasNonTextContent: boolean } {
+const REASONING_BLOCK_TYPES = new Set(["reasoning", "thinking"]);
+
+function resolveMessageText(
+  content: unknown,
+  options?: { allowReasoningBlocks?: boolean },
+): { text: string; hasNonTextContent: boolean } {
   if (typeof content === "string") {
     return { text: content, hasNonTextContent: false };
   }
@@ -269,6 +274,9 @@ function resolveMessageText(content: unknown): { text: string; hasNonTextContent
       continue;
     }
     if (block.type !== "text" && block.type !== "input_text" && block.type !== "output_text") {
+      if (options?.allowReasoningBlocks && REASONING_BLOCK_TYPES.has(block.type as string)) {
+        continue;
+      }
       hasNonTextContent = true;
       continue;
     }
@@ -336,7 +344,9 @@ export function isHeartbeatOkResponse(
   if (hasAssistantToolCall(message)) {
     return false;
   }
-  const { text, hasNonTextContent } = resolveMessageText(message.content);
+  const { text, hasNonTextContent } = resolveMessageText(message.content, {
+    allowReasoningBlocks: true,
+  });
   if (hasNonTextContent) {
     return false;
   }


### PR DESCRIPTION
## What Problem This Solves

`isHeartbeatOkResponse` rejected heartbeat acknowledgements whenever the assistant message contained a non-text block such as `reasoning` or `thinking`, even when the visible text was just `HEARTBEAT_OK`. This caused `filterHeartbeatTranscriptArtifacts` to leave heartbeat prompt/ack pairs in the transcript, inflating context and confusing the model.

## Why This Change Was Made

`resolveMessageText` treated every block other than `text`/`input_text`/`output_text` as non-text content and made `isHeartbeatOkResponse` bail out. Reasoning/thinking blocks are internal model artifacts, not user-visible content, so they should not prevent pruning a short `HEARTBEAT_OK` ack.

## User Impact

Users with models that emit reasoning/thinking blocks during heartbeat responses will no longer see those transient turns accumulate in the conversation context.

## Evidence

- Added unit tests in `src/auto-reply/heartbeat-filter.test.ts` covering `reasoning` and `thinking` blocks paired with `HEARTBEAT_OK`.
- Existing tests continue to reject tool-call-only and meaningful non-heartbeat responses.
- `pnpm test src/auto-reply/heartbeat-filter.test.ts --run` passes locally.