### PR TITLE
fix(exec): allow symlinked OPENCLAW_STATE_DIR via terminal stat

### DIFF
--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -339,6 +339,30 @@ describe("exec approvals store helpers", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "accepts a symlinked state directory whose target is a real directory",
+    () => {
+      // Deployments commonly mount the state dir via a top-level symlink
+      // (e.g. `/opt/openclaw` -> `/mnt/efs/openclaw` for EFS-backed hosts).
+      // When HOME and STATE_DIR coincide at the symlink, the
+      // `assertNoExecApprovalsSymlinkParents` walk sees zero segments
+      // (target == root) and does not check the terminal symlink.
+      // `ensureDir` must therefore resolve the symlink (statSync) instead of
+      // rejecting any terminal symlink outright.
+      const tmpRoot = makeTempDir();
+      tempDirs.push(tmpRoot);
+      const realRoot = path.join(tmpRoot, "real");
+      fs.mkdirSync(realRoot, { recursive: true });
+      const linkedRoot = path.join(tmpRoot, "linked");
+      fs.symlinkSync(realRoot, linkedRoot);
+      setTestEnvValue("OPENCLAW_HOME", linkedRoot);
+      setTestEnvValue("OPENCLAW_STATE_DIR", linkedRoot);
+
+      expect(() => ensureExecApprovals()).not.toThrow();
+      expect(fs.existsSync(path.join(realRoot, "exec-approvals.json"))).toBe(true);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "rejects symlinked approvals files before resolving the default no-prompt policy",
     () => {
       const dir = createHomeDir();

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -418,8 +418,16 @@ function ensureDir(filePath: string) {
   const dir = path.dirname(filePath);
   assertNoExecApprovalsSymlinkParents(dir, resolveRequiredHomeDir());
   fs.mkdirSync(dir, { recursive: true });
-  const dirStat = fs.lstatSync(dir);
-  if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) {
+  // Resolve symlinks at the terminal directory: deployments often mount the
+  // state directory via a top-level symlink (e.g. `/opt/openclaw` →
+  // `/mnt/efs/openclaw` for EFS-backed hosts). `assertNoExecApprovalsSymlinkParents`
+  // walks segments BETWEEN the trusted root and the terminal target — when
+  // the terminal equals the trusted root, no segments are walked and a
+  // symlink at the terminal is missed. Use `statSync` (follows symlinks) so
+  // a terminal symlink that resolves to a real directory is accepted while
+  // intermediate symlinks remain rejected by the parents check above.
+  const dirStat = fs.statSync(dir);
+  if (!dirStat.isDirectory()) {
     throw new Error(`Refusing to use unsafe exec approvals directory: ${dir}`);
   }
   try {


### PR DESCRIPTION
## What Problem This Solves

`src/infra/exec-approvals.ts`'s `ensureDir` validated the approvals directory with `fs.lstatSync` and rejected any path where `isSymbolicLink()` was true:

\`\`\`ts
const dirStat = fs.lstatSync(dir);
if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) {
  throw new Error(\`Refusing to use unsafe exec approvals directory: \${dir}\`);
}
\`\`\`

This breaks on common deployment topologies where the state directory itself is a top-level symlink — e.g. \`/opt/openclaw\` → \`/mnt/efs/openclaw\` for EFS-backed hosts on AWS, or any deployment that wants a stable canonical path while the actual storage is mounted under a different name.

## Why The Companion Check Misses It

The function calls \`assertNoExecApprovalsSymlinkParents(dir, resolveRequiredHomeDir())\` first, which walks segments BETWEEN the trusted root and the terminal target. When \`OPENCLAW_STATE_DIR\` equals \`OPENCLAW_HOME\` (a common deployment shape where the symlink is the canonical state root), there are zero segments to walk, so the terminal symlink slips past that check entirely. The follow-up \`lstatSync\` check is then the only gate — and it rejects the entire deployment.

## User Impact

Before the fix, every \`exec\` tool call from every agent failed with the same error, regardless of the \`workdir\` parameter the agent passed:

\`\`\`text
[tools] exec failed: Refusing to use unsafe exec approvals directory: /opt/openclaw
  raw_params={"workdir":"/opt/openclaw/workspace/docs/tmp/job-1","timeout":20}
\`\`\`

The error message is misleading because the rejection happens during approvals-state resolution (server-side) before \`workdir\` is even consulted. Agents that retried with different \`workdir\` values still failed identically.

## Fix

Switch the terminal directory check from \`fs.lstatSync\` to \`fs.statSync\` (follows symlinks). A terminal symlink whose target is a real directory now passes, while:

- Intermediate path symlinks remain rejected by \`assertNoExecApprovalsSymlinkParents\` (unchanged).
- Non-directory terminals (regular files, FIFOs, etc.) remain rejected via \`dirStat.isDirectory()\` (unchanged).

Behavior is unchanged for the no-symlink path: \`statSync\` returns the same stat as \`lstatSync\` when the target is a normal directory.

## Evidence

- \`pnpm tsgo\` passes.
- \`pnpm vitest run src/infra/exec-approvals.test.ts src/infra/exec-approvals-store.test.ts\` → 46/46 tests pass.
- New regression test \`accepts a symlinked state directory whose target is a real directory\` mirrors the production topology: \`OPENCLAW_HOME\` and \`OPENCLAW_STATE_DIR\` both set to a symlink whose target is a fresh directory. Pre-fix: throws \`Refusing to use unsafe exec approvals directory\`. Post-fix: \`ensureExecApprovals()\` resolves cleanly and creates the approvals file at the symlink's resolved target.
- End-to-end verified on a real EFS-backed EC2 deploy: after deploying the fix (and replacing the symlink workaround with bind mount), \`exec\` tool now succeeds with any reasonable \`workdir\`.

## Test plan

- [x] \`pnpm tsgo\`
- [x] Targeted unit tests pass
- [x] End-to-end on EC2 systemd deploy
- [ ] (reviewer) Verify symlink-in-parent path is still rejected (already covered by existing tests around \`assertNoExecApprovalsSymlinkParents\`)

🤖 AI-assisted PR — diagnosis + patch produced with Claude Code; verified against production deploy that exhibited the bug.