### PR TITLE
feat(copilot): mirror native plan and subagent events

### DIFF
--- a/extensions/copilot/src/attempt.ts
+++ b/extensions/copilot/src/attempt.ts
@@ -44,6 +44,7 @@ import {
   type SessionLike,
 } from "./event-bridge.js";
 import { createHooksBridge, type CopilotHooksConfig } from "./hooks-bridge.js";
+import { createCopilotNativeSubagentTaskMirror } from "./native-subagent-task-mirror.js";
 import {
   createPermissionBridge,
   rejectAllPolicy,
@@ -228,6 +229,7 @@ function deferBackgroundCompactionCleanup(params: {
   handle: PooledClient;
   pool: CopilotClientPool;
   cleanupToolBridge?: () => void;
+  finalizeNativeSubagents?: () => void;
   sdkSessionId?: string;
   session: SessionLike;
   timeoutMs: number;
@@ -250,6 +252,7 @@ function deferBackgroundCompactionCleanup(params: {
         await cancelBackgroundCompactionBeforeTeardown(params.session);
         params.bridge.settleCompactionWait();
       }
+      params.finalizeNativeSubagents?.();
       params.bridge.detach();
       try {
         await params.session.disconnect();
@@ -410,6 +413,11 @@ export async function runCopilotAttempt(
   let handle: PooledClient | undefined;
   let session: SessionLike | undefined;
   let bridge: ReturnType<typeof attachEventBridge> | undefined;
+  const nativeSubagentTaskMirror = createCopilotNativeSubagentTaskMirror({
+    agentId: sessionAgentId,
+    now,
+    scope: input.agentHarnessTaskRuntimeScope,
+  });
   let activeRunHandleRef: Parameters<typeof clearActiveEmbeddedRun>[1] | undefined;
   let userInputBridgeRef: ReturnType<typeof createCopilotUserInputBridge> | undefined;
   let cleanupToolBridge: (() => void) | undefined;
@@ -748,6 +756,8 @@ export async function runCopilotAttempt(
     }
     bridge = attachEventBridge(session, {
       onAssistantDelta: input.onAssistantDelta,
+      onAgentEvent: input.onAgentEvent,
+      onNativeSubagentEvent: (event) => nativeSubagentTaskMirror?.handleEvent(event),
       onCompactionStart: async () => {
         const sessionFile = readString(input.sessionFile);
         if (!sessionFile) {
@@ -813,6 +823,7 @@ export async function runCopilotAttempt(
       }
       const result = await session.sendAndWait(messageOptions, input.timeoutMs);
       await bridge.awaitDeltaChain();
+      await bridge.awaitAgentEventChain();
       if (!bridge.recordSendResult(result) && !aborted) {
         // SDK sendAndWait returning undefined is treated as a timeout by the
         // capability inventory. Do not call session.abort() here: OpenClaw may
@@ -848,6 +859,7 @@ export async function runCopilotAttempt(
         } catch {
           // delta-flush failure must not mask the timeout state
         }
+        await bridge?.awaitAgentEventChain();
       } else {
         promptError = toError(error);
       }
@@ -878,6 +890,7 @@ export async function runCopilotAttempt(
         awaitSessionIdle: !bridge.hasObservedSessionIdle(),
         bridge,
         cleanupToolBridge,
+        finalizeNativeSubagents: () => nativeSubagentTaskMirror?.finalizeActiveRuns(),
         handle,
         pool: deps.pool,
         sdkSessionId,
@@ -906,6 +919,8 @@ export async function runCopilotAttempt(
       // defines as no background agents in flight. Timeouts retain the bridge
       // until that event so compaction that starts after the timer still completes.
       await bridge?.awaitCompactionChain();
+      await bridge?.awaitAgentEventChain();
+      nativeSubagentTaskMirror?.finalizeActiveRuns();
       cleanupToolBridge?.();
       bridge?.detach();
       params.abortSignal?.removeEventListener("abort", onAbort);

--- a/extensions/copilot/src/event-bridge.test.ts
+++ b/extensions/copilot/src/event-bridge.test.ts
@@ -15,6 +15,11 @@ const REGISTERED_EVENT_TYPES = [
   "assistant.usage",
   "tool.execution_start",
   "tool.execution_complete",
+  "session.plan_changed",
+  "exit_plan_mode.requested",
+  "subagent.started",
+  "subagent.completed",
+  "subagent.failed",
   "session.compaction_start",
   "session.compaction_complete",
   "session.idle",
@@ -453,6 +458,78 @@ describe("attachEventBridge", () => {
         total: 9,
       },
     });
+  });
+
+  it("projects Copilot plan events through the generic plan stream", async () => {
+    const session = createFakeSession();
+    const onAgentEvent = vi.fn().mockResolvedValue(undefined);
+    const bridge = attachEventBridge(session, {
+      getSdkSessionId: () => "sdk-session-id",
+      isAborted: () => false,
+      onAgentEvent,
+    });
+
+    session.emit(
+      "session.plan_changed",
+      makeEvent("session.plan_changed", { operation: "update" }),
+    );
+    session.emit(
+      "exit_plan_mode.requested",
+      makeEvent("exit_plan_mode.requested", {
+        actions: ["approve", "edit"],
+        planContent: "# Plan\n- inspect\n- patch",
+        recommendedAction: "approve",
+        requestId: "request-1",
+        summary: "Plan ready",
+      }),
+    );
+
+    await bridge.awaitAgentEventChain();
+
+    expect(onAgentEvent).toHaveBeenCalledTimes(2);
+    expect(onAgentEvent).toHaveBeenNthCalledWith(1, {
+      stream: "plan",
+      data: {
+        phase: "update",
+        title: "Plan updated",
+        source: "copilot-sdk",
+        operation: "update",
+      },
+    });
+    expect(onAgentEvent).toHaveBeenNthCalledWith(2, {
+      stream: "plan",
+      data: {
+        phase: "update",
+        title: "Plan updated",
+        source: "copilot-sdk",
+        explanation: "Plan ready",
+        steps: ["# Plan", "inspect", "patch"],
+        actions: ["approve", "edit"],
+        requestId: "request-1",
+        recommendedAction: "approve",
+      },
+    });
+  });
+
+  it("forwards native Copilot subagent lifecycle events to the adapter", () => {
+    const session = createFakeSession();
+    const onNativeSubagentEvent = vi.fn();
+    const bridge = attachEventBridge(session, {
+      getSdkSessionId: () => "sdk-session-id",
+      isAborted: () => false,
+      onNativeSubagentEvent,
+    });
+    const event = makeEvent("subagent.started", {
+      agentDescription: "inspect the repository",
+      agentDisplayName: "Researcher",
+      agentName: "researcher",
+      toolCallId: "call-1",
+    });
+
+    session.emit("subagent.started", event);
+
+    expect(onNativeSubagentEvent).toHaveBeenCalledWith(event);
+    bridge.detach();
   });
 
   it("preserves all-zero usage snapshot after an invalid assistant.usage event", () => {

--- a/extensions/copilot/src/event-bridge.ts
+++ b/extensions/copilot/src/event-bridge.ts
@@ -41,6 +41,16 @@ export interface SessionLike {
 
 export interface EventBridgeOptions {
   onAssistantDelta?: (payload: OnAssistantDeltaPayload) => void | Promise<void>;
+  onAgentEvent?: (event: {
+    stream: "item" | "plan";
+    data: Record<string, unknown>;
+  }) => void | Promise<void>;
+  onNativeSubagentEvent?: (
+    event: Extract<
+      SessionEvent,
+      { type: "subagent.started" | "subagent.completed" | "subagent.failed" }
+    >,
+  ) => void;
   onCompactionComplete?: (payload: {
     messagesRemoved?: number;
     success: boolean;
@@ -72,6 +82,7 @@ export interface EventBridgeController {
   awaitSessionIdle(): Promise<void>;
   settleCompactionWait(): void;
   awaitDeltaChain(): Promise<void>;
+  awaitAgentEventChain(): Promise<void>;
   hasObservedCompaction(): boolean;
   hasObservedSessionIdle(): boolean;
   isCompacting(): boolean;
@@ -103,6 +114,7 @@ export function attachEventBridge(
   let observedCompaction = false;
   let deltaQueue = Promise.resolve();
   let deltaChain = Promise.resolve();
+  let agentEventChain = Promise.resolve();
   let compactionChain = Promise.resolve();
   let compactionIdle = Promise.resolve();
   let resolveCompactionIdle: (() => void) | undefined;
@@ -191,6 +203,51 @@ export function attachEventBridge(
     }
   });
 
+  registerListener(session, unsubscribeFns, "session.plan_changed", (event) => {
+    enqueueAgentEvent({
+      stream: "plan",
+      data: {
+        phase: "update",
+        title: "Plan updated",
+        source: "copilot-sdk",
+        operation: event.data.operation,
+        ...(event.agentId ? { agentId: event.agentId } : {}),
+      },
+    });
+  });
+
+  registerListener(session, unsubscribeFns, "exit_plan_mode.requested", (event) => {
+    const steps = splitPlanText(event.data.planContent);
+    enqueueAgentEvent({
+      stream: "plan",
+      data: {
+        phase: "update",
+        title: "Plan updated",
+        source: "copilot-sdk",
+        ...(event.data.summary ? { explanation: event.data.summary } : {}),
+        ...(steps.length > 0 ? { steps } : {}),
+        ...(event.data.actions.length > 0 ? { actions: event.data.actions } : {}),
+        ...(event.data.requestId ? { requestId: event.data.requestId } : {}),
+        ...(event.data.recommendedAction
+          ? { recommendedAction: event.data.recommendedAction }
+          : {}),
+        ...(event.agentId ? { agentId: event.agentId } : {}),
+      },
+    });
+  });
+
+  registerListener(session, unsubscribeFns, "subagent.started", (event) => {
+    forwardNativeSubagentEvent(event);
+  });
+
+  registerListener(session, unsubscribeFns, "subagent.completed", (event) => {
+    forwardNativeSubagentEvent(event);
+  });
+
+  registerListener(session, unsubscribeFns, "subagent.failed", (event) => {
+    forwardNativeSubagentEvent(event);
+  });
+
   registerListener(session, unsubscribeFns, "session.compaction_start", (event) => {
     if (!isRootCompactionEvent(event)) {
       return;
@@ -276,6 +333,9 @@ export function attachEventBridge(
     awaitDeltaChain() {
       return deltaChain;
     },
+    awaitAgentEventChain() {
+      return agentEventChain;
+    },
     hasObservedCompaction() {
       return observedCompaction;
     },
@@ -332,6 +392,31 @@ export function attachEventBridge(
     }
     const queued = compactionChain.then(callback, callback);
     compactionChain = queued.catch(() => undefined);
+  }
+
+  function enqueueAgentEvent(event: {
+    stream: "item" | "plan";
+    data: Record<string, unknown>;
+  }): void {
+    const callback = options.onAgentEvent;
+    if (!callback) {
+      return;
+    }
+    const invoke = () => callback(event);
+    agentEventChain = agentEventChain.then(invoke, invoke).catch(() => undefined);
+  }
+
+  function forwardNativeSubagentEvent(
+    event: Extract<
+      SessionEvent,
+      { type: "subagent.started" | "subagent.completed" | "subagent.failed" }
+    >,
+  ): void {
+    try {
+      options.onNativeSubagentEvent?.(event);
+    } catch {
+      // Native task mirroring must not corrupt the Copilot turn.
+    }
   }
 
   async function awaitStableCompaction(): Promise<void> {
@@ -454,6 +539,13 @@ function isRootCompactionEvent(event: { agentId?: string }): boolean {
 
 function joinReasoning(order: string[], reasoningById: Map<string, string>): string {
   return order.map((reasoningId) => reasoningById.get(reasoningId) ?? "").join("");
+}
+
+function splitPlanText(text: string | undefined): string[] {
+  return (text ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim().replace(/^[-*]\s+/, ""))
+    .filter((line) => line.length > 0);
 }
 
 function readString(value: unknown): string | undefined {

--- a/extensions/copilot/src/native-subagent-task-mirror.test.ts
+++ b/extensions/copilot/src/native-subagent-task-mirror.test.ts
@@ -1,0 +1,156 @@
+import type { SessionEvent } from "@github/copilot-sdk";
+import type {
+  AgentHarnessTaskRecord,
+  AgentHarnessTaskRuntime,
+} from "openclaw/plugin-sdk/agent-harness-task-runtime";
+import { describe, expect, it, vi } from "vitest";
+import {
+  CopilotNativeSubagentTaskMirror,
+  createCopilotNativeSubagentTaskMirror,
+} from "./native-subagent-task-mirror.js";
+
+type NativeSubagentEventType = "subagent.started" | "subagent.completed" | "subagent.failed";
+
+function makeEvent<T extends NativeSubagentEventType>(
+  type: T,
+  data: Extract<SessionEvent, { type: T }>["data"],
+  agentId?: string,
+): Extract<SessionEvent, { type: T }> {
+  return {
+    data,
+    id: `${type}-id`,
+    parentId: null,
+    timestamp: "2024-01-01T00:00:00.000Z",
+    type,
+    ...(agentId ? { agentId } : {}),
+  } as Extract<SessionEvent, { type: T }>;
+}
+
+function createRuntime() {
+  const task = {} as AgentHarnessTaskRecord;
+  return {
+    tryCreateRunningTaskRun: vi.fn(() => task),
+    recordTaskRunProgressByRunId: vi.fn(() => []),
+    finalizeTaskRunByRunId: vi.fn(() => []),
+  } satisfies Pick<
+    AgentHarnessTaskRuntime,
+    "tryCreateRunningTaskRun" | "recordTaskRunProgressByRunId" | "finalizeTaskRunByRunId"
+  >;
+}
+
+describe("CopilotNativeSubagentTaskMirror", () => {
+  it("does not create a mirror without a host-issued task scope", () => {
+    expect(createCopilotNativeSubagentTaskMirror({})).toBeUndefined();
+  });
+
+  it("mirrors start and completion using agentId with toolCallId fallback", () => {
+    const runtime = createRuntime();
+    const mirror = new CopilotNativeSubagentTaskMirror(
+      { agentId: "parent-agent", now: () => 100 },
+      runtime,
+    );
+
+    mirror.handleEvent(
+      makeEvent(
+        "subagent.started",
+        {
+          agentDescription: "inspect the repository",
+          agentDisplayName: "Researcher",
+          agentName: "researcher",
+          toolCallId: "call-1",
+        },
+        "child-1",
+      ),
+    );
+    mirror.handleEvent(
+      makeEvent(
+        "subagent.completed",
+        {
+          agentDisplayName: "Researcher",
+          agentName: "researcher",
+          toolCallId: "call-1",
+          totalToolCalls: 2,
+          totalTokens: 30,
+        },
+        "child-1",
+      ),
+    );
+
+    expect(runtime.tryCreateRunningTaskRun).toHaveBeenCalledWith({
+      sourceId: "call-1",
+      agentId: "parent-agent",
+      runId: "copilot-agent:child-1",
+      label: "Researcher",
+      task: "inspect the repository",
+      notifyPolicy: "silent",
+      deliveryStatus: "not_applicable",
+      preferMetadata: true,
+      startedAt: 100,
+      lastEventAt: 100,
+      progressSummary: "Copilot native subagent started.",
+    });
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith({
+      runId: "copilot-agent:child-1",
+      status: "succeeded",
+      endedAt: 100,
+      lastEventAt: 100,
+      progressSummary: "Copilot native subagent completed.",
+      terminalSummary: "Copilot native subagent completed (2 tool calls, 30 tokens).",
+    });
+  });
+
+  it("uses toolCallId when the SDK omits agentId", () => {
+    const runtime = createRuntime();
+    const mirror = new CopilotNativeSubagentTaskMirror({ now: () => 200 }, runtime);
+
+    mirror.handleEvent(
+      makeEvent("subagent.started", {
+        agentDescription: "",
+        agentDisplayName: "Researcher",
+        agentName: "researcher",
+        toolCallId: "call-2",
+      }),
+    );
+    mirror.handleEvent(
+      makeEvent("subagent.failed", {
+        agentDisplayName: "Researcher",
+        agentName: "researcher",
+        error: "failed",
+        toolCallId: "call-2",
+      }),
+    );
+
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "copilot-agent:call-2",
+        status: "failed",
+        error: "failed",
+      }),
+    );
+  });
+
+  it("finalizes active tasks when the parent attempt tears down", () => {
+    const runtime = createRuntime();
+    const mirror = new CopilotNativeSubagentTaskMirror({ now: () => 300 }, runtime);
+
+    mirror.handleEvent(
+      makeEvent("subagent.started", {
+        agentDescription: "inspect",
+        agentDisplayName: "Researcher",
+        agentName: "researcher",
+        toolCallId: "call-3",
+      }),
+    );
+    mirror.finalizeActiveRuns();
+
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith({
+      runId: "copilot-agent:call-3",
+      status: "cancelled",
+      endedAt: 300,
+      lastEventAt: 300,
+      error: "Copilot native subagent ended with its parent attempt.",
+      progressSummary: "Copilot native subagent cancelled with its parent attempt.",
+      terminalSummary: "Copilot native subagent cancelled.",
+    });
+  });
+});

--- a/extensions/copilot/src/native-subagent-task-mirror.test.ts
+++ b/extensions/copilot/src/native-subagent-task-mirror.test.ts
@@ -129,6 +129,50 @@ describe("CopilotNativeSubagentTaskMirror", () => {
     );
   });
 
+  it("keeps parallel subagents distinct when they share a parent tool call", () => {
+    const runtime = createRuntime();
+    const mirror = new CopilotNativeSubagentTaskMirror({ now: () => 250 }, runtime);
+
+    for (const agentId of ["child-1", "child-2"]) {
+      mirror.handleEvent(
+        makeEvent(
+          "subagent.started",
+          {
+            agentDescription: `inspect ${agentId}`,
+            agentDisplayName: "Researcher",
+            agentName: "researcher",
+            toolCallId: "call-shared",
+          },
+          agentId,
+        ),
+      );
+    }
+    for (const agentId of ["child-1", "child-2"]) {
+      mirror.handleEvent(
+        makeEvent(
+          "subagent.completed",
+          {
+            agentDisplayName: "Researcher",
+            agentName: "researcher",
+            toolCallId: "call-shared",
+          },
+          agentId,
+        ),
+      );
+    }
+
+    expect(runtime.tryCreateRunningTaskRun).toHaveBeenCalledTimes(2);
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(2);
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ runId: "copilot-agent:child-1" }),
+    );
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ runId: "copilot-agent:child-2" }),
+    );
+  });
+
   it("finalizes active tasks when the parent attempt tears down", () => {
     const runtime = createRuntime();
     const mirror = new CopilotNativeSubagentTaskMirror({ now: () => 300 }, runtime);

--- a/extensions/copilot/src/native-subagent-task-mirror.ts
+++ b/extensions/copilot/src/native-subagent-task-mirror.ts
@@ -93,7 +93,11 @@ export class CopilotNativeSubagentTaskMirror {
     runId: string,
     toolCallId: string,
   ): void {
-    if (this.runIdByToolCallId.has(toolCallId)) {
+    const agentId = event.agentId?.trim();
+    const existingRunId = agentId
+      ? this.runIdByAgentId.get(agentId)
+      : this.runIdByToolCallId.get(toolCallId);
+    if (existingRunId) {
       return;
     }
     const eventAt = this.now();
@@ -115,10 +119,10 @@ export class CopilotNativeSubagentTaskMirror {
     if (!taskRecord) {
       return;
     }
-    this.runIdByToolCallId.set(toolCallId, runId);
-    const agentId = event.agentId?.trim();
     if (agentId) {
       this.runIdByAgentId.set(agentId, runId);
+    } else {
+      this.runIdByToolCallId.set(toolCallId, runId);
     }
     this.terminalRunIds.delete(runId);
     this.activeRunIds.add(runId);

--- a/extensions/copilot/src/native-subagent-task-mirror.ts
+++ b/extensions/copilot/src/native-subagent-task-mirror.ts
@@ -1,0 +1,195 @@
+import type { SessionEvent } from "@github/copilot-sdk";
+import {
+  createAgentHarnessTaskRuntime,
+  type AgentHarnessTaskRuntime,
+  type AgentHarnessTaskRuntimeScope,
+} from "openclaw/plugin-sdk/agent-harness-task-runtime";
+
+const COPILOT_NATIVE_SUBAGENT_TASK_KIND = "copilot-native";
+const COPILOT_NATIVE_SUBAGENT_RUN_ID_PREFIX = "copilot-agent:";
+
+type CopilotNativeSubagentEvent = Extract<
+  SessionEvent,
+  { type: "subagent.started" | "subagent.completed" | "subagent.failed" }
+>;
+
+type TaskLifecycleRuntime = Pick<
+  AgentHarnessTaskRuntime,
+  "tryCreateRunningTaskRun" | "recordTaskRunProgressByRunId" | "finalizeTaskRunByRunId"
+>;
+
+export function createCopilotNativeSubagentTaskMirror(params: {
+  agentId?: string;
+  now?: () => number;
+  scope?: AgentHarnessTaskRuntimeScope;
+}): CopilotNativeSubagentTaskMirror | undefined {
+  if (!params.scope) {
+    return undefined;
+  }
+  return new CopilotNativeSubagentTaskMirror(
+    {
+      agentId: params.agentId,
+      now: params.now,
+    },
+    createAgentHarnessTaskRuntime({
+      runtime: "subagent",
+      taskKind: COPILOT_NATIVE_SUBAGENT_TASK_KIND,
+      scope: params.scope,
+      runIdPrefix: COPILOT_NATIVE_SUBAGENT_RUN_ID_PREFIX,
+    }),
+  );
+}
+
+export class CopilotNativeSubagentTaskMirror {
+  private readonly runIdByAgentId = new Map<string, string>();
+  private readonly runIdByToolCallId = new Map<string, string>();
+  private readonly terminalRunIds = new Set<string>();
+  private readonly activeRunIds = new Set<string>();
+  private readonly now: () => number;
+
+  constructor(
+    private readonly params: { agentId?: string; now?: () => number },
+    private readonly runtime: TaskLifecycleRuntime,
+  ) {
+    this.now = params.now ?? Date.now;
+  }
+
+  handleEvent(event: CopilotNativeSubagentEvent): void {
+    const toolCallId = event.data.toolCallId.trim();
+    if (!toolCallId) {
+      return;
+    }
+    const runId = this.resolveRunId(event);
+    if (event.type === "subagent.started") {
+      this.handleStarted(event, runId, toolCallId);
+      return;
+    }
+    if (event.type === "subagent.completed") {
+      this.handleCompleted(event, runId);
+      return;
+    }
+    this.handleFailed(event, runId);
+  }
+
+  finalizeActiveRuns(): void {
+    const eventAt = this.now();
+    for (const runId of this.activeRunIds) {
+      this.terminalRunIds.add(runId);
+      this.runtime.finalizeTaskRunByRunId({
+        runId,
+        status: "cancelled",
+        endedAt: eventAt,
+        lastEventAt: eventAt,
+        error: "Copilot native subagent ended with its parent attempt.",
+        progressSummary: "Copilot native subagent cancelled with its parent attempt.",
+        terminalSummary: "Copilot native subagent cancelled.",
+      });
+    }
+    this.activeRunIds.clear();
+  }
+
+  private handleStarted(
+    event: Extract<CopilotNativeSubagentEvent, { type: "subagent.started" }>,
+    runId: string,
+    toolCallId: string,
+  ): void {
+    if (this.runIdByToolCallId.has(toolCallId)) {
+      return;
+    }
+    const eventAt = this.now();
+    const label = event.data.agentDisplayName.trim() || event.data.agentName.trim();
+    const task = event.data.agentDescription.trim() || `Copilot native subagent ${label}`;
+    const taskRecord = this.runtime.tryCreateRunningTaskRun({
+      sourceId: toolCallId,
+      agentId: this.params.agentId,
+      runId,
+      label: label || "Copilot subagent",
+      task,
+      notifyPolicy: "silent",
+      deliveryStatus: "not_applicable",
+      preferMetadata: true,
+      startedAt: eventAt,
+      lastEventAt: eventAt,
+      progressSummary: "Copilot native subagent started.",
+    });
+    if (!taskRecord) {
+      return;
+    }
+    this.runIdByToolCallId.set(toolCallId, runId);
+    const agentId = event.agentId?.trim();
+    if (agentId) {
+      this.runIdByAgentId.set(agentId, runId);
+    }
+    this.terminalRunIds.delete(runId);
+    this.activeRunIds.add(runId);
+  }
+
+  private handleCompleted(
+    event: Extract<CopilotNativeSubagentEvent, { type: "subagent.completed" }>,
+    runId: string,
+  ): void {
+    if (this.terminalRunIds.has(runId)) {
+      return;
+    }
+    const eventAt = this.now();
+    this.terminalRunIds.add(runId);
+    this.activeRunIds.delete(runId);
+    this.runtime.finalizeTaskRunByRunId({
+      runId,
+      status: "succeeded",
+      endedAt: eventAt,
+      lastEventAt: eventAt,
+      progressSummary: "Copilot native subagent completed.",
+      terminalSummary: buildCompletionSummary(event),
+    });
+  }
+
+  private handleFailed(
+    event: Extract<CopilotNativeSubagentEvent, { type: "subagent.failed" }>,
+    runId: string,
+  ): void {
+    if (this.terminalRunIds.has(runId)) {
+      return;
+    }
+    const eventAt = this.now();
+    this.terminalRunIds.add(runId);
+    this.activeRunIds.delete(runId);
+    this.runtime.finalizeTaskRunByRunId({
+      runId,
+      status: "failed",
+      endedAt: eventAt,
+      lastEventAt: eventAt,
+      error: event.data.error,
+      progressSummary: "Copilot native subagent failed.",
+      terminalSummary: "Copilot native subagent failed.",
+    });
+  }
+
+  private resolveRunId(event: CopilotNativeSubagentEvent): string {
+    const agentId = event.agentId?.trim();
+    if (agentId) {
+      const existing = this.runIdByAgentId.get(agentId);
+      if (existing) {
+        return existing;
+      }
+    }
+    const existing = this.runIdByToolCallId.get(event.data.toolCallId);
+    if (existing) {
+      return existing;
+    }
+    const identity = agentId || event.data.toolCallId.trim();
+    return `${COPILOT_NATIVE_SUBAGENT_RUN_ID_PREFIX}${identity}`;
+  }
+}
+
+function buildCompletionSummary(
+  event: Extract<CopilotNativeSubagentEvent, { type: "subagent.completed" }>,
+): string {
+  const details = [
+    event.data.totalToolCalls !== undefined ? `${event.data.totalToolCalls} tool calls` : undefined,
+    event.data.totalTokens !== undefined ? `${event.data.totalTokens} tokens` : undefined,
+  ].filter((value): value is string => value !== undefined);
+  return details.length > 0
+    ? `Copilot native subagent completed (${details.join(", ")}).`
+    : "Copilot native subagent completed.";
+}

--- a/src/tasks/codex-native-subagent-task.ts
+++ b/src/tasks/codex-native-subagent-task.ts
@@ -1,4 +1,8 @@
 // Runs Codex native subagent tasks and maps their lifecycle into task registry state.
+import {
+  isChildlessNativeSubagentTask,
+  resolveChildlessNativeSubagentTaskDefinition,
+} from "./native-subagent-task.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
 /** Runtime label used for Codex-native subagent task records. */
@@ -9,16 +13,8 @@ export const CODEX_NATIVE_SUBAGENT_STALE_ERROR = "Codex native subagent stopped 
 
 /** Detects native Codex subagent tasks that have no child session to recover from. */
 export function isChildlessCodexNativeSubagentTask(task: TaskRecord): boolean {
-  if (
-    task.runtime !== CODEX_NATIVE_SUBAGENT_RUNTIME ||
-    task.taskKind !== CODEX_NATIVE_SUBAGENT_TASK_KIND
-  ) {
-    return false;
-  }
-  if (task.childSessionKey?.trim()) {
-    return false;
-  }
-  return [task.sourceId, task.runId].some((candidate) =>
-    candidate?.trim().startsWith(CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX),
+  return (
+    isChildlessNativeSubagentTask(task) &&
+    resolveChildlessNativeSubagentTaskDefinition(task)?.taskKind === CODEX_NATIVE_SUBAGENT_TASK_KIND
   );
 }

--- a/src/tasks/native-subagent-task.ts
+++ b/src/tasks/native-subagent-task.ts
@@ -1,0 +1,40 @@
+// Identifies childless native-subagent task rows that are owned by an external
+// harness and therefore cannot be recovered through an OpenClaw child session.
+import type { TaskRecord } from "./task-registry.types.js";
+
+export const COPILOT_NATIVE_SUBAGENT_TASK_KIND = "copilot-native";
+export const COPILOT_NATIVE_SUBAGENT_RUN_ID_PREFIX = "copilot-agent:";
+export const COPILOT_NATIVE_SUBAGENT_STALE_ERROR =
+  "Copilot native subagent stopped reporting progress";
+
+const CHILDLESS_NATIVE_SUBAGENT_DEFINITIONS = [
+  {
+    taskKind: "codex-native",
+    runIdPrefix: "codex-thread:",
+  },
+  {
+    taskKind: COPILOT_NATIVE_SUBAGENT_TASK_KIND,
+    runIdPrefix: COPILOT_NATIVE_SUBAGENT_RUN_ID_PREFIX,
+  },
+] as const;
+
+export type NativeSubagentTaskDefinition = (typeof CHILDLESS_NATIVE_SUBAGENT_DEFINITIONS)[number];
+
+export function resolveChildlessNativeSubagentTaskDefinition(
+  task: TaskRecord,
+): NativeSubagentTaskDefinition | undefined {
+  if (task.runtime !== "subagent" || task.childSessionKey?.trim()) {
+    return undefined;
+  }
+  return CHILDLESS_NATIVE_SUBAGENT_DEFINITIONS.find(
+    (definition) =>
+      task.taskKind === definition.taskKind &&
+      [task.sourceId, task.runId].some((candidate) =>
+        candidate?.trim().startsWith(definition.runIdPrefix),
+      ),
+  );
+}
+
+export function isChildlessNativeSubagentTask(task: TaskRecord): boolean {
+  return resolveChildlessNativeSubagentTaskDefinition(task) !== undefined;
+}

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -35,14 +35,15 @@ import {
   deriveSessionChatTypeFromKey,
   type SessionKeyChatType,
 } from "../sessions/session-chat-type-shared.js";
-import {
-  CODEX_NATIVE_SUBAGENT_STALE_ERROR,
-  isChildlessCodexNativeSubagentTask,
-} from "./codex-native-subagent-task.js";
+import { CODEX_NATIVE_SUBAGENT_STALE_ERROR } from "./codex-native-subagent-task.js";
 import {
   getDetachedTaskLifecycleRuntime,
   tryRecoverTaskBeforeMarkLost,
 } from "./detached-task-runtime.js";
+import {
+  isChildlessNativeSubagentTask,
+  resolveChildlessNativeSubagentTaskDefinition,
+} from "./native-subagent-task.js";
 import {
   deleteTaskRecordById,
   ensureTaskRegistryReady,
@@ -71,7 +72,7 @@ import {
 
 const log = createSubsystemLogger("tasks/task-registry-maintenance");
 const TASK_RECONCILE_GRACE_MS = 5 * 60_000;
-const CHILDLESS_CODEX_NATIVE_RECONCILE_GRACE_MS = 30 * 60_000;
+const CHILDLESS_NATIVE_SUBAGENT_RECONCILE_GRACE_MS = 30 * 60_000;
 const TASK_STALE_RUNNING_MS = 30 * 60_000;
 const TASK_SWEEP_INTERVAL_MS = 60_000;
 
@@ -326,8 +327,8 @@ function isTerminalTask(task: TaskRecord): boolean {
 
 function hasLostGraceExpired(task: TaskRecord, now: number): boolean {
   const referenceAt = task.lastEventAt ?? task.startedAt ?? task.createdAt;
-  const graceMs = isChildlessCodexNativeSubagentTask(task)
-    ? CHILDLESS_CODEX_NATIVE_RECONCILE_GRACE_MS
+  const graceMs = isChildlessNativeSubagentTask(task)
+    ? CHILDLESS_NATIVE_SUBAGENT_RECONCILE_GRACE_MS
     : TASK_RECONCILE_GRACE_MS;
   return now - referenceAt >= graceMs;
 }
@@ -498,7 +499,7 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
 
   const childSessionKey = task.childSessionKey?.trim();
   if (!childSessionKey) {
-    return !isChildlessCodexNativeSubagentTask(task);
+    return !isChildlessNativeSubagentTask(task);
   }
   if (task.runtime === "acp") {
     // The live-turn map is process-local; only the gateway owns it. A standalone CLI
@@ -527,8 +528,11 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
 }
 
 function resolveTaskLostError(task: TaskRecord, context?: BackingSessionLookupContext): string {
-  if (isChildlessCodexNativeSubagentTask(task)) {
-    return CODEX_NATIVE_SUBAGENT_STALE_ERROR;
+  const nativeDefinition = resolveChildlessNativeSubagentTaskDefinition(task);
+  if (nativeDefinition) {
+    return nativeDefinition.taskKind === "codex-native"
+      ? CODEX_NATIVE_SUBAGENT_STALE_ERROR
+      : "Native subagent stopped reporting progress";
   }
   if (task.runtime === "subagent") {
     const entry = findTaskSessionEntry(task, context);

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -2421,6 +2421,70 @@ describe("task-registry", () => {
     });
   });
 
+  it("keeps fresh childless copilot-native subagent tasks live", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryForTests();
+      const now = Date.now();
+
+      const task = createTaskRecord({
+        runtime: "subagent",
+        taskKind: "copilot-native",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        sourceId: "copilot-agent:child-agent",
+        runId: "copilot-agent:child-agent",
+        task: "Copilot native child",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        lastEventAt: now - 10 * 60_000,
+      });
+
+      expect(await runTaskRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        recovered: 0,
+        cleanupStamped: 0,
+        pruned: 0,
+      });
+      expectRecordFields(requireTaskById(task.taskId), {
+        status: "running",
+        lastEventAt: now - 10 * 60_000,
+      });
+    });
+  });
+
+  it("marks stale childless copilot-native subagent tasks lost", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryForTests();
+      const now = Date.now();
+
+      const task = createTaskRecord({
+        runtime: "subagent",
+        taskKind: "copilot-native",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        sourceId: "copilot-agent:child-agent",
+        runId: "copilot-agent:child-agent",
+        task: "Copilot native child",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        lastEventAt: now - 31 * 60_000,
+      });
+
+      expect(await runTaskRegistryMaintenance()).toEqual({
+        reconciled: 1,
+        recovered: 0,
+        cleanupStamped: 0,
+        pruned: 0,
+      });
+      expectRecordFields(requireTaskById(task.taskId), {
+        status: "lost",
+        error: "Native subagent stopped reporting progress",
+      });
+    });
+  });
+
   it("does not mark unrelated childless subagent tasks lost", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryForTests();
@@ -3768,6 +3832,43 @@ describe("task-registry", () => {
         sourceId: "codex-thread:child-thread",
         runId: "codex-thread:child-thread",
         task: "Codex native child",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+      });
+
+      const result = await cancelTaskById({
+        cfg: {} as never,
+        taskId: task.taskId,
+      });
+
+      expectRecordFields(result, {
+        found: true,
+        cancelled: true,
+      });
+      expectRecordFields(result.task, {
+        taskId: task.taskId,
+        status: "cancelled",
+        endedAt: expect.any(Number),
+        lastEventAt: expect.any(Number),
+        cleanupAfter: expect.any(Number),
+        error: "Cancelled by operator.",
+      });
+      expect(hoisted.killSubagentRunAdminMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("cancels childless copilot-native tasks without routing through OpenClaw subagent sessions", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryForTests();
+      const task = createTaskRecord({
+        runtime: "subagent",
+        taskKind: "copilot-native",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        sourceId: "copilot-agent:child-agent",
+        runId: "copilot-agent:child-agent",
+        task: "Copilot native child",
         status: "running",
         deliveryStatus: "not_applicable",
         notifyPolicy: "silent",

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -17,8 +17,8 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import { isDeliverableMessageChannel } from "../utils/message-channel.js";
-import { isChildlessCodexNativeSubagentTask } from "./codex-native-subagent-task.js";
 import { cancelActiveCronTaskRun } from "./cron-task-cancel.js";
+import { isChildlessNativeSubagentTask } from "./native-subagent-task.js";
 import {
   formatTaskBlockedFollowupMessage,
   formatTaskStateChangeMessage,
@@ -2092,7 +2092,7 @@ export async function cancelTaskById(params: {
           };
         }
       } else if (!childSessionKey) {
-        if (!isChildlessCodexNativeSubagentTask(task)) {
+        if (!isChildlessNativeSubagentTask(task)) {
           return {
             found: true,
             cancelled: false,


### PR DESCRIPTION
## What Problem This Solves

Copilot sessions expose native plan and subagent lifecycle events, but the OpenClaw adapter currently drops them. That leaves Copilot behind Codex for plan visibility and native child-task tracking.

## Why This Change Was Made

Route Copilot plan notifications through the existing generic agent-event stream and mirror native subagent lifecycle into the existing scoped task runtime. Keep the harness contract unchanged and keep child completion announcements out until the SDK provides a reliable child result payload. BYOK mapping is intentionally a follow-up.

## User Impact

Copilot plan updates become visible through the same `stream: "plan"` contract used by Codex, and native Copilot subagents appear in task state with correct terminal cleanup on completion, failure, abort, or teardown.

## Evidence

- `node scripts/run-vitest.mjs extensions/copilot/src/event-bridge.test.ts extensions/copilot/src/native-subagent-task-mirror.test.ts extensions/copilot/src/attempt.test.ts` — 148 passed on rebased commit `eb1b0d8df4`.
- `node_modules/.bin/oxfmt --check --threads=1 ...` and `git diff --check` — passed.
- Autoreview on `origin/main` — clean, no accepted/actionable findings.
- GitHub `Real behavior proof` passed on the equivalent pre-rebase patch tree; the rebase only incorporated the latest `origin/main` commits and did not alter this patch.
