### PR TITLE
fix(ci): require release QA evidence artifacts

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -853,7 +853,7 @@ jobs:
           name: release-qa-parity-${{ matrix.lane }}-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Record advisory status
         if: always()
@@ -959,7 +959,7 @@ jobs:
           name: release-qa-parity-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Record advisory status
         if: always()
@@ -1131,7 +1131,7 @@ jobs:
           name: release-qa-runtime-parity-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Record advisory status
         if: always()
@@ -1241,13 +1241,13 @@ jobs:
             --output .artifacts/qa-e2e/runtime-parity-standard-report/qa-runtime-tool-coverage-report.md
 
       - name: Upload runtime tool coverage artifacts
-        if: always()
+        if: ${{ always() && steps.verify_runtime_parity_status.outputs.ready == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-qa-runtime-tool-coverage-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/runtime-parity-standard-report/
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
   qa_live_matrix_release_checks:
     name: Run QA Lab live Matrix lane
@@ -1327,7 +1327,7 @@ jobs:
           name: release-qa-live-matrix-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Record advisory status
         if: always()
@@ -1467,7 +1467,7 @@ jobs:
           name: release-qa-live-telegram-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Record advisory status
         if: always()
@@ -1607,7 +1607,7 @@ jobs:
           name: release-qa-live-discord-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Record advisory status
         if: always()
@@ -1750,7 +1750,7 @@ jobs:
           name: release-qa-live-whatsapp-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Record advisory status
         if: always()
@@ -1890,7 +1890,7 @@ jobs:
           name: release-qa-live-slack-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Record advisory status
         if: always()

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1448,6 +1448,38 @@ describe("package artifact reuse", () => {
     }
   });
 
+  it("requires release-check QA evidence artifacts when lanes run", () => {
+    const cases = [
+      ["qa_lab_parity_lane_release_checks", "Upload parity lane artifacts"],
+      ["qa_lab_parity_report_release_checks", "Upload parity artifacts"],
+      ["qa_lab_runtime_parity_release_checks", "Upload runtime parity artifacts"],
+      ["qa_live_matrix_release_checks", "Upload Matrix QA artifacts"],
+      ["qa_live_telegram_release_checks", "Upload Telegram QA artifacts"],
+      ["qa_live_discord_release_checks", "Upload Discord QA artifacts"],
+      ["qa_live_whatsapp_release_checks", "Upload WhatsApp QA artifacts"],
+      ["qa_live_slack_release_checks", "Upload Slack QA artifacts"],
+    ];
+
+    for (const [jobName, stepName] of cases) {
+      const uploadStep = workflowStep(workflowJob(RELEASE_CHECKS_WORKFLOW, jobName), stepName);
+
+      expect(uploadStep.if, jobName).toBe("always()");
+      expect(uploadStep.uses, jobName).toBe(UPLOAD_ARTIFACT_V7);
+      expect(uploadStep.with?.["if-no-files-found"], jobName).toBe("error");
+    }
+
+    const runtimeCoverageUpload = workflowStep(
+      workflowJob(RELEASE_CHECKS_WORKFLOW, "runtime_tool_coverage_release_checks"),
+      "Upload runtime tool coverage artifacts",
+    );
+    expect(runtimeCoverageUpload.if).toContain("always()");
+    expect(runtimeCoverageUpload.if).toContain(
+      "steps.verify_runtime_parity_status.outputs.ready == 'true'",
+    );
+    expect(runtimeCoverageUpload.uses).toBe(UPLOAD_ARTIFACT_V7);
+    expect(runtimeCoverageUpload.with?.["if-no-files-found"]).toBe("error");
+  });
+
   it("requires live proof evidence artifacts when proof jobs run", () => {
     const cases = [
       {


### PR DESCRIPTION
## Summary

- require release-check QA evidence uploads to fail when lane artifacts are missing
- keep runtime tool coverage upload skipped when its runtime-parity producer was not ready, but fail the upload once coverage artifacts are expected
- add package-acceptance workflow guard coverage for the release-check QA evidence uploads

## Verification

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/openclaw-release-checks.yml`
- `node scripts/crabbox-wrapper.mjs run -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` (`run_8341641cbaef`, `cbx_50c121cdd1d3`, exit 0)
- autoreview: no actionable correctness issues; best-fix judgment confirmed for release-check QA evidence artifacts

Local targeted Vitest was not run in this sparse Codex worktree because `node_modules` is absent and `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` reports `OPENCLAW_MISSING_VITEST`; the remote changed gate above is the pnpm proof.
