### PR TITLE
fix(exa): bound untrusted search JSON response reads

### DIFF
--- a/extensions/exa/src/exa-web-search-provider.runtime.ts
+++ b/extensions/exa/src/exa-web-search-provider.runtime.ts
@@ -20,6 +20,7 @@ import {
   wrapWebContent,
   writeCachedSearchPayload,
 } from "openclaw/plugin-sdk/provider-web-search";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -30,6 +31,10 @@ const EXA_SEARCH_TYPES = ["auto", "neural", "fast", "deep", "deep-reasoning", "i
 const EXA_FRESHNESS_VALUES = ["day", "week", "month", "year"] as const;
 const EXA_MAX_SEARCH_COUNT = 100;
 const EXA_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+// Exa search responses are untrusted external bodies. Cap the success JSON the
+// same way other bundled providers do (16 MiB) so a misbehaving or hostile
+// endpoint cannot stream an unbounded body into memory before we parse it.
+const EXA_SEARCH_JSON_MAX_BYTES = 16 * 1024 * 1024;
 
 type ExaConfig = {
   apiKey?: string;
@@ -70,9 +75,17 @@ type ExaSearchResponse = {
   results?: unknown;
 };
 
-async function readExaSearchResults(response: Response): Promise<ExaSearchResult[]> {
+async function readExaSearchResults(
+  response: Response,
+  opts?: { maxBytes?: number },
+): Promise<ExaSearchResult[]> {
+  const maxBytes = opts?.maxBytes ?? EXA_SEARCH_JSON_MAX_BYTES;
+  const bytes = await readResponseWithLimit(response, maxBytes, {
+    onOverflow: ({ maxBytes: maxBytesLocal }) =>
+      new Error(`Exa API response exceeds ${maxBytesLocal} bytes`),
+  });
   try {
-    return normalizeExaResults(await response.json());
+    return normalizeExaResults(JSON.parse(new TextDecoder().decode(bytes)));
   } catch (cause) {
     throw new Error("Exa API returned malformed JSON", { cause });
   }

--- a/extensions/exa/src/exa-web-search-provider.test.ts
+++ b/extensions/exa/src/exa-web-search-provider.test.ts
@@ -26,6 +26,33 @@ function cancelTrackedResponse(
   };
 }
 
+function streamingJsonResponse(params: { chunkCount: number; chunkSize: number }): {
+  response: Response;
+  getReadCount: () => number;
+} {
+  // Streaming fixture proves an oversized success body stops being read before
+  // the whole payload is buffered into memory.
+  let reads = 0;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (reads >= params.chunkCount) {
+        controller.close();
+        return;
+      }
+      reads += 1;
+      controller.enqueue(encoder.encode("a".repeat(params.chunkSize)));
+    },
+  });
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    getReadCount: () => reads,
+  };
+}
+
 describe("exa web search provider", () => {
   it("exposes the expected metadata and selection wiring", () => {
     const provider = createExaWebSearchProvider();
@@ -263,6 +290,27 @@ describe("exa web search provider", () => {
     await expect(testing.readExaSearchResults(new Response("{ nope"))).rejects.toThrow(
       "Exa API returned malformed JSON",
     );
+  });
+
+  it("parses well-formed Exa search JSON under the byte cap", async () => {
+    const response = new Response(
+      JSON.stringify({ results: [{ url: "https://example.com", title: "Example" }] }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+    await expect(testing.readExaSearchResults(response)).resolves.toEqual([
+      { url: "https://example.com", title: "Example" },
+    ]);
+  });
+
+  it("caps oversized Exa search JSON instead of buffering the whole body", async () => {
+    const streamed = streamingJsonResponse({ chunkCount: 64, chunkSize: 1024 });
+
+    await expect(
+      testing.readExaSearchResults(streamed.response, { maxBytes: 4096 }),
+    ).rejects.toThrow(/Exa API response exceeds 4096 bytes/);
+
+    expect(streamed.getReadCount()).toBeLessThan(64);
   });
 
   it("bounds Exa API error bodies without using response.text()", async () => {


### PR DESCRIPTION
## What Problem This Solves

The Exa web-search provider parses its success response with an unbounded
`await response.json()`. `response.json()` reads the **entire** body into memory
before parsing, with no byte ceiling and regardless of (or in the absence of) a
`Content-Length` header. Exa is an external, untrusted source on the
`web_search` path: a misbehaving, compromised, or hostile endpoint (including a
self-hosted `baseUrl` override) can stream an arbitrarily large or never-ending
JSON body and force the gateway/plugin to buffer it all, causing memory pressure
or a hang on the search code path.

The error-body read in this same file is already bounded
(`readResponseTextLimited`, 8 KiB) — the success-JSON read was the remaining
unbounded surface. This change closes it, making this the success-JSON-side
symmetric companion to the `#95103` / `#95108` response-limit campaign (and to
the already-merged `readProviderJsonResponse` cap in `#95218`).

## Changes

- `readExaSearchResults` now reads the success body through the shared bounded
  reader `readResponseWithLimit` (re-exported via
  `openclaw/plugin-sdk/response-limit-runtime`) with a 16 MiB cap, matching the
  limit other bundled providers use, then `JSON.parse`s the decoded prefix.
- On overflow the helper cancels the underlying stream and throws a bounded
  error (`Exa API response exceeds <N> bytes`); the existing malformed-JSON
  error message is preserved for backward compatibility.
- The cap is overridable via an optional `{ maxBytes }` argument so tests can
  exercise the boundary with a small limit.
- No new abstraction — reuses the existing `media-core` bounded reader already
  used across the codebase.

## Real behavior proof

- **Behavior addressed**: An untrusted Exa search success response with no
  `Content-Length` and an oversized/never-ending body must not be buffered
  whole; the read must stop at the cap, cancel the stream, and throw a bounded
  error — while valid small responses still parse unchanged.
- **Real environment tested**: A real `node:http` server (`createServer`) bound
  to `127.0.0.1`, streaming a JSON body in 64 KiB chunks with **no
  Content-Length** header, driving the **real exported** `readExaSearchResults`
  function (imported through the runtime module, plugin-sdk aliases resolved) on
  Node v22.22.0.
- **Exact steps**:
  1. Boot the server; `GET /huge` streams an unbounded JSON object with no
     `Content-Length`; `GET /small` returns one valid result.
  2. Drive `readExaSearchResults(response, { maxBytes: 1 MiB })` against `/huge`
     and assert it rejects + the server socket is closed early.
  3. **Negative control**: run the OLD path `await response.json()` against the
     same `/huge` body and measure how many bytes the server pushed.
  4. Drive `readExaSearchResults(response)` against `/small` and assert the
     result is parsed intact.
- **Evidence after fix**:
  - Bounded case: threw `Exa API response exceeds 1048576 bytes`; server socket
    closed early (stream cancelled); only **1,114,175 bytes** reached the wire —
    near the 1 MiB cap, not the 24 MiB body.
  - Negative control: the unbounded `response.json()` read pulled the **full
    25,166,988 bytes** (>22x the bounded read), proving the cap is load-bearing.
  - Small case: parsed into exactly one result with `url` intact, no truncation.
- **Observed result**: `ALL PROOF ASSERTIONS PASSED`. Plus the in-repo Vitest
  suite for this provider passes 13/13 (including a streaming-fixture regression
  test that asserts the oversized read stops before consuming all chunks, a
  well-formed-under-cap test, and the existing malformed-JSON / error-body
  tests). `oxlint` and `tsgo` (extensions project) are clean on the changed
  files.
- **What was not tested**: I did not hit the live `api.exa.ai` endpoint (no key
  / would not reproduce a hostile oversized body); the proof uses a local
  server reproducing the exact untrusted-body shape. The 64-bit memory-exhaustion
  end state was not driven to OOM — the proof instead measures bytes-on-wire and
  early socket close, which is the load-bearing signal.

## Evidence

```
[case 1] oversized success JSON, cap=1 MiB, NO content-length
  ok: readExaSearchResults rejected on oversized body
  ok: bounded error message present (got: Exa API response exceeds 1048576 bytes)
  ok: server socket closed early -> stream was cancelled
  ok: bytes on wire stayed near the 1 MiB cap, not the 24 MiB body (sent 1114175)
[negative control] OLD unbounded `await response.json()` buffers whole body
  ok: unbounded read pulled the FULL ~24 MiB body (sent 25166988), proving the cap is load-bearing
  ok: unbounded read consumed >4x the bounded read (25166988 vs 1114175)
[case 3] normal small JSON still parses unchanged
  ok: small body parsed into 1 result
  ok: result content intact (valid small body not truncated)

ALL PROOF ASSERTIONS PASSED
```

```
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

**Label**: security

AI-assisted.
