### PR TITLE
test(providers): align JSON fixtures with bounded readers

### DIFF
--- a/extensions/chutes/models.test.ts
+++ b/extensions/chutes/models.test.ts
@@ -15,6 +15,16 @@ function restoreEnvVar(name: string, value: string | undefined): void {
   }
 }
 
+function jsonResponse(payload: unknown, init?: { ok?: boolean; status?: number }): Response {
+  const body = new TextEncoder().encode(JSON.stringify(payload));
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    json: async () => payload,
+    arrayBuffer: async () => body.slice().buffer,
+  } as Response;
+}
+
 async function withLiveChutesDiscovery<T>(
   fetchMock: ReturnType<typeof vi.fn>,
   run: () => Promise<T>,
@@ -45,12 +55,11 @@ async function withLiveChutesDiscovery<T>(
 function createAuthEchoFetchMock() {
   return vi.fn().mockImplementation((_url, init?: { headers?: HeadersInit }) => {
     const auth = readAuthorizationHeader(init);
-    return Promise.resolve({
-      ok: true,
-      json: async () => ({
+    return Promise.resolve(
+      jsonResponse({
         data: [{ id: auth ? `${auth}-model` : "public-model" }],
       }),
-    });
+    );
   });
 }
 
@@ -124,9 +133,8 @@ describe("chutes-models", () => {
   });
 
   it("discoverChutesModels correctly maps API response when not in test env", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    const mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
         data: [
           { id: "zai-org/GLM-4.7-TEE" },
           {
@@ -140,7 +148,7 @@ describe("chutes-models", () => {
           { id: "new-provider/simple-model" },
         ],
       }),
-    });
+    );
     await withLiveChutesDiscovery(mockFetch, async () => {
       const models = await discoverChutesModels("test-token-real-fetch");
       expect(models.length).toBeGreaterThan(0);
@@ -158,9 +166,8 @@ describe("chutes-models", () => {
   });
 
   it("falls back from malformed live token metadata", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    const mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
         data: [
           {
             id: "provider/bad-window",
@@ -174,7 +181,7 @@ describe("chutes-models", () => {
           },
         ],
       }),
-    });
+    );
 
     await withLiveChutesDiscovery(mockFetch, async () => {
       const models = await discoverChutesModels("malformed-token-metadata");
@@ -200,9 +207,8 @@ describe("chutes-models", () => {
           status: 401,
         });
       }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({
+      return Promise.resolve(
+        jsonResponse({
           data: [
             {
               id: "Qwen/Qwen3-32B",
@@ -232,7 +238,7 @@ describe("chutes-models", () => {
             },
           ],
         }),
-      });
+      );
     });
     await withLiveChutesDiscovery(mockFetch, async () => {
       const models = await discoverChutesModels("test-token-error");
@@ -260,27 +266,24 @@ describe("chutes-models", () => {
     const mockFetch = vi.fn().mockImplementation((_url, init?: { headers?: HeadersInit }) => {
       const auth = readAuthorizationHeader(init);
       if (auth === "Bearer chutes-token-a") {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
+        return Promise.resolve(
+          jsonResponse({
             data: [{ id: "private/model-a" }],
           }),
-        });
+        );
       }
       if (auth === "Bearer chutes-token-b") {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
+        return Promise.resolve(
+          jsonResponse({
             data: [{ id: "private/model-b" }],
           }),
-        });
+        );
       }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({
+      return Promise.resolve(
+        jsonResponse({
           data: [{ id: "public/model" }],
         }),
-      });
+      );
     });
     await withLiveChutesDiscovery(mockFetch, async () => {
       const modelsA = await discoverChutesModels("chutes-token-a");
@@ -330,12 +333,11 @@ describe("chutes-models", () => {
           status: 401,
         });
       }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({
+      return Promise.resolve(
+        jsonResponse({
           data: [{ id: "public/model" }],
         }),
-      });
+      );
     });
     await withLiveChutesDiscovery(mockFetch, async () => {
       await discoverChutesModels("failed-token");

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -31,6 +31,16 @@ vi.mock("openclaw/plugin-sdk/state-paths", () => ({
 import type { ProviderResolveDynamicModelContext } from "openclaw/plugin-sdk/core";
 import { fetchCopilotModelCatalog, resolveCopilotForwardCompatModel } from "./models.js";
 
+function jsonResponse(payload: unknown): Response {
+  const bytes = new TextEncoder().encode(JSON.stringify(payload));
+  return {
+    ok: true,
+    status: 200,
+    json: async () => payload,
+    arrayBuffer: async () => bytes.slice().buffer,
+  } as Response;
+}
+
 function createMockCtx(
   modelId: string,
   registryModels: Record<string, Record<string, unknown>> = {},
@@ -464,11 +474,7 @@ describe("fetchCopilotModelCatalog", () => {
   };
 
   it("maps Copilot /models entries to ModelDefinitionConfig with real context windows", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => sampleApiResponse,
-    });
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(sampleApiResponse));
 
     const out = await fetchCopilotModelCatalog({
       copilotApiToken: "tid=test",
@@ -539,11 +545,7 @@ describe("fetchCopilotModelCatalog", () => {
   });
 
   it("strips trailing slash from baseUrl when building the /models URL", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({ data: [] }),
-    });
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [] }));
 
     await fetchCopilotModelCatalog({
       copilotApiToken: "tid=test",
@@ -555,10 +557,8 @@ describe("fetchCopilotModelCatalog", () => {
   });
 
   it("dedupes by id when API returns duplicates", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
         data: [
           {
             id: "gpt-5.5",
@@ -580,7 +580,7 @@ describe("fetchCopilotModelCatalog", () => {
           },
         ],
       }),
-    });
+    );
 
     const out = await fetchCopilotModelCatalog({
       copilotApiToken: "tid=test",
@@ -593,10 +593,8 @@ describe("fetchCopilotModelCatalog", () => {
   });
 
   it("falls back from malformed live token limits", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
         data: [
           {
             id: "gpt-bad-window",
@@ -624,7 +622,7 @@ describe("fetchCopilotModelCatalog", () => {
           },
         ],
       }),
-    });
+    );
 
     const out = await fetchCopilotModelCatalog({
       copilotApiToken: "tid=test",
@@ -663,11 +661,7 @@ describe("fetchCopilotModelCatalog", () => {
 
   it("throws provider-owned errors for malformed successful /models payloads", async () => {
     for (const payload of [[], { data: {} }, { data: [null] }]) {
-      const fetchImpl = vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: async () => payload,
-      });
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(payload));
 
       await expect(
         fetchCopilotModelCatalog({

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -9,6 +9,16 @@ type TestModelProviderConfig = NonNullable<
 >[string];
 
 function installGeminiFetch() {
+  const payload = {
+    candidates: [
+      {
+        content: { parts: [{ text: "Grounded answer" }] },
+        groundingMetadata: {
+          groundingChunks: [{ web: { uri: "https://example.com", title: "Example" } }],
+        },
+      },
+    ],
+  };
   const mockFetch = vi.fn((_input?: RequestInfo | URL, _init?: RequestInit) =>
     Promise.resolve(
       new Response(

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -9,16 +9,6 @@ type TestModelProviderConfig = NonNullable<
 >[string];
 
 function installGeminiFetch() {
-  const payload = {
-    candidates: [
-      {
-        content: { parts: [{ text: "Grounded answer" }] },
-        groundingMetadata: {
-          groundingChunks: [{ web: { uri: "https://example.com", title: "Example" } }],
-        },
-      },
-    ],
-  };
   const mockFetch = vi.fn((_input?: RequestInfo | URL, _init?: RequestInit) =>
     Promise.resolve(
       new Response(

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -23,6 +23,16 @@ import {
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
 
+function jsonResponse(payload: unknown, body = JSON.stringify(payload)): Response {
+  const bytes = new TextEncoder().encode(body);
+  return {
+    ok: true,
+    status: 200,
+    json: async () => payload,
+    arrayBuffer: async () => bytes.slice().buffer,
+  } as Response;
+}
+
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
   return {
@@ -75,23 +85,20 @@ describe("lmstudio-models", () => {
     vi.fn(async (url: string | URL, init?: RequestInit) => {
       const key = params?.key ?? "qwen3-8b-instruct";
       if (String(url).endsWith("/api/v1/models")) {
-        return {
-          ok: true,
-          json: async () => ({
-            models: [
-              {
-                type: "llm",
-                key,
-                max_context_length: params?.maxContextLength,
-                variants: params?.variants,
-                selected_variant: params?.selectedVariant,
-                loaded_instances: params?.loadedContextLength
-                  ? [{ id: "inst-1", config: { context_length: params.loadedContextLength } }]
-                  : [],
-              },
-            ],
-          }),
-        };
+        return jsonResponse({
+          models: [
+            {
+              type: "llm",
+              key,
+              max_context_length: params?.maxContextLength,
+              variants: params?.variants,
+              selected_variant: params?.selectedVariant,
+              loaded_instances: params?.loadedContextLength
+                ? [{ id: "inst-1", config: { context_length: params.loadedContextLength } }]
+                : [],
+            },
+          ],
+        });
       }
       if (String(url).endsWith("/api/v1/models/load")) {
         return {
@@ -296,9 +303,8 @@ describe("lmstudio-models", () => {
   });
 
   it("discovers llm models and maps metadata", async () => {
-    const fetchMock = vi.fn(async (_url: string | URL, _init?: RequestInit) => ({
-      ok: true,
-      json: async () => ({
+    const fetchMock = vi.fn(async (_url: string | URL, _init?: RequestInit) =>
+      jsonResponse({
         models: [
           {
             type: "llm",
@@ -330,7 +336,7 @@ describe("lmstudio-models", () => {
           },
         ],
       }),
-    }));
+    );
 
     const models = await discoverLmstudioModels({
       baseUrl: "http://localhost:1234/v1",
@@ -386,13 +392,7 @@ describe("lmstudio-models", () => {
   });
 
   it("reports malformed model list JSON with an owned error", async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      json: async () => {
-        throw new SyntaxError("bad json");
-      },
-    }));
+    const fetchMock = vi.fn(async () => jsonResponse(undefined, "{ nope"));
 
     const result = await fetchLmstudioModels({
       baseUrl: "http://localhost:1234/v1",
@@ -405,11 +405,7 @@ describe("lmstudio-models", () => {
 
   it("reports wrong-shaped model list payloads with owned errors", async () => {
     for (const payload of [[], { models: {} }, { models: [null] }]) {
-      const fetchMock = vi.fn(async () => ({
-        ok: true,
-        status: 200,
-        json: async () => payload,
-      }));
+      const fetchMock = vi.fn(async () => jsonResponse(payload));
 
       const result = await fetchLmstudioModels({
         baseUrl: "http://localhost:1234/v1",
@@ -425,10 +421,8 @@ describe("lmstudio-models", () => {
     const timeoutController = new AbortController();
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
     const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => ({
-      ok: true,
-      status: 200,
+      ...jsonResponse({ models: [] }),
       requestInit: init,
-      json: async () => ({ models: [] }),
     }));
 
     const result = await fetchLmstudioModels({
@@ -521,20 +515,17 @@ describe("lmstudio-models", () => {
     const variantKey = `${canonicalKey}@q4_k_m`;
     const fetchMock = vi.fn(async (url: string | URL) => {
       if (String(url).endsWith("/api/v1/models")) {
-        return {
-          ok: true,
-          json: async () => ({
-            models: [
-              {
-                type: "llm",
-                key: canonicalKey,
-                variants: [variantKey],
-                selected_variant: variantKey,
-                loaded_instances: [],
-              },
-            ],
-          }),
-        };
+        return jsonResponse({
+          models: [
+            {
+              type: "llm",
+              key: canonicalKey,
+              variants: [variantKey],
+              selected_variant: variantKey,
+              loaded_instances: [],
+            },
+          ],
+        });
       }
       if (String(url).endsWith("/api/v1/models/load")) {
         return new Response("load failed", { status: 503 });
@@ -575,12 +566,9 @@ describe("lmstudio-models", () => {
   it("reports malformed model load JSON with an owned error", async () => {
     const fetchMock = vi.fn(async (url: string | URL) => {
       if (String(url).endsWith("/api/v1/models")) {
-        return {
-          ok: true,
-          json: async () => ({
-            models: [{ type: "llm", key: "qwen3-8b-instruct", loaded_instances: [] }],
-          }),
-        };
+        return jsonResponse({
+          models: [{ type: "llm", key: "qwen3-8b-instruct", loaded_instances: [] }],
+        });
       }
       if (String(url).endsWith("/api/v1/models/load")) {
         return {
@@ -608,12 +596,9 @@ describe("lmstudio-models", () => {
     const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
     const fetchMock = vi.fn(async (url: string | URL) => {
       if (String(url).endsWith("/api/v1/models")) {
-        return {
-          ok: true,
-          json: async () => ({
-            models: [{ type: "llm", key: "qwen3-8b-instruct", loaded_instances: [] }],
-          }),
-        };
+        return jsonResponse({
+          models: [{ type: "llm", key: "qwen3-8b-instruct", loaded_instances: [] }],
+        });
       }
       if (String(url).endsWith("/api/v1/models/load")) {
         return tracked.response;

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -420,10 +420,9 @@ describe("lmstudio-models", () => {
   it("caps oversized direct fetch timeouts before discovering models", async () => {
     const timeoutController = new AbortController();
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
-    const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => ({
-      ...jsonResponse({ models: [] }),
-      requestInit: init,
-    }));
+    const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) =>
+      Object.assign(jsonResponse({ models: [] }), { requestInit: init }),
+    );
 
     const result = await fetchLmstudioModels({
       baseUrl: "http://localhost:1234/v1",

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -84,22 +84,33 @@ const {
 } = testing;
 
 function installXaiWebSearchFetch() {
+  const payload = {
+    output: [
+      {
+        type: "message",
+        content: [{ type: "output_text", text: "Grounded Grok answer" }],
+      },
+    ],
+  };
   const mockFetch = vi.fn((_input?: unknown, _init?: unknown) =>
     Promise.resolve({
       ok: true,
-      json: () =>
-        Promise.resolve({
-          output: [
-            {
-              type: "message",
-              content: [{ type: "output_text", text: "Grounded Grok answer" }],
-            },
-          ],
-        }),
+      json: async () => payload,
+      arrayBuffer: async () => new TextEncoder().encode(JSON.stringify(payload)).buffer,
     } as Response),
   );
   global.fetch = withFetchPreconnect(mockFetch);
   return mockFetch;
+}
+
+function jsonResponse(payload: unknown, body = JSON.stringify(payload)): Response {
+  const bytes = new TextEncoder().encode(body);
+  return {
+    ok: true,
+    status: 200,
+    json: async () => payload,
+    arrayBuffer: async () => bytes.slice().buffer,
+  } as Response;
 }
 
 function firstFetchUrl(mockFetch: ReturnType<typeof installXaiWebSearchFetch>) {
@@ -370,18 +381,16 @@ describe("xai web search config resolution", () => {
         statusText: "Unauthorized",
         text: () => Promise.resolve("expired"),
       } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            output: [
-              {
-                type: "message",
-                content: [{ type: "output_text", text: "Fresh OAuth Grok answer" }],
-              },
-            ],
-          }),
-      } as Response);
+      .mockResolvedValueOnce(
+        jsonResponse({
+          output: [
+            {
+              type: "message",
+              content: [{ type: "output_text", text: "Fresh OAuth Grok answer" }],
+            },
+          ],
+        }),
+      );
     global.fetch = withFetchPreconnect(mockFetch);
     const provider = createXaiWebSearchProvider();
     const tool = provider.createTool({
@@ -446,18 +455,16 @@ describe("xai web search config resolution", () => {
         statusText: "Unauthorized",
         text: () => Promise.resolve("revoked"),
       } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            output: [
-              {
-                type: "message",
-                content: [{ type: "output_text", text: "API key fallback Grok answer" }],
-              },
-            ],
-          }),
-      } as Response);
+      .mockResolvedValueOnce(
+        jsonResponse({
+          output: [
+            {
+              type: "message",
+              content: [{ type: "output_text", text: "API key fallback Grok answer" }],
+            },
+          ],
+        }),
+      );
     global.fetch = withFetchPreconnect(mockFetch);
     const provider = createXaiWebSearchProvider();
     const tool = provider.createTool({
@@ -548,18 +555,16 @@ describe("xai web search config resolution", () => {
         statusText: "Unauthorized",
         text: () => Promise.resolve("revoked"),
       } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            output: [
-              {
-                type: "message",
-                content: [{ type: "output_text", text: "Profile API key Grok answer" }],
-              },
-            ],
-          }),
-      } as Response);
+      .mockResolvedValueOnce(
+        jsonResponse({
+          output: [
+            {
+              type: "message",
+              content: [{ type: "output_text", text: "Profile API key Grok answer" }],
+            },
+          ],
+        }),
+      );
     global.fetch = withFetchPreconnect(mockFetch);
     const provider = createXaiWebSearchProvider();
     const tool = provider.createTool({
@@ -616,18 +621,16 @@ describe("xai web search config resolution", () => {
         statusText: "Unauthorized",
         text: () => Promise.resolve("stale api key"),
       } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            output: [
-              {
-                type: "message",
-                content: [{ type: "output_text", text: "Env fallback Grok answer" }],
-              },
-            ],
-          }),
-      } as Response);
+      .mockResolvedValueOnce(
+        jsonResponse({
+          output: [
+            {
+              type: "message",
+              content: [{ type: "output_text", text: "Env fallback Grok answer" }],
+            },
+          ],
+        }),
+      );
     global.fetch = withFetchPreconnect(mockFetch);
     const provider = createXaiWebSearchProvider();
     const tool = provider.createTool({
@@ -848,10 +851,7 @@ describe("xai web search config resolution", () => {
 
   it("reports malformed xAI web search JSON as a provider error", async () => {
     const mockFetch = vi.fn((_input?: unknown, _init?: unknown) =>
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.reject(new SyntaxError("Unexpected token")),
-      } as Response),
+      Promise.resolve(jsonResponse(undefined, "{ nope")),
     );
     global.fetch = withFetchPreconnect(mockFetch);
     const provider = createXaiWebSearchProvider();
@@ -881,10 +881,7 @@ describe("xai web search config resolution", () => {
 
   it("rejects xAI web search success JSON without answer text", async () => {
     const mockFetch = vi.fn((_input?: unknown, _init?: unknown) =>
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ output: [] }),
-      } as Response),
+      Promise.resolve(jsonResponse({ output: [] })),
     );
     global.fetch = withFetchPreconnect(mockFetch);
     const provider = createXaiWebSearchProvider();


### PR DESCRIPTION
## What Problem This Solves

Four provider test fixtures still return incomplete response doubles after bounded response parsing was introduced. Their missing `arrayBuffer()`/`body` behavior causes deterministic provider tests to fail before the provider logic is exercised.

## Why This Change Was Made

Update only the affected test response fixtures for Chutes, GitHub Copilot, LM Studio, and xAI web search to provide bounded response bodies. The Google web-search fixture is already corrected on current `main`, so this rebased PR keeps that unrelated mainline change out of the diff.

## User Impact

No production behavior changes. Provider tests now model the response contract consumed by bounded JSON parsing.

## Evidence

- Reproduced the fixture failures on the pre-fix branch.
- Focused proof on the five originally affected files: 129/129 passed before the Google fixture was superseded by `main`.
- `git diff --check` and `oxfmt` passed on the rebased four-file diff.
- Autoreview was clean before and after the rebase.
