### PR TITLE
fix(mattermost): validate channel id before send, fall back to name lookup when not found

### DIFF
--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -749,4 +749,36 @@ describe("sendMessageMattermost user-first resolution", () => {
     expect(retryCall?.[2]?.timeoutMs).toBe(overrideOptions.timeoutMs);
     expect(retryCall?.[2]?.initialDelayMs).toBe(1000);
   });
+
+  it("validates channel id before sending and falls back to name lookup on 404", async () => {
+    const chanId = "fffff666666666666666666666"; // 26 chars
+    mockState.resolveMattermostAccount.mockReturnValue(makeAccount("token-validate-404"));
+    mockState.fetchMattermostChannel.mockRejectedValueOnce(
+      new Error("Mattermost API 404: channel not found"),
+    );
+    mockState.fetchMattermostChannelByName.mockResolvedValueOnce({ id: "resolved-chan-id" });
+
+    const res = await sendMessageMattermost(chanId, "hello", { cfg: TEST_CFG });
+
+    expect(mockState.fetchMattermostChannel).toHaveBeenCalledTimes(1);
+    expect(mockState.fetchMattermostChannelByName).toHaveBeenCalledTimes(1);
+    const params = createMattermostPostParams();
+    expect(params.channelId).toBe("resolved-chan-id");
+    expect(res.channelId).toBe("resolved-chan-id");
+  });
+
+  it("rethrows non-404 channel validation errors instead of falling back", async () => {
+    const chanId = "ababab1111111111ababab1111"; // 26 chars
+    mockState.resolveMattermostAccount.mockReturnValue(makeAccount("token-validate-500"));
+    mockState.fetchMattermostChannel.mockRejectedValueOnce(
+      new Error("Mattermost API 503: service unavailable"),
+    );
+
+    await expect(
+      sendMessageMattermost(chanId, "hello", { cfg: TEST_CFG }),
+    ).rejects.toThrow("Mattermost API 503: service unavailable");
+
+    expect(mockState.fetchMattermostChannel).toHaveBeenCalledTimes(1);
+    expect(mockState.fetchMattermostChannelByName).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -26,6 +26,7 @@ const mockState = vi.hoisted(() => ({
   createMattermostDirectChannel: vi.fn(),
   createMattermostDirectChannelWithRetry: vi.fn(),
   createMattermostPost: vi.fn(),
+  fetchMattermostChannel: vi.fn(),
   fetchMattermostChannelByName: vi.fn(),
   fetchMattermostMe: vi.fn(),
   fetchMattermostUser: vi.fn(),
@@ -157,6 +158,7 @@ vi.mock("./client.js", () => ({
   createMattermostDirectChannel: mockState.createMattermostDirectChannel,
   createMattermostDirectChannelWithRetry: mockState.createMattermostDirectChannelWithRetry,
   createMattermostPost: mockState.createMattermostPost,
+  fetchMattermostChannel: mockState.fetchMattermostChannel,
   fetchMattermostChannelByName: mockState.fetchMattermostChannelByName,
   fetchMattermostMe: mockState.fetchMattermostMe,
   fetchMattermostUser: mockState.fetchMattermostUser,
@@ -205,6 +207,7 @@ describe("sendMessageMattermost", () => {
     mockState.createMattermostDirectChannel.mockReset();
     mockState.createMattermostDirectChannelWithRetry.mockReset();
     mockState.createMattermostPost.mockReset();
+    mockState.fetchMattermostChannel.mockReset();
     mockState.fetchMattermostChannelByName.mockReset();
     mockState.fetchMattermostMe.mockReset();
     mockState.fetchMattermostUser.mockReset();
@@ -216,6 +219,9 @@ describe("sendMessageMattermost", () => {
     mockState.createMattermostDirectChannelWithRetry.mockResolvedValue({ id: "dm-channel-1" });
     mockState.fetchMattermostMe.mockResolvedValue({ id: "bot-user" });
     mockState.fetchMattermostUserTeams.mockResolvedValue([{ id: "team-1" }]);
+    mockState.fetchMattermostChannel.mockImplementation(
+      (_client: unknown, channelId: string) => Promise.resolve({ id: channelId }),
+    );
     mockState.fetchMattermostChannelByName.mockResolvedValue({ id: "town-square" });
     mockState.uploadMattermostFile.mockResolvedValue({ id: "file-1" });
     ({ parseMattermostTarget, sendMessageMattermost } = await import("./send.js"));

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -18,6 +18,7 @@ import {
   createMattermostClient,
   createMattermostDirectChannelWithRetry,
   createMattermostPost,
+  fetchMattermostChannel,
   fetchMattermostChannelByName,
   fetchMattermostMe,
   fetchMattermostUserByUsername,
@@ -299,7 +300,27 @@ function mergeDmRetryOptions(
 
 async function resolveTargetChannelId(params: ResolveTargetChannelIdParams): Promise<string> {
   if (params.target.kind === "channel") {
-    return params.target.id;
+    try {
+      const client = createMattermostClient({
+        baseUrl: params.baseUrl,
+        botToken: params.token,
+        allowPrivateNetwork: params.allowPrivateNetwork,
+      });
+      await fetchMattermostChannel(client, params.target.id);
+      return params.target.id;
+    } catch {
+      if (params.logger?.debug) {
+        params.logger.debug(
+          `mattermost channel ${params.target.id} not found by id, falling back to name lookup`,
+        );
+      }
+      return await resolveChannelIdByName({
+        baseUrl: params.baseUrl,
+        token: params.token,
+        name: params.target.id,
+        allowPrivateNetwork: params.allowPrivateNetwork,
+      });
+    }
   }
   if (params.target.kind === "channel-name") {
     return await resolveChannelIdByName({

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -34,7 +34,7 @@ import {
   setInteractionSecret,
 } from "./interactions.js";
 import { loadOutboundMediaFromUrl, type OpenClawConfig } from "./runtime-api.js";
-import { isMattermostId, resolveMattermostOpaqueTarget } from "./target-resolution.js";
+import { isMattermostId, parseMattermostApiStatus, resolveMattermostOpaqueTarget } from "./target-resolution.js";
 
 export type MattermostSendOpts = {
   cfg: OpenClawConfig;
@@ -308,18 +308,21 @@ async function resolveTargetChannelId(params: ResolveTargetChannelIdParams): Pro
       });
       await fetchMattermostChannel(client, params.target.id);
       return params.target.id;
-    } catch {
-      if (params.logger?.debug) {
-        params.logger.debug(
-          `mattermost channel ${params.target.id} not found by id, falling back to name lookup`,
-        );
+    } catch (err) {
+      if (parseMattermostApiStatus(err) === 404) {
+        if (params.logger?.debug) {
+          params.logger.debug(
+            `mattermost channel ${params.target.id} not found by id, falling back to name lookup`,
+          );
+        }
+        return await resolveChannelIdByName({
+          baseUrl: params.baseUrl,
+          token: params.token,
+          name: params.target.id,
+          allowPrivateNetwork: params.allowPrivateNetwork,
+        });
       }
-      return await resolveChannelIdByName({
-        baseUrl: params.baseUrl,
-        token: params.token,
-        name: params.target.id,
-        allowPrivateNetwork: params.allowPrivateNetwork,
-      });
+      throw err;
     }
   }
   if (params.target.kind === "channel-name") {

--- a/extensions/mattermost/src/mattermost/target-resolution.ts
+++ b/extensions/mattermost/src/mattermost/target-resolution.ts
@@ -94,8 +94,12 @@ export async function resolveMattermostOpaqueTarget(params: {
   } catch (err) {
     if (parseMattermostApiStatus(err) === 404) {
       mattermostOpaqueTargetCache.set(key, false);
+      return { kind: "channel", id: input, to: `channel:${input}` };
     }
-    return { kind: "channel", id: input, to: `channel:${input}` };
+    // Transient errors (5xx, network) or other non-404 responses should not
+    // classify the input as a channel id — let the caller fall through to
+    // parseMattermostTarget and resolveTargetChannelId for proper validation.
+    return null;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

When an agent uses the `message` tool to send to a Mattermost channel by name (e.g. `#finance`), the delivery system can pass the channel **name** directly as a `channel_id` to the Mattermost API. Since the Mattermost API expects a 26-character channel ID, sending a channel name causes **403 Forbidden**. This also silently poisons the delivery queue with entries that retry indefinitely.

**Root cause chain:**
1. `resolveMattermostOpaqueTarget` unconditionally returns `{ kind: "channel" }` for any 26-char bare input after user lookup fails — including transient 5xx/network errors where it should return `null` and defer to proper parsing.
2. `resolveTargetChannelId` returns `params.target.id` directly for `kind: "channel"` with no validation step — a non-existent or name-shaped id hits the API and gets 403.

## Evidence

### Targeted tests

All existing `parseMattermostTarget` tests continue to pass — channel name detection is unchanged:

| Input | Expected |
|-------|----------|
| `channel:finance` (non-ID) | `{ kind: "channel-name", name: "finance" }` |
| `#off-topic` | `{ kind: "channel-name", name: "off-topic" }` |
| `channel:#off-topic` | `{ kind: "channel-name", name: "off-topic" }` |
| `channel:dthcxgoxhifn3pwh65cut3ud3w` (26-char) | `{ kind: "channel", id }` |
| 404 user lookup fallback | returns `{ kind: "channel" }` for valid raw IDs |

### Fix coverage

The `send.test.ts` mock for `fetchMattermostChannel` resolves with the input channel id, simulating successful validation for the happy path. The catch block exercises the name-lookup fallback when validation fails.

**Fix 1 — `resolveTargetChannelId` (kind: "channel" path):**

When the target is classified as a channel id, the code now validates it exists via `fetchMattermostChannel`. If the channel is not found, it falls back to `resolveChannelIdByName` instead of passing the unresolved id directly to the API.

**Fix 2 — `resolveMattermostOpaqueTarget` (non-404 errors):**

Previously any user-lookup failure (including 5xx/network errors) classified bare 26-char inputs as channel ids. Now only explicit 404 responses return `kind: "channel"`; transient errors return `null` so callers fall through to `parseMattermostTarget` + `resolveTargetChannelId` validation.

### Test plan

- `send.test.ts`: Added `fetchMattermostChannel` mock that resolves with input channel id (simulating valid channel). The existing test for 404 user-lookup fallback exercises the validated channel-id path.
- `target-resolution.test.ts`: 404 fallback test unchanged — still returns `kind: "channel"` on explicit 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)