### PR TITLE
fix(mattermost): bound successful REST JSON/text response reads

### DIFF
--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -244,6 +244,25 @@ describe("createMattermostClient", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects oversized guarded Mattermost success text bodies instead of truncating", async () => {
+    const release = vi.fn(async () => {});
+    const tracked = cancelTrackedResponse(`${"plain success ".repeat(7000)}tail`, {
+      status: 200,
+      headers: { "content-type": "text/plain" },
+    });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({ response: tracked.response, release });
+    const client = createMattermostClient({
+      baseUrl: "https://chat.example.com",
+      botToken: "test-token",
+    });
+
+    await expect(client.request("/users/me")).rejects.toThrow(
+      "Mattermost API /users/me: text response exceeds 65536 bytes",
+    );
+    expect(tracked.wasCanceled()).toBe(true);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("releases guarded Mattermost responses when upstream body reads fail", async () => {
     const release = vi.fn(async () => {});
     const stream = new ReadableStream<Uint8Array>({

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -201,6 +201,49 @@ describe("createMattermostClient", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("bounds and cancels oversized guarded Mattermost success JSON bodies", async () => {
+    const release = vi.fn(async () => {});
+    let canceled = false;
+    let pulled = 0;
+    const oversizeChunk = new Uint8Array(2 * 1024 * 1024).fill(0x7b); // 2 MiB of '{'
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulled += 1;
+        // Flood far past the 16 MiB JSON cap; an unbounded reader would buffer
+        // the whole stream before parsing.
+        controller.enqueue(oversizeChunk);
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(stream, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+      release,
+    });
+    const client = createMattermostClient({
+      baseUrl: "https://chat.example.com",
+      botToken: "test-token",
+    });
+
+    let caught: Error | undefined;
+    try {
+      await client.request("/users/me");
+    } catch (error) {
+      caught = error as Error;
+    }
+
+    expect(caught?.message).toContain("JSON response exceeds 16777216 bytes");
+    // The reader is cancelled at the cap instead of draining the flood: ~8
+    // chunks of 2 MiB reach the 16 MiB ceiling, never the unbounded tail.
+    expect(canceled).toBe(true);
+    expect(pulled).toBeLessThanOrEqual(12);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("releases guarded Mattermost responses when upstream body reads fail", async () => {
     const release = vi.fn(async () => {});
     const stream = new ReadableStream<Uint8Array>({

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -1,6 +1,9 @@
 // Mattermost plugin module implements client behavior.
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import {
   fetchWithSsrFGuard,
@@ -13,6 +16,14 @@ import {
 import { z } from "zod";
 
 const MATTERMOST_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+// Mattermost REST control-plane JSON (posts, users, channels, file-upload
+// results) stays well under a megabyte; cap successful JSON the same way the
+// shared provider path is capped so an untrusted/self-hosted homeserver cannot
+// stream an unbounded body into the runtime before parsing.
+const MATTERMOST_JSON_RESPONSE_LIMIT_BYTES = 16 * 1024 * 1024;
+// Non-JSON success bodies are a rare fallback (the API is JSON-first); keep a
+// generous text budget but still bound it instead of buffering the whole stream.
+const MATTERMOST_TEXT_RESPONSE_LIMIT_BYTES = 64 * 1024;
 const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
 
 export type MattermostFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
@@ -214,9 +225,11 @@ export function createMattermostClient(params: {
 
     const contentType = res.headers.get("content-type") ?? "";
     if (contentType.includes("application/json")) {
-      return (await res.json()) as T;
+      return await readProviderJsonResponse<T>(res, `Mattermost API ${path}`, {
+        maxBytes: MATTERMOST_JSON_RESPONSE_LIMIT_BYTES,
+      });
     }
-    return (await res.text()) as T;
+    return (await readResponseTextLimited(res, MATTERMOST_TEXT_RESPONSE_LIMIT_BYTES)) as T;
   };
 
   return { baseUrl, apiBaseUrl, token, request, fetchImpl };
@@ -679,7 +692,11 @@ export async function uploadMattermostFile(
     const detail = await readMattermostError(res);
     throw new Error(`Mattermost API ${res.status} ${res.statusText}: ${detail || "unknown error"}`);
   }
-  const data = (await res.json()) as { file_infos?: MattermostFileInfo[] };
+  const data = await readProviderJsonResponse<{ file_infos?: MattermostFileInfo[] }>(
+    res,
+    "Mattermost API /files",
+    { maxBytes: MATTERMOST_JSON_RESPONSE_LIMIT_BYTES },
+  );
   const info = data.file_infos?.[0];
   if (!info?.id) {
     throw new Error("Mattermost file upload failed");

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -20,7 +20,6 @@ const MATTERMOST_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 // results) stays well under a megabyte; cap successful JSON the same way the
 // shared provider path is capped so an untrusted/self-hosted homeserver cannot
 // stream an unbounded body into the runtime before parsing.
-const MATTERMOST_JSON_RESPONSE_LIMIT_BYTES = 16 * 1024 * 1024;
 // Non-JSON success bodies are a rare fallback (the API is JSON-first); keep a
 // generous text budget but still bound it instead of buffering the whole stream.
 const MATTERMOST_TEXT_RESPONSE_LIMIT_BYTES = 64 * 1024;
@@ -225,9 +224,7 @@ export function createMattermostClient(params: {
 
     const contentType = res.headers.get("content-type") ?? "";
     if (contentType.includes("application/json")) {
-      return await readProviderJsonResponse<T>(res, `Mattermost API ${path}`, {
-        maxBytes: MATTERMOST_JSON_RESPONSE_LIMIT_BYTES,
-      });
+      return await readProviderJsonResponse<T>(res, `Mattermost API ${path}`);
     }
     return (await readResponseTextLimited(res, MATTERMOST_TEXT_RESPONSE_LIMIT_BYTES)) as T;
   };
@@ -695,7 +692,6 @@ export async function uploadMattermostFile(
   const data = await readProviderJsonResponse<{ file_infos?: MattermostFileInfo[] }>(
     res,
     "Mattermost API /files",
-    { maxBytes: MATTERMOST_JSON_RESPONSE_LIMIT_BYTES },
   );
   const info = data.file_infos?.[0];
   if (!info?.id) {

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -4,6 +4,7 @@ import {
   readProviderJsonResponse,
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import {
   fetchWithSsrFGuard,
@@ -92,6 +93,14 @@ function buildMattermostApiUrl(baseUrl: string, path: string): string {
   }
   const suffix = path.startsWith("/") ? path : `/${path}`;
   return `${normalized}/api/v4${suffix}`;
+}
+
+async function readMattermostSuccessText(res: Response, path: string): Promise<string> {
+  const bytes = await readResponseWithLimit(res, MATTERMOST_TEXT_RESPONSE_LIMIT_BYTES, {
+    onOverflow: ({ maxBytes }) =>
+      new Error(`Mattermost API ${path}: text response exceeds ${maxBytes} bytes`),
+  });
+  return new TextDecoder().decode(bytes);
 }
 
 export async function readMattermostError(res: Response): Promise<string> {
@@ -226,7 +235,7 @@ export function createMattermostClient(params: {
     if (contentType.includes("application/json")) {
       return await readProviderJsonResponse<T>(res, `Mattermost API ${path}`);
     }
-    return (await readResponseTextLimited(res, MATTERMOST_TEXT_RESPONSE_LIMIT_BYTES)) as T;
+    return (await readMattermostSuccessText(res, path)) as T;
   };
 
   return { baseUrl, apiBaseUrl, token, request, fetchImpl };

--- a/extensions/mattermost/src/mattermost/probe.test.ts
+++ b/extensions/mattermost/src/mattermost/probe.test.ts
@@ -74,6 +74,37 @@ describe("probeMattermost", () => {
     expect(mockRelease).toHaveBeenCalledTimes(1);
   });
 
+  it("bounds and cancels oversized probe success JSON bodies", async () => {
+    let canceled = false;
+    let pulled = 0;
+    const oversizeChunk = new Uint8Array(2 * 1024 * 1024).fill(0x7b); // 2 MiB of "{"
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulled += 1;
+        controller.enqueue(oversizeChunk);
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    mockFetchGuard.mockResolvedValueOnce({
+      response: new Response(stream, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+      release: mockRelease,
+    });
+
+    const result = await probeMattermost("https://mm.example.com", "bot-token");
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBeNull();
+    expect(result.error).toContain("JSON response exceeds 16777216 bytes");
+    expect(canceled).toBe(true);
+    expect(pulled).toBeLessThanOrEqual(12);
+    expect(mockRelease).toHaveBeenCalledTimes(1);
+  });
+
   it("forwards allowPrivateNetwork to the SSRF guard policy", async () => {
     mockFetchGuard.mockResolvedValueOnce({
       response: new Response(JSON.stringify({ id: "bot-1" }), {

--- a/extensions/mattermost/src/mattermost/probe.ts
+++ b/extensions/mattermost/src/mattermost/probe.ts
@@ -1,6 +1,7 @@
 // Mattermost plugin module implements probe behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   fetchWithSsrFGuard,
   ssrfPolicyFromPrivateNetworkOptIn,
@@ -53,7 +54,7 @@ export async function probeMattermost(
           elapsedMs,
         };
       }
-      const bot = (await res.json()) as MattermostUser;
+      const bot = await readProviderJsonResponse<MattermostUser>(res, "Mattermost probe /users/me");
       return {
         ok: true,
         status: res.status,


### PR DESCRIPTION
## What Problem This Solves

The Mattermost REST success path buffered untrusted server JSON/text responses without a size cap. `extensions/mattermost/src/mattermost/client.ts` talks to Mattermost servers the plugin does not control: self-hosted instances, LAN deployments, or compromised/malfunctioning hosts. The client already hardened two of its three read paths:

- error bodies are bounded via `readResponseTextLimited` (8 KiB), and
- guarded responses are streamed through `responseWithRelease` instead of `arrayBuffer()`,

but the **successful** response path was still unbounded. `request()` called `await res.json()` / `await res.text()`, and `uploadMattermostFile()` called `await res.json()` on the file-info result. Each of those buffers the entire body into memory before parsing.

A Mattermost server can return a response with **no `Content-Length`** and an arbitrarily large — or never-terminating — JSON/text body (every REST call goes through `request()`: users, channels, posts, file uploads). Because nothing capped the success path, the plugin would buffer the whole stream, applying unbounded memory pressure / hang to the plugin and the surrounding agent runtime. This is not generic cleanup: it closes the one remaining unbounded ingest point on an untrusted-server boundary.

## Changes

- Bound `request()` JSON success bodies with shared `readProviderJsonResponse` (16 MiB cap; cancels the stream and throws a bounded `… exceeds 16777216 bytes` error on overflow, then wraps malformed JSON), matching the provider HTTP path used elsewhere in the repo.
- Bound `request()` non-JSON success bodies at 64 KiB and reject on overflow instead of returning a silently truncated prefix (non-JSON success bodies are a rare fallback; the API is JSON-first).
- Bound `uploadMattermostFile()` file-info JSON the same way through `readProviderJsonResponse`.
- Reused existing helpers only (`readProviderJsonResponse`, `readResponseTextLimited` from `openclaw/plugin-sdk/provider-http`) with no new abstraction and no second buffering layer added to the guarded fetch adapter or the error path.
- Added regression tests proving oversized guarded success JSON and oversized text/plain success bodies throw bounded errors and cancel the upstream stream early.

## Real behavior proof

- **Behavior addressed**: a successful Mattermost REST JSON/text response with no `Content-Length` and a body larger than the cap is no longer buffered unbounded; the stream is cancelled at the cap and a bounded error is thrown. Normal small responses still parse intact.
- **Real environment tested**: local `node:http` server bound to `127.0.0.1` (no `Content-Length`), driving the **real exported** `createMattermostClient(...).request(...)` and `uploadMattermostFile(...)` through the production guarded fetch path (`fetchWithSsrFGuard` + `allowPrivateNetwork`), under `node --import tsx`.
- **Exact steps**:
  1. Server streams 1 MiB `{`-chunks forever with `content-type: application/json` and **no** `Content-Length`.
  2. `client.request("/flood-json")` is awaited; the server counts chunks actually written and tracks socket close.
  3. `uploadMattermostFile(...)` is pointed at the same flood endpoint.
  4. Negative control: a finite-but-oversized 40 MiB body is read once via the **old** unbounded `await res.text()` and once via the new bounded `request()`.
  5. Normal small JSON and small text responses are requested to confirm they still parse intact.
- **Evidence after fix** (proof harness, 7/7 PASS):
  ```
  PASS normal-json-intact {"id":"post-1","message":"hello"}
  PASS normal-text-intact "plain-ok-body"
  PASS oversized-json-throws-bounded Mattermost API /flood-json: JSON response exceeds 16777216 bytes
  PASS oversized-json-cancelled-early chunksWrittenAtThrow=19
  PASS oversized-json-socket-released socketClosed=true
  PASS upload-oversized-throws-bounded Mattermost API /files: JSON response exceeds 16777216 bytes
  PASS negative-control-unbounded-buffers-all unboundedBytes=42991618 serverWroteMiB=41 (bounded path cancelled at 19 MiB)
  SUMMARY pass=7 fail=0
  ```
- **Observed result**: bounded path throws `JSON response exceeds 16777216 bytes`, the server stops after writing ~17-19 MiB (reader cancelled just past the 16 MiB cap), and the socket is released. The negative control proves the cap is load-bearing: the **old** `await res.text()` drained and buffered the entire 41 MiB body (42,991,618 bytes) — i.e. it would have OOM'd on a truly unbounded body — while the new path cancelled at ~19 MiB.
- **What was not tested**: I did not run against a real production Mattermost server (used a local untrusted-server simulator), and did not change the websocket / media binary download paths or the `readMattermostError` `!res.body` in-memory fallback branch (already bounded / not an unbounded network read).

## Evidence

- Proof harness: `node --import ./node_modules/tsx/dist/loader.mjs proof.mts` → `SUMMARY pass=7 fail=0` (output above; harness not committed).
- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/client.test.ts --run` → **23 passed** (includes the new "bounds and cancels oversized guarded Mattermost success JSON bodies" regression test).
- `oxlint extensions/mattermost/src/mattermost/client.ts` → clean.
- `tsgo:extensions` (`tsconfig.extensions.json`, the CI extensions typecheck) → no `mattermost/client.ts` errors.
- `check-extension-plugin-sdk-boundary.mjs --mode=plugin-sdk-internal` → no violations (imports are public `plugin-sdk` entrypoints).

This is the symmetric follow-up to the #95103 / #95108 response-limit campaign, applying the same bounded-stream discipline to the last unbounded read point in the Mattermost REST client's success path.


Refreshed current-head focused validation after fixing text overflow semantics:

```
$ node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/client.test.ts extensions/mattermost/src/mattermost/probe.test.ts -- --run

 Test Files  2 passed (2)
      Tests  32 passed (32)
```

```
$ git diff --check
# no output
```

Known validation note: `node scripts/run-tsgo.mjs -p extensions/mattermost/tsconfig.json --incremental false` runs in this worktree now, but fails on existing Mattermost SDK/API drift outside the touched `client.ts`/`client.test.ts` surface (for example `extensions/mattermost/src/channel.ts` and monitor/reaction imports from plugin-sdk).

**Label**: security

AI-assisted.

