### PR TITLE
fix(telegram): materialize block-boundary newlines in rich HTML for Bot API 10.1

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -119,16 +119,32 @@ describe("markdownToTelegramHtml", () => {
     );
   });
 
-  it("preserves structural newlines that only separate block tags", () => {
+  it("preserves structural newlines that only separate block tags with text content", () => {
     // Block tags already break; a stray <br> would add a blank line or land as an
     // invalid container child. Mixed text hugging a block keeps its boundary \n too.
-    const blocks = "<h2>Plan</h2>\n<table><tbody><tr><td>A</td></tr></tbody></table>";
-    expect(materializeTelegramRichHtmlLineBreaks(blocks)).toBe(blocks);
     expect(
       materializeTelegramRichHtmlLineBreaks(
         'A\n\n<figure><img src="https://x/a.jpg"/></figure>\n\nB',
       ),
     ).toBe('A\n\n<figure><img src="https://x/a.jpg"/></figure>\n\nB');
+  });
+
+  it("materializes pure-whitespace newlines between block tags outside containers", () => {
+    // Bot API 10.1 rich messages collapse bare newlines between block elements.
+    // When a segment between two block tags is purely whitespace newlines (no text),
+    // they must become <br> so block boundaries are visible (#95538).
+    expect(materializeTelegramRichHtmlLineBreaks("<h2>Plan</h2>\n<p>Details</p>")).toBe(
+      "<h2>Plan</h2><br><p>Details</p>",
+    );
+    expect(materializeTelegramRichHtmlLineBreaks("<h2>Plan</h2>\n\n<p>Details</p>")).toBe(
+      "<h2>Plan</h2><br><br><p>Details</p>",
+    );
+    // Newlines before a container tag (table/figure/details) are also materialized
+    // when the segment is purely whitespace, but container internals are preserved.
+    const beforeTable = "<h2>Plan</h2>\n<table><tbody><tr><td>A</td></tr></tbody></table>";
+    expect(materializeTelegramRichHtmlLineBreaks(beforeTable)).toBe(
+      "<h2>Plan</h2><br><table><tbody><tr><td>A</td></tr></tbody></table>",
+    );
   });
 
   it("does not let a self-closing literal tag swallow later line breaks", () => {
@@ -147,6 +163,12 @@ describe("markdownToTelegramHtml", () => {
     expect(materializeTelegramRichHtmlLineBreaks(figure)).toBe(figure);
     const details = "<details>\n<summary>\nMore\n</summary>\nBody\n</details>";
     expect(materializeTelegramRichHtmlLineBreaks(details)).toBe(details);
+    // Pretty-printed lists: newlines inside <ul>/<ol> stay literal so <br> is
+    // not injected as an invalid child or unwanted spacing between items.
+    const ul = "<ul>\n<li>One</li>\n<li>Two</li>\n</ul>";
+    expect(materializeTelegramRichHtmlLineBreaks(ul)).toBe(ul);
+    const ol = "<ol>\n<li>First</li>\n<li>Second</li>\n</ol>";
+    expect(materializeTelegramRichHtmlLineBreaks(ol)).toBe(ol);
   });
 
   it("keeps existing <br> tags intact without doubling adjacent newlines", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -1020,6 +1020,7 @@ function convertTelegramRichSegmentNewlines(
   segment: string,
   prevStructural: boolean,
   nextStructural: boolean,
+  insideRichContainer: boolean,
 ): string {
   if (!segment.includes("\n")) {
     return segment;
@@ -1027,10 +1028,20 @@ function convertTelegramRichSegmentNewlines(
   // Keep newline runs that hug a structural tag: Telegram already starts a new
   // line there, so a stray <br> would add a blank line or land as an invalid
   // child inside a container (table/figure/details/list).
+  // However, Bot API 10.1 rich messages do not reliably render bare newlines
+  // between block-level elements — they collapse as insignificant whitespace.
+  // When the segment is purely whitespace newlines (no text content) and not
+  // inside a rich container (table/figure/details), the run must still be
+  // materialized as <br> so that block boundaries are visible (#95538: /status
+  // card loses field-per-line layout under richMessages).
+  const segmentIsPureNewlines = segment.trim() === "";
   return segment.replace(/\n+/g, (run: string, offset: number) => {
     const hugsPrev = offset === 0 && prevStructural;
     const hugsNext = offset + run.length === segment.length && nextStructural;
-    return hugsPrev || hugsNext ? run : "<br>".repeat(run.length);
+    if ((hugsPrev || hugsNext) && (!segmentIsPureNewlines || insideRichContainer)) {
+      return run;
+    }
+    return "<br>".repeat(run.length);
   });
 }
 
@@ -1064,6 +1075,20 @@ function isTelegramRichLineBreakStructuralTag(rawTag: string, tagName: string): 
   );
 }
 
+// Rich containers whose pretty-printed internal newlines must stay literal:
+// a <br> inside <table>/<figure>/<details>/<ul>/<ol> is either an invalid
+// child or an unwanted blank line between layout elements. Lists are included
+// because pretty-printed <ul>/<ol> HTML (e.g. <ul>\n<li>…</li>\n</ul>) would
+// otherwise have its internal newlines materialized as <br>, producing visible
+// extra spacing or invalid markup inside the list container.
+const TELEGRAM_RICH_LINE_BREAK_CONTAINER_TAGS: ReadonlySet<string> = new Set([
+  "table",
+  "figure",
+  "details",
+  "ol",
+  "ul",
+]);
+
 // Bot API 10.1 rich messages parse structured HTML, so literal newlines are
 // insignificant whitespace — unlike the legacy HTML parse mode that renders them
 // as line breaks. Materialize inline newlines as <br> so multi-line prose and
@@ -1076,6 +1101,7 @@ export function materializeTelegramRichHtmlLineBreaks(html: string): string {
   let result = "";
   let lastIndex = 0;
   let literalDepth = 0;
+  let containerDepth = 0;
   let prevStructural = false;
 
   HTML_TAG_PATTERN.lastIndex = 0;
@@ -1091,15 +1117,24 @@ export function materializeTelegramRichHtmlLineBreaks(html: string): string {
     const tagIsStructural =
       tagName === "br" || isTelegramRichLineBreakStructuralTag(rawTag, tagName);
     const segment = html.slice(lastIndex, tagStart);
+    const insideRichContainer = containerDepth > 0;
     result +=
       literalDepth > 0
         ? segment
-        : convertTelegramRichSegmentNewlines(segment, prevStructural, tagIsStructural);
+        : convertTelegramRichSegmentNewlines(
+            segment,
+            prevStructural,
+            tagIsStructural,
+            insideRichContainer,
+          );
 
     // Self-closing literal tags (e.g. a stray <pre/>) must not open a region that
     // never closes and swallows every later line break.
     if (TELEGRAM_RICH_LITERAL_WHITESPACE_TAGS.has(tagName) && !rawTag.trimEnd().endsWith("/>")) {
       literalDepth = isClosing ? Math.max(0, literalDepth - 1) : literalDepth + 1;
+    }
+    if (TELEGRAM_RICH_LINE_BREAK_CONTAINER_TAGS.has(tagName) && !rawTag.trimEnd().endsWith("/>")) {
+      containerDepth = isClosing ? Math.max(0, containerDepth - 1) : containerDepth + 1;
     }
     result += rawTag;
     lastIndex = tagEnd;
@@ -1108,7 +1143,9 @@ export function materializeTelegramRichHtmlLineBreaks(html: string): string {
 
   const tail = html.slice(lastIndex);
   result +=
-    literalDepth > 0 ? tail : convertTelegramRichSegmentNewlines(tail, prevStructural, false);
+    literalDepth > 0
+      ? tail
+      : convertTelegramRichSegmentNewlines(tail, prevStructural, false, containerDepth > 0);
   return result;
 }
 


### PR DESCRIPTION
## Summary

Bot API 10.1 rich messages treat literal newlines between block-level elements as insignificant whitespace, collapsing them instead of rendering line breaks. When the `/status` card (or any multi-line text built with single `\n` separators) is routed through the rich-message path, every field merges into a single run-on line.

The root cause is that `convertTelegramRichSegmentNewlines` skips pure-newline segments that hug a structural tag (prev/next block), assuming the block tag itself produces a visual break. This assumption holds in browsers but not in Bot API 10.1 rich messages.

Fix: when a segment between two block tags is purely whitespace newlines (no text content) and not inside a rich container (table/figure/details/ul/ol), materialize the newlines as `<br>` so block boundaries remain visible.

Also adds `ul` and `ol` to the rich container tracking set (`TELEGRAM_RICH_LINE_BREAK_CONTAINER_TAGS`) so that pretty-printed list HTML (e.g. `<ul>\n<li>…</li>\n</ul>`) does not get spurious `<br>` children injected inside the list container.

Fixes #95538

## Root Cause

In `extensions/telegram/src/format.ts`, `convertTelegramRichSegmentNewlines` has `hugsPrev`/`hugsNext` logic that keeps bare `\n` runs literal when they hug a structural tag. This is correct for browsers (block tags produce their own line break) but incorrect for Bot API 10.1 rich messages, where bare newlines between block elements collapse as insignificant whitespace.

Additionally, the container tracking set (`TELEGRAM_RICH_LINE_BREAK_CONTAINER_TAGS`) omitted `ul` and `ol`, meaning pretty-printed list HTML could receive unwanted `<br>` injections inside list containers.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Real behavior proof

**Behavior addressed:** Telegram `/status` card delivered as a single run-on line when `richMessages: true`. Block-boundary newlines between fields collapse.

**Environment tested:** Node.js v24.13.1 on Linux, OpenClaw main branch and PR branch.

**Before fix (upstream/main — bug present):**
```
materializeTelegramRichHtmlLineBreaks("<h2>Plan</h2>\n<p>Details</p>")
→ "<h2>Plan</h2>\n<p>Details</p>"    ← bare \n preserved, collapses in rich messages
```

**After fix (PR branch — bug fixed):**
```
materializeTelegramRichHtmlLineBreaks("<h2>Plan</h2>\n<p>Details</p>")
→ "<h2>Plan</h2><br><p>Details</p>"  ← \n materialized as <br>, visible in rich messages
```

**Container protection (ul/ol — no spurious <br>):**
```
materializeTelegramRichHtmlLineBreaks("<ul>\n<li>One</li>\n<li>Two</li>\n</ul>")
→ "<ul>\n<li>One</li>\n<li>Two</li>\n</ul>"  ← newlines preserved inside list container
```

**/status card simulation:**
```
Input:  "<h2>Status</h2>\n<p>Uptime: 39s</p>\n<p>Model: claude</p>"
Output: "<h2>Status</h2><br><p>Uptime: 39s</p><br><p>Model: claude</p>"
→ Each field on its own line ✅
```

**Pretty-printed list protection:**
```
Input:  "<ul>\n<li>One</li>\n<li>Two</li>\n</ul>"
Output: "<ul>\n<li>One</li>\n<li>Two</li>\n</ul>"
→ No spurious <br> inside list ✅
```

**Supersedes:** #95732 (closed — same fix with added ul/ol container protection per ClawSweeper review)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclaw/openclaw/blob/main/CONTRIBUTING.md)
- [x] My changes are covered by tests
- [x] I have tested my changes locally