### PR TITLE
fix(openshell): upload mirror workspace flat to avoid self-nesting

### DIFF
--- a/extensions/openshell/src/backend.mirror-sync.test.ts
+++ b/extensions/openshell/src/backend.mirror-sync.test.ts
@@ -1,0 +1,207 @@
+// Openshell tests cover mirror-mode workspace sync against the OpenShell CLI.
+//
+// These tests simulate the OpenShell CLI `sandbox upload`/`download` contract
+// (including the >= 0.0.37 behavior from NVIDIA/OpenShell #952 and #1028, where
+// `upload <named-dir> <dest>` nests under `<dest>/<basename>/` and only `.`/`/`
+// and file uploads stay flat). They drive the real mirror sync code through the
+// public backend handle, stubbing only the external CLI and the SSH transport.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  createSandboxBrowserConfig,
+  createSandboxPruneConfig,
+  createSandboxSshConfig,
+} from "openclaw/plugin-sdk/test-fixtures";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  // Local directory standing in for the OpenShell sandbox filesystem; remote
+  // absolute paths map to `remoteRoot + remotePath`.
+  remoteRoot: "",
+  sandboxExists: false,
+  uploadCalls: [] as Array<{ src: string; dest: string; cwd?: string }>,
+}));
+
+async function copyDirContents(srcDir: string, destDir: string): Promise<void> {
+  await fs.mkdir(destDir, { recursive: true });
+  const entries = await fs.readdir(srcDir);
+  for (const entry of entries) {
+    await fs.cp(path.join(srcDir, entry), path.join(destDir, entry), { recursive: true });
+  }
+}
+
+vi.mock("./cli.js", async (importActual) => {
+  const actual = await importActual<typeof import("./cli.js")>();
+  return {
+    ...actual,
+    createOpenShellSshSession: vi.fn(async () => ({
+      command: "ssh",
+      configPath: path.join(os.tmpdir(), "openclaw-openshell-fake-config"),
+      host: "fake-openshell-host",
+    })),
+    runOpenShellCli: vi.fn(async (params: { args: string[]; cwd?: string }) => {
+      const [domain, action] = params.args;
+      if (domain === "sandbox" && action === "get") {
+        return { code: harness.sandboxExists ? 0 : 1, stdout: "", stderr: "" };
+      }
+      if (domain === "sandbox" && action === "create") {
+        harness.sandboxExists = true;
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (domain === "sandbox" && action === "ssh-config") {
+        return { code: 0, stdout: "Host fake-openshell-host\n", stderr: "" };
+      }
+      if (domain === "sandbox" && action === "upload") {
+        // args: sandbox upload --no-git-ignore <name> <src> <dest>
+        const src = params.args[4] ?? ".";
+        const dest = params.args[5] ?? "/";
+        harness.uploadCalls.push({ src, dest, cwd: params.cwd });
+        const srcDir = src === "." ? (params.cwd ?? process.cwd()) : src;
+        const destReal = path.join(harness.remoteRoot, dest);
+        // Mirror sync clears the remote dir before each upload, so model the
+        // net result as replace-dest.
+        await fs.rm(destReal, { recursive: true, force: true });
+        await fs.mkdir(destReal, { recursive: true });
+        const flat = src === "." || src === "/";
+        if (flat) {
+          await copyDirContents(srcDir, destReal);
+        } else {
+          // >= 0.0.37: a named source directory lands under its basename.
+          await fs.cp(srcDir, path.join(destReal, path.basename(srcDir)), { recursive: true });
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (domain === "sandbox" && action === "download") {
+        // args: sandbox download <name> <remoteDir> <localDest>
+        const remoteDir = params.args[3] ?? "/";
+        const localDest = params.args[4] ?? "";
+        const remoteReal = path.join(harness.remoteRoot, remoteDir);
+        const exists = await fs.stat(remoteReal).then(
+          () => true,
+          () => false,
+        );
+        if (exists) {
+          await copyDirContents(remoteReal, localDest);
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    }),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/sandbox", async (importActual) => {
+  const actual = await importActual<typeof import("openclaw/plugin-sdk/sandbox")>();
+  return {
+    ...actual,
+    // The remote clear runs over SSH; its effect is folded into the upload
+    // replace-dest model above, so the transport can be a no-op here.
+    runSshSandboxCommand: vi.fn(async () => ({ code: 0, stdout: "", stderr: "" })),
+    disposeSshSandboxSession: vi.fn(async () => {}),
+  };
+});
+
+const { createOpenShellSandboxBackendFactory } = await import("./backend.js");
+const { resolveOpenShellPluginConfig } = await import("./config.js");
+
+function buildSandboxConfig(workspaceRoot: string) {
+  return {
+    mode: "all" as const,
+    backend: "openshell" as const,
+    scope: "session" as const,
+    workspaceAccess: "ro" as const,
+    workspaceRoot,
+    docker: {
+      image: "openclaw-sandbox:bookworm-slim",
+      containerPrefix: "openclaw-sbx-",
+      workdir: "/workspace",
+      readOnlyRoot: true,
+      tmpfs: ["/tmp"],
+      network: "none" as const,
+      capDrop: ["ALL"],
+      env: {},
+    },
+    ssh: createSandboxSshConfig("/tmp/openclaw-sandboxes"),
+    browser: createSandboxBrowserConfig(),
+    tools: { allow: [], deny: [] },
+    prune: createSandboxPruneConfig(),
+  };
+}
+
+describe("openshell mirror-mode workspace sync", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-openshell-mirror-"));
+    harness.remoteRoot = path.join(rootDir, "remote");
+    harness.sandboxExists = false;
+    harness.uploadCalls = [];
+    await fs.mkdir(harness.remoteRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (rootDir) {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+    vi.clearAllMocks();
+  });
+
+  it("uploads staged workspace contents flat so syncs do not self-nest", async () => {
+    const workspaceDir = path.join(rootDir, "workspace");
+    const agentWorkspaceDir = path.join(rootDir, "agent");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(agentWorkspaceDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "note.txt"), "v1\n", "utf8");
+
+    const pluginConfig = resolveOpenShellPluginConfig({
+      command: "openshell",
+      mode: "mirror",
+      autoProviders: false,
+    });
+    const backend = await createOpenShellSandboxBackendFactory({ pluginConfig })({
+      sessionKey: "session:mirror",
+      scopeKey: "session:mirror",
+      workspaceDir,
+      agentWorkspaceDir,
+      cfg: buildSandboxConfig(path.join(rootDir, "sandboxes")),
+    });
+
+    const runSyncCycle = async () => {
+      const execSpec = await backend.buildExecSpec({
+        command: "echo hi",
+        env: {},
+        usePty: false,
+      });
+      await backend.finalizeExec?.({
+        status: "completed",
+        exitCode: 0,
+        timedOut: false,
+        token: execSpec.finalizeToken,
+      });
+    };
+
+    await runSyncCycle();
+    await runSyncCycle();
+
+    // The upload contract must request flat extraction: source "." resolved
+    // from the staged dir, never an absolute named directory.
+    expect(harness.uploadCalls.length).toBeGreaterThan(0);
+    for (const call of harness.uploadCalls) {
+      expect(call.src).toBe(".");
+      expect(call.cwd).toBeTruthy();
+    }
+
+    // Host workspace keeps the file flat across repeated syncs.
+    const hostEntries = await fs.readdir(workspaceDir);
+    expect(hostEntries).toContain("note.txt");
+    expect(hostEntries.some((entry) => entry.startsWith("openclaw-openshell-upload-"))).toBe(false);
+    expect(hostEntries).not.toContain("sandbox");
+    await expect(fs.readFile(path.join(workspaceDir, "note.txt"), "utf8")).resolves.toBe("v1\n");
+
+    // Remote workspace also stays flat (no nested upload-id snapshot dirs).
+    const remoteWorkspace = path.join(harness.remoteRoot, pluginConfig.remoteWorkspaceDir);
+    const remoteEntries = await fs.readdir(remoteWorkspace);
+    expect(remoteEntries).toEqual(["note.txt"]);
+  });
+});

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -744,15 +744,22 @@ class OpenShellSandboxBackendImpl {
         });
         const result = await runOpenShellCli({
           context: this.params.execContext,
+          // OpenShell >= 0.0.37 nests `upload <named-dir> <dest>` under
+          // `<dest>/<basename>/` and keeps flat extraction only for the
+          // basename-less `.`/`/` paths and file uploads (NVIDIA/OpenShell
+          // #952, #1028). Upload the staged tree as "." from its own directory
+          // so its contents land flat in <dest>; uploading the absolute tmp dir
+          // would nest the workspace under the staged dir name, and the
+          // download-back step would then compound that nesting every sync.
           args: [
             "sandbox",
             "upload",
             "--no-git-ignore",
             this.params.execContext.sandboxName,
-            tmpDir,
+            ".",
             remotePath,
           ],
-          cwd: this.params.createParams.workspaceDir,
+          cwd: tmpDir,
         });
         if (result.code !== 0) {
           throw new Error(result.stderr.trim() || "openshell sandbox upload failed");


### PR DESCRIPTION
## What Problem This Solves

Fixes #96016. With the OpenShell sandbox plugin in `mirror` mode against an
OpenShell backend `>= 0.0.37`, each workspace sync created a subdirectory
(named after the staged upload payload) inside the sandbox workspace, and every
subsequent sync nested the previous workspace snapshot one level deeper. Over
time the workspace accumulated recursively nested historical copies of itself.

Root cause is an OpenShell CLI contract change. Upstream
NVIDIA/OpenShell #952 and #1028 changed `sandbox upload <named-dir> <dest>` to
preserve the source directory basename, so contents now land under
`<dest>/<basename>/...`; only basename-less paths (`.`, `/`) and file uploads
keep the legacy flat extraction.

`uploadPathToRemote` stages the workspace into a named temp dir
(`openclaw-openshell-upload-<id>`) and uploaded that **absolute** path, so under
`>= 0.0.37` the workspace landed under `<remoteWorkspaceDir>/<staged-dir-name>/`.
The `mirror` download-back step (`syncWorkspaceFromRemote`) then mirrored that
nesting onto the host workspace, and the next upload re-staged and re-uploaded
the now-nested host tree — compounding the depth on every exec.

## Why This Change Was Made

The upload is changed to request flat extraction explicitly: the staged tree is
uploaded as `.` with the OpenShell process `cwd` set to the staged directory,
instead of passing the staged directory's absolute path. Per the upstream PRs,
`upload .` is the documented flat (basename-less) path, and it has always been
flat — both before and after `0.0.37` — so the fix is backward compatible with
older OpenShell CLIs as well. Only `uploadPathToRemote` (the single chokepoint
for workspace, agent, and skills directory uploads) is affected; file uploads in
`syncLocalPathToRemote` were already flat and are unchanged.

## User Impact

Mirror-mode sandbox workspaces no longer accumulate recursively nested
previous-workspace directories. After each sync the sandbox workspace contains
only the current workspace contents, as expected. No configuration changes are
required.

## Evidence

New regression test `extensions/openshell/src/backend.mirror-sync.test.ts`
simulates the OpenShell `sandbox upload`/`download` contract (including the
`>= 0.0.37` nesting behavior) and drives the real mirror sync code through the
public backend handle, stubbing only the external CLI and SSH transport. It runs
two full sync cycles and asserts the host and remote workspaces stay flat, and
that the upload is issued as `.`.

Test passes with the fix:

```
$ node scripts/run-vitest.mjs extensions/openshell/src/backend.mirror-sync.test.ts
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Reverting the fix (uploading the absolute staged dir again) makes the same test
fail, reproducing the reported self-nesting:

```
AssertionError: expected '/tmp/openclaw/openclaw-openshell-uplo…' to be '.'
Expected: "."
Received: "/tmp/openclaw/openclaw-openshell-upload-d6eb358e-...-ynfCAW"
```

Full openshell suite green and changed files pass `oxfmt --check`:

```
$ node scripts/run-vitest.mjs extensions/openshell/src/backend.mirror-sync.test.ts \
    extensions/openshell/src/backend.test.ts extensions/openshell/src/mirror.test.ts
 Test Files  3 passed (3)
      Tests  10 passed (10)
```

### Live behavior proof — real OpenShell v0.0.68 (>= 0.0.37) gateway + Docker sandbox

Run against a self-hosted local OpenShell gateway (free OSS, Apache-2.0; `openshell`
0.0.68 CLI + `openshell-gateway` with mTLS and per-sandbox JWT, Docker compute
driver) and a real sandbox. This exercises the actual `openshell sandbox upload`
CLI contract the fix depends on, not a mock.

The staged payload is a directory named `openclaw-openshell-upload-<id>` exactly
like `uploadPathToRemote` produces:

```
<staged-dir>/openclaw-openshell-upload-deadbeef/hello.txt
<staged-dir>/openclaw-openshell-upload-deadbeef/sub/nested.txt
```

A) Current `main` shape — upload the **named** staged dir as `LOCAL_PATH`:

```
$ openshell --version
openshell 0.0.68
$ openshell sandbox upload --no-git-ignore SB <staged-dir> /tmp/mirrorA
✓ Upload complete
$ openshell sandbox exec -n SB -- find /tmp/mirrorA
/tmp/mirrorA
/tmp/mirrorA/openclaw-openshell-upload-deadbeef            <-- self-nesting basename dir
/tmp/mirrorA/openclaw-openshell-upload-deadbeef/hello.txt
/tmp/mirrorA/openclaw-openshell-upload-deadbeef/sub/nested.txt
```

B) This PR's shape — `cd` into the staged dir and upload `.`:

```
$ ( cd <staged-dir> && openshell sandbox upload --no-git-ignore SB . /tmp/mirrorB )
✓ Upload complete
$ openshell sandbox exec -n SB -- find /tmp/mirrorB
/tmp/mirrorB
/tmp/mirrorB/hello.txt                                     <-- flat, no basename dir
/tmp/mirrorB/sub/nested.txt
```

C) The bug compounds across mirror cycles. In `mirror` mode the download-back step
leaves the nested remote tree on the host workspace; the next sync re-stages that
already-nested tree under a new named temp dir and re-uploads it the `main` way,
so the depth grows one basename level every exec turn:

```
$ openshell sandbox upload --no-git-ignore SB <staged-dir-cycle2> /tmp/mirrorA2
✓ Upload complete
$ openshell sandbox exec -n SB -- find /tmp/mirrorA2
/tmp/mirrorA2/openclaw-openshell-upload-cafef00d/openclaw-openshell-upload-deadbeef/hello.txt
/tmp/mirrorA2/openclaw-openshell-upload-cafef00d/openclaw-openshell-upload-deadbeef/sub/nested.txt
```

This confirms on a live `>= 0.0.37` backend that the named-directory upload nests
under the source basename (the reported recursive self-nesting), while `upload .`
from the staged cwd — what this PR does — stays flat across syncs.

AI-assisted.
