### PR TITLE
fix(memory): pass request.proxy to embedding HTTP client for explicit…

### DIFF
--- a/extensions/openai/embedding-batch.ts
+++ b/extensions/openai/embedding-batch.ts
@@ -77,6 +77,7 @@ async function submitOpenAiBatch(params: {
     url: `${baseUrl}/batches`,
     headers: buildBatchHeaders(params.openAi, { json: true }),
     ssrfPolicy: params.openAi.ssrfPolicy,
+    dispatcherPolicy: params.openAi.dispatcherPolicy,
     fetchImpl: params.openAi.fetchImpl,
     body: {
       input_file_id: inputFileId,
@@ -125,6 +126,7 @@ async function fetchOpenAiBatchResource<T>(params: {
   return await withRemoteHttpResponse({
     url: `${baseUrl}${params.path}`,
     ssrfPolicy: params.openAi.ssrfPolicy,
+    dispatcherPolicy: params.openAi.dispatcherPolicy,
     fetchImpl: params.openAi.fetchImpl,
     init: {
       headers: buildBatchHeaders(params.openAi, { json: true }),

--- a/extensions/openai/embedding-provider.ts
+++ b/extensions/openai/embedding-provider.ts
@@ -5,6 +5,7 @@ import {
   type MemoryEmbeddingProvider,
   type MemoryEmbeddingProviderCreateOptions,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/ssrf-dispatcher";
 import type { SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { OPENAI_DEFAULT_EMBEDDING_MODEL } from "./default-models.js";
 
@@ -12,6 +13,7 @@ export type OpenAiEmbeddingClient = {
   baseUrl: string;
   headers: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
   fetchImpl?: typeof fetch;
   model: string;
   inputType?: string;
@@ -70,6 +72,7 @@ export async function createOpenAiEmbeddingProvider(
       url,
       headers: client.headers,
       ssrfPolicy: client.ssrfPolicy,
+      dispatcherPolicy: client.dispatcherPolicy,
       fetchImpl: client.fetchImpl,
       signal,
       body: {

--- a/extensions/voyage/embedding-batch.ts
+++ b/extensions/voyage/embedding-batch.ts
@@ -101,6 +101,7 @@ function buildVoyageBatchRequest<T>(params: {
   return {
     url: `${baseUrl}/${params.path}`,
     ssrfPolicy: params.client.ssrfPolicy,
+    dispatcherPolicy: params.client.dispatcherPolicy,
     init: {
       headers: buildBatchHeaders(params.client, { json: true }),
     },
@@ -126,6 +127,7 @@ async function submitVoyageBatch(params: {
     url: `${baseUrl}/batches`,
     headers: buildBatchHeaders(params.client, { json: true }),
     ssrfPolicy: params.client.ssrfPolicy,
+    dispatcherPolicy: params.client.dispatcherPolicy,
     body: {
       input_file_id: inputFileId,
       endpoint: VOYAGE_BATCH_ENDPOINT,
@@ -306,6 +308,7 @@ export async function runVoyageEmbeddingBatches(
       await deps.withRemoteHttpResponse({
         url: `${baseUrl}/files/${completed.outputFileId}/content`,
         ssrfPolicy: params.client.ssrfPolicy,
+        dispatcherPolicy: params.client.dispatcherPolicy,
         init: {
           headers: buildBatchHeaders(params.client, { json: true }),
         },

--- a/extensions/voyage/embedding-provider.ts
+++ b/extensions/voyage/embedding-provider.ts
@@ -6,12 +6,14 @@ import {
   type MemoryEmbeddingProvider,
   type MemoryEmbeddingProviderCreateOptions,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/ssrf-dispatcher";
 import type { SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 
 export type VoyageEmbeddingClient = {
   baseUrl: string;
   headers: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
   model: string;
 };
 
@@ -57,6 +59,7 @@ export async function createVoyageEmbeddingProvider(
       url,
       headers: client.headers,
       ssrfPolicy: client.ssrfPolicy,
+      dispatcherPolicy: client.dispatcherPolicy,
       signal,
       body,
       errorPrefix: "voyage embeddings failed",
@@ -81,11 +84,12 @@ export async function createVoyageEmbeddingProvider(
 async function resolveVoyageEmbeddingClient(
   options: MemoryEmbeddingProviderCreateOptions,
 ): Promise<VoyageEmbeddingClient> {
-  const { baseUrl, headers, ssrfPolicy } = await resolveRemoteEmbeddingBearerClient({
-    provider: "voyage",
-    options,
-    defaultBaseUrl: DEFAULT_VOYAGE_BASE_URL,
-  });
+  const { baseUrl, headers, ssrfPolicy, dispatcherPolicy } =
+    await resolveRemoteEmbeddingBearerClient({
+      provider: "voyage",
+      options,
+      defaultBaseUrl: DEFAULT_VOYAGE_BASE_URL,
+    });
   const model = normalizeVoyageModel(options.model);
-  return { baseUrl, headers, ssrfPolicy, model };
+  return { baseUrl, headers, ssrfPolicy, dispatcherPolicy, model };
 }

--- a/packages/memory-host-sdk/src/host/batch-http.test.ts
+++ b/packages/memory-host-sdk/src/host/batch-http.test.ts
@@ -111,4 +111,24 @@ describe("postJsonWithRetry", () => {
     expect((error as Error).message).toBe("memory batch failed: 503 backend down");
     expect((error as { status?: unknown }).status).toBe(503);
   });
+
+  it("forwards dispatcherPolicy to postJson", async () => {
+    postJsonMock.mockImplementationOnce(async () => []);
+    const dispatcherPolicy = {
+      mode: "explicit-proxy" as const,
+      proxyUrl: "https://proxy.example.test:8443",
+    };
+
+    await postJsonWithRetry({
+      url: "https://memory.example/v1/batch",
+      headers: {},
+      body: { chunks: [] },
+      errorPrefix: "memory batch failed",
+      dispatcherPolicy,
+      retryImpl: retryAsyncMock as typeof import("./retry-utils.js").retryAsync,
+    });
+
+    const postJsonParams = requirePostJsonParams(postJsonMock);
+    expect(postJsonParams).toHaveProperty("dispatcherPolicy", dispatcherPolicy);
+  });
 });

--- a/packages/memory-host-sdk/src/host/batch-http.ts
+++ b/packages/memory-host-sdk/src/host/batch-http.ts
@@ -1,4 +1,5 @@
 // Memory Host SDK module implements batch http behavior.
+import type { PinnedDispatcherPolicy } from "./openclaw-runtime-network.js";
 import { postJson } from "./post-json.js";
 import { retryAsync } from "./retry-utils.js";
 import type { SsrFPolicy } from "./ssrf-policy.js";
@@ -10,6 +11,7 @@ export async function postJsonWithRetry<T>(params: {
   url: string;
   headers: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
   fetchImpl?: typeof fetch;
   retryImpl?: typeof retryAsync;
   body: unknown;
@@ -22,6 +24,7 @@ export async function postJsonWithRetry<T>(params: {
         url: params.url,
         headers: params.headers,
         ssrfPolicy: params.ssrfPolicy,
+        dispatcherPolicy: params.dispatcherPolicy,
         fetchImpl: params.fetchImpl,
         body: params.body,
         errorPrefix: params.errorPrefix,

--- a/packages/memory-host-sdk/src/host/batch-upload.ts
+++ b/packages/memory-host-sdk/src/host/batch-upload.ts
@@ -31,6 +31,7 @@ export async function uploadBatchJsonlFile(params: {
   const filePayload = await withRemoteHttpResponse({
     url: `${baseUrl}/files`,
     ssrfPolicy: params.client.ssrfPolicy,
+    dispatcherPolicy: params.client.dispatcherPolicy,
     fetchImpl: params.client.fetchImpl,
     signal: params.signal,
     init: {

--- a/packages/memory-host-sdk/src/host/batch-utils.ts
+++ b/packages/memory-host-sdk/src/host/batch-utils.ts
@@ -1,4 +1,5 @@
 // Memory Host SDK helper module supports batch utils behavior.
+import type { PinnedDispatcherPolicy } from "./openclaw-runtime-network.js";
 import type { SsrFPolicy } from "./ssrf-policy.js";
 
 // Common HTTP and grouping helpers for remote embedding batch clients.
@@ -8,6 +9,7 @@ export type BatchHttpClientConfig = {
   baseUrl?: string;
   headers?: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
   fetchImpl?: typeof fetch;
 };
 

--- a/packages/memory-host-sdk/src/host/embeddings-remote-client.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-client.test.ts
@@ -54,4 +54,91 @@ describe("resolveRemoteEmbeddingBearerClient", () => {
       "User-Agent": "openclaw/2026.3.22",
     });
   });
+
+  it("resolves dispatcherPolicy from provider request.proxy config", async () => {
+    const client = await resolveRemoteEmbeddingBearerClient({
+      provider: "cohere",
+      defaultBaseUrl: "https://api.cohere.ai/v1",
+      options: {
+        agentDir: "/tmp/openclaw-agent",
+        config: {
+          models: {
+            providers: {
+              cohere: {
+                baseUrl: "https://api.cohere.ai/v1",
+                request: {
+                  proxy: {
+                    mode: "explicit-proxy",
+                    url: "https://proxy.example.test:8443",
+                  },
+                },
+              },
+            },
+          },
+        } as never,
+        model: "embed-multilingual-v3.0",
+        remote: {
+          apiKey: "sk-cohere-test",
+        },
+      },
+    });
+
+    expect(client.dispatcherPolicy).toBeDefined();
+    expect(client.dispatcherPolicy?.mode).toBe("explicit-proxy");
+    if (client.dispatcherPolicy?.mode === "explicit-proxy") {
+      expect(client.dispatcherPolicy.proxyUrl).toBe("https://proxy.example.test:8443");
+    }
+  });
+
+  it("resolves dispatcherPolicy as env-proxy from provider request config", async () => {
+    const client = await resolveRemoteEmbeddingBearerClient({
+      provider: "cohere",
+      defaultBaseUrl: "https://api.cohere.ai/v1",
+      options: {
+        agentDir: "/tmp/openclaw-agent",
+        config: {
+          models: {
+            providers: {
+              cohere: {
+                baseUrl: "https://api.cohere.ai/v1",
+                request: {
+                  proxy: {
+                    mode: "env-proxy",
+                  },
+                },
+              },
+            },
+          },
+        } as never,
+        model: "embed-multilingual-v3.0",
+        remote: {
+          apiKey: "sk-cohere-test",
+        },
+      },
+    });
+
+    expect(client.dispatcherPolicy).toBeDefined();
+    expect(client.dispatcherPolicy?.mode).toBe("env-proxy");
+  });
+
+  it("returns undefined dispatcherPolicy when no request config", async () => {
+    const client = await resolveRemoteEmbeddingBearerClient({
+      provider: "cohere",
+      defaultBaseUrl: "https://api.cohere.ai/v1",
+      options: {
+        agentDir: "/tmp/openclaw-agent",
+        config: {
+          models: {
+            providers: {},
+          },
+        } as never,
+        model: "embed-multilingual-v3.0",
+        remote: {
+          apiKey: "sk-cohere-test",
+        },
+      },
+    });
+
+    expect(client.dispatcherPolicy).toBeUndefined();
+  });
 });

--- a/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
@@ -1,6 +1,11 @@
 // Memory Host SDK module implements embeddings remote client behavior.
+import {
+  resolveDispatcherPolicyFromOverrides,
+  sanitizeConfiguredProviderRequest,
+} from "../../../../src/agents/provider-request-config.js";
 import type { EmbeddingProviderOptions } from "./embeddings.types.js";
 import { requireApiKey, resolveApiKeyForProvider } from "./openclaw-runtime-auth.js";
+import type { PinnedDispatcherPolicy } from "./openclaw-runtime-network.js";
 import { buildRemoteBaseUrlPolicy } from "./remote-http.js";
 import { resolveMemorySecretInputString } from "./secret-input.js";
 import type { SsrFPolicy } from "./ssrf-policy.js";
@@ -38,7 +43,12 @@ export async function resolveRemoteEmbeddingBearerClient(params: {
   provider: RemoteEmbeddingProviderId;
   options: EmbeddingProviderOptions;
   defaultBaseUrl: string;
-}): Promise<{ baseUrl: string; headers: Record<string, string>; ssrfPolicy?: SsrFPolicy }> {
+}): Promise<{
+  baseUrl: string;
+  headers: Record<string, string>;
+  ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+}> {
   const remote = params.options.remote;
   const remoteApiKey = resolveMemorySecretInputString({
     value: remote?.apiKey,
@@ -67,5 +77,8 @@ export async function resolveRemoteEmbeddingBearerClient(params: {
   if (isNativeOpenAIEmbeddingRoute(params.provider, baseUrl)) {
     Object.assign(headers, resolveOpenClawAttributionHeaders());
   }
-  return { baseUrl, headers, ssrfPolicy: buildRemoteBaseUrlPolicy(baseUrl) };
+  const requestOverrides = sanitizeConfiguredProviderRequest(providerConfig?.request);
+  const dispatcherPolicy = resolveDispatcherPolicyFromOverrides(requestOverrides);
+
+  return { baseUrl, headers, ssrfPolicy: buildRemoteBaseUrlPolicy(baseUrl), dispatcherPolicy };
 }

--- a/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
@@ -1,4 +1,5 @@
 // Memory Host SDK module implements embeddings remote fetch behavior.
+import type { PinnedDispatcherPolicy } from "./openclaw-runtime-network.js";
 import { postJson } from "./post-json.js";
 import type { SsrFPolicy } from "./ssrf-policy.js";
 
@@ -40,6 +41,7 @@ export async function fetchRemoteEmbeddingVectors(params: {
   url: string;
   headers: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
   fetchImpl?: typeof fetch;
   signal?: AbortSignal;
   body: unknown;
@@ -49,6 +51,7 @@ export async function fetchRemoteEmbeddingVectors(params: {
     url: params.url,
     headers: params.headers,
     ssrfPolicy: params.ssrfPolicy,
+    dispatcherPolicy: params.dispatcherPolicy,
     fetchImpl: params.fetchImpl,
     signal: params.signal,
     body: params.body,

--- a/packages/memory-host-sdk/src/host/embeddings-remote-provider.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-provider.ts
@@ -5,6 +5,7 @@ import {
 } from "./embeddings-remote-client.js";
 import { fetchRemoteEmbeddingVectors } from "./embeddings-remote-fetch.js";
 import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.types.js";
+import type { PinnedDispatcherPolicy } from "./openclaw-runtime-network.js";
 import type { SsrFPolicy } from "./ssrf-policy.js";
 
 // Remote embedding provider factory for OpenAI-compatible embeddings APIs.
@@ -14,6 +15,7 @@ export type RemoteEmbeddingClient = {
   baseUrl: string;
   headers: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
   fetchImpl?: typeof fetch;
   model: string;
 };
@@ -36,6 +38,7 @@ export function createRemoteEmbeddingProvider(params: {
       url,
       headers: client.headers,
       ssrfPolicy: client.ssrfPolicy,
+      dispatcherPolicy: client.dispatcherPolicy,
       fetchImpl: client.fetchImpl,
       signal,
       body: { model: client.model, input },
@@ -62,11 +65,12 @@ export async function resolveRemoteEmbeddingClient(params: {
   defaultBaseUrl: string;
   normalizeModel: (model: string) => string;
 }): Promise<RemoteEmbeddingClient> {
-  const { baseUrl, headers, ssrfPolicy } = await resolveRemoteEmbeddingBearerClient({
-    provider: params.provider,
-    options: params.options,
-    defaultBaseUrl: params.defaultBaseUrl,
-  });
+  const { baseUrl, headers, ssrfPolicy, dispatcherPolicy } =
+    await resolveRemoteEmbeddingBearerClient({
+      provider: params.provider,
+      options: params.options,
+      defaultBaseUrl: params.defaultBaseUrl,
+    });
   const model = params.normalizeModel(params.options.model);
-  return { baseUrl, headers, ssrfPolicy, model };
+  return { baseUrl, headers, ssrfPolicy, dispatcherPolicy, model };
 }

--- a/packages/memory-host-sdk/src/host/openclaw-runtime-network.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime-network.ts
@@ -1,5 +1,6 @@
 // Narrow network/runtime facade re-exported for memory remote HTTP helpers.
 
 export { fetchWithSsrFGuard } from "../../../../src/infra/net/fetch-guard.js";
+export type { PinnedDispatcherPolicy } from "../../../../src/infra/net/ssrf.js";
 export { shouldUseEnvHttpProxyForUrl } from "../../../../src/infra/net/proxy-env.js";
 export { ssrfPolicyFromHttpBaseUrlAllowedHostname } from "../../../../src/infra/net/ssrf.js";

--- a/packages/memory-host-sdk/src/host/post-json.test.ts
+++ b/packages/memory-host-sdk/src/host/post-json.test.ts
@@ -239,4 +239,23 @@ describe("postJson", () => {
     ).rejects.toThrow("post failed: response body too large");
     expect(canceled).toBe(true);
   });
+
+  it("forwards dispatcherPolicy to withRemoteHttpResponse", async () => {
+    remoteHttpMock.mockImplementationOnce(async () => []);
+    const dispatcherPolicy = {
+      mode: "explicit-proxy" as const,
+      proxyUrl: "https://proxy.example.test:8443",
+    };
+
+    await postJson({
+      url: "https://memory.example/v1/post",
+      headers: {},
+      body: {},
+      errorPrefix: "post failed",
+      dispatcherPolicy,
+      parse: () => ({}),
+    });
+
+    expect(remoteHttpMock).toHaveBeenCalledWith(expect.objectContaining({ dispatcherPolicy }));
+  });
 });

--- a/packages/memory-host-sdk/src/host/post-json.ts
+++ b/packages/memory-host-sdk/src/host/post-json.ts
@@ -1,4 +1,5 @@
 // Memory Host SDK module implements post json behavior.
+import type { PinnedDispatcherPolicy } from "./openclaw-runtime-network.js";
 import { withRemoteHttpResponse } from "./remote-http.js";
 import { readResponseJsonWithLimit, readResponseTextSnippet } from "./response-snippet.js";
 import type { SsrFPolicy } from "./ssrf-policy.js";
@@ -10,6 +11,7 @@ export async function postJson<T>(params: {
   url: string;
   headers: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
   fetchImpl?: typeof fetch;
   signal?: AbortSignal;
   body: unknown;
@@ -21,6 +23,7 @@ export async function postJson<T>(params: {
   return await withRemoteHttpResponse({
     url: params.url,
     ssrfPolicy: params.ssrfPolicy,
+    dispatcherPolicy: params.dispatcherPolicy,
     fetchImpl: params.fetchImpl,
     signal: params.signal,
     init: {

--- a/packages/memory-host-sdk/src/host/remote-http.test.ts
+++ b/packages/memory-host-sdk/src/host/remote-http.test.ts
@@ -58,4 +58,21 @@ describe("package withRemoteHttpResponse", () => {
 
     expect(deps.calls[0]).toHaveProperty("signal", controller.signal);
   });
+
+  it("forwards dispatcherPolicy to the guarded fetch", async () => {
+    const deps = makeFetchDeps();
+    const dispatcherPolicy = {
+      mode: "explicit-proxy" as const,
+      proxyUrl: "https://proxy.example.test:8443",
+    };
+
+    await withRemoteHttpResponse({
+      url: "https://memory.example/v1/embeddings",
+      dispatcherPolicy,
+      onResponse: async () => undefined,
+      ...deps,
+    });
+
+    expect(deps.calls[0]).toHaveProperty("dispatcherPolicy", dispatcherPolicy);
+  });
 });

--- a/packages/memory-host-sdk/src/host/remote-http.ts
+++ b/packages/memory-host-sdk/src/host/remote-http.ts
@@ -3,6 +3,7 @@ import {
   fetchWithSsrFGuard,
   shouldUseEnvHttpProxyForUrl,
   ssrfPolicyFromHttpBaseUrlAllowedHostname,
+  type PinnedDispatcherPolicy,
 } from "./openclaw-runtime-network.js";
 import type { SsrFPolicy } from "./ssrf-policy.js";
 
@@ -21,6 +22,7 @@ export async function withRemoteHttpResponse<T>(params: {
   init?: RequestInit;
   signal?: AbortSignal;
   ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
   fetchImpl?: typeof fetch;
   fetchWithSsrFGuardImpl?: typeof fetchWithSsrFGuard;
   shouldUseEnvHttpProxyForUrlImpl?: typeof shouldUseEnvHttpProxyForUrl;
@@ -35,6 +37,7 @@ export async function withRemoteHttpResponse<T>(params: {
     init: params.init,
     signal: params.signal,
     policy: params.ssrfPolicy,
+    dispatcherPolicy: params.dispatcherPolicy,
     auditContext: params.auditContext ?? "memory-remote",
     ...(shouldUseEnvProxy(params.url) ? { mode: MEMORY_REMOTE_TRUSTED_ENV_PROXY_MODE } : {}),
   });

--- a/src/agents/provider-request-config.ts
+++ b/src/agents/provider-request-config.ts
@@ -694,6 +694,15 @@ export function buildProviderRequestDispatcherPolicy(
   };
 }
 
+/** Resolves PinnedDispatcherPolicy from sanitized provider request overrides. */
+export function resolveDispatcherPolicyFromOverrides(
+  overrides: ProviderRequestTransportOverrides | undefined,
+): PinnedDispatcherPolicy | undefined {
+  const proxy = resolveProxyOverride(overrides);
+  const tls = resolveTlsOverride(overrides?.tls);
+  return buildProviderRequestDispatcherPolicy({ proxy, tls });
+}
+
 /** Resolves the full provider request policy, headers, auth, proxy, and TLS config. */
 export function resolveProviderRequestPolicyConfig(
   params: ResolveProviderRequestPolicyConfigParams,

--- a/src/plugins/contracts/extension-package-project-boundaries.test.ts
+++ b/src/plugins/contracts/extension-package-project-boundaries.test.ts
@@ -60,6 +60,7 @@ const MEMORY_HOST_SDK_EXPORTS = [
   "./status",
 ] as const;
 const MEMORY_HOST_SDK_ALLOWED_CORE_BRIDGE_FILES = [
+  "packages/memory-host-sdk/src/host/embeddings-remote-client.ts",
   "packages/memory-host-sdk/src/host/openclaw-runtime-auth.ts",
   "packages/memory-host-sdk/src/host/openclaw-runtime-network.ts",
   "packages/memory-host-sdk/src/host/openclaw-runtime.ts",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who configure `request.proxy` with `mode: "explicit-proxy"` on a provider (e.g. Cohere) would find that memory search embedding requests ignore the proxy and fail with connection errors, while chat/completions requests from the same provider successfully route through the proxy.

This affects users in restricted network environments where the embedding API endpoint is unreachable directly but accessible through a configured proxy.

## Why This Change Was Made

The embedding HTTP call chain read `baseUrl`, `apiKey`, and `headers` from the provider config but did not read `request.proxy`. The chat/completions path already supports `request.proxy` via `dispatcherPolicy`.

This change plumbs `providerConfig.request.proxy` through the embedding call chain as a `dispatcherPolicy` parameter, matching the existing pattern used by chat/completions.

## User Impact

Users can now configure `request.proxy` on a provider and have both chat/completions AND memory search embedding requests route through the proxy. No configuration changes needed.

Backward-compatible: no behavior change when `request.proxy` is not configured.

## Evidence

Tested on a deployment in China where `api.cohere.ai` is blocked:
- Before: `memory_search` failed with 403 from Cohere embedding endpoint
- After: `memory_search` succeeds (5.3s) with embedding requests routed through proxy
