### PR TITLE
fix(tavily): bound untrusted JSON response reads

### DIFF
--- a/extensions/tavily/src/tavily-client.test.ts
+++ b/extensions/tavily/src/tavily-client.test.ts
@@ -124,12 +124,12 @@ describe("tavily client X-Client-Source header", () => {
   });
 
   it("caps oversized JSON responses instead of buffering the whole body", async () => {
-    // 20 x 1 KiB chunks behind a 2 KiB cap: the reader must stop early.
-    const streamed = createStreamingJsonResponse({ chunkCount: 20, chunkSize: 1024 });
+    // 20 x 1 MiB chunks behind the shared 16 MiB cap: the reader must stop early.
+    const streamed = createStreamingJsonResponse({ chunkCount: 20, chunkSize: 1024 * 1024 });
 
     await expect(
-      testing.readTavilyJsonResponse(streamed.response, "Tavily Search", { maxBytes: 2048 }),
-    ).rejects.toThrow("Tavily Search: JSON response exceeds 2048 bytes");
+      testing.readTavilyJsonResponse(streamed.response, "Tavily Search"),
+    ).rejects.toThrow("Tavily Search: JSON response exceeds 16777216 bytes");
 
     expect(streamed.getReadCount()).toBeLessThan(20);
   });

--- a/extensions/tavily/src/tavily-client.test.ts
+++ b/extensions/tavily/src/tavily-client.test.ts
@@ -26,12 +26,44 @@ vi.mock("./config.js", () => ({
   resolveTavilyExtractTimeoutSeconds: () => 60,
 }));
 
+// Streaming JSON fixture (no content-length) that counts reads so a test can
+// prove the bounded reader stops before buffering the whole oversized body.
+function createStreamingJsonResponse(params: { chunkCount: number; chunkSize: number }): {
+  response: Response;
+  getReadCount: () => number;
+} {
+  let reads = 0;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (reads >= params.chunkCount) {
+        controller.close();
+        return;
+      }
+      reads += 1;
+      controller.enqueue(encoder.encode("a".repeat(params.chunkSize)));
+    },
+  });
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    getReadCount: () => reads,
+  };
+}
+
 describe("tavily client X-Client-Source header", () => {
   let runTavilySearch: typeof import("./tavily-client.js").runTavilySearch;
   let runTavilyExtract: typeof import("./tavily-client.js").runTavilyExtract;
+  let testing: typeof import("./tavily-client.js").__testing;
 
   beforeAll(async () => {
-    ({ runTavilySearch, runTavilyExtract } = await import("./tavily-client.js"));
+    ({
+      runTavilySearch,
+      runTavilyExtract,
+      __testing: testing,
+    } = await import("./tavily-client.js"));
   });
 
   beforeEach(() => {
@@ -78,5 +110,27 @@ describe("tavily client X-Client-Source header", () => {
     await expect(runTavilyExtract({ urls: ["https://example.com"] })).rejects.toThrow(
       "Tavily Extract: malformed JSON response",
     );
+  });
+
+  it("parses well-formed JSON responses under the byte cap", async () => {
+    const response = new Response(JSON.stringify({ results: [{ url: "https://e.com" }] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    await expect(testing.readTavilyJsonResponse(response, "Tavily Search")).resolves.toEqual({
+      results: [{ url: "https://e.com" }],
+    });
+  });
+
+  it("caps oversized JSON responses instead of buffering the whole body", async () => {
+    // 20 x 1 KiB chunks behind a 2 KiB cap: the reader must stop early.
+    const streamed = createStreamingJsonResponse({ chunkCount: 20, chunkSize: 1024 });
+
+    await expect(
+      testing.readTavilyJsonResponse(streamed.response, "Tavily Search", { maxBytes: 2048 }),
+    ).rejects.toThrow("Tavily Search: JSON response exceeds 2048 bytes");
+
+    expect(streamed.getReadCount()).toBeLessThan(20);
   });
 });

--- a/extensions/tavily/src/tavily-client.ts
+++ b/extensions/tavily/src/tavily-client.ts
@@ -1,5 +1,6 @@
 // Tavily plugin module implements tavily client behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   DEFAULT_CACHE_TTL_MINUTES,
   normalizeCacheKey,
@@ -8,7 +9,6 @@ import {
   resolveCacheTtlMs,
   writeCache,
 } from "openclaw/plugin-sdk/provider-web-search";
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { wrapExternalContent, wrapWebContent } from "openclaw/plugin-sdk/security-runtime";
 import {
   DEFAULT_TAVILY_BASE_URL,
@@ -27,11 +27,6 @@ const EXTRACT_CACHE = new Map<
   { value: Record<string, unknown>; expiresAt: number; insertedAt: number }
 >();
 const DEFAULT_SEARCH_COUNT = 5;
-// Tavily search/extract bodies are untrusted external responses (web content),
-// so cap the JSON read at the same 16 MiB ceiling other providers use to keep a
-// hostile or buggy upstream from forcing the runtime to buffer an unbounded body.
-const TAVILY_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
-
 export type TavilySearchParams = {
   cfg?: OpenClawConfig;
   query: string;
@@ -95,21 +90,8 @@ async function postTavilyJson(params: {
 async function readTavilyJsonResponse(
   response: Response,
   label: string,
-  opts?: { maxBytes?: number },
 ): Promise<Record<string, unknown>> {
-  // Read through the bounded reader (cancelling the stream on overflow) so an
-  // untrusted Tavily endpoint cannot force the runtime to buffer the whole body
-  // before parsing. Mirrors readProviderJsonResponse in src/agents.
-  const maxBytes = opts?.maxBytes ?? TAVILY_JSON_RESPONSE_MAX_BYTES;
-  const bytes = await readResponseWithLimit(response, maxBytes, {
-    onOverflow: ({ maxBytes: maxBytesLocal }) =>
-      new Error(`${label}: JSON response exceeds ${maxBytesLocal} bytes`),
-  });
-  try {
-    return JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>;
-  } catch (cause) {
-    throw new Error(`${label}: malformed JSON response`, { cause });
-  }
+  return await readProviderJsonResponse<Record<string, unknown>>(response, label);
 }
 
 export async function runTavilySearch(

--- a/extensions/tavily/src/tavily-client.ts
+++ b/extensions/tavily/src/tavily-client.ts
@@ -8,6 +8,7 @@ import {
   resolveCacheTtlMs,
   writeCache,
 } from "openclaw/plugin-sdk/provider-web-search";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { wrapExternalContent, wrapWebContent } from "openclaw/plugin-sdk/security-runtime";
 import {
   DEFAULT_TAVILY_BASE_URL,
@@ -26,6 +27,10 @@ const EXTRACT_CACHE = new Map<
   { value: Record<string, unknown>; expiresAt: number; insertedAt: number }
 >();
 const DEFAULT_SEARCH_COUNT = 5;
+// Tavily search/extract bodies are untrusted external responses (web content),
+// so cap the JSON read at the same 16 MiB ceiling other providers use to keep a
+// hostile or buggy upstream from forcing the runtime to buffer an unbounded body.
+const TAVILY_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 
 export type TavilySearchParams = {
   cfg?: OpenClawConfig;
@@ -90,9 +95,18 @@ async function postTavilyJson(params: {
 async function readTavilyJsonResponse(
   response: Response,
   label: string,
+  opts?: { maxBytes?: number },
 ): Promise<Record<string, unknown>> {
+  // Read through the bounded reader (cancelling the stream on overflow) so an
+  // untrusted Tavily endpoint cannot force the runtime to buffer the whole body
+  // before parsing. Mirrors readProviderJsonResponse in src/agents.
+  const maxBytes = opts?.maxBytes ?? TAVILY_JSON_RESPONSE_MAX_BYTES;
+  const bytes = await readResponseWithLimit(response, maxBytes, {
+    onOverflow: ({ maxBytes: maxBytesLocal }) =>
+      new Error(`${label}: JSON response exceeds ${maxBytesLocal} bytes`),
+  });
   try {
-    return (await response.json()) as Record<string, unknown>;
+    return JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>;
   } catch (cause) {
     throw new Error(`${label}: malformed JSON response`, { cause });
   }


### PR DESCRIPTION
## What Problem This Solves

`extensions/tavily/src/tavily-client.ts` reads the `/search` and `/extract` responses with an unbounded `await response.json()` inside `readTavilyJsonResponse`. Those responses are **untrusted external web content** (the whole point of the Tavily plugin is to fetch arbitrary web data), and Tavily / a reverse proxy / a hostile-or-buggy upstream can send a body with **no `Content-Length`**.

With the unbounded read, `response.json()` keeps consuming the stream until it completes, so a single oversized or slow/hung JSON body forces the runtime to buffer the *entire* payload into memory before parsing. On the web-search/extract path this is memory pressure (and, for a body that streams indefinitely without ever closing, a hang) driven entirely by the untrusted remote — a classic unbounded-external-input issue.

This is the symmetric counterpart to the response-limit campaign that already bounded the core provider read paths: #95103 (gateway pricing catalog streams), #95108 (Anthropic error streams), and #95218 (`readProviderJsonResponse` for provider JSON). The Tavily plugin was on the same unbounded `response.json()` shape and was missed.

## Changes

- `readTavilyJsonResponse` now reads through the shared bounded reader `readResponseWithLimit` (from `openclaw/plugin-sdk/response-limit-runtime`, backed by `@openclaw/media-core`), which **cancels the stream on overflow**, then `JSON.parse`s the decoded prefix.
- Cap is `16 * 1024 * 1024` (16 MiB), aligned with the existing provider JSON ceiling in `src/agents` (`readProviderJsonResponse`).
- Overflow throws a stable `"<label>: JSON response exceeds <n> bytes"` error; malformed JSON keeps its existing `"<label>: malformed JSON response"` error.
- No new abstraction — reuses the existing helper, mirroring `readProviderJsonResponse`.
- Adds regression tests: small valid JSON still parses unchanged under the cap, and an oversized streaming body (20 × 1 KiB behind a 2 KiB cap) rejects with the bounded error while the reader stops early (`getReadCount() < 20`).

## Real behavior proof

- **Behavior addressed**: an untrusted Tavily response with no `Content-Length` that streams past the cap must be cancelled and rejected with a bounded error, instead of buffering the whole body; small valid responses must still parse.
- **Real environment tested**: a local `node:http` server (`node --import tsx`) streaming a JSON body in 1 MiB chunks with **no `Content-Length`**, driving the **real exported** `__testing.readTavilyJsonResponse` over a real `fetch()` `Response` (real `ReadableStream` body, not a mock).
- **Exact steps**:
  1. Start a `node:http` server with a `/oversized` route that opens `{"results":[` and keeps `res.write()`-ing 1 MiB string chunks (tracking total bytes pushed), and a `/small` route returning a normal JSON object.
  2. `fetch()` `/oversized`, pass the live `Response` to `readTavilyJsonResponse(res, "Tavily Search")`, time it and capture the thrown error and the server-side bytes pushed before the socket closed.
  3. **Negative control**: `fetch()` `/oversized` again and read it with the *old* path inlined verbatim — `await r.json()` with no cap — racing against a 1.5 s timer, and record how many bytes the server pushed.
  4. `fetch()` `/small` and parse it through the same real function.
- **Evidence after fix**:
  - `[oversized] content-length header: null` → `threw: Tavily Search: JSON response exceeds 16777216 bytes (after ~200ms)`; server pushed ~18–21 MiB before the cancel stopped it (the 16 MiB cap plus socket buffering), far below the 64 MiB safety ceiling the fixture would otherwise reach.
  - `[negative-control] unbounded json() ... server pushed 68157375 bytes` → with no cap the read consumed the **full ~64 MiB** until the fixture self-terminated; the cap is therefore load-bearing.
  - `[small] PASS: small valid JSON parses unchanged under the cap`.
  - `vitest extensions/tavily/src/tavily-client.test.ts --run` → **6 passed** (4 existing + 2 new boundary tests).
- **Observed result**: oversized stream is cancelled at the cap and rejected with the bounded error; the unbounded control buffers ~64 MiB (proving the fix is what stops it); small JSON is unaffected.
- **What was not tested**: live calls against the real Tavily API (would need a paid key and cannot be made to stream an oversized body deterministically); the 16 MiB ceiling itself is asserted at a scaled-down 2 KiB cap in the unit test for speed.

## Evidence

```
[oversized] content-length header: null
[oversized] threw: Tavily Search: JSON response exceeds 16777216 bytes (after 274ms)
[oversized] server bytes pushed before cancel: 20971500
[oversized] PASS: stream cancelled well below the 64 MiB ceiling
[negative-control] unbounded json() after 964ms => threw:Unexpected token ']' ...; server pushed 68157375 bytes
[negative-control] PASS: unbounded await response.json() buffers past the 16 MiB cap (cap is load-bearing)
[small] parsed: {"results":[{"title":"ok","url":"https://e.com"}],"answer":"hi"}
[small] PASS: small valid JSON parses unchanged under the cap

PROOF PASSED: bounded read cancels oversized stream; cap is load-bearing; small JSON intact
```

```
$ node scripts/run-vitest.mjs extensions/tavily/src/tavily-client.test.ts --run
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

`oxlint` clean on the changed files; `tsgo -p extensions/tavily/tsconfig.json` type-checks clean.

**Label**: security

---

_AI-assisted: implementation and proof harness were written with AI assistance; all changes were reviewed and the proof was run locally by the author._

_This is the symmetric counterpart of the #95103 / #95108 / #95218 response-limit campaign, extending the same bounded-read treatment to the Tavily plugin's untrusted web-search/extract path._
