### PR TITLE
fix(parallel): bound successful web-search JSON response reads

### DIFF
--- a/extensions/parallel/src/parallel-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.runtime.ts
@@ -43,7 +43,7 @@ const PARALLEL_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 // (web-search upstream) and untrusted. Cap the successful JSON read so a
 // hostile or malfunctioning endpoint streaming an unbounded body cannot force
 // the runtime to buffer the whole payload before parsing. 16 MiB matches the
-// shared provider JSON cap (readProviderJsonResponse default / #95218).
+// shared provider JSON cap (readProviderJsonResponse default).
 const PARALLEL_SEARCH_RESPONSE_LIMIT_BYTES = 16 * 1024 * 1024;
 
 const require = createRequire(import.meta.url);

--- a/extensions/parallel/src/parallel-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.runtime.ts
@@ -1,6 +1,9 @@
 import { createRequire } from "node:module";
 import { readPluginPackageVersion } from "openclaw/plugin-sdk/extension-shared";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import {
   DEFAULT_SEARCH_COUNT,
   mergeScopedSearchConfig,
@@ -36,6 +39,12 @@ import {
 const PARALLEL_BASE_URL = "https://api.parallel.ai";
 const PARALLEL_SEARCH_PATHNAME = "/v1/search";
 const PARALLEL_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+// Parallel's /v1/search returns a bounded result set, but the body is external
+// (web-search upstream) and untrusted. Cap the successful JSON read so a
+// hostile or malfunctioning endpoint streaming an unbounded body cannot force
+// the runtime to buffer the whole payload before parsing. 16 MiB matches the
+// shared provider JSON cap (readProviderJsonResponse default / #95218).
+const PARALLEL_SEARCH_RESPONSE_LIMIT_BYTES = 16 * 1024 * 1024;
 
 const require = createRequire(import.meta.url);
 const PLUGIN_VERSION = readPluginPackageVersion({ require });
@@ -151,11 +160,9 @@ async function runParallelSearch(params: {
         );
         throw new Error(`Parallel API error (${res.status}): ${detail || res.statusText}`);
       }
-      try {
-        return (await res.json()) as ParallelSearchResponse;
-      } catch (cause) {
-        throw new Error("Parallel API returned malformed JSON", { cause });
-      }
+      return await readProviderJsonResponse<ParallelSearchResponse>(res, "Parallel API", {
+        maxBytes: PARALLEL_SEARCH_RESPONSE_LIMIT_BYTES,
+      });
     },
   );
 }
@@ -282,6 +289,7 @@ export const testing = {
   resolveParallelSearchCount,
   resolveParallelSearchEndpoint,
   PARALLEL_ERROR_BODY_LIMIT_BYTES,
+  PARALLEL_SEARCH_RESPONSE_LIMIT_BYTES,
   USER_AGENT,
 } as const;
 

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -59,6 +59,40 @@ function cancelTrackedResponse(
   };
 }
 
+function streamedJsonResponse(params: { chunkCount: number; chunkSize: number }): {
+  response: Response;
+  getReadCount: () => number;
+  wasCanceled: () => boolean;
+} {
+  // Multi-chunk fixture: proves the bounded read stops pulling chunks before
+  // the whole (here syntactically broken / unbounded) body is buffered, and
+  // that the stream is cancelled on overflow.
+  let reads = 0;
+  let canceled = false;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (reads >= params.chunkCount) {
+        controller.close();
+        return;
+      }
+      reads += 1;
+      controller.enqueue(encoder.encode("a".repeat(params.chunkSize)));
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+    getReadCount: () => reads,
+    wasCanceled: () => canceled,
+  };
+}
+
 import { testing } from "../test-api.js";
 import { createParallelWebSearchProvider as createContractParallelWebSearchProvider } from "../web-search-contract-api.js";
 import { createParallelWebSearchProvider } from "./parallel-web-search-provider.js";
@@ -581,6 +615,65 @@ describe("parallel web search provider", () => {
     expect((error as Error).message).not.toContain("tail");
     expect(tracked.wasCanceled()).toBe(true);
     expect(textSpy).not.toHaveBeenCalled();
+  });
+
+  it("bounds successful Parallel JSON bodies instead of buffering the whole response", async () => {
+    // 200-chunk x 1 MiB body (~200 MiB) caps at 16 MiB: the bounded reader must
+    // stop pulling chunks and cancel the stream well before draining it, then
+    // surface a bounded error rather than buffering the whole payload.
+    const streamed = streamedJsonResponse({ chunkCount: 200, chunkSize: 1024 * 1024 });
+    endpointMockState.responses.push(streamed.response);
+    const provider = createParallelWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: { parallel: { apiKey: "par-secret" } },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const error = await tool
+      .execute({
+        objective: `parallel-success-body-${Date.now()}-${Math.random()}`,
+        search_queries: ["openclaw"],
+      })
+      .catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(
+      new RegExp(
+        `Parallel API: JSON response exceeds ${testing.PARALLEL_SEARCH_RESPONSE_LIMIT_BYTES} bytes`,
+      ),
+    );
+    // Stopped well before draining all 200 chunks, and cancelled the stream.
+    expect(streamed.getReadCount()).toBeLessThan(200);
+    expect(streamed.wasCanceled()).toBe(true);
+  });
+
+  it("parses a well-formed Parallel JSON body under the byte cap", async () => {
+    endpointMockState.responses.push(
+      new Response(
+        JSON.stringify({
+          search_id: "ok",
+          session_id: "ok-session",
+          results: [{ url: "https://example.com/a", title: "A", excerpts: ["alpha"] }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const provider = createParallelWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: { parallel: { apiKey: "par-secret" } },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    const result = (await tool.execute({
+      objective: `parallel-success-ok-${Date.now()}-${Math.random()}`,
+      search_queries: ["openclaw"],
+    })) as { provider?: string; searchId?: string; count?: number };
+    expect(result).toMatchObject({ provider: "parallel", searchId: "ok", count: 1 });
   });
 
   it("does not surface a Parallel-generated sessionId on a cache hit", async () => {


### PR DESCRIPTION
## What Problem This Solves

The Parallel `web_search` provider parses its `/v1/search` success response with an unbounded `await res.json()`:

```ts
return (await res.json()) as ParallelSearchResponse;
```

That body comes from an **external web-search upstream** (`api.parallel.ai`, or an operator-configured `baseUrl` proxy) and is explicitly treated as untrusted (`externalContent.untrusted: true`). With no `Content-Length` guard and no byte cap, a hostile or malfunctioning endpoint that streams an unbounded or absurdly large JSON body forces the runtime to buffer the **entire** payload into memory before `JSON.parse` ever runs. On the provider/plugin path that means memory pressure (potential OOM) or an indefinite hang while the runtime keeps draining bytes — a denial-of-service surface driven entirely by the remote side.

The sibling error-body path was already hardened (`readResponseTextLimited`, 8 KiB cap, added in "fix(parallel): bound search error bodies"). The **success** path was the remaining unbounded read. This closes it, mirroring the [#95103](https://github.com/openclaw/openclaw/pull/95103) / [#95108](https://github.com/openclaw/openclaw/pull/95108) response-limit campaign and reusing the exact same shared helper landed in [#95218](https://github.com/openclaw/openclaw/pull/95218).

## Changes

- `parallel-web-search-provider.runtime.ts`: replace unbounded `await res.json()` with the shared `readProviderJsonResponse<ParallelSearchResponse>(res, "Parallel API", { maxBytes: 16 MiB })` from `openclaw/plugin-sdk/provider-http`. This reads through the same bounded reader used for binary/provider JSON responses: on overflow it cancels the underlying stream and throws a bounded error; malformed JSON still surfaces a wrapped error. No new abstraction — reuses the existing helper.
- New `PARALLEL_SEARCH_RESPONSE_LIMIT_BYTES = 16 * 1024 * 1024` constant (matches `readProviderJsonResponse`'s default / #95218's `PROVIDER_JSON_RESPONSE_MAX_BYTES`), exported via `testing` alongside the existing `PARALLEL_ERROR_BODY_LIMIT_BYTES`.
- `parallel-web-search-provider.test.ts`: add two regression tests — a multi-chunk streamed oversized body that must throw the bounded error, stop pulling chunks early, and cancel the stream; and a well-formed body that still parses under the cap.

## Real behavior proof

- **Behavior addressed**: an unbounded successful-JSON read on the Parallel web-search path lets a remote endpoint force unbounded memory buffering / hang; the fix caps the read at 16 MiB and cancels the stream on overflow.
- **Real environment tested**: a real `node:http` server bound to `127.0.0.1` streaming a JSON body with **no `Content-Length`** in 1 MiB chunks (64 MiB total, 4× the cap), driving the **real exported** `executeParallelWebSearchProviderTool(...)` via a real `fetch()` Response. Only the SSRF-guarded transport wrapper (which by design refuses loopback) was swapped for a plain fetch; the code under test — the new bounded read — ran unmodified.
- **Exact steps**: `node --import <tsx+resolve-hook> proof.mts` → (1) drive the real exported function against the oversized stream; (2) negative control reading the same body with an unbounded reader; (3) drive it against a small well-formed body.
- **Evidence after fix**:
  - Real exported fn threw `Parallel API: JSON response exceeds 16777216 bytes`.
  - Server sent only ~20 MiB of the 64 MiB body before the read stopped, and observed a **client disconnect** → the underlying stream was cancelled on overflow (no full buffering).
  - Negative control (unbounded read) buffered the **entire** 64 MiB → the 16 MiB cap is load-bearing, not incidental.
  - Small well-formed body still parsed end-to-end (`provider: "parallel"`).
- **Observed result**: oversized → bounded error + early stream cancel; unbounded baseline → full buffer (regression reproduced); normal → unaffected.
- **What was not tested**: the SSRF/host-trust transport layer itself (out of scope, already covered upstream) and a truly infinite (never-ending) body — the cap makes the read terminate deterministically, so an infinite stream is bounded by the same code path the finite oversized fixture exercises.

## Evidence

```
PASS: real runtime exports PARALLEL_SEARCH_RESPONSE_LIMIT_BYTES=16777216 (16 MiB)
PASS: oversized stream -> real fn threw bounded error: "Parallel API: JSON response exceeds 16777216 bytes"
PASS: bounded read stopped early: server sent 20971520 bytes of 67108864 (stream cancelled before draining)
PASS: server observed client disconnect -> overflow cancelled the underlying stream
PASS: negative control (unbounded read) buffered the ENTIRE 67108864 bytes (>= 16 MiB cap) -> the byte cap is load-bearing
PASS: normal small well-formed response still parses end-to-end: provider=parallel
ALL PROOF CHECKS PASSED
```

Regression suite (`node scripts/run-vitest.mjs extensions/parallel/src/parallel-web-search-provider.test.ts --run`): **29 passed**. `oxlint` on changed files: clean. `tsgo -p tsconfig.extensions.json`: no errors in `extensions/parallel` (only a pre-existing unrelated `crabline` module-resolution issue in `extensions/qa-lab`).

**Label**: security

---

🤖 AI-assisted: implementation and proof harness authored with AI assistance; all code, tests, and the real-environment proof were reviewed and run locally by the author. Symmetric follow-up to the #95103 / #95108 response-limit campaign.
