### PR TITLE
perf(ci): widen main test fanout and move codeql off blacksmith

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1177,7 +1177,9 @@ jobs:
     timeout-minutes: ${{ matrix.timeout_minutes || 60 }}
     strategy:
       fail-fast: false
-      max-parallel: 12
+      # The canonical main path waits for the admission debounce above, so
+      # modestly widen this large matrix without recreating registration bursts.
+      max-parallel: 16
       matrix: ${{ fromJson(needs.preflight.outputs.checks_node_core_nondist_matrix) }}
     steps:
       - name: Checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,12 +22,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - ".github/actions/**"
-      - ".github/codeql/**"
-      - ".github/workflows/**"
-      - "packages/**"
-      - "src/**"
   schedule:
     - cron: "0 6 * * *"
 
@@ -55,32 +49,32 @@ jobs:
         include:
           - language: javascript-typescript
             category: core-auth-secrets
-            runs_on: blacksmith-8vcpu-ubuntu-2404
+            runs_on: ubuntu-24.04
             timeout_minutes: 25
             config_file: ./.github/codeql/codeql-core-auth-secrets-critical-security.yml
           - language: javascript-typescript
             category: channel-runtime-boundary
-            runs_on: blacksmith-8vcpu-ubuntu-2404
+            runs_on: ubuntu-24.04
             timeout_minutes: 25
             config_file: ./.github/codeql/codeql-channel-runtime-boundary-critical-security.yml
           - language: javascript-typescript
             category: network-ssrf-boundary
-            runs_on: blacksmith-4vcpu-ubuntu-2404
+            runs_on: ubuntu-24.04
             timeout_minutes: 25
             config_file: ./.github/codeql/codeql-network-ssrf-boundary-critical-security.yml
           - language: javascript-typescript
             category: mcp-process-tool-boundary
-            runs_on: blacksmith-4vcpu-ubuntu-2404
+            runs_on: ubuntu-24.04
             timeout_minutes: 25
             config_file: ./.github/codeql/codeql-mcp-process-tool-boundary-critical-security.yml
           - language: javascript-typescript
             category: plugin-trust-boundary
-            runs_on: blacksmith-4vcpu-ubuntu-2404
+            runs_on: ubuntu-24.04
             timeout_minutes: 25
             config_file: ./.github/codeql/codeql-plugin-trust-boundary-critical-security.yml
           - language: actions
             category: actions
-            runs_on: blacksmith-8vcpu-ubuntu-2404
+            runs_on: ubuntu-24.04
             timeout_minutes: 10
             config_file: ./.github/codeql/codeql-actions-critical-security.yml
     steps:

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -141,7 +141,7 @@ describe("ci workflow guards", () => {
       "github.event_name == 'pull_request'",
     );
     expect(workflow.jobs["checks-fast-core"].strategy["max-parallel"]).toBe(8);
-    expect(workflow.jobs["checks-node-core-test-nondist-shard"].strategy["max-parallel"]).toBe(12);
+    expect(workflow.jobs["checks-node-core-test-nondist-shard"].strategy["max-parallel"]).toBe(16);
     expect(workflow.jobs["checks-fast-plugin-contracts-shard"].strategy["max-parallel"]).toBe(8);
     expect(workflow.jobs["checks-fast-channel-contracts-shard"].strategy["max-parallel"]).toBe(8);
     expect(workflow.jobs["check-shard"].strategy["max-parallel"]).toBe(8);


### PR DESCRIPTION
## Summary

- widen the canonical OpenClaw non-dist Node test matrix from 12 to 16 concurrent jobs after the existing main-branch admission debounce
- run the primary CodeQL security matrix on GitHub-hosted `ubuntu-24.04` runners instead of Blacksmith
- trigger that CodeQL workflow for every push to `main`, while retaining PR path filtering and existing cancellation

This keeps the existing 74-shard test graph intact. The goal is lower main-branch wall time without increasing the number of runner registrations that caused the recent burst incident.

## Verification

- `git diff --check`
- Ruby YAML parse for `.github/workflows/ci.yml` and `.github/workflows/codeql.yml`
- autoreview: clean, no accepted/actionable findings
- current live evidence: CodeQL main runs were completing in roughly 95 seconds, with Blacksmith usage of 6,273 jobs / 73,392 billable minutes in the last 24h; moving this matrix off Blacksmith removes that registration load

`actionlint` is not installed in the local environment.
