### PR TITLE
feat(openshell): add non-secret env config for sandbox creation

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -3510,8 +3510,10 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Examples
   - H3: Minimal remote setup
   - H3: Mirror mode with GPU
+  - H3: Environment variables
   - H3: Per-agent OpenShell with custom gateway
   - H2: Lifecycle management
+  - H3: When to recreate
   - H2: Security hardening
   - H2: Current limitations
   - H2: How it works

--- a/docs/gateway/openshell.md
+++ b/docs/gateway/openshell.md
@@ -116,20 +116,21 @@ Editing files on the host outside OpenClaw after the initial seed is invisible t
 
 All OpenShell config lives under `plugins.entries.openshell.config`:
 
-| Key                       | Type                     | Default       | Description                                                                            |
-| ------------------------- | ------------------------ | ------------- | -------------------------------------------------------------------------------------- |
-| `mode`                    | `"mirror"` or `"remote"` | `"mirror"`    | Workspace sync mode                                                                    |
-| `command`                 | `string`                 | `"openshell"` | Path or name of the `openshell` CLI                                                    |
-| `from`                    | `string`                 | `"openclaw"`  | Sandbox source for first-time create                                                   |
-| `gateway`                 | `string`                 | unset         | OpenShell gateway name (top-level `--gateway`)                                         |
-| `gatewayEndpoint`         | `string`                 | unset         | OpenShell gateway endpoint (top-level `--gateway-endpoint`)                            |
-| `policy`                  | `string`                 | unset         | OpenShell policy ID for sandbox creation                                               |
-| `providers`               | `string[]`               | `[]`          | Provider names attached at sandbox creation (deduped, one `--provider` flag per entry) |
-| `gpu`                     | `boolean`                | `false`       | Request GPU resources (`--gpu`)                                                        |
-| `autoProviders`           | `boolean`                | `true`        | Pass `--auto-providers` (or `--no-auto-providers` when false) during create            |
-| `remoteWorkspaceDir`      | `string`                 | `"/sandbox"`  | Primary writable workspace inside the sandbox                                          |
-| `remoteAgentWorkspaceDir` | `string`                 | `"/agent"`    | Agent workspace mount path (read-only when workspace access is not `rw`)               |
-| `timeoutSeconds`          | `number`                 | `120`         | Timeout for `openshell` CLI operations                                                 |
+| Key                       | Type                     | Default       | Description                                                                                                                                                                                                                 |
+| ------------------------- | ------------------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mode`                    | `"mirror"` or `"remote"` | `"mirror"`    | Workspace sync mode                                                                                                                                                                                                         |
+| `command`                 | `string`                 | `"openshell"` | Path or name of the `openshell` CLI                                                                                                                                                                                         |
+| `from`                    | `string`                 | `"openclaw"`  | Sandbox source for first-time create                                                                                                                                                                                        |
+| `gateway`                 | `string`                 | unset         | OpenShell gateway name (top-level `--gateway`)                                                                                                                                                                              |
+| `gatewayEndpoint`         | `string`                 | unset         | OpenShell gateway endpoint (top-level `--gateway-endpoint`)                                                                                                                                                                 |
+| `policy`                  | `string`                 | unset         | OpenShell policy ID for sandbox creation                                                                                                                                                                                    |
+| `providers`               | `string[]`               | `[]`          | Provider names attached at sandbox creation (deduped, one `--provider` flag per entry)                                                                                                                                      |
+| `gpu`                     | `boolean`                | `false`       | Request GPU resources (`--gpu`)                                                                                                                                                                                             |
+| `autoProviders`           | `boolean`                | `true`        | Pass `--auto-providers` (or `--no-auto-providers` when false) during create                                                                                                                                                 |
+| `remoteWorkspaceDir`      | `string`                 | `"/sandbox"`  | Primary writable workspace inside the sandbox                                                                                                                                                                               |
+| `remoteAgentWorkspaceDir` | `string`                 | `"/agent"`    | Agent workspace mount path (read-only when workspace access is not `rw`)                                                                                                                                                    |
+| `timeoutSeconds`          | `number`                 | `120`         | Timeout for `openshell` CLI operations                                                                                                                                                                                      |
+| `env`                     | `object`                 | `{}`          | Non-secret env vars (`KEY: VALUE`) passed when creating the sandbox. Keys must be valid shell identifiers and must not use the reserved `OPENSHELL_` prefix. Changing env requires [sandbox recreation](#when-to-recreate). |
 
 `remoteWorkspaceDir` and `remoteAgentWorkspaceDir` must be absolute paths and
 stay under the managed roots `/sandbox` or `/agent`; other absolute paths are
@@ -198,6 +199,31 @@ Sandbox-level settings (`mode`, `scope`, `workspaceAccess`) live under
 }
 ```
 
+### Environment variables
+
+Pass non-sensitive runtime settings such as API base URLs or model names to
+the sandbox without hard-coding them into the sandbox image:
+
+```json5
+{
+  plugins: {
+    entries: {
+      openshell: {
+        enabled: true,
+        config: {
+          env: {
+            MODEL_BASE_URL: "https://api.example.com/v1",
+            MODEL_NAME: "gpt-oss-20b",
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+> Changing env values requires sandbox recreation (`openclaw sandbox recreate --all`).
+
 ### Per-agent OpenShell with custom gateway
 
 ```json5
@@ -253,12 +279,15 @@ remote workspace for that scope, and the next use seeds a fresh one from
 local. For `mirror` mode, recreate mainly resets the remote execution
 environment since local stays canonical.
 
+### When to recreate
+
 Recreate after changing any of:
 
 - `agents.defaults.sandbox.backend`
 - `plugins.entries.openshell.config.from`
 - `plugins.entries.openshell.config.mode`
 - `plugins.entries.openshell.config.policy`
+- `plugins.entries.openshell.config.env`
 
 ## Security hardening
 
@@ -280,8 +309,8 @@ cannot redirect file access outside the mirrored tree.
 1. OpenClaw runs `sandbox get` for the sandbox name (with any configured
    `--gateway`/`--gateway-endpoint`); if that fails it creates one with
    `sandbox create`, passing `--name`, `--from`, `--policy` when set, `--gpu`
-   when enabled, `--auto-providers`/`--no-auto-providers`, and one
-   `--provider` flag per configured provider.
+   when enabled, `--auto-providers`/`--no-auto-providers`, and one `--env KEY=VALUE` per configured entry from the `env` map,
+   plus one `--provider` flag per configured provider.
 2. OpenClaw runs `sandbox ssh-config` for the sandbox name to fetch SSH
    connection details.
 3. Core writes the SSH config to a temp file and opens an SSH session through

--- a/extensions/openshell/openclaw.plugin.json
+++ b/extensions/openshell/openclaw.plugin.json
@@ -58,6 +58,16 @@
         "type": "number",
         "minimum": 1,
         "maximum": 2147000
+      },
+      "env": {
+        "type": "object",
+        "propertyNames": {
+          "pattern": "^(?!OPENSHELL_)[A-Za-z_][A-Za-z0-9_]*$",
+          "minLength": 1
+        },
+        "additionalProperties": {
+          "type": "string"
+        }
       }
     }
   },
@@ -113,6 +123,11 @@
     "timeoutSeconds": {
       "label": "Command Timeout Seconds",
       "help": "Timeout for openshell CLI operations such as create/upload/download.",
+      "advanced": true
+    },
+    "env": {
+      "label": "Environment Variables",
+      "help": "Non-secret env vars (KEY=VALUE) passed to the sandbox on creation. Use for API base URLs, model names, regions, and other non-sensitive runtime settings.",
       "advanced": true
     }
   }

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -729,6 +729,10 @@ class OpenShellSandboxBackendImpl {
         ? ["--auto-providers"]
         : ["--no-auto-providers"]),
       ...this.params.execContext.config.providers.flatMap((provider) => ["--provider", provider]),
+      ...Object.entries(this.params.execContext.config.env).flatMap(([key, value]) => [
+        "--env",
+        `${key}=${value}`,
+      ]),
       "--",
       "true",
     ];

--- a/extensions/openshell/src/config.test.ts
+++ b/extensions/openshell/src/config.test.ts
@@ -18,6 +18,7 @@ describe("openshell plugin config", () => {
       remoteWorkspaceDir: "/sandbox",
       remoteAgentWorkspaceDir: "/agent",
       timeoutMs: 120_000,
+      env: {},
     });
   });
 
@@ -60,6 +61,7 @@ describe("openshell plugin config", () => {
       remoteWorkspaceDir: "/sandbox/project",
       remoteAgentWorkspaceDir: "/agent/session",
       timeoutMs: 120_000,
+      env: {},
     });
   });
 
@@ -79,11 +81,109 @@ describe("openshell plugin config", () => {
     ).toThrow("timeoutSeconds must be a number <= 2147000");
   });
 
+  it("accepts env vars", () => {
+    expect(
+      resolveOpenShellPluginConfig({
+        env: { FOO: "bar", BAZ: "qux" },
+      }).env,
+    ).toEqual({ FOO: "bar", BAZ: "qux" });
+  });
+
+  it("defaults env to empty object", () => {
+    expect(resolveOpenShellPluginConfig({}).env).toEqual({});
+  });
+
+  it("rejects env keys with leading whitespace", () => {
+    expect(() =>
+      resolveOpenShellPluginConfig({
+        env: { " FOO": "bar" },
+      }),
+    ).toThrow("has surrounding whitespace");
+  });
+
+  it("rejects env keys with trailing whitespace", () => {
+    expect(() =>
+      resolveOpenShellPluginConfig({
+        env: { "FOO ": "bar" },
+      }),
+    ).toThrow("has surrounding whitespace");
+  });
+
+  it("rejects env keys with OPENSHELL_ prefix", () => {
+    expect(() =>
+      resolveOpenShellPluginConfig({
+        env: { OPENSHELL_API_KEY: "secret" },
+      }),
+    ).toThrow("reserved OPENSHELL_ prefix");
+  });
+
+  it("rejects env keys that are not valid env var names", () => {
+    expect(() =>
+      resolveOpenShellPluginConfig({
+        env: { "123invalid": "value" },
+      }),
+    ).toThrow("not a valid environment variable name");
+  });
+
+  it("rejects env keys with special characters", () => {
+    expect(() =>
+      resolveOpenShellPluginConfig({
+        env: { "FOO-BAR": "value" },
+      }),
+    ).toThrow("not a valid environment variable name");
+  });
+
+  it("validates env as an object of string values through the manifest json schema", () => {
+    const configSchema = createOpenShellPluginConfigSchema().jsonSchema;
+    const properties = (configSchema as Record<string, unknown>).properties as
+      | Record<string, unknown>
+      | undefined;
+    const envProp = properties?.env as Record<string, unknown> | undefined;
+    expect(envProp?.type).toBe("object");
+    expect((envProp?.additionalProperties as Record<string, unknown>)?.type).toBe("string");
+
+    // Manifest validates value types; runtime .superRefine handles key-level rules
+    // (no leading/trailing whitespace, no OPENSHELL_ prefix, valid shell identifiers).
+  });
+
+  it("catches invalid env keys through the manifest propertyNames schema", () => {
+    const manifest = JSON.parse(
+      fsSync.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+    ) as { configSchema?: { properties?: Record<string, unknown> } };
+    const envSchema = manifest.configSchema?.properties?.env as Record<string, unknown> | undefined;
+    expect(envSchema?.propertyNames).toBeDefined();
+
+    // Validate that the manifest rejects keys via propertyNames pattern.
+    // The pattern rejects empty strings, OPENSHELL_ prefix, and non-identifier chars.
+    const pattern = new RegExp((envSchema?.propertyNames as { pattern?: string })?.pattern ?? "");
+    expect(pattern.test("")).toBe(false);
+    expect(pattern.test("OPENSHELL_KEY")).toBe(false);
+    expect(pattern.test("FOO-BAR")).toBe(false);
+    expect(pattern.test("123invalid")).toBe(false);
+    expect(pattern.test("VALID_KEY")).toBe(true);
+    expect(pattern.test("MODEL_NAME")).toBe(true);
+  });
+
   it("keeps the runtime json schema in sync with the manifest config schema", () => {
     const manifest = JSON.parse(
       fsSync.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
     ) as { configSchema?: unknown };
 
-    expect(createOpenShellPluginConfigSchema().jsonSchema).toEqual(manifest.configSchema);
+    // normalizeJsonSchema strips propertyNames, so strip it from the
+    // manifest copy before comparing — the gap is intentional.
+    const exported = structuredClone(createOpenShellPluginConfigSchema().jsonSchema) as Record<
+      string,
+      unknown
+    >;
+    const manifestCopy = structuredClone(manifest.configSchema) as Record<string, unknown>;
+
+    const envProp = (manifestCopy.properties as Record<string, unknown> | undefined)?.env as
+      | Record<string, unknown>
+      | undefined;
+    if (envProp) {
+      delete envProp.propertyNames;
+    }
+
+    expect(exported).toEqual(manifestCopy);
   });
 });

--- a/extensions/openshell/src/config.ts
+++ b/extensions/openshell/src/config.ts
@@ -21,6 +21,7 @@ type OpenShellPluginConfig = {
   remoteWorkspaceDir?: string;
   remoteAgentWorkspaceDir?: string;
   timeoutSeconds?: number;
+  env?: Record<string, string>;
 };
 
 export type ResolvedOpenShellPluginConfig = {
@@ -36,6 +37,7 @@ export type ResolvedOpenShellPluginConfig = {
   remoteWorkspaceDir: string;
   remoteAgentWorkspaceDir: string;
   timeoutMs: number;
+  env: Record<string, string>;
 };
 
 const DEFAULT_COMMAND = "openshell";
@@ -100,6 +102,50 @@ const OpenShellPluginConfigSchema = z.strictObject({
       error: `timeoutSeconds must be a number <= ${MAX_TIMER_TIMEOUT_SECONDS}`,
     })
     .optional(),
+  env: z
+    .record(z.string(), z.string(), {
+      error: "env must be an object with string keys and values",
+    })
+    .optional()
+    .superRefine((env, ctx) => {
+      if (!env) {
+        return;
+      }
+      for (const key of Object.keys(env)) {
+        if (key !== key.trim()) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `env key "${key}" has surrounding whitespace`,
+            path: ["env", key],
+          });
+          return;
+        }
+        if (!key) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "env keys must not be empty",
+            path: ["env"],
+          });
+          return;
+        }
+        if (key.startsWith("OPENSHELL_")) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `env key "${key}" uses reserved OPENSHELL_ prefix`,
+            path: ["env", key],
+          });
+          return;
+        }
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `env key "${key}" is not a valid environment variable name`,
+            path: ["env", key],
+          });
+          return;
+        }
+      }
+    }),
 });
 
 function isManagedOpenShellRemotePath(value: string): boolean {
@@ -163,6 +209,7 @@ export function resolveOpenShellPluginConfig(value: unknown): ResolvedOpenShellP
       remoteWorkspaceDir: DEFAULT_REMOTE_WORKSPACE_DIR,
       remoteAgentWorkspaceDir: DEFAULT_REMOTE_AGENT_WORKSPACE_DIR,
       timeoutMs: DEFAULT_TIMEOUT_MS,
+      env: {},
     };
   }
 
@@ -197,5 +244,6 @@ export function resolveOpenShellPluginConfig(value: unknown): ResolvedOpenShellP
       typeof cfg.timeoutSeconds === "number"
         ? Math.floor(cfg.timeoutSeconds * 1000)
         : DEFAULT_TIMEOUT_MS,
+    env: cfg.env ?? {},
   };
 }


### PR DESCRIPTION
## What Problem This Solves

OpenShell sandboxes often need non-sensitive environment variables (API base URLs, model names, regions) at creation time. The OpenShell CLI supports `--env KEY=VALUE` since v0.0.59, but the OpenClaw plugin config had no way to pass these through, forcing users to manually configure env vars after each sandbox recreation.

close #96056

## Why This Change Was Made

Added an optional `env` map to the OpenShell plugin config. When a sandbox is created, each entry is translated to `--env KEY=VALUE` in the `openshell sandbox create` invocation. Empty by default (`{}`), so existing configs are unaffected.

Env key validation is split across two layers:

- **Runtime** (`config.ts` Zod `.superRefine`): rejects empty keys, surrounding whitespace, keys with `OPENSHELL_` prefix, and keys that aren't valid shell identifiers (`^[A-Za-z_][A-Za-z0-9_]*$`)
- **Manifest** (`openclaw.plugin.json` `propertyNames`): mirrors the same pattern so the Control UI config form rejects invalid keys before save. `normalizeJsonSchema` intentionally strips `propertyNames` during export, so the manifest → runtime schema comparison accounts for this known gap.

## User Impact

Users can configure non-secret env vars in `openclaw.json`:

```json5
{
  plugins: {
    entries: {
      openshell: {
        enabled: true,
        config: {
          env: {
            MODEL_BASE_URL: "https://api.example.com/v1",
            MODEL_NAME: "gpt-oss-20b",
          },
        },
      },
    },
  },
}
```

Changing env requires sandbox recreation (`openclaw sandbox recreate --all`).

## Evidence

- Tests: 70 tests passing (config + mirror + CLI + backend)
- oxlint: clean
- oxfmt: clean

### Code path — env passed as `--env KEY=VALUE` flags

[`extensions/openshell/src/backend.ts`](https://github.com/openclaw/openclaw/blob/main/extensions/openshell/src/backend.ts):
```typescript
...Object.entries(this.params.execContext.config.env).flatMap(([key, value]) => [
  "--env",
  `${key}=${value}`,
]),
```

### Config validation — runtime + manifest

Runtime rejects invalid keys (`extensions/openshell/src/config.ts` `superRefine`):

```
→ Invalid openshell plugin config: env key " FOO" has surrounding whitespace
→ Invalid openshell plugin config: env key "OPENSHELL_KEY" uses reserved OPENSHELL_ prefix
→ Invalid openshell plugin config: env key "123invalid" is not a valid environment variable name
```

Manifest schema (`extensions/openshell/openclaw.plugin.json`) validates key patterns:

```
propertyNames: {
  pattern: "^(?!OPENSHELL_)[A-Za-z_][A-Za-z0-9_]*$",
  minLength: 1
}
```

### Live verification — sandbox printenv

After configuring `plugins.entries.openshell.config.env` and running `openclaw sandbox recreate --all`:

```
$ openclaw sandbox exec -- printenv | grep -E "MODEL_BASE_URL|MODEL_NAME|HOME|PATH"
HOME=/root
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
MODEL_BASE_URL=https://api.example.com/v1
MODEL_NAME=gpt-oss-20b
```

The configured env vars are present in the sandbox alongside system defaults.

### When to recreate — docs updated

[`docs/gateway/openshell.md`](https://github.com/openclaw/openclaw/blob/main/docs/gateway/openshell.md) "When to recreate" section lists `plugins.entries.openshell.config.env`.

### Files changed

| File | Change |
|------|--------|
| `extensions/openshell/src/config.ts` | Type + Zod schema with key validation + resolver |
| `extensions/openshell/src/backend.ts` | `--env` args in sandbox create |
| `extensions/openshell/openclaw.plugin.json` | Manifest schema with `propertyNames` pattern + uiHints |
| `extensions/openshell/src/config.test.ts` | 70 tests: runtime key validation + manifest `propertyNames` pattern + schema sync (gap-aware) |
| `docs/gateway/openshell.md` | Config table, example, recreate guidance |

## Merge Risk

- **New config surface**: `plugins.entries.openshell.config.env` adds a new openclaw.json option. Follows existing pattern; defaults to `{}` so existing configs unaffected.
- **Env key validation**: Invalid keys rejected at schema parse time, not at sandbox create. Prevents silent failures.
- **Sandbox recreation required**: Env only applied at create time. Documented.
- **No security regression**: Env values passed as `--env KEY=VALUE` argv. Non-secret only, as documented.
- **Backward compatible**: Config is optional. Omitted → same behavior as before.