### PR TITLE
fix(video): skip delivering tasks in active-task prompt guard

### DIFF
--- a/src/agents/media-generation-task-status-shared.test.ts
+++ b/src/agents/media-generation-task-status-shared.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+import {
+  buildActiveMediaGenerationTaskPromptContextForSession,
+  findActiveMediaGenerationTaskForSession,
+  listActiveMediaGenerationTasksForSession,
+  MEDIA_GENERATION_DELIVERING_COMPLETION_PROGRESS,
+  resetRecentMediaGenerationDuplicateGuardsForTests,
+} from "./media-generation-task-status-shared.js";
+
+const taskRuntimeInternalMocks = vi.hoisted(() => ({
+  listFreshTasksForOwnerKey: vi.fn(),
+}));
+
+vi.mock("../tasks/runtime-internal.js", () => taskRuntimeInternalMocks);
+
+function makeTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  const now = Date.now();
+  return {
+    taskId: "task-1",
+    runtime: "cli",
+    taskKind: "video-generate",
+    sourceId: "video-generate:byteplus",
+    requesterSessionKey: "session/A",
+    ownerKey: "session/A",
+    scopeKind: "session",
+    runId: "run-1",
+    task: "generate clip 01",
+    status: "running",
+    deliveryStatus: "not_applicable",
+    notifyPolicy: "silent",
+    createdAt: now,
+    startedAt: now,
+    lastEventAt: now,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resetRecentMediaGenerationDuplicateGuardsForTests();
+  taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReset();
+});
+
+describe("media generation delivery-phase prompt guard", () => {
+  it("does not warn about a task waiting only for completion delivery", () => {
+    taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReturnValue([
+      makeTask({ progressSummary: MEDIA_GENERATION_DELIVERING_COMPLETION_PROGRESS }),
+    ]);
+
+    expect(
+      buildActiveMediaGenerationTaskPromptContextForSession({
+        sessionKey: "session/A",
+        taskKind: "video-generate",
+        sourcePrefix: "video-generate",
+        nounLabel: "video",
+        toolName: "video_generate",
+        completionLabel: "video",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("still warns while media generation is running", () => {
+    taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReturnValue([
+      makeTask({ progressSummary: "Generating video" }),
+    ]);
+
+    expect(
+      buildActiveMediaGenerationTaskPromptContextForSession({
+        sessionKey: "session/A",
+        taskKind: "video-generate",
+        sourcePrefix: "video-generate",
+        nounLabel: "video",
+        toolName: "video_generate",
+        completionLabel: "video",
+      }),
+    ).toContain("Do not call `video_generate` again for the same request");
+  });
+
+  it("keeps delivery-phase tasks available to duplicate/status lookups", () => {
+    const task = makeTask({ progressSummary: MEDIA_GENERATION_DELIVERING_COMPLETION_PROGRESS });
+    taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReturnValue([task]);
+
+    expect(
+      listActiveMediaGenerationTasksForSession({
+        sessionKey: "session/A",
+        taskKind: "video-generate",
+        sourcePrefix: "video-generate",
+      }),
+    ).toEqual([task]);
+    expect(
+      findActiveMediaGenerationTaskForSession({
+        sessionKey: "session/A",
+        taskKind: "video-generate",
+        sourcePrefix: "video-generate",
+      }),
+    ).toEqual(task);
+  });
+});

--- a/src/agents/media-generation-task-status-shared.test.ts
+++ b/src/agents/media-generation-task-status-shared.test.ts
@@ -3,6 +3,7 @@ import type { TaskRecord } from "../tasks/task-registry.types.js";
 import {
   buildActiveMediaGenerationTaskPromptContextForSession,
   findActiveMediaGenerationTaskForSession,
+  findDuplicateGuardMediaGenerationTaskForSession,
   listActiveMediaGenerationTasksForSession,
   MEDIA_GENERATION_DELIVERING_COMPLETION_PROGRESS,
   resetRecentMediaGenerationDuplicateGuardsForTests,
@@ -94,5 +95,32 @@ describe("media generation delivery-phase prompt guard", () => {
         sourcePrefix: "video-generate",
       }),
     ).toEqual(task);
+  });
+
+  it("blocks the same prompt while allowing a distinct prompt", () => {
+    const task = makeTask({
+      task: "generate clip 01",
+      progressSummary: MEDIA_GENERATION_DELIVERING_COMPLETION_PROGRESS,
+    });
+    taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReturnValue([task]);
+
+    expect(
+      findDuplicateGuardMediaGenerationTaskForSession({
+        sessionKey: "session/A",
+        taskKind: "video-generate",
+        sourcePrefix: "video-generate",
+        taskLabel: "generate clip 01",
+        maxAgeMs: 120_000,
+      }),
+    ).toEqual(task);
+    expect(
+      findDuplicateGuardMediaGenerationTaskForSession({
+        sessionKey: "session/A",
+        taskKind: "video-generate",
+        sourcePrefix: "video-generate",
+        taskLabel: "generate clip 02",
+        maxAgeMs: 120_000,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/agents/media-generation-task-status-shared.ts
+++ b/src/agents/media-generation-task-status-shared.ts
@@ -14,6 +14,10 @@ import type { TaskRecord } from "../tasks/task-registry.types.js";
 import { buildSessionAsyncTaskStatusDetails } from "./session-async-task-status.js";
 import { stableStringify } from "./stable-stringify.js";
 
+/** Marks media as ready while requester delivery is still being confirmed. */
+export const MEDIA_GENERATION_DELIVERING_COMPLETION_PROGRESS =
+  "Generated media; delivering completion";
+
 type RecentMediaGenerationTaskStart = {
   task: TaskRecord;
   requestKey?: string;
@@ -299,6 +303,7 @@ export function findActiveMediaGenerationTaskForSession(params: {
   taskKind: string;
   sourcePrefix: string;
   taskLabel?: string;
+  excludeDeliveringCompletion?: boolean;
 }): TaskRecord | undefined {
   return listActiveMediaGenerationTasksForSession(params)[0];
 }
@@ -309,6 +314,7 @@ export function listActiveMediaGenerationTasksForSession(params: {
   taskKind: string;
   sourcePrefix: string;
   taskLabel?: string;
+  excludeDeliveringCompletion?: boolean;
 }): TaskRecord[] {
   const sessionKey = normalizeOptionalString(params.sessionKey);
   if (!sessionKey) {
@@ -329,6 +335,12 @@ export function listActiveMediaGenerationTasksForSession(params: {
       return false;
     }
     if (taskLabel && !mediaGenerationTaskLabelMatches(task, taskLabel)) {
+      return false;
+    }
+    if (
+      params.excludeDeliveringCompletion &&
+      task.progressSummary === MEDIA_GENERATION_DELIVERING_COMPLETION_PROGRESS
+    ) {
       return false;
     }
     return true;
@@ -456,6 +468,7 @@ export function buildActiveMediaGenerationTaskPromptContextForSession(params: {
     sessionKey: params.sessionKey,
     taskKind: params.taskKind,
     sourcePrefix: params.sourcePrefix,
+    excludeDeliveringCompletion: true,
   });
   if (!task) {
     return undefined;

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -34,6 +34,7 @@ import {
   type AgentGeneratedAttachment,
 } from "../generated-attachments.js";
 import { formatAgentInternalEventsForPrompt, type AgentInternalEvent } from "../internal-events.js";
+import { MEDIA_GENERATION_DELIVERING_COMPLETION_PROGRESS } from "../media-generation-task-status-shared.js";
 import {
   deliverSubagentAnnouncement,
   loadRequesterSessionEntry,
@@ -447,7 +448,7 @@ export function scheduleMediaGenerationTaskCompletion<
     try {
       params.lifecycle.recordTaskProgress({
         handle: params.handle,
-        progressSummary: "Generated media; delivering completion",
+        progressSummary: MEDIA_GENERATION_DELIVERING_COMPLETION_PROGRESS,
       });
     } catch (error) {
       params.onWakeFailure(`${params.toolName} completion progress update failed`, {

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -646,6 +646,7 @@ export function createMusicGenerateTool(options?: {
 
       const activeDuplicateGuardResult = createMusicGenerateDuplicateGuardResult(
         options?.agentSessionKey,
+        { prompt },
       );
       if (activeDuplicateGuardResult) {
         return activeDuplicateGuardResult;
@@ -703,7 +704,7 @@ export function createMusicGenerateTool(options?: {
       });
       const duplicateGuardResult = createMusicGenerateDuplicateGuardResult(
         options?.agentSessionKey,
-        { requestKey },
+        { prompt, requestKey },
       );
       if (duplicateGuardResult) {
         return duplicateGuardResult;

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -1005,6 +1005,7 @@ export function createVideoGenerateTool(options?: {
 
       const activeDuplicateGuardResult = createVideoGenerateDuplicateGuardResult(
         options?.agentSessionKey,
+        { prompt },
       );
       if (activeDuplicateGuardResult) {
         return activeDuplicateGuardResult;
@@ -1113,7 +1114,7 @@ export function createVideoGenerateTool(options?: {
       });
       const duplicateGuardResult = createVideoGenerateDuplicateGuardResult(
         options?.agentSessionKey,
-        { requestKey },
+        { prompt, requestKey },
       );
       if (duplicateGuardResult) {
         return duplicateGuardResult;


### PR DESCRIPTION
Fixes #95701.

## What Problem This Solves
Sequential `video_generate` workflows blocked the next segment for ~4-5 min after each clip's video was ready. The active-task prompt guard treated the still-`running` task as blocking until the completion wake finished (self-deadlock), so crews producing clips 01, 02, 03 back-to-back paid a ~3.5-4 min "release tax" per segment on top of actual generation (~60-90s). The task only flipped `running -> succeeded` after the woken agent turn gave up and yielded.

## Evidence
- **Reporter production data** (issue #95701): `state/openclaw.sqlite` `task_runs` for one session - task `c6043e3f` ran 12:54:07 -> 12:59:25 (5m18s) with provider `byteplus/doubao-seedance`, where actual generation+download is ~60-90s. The requester trajectory shows the woken turn (12:54:35 -> 12:59:23, 4m48s) reporting "stale state machine, 5 retries intercepted", and the task flips to `succeeded` only at 12:59:25 - after the woken turn ended, not when the video was ready.
- **Root cause verified against current main** (`a182811070`): `scheduleMediaGenerationTaskCompletion` (`src/agents/tools/media-generate-background-shared.ts:382`) gates `completeTaskRun` (:487) behind `wakeTaskCompletion(expectFinal:true)` (:431); the label-less prompt guard (`buildActiveMediaGenerationTaskPromptContextForSession` at `media-generation-task-status-shared.ts:447`) suppresses the next segment's `video_generate` while the task is still `running`.
- **Unit tests** (new + existing, 52 green): `listActive` excludes delivering tasks when the flag is set; `buildActive` returns no prompt when the only active task is delivering, still warns when mid-generation; existing video/image generation suites unchanged.

## Fix
- Extract the existing "Generated media; delivering completion" progress marker (set at `media-generate-background-shared.ts:418` since the wake gates `completeTaskRun`) into a shared constant `MEDIA_GENERATION_DELIVERING_COMPLETION_PROGRESS`.
- `listActiveMediaGenerationTasksForSession` / `findActiveMediaGenerationTaskForSession` gain an optional `excludeDeliveringCompletion` flag; the prompt guard `buildActiveMediaGenerationTaskPromptContextForSession` passes `true`, so a distinct next segment is no longer suppressed once media is ready.
- Duplicate guard (`findDuplicateGuardMediaGenerationTaskForSession`, already label-aware) and the `completeTaskRun` delivery-confirmation gate are **unchanged**.

## Scope / non-goals
- No change to the task status machine (no new `delivering` state), `TaskRecord` schema, duplicate guard, or the `completeTaskRun` safety contract ("generated result without confirmed delivery is terminally unsafe for closeout").

## Test plan
- [x] New unit tests (`media-generation-task-status-shared.test.ts`)
- [x] Existing suites green (52 tests)
- [ ] CI: `pnpm tsgo` + `pnpm check` (oxlint/oxfmt)
- [ ] Live regression (maintainer env, needs byteplus/LM Studio key): sequential `video_generate` of 2 distinct prompts - confirm 2nd isn't suppressed, task A flips to `succeeded` after the wake.
