### PR TITLE
[codex] Confirm Telegram final delivery before completion

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -72,17 +72,19 @@ export function createTelegramReplyDelivery(params: {
     noteDelivered: () => reasoningStepState.noteReasoningDelivered(),
   });
 
-  const flushBufferedFinalAnswer = async () => {
+  const flushBufferedFinalAnswer = async (): Promise<boolean> => {
     const buffered = reasoningStepState.takeBufferedFinalAnswer(params.fence.generation());
     if (!buffered) {
-      return;
+      return false;
     }
-    await params.delivery.deliverFinalAnswerText(
+    params.state.attemptedVisibleFinalDelivery = true;
+    const result = await params.delivery.deliverFinalAnswerText(
       buffered.payload,
       buffered.text,
       resolvePayloadTelegramInlineButtons(buffered.payload),
     );
     reasoningStepState.resetForNextStep();
+    return result.kind !== "skipped";
   };
   const trackBlockMedia = (delivered: boolean, kind: string, payload: ReplyPayload) => {
     if (delivered && kind === "block" && payload.mediaUrls?.length) {
@@ -94,18 +96,18 @@ export function createTelegramReplyDelivery(params: {
 
   const deliver: Deliver = async (payload, info) => {
     if (params.fence.isSuperseded()) {
-      return;
+      return false;
     }
     const normalizedPayload = params.delivery.normalizeDeliveryPayload(payload);
     if (!normalizedPayload) {
-      return;
+      return false;
     }
     const deduped =
       info.kind === "final"
         ? deduplicateBlockSentMedia(normalizedPayload, sentBlockMediaUrls)
         : normalizedPayload;
     if (!deduped) {
-      return;
+      return false;
     }
     const effectivePayload = deduped;
     if (
@@ -116,7 +118,7 @@ export function createTelegramReplyDelivery(params: {
       })
     ) {
       params.state.queuedFinal = true;
-      return;
+      return false;
     }
     const telegramButtons = resolvePayloadTelegramInlineButtons(effectivePayload);
     const lanePayload =
@@ -151,7 +153,7 @@ export function createTelegramReplyDelivery(params: {
       !reply.hasMedia &&
       !hasExecApprovalPayload(effectivePayload)
     ) {
-      return;
+      return false;
     }
     if (payload.isError === true) {
       params.state.hadErrorReplyFailureOrSkip = true;
@@ -264,11 +266,14 @@ export function createTelegramReplyDelivery(params: {
       }
       const result =
         segment.lane === "answer" && info.kind === "final"
-          ? await params.delivery.deliverFinalAnswerText(
-              effectivePayload,
-              segment.update.text,
-              telegramButtons,
-            )
+          ? await (async () => {
+              params.state.attemptedVisibleFinalDelivery = true;
+              return await params.delivery.deliverFinalAnswerText(
+                effectivePayload,
+                segment.update.text,
+                telegramButtons,
+              );
+            })()
           : await params.delivery.deliverLaneText({
               laneName: segment.lane,
               text: segment.update.text,
@@ -294,7 +299,7 @@ export function createTelegramReplyDelivery(params: {
       if (segment.lane === "reasoning") {
         if (result.kind !== "skipped") {
           reasoningStepState.noteReasoningDelivered();
-          await flushBufferedFinalAnswer();
+          blockDelivered = (await flushBufferedFinalAnswer()) || blockDelivered;
         }
       } else if (info.kind === "final") {
         reasoningStepState.resetForNextStep();
@@ -302,13 +307,14 @@ export function createTelegramReplyDelivery(params: {
     }
     if (segments.length > 0) {
       trackBlockMedia(blockDelivered, info.kind, effectivePayload);
-      return;
+      return blockDelivered;
     }
 
     if (split.suppressedReasoningOnly) {
       let delivered = false;
       if (reply.hasMedia) {
         if (info.kind === "final") {
+          params.state.attemptedVisibleFinalDelivery = true;
           await params.draft.rotateAnswerLaneAfterToolProgress();
           await params.draft.answerLane.stream?.stop();
           await params.draft.reasoningLane.stream?.stop();
@@ -329,7 +335,7 @@ export function createTelegramReplyDelivery(params: {
         await flushBufferedFinalAnswer();
       }
       trackBlockMedia(delivered, info.kind, effectivePayload);
-      return;
+      return delivered;
     }
 
     if (info.kind === "final") {
@@ -342,7 +348,10 @@ export function createTelegramReplyDelivery(params: {
       if (info.kind === "final") {
         await flushBufferedFinalAnswer();
       }
-      return;
+      return false;
+    }
+    if (info.kind === "final") {
+      params.state.attemptedVisibleFinalDelivery = true;
     }
     const delivered = await params.delivery.sendPayload(effectivePayload, {
       durable: info.kind === "final",
@@ -354,6 +363,7 @@ export function createTelegramReplyDelivery(params: {
       await flushBufferedFinalAnswer();
     }
     trackBlockMedia(delivered, info.kind, effectivePayload);
+    return delivered;
   };
 
   const onSkip: Skip = (payload, info) => {

--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -267,6 +267,9 @@ export async function runTelegramDispatchTurn(params: {
       return false;
     }
     params.state.queuedFinal = turnResult.dispatchResult.queuedFinal;
+    if (turnResult.dispatchResult.attemptedVisibleFinalDelivery === true) {
+      params.state.attemptedVisibleFinalDelivery = true;
+    }
     if ((turnResult.dispatchResult.counts?.final ?? 0) > 0) {
       params.progress.markSawFinal();
     }

--- a/extensions/telegram/src/bot-message-dispatch.delivery-basics.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.delivery-basics.test.ts
@@ -596,4 +596,104 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-basics", () => {
       }
     },
   );
+
+  it("sends a fallback when Telegram does not confirm final delivery", async () => {
+    deliverReplies.mockResolvedValueOnce({ delivered: false }).mockResolvedValueOnce({
+      delivered: true,
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+      return { queuedFinal: false, counts: { block: 0, final: 1, tool: 0 } };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:default:telegram:direct:123",
+          ChatType: "direct",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "off",
+      telegramDeps: telegramDepsForTest,
+    });
+
+    expect(deliverReplies).toHaveBeenCalledTimes(2);
+    const attemptedFinal = expectRecordFields(mockCallArg(deliverReplies, 0), {});
+    expectRecordFields((attemptedFinal.replies as Array<Record<string, unknown>>)[0], {
+      text: "Final answer",
+    });
+    const fallback = expectRecordFields(mockCallArg(deliverReplies, 1), {});
+    expectRecordFields((fallback.replies as Array<Record<string, unknown>>)[0], {
+      text: "I generated a reply, but Telegram did not confirm delivery. Please try again.",
+    });
+  });
+
+  it("sends a fallback when routed dispatch reports unconfirmed visible final delivery", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+      attemptedVisibleFinalDelivery: true,
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:default:telegram:direct:123",
+          ChatType: "direct",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "off",
+      telegramDeps: telegramDepsForTest,
+    });
+
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
+    const fallback = expectRecordFields(mockCallArg(deliverReplies), {});
+    expectRecordFields((fallback.replies as Array<Record<string, unknown>>)[0], {
+      text: "I generated a reply, but Telegram did not confirm delivery. Please try again.",
+    });
+  });
+
+  it("keeps silent direct turns silent when no visible final delivery was attempted", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:default:telegram:direct:123",
+          ChatType: "direct",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "off",
+      telegramDeps: telegramDepsForTest,
+    });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("returns retryable when unconfirmed final delivery fallback is suppressed", async () => {
+    deliverReplies.mockResolvedValueOnce({ delivered: false });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+      return { queuedFinal: false, counts: { block: 0, final: 1, tool: 0 } };
+    });
+
+    const result = await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:default:telegram:direct:123",
+          ChatType: "direct",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "off",
+      telegramDeps: telegramDepsForTest,
+      retryDispatchErrors: true,
+      suppressFailureFallback: true,
+    });
+
+    expect(result.kind).toBe("failed-retryable");
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -471,17 +471,25 @@ export const dispatchTelegramMessage = async ({
 
   const deliverySummary = delivery.snapshot();
   let sentFallback = false;
+  const visibleFinalDeliveryWithoutConfirmation =
+    state.attemptedVisibleFinalDelivery === true &&
+    !deliverySummary.delivered &&
+    !progress.finalAnswerDelivered() &&
+    !state.suppressSilentReplyFallback;
   const shouldSendFailureFallback =
     !isRoomEvent &&
     !suppressFailureFallback &&
     !progress.finalAnswerDelivered() &&
     (state.dispatchError ||
+      visibleFinalDeliveryWithoutConfirmation ||
       deliverySummary.skippedNonSilent > 0 ||
       deliverySummary.failedNonSilent > 0);
   if (shouldSendFailureFallback) {
     const fallbackText = state.dispatchError
       ? "Something went wrong while processing your request. Please try again."
-      : EMPTY_RESPONSE_FALLBACK;
+      : visibleFinalDeliveryWithoutConfirmation
+        ? "I generated a reply, but Telegram did not confirm delivery. Please try again."
+        : EMPTY_RESPONSE_FALLBACK;
     const result = await delivery.deliverFallback(
       [{ text: fallbackText }],
       telegramCfg.silentErrorReplies === true &&
@@ -533,7 +541,9 @@ export const dispatchTelegramMessage = async ({
     state.queuedFinal;
   const deliveryFailureWithoutFinalResponse =
     !progress.finalAnswerDelivered() &&
-    (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0);
+    (visibleFinalDeliveryWithoutConfirmation ||
+      deliverySummary.skippedNonSilent > 0 ||
+      deliverySummary.failedNonSilent > 0);
   const retryableDispatchFailure =
     state.dispatchError ??
     (deliveryFailureWithoutFinalResponse

--- a/extensions/telegram/src/bot-message-dispatch.types.ts
+++ b/extensions/telegram/src/bot-message-dispatch.types.ts
@@ -66,6 +66,7 @@ export type TelegramAnswerBlockDelivery = {
 
 export type TelegramDispatchTurnState = {
   queuedFinal: boolean;
+  attemptedVisibleFinalDelivery?: boolean;
   suppressSilentReplyFallback: boolean;
   hadErrorReplyFailureOrSkip: boolean;
   dispatchError?: unknown;

--- a/src/auto-reply/reply/dispatch-from-config.abort.ts
+++ b/src/auto-reply/reply/dispatch-from-config.abort.ts
@@ -83,6 +83,9 @@ export function createAbortAwareDispatcher(params: {
       }
     },
   };
+  if (params.dispatcher.getDeliveredCounts) {
+    dispatcher.getDeliveredCounts = () => params.dispatcher.getDeliveredCounts!();
+  }
   if (params.dispatcher.getCancelledCounts) {
     dispatcher.getCancelledCounts = () => params.dispatcher.getCancelledCounts!();
   }

--- a/src/auto-reply/reply/dispatch-from-config.final-outcome-counts.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.final-outcome-counts.test.ts
@@ -14,7 +14,11 @@ describe("getDispatcherFinalOutcomeCounts (#89116)", () => {
     } as unknown as ReplyDispatcher;
 
     expect(() => getDispatcherFinalOutcomeCounts(dispatcher)).not.toThrow();
-    expect(getDispatcherFinalOutcomeCounts(dispatcher)).toEqual({ cancelled: 2, failed: 0 });
+    expect(getDispatcherFinalOutcomeCounts(dispatcher)).toEqual({
+      delivered: 0,
+      cancelled: 2,
+      failed: 0,
+    });
   });
 
   it("returns cancelled: 0 when getCancelledCounts is absent (existing behavior preserved)", () => {
@@ -22,15 +26,24 @@ describe("getDispatcherFinalOutcomeCounts (#89116)", () => {
       getFailedCounts: () => ({ tool: 0, block: 1, final: 3 }),
     } as unknown as ReplyDispatcher;
 
-    expect(getDispatcherFinalOutcomeCounts(dispatcher)).toEqual({ cancelled: 0, failed: 3 });
+    expect(getDispatcherFinalOutcomeCounts(dispatcher)).toEqual({
+      delivered: 0,
+      cancelled: 0,
+      failed: 3,
+    });
   });
 
   it("uses the real final counts when both methods are present", () => {
     const dispatcher = {
       getCancelledCounts: () => ({ tool: 0, block: 0, final: 1 }),
+      getDeliveredCounts: () => ({ tool: 0, block: 0, final: 2 }),
       getFailedCounts: () => ({ tool: 0, block: 0, final: 5 }),
     } as unknown as ReplyDispatcher;
 
-    expect(getDispatcherFinalOutcomeCounts(dispatcher)).toEqual({ cancelled: 1, failed: 5 });
+    expect(getDispatcherFinalOutcomeCounts(dispatcher)).toEqual({
+      delivered: 2,
+      cancelled: 1,
+      failed: 5,
+    });
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -86,6 +86,11 @@ describe("before_dispatch hook", () => {
   it("uses canonical hook metadata and shared routed final delivery", async () => {
     ttsMocks.state.synthesizeFinalAudio = true;
     hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: true, text: "Blocked" });
+    mocks.routeReply.mockResolvedValueOnce({
+      ok: true,
+      attemptedDelivery: true,
+      messageId: "m1",
+    } as never);
     installThreadingTestPlugin({ id: "telegram" });
     const dispatcher = createDispatcher();
     const ctx = createHookCtx({
@@ -139,6 +144,31 @@ describe("before_dispatch hook", () => {
     expect(routeCall?.payload?.mediaUrl).toBe("https://example.com/tts-synth.opus");
     expect(routeCall?.payload?.audioAsVoice).toBe(true);
     expect(result.queuedFinal).toBe(true);
+  });
+
+  it("does not mark routed hook-suppressed finals as attempted visible delivery", async () => {
+    hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: true, text: "Blocked" });
+    mocks.routeReply.mockResolvedValueOnce({
+      ok: true,
+      suppressed: true,
+      reason: "cancelled_by_reply_payload_sending_hook",
+    } as never);
+    installThreadingTestPlugin({ id: "telegram" });
+    const dispatcher = createDispatcher();
+    const ctx = createHookCtx({
+      Provider: "slack",
+      Surface: "slack",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:999",
+      ChatType: "direct",
+    });
+
+    const result = await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(mocks.routeReply).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(false);
+    expect(result.attemptedVisibleFinalDelivery).toBeUndefined();
   });
 
   it("passes inbound reply metadata to before_dispatch event and context", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.transcript.ts
+++ b/src/auto-reply/reply/dispatch-from-config.transcript.ts
@@ -59,10 +59,12 @@ export async function mirrorDeliveredReplyToTranscript(params: {
 
 /** Reads final outcome counters from dispatchers that expose them. */
 export function getDispatcherFinalOutcomeCounts(dispatcher: DispatcherOutcomeCountsView): {
+  delivered: number;
   cancelled: number;
   failed: number;
 } {
   return {
+    delivered: dispatcher.getDeliveredCounts?.().final ?? 0,
     cancelled: dispatcher.getCancelledCounts?.().final ?? 0,
     failed: readDispatcherFailedCounts(dispatcher).final,
   };
@@ -192,9 +194,10 @@ export function captureDeliveredTranscriptMirror(params: {
 
 export async function mirrorTranscriptAfterDispatcherSettled(params: {
   dispatcher: ReplyDispatcher;
-  before: { cancelled: number; failed: number };
+  before: { delivered: number; cancelled: number; failed: number };
   metadata: () => TranscriptMirror | undefined;
   cfg: OpenClawConfig;
+  requireDeliveredCount?: boolean;
 }): Promise<void> {
   const after = getDispatcherFinalOutcomeCounts(params.dispatcher);
   const metadata = params.metadata();
@@ -202,9 +205,12 @@ export async function mirrorTranscriptAfterDispatcherSettled(params: {
     return;
   }
   const suppressedFinal = metadata.deliveryMirror?.kind === "channel-final-suppressed";
+  const delivered = after.delivered > params.before.delivered;
   if (
     !suppressedFinal &&
-    (after.cancelled > params.before.cancelled || after.failed > params.before.failed)
+    ((params.requireDeliveredCount === true && !delivered) ||
+      after.cancelled > params.before.cancelled ||
+      after.failed > params.before.failed)
   ) {
     return;
   }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -659,6 +659,10 @@ async function dispatchReplyFromConfigInner(
   });
   const routeReplyTo = replyRoute.to;
   const deliveryChannel = shouldRouteToOriginating ? routeReplyChannel : currentSurface;
+  const requiresConfirmedRoutedFinalDelivery =
+    normalizeMessageChannel(deliveryChannel) === "telegram";
+  const requiresConfirmedDispatcherFinalDelivery =
+    requiresConfirmedRoutedFinalDelivery && typeof dispatcher.getDeliveredCounts === "function";
   const shouldPrepareRoutedReplyDelivery = shouldRouteToOriginating && Boolean(routeReplyChannel);
   const replyContextAccountId = routeReplyChannel
     ? resolveReplyDeliveryAccountId(cfg, routeReplyChannel, replyRoute.accountId)
@@ -752,8 +756,16 @@ async function dispatchReplyFromConfigInner(
     });
   };
 
-  const isRoutedReplyDelivered = (result: { ok: boolean; suppressed?: boolean }) =>
-    result.ok && result.suppressed !== true;
+  const hasRoutedReplyMessageIdentity = (result: { messageId?: string }) =>
+    result.messageId !== undefined && result.messageId.trim().length > 0;
+  const isRoutedReplyDelivered = (result: {
+    ok: boolean;
+    suppressed?: boolean;
+    messageId?: string;
+  }) =>
+    result.ok &&
+    result.suppressed !== true &&
+    (!requiresConfirmedRoutedFinalDelivery || hasRoutedReplyMessageIdentity(result));
 
   /**
    * Helper to send a payload via route-reply (async).
@@ -1588,7 +1600,9 @@ async function dispatchReplyFromConfigInner(
     ): Promise<{
       queuedFinal: boolean;
       routedFinalCount: number;
+      visibleFinalDeliveryAttempted: boolean;
       dispatcherOutcome?: Promise<ReplyDispatchDeliveryOutcome>;
+      dispatcherDeliveredBefore?: number;
     }> => {
       const abortSignal = options.abortSignal ?? getDispatchAbortSignal();
       const throwIfFinalDeliveryAborted = () => {
@@ -1642,20 +1656,22 @@ async function dispatchReplyFromConfigInner(
         ...(hasTranscriptOwner ? { mirror: false } : {}),
       });
       if (result) {
+        const routedDelivered = isRoutedReplyDelivered(result);
         if (!result.ok) {
           logVerbose(
             `dispatch-from-config: route-reply (final) failed: ${result.error ?? "unknown error"}`,
           );
         }
-        if (isRoutedReplyDelivered(result)) {
+        if (routedDelivered) {
           await mirrorDeliveredReplyToTranscript({
             metadata: sourceReplyTranscriptMirror,
             cfg,
           });
         }
         return {
-          queuedFinal: result.ok,
-          routedFinalCount: isRoutedReplyDelivered(result) ? 1 : 0,
+          queuedFinal: requiresConfirmedRoutedFinalDelivery ? routedDelivered : result.ok,
+          routedFinalCount: routedDelivered ? 1 : 0,
+          visibleFinalDeliveryAttempted: result.attemptedDelivery === true,
         };
       }
       throwIfFinalDeliveryAborted();
@@ -1712,6 +1728,9 @@ async function dispatchReplyFromConfigInner(
         setReplyPayloadMetadata(normalizedPayload, { finalDeliveryCapture });
       }
       const deliveryOutcome = captureReplyDispatchDeliveryOutcome(normalizedPayload);
+      const dispatcherDeliveredBefore = requiresConfirmedDispatcherFinalDelivery
+        ? (dispatcher.getDeliveredCounts?.().final ?? 0)
+        : undefined;
       const queuedFinal = dispatcher.sendFinalReply(normalizedPayload);
       const dispatcherOutcome =
         queuedFinal && deliveryOutcome.isTracked() ? deliveryOutcome.promise : undefined;
@@ -1725,14 +1744,39 @@ async function dispatchReplyFromConfigInner(
             before: finalOutcomeBefore,
             metadata: deliveredTranscriptMirror,
             cfg,
+            requireDeliveredCount: requiresConfirmedDispatcherFinalDelivery,
           }),
         );
       }
       return {
         queuedFinal,
         routedFinalCount: 0,
+        visibleFinalDeliveryAttempted: queuedFinal,
         ...(queuedFinal && dispatcherOutcome ? { dispatcherOutcome } : {}),
+        ...(dispatcherDeliveredBefore !== undefined ? { dispatcherDeliveredBefore } : {}),
       };
+    };
+
+    const confirmFinalReplyQueued = async (finalReply: {
+      queuedFinal: boolean;
+      routedFinalCount: number;
+      dispatcherOutcome?: Promise<ReplyDispatchDeliveryOutcome>;
+      dispatcherDeliveredBefore?: number;
+    }): Promise<boolean> => {
+      if (!requiresConfirmedDispatcherFinalDelivery) {
+        return finalReply.queuedFinal;
+      }
+      if (finalReply.routedFinalCount > 0) {
+        return finalReply.queuedFinal;
+      }
+      if (!finalReply.dispatcherOutcome || finalReply.dispatcherDeliveredBefore === undefined) {
+        return false;
+      }
+      const outcome = await finalReply.dispatcherOutcome;
+      return (
+        outcome === "delivered" &&
+        (dispatcher.getDeliveredCounts?.().final ?? 0) > finalReply.dispatcherDeliveredBefore
+      );
     };
 
     // Run before_dispatch hook — let plugins inspect or handle before model dispatch.
@@ -1779,6 +1823,7 @@ async function dispatchReplyFromConfigInner(
         const text = beforeDispatchResult.text;
         let queuedFinal = false;
         let routedFinalCount = 0;
+        let attemptedVisibleFinalDelivery = false;
         if (text && !suppressDelivery) {
           const handledReply = await sendFinalPayload(
             { text },
@@ -1787,8 +1832,10 @@ async function dispatchReplyFromConfigInner(
               deliveryId: "before-dispatch",
             },
           );
-          queuedFinal = handledReply.queuedFinal;
+          queuedFinal = await confirmFinalReplyQueued(handledReply);
           routedFinalCount += handledReply.routedFinalCount;
+          attemptedVisibleFinalDelivery =
+            handledReply.visibleFinalDeliveryAttempted || attemptedVisibleFinalDelivery;
         }
         const counts = dispatcher.getQueuedCounts();
         counts.final += routedFinalCount;
@@ -1796,7 +1843,13 @@ async function dispatchReplyFromConfigInner(
         markIdle("message_completed");
         commitInboundDedupeIfClaimed();
         completeDispatchReplyOperation();
-        return attachSourceReplyDeliveryMode({ queuedFinal, counts });
+        return attachSourceReplyDeliveryMode({
+          queuedFinal,
+          counts,
+          ...(!queuedFinal && attemptedVisibleFinalDelivery
+            ? { attemptedVisibleFinalDelivery: true }
+            : {}),
+        });
       }
     }
 
@@ -2834,7 +2887,7 @@ async function dispatchReplyFromConfigInner(
 
     let queuedFinal = false;
     let routedFinalCount = 0;
-    let attemptedFinalDelivery = false;
+    let attemptedVisibleFinalDelivery = false;
     let finalDeliveryFailed = false;
     const finalDeliveries: Array<{
       outcome: Promise<ReplyDispatchDeliveryOutcome>;
@@ -2885,23 +2938,29 @@ async function dispatchReplyFromConfigInner(
         continue;
       }
       sentFinalPayloadDedupeKeys.add(finalPayloadDedupeKey);
-      attemptedFinalDelivery = true;
       const finalReply = await sendFinalPayload(reply, { deliveryId: String(replyIndex) });
-      queuedFinal = finalReply.queuedFinal || queuedFinal;
+      const finalQueued = await confirmFinalReplyQueued(finalReply);
+      queuedFinal = finalQueued || queuedFinal;
       routedFinalCount += finalReply.routedFinalCount;
-      if (finalReply.queuedFinal) {
+      attemptedVisibleFinalDelivery =
+        finalReply.visibleFinalDeliveryAttempted || attemptedVisibleFinalDelivery;
+      if (finalQueued) {
         if (finalReply.dispatcherOutcome) {
           finalDeliveries.push({ outcome: finalReply.dispatcherOutcome, payload: reply });
         } else {
           allQueuedFinalsObserved = false;
         }
       }
-      if (!finalReply.queuedFinal && finalReply.routedFinalCount === 0) {
+      if (
+        finalReply.visibleFinalDeliveryAttempted &&
+        !finalQueued &&
+        finalReply.routedFinalCount === 0
+      ) {
         finalDeliveryFailed = true;
       }
     }
 
-    if (attemptedFinalDelivery && !finalDeliveryFailed) {
+    if (attemptedVisibleFinalDelivery && !finalDeliveryFailed) {
       if (queuedFinal && allQueuedFinalsObserved) {
         // Delivery observers run from the queue itself, so direct low-level callers
         // reconcile too; the settle task only makes lifecycle owners await it.
@@ -2987,8 +3046,10 @@ async function dispatchReplyFromConfigInner(
               kind: "final",
             });
             if (result) {
-              queuedFinal = result.ok || queuedFinal;
-              if (isRoutedReplyDelivered(result)) {
+              const routedDelivered = isRoutedReplyDelivered(result);
+              queuedFinal =
+                (requiresConfirmedRoutedFinalDelivery ? routedDelivered : result.ok) || queuedFinal;
+              if (routedDelivered) {
                 routedFinalCount += 1;
               }
               if (!result.ok) {
@@ -2999,8 +3060,26 @@ async function dispatchReplyFromConfigInner(
             } else {
               throwIfDispatchOperationAborted();
               markInboundDedupeReplayUnsafe();
+              const deliveryOutcome = captureReplyDispatchDeliveryOutcome(normalizedTtsOnlyPayload);
+              const dispatcherDeliveredBefore = requiresConfirmedDispatcherFinalDelivery
+                ? (dispatcher.getDeliveredCounts?.().final ?? 0)
+                : undefined;
               const didQueue = dispatcher.sendFinalReply(normalizedTtsOnlyPayload);
-              queuedFinal = didQueue || queuedFinal;
+              let ttsQueued = didQueue;
+              if (requiresConfirmedDispatcherFinalDelivery) {
+                ttsQueued = false;
+                if (
+                  didQueue &&
+                  deliveryOutcome.isTracked() &&
+                  dispatcherDeliveredBefore !== undefined
+                ) {
+                  const outcome = await deliveryOutcome.promise;
+                  ttsQueued =
+                    outcome === "delivered" &&
+                    (dispatcher.getDeliveredCounts?.().final ?? 0) > dispatcherDeliveredBefore;
+                }
+              }
+              queuedFinal = ttsQueued || queuedFinal;
             }
           }
         } catch (err) {
@@ -3034,6 +3113,9 @@ async function dispatchReplyFromConfigInner(
       ...(getObservedReplyDelivery() ? { observedReplyDelivery: true } : {}),
       ...(!queuedFinal && !getObservedReplyDelivery() && !emptyFinalAllowedAsSilent
         ? { noVisibleReplyFallbackEligible: true }
+        : {}),
+      ...(!queuedFinal && attemptedVisibleFinalDelivery
+        ? { attemptedVisibleFinalDelivery: true }
         : {}),
       ...(beforeAgentRunBlocked ? { beforeAgentRunBlocked } : {}),
     });

--- a/src/auto-reply/reply/dispatch-from-config.types.ts
+++ b/src/auto-reply/reply/dispatch-from-config.types.ts
@@ -15,6 +15,7 @@ export type DispatchFromConfigResult = {
   sendPolicyDenied?: boolean;
   observedReplyDelivery?: boolean;
   noVisibleReplyFallbackEligible?: boolean;
+  attemptedVisibleFinalDelivery?: boolean;
   beforeAgentRunBlocked?: boolean;
   sessionMetadataChanges?: CommandSessionMetadataChange[];
 };

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -369,6 +369,11 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     block: 0,
     final: 0,
   };
+  const deliveredCounts: Record<ReplyDispatchKind, number> = {
+    tool: 0,
+    block: 0,
+    final: 0,
+  };
 
   // Register this dispatcher globally for gateway restart coordination.
   const { unregister } = registerDispatcher({
@@ -473,7 +478,12 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           deliverPayload = copyReplyPayloadMetadata(normalized, deliverPayload);
         }
         deliveryStarted = true;
-        await options.deliver(deliverPayload, dispatchInfo);
+        const deliveryResult = await options.deliver(deliverPayload, dispatchInfo);
+        // Delivery owners opt in to confirmation with an explicit boolean.
+        // Opaque return objects remain unconfirmed instead of being guessed at here.
+        if (deliveryResult === true) {
+          deliveredCounts[kind] += 1;
+        }
         deliveryOutcome = "delivered";
       })
       .catch(async (err: unknown) => {
@@ -543,6 +553,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     },
     waitForIdle: () => sendChain,
     getQueuedCounts: () => ({ ...queuedCounts }),
+    getDeliveredCounts: () => ({ ...deliveredCounts }),
     getCancelledCounts: () => ({ ...cancelledCounts }),
     getFailedCounts: () => ({ ...failedCounts }),
     markComplete,

--- a/src/auto-reply/reply/reply-dispatcher.types.ts
+++ b/src/auto-reply/reply/reply-dispatcher.types.ts
@@ -36,6 +36,7 @@ export type ReplyDispatcher = {
   ) => void;
   waitForIdle: () => Promise<void>;
   getQueuedCounts: () => Record<ReplyDispatchKind, number>;
+  getDeliveredCounts?: () => Record<ReplyDispatchKind, number>;
   getCancelledCounts?: () => Record<ReplyDispatchKind, number>;
   getFailedCounts: () => Record<ReplyDispatchKind, number>;
   markComplete: () => void;
@@ -53,6 +54,7 @@ export type ReplyDispatcher = {
  * type-correct without weakening the SDK-visible ReplyDispatcher type.
  */
 export type DispatcherOutcomeCountsView = {
+  getDeliveredCounts?: () => Record<ReplyDispatchKind, number>;
   getCancelledCounts?: () => Record<ReplyDispatchKind, number>;
   getFailedCounts?: () => Record<ReplyDispatchKind, number>;
 };

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -166,6 +166,27 @@ describe("createReplyDispatcher", () => {
     expect(delivered).toEqual(["tool", "block", "final"]);
   });
 
+  it("tracks delivered counts only from explicit delivery confirmation", async () => {
+    const deliver = vi.fn(async (_payload, info) => {
+      if (info.kind === "tool") {
+        return { delivered: false };
+      }
+      if (info.kind === "block") {
+        return { delivered: true, messageId: "block-1" };
+      }
+      return true;
+    });
+    const dispatcher = createReplyDispatcher({ deliver });
+
+    dispatcher.sendToolResult({ text: "tool" });
+    dispatcher.sendBlockReply({ text: "block" });
+    dispatcher.sendFinalReply({ text: "final" });
+
+    await dispatcher.waitForIdle();
+    expect(dispatcher.getQueuedCounts()).toEqual({ tool: 1, block: 1, final: 1 });
+    expect(dispatcher.getDeliveredCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
+  });
+
   it("waits for asynchronous delivery error cleanup before becoming idle", async () => {
     const cleanup = createDeferred<void>();
     const order: string[] = [];

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -576,6 +576,7 @@ describe("routeReply", () => {
       suppressed: true,
       reason: "cancelled_by_reply_payload_sending_hook",
     });
+    expect(res).not.toHaveProperty("attemptedDelivery");
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);
     expect(lastDelivery().replyPayloadSendingHook).toMatchObject({
       kind: "final",
@@ -615,6 +616,7 @@ describe("routeReply", () => {
       suppressed: true,
       reason: "cancelled_by_reply_payload_sending_hook",
     });
+    expect(res).not.toHaveProperty("attemptedDelivery");
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);
   });
 
@@ -646,6 +648,7 @@ describe("routeReply", () => {
       suppressed: true,
       reason: "empty_after_reply_payload_sending_hook",
     });
+    expect(res).not.toHaveProperty("attemptedDelivery");
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);
   });
 

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -117,6 +117,8 @@ type RouteReplyResult = {
   reason?: "cancelled_by_reply_payload_sending_hook" | "empty_after_reply_payload_sending_hook";
   /** Optional message ID from the provider. */
   messageId?: string;
+  /** True once provider delivery was attempted past suppression hooks. */
+  attemptedDelivery?: boolean;
   /** Error message if the send failed. */
   error?: string;
 };
@@ -262,6 +264,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     replyToId: resolvedReplyToId,
   };
 
+  let attemptedDelivery = false;
   try {
     // Provider docking: this is an execution boundary (we're about to send).
     // Keep the module cheap to import by loading outbound plumbing lazily.
@@ -315,6 +318,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
             }
           : undefined,
     });
+    attemptedDelivery = send.status !== "suppressed";
     if (send.status === "failed" || send.status === "partial_failed") {
       throw send.error;
     }
@@ -332,11 +336,12 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     const results = send.status === "sent" ? send.results : [];
 
     const last = results.at(-1);
-    return { ok: true, messageId: last?.messageId };
+    return { ok: true, attemptedDelivery: true, messageId: last?.messageId };
   } catch (err) {
     const message = formatErrorMessage(err);
     return {
       ok: false,
+      ...(attemptedDelivery ? { attemptedDelivery: true } : {}),
       error: `Failed to route reply to ${channel}: ${message}`,
     };
   }


### PR DESCRIPTION
## What Problem This Solves

Telegram visible final replies must not count as complete merely because delivery was queued or attempted. Completion now requires authoritative transport evidence. If a visible final was attempted but delivery was not confirmed, Telegram produces exactly one bounded recovery outcome instead of silently finalizing.

Intentional silence remains silent: `NO_REPLY`, empty/whitespace-only finals, reasoning-only output, and reply-payload-hook-suppressed finals do not trigger recovery.

## Current Architecture and Invariants

- The shared reply dispatcher records explicit delivered counts only when the durable delivery callback returns usable transport evidence.
- Telegram final-outcome handling distinguishes attempted visible delivery from confirmed delivery.
- A confirmed visible final completes normally.
- An attempted-but-unconfirmed visible final produces one fallback; if fallback delivery is also unavailable, the turn fails retryably.
- Recovery is bounded and excluded from normal final-attempt accounting, preventing recursive or duplicate fallback.
- Silent and hook-suppressed finals never become visible delivery attempts.
- Legacy/non-Telegram callers remain compatible when explicit delivery counts are unavailable.

## Changed Areas

- `src/auto-reply/reply/`: delivery evidence accounting, routed/dispatcher outcome propagation, and focused regressions.
- `extensions/telegram/src/`: Telegram final-attempt tracking, confirmed-delivery gating, bounded recovery, and behavior tests.

No dependency manifests, lockfiles, configuration, or unrelated channel implementations are changed.

## Evidence

Clean rebuild on base `33f5c0bbb271f7f82ebffa34b209228e49251ff9`, tested at exact PR head `863beafa1da1220d7eb83db958cf7eeac89a1454`:

- Focused Vitest: 5 files, 365 tests passed.
- `pnpm check:test-types` passed.
- `pnpm lint` passed.
- `pnpm exec oxfmt --check` passed for all touched files.
- `git diff --check HEAD~1..HEAD` passed.

Focused coverage includes confirmed delivery, attempted-but-unconfirmed delivery, exactly one recovery outcome, duplicate prevention, `NO_REPLY`, empty/whitespace-only finals, and reply-payload-hook suppression.

## Runtime-Proof Status

No live Telegram canary was sent. Local automated behavior proof is complete, but observed Telegram transport proof remains pending maintainer-authorized execution because contributor-triggered Mantis workflow dispatch requires repository admin rights.

## Compatibility and Risk

- OpenClaw callers without explicit delivered counts retain legacy behavior.
- The behavior change is intentionally scoped to Telegram visible-final completion.
- Remaining risk is integration-level transport behavior not reproducible without the separately gated live proof; the code and focused regression suite fail closed when authoritative evidence is absent.
