### PR TITLE
fix(irc): prevent ghost nick loops on collision recovery

### DIFF
--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -66,16 +66,18 @@ function toError(err: unknown): Error {
   return new Error(typeof err === "string" ? err : JSON.stringify(err));
 }
 
-function buildFallbackNick(nick: string): string {
+function buildFallbackNick(nick: string, attempt: number = 0): string {
   const normalized = nick.replace(/\s+/g, "");
   const safe = normalized.replace(/[^A-Za-z0-9_\-[\]\\`^{}|]/g, "");
   const base = safe || "openclaw";
-  const suffix = "_";
+  // Use numeric suffix for uniqueness when attempt > 0, otherwise just "_"
+  const suffix = attempt > 0 ? `${attempt}` : "_";
   const maxNickLen = 30;
-  if (base.length >= maxNickLen) {
-    return `${base.slice(0, maxNickLen - suffix.length)}${suffix}`;
+  const result = base + suffix;
+  if (result.length > maxNickLen) {
+    return base.slice(0, maxNickLen - suffix.length) + suffix;
   }
-  return `${base}${suffix}`;
+  return result;
 }
 
 function normalizeIrcNick(value: string): string {
@@ -119,7 +121,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
   let ready = false;
   let closed = false;
   let nickServRecoverAttempted = false;
-  let fallbackNickAttempted = false;
+  let fallbackNickAttemptCount = 0;
   let removeAbortListener: (() => void) | null = null;
 
   const socket = options.tls
@@ -179,9 +181,9 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
       }
     }
 
-    if (!fallbackNickAttempted) {
-      fallbackNickAttempted = true;
-      const fallbackNick = buildFallbackNick(desiredNick);
+    if (fallbackNickAttemptCount < 10) {
+      fallbackNickAttemptCount++;
+      const fallbackNick = buildFallbackNick(desiredNick, fallbackNickAttemptCount);
       if (normalizeIrcNick(fallbackNick) !== normalizeIrcNick(currentNick)) {
         try {
           sendRaw(`NICK ${fallbackNick}`);


### PR DESCRIPTION
## Summary

Fixes #96064

When multiple IRC accounts are configured, the nick collision recovery logic creates "ghost" nicks with underscore suffixes that connect and immediately disconnect in a loop.

## Root Cause

The `buildFallbackNick` function always returns `nick + "_"` with no uniqueness. Combined with a per-connection `fallbackNickAttempted` flag that resets on each reconnect, this causes the same ghost nick to be used repeatedly.

## Changes

1. **`buildFallbackNick` now accepts an `attempt` parameter** — allows generating unique fallback nicks (`Nick1`, `Nick2`, etc.) instead of always `Nick_`

2. **Track fallback attempt count instead of boolean flag** — allows attempting multiple unique fallbacks instead of just one

3. **Limit attempts to 10 per connection** — prevents infinite loops if all fallbacks are taken

## Before

```javascript
function buildFallbackNick(nick: string): string {
  const suffix = "_";  // Always the same
  return `${base}${suffix}`;
}

// Only one attempt per connection
if (!fallbackNickAttempted) {
  fallbackNickAttempted = true;
  const fallbackNick = buildFallbackNick(desiredNick);  // Always "Nick_"
  ...
}
```

## After

```javascript
function buildFallbackNick(nick: string, attempt: number = 0): string {
  const suffix = attempt > 0 ? `${attempt}` : "_";  // Unique suffix
  ...
}

// Up to 10 unique attempts
if (fallbackNickAttemptCount < 10) {
  fallbackNickAttemptCount++;
  const fallbackNick = buildFallbackNick(desiredNick, fallbackNickAttemptCount);  // "Nick1", "Nick2", etc.
  ...
}
```

## Testing

- NoPII leaked (generic bug report, no mesh-specific details)
- Tested locally with a simple node script verifying `buildFallbackNick("Test", 0)` → `"Test_"` and `buildFallbackNick("Test", 1)` → `"Test1"`

## Notes

This is a minimal fix. A more comprehensive solution might involve:
- Caching successful fallback nicks across reconnects
- Better GHOST command handling (wait for response before proceeding)
- Server-side detection of "my own ghost" vs "someone else's nick"