### PR TITLE
feat(copilot): wire harness parity helpers

### DIFF
--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -1466,9 +1466,9 @@ jobs:
           fi
 
       - name: Upload postpublish evidence
-        if: ${{ always() }}
+        if: ${{ always() && inputs.publish_openclaw_npm }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: openclaw-release-postpublish-evidence-${{ inputs.tag }}
           path: ${{ runner.temp }}/openclaw-release-postpublish-evidence
-          if-no-files-found: ignore
+          if-no-files-found: error

--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -243,6 +243,9 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=8192
         run: node scripts/build-all.mjs qaRuntime
 
+      - name: Ensure Playwright Chromium
+        run: node scripts/ensure-playwright-chromium.mjs
+
       - name: Run QA profile
         id: run_profile
         env:

--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -284,6 +284,7 @@ def normalize_watch_screenshot_status_bar(path)
   script = <<~SWIFT
     import AppKit
     import Foundation
+    import ImageIO
 
     let path = CommandLine.arguments[1]
     let timeText = CommandLine.arguments[2]
@@ -295,36 +296,37 @@ def normalize_watch_screenshot_status_bar(path)
       exit(2)
     }
 
-    let width = CGFloat(cgImage.width)
-    let height = CGFloat(cgImage.height)
-    guard let bitmap = NSBitmapImageRep(
-      bitmapDataPlanes: nil,
-      pixelsWide: Int(width),
-      pixelsHigh: Int(height),
-      bitsPerSample: 8,
-      samplesPerPixel: 4,
-      hasAlpha: true,
-      isPlanar: false,
-      colorSpaceName: .deviceRGB,
-      bytesPerRow: 0,
-      bitsPerPixel: 0),
-      let graphicsContext = NSGraphicsContext(bitmapImageRep: bitmap)
+    let width = cgImage.width
+    let height = cgImage.height
+    let drawWidth = CGFloat(width)
+    let drawHeight = CGFloat(height)
+    let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+    guard let bitmapContext = CGContext(
+      data: nil,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: width * 4,
+      space: colorSpace,
+      bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue)
     else {
       fputs("Failed to create normalized screenshot bitmap at \\(path)\\n", stderr)
       exit(3)
     }
 
-    bitmap.size = NSSize(width: width, height: height)
+    let graphicsContext = NSGraphicsContext(cgContext: bitmapContext, flipped: false)
     NSGraphicsContext.saveGraphicsState()
     NSGraphicsContext.current = graphicsContext
+    NSColor.black.setFill()
+    NSBezierPath(rect: NSRect(x: 0, y: 0, width: drawWidth, height: drawHeight)).fill()
     source.draw(
-      in: NSRect(x: 0, y: 0, width: width, height: height),
-      from: NSRect(x: 0, y: 0, width: width, height: height),
-      operation: .copy,
+      in: NSRect(x: 0, y: 0, width: drawWidth, height: drawHeight),
+      from: NSRect(x: 0, y: 0, width: drawWidth, height: drawHeight),
+      operation: .sourceOver,
       fraction: 1.0)
 
     NSColor.black.setFill()
-    NSBezierPath(rect: NSRect(x: width - 146, y: height - 92, width: 124, height: 70)).fill()
+    NSBezierPath(rect: NSRect(x: drawWidth - 146, y: drawHeight - 92, width: 124, height: 70)).fill()
 
     let paragraphStyle = NSMutableParagraphStyle()
     paragraphStyle.alignment = .right
@@ -334,17 +336,26 @@ def normalize_watch_screenshot_status_bar(path)
       .paragraphStyle: paragraphStyle,
     ]
     timeText.draw(
-      in: NSRect(x: width - 134, y: height - 82, width: 102, height: 44),
+      in: NSRect(x: drawWidth - 134, y: drawHeight - 82, width: 102, height: 44),
       withAttributes: attributes)
     NSGraphicsContext.restoreGraphicsState()
 
-    guard let png = bitmap.representation(using: .png, properties: [:])
+    guard let output = bitmapContext.makeImage(),
+          let destination = CGImageDestinationCreateWithURL(
+            URL(fileURLWithPath: path) as CFURL,
+            "public.png" as CFString,
+            1,
+            nil)
     else {
       fputs("Failed to encode normalized screenshot at \\(path)\\n", stderr)
       exit(4)
     }
 
-    try png.write(to: URL(fileURLWithPath: path))
+    CGImageDestinationAddImage(destination, output, nil)
+    guard CGImageDestinationFinalize(destination) else {
+      fputs("Failed to write normalized screenshot at \\(path)\\n", stderr)
+      exit(5)
+    }
   SWIFT
 
   Tempfile.create(["openclaw-watch-status-bar", ".swift"]) do |file|

--- a/docs/plugins/copilot.md
+++ b/docs/plugins/copilot.md
@@ -325,7 +325,7 @@ controls it can enforce at the SDK boundary: `includeCoreTools`, the
 runtime tool allowlist, and `toolConstructionPlan`.
 
 The bridge also uses the shared harness tool-surface helper from
-`openclaw/plugin-sdk/agent-harness-runtime` for PI parity. When
+`openclaw/plugin-sdk/agent-harness-tool-runtime` for PI parity. When
 tool-search is enabled, the SDK sees compact control tools plus a hidden
 catalog executor instead of every OpenClaw tool schema. When code mode is
 enabled, the helper builds the same code-mode control surface and catalog

--- a/docs/plugins/copilot.md
+++ b/docs/plugins/copilot.md
@@ -259,14 +259,10 @@ under `describe("runSideQuestion")`.
   fallback for whatever runtimes do not have a peer surface.
 - PI session state is not migrated when an agent switches to `copilot`.
   Selection is per attempt; existing PI sessions remain valid.
-- **Interactive `ask_user` is not yet wired.** The SDK's
-  `onUserInputRequest` handler is intentionally not registered, which
-  per the SDK contract hides the `ask_user` tool from the model
-  entirely. Agents running under this harness make best-judgment
-  decisions from the initial prompt rather than asking clarifying
-  questions mid-turn. A follow-up will port the codex pattern at
-  `extensions/codex/src/app-server/user-input-bridge.ts` to route SDK
-  `UserInputRequest`s through the OpenClaw channel/TUI prompt path.
+- `ask_user` uses the same OpenClaw prompt-and-reply path as the Codex
+  harness. When the Copilot SDK asks for user input, OpenClaw posts a
+  blocking prompt to the active channel/TUI and the next queued user
+  message resolves the SDK request.
 
 ## Permissions and ask_user
 
@@ -328,11 +324,15 @@ the tool bridge. The bridge also forwards the bounded tool-construction
 controls it can enforce at the SDK boundary: `includeCoreTools`, the
 runtime tool allowlist, and `toolConstructionPlan`.
 
-The remaining PI tool-search/code-mode fields are intentionally **not**
-forwarded at MVP and tracked as follow-ups: `toolSearchCatalogRef`,
-`includeToolSearchControls`, and `toolSearchCatalogExecutor`. Those
-controls drive PI's native tool-search UI and have no direct Copilot SDK
-analog yet.
+The bridge also uses the shared harness tool-surface helper from
+`openclaw/plugin-sdk/agent-harness-runtime` for PI parity. When
+tool-search is enabled, the SDK sees compact control tools plus a hidden
+catalog executor instead of every OpenClaw tool schema. When code mode is
+enabled, the helper builds the same code-mode control surface and catalog
+lifecycle used by other agent harnesses. Local-model lean defaults,
+runtime-compatible schema filtering, directory hydration, and catalog
+cleanup all stay in the shared helper so Copilot and Codex-adjacent
+harnesses do not drift.
 
 ### Session-level GitHub token
 
@@ -349,7 +349,10 @@ When the resolved mode is `useLoggedInUser`, the session-level field
 is omitted so the SDK keeps deriving identity from the logged-in
 identity.
 
-`ask_user` is intentionally hidden — see Limitations above.
+`ask_user` uses `SessionConfig.onUserInputRequest`. The bridge accepts
+choice indexes or labels for fixed-choice requests, accepts free-form
+answers when the SDK request allows them, and cancels a pending request
+when the OpenClaw attempt is aborted.
 
 ## Related
 

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -206,7 +206,8 @@ helper keeps channel/TUI presentation consistent while each harness keeps its
 own protocol parsing and pending-request lifecycle.
 
 Native harnesses that need PI-like compact tool routing should use
-`createAgentHarnessToolSurfaceRuntime(...)` from the same SDK subpath. It owns
+`createAgentHarnessToolSurfaceRuntime(...)` from
+`openclaw/plugin-sdk/agent-harness-tool-runtime`. It owns
 tool-search/code-mode control selection, local-model lean defaults,
 runtime-compatible schema filtering, hidden catalog execution, directory
 hydration, and catalog cleanup. Harnesses still own their SDK-specific tool

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -196,6 +196,22 @@ finish. Both helpers accept the same `{ event, ctx }` payload as
 `runAgentHarnessAgentEndHook(...)`; their failures do not alter the completed
 attempt result.
 
+### User input and tool surfaces
+
+Native harnesses that expose a runtime-level user-input request should use the
+user-input helpers from `openclaw/plugin-sdk/agent-harness-runtime` to format
+the prompt, deliver it through OpenClaw's blocking reply path, and normalize
+choice/free-form answers back into the runtime's native response shape. The
+helper keeps channel/TUI presentation consistent while each harness keeps its
+own protocol parsing and pending-request lifecycle.
+
+Native harnesses that need PI-like compact tool routing should use
+`createAgentHarnessToolSurfaceRuntime(...)` from the same SDK subpath. It owns
+tool-search/code-mode control selection, local-model lean defaults,
+runtime-compatible schema filtering, hidden catalog execution, directory
+hydration, and catalog cleanup. Harnesses still own their SDK-specific tool
+conversion and native execution callback.
+
 ### Native Codex harness mode
 
 The bundled `codex` harness is the native Codex mode for embedded OpenClaw

--- a/docs/providers/xiaomi.md
+++ b/docs/providers/xiaomi.md
@@ -84,8 +84,8 @@ Choose the Token Plan auth choice that matches the regional base URL shown in Xi
 
 | Model ref                         | Input       | Context   | Max output | Reasoning | Notes         |
 | --------------------------------- | ----------- | --------- | ---------- | --------- | ------------- |
-| `xiaomi-token-plan/mimo-v2.5-pro` | text        | 1,048,576 | 32,000     | Yes       | Default model |
-| `xiaomi-token-plan/mimo-v2.5`     | text, image | 1,048,576 | 32,000     | Yes       | Multimodal    |
+| `xiaomi-token-plan/mimo-v2.5-pro` | text        | 1,048,576 | 131,072    | Yes       | Default model |
+| `xiaomi-token-plan/mimo-v2.5`     | text, image | 1,048,576 | 131,072    | Yes       | Multimodal    |
 
 <Tip>
 Token Plan onboarding validates the key shape and warns when a `tp-...` key is entered into the pay-as-you-go path, or an `sk-...` key is entered into the Token Plan path.
@@ -222,7 +222,7 @@ Token Plan:
             reasoning: true,
             input: ["text"],
             contextWindow: 1048576,
-            maxTokens: 32000,
+            maxTokens: 131072,
           },
           {
             id: "mimo-v2.5",
@@ -230,7 +230,7 @@ Token Plan:
             reasoning: true,
             input: ["text", "image"],
             contextWindow: 1048576,
-            maxTokens: 32000,
+            maxTokens: 131072,
           },
         ],
       },

--- a/extensions/codex/src/app-server/user-input-bridge.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.ts
@@ -3,7 +3,12 @@
  * turns replies into app-server answer payloads.
  */
 import {
+  buildAgentHarnessUserInputAnswers,
+  deliverAgentHarnessUserInputPrompt,
   embeddedAgentLog,
+  emptyAgentHarnessUserInputAnswers,
+  type AgentHarnessUserInputOption,
+  type AgentHarnessUserInputQuestion,
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { formatCodexDisplayText } from "../command-formatters.js";
@@ -19,23 +24,9 @@ type PendingUserInput = {
   threadId: string;
   turnId: string;
   itemId: string;
-  questions: UserInputQuestion[];
+  questions: AgentHarnessUserInputQuestion[];
   resolve: (value: JsonValue) => void;
   cleanup: () => void;
-};
-
-type UserInputQuestion = {
-  id: string;
-  header: string;
-  question: string;
-  isOther: boolean;
-  isSecret: boolean;
-  options: UserInputOption[] | null;
-};
-
-type UserInputOption = {
-  label: string;
-  description: string;
 };
 
 type CodexUserInputBridge = {
@@ -142,7 +133,7 @@ function readUserInputParams(value: JsonValue | undefined):
       threadId: string;
       turnId: string;
       itemId: string;
-      questions: UserInputQuestion[];
+      questions: AgentHarnessUserInputQuestion[];
     }
   | undefined {
   if (!isJsonObject(value)) {
@@ -157,11 +148,11 @@ function readUserInputParams(value: JsonValue | undefined):
   }
   const questions = questionsRaw
     .map(readQuestion)
-    .filter((question): question is UserInputQuestion => Boolean(question));
+    .filter((question): question is AgentHarnessUserInputQuestion => Boolean(question));
   return { threadId, turnId, itemId, questions };
 }
 
-function readQuestion(value: JsonValue): UserInputQuestion | undefined {
+function readQuestion(value: JsonValue): AgentHarnessUserInputQuestion | undefined {
   if (!isJsonObject(value)) {
     return undefined;
   }
@@ -181,17 +172,17 @@ function readQuestion(value: JsonValue): UserInputQuestion | undefined {
   };
 }
 
-function readOptions(value: JsonValue | undefined): UserInputOption[] | null {
+function readOptions(value: JsonValue | undefined): AgentHarnessUserInputOption[] | null {
   if (!Array.isArray(value)) {
     return null;
   }
   const options = value
     .map(readOption)
-    .filter((option): option is UserInputOption => Boolean(option));
+    .filter((option): option is AgentHarnessUserInputOption => Boolean(option));
   return options.length > 0 ? options : null;
 }
 
-function readOption(value: JsonValue): UserInputOption | undefined {
+function readOption(value: JsonValue): AgentHarnessUserInputOption | undefined {
   if (!isJsonObject(value)) {
     return undefined;
   }
@@ -202,116 +193,25 @@ function readOption(value: JsonValue): UserInputOption | undefined {
 
 async function deliverUserInputPrompt(
   params: EmbeddedRunAttemptParams,
-  questions: UserInputQuestion[],
+  questions: AgentHarnessUserInputQuestion[],
 ): Promise<void> {
-  const text = formatUserInputPrompt(questions);
-  if (params.onBlockReply) {
-    await params.onBlockReply({ text });
-    return;
-  }
-  await params.onPartialReply?.({ text });
-}
-
-function formatUserInputPrompt(questions: UserInputQuestion[]): string {
-  const lines = ["Codex needs input:"];
-  questions.forEach((question, index) => {
-    if (questions.length > 1) {
-      lines.push(
-        "",
-        `${index + 1}. ${formatCodexDisplayText(question.header)}`,
-        formatCodexDisplayText(question.question),
-      );
-    } else {
-      lines.push(
-        "",
-        formatCodexDisplayText(question.header),
-        formatCodexDisplayText(question.question),
-      );
-    }
-    if (question.isSecret) {
-      lines.push("This channel may show your reply to other participants.");
-    }
-    question.options?.forEach((option, optionIndex) => {
-      lines.push(
-        `${optionIndex + 1}. ${formatCodexDisplayText(option.label)}${
-          option.description ? ` - ${formatCodexDisplayText(option.description)}` : ""
-        }`,
-      );
-    });
-    if (question.isOther) {
-      lines.push("Other: reply with your own answer.");
-    }
+  await deliverAgentHarnessUserInputPrompt(params, questions, {
+    formatText: formatCodexDisplayText,
+    intro: "Codex needs input:",
   });
-  return lines.join("\n");
 }
 
-function buildUserInputResponse(questions: UserInputQuestion[], inputText: string): JsonObject {
+function buildUserInputResponse(
+  questions: AgentHarnessUserInputQuestion[],
+  inputText: string,
+): JsonObject {
   // Multi-question replies may use "header: answer" or numbered lines. Keep the
   // parser permissive so chat-channel replies remain ergonomic.
-  const answers: JsonObject = {};
-  if (questions.length === 1) {
-    const question = questions[0];
-    if (question) {
-      const answer = normalizeAnswer(inputText, question);
-      answers[question.id] = { answers: answer ? [answer] : [] };
-    }
-    return { answers };
-  }
-
-  const keyed = parseKeyedAnswers(inputText);
-  const fallbackLines = inputText
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
-  questions.forEach((question, index) => {
-    const key =
-      keyed.get(question.id.toLowerCase()) ??
-      keyed.get(question.header.toLowerCase()) ??
-      keyed.get(question.question.toLowerCase()) ??
-      keyed.get(String(index + 1));
-    const answer = key ?? fallbackLines[index] ?? "";
-    const normalized = answer ? normalizeAnswer(answer, question) : undefined;
-    answers[question.id] = { answers: normalized ? [normalized] : [] };
-  });
-  return { answers };
-}
-
-function normalizeAnswer(answer: string, question: UserInputQuestion): string | undefined {
-  const trimmed = answer.trim();
-  const options = question.options ?? [];
-  const optionIndex = /^\d+$/.test(trimmed) ? Number(trimmed) - 1 : -1;
-  const indexed = optionIndex >= 0 ? options[optionIndex] : undefined;
-  if (indexed) {
-    return indexed.label;
-  }
-  const exact = options.find((option) => option.label.toLowerCase() === trimmed.toLowerCase());
-  if (exact) {
-    return exact.label;
-  }
-  if (options.length > 0 && !question.isOther) {
-    return undefined;
-  }
-  return trimmed || undefined;
-}
-
-function parseKeyedAnswers(inputText: string): Map<string, string> {
-  const answers = new Map<string, string>();
-  for (const line of inputText.split(/\r?\n/)) {
-    const match = line.match(/^\s*([^:=-]+?)\s*[:=-]\s*(.+?)\s*$/);
-    if (!match) {
-      continue;
-    }
-    const key = match[1]?.trim().toLowerCase();
-    const value = match[2]?.trim();
-    if (key && value) {
-      answers.set(key, value);
-    }
-  }
-  return answers;
+  return buildAgentHarnessUserInputAnswers(questions, inputText) as unknown as JsonObject;
 }
 
 function emptyUserInputResponse(): JsonObject {
-  return { answers: {} };
+  return emptyAgentHarnessUserInputAnswers() as unknown as JsonObject;
 }
 
 function readString(record: JsonObject, key: string): string | undefined {

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -3,9 +3,11 @@ import fsp from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { CopilotClient, Tool as SdkTool } from "@github/copilot-sdk";
-import type {
-  AgentHarnessAttemptParams,
-  AgentHarnessAttemptResult,
+import {
+  abortAgentHarnessRun,
+  queueAgentHarnessMessage,
+  type AgentHarnessAttemptParams,
+  type AgentHarnessAttemptResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { SandboxContext } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
@@ -1171,6 +1173,36 @@ describe("runCopilotAttempt", () => {
     expect(result.externalAbort).toBe(true);
   });
 
+  it("active-run abort path marks the attempt as externally aborted", async () => {
+    const sendDeferred = createDeferred<SessionEventShape | undefined>();
+    const sessionCreated = createDeferred<FakeSession>();
+    const sdk = makeFakeSdk({
+      onCreateSession: (session) => {
+        session.sendAndWait.mockReturnValue(sendDeferred.promise);
+        session.abort.mockImplementationOnce(async () => {
+          sendDeferred.resolve(undefined);
+        });
+        sessionCreated.resolve(session);
+      },
+    });
+    const pool = makeFakePool(sdk);
+    const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+
+    const runPromise = runCopilotAttempt(makeParams(), {
+      createToolBridge,
+      pool,
+    });
+    const session = await sessionCreated.promise;
+    await vi.waitFor(() => expect(session.sendAndWait).toHaveBeenCalledTimes(1));
+
+    expect(abortAgentHarnessRun("session-1")).toBe(true);
+    const result = await runPromise;
+
+    expect(session.abort).toHaveBeenCalledTimes(1);
+    expect(result.aborted).toBe(true);
+    expect(result.externalAbort).toBe(true);
+  });
+
   it("abort path (signal already aborted)", async () => {
     const controller = new AbortController();
     controller.abort();
@@ -1447,18 +1479,42 @@ describe("runCopilotAttempt", () => {
     expect(result.feedback).toContain("no permission policy installed");
   });
 
-  it("does not register onUserInputRequest (ask_user hidden from the model in MVP)", async () => {
-    const sdk = makeFakeSdk();
+  it("registers ask_user and resolves it from the active OpenClaw queue", async () => {
+    const onBlockReply = vi.fn();
+    const sdk = makeFakeSdk({
+      onCreateSession: (session, cfg) => {
+        session.sendAndWait.mockImplementationOnce(async () => {
+          const handler = cfg.onUserInputRequest;
+          if (typeof handler !== "function") {
+            throw new Error("expected onUserInputRequest handler");
+          }
+          const response = await handler(
+            {
+              question: "Pick a mode",
+              choices: ["Fast", "Deep"],
+              allowFreeform: false,
+            },
+            { sessionId: session.sessionId },
+          );
+          return makeAssistantMessageEvent(`selected ${response.answer}`);
+        });
+      },
+    });
     const pool = makeFakePool(sdk);
 
-    await runCopilotAttempt(makeParams(), { pool });
+    const attempt = runCopilotAttempt(makeParams({ onBlockReply }), { pool });
+
+    await vi.waitFor(() => expect(onBlockReply).toHaveBeenCalledTimes(1));
+    expect(queueAgentHarnessMessage("session-1", "2")).toBe(true);
+    const result = await attempt;
 
     const cfg = sdk.createSession.mock.calls[0]?.[0];
-    // Per the SDK contract (types.d.ts: `When provided, enables the
-    // ask_user tool allowing the agent to ask questions`), omitting the
-    // handler hides ask_user from the model entirely. The MVP keeps it
-    // hidden until a real channel/TUI prompt bridge exists.
-    expect("onUserInputRequest" in cfg).toBe(false);
+    expect(typeof cfg.onUserInputRequest).toBe("function");
+    expect(onBlockReply.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ text: expect.stringContaining("Pick a mode") }),
+    );
+    expect(result.assistantTexts).toEqual(["selected Deep"]);
+    expect(queueAgentHarnessMessage("session-1", "late")).toBe(false);
   });
 
   it("enableSessionTelemetry is omitted from createSession when undefined (SDK default)", async () => {
@@ -3066,7 +3122,8 @@ describe("runCopilotAttempt", () => {
   // permission policy and pollute the catalog under the default reject
   // policy. `createSessionConfig` derives `availableTools` from the
   // post-filter `sdkTools` so create- and resume-session always carry
-  // exactly the names of the tools the bridge actually exposed.
+  // exactly the names of the tools the bridge actually exposed plus the
+  // built-in `ask_user` tool owned by the registered user-input handler.
   describe("availableTools surface restriction (PR #86155 [P1] round-8)", () => {
     function makeFakeSdkTool(name: string): SdkTool {
       return {
@@ -3090,7 +3147,12 @@ describe("runCopilotAttempt", () => {
 
       await runCopilotAttempt(makeParams(), { createToolBridge, pool });
 
-      expect(readAvailableTools(sdk.createSession.mock.calls[0])).toEqual(["read", "edit"]);
+      expect(readAvailableTools(sdk.createSession.mock.calls[0])).toEqual([
+        "read",
+        "edit",
+        "ask_user",
+        "builtin:ask_user",
+      ]);
     });
 
     it("forwards `[]` to the SDK when the bridge returns no tools (disable / raw / fully filtered)", async () => {
@@ -3100,12 +3162,16 @@ describe("runCopilotAttempt", () => {
       // (`modelRun: true` or `promptMode: "none"`), an empty
       // `toolsAllow: []`, and an unsupported provider to `sdkTools: []`.
       // Whatever the upstream reason, `availableTools` must be the same
-      // empty list so the SDK cannot fall back to its native catalog.
+      // ask_user-only list so the SDK cannot fall back to its native
+      // catalog while the registered user-input handler remains usable.
       const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
 
       await runCopilotAttempt(makeParams(), { createToolBridge, pool });
 
-      expect(readAvailableTools(sdk.createSession.mock.calls[0])).toEqual([]);
+      expect(readAvailableTools(sdk.createSession.mock.calls[0])).toEqual([
+        "ask_user",
+        "builtin:ask_user",
+      ]);
     });
 
     it("forwards the full bridged set when the run is unrestricted (no toolsAllow)", async () => {
@@ -3131,6 +3197,8 @@ describe("runCopilotAttempt", () => {
         "edit",
         "exec",
         "message",
+        "ask_user",
+        "builtin:ask_user",
       ]);
     });
 
@@ -3156,7 +3224,7 @@ describe("runCopilotAttempt", () => {
 
       const resumeCall = sdk.resumeSession.mock.calls[0] as unknown[] | undefined;
       const resumeCfg = resumeCall?.[1] as { availableTools?: string[] };
-      expect(resumeCfg?.availableTools).toEqual(["read"]);
+      expect(resumeCfg?.availableTools).toEqual(["read", "ask_user", "builtin:ask_user"]);
     });
 
     it("forwards `[]` to resumeSession when the bridge returns no tools", async () => {
@@ -3175,7 +3243,7 @@ describe("runCopilotAttempt", () => {
 
       const resumeCall = sdk.resumeSession.mock.calls[0] as unknown[] | undefined;
       const resumeCfg = resumeCall?.[1] as { availableTools?: string[] };
-      expect(resumeCfg?.availableTools).toEqual([]);
+      expect(resumeCfg?.availableTools).toEqual(["ask_user", "builtin:ask_user"]);
     });
   });
 

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -1910,6 +1910,7 @@ describe("runCopilotAttempt", () => {
   it("retains a timed-out session until later compaction reaches session.idle", async () => {
     const afterCompaction = vi.fn();
     const onDeferredCompaction = vi.fn();
+    const cleanupToolBridge = vi.fn();
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "after_compaction", handler: afterCompaction }]),
     );
@@ -1922,8 +1923,14 @@ describe("runCopilotAttempt", () => {
         );
       },
     });
+    const createToolBridge = vi.fn(async () => ({
+      cleanup: cleanupToolBridge,
+      sdkTools: [],
+      sourceTools: [],
+    }));
 
     const result = await runCopilotAttempt(makeParams(), {
+      createToolBridge,
       onDeferredCompaction,
       pool: makeFakePool(sdk),
     });
@@ -1933,6 +1940,7 @@ describe("runCopilotAttempt", () => {
     expect(onDeferredCompaction).toHaveBeenCalledWith(
       expect.objectContaining({ sdkSessionId: "sess-1" }),
     );
+    expect(cleanupToolBridge).not.toHaveBeenCalled();
     expect(activeSession?.disconnect).not.toHaveBeenCalled();
 
     activeSession?.emit("session.compaction_start", {});
@@ -1946,6 +1954,7 @@ describe("runCopilotAttempt", () => {
     await vi.waitFor(() => {
       expect(activeSession?.disconnect).toHaveBeenCalledTimes(1);
     });
+    expect(cleanupToolBridge).toHaveBeenCalledTimes(1);
   });
 
   it("does not mark a timeout after SDK compaction has completed as active compaction", async () => {
@@ -3150,7 +3159,6 @@ describe("runCopilotAttempt", () => {
       expect(readAvailableTools(sdk.createSession.mock.calls[0])).toEqual([
         "read",
         "edit",
-        "ask_user",
         "builtin:ask_user",
       ]);
     });
@@ -3168,10 +3176,7 @@ describe("runCopilotAttempt", () => {
 
       await runCopilotAttempt(makeParams(), { createToolBridge, pool });
 
-      expect(readAvailableTools(sdk.createSession.mock.calls[0])).toEqual([
-        "ask_user",
-        "builtin:ask_user",
-      ]);
+      expect(readAvailableTools(sdk.createSession.mock.calls[0])).toEqual(["builtin:ask_user"]);
     });
 
     it("forwards the full bridged set when the run is unrestricted (no toolsAllow)", async () => {
@@ -3197,7 +3202,6 @@ describe("runCopilotAttempt", () => {
         "edit",
         "exec",
         "message",
-        "ask_user",
         "builtin:ask_user",
       ]);
     });
@@ -3224,7 +3228,7 @@ describe("runCopilotAttempt", () => {
 
       const resumeCall = sdk.resumeSession.mock.calls[0] as unknown[] | undefined;
       const resumeCfg = resumeCall?.[1] as { availableTools?: string[] };
-      expect(resumeCfg?.availableTools).toEqual(["read", "ask_user", "builtin:ask_user"]);
+      expect(resumeCfg?.availableTools).toEqual(["read", "builtin:ask_user"]);
     });
 
     it("forwards `[]` to resumeSession when the bridge returns no tools", async () => {
@@ -3243,7 +3247,7 @@ describe("runCopilotAttempt", () => {
 
       const resumeCall = sdk.resumeSession.mock.calls[0] as unknown[] | undefined;
       const resumeCfg = resumeCall?.[1] as { availableTools?: string[] };
-      expect(resumeCfg?.availableTools).toEqual(["ask_user", "builtin:ask_user"]);
+      expect(resumeCfg?.availableTools).toEqual(["builtin:ask_user"]);
     });
   });
 

--- a/extensions/copilot/src/attempt.ts
+++ b/extensions/copilot/src/attempt.ts
@@ -24,6 +24,8 @@ import {
   runAgentEndSideEffects,
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
+  clearActiveEmbeddedRun,
+  setActiveEmbeddedRun,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveCopilotAuth } from "./auth-bridge.js";
 import {
@@ -55,10 +57,12 @@ import {
 } from "./replay-shim.js";
 import type { ClientCreateOptions, CopilotClientPool, PoolKey, PooledClient } from "./runtime.js";
 import { createCopilotToolBridge } from "./tool-bridge.js";
+import { createCopilotUserInputBridge } from "./user-input-bridge.js";
 import { resolveCopilotWorkspaceBootstrapContext } from "./workspace-bootstrap.js";
 
 const SUPPORTED_PROVIDERS = new Set(["github-copilot"]);
 const BACKGROUND_COMPACTION_CANCEL_TIMEOUT_MS = 5_000;
+const COPILOT_ASK_USER_AVAILABLE_TOOLS = ["ask_user", "builtin:ask_user"] as const;
 
 type AttemptResultWithSdkSessionId = AgentHarnessAttemptResult & { sdkSessionId?: string };
 type PromptErrorWithCode = Error & { code?: string; cause?: unknown };
@@ -73,6 +77,7 @@ export type CopilotSessionConfig = Pick<
   | "infiniteSessions"
   | "model"
   | "onPermissionRequest"
+  | "onUserInputRequest"
   | "reasoningEffort"
   | "systemMessage"
   | "tools"
@@ -403,6 +408,9 @@ export async function runCopilotAttempt(
   let handle: PooledClient | undefined;
   let session: SessionLike | undefined;
   let bridge: ReturnType<typeof attachEventBridge> | undefined;
+  let activeRunHandleRef: Parameters<typeof clearActiveEmbeddedRun>[1] | undefined;
+  let userInputBridgeRef: ReturnType<typeof createCopilotUserInputBridge> | undefined;
+  let cleanupToolBridge: (() => void) | undefined;
   let releaseError: Error | undefined;
   let downgradedFromResume = false;
   let resumeFailureRecovered = false;
@@ -415,14 +423,22 @@ export async function runCopilotAttempt(
   // `src/agents/pi-embedded-runner/run/types.ts:139`.
   let yieldDetected = false;
 
-  const onAbort = () => {
+  const markExternalAbort = () => {
     abortRequested = true;
     externalAbort = true;
     aborted = true;
+  };
+
+  const abortActiveSession = () => {
+    markExternalAbort();
     if (settled || !sentTurnStarted || !session) {
       return;
     }
     void session.abort().catch(() => undefined);
+  };
+
+  const onAbort = () => {
+    abortActiveSession();
   };
 
   params.abortSignal?.addEventListener("abort", onAbort, { once: true });
@@ -575,6 +591,7 @@ export async function runCopilotAttempt(
             startedAt,
           }),
       });
+      cleanupToolBridge = toolBridge.cleanup;
       sdkTools = toolBridge.sdkTools;
     } catch (error: unknown) {
       const result = createResult(input, {
@@ -655,6 +672,11 @@ export async function runCopilotAttempt(
       });
     };
     const hasNativePromptHook = Boolean(attemptInput.hooksConfig?.onUserPromptSubmitted);
+    const userInputBridge = createCopilotUserInputBridge({
+      paramsForRun: attemptInput,
+      signal: params.abortSignal,
+    });
+    userInputBridgeRef = userInputBridge;
     const sessionConfig = createSessionConfig(
       attemptInput,
       modelRef.id,
@@ -663,6 +685,7 @@ export async function runCopilotAttempt(
       promptBuild.developerInstructions || undefined,
       effectiveWorkspaceDir,
       effectiveCwd,
+      userInputBridge.onUserInputRequest,
       hasNativePromptHook
         ? {
             onUserPromptSubmitted: ({ additionalContext, prompt }) =>
@@ -748,6 +771,29 @@ export async function runCopilotAttempt(
       isAborted: () => aborted,
     });
 
+    const activeRunHandle = {
+      kind: "embedded" as const,
+      queueMessage: async (text: string) => {
+        if (userInputBridge.handleQueuedMessage(text)) {
+          return;
+        }
+        throw new Error("Copilot runtime is not waiting for user input.");
+      },
+      isStreaming: () => !settled && !aborted,
+      isCompacting: () => bridge?.isCompacting() ?? false,
+      sourceReplyDeliveryMode: input.sourceReplyDeliveryMode,
+      cancel: () => {
+        userInputBridge.cancelPending();
+        abortActiveSession();
+      },
+      abort: () => {
+        userInputBridge.cancelPending();
+        abortActiveSession();
+      },
+    };
+    setActiveEmbeddedRun(input.sessionId, activeRunHandle, input.sessionKey, input.sessionFile);
+    activeRunHandleRef = activeRunHandle;
+
     const messageOptions = await createMessageOptions(attemptInput, {
       effectiveCwd,
       effectiveWorkspaceDir,
@@ -806,6 +852,16 @@ export async function runCopilotAttempt(
     }
   } finally {
     settled = true;
+    cleanupToolBridge?.();
+    userInputBridgeRef?.cancelPending();
+    if (activeRunHandleRef) {
+      clearActiveEmbeddedRun(
+        input.sessionId,
+        activeRunHandleRef,
+        input.sessionKey,
+        input.sessionFile,
+      );
+    }
     const retainSessionForDeferredCleanup =
       bridge?.hasObservedCompaction() || (timedOut && bridge?.hasObservedSessionIdle() === false);
     if (retainSessionForDeferredCleanup && bridge && session && handle) {
@@ -1118,6 +1174,7 @@ function createSessionConfig(
   systemMessageContent: string | undefined,
   effectiveWorkspaceDir: string | undefined,
   effectiveCwd: string | undefined,
+  onUserInputRequest: NonNullable<SessionConfig["onUserInputRequest"]>,
   hooksBridgeOptions?: Parameters<typeof createHooksBridge>[1],
 ): CopilotSessionConfig {
   const permissionPolicy = params.permissionPolicy ?? rejectAllPolicy;
@@ -1145,10 +1202,9 @@ function createSessionConfig(
     // tool wrapper, and the SDK gate is a safety net for kinds we
     // don't surface. See permission-bridge.ts and docs/plugins/copilot.md.
     onPermissionRequest: createPermissionBridge(permissionPolicy),
-    // `onUserInputRequest` is intentionally NOT registered: per the SDK
-    // contract, omitting the handler hides the `ask_user` tool from the
-    // model entirely. Interactive ask_user will need a real channel/TUI
-    // prompt bridge before this runtime can expose the handler.
+    // Registers the SDK ask_user bridge. The bridge itself owns pending
+    // reply routing so generic mid-run steering still fails closed.
+    onUserInputRequest,
     // Preserve the shipped native SDK hook contract. These callbacks expose
     // Copilot-specific events and decisions that generic lifecycle hooks do
     // not model.
@@ -1166,8 +1222,9 @@ function createSessionConfig(
     ...(infiniteSessions ? { infiniteSessions } : {}),
     reasoningEffort: params.reasoningEffort,
     tools: sdkTools,
-    // Restrict the SDK's tool catalog to exactly the bridged tool names
-    // returned by `createCopilotToolBridge`. Without this, the SDK
+    // Restrict the SDK's tool catalog to the bridged tool names returned
+    // by `createCopilotToolBridge` plus the built-in `ask_user` tool owned
+    // by `onUserInputRequest`. Without this, the SDK
     // would still expose its native read/write/shell/url/mcp/memory/
     // hook tools to the model alongside our overrides, which would
     // bypass OpenClaw's wrapped-tool enforcement under any permissive
@@ -1182,7 +1239,7 @@ function createSessionConfig(
     // `@github/copilot-sdk/dist/types.d.ts:1198` (it picks
     // `availableTools`, so the spread into `resumeSession` covers
     // the resume path too).
-    availableTools: sdkTools.map((tool) => tool.name),
+    availableTools: buildCopilotAvailableTools(sdkTools),
     workingDirectory:
       effectiveCwd ?? effectiveWorkspaceDir ?? readResolvedAttemptPath(params.workspaceDir),
     // When a task runs from a sub-cwd, keep SDK-native project docs
@@ -1226,6 +1283,10 @@ function createSessionConfig(
         }
       : {}),
   };
+}
+
+function buildCopilotAvailableTools(sdkTools: SdkTool[]): string[] {
+  return [...new Set([...sdkTools.map((tool) => tool.name), ...COPILOT_ASK_USER_AVAILABLE_TOOLS])];
 }
 
 async function createMessageOptions(

--- a/extensions/copilot/src/attempt.ts
+++ b/extensions/copilot/src/attempt.ts
@@ -62,7 +62,7 @@ import { resolveCopilotWorkspaceBootstrapContext } from "./workspace-bootstrap.j
 
 const SUPPORTED_PROVIDERS = new Set(["github-copilot"]);
 const BACKGROUND_COMPACTION_CANCEL_TIMEOUT_MS = 5_000;
-const COPILOT_ASK_USER_AVAILABLE_TOOLS = ["ask_user", "builtin:ask_user"] as const;
+const COPILOT_ASK_USER_AVAILABLE_TOOLS = ["builtin:ask_user"] as const;
 
 type AttemptResultWithSdkSessionId = AgentHarnessAttemptResult & { sdkSessionId?: string };
 type PromptErrorWithCode = Error & { code?: string; cause?: unknown };
@@ -227,6 +227,7 @@ function deferBackgroundCompactionCleanup(params: {
   bridge: ReturnType<typeof attachEventBridge>;
   handle: PooledClient;
   pool: CopilotClientPool;
+  cleanupToolBridge?: () => void;
   sdkSessionId?: string;
   session: SessionLike;
   timeoutMs: number;
@@ -255,6 +256,7 @@ function deferBackgroundCompactionCleanup(params: {
       } catch {
         // The attempt has already returned its timeout result.
       }
+      params.cleanupToolBridge?.();
       if (outcome !== "completed" && params.sdkSessionId) {
         try {
           await params.handle.client.deleteSession(params.sdkSessionId);
@@ -852,7 +854,6 @@ export async function runCopilotAttempt(
     }
   } finally {
     settled = true;
-    cleanupToolBridge?.();
     userInputBridgeRef?.cancelPending();
     if (activeRunHandleRef) {
       clearActiveEmbeddedRun(
@@ -876,6 +877,7 @@ export async function runCopilotAttempt(
         abortSignal: cleanupAbort.signal,
         awaitSessionIdle: !bridge.hasObservedSessionIdle(),
         bridge,
+        cleanupToolBridge,
         handle,
         pool: deps.pool,
         sdkSessionId,
@@ -904,6 +906,7 @@ export async function runCopilotAttempt(
       // defines as no background agents in flight. Timeouts retain the bridge
       // until that event so compaction that starts after the timer still completes.
       await bridge?.awaitCompactionChain();
+      cleanupToolBridge?.();
       bridge?.detach();
       params.abortSignal?.removeEventListener("abort", onAbort);
 

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -156,9 +156,182 @@ describe("createCopilotToolBridge", () => {
       sessionId: "session-1",
     });
 
-    expect(result.sourceTools).toBe(sourceTools);
+    expect(result.sourceTools).toEqual(sourceTools);
     expect(result.sdkTools).toHaveLength(2);
     expect(result.sdkTools.map((tool) => tool.name)).toEqual(["tool-a", "tool-b"]);
+  });
+
+  it("compacts the Copilot tool surface behind tool_search controls when enabled", async () => {
+    const createOpenClawCodingTools = vi.fn(async (opts: unknown) => {
+      const includeToolSearchControls = Boolean(
+        (opts as { includeToolSearchControls?: boolean }).includeToolSearchControls,
+      );
+      return includeToolSearchControls
+        ? [
+            makeTool({ name: "tool_search_code" }),
+            makeTool({ name: "fake_hidden" }),
+            makeTool({ name: "read" }),
+          ]
+        : [makeTool({ name: "fake_hidden" }), makeTool({ name: "read" })];
+    });
+
+    const result = await createCopilotToolBridge({
+      agentId: "agent-1",
+      attemptParams: {
+        config: { tools: { toolSearch: true } },
+        runId: "run-tool-search",
+        sessionKey: "agent:main:main",
+      } as never,
+      createOpenClawCodingTools,
+      modelId: "gpt-4o",
+      modelProvider: "github-copilot",
+      sessionId: "session-1",
+    });
+
+    expect(createOpenClawCodingTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeToolSearchControls: true,
+        toolSearchCatalogRef: expect.any(Object),
+        toolSearchCatalogExecutor: expect.any(Function),
+      }),
+    );
+    expect(result.sourceTools.map((tool) => tool.name)).toEqual(["tool_search_code"]);
+    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["tool_search_code"]);
+  });
+
+  it("keeps tool_search controls visible when a narrow allowlist is active", async () => {
+    const createOpenClawCodingTools = vi.fn(async (opts: unknown) => {
+      const includeToolSearchControls = Boolean(
+        (opts as { includeToolSearchControls?: boolean }).includeToolSearchControls,
+      );
+      return includeToolSearchControls
+        ? [makeTool({ name: "tool_search_code" }), makeTool({ name: "read" })]
+        : [makeTool({ name: "read" })];
+    });
+
+    const result = await createCopilotToolBridge({
+      agentId: "agent-1",
+      attemptParams: {
+        config: { tools: { toolSearch: true } },
+        runId: "run-tool-search",
+        sessionKey: "agent:main:main",
+        toolsAllow: ["read"],
+      } as never,
+      createOpenClawCodingTools,
+      modelId: "gpt-4o",
+      modelProvider: "github-copilot",
+      sessionId: "session-1",
+    });
+
+    expect(result.sourceTools.map((tool) => tool.name)).toEqual(["tool_search_code"]);
+    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["tool_search_code"]);
+  });
+
+  it("filters the hidden tool_search catalog before compacting narrowed tools", async () => {
+    let catalogRef: { current?: { entries?: Array<{ name: string }> } } | undefined;
+    const createOpenClawCodingTools = vi.fn(async (opts: unknown) => {
+      catalogRef = (opts as { toolSearchCatalogRef?: typeof catalogRef }).toolSearchCatalogRef;
+      return [
+        makeTool({ name: "tool_search_code" }),
+        makeTool({ name: "read" }),
+        makeTool({ name: "edit" }),
+        makeTool({ name: "write" }),
+      ];
+    });
+
+    await createCopilotToolBridge({
+      agentId: "agent-1",
+      attemptParams: {
+        config: { tools: { toolSearch: true } },
+        runId: "run-tool-search",
+        sessionKey: "agent:main:main",
+        toolsAllow: ["read"],
+      } as never,
+      createOpenClawCodingTools,
+      modelId: "gpt-4o",
+      modelProvider: "github-copilot",
+      sessionId: "session-1",
+    });
+
+    expect(catalogRef?.current?.entries?.map((entry) => entry.name)).toEqual(["read"]);
+  });
+
+  it("compacts the Copilot tool surface behind code-mode exec/wait when enabled", async () => {
+    const createOpenClawCodingTools = vi.fn(async () => [
+      makeTool({ name: "fake_hidden" }),
+      makeTool({ name: "read" }),
+    ]);
+
+    const result = await createCopilotToolBridge({
+      agentId: "agent-1",
+      attemptParams: {
+        config: { tools: { codeMode: true } },
+        runId: "run-code-mode",
+        sessionKey: "agent:main:main",
+      } as never,
+      createOpenClawCodingTools,
+      modelId: "gpt-4o",
+      modelProvider: "github-copilot",
+      sessionId: "session-1",
+    });
+
+    expect(createOpenClawCodingTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeToolSearchControls: false,
+        toolSearchCatalogRef: expect.any(Object),
+        toolSearchCatalogExecutor: expect.any(Function),
+      }),
+    );
+    expect(result.sourceTools.map((tool) => tool.name)).toEqual(["exec", "wait"]);
+    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["exec", "wait"]);
+  });
+
+  it("keeps code-mode controls visible when a narrow allowlist is active", async () => {
+    const createOpenClawCodingTools = vi.fn(async () => [
+      makeTool({ name: "fake_hidden" }),
+      makeTool({ name: "read" }),
+    ]);
+
+    const result = await createCopilotToolBridge({
+      agentId: "agent-1",
+      attemptParams: {
+        config: { tools: { codeMode: true } },
+        runId: "run-code-mode",
+        sessionKey: "agent:main:main",
+        toolsAllow: ["read"],
+      } as never,
+      createOpenClawCodingTools,
+      modelId: "gpt-4o",
+      modelProvider: "github-copilot",
+      sessionId: "session-1",
+    });
+
+    expect(result.sourceTools.map((tool) => tool.name)).toEqual(["exec", "wait"]);
+    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["exec", "wait"]);
+  });
+
+  it("filters the hidden code-mode catalog before compacting narrowed tools", async () => {
+    let catalogRef: { current?: { entries?: Array<{ name: string }> } } | undefined;
+    const createOpenClawCodingTools = vi.fn(async (opts: unknown) => {
+      catalogRef = (opts as { toolSearchCatalogRef?: typeof catalogRef }).toolSearchCatalogRef;
+      return [makeTool({ name: "read" }), makeTool({ name: "edit" }), makeTool({ name: "write" })];
+    });
+
+    await createCopilotToolBridge({
+      agentId: "agent-1",
+      attemptParams: {
+        config: { tools: { codeMode: true } },
+        runId: "run-code-mode",
+        sessionKey: "agent:main:main",
+        toolsAllow: ["read"],
+      } as never,
+      createOpenClawCodingTools,
+      modelId: "gpt-4o",
+      modelProvider: "github-copilot",
+      sessionId: "session-1",
+    });
+
+    expect(catalogRef?.current?.entries?.map((entry) => entry.name)).toEqual(["read"]);
   });
 
   it("throws when createOpenClawCodingTools returns a non-array", async () => {

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -8,6 +8,7 @@ import type {
 import {
   applyEmbeddedAttemptToolsAllow,
   buildEmbeddedAttemptToolRunContext,
+  createAgentHarnessToolSurfaceRuntime,
   extractToolErrorMessage,
   getPluginToolMeta,
   isSubagentSessionKey,
@@ -21,6 +22,10 @@ import {
 type CreateOpenClawCodingTools =
   (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"];
 type OpenClawCodingToolsOptions = NonNullable<Parameters<CreateOpenClawCodingTools>[0]>;
+type AgentHarnessToolSurfaceRuntime = ReturnType<typeof createAgentHarnessToolSurfaceRuntime>;
+type CatalogExecuteParams = Parameters<
+  NonNullable<AgentHarnessToolSurfaceRuntime["toolSearchCatalogExecutor"]>
+>[0];
 
 type AgentToolResultLike = {
   content?: unknown;
@@ -130,6 +135,7 @@ export interface CopilotToolBridgeInput {
 }
 
 export interface CopilotToolBridge {
+  cleanup?: () => void;
   sdkTools: SdkTool[];
   sourceTools: AnyAgentTool[];
 }
@@ -178,7 +184,31 @@ export async function createCopilotToolBridge(
     input.createOpenClawCodingTools ??
     (await import("openclaw/plugin-sdk/agent-harness")).createOpenClawCodingTools;
 
-  const toolOptions = buildOpenClawCodingToolsOptions(input, effectiveToolPlan);
+  const toolSurfaceRuntime = createAgentHarnessToolSurfaceRuntime({
+    abortSignal: input.abortSignal,
+    agentId: input.agentId,
+    config: attemptParams.config,
+    disableTools: attemptParams.disableTools,
+    executeTool: (toolParams) => executeCatalogTool(input, toolParams),
+    forceMessageTool: shouldForceCopilotMessageTool(attemptParams),
+    isRawModelRun: isCopilotRawModelRun(attemptParams),
+    modelToolsEnabled: true,
+    prompt: attemptParams.prompt,
+    runId: attemptParams.runId,
+    runtimeToolAllowlist: effectiveToolPlan.runtimeToolAllowlist,
+    sessionId: input.sessionId,
+    sessionKey: attemptParams.sandboxSessionKey ?? attemptParams.sessionKey ?? input.sessionKey,
+    sourceReplyDeliveryMode: attemptParams.sourceReplyDeliveryMode,
+    toolsAllow: attemptParams.toolsAllow,
+  });
+  const toolOptions = buildOpenClawCodingToolsOptions(
+    input,
+    {
+      ...effectiveToolPlan,
+      runtimeToolAllowlist: toolSurfaceRuntime.runtimeToolAllowlist,
+    },
+    toolSurfaceRuntime,
+  );
 
   let sourceTools: unknown;
   try {
@@ -196,13 +226,19 @@ export async function createCopilotToolBridge(
     );
   }
 
-  const plannedTools = filterCopilotToolsForConstructionPlan(
+  const allowedSourceTools = filterCopilotToolsForAllowlist(
     sourceTools as AnyAgentTool[],
+    toolSurfaceRuntime.runtimeToolAllowlist,
+  );
+  const compactedTools = toolSurfaceRuntime.compactTools(allowedSourceTools);
+  const plannedTools = filterCopilotToolsForConstructionPlan(
+    compactedTools.tools,
     effectiveToolPlan.codingToolConstructionPlan,
+    { preserveToolNames: toolSurfaceRuntime.runtimeToolAllowlist },
   );
   const filteredTools = filterCopilotToolsForAllowlist(
     plannedTools,
-    effectiveToolPlan.runtimeToolAllowlist,
+    toolSurfaceRuntime.runtimeToolAllowlist,
   );
 
   // Run duplicate detection after filtering so a duplicate in a
@@ -214,6 +250,7 @@ export async function createCopilotToolBridge(
   }
 
   return {
+    cleanup: toolSurfaceRuntime.cleanup,
     sdkTools: filteredTools.map((sourceTool) =>
       convertOpenClawToolToSdkTool(sourceTool, {
         abortSignal: input.abortSignal,
@@ -251,6 +288,7 @@ export async function createCopilotToolBridge(
 function buildOpenClawCodingToolsOptions(
   input: CopilotToolBridgeInput,
   toolPlan: ReturnType<typeof resolveEmbeddedAttemptToolConstructionPlan>,
+  toolSurfaceRuntime?: ReturnType<typeof createAgentHarnessToolSurfaceRuntime>,
 ): OpenClawCodingToolsOptions {
   const a = input.attemptParams ?? ({} as CopilotToolAttemptParams);
 
@@ -339,11 +377,14 @@ function buildOpenClawCodingToolsOptions(
     // `resolveSandboxContext`).
     sandbox,
     spawnWorkspaceDir,
-    config: a.config,
+    config: toolSurfaceRuntime?.config ?? a.config,
     abortSignal: input.abortSignal,
     modelProvider: input.modelProvider,
     modelId: input.modelId,
     includeCoreTools: toolPlan.includeCoreTools,
+    includeToolSearchControls: toolSurfaceRuntime?.includeToolSearchControls,
+    toolSearchCatalogRef: toolSurfaceRuntime?.toolSearchCatalogRef,
+    toolSearchCatalogExecutor: toolSurfaceRuntime?.toolSearchCatalogExecutor,
     runtimeToolAllowlist: toolPlan.runtimeToolAllowlist,
     toolConstructionPlan: toolPlan.codingToolConstructionPlan,
     modelCompat,
@@ -575,6 +616,63 @@ export function convertOpenClawToolToSdkTool(
   };
 }
 
+async function executeCatalogTool(
+  input: CopilotToolBridgeInput,
+  params: CatalogExecuteParams,
+): Promise<Awaited<ReturnType<AnyAgentTool["execute"]>>> {
+  const sourceTool = params.tool as AnyAgentTool;
+  const startedAt = Date.now();
+  let preparedArgs: unknown = params.input;
+  try {
+    preparedArgs = sourceTool.prepareArguments
+      ? sourceTool.prepareArguments(params.input)
+      : params.input;
+    const result = await sourceTool.execute(
+      params.toolCallId,
+      preparedArgs,
+      params.signal ?? input.abortSignal,
+      params.onUpdate,
+    );
+    const sanitizedResult = sanitizeToolResult(result);
+    const isError = isToolResultError(sanitizedResult);
+    input.attemptParams?.onAgentToolResult?.({
+      toolName: params.toolName,
+      result: sanitizedResult,
+      isError,
+    });
+    await input.onToolCompleted?.({
+      toolName: params.toolName,
+      toolCallId: params.toolCallId,
+      args: toToolStartArgs(preparedArgs),
+      result: sanitizedResult,
+      ...(isError
+        ? { error: extractToolErrorMessage(sanitizedResult) ?? "tool returned an error" }
+        : {}),
+      startedAt,
+    });
+    return result;
+  } catch (error: unknown) {
+    const message = toError(error).message;
+    const failure = sanitizeToolResult({
+      content: [{ type: "text", text: message }],
+      details: { status: "failed", error: message },
+    });
+    input.attemptParams?.onAgentToolResult?.({
+      toolName: params.toolName,
+      result: failure,
+      isError: true,
+    });
+    await input.onToolCompleted?.({
+      toolName: params.toolName,
+      toolCallId: params.toolCallId,
+      args: toToolStartArgs(preparedArgs),
+      error: message,
+      startedAt,
+    });
+    throw error;
+  }
+}
+
 function toToolStartArgs(args: unknown): Record<string, unknown> {
   return args && typeof args === "object" && !Array.isArray(args)
     ? (args as Record<string, unknown>)
@@ -712,11 +810,16 @@ function filterCopilotToolsForAllowlist<T extends { name: string }>(
 function filterCopilotToolsForConstructionPlan<T extends { name: string }>(
   tools: T[],
   plan: ReturnType<typeof resolveEmbeddedAttemptToolConstructionPlan>["codingToolConstructionPlan"],
+  options: { preserveToolNames?: readonly string[] } = {},
 ): T[] {
   if (plan.includeBaseCodingTools && plan.includeShellTools) {
     return tools;
   }
+  const preserveToolNames = new Set(options.preserveToolNames);
   return tools.filter((tool) => {
+    if (preserveToolNames.has(tool.name)) {
+      return true;
+    }
     if (!plan.includeBaseCodingTools && BASE_COPILOT_CODING_TOOL_NAMES.has(tool.name)) {
       return false;
     }

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -8,7 +8,6 @@ import type {
 import {
   applyEmbeddedAttemptToolsAllow,
   buildEmbeddedAttemptToolRunContext,
-  createAgentHarnessToolSurfaceRuntime,
   extractToolErrorMessage,
   getPluginToolMeta,
   isSubagentSessionKey,
@@ -18,6 +17,7 @@ import {
   resolveModelAuthMode,
   sanitizeToolResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createAgentHarnessToolSurfaceRuntime } from "openclaw/plugin-sdk/agent-harness-tool-runtime";
 
 type CreateOpenClawCodingTools =
   (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"];

--- a/extensions/copilot/src/user-input-bridge.test.ts
+++ b/extensions/copilot/src/user-input-bridge.test.ts
@@ -1,0 +1,121 @@
+// Copilot tests cover SDK ask_user bridge behavior.
+import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { createCopilotUserInputBridge } from "./user-input-bridge.js";
+
+function createParams(): EmbeddedRunAttemptParams {
+  return {
+    sessionId: "session-1",
+    sessionKey: "agent:main:session-1",
+    onBlockReply: vi.fn(),
+  } as unknown as EmbeddedRunAttemptParams;
+}
+
+function expectFirstBlockReplyText(params: EmbeddedRunAttemptParams): string {
+  const onBlockReply = params.onBlockReply;
+  if (!onBlockReply) {
+    throw new Error("Expected onBlockReply callback");
+  }
+  const payload = vi.mocked(onBlockReply).mock.calls[0]?.[0];
+  if (typeof payload?.text !== "string") {
+    throw new Error("Expected first block reply text");
+  }
+  return payload.text;
+}
+
+describe("Copilot user input bridge", () => {
+  it("prompts through OpenClaw and resolves the SDK request from the next queued message", async () => {
+    const params = createParams();
+    const bridge = createCopilotUserInputBridge({ paramsForRun: params });
+
+    const response = bridge.onUserInputRequest(
+      {
+        question: "Pick a mode",
+        choices: ["Fast", "Deep"],
+        allowFreeform: false,
+      },
+      { sessionId: "sdk-session-1" },
+    );
+
+    await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledTimes(1));
+    expect(expectFirstBlockReplyText(params)).toContain("Pick a mode");
+    expect(bridge.handleQueuedMessage("2")).toBe(true);
+
+    await expect(response).resolves.toEqual({ answer: "Deep", wasFreeform: false });
+  });
+
+  it("returns free-form answers when Copilot allows them", async () => {
+    const params = createParams();
+    const bridge = createCopilotUserInputBridge({ paramsForRun: params });
+
+    const response = bridge.onUserInputRequest(
+      {
+        question: "Which branch?",
+        allowFreeform: true,
+      },
+      { sessionId: "sdk-session-1" },
+    );
+
+    await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledTimes(1));
+    expect(bridge.handleQueuedMessage("fix/harness-parity")).toBe(true);
+
+    await expect(response).resolves.toEqual({
+      answer: "fix/harness-parity",
+      wasFreeform: true,
+    });
+  });
+
+  it("escapes SDK-controlled prompt text before channel delivery", async () => {
+    const params = createParams();
+    const bridge = createCopilotUserInputBridge({ paramsForRun: params });
+
+    void bridge.onUserInputRequest(
+      {
+        question: "Pick [trusted](https://evil) <@U123> @here\u202e",
+        choices: ["One @everyone", "Two `code`"],
+        allowFreeform: false,
+      },
+      { sessionId: "sdk-session-1" },
+    );
+
+    await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledTimes(1));
+    const text = expectFirstBlockReplyText(params);
+    expect(text).not.toContain("@here");
+    expect(text).not.toContain("@everyone");
+    expect(text).not.toContain("<@U123>");
+    expect(text).not.toContain("[trusted](https://evil)");
+    expect(text).not.toContain("`code`");
+    expect(text).toContain("\uff20here");
+    expect(text).toContain("\uff3btrusted\uff3d");
+  });
+
+  it("rejects queued messages when no ask_user request is pending", () => {
+    const bridge = createCopilotUserInputBridge({ paramsForRun: createParams() });
+
+    expect(bridge.handleQueuedMessage("late")).toBe(false);
+  });
+
+  it("resolves pending requests with an empty answer when aborted", async () => {
+    const params = createParams();
+    const controller = new AbortController();
+    const bridge = createCopilotUserInputBridge({
+      paramsForRun: params,
+      signal: controller.signal,
+    });
+
+    const response = bridge.onUserInputRequest(
+      {
+        question: "Continue?",
+        choices: ["Yes", "No"],
+        allowFreeform: false,
+      },
+      { sessionId: "sdk-session-1" },
+    );
+
+    await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledTimes(1));
+    controller.abort();
+
+    await expect(response).resolves.toEqual({ answer: "", wasFreeform: true });
+    expect(bridge.handleQueuedMessage("1")).toBe(false);
+  });
+});

--- a/extensions/copilot/src/user-input-bridge.ts
+++ b/extensions/copilot/src/user-input-bridge.ts
@@ -1,0 +1,161 @@
+import type { SessionConfig } from "@github/copilot-sdk";
+import {
+  buildAgentHarnessUserInputAnswers,
+  deliverAgentHarnessUserInputPrompt,
+  embeddedAgentLog,
+  type AgentHarnessUserInputQuestion,
+  type EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+
+type PendingCopilotUserInput = {
+  question: AgentHarnessUserInputQuestion;
+  resolve: (value: CopilotUserInputResponse) => void;
+  cleanup: () => void;
+};
+
+type CopilotUserInputHandler = NonNullable<SessionConfig["onUserInputRequest"]>;
+type CopilotUserInputRequest = Parameters<CopilotUserInputHandler>[0];
+type CopilotUserInputResponse = Awaited<ReturnType<CopilotUserInputHandler>>;
+
+type CopilotUserInputBridge = {
+  onUserInputRequest: CopilotUserInputHandler;
+  handleQueuedMessage: (text: string) => boolean;
+  cancelPending: () => void;
+};
+
+const COPILOT_USER_INPUT_QUESTION_ID = "answer";
+
+export function createCopilotUserInputBridge(params: {
+  paramsForRun: EmbeddedRunAttemptParams;
+  signal?: AbortSignal;
+}): CopilotUserInputBridge {
+  let pending: PendingCopilotUserInput | undefined;
+
+  const resolvePending = (value: CopilotUserInputResponse) => {
+    const current = pending;
+    if (!current) {
+      return;
+    }
+    pending = undefined;
+    current.cleanup();
+    current.resolve(value);
+  };
+
+  return {
+    onUserInputRequest(request) {
+      const question = toQuestion(request);
+      resolvePending(emptyCopilotUserInputResponse());
+      return new Promise<CopilotUserInputResponse>((resolve) => {
+        const abortListener = () => resolvePending(emptyCopilotUserInputResponse());
+        const cleanup = () => params.signal?.removeEventListener("abort", abortListener);
+        pending = { question, resolve, cleanup };
+        params.signal?.addEventListener("abort", abortListener, { once: true });
+        if (params.signal?.aborted) {
+          resolvePending(emptyCopilotUserInputResponse());
+          return;
+        }
+        void deliverAgentHarnessUserInputPrompt(params.paramsForRun, [question], {
+          intro: "Copilot needs input:",
+          formatText: formatCopilotDisplayText,
+        }).catch((error: unknown) => {
+          embeddedAgentLog.warn("failed to deliver copilot user input prompt", { error });
+        });
+      });
+    },
+    handleQueuedMessage(text) {
+      const current = pending;
+      if (!current) {
+        return false;
+      }
+      resolvePending(buildCopilotUserInputResponse(current.question, text));
+      return true;
+    },
+    cancelPending() {
+      resolvePending(emptyCopilotUserInputResponse());
+    },
+  };
+}
+
+function toQuestion(request: CopilotUserInputRequest): AgentHarnessUserInputQuestion {
+  return {
+    id: COPILOT_USER_INPUT_QUESTION_ID,
+    header: "Copilot needs input",
+    question: request.question,
+    isOther: request.allowFreeform !== false,
+    isSecret: false,
+    options:
+      request.choices && request.choices.length > 0
+        ? request.choices.map((choice: string) => ({ label: choice }))
+        : null,
+  };
+}
+
+function buildCopilotUserInputResponse(
+  question: AgentHarnessUserInputQuestion,
+  inputText: string,
+): CopilotUserInputResponse {
+  const rawAnswers = buildAgentHarnessUserInputAnswers([question], inputText);
+  const selected = rawAnswers.answers[COPILOT_USER_INPUT_QUESTION_ID]?.answers[0] ?? "";
+  return {
+    answer: selected,
+    wasFreeform: !isChoiceAnswer(question, selected),
+  };
+}
+
+function emptyCopilotUserInputResponse(): CopilotUserInputResponse {
+  return { answer: "", wasFreeform: true };
+}
+
+function isChoiceAnswer(question: AgentHarnessUserInputQuestion, answer: string): boolean {
+  return Boolean(
+    answer &&
+    question.options?.some((option) => option.label.toLowerCase() === answer.toLowerCase()),
+  );
+}
+
+function formatCopilotDisplayText(value: string): string {
+  const safe = sanitizeCopilotDisplayText(value).trim();
+  return escapeCopilotChatText(safe || "<unknown>");
+}
+
+function sanitizeCopilotDisplayText(value: string): string {
+  let safe = "";
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    safe += codePoint != null && isUnsafeDisplayCodePoint(codePoint) ? "?" : character;
+  }
+  return safe;
+}
+
+function escapeCopilotChatText(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("@", "\uff20")
+    .replaceAll("`", "\uff40")
+    .replaceAll("[", "\uff3b")
+    .replaceAll("]", "\uff3d")
+    .replaceAll("(", "\uff08")
+    .replaceAll(")", "\uff09")
+    .replaceAll("*", "\u2217")
+    .replaceAll("_", "\uff3f")
+    .replaceAll("~", "\uff5e")
+    .replaceAll("|", "\uff5c");
+}
+
+function isUnsafeDisplayCodePoint(codePoint: number): boolean {
+  return (
+    codePoint <= 0x001f ||
+    (codePoint >= 0x007f && codePoint <= 0x009f) ||
+    codePoint === 0x00ad ||
+    codePoint === 0x061c ||
+    codePoint === 0x180e ||
+    (codePoint >= 0x200b && codePoint <= 0x200f) ||
+    (codePoint >= 0x202a && codePoint <= 0x202e) ||
+    (codePoint >= 0x2060 && codePoint <= 0x206f) ||
+    codePoint === 0xfeff ||
+    (codePoint >= 0xfff9 && codePoint <= 0xfffb) ||
+    (codePoint >= 0xe0000 && codePoint <= 0xe007f)
+  );
+}

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -1231,6 +1231,9 @@ describe("buildQaRuntimeEnv", () => {
     await expect(readFile(path.join(artifactDir, "README.txt"), "utf8")).resolves.toContain(
       "was not copied because it may contain credentials or auth tokens",
     );
+    await expect(readFile(path.join(artifactDir, "README.txt"), "utf8")).resolves.not.toContain(
+      tempRoot,
+    );
   });
 
   it("rejects preserved gateway artifacts outside the repo root", async () => {

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -162,7 +162,7 @@ async function preserveQaGatewayDebugArtifacts(params: {
     [
       "Only sanitized gateway debug artifacts are preserved here.",
       "The full QA gateway runtime was not copied because it may contain credentials or auth tokens.",
-      `Original runtime temp root: ${params.tempRoot}`,
+      "Original runtime temp root omitted because local temp paths can identify the runner.",
       "",
     ].join("\n"),
     "utf8",

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -3314,7 +3314,7 @@ describe("qa mock openai server", () => {
     const toolPlanOutput = outputItem(await response.json());
     expect(toolPlanOutput.type).toBe("function_call");
     expect(toolPlanOutput.name).toBe("web_search");
-    expect(String(toolPlanOutput.arguments)).toContain("denied-input");
+    expect(String(toolPlanOutput.arguments)).toContain("OPENCLAW_QA_WEB_SEARCH_DENIED_INPUT");
   });
 
   it("plans QA subagent handoff calls even when Codex dynamic tools are not in body.tools", async () => {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -5,6 +5,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
 import { readRequestBodyWithLimit } from "openclaw/plugin-sdk/webhook-ingress";
 import { closeQaHttpServer } from "../../bus-server.js";
+import { QA_LAB_WEB_SEARCH_DENIED_INPUT_QUERY } from "../../qa-web-search-provider.js";
 import { writeJson } from "../shared/http-json.js";
 
 type ResponsesInputItem = Record<string, unknown>;
@@ -860,6 +861,9 @@ function extractToolSearchTarget(text: string): string | null {
 }
 
 function buildQaToolSearchArgs(targetTool: string, failureMode: boolean): Record<string, unknown> {
+  if (failureMode && targetTool === "web_search") {
+    return { query: QA_LAB_WEB_SEARCH_DENIED_INPUT_QUERY };
+  }
   if (failureMode) {
     return { __qaFailureMode: "denied-input" };
   }
@@ -1535,49 +1539,57 @@ function buildToolCallEvents(prompt: string): StreamEvent[] {
 function buildReleaseAuditJson() {
   return `${JSON.stringify(
     {
-      verified: true,
+      verified: false,
       findings: [
         {
           id: "REL-GATEWAY-417",
           source: "src/gateway/reconnect.ts",
           status: "retry jitter verified, resume token fallback still needs manual spot check",
+          verified: true,
         },
         {
           id: "REL-CHANNEL-238",
           source: "src/channels/delivery.ts",
           status: "thread replies preserve ordering, root-channel fallback needs handoff note",
+          verified: true,
         },
         {
           id: "REL-CRON-904",
           source: "src/scheduling/cron.ts",
           status: "single-run lock verified for restart wakeups",
+          verified: true,
         },
         {
           id: "REL-MEMORY-552",
           source: "src/memory/recall.ts",
           status:
             "fallback summary survives empty memory search; ranking sample needs second reviewer",
+          verified: true,
         },
         {
           id: "REL-PLUGIN-319",
           source: "src/plugins/runtime.ts",
           status: "bundled runtime manifest loads cleanly after restart",
+          verified: true,
         },
         {
           id: "REL-INSTALL-846",
           source: "install/update.ts",
           status: "update smoke passed from previous stable tag",
+          verified: true,
         },
         {
           id: "REL-DOCS-611",
           source: "docs/operator-notes.md",
           status:
             "docs mention reconnect, cron, memory, plugin, and installer checks; channel ordering and UI notes need maintainer handoff",
+          verified: true,
         },
         {
           id: "REL-UI-BLOCKED",
           source: "ui/control-panel.ts",
           status: "blocked: source file was referenced by checklist but missing from the fixture",
+          verified: false,
         },
       ],
     },

--- a/extensions/qa-lab/src/qa-web-search-provider.test.ts
+++ b/extensions/qa-lab/src/qa-web-search-provider.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { createQaLabWebSearchProvider as createQaLabWebSearchContractProvider } from "../web-search-contract-api.js";
 import {
   createQaLabWebSearchProvider,
+  QA_LAB_WEB_SEARCH_DENIED_INPUT_QUERY,
   QA_LAB_WEB_SEARCH_PROVIDER_ID,
 } from "./qa-web-search-provider.js";
 
@@ -54,5 +55,17 @@ describe("qa-lab web search provider", () => {
     }
 
     await expect(tool.execute({ __qaFailureMode: "denied-input" })).rejects.toThrow(/query/i);
+  });
+
+  it("keeps the QA failure sentinel as a deterministic tool failure", async () => {
+    const provider = createQaLabWebSearchProvider();
+    const tool = provider.createTool({});
+    if (!tool) {
+      throw new Error("expected QA Lab web search tool");
+    }
+
+    await expect(tool.execute({ query: QA_LAB_WEB_SEARCH_DENIED_INPUT_QUERY })).rejects.toThrow(
+      /denied input sentinel/i,
+    );
   });
 });

--- a/extensions/qa-lab/src/qa-web-search-provider.ts
+++ b/extensions/qa-lab/src/qa-web-search-provider.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/provider-web-search";
 
 export const QA_LAB_WEB_SEARCH_PROVIDER_ID = "qa-lab-search";
+export const QA_LAB_WEB_SEARCH_DENIED_INPUT_QUERY = "OPENCLAW_QA_WEB_SEARCH_DENIED_INPUT";
 
 const QaLabWebSearchSchema = {
   type: "object",
@@ -64,6 +65,9 @@ export function createQaLabWebSearchProvider(): WebSearchProviderPlugin {
       parameters: QaLabWebSearchSchema,
       execute: async (args) => {
         const query = readStringParam(args, "query", { required: true });
+        if (query === QA_LAB_WEB_SEARCH_DENIED_INPUT_QUERY) {
+          throw new Error("QA Lab web_search denied input sentinel");
+        }
         const count =
           readPositiveIntegerParam(args, "count", {
             max: MAX_SEARCH_COUNT,

--- a/extensions/xiaomi/openclaw.plugin.json
+++ b/extensions/xiaomi/openclaw.plugin.json
@@ -78,7 +78,7 @@
             "input": ["text"],
             "reasoning": true,
             "contextWindow": 1048576,
-            "maxTokens": 32000,
+            "maxTokens": 131072,
             "cost": {
               "input": 1,
               "output": 3,
@@ -96,7 +96,7 @@
             "input": ["text", "image"],
             "reasoning": true,
             "contextWindow": 1048576,
-            "maxTokens": 32000,
+            "maxTokens": 131072,
             "cost": {
               "input": 0.4,
               "output": 2,

--- a/package.json
+++ b/package.json
@@ -629,6 +629,10 @@
       "types": "./dist/plugin-sdk/agent-harness-runtime.d.ts",
       "default": "./dist/plugin-sdk/agent-harness-runtime.js"
     },
+    "./plugin-sdk/agent-harness-tool-runtime": {
+      "types": "./dist/plugin-sdk/agent-harness-tool-runtime.d.ts",
+      "default": "./dist/plugin-sdk/agent-harness-tool-runtime.js"
+    },
     "./plugin-sdk/hook-runtime": {
       "types": "./dist/plugin-sdk/hook-runtime.d.ts",
       "default": "./dist/plugin-sdk/hook-runtime.js"

--- a/packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "../../types.js";
+import type { SessionTreeEntry } from "../types.js";
+import { estimateTokens, findCutPoint } from "./compaction.js";
+
+const KEEP_RECENT_TOKENS = 20000;
+const LARGE_TOOL_OUTPUT = "x".repeat(120000);
+
+function userText(text: string, timestamp: number): AgentMessage {
+  return { role: "user", content: [{ type: "text", text }], timestamp };
+}
+
+function assistantText(text: string, timestamp: number): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "claude-fable-5",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp,
+  };
+}
+
+function toolResultText(text: string, timestamp: number): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call-1",
+    toolName: "bash",
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp,
+  };
+}
+
+function messageEntry(message: AgentMessage, index: number): SessionTreeEntry {
+  return {
+    type: "message",
+    id: `entry-${index}`,
+    parentId: index === 0 ? null : `entry-${index - 1}`,
+    timestamp: new Date(message.timestamp).toISOString(),
+    message,
+  };
+}
+
+function buildTranscript(): SessionTreeEntry[] {
+  const messages: AgentMessage[] = [
+    userText("start of the conversation", 1),
+    assistantText("first reply", 2),
+    userText("please run the command", 3),
+    assistantText("running it now", 4),
+    toolResultText(LARGE_TOOL_OUTPUT, 5),
+  ];
+  return messages.map((message, index) => messageEntry(message, index));
+}
+
+describe("findCutPoint with a trailing oversized tool result", () => {
+  it("counts the final tool result as larger than the keep budget", () => {
+    const trailing = toolResultText(LARGE_TOOL_OUTPUT, 5);
+
+    expect(estimateTokens(trailing)).toBeGreaterThanOrEqual(KEEP_RECENT_TOKENS);
+  });
+
+  it("trims the prefix instead of keeping the whole transcript", () => {
+    const entries = buildTranscript();
+
+    const result = findCutPoint(entries, 0, entries.length, KEEP_RECENT_TOKENS);
+
+    expect(result.firstKeptEntryIndex).toBeGreaterThan(0);
+    expect(result.firstKeptEntryIndex).toBe(3);
+  });
+});

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -407,6 +407,7 @@ export function findCutPoint(
     const messageTokens = estimateTokens(entry.message);
     accumulatedTokens += messageTokens;
     if (accumulatedTokens >= keepRecentTokens) {
+      cutIndex = cutPoints[cutPoints.length - 1];
       for (const cutPoint of cutPoints) {
         if (cutPoint >= i) {
           cutIndex = cutPoint;

--- a/qa/scenarios/memory/commitments-heartbeat-target-none.yaml
+++ b/qa/scenarios/memory/commitments-heartbeat-target-none.yaml
@@ -55,7 +55,7 @@ flow:
         - call: reset
         - set: beforeHeartbeatTs
           value:
-            expr: "((await env.gateway.call('last-heartbeat', {}, { timeoutMs: liveTurnTimeoutMs(env, 30000) }))?.ts ?? 0)"
+            expr: "((await env.gateway.call('last-heartbeat', {}, { timeoutMs: liveTurnTimeoutMs(env, 15000) }))?.ts ?? 0)"
         - set: sessionKey
           value:
             expr: "`agent:qa:qa-channel:${config.conversationId}`"
@@ -106,7 +106,7 @@ flow:
           args:
             - lambda:
                 async: true
-                expr: "(async () => { const last = await env.gateway.call('last-heartbeat', {}, { timeoutMs: liveTurnTimeoutMs(env, 30000) }); return last && last.ts > beforeHeartbeatTs ? last : undefined; })()"
+                expr: "(async () => { const last = await env.gateway.call('last-heartbeat', {}, { timeoutMs: liveTurnTimeoutMs(env, 15000) }); return last && last.ts > beforeHeartbeatTs ? last : undefined; })()"
             - expr: liveTurnTimeoutMs(env, 45000)
             - 250
         - call: sleep

--- a/qa/scenarios/runtime/tools/web-search.yaml
+++ b/qa/scenarios/runtime/tools/web-search.yaml
@@ -44,6 +44,7 @@ scenario:
         action: hard gate in the standard direct-loading tier
         reason: web_search is an OpenClaw integration tool and must stay visible and callable under OpenClaw and Codex direct runtime parity.
       promptSnippet: "target=web_search"
+      failurePrompt: "tool search qa failure target=web_search. Call web_search exactly once with query OPENCLAW_QA_WEB_SEARCH_DENIED_INPUT and then summarize the failure."
       failurePromptSnippet: "failure target=web_search"
 
 flow:

--- a/qa/scenarios/workspace/long-running-release-audit.yaml
+++ b/qa/scenarios/workspace/long-running-release-audit.yaml
@@ -14,6 +14,7 @@ scenario:
     - Agent starts from the seeded project README instead of guessing.
     - Agent inspects docs and source files across multiple directories.
     - Agent writes a JSON audit and a Markdown handoff with all required findings.
+    - Each JSON finding carries a boolean verified field; missing current source evidence is verified false.
     - Agent verifies the generated JSON before finalizing.
   docsRefs:
     - docs/help/testing.md
@@ -131,7 +132,8 @@ scenario:
         Do a release readiness audit for the small project under `audit-fixture/`.
         Start from `audit-fixture/README.md`, find the current checklist, inspect the referenced docs/source, then create `audit-fixture/release-audit.json` and `audit-fixture/release-handoff.md`.
 
-        The JSON should include current finding ids, source files, statuses, and a boolean `verified`.
+        The JSON should include current finding ids, source files, statuses, and a boolean `verified` on each finding.
+        If a current checklist source is referenced but missing from the fixture, include that source as a finding with `verified: false`.
         The Markdown handoff should summarize what is ready and what needs follow-up.
         Check your generated JSON before finalizing.
         Final reply exactly: RELEASE-AUDIT-COMPLETE
@@ -211,14 +213,20 @@ flow:
             expr: "!JSON.stringify(Array.isArray(report.findings) ? report.findings : report).includes('REL-STALE-000') && !handoffText.includes('REL-STALE-000')"
             message:
               expr: "`stale archive finding leaked into audit: report=${reportText}\\nhandoff=${handoffText}`"
+        - set: reportFindings
+          value:
+            expr: "Array.isArray(report) ? report : (Array.isArray(report.findings) ? report.findings : [])"
+        - set: uiFinding
+          value:
+            expr: "reportFindings.find((finding) => JSON.stringify(finding).includes('ui/control-panel.ts'))"
         - assert:
-            expr: "JSON.stringify(report).includes('ui/control-panel.ts') && /blocked|missing|not found|no current source file|no matching source file/i.test(`${reportText}\\n${handoffText}`)"
+            expr: "uiFinding && uiFinding.verified === false"
             message:
-              expr: "`missing UI evidence was not explicitly blocked: report=${reportText}\\nhandoff=${handoffText}`"
+              expr: "`missing UI evidence was not marked unverified: report=${reportText}\\nhandoff=${handoffText}`"
         - assert:
-            expr: "JSON.stringify(report).includes('verified')"
+            expr: "reportFindings.length > 0 && reportFindings.every((finding) => typeof finding?.verified === 'boolean')"
             message:
-              expr: "`report did not include a verification field: ${reportText}`"
+              expr: "`each report finding must include a boolean verified field: ${reportText}`"
         - call: waitForAgentHistoryReply
           saveAs: outbound
           args:

--- a/scripts/ios-release-upload.sh
+++ b/scripts/ios-release-upload.sh
@@ -51,5 +51,6 @@ done
 
 (
   cd "${ROOT_DIR}/apps/ios"
-  OPENCLAW_IOS_RELEASE_WRAPPER=1 IOS_RELEASE_BUILD_NUMBER="${BUILD_NUMBER}" run_ios_fastlane ios release_upload
+  # App Store Connect screenshot reservations can fail with 500s under parallel deliver uploads.
+  DELIVER_NUMBER_OF_THREADS=1 FL_MAX_NUMBER_OF_THREADS=1 OPENCLAW_IOS_RELEASE_WRAPPER=1 IOS_RELEASE_BUILD_NUMBER="${BUILD_NUMBER}" run_ios_fastlane ios release_upload
 )

--- a/scripts/lib/docker-e2e-image.sh
+++ b/scripts/lib/docker-e2e-image.sh
@@ -44,6 +44,17 @@ docker_e2e_read_nonnegative_decimal_env() {
     echo "invalid $name: $value" >&2
     return 2
   fi
+  local integer_part="${value%%.*}"
+  local fractional_part=""
+  if [[ "$value" == *.* ]]; then
+    fractional_part="${value#*.}"
+  fi
+  # These suite knobs are human-authored resource/time ceilings. Reject
+  # pathological decimal strings before Docker setup instead of failing later.
+  if [ "${#integer_part}" -gt 9 ] || [ "${#fractional_part}" -gt 6 ]; then
+    echo "invalid $name: $value" >&2
+    return 2
+  fi
   printf '%s\n' "$value"
 }
 

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -113,6 +113,7 @@
   "agent-harness",
   "agent-harness-exec-review-runtime",
   "agent-harness-runtime",
+  "agent-harness-tool-runtime",
   "hook-runtime",
   "host-runtime",
   "types",

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -162,9 +162,9 @@ let budgets;
 let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
-    publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 321),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10349),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5190),
+    publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 322),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10369),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5201),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
       3247,

--- a/src/agents/harness/tool-surface-bridge.ts
+++ b/src/agents/harness/tool-surface-bridge.ts
@@ -1,0 +1,216 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { HookContext } from "../agent-tools.before-tool-call.js";
+import {
+  CODE_MODE_EXEC_TOOL_NAME,
+  CODE_MODE_WAIT_TOOL_NAME,
+  applyCodeModeCatalog,
+  createCodeModeTools,
+  resolveCodeModeConfig,
+} from "../code-mode.js";
+import {
+  applyLocalModelLeanToolSearchDefaults,
+  filterLocalModelLeanTools,
+  resolveLocalModelLeanPreserveToolNames,
+} from "../local-model-lean.js";
+import { filterRuntimeCompatibleTools } from "../tool-schema-projection.js";
+import {
+  applyToolSchemaDirectoryCatalog,
+  applyToolSearchCatalog,
+  clearToolSearchCatalog,
+  createToolSearchCatalogRef,
+  estimateToolSchemaDirectoryToolNames,
+  resolveToolSearchConfig,
+  TOOL_CALL_RAW_TOOL_NAME,
+  TOOL_DESCRIBE_RAW_TOOL_NAME,
+  TOOL_SEARCH_CODE_MODE_TOOL_NAME,
+  TOOL_SEARCH_RAW_TOOL_NAME,
+  type ToolSearchCatalogRef,
+  type ToolSearchCatalogToolExecutor,
+} from "../tool-search.js";
+import type { AnyAgentTool } from "../tools/common.js";
+
+const TOOL_SEARCH_CONTROL_ALLOWLIST_NAMES = [
+  TOOL_SEARCH_CODE_MODE_TOOL_NAME,
+  TOOL_SEARCH_RAW_TOOL_NAME,
+  TOOL_DESCRIBE_RAW_TOOL_NAME,
+  TOOL_CALL_RAW_TOOL_NAME,
+];
+const CODE_MODE_CONTROL_ALLOWLIST_NAMES = [CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME];
+
+export type AgentHarnessToolSurfaceRuntime = {
+  codeModeControlsEnabled: boolean;
+  compactTools: (
+    tools: AnyAgentTool[],
+    options?: { hookContext?: HookContext },
+  ) => {
+    tools: AnyAgentTool[];
+  };
+  config: OpenClawConfig | undefined;
+  includeToolSearchControls: boolean;
+  runtimeToolAllowlist: string[] | undefined;
+  toolSearchCatalogRef: ToolSearchCatalogRef | undefined;
+  toolSearchControlsEnabled: boolean;
+  cleanup: () => void;
+  toolSearchCatalogExecutor: ToolSearchCatalogToolExecutor | undefined;
+};
+
+export function createAgentHarnessToolSurfaceRuntime(params: {
+  abortSignal?: AbortSignal;
+  agentId?: string;
+  config?: OpenClawConfig;
+  disableTools?: boolean;
+  executeTool: ToolSearchCatalogToolExecutor;
+  forceMessageTool?: boolean;
+  isRawModelRun?: boolean;
+  modelToolsEnabled: boolean;
+  prompt?: string;
+  runId?: string;
+  runtimeToolAllowlist?: readonly string[];
+  sessionId?: string;
+  sessionKey?: string;
+  sourceReplyDeliveryMode?: string;
+  toolsAllow?: readonly string[];
+}): AgentHarnessToolSurfaceRuntime {
+  const forceDirectMessageTool =
+    params.forceMessageTool === true || params.sourceReplyDeliveryMode === "message_tool_only";
+  const codeModeConfig = resolveCodeModeConfig(params.config, params.agentId);
+  const toolSearchRuntimeConfig = forceDirectMessageTool
+    ? params.config
+    : applyLocalModelLeanToolSearchDefaults({
+        config: params.config,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+      });
+  const toolSearchConfig = resolveToolSearchConfig(toolSearchRuntimeConfig);
+  const toolsAvailable =
+    params.modelToolsEnabled &&
+    params.disableTools !== true &&
+    params.isRawModelRun !== true &&
+    params.toolsAllow?.length !== 0;
+  const codeModeControlsEnabled = toolsAvailable && codeModeConfig.enabled;
+  const toolSearchControlsEnabled =
+    toolsAvailable && !codeModeControlsEnabled && toolSearchConfig.enabled;
+  const toolSearchCatalogRef =
+    toolSearchControlsEnabled || codeModeControlsEnabled ? createToolSearchCatalogRef() : undefined;
+  const runtimeToolAllowlist =
+    (toolSearchControlsEnabled || codeModeControlsEnabled) && params.runtimeToolAllowlist
+      ? [
+          ...new Set([
+            ...params.runtimeToolAllowlist,
+            ...(toolSearchControlsEnabled ? TOOL_SEARCH_CONTROL_ALLOWLIST_NAMES : []),
+            ...(codeModeControlsEnabled ? CODE_MODE_CONTROL_ALLOWLIST_NAMES : []),
+          ]),
+        ]
+      : params.runtimeToolAllowlist
+        ? [...params.runtimeToolAllowlist]
+        : undefined;
+  const toolSearchCatalogExecutor =
+    toolSearchControlsEnabled || codeModeControlsEnabled ? params.executeTool : undefined;
+  const compactTools = (
+    tools: AnyAgentTool[],
+    options: { hookContext?: HookContext } = {},
+  ): { tools: AnyAgentTool[] } => {
+    const preserveToolNames = resolveLocalModelLeanPreserveToolNames({
+      toolNames: runtimeToolAllowlist,
+      forceMessageTool: params.forceMessageTool,
+      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+    });
+    const projectedUncompactedTools = filterLocalModelLeanTools({
+      tools,
+      config: params.config,
+      agentId: params.agentId,
+      preserveToolNames,
+    });
+    const uncompactedProjection = filterRuntimeCompatibleTools(projectedUncompactedTools);
+    let effectiveTools = [...uncompactedProjection.tools];
+    const codeModeTools = codeModeControlsEnabled
+      ? createCodeModeTools({
+          config: params.config,
+          runtimeConfig: params.config,
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+          runId: params.runId,
+          catalogRef: toolSearchCatalogRef,
+          abortSignal: params.abortSignal,
+          executeTool: params.executeTool,
+        })
+      : [];
+    const directoryRequiredToolNames = forceDirectMessageTool ? ["message"] : [];
+    const directoryHydratedToolNames =
+      toolSearchControlsEnabled && toolSearchConfig.mode === "directory"
+        ? (() => {
+            try {
+              return estimateToolSchemaDirectoryToolNames({
+                tools: effectiveTools,
+                query: params.prompt ?? "",
+                maxTools: 4,
+                requiredToolNames: directoryRequiredToolNames,
+              });
+            } catch {
+              return directoryRequiredToolNames;
+            }
+          })()
+        : [];
+    const compacted = codeModeControlsEnabled
+      ? applyCodeModeCatalog({
+          tools: [...codeModeTools, ...effectiveTools],
+          config: params.config,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          agentId: params.agentId,
+          runId: params.runId,
+          catalogRef: toolSearchCatalogRef,
+          toolHookContext: options.hookContext,
+        })
+      : toolSearchConfig.mode === "directory"
+        ? applyToolSchemaDirectoryCatalog({
+            tools: effectiveTools,
+            config: toolSearchRuntimeConfig,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            agentId: params.agentId,
+            runId: params.runId,
+            catalogRef: toolSearchCatalogRef,
+            toolHookContext: options.hookContext,
+            hydrateToolNames: directoryHydratedToolNames,
+          })
+        : applyToolSearchCatalog({
+            tools: effectiveTools,
+            config: toolSearchRuntimeConfig,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            agentId: params.agentId,
+            runId: params.runId,
+            catalogRef: toolSearchCatalogRef,
+            toolHookContext: options.hookContext,
+          });
+    const projectedCompactedTools = filterLocalModelLeanTools({
+      tools: compacted.tools,
+      config: params.config,
+      agentId: params.agentId,
+      preserveToolNames,
+    });
+    effectiveTools = [...filterRuntimeCompatibleTools(projectedCompactedTools).tools];
+    return { tools: effectiveTools };
+  };
+  return {
+    codeModeControlsEnabled,
+    compactTools,
+    config: toolSearchControlsEnabled ? toolSearchRuntimeConfig : params.config,
+    includeToolSearchControls: toolSearchControlsEnabled,
+    runtimeToolAllowlist,
+    toolSearchCatalogRef,
+    toolSearchControlsEnabled,
+    cleanup: () => {
+      clearToolSearchCatalog({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        agentId: params.agentId,
+        runId: params.runId,
+        catalogRef: toolSearchCatalogRef,
+      });
+    },
+    toolSearchCatalogExecutor,
+  };
+}

--- a/src/agents/harness/user-input-bridge.ts
+++ b/src/agents/harness/user-input-bridge.ts
@@ -1,0 +1,145 @@
+import type { EmbeddedRunAttemptParams } from "../embedded-agent-runner/run/types.js";
+
+export type AgentHarnessUserInputOption = {
+  label: string;
+  description?: string;
+};
+
+export type AgentHarnessUserInputQuestion = {
+  id: string;
+  header: string;
+  question: string;
+  isOther?: boolean;
+  isSecret?: boolean;
+  options?: readonly AgentHarnessUserInputOption[] | null;
+};
+
+export type AgentHarnessUserInputAnswers = {
+  answers: Record<string, { answers: string[] }>;
+};
+
+export type AgentHarnessUserInputPromptOptions = {
+  intro?: string;
+  formatText?: (text: string) => string;
+  secretWarning?: string;
+  otherLabel?: string;
+};
+
+type PromptDeliveryParams = Pick<EmbeddedRunAttemptParams, "onBlockReply" | "onPartialReply">;
+
+export function emptyAgentHarnessUserInputAnswers(): AgentHarnessUserInputAnswers {
+  return { answers: {} };
+}
+
+export function formatAgentHarnessUserInputPrompt(
+  questions: readonly AgentHarnessUserInputQuestion[],
+  options: AgentHarnessUserInputPromptOptions = {},
+): string {
+  const formatText = options.formatText ?? ((text: string) => text);
+  const lines = [options.intro ?? "Agent needs input:"];
+  questions.forEach((question, index) => {
+    if (questions.length > 1) {
+      lines.push("", `${index + 1}. ${formatText(question.header)}`, formatText(question.question));
+    } else {
+      lines.push("", formatText(question.header), formatText(question.question));
+    }
+    if (question.isSecret) {
+      lines.push(
+        options.secretWarning ?? "This channel may show your reply to other participants.",
+      );
+    }
+    question.options?.forEach((option, optionIndex) => {
+      lines.push(
+        `${optionIndex + 1}. ${formatText(option.label)}${
+          option.description ? ` - ${formatText(option.description)}` : ""
+        }`,
+      );
+    });
+    if (question.isOther) {
+      lines.push(options.otherLabel ?? "Other: reply with your own answer.");
+    }
+  });
+  return lines.join("\n");
+}
+
+export async function deliverAgentHarnessUserInputPrompt(
+  params: PromptDeliveryParams,
+  questions: readonly AgentHarnessUserInputQuestion[],
+  options: AgentHarnessUserInputPromptOptions = {},
+): Promise<void> {
+  const text = formatAgentHarnessUserInputPrompt(questions, options);
+  if (params.onBlockReply) {
+    await params.onBlockReply({ text });
+    return;
+  }
+  await params.onPartialReply?.({ text });
+}
+
+export function buildAgentHarnessUserInputAnswers(
+  questions: readonly AgentHarnessUserInputQuestion[],
+  inputText: string,
+): AgentHarnessUserInputAnswers {
+  const answers: AgentHarnessUserInputAnswers["answers"] = {};
+  if (questions.length === 1) {
+    const question = questions[0];
+    if (question) {
+      const answer = normalizeAgentHarnessUserInputAnswer(inputText, question);
+      answers[question.id] = { answers: answer ? [answer] : [] };
+    }
+    return { answers };
+  }
+
+  const keyed = parseKeyedAnswers(inputText);
+  const fallbackLines = inputText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  questions.forEach((question, index) => {
+    const key =
+      keyed.get(question.id.toLowerCase()) ??
+      keyed.get(question.header.toLowerCase()) ??
+      keyed.get(question.question.toLowerCase()) ??
+      keyed.get(String(index + 1));
+    const answer = key ?? fallbackLines[index] ?? "";
+    const normalized = answer ? normalizeAgentHarnessUserInputAnswer(answer, question) : undefined;
+    answers[question.id] = { answers: normalized ? [normalized] : [] };
+  });
+  return { answers };
+}
+
+export function normalizeAgentHarnessUserInputAnswer(
+  answer: string,
+  question: AgentHarnessUserInputQuestion,
+): string | undefined {
+  const trimmed = answer.trim();
+  const options = question.options ?? [];
+  const optionIndex = /^\d+$/.test(trimmed) ? Number(trimmed) - 1 : -1;
+  const indexed = optionIndex >= 0 ? options[optionIndex] : undefined;
+  if (indexed) {
+    return indexed.label;
+  }
+  const exact = options.find((option) => option.label.toLowerCase() === trimmed.toLowerCase());
+  if (exact) {
+    return exact.label;
+  }
+  if (options.length > 0 && !question.isOther) {
+    return undefined;
+  }
+  return trimmed || undefined;
+}
+
+function parseKeyedAnswers(inputText: string): Map<string, string> {
+  const answers = new Map<string, string>();
+  for (const line of inputText.split(/\r?\n/)) {
+    const match = line.match(/^\s*([^:=-]+?)\s*[:=-]\s*(.+?)\s*$/);
+    if (!match) {
+      continue;
+    }
+    const key = match[1]?.trim().toLowerCase();
+    const value = match[2]?.trim();
+    if (key && value) {
+      answers.set(key, value);
+    }
+  }
+  return answers;
+}

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -5269,6 +5269,7 @@ describe("dispatchReplyFromConfig", () => {
       Provider: "whatsapp",
       OriginatingChannel: "whatsapp",
       OriginatingTo: "whatsapp:+15555550123",
+      AccountId: "default",
       MessageSid: "msg-1",
     });
     const replyResolver = vi.fn(async () => ({ text: "hi" }) as ReplyPayload);
@@ -5689,6 +5690,7 @@ describe("dispatchReplyFromConfig", () => {
       CommandBody: "hello",
       RawBody: "hello",
       Body: "hello",
+      AccountId: "default",
       MessageSid: "wa-msg-1",
       SessionKey: "agent:main:whatsapp:+15555550123",
       SuppressMessageReceivedHooks: true,
@@ -7038,6 +7040,7 @@ describe("dispatchReplyFromConfig", () => {
       Provider: "whatsapp",
       OriginatingChannel: "whatsapp",
       OriginatingTo: "whatsapp:+15555550123",
+      AccountId: "default",
       MessageSid: "msg-dup",
     });
     const replyResolver = vi.fn(async () => ({ text: "hi" }) as ReplyPayload);
@@ -7063,6 +7066,7 @@ describe("dispatchReplyFromConfig", () => {
       Provider: "whatsapp",
       OriginatingChannel: "whatsapp",
       OriginatingTo: "whatsapp:+15555550123",
+      AccountId: "default",
       MessageSid: "msg-dup-trace",
     });
     const replyResolver = vi.fn(async () => ({ text: "hi" }) as ReplyPayload);

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -118,6 +118,115 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     return event;
   }
 
+  it("uses configured session.store when storePath is omitted", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "transcript-config-store-"));
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    try {
+      process.env.OPENCLAW_STATE_DIR = path.join(tempDir, "default-state");
+      const sessionsDir = path.join(tempDir, "configured", "sessions");
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      const storePath = path.join(sessionsDir, "sessions.json");
+      const configuredSessionKey = "agent:main:configured-store";
+      fs.writeFileSync(
+        storePath,
+        JSON.stringify({
+          [configuredSessionKey]: {
+            sessionId: "configured-session-id",
+            chatType: "direct",
+          },
+        }),
+        "utf-8",
+      );
+
+      const result = await appendAssistantMessageToSessionTranscript({
+        agentId: "main",
+        sessionKey: configuredSessionKey,
+        text: "mirrored configured store reply",
+        config: { session: { store: storePath } },
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      expect(path.basename(result.sessionFile)).toBe("configured-session-id.jsonl");
+      expect(fs.realpathSync.native(path.dirname(result.sessionFile))).toBe(
+        fs.realpathSync.native(sessionsDir),
+      );
+      await expect(fs.promises.readFile(result.sessionFile, "utf-8")).resolves.toContain(
+        "mirrored configured store reply",
+      );
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the session key agent for configured session.store templates", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "transcript-agent-store-"));
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const emitSpy = vi.spyOn(transcriptEvents, "emitSessionTranscriptUpdate");
+    try {
+      process.env.OPENCLAW_STATE_DIR = path.join(tempDir, "default-state");
+      const storeTemplate = path.join(tempDir, "agents", "{agentId}", "sessions", "sessions.json");
+      const sessionsDir = path.join(tempDir, "agents", "worker", "sessions");
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      const storePath = path.join(sessionsDir, "sessions.json");
+      const configuredSessionKey = "agent:worker:configured-store";
+      fs.writeFileSync(
+        storePath,
+        JSON.stringify({
+          [configuredSessionKey]: {
+            sessionId: "worker-session-id",
+            chatType: "direct",
+          },
+        }),
+        "utf-8",
+      );
+      const beforeMessageWrite = vi.fn(({ message }: BeforeMessageWriteParams) => message);
+
+      const result = await appendAssistantMessageToSessionTranscript({
+        sessionKey: configuredSessionKey,
+        text: "mirrored worker store reply",
+        config: { session: { store: storeTemplate } },
+        beforeMessageWrite,
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      expect(path.basename(result.sessionFile)).toBe("worker-session-id.jsonl");
+      expect(fs.realpathSync.native(path.dirname(result.sessionFile))).toBe(
+        fs.realpathSync.native(sessionsDir),
+      );
+      await expect(fs.promises.readFile(result.sessionFile, "utf-8")).resolves.toContain(
+        "mirrored worker store reply",
+      );
+      expect(beforeMessageWrite).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: "worker",
+          sessionKey: configuredSessionKey,
+        }),
+      );
+      const event = requireTranscriptUpdateCall(emitSpy);
+      expect(event.agentId).toBe("worker");
+      expect(event.sessionKey).toBe(configuredSessionKey);
+    } finally {
+      emitSpy.mockRestore();
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("creates transcript file and appends message for valid session", async () => {
     writeTranscriptStore();
 

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -4,13 +4,18 @@ import type { AgentMessage } from "../../agents/runtime/index.js";
 import type { SessionManager } from "../../agents/sessions/session-manager.js";
 import { redactTranscriptMessage } from "../../agents/transcript-redact.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import {
   extractAssistantVisibleText,
   extractFirstTextBlock,
 } from "../../shared/chat-message-content.js";
 import { isTranscriptOnlyOpenClawAssistantModel } from "../../shared/transcript-only-openclaw-assistant.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
-import { resolveDefaultSessionStorePath, resolveSessionFilePath } from "./paths.js";
+import {
+  resolveDefaultSessionStorePath,
+  resolveSessionFilePath,
+  resolveStorePath,
+} from "./paths.js";
 import { persistSessionTranscriptTurn } from "./session-accessor.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import { loadSessionStore, resolveSessionStoreEntry } from "./store.js";
@@ -396,7 +401,12 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
     return { ok: false, reason: "message role must be assistant" };
   }
 
-  const storePath = params.storePath ?? resolveDefaultSessionStorePath(params.agentId);
+  const explicitAgentId = params.agentId?.trim() || undefined;
+  const sessionAgentId = parseAgentSessionKey(sessionKey)?.agentId;
+  const transcriptAgentId = explicitAgentId ?? sessionAgentId;
+  const storeAgentId = transcriptAgentId ?? resolveAgentIdFromSessionKey(sessionKey);
+  const storePath =
+    params.storePath ?? resolveStorePath(params.config?.session?.store, { agentId: storeAgentId });
   const store = loadSessionStore(storePath, { skipCache: true });
   const resolved = resolveSessionStoreEntry({ store, sessionKey });
   const entry = resolved.existing;
@@ -427,7 +437,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
         ? applyBeforeMessageWriteToAssistant({
             message,
             beforeMessageWrite: params.beforeMessageWrite,
-            agentId: params.agentId,
+            agentId: transcriptAgentId,
             sessionKey: resolved.normalizedKey,
           })
         : message;
@@ -449,7 +459,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
         sessionKey: resolved.normalizedKey,
         storePath,
         ...(sessionFile ? { sessionFile } : {}),
-        ...(params.agentId ? { agentId: params.agentId } : {}),
+        ...(transcriptAgentId ? { agentId: transcriptAgentId } : {}),
       },
       {
         cwd: currentEntry.spawnedCwd,
@@ -468,7 +478,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
                       message: candidate as Parameters<SessionManager["appendMessage"]>[0],
                       beforeMessageWrite: params.beforeMessageWrite,
                       explicitIdempotencyKey,
-                      agentId: params.agentId,
+                      agentId: transcriptAgentId,
                       sessionKey: resolved.normalizedKey,
                     }),
                 }
@@ -522,7 +532,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
         sessionStore: store,
         storePath,
         sessionEntry: entry,
-        agentId: params.agentId,
+        agentId: transcriptAgentId,
         sessionsDir: path.dirname(storePath),
       });
       sessionFile = resolvedSessionFile.sessionFile;

--- a/src/plugin-sdk/agent-harness-runtime.test.ts
+++ b/src/plugin-sdk/agent-harness-runtime.test.ts
@@ -3,7 +3,10 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  buildAgentHarnessUserInputAnswers,
   classifyAgentHarnessTerminalOutcome,
+  deliverAgentHarnessUserInputPrompt,
+  formatAgentHarnessUserInputPrompt,
   type AgentHarnessTerminalOutcomeClassification,
 } from "./agent-harness-runtime.js";
 
@@ -150,5 +153,79 @@ describe("agent harness runtime SDK facade", () => {
     await import("./agent-harness-runtime.js");
 
     expect(loadResearchAutocapture).not.toHaveBeenCalled();
+  });
+});
+
+describe("agent harness user input helpers", () => {
+  it("formats prompts and delivers through blocking replies first", async () => {
+    const onBlockReply = vi.fn();
+
+    await deliverAgentHarnessUserInputPrompt(
+      { onBlockReply },
+      [
+        {
+          id: "mode",
+          header: "Mode",
+          question: "Pick a mode",
+          isOther: true,
+          options: [{ label: "Deep", description: "Use more context" }],
+        },
+      ],
+      { intro: "Runtime needs input:" },
+    );
+
+    expect(onBlockReply).toHaveBeenCalledWith({
+      text: [
+        "Runtime needs input:",
+        "",
+        "Mode",
+        "Pick a mode",
+        "1. Deep - Use more context",
+        "Other: reply with your own answer.",
+      ].join("\n"),
+    });
+  });
+
+  it("normalizes keyed multi-question answers with option indexes", () => {
+    expect(
+      buildAgentHarnessUserInputAnswers(
+        [
+          {
+            id: "repo",
+            header: "Repository",
+            question: "Which repo?",
+            isOther: true,
+          },
+          {
+            id: "mode",
+            header: "Mode",
+            question: "Which mode?",
+            isOther: false,
+            options: [{ label: "Fast" }, { label: "Deep" }],
+          },
+        ],
+        "repo: openclaw\nmode: 2",
+      ),
+    ).toEqual({
+      answers: {
+        mode: { answers: ["Deep"] },
+        repo: { answers: ["openclaw"] },
+      },
+    });
+  });
+
+  it("supports runtime-specific text formatting", () => {
+    expect(
+      formatAgentHarnessUserInputPrompt(
+        [
+          {
+            id: "answer",
+            header: "Header",
+            question: "a < b",
+          },
+        ],
+        { formatText: (text) => text.replaceAll("<", "&lt;") },
+      ),
+    ).toContain("a &lt; b");
   });
 });

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -51,7 +51,6 @@ export type {
   AgentHarnessUserInputPromptOptions,
   AgentHarnessUserInputQuestion,
 } from "../agents/harness/user-input-bridge.js";
-export type { AgentHarnessToolSurfaceRuntime } from "../agents/harness/tool-surface-bridge.js";
 export type {
   EmbeddedRunAttemptParams,
   EmbeddedRunAttemptResult,
@@ -165,7 +164,6 @@ export {
   formatAgentHarnessUserInputPrompt,
   normalizeAgentHarnessUserInputAnswer,
 } from "../agents/harness/user-input-bridge.js";
-export { createAgentHarnessToolSurfaceRuntime } from "../agents/harness/tool-surface-bridge.js";
 export {
   buildSkillWorkshopPromptSection,
   SKILL_WORKSHOP_TOOL_NAME,

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -46,6 +46,13 @@ export type {
   AgentHarnessSupportContext,
 } from "../agents/harness/types.js";
 export type {
+  AgentHarnessUserInputAnswers,
+  AgentHarnessUserInputOption,
+  AgentHarnessUserInputPromptOptions,
+  AgentHarnessUserInputQuestion,
+} from "../agents/harness/user-input-bridge.js";
+export type { AgentHarnessToolSurfaceRuntime } from "../agents/harness/tool-surface-bridge.js";
+export type {
   EmbeddedRunAttemptParams,
   EmbeddedRunAttemptResult,
 } from "../agents/embedded-agent-runner/run/types.js";
@@ -151,6 +158,14 @@ export { resolveModelAuthMode } from "../agents/model-auth.js";
 export { supportsModelTools } from "../agents/model-tool-support.js";
 export { isAgentToolReplaySafe } from "../agents/tool-replay-safety.js";
 export { getChannelAgentToolMeta } from "../agents/channel-tool-metadata.js";
+export {
+  buildAgentHarnessUserInputAnswers,
+  deliverAgentHarnessUserInputPrompt,
+  emptyAgentHarnessUserInputAnswers,
+  formatAgentHarnessUserInputPrompt,
+  normalizeAgentHarnessUserInputAnswer,
+} from "../agents/harness/user-input-bridge.js";
+export { createAgentHarnessToolSurfaceRuntime } from "../agents/harness/tool-surface-bridge.js";
 export {
   buildSkillWorkshopPromptSection,
   SKILL_WORKSHOP_TOOL_NAME,

--- a/src/plugin-sdk/agent-harness-tool-runtime.ts
+++ b/src/plugin-sdk/agent-harness-tool-runtime.ts
@@ -1,0 +1,10 @@
+/**
+ * Focused runtime SDK subpath for native harness tool-surface routing.
+ *
+ * Keep tool-search and code-mode dependencies out of the lightweight harness
+ * lifecycle facade used during plugin startup.
+ */
+export {
+  createAgentHarnessToolSurfaceRuntime,
+  type AgentHarnessToolSurfaceRuntime,
+} from "../agents/harness/tool-surface-bridge.js";

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -619,6 +619,10 @@ describe("ci workflow guards", () => {
       "taxonomy.profiles.find((entry) => entry.id === requested)",
     );
     expect(validateProfileStep.run).toContain("profile=${profile.id}");
+    const ensurePlaywrightStep = qaRunJob.steps.find(
+      (step) => step.name === "Ensure Playwright Chromium",
+    );
+    expect(ensurePlaywrightStep.run).toBe("node scripts/ensure-playwright-chromium.mjs");
     expect(generateJob.if).toBe("${{ inputs.qa_evidence_run_id == '' }}");
     expect(generateJob.uses).toBe("./.github/workflows/qa-profile-evidence.yml");
     expect(generateJob.with).toMatchObject({

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -417,9 +417,15 @@ print_log_tail "$LOG_PATH"
     };
 
     const invalid = runProbe("12mb");
+    const overlarge = runProbe("9999999999");
+    const overprecise = runProbe("12.1234567");
     const decimal = runProbe("12.5");
     expect(invalid.status).toBe(2);
     expect(invalid.stderr).toContain("invalid OPENCLAW_SAMPLE_RESOURCE_LIMIT: 12mb");
+    expect(overlarge.status).toBe(2);
+    expect(overlarge.stderr).toContain("invalid OPENCLAW_SAMPLE_RESOURCE_LIMIT: 9999999999");
+    expect(overprecise.status).toBe(2);
+    expect(overprecise.stderr).toContain("invalid OPENCLAW_SAMPLE_RESOURCE_LIMIT: 12.1234567");
     expect(decimal.status).toBe(0);
     expect(decimal.stdout.trimEnd()).toBe("12.5");
   });

--- a/test/scripts/ios-release-fastlane-gates.test.ts
+++ b/test/scripts/ios-release-fastlane-gates.test.ts
@@ -39,6 +39,8 @@ describe("iOS Fastlane release upload gates", () => {
     const script = readFileSync(uploadScriptPath, "utf8");
 
     expect(script).toContain("OPENCLAW_IOS_RELEASE_WRAPPER=1");
+    expect(script).toContain("DELIVER_NUMBER_OF_THREADS=1");
+    expect(script).toContain("FL_MAX_NUMBER_OF_THREADS=1");
     expect(script).toContain("run_ios_fastlane ios release_upload");
   });
 
@@ -70,5 +72,14 @@ describe("iOS Fastlane release upload gates", () => {
 
     expect(validationCall).toBeGreaterThanOrEqual(0);
     expect(uploadCall).toBeGreaterThan(validationCall);
+  });
+
+  it("normalizes Watch screenshots as opaque RGB PNGs for App Store upload", () => {
+    const fastfile = readFastfile();
+
+    expect(fastfile).toContain("def normalize_watch_screenshot_status_bar(path)");
+    expect(fastfile).toContain("CGImageAlphaInfo.noneSkipLast.rawValue");
+    expect(fastfile).toContain("CGImageDestinationCreateWithURL");
+    expect(fastfile).toContain("operation: .sourceOver");
   });
 });

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2237,6 +2237,13 @@ describe("package artifact reuse", () => {
     expect(clawHubReleasePlanScript).toContain("--plugin-clawhub-bootstrap-run");
     expect(releaseWorkflow).toContain('verify_args+=(--plugins "${PLUGINS}")');
     expect(releaseWorkflow).toContain("openclaw-release-postpublish-evidence");
+    const postpublishEvidenceUpload = workflowStep(
+      workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish"),
+      "Upload postpublish evidence",
+    );
+    expect(postpublishEvidenceUpload.if).toContain("always()");
+    expect(postpublishEvidenceUpload.if).toContain("inputs.publish_openclaw_npm");
+    expect(postpublishEvidenceUpload.with?.["if-no-files-found"]).toBe("error");
     expect(releaseWorkflow).toContain("Failed child job summary");
     expect(releaseWorkflow).toContain("Workflow completion waits for ClawHub");
     expect(releaseWorkflow).toContain("Workflow completion does not wait for ClawHub");


### PR DESCRIPTION
## Summary

- Add shared agent-harness helpers for user-input prompt delivery/answer normalization and compact tool-surface routing.
- Wire Copilot to SDK `ask_user` via OpenClaw active-run queueing, with channel-safe prompt escaping and abort cleanup.
- Route Copilot tool-search/code-mode through the shared compact catalog helper, including hidden-catalog allowlist filtering, cleanup, and docs updates.
- Refactor Codex request-user-input formatting onto the shared helper while keeping Codex app-server protocol parsing local.

## What Problem This Solves

Copilot was behind Codex/PI on harness parity: no interactive `ask_user`, no compact tool-search/code-mode surface, and duplicated user-input formatting logic. This makes those behaviors like-for-like through generic harness helpers instead of provider-local copy/paste.

## Dependency Contract Checked

- `@github/copilot-sdk/dist/types.d.ts:1288-1305` documents `availableTools` as the session allowlist and supports source-qualified entries.
- `@github/copilot-sdk/dist/toolSet.js:54-78` lists `ask_user` as a built-in isolated tool, so Copilot adds `ask_user` and `builtin:ask_user` alongside bridged custom tools.
- `../codex/codex-rs/app-server-protocol/src/protocol/common.rs:1438-1442` defines `item/tool/requestUserInput`.
- `../codex/codex-rs/core/src/session/mod.rs:2329-2355` stores pending user input on the active turn.
- `../codex/codex-rs/core/src/session/turn.rs:2271-2276` confirms `request_user_input` intentionally pauses the turn until pending tools resolve.
- `../codex/codex-rs/core/src/tools/spec_plan.rs:652-658` exposes the request-user-input handler as direct-model-only when enabled.

## Evidence

- `node scripts/run-vitest.mjs src/plugin-sdk/agent-harness-runtime.test.ts extensions/codex/src/app-server/user-input-bridge.test.ts extensions/copilot/src/user-input-bridge.test.ts extensions/copilot/src/attempt.test.ts extensions/copilot/src/tool-bridge.test.ts` — passed 3 shards, 209 tests total after rebase.
- `OPENCLAW_LIVE_TEST=1 OPENCLAW_COPILOT_AGENT_LIVE_TEST=1 OPENCLAW_LIVE_TEST_QUIET=1 OPENCLAW_COPILOT_AGENT_LIVE_TOKEN="$(gh auth token)" node_modules/.bin/vitest run --config test/vitest/vitest.live.config.ts extensions/copilot/src/attempt.live.test.ts --reporter=verbose` — passed against local GitHub/Copilot auth; `live_echo` tool call returned `phase-1-green`, usage total 24533.
- `.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` — clean, no accepted/actionable findings.
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --timing-json --blacksmith-workflow .github/workflows/ci-check-testbox.yml -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed on Blacksmith Testbox `tbx_01kvsm2a8prtshea0k6a69cct8` (`golden-barnacle`), Actions run `28008038755`, exit 0.
- `git diff --check` — passed.

## Notes

- `pnpm docs:list` was attempted locally because docs changed, but in this Codex GWT it tried to reconcile dependencies and aborted before touching the symlinked `node_modules`. The final Testbox `check:changed` included the docs lane.
- AI-assisted: yes.
