### PR TITLE
fix(sandbox): materialize protected skill mount roots

### DIFF
--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -27,7 +27,10 @@ import { updateRegistry } from "./registry.js";
 import { resolveSandboxRuntimeStatus } from "./runtime-status.js";
 import { resolveSandboxScopeKey, resolveSandboxWorkspaceDir } from "./shared.js";
 import type { SandboxContext, SandboxDockerConfig, SandboxWorkspaceInfo } from "./types.js";
-import { resolveMaterializedSandboxSkillsWorkspaceDir } from "./workspace-mounts.js";
+import {
+  ensureReadOnlyWorkspaceSkillMountSources,
+  resolveMaterializedSandboxSkillsWorkspaceDir,
+} from "./workspace-mounts.js";
 import { ensureSandboxWorkspace } from "./workspace.js";
 
 async function syncSandboxSkillsToWorkspace(params: {
@@ -124,6 +127,13 @@ async function ensureSandboxWorkspaceLayout(params: {
       config: params.config,
       agentId: params.agentId,
       rawSessionKey,
+    });
+    await ensureReadOnlyWorkspaceSkillMountSources({
+      workspaceDir,
+      agentWorkspaceDir,
+      skillsWorkspaceDir,
+      workdir: cfg.docker.workdir,
+      workspaceAccess: cfg.workspaceAccess,
     });
   }
 

--- a/src/agents/sandbox/workspace-mounts.test.ts
+++ b/src/agents/sandbox/workspace-mounts.test.ts
@@ -4,7 +4,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { appendWorkspaceMountArgs } from "./workspace-mounts.js";
+import {
+  appendWorkspaceMountArgs,
+  ensureReadOnlyWorkspaceSkillMountSources,
+  resolveReadOnlyWorkspaceSkillMounts,
+} from "./workspace-mounts.js";
 
 const tmpDirs: string[] = [];
 
@@ -104,6 +108,46 @@ describe("appendWorkspaceMountArgs", () => {
     ]);
   });
 
+  it("materializes missing protected skill roots before first rw sandbox launch", async () => {
+    const agentWorkspaceDir = makeTempWorkspace();
+    const skillsWorkspaceDir = path.join(makeTempWorkspace(), ".openclaw", "sandbox-skills");
+
+    await ensureReadOnlyWorkspaceSkillMountSources({
+      workspaceDir: agentWorkspaceDir,
+      agentWorkspaceDir,
+      skillsWorkspaceDir,
+      workdir: "/workspace",
+      workspaceAccess: "rw",
+    });
+
+    expect(fs.statSync(path.join(agentWorkspaceDir, "skills")).isDirectory()).toBe(true);
+    expect(fs.statSync(path.join(agentWorkspaceDir, ".agents", "skills")).isDirectory()).toBe(true);
+    expect(fs.statSync(path.join(skillsWorkspaceDir, "skills")).isDirectory()).toBe(true);
+
+    expect(
+      resolveReadOnlyWorkspaceSkillMounts({
+        workspaceDir: agentWorkspaceDir,
+        agentWorkspaceDir,
+        skillsWorkspaceDir,
+        workdir: "/workspace",
+        workspaceAccess: "rw",
+      }),
+    ).toEqual([
+      {
+        hostPath: path.join(agentWorkspaceDir, "skills"),
+        containerPath: "/workspace/skills",
+      },
+      {
+        hostPath: path.join(agentWorkspaceDir, ".agents", "skills"),
+        containerPath: "/workspace/.agents/skills",
+      },
+      {
+        hostPath: path.join(skillsWorkspaceDir, "skills"),
+        containerPath: "/workspace/.openclaw/sandbox-skills/skills",
+      },
+    ]);
+  });
+
   it.runIf(process.platform !== "win32")("does not overlay symlinked workspace skill roots", () => {
     // Skill overlays must be real workspace directories; symlinks could expose
     // arbitrary host paths read-only inside the sandbox.
@@ -144,6 +188,44 @@ describe("appendWorkspaceMountArgs", () => {
 
       const mounts = args.filter((arg) => arg.startsWith(agentWorkspaceDir));
       expect(mounts).toEqual([`${agentWorkspaceDir}:/workspace:z`]);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not materialize missing skill roots through a symlinked parent",
+    async () => {
+      const agentWorkspaceDir = makeTempWorkspace();
+      const outsideDir = makeTempWorkspace();
+      const skillsWorkspaceDir = path.join(makeTempWorkspace(), ".openclaw", "sandbox-skills");
+      fs.symlinkSync(outsideDir, path.join(agentWorkspaceDir, ".agents"), "dir");
+
+      await ensureReadOnlyWorkspaceSkillMountSources({
+        workspaceDir: agentWorkspaceDir,
+        agentWorkspaceDir,
+        skillsWorkspaceDir,
+        workdir: "/workspace",
+        workspaceAccess: "rw",
+      });
+
+      expect(fs.existsSync(path.join(outsideDir, "skills"))).toBe(false);
+      expect(
+        resolveReadOnlyWorkspaceSkillMounts({
+          workspaceDir: agentWorkspaceDir,
+          agentWorkspaceDir,
+          skillsWorkspaceDir,
+          workdir: "/workspace",
+          workspaceAccess: "rw",
+        }),
+      ).toEqual([
+        {
+          hostPath: path.join(agentWorkspaceDir, "skills"),
+          containerPath: "/workspace/skills",
+        },
+        {
+          hostPath: path.join(skillsWorkspaceDir, "skills"),
+          containerPath: "/workspace/.openclaw/sandbox-skills/skills",
+        },
+      ]);
     },
   );
 

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -4,6 +4,7 @@
  * Creates Docker bind specs for writable workspaces and read-only skill source mounts.
  */
 import fs from "node:fs";
+import fsp from "node:fs/promises";
 import path from "node:path";
 import { isPathInside } from "../../infra/path-guards.js";
 import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
@@ -17,6 +18,10 @@ const MATERIALIZED_SANDBOX_SKILLS_WORKSPACE_PARTS = [".openclaw", "sandbox-skill
 export type ReadOnlyWorkspaceSkillMount = {
   hostPath: string;
   containerPath: string;
+};
+
+type ReadOnlyWorkspaceSkillMountCandidate = ReadOnlyWorkspaceSkillMount & {
+  rootDir: string;
 };
 
 function formatManagedWorkspaceBind(params: {
@@ -41,6 +46,15 @@ export function resolveMaterializedSandboxSkillsWorkspaceDir(rootDir: string): s
   return path.join(rootDir, ...MATERIALIZED_SANDBOX_SKILLS_WORKSPACE_PARTS);
 }
 
+function isCanonicalWorkspaceSkillMountSource(params: {
+  rootDir: string;
+  hostPath: string;
+}): boolean {
+  const agentRoot = resolveSandboxHostPathViaExistingAncestor(path.resolve(params.rootDir));
+  const canonicalSource = resolveSandboxHostPathViaExistingAncestor(path.resolve(params.hostPath));
+  return isPathInside(agentRoot, canonicalSource);
+}
+
 /** Returns true when a skill mount source exists inside the canonical mount root. */
 export function isExistingWorkspaceSkillMountSource(params: {
   rootDir: string;
@@ -54,19 +68,16 @@ export function isExistingWorkspaceSkillMountSource(params: {
     return false;
   }
 
-  const agentRoot = resolveSandboxHostPathViaExistingAncestor(path.resolve(params.rootDir));
-  const canonicalSource = resolveSandboxHostPathViaExistingAncestor(path.resolve(params.hostPath));
-  return isPathInside(agentRoot, canonicalSource);
+  return isCanonicalWorkspaceSkillMountSource(params);
 }
 
-/** Finds agent-workspace skill directories that should be mounted read-only in rw workspaces. */
-export function resolveReadOnlyWorkspaceSkillMounts(params: {
+function resolveReadOnlyWorkspaceSkillMountCandidates(params: {
   workspaceDir: string;
   agentWorkspaceDir: string;
   skillsWorkspaceDir?: string;
   workdir: string;
   workspaceAccess: SandboxWorkspaceAccess;
-}): ReadOnlyWorkspaceSkillMount[] {
+}): ReadOnlyWorkspaceSkillMountCandidate[] {
   if (params.workspaceAccess !== "rw") {
     return [];
   }
@@ -74,7 +85,8 @@ export function resolveReadOnlyWorkspaceSkillMounts(params: {
   // RW workspaces mount the project as writable, but skill sources remain read-only so agent
   // instructions are visible without letting sandbox commands mutate them.
   const materializedSkillsWorkspaceDir =
-    params.skillsWorkspaceDir ?? resolveMaterializedSandboxSkillsWorkspaceDir(params.agentWorkspaceDir);
+    params.skillsWorkspaceDir ??
+    resolveMaterializedSandboxSkillsWorkspaceDir(params.agentWorkspaceDir);
   const mounts = [
     {
       hostPath: path.join(params.agentWorkspaceDir, "skills"),
@@ -96,8 +108,56 @@ export function resolveReadOnlyWorkspaceSkillMounts(params: {
       rootDir: materializedSkillsWorkspaceDir,
     },
   ];
+  return mounts;
+}
 
-  return mounts
+/** Materializes protected skill mount roots before a first rw sandbox launch. */
+export async function ensureReadOnlyWorkspaceSkillMountSources(params: {
+  workspaceDir: string;
+  agentWorkspaceDir: string;
+  skillsWorkspaceDir?: string;
+  workdir: string;
+  workspaceAccess: SandboxWorkspaceAccess;
+}): Promise<void> {
+  for (const mount of resolveReadOnlyWorkspaceSkillMountCandidates(params)) {
+    if (
+      !isCanonicalWorkspaceSkillMountSource({ rootDir: mount.rootDir, hostPath: mount.hostPath })
+    ) {
+      continue;
+    }
+    try {
+      const stat = await fsp.lstat(mount.hostPath);
+      if (stat.isDirectory()) {
+        continue;
+      }
+      // Existing non-directory or symlink leaves stay rejected by the mount resolver.
+      continue;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+
+    await fsp.mkdir(mount.hostPath, { recursive: true });
+    if (
+      !isExistingWorkspaceSkillMountSource({ rootDir: mount.rootDir, hostPath: mount.hostPath })
+    ) {
+      throw new Error(
+        `Created sandbox skill mount source outside workspace root: ${mount.hostPath}`,
+      );
+    }
+  }
+}
+
+/** Finds agent-workspace skill directories that should be mounted read-only in rw workspaces. */
+export function resolveReadOnlyWorkspaceSkillMounts(params: {
+  workspaceDir: string;
+  agentWorkspaceDir: string;
+  skillsWorkspaceDir?: string;
+  workdir: string;
+  workspaceAccess: SandboxWorkspaceAccess;
+}): ReadOnlyWorkspaceSkillMount[] {
+  return resolveReadOnlyWorkspaceSkillMountCandidates(params)
     .filter((mount) =>
       isExistingWorkspaceSkillMountSource({
         rootDir: mount.rootDir,


### PR DESCRIPTION
## What Problem This Solves

Fixes #94425.

A first-launch rw sandbox can currently skip the read-only overlays for `/workspace/skills` and `/workspace/.agents/skills` when the corresponding host directories do not exist yet. Because `/workspace` itself is writable, the sandbox can create those paths before the next container recreation applies the intended read-only mount.

## Why This Change Was Made

This materializes the protected skill mount roots during rw sandbox workspace setup, before Docker/browser/fs-bridge mount resolution runs. The mount-source predicate remains validation-only: it still requires an existing directory and the same canonical-root containment check, so missing paths under symlinked parents are not accepted as protected mounts.

This differs from the earlier candidate in #94820 by creating missing roots before mount resolution while preserving the existing canonical containment validation after creation.

## User Impact

New rw sandbox launches get read-only skill overlays on the first container creation, even for fresh workspaces that did not already have `skills` or `.agents/skills` directories. Existing symlink and non-directory rejection behavior stays intact.

## Evidence

- `node scripts/run-vitest.mjs src/agents/sandbox/workspace-mounts.test.ts`
  - 15 tests passed, including missing-root materialization and symlink-parent regression coverage.
- `pnpm tsgo:test:src`
  - Passed. Local environment warns that Node is `v22.18.0` while the repo requests `>=22.19.0`.
- `node scripts/run-oxlint.mjs src/agents/sandbox/context.ts src/agents/sandbox/workspace-mounts.ts src/agents/sandbox/workspace-mounts.test.ts`
  - Passed.
- `pnpm exec tsx -e '<helper proof script>'`
  - Confirmed the helper creates all three protected roots and `resolveReadOnlyWorkspaceSkillMounts` returns mounts for `/workspace/skills`, `/workspace/.agents/skills`, and `/workspace/.openclaw/sandbox-skills/skills`.

Proof gap: I attempted local Docker proof, but Docker could not connect because Colima was stopped, and `colima start` failed while starting the VM. I could not produce first-launch container write-failure proof from this machine.
