### PR TITLE
fix(cli): keep commitments table columns aligned

### DIFF
--- a/src/commands/commitments.test.ts
+++ b/src/commands/commitments.test.ts
@@ -90,6 +90,42 @@ describe("commitments command", () => {
     ]);
   });
 
+  it("keeps fixed-width table columns aligned when values are truncated", async () => {
+    mocks.listCommitments.mockResolvedValue([
+      commitment({
+        id: "cm_abcdefghijklmnopqrstuvwxyz",
+        agentId: "agent-with-a-very-long-name",
+        channel: "telegram",
+        to: "recipient-with-a-very-long-address",
+        suggestedText:
+          "This suggested text is intentionally long enough to exceed the table cell width and be truncated.",
+      }),
+    ]);
+    const { runtime, logs } = createRuntime();
+
+    await commitmentsListCommand({}, runtime);
+
+    const tableLines = logs.map(stripAnsi).slice(3);
+    const [header, row] = tableLines;
+    if (!header || !row) {
+      throw new Error("Expected commitments table header and row");
+    }
+    expect(row).toContain("…");
+    expect(row).not.toContain("...");
+    const rowValuesByHeader = new Map([
+      ["Status", "pending"],
+      ["Kind", "event_check_in"],
+      ["Due", "2026-04-30T17:00:00.000Z"],
+      ["Scope", "agent-with-a-very-long-name"],
+      ["Suggested text", "This suggested text"],
+    ]);
+    for (const [label, rowValue] of rowValuesByHeader) {
+      const expectedColumn = header.indexOf(label);
+      expect(expectedColumn).toBeGreaterThanOrEqual(0);
+      expect(row.indexOf(rowValue)).toBe(expectedColumn);
+    }
+  });
+
   it("tolerates Date-invalid commitment due timestamps in table output", async () => {
     mocks.listCommitments.mockResolvedValue([
       commitment({

--- a/src/commands/commitments.ts
+++ b/src/commands/commitments.ts
@@ -24,7 +24,13 @@ const STATUS_VALUES = new Set<CommitmentStatus>([
 ]);
 
 function truncate(value: string, maxChars: number): string {
-  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}...`;
+  if (value.length <= maxChars) {
+    return value;
+  }
+  if (maxChars <= 1) {
+    return value.slice(0, maxChars);
+  }
+  return `${value.slice(0, maxChars - 1)}…`;
 }
 
 function safe(value: string): string {


### PR DESCRIPTION
Closes #95921

## What Problem This Solves

Fixes an issue where users running `openclaw commitments` would see the fixed-width table drift out of alignment when long commitment fields were truncated.

The commitments table reserved one character for truncation but appended the three-character string `...`, so every truncated cell overflowed its `padEnd` width by two characters and shifted later columns.

## Why This Change Was Made

The table truncation helper now uses a single ellipsis character for shortened values, matching the one-character budget used before padding. A focused regression test covers a long commitment row and verifies that each displayed value starts under the same column as its header.

This is limited to the text table output path; JSON output and commitment storage/delivery behavior are unchanged.

## User Impact

Users can read `openclaw commitments` output reliably even when commitment ids, agent ids, recipient addresses, or suggested text are long enough to be truncated.

## Evidence

AI-assisted: yes. I used Codex to inspect the issue, implement the patch, and run validation; I reviewed the final diff and understand the change.

Validation run locally:

```text
node scripts/run-vitest.mjs src/commands/commitments.test.ts
# Test Files 1 passed (1), Tests 5 passed (5)

git diff --check origin/main...HEAD
pnpm changed:lanes --json
# lanes: core=true, coreTests=true; changed paths limited to src/commands/commitments.ts and src/commands/commitments.test.ts
pnpm exec oxfmt --check src/commands/commitments.ts src/commands/commitments.test.ts
pnpm exec oxlint src/commands/commitments.ts src/commands/commitments.test.ts
codex review --base origin/main
# No concrete regression identified in the touched command, callers, or adjacent CLI docs.
```
