### PR TITLE
fix(copilot): preserve compaction metadata

### DIFF
--- a/extensions/copilot/harness.test.ts
+++ b/extensions/copilot/harness.test.ts
@@ -1609,6 +1609,12 @@ describe("createCopilotAgentHarness", () => {
         success: true,
         tokensRemoved: 123,
         messagesRemoved: 4,
+        summaryContent: "compacted summary",
+        contextWindow: {
+          tokenLimit: 1000,
+          currentTokens: 777,
+          messagesLength: 12,
+        },
       }));
       const disconnect = vi.fn(async () => {
         throw new Error("disconnect failed");
@@ -1649,6 +1655,7 @@ describe("createCopilotAgentHarness", () => {
         model: "gpt-4.1",
         sessionKey: "agent:main:main",
         sessionId: "oc-sess-compact-1",
+        currentTokenCount: 900,
         workspaceDir: "/this\u0000is/illegal",
         customInstructions: "Keep decisions.",
       });
@@ -1684,6 +1691,25 @@ describe("createCopilotAgentHarness", () => {
         ok: true,
         compacted: true,
         reason: "copilot-sdk-history-compacted",
+        result: {
+          summary: "compacted summary",
+          firstKeptEntryId: "",
+          tokensBefore: 900,
+          tokensAfter: 777,
+          details: {
+            success: true,
+            tokensRemoved: 123,
+            messagesRemoved: 4,
+            summaryContent: "compacted summary",
+            contextWindow: {
+              tokenLimit: 1000,
+              currentTokens: 777,
+              messagesLength: 12,
+            },
+          },
+          sessionId: "oc-sess-compact-1",
+          sessionFile: "/session.json",
+        },
       });
     });
 

--- a/extensions/copilot/harness.ts
+++ b/extensions/copilot/harness.ts
@@ -62,6 +62,14 @@ interface CopilotHistoryCompactResult {
   tokensRemoved: number;
   messagesRemoved: number;
   summaryContent?: string;
+  contextWindow?: {
+    tokenLimit: number;
+    currentTokens: number;
+    messagesLength: number;
+    systemTokens?: number;
+    conversationTokens?: number;
+    toolDefinitionsTokens?: number;
+  };
 }
 
 interface CopilotHistoryCompactSession {
@@ -872,6 +880,21 @@ export function createCopilotAgentHarness(
         ok: true,
         compacted,
         reason: compacted ? "copilot-sdk-history-compacted" : "already under target",
+        ...(compacted
+          ? {
+              result: {
+                summary: compactResult.summaryContent ?? "",
+                firstKeptEntryId: "",
+                tokensBefore:
+                  params.currentTokenCount ??
+                  (compactResult.contextWindow?.currentTokens ?? 0) + compactResult.tokensRemoved,
+                tokensAfter: compactResult.contextWindow?.currentTokens,
+                details: compactResult,
+                sessionId: params.sessionId,
+                sessionFile: params.sessionFile,
+              },
+            }
+          : {}),
       };
     },
 


### PR DESCRIPTION
## What Problem This Solves

The Copilot harness already bridges compaction into the generic runtime, but successful SDK compactions were dropping the canonical compaction metadata that sibling harnesses expose. That made downstream token/session accounting less complete for Copilot.

## Why This Change Was Made

Preserve the SDK compaction summary and context-window facts in the generic harness result, while keeping the existing no-op and failure shapes unchanged. The implementation is scoped to the Copilot adapter boundary and uses the installed SDK contract directly.

## User Impact

Copilot compaction results now carry summary, token-before/token-after, session, and SDK detail metadata consistently with the generic harness contract. No-op compactions and failed compactions retain their prior behavior.

## Evidence

- Local focused proof: `node scripts/run-vitest.mjs extensions/copilot/harness.test.ts src/agents/command/cli-compaction.test.ts` passed (90 tests).
- Local parity suite: 15 files, 450 tests passed.
- Remote changed validation on Testbox run `28014113900`: passed.
- Remote Copilot extension acceptance: 17 files, 464 tests passed.
- Live Copilot smoke with real `gpt-4.1` and `live_echo`: passed.
- Fresh autoreview: clean, no accepted/actionable findings.