### PR TITLE
fix(utils): normalizeE164 returns "" when there are no digits

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -8,6 +8,7 @@ import { withEnv } from "./test-utils/env.js";
 import {
   CONFIG_DIR,
   ensureDir,
+  normalizeE164,
   pinConfigDir,
   resolveConfigDir,
   resolveHomeDir,
@@ -16,6 +17,25 @@ import {
   shortenHomePath,
   sleep,
 } from "./utils.js";
+
+describe("normalizeE164", () => {
+  it("normalizes phone-like input into loose E.164", () => {
+    expect(normalizeE164("+1 (555) 234-5678")).toBe("+15552345678");
+    expect(normalizeE164("15552345678")).toBe("+15552345678");
+    expect(normalizeE164("tel:+1-555-234-5678")).toBe("+15552345678");
+  });
+
+  it("returns an empty string when there are no digits to normalize", () => {
+    // Carriers report blocked caller id as a literal like "Anonymous", and a
+    // bare scheme such as "sms://" carries no number. These must not collapse to
+    // a stray "+" (not a valid E.164); returning "" lets callers fall back to
+    // their own sentinel (e.g. `from || "unknown"`).
+    expect(normalizeE164("Anonymous")).toBe("");
+    expect(normalizeE164("sms://")).toBe("");
+    expect(normalizeE164("")).toBe("");
+    expect(normalizeE164("+")).toBe("");
+  });
+});
 
 describe("ensureDir", () => {
   it("creates nested directory", async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,10 +56,14 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
 export function normalizeE164(number: string): string {
   const withoutPrefix = number.replace(/^[a-z][a-z0-9-]*:/i, "").trim();
   const digits = withoutPrefix.replace(/[^\d+]/g, "");
-  if (digits.startsWith("+")) {
-    return `+${digits.slice(1)}`;
+  const bare = digits.startsWith("+") ? digits.slice(1) : digits;
+  if (!bare) {
+    // No digits to normalize (e.g. an "Anonymous" caller id or a bare "sms://"
+    // scheme). Return "" rather than a stray "+", which is not a valid E.164 and
+    // silently defeats caller fallbacks like `from || "unknown"`.
+    return "";
   }
-  return `+${digits}`;
+  return `+${bare}`;
 }
 
 /** Promise-based sleep that clamps timer inputs through the shared timeout resolver. */


### PR DESCRIPTION
## What Problem This Solves

An inbound `From` that contains no digits normalizes to a stray `"+"`. Two real cases hit this:

- a blocked caller that the carrier reports as a literal `Anonymous`
- a bare scheme like `sms://` with no number attached

`"+"` is not a valid E.164 number, and because it is truthy, `deriveSessionKey`'s `from || "unknown"` fallback never fires. Those messages get keyed to a junk `"+"` session bucket instead of the intended `"unknown"`, so anything that special-cases the unknown sender silently skips them.

## Why This Change Was Made

`normalizeE164` only ever returned `` `+${digits}` ``, so empty `digits` produced a bare `"+"`. The fix returns `""` when there is nothing to normalize — which is exactly the value the internal caller already treats as "fall back to unknown". Valid numbers go through the same path as before.

## User Impact

Anonymous / unidentified senders now collapse to the intended `"unknown"` session bucket instead of a bogus `"+"` one, so unknown-sender handling and session bookkeeping behave as designed. No change for normal phone numbers.

## Evidence

The full vitest suite won't start on my Windows checkout (the `@rolldown` native binding is missing — npm optional-dependency bug), so I ran a small script that imports the real post-fix `normalizeE164` from `src/utils.ts`, puts it next to main's verbatim pre-fix implementation, and feeds both through the verbatim direct-chat branch of `deriveSessionKey` (`const from = ctx.From ? normalizeE164(ctx.From) : ""; return from || "unknown"`), using the repo's bundled `tsx`:

```text
$ node --import ./node_modules/tsx/dist/loader.mjs _repro_e164.mts
input                | before        | after  | sessionKey before | sessionKey after
---------------------|---------------|--------|-------------------|-----------------
"+1 (415) 555-0100"  | "+14155550100" | "+14155550100" | "+14155550100"    | "+14155550100"
"Anonymous"          | "+"           | ""     | "+"               | "unknown"
"sms://"             | "+"           | ""     | "+"               | "unknown"
"+"                  | "+"           | ""     | "+"               | "unknown"
""                   | "+"           | ""     | "unknown"         | "unknown"
```

So for a no-digit sender like `Anonymous` / `sms://` / `+`, the session key moves from the bogus `"+"` bucket to `"unknown"`, while a real number is untouched. (An empty `From` already short-circuited to `"unknown"` because the ternary never calls `normalizeE164`; the regression was specifically the non-empty no-digit inputs.)

Added a `normalizeE164` unit test in `src/utils.test.ts` covering both valid numbers and the no-digit cases; it fails on the old behavior and passes with this change (runs in CI).

## Note for maintainers

`normalizeE164` is re-exported through the plugin SDK, so this is an intentional contract change for invalid no-digit input: plugin callers that previously saw `"+"` will now see `""`. That seems correct since `"+"` was never a valid E.164 value, but happy to gate it behind a guard at the `deriveSessionKey` call site instead if you'd rather not change the exported helper's behavior.
