### PR TITLE
fix(memory): prove live manager recovery after CLI reindex

### DIFF
--- a/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
+++ b/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
@@ -31,7 +31,7 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
   let caseId = 0;
   let workspaceDir = "";
   let indexPath = "";
-  let manager: MemoryIndexManager | null = null;
+  let managers: MemoryIndexManager[] = [];
 
   function indexIdentityStatus(memoryManager: MemoryIndexManager): string | undefined {
     const identity = memoryManager.status().custom?.indexIdentity as
@@ -54,10 +54,10 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
   });
 
   afterEach(async () => {
-    if (manager) {
-      await manager.close();
-      manager = null;
+    for (const activeManager of managers.toReversed()) {
+      await activeManager.close();
     }
+    managers = [];
     await closeAllMemorySearchManagers();
     vi.unstubAllEnvs();
   });
@@ -70,7 +70,11 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
   });
 
   async function createManager(
-    params: { provider?: string; vectorEnabled?: boolean } = {},
+    params: {
+      provider?: string;
+      vectorEnabled?: boolean;
+      purpose?: "default" | "status" | "cli";
+    } = {},
   ): Promise<MemoryIndexManager> {
     const store =
       params.vectorEnabled === undefined
@@ -92,12 +96,17 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
         list: [{ id: "main", default: true }],
       },
     } as OpenClawConfig;
-    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    const result = await getMemorySearchManager({
+      cfg,
+      agentId: "main",
+      purpose: params.purpose,
+    });
     if (!result.manager) {
       throw new Error(result.error ?? "manager missing");
     }
-    manager = result.manager as unknown as MemoryIndexManager;
-    return manager;
+    const activeManager = result.manager as unknown as MemoryIndexManager;
+    managers.push(activeManager);
+    return activeManager;
   }
 
   async function seedChunksWithNoMeta(model = "fts-only"): Promise<void> {
@@ -158,5 +167,31 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
     expect(indexIdentityStatus(memoryManager)).toBe("missing");
     expect(statusAfter.chunks).toBe(1);
     expect(statusAfter.dirty).toBe(true);
+  });
+
+  it("observes a separate CLI reindex without reopening the live gateway manager", async () => {
+    const liveManager = await createManager({ provider: "none", vectorEnabled: false });
+    await liveManager.sync({ reason: "test", force: true });
+    (
+      liveManager as unknown as {
+        db: { exec: (sql: string) => void };
+      }
+    ).db.exec(`DELETE FROM memory_index_meta WHERE key = 'memory_index_meta_v1'`);
+    expect(indexIdentityStatus(liveManager)).toBe("missing");
+
+    await fs.writeFile(
+      path.join(workspaceDir, "MEMORY.md"),
+      "Beta topic\n\nKeep this repaired note.",
+    );
+    const cliManager = await createManager({
+      provider: "none",
+      vectorEnabled: false,
+      purpose: "cli",
+    });
+    await cliManager.sync({ reason: "cli", force: true });
+
+    expect(indexIdentityStatus(liveManager)).toBe("valid");
+    const results = await liveManager.search("beta repaired");
+    expect(results.some((result) => result.snippet.includes("Beta topic"))).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #91167
Related #90453
Related #92943

## What Problem This Solves

Fixes the proof gap for #91167 where a running gateway/default memory manager could be suspected of staying stuck on `index metadata is missing` after a separate CLI/status reindex rebuilt the same SQLite store.

## Why This Change Was Made

Current `main` already publishes full memory reindexes into the canonical SQLite database instead of swapping the whole DB file, and the live manager refreshes index identity from that handle on status/search reads. This PR keeps the source change intentionally small by adding the missing regression coverage for that manager-owned live/CLI publication contract, without duplicating the broader in-flight reindex barrier work in #90453.

## User Impact

Users and maintainers get a pinned regression proving that the live gateway manager can recover visibility after an external CLI reindex without requiring a gateway restart for this #91167 path.

## Evidence

Real behavior proof:

- Behavior addressed: A live default memory manager with a missing index identity observes a separate `purpose: "cli"` forced reindex on the same SQLite store, refreshes to a valid index identity, and returns the newly indexed memory content without reopening the live manager.
- Real environment tested: local source checkout at `541917a3fd90`, Node `v24.15.0`, macOS host, real `node:sqlite` manager path with temporary `OPENCLAW_STATE_DIR`, built-in memory backend, FTS-only provider mode (`provider: "none"`) so no external credentials are required.
- Exact steps or command run after this patch:

```bash
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
git diff --check
pnpm exec oxfmt --check extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
pnpm exec oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
.agents/skills/autoreview/scripts/autoreview --mode local
```

- Evidence after fix:

```text
RUN  v4.1.8 /Users/psx849261680/Desktop/projects/openclaw-91167

Test Files  1 passed (1)
Tests  3 passed (3)
Duration  35.12s
[test] passed 1 Vitest shard in 93.46s

git diff --check: clean
oxfmt --check: All matched files use the correct format.
oxlint: clean
autoreview clean: no accepted/actionable findings reported
```

- Observed result after fix: The new regression deletes `memory_index_meta_v1` from an already-open live manager, runs a separate CLI-purpose manager `sync({ reason: "cli", force: true })` after changing the memory note, then verifies the original live manager reports `indexIdentity.status === "valid"` and `search("beta repaired")` returns the newly indexed `Beta topic` snippet.
- What was not tested: full Gateway process with a real tool invocation, remote embedding provider, large-index latency, and concurrent stress during an in-flight reindex; #90453 owns the in-flight reindex race/barrier proof.

Regression coverage added:

- `extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts` now covers the live-manager plus separate CLI-manager recovery path for #91167.
