### PR TITLE
Reject delete-after-run recurring cron jobs

### DIFF
--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -633,6 +633,49 @@ describe("applyJobPatch", () => {
     applyJobPatch(job, { enabled: true });
     expect(job.enabled).toBe(true);
   });
+
+  it("allows safe recovery patches on legacy recurring deleteAfterRun jobs", () => {
+    const job = createMainSystemEventJob("legacy-invalid-delete-after-run", undefined);
+    job.deleteAfterRun = true;
+
+    applyJobPatch(job, { name: "renamed legacy job" });
+    expect(job.name).toBe("renamed legacy job");
+    expect(job.deleteAfterRun).toBe(true);
+
+    applyJobPatch(job, {
+      enabled: false,
+      deleteAfterRun: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+    });
+    expect(job.enabled).toBe(false);
+
+    applyJobPatch(job, { deleteAfterRun: false });
+    expect(job.deleteAfterRun).toBe(false);
+
+    applyJobPatch(job, { enabled: true });
+    expect(job.enabled).toBe(true);
+  });
+
+  it("rejects re-enabling legacy recurring deleteAfterRun jobs before clearing the flag", () => {
+    const job = createMainSystemEventJob("legacy-disabled-delete-after-run", undefined);
+    job.deleteAfterRun = true;
+    job.enabled = false;
+
+    expect(() => applyJobPatch(job, { enabled: true })).toThrow(
+      'cron deleteAfterRun is only supported for schedule.kind="at"',
+    );
+  });
+
+  it("rejects recurring schedule changes that keep legacy deleteAfterRun jobs invalid", () => {
+    const job = createMainSystemEventJob("legacy-schedule-delete-after-run", undefined);
+    job.deleteAfterRun = true;
+
+    expect(() =>
+      applyJobPatch(job, {
+        schedule: { kind: "cron", expr: "*/5 * * * *" },
+      }),
+    ).toThrow('cron deleteAfterRun is only supported for schedule.kind="at"');
+  });
 });
 
 function createMockState(now: number, opts?: { defaultAgentId?: string }): CronServiceState {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -305,6 +305,13 @@ function assertCronExpressionSatisfiable(job: CronJob, nowMs: number) {
   );
 }
 
+function assertDeleteAfterRunSchedule(job: Pick<CronJob, "deleteAfterRun" | "schedule">) {
+  if (job.deleteAfterRun !== true || job.schedule.kind === "at") {
+    return;
+  }
+  throw new Error('cron deleteAfterRun is only supported for schedule.kind="at"');
+}
+
 function assertMainSessionAgentId(
   job: Pick<CronJob, "sessionTarget" | "agentId">,
   defaultAgentId: string | undefined,
@@ -797,6 +804,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     },
   };
   assertSupportedJobSpec(job);
+  assertDeleteAfterRunSchedule(job);
   assertMainSessionAgentId(job, state.deps.defaultAgentId);
   assertDeliverySupport(job);
   assertFailureDestinationSupport(job);
@@ -886,6 +894,7 @@ export function applyJobPatch(
     job.sessionKey = normalizeOptionalString((patch as { sessionKey?: unknown }).sessionKey);
   }
   assertSupportedJobSpec(job);
+  assertDeleteAfterRunSchedule(job);
   assertMainSessionAgentId(job, opts?.defaultAgentId);
   assertDeliverySupport(job);
   assertFailureDestinationSupport(job);

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -340,10 +340,10 @@ function assertDeleteAfterRunSchedulePatch(params: {
   if (!hasInvalidDeleteAfterRunSchedule(params.before)) {
     throw new Error('cron deleteAfterRun is only supported for schedule.kind="at"');
   }
-  if (params.after.enabled === false) {
+  if (!params.after.enabled) {
     return;
   }
-  if (params.before.enabled === false && params.after.enabled === true) {
+  if (!params.before.enabled && params.after.enabled) {
     throw new Error('cron deleteAfterRun is only supported for schedule.kind="at"');
   }
   if (

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -26,6 +26,7 @@ import type {
   CronJobPatch,
   CronPayload,
   CronPayloadPatch,
+  CronSchedule,
 } from "../types.js";
 import { normalizeHttpWebhookUrl } from "../webhook-url.js";
 import { resolveInitialCronDelivery } from "./initial-delivery.js";
@@ -305,11 +306,52 @@ function assertCronExpressionSatisfiable(job: CronJob, nowMs: number) {
   );
 }
 
+function hasInvalidDeleteAfterRunSchedule(job: Pick<CronJob, "deleteAfterRun" | "schedule">) {
+  return job.deleteAfterRun === true && job.schedule.kind !== "at";
+}
+
 function assertDeleteAfterRunSchedule(job: Pick<CronJob, "deleteAfterRun" | "schedule">) {
-  if (job.deleteAfterRun !== true || job.schedule.kind === "at") {
+  if (!hasInvalidDeleteAfterRunSchedule(job)) {
     return;
   }
   throw new Error('cron deleteAfterRun is only supported for schedule.kind="at"');
+}
+
+function schedulesEqual(a: CronSchedule, b: CronSchedule): boolean {
+  if (a.kind !== b.kind) {
+    return false;
+  }
+  if (a.kind === "at") {
+    return b.kind === "at" && a.at === b.at;
+  }
+  if (a.kind === "every") {
+    return b.kind === "every" && a.everyMs === b.everyMs && a.anchorMs === b.anchorMs;
+  }
+  return b.kind === "cron" && a.expr === b.expr && a.tz === b.tz && a.staggerMs === b.staggerMs;
+}
+
+function assertDeleteAfterRunSchedulePatch(params: {
+  before: Pick<CronJob, "deleteAfterRun" | "enabled" | "schedule">;
+  after: Pick<CronJob, "deleteAfterRun" | "enabled" | "schedule">;
+}) {
+  if (!hasInvalidDeleteAfterRunSchedule(params.after)) {
+    return;
+  }
+  if (!hasInvalidDeleteAfterRunSchedule(params.before)) {
+    throw new Error('cron deleteAfterRun is only supported for schedule.kind="at"');
+  }
+  if (params.after.enabled === false) {
+    return;
+  }
+  if (params.before.enabled === false && params.after.enabled === true) {
+    throw new Error('cron deleteAfterRun is only supported for schedule.kind="at"');
+  }
+  if (
+    params.before.deleteAfterRun !== params.after.deleteAfterRun ||
+    !schedulesEqual(params.before.schedule, params.after.schedule)
+  ) {
+    throw new Error('cron deleteAfterRun is only supported for schedule.kind="at"');
+  }
 }
 
 function assertMainSessionAgentId(
@@ -819,6 +861,11 @@ export function applyJobPatch(
   patch: CronJobPatch,
   opts?: { defaultAgentId?: string; scheduleValidationNowMs?: number },
 ) {
+  const beforeDeleteAfterRunSchedule = {
+    deleteAfterRun: job.deleteAfterRun,
+    enabled: job.enabled,
+    schedule: job.schedule,
+  };
   if ("name" in patch) {
     job.name = normalizeRequiredName(patch.name);
   }
@@ -894,7 +941,10 @@ export function applyJobPatch(
     job.sessionKey = normalizeOptionalString((patch as { sessionKey?: unknown }).sessionKey);
   }
   assertSupportedJobSpec(job);
-  assertDeleteAfterRunSchedule(job);
+  assertDeleteAfterRunSchedulePatch({
+    before: beforeDeleteAfterRunSchedule,
+    after: job,
+  });
   assertMainSessionAgentId(job, opts?.defaultAgentId);
   assertDeliverySupport(job);
   assertFailureDestinationSupport(job);

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -612,6 +612,72 @@ describe("gateway server cron", () => {
     }
   });
 
+  test("allows safe recovery updates for legacy delete-after-run recurring jobs", async () => {
+    const now = Date.now();
+    const legacyJobId = "legacy-delete-after-run-recurring";
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-delete-after-legacy-recovery-",
+      cronEnabled: false,
+      jobs: [
+        {
+          id: legacyJobId,
+          name: "legacy invalid",
+          enabled: true,
+          deleteAfterRun: true,
+          createdAtMs: now - 60_000,
+          updatedAtMs: now - 60_000,
+          schedule: { kind: "every", everyMs: 60_000, anchorMs: now - 60_000 },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "hello" },
+          state: { nextRunAtMs: now + 60_000 },
+        },
+      ],
+    });
+    const cronState = await createDirectCronState();
+
+    try {
+      const renameRes = await directCronReq(cronState, "cron.update", {
+        id: legacyJobId,
+        patch: { name: "renamed legacy invalid" },
+      });
+      expect(renameRes.ok).toBe(true);
+      expect((renameRes.payload as { name?: unknown } | null)?.name).toBe("renamed legacy invalid");
+
+      const disableRes = await directCronReq(cronState, "cron.update", {
+        id: legacyJobId,
+        patch: { enabled: false },
+      });
+      expect(disableRes.ok).toBe(true);
+      expect((disableRes.payload as { enabled?: unknown } | null)?.enabled).toBe(false);
+
+      const reenableRes = await directCronReq(cronState, "cron.update", {
+        id: legacyJobId,
+        patch: { enabled: true },
+      });
+      expect(reenableRes.ok).toBe(false);
+      expect(reenableRes.error?.message).toContain(
+        'cron deleteAfterRun is only supported for schedule.kind="at"',
+      );
+
+      const clearRes = await directCronReq(cronState, "cron.update", {
+        id: legacyJobId,
+        patch: { deleteAfterRun: false },
+      });
+      expect(clearRes.ok).toBe(true);
+      expect((clearRes.payload as { deleteAfterRun?: unknown } | null)?.deleteAfterRun).toBe(false);
+
+      const validReenableRes = await directCronReq(cronState, "cron.update", {
+        id: legacyJobId,
+        patch: { enabled: true },
+      });
+      expect(validReenableRes.ok).toBe(true);
+      expect((validReenableRes.payload as { enabled?: unknown } | null)?.enabled).toBe(true);
+    } finally {
+      await cleanupCronTestRun({ cronState, prevSkipCron });
+    }
+  });
+
   test("routes forced cron runs to the configured session", async () => {
     const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "openclaw-gw-cron-route-",

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -525,6 +525,93 @@ describe("gateway server cron", () => {
     }
   });
 
+  test("rejects delete-after-run recurring cron creation", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-delete-after-recurring-",
+      cronEnabled: false,
+    });
+    const cronState = await createDirectCronState();
+
+    try {
+      for (const schedule of [
+        { kind: "every", everyMs: 60_000 },
+        { kind: "cron", expr: "*/5 * * * *" },
+      ]) {
+        const addRes = await directCronReq(cronState, "cron.add", {
+          name: `invalid ${schedule.kind}`,
+          enabled: true,
+          deleteAfterRun: true,
+          schedule,
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "hello" },
+        });
+        expect(addRes.ok).toBe(false);
+        expect(addRes.error?.message).toContain(
+          'cron deleteAfterRun is only supported for schedule.kind="at"',
+        );
+      }
+
+      const listRes = await directCronReq(cronState, "cron.list", { includeDisabled: true });
+      expect(listRes.ok).toBe(true);
+      expect((listRes.payload as { jobs?: unknown[] } | null)?.jobs).toEqual([]);
+    } finally {
+      await cleanupCronTestRun({ cronState, prevSkipCron });
+    }
+  });
+
+  test("rejects updates that make delete-after-run jobs recurring", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-delete-after-update-",
+      cronEnabled: false,
+    });
+    const cronState = await createDirectCronState();
+
+    try {
+      const oneShotRes = await directCronReq(cronState, "cron.add", {
+        name: "one shot",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(Date.now() + 60_000).toISOString() },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "hello" },
+      });
+      const oneShotId = expectCronJobIdFromResponse(oneShotRes);
+
+      const recurringPatchRes = await directCronReq(cronState, "cron.update", {
+        id: oneShotId,
+        patch: {
+          schedule: { kind: "every", everyMs: 60_000 },
+        },
+      });
+      expect(recurringPatchRes.ok).toBe(false);
+      expect(recurringPatchRes.error?.message).toContain(
+        'cron deleteAfterRun is only supported for schedule.kind="at"',
+      );
+
+      const recurringRes = await directCronReq(cronState, "cron.add", {
+        name: "recurring",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "hello" },
+      });
+      const recurringId = expectCronJobIdFromResponse(recurringRes);
+
+      const deleteAfterRunPatchRes = await directCronReq(cronState, "cron.update", {
+        id: recurringId,
+        patch: { deleteAfterRun: true },
+      });
+      expect(deleteAfterRunPatchRes.ok).toBe(false);
+      expect(deleteAfterRunPatchRes.error?.message).toContain(
+        'cron deleteAfterRun is only supported for schedule.kind="at"',
+      );
+    } finally {
+      await cleanupCronTestRun({ cronState, prevSkipCron });
+    }
+  });
+
   test("routes forced cron runs to the configured session", async () => {
     const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "openclaw-gw-cron-route-",


### PR DESCRIPTION
## What Problem This Solves

`deleteAfterRun` is a one-shot lifecycle flag, but cron accepted jobs that combined it with recurring schedules. That leaves the scheduler with conflicting semantics: a job can be marked for deletion after a run while also being scheduled to run repeatedly.

## Why This Change Was Made

This adds service-level validation so `deleteAfterRun: true` is only accepted for `schedule.kind="at"` on new jobs and on updates that would newly create or re-enable the invalid combination.

The update path is intentionally compatibility-aware for already-persisted legacy jobs: an existing recurring `deleteAfterRun` job can still be renamed, disabled, or cleared with `deleteAfterRun: false`. A disabled legacy-invalid job cannot be re-enabled until the flag is cleared or the schedule is changed to `at`.

## User Impact

Valid recurring jobs are unchanged. One-shot jobs still default to `deleteAfterRun`. Invalid new recurring delete-after-run jobs fail fast with a clear validation error instead of being persisted as scheduler state.

Users who already have an invalid persisted recurring job are not trapped: they can disable it, rename it, or clear `deleteAfterRun`; re-enabling is allowed after the job is valid again.

## Evidence

- `node scripts/run-vitest.mjs src/cron/service.jobs.test.ts` — 71 passed
- `node scripts/run-vitest.mjs src/gateway/server.cron.test.ts` — 42 passed
- `node scripts/run-vitest.mjs src/gateway/server.cron.test.ts -t "delete-after-run"` — 3 passed, 18 skipped
- `node_modules/oxfmt/bin/oxfmt --check src/cron/service/jobs.ts src/cron/service.jobs.test.ts src/gateway/server.cron.test.ts`
- `node_modules/oxlint/bin/oxlint src/cron/service/jobs.ts src/cron/service.jobs.test.ts src/gateway/server.cron.test.ts`
- `git diff --check`

Redacted live Gateway handler proof from a temp state directory against this branch:

```text
gateway add recurring deleteAfterRun: error cron deleteAfterRun is only supported for schedule.kind="at"
gateway rename legacy invalid: ok {"id":"legacy-delete-after-run-recurring","name":"renamed legacy invalid","enabled":true,"deleteAfterRun":true,"scheduleKind":"every"}
gateway disable legacy invalid: ok {"id":"legacy-delete-after-run-recurring","name":"renamed legacy invalid","enabled":false,"deleteAfterRun":true,"scheduleKind":"every"}
gateway reenable before clear: error invalid cron.update params: cron deleteAfterRun is only supported for schedule.kind="at"
gateway clear legacy flag: ok {"id":"legacy-delete-after-run-recurring","name":"renamed legacy invalid","enabled":false,"deleteAfterRun":false,"scheduleKind":"every"}
gateway reenable after clear: ok {"id":"legacy-delete-after-run-recurring","name":"renamed legacy invalid","enabled":true,"deleteAfterRun":false,"scheduleKind":"every"}
```
