### PR TITLE
Doctor: expose state integrity findings

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -16,7 +16,12 @@ import {
   moveHeartbeatMainSessionEntry,
   resolveHeartbeatMainSessionRepairCandidate,
 } from "./doctor-heartbeat-main-session-repair.js";
-import { noteStateIntegrity } from "./doctor-state-integrity.js";
+import {
+  detectStateIntegrityHealthIssues,
+  noteStateIntegrity,
+  stateIntegrityIssueToHealthFinding,
+  stateIntegrityIssueToRepairEffect,
+} from "./doctor-state-integrity.js";
 
 vi.mock("../channels/plugins/bundled-ids.js", () => ({
   listBundledChannelIds: () => ["matrix", "whatsapp"],
@@ -102,6 +107,75 @@ async function runStateIntegrityText(cfg: OpenClawConfig): Promise<string> {
   await noteStateIntegrity(cfg, { confirmRuntimeRepair: vi.fn(async () => false), note: noteMock });
   return stateIntegrityText();
 }
+
+describe("structured state integrity findings", () => {
+  let envSnapshot: ReturnType<typeof captureEnv>;
+  let tempHome = "";
+
+  beforeEach(() => {
+    envSnapshot = captureEnv(["HOME", "OPENCLAW_HOME", "OPENCLAW_STATE_DIR"]);
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-state-integrity-"));
+    setTestEnvValue("HOME", tempHome);
+    setTestEnvValue("OPENCLAW_HOME", tempHome);
+    setTestEnvValue("OPENCLAW_STATE_DIR", path.join(tempHome, ".openclaw"));
+  });
+
+  afterEach(() => {
+    envSnapshot.restore();
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("maps a missing state directory to a structured finding and dry-run effect", () => {
+    const [issue] = detectStateIntegrityHealthIssues({});
+
+    expect(issue).toEqual({
+      kind: "missing-state-dir",
+      path: path.join(tempHome, ".openclaw"),
+    });
+    expect(stateIntegrityIssueToHealthFinding(issue)).toMatchObject({
+      checkId: "core/doctor/state-integrity",
+      severity: "error",
+      path: path.join(tempHome, ".openclaw"),
+      fixHint: "Run `openclaw doctor --fix` to create the state directory.",
+    });
+    expect(stateIntegrityIssueToRepairEffect(issue)).toEqual({
+      kind: "state",
+      action: "would-create-state-dir",
+      target: path.join(tempHome, ".openclaw"),
+      dryRunSafe: false,
+    });
+  });
+
+  it("reports permissive state and config file permissions as structured findings", () => {
+    const stateDir = path.join(tempHome, ".openclaw");
+    const configPath = path.join(tempHome, "openclaw.json");
+    fs.mkdirSync(stateDir, { recursive: true, mode: 0o755 });
+    fs.chmodSync(stateDir, 0o755);
+    fs.writeFileSync(configPath, "{}\n", { mode: 0o644 });
+    fs.chmodSync(configPath, 0o644);
+
+    const findings = detectStateIntegrityHealthIssues({}, { configPath }).map(
+      stateIntegrityIssueToHealthFinding,
+    );
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "core/doctor/state-integrity",
+          severity: "warning",
+          path: stateDir,
+          message: "State directory permissions are too open. Recommend chmod 700.",
+        }),
+        expect.objectContaining({
+          checkId: "core/doctor/state-integrity",
+          severity: "warning",
+          path: configPath,
+          message: "Config file is group/world readable. Recommend chmod 600.",
+        }),
+      ]),
+    );
+  });
+});
 
 async function runOrphanTranscriptCheckWithQmdSessions(enabled: boolean, homeDir: string) {
   const cfg: OpenClawConfig = {

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -126,7 +126,12 @@ describe("structured state integrity findings", () => {
   });
 
   it("maps a missing state directory to a structured finding and dry-run effect", () => {
-    const [issue] = detectStateIntegrityHealthIssues({});
+    const issue = detectStateIntegrityHealthIssues({}).find(
+      (candidate) => candidate.kind === "missing-state-dir",
+    );
+    if (!issue) {
+      throw new Error("expected missing state directory issue");
+    }
 
     expect(issue).toEqual({
       kind: "missing-state-dir",

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -147,6 +147,9 @@ describe("structured state integrity findings", () => {
   });
 
   it("reports permissive state and config file permissions as structured findings", () => {
+    if (process.platform === "win32") {
+      return;
+    }
     const stateDir = path.join(tempHome, ".openclaw");
     const configPath = path.join(tempHome, "openclaw.json");
     fs.mkdirSync(stateDir, { recursive: true, mode: 0o755 });
@@ -171,6 +174,46 @@ describe("structured state integrity findings", () => {
           severity: "warning",
           path: configPath,
           message: "Config file is group/world readable. Recommend chmod 600.",
+        }),
+      ]),
+    );
+  });
+
+  it("keeps checking config permissions when the state directory is missing", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const stateDir = path.join(tempHome, ".openclaw");
+    const configPath = path.join(tempHome, "openclaw.json");
+    fs.writeFileSync(configPath, "{}\n", { mode: 0o644 });
+    fs.chmodSync(configPath, 0o644);
+
+    const findings = detectStateIntegrityHealthIssues({}, { configPath }).map(
+      stateIntegrityIssueToHealthFinding,
+    );
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "core/doctor/state-integrity",
+          severity: "error",
+          path: stateDir,
+          message:
+            "State directory is missing. Sessions, credentials, logs, and config are stored there.",
+        }),
+        expect.objectContaining({
+          checkId: "core/doctor/state-integrity",
+          severity: "warning",
+          path: configPath,
+          message: "Config file is group/world readable. Recommend chmod 600.",
+        }),
+      ]),
+    );
+    expect(findings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "core/doctor/state-integrity",
+          message: expect.stringContaining("runtime directory is missing"),
         }),
       ]),
     );

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -809,10 +809,9 @@ export function detectStateIntegrityHealthIssues(
   const stateDirExists = existsDir(stateDir);
   if (!stateDirExists) {
     issues.push({ kind: "missing-state-dir", path: stateDir });
-    return issues;
   }
 
-  if (!canWriteDir(stateDir)) {
+  if (stateDirExists && !canWriteDir(stateDir)) {
     const hint = dirPermissionHint(stateDir);
     issues.push({
       kind: "state-dir-not-writable",
@@ -821,7 +820,7 @@ export function detectStateIntegrityHealthIssues(
     });
   }
 
-  if (process.platform !== "win32") {
+  if (stateDirExists && process.platform !== "win32") {
     try {
       const dirLstat = fs.lstatSync(stateDir);
       const isDirSymlink = dirLstat.isSymbolicLink();
@@ -850,25 +849,27 @@ export function detectStateIntegrityHealthIssues(
     }
   }
 
-  const dirCandidates = new Map<string, "Sessions dir" | "Session store dir" | "OAuth dir">();
-  dirCandidates.set(sessionsDir, "Sessions dir");
-  dirCandidates.set(storeDir, "Session store dir");
-  if (requireOAuthDir) {
-    dirCandidates.set(oauthDir, "OAuth dir");
-  }
-  for (const [dir, label] of dirCandidates) {
-    if (!existsDir(dir)) {
-      issues.push({ kind: "missing-runtime-dir", label, path: dir });
-      continue;
+  if (stateDirExists) {
+    const dirCandidates = new Map<string, "Sessions dir" | "Session store dir" | "OAuth dir">();
+    dirCandidates.set(sessionsDir, "Sessions dir");
+    dirCandidates.set(storeDir, "Session store dir");
+    if (requireOAuthDir) {
+      dirCandidates.set(oauthDir, "OAuth dir");
     }
-    if (!canWriteDir(dir)) {
-      const hint = dirPermissionHint(dir);
-      issues.push({
-        kind: "runtime-dir-not-writable",
-        label,
-        path: dir,
-        ...(hint ? { hint } : {}),
-      });
+    for (const [dir, label] of dirCandidates) {
+      if (!existsDir(dir)) {
+        issues.push({ kind: "missing-runtime-dir", label, path: dir });
+        continue;
+      }
+      if (!canWriteDir(dir)) {
+        const hint = dirPermissionHint(dir);
+        issues.push({
+          kind: "runtime-dir-not-writable",
+          label,
+          path: dir,
+          ...(hint ? { hint } : {}),
+        });
+      }
     }
   }
 
@@ -959,6 +960,7 @@ export function stateIntegrityIssueToHealthFinding(
         fixHint: "Run `openclaw doctor --fix` to repair runtime state directory permissions.",
       };
   }
+  return assertNeverStateIntegrityIssue(issue);
 }
 
 export function stateIntegrityIssueToRepairEffect(
@@ -1011,6 +1013,13 @@ export function stateIntegrityIssueToRepairEffect(
         dryRunSafe: false,
       };
   }
+  return assertNeverStateIntegrityIssue(issue);
+}
+
+function assertNeverStateIntegrityIssue(issue: never): never {
+  throw new Error(
+    `Unhandled state integrity issue kind: ${String((issue as { kind?: unknown }).kind)}`,
+  );
 }
 
 /** Emits state integrity warnings and applies selected runtime repairs. */

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -28,6 +28,7 @@ import {
 import { loadSessionStore } from "../config/sessions/store-load.js";
 import { updateSessionStore } from "../config/sessions/store.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { resolveMemoryBackendConfig } from "../memory-host-sdk/engine-storage.js";
 import { resolveOpenClawAgentDir } from "../plugin-sdk/agent-dir-compat.js";
@@ -38,6 +39,8 @@ import { shortenHomePath } from "../utils.js";
 import { repairHeartbeatPoisonedMainSession } from "./doctor-heartbeat-main-session-repair.js";
 import { describeHeartbeatSessionTargetIssues } from "./doctor-heartbeat-session-target.js";
 import { runPluginSessionStateDoctorRepairs } from "./doctor-session-state-providers.js";
+
+const STATE_INTEGRITY_CHECK_ID = "core/doctor/state-integrity";
 
 type DoctorPrompterLike = {
   confirmRuntimeRepair: (params: {
@@ -81,6 +84,56 @@ type OrphanAgentDir = {
   dirName: string;
   agentId: string;
 };
+
+export type StateIntegrityHealthIssue =
+  | {
+      kind: "mac-cloud-state-dir";
+      path: string;
+      storage: string;
+    }
+  | {
+      kind: "linux-sd-state-dir";
+      path: string;
+      mountPoint: string;
+      fsType: string;
+      source: string;
+    }
+  | {
+      kind: "linux-volatile-state-dir";
+      path: string;
+      mountPoint: string;
+      fsType: string;
+    }
+  | {
+      kind: "missing-state-dir";
+      path: string;
+    }
+  | {
+      kind: "state-dir-not-writable";
+      path: string;
+      hint?: string;
+    }
+  | {
+      kind: "state-dir-too-open";
+      path: string;
+      mode: number;
+    }
+  | {
+      kind: "config-file-too-open";
+      path: string;
+      mode: number;
+    }
+  | {
+      kind: "missing-runtime-dir";
+      label: "Sessions dir" | "Session store dir" | "OAuth dir";
+      path: string;
+    }
+  | {
+      kind: "runtime-dir-not-writable";
+      label: "Sessions dir" | "Session store dir" | "OAuth dir";
+      path: string;
+      hint?: string;
+    };
 
 function tryResolveNativeRealPath(targetPath: string): string | null {
   try {
@@ -702,6 +755,262 @@ function shouldRequireOAuthDir(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boo
 function shouldSuppressOrphanTranscriptWarning(cfg: OpenClawConfig, agentId: string): boolean {
   const backendConfig = resolveMemoryBackendConfig({ cfg, agentId });
   return backendConfig?.backend === "qmd" && backendConfig.qmd?.sessions.enabled === true;
+}
+
+export function detectStateIntegrityHealthIssues(
+  cfg: OpenClawConfig,
+  params?: {
+    configPath?: string;
+    env?: NodeJS.ProcessEnv;
+    homedir?: () => string;
+  },
+): StateIntegrityHealthIssue[] {
+  const issues: StateIntegrityHealthIssue[] = [];
+  const env = params?.env ?? process.env;
+  const homedir = () => resolveRequiredHomeDir(env, params?.homedir ?? os.homedir);
+  const stateDir = resolveStateDir(env, homedir);
+  const oauthDir = resolveOAuthDir(env, stateDir);
+  const agentId = resolveDefaultAgentId(cfg);
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId, env, homedir);
+  const storePath = resolveStorePath(cfg.session?.store, { agentId });
+  const storeDir = path.dirname(storePath);
+  const requireOAuthDir = shouldRequireOAuthDir(cfg, env);
+
+  const cloudSyncedStateDir = detectMacCloudSyncedStateDir(stateDir);
+  if (cloudSyncedStateDir) {
+    issues.push({
+      kind: "mac-cloud-state-dir",
+      path: cloudSyncedStateDir.path,
+      storage: cloudSyncedStateDir.storage,
+    });
+  }
+
+  const linuxSdBackedStateDir = detectLinuxSdBackedStateDir(stateDir);
+  if (linuxSdBackedStateDir) {
+    issues.push({
+      kind: "linux-sd-state-dir",
+      path: linuxSdBackedStateDir.path,
+      mountPoint: linuxSdBackedStateDir.mountPoint,
+      fsType: linuxSdBackedStateDir.fsType,
+      source: linuxSdBackedStateDir.source,
+    });
+  }
+
+  const linuxVolatileStateDir = detectLinuxVolatileStateDir(stateDir);
+  if (linuxVolatileStateDir) {
+    issues.push({
+      kind: "linux-volatile-state-dir",
+      path: linuxVolatileStateDir.path,
+      mountPoint: linuxVolatileStateDir.mountPoint,
+      fsType: linuxVolatileStateDir.fsType,
+    });
+  }
+
+  const stateDirExists = existsDir(stateDir);
+  if (!stateDirExists) {
+    issues.push({ kind: "missing-state-dir", path: stateDir });
+    return issues;
+  }
+
+  if (!canWriteDir(stateDir)) {
+    const hint = dirPermissionHint(stateDir);
+    issues.push({
+      kind: "state-dir-not-writable",
+      path: stateDir,
+      ...(hint ? { hint } : {}),
+    });
+  }
+
+  if (process.platform !== "win32") {
+    try {
+      const dirLstat = fs.lstatSync(stateDir);
+      const isDirSymlink = dirLstat.isSymbolicLink();
+      const stat = isDirSymlink ? fs.statSync(stateDir) : dirLstat;
+      const resolvedDir = isDirSymlink ? fs.realpathSync(stateDir) : stateDir;
+      if (!resolvedDir.startsWith("/nix/store/") && (stat.mode & 0o077) !== 0) {
+        issues.push({ kind: "state-dir-too-open", path: stateDir, mode: stat.mode });
+      }
+    } catch {
+      // Legacy noteStateIntegrity reports stat failures. Structured findings
+      // are limited to actionable state that can be inspected safely.
+    }
+  }
+
+  if (params?.configPath && existsFile(params.configPath) && process.platform !== "win32") {
+    try {
+      const configLstat = fs.lstatSync(params.configPath);
+      const isSymlink = configLstat.isSymbolicLink();
+      const stat = isSymlink ? fs.statSync(params.configPath) : configLstat;
+      const resolvedConfig = isSymlink ? fs.realpathSync(params.configPath) : params.configPath;
+      if (!resolvedConfig.startsWith("/nix/store/") && (stat.mode & 0o077) !== 0) {
+        issues.push({ kind: "config-file-too-open", path: params.configPath, mode: stat.mode });
+      }
+    } catch {
+      // See state-dir stat handling above.
+    }
+  }
+
+  const dirCandidates = new Map<string, "Sessions dir" | "Session store dir" | "OAuth dir">();
+  dirCandidates.set(sessionsDir, "Sessions dir");
+  dirCandidates.set(storeDir, "Session store dir");
+  if (requireOAuthDir) {
+    dirCandidates.set(oauthDir, "OAuth dir");
+  }
+  for (const [dir, label] of dirCandidates) {
+    if (!existsDir(dir)) {
+      issues.push({ kind: "missing-runtime-dir", label, path: dir });
+      continue;
+    }
+    if (!canWriteDir(dir)) {
+      const hint = dirPermissionHint(dir);
+      issues.push({
+        kind: "runtime-dir-not-writable",
+        label,
+        path: dir,
+        ...(hint ? { hint } : {}),
+      });
+    }
+  }
+
+  return issues;
+}
+
+export function stateIntegrityIssueToHealthFinding(
+  issue: StateIntegrityHealthIssue,
+): HealthFinding {
+  switch (issue.kind) {
+    case "mac-cloud-state-dir":
+      return {
+        checkId: STATE_INTEGRITY_CHECK_ID,
+        severity: "warning",
+        message: `State directory is under macOS cloud-synced storage (${issue.storage}), which can cause slow I/O and sync races.`,
+        path: issue.path,
+        fixHint: "Move OPENCLAW_STATE_DIR to local non-synced storage such as ~/.openclaw.",
+      };
+    case "linux-sd-state-dir":
+      return {
+        checkId: STATE_INTEGRITY_CHECK_ID,
+        severity: "warning",
+        message: `State directory appears to be on SD/eMMC storage (${issue.source}, ${issue.fsType}), which can hurt startup and durability.`,
+        path: issue.path,
+        target: issue.mountPoint,
+        fixHint: "Move OPENCLAW_STATE_DIR to SSD/NVMe-backed storage.",
+      };
+    case "linux-volatile-state-dir":
+      return {
+        checkId: STATE_INTEGRITY_CHECK_ID,
+        severity: "warning",
+        message: `State directory is on volatile ${issue.fsType} storage and may disappear on reboot.`,
+        path: issue.path,
+        target: issue.mountPoint,
+        fixHint: "Move OPENCLAW_STATE_DIR to persistent local storage.",
+      };
+    case "missing-state-dir":
+      return {
+        checkId: STATE_INTEGRITY_CHECK_ID,
+        severity: "error",
+        message:
+          "State directory is missing. Sessions, credentials, logs, and config are stored there.",
+        path: issue.path,
+        fixHint: "Run `openclaw doctor --fix` to create the state directory.",
+      };
+    case "state-dir-not-writable":
+      return {
+        checkId: STATE_INTEGRITY_CHECK_ID,
+        severity: "error",
+        message: issue.hint
+          ? `State directory is not writable. ${issue.hint}`
+          : "State directory is not writable.",
+        path: issue.path,
+        fixHint: "Run `openclaw doctor --fix` to repair state directory permissions.",
+      };
+    case "state-dir-too-open":
+      return {
+        checkId: STATE_INTEGRITY_CHECK_ID,
+        severity: "warning",
+        message: "State directory permissions are too open. Recommend chmod 700.",
+        path: issue.path,
+        fixHint: "Run `openclaw doctor --fix` to tighten state directory permissions.",
+      };
+    case "config-file-too-open":
+      return {
+        checkId: STATE_INTEGRITY_CHECK_ID,
+        severity: "warning",
+        message: "Config file is group/world readable. Recommend chmod 600.",
+        path: issue.path,
+        fixHint: "Run `openclaw doctor --fix` to tighten config file permissions.",
+      };
+    case "missing-runtime-dir":
+      return {
+        checkId: STATE_INTEGRITY_CHECK_ID,
+        severity: "error",
+        message: `${issue.label} is missing.`,
+        path: issue.path,
+        fixHint: "Run `openclaw doctor --fix` to create missing runtime state directories.",
+      };
+    case "runtime-dir-not-writable":
+      return {
+        checkId: STATE_INTEGRITY_CHECK_ID,
+        severity: "error",
+        message: issue.hint
+          ? `${issue.label} is not writable. ${issue.hint}`
+          : `${issue.label} is not writable.`,
+        path: issue.path,
+        fixHint: "Run `openclaw doctor --fix` to repair runtime state directory permissions.",
+      };
+  }
+}
+
+export function stateIntegrityIssueToRepairEffect(
+  issue: StateIntegrityHealthIssue,
+): HealthRepairEffect {
+  switch (issue.kind) {
+    case "mac-cloud-state-dir":
+    case "linux-sd-state-dir":
+    case "linux-volatile-state-dir":
+      return {
+        kind: "state",
+        action: "would-recommend-moving-state-dir",
+        target: issue.path,
+        dryRunSafe: true,
+      };
+    case "missing-state-dir":
+      return {
+        kind: "state",
+        action: "would-create-state-dir",
+        target: issue.path,
+        dryRunSafe: false,
+      };
+    case "state-dir-not-writable":
+    case "state-dir-too-open":
+      return {
+        kind: "state",
+        action: "would-repair-state-dir-permissions",
+        target: issue.path,
+        dryRunSafe: false,
+      };
+    case "config-file-too-open":
+      return {
+        kind: "file",
+        action: "would-tighten-config-file-permissions",
+        target: issue.path,
+        dryRunSafe: false,
+      };
+    case "missing-runtime-dir":
+      return {
+        kind: "state",
+        action: "would-create-runtime-state-dir",
+        target: issue.path,
+        dryRunSafe: false,
+      };
+    case "runtime-dir-not-writable":
+      return {
+        kind: "state",
+        action: "would-repair-runtime-state-dir-permissions",
+        target: issue.path,
+        dryRunSafe: false,
+      };
+  }
 }
 
 /** Emits state integrity warnings and applies selected runtime repairs. */

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1046,6 +1046,7 @@ describe("doctor health contributions", () => {
     }
     expect(contributionIds).toContain("core/doctor/sandbox/registry-files");
     expect(contributionIds).toContain("core/doctor/gateway-services/extra");
+    expect(contributionIds).toContain("core/doctor/state-integrity");
     expect(contributionIds).toContain("core/doctor/config-audit-scrub");
     expect(contributionIds).toContain("core/doctor/session-transcripts");
     expect(contributionIds).toContain("core/doctor/session-snapshots");

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -9,6 +9,7 @@ import {
   resolveDoctorHealthContributions,
   shouldSkipLegacyUpdateDoctorConfigWrite,
 } from "./doctor-health-contributions.js";
+import { runDoctorLintChecks } from "./doctor-lint-flow.js";
 import type { HealthCheck } from "./health-checks.js";
 
 const mocks = vi.hoisted(() => ({
@@ -1051,6 +1052,39 @@ describe("doctor health contributions", () => {
     expect(contributionIds).toContain("core/doctor/session-transcripts");
     expect(contributionIds).toContain("core/doctor/session-snapshots");
     expect(contributionChecks.map((check) => check.id)).toEqual(contributionIds);
+  });
+
+  it("keeps state integrity opt-in for default lint selection", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const stateIntegrityCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/state-integrity",
+    );
+    expect(stateIntegrityCheck).toMatchObject({ defaultEnabled: false });
+    expect(stateIntegrityCheck).toBeDefined();
+
+    const ctx = {
+      cfg: {},
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+    const checks = [stateIntegrityCheck!];
+
+    await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
+      checksRun: 0,
+      checksSkipped: 1,
+    });
+    await expect(
+      runDoctorLintChecks(ctx, { checks, includeAllChecks: true }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+    });
+    await expect(
+      runDoctorLintChecks(ctx, { checks, onlyIds: ["core/doctor/state-integrity"] }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+    });
   });
 
   it("uses legacy run when a contribution also declares structured health", async () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1285,6 +1285,7 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       healthChecks: {
         id: "core/doctor/state-integrity",
         description: "State directory, config permission, and runtime state issues are findings.",
+        defaultEnabled: false,
         async detect(ctx) {
           const { detectStateIntegrityHealthIssues, stateIntegrityIssueToHealthFinding } =
             await import("../commands/doctor-state-integrity.js");

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1282,6 +1282,35 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:state-integrity",
       label: "State integrity",
+      healthChecks: {
+        id: "core/doctor/state-integrity",
+        description: "State directory, config permission, and runtime state issues are findings.",
+        async detect(ctx) {
+          const { detectStateIntegrityHealthIssues, stateIntegrityIssueToHealthFinding } =
+            await import("../commands/doctor-state-integrity.js");
+          return detectStateIntegrityHealthIssues(ctx.cfg, {
+            configPath: ctx.configPath,
+            env: process.env,
+          }).map(stateIntegrityIssueToHealthFinding);
+        },
+        async repair(ctx) {
+          const { detectStateIntegrityHealthIssues, stateIntegrityIssueToRepairEffect } =
+            await import("../commands/doctor-state-integrity.js");
+          const effects = detectStateIntegrityHealthIssues(ctx.cfg, {
+            configPath: ctx.configPath,
+            env: process.env,
+          }).map(stateIntegrityIssueToRepairEffect);
+          if (ctx.dryRun === true) {
+            return { status: "repaired", changes: [], effects };
+          }
+          return {
+            status: "skipped",
+            reason: "legacy doctor state integrity contribution owns state repairs",
+            changes: [],
+            effects,
+          };
+        },
+      },
       run: runStateIntegrityHealth,
     }),
     createDoctorHealthContribution({


### PR DESCRIPTION
## Summary

- Exposes `core/doctor/state-integrity` as a structured Doctor health finding surface.
- Maps existing state directory, storage-class, config permission, and runtime state-directory diagnostics into stable `HealthFinding` output.
- Adds dry-run repair effects for the state-integrity issues while leaving real mutations in the legacy `noteStateIntegrity` Doctor path.
- Keeps the structured check opt-in for lint by setting `defaultEnabled: false`; default `doctor --lint` behavior is unchanged, while `doctor --lint --all` and `--only core/doctor/state-integrity` include it.
- Preserves independent config-file permission findings even when the OpenClaw state directory is missing.
- Does not add or change config, plugin, or public SDK contract surface.

This is the next narrow structured Doctor rule slice after session artifacts. It intentionally keeps the existing Doctor state-integrity implementation authoritative for real `doctor` / `doctor --fix` behavior.

## Stack

Rebased onto current `main` at `81e53202f2` after #96471 merged. Current branch head is `d0fb93fa2f` (`fix(doctor): preserve config permission findings`).

## Validation

Current head `d0fb93fa2f`:

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run src/flows/doctor-health-contributions.test.ts src/flows/doctor-lint-flow.test.ts src/commands/doctor-state-integrity.test.ts --reporter=dot` - 88 tests passed, 1 Windows-only permission-mode test skipped, across 2 Vitest shards
- `pnpm exec oxlint.CMD src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-lint-flow.ts src/flows/doctor-lint-flow.test.ts src/commands/doctor-state-integrity.ts src/commands/doctor-state-integrity.test.ts`
- `pnpm exec oxfmt.CMD --check src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-lint-flow.ts src/flows/doctor-lint-flow.test.ts src/commands/doctor-state-integrity.ts src/commands/doctor-state-integrity.test.ts`
- `pnpm tsgo:test:src`
- `git diff --check`

## Real behavior proof

Behavior or issue addressed:
Structured Doctor state-integrity findings now surface existing missing state-directory diagnostics through `core/doctor/state-integrity`, and the structured repair adapter reports a dry-run effect for the same issue while real mutation remains owned by the legacy Doctor path. The structured check is opt-in for lint so default `doctor --lint` compatibility is preserved.

Real environment tested:
Windows source checkout at PR head `d0fb93fa2f`, using isolated temp state paths where needed, `NO_COLOR=1`, and `OPENCLAW_DISABLE_AUTO_UPDATE=1`. The lint-selection proof uses the source health-check runner because it directly proves default-vs-`--all` selection without running unrelated lint checks. The focused CLI proof uses the public source CLI path with `--only core/doctor/state-integrity`.

Exact steps or command run after this patch:
1. Ran a source harness that resolved Doctor contribution checks, filtered to `core/doctor/state-integrity`, and called `runDoctorLintChecks(...)` once with default options and once with `includeAllChecks: true`.
2. Ran `node scripts/run-node.mjs doctor --lint --json --only core/doctor/state-integrity` against an isolated missing `OPENCLAW_STATE_DIR`.
3. Ran the structured repair source harness for the same isolated missing state directory with `dryRun: true`.

Evidence after fix:
Default-vs-all selection source harness:

```json
{
  "default": {
    "checksRun": 0,
    "checksSkipped": 1
  },
  "all": {
    "checksRun": 1,
    "checksSkipped": 0
  },
  "defaultEnabled": false
}
```

Public CLI structured finding through explicit opt-in, redacted:

```text
OPENCLAW_STATE_DIR=<TEMP_PROOF_ROOT>\missing-state
{"ok":false,"checksRun":1,"checksSkipped":27,"findings":[{"checkId":"core/doctor/state-integrity","severity":"error","message":"State directory is missing. Sessions, credentials, logs, and config are stored there.","path":"<TEMP_PROOF_ROOT>\\missing-state","fixHint":"Run `openclaw doctor --fix` to create the state directory."}]}
EXIT_CODE=1
```

Structured dry-run repair effect source harness, redacted:

```json
{
  "findings": [
    {
      "checkId": "core/doctor/state-integrity",
      "severity": "error",
      "message": "State directory is missing. Sessions, credentials, logs, and config are stored there.",
      "path": "<TEMP_PROOF_ROOT>\\missing-state",
      "fixHint": "Run `openclaw doctor --fix` to create the state directory."
    }
  ],
  "repair": {
    "status": "repaired",
    "changes": [],
    "effects": [
      {
        "kind": "state",
        "action": "would-create-state-dir",
        "target": "<TEMP_PROOF_ROOT>\\missing-state",
        "dryRunSafe": false
      }
    ]
  }
}
```

Observed result after fix:
Default lint selection skips the state-integrity check. `--all` selection includes it. The explicit `--only` public lint command ran exactly one check, emitted one `error` finding for `core/doctor/state-integrity`, and exited 1. The structured repair adapter reported the matching `would-create-state-dir` effect without mutating the missing state directory.

What was not tested:
POSIX config permission live CLI output was not tested on this Windows host; that branch remains covered by the POSIX-only regression because Windows intentionally skips mode diagnostics. Command-wide dry-run report output was not tested because that public reporting surface is planned in #84472, not this PR.

## Notes

The rebased diff is 4 files changed. The latest update resolves ClawSweeper's default-lint compatibility finding by making `core/doctor/state-integrity` opt-in for lint while preserving `--all` and `--only` access.