### PR TITLE
Reject split outbound agent session ownership

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -493,6 +493,14 @@ methods. Treat this as feature discovery, not a full enumeration of
 
   <Accordion title="Messaging and logs">
     - `send` is the direct outbound-delivery RPC for channel/account/thread-targeted sends outside the chat runner.
+    - `send` and `message.action` reject a request when an explicit `agentId`
+      does not own its agent-scoped `sessionKey`. Agent-scoped keys must use the
+      complete `agent:<agentId>:<session>` shape; malformed `agent:` keys are
+      rejected, while legacy unscoped session keys remain valid.
+      Queue recovery applies the same ownership check and permanently fails
+      inconsistent stored deliveries instead of replaying them. `policyKey` is
+      excluded because routed delivery can intentionally use another agent's
+      policy or origin session.
     - `logs.tail` returns the configured gateway file-log tail with cursor/limit and max-byte controls.
 
   </Accordion>

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -1391,6 +1391,26 @@ describe("gateway send mirroring", () => {
     });
   });
 
+  it("keeps explicit agent ownership for legacy unscoped session keys", async () => {
+    mockDeliverySuccess("m-legacy-unscoped-agent");
+
+    await runSend({
+      to: "channel:C1",
+      message: "hello",
+      channel: "slack",
+      agentId: "work",
+      sessionKey: "legacy:slack:channel:c1",
+      idempotencyKey: "idem-legacy-unscoped-agent",
+    });
+
+    expect(outboundRouteCall()?.agentId).toBe("work");
+    expect(outboundRouteCall()?.currentSessionKey).toBe("legacy:slack:channel:c1");
+    expectDeliverySessionMirror({
+      agentId: "work",
+      sessionKey: "legacy:slack:channel:c1",
+    });
+  });
+
   it("rejects a missing reserved agent-harness session before persistence or delivery", async () => {
     const sessionKey = "agent:main:harness:codex:supervision:missing";
 
@@ -1487,22 +1507,84 @@ describe("gateway send mirroring", () => {
     expect(deliveryCall()?.mirror?.agentId).toBe("work");
   });
 
-  it("prefers explicit agentId over sessionKey agent for delivery and mirror", async () => {
-    mockDeliverySuccess("m-agent-precedence");
-
-    await runSend({
+  it("rejects explicit agentId when it conflicts with the sessionKey agent", async () => {
+    const { respond } = await runSend({
       to: "channel:C1",
       message: "hello",
       channel: "slack",
       agentId: "work",
       sessionKey: "agent:main:slack:channel:c1",
-      idempotencyKey: "idem-agent-precedence",
+      idempotencyKey: "idem-agent-mismatch",
     });
 
-    expect(deliveryCall()?.session?.agentId).toBe("work");
-    expect(deliveryCall()?.session?.key).toBe("agent:main:slack:channel:c1");
-    expect(deliveryCall()?.mirror?.sessionKey).toBe("agent:main:slack:channel:c1");
-    expect(deliveryCall()?.mirror?.agentId).toBe("work");
+    expect(firstRespondCall(respond)).toMatchObject([
+      false,
+      undefined,
+      {
+        code: "INVALID_REQUEST",
+        message: 'send agentId "work" does not match session key agent "main"',
+      },
+      undefined,
+    ]);
+    expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
+    expect(mocks.resolveOutboundTarget).not.toHaveBeenCalled();
+    expect(mocks.resolveOutboundSessionRoute).not.toHaveBeenCalled();
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
+  it.each(["agent::broken", "agent:main"])(
+    "rejects malformed agent-scoped send session key %s before channel work",
+    async (sessionKey) => {
+      const { respond } = await runSend({
+        to: "channel:C1",
+        message: "hello",
+        channel: "slack",
+        sessionKey,
+        idempotencyKey: `idem-malformed-${sessionKey}`,
+      });
+
+      expect(firstRespondCall(respond)?.[2]).toMatchObject({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("is malformed"),
+      });
+      expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
+      expect(mocks.resolveOutboundTarget).not.toHaveBeenCalled();
+      expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+    },
+  );
+
+  it("caches ownership validation failures under the send idempotency key", async () => {
+    const context = makeContext();
+    const invoke = async () => {
+      const respond = vi.fn();
+      await expectDefined(sendHandlers.send, "sendHandlers.send test invariant").call(
+        sendHandlers,
+        {
+          params: {
+            to: "channel:C1",
+            message: "hello",
+            channel: "slack",
+            agentId: "work",
+            sessionKey: "agent:main:slack:channel:c1",
+            idempotencyKey: "idem-agent-mismatch-cached",
+          } as never,
+          respond,
+          context,
+          req: { type: "req", id: "1", method: "send" },
+          client: null as never,
+          isWebchatConnect: () => false,
+        },
+      );
+      return respond;
+    };
+
+    const firstRespond = await invoke();
+    const secondRespond = await invoke();
+
+    expect(firstRespondCall(firstRespond)?.[2]?.code).toBe("INVALID_REQUEST");
+    expect(firstRespondCall(secondRespond)?.[3]).toEqual({ cached: true });
+    expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
   });
 
   it("ignores blank explicit agentId and falls back to sessionKey agent", async () => {
@@ -1887,6 +1969,52 @@ describe("gateway send mirroring", () => {
         }),
       }),
     );
+  });
+
+  it("rejects message.action agentId when it conflicts with the sessionKey agent", async () => {
+    const { respond } = await runMessageActionRequest(
+      {
+        channel: "whatsapp",
+        action: "react",
+        params: { messageId: "wamid.1", emoji: "ok" },
+        sessionKey: "agent:main:whatsapp:direct:15551234567",
+        agentId: "work",
+        idempotencyKey: "idem-message-action-agent-mismatch",
+      },
+      null,
+    );
+
+    expect(firstRespondCall(respond)).toMatchObject([
+      false,
+      undefined,
+      {
+        code: "INVALID_REQUEST",
+        message: 'message.action agentId "work" does not match session key agent "main"',
+      },
+      undefined,
+    ]);
+    expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
+    expect(mocks.dispatchChannelMessageAction).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed message.action session keys before plugin discovery", async () => {
+    const { respond } = await runMessageActionRequest(
+      {
+        channel: "whatsapp",
+        action: "react",
+        params: { messageId: "wamid.1", emoji: "ok" },
+        sessionKey: "agent::broken",
+        idempotencyKey: "idem-message-action-malformed-session",
+      },
+      null,
+    );
+
+    expect(firstRespondCall(respond)?.[2]).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: expect.stringContaining("is malformed"),
+    });
+    expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
+    expect(mocks.dispatchChannelMessageAction).not.toHaveBeenCalled();
   });
 
   it("strips current-turn context from unauthenticated message action callers", async () => {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -41,6 +41,7 @@ import {
   projectOutboundPayloadPlanForMirror,
 } from "../../infra/outbound/payloads.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
+import { validateAgentSessionOwnerPair } from "../../infra/outbound/session-owner.js";
 import {
   beginTerminalSourceReplyDelivery,
   cancelTerminalSourceReplyDelivery,
@@ -417,6 +418,20 @@ function createGatewayInflightUnavailableFailure(params: {
   };
 }
 
+function createGatewayInflightInvalidRequestFailure(params: {
+  context: GatewayRequestContext;
+  dedupeKey: string;
+  message: string;
+}): InflightResult {
+  const error = errorShape(ErrorCodes.INVALID_REQUEST, params.message);
+  cacheGatewayDedupeFailure({
+    context: params.context,
+    dedupeKey: params.dedupeKey,
+    error,
+  });
+  return { ok: false, error };
+}
+
 async function mirrorDeliveredSourceReplyToTranscriptBestEffort(params: {
   context: GatewayRequestContext;
   mirror: Parameters<typeof mirrorDeliveredSourceReplyToTranscript>[0];
@@ -506,6 +521,20 @@ export const sendHandlers: GatewayRequestHandlers = {
     }
     const { dedupeKey, inflightMap } = inflight;
     const work = (async (): Promise<InflightResult> => {
+      const sessionKey = normalizeOptionalString(request.sessionKey) ?? undefined;
+      const explicitAgentId = normalizeOptionalString(request.agentId);
+      const ownership = validateAgentSessionOwnerPair({
+        ownerLabel: "message.action",
+        agentId: explicitAgentId,
+        sessionKey,
+      });
+      if (!ownership.ok) {
+        return createGatewayInflightInvalidRequestFailure({
+          context,
+          dedupeKey,
+          message: ownership.error.message,
+        });
+      }
       const resolvedChannel = await resolveRequestedChannel({
         requestChannel: request.channel,
         unsupportedMessage: (input) => `unsupported channel: ${input}`,
@@ -529,9 +558,8 @@ export const sendHandlers: GatewayRequestHandlers = {
       }
 
       try {
-        const sessionKey = normalizeOptionalString(request.sessionKey) ?? undefined;
         const agentId =
-          normalizeOptionalString(request.agentId) ??
+          explicitAgentId ??
           (sessionKey ? resolveSessionAgentId({ sessionKey, config: cfg }) : undefined);
         const accountId = normalizeOptionalString(request.accountId) ?? undefined;
         if (request.action === "send") {
@@ -688,6 +716,21 @@ export const sendHandlers: GatewayRequestHandlers = {
     const threadId = normalizeOptionalString(request.threadId);
 
     const work = (async (): Promise<InflightResult> => {
+      const providedSessionKey =
+        normalizeSessionKeyPreservingOpaquePeerIds(request.sessionKey) || undefined;
+      const explicitAgentId = normalizeOptionalString(request.agentId);
+      const ownership = validateAgentSessionOwnerPair({
+        ownerLabel: "send",
+        agentId: explicitAgentId,
+        sessionKey: providedSessionKey,
+      });
+      if (!ownership.ok) {
+        return createGatewayInflightInvalidRequestFailure({
+          context,
+          dedupeKey,
+          message: ownership.error.message,
+        });
+      }
       const resolvedChannel = await resolveInternalDeliveryChannel(request.channel, context);
       if (resolvedChannel.kind !== "ready") {
         return resolvedChannel.result;
@@ -726,9 +769,6 @@ export const sendHandlers: GatewayRequestHandlers = {
         // Preserve opaque, case-sensitive peer IDs (e.g. Matrix room ids) on an
         // explicit session key instead of raw-lowercasing it (openclaw#75670).
         // Non-enrolled channels still canonicalize to lowercase via the registry.
-        const providedSessionKey =
-          normalizeSessionKeyPreservingOpaquePeerIds(request.sessionKey) || undefined;
-        const explicitAgentId = normalizeOptionalString(request.agentId);
         const sessionAgentId = providedSessionKey
           ? resolveSessionAgentId({ sessionKey: providedSessionKey, config: cfg })
           : undefined;

--- a/src/infra/outbound/deliver-queue.ts
+++ b/src/infra/outbound/deliver-queue.ts
@@ -48,6 +48,7 @@ import {
   uniformOutboundAuditTerminals,
 } from "./outbound-audit.js";
 import type { NormalizedOutboundPayload } from "./payloads.js";
+import { assertOutboundDeliverySessionOwnership } from "./session-owner.js";
 
 const log = createSubsystemLogger("outbound/deliver");
 
@@ -77,6 +78,16 @@ export async function runOutboundDeliveryInternal(
       startedAt: auditStartedAt,
     });
   };
+  try {
+    assertOutboundDeliverySessionOwnership({
+      ownerLabel: "runOutboundDelivery",
+      session: params.session,
+      mirror: params.mirror,
+    });
+  } catch (error) {
+    emitPreQueueFailure();
+    throw error;
+  }
   if (params.requireUnknownSendReconciliation === true && payloads.length !== 1) {
     emitPreQueueFailure();
     throw new Error(

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -458,6 +458,89 @@ describe("deliverOutboundPayloads", () => {
     expect(results).toEqual([{ channel: "matrix", messageId: "m1", roomId: "!room:example" }]);
   });
 
+  it("rejects mismatched session ownership before queue or platform I/O", async () => {
+    const events: TrustedMessageAuditEvent[] = [];
+    const unsubscribe = onTrustedMessageAuditEvent((event) => events.push(event));
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+
+    try {
+      await expect(
+        deliverOutboundPayloads({
+          cfg: matrixChunkConfig,
+          channel: "matrix",
+          to: "!room:example",
+          payloads: [{ text: "hello" }],
+          deps: { matrix: sendMatrix },
+          session: {
+            agentId: "work",
+            key: "agent:main:matrix:room:ops",
+          },
+        }),
+      ).rejects.toThrow(
+        'runOutboundDelivery agentId "work" does not match session key agent "main"',
+      );
+    } finally {
+      unsubscribe();
+    }
+
+    expect(queueMocks.enqueueDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.enqueueDeliveryOnce).not.toHaveBeenCalled();
+    expect(sendMatrix).not.toHaveBeenCalled();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ outcome: "failed", failureStage: "queue" });
+  });
+
+  it("accepts same-owner control and transcript keys with a cross-agent policy key", async () => {
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+
+    await deliverOutboundPayloads({
+      cfg: matrixChunkConfig,
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hello" }],
+      deps: { matrix: sendMatrix },
+      session: {
+        agentId: "controller",
+        key: "agent:controller:acp:spawned",
+        policyKey: "agent:policy-owner:matrix:room:ops",
+      },
+      mirror: {
+        agentId: "controller",
+        sessionKey: "agent:controller:matrix:room:ops",
+      },
+    });
+
+    expect(sendMatrix).toHaveBeenCalledOnce();
+  });
+
+  it("rejects different control and transcript owners before queueing or sending", async () => {
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: matrixChunkConfig,
+        channel: "matrix",
+        to: "!room:example",
+        payloads: [{ text: "hello" }],
+        deps: { matrix: sendMatrix },
+        session: {
+          agentId: "controller",
+          key: "agent:controller:acp:spawned",
+          policyKey: "agent:policy-owner:matrix:room:ops",
+        },
+        mirror: {
+          sessionKey: "agent:transcript:matrix:room:ops",
+        },
+      }),
+    ).rejects.toThrow(
+      'runOutboundDelivery mirror session key agent "transcript" does not match operation agent "controller"',
+    );
+
+    expect(queueMocks.enqueueDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.enqueueDeliveryOnce).not.toHaveBeenCalled();
+    expect(sendMatrix).not.toHaveBeenCalled();
+  });
+
   it("reports unsupported durable final delivery when required capabilities are missing", async () => {
     setTestOutbound({
       deliveryMode: "direct",

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -62,6 +62,7 @@ import {
   failedOutboundAuditTerminals,
   uniformOutboundAuditTerminals,
 } from "./outbound-audit.js";
+import { validateOutboundDeliverySessionOwnership } from "./session-owner.js";
 
 export type DeliverFn = (
   params: {
@@ -231,12 +232,25 @@ async function applyRecoveryDeliveryAdmission(params: {
   if (admission.status === "allowed") {
     return "allowed";
   }
+  return await failRecoveryEntryPermanentlyBeforeReplay({
+    ...params,
+    reason: admission.reason,
+  });
+}
+
+async function failRecoveryEntryPermanentlyBeforeReplay(params: {
+  entry: QueuedDelivery;
+  reason: string;
+  log: RecoveryLogger;
+  stateDir?: string;
+  logLabel: string;
+}): Promise<"failed" | "not_pending"> {
   markDurableDeliveryFailedBestEffort(params.entry, params.log);
   const result = await failPendingDelivery(
     {
       id: params.entry.id,
       expectedStatus: "pending",
-      lastError: admission.reason,
+      lastError: params.reason,
       entry: params.entry,
     },
     params.stateDir,
@@ -244,14 +258,36 @@ async function applyRecoveryDeliveryAdmission(params: {
   if (result.status === "failed") {
     emitQueuedAuditTerminals(params.entry, () => queuedDeadLetterAuditTerminals(params.entry));
     params.log.warn(
-      `${params.logLabel}: entry ${params.entry.id} permanently rejected before recovery: ${admission.reason}`,
+      `${params.logLabel}: entry ${params.entry.id} permanently rejected before recovery: ${params.reason}`,
     );
     return "failed";
   }
   params.log.info(
-    `${params.logLabel}: entry ${params.entry.id} changed status before admission failure was persisted`,
+    `${params.logLabel}: entry ${params.entry.id} changed status before permanent rejection was persisted`,
   );
   return "not_pending";
+}
+
+async function applyRecoverySessionOwnership(params: {
+  entry: QueuedDelivery;
+  log: RecoveryLogger;
+  stateDir?: string;
+  logLabel: string;
+}): Promise<"allowed" | "failed" | "not_pending"> {
+  // Old queued intents can predate this invariant. Fail them permanently instead
+  // of replaying across agent boundaries; the persisted queue shape is unchanged.
+  const ownership = validateOutboundDeliverySessionOwnership({
+    ownerLabel: "queued delivery",
+    session: params.entry.session,
+    mirror: params.entry.mirror,
+  });
+  if (ownership.ok) {
+    return "allowed";
+  }
+  return await failRecoveryEntryPermanentlyBeforeReplay({
+    ...params,
+    reason: ownership.error.message,
+  });
 }
 
 async function reconcileUnknownQueuedDelivery(opts: {
@@ -1098,6 +1134,19 @@ export async function drainPendingDeliveries(opts: {
         if (hasActiveStableDeliveryOwner(currentEntry, Date.now())) {
           return;
         }
+
+        // Persisted rows can predate this invariant. Dead-letter invalid ownership
+        // before admission, backoff, reconciliation, or any provider-side work.
+        const ownership = await applyRecoverySessionOwnership({
+          entry: currentEntry,
+          log: opts.log,
+          stateDir: opts.stateDir,
+          logLabel: opts.logLabel,
+        });
+        if (ownership !== "allowed") {
+          return;
+        }
+
         const admission = await applyRecoveryDeliveryAdmission({
           entry: currentEntry,
           cfg: opts.cfg,
@@ -1224,6 +1273,22 @@ export async function recoverPendingDeliveries(opts: {
         opts.log.info(`Recovery skipped for delivery ${currentEntry.id}: active platform owner`);
         return "continue";
       }
+
+      // Persisted rows can predate this invariant. Dead-letter invalid ownership
+      // before admission, backoff, reconciliation, or any provider-side work.
+      const ownership = await applyRecoverySessionOwnership({
+        entry: currentEntry,
+        log: opts.log,
+        stateDir: opts.stateDir,
+        logLabel: "Recovery",
+      });
+      if (ownership !== "allowed") {
+        if (ownership === "failed") {
+          summary.failed += 1;
+        }
+        return "continue";
+      }
+
       const admission = await applyRecoveryDeliveryAdmission({
         entry: currentEntry,
         cfg: opts.cfg,

--- a/src/infra/outbound/delivery-queue.reconnect-drain.test.ts
+++ b/src/infra/outbound/delivery-queue.reconnect-drain.test.ts
@@ -199,6 +199,44 @@ describe("drainPendingDeliveries for reconnect", () => {
     expect(after.lastError).toBe("transient failure");
   });
 
+  it("dead-letters invalid ownership before reconnect admission or replay", async () => {
+    const log = createRecoveryLog();
+    const deliver = vi.fn<DeliverFn>(async () => {});
+    const id = await enqueueDelivery(
+      {
+        channel: "directchat",
+        to: "+1555",
+        payloads: [{ text: "hi" }],
+        accountId: "acct1",
+        session: {
+          agentId: "main",
+          key: "agent:main:directchat:direct:+1555",
+        },
+        mirror: {
+          sessionKey: "agent:work:directchat:direct:+1555",
+        },
+      },
+      tmpDir,
+    );
+    setQueuedEntryState(tmpDir, id, {
+      retryCount: 2,
+      lastAttemptAt: Date.now(),
+      lastError: NO_LISTENER_ERROR,
+    });
+
+    await drainAcct1DirectChatReconnect({ deliver, log, stateDir: tmpDir });
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(resolveOutboundChannelMessageAdapterMock).not.toHaveBeenCalled();
+    expect(sleepMock).not.toHaveBeenCalled();
+    expect(readOutboundQueueStatus(tmpDir, id)).toBe("failed");
+    expect(readQueuedEntry(tmpDir, id)).toMatchObject({
+      retryCount: 2,
+      lastError:
+        'queued delivery mirror session key agent "work" does not match operation agent "main"',
+    });
+  });
+
   it("records retry state if delivery fails during drain", async () => {
     const log = createRecoveryLog();
     const deliver = createTransientFailureDeliver();

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -476,6 +476,86 @@ describe("delivery-queue recovery", () => {
     });
   });
 
+  it("dead-letters mismatched and malformed ownership before admission, backoff, or replay", async () => {
+    const auditEvents: TrustedMessageAuditEvent[] = [];
+    const unsubscribe = onTrustedMessageAuditEvent((event) => auditEvents.push(event));
+    const mismatchId = await enqueueDelivery(
+      {
+        channel: "slack",
+        to: "C123",
+        payloads: [{ text: "mismatch" }],
+        session: {
+          agentId: "work",
+          key: "agent:main:slack:channel:C123",
+        },
+      },
+      tmpDir(),
+    );
+    const malformedId = await enqueueDelivery(
+      {
+        channel: "slack",
+        to: "C456",
+        payloads: [{ text: "malformed" }],
+        mirror: {
+          sessionKey: "agent::broken",
+        },
+      },
+      tmpDir(),
+    );
+    setQueuedEntryState(tmpDir(), mismatchId, {
+      retryCount: 3,
+      lastAttemptAt: Date.now(),
+    });
+    setQueuedEntryState(tmpDir(), malformedId, {
+      retryCount: 4,
+      lastAttemptAt: Date.now(),
+    });
+    const admitDeferredDelivery = vi.fn(() => ({ status: "allowed" as const }));
+    resolveOutboundChannelMessageAdapterMock.mockReturnValue({
+      durableFinal: { admitDeferredDelivery },
+    });
+    const deliver = vi.fn();
+
+    const { result } = await runRecovery({ deliver });
+    unsubscribe();
+
+    expect(result).toEqual({
+      recovered: 0,
+      failed: 2,
+      skippedMaxRetries: 0,
+      deferredBackoff: 0,
+    });
+    expect(admitDeferredDelivery).not.toHaveBeenCalled();
+    expect(resolveOutboundChannelMessageAdapterMock).not.toHaveBeenCalled();
+    expect(deliver).not.toHaveBeenCalled();
+    expect(sleepMock).not.toHaveBeenCalled();
+    expect(readOutboundQueueStatus(tmpDir(), mismatchId)).toBe("failed");
+    expect(readOutboundQueueStatus(tmpDir(), malformedId)).toBe("failed");
+    expect(readQueuedEntry(tmpDir(), mismatchId)).toMatchObject({
+      retryCount: 3,
+      lastError: 'queued delivery agentId "work" does not match session key agent "main"',
+    });
+    expect(readQueuedEntry(tmpDir(), malformedId)).toMatchObject({
+      retryCount: 4,
+      lastError: expect.stringContaining("mirror session key"),
+    });
+    expect(auditEvents).toHaveLength(2);
+    expect(auditEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceId: `message:outbound:queue:${mismatchId}:payload:0`,
+          outcome: "failed",
+          failureStage: "queue",
+        }),
+        expect.objectContaining({
+          sourceId: `message:outbound:queue:${malformedId}:payload:0`,
+          outcome: "failed",
+          failureStage: "queue",
+        }),
+      ]),
+    );
+  });
+
   it("paces startup replay instead of draining eligible entries back-to-back", async () => {
     vi.useFakeTimers();
     const startedAt = new Date("2026-04-23T00:00:00.000Z");
@@ -1917,7 +1997,7 @@ describe("delivery-queue recovery", () => {
     }
   });
 
-  it("replays stored delivery options during recovery", async () => {
+  it("replays stored delivery options with a cross-agent policy key", async () => {
     await enqueueRecoveryDelivery({
       replyToId: "root-message",
       replyToMode: "first",
@@ -1944,7 +2024,8 @@ describe("delivery-queue recovery", () => {
       },
       session: {
         key: "agent:main:main",
-        agentId: "agent-main",
+        agentId: "main",
+        policyKey: "agent:policy-owner:directchat:direct:+1",
         requesterAccountId: "acct-1",
         requesterSenderId: "sender-1",
         requesterSenderName: "Sender One",
@@ -1992,7 +2073,8 @@ describe("delivery-queue recovery", () => {
     });
     expect(deliverInput.session).toEqual({
       key: "agent:main:main",
-      agentId: "agent-main",
+      agentId: "main",
+      policyKey: "agent:policy-owner:directchat:direct:+1",
       requesterAccountId: "acct-1",
       requesterSenderId: "sender-1",
       requesterSenderName: "Sender One",

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -36,6 +36,114 @@ describe("runMessageAction send validation", () => {
     setActivePluginRegistry(createTestRegistry([]));
   });
 
+  it("rejects mismatched and malformed session ownership before message policy", async () => {
+    await expect(
+      runMessageAction({
+        cfg: emptyConfig,
+        action: "send",
+        params: { message: "hello from codex" },
+        toolContext: { currentChannelProvider: "webchat" },
+        sessionKey: "agent:main:webchat:direct:current-run",
+        agentId: "work",
+        sourceReplyDeliveryMode: "message_tool_only",
+      }),
+    ).rejects.toThrow('message action agentId "work" does not match session key agent "main"');
+
+    await expect(
+      runMessageAction({
+        cfg: emptyConfig,
+        action: "send",
+        params: { message: "hello from codex" },
+        toolContext: { currentChannelProvider: "webchat" },
+        sessionKey: "agent::broken",
+        sourceReplyDeliveryMode: "message_tool_only",
+      }),
+    ).rejects.toThrow("is malformed");
+  });
+
+  it("rejects mismatched transcript mirror ownership before channel delivery", async () => {
+    const sendText = vi.fn(async () => ({
+      channel: "workspace",
+      messageId: "workspace-test-message",
+    }));
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "workspace",
+          source: "test",
+          plugin: {
+            ...workspaceTestPlugin,
+            outbound: {
+              ...workspaceTestPlugin.outbound,
+              sendText,
+            },
+          },
+        },
+      ]),
+    );
+
+    await expect(
+      runMessageAction({
+        cfg: workspaceConfig,
+        action: "send",
+        params: {
+          channel: "workspace",
+          target: "#C12345678",
+          message: "hello from codex",
+        },
+        transcriptMirror: {
+          agentId: "work",
+          sessionKey: "agent:main:workspace:channel:C12345678",
+        },
+      }),
+    ).rejects.toThrow(
+      'message action agentId "work" does not match mirror session key agent "main"',
+    );
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
+  it("rejects different control and transcript owners before channel delivery", async () => {
+    const sendText = vi.fn(async () => ({
+      channel: "workspace",
+      messageId: "workspace-test-message",
+    }));
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "workspace",
+          source: "test",
+          plugin: {
+            ...workspaceTestPlugin,
+            outbound: {
+              ...workspaceTestPlugin.outbound,
+              sendText,
+            },
+          },
+        },
+      ]),
+    );
+
+    await expect(
+      runMessageAction({
+        cfg: workspaceConfig,
+        action: "send",
+        params: {
+          channel: "workspace",
+          target: "#C12345678",
+          message: "hello from codex",
+        },
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        transcriptMirror: {
+          sessionKey: "agent:work:workspace:channel:C12345678",
+        },
+      }),
+    ).rejects.toThrow(
+      'message action mirror session key agent "work" does not match operation agent "main"',
+    );
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
   it("requires message when no media hint is provided", async () => {
     await expect(
       runDrySend({
@@ -137,7 +245,7 @@ describe("runMessageAction send validation", () => {
       toolContext: {
         currentChannelProvider: "webchat",
       },
-      sessionKey: "agent:main",
+      sessionKey: "agent:main:main",
       sourceReplyDeliveryMode: "message_tool_only",
     });
 
@@ -260,7 +368,7 @@ describe("runMessageAction send validation", () => {
       toolContext: {
         currentChannelProvider: "webchat",
       },
-      sessionKey: "agent:main",
+      sessionKey: "agent:main:main",
       sourceReplyDeliveryMode: "message_tool_only",
     });
 
@@ -286,7 +394,7 @@ describe("runMessageAction send validation", () => {
         toolContext: {
           currentChannelProvider: "webchat",
         },
-        sessionKey: "agent:main",
+        sessionKey: "agent:main:main",
         sourceReplyDeliveryMode: "automatic",
       }),
     ).rejects.toThrow(/requires a target/i);
@@ -319,7 +427,7 @@ describe("runMessageAction send validation", () => {
       toolContext: {
         currentChannelProvider: "webchat",
       },
-      sessionKey: "agent:main",
+      sessionKey: "agent:main:main",
       sourceReplyDeliveryMode: "message_tool_only",
       dryRun: true,
     });
@@ -595,7 +703,7 @@ describe("message body alias normalization", () => {
       toolContext: {
         currentChannelProvider: "webchat",
       },
-      sessionKey: "agent:main",
+      sessionKey: "agent:main:main",
       sourceReplyDeliveryMode: "message_tool_only",
     });
 

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -111,6 +111,7 @@ import {
   materializeMessagePresentationFallback,
 } from "./outbound-send-service.js";
 import { ensureOutboundSessionEntry, resolveOutboundSessionRoute } from "./outbound-session.js";
+import { assertAgentSessionOwnerPairs } from "./session-owner.js";
 import {
   beginTerminalSourceReplyDelivery,
   cancelTerminalSourceReplyDelivery,
@@ -1848,8 +1849,22 @@ export async function runMessageAction(
 ): Promise<MessageActionRunResult> {
   const cfg = input.cfg;
   let params = { ...input.params };
+  const explicitAgentId = normalizeOptionalString(input.agentId);
+  assertAgentSessionOwnerPairs([
+    {
+      ownerLabel: "message action",
+      agentId: explicitAgentId,
+      sessionKey: input.sessionKey,
+    },
+    {
+      ownerLabel: "message action",
+      agentId: input.transcriptMirror?.agentId,
+      sessionKey: input.transcriptMirror?.sessionKey,
+      sessionKeyLabel: "mirror session key",
+    },
+  ]);
   const resolvedAgentId =
-    input.agentId ??
+    explicitAgentId ??
     (input.sessionKey
       ? resolveSessionAgentId({ sessionKey: input.sessionKey, config: cfg })
       : undefined);

--- a/src/infra/outbound/message.channels.test.ts
+++ b/src/infra/outbound/message.channels.test.ts
@@ -443,6 +443,24 @@ describe("gateway url override hardening", () => {
     }
   });
 
+  it("accepts same-owner control and transcript sessions through the legacy gateway pair", async () => {
+    const result = await sendThreadChatGatewayMessage({
+      agentId: "main",
+      requesterSessionKey: "agent:main:main",
+      mirror: {
+        agentId: "main",
+        sessionKey: "agent:main:threadchat:channel:town-square",
+      },
+    });
+
+    expect(result.params).toMatchObject({
+      agentId: "main",
+      sessionKey: "agent:main:threadchat:channel:town-square",
+    });
+    expect(result.params).not.toHaveProperty("requesterSessionKey");
+    expect(result.params).not.toHaveProperty("mirrorAgentId");
+  });
+
   it("forwards buffer metadata for gateway delivery-mode sends", async () => {
     const buffer = Buffer.from("gateway delivery bytes").toString("base64");
     const result = await sendThreadChatGatewayMessage({

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -162,6 +162,60 @@ describe("sendMessage", () => {
     expectRecordFields(deliveryParams.session, { agentId: "work" }, "outbound session");
   });
 
+  it("rejects requester and mirror pair mismatches before channel resolution", async () => {
+    await expect(
+      sendMessage({
+        cfg: {},
+        channel: "forum",
+        to: "123456",
+        content: "hi",
+        agentId: "work",
+        requesterSessionKey: "agent:main:forum:group:ops",
+      }),
+    ).rejects.toThrow(
+      'sendMessage agentId "work" does not match requester session key agent "main"',
+    );
+
+    await expect(
+      sendMessage({
+        cfg: {},
+        channel: "forum",
+        to: "123456",
+        content: "hi",
+        mirror: {
+          agentId: "work",
+          sessionKey: "agent:main:forum:dm:123456",
+        },
+      }),
+    ).rejects.toThrow('sendMessage agentId "work" does not match mirror session key agent "main"');
+
+    expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
+    expect(mocks.resolveOutboundTarget).not.toHaveBeenCalled();
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
+  it("rejects different control and mirror owners before channel resolution", async () => {
+    await expect(
+      sendMessage({
+        cfg: {},
+        channel: "forum",
+        to: "123456",
+        content: "hi",
+        agentId: "controller",
+        requesterSessionKey: "agent:controller:main",
+        mirror: {
+          sessionKey: "agent:transcript:forum:dm:123456",
+        },
+      }),
+    ).rejects.toThrow(
+      'sendMessage mirror session key agent "transcript" does not match operation agent "controller"',
+    );
+
+    expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
+    expect(mocks.resolveOutboundTarget).not.toHaveBeenCalled();
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
   it("forwards requesterSenderId into the outbound delivery session", async () => {
     await sendMessage({
       cfg: {},

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -37,6 +37,7 @@ import {
   type NormalizedOutboundPayload,
 } from "./payloads.js";
 import { buildOutboundSessionContext } from "./session-context.js";
+import { assertAgentSessionOwnerPairs } from "./session-owner.js";
 import { resolveOutboundTarget } from "./targets.js";
 
 const SEND_BUFFER_MEDIA_URL = "buffer://message-send/attachment";
@@ -342,6 +343,20 @@ async function resolveGatewayIdempotencyKey(idempotencyKey?: string): Promise<st
 }
 
 export async function sendMessage(params: MessageSendParams): Promise<MessageSendResult> {
+  assertAgentSessionOwnerPairs([
+    {
+      ownerLabel: "sendMessage",
+      agentId: params.agentId,
+      sessionKey: params.requesterSessionKey,
+      sessionKeyLabel: "requester session key",
+    },
+    {
+      ownerLabel: "sendMessage",
+      agentId: params.mirror?.agentId,
+      sessionKey: params.mirror?.sessionKey,
+      sessionKeyLabel: "mirror session key",
+    },
+  ]);
   const cfg = await resolveMessageConfig(params.cfg);
   const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
   const plugin = resolveRequiredPlugin(channel, cfg);

--- a/src/infra/outbound/outbound-send-service.test.ts
+++ b/src/infra/outbound/outbound-send-service.test.ts
@@ -199,7 +199,7 @@ describe("executeSendAction", () => {
         params: { to: "channel:123", message: "hello" },
         dryRun: false,
         mirror: {
-          sessionKey: "agent:main:demo-outbound:channel:123",
+          sessionKey: `agent:${params.mirror?.agentId ?? "main"}:demo-outbound:channel:123`,
           ...params.mirror,
         },
       },
@@ -246,6 +246,72 @@ describe("executeSendAction", () => {
     mocks.createAgentScopedHostMediaReadFile.mockClear();
     mocks.resolveAgentScopedOutboundMediaAccess.mockClear();
     mocks.appendAssistantMessageToSessionTranscript.mockClear();
+  });
+
+  it("rejects paired ownership failures before send or poll plugin dispatch", async () => {
+    await expect(
+      executeSendAction({
+        ctx: {
+          cfg: {},
+          channel: "demo-outbound",
+          params: { to: "channel:123", message: "hello" },
+          agentId: "work",
+          sessionKey: "agent:main:demo-outbound:channel:123",
+          dryRun: false,
+        },
+        to: "channel:123",
+        message: "hello",
+      }),
+    ).rejects.toThrow('executeSendAction agentId "work" does not match session key agent "main"');
+
+    const resolveCorePoll = vi.fn(() => ({
+      to: "channel:123",
+      question: "Lunch?",
+      options: ["Pizza", "Sushi"],
+      maxSelections: 1,
+    }));
+    await expect(
+      executePollAction({
+        ctx: {
+          cfg: {},
+          channel: "demo-outbound",
+          params: {},
+          mirror: {
+            agentId: "work",
+            sessionKey: "agent:main:demo-outbound:channel:123",
+          },
+          dryRun: false,
+        },
+        resolveCorePoll,
+      }),
+    ).rejects.toThrow(
+      'executePollAction agentId "work" does not match mirror session key agent "main"',
+    );
+
+    await expect(
+      executeSendAction({
+        ctx: {
+          cfg: {},
+          channel: "demo-outbound",
+          params: { to: "channel:123", message: "hello" },
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          mirror: {
+            sessionKey: "agent:work:demo-outbound:channel:123",
+          },
+          dryRun: false,
+        },
+        to: "channel:123",
+        message: "hello",
+      }),
+    ).rejects.toThrow(
+      'executeSendAction mirror session key agent "work" does not match operation agent "main"',
+    );
+
+    expect(mocks.dispatchChannelMessageAction).not.toHaveBeenCalled();
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(mocks.sendPoll).not.toHaveBeenCalled();
+    expect(resolveCorePoll).not.toHaveBeenCalled();
   });
 
   it("forwards ctx.agentId to sendMessage on core outbound path", async () => {
@@ -985,7 +1051,7 @@ describe("executeSendAction", () => {
 
     expectMirrorWrite({
       agentId: "agent-9",
-      sessionKey: "agent:main:demo-outbound:channel:123",
+      sessionKey: "agent:agent-9:demo-outbound:channel:123",
       text: "hello",
       mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
     });

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -34,6 +34,7 @@ import { collectActionMediaSourceHints } from "./message-action-params.js";
 import type { MessagePollResult, MessageSendResult } from "./message.js";
 import { sendMessage, sendPoll } from "./message.js";
 import type { OutboundMirror } from "./mirror.js";
+import { assertAgentSessionOwnerPairs } from "./session-owner.js";
 
 const log = createSubsystemLogger("outbound/send-service");
 
@@ -101,6 +102,22 @@ type PluginHandledResult = {
 };
 
 type SendMessageParams = Parameters<typeof sendMessage>[0];
+
+function assertOutboundSendContextOwnership(ctx: OutboundSendContext, ownerLabel: string): void {
+  assertAgentSessionOwnerPairs([
+    {
+      ownerLabel,
+      agentId: ctx.agentId,
+      sessionKey: ctx.sessionKey,
+    },
+    {
+      ownerLabel,
+      agentId: ctx.mirror?.agentId,
+      sessionKey: ctx.mirror?.sessionKey,
+      sessionKeyLabel: "mirror session key",
+    },
+  ]);
+}
 
 export function materializeMessagePresentationFallback(params: {
   payload: Pick<ReplyPayload, "presentation" | "text">;
@@ -341,6 +358,7 @@ export async function executeSendAction(params: {
   sendResult?: MessageSendResult;
 }> {
   throwIfAborted(params.ctx.abortSignal);
+  assertOutboundSendContextOwnership(params.ctx, "executeSendAction");
   const defaultPayload: ReplyPayload = params.payload ?? {
     text: params.message,
     mediaUrl: params.mediaUrl,
@@ -492,6 +510,7 @@ export async function executePollAction(params: {
   toolResult?: AgentToolResult<unknown>;
   pollResult?: MessagePollResult;
 }> {
+  assertOutboundSendContextOwnership(params.ctx, "executePollAction");
   const pluginHandled = await tryHandleWithPluginAction({
     ctx: params.ctx,
     action: "poll",

--- a/src/infra/outbound/session-owner.test.ts
+++ b/src/infra/outbound/session-owner.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertAgentSessionOwnerPairs,
+  validateAgentSessionOwnerPair,
+  validateOutboundDeliverySessionOwnership,
+} from "./session-owner.js";
+
+describe("outbound agent session ownership", () => {
+  it("accepts normalized matching owners", () => {
+    expect(
+      validateAgentSessionOwnerPair({
+        ownerLabel: "send",
+        agentId: " Support ",
+        sessionKey: " AGENT:SUPPORT:main ",
+      }),
+    ).toEqual({ ok: true, value: undefined });
+  });
+
+  it("accepts legacy and missing session keys", () => {
+    expect(
+      validateAgentSessionOwnerPair({
+        ownerLabel: "send",
+        agentId: "support",
+        sessionKey: "legacy-session",
+      }),
+    ).toEqual({ ok: true, value: undefined });
+    expect(validateAgentSessionOwnerPair({ ownerLabel: "send", agentId: "support" })).toEqual({
+      ok: true,
+      value: undefined,
+    });
+  });
+
+  it.each(["agent::broken", "agent:main"])(
+    "rejects malformed agent-scoped key %s without an explicit owner",
+    (sessionKey) => {
+      const result = validateAgentSessionOwnerPair({ ownerLabel: "send", sessionKey });
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: { reason: "malformed_session_key", sessionKey },
+      });
+    },
+  );
+
+  it("rejects a paired owner mismatch", () => {
+    expect(
+      validateAgentSessionOwnerPair({
+        ownerLabel: "send",
+        agentId: "alpha",
+        sessionKey: "agent:beta:main",
+      }),
+    ).toEqual({
+      ok: false,
+      error: {
+        reason: "owner_mismatch",
+        agentId: "alpha",
+        sessionAgentId: "beta",
+        message: 'send agentId "alpha" does not match session key agent "beta"',
+      },
+    });
+  });
+
+  it("accepts same-owner control and transcript keys while ignoring policyKey", () => {
+    expect(
+      validateOutboundDeliverySessionOwnership({
+        ownerLabel: "delivery",
+        session: {
+          agentId: "controller",
+          key: "agent:controller:main",
+          policyKey: "agent:policy-owner:main",
+        },
+        mirror: {
+          agentId: "controller",
+          sessionKey: "agent:controller:channel:ops",
+        },
+      }),
+    ).toEqual({ ok: true, value: undefined });
+  });
+
+  it("rejects different owners across one operation when the mirror owner is derived", () => {
+    expect(
+      validateOutboundDeliverySessionOwnership({
+        ownerLabel: "delivery",
+        session: {
+          agentId: "controller",
+          key: "agent:controller:main",
+          policyKey: "agent:policy-owner:main",
+        },
+        mirror: {
+          sessionKey: "agent:transcript:channel:ops",
+        },
+      }),
+    ).toEqual({
+      ok: false,
+      error: {
+        reason: "owner_mismatch",
+        agentId: "controller",
+        sessionAgentId: "transcript",
+        message:
+          'delivery mirror session key agent "transcript" does not match operation agent "controller"',
+      },
+    });
+  });
+
+  it("throws the ownership error at side-effect boundaries", () => {
+    expect(() =>
+      assertAgentSessionOwnerPairs([
+        {
+          ownerLabel: "delivery",
+          agentId: "alpha",
+          sessionKey: "agent:beta:main",
+        },
+      ]),
+    ).toThrow('delivery agentId "alpha" does not match session key agent "beta"');
+  });
+});

--- a/src/infra/outbound/session-owner.ts
+++ b/src/infra/outbound/session-owner.ts
@@ -1,0 +1,150 @@
+// Enforces one canonical agent owner across outbound control and transcript metadata.
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  classifySessionKeyShape,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../../routing/session-key.js";
+
+type AgentSessionOwnerPair = {
+  agentId?: string | null;
+  sessionKey?: string | null;
+  ownerLabel: string;
+  sessionKeyLabel?: string;
+};
+
+type AgentSessionOwnershipFailure =
+  | {
+      reason: "malformed_session_key";
+      sessionKey: string;
+      message: string;
+    }
+  | {
+      reason: "owner_mismatch";
+      agentId: string;
+      sessionAgentId: string;
+      message: string;
+    };
+
+class AgentSessionOwnershipError extends Error {
+  readonly failure: AgentSessionOwnershipFailure;
+
+  constructor(failure: AgentSessionOwnershipFailure) {
+    super(failure.message);
+    this.name = "AgentSessionOwnershipError";
+    this.failure = failure;
+  }
+}
+
+export function validateAgentSessionOwnerPair(
+  params: AgentSessionOwnerPair,
+): Result<undefined, AgentSessionOwnershipFailure> {
+  const sessionKey = normalizeOptionalString(params.sessionKey);
+  if (!sessionKey) {
+    return ok(undefined);
+  }
+  const sessionKeyLabel = params.sessionKeyLabel ?? "session key";
+  if (classifySessionKeyShape(sessionKey) === "malformed_agent") {
+    return err({
+      reason: "malformed_session_key",
+      sessionKey,
+      message: `${params.ownerLabel} ${sessionKeyLabel} "${sessionKey}" is malformed; expected "agent:<agentId>:<session>"`,
+    });
+  }
+
+  const explicitAgentId = normalizeOptionalString(params.agentId);
+  const parsedSessionKey = parseAgentSessionKey(sessionKey);
+  if (!explicitAgentId || !parsedSessionKey) {
+    return ok(undefined);
+  }
+  const agentId = normalizeAgentId(explicitAgentId);
+  const sessionAgentId = normalizeAgentId(parsedSessionKey.agentId);
+  if (agentId === sessionAgentId) {
+    return ok(undefined);
+  }
+  return err({
+    reason: "owner_mismatch",
+    agentId,
+    sessionAgentId,
+    message: `${params.ownerLabel} agentId "${agentId}" does not match ${sessionKeyLabel} agent "${sessionAgentId}"`,
+  });
+}
+
+function validateAgentSessionOwnerPairs(
+  pairs: readonly AgentSessionOwnerPair[],
+): Result<undefined, AgentSessionOwnershipFailure> {
+  let operationAgentId: string | undefined;
+  for (const pair of pairs) {
+    const result = validateAgentSessionOwnerPair(pair);
+    if (!result.ok) {
+      return result;
+    }
+
+    const sessionKey = normalizeOptionalString(pair.sessionKey);
+    const sessionAgentId = sessionKey ? parseAgentSessionKey(sessionKey)?.agentId : undefined;
+    const explicitAgentId = normalizeOptionalString(pair.agentId);
+    const declaredAgentId = sessionAgentId ?? explicitAgentId;
+    if (!declaredAgentId) {
+      continue;
+    }
+    const normalizedDeclaredAgentId = normalizeAgentId(declaredAgentId);
+    if (!operationAgentId) {
+      operationAgentId = normalizedDeclaredAgentId;
+      continue;
+    }
+    if (normalizedDeclaredAgentId === operationAgentId) {
+      continue;
+    }
+    const declaredOwnerLabel = sessionAgentId
+      ? `${pair.sessionKeyLabel ?? "session key"} agent`
+      : "agentId";
+    return err({
+      reason: "owner_mismatch",
+      agentId: operationAgentId,
+      sessionAgentId: normalizedDeclaredAgentId,
+      message: `${pair.ownerLabel} ${declaredOwnerLabel} "${normalizedDeclaredAgentId}" does not match operation agent "${operationAgentId}"`,
+    });
+  }
+  return ok(undefined);
+}
+
+export function assertAgentSessionOwnerPairs(pairs: readonly AgentSessionOwnerPair[]): void {
+  const result = validateAgentSessionOwnerPairs(pairs);
+  if (!result.ok) {
+    throw new AgentSessionOwnershipError(result.error);
+  }
+}
+
+export function validateOutboundDeliverySessionOwnership(params: {
+  ownerLabel: string;
+  session?: { agentId?: string | null; key?: string | null; policyKey?: string | null };
+  mirror?: { agentId?: string | null; sessionKey?: string | null };
+}): Result<undefined, AgentSessionOwnershipFailure> {
+  // policyKey selects delivery policy and can intentionally name another agent.
+  // Canonical control and transcript keys must still share one operation owner.
+  return validateAgentSessionOwnerPairs([
+    {
+      ownerLabel: params.ownerLabel,
+      agentId: params.session?.agentId,
+      sessionKey: params.session?.key,
+    },
+    {
+      ownerLabel: params.ownerLabel,
+      agentId: params.mirror?.agentId,
+      sessionKey: params.mirror?.sessionKey,
+      sessionKeyLabel: "mirror session key",
+    },
+  ]);
+}
+
+export function assertOutboundDeliverySessionOwnership(params: {
+  ownerLabel: string;
+  session?: { agentId?: string | null; key?: string | null; policyKey?: string | null };
+  mirror?: { agentId?: string | null; sessionKey?: string | null };
+}): void {
+  const result = validateOutboundDeliverySessionOwnership(params);
+  if (!result.ok) {
+    throw new AgentSessionOwnershipError(result.error);
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes #96075.

Outbound send/action paths could accept an explicit `agentId` while also carrying an agent-scoped session key owned by another agent. That could split ownership across media policy, plugin dispatch, transcript mirroring, queueing, and internal hook correlation.

## Why This Change Was Made

This adds a shared outbound ownership guard that parses `agent:<owner>:...` session keys and compares only the normalized owner segment against explicit agent owners. The guard is applied at both Gateway boundaries and lower outbound helpers so internal callers cannot bypass the Gateway check.

`policyKey` remains intentionally excluded from equality checks because routed ACP-style delivery can use a separate policy/origin session while the canonical session/mirror keys still describe the owning agent.

## User Impact

Contradictory outbound requests such as `agentId: "work"` with `sessionKey: "agent:main:..."` now fail before dispatch, media resolution, durable queueing, mirroring, or hook correlation. Omitted/blank agent ids, legacy session keys, same-agent different conversation keys, and cross-agent delivery policy keys remain supported.

## Compatibility and Stored Queue Behavior

This intentionally changes contradictory split-owner outbound requests from accepted dispatch to fail-closed validation. The rejected shape is an explicit agent owner paired with an agent-scoped session key owned by a different agent, for example `agentId: "work"` with `sessionKey: "agent:main:slack:channel:c1"`.

I am not preserving explicit-agent precedence for that contradictory shape because it can route media policy, plugin dispatch, transcript mirroring, queueing, and hook correlation under different owners. Same-agent session keys, omitted or blank agent ids, legacy/non-agent session keys, and cross-agent `policyKey` routing remain allowed.

There is no serialized queue-shape, schema-version, or migration change. Recovery validates the existing `session` and `mirror` fields. A previously stored entry whose canonical owners disagree is permanently marked `failed` through the existing queue failure path instead of being replayed across agent boundaries. This is the intended compatibility behavior; `policyKey` remains excluded from the recovery equality check.

## Evidence

### Exact-head behavior proof

Exact reviewed head:

```text
HEAD=78e7ee8724ba103ed24686f3bf37cd85f1e0e318
```

The canonical PR CI completed successfully on that exact SHA: https://github.com/openclaw/openclaw/actions/runs/29933742723

Selected terminal output from the exact-head Node shards:

```text
✓ src/gateway/server-methods/send.test.ts (84 tests)
✓ src/infra/outbound/message-action-runner.send-validation.test.ts (33 tests)
✓ src/infra/outbound/deliver.test.ts (163 tests)
✓ src/infra/outbound/delivery-queue.recovery.test.ts (53 tests)
✓ src/infra/outbound/delivery-queue.reconnect-drain.test.ts (19 tests)
✓ src/infra/outbound/outbound-send-service.test.ts (32 tests)
✓ src/infra/outbound/message.test.ts (16 tests)
✓ src/infra/outbound/session-owner.test.ts (8 tests)
CI workflow: 58 jobs succeeded, 11 scope-disabled jobs skipped, 0 failed
```

Those exact-head suites exercise the final side-effect boundaries:

- `deliver.test.ts` rejects mismatched canonical ownership before queue or platform I/O and asserts zero enqueue/platform calls.
- `deliver.test.ts` allows same-owner control and mirror keys with a cross-agent `policyKey` and reaches the adapter once.
- `delivery-queue.recovery.test.ts` permanently fails mismatched or malformed stored entries before admission, backoff, adapter lookup, or replay.
- `delivery-queue.recovery.test.ts` replays a valid stored entry whose canonical owner is `main` while its `policyKey` belongs to `policy-owner`.
- Gateway and message-action tests reject mismatches before channel/plugin discovery.

### Additional checks

- `git diff --check`
- Exact-head canonical PR CI, including build artifacts, prod/test types, lint, guards, docs, Gateway methods, outbound delivery, and queue recovery
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` for the recovery contract follow-up: clean, no accepted/actionable findings
