### PR TITLE
fix(codex): allow configured apps with disabled base defaults

### DIFF
--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -254,7 +254,7 @@ describe("Codex plugin thread config", () => {
     const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "app/list") {
         appListParams.push(params as v2.AppsListParams);
-        return { data: [appInfo("google-calendar-app", true)], nextCursor: null };
+        return { data: [appInfo("google-calendar-app", true, false)], nextCursor: null };
       }
       if (method === "plugin/list") {
         return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
@@ -375,7 +375,7 @@ describe("Codex plugin thread config", () => {
           allowDestructiveActions: true,
           destructiveApprovalMode: "allow",
         },
-        message: "google-calendar-app is not accessible or enabled for google-calendar.",
+        message: "google-calendar-app is not accessible for google-calendar.",
       },
     ]);
   });
@@ -572,9 +572,7 @@ describe("Codex plugin thread config", () => {
     let installed = false;
     const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "plugin/list") {
-        return pluginList([
-          pluginSummary("google-calendar", { installed, enabled: installed }),
-        ]);
+        return pluginList([pluginSummary("google-calendar", { installed, enabled: installed })]);
       }
       if (method === "plugin/read") {
         return pluginDetail("google-calendar", [appSummary("google-calendar-app")]);

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -232,11 +232,11 @@ export async function buildCodexPluginThreadConfig(
     }
     pluginAppIds[record.policy.configKey] = [...record.ownedAppIds].toSorted();
     for (const app of resolveThreadConfigAppsForRecord({ record, inventory })) {
-      if (!app.accessible || !app.enabled) {
+      if (!app.accessible) {
         diagnostics.push({
           code: "app_not_ready",
           plugin: record.policy,
-          message: `${app.id} is not accessible or enabled for ${record.policy.pluginName}.`,
+          message: `${app.id} is not accessible for ${record.policy.pluginName}.`,
         });
         continue;
       }
@@ -434,7 +434,7 @@ function shouldForceRefreshForNotReadyPluginApps(
     (record) =>
       record.appOwnership === "proven" &&
       record.ownedAppIds.length > 0 &&
-      (record.apps.length === 0 || record.apps.some((app) => !app.accessible || !app.enabled)),
+      (record.apps.length === 0 || record.apps.some((app) => !app.accessible)),
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an explicitly configured Codex app plugin could not be
enabled for a gateway thread when the app was accessible and ownership-proven
but its base profile intentionally reported `isEnabled = false`.

## Why This Change Was Made

OpenClaw now treats explicit plugin configuration plus proven ownership and app
accessibility as the positive per-thread grant. Base-profile enablement is no
longer required, while inaccessible, unowned, disabled, and activation-failed
apps retain their existing fail-closed paths.

## User Impact

Operators can keep Codex apps disabled by default in the devbox profile and
still grant only the configured plugin-owned app for a thread. This does not
enable unconfigured apps or bypass Codex managed requirements.

## Evidence

- `node scripts/run-vitest.mjs run extensions/codex/src/app-server/plugin-thread-config.test.ts` — 16 tests passed.
- `node_modules/oxfmt/bin/oxfmt --check extensions/codex/src/app-server/plugin-thread-config.ts extensions/codex/src/app-server/plugin-thread-config.test.ts` — passed.
- `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/tsdown-build.mjs` — passed.
- `node scripts/runtime-postbuild.mjs` — passed.
- `git diff --check -- extensions/codex/src/app-server/plugin-thread-config.ts extensions/codex/src/app-server/plugin-thread-config.test.ts` — passed.
