### PR TITLE
fix(net): pass NO_PROXY explicitly to undici EnvHttpProxyAgent (fixes #95998)

### DIFF
--- a/src/infra/net/proxy-env.test.ts
+++ b/src/infra/net/proxy-env.test.ts
@@ -143,6 +143,29 @@ describe("resolveEnvHttpProxyAgentOptions", () => {
       } as NodeJS.ProcessEnv,
       expected: undefined,
     },
+    {
+      name: "passes NO_PROXY through as noProxy option",
+      env: {
+        HTTPS_PROXY: "http://https-proxy.test:8443",
+        NO_PROXY: ".myqcloud.com,localhost",
+      } as NodeJS.ProcessEnv,
+      expected: {
+        httpsProxy: "http://https-proxy.test:8443",
+        noProxy: ".myqcloud.com,localhost",
+      },
+    },
+    {
+      name: "prefers lower-case no_proxy over upper-case NO_PROXY",
+      env: {
+        HTTPS_PROXY: "http://https-proxy.test:8443",
+        no_proxy: ".example.test",
+        NO_PROXY: "localhost",
+      } as NodeJS.ProcessEnv,
+      expected: {
+        httpsProxy: "http://https-proxy.test:8443",
+        noProxy: ".example.test",
+      },
+    },
   ])("$name", ({ env, expected }) => {
     expect(resolveEnvHttpProxyAgentOptions(env)).toEqual(expected);
     expect(hasEnvHttpProxyAgentConfigured(env)).toBe(expected !== undefined);

--- a/src/infra/net/proxy-env.ts
+++ b/src/infra/net/proxy-env.ts
@@ -36,6 +36,8 @@ export type EnvHttpProxyAgentProxyOptions = {
   httpProxy?: string;
   /** Proxy URL used for HTTPS requests. */
   httpsProxy?: string;
+  /** Overrides the value of the NO_PROXY environment variable. */
+  noProxy?: string;
 };
 
 /**
@@ -88,9 +90,12 @@ export function resolveEnvHttpProxyAgentOptions(
   const allProxy = resolveEnvAllProxyUrl(env);
   const httpProxy = resolveEnvHttpProxyUrl("http", env) ?? allProxy;
   const httpsProxy = resolveEnvHttpProxyUrl("https", env) ?? httpProxy;
+  const noProxy =
+    normalizeProxyEnvValue(env.no_proxy) ?? normalizeProxyEnvValue(env.NO_PROXY) ?? undefined;
   const options: EnvHttpProxyAgentProxyOptions = {
     ...(httpProxy ? { httpProxy } : {}),
     ...(httpsProxy ? { httpsProxy } : {}),
+    ...(noProxy ? { noProxy } : {}),
   };
   return options.httpProxy || options.httpsProxy ? options : undefined;
 }


### PR DESCRIPTION
## What Problem This Solves

Issue #95998 reports that when `HTTPS_PROXY` is set globally, the qqbot plugin's COS chunked upload is routed through the proxy even when `NO_PROXY` includes `.myqcloud.com`. The root cause is that `ensureGlobalUndiciEnvProxyDispatcher()` installs an `EnvHttpProxyAgent` but leaves `NO_PROXY` resolution entirely to undici's internal environment-variable reader, which can miss or misread the value depending on how the gateway process inherited its env vars.

## Why This Change Was Made

`resolveEnvHttpProxyAgentOptions()` already reads `HTTP_PROXY`/`HTTPS_PROXY` and passes them explicitly to `EnvHttpProxyAgent`. `NO_PROXY`/`no_proxy` should be treated the same way: read once from the process environment and passed explicitly via the `noProxy` option so the global dispatcher uses a deterministic value rather than depending on undici's runtime env parsing.

## User Impact

Users who run the gateway behind an HTTP proxy and rely on `NO_PROXY` to exclude Tencent COS endpoints should now see those exclusions respected consistently by the global undici dispatcher.

## Evidence

- Added unit tests in `src/infra/net/proxy-env.test.ts` verifying that `resolveEnvHttpProxyAgentOptions()` forwards both upper-case `NO_PROXY` and lower-case `no_proxy` as the `noProxy` option.
- Existing `undici-global-dispatcher` and `server-network-runtime` tests continue to pass, confirming the env-proxy dispatcher bootstrap is unchanged.
- `pnpm test src/infra/net/proxy-env.test.ts --run` passes locally.