### PR TITLE
fix: suppress exec-like tool error warnings regardless of includeDetails

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -207,7 +207,9 @@ function resolveToolErrorWarningPolicy(params: {
       includeDetails,
     };
   }
-  if (isExecLikeToolName(params.lastToolError.toolName) && !includeDetails) {
+  // Exec-like tool errors should always be suppressed regardless of includeDetails;
+  // they produce noisy exit-code warnings that leak into chat surfaces (#96009).
+  if (isExecLikeToolName(params.lastToolError.toolName)) {
     return { showWarning: false, includeDetails };
   }
   return {


### PR DESCRIPTION
Closes #96009

## Problem

`resolveToolErrorWarningPolicy` correctly identifies exec-like tools (exec, bash) but has an extra `&& !includeDetails` guard that skips suppression when `includeDetails` is true. This causes exit-code warnings like `⚠️ … failed (non-zero exit code: …)` to leak into chat surfaces even when the agent handled the error internally.

## Root Cause

Line 210 in `payloads.ts`:

```ts
if (isExecLikeToolName(params.lastToolError.toolName) && !includeDetails) {
```

The `!includeDetails` guard contradicts the intent: exec-like tool errors should always be suppressed, regardless of whether redacted details are available. These are noise-level exit code warnings that add no value to the user.

## Fix

Removed the `&& !includeDetails` guard. Exec-like tool errors are now always suppressed:

```ts
if (isExecLikeToolName(params.lastToolError.toolName)) {
```

## Change

- `src/agents/embedded-agent-runner/run/payloads.ts`: 1 line changed, comment added with issue reference

## Prevention

This fix should be paired with:
1. A unit test covering `resolveToolErrorWarningPolicy` with `includeDetails: true` + exec-like tool name
2. Patch durability via `safe_openclaw_update.sh` re-apply hook + patch guardian systemd watcher (#228)