### PR TITLE
test(scripts): include workflow guard helper

### DIFF
--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -882,6 +882,7 @@ describe("test-projects args", () => {
           "test/scripts/android-pin-version.test.ts",
           "test/scripts/bench-cli-startup.test.ts",
           "test/scripts/check-package-dist-imports.test.ts",
+          "test/scripts/check-workflows.test.ts",
           "test/scripts/ci-hydrate-testbox-env.test.ts",
           "test/scripts/clawhub-fixture-server.test.ts",
           "test/scripts/codex-install-assertions.test.ts",


### PR DESCRIPTION
## What Problem This Solves

The tooling test-projects expectation omitted `test/scripts/check-workflows.test.ts`, even though that test uses the shared temporary-directory helper and is routed through the tooling lane. The omission caused the exact-head CI shard to fail before unrelated focused fixes could land.

## Why This Change Was Made

Add the missing test path to the existing sorted expected list. This keeps the test-projects routing assertion aligned with the current repository contents without changing runtime behavior.

## User Impact

No production behavior changes. CI correctly recognizes the workflow-check test as part of the tooling lane.

## Evidence

- Focused proof: `node scripts/run-vitest.mjs src/scripts/test-projects.test.ts --config test/vitest/vitest.tooling.config.ts --maxWorkers=1 --no-file-parallelism` (83/83 passed)
- `git diff --check` passed
- Autoreview: clean, patch correct (0.93)
