### PR TITLE
fix(plugins): remove Simple Icons color paths

### DIFF
--- a/extensions/alibaba/openclaw.plugin.json
+++ b/extensions/alibaba/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "alibaba",
-  "icon": "https://cdn.simpleicons.org/alibabacloud/111111",
+  "icon": "https://cdn.simpleicons.org/alibabacloud",
   "activation": {
     "onStartup": false
   },

--- a/extensions/anthropic-vertex/openclaw.plugin.json
+++ b/extensions/anthropic-vertex/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "anthropic-vertex",
   "name": "Anthropic Vertex",
   "description": "OpenClaw Anthropic Vertex provider plugin for Claude models on Google Vertex AI.",
-  "icon": "https://cdn.simpleicons.org/anthropic/111111",
+  "icon": "https://cdn.simpleicons.org/anthropic",
   "activation": {
     "onStartup": false
   },

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "anthropic",
-  "icon": "https://cdn.simpleicons.org/anthropic/111111",
+  "icon": "https://cdn.simpleicons.org/anthropic",
   "activation": {
     "onStartup": false
   },

--- a/extensions/brave/openclaw.plugin.json
+++ b/extensions/brave/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "brave",
   "name": "Brave",
   "description": "OpenClaw Brave Search provider plugin for web search.",
-  "icon": "https://cdn.simpleicons.org/brave/111111",
+  "icon": "https://cdn.simpleicons.org/brave",
   "activation": {
     "onStartup": false
   },

--- a/extensions/cloudflare-ai-gateway/openclaw.plugin.json
+++ b/extensions/cloudflare-ai-gateway/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "cloudflare-ai-gateway",
-  "icon": "https://cdn.simpleicons.org/cloudflare/111111",
+  "icon": "https://cdn.simpleicons.org/cloudflare",
   "activation": {
     "onStartup": false
   },

--- a/extensions/copilot-proxy/openclaw.plugin.json
+++ b/extensions/copilot-proxy/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "copilot-proxy",
-  "icon": "https://cdn.simpleicons.org/githubcopilot/111111",
+  "icon": "https://cdn.simpleicons.org/githubcopilot",
   "activation": {
     "onStartup": false
   },

--- a/extensions/copilot/openclaw.plugin.json
+++ b/extensions/copilot/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "copilot",
   "name": "GitHub Copilot agent runtime",
   "description": "Registers the GitHub Copilot agent runtime.",
-  "icon": "https://cdn.simpleicons.org/githubcopilot/111111",
+  "icon": "https://cdn.simpleicons.org/githubcopilot",
   "version": "2026.6.2",
   "activation": {
     "onStartup": false,

--- a/extensions/deepgram/openclaw.plugin.json
+++ b/extensions/deepgram/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "deepgram",
-  "icon": "https://cdn.simpleicons.org/deepgram/111111",
+  "icon": "https://cdn.simpleicons.org/deepgram",
   "activation": {
     "onStartup": false
   },

--- a/extensions/deepseek/openclaw.plugin.json
+++ b/extensions/deepseek/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "deepseek",
-  "icon": "https://cdn.simpleicons.org/deepseek/111111",
+  "icon": "https://cdn.simpleicons.org/deepseek",
   "activation": {
     "onStartup": false
   },

--- a/extensions/discord/openclaw.plugin.json
+++ b/extensions/discord/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "discord",
   "name": "Discord",
   "description": "OpenClaw Discord channel plugin for channels, DMs, commands, and app events.",
-  "icon": "https://cdn.simpleicons.org/discord/111111",
+  "icon": "https://cdn.simpleicons.org/discord",
   "skills": ["./skills"],
   "activation": {
     "onStartup": false

--- a/extensions/duckduckgo/openclaw.plugin.json
+++ b/extensions/duckduckgo/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "duckduckgo",
-  "icon": "https://cdn.simpleicons.org/duckduckgo/111111",
+  "icon": "https://cdn.simpleicons.org/duckduckgo",
   "activation": {
     "onStartup": false
   },

--- a/extensions/elevenlabs/openclaw.plugin.json
+++ b/extensions/elevenlabs/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "elevenlabs",
-  "icon": "https://cdn.simpleicons.org/elevenlabs/111111",
+  "icon": "https://cdn.simpleicons.org/elevenlabs",
   "activation": {
     "onStartup": false
   },

--- a/extensions/google-meet/openclaw.plugin.json
+++ b/extensions/google-meet/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "google-meet",
   "name": "Google Meet",
   "description": "OpenClaw Google Meet participant plugin for joining calls through Chrome or Twilio transports.",
-  "icon": "https://cdn.simpleicons.org/googlemeet/111111",
+  "icon": "https://cdn.simpleicons.org/googlemeet",
   "enabledByDefault": false,
   "commandAliases": [{ "name": "googlemeet" }],
   "activation": {

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "google",
-  "icon": "https://cdn.simpleicons.org/google/111111",
+  "icon": "https://cdn.simpleicons.org/google",
   "activation": {
     "onStartup": false
   },

--- a/extensions/googlechat/openclaw.plugin.json
+++ b/extensions/googlechat/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "googlechat",
   "name": "Google Chat",
   "description": "OpenClaw Google Chat channel plugin for spaces and direct messages.",
-  "icon": "https://cdn.simpleicons.org/googlechat/111111",
+  "icon": "https://cdn.simpleicons.org/googlechat",
   "activation": {
     "onStartup": false
   },

--- a/extensions/huggingface/openclaw.plugin.json
+++ b/extensions/huggingface/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "huggingface",
-  "icon": "https://cdn.simpleicons.org/huggingface/111111",
+  "icon": "https://cdn.simpleicons.org/huggingface",
   "activation": {
     "onStartup": false
   },

--- a/extensions/imessage/openclaw.plugin.json
+++ b/extensions/imessage/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "imessage",
-  "icon": "https://cdn.simpleicons.org/imessage/111111",
+  "icon": "https://cdn.simpleicons.org/imessage",
   "activation": {
     "onStartup": false
   },

--- a/extensions/line/openclaw.plugin.json
+++ b/extensions/line/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "line",
   "name": "LINE",
   "description": "OpenClaw LINE channel plugin for LINE Bot API chats.",
-  "icon": "https://cdn.simpleicons.org/line/111111",
+  "icon": "https://cdn.simpleicons.org/line",
   "activation": {
     "onStartup": false
   },

--- a/extensions/lmstudio/openclaw.plugin.json
+++ b/extensions/lmstudio/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "lmstudio",
-  "icon": "https://cdn.simpleicons.org/lmstudio/111111",
+  "icon": "https://cdn.simpleicons.org/lmstudio",
   "activation": {
     "onStartup": false
   },

--- a/extensions/matrix/openclaw.plugin.json
+++ b/extensions/matrix/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "matrix",
   "name": "Matrix",
   "description": "OpenClaw Matrix channel plugin for rooms and direct messages.",
-  "icon": "https://cdn.simpleicons.org/matrix/111111",
+  "icon": "https://cdn.simpleicons.org/matrix",
   "commandAliases": [{ "name": "matrix" }],
   "activation": {
     "onStartup": false,

--- a/extensions/mattermost/openclaw.plugin.json
+++ b/extensions/mattermost/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "mattermost",
-  "icon": "https://cdn.simpleicons.org/mattermost/111111",
+  "icon": "https://cdn.simpleicons.org/mattermost",
   "activation": {
     "onStartup": false
   },

--- a/extensions/minimax/openclaw.plugin.json
+++ b/extensions/minimax/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "minimax",
-  "icon": "https://cdn.simpleicons.org/minimax/111111",
+  "icon": "https://cdn.simpleicons.org/minimax",
   "activation": {
     "onStartup": false
   },

--- a/extensions/mistral/openclaw.plugin.json
+++ b/extensions/mistral/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "mistral",
-  "icon": "https://cdn.simpleicons.org/mistralai/111111",
+  "icon": "https://cdn.simpleicons.org/mistralai",
   "activation": {
     "onStartup": false
   },

--- a/extensions/nextcloud-talk/openclaw.plugin.json
+++ b/extensions/nextcloud-talk/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "nextcloud-talk",
   "name": "Nextcloud Talk",
   "description": "OpenClaw Nextcloud Talk channel plugin for conversations.",
-  "icon": "https://cdn.simpleicons.org/nextcloud/111111",
+  "icon": "https://cdn.simpleicons.org/nextcloud",
   "activation": {
     "onStartup": false
   },

--- a/extensions/nvidia/openclaw.plugin.json
+++ b/extensions/nvidia/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "nvidia",
-  "icon": "https://cdn.simpleicons.org/nvidia/111111",
+  "icon": "https://cdn.simpleicons.org/nvidia",
   "activation": {
     "onStartup": false
   },

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "ollama",
-  "icon": "https://cdn.simpleicons.org/ollama/111111",
+  "icon": "https://cdn.simpleicons.org/ollama",
   "activation": {
     "onStartup": false
   },

--- a/extensions/opencode-go/openclaw.plugin.json
+++ b/extensions/opencode-go/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "opencode-go",
-  "icon": "https://cdn.simpleicons.org/opencode/111111",
+  "icon": "https://cdn.simpleicons.org/opencode",
   "activation": {
     "onStartup": false
   },

--- a/extensions/opencode/openclaw.plugin.json
+++ b/extensions/opencode/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "opencode",
-  "icon": "https://cdn.simpleicons.org/opencode/111111",
+  "icon": "https://cdn.simpleicons.org/opencode",
   "activation": {
     "onStartup": false
   },

--- a/extensions/openrouter/openclaw.plugin.json
+++ b/extensions/openrouter/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "openrouter",
-  "icon": "https://cdn.simpleicons.org/openrouter/111111",
+  "icon": "https://cdn.simpleicons.org/openrouter",
   "activation": {
     "onStartup": false
   },

--- a/extensions/perplexity/openclaw.plugin.json
+++ b/extensions/perplexity/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "perplexity",
-  "icon": "https://cdn.simpleicons.org/perplexity/111111",
+  "icon": "https://cdn.simpleicons.org/perplexity",
   "activation": {
     "onStartup": false
   },

--- a/extensions/qianfan/openclaw.plugin.json
+++ b/extensions/qianfan/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "qianfan",
-  "icon": "https://cdn.simpleicons.org/baidu/111111",
+  "icon": "https://cdn.simpleicons.org/baidu",
   "activation": {
     "onStartup": false
   },

--- a/extensions/qqbot/openclaw.plugin.json
+++ b/extensions/qqbot/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "qqbot",
   "name": "QQ Bot",
   "description": "OpenClaw QQ Bot channel plugin for group and direct-message workflows.",
-  "icon": "https://cdn.simpleicons.org/qq/111111",
+  "icon": "https://cdn.simpleicons.org/qq",
   "activation": {
     "onStartup": false
   },

--- a/extensions/qwen/openclaw.plugin.json
+++ b/extensions/qwen/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "qwen",
-  "icon": "https://cdn.simpleicons.org/qwen/111111",
+  "icon": "https://cdn.simpleicons.org/qwen",
   "activation": {
     "onStartup": false
   },

--- a/extensions/searxng/openclaw.plugin.json
+++ b/extensions/searxng/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "searxng",
-  "icon": "https://cdn.simpleicons.org/searxng/111111",
+  "icon": "https://cdn.simpleicons.org/searxng",
   "activation": {
     "onStartup": false
   },

--- a/extensions/signal/openclaw.plugin.json
+++ b/extensions/signal/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "signal",
-  "icon": "https://cdn.simpleicons.org/signal/111111",
+  "icon": "https://cdn.simpleicons.org/signal",
   "activation": {
     "onStartup": false
   },

--- a/extensions/synology-chat/openclaw.plugin.json
+++ b/extensions/synology-chat/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "synology-chat",
   "name": "Synology Chat",
   "description": "Synology Chat channel plugin for OpenClaw channels and direct messages.",
-  "icon": "https://cdn.simpleicons.org/synology/111111",
+  "icon": "https://cdn.simpleicons.org/synology",
   "activation": {
     "onStartup": false
   },

--- a/extensions/telegram/openclaw.plugin.json
+++ b/extensions/telegram/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "telegram",
-  "icon": "https://cdn.simpleicons.org/telegram/111111",
+  "icon": "https://cdn.simpleicons.org/telegram",
   "activation": {
     "onStartup": false
   },

--- a/extensions/twitch/openclaw.plugin.json
+++ b/extensions/twitch/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "twitch",
   "name": "Twitch",
   "description": "OpenClaw Twitch channel plugin for chat and moderation workflows.",
-  "icon": "https://cdn.simpleicons.org/twitch/111111",
+  "icon": "https://cdn.simpleicons.org/twitch",
   "activation": {
     "onStartup": false
   },

--- a/extensions/vercel-ai-gateway/openclaw.plugin.json
+++ b/extensions/vercel-ai-gateway/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "vercel-ai-gateway",
-  "icon": "https://cdn.simpleicons.org/vercel/111111",
+  "icon": "https://cdn.simpleicons.org/vercel",
   "activation": {
     "onStartup": false
   },

--- a/extensions/whatsapp/openclaw.plugin.json
+++ b/extensions/whatsapp/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "whatsapp",
   "name": "WhatsApp",
   "description": "OpenClaw WhatsApp channel plugin for WhatsApp Web chats.",
-  "icon": "https://cdn.simpleicons.org/whatsapp/111111",
+  "icon": "https://cdn.simpleicons.org/whatsapp",
   "skills": ["./skills"],
   "activation": {
     "onStartup": false

--- a/extensions/xiaomi/openclaw.plugin.json
+++ b/extensions/xiaomi/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "xiaomi",
-  "icon": "https://cdn.simpleicons.org/xiaomi/111111",
+  "icon": "https://cdn.simpleicons.org/xiaomi",
   "activation": {
     "onStartup": false
   },

--- a/extensions/zalo/openclaw.plugin.json
+++ b/extensions/zalo/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zalo",
   "name": "Zalo",
   "description": "OpenClaw Zalo channel plugin for bot and webhook chats.",
-  "icon": "https://cdn.simpleicons.org/zalo/111111",
+  "icon": "https://cdn.simpleicons.org/zalo",
   "activation": {
     "onStartup": false
   },

--- a/extensions/zalouser/openclaw.plugin.json
+++ b/extensions/zalouser/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zalouser",
   "name": "Zalo Personal",
   "description": "OpenClaw Zalo Personal Account plugin via native zca-js integration.",
-  "icon": "https://cdn.simpleicons.org/zalo/111111",
+  "icon": "https://cdn.simpleicons.org/zalo",
   "activation": {
     "onStartup": false
   },

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -463,7 +463,7 @@ describe("loadPluginManifestRegistry", () => {
     writeManifest(dir, {
       id: "icon-demo",
       name: "Icon Demo",
-      icon: "https://cdn.simpleicons.org/simpleicons/111111",
+      icon: "https://cdn.simpleicons.org/simpleicons",
       configSchema: { type: "object" },
     });
 
@@ -475,7 +475,7 @@ describe("loadPluginManifestRegistry", () => {
       }),
     ]);
 
-    expect(registry.plugins[0]?.icon).toBe("https://cdn.simpleicons.org/simpleicons/111111");
+    expect(registry.plugins[0]?.icon).toBe("https://cdn.simpleicons.org/simpleicons");
   });
 
   it("keeps only the higher-precedence plugin for truly distinct duplicates", () => {


### PR DESCRIPTION
## What Problem This Solves
PR #95845 populated bundled plugin manifest icons with Simple Icons CDN URLs that included an explicit `/111111` color segment. This follow-up removes the forced color path so ClawHub can consume the default Simple Icons artwork URL shape directly.

## Why This Change Was Made
- Removes the trailing color segment from the 43 bundled plugin manifest icon URLs added in #95845.
- Updates the manifest-registry preservation test fixture to match the new URL shape.
- Leaves unrelated `#111111` UI colors and non-Simple Icons values untouched.

## User Impact
Bundled plugin icon metadata continues to point at live HTTPS SVG icons, but without pinning every Simple Icons render to the same explicit color.

## Evidence
- Found original session/rollout for branch `pe/claw-360-bundled-plugin-icons`, PR #95845, and commit `188da3f15aa`.
- `rg -n 'https://cdn\.simpleicons\.org/[A-Za-z0-9_-]+/[0-9A-Fa-f]{3,8}' . --glob '!node_modules/**' --glob '!dist/**' --glob '!build/**'` exited 1 with no matches.
- `git diff --check` exited 0.
- `pnpm format:check -- $(git diff --name-only)` exited 0:

```text
All matched files use the correct format.
```

- `node scripts/run-vitest.mjs src/plugins/manifest-registry.test.ts` exited 0:

```text
Test Files  1 passed (1)
Tests  72 passed (72)
```

- Live Simple Icons URL proof checked all unique changed CDN URLs:

```text
checked=40
all returned 200 image/svg+xml with SVG content
```

- `.agents/skills/autoreview/scripts/autoreview --mode local` exited 0:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.88)
```
