### PR TITLE
feat(gateway): report workspace disk failure via /readyz probe

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -168,7 +168,7 @@ openclaw gateway health --url ws://127.0.0.1:18789
 openclaw gateway health --port 18789
 ```
 
-The HTTP `/healthz` endpoint is a liveness probe: it returns once the server can answer HTTP. The HTTP `/readyz` endpoint is stricter and stays red while startup plugin sidecars, channels, or configured hooks are still settling. Local or authenticated detailed readiness responses include an `eventLoop` diagnostic block with event-loop delay, event-loop utilization, CPU core ratio, and a `degraded` flag.
+The HTTP `/healthz` endpoint is a liveness probe: it returns once the server can answer HTTP. The HTTP `/readyz` endpoint is stricter and stays red while startup plugin sidecars, channels, or configured hooks are still settling. It also reports `workspace-disk` when the workspace directory is not writable (e.g. `ENOSPC`, permissions), preventing Kubernetes from routing traffic to a pod with disk failures. Local or authenticated detailed readiness responses include an `eventLoop` diagnostic block with event-loop delay, event-loop utilization, CPU core ratio, and a `degraded` flag.
 
 <ParamField path="--port <port>" type="number">
   Target a local loopback Gateway on this port. This overrides `OPENCLAW_GATEWAY_URL` and `OPENCLAW_GATEWAY_PORT` for the health call.

--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -49,6 +49,23 @@ External uptime monitoring services should use the dedicated `/health` endpoint,
 - **DO use:** `GET /health` — instant response, no session created, no LLM call, returns `{"ok":true,"status":"live"}`
 - **DON'T use:** `/v1/chat/completions` for health checks — each request creates a full agent session with skill snapshot, context assembly, and LLM calls
 
+### Gateway readiness (`/readyz`)
+
+The `/readyz` endpoint is designed for Kubernetes readiness probes and similar
+orchestrator health checks. It reports not-ready during:
+
+- Startup sidecar settling
+- Gateway draining for restart
+- Channel health failures (disconnected, restart-exhausted)
+- **Workspace disk failure** — when the workspace directory is not writable (e.g.
+  `ENOSPC`, permissions), `/readyz` returns a `workspace-disk` failure. This
+  prevents Kubernetes from routing traffic to a pod that cannot persist
+  sessions, transcripts, or media.
+
+The workspace check is only active when a `workspaceDir` is configured (the
+default in gateway/server deployments). It writes and removes a temporary probe
+file on each check; the 1s cache keeps I/O overhead negligible.
+
 When no `x-openclaw-session-key` header or `user` field is provided, `/v1/chat/completions` generates a new random session for each request. Monitoring services that ping every 15 minutes create ~96 sessions/day, each consuming 4–22KB. Over time this causes session store bloat and can lead to context window overflow.
 
 ### Monitoring service setup examples

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -881,6 +881,7 @@ export async function startGatewayServer(
     shouldSkipChannelReadiness: () =>
       isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
       isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS),
+    workspaceDir: defaultWorkspaceDir,
   });
   log.info("starting HTTP server...");
   let currentPluginRegistryGatewayContext: GatewayRequestContext | undefined;

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -1,4 +1,7 @@
 // Readiness checker tests cover startup grace, channel health, and stale socket decisions.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { ChannelId } from "../../channels/plugins/index.js";
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.js";
@@ -74,6 +77,7 @@ function createReadinessHarness(params: {
     typeof createReadinessChecker
   >[0]["shouldSkipChannelReadiness"];
   cacheTtlMs?: number;
+  workspaceDir?: string;
 }) {
   const startedAt = Date.now() - (params.startedAgoMs ?? FIVE_MIN_MS);
   const manager = createManager(snapshotWith(params.accounts ?? {}));
@@ -88,6 +92,7 @@ function createReadinessHarness(params: {
       getEventLoopHealth: params.getEventLoopHealth,
       shouldSkipChannelReadiness: params.shouldSkipChannelReadiness,
       cacheTtlMs: params.cacheTtlMs,
+      workspaceDir: params.workspaceDir,
     }),
   };
 }
@@ -328,6 +333,54 @@ describe("createReadinessChecker", () => {
       vi.advanceTimersByTime(600);
       expect(readiness()).toEqual(readySnapshot(301_100));
       expect(manager.getRuntimeSnapshot).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("reports ready when workspace probe succeeds", () => {
+    withReadinessClock(() => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "readiness-test-"));
+      try {
+        const { readiness } = createReadinessHarness({
+          workspaceDir: tmpDir,
+        });
+        expect(readiness()).toEqual(readySnapshot());
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it("reports workspace-disk failure when workspace probe write fails", () => {
+    withReadinessClock(() => {
+      const { readiness } = createReadinessHarness({
+        workspaceDir: "/nonexistent-readiness-probe-path",
+      });
+      const result = readiness();
+      expect(result.ready).toBe(false);
+      expect(result.failing).toContain("workspace-disk");
+    });
+  });
+
+  it("skips workspace probe when workspaceDir is not set", () => {
+    withReadinessClock(() => {
+      const { readiness } = createReadinessHarness({});
+      expect(readiness()).toEqual(readySnapshot());
+    });
+  });
+
+  it("cleans up the probe file after each check", () => {
+    withReadinessClock(() => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "readiness-probe-cleanup-"));
+      try {
+        const probePath = path.join(tmpDir, ".readiness-probe");
+        const { readiness } = createReadinessHarness({
+          workspaceDir: tmpDir,
+        });
+        readiness();
+        expect(fs.existsSync(probePath)).toBe(false);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/src/gateway/server/readiness.ts
+++ b/src/gateway/server/readiness.ts
@@ -1,4 +1,6 @@
 // Gateway readiness checker for channel health and startup sidecar state.
+import fs from "node:fs";
+import path from "node:path";
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
 import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
@@ -36,6 +38,8 @@ function shouldIgnoreReadinessFailure(
   return health.reason === "not-running" && accountSnapshot.restartPending === true;
 }
 
+const READINESS_PROBE_FILENAME = ".readiness-probe";
+
 /** Create a cached readiness checker over channel runtime health. */
 export function createReadinessChecker(deps: {
   channelManager: ChannelManager;
@@ -46,6 +50,8 @@ export function createReadinessChecker(deps: {
   getEventLoopHealth?: () => GatewayEventLoopHealth | undefined;
   shouldSkipChannelReadiness?: () => boolean;
   cacheTtlMs?: number;
+  /** When set, the readiness probe writes a probe file to verify writability. */
+  workspaceDir?: string;
 }): ReadinessChecker {
   const { channelManager, startedAt } = deps;
   const cacheTtlMs = Math.max(0, deps.cacheTtlMs ?? DEFAULT_READINESS_CACHE_TTL_MS);
@@ -97,6 +103,16 @@ export function createReadinessChecker(deps: {
           failing.push(channelId);
           break;
         }
+      }
+    }
+
+    if (deps.workspaceDir) {
+      try {
+        const probePath = path.join(deps.workspaceDir, READINESS_PROBE_FILENAME);
+        fs.writeFileSync(probePath, "", "utf-8");
+        fs.unlinkSync(probePath);
+      } catch {
+        failing.push("workspace-disk");
       }
     }
 


### PR DESCRIPTION
## What Problem This Solves
  
  In Kubernetes deployments with a PVC-backed workspace, OpenClaw can keep reporting `/readyz` as healthy while the workspace disk is full and normal writes fail with `ENOSPC`.
  Kubernetes keeps the pod `Ready=true` and continues routing traffic to it, even though heartbeat/cron writes, transcripts, media/session persistence, and other workspace writes
  are silently failing.
  
## Why This Change Was Made
  
  Added an optional `workspaceDir` parameter to `createReadinessChecker`. When set, each readiness probe writes and removes a probe file at `${workspaceDir}/.readiness-probe`. If
  the write fails (ENOSPC, permissions, read-only filesystem), the probe reports a `"workspace-disk"` failure so `/readyz` returns non-ready and Kubernetes removes the pod from
  Service endpoints.

## User Impact
  
  Kuberentes operators with PVC-backed workspaces will now see pods removed from Service endpoints when the workspace disk is full, preventing silent traffic routing to unhealthy
  pods. No configuration changes required.

## Evidence

  - **Logic verified via inline tests:**
    - No `workspaceDir` → `{ ready: true }` ✅
    - Writable `workspaceDir` → `{ ready: true }` ✅
    - Non-writable `workspaceDir` → `{ ready: false, failing: ["workspace-disk"] }` ✅
  - **Tests added:** 4 new test cases in `readiness.test.ts` covering probe success, failure, skipped, and cleanup
  - **Existing test status:** 57/57 tests pass across 3 test files
  - **Lint:** `oxlint` — no errors
  - **Files changed:** 3 files, +70 lines
    - `src/gateway/server/readiness.ts` — core probe logic
    - `src/gateway/server/readiness.test.ts` — test coverage
    - `src/gateway/server.impl.ts` — wiring `workspaceDir: defaultWorkspaceDir`
  - **Docs:** `docs/gateway/health.md` and `docs/cli/gateway.md` updated with workspace disk check documentation
  - **Closes:** #96084