### PR TITLE
fix(lmstudio): bound model load success response body to prevent OOM

### DIFF
--- a/extensions/lmstudio/src/models.fetch.ts
+++ b/extensions/lmstudio/src/models.fetch.ts
@@ -3,6 +3,7 @@ import { createSubsystemLogger } from "openclaw/plugin-sdk/logging-core";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   readProviderJsonArrayFieldResponse,
+  readProviderJsonResponse,
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
@@ -285,12 +286,13 @@ export async function ensureLmstudioModelLoaded(params: {
           `LM Studio model load failed (${response.status})${body ? `: ${body}` : ""}`,
         );
       }
-      let payload: LmstudioLoadResponse;
-      try {
-        payload = (await response.json()) as LmstudioLoadResponse;
-      } catch (cause) {
-        throw new Error("LM Studio model load returned malformed JSON", { cause });
-      }
+      // Read the success body through the shared byte-capped reader so a misbehaving
+      // or compromised LM Studio server cannot stream an unbounded JSON payload into
+      // memory before we parse it. Malformed JSON is wrapped with our own label.
+      const payload = await readProviderJsonResponse<LmstudioLoadResponse>(
+        response,
+        "LM Studio model load",
+      );
       if (typeof payload.status === "string" && payload.status.toLowerCase() !== "loaded") {
         throw new Error(`LM Studio model load returned unexpected status: ${payload.status}`);
       }

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -44,6 +44,21 @@ describe("lmstudio-models", () => {
     }
     return JSON.parse(init.body) as unknown;
   };
+  // The model fetch/load helpers now read bodies through the shared byte-capped
+  // reader, so success-path mocks must be real Response objects with a body
+  // stream rather than bare `{ ok, json }` placeholders.
+  const jsonResponse = (payload: unknown, init?: ResponseInit): Response =>
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      ...init,
+    });
+  const malformedJsonResponse = (init?: ResponseInit): Response =>
+    new Response("{ this is not valid json", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      ...init,
+    });
   const cancelTrackedResponse = (
     text: string,
     init: ResponseInit,
@@ -74,31 +89,25 @@ describe("lmstudio-models", () => {
   }) =>
     vi.fn(async (url: string | URL, init?: RequestInit) => {
       const key = params?.key ?? "qwen3-8b-instruct";
+      void init;
       if (String(url).endsWith("/api/v1/models")) {
-        return {
-          ok: true,
-          json: async () => ({
-            models: [
-              {
-                type: "llm",
-                key,
-                max_context_length: params?.maxContextLength,
-                variants: params?.variants,
-                selected_variant: params?.selectedVariant,
-                loaded_instances: params?.loadedContextLength
-                  ? [{ id: "inst-1", config: { context_length: params.loadedContextLength } }]
-                  : [],
-              },
-            ],
-          }),
-        };
+        return jsonResponse({
+          models: [
+            {
+              type: "llm",
+              key,
+              max_context_length: params?.maxContextLength,
+              variants: params?.variants,
+              selected_variant: params?.selectedVariant,
+              loaded_instances: params?.loadedContextLength
+                ? [{ id: "inst-1", config: { context_length: params.loadedContextLength } }]
+                : [],
+            },
+          ],
+        });
       }
       if (String(url).endsWith("/api/v1/models/load")) {
-        return {
-          ok: true,
-          json: async () => ({ status: "loaded" }),
-          requestInit: init,
-        };
+        return jsonResponse({ status: "loaded" });
       }
       throw new Error(`Unexpected fetch URL: ${String(url)}`);
     });
@@ -296,9 +305,8 @@ describe("lmstudio-models", () => {
   });
 
   it("discovers llm models and maps metadata", async () => {
-    const fetchMock = vi.fn(async (_url: string | URL, _init?: RequestInit) => ({
-      ok: true,
-      json: async () => ({
+    const fetchMock = vi.fn(async (_url: string | URL, _init?: RequestInit) =>
+      jsonResponse({
         models: [
           {
             type: "llm",
@@ -330,7 +338,7 @@ describe("lmstudio-models", () => {
           },
         ],
       }),
-    }));
+    );
 
     const models = await discoverLmstudioModels({
       baseUrl: "http://localhost:1234/v1",
@@ -386,13 +394,7 @@ describe("lmstudio-models", () => {
   });
 
   it("reports malformed model list JSON with an owned error", async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      json: async () => {
-        throw new SyntaxError("bad json");
-      },
-    }));
+    const fetchMock = vi.fn(async () => malformedJsonResponse());
 
     const result = await fetchLmstudioModels({
       baseUrl: "http://localhost:1234/v1",
@@ -405,11 +407,7 @@ describe("lmstudio-models", () => {
 
   it("reports wrong-shaped model list payloads with owned errors", async () => {
     for (const payload of [[], { models: {} }, { models: [null] }]) {
-      const fetchMock = vi.fn(async () => ({
-        ok: true,
-        status: 200,
-        json: async () => payload,
-      }));
+      const fetchMock = vi.fn(async () => jsonResponse(payload));
 
       const result = await fetchLmstudioModels({
         baseUrl: "http://localhost:1234/v1",
@@ -424,12 +422,9 @@ describe("lmstudio-models", () => {
   it("caps oversized direct fetch timeouts before discovering models", async () => {
     const timeoutController = new AbortController();
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
-    const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => ({
-      ok: true,
-      status: 200,
-      requestInit: init,
-      json: async () => ({ models: [] }),
-    }));
+    const fetchMock = vi.fn(async (_url: string | URL, _init?: RequestInit) =>
+      jsonResponse({ models: [] }),
+    );
 
     const result = await fetchLmstudioModels({
       baseUrl: "http://localhost:1234/v1",
@@ -521,20 +516,17 @@ describe("lmstudio-models", () => {
     const variantKey = `${canonicalKey}@q4_k_m`;
     const fetchMock = vi.fn(async (url: string | URL) => {
       if (String(url).endsWith("/api/v1/models")) {
-        return {
-          ok: true,
-          json: async () => ({
-            models: [
-              {
-                type: "llm",
-                key: canonicalKey,
-                variants: [variantKey],
-                selected_variant: variantKey,
-                loaded_instances: [],
-              },
-            ],
-          }),
-        };
+        return jsonResponse({
+          models: [
+            {
+              type: "llm",
+              key: canonicalKey,
+              variants: [variantKey],
+              selected_variant: variantKey,
+              loaded_instances: [],
+            },
+          ],
+        });
       }
       if (String(url).endsWith("/api/v1/models/load")) {
         return new Response("load failed", { status: 503 });
@@ -575,20 +567,12 @@ describe("lmstudio-models", () => {
   it("reports malformed model load JSON with an owned error", async () => {
     const fetchMock = vi.fn(async (url: string | URL) => {
       if (String(url).endsWith("/api/v1/models")) {
-        return {
-          ok: true,
-          json: async () => ({
-            models: [{ type: "llm", key: "qwen3-8b-instruct", loaded_instances: [] }],
-          }),
-        };
+        return jsonResponse({
+          models: [{ type: "llm", key: "qwen3-8b-instruct", loaded_instances: [] }],
+        });
       }
       if (String(url).endsWith("/api/v1/models/load")) {
-        return {
-          ok: true,
-          json: async () => {
-            throw new SyntaxError("bad json");
-          },
-        };
+        return malformedJsonResponse();
       }
       throw new Error(`Unexpected fetch URL: ${String(url)}`);
     });
@@ -599,7 +583,53 @@ describe("lmstudio-models", () => {
         baseUrl: "http://localhost:1234/v1",
         modelKey: "qwen3-8b-instruct",
       }),
-    ).rejects.toThrow("LM Studio model load returned malformed JSON");
+    ).rejects.toThrow("LM Studio model load: malformed JSON response");
+  });
+
+  it("bounds oversized model load success bodies", async () => {
+    // A misbehaving server may stream an unbounded success JSON body; the load
+    // path must stop reading at the byte cap instead of buffering it all.
+    let canceled = false;
+    let bytesEmitted = 0;
+    const oversizedStream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        // Far exceeds the 16 MiB provider JSON cap if read to completion.
+        if (bytesEmitted >= 32 * 1024 * 1024) {
+          controller.close();
+          return;
+        }
+        bytesEmitted += 64 * 1024;
+        controller.enqueue(new Uint8Array(64 * 1024).fill(0x61));
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (String(url).endsWith("/api/v1/models")) {
+        return jsonResponse({
+          models: [{ type: "llm", key: "qwen3-8b-instruct", loaded_instances: [] }],
+        });
+      }
+      if (String(url).endsWith("/api/v1/models/load")) {
+        return new Response(oversizedStream, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected fetch URL: ${String(url)}`);
+    });
+    vi.stubGlobal("fetch", asFetch(fetchMock));
+
+    const error = await ensureLmstudioModelLoaded({
+      baseUrl: "http://localhost:1234/v1",
+      modelKey: "qwen3-8b-instruct",
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/JSON response exceeds \d+ bytes/);
+    expect(canceled).toBe(true);
+    expect(bytesEmitted).toBeLessThan(32 * 1024 * 1024);
   });
 
   it("bounds model load error bodies", async () => {
@@ -608,12 +638,9 @@ describe("lmstudio-models", () => {
     const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
     const fetchMock = vi.fn(async (url: string | URL) => {
       if (String(url).endsWith("/api/v1/models")) {
-        return {
-          ok: true,
-          json: async () => ({
-            models: [{ type: "llm", key: "qwen3-8b-instruct", loaded_instances: [] }],
-          }),
-        };
+        return jsonResponse({
+          models: [{ type: "llm", key: "qwen3-8b-instruct", loaded_instances: [] }],
+        });
       }
       if (String(url).endsWith("/api/v1/models/load")) {
         return tracked.response;


### PR DESCRIPTION
## What Problem This Solves

`ensureLmstudioModelLoaded` in `extensions/lmstudio/src/models.fetch.ts` POSTs to LM Studio's `/api/v1/models/load` and reads the **success** response with an unbounded `await response.json()`. LM Studio is a self-hosted/local server endpoint that the agent reaches over HTTP; a misbehaving, misconfigured, or compromised server (or anything sitting on the configured `baseUrl`, including an SSRF-redirected target) can return a success body with no `Content-Length` and stream an arbitrarily large JSON payload.

Because `response.json()` buffers the entire body before parsing, that unbounded body is fully read into memory on the provider/discovery path before any size check runs. That is a memory-pressure / hang vector on a code path that runs during model discovery and before first inference — exactly the kind of unbounded external-response read the response-limit campaign has been closing across the codebase.

The sibling **error** body on the same endpoint was already bounded (`readResponseTextLimited`, 8 KiB) in a prior change. This PR closes the remaining unbounded read: the **success** JSON body.

## Changes

- `extensions/lmstudio/src/models.fetch.ts`: replace the unbounded `await response.json()` on the `/api/v1/models/load` success path with the shared, already-bounded `readProviderJsonResponse<LmstudioLoadResponse>(...)` helper (re-exported from `openclaw/plugin-sdk/provider-http`, same helper the `/api/v1/models` discovery path already uses). It reads the body through `readResponseWithLimit` under the 16 MiB provider-JSON cap, cancels the stream on overflow, and wraps malformed JSON with the caller's label. No new abstraction is introduced and the redundant local `try/catch` is removed.
- `extensions/lmstudio/src/models.test.ts`: migrate the model fetch/load mocks from bare `{ ok, json }` placeholders to real `Response` objects (the bounded readers require a real body stream), and add a regression test that streams an oversized (>16 MiB) success body and asserts the load path throws a bounded error and cancels the stream instead of buffering it all. Updates the malformed-load assertion to the helper's owned message.

## Real behavior proof

- **Behavior addressed**: unbounded buffering of the LM Studio `/api/v1/models/load` success JSON body; after the fix the read is capped at 16 MiB and the stream is cancelled on overflow.
- **Real environment tested**: a local `node:http` server (real sockets, chunked transfer-encoding, no `Content-Length`) driving the real exported `ensureLmstudioModelLoaded` / `readProviderJsonResponse` via the global `fetch` (real `Response` body streams). Run with `node --import tsx proof.mts`.
- **Exact steps**: (1) normal small `{ "status": "loaded" }` response, end-to-end `ensureLmstudioModelLoaded`; (2) oversized 20 MiB chunked success body, end-to-end; (3) a body that hangs forever after a prefix, driving `readProviderJsonResponse` with an explicit small cap; (4) negative control reading the same 20 MiB body with the pre-fix unbounded `await response.text()`.
- **Evidence after fix**: (1) returns `"proof-model"` (still parses normally); (2) throws `LM Studio model load: JSON response exceeds 16777216 bytes` and the server observed only ~17.5 MiB sent before the socket closed (vs 20 MiB total) — the stream was cancelled mid-flight; (3) throws `... exceeds 2048 bytes` and the server socket was closed (cancelled) instead of hanging; (4) the unbounded read consumed the full 20 MiB, confirming the cap is load-bearing.
- **Observed result**: oversized/hanging bodies are stopped at the cap with a bounded error and the upstream stream is cancelled; well-formed small bodies still parse.
- **What was not tested**: a real third-party LM Studio binary returning a pathological body (used a faithful local HTTP server instead); behavior under genuine OS memory exhaustion (the goal is to prevent reaching it).

## Evidence

```
[proof] 本地 server 启动 http://127.0.0.1:36821
PASS  normal-small 端到端解析不破 — ensureLmstudioModelLoaded 返回 proof-model
PASS  oversized 抛 bounded error — error="LM Studio model load: JSON response exceeds 16777216 bytes"
PASS  oversized server 发送量 < 全量 20MiB(stream 被提前 cancel) — server 实发 17.50MiB (cap 16MiB,远小于 20MiB 全量)
PASS  hang body 到 cap 即抛 bounded error(不无限挂起) — error="LM Studio model load: JSON response exceeds 2048 bytes"
PASS  hang body cap 命中后 server 端 socket 被 cancel/close — server 实发 720922 bytes 后 socket close=true
PASS  negative control:无界 await .text() 全量读入 20MiB(证明 cap load-bearing) — 无界读到 20.00MiB 文本 / server 实发 20.00MiB(对照:bounded 仅读到 cap)
[proof] ALL PASS
```

Unit tests: `node scripts/run-vitest.mjs extensions/lmstudio/src/models.test.ts --run` → 24 passed (24), including the new `bounds oversized model load success bodies`. `oxlint` and `tsgo` (extensions source + test) clean on the changed files.

**Label**: security

---

This is the symmetric companion to the response-limit campaign (e.g. #95103 / #95108 / #95218): the LM Studio discovery `/api/v1/models` path and the `/api/v1/models/load` error body were already bounded; this PR finishes the set by bounding the `/api/v1/models/load` success body with the same shared helper and cap.

AI-assisted: implemented and proof-tested with AI assistance; reviewed by a human before submission.
