### PR TITLE
docs: place maturity pages under release reference

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,6 +69,14 @@
       "destination": "/gateway/external-apps"
     },
     {
+      "source": "/reference/maturity-scorecard",
+      "destination": "/maturity/scorecard"
+    },
+    {
+      "source": "/reference/maturity-taxonomy",
+      "destination": "/maturity/taxonomy"
+    },
+    {
       "source": "/mcp",
       "destination": "/cli/mcp"
     },
@@ -1655,15 +1663,6 @@
             ]
           },
           {
-            "tab": "Maturity",
-            "groups": [
-              {
-                "group": "Maturity docs",
-                "pages": ["maturity/scorecard", "maturity/taxonomy"]
-              }
-            ]
-          },
-          {
             "tab": "Reference",
             "groups": [
               {
@@ -1861,6 +1860,8 @@
               {
                 "group": "Release and CI",
                 "pages": [
+                  "maturity/scorecard",
+                  "maturity/taxonomy",
                   "reference/RELEASING",
                   "reference/full-release-validation",
                   "reference/release-performance-sweep",


### PR DESCRIPTION
## What Problem This Solves

The maturity pages should support release-readiness work without adding another top-level documentation area.

## Why This Change Was Made

- Move the maturity scorecard and taxonomy links into Reference > Release and CI.
- Keep the canonical /maturity/scorecard and /maturity/taxonomy URLs stable.
- Add reference-path redirects for future and legacy links.

## User Impact

Maturity docs are discoverable from the existing release documentation area, while direct links continue to work.

## Evidence

- docs.json parses and the navigation/redirect assertions pass.
- node scripts/check-docs-mdx.mjs /private/tmp/openclaw-maturity-reference-nav/docs README.md
- git diff --check

AI-assisted disclosure: this PR was prepared with AI assistance and manually verified.