### PR TITLE
fix(discord): keep audio voice replies threaded

### DIFF
--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -345,7 +345,7 @@ describe("discordOutbound", () => {
       2,
     );
     expect(messageOptions.accountId).toBe("default");
-    expect(messageOptions.replyTo).toBeUndefined();
+    expect(messageOptions.replyTo).toBe("reply-1");
 
     const mediaCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1);
     expect(mediaCall[0]).toBe("channel:123456");
@@ -353,12 +353,37 @@ describe("discordOutbound", () => {
     const mediaOptions = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1, 2);
     expect(mediaOptions.accountId).toBe("default");
     expect(mediaOptions.mediaUrl).toBe("https://example.com/extra.png");
-    expect(mediaOptions.replyTo).toBeUndefined();
+    expect(mediaOptions.replyTo).toBe("reply-1");
     expect(result).toEqual({
       channel: "discord",
       messageId: "msg-1",
       channelId: "ch-1",
     });
+  });
+
+  it("keeps captured replyTo on audioAsVoice sends when replyToMode is batched", async () => {
+    await discordOutbound.sendPayload?.({
+      cfg: {},
+      to: "channel:123456",
+      text: "",
+      payload: {
+        text: "voice note",
+        mediaUrls: ["https://example.com/voice.ogg", "https://example.com/extra.png"],
+        audioAsVoice: true,
+      },
+      accountId: "default",
+      replyToId: "reply-1",
+      replyToMode: "batched",
+    });
+
+    expect(
+      mockObjectArg(hoisted.sendVoiceMessageDiscordMock, "sendVoiceMessageDiscord", 0, 2).replyTo,
+    ).toBe("reply-1");
+    expect(
+      hoisted.sendMessageDiscordMock.mock.calls.map(
+        (call) => (call[2] as { replyTo?: unknown } | undefined)?.replyTo,
+      ),
+    ).toEqual(["reply-1", "reply-1"]);
   });
 
   it("keeps replyToId on every internal audioAsVoice send when replyToMode is all", async () => {

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -84,13 +84,15 @@ export async function sendDiscordOutboundPayload(params: {
   const sendContext = await createDiscordPayloadSendContext(ctx);
 
   if (payload.audioAsVoice && mediaUrls.length > 0) {
+    // audioAsVoice emits one logical Discord reply across voice/text/media sends.
+    // Capture before helper calls consume implicit single-use reply targets.
+    const voiceReplyTo = sendContext.resolveReplyTo();
     let lastResult = await sendContext.withRetry(
       async () =>
-        await sendContext.sendVoice(
-          sendContext.target,
-          mediaUrls[0],
-          resolveDiscordDeliveryOptions(ctx, sendContext),
-        ),
+        await sendContext.sendVoice(sendContext.target, mediaUrls[0], {
+          ...resolveDiscordDeliveryOptions(ctx, sendContext),
+          replyTo: voiceReplyTo,
+        }),
     );
     if (payload.text?.trim()) {
       lastResult = await sendContext.withRetry(
@@ -98,6 +100,7 @@ export async function sendDiscordOutboundPayload(params: {
           await sendContext.send(sendContext.target, payload.text, {
             verbose: false,
             ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
+            replyTo: voiceReplyTo,
           }),
       );
     }
@@ -107,6 +110,7 @@ export async function sendDiscordOutboundPayload(params: {
           await sendContext.send(sendContext.target, "", {
             verbose: false,
             ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
+            replyTo: voiceReplyTo,
           }),
       );
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes #95977.

Fixes an issue where Discord `audioAsVoice` payloads with text or additional media would only thread the first internal voice send when `replyToMode` was single-use. The follow-up text and media sends belong to the same logical voice reply, but they resolved `replyTo` after the implicit reply target had already been consumed.

## Why This Change Was Made

The Discord `audioAsVoice` branch now captures the resolved reply target once before sending the voice payload, then reuses that captured value for the voice send, the text follow-up, and additional media sends. The normal non-`audioAsVoice` helper paths still resolve reply targets per send, so existing single-use behavior for ordinary multi-send payloads is unchanged.

## User Impact

Discord voice replies with accompanying text or extra media stay threaded to the source message instead of leaving follow-up sends unthreaded. Regular Discord payloads still only use an implicit single-use reply target on the first delivered message.

## Evidence

- RED before source change: after updating the `audioAsVoice` regression expectation, the current source failed because the text follow-up received `replyTo: undefined` instead of `"reply-1"`.
- Live Discord sandbox proof after fix: nonce `oc-audio-replyto-2026-06-23T03-28-44-084Z-1dde4ee6` sent a real seed message, then `discordOutbound.sendPayload` delivered real voice, text, and image follow-up messages. Independent Discord API readback confirmed all three payload messages referenced the seed; a redacted local artifact contains no token, channel id, or raw message ids.
- Focused regressions: `node scripts/run-vitest.mjs extensions/discord/src/outbound-adapter.test.ts -t audioAsVoice`
- Full touched test file: `node scripts/run-vitest.mjs extensions/discord/src/outbound-adapter.test.ts`
- Lint: `node scripts/run-oxlint.mjs extensions/discord/src/outbound-payload.ts extensions/discord/src/outbound-adapter.test.ts`
- Format: `node_modules/.bin/oxfmt --check --threads=1 extensions/discord/src/outbound-payload.ts extensions/discord/src/outbound-adapter.test.ts`
- Types: `node scripts/run-tsgo.mjs -p extensions/discord/tsconfig.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/discord-extension.tsbuildinfo`
- Diff hygiene: `git diff --check`

## Real behavior proof

- Behavior or issue addressed:
  Discord `audioAsVoice` payload sends use multiple internal Discord send calls for one logical response. With an implicit single-use reply target, resolving `replyTo` separately at each internal send caused the text follow-up and extra media send to lose the reply target after the voice send consumed it.

- Real environment tested:
  Local OpenClaw checkout using the Discord outbound adapter test harness, the repository's Vitest wrapper, and a live sandbox Discord text channel. Unit tests inspect the production outbound option objects directly; the live run sends through `discordOutbound.sendPayload` and confirms Discord API message references after delivery.

- Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs extensions/discord/src/outbound-adapter.test.ts -t audioAsVoice
node scripts/run-vitest.mjs extensions/discord/src/outbound-adapter.test.ts
node scripts/run-oxlint.mjs extensions/discord/src/outbound-payload.ts extensions/discord/src/outbound-adapter.test.ts
node_modules/.bin/oxfmt --check --threads=1 extensions/discord/src/outbound-payload.ts extensions/discord/src/outbound-adapter.test.ts
node scripts/run-tsgo.mjs -p extensions/discord/tsconfig.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/discord-extension.tsbuildinfo
git diff --check
node_modules/.bin/tsx /tmp/openclaw-discord-audio-replyto-live-proof.mts
```

- Evidence after fix:

```text
Focused audioAsVoice shard: 4 passed, 32 skipped.
Full touched test file: 36 passed (36).

Found 0 warnings and 0 errors.
All matched files use the correct format.
Discord package typecheck passed.
git diff --check passed.

Live Discord sandbox nonce: oc-audio-replyto-2026-06-23T03-28-44-084Z-1dde4ee6
Send order: voice -> text -> media.
All three real payload messages referenced the seed message in Discord API readback.
Voice message: 1 attachment and Discord voice-message flag set.
Text follow-up: content included the nonce.
Image follow-up: 1 attachment.
```

- Observed result after fix:
  The `audioAsVoice` regressions now assert the voice send, text follow-up, and extra media send all carry `replyTo: "reply-1"` for both single-use modes (`first` and `batched`). The live Discord sandbox run confirmed the same shape after real delivery: voice, text, and image follow-up messages all referenced the seed message. The same file still covers ordinary non-`audioAsVoice` single-use behavior with `["reply-1", undefined]` for chunked approval payload fallbacks.

- What was not tested:
  No non-sandbox Discord channel or production user workflow was used. The live proof was limited to a sandbox Discord text channel plus local automated API readback.

AI-assisted; contributor manually reviewed and is responsible for the change.
