### PR TITLE
Guard Skill Workshop create proposals from existing-skill patch content

### DIFF
--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -154,6 +154,11 @@ openclaw skills workshop reject <proposal-id> --reason "Duplicate"
 openclaw skills workshop quarantine <proposal-id> --reason "Needs security review"
 ```
 
+`propose-create` always targets a new sibling skill under `skills/<name>/` and
+rejects drafts that reference existing workspace skill paths such as
+`skills/qa-check/SKILL.md`. Use `propose-update <skill>` once per existing skill
+when a change touches current skills.
+
 ## Related
 
 - [CLI reference](/cli)

--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -27,7 +27,13 @@ plugin, ClawHub, extra-root, managed, personal-agent, or system skills.
   active skills.
 - **Workspace scoped:** creates target the workspace `skills/` root. Updates
   are allowed only for writable workspace skills.
+- **Single target:** create always proposes one new sibling skill, and update
+  targets one existing skill. Split multi-skill changes into separate update
+  proposals.
 - **No clobber:** create fails if the target skill already exists.
+- **Wrong-target guard:** create rejects proposal content that references
+  existing workspace skill paths such as `skills/trip-planning/SKILL.md`;
+  those changes belong in update proposals.
 - **Hash bound:** update proposals bind to the current target hash and become
   stale if the live skill changes before apply.
 - **Scanner gated:** apply reruns scanning before writing.
@@ -88,11 +94,19 @@ openclaw skills workshop propose-create \
   --proposal ./PROPOSAL.md
 ```
 
+`propose-create` always creates a new sibling under `skills/<name>/`. If the
+draft references an existing workspace skill path such as
+`skills/trip-planning/SKILL.md`, Skill Workshop rejects it so the update does
+not silently land in an unused sibling skill.
+
 Create an update proposal for an existing workspace skill:
 
 ```bash
 openclaw skills workshop propose-update trip-planning --proposal ./PROPOSAL.md
 ```
+
+For changes that touch multiple existing skills, create one update proposal per
+target skill.
 
 List and inspect:
 
@@ -166,6 +180,10 @@ The model uses `skill_workshop`:
 ```text
 action: create | update | revise | list | inspect | apply | reject | quarantine
 ```
+
+`action=create` is only for a brand-new workspace skill. `action=update` targets
+one existing skill through `skill_name`. Agents should split multi-skill patches
+into separate `action=update` calls before applying them.
 
 Agents must use `skill_workshop` for generated skill work. They must not create
 or change proposal files through `write`, `edit`, `exec`, shell commands, or

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -259,6 +259,30 @@ describe("skill_workshop tool", () => {
     );
   });
 
+  it("rejects create proposals that look like existing skill patches", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-tool-");
+    const existingSkillDir = path.join(workspaceDir, "skills", "weather-planner");
+    await fs.mkdir(existingSkillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(existingSkillDir, "SKILL.md"),
+      "---\nname: weather-planner\ndescription: Existing weather skill\n---\n\n# Weather\n",
+      "utf8",
+    );
+    const tool = createSkillWorkshopTool({ workspaceDir, config: {}, agentId: "main" });
+
+    await expect(
+      tool.execute("call-create", {
+        action: "create",
+        name: "Weather Planner Hardening",
+        description: "Patch existing weather planner",
+        proposal_content:
+          "# Weather patch\n\nUpdate skills/weather-planner/SKILL.md with alert checks.\n",
+      }),
+    ).rejects.toThrow(
+      "Create proposal content references existing workspace skill paths: skills/weather-planner",
+    );
+  });
+
   it("applies, rejects, and quarantines proposals through the workshop service", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skill-workshop-tool-");
     const tool = createSkillWorkshopTool({ workspaceDir, config: {}, agentId: "main" });

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -55,7 +55,7 @@ const SkillWorkshopToolSchema = Type.Object(
   {
     action: stringEnum(SKILL_WORKSHOP_ACTIONS, {
       description:
-        "create for a new skill proposal, update for an existing skill, revise for a pending proposal, list or inspect proposals for proposal discovery, apply/reject/quarantine for explicit proposal lifecycle actions.",
+        "create for a brand-new sibling skill proposal, update for one existing skill, revise for a pending proposal, list or inspect proposals for proposal discovery, apply/reject/quarantine for explicit proposal lifecycle actions. Split multi-skill changes into separate update calls.",
     }),
     proposal_id: Type.Optional(
       Type.String({
@@ -66,7 +66,7 @@ const SkillWorkshopToolSchema = Type.Object(
     name: Type.Optional(
       Type.String({
         description:
-          "Skill/proposal name. Required for action=create; optional resolver for action=inspect or action=revise when proposal_id is unknown.",
+          "Skill/proposal name. Required for action=create; create always targets a new workspace skills/<name>/ sibling. Optional resolver for action=inspect or action=revise when proposal_id is unknown.",
       }),
     ),
     query: Type.Optional(Type.String({ description: "Optional query for action=list." })),
@@ -90,12 +90,12 @@ const SkillWorkshopToolSchema = Type.Object(
       }),
     ),
     skill_name: Type.Optional(
-      Type.String({ description: "Existing skill name or key for action=update." }),
+      Type.String({ description: "Single existing skill name or key for action=update." }),
     ),
     proposal_content: Type.Optional(
       Type.String({
         description:
-          "Full proposed procedure markdown for action=create, action=update, or action=revise. It will be stored as PROPOSAL.md. Keep under configured skills.workshop.maxSkillBytes; default max is 40000 bytes.",
+          "Full proposed procedure markdown for action=create, action=update, or action=revise. It will be stored as PROPOSAL.md. action=create must describe only the new skill and rejects existing skills/<name>/ paths; use action=update separately for existing skills. Keep under configured skills.workshop.maxSkillBytes; default max is 40000 bytes.",
       }),
     ),
     support_files: Type.Optional(
@@ -138,7 +138,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
     name: "skill_workshop",
     displaySummary: "Propose a reusable skill",
     description:
-      "Create, update, revise, list, inspect, apply, reject, or quarantine Skill Workshop proposals when reusable procedures should be captured, improved, or explicitly approved.",
+      "Create, update, revise, list, inspect, apply, reject, or quarantine Skill Workshop proposals when reusable procedures should be captured, improved, or explicitly approved. Create always proposes a new sibling skill; update targets one existing skill.",
     parameters: SkillWorkshopToolSchema,
     execute: async (_toolCallId, args) => {
       const params = asToolParamsRecord(args);

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -362,6 +362,58 @@ describe("skill workshop proposals", () => {
     ).rejects.toThrow("Skill already exists");
   });
 
+  it("rejects create proposals that reference existing workspace skill paths", async () => {
+    const workspaceDir = await makeWorkspace();
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "foo"),
+      name: "foo",
+      description: "Existing foo skill",
+      body: "# Foo\n\nOld foo body.\n",
+    });
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "bar"),
+      name: "bar",
+      description: "Existing bar skill",
+      body: "# Bar\n\nOld bar body.\n",
+    });
+
+    await expect(
+      proposeCreateSkill({
+        workspaceDir,
+        name: "Foo Hardening",
+        description: "Patch existing skills",
+        content:
+          "# Intended patch\n\n- Update skills/foo/SKILL.md.\n- Add notes under ./skills/bar/references/bar.md.\n",
+        supportFiles: [{ path: "scripts/new-helper.js", content: "export const helper = true;\n" }],
+      }),
+    ).rejects.toThrow(
+      "Create proposal content references existing workspace skill paths: skills/bar, skills/foo",
+    );
+
+    await expect(listSkillProposals({ workspaceDir })).resolves.toMatchObject({
+      proposals: [],
+    });
+  });
+
+  it("allows create proposals whose markdown heading matches an existing skill name", async () => {
+    const workspaceDir = await makeWorkspace();
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "first"),
+      name: "first",
+      description: "Existing first skill",
+      body: "# First\n\nOld first body.\n",
+    });
+
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "First Aid",
+      description: "New first aid skill",
+      content: "# First\n\nThis is a new skill, not a skills/first path reference.\n",
+    });
+
+    expect(proposal.record.target.skillKey).toBe("first-aid");
+  });
+
   it("revises pending proposals in place before approval", async () => {
     const workspaceDir = await makeWorkspace();
     const proposal = await proposeCreateSkill({

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -76,6 +76,8 @@ const WRITABLE_WORKSPACE_SOURCES = new Set(["openclaw-workspace", "agents-skills
 const MAX_PROPOSAL_DRAFT_BYTES = 1024 * 1024;
 const MAX_PROPOSAL_DIRECTORY_ENTRIES = MAX_PROPOSAL_SUPPORT_FILES * 4;
 const MAX_SKILL_PROPOSAL_DESCRIPTION_BYTES = 160;
+const WORKSPACE_SKILL_PATH_REFERENCE_PATTERN =
+  /(?:^|[^A-Za-z0-9._-])(?:\.\/)?skills\/([^/\\\s"'`<>]+)\//g;
 
 /** Lists skill workshop proposals, optionally scoped to a workspace. */
 export async function listSkillProposals(
@@ -252,6 +254,10 @@ export async function proposeCreateSkill(
   if ((await readWorkspaceSkillFile(target.skillFile)) !== null) {
     throw new Error(`Skill already exists at ${target.skillFile}.`);
   }
+  await assertCreateProposalDoesNotReferenceExistingWorkspaceSkills({
+    workspaceDir: input.workspaceDir,
+    content: input.content,
+  });
 
   const supportFiles = prepareSkillProposalSupportFiles(input.supportFiles);
   const now = new Date().toISOString();
@@ -760,6 +766,36 @@ function assertProposalContentWithinLimit(content: string, maxSkillBytes: number
       `Skill proposal content is too large (${sizeBytes} bytes, max ${maxSkillBytes}).`,
     );
   }
+}
+
+async function assertCreateProposalDoesNotReferenceExistingWorkspaceSkills(params: {
+  workspaceDir: string;
+  content: string;
+}): Promise<void> {
+  const referencedExistingKeys = new Set<string>();
+  for (const match of params.content.matchAll(WORKSPACE_SKILL_PATH_REFERENCE_PATTERN)) {
+    const referencedKey = normalizeSkillIndexName(match[1] ?? "");
+    if (!referencedKey) {
+      continue;
+    }
+    const target = resolveSkillProposalTarget({
+      workspaceDir: params.workspaceDir,
+      skillName: referencedKey,
+    });
+    if ((await readWorkspaceSkillFile(target.skillFile)) !== null) {
+      referencedExistingKeys.add(target.skillKey);
+    }
+  }
+  if (referencedExistingKeys.size === 0) {
+    return;
+  }
+
+  const references = [...referencedExistingKeys].toSorted().map((key) => `skills/${key}`);
+  throw new Error(
+    `Create proposal content references existing workspace skill paths: ${references.join(
+      ", ",
+    )}. action=create always creates a new sibling skill; use action=update or propose-update separately for existing skills.`,
+  );
 }
 
 async function buildSupportFileMetadata(


### PR DESCRIPTION
## What Problem This Solves

Fixes #94947.

Skill Workshop `create` proposals could silently accept proposal content that was clearly meant to patch existing workspace skills, then apply that content as a brand-new sibling skill. That left the referenced existing skills untouched while the proposal appeared to have succeeded.

## Why This Change Was Made

This keeps the current public contract conservative: `create` still creates one new sibling skill, and `update` still targets one existing skill. Instead of adding a new multi-target patch API in this PR, `proposeCreateSkill` now rejects create drafts that reference existing writable workspace skill paths like `skills/foo/SKILL.md` and tells callers to split the work into update proposals.

The guard lives in the shared workshop service so CLI, Gateway, and the agent-side `skill_workshop` tool all get the same behavior. Tool schema text and docs now spell out the single-target contract.

## User Impact

Users no longer get a successful-looking Skill Workshop apply that lands update-shaped content in an unused sibling skill. Agents and operators get an immediate error when `create` content references existing workspace skill paths, and can retry with `update` for each target skill.

## Evidence

- `node scripts/run-vitest.mjs src/skills/workshop/service.test.ts src/agents/tools/skill-workshop-tool.test.ts`
- `pnpm exec oxfmt --write --threads=1 src/skills/workshop/service.ts src/skills/workshop/service.test.ts src/agents/tools/skill-workshop-tool.ts src/agents/tools/skill-workshop-tool.test.ts`
- `pnpm format:docs:check docs/tools/skill-workshop.md docs/cli/skills.md` (passes; pnpm warned this local shell is Node v22.18.0 while the repo wants >=22.19.0)
- `pnpm exec oxlint src/skills/workshop/service.ts src/skills/workshop/service.test.ts src/agents/tools/skill-workshop-tool.ts src/agents/tools/skill-workshop-tool.test.ts`
- `git diff --check`
- Manual tool repro: with existing `skills/foo` and `skills/bar`, `skill_workshop action=create name=foo-hardening` containing `skills/foo/SKILL.md` and `skills/bar/SKILL.md` now rejects before creating a proposal.
