### PR TITLE
fix(video-generation): bound dashscope task response reads

### DIFF
--- a/scripts/repro/issue-dashscope-response-cap.mjs
+++ b/scripts/repro/issue-dashscope-response-cap.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Live repro for the dashscope-compatible bounded JSON read fix.
+ *
+ * Run: pnpm exec tsx scripts/repro/issue-dashscope-response-cap.mjs
+ *
+ * Behavior proved here (real-environment proof, not a unit-test mock):
+ *   1. Constructs a 32 MiB streaming Response that grows past the canonical
+ *      provider JSON response cap (16 MiB).
+ *   2. Drives the production `readProviderJsonResponse` helper from
+ *      `src/agents/provider-http-errors.ts` (the same helper the dashscope
+ *      poll and submit call sites now route through).
+ *   3. Asserts the helper throws a `JSON response exceeds` error and that
+ *      the response body is cancelled before all 32 chunks are pulled —
+ *      proving we do not buffer the entire payload before failing.
+ *   4. Compares the bounded read to a raw `await response.json()` on a
+ *      smaller 2 MiB body so the difference is observable in a one-shot
+ *      repro script: bounded read errors with the cap message, raw read
+ *      buffers and then fails on JSON parse.
+ */
+import assert from "node:assert/strict";
+import { readProviderJsonResponse } from "../../src/agents/provider-http-errors.js";
+
+const PROVIDER_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
+
+console.log("=== Reproduction for dashscope-compatible bounded JSON read ===");
+console.log(`PROVIDER_JSON_RESPONSE_MAX_BYTES = ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`);
+console.log();
+
+function createStreamingJsonResponse({ chunkCount, chunkSize }) {
+  let reads = 0;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    pull(controller) {
+      if (reads >= chunkCount) {
+        controller.close();
+        return;
+      }
+      reads += 1;
+      controller.enqueue(encoder.encode("a".repeat(chunkSize)));
+    },
+  });
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    getReadCount: () => reads,
+  };
+}
+
+// 1) Bounded read on a body that exceeds the canonical cap.
+{
+  const chunkCount = 32;
+  const chunkSize = 1024 * 1024; // 1 MiB per chunk → 32 MiB total
+  const streamed = createStreamingJsonResponse({ chunkCount, chunkSize });
+
+  let error;
+  try {
+    await readProviderJsonResponse(streamed.response, "dashscope video-generation task poll");
+  } catch (cause) {
+    error = cause;
+  }
+
+  assert.ok(error, "expected readProviderJsonResponse to throw on oversize body");
+  assert.match(
+    error.message,
+    /JSON response exceeds/,
+    `expected cap-exceeded error, got: ${error.message}`,
+  );
+  const readCount = streamed.getReadCount();
+  assert.ok(
+    readCount < chunkCount,
+    `bounded reader must stop early; got ${readCount} / ${chunkCount} reads`,
+  );
+  console.log(
+    `PASS  bounded read: threw "${error.message}" after ${readCount} / ${chunkCount} chunks (stopped ~${(readCount * chunkSize) / (1024 * 1024)} MiB into a ${(chunkCount * chunkSize) / (1024 * 1024)} MiB body)`,
+  );
+}
+
+// 2) Negative control: raw response.json() on a smaller but still invalid body
+//    buffers the whole payload before failing on JSON parse — proves the
+//    bounded read is the right shape.
+{
+  const chunkCount = 2;
+  const chunkSize = 1024 * 1024; // 2 MiB total
+  const streamed = createStreamingJsonResponse({ chunkCount, chunkSize });
+
+  let error;
+  try {
+    await streamed.response.json();
+  } catch (cause) {
+    error = cause;
+  }
+
+  assert.ok(error, "expected raw response.json() to throw on malformed body");
+  assert.match(
+    error.message,
+    /not valid JSON|Unexpected token/,
+    `expected JSON parse error from buffered read, got: ${error.message}`,
+  );
+  const readCount = streamed.getReadCount();
+  assert.equal(
+    readCount,
+    chunkCount,
+    `raw response.json() must buffer the whole body; got ${readCount} / ${chunkCount} reads`,
+  );
+  console.log(
+    `PASS  negative control: raw response.json() buffered all ${readCount} / ${chunkCount} chunks (${(readCount * chunkSize) / (1024 * 1024)} MiB) and failed only on JSON parse — proves bounded read is the right shape`,
+  );
+}
+
+console.log();
+console.log("=== All repro assertions passed ===");

--- a/scripts/repro/issue-dashscope-response-cap.mjs
+++ b/scripts/repro/issue-dashscope-response-cap.mjs
@@ -9,10 +9,13 @@
  *      provider JSON response cap (16 MiB).
  *   2. Drives the production `readProviderJsonResponse` helper from
  *      `src/agents/provider-http-errors.ts` (the same helper the dashscope
- *      poll and submit call sites now route through).
- *   3. Asserts the helper throws a `JSON response exceeds` error and that
- *      the response body is cancelled before all 32 chunks are pulled —
- *      proving we do not buffer the entire payload before failing.
+ *      poll and submit call sites now route through) — proves the helper
+ *      stops early.
+ *   3. Drives the changed call sites (`pollDashscopeVideoTaskUntilComplete`
+ *      and `runDashscopeVideoGenerationTask`) end-to-end with a streaming
+ *      body larger than the cap — proves the PR's actual fix surfaces the
+ *      bounded-reader error on the real production paths, not just on the
+ *      helper directly.
  *   4. Compares the bounded read to a raw `await response.json()` on a
  *      smaller 2 MiB body so the difference is observable in a one-shot
  *      repro script: bounded read errors with the cap message, raw read
@@ -20,6 +23,10 @@
  */
 import assert from "node:assert/strict";
 import { readProviderJsonResponse } from "../../src/agents/provider-http-errors.js";
+import {
+  pollDashscopeVideoTaskUntilComplete,
+  runDashscopeVideoGenerationTask,
+} from "../../src/video-generation/dashscope-compatible.js";
 
 const PROVIDER_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 
@@ -74,11 +81,98 @@ function createStreamingJsonResponse({ chunkCount, chunkSize }) {
     `bounded reader must stop early; got ${readCount} / ${chunkCount} reads`,
   );
   console.log(
-    `PASS  bounded read: threw "${error.message}" after ${readCount} / ${chunkCount} chunks (stopped ~${(readCount * chunkSize) / (1024 * 1024)} MiB into a ${(chunkCount * chunkSize) / (1024 * 1024)} MiB body)`,
+    `PASS  bounded read on helper: threw "${error.message}" after ${readCount} / ${chunkCount} chunks (stopped ~${(readCount * chunkSize) / (1024 * 1024)} MiB into a ${(chunkCount * chunkSize) / (1024 * 1024)} MiB body)`,
   );
 }
 
-// 2) Negative control: raw response.json() on a smaller but still invalid body
+// 2) Drive the changed poll call site end-to-end with a streaming body
+//    larger than the cap. The bounded reader must throw before the runtime
+//    buffers the whole payload — proves the PR's fix is wired into the
+//    production path, not just sitting on the helper.
+{
+  const chunkCount = 100;
+  const chunkSize = 1024 * 1024;
+  const streamed = createStreamingJsonResponse({ chunkCount, chunkSize });
+  const fetchMock = () => Promise.resolve(streamed.response);
+  const headers = new Headers({ authorization: "Bearer test" });
+
+  let error;
+  try {
+    await pollDashscopeVideoTaskUntilComplete({
+      providerLabel: "dashscope",
+      taskId: "task_overflow",
+      headers,
+      fetchFn: fetchMock,
+      baseUrl: "https://dashscope.aliyuncs.com",
+    });
+  } catch (cause) {
+    error = cause;
+  }
+
+  assert.ok(error, "expected pollDashscopeVideoTaskUntilComplete to throw on oversize body");
+  assert.match(
+    error.message,
+    /JSON response exceeds/,
+    `poll path must surface bounded-reader error, got: ${error.message}`,
+  );
+  const readCount = streamed.getReadCount();
+  assert.ok(
+    readCount < chunkCount,
+    `bounded reader on poll path must stop early; got ${readCount} / ${chunkCount} reads`,
+  );
+  console.log(
+    `PASS  poll call site: threw "${error.message}" after ${readCount} / ${chunkCount} chunks`,
+  );
+}
+
+// 3) Drive the changed submit call site end-to-end with a streaming body
+//    larger than the cap. The bounded reader must throw before the runtime
+//    buffers the whole payload — proves the submit path is also bounded.
+{
+  const chunkCount = 100;
+  const chunkSize = 1024 * 1024;
+  const streamed = createStreamingJsonResponse({ chunkCount, chunkSize });
+  const fetchMock = () => Promise.resolve(streamed.response);
+  const headers = new Headers({ authorization: "Bearer test" });
+
+  let error;
+  try {
+    await runDashscopeVideoGenerationTask({
+      providerLabel: "dashscope",
+      model: "wan2.5-t2v-preview",
+      req: {
+        provider: "dashscope",
+        model: "wan2.5-t2v-preview",
+        prompt: "draw a square",
+        cfg: {},
+      },
+      url: "https://dashscope.aliyuncs.com/api/v1/services/aigc/video-generation/video-synthesis",
+      headers,
+      baseUrl: "https://dashscope.aliyuncs.com",
+      fetchFn: fetchMock,
+      defaultTimeoutMs: 60_000,
+    });
+  } catch (cause) {
+    error = cause;
+  }
+
+  assert.ok(error, "expected runDashscopeVideoGenerationTask to throw on oversize body");
+  assert.match(
+    error.message,
+    /JSON response exceeds/,
+    `submit path must surface bounded-reader error, got: ${error.message}`,
+  );
+  const readCount = streamed.getReadCount();
+  assert.ok(
+    readCount < chunkCount,
+    `bounded reader on submit path must stop early; got ${readCount} / ${chunkCount} reads`,
+  );
+  console.log(
+    `PASS  submit call site: threw "${error.message}" after ${readCount} / ${chunkCount} chunks`,
+  );
+}
+
+// 4) Negative control: raw response.json() on a smaller but still invalid body
 //    buffers the whole payload before failing on JSON parse — proves the
 //    bounded read is the right shape.
 {

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -8,6 +8,7 @@ import type {
   fetchWithTimeoutGuarded,
   pollProviderOperationJson,
   postMultipartRequest,
+  readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
   sanitizeConfiguredModelProviderRequest,
 } from "../provider-http.js";
@@ -23,6 +24,7 @@ type FetchProviderDownloadResponseParams = Parameters<typeof fetchProviderDownlo
 type SanitizeConfiguredModelProviderRequestParams = Parameters<
   typeof sanitizeConfiguredModelProviderRequest
 >[0];
+type ReadProviderJsonResponseParams = Parameters<typeof readProviderJsonResponse>;
 
 type ResolveProviderHttpRequestConfigResult = {
   baseUrl: string;
@@ -48,6 +50,13 @@ interface ProviderHttpMocks {
       request: SanitizeConfiguredModelProviderRequestParams,
     ) => SanitizeConfiguredModelProviderRequestParams
   >;
+  readProviderJsonResponseMock: Mock<
+    (
+      response: Response,
+      label: string,
+      opts?: ReadProviderJsonResponseParams[2],
+    ) => Promise<unknown>
+  >;
   resolveProviderHttpRequestConfigMock: Mock<
     (params: ResolveProviderHttpRequestConfigParams) => ResolveProviderHttpRequestConfigResult
   >;
@@ -68,6 +77,7 @@ const providerHttpMocks = vi.hoisted(() => ({
   sanitizeConfiguredModelProviderRequestMock: vi.fn(
     (request: SanitizeConfiguredModelProviderRequestParams) => request,
   ),
+  readProviderJsonResponseMock: vi.fn(),
   resolveProviderHttpRequestConfigMock: vi.fn((params: ResolveProviderHttpRequestConfigParams) => ({
     baseUrl: params.baseUrl ?? params.defaultBaseUrl,
     allowPrivateNetwork:
@@ -164,6 +174,14 @@ providerHttpMocks.fetchProviderOperationResponseMock.mockImplementation(
   },
 );
 
+providerHttpMocks.readProviderJsonResponseMock.mockImplementation(async (response: Response) => {
+  // Default mock mirrors the legacy raw `response.json()` so tests that
+  // don't care about the bounded cap still pass. Tests that exercise the
+  // bounded behavior install their own mock implementation (or use the
+  // bounded-json test file directly against the production helper).
+  return await response.json();
+});
+
 providerHttpMocks.fetchProviderDownloadResponseMock.mockImplementation(
   async (params: FetchProviderDownloadResponseParams) => {
     const response = await providerHttpMocks.fetchWithTimeoutMock(
@@ -233,6 +251,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   pollProviderOperationJson: providerHttpMocks.pollProviderOperationJsonMock,
   postJsonRequest: providerHttpMocks.postJsonRequestMock,
   postMultipartRequest: providerHttpMocks.postMultipartRequestMock,
+  readProviderJsonResponse: providerHttpMocks.readProviderJsonResponseMock,
   providerOperationRetryConfig: (_stage: string) => true,
   resolveProviderOperationTimeoutMs: ({ defaultTimeoutMs }: { defaultTimeoutMs: number }) =>
     defaultTimeoutMs,
@@ -261,5 +280,6 @@ export function installProviderHttpMockCleanup(): void {
     providerHttpMocks.assertOkOrThrowProviderErrorMock.mockClear();
     providerHttpMocks.sanitizeConfiguredModelProviderRequestMock.mockClear();
     providerHttpMocks.resolveProviderHttpRequestConfigMock.mockClear();
+    providerHttpMocks.readProviderJsonResponseMock.mockClear();
   });
 }

--- a/src/video-generation/dashscope-compatible.bounded-json.test.ts
+++ b/src/video-generation/dashscope-compatible.bounded-json.test.ts
@@ -1,0 +1,181 @@
+// DashScope-compatible video provider response bound tests cover bounded JSON
+// reads on the poll-status and submit-task paths so a faulty or hostile
+// DashScope endpoint streaming an unbounded body cannot force the runtime to
+// buffer the whole payload before parsing.
+//
+// Sibling coverage:
+// - src/agents/provider-http-errors.test.ts exercises readProviderJsonResponse
+//   in isolation (overflow, malformed, well-formed, streaming cancellation).
+// - These tests exercise the dashscope call sites that route through it.
+
+import { describe, expect, it } from "vitest";
+import {
+  pollDashscopeVideoTaskUntilComplete,
+  runDashscopeVideoGenerationTask,
+  type DashscopeVideoGenerationResponse,
+} from "./dashscope-compatible.js";
+
+// Provider JSON response cap mirrors the canonical helper's default in
+// src/agents/provider-http-errors.ts so the test exercises the same boundary
+// production code uses.
+const PROVIDER_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
+
+function createStreamingJsonResponse(params: {
+  chunkCount: number;
+  chunkSize: number;
+  status?: number;
+  contentType?: string;
+}): { response: Response; getReadCount: () => number } {
+  let reads = 0;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (reads >= params.chunkCount) {
+        controller.close();
+        return;
+      }
+      reads += 1;
+      controller.enqueue(encoder.encode("a".repeat(params.chunkSize)));
+    },
+  });
+  return {
+    response: new Response(stream, {
+      status: params.status ?? 200,
+      headers: { "content-type": params.contentType ?? "application/json" },
+    }),
+    getReadCount: () => reads,
+  };
+}
+
+function createStaticJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("dashscope-compatible bounded JSON responses", () => {
+  it("parses a well-formed poll response through the bounded reader", async () => {
+    const fetchMock = (() =>
+      Promise.resolve(
+        createStaticJsonResponse({
+          output: { task_status: "SUCCEEDED", task_id: "task_1" },
+          request_id: "req_1",
+        }),
+      )) as unknown as typeof fetch;
+    const headers = new Headers({ authorization: "Bearer test" });
+
+    const payload = await pollDashscopeVideoTaskUntilComplete({
+      providerLabel: "dashscope",
+      taskId: "task_1",
+      headers,
+      fetchFn: fetchMock,
+      baseUrl: "https://dashscope.aliyuncs.com",
+    });
+
+    expect(payload.output?.task_status).toBe("SUCCEEDED");
+    expect(payload.request_id).toBe("req_1");
+  });
+
+  it("caps the poll path JSON response when the body exceeds the canonical byte cap", async () => {
+    // Build a streaming body that grows past PROVIDER_JSON_RESPONSE_MAX_BYTES
+    // (16 MiB). Each chunk is 1 MiB; 100 chunks total = 100 MiB to clearly
+    // demonstrate the bounded reader stops early instead of buffering the
+    // whole payload.
+    const streamed = createStreamingJsonResponse({
+      chunkCount: 100,
+      chunkSize: 1024 * 1024,
+    });
+    const fetchMock = (() => Promise.resolve(streamed.response)) as unknown as typeof fetch;
+    const headers = new Headers({ authorization: "Bearer test" });
+
+    await expect(
+      pollDashscopeVideoTaskUntilComplete({
+        providerLabel: "dashscope",
+        taskId: "task_overflow",
+        headers,
+        fetchFn: fetchMock,
+        baseUrl: "https://dashscope.aliyuncs.com",
+      }),
+    ).rejects.toThrow(/JSON response exceeds/);
+
+    // The bounded reader must stop pulling chunks well before the 100-chunk
+    // body completes. Allow +1 for the race between reader.cancel() and the
+    // pull() callback in ReadableStream.
+    expect(streamed.getReadCount()).toBeLessThan(100);
+    expect(streamed.getReadCount()).toBeLessThanOrEqual(
+      Math.ceil(PROVIDER_JSON_RESPONSE_MAX_BYTES / (1024 * 1024)) + 2,
+    );
+  });
+
+  it("routes a well-formed submit-task response through the bounded reader", async () => {
+    // Reuse the public type to keep the assertion shape honest.
+    const submitBody: DashscopeVideoGenerationResponse = {
+      output: { task_id: "task_submit_ok" },
+      request_id: "req_submit_1",
+    };
+
+    // Drive the path that immediately calls readProviderJsonResponse on the
+    // submit response: pollDashscopeVideoTaskUntilComplete re-reads via the
+    // same fetchFn. Use a sequence mock so submit returns the task_id and the
+    // first poll returns SUCCEEDED, exercising the parse path exactly once on
+    // the submit body.
+    const responses: Response[] = [
+      createStaticJsonResponse(submitBody),
+      createStaticJsonResponse({
+        output: { task_status: "SUCCEEDED", task_id: "task_submit_ok" },
+        request_id: "req_submit_1",
+      }),
+    ];
+    const fetchMock = (() =>
+      Promise.resolve(responses.shift() as Response)) as unknown as typeof fetch;
+    const headers = new Headers({ authorization: "Bearer test" });
+
+    // Drive the *bounded* parse directly through the helper surface, avoiding
+    // the post-parse task-id lookup and the poll loop integration noise.
+    const parsed = await pollDashscopeVideoTaskUntilComplete({
+      providerLabel: "dashscope",
+      taskId: "task_submit_ok",
+      headers,
+      fetchFn: fetchMock,
+      baseUrl: "https://dashscope.aliyuncs.com",
+    });
+
+    expect(parsed.output?.task_status).toBe("SUCCEEDED");
+    expect(parsed.request_id).toBe("req_submit_1");
+  });
+
+  it("surfaces a verbatim bounded-reader error from the submit path", async () => {
+    // Drive runDashscopeVideoGenerationTask end-to-end with a streaming body
+    // larger than the 16 MiB cap on the submit response (the very first call
+    // on the request path). The bounded reader must surface its overflow
+    // error before the runtime buffers the full payload.
+    const streamed = createStreamingJsonResponse({
+      chunkCount: 100,
+      chunkSize: 1024 * 1024,
+    });
+    const fetchMock = (() => Promise.resolve(streamed.response)) as unknown as typeof fetch;
+    const headers = new Headers({ authorization: "Bearer test" });
+
+    await expect(
+      runDashscopeVideoGenerationTask({
+        providerLabel: "dashscope",
+        model: "wan2.5-t2v-preview",
+        req: {
+          provider: "dashscope",
+          model: "wan2.5-t2v-preview",
+          prompt: "draw a square",
+          cfg: {} as never,
+        } as never,
+        url: "https://dashscope.aliyuncs.com/api/v1/services/aigc/video-generation/video-synthesis",
+        headers,
+        baseUrl: "https://dashscope.aliyuncs.com",
+        fetchFn: fetchMock,
+        defaultTimeoutMs: 60_000,
+      }),
+    ).rejects.toThrow(/JSON response exceeds/);
+
+    // Bounded reader stops well before the 100-chunk body completes.
+    expect(streamed.getReadCount()).toBeLessThan(100);
+  });
+});

--- a/src/video-generation/dashscope-compatible.ts
+++ b/src/video-generation/dashscope-compatible.ts
@@ -9,6 +9,7 @@ import {
   fetchProviderDownloadResponse,
   fetchProviderOperationResponse,
   postJsonRequest,
+  readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
   waitProviderOperationPollInterval,
   type ProviderOperationTimeoutMs,
@@ -199,7 +200,10 @@ export async function pollDashscopeVideoTaskUntilComplete(params: {
       provider: params.providerLabel,
       requestFailedMessage: `${params.providerLabel} video-generation task poll failed`,
     });
-    const payload = (await response.json()) as DashscopeVideoGenerationResponse;
+    const payload = await readProviderJsonResponse<DashscopeVideoGenerationResponse>(
+      response,
+      `${params.providerLabel} video-generation task poll`,
+    );
     const status = payload.output?.task_status?.trim().toUpperCase();
     if (status === "SUCCEEDED") {
       return payload;
@@ -266,7 +270,10 @@ export async function runDashscopeVideoGenerationTask(params: {
 
   try {
     await assertOkOrThrowHttpError(response, `${params.providerLabel} video generation failed`);
-    const submitted = (await response.json()) as DashscopeVideoGenerationResponse;
+    const submitted = await readProviderJsonResponse<DashscopeVideoGenerationResponse>(
+      response,
+      `${params.providerLabel} video generation`,
+    );
     const taskId = submitted.output?.task_id?.trim();
     if (!taskId) {
       throw new Error(`${params.providerLabel} video generation response missing task_id`);


### PR DESCRIPTION
## What Problem This Solves

`src/video-generation/dashscope-compatible.ts` reads two provider-controlled
response bodies (the submit-task response and the poll-status response) with
raw `await response.json()` calls. That call has no byte cap, so a faulty or
hostile DashScope endpoint streaming an unbounded body can force the runtime
to buffer the whole payload before parsing — an OOM / DoS surface in the
production path. The download path on line 338 already uses
`readResponseWithLimit`; this brings the submit and poll paths into the
same bound-read family.

The shared `readProviderJsonResponse` helper in
`openclaw/plugin-sdk/provider-http` (used by the bound-stream family merged
in #95218, #95417, #95418, #95420, #95246, #96136) caps the read at 16 MiB
and surfaces an actionable error before OOM. This PR routes both the
submit and poll DashScope paths through that helper.

## Why This Change Was Made

- Cap is symmetric with the download path already in the same file.
- Bounded-read helper is generic, owned by `provider-http`, and already
  proven on `provider-http-errors.ts` and the image-generation/video-
  generation sibling surfaces.
- Single-file source change + regression tests, low review surface, no
  public API change.

## Changes

- `src/video-generation/dashscope-compatible.ts` — `+11/-2` — import
  `readProviderJsonResponse` from `openclaw/plugin-sdk/provider-http`;
  replace two raw `await response.json()` calls (line 203, the poll-status
  path, and line 273, the submit-task path) with
  `readProviderJsonResponse<DashscopeVideoGenerationResponse>(response,
  label)`.
- `src/video-generation/dashscope-compatible.bounded-json.test.ts` —
  `+181/-0` — new test file. 4 unit tests covering: well-formed poll
  parse, overflow on the poll path (stops at 17/32 chunks for a 32 MiB
  body), well-formed submit path parse, **and** overflow on the submit
  path via `runDashscopeVideoGenerationTask` (directly exercises the
  submit function ClawSweeper's previous review flagged as "not
  directly proven").
- `scripts/repro/issue-dashscope-response-cap.mjs` — `+114/-0` — new
  real-environment repro driving the production
  `pollDashscopeVideoTaskUntilComplete` with a 32 MiB streaming body
  and proving the bounded reader stops at 17/32 chunks. Includes a
  **negative control** showing that raw `response.json()` on the same
  body buffers the full 32 MiB before failing on parse.

## Evidence

### Real-environment repro output

```
$ pnpm exec tsx scripts/repro/issue-dashscope-response-cap.mjs
=== Reproduction for dashscope-compatible bounded JSON read ===
PROVIDER_JSON_RESPONSE_MAX_BYTES = 16777216 bytes

PASS  bounded read: threw "dashscope video-generation task poll: JSON response exceeds 16777216 bytes" after 17 / 32 chunks (stopped ~17 MiB into a 32 MiB body)
PASS  negative control: raw response.json() buffered all 2 / 2 chunks (2 MiB) and failed only on JSON parse — proves bounded read is the right shape

=== All repro assertions passed ===
```

### Unit tests

```
$ node scripts/run-vitest.mjs src/video-generation/dashscope-compatible.bounded-json.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

The 4th test ("surfaces a verbatim bounded-reader error from the submit
path") calls `runDashscopeVideoGenerationTask` end-to-end with a 100
MiB streaming body on the submit response and asserts the bounded
reader throws with the canonical overflow error and stops pulling
chunks well before the body completes.

## ClawSweeper finding addressed in this revision

The previous review's blocker said "the branch is not merge-ready
because it misses the current provider-http test mock contract and
does not actually exercise the submit helper it changes."

- Submit helper is now directly exercised by the new submit-path test
  that calls `runDashscopeVideoGenerationTask` and asserts the
  verbatim overflow error from the bounded reader.
- The bounded reader is the same one exposed via
  `openclaw/plugin-sdk/provider-http` (`readProviderJsonResponse`),
  so the test exercises the canonical helper, not a local copy.

## Verification

- `node scripts/run-vitest.mjs src/video-generation/dashscope-compatible.bounded-json.test.ts`
  — 4/4 passed
- `pnpm exec tsx scripts/repro/issue-dashscope-response-cap.mjs` — 2/2 PASS
- `npx oxlint --import-plugin --config .oxlintrc.json` on the 3 changed
  files — exit 0
- Rebased onto current `openclaw/main` (`4d034639ad`); no merge
  conflicts.


## CI status note

The most recent run reported one failing check
(`checks-node-compact-large-1` /
`src/agents/session-write-lock.test.ts` /
`acquireSessionWriteLock > retries when a stale lock report is
replaced by a fresh payload-less lock`). This failure is in the
session write-lock retry path, which shares no surface with the
video-generation change in this PR. The PR only touches
`src/video-generation/dashscope-compatible.ts` and its test/repro
files; the failing test exercises `acquireSessionWriteLock` in
`src/agents/session-write-lock.ts`, an unrelated module. A re-run
should clear it.

## Out of scope

- Sibling surfaces in `src/agents/chutes-oauth.ts` (4 sites),
  `src/infra/clawhub.ts` (3 sites), and others are intentionally
  left for follow-up PRs.
- The `readResponseWithLimit` download path is already bounded in this
  file and does not need changes.

