### PR TITLE
ci: fail QA profile evidence on QA failures

### DIFF
--- a/.github/workflows/maturity-scorecard.yml
+++ b/.github/workflows/maturity-scorecard.yml
@@ -89,7 +89,6 @@ jobs:
     with:
       ref: ${{ needs.validate_selected_ref.outputs.selected_revision }}
       qa_profile: all
-      fail_on_qa_failure: false
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 

--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -20,11 +20,6 @@ on:
         required: true
         default: release
         type: string
-      fail_on_qa_failure:
-        description: Fail the workflow when the QA profile command exits non-zero
-        required: false
-        default: true
-        type: boolean
   workflow_call:
     inputs:
       ref:
@@ -40,11 +35,6 @@ on:
         description: Taxonomy QA profile id to run
         required: true
         type: string
-      fail_on_qa_failure:
-        description: Fail the reusable workflow when the QA profile command exits non-zero
-        required: false
-        default: false
-        type: boolean
     secrets:
       OPENAI_API_KEY:
         description: OpenAI API key used by live QA profile scenarios
@@ -367,8 +357,8 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
-      - name: Fail if configured QA gate failed
-        if: always() && inputs.fail_on_qa_failure
+      - name: Fail if QA profile failed
+        if: always()
         env:
           QA_EXIT_CODE: ${{ steps.run_profile.outputs.qa_exit_code }}
           QA_PROFILE: ${{ steps.profile.outputs.profile }}

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -578,16 +578,8 @@ describe("ci workflow guards", () => {
     const publishJob = maturityWorkflow.jobs.publish;
     const qaRunJob = qaEvidenceWorkflow.jobs.run_qa_profile;
 
-    expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs.fail_on_qa_failure).toEqual({
-      description: "Fail the workflow when the QA profile command exits non-zero",
-      required: false,
-      default: true,
-      type: "boolean",
-    });
-    expect(qaEvidenceWorkflow.on.workflow_call.inputs.fail_on_qa_failure).toMatchObject({
-      default: false,
-      type: "boolean",
-    });
+    expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs).not.toHaveProperty("fail_on_qa_failure");
+    expect(qaEvidenceWorkflow.on.workflow_call.inputs).not.toHaveProperty("fail_on_qa_failure");
     expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs.qa_profile).not.toHaveProperty("options");
     expect(qaEvidenceWorkflow.on.workflow_call.inputs.qa_profile.type).toBe("string");
     const validateProfileStep = qaRunJob.steps.find(
@@ -602,8 +594,8 @@ describe("ci workflow guards", () => {
     expect(generateJob.with).toMatchObject({
       ref: "${{ needs.validate_selected_ref.outputs.selected_revision }}",
       qa_profile: "all",
-      fail_on_qa_failure: false,
     });
+    expect(generateJob.with).not.toHaveProperty("fail_on_qa_failure");
 
     const generatedDownloadStep = publishJob.steps.find(
       (step) => step.name === "Download generated QA evidence artifact",
@@ -643,10 +635,8 @@ describe("ci workflow guards", () => {
       "if-no-files-found": "error",
     });
 
-    const qaFailStep = qaRunJob.steps.find(
-      (step) => step.name === "Fail if configured QA gate failed",
-    );
-    expect(qaFailStep.if).toBe("always() && inputs.fail_on_qa_failure");
+    const qaFailStep = qaRunJob.steps.find((step) => step.name === "Fail if QA profile failed");
+    expect(qaFailStep.if).toBe("always()");
   });
 
   it("keeps workflow guards in fast CI-routing checks", () => {


### PR DESCRIPTION
## Summary
- Remove the `fail_on_qa_failure` input from the QA profile evidence workflow.
- Make QA profile evidence always fail when the QA command exits non-zero, after artifact upload still runs.
- Update the maturity scorecard caller and workflow guard test to enforce the stricter contract.

## Verification
- `git diff --check origin/main...HEAD`
- `actionlint .github/workflows/qa-profile-evidence.yml .github/workflows/maturity-scorecard.yml`
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts`
