### PR TITLE
Fix/skill loading catch scope

### DIFF
--- a/src/skills/loading/session-resilience.test.ts
+++ b/src/skills/loading/session-resilience.test.ts
@@ -1,0 +1,148 @@
+// Session resilience tests cover error isolation during skill directory scanning.
+// A single broken skill file must not prevent other skills in the same directory from loading.
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempDir } from "../../test-utils/temp-dir.js";
+import { loadSkillsFromDir } from "./session.js";
+
+describe("loadSkillsFromDir error isolation", () => {
+  it("continues loading other skills when one root .md file throws during read", async () => {
+    await withTempDir("openclaw-skill-resilience-", async (tmpDir) => {
+      // Create two .md skill files in the root directory
+      const goodSkillPath = path.join(tmpDir, "good-skill.md");
+      const badSkillPath = path.join(tmpDir, "bad-skill.md");
+
+      // Good skill: valid frontmatter
+      await fsPromises.writeFile(
+        goodSkillPath,
+        ["---", "name: good-skill", "description: A working skill", "---", "# Good Skill", ""].join(
+          "\n",
+        ),
+        "utf-8",
+      );
+
+      // Bad skill: valid frontmatter but we'll make it unreadable via permissions
+      await fsPromises.writeFile(
+        badSkillPath,
+        ["---", "name: bad-skill", "description: A broken skill", "---", "# Bad Skill", ""].join(
+          "\n",
+        ),
+        "utf-8",
+      );
+
+      // Make the bad file unreadable (chmod 000)
+      fs.chmodSync(badSkillPath, 0o000);
+
+      const result = loadSkillsFromDir({ dir: tmpDir, source: "test" });
+
+      // The good skill should still be loaded
+      const goodSkill = result.skills.find((s) => s.name === "good-skill");
+      expect(goodSkill).toBeDefined();
+      expect(goodSkill!.description).toBe("A working skill");
+
+      // There should be a diagnostic warning for the bad skill
+      const warningForBad = result.diagnostics.find(
+        (d) => d.type === "warning" && d.message.includes("bad-skill.md"),
+      );
+      expect(warningForBad).toBeDefined();
+
+      // Restore permissions so cleanup can delete it
+      try {
+        fs.chmodSync(badSkillPath, 0o644);
+      } catch {
+        // best effort
+      }
+    });
+  });
+
+  it("continues loading other skills when one subdirectory skill throws", async () => {
+    await withTempDir("openclaw-skill-resilience-", async (tmpDir) => {
+      // good-skill/ directory with valid SKILL.md
+      const goodDir = path.join(tmpDir, "good-skill");
+      await fsPromises.mkdir(goodDir, { recursive: true });
+      await fsPromises.writeFile(
+        path.join(goodDir, "SKILL.md"),
+        [
+          "---",
+          "name: good-skill",
+          "description: Working subdirectory skill",
+          "---",
+          "# Good",
+          "",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      // bad-skill/ directory with SKILL.md that has invalid frontmatter (unparseable)
+      const badDir = path.join(tmpDir, "bad-skill");
+      await fsPromises.mkdir(badDir, { recursive: true });
+      await fsPromises.writeFile(
+        path.join(badDir, "SKILL.md"),
+        "---\nthis is not: valid yaml: [[[nope\n---\n# Broken\n",
+        "utf-8",
+      );
+
+      // another-skill/ directory with valid SKILL.md
+      const anotherDir = path.join(tmpDir, "another-skill");
+      await fsPromises.mkdir(anotherDir, { recursive: true });
+      await fsPromises.writeFile(
+        path.join(anotherDir, "SKILL.md"),
+        [
+          "---",
+          "name: another-skill",
+          "description: Another working skill",
+          "---",
+          "# Another",
+          "",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const result = loadSkillsFromDir({ dir: tmpDir, source: "test" });
+
+      // Both good skills should be loaded despite the bad one
+      const goodSkill = result.skills.find((s) => s.name === "good-skill");
+      const anotherSkill = result.skills.find((s) => s.name === "another-skill");
+      expect(goodSkill).toBeDefined();
+      expect(anotherSkill).toBeDefined();
+
+      // bad-skill should not be loaded (missing description after parse failure)
+      const badSkill = result.skills.find((s) => s.name === "bad-skill");
+      expect(badSkill).toBeUndefined();
+
+      // There should be diagnostics for the bad skill
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("returns empty result with no diagnostics for a non-existent directory", () => {
+    const result = loadSkillsFromDir({
+      dir: path.join(os.tmpdir(), "openclaw-nonexistent-" + Date.now()),
+      source: "test",
+    });
+
+    expect(result.skills).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("loads all valid root .md files when no errors occur", async () => {
+    await withTempDir("openclaw-skill-resilience-", async (tmpDir) => {
+      for (const name of ["alpha", "beta", "gamma"]) {
+        const filePath = path.join(tmpDir, `${name}.md`);
+        await fsPromises.writeFile(
+          filePath,
+          ["---", `name: ${name}`, `description: ${name} skill`, "---", `# ${name}`, ""].join("\n"),
+          "utf-8",
+        );
+      }
+
+      const result = loadSkillsFromDir({ dir: tmpDir, source: "test" });
+
+      expect(result.skills.map((s) => s.name).toSorted()).toEqual(["alpha", "beta", "gamma"]);
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+});

--- a/src/skills/loading/session.ts
+++ b/src/skills/loading/session.ts
@@ -1,5 +1,5 @@
 // Session skill helpers resolve skills attached to a session and its transcript state.
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { Dirent, existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import ignore from "ignore";
@@ -144,10 +144,16 @@ function loadSkillsFromDirInternal(
   const ig = ignoreMatcher ?? ignore();
   addIgnoreRules(ig, dir, root);
 
+  let entries: Dirent[];
   try {
-    const entries = readdirSync(dir, { withFileTypes: true });
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return { skills, diagnostics };
+  }
 
-    for (const entry of entries) {
+  // First pass: check for SKILL.md at this directory level
+  for (const entry of entries) {
+    try {
       if (entry.name !== "SKILL.md") {
         continue;
       }
@@ -174,9 +180,19 @@ function loadSkillsFromDirInternal(
       }
       diagnostics.push(...result.diagnostics);
       return { skills, diagnostics };
+    } catch (err) {
+      diagnostics.push({
+        type: "warning",
+        message: `Failed to load skill from ${entry.name}: ${err instanceof Error ? err.message : String(err)}`,
+        path: join(dir, entry.name),
+      });
+      continue;
     }
+  }
 
-    for (const entry of entries) {
+  // Second pass: recurse into subdirectories and load root .md files
+  for (const entry of entries) {
+    try {
       if (entry.name.startsWith(".")) {
         continue;
       }
@@ -224,8 +240,15 @@ function loadSkillsFromDirInternal(
         skills.push(result.skill);
       }
       diagnostics.push(...result.diagnostics);
+    } catch (err) {
+      diagnostics.push({
+        type: "warning",
+        message: `Failed to load skill from ${entry.name}: ${err instanceof Error ? err.message : String(err)}`,
+        path: join(dir, entry.name),
+      });
+      continue;
     }
-  } catch {}
+  }
 
   return { skills, diagnostics };
 }


### PR DESCRIPTION
## Summary

`loadSkillsFromDirInternal` in `src/skills/loading/session.ts` wrapped both directory traversal `for` loops inside a single `try { ... } catch {}` block. If any single skill entry triggered an unexpected error during iteration (permission denied, I/O error, parse exception), the entire loop terminated, silently skipping all remaining skills in that directory — with zero diagnostic output.

This patch moves the `try/catch` into each loop iteration so that a single broken entry only affects itself, emits a `{ type: "warning", message, path }` diagnostic, and continues processing the rest of the directory. The `readdirSync` call retains its own `try/catch` since an unreadable directory means nothing can be iterated.

## Verification

- `npx tsx scripts/verify-skill-resilience.mjs`
  - `Skills loaded: 2`
  - `  - good-skill-a: First good skill`
  - `  - good-skill-b: Second good skill`
  - `Diagnostics: 1`
  - `  - [warning] EACCES: permission denied, open '…/bad-skill/SKILL.md' (path: …/bad-skill/SKILL.md)`
  - `PASS: Good skills loaded despite bad skill; diagnostic warning emitted for bad-skill.`
- `npx vitest run src/skills/loading/session-resilience.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests  4 passed (4)`
- `npx vitest run src/skills/loading/skills.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests  21 passed (21)`
- `npx vitest run src/skills/loading/frontmatter.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests  8 passed (8)`

## Real behavior proof

Behavior addressed: A single unreadable or corrupt skill file no longer prevents other skills in the same directory from loading; the error is surfaced as a diagnostic warning instead of being silently swallowed.

Real environment tested: Local checkout on branch `fix/skill-loading-catch-scope`.

Exact steps or command run after this patch:
- `npx tsx scripts/verify-skill-resilience.mjs` — creates a directory with 3 subdirectory skills (2 valid, 1 chmod 000), calls `loadSkillsFromDir`, and reports results
- `npx vitest run src/skills/loading/session-resilience.test.ts` — dedicated resilience test suite
- `npx vitest run src/skills/loading/skills.test.ts` — existing skills integration tests
- `npx vitest run src/skills/loading/frontmatter.test.ts` — existing frontmatter parsing tests

Evidence after fix:
- `verify-skill-resilience.mjs` output:
  - `Skills loaded: 2` (`good-skill-a`, `good-skill-b` both loaded despite `bad-skill` being unreadable)
  - `Diagnostics: 1` (`[warning] EACCES: permission denied … bad-skill/SKILL.md`)
  - Verdict: `PASS`
- `session-resilience.test.ts`: `Test Files  1 passed (1)`, `Tests  4 passed (4)` — covers permission-denied root .md, malformed subdirectory SKILL.md, non-existent directory, and clean loading with no diagnostics
- `skills.test.ts`: `Test Files  1 passed (1)`, `Tests  21 passed (21)` — no regressions in existing skill loading behavior
- `frontmatter.test.ts`: `Test Files  1 passed (1)`, `Tests  8 passed (8)` — no regressions in frontmatter parsing
- Combined: `Test Files  3 passed (3)`, `Tests  33 passed (33)`, `Duration  2.58s`

Observed result after fix: A skill directory containing a mix of valid and broken entries now loads all valid skills and emits per-entry warning diagnostics for the broken ones, instead of aborting the entire scan on the first error.