### PR TITLE
fix(test): route maturity docs helper in unit-fast

### DIFF
--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -862,6 +862,7 @@ describe("test-projects args", () => {
           "src/install-sh-version.test.ts",
           "src/proxy-capture/store.sqlite.test.ts",
           "test/scripts/android-version.test.ts",
+          "test/scripts/render-maturity-docs.test.ts",
           "test/scripts/resolve-openclaw-ref.test.ts",
         ],
         watchMode: false,


### PR DESCRIPTION
## What Problem This Solves

The tooling test for shared helper routing failed because the maturity-docs test was not listed in the expected unit-fast plan.

## Why This Change Was Made

The maturity-docs test imports the shared temp-directory helper and must be included in the planner expectation.

## User Impact

No production behavior changes. The tooling routing test now matches the current import graph.

## Evidence

- Focused test: 83/83 passed.
- Autoreview: clean.
- git diff --check: passed.