### PR TITLE
fix(release): require postpublish evidence artifact

### DIFF
--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -1466,9 +1466,9 @@ jobs:
           fi
 
       - name: Upload postpublish evidence
-        if: ${{ always() }}
+        if: ${{ always() && inputs.publish_openclaw_npm }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: openclaw-release-postpublish-evidence-${{ inputs.tag }}
           path: ${{ runner.temp }}/openclaw-release-postpublish-evidence
-          if-no-files-found: ignore
+          if-no-files-found: error

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2237,6 +2237,13 @@ describe("package artifact reuse", () => {
     expect(clawHubReleasePlanScript).toContain("--plugin-clawhub-bootstrap-run");
     expect(releaseWorkflow).toContain('verify_args+=(--plugins "${PLUGINS}")');
     expect(releaseWorkflow).toContain("openclaw-release-postpublish-evidence");
+    const postpublishEvidenceUpload = workflowStep(
+      workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish"),
+      "Upload postpublish evidence",
+    );
+    expect(postpublishEvidenceUpload.if).toContain("always()");
+    expect(postpublishEvidenceUpload.if).toContain("inputs.publish_openclaw_npm");
+    expect(postpublishEvidenceUpload.with?.["if-no-files-found"]).toBe("error");
     expect(releaseWorkflow).toContain("Failed child job summary");
     expect(releaseWorkflow).toContain("Workflow completion waits for ClawHub");
     expect(releaseWorkflow).toContain("Workflow completion does not wait for ClawHub");


### PR DESCRIPTION
## Summary

- upload postpublish evidence only for OpenClaw npm publish runs
- fail the workflow artifact upload when required postpublish evidence is missing
- add package-acceptance workflow guard coverage for the postpublish evidence upload policy

## Verification

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/openclaw-release-publish.yml`
- `node scripts/crabbox-wrapper.mjs run -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` (`run_8bf6be77e546`, `cbx_832e537e8ca8`, exit 0; Crabbox emitted transient telemetry/heartbeat warnings but the command completed successfully and the lease cleaned up)

Local targeted Vitest was not run in this sparse Codex worktree because `node_modules` is absent and `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` reports `OPENCLAW_MISSING_VITEST`; the remote changed gate above is the pnpm proof.
