### PR TITLE
fix(ollama): bound model-discovery JSON response reads

### DIFF
--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -5,7 +5,9 @@ import {
   buildOllamaProvider,
   buildOllamaModelDefinition,
   enrichOllamaModelsWithContext,
+  fetchOllamaModels,
   parseOllamaNumCtxParameter,
+  queryOllamaModelShowInfo,
   resetOllamaModelShowInfoCacheForTest,
   resolveOllamaApiBase,
   type OllamaTagModel,
@@ -379,5 +381,58 @@ describe("ollama provider models", () => {
     expect(parseOllamaNumCtxParameter("temperature 0.8\nnum_ctx -1\nnum_ctx 0")).toBeUndefined();
     expect(parseOllamaNumCtxParameter('stop "<|eot_id|>"')).toBeUndefined();
     expect(parseOllamaNumCtxParameter({ num_ctx: 8192 })).toBeUndefined();
+  });
+
+  it("fails soft and stops reading when discovery streams exceed the JSON byte cap", async () => {
+    // Larger than the shared 16 MiB readProviderJsonResponse cap so the bounded reader cancels
+    // the stream mid-flight; if the cap were removed the reader would buffer the whole payload.
+    const ONE_MIB = 1024 * 1024;
+    const TOTAL_CHUNKS = 32; // 32 MiB advertised body, double the cap.
+    const chunk = new Uint8Array(ONE_MIB);
+
+    let bytesPulled = 0;
+    let canceled = false;
+    const makeOversizedJsonResponse = (): Response => {
+      bytesPulled = 0;
+      canceled = false;
+      let pulled = 0;
+      const body = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (pulled >= TOTAL_CHUNKS) {
+            controller.close();
+            return;
+          }
+          pulled += 1;
+          bytesPulled += chunk.length;
+          controller.enqueue(chunk);
+        },
+        cancel() {
+          canceled = true;
+        },
+      });
+      return new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => makeOversizedJsonResponse()),
+    );
+    const tags = await fetchOllamaModels("http://127.0.0.1:11434");
+    expect(tags).toEqual({ reachable: false, models: [] });
+    expect(canceled).toBe(true);
+    // Only the bounded prefix is pulled, never the full advertised 32 MiB stream.
+    expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => makeOversizedJsonResponse()),
+    );
+    const showInfo = await queryOllamaModelShowInfo("http://127.0.0.1:11434", "evil-model:latest");
+    expect(showInfo).toEqual({});
+    expect(canceled).toBe(true);
+    expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
   });
 });

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-onboard";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   OLLAMA_DEFAULT_BASE_URL,
@@ -38,6 +39,25 @@ const OLLAMA_CONTEXT_ENRICH_LIMIT = 200;
 const MAX_OLLAMA_SHOW_CACHE_ENTRIES = 256;
 const ollamaModelShowInfoCache = new Map<string, Promise<OllamaModelShowInfo>>();
 const OLLAMA_ALWAYS_BLOCKED_HOSTNAMES = new Set(["metadata.google.internal"]);
+// Ollama base URLs are user-supplied and can point at remote/cloud endpoints, so the discovery
+// responses (`/api/tags`, `/api/show`) are untrusted. Cap the success body before parsing so a
+// hostile or buggy server cannot stream an unbounded JSON payload into memory during discovery.
+const OLLAMA_DISCOVERY_JSON_MAX_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Reads an Ollama discovery JSON body under a byte cap, cancelling the stream on overflow.
+ *
+ * The body is read through the shared bounded reader instead of `await response.json()` so an
+ * endpoint that streams an unbounded (or never-ending) body cannot force the discovery path to
+ * buffer the whole payload before parsing. Overflow throws a bounded error that the existing
+ * fail-soft discovery handlers swallow.
+ */
+async function readOllamaDiscoveryJson<T>(response: Response, label: string): Promise<T> {
+  const bytes = await readResponseWithLimit(response, OLLAMA_DISCOVERY_JSON_MAX_BYTES, {
+    onOverflow: ({ maxBytes }) => new Error(`${label}: JSON response exceeds ${maxBytes} bytes`),
+  });
+  return JSON.parse(new TextDecoder().decode(bytes)) as T;
+}
 
 export function buildOllamaBaseUrlSsrFPolicy(baseUrl: string) {
   const trimmed = baseUrl.trim();
@@ -146,11 +166,11 @@ export async function queryOllamaModelShowInfo(
       if (!response.ok) {
         return {};
       }
-      const data = (await response.json()) as {
+      const data = await readOllamaDiscoveryJson<{
         model_info?: Record<string, unknown>;
         capabilities?: unknown;
         parameters?: unknown;
-      };
+      }>(response, "ollama-provider-models.show");
 
       let contextWindow: number | undefined;
       if (data.model_info) {
@@ -314,7 +334,10 @@ export async function fetchOllamaModels(
       if (!response.ok) {
         return { reachable: true, models: [] };
       }
-      const data = (await response.json()) as OllamaTagsResponse;
+      const data = await readOllamaDiscoveryJson<OllamaTagsResponse>(
+        response,
+        "ollama-provider-models.tags",
+      );
       const models = (data.models ?? []).filter((m) => m.name);
       return { reachable: true, models };
     } finally {

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -2,7 +2,7 @@
 import { createHash } from "node:crypto";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-onboard";
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   OLLAMA_DEFAULT_BASE_URL,
@@ -39,25 +39,6 @@ const OLLAMA_CONTEXT_ENRICH_LIMIT = 200;
 const MAX_OLLAMA_SHOW_CACHE_ENTRIES = 256;
 const ollamaModelShowInfoCache = new Map<string, Promise<OllamaModelShowInfo>>();
 const OLLAMA_ALWAYS_BLOCKED_HOSTNAMES = new Set(["metadata.google.internal"]);
-// Ollama base URLs are user-supplied and can point at remote/cloud endpoints, so the discovery
-// responses (`/api/tags`, `/api/show`) are untrusted. Cap the success body before parsing so a
-// hostile or buggy server cannot stream an unbounded JSON payload into memory during discovery.
-const OLLAMA_DISCOVERY_JSON_MAX_BYTES = 16 * 1024 * 1024;
-
-/**
- * Reads an Ollama discovery JSON body under a byte cap, cancelling the stream on overflow.
- *
- * The body is read through the shared bounded reader instead of `await response.json()` so an
- * endpoint that streams an unbounded (or never-ending) body cannot force the discovery path to
- * buffer the whole payload before parsing. Overflow throws a bounded error that the existing
- * fail-soft discovery handlers swallow.
- */
-async function readOllamaDiscoveryJson<T>(response: Response, label: string): Promise<T> {
-  const bytes = await readResponseWithLimit(response, OLLAMA_DISCOVERY_JSON_MAX_BYTES, {
-    onOverflow: ({ maxBytes }) => new Error(`${label}: JSON response exceeds ${maxBytes} bytes`),
-  });
-  return JSON.parse(new TextDecoder().decode(bytes)) as T;
-}
 
 export function buildOllamaBaseUrlSsrFPolicy(baseUrl: string) {
   const trimmed = baseUrl.trim();
@@ -166,7 +147,7 @@ export async function queryOllamaModelShowInfo(
       if (!response.ok) {
         return {};
       }
-      const data = await readOllamaDiscoveryJson<{
+      const data = await readProviderJsonResponse<{
         model_info?: Record<string, unknown>;
         capabilities?: unknown;
         parameters?: unknown;
@@ -334,7 +315,7 @@ export async function fetchOllamaModels(
       if (!response.ok) {
         return { reachable: true, models: [] };
       }
-      const data = await readOllamaDiscoveryJson<OllamaTagsResponse>(
+      const data = await readProviderJsonResponse<OllamaTagsResponse>(
         response,
         "ollama-provider-models.tags",
       );


### PR DESCRIPTION
## What Problem This Solves

`extensions/ollama/src/provider-models.ts` discovers Ollama models by calling `/api/tags`
(`fetchOllamaModels`) and `/api/show` (`queryOllamaModelShowInfo`), and parsed both responses with
an **unbounded** `await response.json()`. The Ollama base URL is user-supplied and can point at a
remote/cloud endpoint (`https://ollama.com`, a self-hosted box, or a host reachable via SSRF), so
these discovery responses are untrusted input. A hostile or buggy server can return a
`Content-Length`-less JSON body that streams forever (or many MiB), and `response.json()` buffers the
entire payload before parsing — driving the provider model-discovery path into memory pressure / OOM
or hanging the discovery call. This is not a cosmetic cleanup: the read sits on the provider
onboarding/refresh path that runs against an attacker-influenceable endpoint.

## Changes

- Add a `OLLAMA_DISCOVERY_JSON_MAX_BYTES` cap (16 MiB, aligned with the merged provider-JSON
  bound-stream PRs #95218 / #95418 / #95420) and a small `readOllamaDiscoveryJson<T>(response, label)`
  helper that reads the success body via `readResponseWithLimit` from `@openclaw/media-core`
  (re-exported through `openclaw/plugin-sdk/response-limit-runtime`, the same path style this module
  already uses for `ssrf-runtime`), cancelling the stream on overflow, then `JSON.parse`s the decoded
  bytes. No new abstraction — it reuses the shared bounded reader.
- Route both `/api/tags` (`fetchOllamaModels`) and `/api/show` (`queryOllamaModelShowInfo`) through
  the bounded reader instead of `await response.json()`.
- **Fail-soft semantics preserved**: the overflow throw is caught by the existing discovery error
  handling, so a capped endpoint degrades gracefully — `/api/tags` returns
  `{ reachable: false, models: [] }` and `/api/show` returns `{}`. No OOM, no hang.

## Real behavior proof

- **Behavior addressed**: Unbounded `await response.json()` on the two Ollama discovery reads lets an
  untrusted endpoint stream an unbounded JSON body into memory.
- **Real environment tested**: A real local `node:http` server (`createServer`) bound to
  `127.0.0.1`, returning a `Content-Length`-less body that streams 64 KiB chunks until the socket is
  torn down (would total ~64 MiB, 4× the 16 MiB cap). The **real exported** `fetchOllamaModels` and
  `queryOllamaModelShowInfo` were driven against it (through the real `fetchWithSsrFGuard` dispatcher,
  with the loopback allowed by the existing `buildOllamaBaseUrlSsrFPolicy`).
- **Exact steps**: `node --import tsx proof.mts` — start server → drive the real functions →
  read back fail-soft results + the server's observed bytes-sent / socket-abort counters → run a
  negative control (raw unbounded read of the same endpoint) → flip the server to small valid bodies
  and re-drive the real functions.
- **Evidence after fix**: `readResponseWithLimit` threw `... exceeds 16777216 bytes`; the server
  observed the socket aborted after ~17–19 MiB (≪ the ~64 MiB it would have sent), confirming the
  stream was **cancelled**, not drained. `fetchOllamaModels` returned `{ reachable: false, models: [] }`
  and `queryOllamaModelShowInfo` returned `{}` (fail-soft intact).
- **Observed result (all 8 checks PASS)**:
  - `readResponseWithLimit throws bounded error on unbounded body` → threw, msg `exceeds 16777216 bytes`
  - `stream cancelled: server saw socket abort` → aborted=true, bytesSent=19333120 (< 33554432)
  - `fetchOllamaModels fail-soft on overflow` → `{ reachable:false, models:[] }`
  - `queryOllamaModelShowInfo fail-soft on overflow` → `{}`
  - `show stream cancelled` → aborted=true, bytesSent=17825792
  - `negative control: unbounded read buffers PAST the 16 MiB cap` → buffered 16799524 bytes (> cap)
    — proves the cap is load-bearing (without it the body keeps accumulating past 16 MiB).
  - `happy path: small /api/tags still parsed` → `reachable:true, 2 models`
  - `happy path: small /api/show still parsed` → `contextWindow=65536`
- **What was not tested**: Did not exercise a live external Ollama Cloud endpoint (`ollama.com`); the
  untrusted-body behavior is fully reproduced with a local streaming server, which is the same
  transport path. The proof script is not committed.

## Evidence

```
[proof] local server on http://127.0.0.1:46829, cap=16777216 bytes, would-stream≈67108864 bytes

PASS  readResponseWithLimit throws bounded error on unbounded body :: threw=true msg="bounded: exceeds 16777216 bytes"
PASS  stream cancelled: server saw socket abort before sending the full ~64MiB :: aborted=true bytesSent=19333120 (<33554432)
PASS  fetchOllamaModels fail-soft on overflow (reachable:false, models:[]) :: {"reachable":false,"models":[]}
PASS  queryOllamaModelShowInfo fail-soft on overflow ({}) :: {}
PASS  show stream cancelled: server saw socket abort, bytes ≪ full body :: aborted=true bytesSent=17825792
PASS  negative control: unbounded read buffers PAST the 16MiB cap (cap is load-bearing) :: buffered=16799524 bytes (>16777216)
PASS  happy path: small /api/tags still parsed (2 models) :: {"reachable":true,"models":[{"name":"llama3:8b"},{"name":"qwen3:4b"}]}
PASS  happy path: small /api/show still parsed (contextWindow=65536) :: contextWindow=65536

[proof] ALL PASS
```

Regression suite + checks (worktree on `upstream/main`):
- `node scripts/run-vitest.mjs extensions/ollama/src/provider-models.test.ts --run` → **16/16 passed**
- `oxlint extensions/ollama/src/provider-models.ts` → exit 0, clean
- `tsgo -p tsconfig.extensions.json` → no errors in `extensions/ollama` (only pre-existing,
  unrelated `extensions/qa-lab` `crabline` module-resolution failures present on untouched main)

This is the symmetric counterpart to the #95103 / #95108 response-limit campaign, applying the same
`@openclaw/media-core` bounded reader to the two Ollama provider-discovery JSON reads.

**Label**: security

_AI-assisted._
