### PR TITLE
docs: rename top maturity tier to Clawesome

### DIFF
--- a/.agents/skills/claw-score/SKILL.md
+++ b/.agents/skills/claw-score/SKILL.md
@@ -146,7 +146,7 @@ Default guidance:
 
 Default Completeness bands:
 
-- `Lovable` (95-100): complete across expected workflows, variants, and
+- `Clawesome` (95-100): complete across expected workflows, variants, and
   recovery branches, with only minor polish gaps.
 - `Stable` (80-95): the expected workflow set is broadly present, with only
   bounded missing branches.
@@ -172,7 +172,7 @@ Default Completeness bands:
 
 Bands:
 
-- `Lovable`: 95-100
+- `Clawesome`: 95-100
 - `Stable`: 80-95
 - `Beta`: 70-80
 - `Alpha`: 50-70

--- a/docs/maturity/scorecard.md
+++ b/docs/maturity/scorecard.md
@@ -24,7 +24,7 @@ The current scorecard covers 50 surfaces and 281 capability areas.
 
 | Label        | Score range |
 | ------------ | ----------- |
-| Lovable      | 95-100%     |
+| Clawesome    | 95-100%     |
 | Stable       | 80-95%      |
 | Beta         | 70-80%      |
 | Alpha        | 50-70%      |

--- a/docs/maturity/taxonomy.md
+++ b/docs/maturity/taxonomy.md
@@ -16,7 +16,7 @@ This page explains the product areas and capability groups behind the maturity s
 | `M2`  | Alpha        | Real users can try it, but breaking changes and incomplete UX are expected.                 | Documented setup, basic tests, known caveats, and at least one real-environment proof.                                 |
 | `M3`  | Beta         | Public path exists and the main workflow is usable with bounded caveats.                    | Install/update docs, regression tests, support runbook, and successful scenario proof across the expected environment. |
 | `M4`  | Stable       | Recommended path for normal users. Failures are treated as regressions.                     | Release gate, doctor/troubleshooting path, broad docs, and repeated real-world proof.                                  |
-| `M5`  | Lovable      | Polished, delightful, well-instrumented, and competitive with the best comparable workflow. | Stable plus user scorecard pass across representative users.                                                           |
+| `M5`  | Clawesome    | Polished, delightful, well-instrumented, and competitive with the best comparable workflow. | Stable plus user scorecard pass across representative users.                                                           |
 
 ## Product areas
 

--- a/extensions/qa-lab/src/scorecard-taxonomy.ts
+++ b/extensions/qa-lab/src/scorecard-taxonomy.ts
@@ -10,7 +10,7 @@ export const QA_MATURITY_TAXONOMY_PATH = "taxonomy.yaml";
 export const QA_MATURITY_SCORES_PATH = "qa/maturity-scores.yaml";
 export const QA_MATURITY_SCORE_KEYS = ["quality", "completeness"] as const;
 export const QA_MATURITY_SCORE_LABELS = [
-  "Lovable",
+  "Clawesome",
   "Stable",
   "Beta",
   "Alpha",

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -251,9 +251,9 @@ levels:
     label: Stable
     meaning: Recommended path for normal users. Failures are treated as regressions.
     promotion_bar: Release gate, doctor/troubleshooting path, broad docs, and repeated real-world proof.
-  - id: lovable
+  - id: clawesome
     code: M5
-    label: Lovable
+    label: Clawesome
     meaning: Polished, delightful, well-instrumented, and competitive with the best comparable workflow.
     promotion_bar: Stable plus user scorecard pass across representative users.
 surfaces:


### PR DESCRIPTION
Summary:
- Rename the top maturity tier from `Lovable` to `Clawesome` across the taxonomy, QA score labels, maturity docs, and `$claw-score` skill guidance.
- Keep the score bands and promotion semantics unchanged.
- Update the taxonomy level id from `lovable` to `clawesome` so source data matches the new label.

Verification:
- `rg -n -i --hidden "lovable|loveable" . -g '!node_modules' -g '!.git'` (no matches)
- Parser probe: loaded `taxonomy.yaml`, verified M5 id/label, verified `qaMaturityScoreObjectForScore(95)` returns `Clawesome`, and checked validated score sources report 0 warnings
- `node scripts/run-vitest.mjs extensions/qa-lab/src/coverage-report.test.ts`
- `pnpm docs:list`
- `pnpm docs:check-mdx`
- `git diff --check`

Note: `pnpm maturity:render` was not run to completion because the renderer now requires QA evidence artifacts with scorecard data; the generated maturity docs were updated directly for this label-only rename.
