### PR TITLE
fix(install): manage auth-profile env refs via OPENCLAW_SERVICE_MANAGED_ENV_KEYS

### DIFF
--- a/scripts/repro/issue-95895-auth-profile-managed-env-keys.mts
+++ b/scripts/repro/issue-95895-auth-profile-managed-env-keys.mts
@@ -1,0 +1,78 @@
+// Reproduction for #95895: Auth-profile provider API keys (e.g. GEMINI_API_KEY)
+// must be managed via OPENCLAW_SERVICE_MANAGED_ENV_KEYS in generated gateway
+// service files, not written as plaintext literals.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { buildGatewayInstallPlan } from "../../src/commands/daemon-install-helpers.ts";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "../..");
+
+async function main() {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-repro-95895-"));
+  const nodePath = process.execPath;
+  const wrapperPath = path.resolve(repoRoot, "openclaw.mjs");
+
+  try {
+    const plan = await buildGatewayInstallPlan({
+      env: {
+        HOME: tmpHome,
+        GEMINI_API_KEY: "sk-gemini-repro-95895", // pragma: allowlist secret
+        PATH: process.env.PATH,
+      },
+      port: 18789,
+      runtime: "node",
+      nodePath,
+      wrapperPath,
+      devMode: true,
+      platform: process.platform,
+      authStore: {
+        version: 1,
+        profiles: {
+          "google:default": {
+            type: "api_key",
+            provider: "google",
+            keyRef: { source: "env", provider: "default", id: "GEMINI_API_KEY" },
+          },
+        },
+      },
+    });
+
+    const managedKeys = plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS;
+    const geminiInline = plan.environment.GEMINI_API_KEY;
+
+    console.log("=== Reproduction for issue #95895 ===");
+    console.log(`OPENCLAW_SERVICE_MANAGED_ENV_KEYS=${managedKeys ?? "(missing)"}`);
+    console.log(`GEMINI_API_KEY inline=${geminiInline ?? "(not inline - good)"}`);
+
+    const isManaged =
+      typeof managedKeys === "string" &&
+      managedKeys
+        .split(",")
+        .map((k) => k.trim())
+        .includes("GEMINI_API_KEY");
+
+    if (!isManaged) {
+      console.error("FAIL: GEMINI_API_KEY from an auth profile is not managed.");
+      process.exitCode = 1;
+      return;
+    }
+    if (geminiInline !== undefined) {
+      console.error("FAIL: GEMINI_API_KEY is still written as a plaintext literal.");
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log("PASS: Auth-profile GEMINI_API_KEY is managed, not written as plaintext.");
+  } finally {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -993,8 +993,8 @@ describe("buildGatewayInstallPlan", () => {
       },
     });
 
-    expect(plan.environment.OPENAI_API_KEY).toBe("sk-openai-test");
-    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBeUndefined();
+    expect(plan.environment.OPENAI_API_KEY).toBeUndefined();
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("OPENAI_API_KEY");
     expect(mocks.hasAnyAuthProfileStoreSource).not.toHaveBeenCalled();
     expect(mocks.loadAuthProfileStoreForSecretsRuntime).not.toHaveBeenCalled();
   });
@@ -1058,9 +1058,11 @@ describe("buildGatewayInstallPlan", () => {
     expect(plan.environment.GIT_ASKPASS).toBeUndefined();
     expect(plan.environment["BAD KEY"]).toBeUndefined();
     expect(plan.environment.MISSING_TOKEN).toBeUndefined();
-    expect(plan.environment.OPENAI_API_KEY).toBe("sk-openai-test");
-    expect(plan.environment.ANTHROPIC_TOKEN).toBe("ant-test-token");
-    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBeUndefined();
+    expect(plan.environment.OPENAI_API_KEY).toBeUndefined();
+    expect(plan.environment.ANTHROPIC_TOKEN).toBeUndefined();
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe(
+      "ANTHROPIC_TOKEN,OPENAI_API_KEY",
+    );
     expect(warn).toHaveBeenCalledWith(
       'Auth profile env ref "NODE_OPTIONS" blocked by host-env security policy',
       "Auth profile",
@@ -1069,6 +1071,35 @@ describe("buildGatewayInstallPlan", () => {
       'Auth profile env ref "GIT_ASKPASS" blocked by host-env security policy',
       "Auth profile",
     );
+  });
+
+  it("marks auth-profile env refs as managed so they are not written as plaintext literals (#95895)", async () => {
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        OPENCLAW_PORT: "3000",
+      },
+    });
+    mocks.loadAuthProfileStoreForSecretsRuntime.mockReturnValue({
+      version: 1,
+      profiles: {
+        "google:default": {
+          type: "api_key",
+          provider: "google",
+          keyRef: { source: "env", provider: "default", id: "GEMINI_API_KEY" },
+        },
+      },
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: isolatedPlanEnv({
+        GEMINI_API_KEY: "sk-gemini-test", // pragma: allowlist secret
+      }),
+      port: 3000,
+      runtime: "node",
+    });
+
+    expect(plan.environment.GEMINI_API_KEY).toBeUndefined();
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("GEMINI_API_KEY");
   });
 });
 

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -568,9 +568,14 @@ async function buildGatewayInstallEnvironment(params: {
   addServiceEnvPlanEntries(plan, configSecretRefEnvironment, { source: "config-secretref-env" });
   addServiceEnvPlanEntries(plan, execSecretRefPassEnvEnvironment, { source: "exec-passenv" });
   addServiceEnvPlanEntries(plan, authProfileEnvironment, { source: "auth-profile-env" });
-  const managedServiceEnvKeys = formatManagedServiceEnvKeys(durableEnvironment, {
-    omitKeys: Object.keys(params.serviceEnvironment),
-  });
+  // Auth-profile env refs (e.g. GEMINI_API_KEY resolved from an auth profile) are
+  // also service-managed secrets. Include them when computing managed keys so the
+  // generated service file references them via OPENCLAW_SERVICE_MANAGED_ENV_KEYS
+  // instead of writing the plaintext value inline (#95895).
+  const managedServiceEnvKeys = formatManagedServiceEnvKeys(
+    { ...durableEnvironment, ...authProfileEnvironment },
+    { omitKeys: Object.keys(params.serviceEnvironment) },
+  );
   applyManagedServiceEnvRenderPolicy({
     plan,
     managedServiceEnvKeys,


### PR DESCRIPTION
## Summary

Fixes #95895. When a provider API key such as `GEMINI_API_KEY` is configured via an auth profile, `openclaw gateway install` was writing the key as a plaintext literal in the generated systemd/LaunchAgent service file. All other provider secrets were already handled via `OPENCLAW_SERVICE_MANAGED_ENV_KEYS` and resolved at runtime; auth-profile env refs were the missing source.

## Changes

- `src/commands/daemon-install-helpers.ts`: include auth-profile env refs when computing `OPENCLAW_SERVICE_MANAGED_ENV_KEYS`, so they are removed from inline service env values and referenced via the managed-keys list instead.
- `src/commands/daemon-install-helpers.test.ts`: update existing auth-profile assertions and add a GEMINI_API_KEY regression test.
- `scripts/repro/issue-95895-auth-profile-managed-env-keys.mts`: standalone reproduction script that runs `buildGatewayInstallPlan` against a real temp home and verifies the key is managed, not inline.

## Real behavior proof

- **Behavior addressed**: auth-profile `GEMINI_API_KEY` no longer appears as a plaintext literal in the generated gateway service environment; it is listed in `OPENCLAW_SERVICE_MANAGED_ENV_KEYS`.
- **Real environment tested**: Linux, Node 24.13, source tree at current main.
- **Exact steps or command run after this patch**:
  - `pnpm build`
  - `node --import tsx scripts/repro/issue-95895-auth-profile-managed-env-keys.mts`
- **Evidence after fix**:
  ```text
  OPENCLAW_SERVICE_MANAGED_ENV_KEYS=GEMINI_API_KEY
  GEMINI_API_KEY inline=(not inline - good)
  PASS: Auth-profile GEMINI_API_KEY is managed, not written as plaintext.
  ```
- **Observed result after fix**: `plan.environment.GEMINI_API_KEY` is `undefined`; `plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS` contains `GEMINI_API_KEY`.
- **What was not tested**: Actual systemd service file rendering on a host with `systemctl`; the fix is at the install-plan environment level.

## Verification

- `pnpm test src/commands/daemon-install-helpers.test.ts --run` — 45 passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/commands/daemon-install-helpers.ts src/commands/daemon-install-helpers.test.ts` — passed
- `node --import tsx scripts/repro/issue-95895-auth-profile-managed-env-keys.mts` — PASS

AI-assisted: yes.