### PR TITLE
fix(codex): stamp transcript messages with explicit harness field (#95875)

### DIFF
--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -237,6 +237,48 @@ describe("mirrorCodexAppServerTranscript", () => {
     ]);
   });
 
+  it("stamps every codex transcript message with an explicit harness field", async () => {
+    const sessionFile = await createTempSessionFile();
+
+    await mirrorCodexAppServerTranscript({
+      sessionFile,
+      sessionKey: "agent:main:main",
+      messages: [
+        attachCodexMirrorIdentity(
+          makeAgentUserMessage({
+            content: [{ type: "text", text: "prompt" }],
+            timestamp: Date.now(),
+          }),
+          "turn-1:prompt",
+        ),
+        attachCodexMirrorIdentity(
+          makeAgentAssistantMessage({
+            content: [{ type: "text", text: "reply" }],
+            timestamp: Date.now() + 1,
+          }),
+          "turn-1:assistant",
+        ),
+      ],
+      idempotencyScope: "codex-app-server:thread-1",
+    });
+
+    // The persisted transcript must carry an explicit harness field so an
+    // operator reads "ran on Codex" directly, instead of inferring it from the
+    // canonical openai provider/api labels (#95875).
+    const raw = await fs.readFile(sessionFile, "utf8");
+    const messageEntries = raw
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line) as { type?: string; message?: unknown })
+      .filter((entry) => entry.type === "message");
+    expect(messageEntries.length).toBe(2);
+    for (const entry of messageEntries) {
+      const message = entry.message as Record<string, unknown> | undefined;
+      const openclaw = (message?.["__openclaw"] ?? undefined) as { harness?: string } | undefined;
+      expect(openclaw?.harness).toBe("codex");
+    }
+  });
+
   it("creates the transcript directory on first mirror", async () => {
     const root = await makeRoot("openclaw-codex-transcript-missing-dir-");
     const sessionFile = path.join(root, "nested", "sessions", "session.jsonl");

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -24,6 +24,13 @@ export type CodexAppServerTranscriptMirrorResult = {
 };
 
 const MIRROR_IDENTITY_META_KEY = "mirrorIdentity" as const;
+// Harness stamped on every Codex-owned transcript message so operators read
+// the actual execution harness directly. Provider/api labels on these messages
+// track the canonical openai migration artifact (#95875); without an explicit
+// harness field an operator must infer "this ran on Codex" indirectly from the
+// codex-app-server mirror-identity prefix.
+const HARNESS_META_KEY = "harness" as const;
+const CODEX_TRANSCRIPT_HARNESS = "codex" as const;
 
 function buildSenderLabel(params: {
   senderId?: string;
@@ -221,7 +228,9 @@ export async function mirrorPromptAtTurnStartBestEffort(params: {
 }
 
 /**
- * Tag a message with a stable logical identity for mirror dedupe. Callers
+ * Tag a Codex-owned transcript message with provenance metadata: a stable
+ * logical identity for mirror dedupe, plus the execution harness so operators
+ * can read it directly instead of inferring it from provider/api labels (#95875). Callers
  * should use a value that is invariant for the same logical message across
  * re-emits (e.g. `${turnId}:prompt`, `${turnId}:assistant`) but distinct
  * for genuinely-distinct messages (different turns, different kinds). When
@@ -238,7 +247,11 @@ export function attachCodexMirrorIdentity<T extends AgentMessage>(message: T, id
       : {};
   return {
     ...record,
-    __openclaw: { ...baseMeta, [MIRROR_IDENTITY_META_KEY]: identity },
+    __openclaw: {
+      ...baseMeta,
+      [MIRROR_IDENTITY_META_KEY]: identity,
+      [HARNESS_META_KEY]: CODEX_TRANSCRIPT_HARNESS,
+    },
   } as unknown as T;
 }
 

--- a/scripts/repro/issue-95875-codex-transcript-harness.mts
+++ b/scripts/repro/issue-95875-codex-transcript-harness.mts
@@ -1,0 +1,110 @@
+// Reproduction for #95875: Codex-backed transcript messages must carry an
+// explicit `__openclaw.harness` field so operators read "ran on Codex" directly
+// instead of inferring it from the canonical openai provider/api labels.
+//
+// Runs the production transcript-mirror path against a real temp session file
+// and asserts the persisted JSONL carries the harness stamp.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  attachCodexMirrorIdentity,
+  mirrorCodexAppServerTranscript,
+} from "../../extensions/codex/src/app-server/transcript-mirror.ts";
+import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function makeUserMessage(text: string, timestamp: number): AgentMessage {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+    timestamp,
+  } as AgentMessage;
+}
+
+function makeAssistantMessage(text: string, timestamp: number): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "openai-responses",
+    provider: "openai",
+    model: "gpt-5.5",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp,
+  } as AgentMessage;
+}
+
+async function main() {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-repro-95875-"));
+  const sessionFile = path.join(tmpDir, "session.jsonl");
+  const base = Number(Date.now());
+
+  try {
+    await mirrorCodexAppServerTranscript({
+      sessionFile,
+      sessionKey: "agent:main:main",
+      messages: [
+        attachCodexMirrorIdentity(makeUserMessage("hello", base), "turn-1:prompt"),
+        attachCodexMirrorIdentity(
+          makeAssistantMessage("codex reply", base + 1),
+          "turn-1:assistant",
+        ),
+      ],
+      idempotencyScope: "codex-app-server:thread-1",
+    });
+
+    const raw = await fs.readFile(sessionFile, "utf8");
+    const messages = raw
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line) as { type?: string; message?: Record<string, unknown> })
+      .filter((entry) => entry.type === "message");
+
+    console.log(`=== Reproduction for issue #95875 ===`);
+    console.log(`Session file: ${sessionFile}`);
+    console.log(`Persisted message entries: ${messages.length}`);
+
+    let allStamped = true;
+    for (const entry of messages) {
+      const openclaw = entry.message?.["__openclaw"] as { harness?: string } | undefined;
+      const provider = entry.message?.provider;
+      const api = entry.message?.api;
+      const stamped = openclaw?.harness === "codex";
+      allStamped = allStamped && stamped;
+      console.log(
+        `  role=${entry.message?.role} provider=${provider ?? "(none)"} api=${api ?? "(none)"} ` +
+          `harness=${openclaw?.harness ?? "(MISSING)"}`,
+      );
+    }
+
+    const firstMessageRaw = messages[0]
+      ? JSON.stringify(messages[0].message?.["__openclaw"])
+      : "(none)";
+    console.log(`First message __openclaw: ${firstMessageRaw}`);
+
+    if (messages.length !== 2 || !allStamped) {
+      console.error("FAIL: Codex transcript messages are not stamped with __openclaw.harness=codex.");
+      process.exitCode = 1;
+      return;
+    }
+    console.log("PASS: Every Codex-backed transcript message carries an explicit harness=codex field.");
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What Problem This Solves

After the legacy `openai-codex/*` → canonical `openai/*` migration, Codex-backed cron runs still execute on the Codex harness but the persisted transcript labels them with the canonical migration artifact:

- `provider=openai`
- `api=openai-chatgpt-responses`

That surface is indistinguishable from a plain canonical-OpenAI run, so during a cron incident an operator concluded the job had fallen off Codex when it had not — only the labeling changed (#95875). Operators had to infer "this ran on Codex" indirectly from the `codex-app-server:` mirror-identity prefix instead of reading it directly.

## Why This Change Was Made

Every Codex-owned transcript message already flows through `attachCodexMirrorIdentity` (`extensions/codex/src/app-server/transcript-mirror.ts`), which is the single canonical provenance-metadata injection point for the prompt, reasoning, plan, assistant, and tool-call/result mirror records. That helper now also stamps `__openclaw.harness = "codex"` alongside the existing `mirrorIdentity`, so the execution harness is directly inspectable in the persisted transcript without changing routing, the migration, or any Codex protocol surface. The harness label is OpenClaw-side provenance metadata; it does not read or modify Codex protocol/runtime behavior.

This is additive observability metadata only — no provider/api label, routing, or persisted-shape change beyond the new field.

## User Impact

Operators debugging Codex-backed runs (cron or interactive) can read `__openclaw.harness` directly from the transcript to confirm the run executed on Codex, instead of reverse-engineering it from provider/api labels or the mirror-identity prefix. Non-Codex / third-party-harness messages that do not route through `attachCodexMirrorIdentity` are unaffected (they never carried Codex provenance).

## Evidence

**Reproduction (real filesystem + production code, non-mock persistence):**
```
$ node --import tsx scripts/repro/issue-95875-codex-transcript-harness.mts
=== Reproduction for issue #95875 ===
Session file: /tmp/.../openclaw-repro-95875-.../session.jsonl
Persisted message entries: 2
  role=user provider=(none) api=(none) harness=codex
  role=assistant provider=openai api=openai-responses harness=codex
First message __openclaw: {"mirrorIdentity":"turn-1:prompt","harness":"codex"}
PASS: Every Codex-backed transcript message carries an explicit harness=codex field.
```

The assistant row keeps `provider=openai api=openai-responses` (the migration artifact) but now also carries `harness=codex`, so the actual harness is unambiguous.

**Unit/regression (real session-file persistence):**
```
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/transcript-mirror.test.ts
Test Files  1 passed (1)
     Tests  16 passed (16)
```

**Sibling surfaces (attachCodexMirrorIdentity is shared across event projection):**
```
$ node scripts/run-vitest.mjs \
    extensions/codex/src/app-server/event-projector.test.ts \
    extensions/codex/src/app-server/run-attempt.test.ts \
    extensions/codex/src/app-server/thread-lifecycle.test.ts
Test Files  3 passed (3)
     Tests  277 passed (277)
```

Refs #95875.
