### PR TITLE
Verify installed ClawHub skill file hashes

### DIFF
--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -118,6 +118,10 @@ Notes:
   verifies the installed version against the registry it came from. `--version`
   and `--tag` override the version selector but keep that installed registry
   when origin metadata exists.
+- For installed-version verification, OpenClaw also compares the installed
+  `SKILL.md` hash against `.clawhub/lock.json` when that integrity metadata is
+  present. Reinstall the skill from ClawHub if this local audit check reports
+  drift.
 - `verify --card` prints the generated Skill Card Markdown instead of JSON. The
   command exits non-zero when ClawHub returns `ok: false` or `decision: "fail"`;
   unsigned signatures are informational unless ClawHub policy changes.

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -175,7 +175,9 @@ publish and sync.
     `clawhub.skill.verify.v1` trust envelope. Installed ClawHub skills verify
     against the version and registry recorded in `.clawhub/origin.json`.
     Bare slugs remain accepted for existing installed or unambiguous skills, but
-    owner-qualified refs avoid publisher ambiguity.
+    owner-qualified refs avoid publisher ambiguity. When the lockfile has
+    installed `SKILL.md` integrity metadata, default installed verification also
+    rejects local skill-file drift and asks you to reinstall from ClawHub.
 
     ClawHub skill pages expose the latest security scan state before install,
     with detail pages for VirusTotal, ClawScan, and static analysis. The

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -123,6 +123,7 @@ async function writeClawHubOriginFixture(params: {
   installedVersion?: string;
   installedAt?: number;
   writeLock?: boolean;
+  skillFile?: { path: string; sha256: string };
 }) {
   const skillDir = path.join(params.workspaceDir, "skills", params.slug);
   const registry = params.registry ?? "https://private.example.com/clawhub";
@@ -139,6 +140,7 @@ async function writeClawHubOriginFixture(params: {
         ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
         installedVersion,
         installedAt,
+        ...(params.skillFile ? { skillFile: params.skillFile } : {}),
       },
       null,
       2,
@@ -158,6 +160,7 @@ async function writeClawHubOriginFixture(params: {
               installedAt,
               registry,
               ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+              ...(params.skillFile ? { skillFile: params.skillFile } : {}),
             },
           },
         },
@@ -1601,6 +1604,75 @@ describe("skills-clawhub", () => {
           throw new Error("expected registry mismatch failure");
         }
         expect(result.error).toContain("does not match the workspace ClawHub lockfile");
+      } finally {
+        await fs.rm(workspaceDir, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects installed-version verification when the installed skill file changed", async () => {
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
+      try {
+        const expectedContent = "# AgentReceipt\n";
+        const skillDir = await writeClawHubOriginFixture({
+          workspaceDir,
+          slug: "agentreceipt",
+          skillFile: {
+            path: "SKILL.md",
+            sha256: createHash("sha256").update(expectedContent).digest("hex"),
+          },
+        });
+        await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Modified locally\n", "utf8");
+
+        const result = await resolveClawHubSkillVerificationTarget({
+          workspaceDir,
+          slug: "agentreceipt",
+        });
+
+        expect(result.ok).toBe(false);
+        if (result.ok) {
+          throw new Error("expected skill file drift failure");
+        }
+        expect(result.error).toContain("installed skill file does not match");
+        expect(result.error).toContain("Reinstall it from ClawHub");
+      } finally {
+        await fs.rm(workspaceDir, { recursive: true, force: true });
+      }
+    });
+
+    it("allows explicit version verification when the installed skill file changed", async () => {
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
+      try {
+        const expectedContent = "# AgentReceipt\n";
+        const skillDir = await writeClawHubOriginFixture({
+          workspaceDir,
+          slug: "agentreceipt",
+          registry: "https://private.example.com/clawhub",
+          installedVersion: "2.0.0",
+          skillFile: {
+            path: "SKILL.md",
+            sha256: createHash("sha256").update(expectedContent).digest("hex"),
+          },
+        });
+        await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Modified locally\n", "utf8");
+
+        await expect(
+          resolveClawHubSkillVerificationTarget({
+            workspaceDir,
+            slug: "agentreceipt",
+            version: "2.1.0",
+          }),
+        ).resolves.toMatchObject({
+          ok: true,
+          slug: "agentreceipt",
+          baseUrl: "https://private.example.com/clawhub",
+          version: "2.1.0",
+          resolution: {
+            source: "installed",
+            selector: "version",
+            registry: "https://private.example.com/clawhub",
+            installedVersion: "2.0.0",
+          },
+        });
       } finally {
         await fs.rm(workspaceDir, { recursive: true, force: true });
       }

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -474,6 +474,25 @@ async function readInstalledSkillFileLock(
   return undefined;
 }
 
+async function readInstalledSkillFileLockMismatch(params: {
+  trackedSlug: string;
+  skillDir: string;
+  locked: ClawHubSkillLockEntry;
+}): Promise<string | undefined> {
+  const lockedSkillFile = normalizeSkillFileLock(params.locked.skillFile);
+  if (!lockedSkillFile) {
+    return undefined;
+  }
+  const current = await readInstalledSkillFileLock(params.skillDir);
+  if (!current) {
+    return `Skill "${params.trackedSlug}" is tracked by the workspace ClawHub lockfile but its installed skill file is missing. Reinstall it from ClawHub before verifying it as an installed ClawHub skill.`;
+  }
+  if (current.path !== lockedSkillFile.path || current.sha256 !== lockedSkillFile.sha256) {
+    return `Skill "${params.trackedSlug}" installed skill file does not match the workspace ClawHub lockfile. Reinstall it from ClawHub before verifying it as an installed ClawHub skill.`;
+  }
+  return undefined;
+}
+
 export function readClawHubSkillsLockfileStatusSync(
   workspaceDir: string,
 ): ClawHubSkillsLockfileStatusRead {
@@ -1010,6 +1029,16 @@ export async function resolveClawHubSkillVerificationTarget(params: {
         : tag
           ? "tag"
           : "installed-version";
+      if (selector === "installed-version") {
+        const skillFileMismatch = await readInstalledSkillFileLockMismatch({
+          trackedSlug,
+          skillDir,
+          locked,
+        });
+        if (skillFileMismatch) {
+          return { ok: false, error: skillFileMismatch };
+        }
+      }
       return {
         ok: true,
         slug: trackedSlug,


### PR DESCRIPTION
## What Problem This Solves

`openclaw skills install` already persists installed `SKILL.md` integrity metadata in `.clawhub/lock.json`, but `openclaw skills verify <slug>` did not re-read the current installed skill file before resolving the default installed-version verification target.

That meant a local edit to an installed ClawHub `SKILL.md` could still verify the locked remote version, which made the user-invoked audit path miss local drift.

Refs #92077. Supersedes #93600 with the narrow ClawHub-only fix on current `main`.

## Why This Change Was Made

This keeps the fix at the local verification boundary:

- when an installed ClawHub skill resolves with the default installed-version selector, compare the current installed `SKILL.md` marker file against the lockfile `skillFile` path/hash;
- return a reinstall error before making a ClawHub verification request when the file is missing or has drifted;
- keep old lockfiles compatible by skipping the check when `skillFile` metadata is absent;
- preserve explicit `--version` / `--tag` behavior so those still query remote ClawHub versions via the installed registry;
- update the CLI reference and skills guide to describe the local audit check.

## User Impact

Users get a clearer and safer `openclaw skills verify <slug>` result for ClawHub-tracked installed skills: default installed-version verification now fails closed when the installed `SKILL.md` no longer matches the workspace lockfile.

Users who intentionally want to inspect a remote ClawHub version can still use `--version` or `--tag`; those selectors are not blocked by local file drift.

## Evidence

Targeted tests:

```bash
node scripts/run-vitest.mjs src/skills/lifecycle/clawhub.test.ts src/cli/skills-cli.verify.test.ts
```

Result: passed 2 Vitest shards; `src/skills/lifecycle/clawhub.test.ts` 55 tests passed and `src/cli/skills-cli.verify.test.ts` 3 tests passed.

Formatting, lint, docs, and type checks:

```bash
pnpm exec oxfmt --check --threads=1 src/skills/lifecycle/clawhub.ts src/skills/lifecycle/clawhub.test.ts docs/cli/skills.md docs/tools/skills.md
node scripts/run-oxlint.mjs src/skills/lifecycle/clawhub.ts src/skills/lifecycle/clawhub.test.ts
pnpm docs:list
git diff --check
pnpm tsgo:core
pnpm tsgo:test:src
```

Result: all exited 0. Local checks used Node v22.22.2 where the CLI requires Node >=22.19.0.

Real behavior proof:

Behavior addressed: default installed-version CLI verification rejects local `SKILL.md` drift before querying ClawHub.

Real environment tested: local OpenClaw checkout on macOS, isolated temporary state/workspace directories, Node v22.22.2, pnpm 11.2.2.

Exact steps or command run after this patch:

```bash
export PATH="/Users/mauriceniu/.nvm/versions/node/v22.22.2/bin:$PATH"
proof_root=$(mktemp -d /tmp/openclaw-clawhub-verify-proof-XXXXXX)
state_dir="$proof_root/state"
workspace_dir="$proof_root/workspace"
skill_dir="$workspace_dir/skills/agentreceipt"
mkdir -p "$skill_dir/.clawhub" "$workspace_dir/.clawhub"
expected_hash=$(printf '# AgentReceipt\n' | shasum -a 256 | awk '{print $1}')
# origin.json and lock.json both recorded skillFile.path=SKILL.md and the expected hash.
printf '# Modified locally\n' > "$skill_dir/SKILL.md"
OPENCLAW_STATE_DIR="$state_dir" \
  OPENCLAW_CONFIG_PATH="$state_dir/openclaw.json" \
  OPENCLAW_WORKSPACE_DIR="$workspace_dir" \
  pnpm openclaw skills verify agentreceipt
```

Evidence after fix / observed result:

```text
exit_code=1
Skill "agentreceipt" installed skill file does not match the workspace ClawHub lockfile. Reinstall it from ClawHub before verifying it as an installed ClawHub skill.
```

Autoreview:

```bash
.agents/skills/autoreview/scripts/autoreview --mode local
```

Result: clean; no accepted/actionable findings reported; overall patch is correct (0.84).

What was not tested: a live positive ClawHub verification success after reinstall. This change is intentionally scoped to the local preflight/audit rejection path when lockfile integrity metadata is present.
