### PR TITLE
fix(session-lock): allow reentrant acquire from inner transcript writers

### DIFF
--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1167,6 +1167,10 @@ async function compactEmbeddedAgentSessionDirectOnce(
           timeoutMs: compactionTimeoutMs,
         }),
       }),
+      // See allowReentrant note in tool-result-truncation.ts. Compaction can
+      // be triggered mid-attempt by context overflow precheck and must share
+      // the outer attempt lock.
+      allowReentrant: true,
     });
     try {
       await repairSessionFileIfNeeded({

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -1069,6 +1069,12 @@ export async function truncateOversizedToolResultsInSession(params: {
     sessionLock = await acquireSessionWriteLock({
       sessionFile,
       ...resolveSessionWriteLockOptions(params.config),
+      // Callers run inside the embedded agent attempt which already holds the
+      // outer session-write lock (non-reentrant by design). Without reentrant
+      // acquire here, same-pid lock contention deadlocks for 60s when a large
+      // tool result triggers truncation mid-attempt (e.g. context overflow
+      // precheck in run.ts after parallel sessions_spawn).
+      allowReentrant: true,
     });
     const state = await readTranscriptFileState(sessionFile);
     return await truncateOversizedToolResultsInTranscriptState({

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -444,6 +444,9 @@ export async function rewriteTranscriptEntriesInRuntimeTranscript(params: {
     sessionLock = await acquireSessionWriteLock({
       sessionFile: target.sessionFile,
       ...resolveSessionWriteLockOptions(params.config),
+      // See allowReentrant note in tool-result-truncation.ts. Transcript
+      // rewrites can be invoked mid-attempt and must share the outer lock.
+      allowReentrant: true,
     });
     const state = await readTranscriptFileState(target.sessionFile);
     const result = rewriteTranscriptEntriesInState({


### PR DESCRIPTION
## What Problem This Solves

Three mid-attempt transcript writers — `compact.ts`, `tool-result-truncation.ts`, `transcript-rewrite.ts` — acquire the session write lock without `allowReentrant: true`. The outer embedded-attempt lock (acquired by `createEmbeddedAttemptSessionLockController`) is non-reentrant by design, so same-pid contention deadlocks for 60 seconds when one of the inner writers is invoked mid-turn.

## Why This Change Was Made

Reliable repro: in a long-running session where the agent produces a large tool result that triggers context overflow precheck in `run.ts`, the precheck calls `truncateOversizedToolResultsInSession` or `compactEmbeddedAgentSessionDirect` while the attempt still holds the outer lock. The inner writer hits the file lock manager, sees the lock held by the same PID, and waits the full \`DEFAULT_SESSION_WRITE_LOCK_ACQUIRE_TIMEOUT_MS\` (60s) before throwing.

`src/config/sessions/transcript-append.ts` already uses \`allowReentrant: true\` for the same reason (writes session events during the attempt's turn). This PR extends the same fix to the other three inner writers that share the same locking pattern.

## User Impact

Without this fix, agents running parallel `sessions_spawn` with substantial tool outputs hit \`SessionWriteLockTimeoutError\` mid-turn:

\`\`\`text
[diagnostic] lane task error: lane=main durationMs=~290s
error="SessionWriteLockTimeoutError: session file locked (timeout 60000ms):
       pid=<same gateway pid> alive=true ageMs=~60s
       /path/<session>.jsonl.lock"
Embedded agent failed before reply: session file locked ...
\`\`\`

The agent fails to deliver its reply (the followup reply path falls back to other channels), turn is wasted, and the user sees a stalled response after ~5 minutes.

## Evidence

- Production journal from internal deploy showing the lock contention before the fix (60s timeout, `alive=true`, same gateway PID).
- After fix deployed to dev environment: same parallel-spawn scenario completes normally, no `SessionWriteLockTimeoutError` events in the inner-writer path.
- `pnpm tsgo` passes locally.
- Same fix pattern already exists in `transcript-append.ts:325` (\`allowReentrant: true\` with a comment explaining the same reasoning).

## Test plan

- [x] Local typecheck (`pnpm tsgo`)
- [x] Manual scenario: parallel `sessions_spawn` with large tool results — no longer deadlocks
- [ ] Reviewer can verify by injecting an artificial delay in any inner writer + outer attempt and confirming the outer doesn't time out

Existing tests in `src/agents/session-write-lock.test.ts` already cover reentrant acquire semantics (lines around 192/197/221/226), so the lock primitive itself is exercised.

🤖 AI-assisted PR. Diagnosis + patch produced with Claude Code; locked behavior verified against production journals.