### PR TITLE
fix(firecrawl): bound successful JSON response reads

### DIFF
--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -12,6 +12,7 @@ import {
   withStrictWebToolsEndpoint,
   writeCache,
 } from "openclaw/plugin-sdk/provider-web-fetch";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { normalizeSecretInput } from "openclaw/plugin-sdk/secret-input";
 import { wrapExternalContent, wrapWebContent } from "openclaw/plugin-sdk/security-runtime";
 import {
@@ -41,6 +42,10 @@ const SCRAPE_CACHE = new Map<
 >();
 const DEFAULT_SEARCH_COUNT = 5;
 const DEFAULT_SCRAPE_MAX_CHARS = 50_000;
+// Cap successful Firecrawl JSON bodies so a self-hosted or custom endpoint cannot force the
+// runtime to buffer an unbounded payload before parsing. Aligned with the provider JSON cap
+// established by the #95103/#95108 response-limit campaign (e.g. #95218).
+const FIRECRAWL_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const ALLOWED_FIRECRAWL_HOSTS = new Set(["api.firecrawl.dev"]);
 const FIRECRAWL_SELF_HOSTED_PRIVATE_ERROR =
   "Firecrawl custom baseUrl must target a private or internal self-hosted endpoint.";
@@ -66,8 +71,11 @@ async function readFirecrawlJsonResponse(
   response: Response,
   label: string,
 ): Promise<Record<string, unknown>> {
+  const bytes = await readResponseWithLimit(response, FIRECRAWL_JSON_RESPONSE_MAX_BYTES, {
+    onOverflow: ({ maxBytes }) => new Error(`${label}: JSON response exceeds ${maxBytes} bytes`),
+  });
   try {
-    return (await response.json()) as Record<string, unknown>;
+    return JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>;
   } catch (cause) {
     throw new Error(`${label}: malformed JSON response`, { cause });
   }
@@ -613,8 +621,10 @@ export const testing = {
   assertFirecrawlScrapeTargetAllowed,
   parseFirecrawlScrapePayload,
   postFirecrawlJson,
+  readFirecrawlJsonResponse,
   resolveEndpoint,
   validateFirecrawlBaseUrl,
   resolveSearchItems,
+  FIRECRAWL_JSON_RESPONSE_MAX_BYTES,
 };
 export { testing as __testing };

--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -997,6 +997,54 @@ describe("firecrawl tools", () => {
     ).rejects.toThrow("Firecrawl fetch failed: malformed JSON response");
   });
 
+  it("parses a well-formed Firecrawl JSON body under the byte cap", async () => {
+    const response = new Response(JSON.stringify({ success: true, data: [{ url: "x" }] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    await expect(
+      firecrawlClientTesting.readFirecrawlJsonResponse(response, "Firecrawl Search API error"),
+    ).resolves.toEqual({ success: true, data: [{ url: "x" }] });
+  });
+
+  it("caps oversized successful Firecrawl JSON bodies instead of buffering them", async () => {
+    // Streaming fixture proves the bounded reader stops before consuming the whole body and
+    // cancels the underlying stream, mirroring a self-hosted Firecrawl endpoint that streams an
+    // unbounded JSON payload with no Content-Length.
+    const chunkSize = 64 * 1024;
+    const chunkCount = 512;
+    let pulls = 0;
+    let cancelled = false;
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (pulls >= chunkCount) {
+          controller.close();
+          return;
+        }
+        pulls += 1;
+        controller.enqueue(encoder.encode("a".repeat(chunkSize)));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const response = new Response(stream, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    await expect(
+      firecrawlClientTesting.readFirecrawlJsonResponse(response, "Firecrawl Search API error"),
+    ).rejects.toThrow(/JSON response exceeds \d+ bytes/);
+
+    // The whole body is chunkCount * chunkSize = 32MiB, well over the 16MiB cap, so the reader
+    // must stop early and cancel the stream rather than buffer everything.
+    expect(pulls).toBeLessThan(chunkCount);
+    expect(cancelled).toBe(true);
+  });
+
   it("respects positive numeric overrides for scrape and cache behavior", () => {
     const cfg = {
       tools: {


### PR DESCRIPTION
## What Problem This Solves

The Firecrawl plugin treats its endpoint as an untrusted external source: a user
can point it at a self-hosted or custom Firecrawl instance (`baseUrl`), and even
the official API is a third party. The **success path** buffered the entire
response via `await response.json()`.

A self-hosted/custom Firecrawl endpoint (or a compromised/misbehaving upstream)
can return a success status with an oversized JSON body and **no
`Content-Length`** — a chunked/streamed response. With `response.json()` the
whole payload is buffered into memory before parsing, so a malicious or buggy
endpoint can drive the plugin/provider path into unbounded memory growth on a
body that keeps streaming past any sane size. This is the same class of issue
the response-limit campaign closed for the provider JSON paths.

## Changes

- `extensions/firecrawl/src/firecrawl-client.ts`: `readFirecrawlJsonResponse`
  now reads the success body through `readResponseWithLimit` (from
  `openclaw/plugin-sdk/response-limit-runtime`, the same helper used by the
  bounded provider JSON reads), capped at **16 MiB** and cancelling the stream
  on overflow, then `JSON.parse`s the bounded buffer. Malformed-JSON and normal
  small-response behavior (parse + cache) are unchanged.
- Reuses the existing helper — no new abstraction. This adds the missing
  success-path size cap; it is a byte-size bound only and does **not** pass
  `chunkTimeoutMs`, so it does not add a per-chunk stall timeout (see Scope).
- Added regression tests in `firecrawl-tools.test.ts`: a well-formed body under
  the cap still parses, and an oversized streamed body throws a bounded error
  while cancelling the stream before buffering everything.

## Scope / What This PR Does and Does Not Bound

- **In scope (this PR):** the **success-path** JSON read is now bounded by a
  16 MiB byte cap. An oversized or continuously streaming success body that
  crosses 16 MiB is bounded/cancelled before the whole payload is buffered.
- **Not changed by this PR — stall before the cap:** because no
  `chunkTimeoutMs` is passed, a success body that streams *slowly but never
  exceeds 16 MiB* is **not** cancelled by this cap; that stall case remains
  governed by the existing request timeout, exactly as before.
- **Not changed by this PR — error path:** the error-detail path
  (`response.status` not ok) first attempts to parse a JSON error body via
  `jsonResponse.json()` on a cloned response (line ~228), which is still an
  **unbounded** read; only its non-JSON fallback uses the bounded
  `readResponseText(..., { maxBytes: 64_000 })`. Bounding that error-JSON
  pre-read is out of scope here — this PR is intentionally the success-JSON
  complement only and does not claim the entire error path is bounded.

## Verification (covered by committed tests)

The behavior is exercised by the two regression tests added in
`firecrawl-tools.test.ts`, which run against the **real exported**
`testing.readFirecrawlJsonResponse`:

- **Well-formed under cap parses:** a small `{ success: true, data: [{ url:
  "x" }] }` body resolves to the parsed object unchanged.
- **Oversized streamed body is capped, not buffered:** a `ReadableStream`
  fixture of 512 × 64 KiB chunks (32 MiB total, over the 16 MiB cap) makes
  `readFirecrawlJsonResponse` reject with `JSON response exceeds <bytes>`,
  and the test asserts the stream stopped early (`pulls < chunkCount`) and was
  cancelled (`cancel()` observed) — i.e. the reader did not pull the whole body
  before failing. This is the load-bearing check that the cap cancels the
  underlying stream rather than buffering everything.

What the committed tests deliberately do **not** cover: a live production
`api.firecrawl.dev` call (no API key in this environment); a per-chunk stall
timeout (not implemented — see Scope); and the SSRF/private-network validation
and caching layers (unchanged by this PR).

## Real behavior proof

- **Behavior addressed:** Firecrawl success JSON responses from an untrusted/self-hosted endpoint are no longer read with unbounded `response.json()`; an oversized no-`Content-Length` stream is cancelled at the 16 MiB cap, while small JSON still parses normally.
- **Real environment tested:** Local OpenClaw checkout on Linux, running a standalone `node --import tsx --input-type=module` harness from the repository root. The harness imports the real exported `testing.readFirecrawlJsonResponse` from `extensions/firecrawl/src/firecrawl-client.ts` and feeds real WHATWG `Response`/`ReadableStream` bodies with no `Content-Length`.
- **Exact steps or command run after this patch:** The harness ran three paths: small JSON through the patched helper, a 64 MiB streaming body through the patched helper, and a negative control using the old unbounded `response.json()` shape against a 32 MiB streamed body.
- **Evidence after fix:**

  ```text
  PASS small-json-intact {"success":true,"data":[{"url":"https://example.com"}]}
  PASS oversized-json-bounded Firecrawl Search API: JSON response exceeds 16777216 bytes; {"pulls":17,"canceled":true,"bytesPulled":17825792}
  PASS negative-control-unbounded-json-drains Unexpected token 'a', "aaaaaaaaaa"... is not valid JSON; {"pulls":32,"canceled":false,"bytesPulled":33554432}
  SUMMARY pass=3 fail=0
  ```

- **Observed result after fix:** The patched Firecrawl reader throws the bounded `JSON response exceeds 16777216 bytes` error after 17 MiB of 1 MiB chunks and cancels the stream (`canceled=true`) instead of draining the full fixture. The old `response.json()` negative control consumes all 32 MiB before failing, proving the cap is load-bearing.
- **What was not tested:** A live `api.firecrawl.dev` call, because no API key is available and the public API cannot deterministically stream an oversized success body on demand. The standalone harness reproduces the relevant external-response condition with a real stream and the real exported parser.

**Label**: security

---

AI-assisted: implemented and verified with AI assistance (Claude). This is the
symmetric success-path complement to the #95103/#95108 response-limit campaign
(this adds the missing success-JSON byte cap, same helper and 16 MiB cap as
#95218; the error-JSON pre-read remains unbounded and is out of scope here).

