### PR TITLE
fix(wiki): wiki_get and wiki compile miss nested source files

### DIFF
--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -121,6 +121,46 @@ describe("compileMemoryWikiVault", () => {
     ).resolves.toContain('"text":"Alpha is the canonical source page."');
   });
 
+  it("discovers pages in nested subdirectories during compile", async () => {
+    const { rootDir, config } = await createVault({
+      rootDir: nextCaseRoot(),
+      initialize: true,
+    });
+
+    await fs.mkdir(path.join(rootDir, "sources", "sub"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "sources", "top.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.top", title: "Top Source" },
+        body: "# Top Source\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "sub", "nested.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.nested", title: "Nested Source" },
+        body: "# Nested Source\n",
+      }),
+      "utf8",
+    );
+
+    const result = await compileMemoryWikiVault(config);
+
+    expect(result.pageCounts.source).toBe(2);
+    // Root index should link to both
+    await expect(fs.readFile(path.join(rootDir, "index.md"), "utf8")).resolves.toContain(
+      "[Top Source](sources/top.md)",
+    );
+    await expect(fs.readFile(path.join(rootDir, "index.md"), "utf8")).resolves.toContain(
+      "[Nested Source](sources/sub/nested.md)",
+    );
+    // Sources index should link to nested file
+    await expect(fs.readFile(path.join(rootDir, "sources", "index.md"), "utf8")).resolves.toContain(
+      "[Nested Source](sub/nested.md)",
+    );
+  });
+
   it("renders native directory index links relative to each generated index", async () => {
     const { rootDir, config } = await createVault({
       rootDir: nextCaseRoot(),

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -364,10 +364,13 @@ export type RefreshMemoryWikiIndexesResult = {
 
 async function collectMarkdownFiles(rootDir: string, relativeDir: string): Promise<string[]> {
   const dirPath = path.join(rootDir, relativeDir);
-  const entries = await fs.readdir(dirPath, { withFileTypes: true }).catch(() => []);
+  const entries = await fs.readdir(dirPath, { withFileTypes: true, recursive: true }).catch(() => []);
   return entries
     .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
-    .map((entry) => path.join(relativeDir, entry.name))
+    .map((entry) => {
+      const absPath = path.join(entry.parentPath ?? entry.path ?? dirPath, entry.name);
+      return path.relative(rootDir, absPath).split(path.sep).join("/");
+    })
     .filter((relativePath) => path.basename(relativePath) !== "index.md")
     .toSorted((left, right) => left.localeCompare(right));
 }

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -368,7 +368,7 @@ async function collectMarkdownFiles(rootDir: string, relativeDir: string): Promi
   return entries
     .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
     .map((entry) => {
-      const absPath = path.join(entry.parentPath ?? entry.path ?? dirPath, entry.name);
+      const absPath = path.join(entry.parentPath ?? dirPath, entry.name);
       return path.relative(rootDir, absPath).split(path.sep).join("/");
     })
     .filter((relativePath) => path.basename(relativePath) !== "index.md")

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -364,7 +364,9 @@ export type RefreshMemoryWikiIndexesResult = {
 
 async function collectMarkdownFiles(rootDir: string, relativeDir: string): Promise<string[]> {
   const dirPath = path.join(rootDir, relativeDir);
-  const entries = await fs.readdir(dirPath, { withFileTypes: true, recursive: true }).catch(() => []);
+  const entries = await fs
+    .readdir(dirPath, { withFileTypes: true, recursive: true })
+    .catch(() => []);
   return entries
     .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
     .map((entry) => {

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -1092,7 +1092,7 @@ describe("searchMemoryWiki", () => {
     const results = await searchMemoryWiki({ config, query: "Source" });
 
     expect(results).toHaveLength(2);
-    const paths = results.map((r) => r.path).sort();
+    const paths = results.map((r) => r.path).toSorted();
     expect(paths).toEqual(["sources/sub/nested.md", "sources/top.md"]);
   });
 

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -1067,6 +1067,35 @@ describe("searchMemoryWiki", () => {
     ]);
   });
 
+  it("discovers pages in nested subdirectories", async () => {
+    const { rootDir, config } = await createQueryVault({
+      initialize: true,
+    });
+    await fs.mkdir(path.join(rootDir, "sources", "sub"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "sources", "top.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.top", title: "Top Source" },
+        body: "# Top Source\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "sub", "nested.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.nested", title: "Nested Source" },
+        body: "# Nested Source\n",
+      }),
+      "utf8",
+    );
+
+    const results = await searchMemoryWiki({ config, query: "Source" });
+
+    expect(results).toHaveLength(2);
+    const paths = results.map((r) => r.path).sort();
+    expect(paths).toEqual(["sources/sub/nested.md", "sources/top.md"]);
+  });
+
   it("drops gateway-style owner-qualified session hits that collide with the scoped store", async () => {
     const { config } = await createQueryVault({
       initialize: true,

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -245,7 +245,9 @@ async function listWikiMarkdownFiles(rootDir: string): Promise<string[]> {
     await Promise.all(
       QUERY_DIRS.map(async (relativeDir) => {
         const dirPath = path.join(rootDir, relativeDir);
-        const entries = await fs.readdir(dirPath, { withFileTypes: true, recursive: true }).catch(() => []);
+        const entries = await fs
+          .readdir(dirPath, { withFileTypes: true, recursive: true })
+          .catch(() => []);
         return entries
           .filter(
             (entry) => entry.isFile() && entry.name.endsWith(".md") && entry.name !== "index.md",

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -245,12 +245,15 @@ async function listWikiMarkdownFiles(rootDir: string): Promise<string[]> {
     await Promise.all(
       QUERY_DIRS.map(async (relativeDir) => {
         const dirPath = path.join(rootDir, relativeDir);
-        const entries = await fs.readdir(dirPath, { withFileTypes: true }).catch(() => []);
+        const entries = await fs.readdir(dirPath, { withFileTypes: true, recursive: true }).catch(() => []);
         return entries
           .filter(
             (entry) => entry.isFile() && entry.name.endsWith(".md") && entry.name !== "index.md",
           )
-          .map((entry) => path.join(relativeDir, entry.name));
+          .map((entry) => {
+            const absPath = path.join(entry.parentPath ?? entry.path ?? dirPath, entry.name);
+            return path.relative(rootDir, absPath).split(path.sep).join("/");
+          });
       }),
     )
   ).flat();

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -251,7 +251,7 @@ async function listWikiMarkdownFiles(rootDir: string): Promise<string[]> {
             (entry) => entry.isFile() && entry.name.endsWith(".md") && entry.name !== "index.md",
           )
           .map((entry) => {
-            const absPath = path.join(entry.parentPath ?? entry.path ?? dirPath, entry.name);
+            const absPath = path.join(entry.parentPath ?? dirPath, entry.name);
             return path.relative(rootDir, absPath).split(path.sep).join("/");
           });
       }),

--- a/extensions/memory-wiki/src/status.test.ts
+++ b/extensions/memory-wiki/src/status.test.ts
@@ -92,6 +92,39 @@ describe("resolveMemoryWikiStatus", () => {
     expect(status.warnings.map((warning) => warning.code)).toContain("bridge-artifacts-missing");
   });
 
+  it("discovers pages in nested subdirectories", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-nested-",
+      initialize: true,
+    });
+
+    await fs.mkdir(path.join(rootDir, "sources", "sub"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "sources", "top.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.top", title: "Top Source" },
+        body: "# Top Source\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "sub", "nested.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.nested", title: "Nested Source" },
+        body: "# Nested Source\n",
+      }),
+      "utf8",
+    );
+
+    const status = await resolveMemoryWikiStatus(config, {
+      pathExists: async () => true,
+      resolveCommand: async () => null,
+    });
+
+    expect(status.pageCounts.source).toBe(2);
+    expect(status.sourceCounts.native).toBe(2);
+  });
+
   it("counts source provenance from the vault", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-status-",

--- a/extensions/memory-wiki/src/status.ts
+++ b/extensions/memory-wiki/src/status.ts
@@ -87,26 +87,28 @@ async function collectVaultCounts(vaultPath: string): Promise<{
   };
   const dirs = ["entities", "concepts", "sources", "syntheses", "reports"] as const;
   for (const dir of dirs) {
+    const dirPath = path.join(vaultPath, dir);
     const entries = await fs
-      .readdir(path.join(vaultPath, dir), { withFileTypes: true })
+      .readdir(dirPath, { withFileTypes: true, recursive: true })
       .catch(() => []);
     for (const entry of entries) {
       if (!entry.isFile() || !entry.name.endsWith(".md") || entry.name === "index.md") {
         continue;
       }
-      const kind = inferWikiPageKind(path.join(dir, entry.name));
+      const absolutePath = path.join(entry.parentPath ?? dirPath, entry.name);
+      const relativeToVault = path.relative(vaultPath, absolutePath).split(path.sep).join("/");
+      const kind = inferWikiPageKind(relativeToVault);
       if (kind) {
         pageCounts[kind] += 1;
       }
       if (dir === "sources") {
-        const absolutePath = path.join(vaultPath, dir, entry.name);
         const raw = await fs.readFile(absolutePath, "utf8").catch(() => null);
         if (!raw) {
           continue;
         }
         const page = toWikiPageSummary({
           absolutePath,
-          relativePath: path.join(dir, entry.name),
+          relativePath: relativeToVault,
           raw,
         });
         if (!page) {


### PR DESCRIPTION
## What Problem This Solves

Fixes issue where wiki vaults with nested source files (e.g.
`sources/audi/car.md`, `sources/trading/Qullamaggie/`) silently
fail on `wiki_get` and are not indexed by `wiki compile`. Only
flat files directly in top-level QUERY_DIRS are discovered. Any
real-world vault organized with subdirectories hits this bug.

## Why This Change Was Made

Two functions — `listWikiMarkdownFiles` (wiki_get runtime lookup)
and `collectMarkdownFiles` (wiki compile indexing) — both call
`fs.readdir` without `{ recursive: true }`. Adding the flag and
adjusting path construction via `entry.parentPath` fixes both.
No other code paths affected.

## User Impact

- Nested vault pages in all QUERY_DIRS now discoverable by
  `wiki_get` and indexed by `wiki compile`
- Test vault went 385 → 1,093 pages, 11 → hundreds of sources
- Backward compatible — flat vaults unaffected

## Evidence

Before:
```
$ wiki_get("sources/audi/car.md")
Wiki page not found: sources/audi/car.md
```

After:
```
$ wiki_get("sources/audi/car.md")
# Audi A4 B8.5 2.0 TDI — Complete Vehicle History
## 1. Vehicle Overview ...

$ wiki compile
Compiled wiki vault (1093 pages, 467 indexes updated).
```

## Test plan
- [x] `wiki_get` resolves nested paths across all QUERY_DIRS
- [x] `wiki compile` indexes nested files (385 → 1,093 pages)
- [x] `index.md` exclusion still works for nested index.md
- [x] Backward compatible — flat vaults unaffected
- [ ] CI: `pnpm test:extension memory-wiki`
- [ ] CI: `pnpm build && pnpm check`

🤖 AI-assisted: drafted by Clawed (OpenClaw agent). Bug found live
on a real vault, root cause traced via source inspection, fix
validated with before/after evidence. I stand behind the change.
