### PR TITLE
fix: use single-char ellipsis in commitments truncate() to prevent table misalignment

### DIFF
--- a/src/commands/commitments.ts
+++ b/src/commands/commitments.ts
@@ -24,7 +24,7 @@ const STATUS_VALUES = new Set<CommitmentStatus>([
 ]);
 
 function truncate(value: string, maxChars: number): string {
-  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}...`;
+  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}…`;
 }
 
 function safe(value: string): string {


### PR DESCRIPTION
## What Problem This Solves

In `openclaw commitments`, the `truncate()` helper reserved only 1 character for the overflow indicator (`maxChars - 1`) but appended a 3-character ASCII `...`, making the truncated string `maxChars + 2` characters wide. This caused `padEnd`-based table columns to misalign — truncated rows pushed past the column boundary, breaking visual alignment of the commitments table output.

**Root cause:** `src/commands/commitments.ts` — `truncate()` appended 3 chars of ellipsis after slicing to `maxChars - 1`, producing `maxChars + 2` total width instead of the expected `maxChars`.

**Fix:** Replace `...` with single Unicode ellipsis `\u2026`, matching the identical pattern already used in `flows.ts`, `tasks.ts`, and `onboard-skills.ts`.

## Evidence

### Fix (commitments.ts, line 27)

```diff
 function truncate(value: string, maxChars: string): string {
-  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}...`;
+  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}\u2026`;
 }
```

### Consistency with existing codebase

The single-char Unicode ellipsis is already the repo convention for truncation helpers:

| File | Ellipsis |
|------|----------|
| `src/cli/flows.ts` | `\u2026` (single unicode) |
| `src/cli/tasks.ts` | `\u2026` (single unicode) |
| `src/cli/onboard-skills.ts` | `\u2026` (single unicode) |
| `src/commands/commitments.ts` (BEFORE) | `...` (3-char ASCII) |
| `src/commands/commitments.ts` (AFTER) | `\u2026` (single unicode) |

### Impact

- Single-character change; zero behavioral difference for text content
- `padEnd(maxChars)` now produces correctly aligned columns since truncated values are exactly `maxChars` wide
- Consistent with the existing truncation convention used across the CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)