### PR TITLE
feat: export OPENCLAW_SESSION_ID to bash tool subprocesses

### DIFF
--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -76,7 +76,7 @@ import type { SandboxContext } from "./sandbox.js";
 import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./sandbox/constants.js";
 import { resolveReadOnlyWorkspaceSkillMounts } from "./sandbox/workspace-mounts.js";
 import { resolveSenderToolPolicy } from "./sender-tool-policy.js";
-import { createCodingTools, createReadTool } from "./sessions/index.js";
+import { createCodingTools, createReadTool, type ToolsOptions } from "./sessions/index.js";
 import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
@@ -746,7 +746,18 @@ export function createOpenClawCodingTools(options?: {
 
   const base: AnyAgentTool[] = [];
   if (includeBaseCodingTools) {
-    for (const tool of createCodingTools(codingRoot) as unknown as AnyAgentTool[]) {
+    // Inject OPENCLAW_SESSION_ID into bash tool spawn env for external observability.
+    const codingToolsOptions: ToolsOptions | undefined = options?.sessionId
+      ? {
+          bash: {
+            spawnHook: (ctx) => {
+              ctx.env.OPENCLAW_SESSION_ID = options.sessionId!;
+              return ctx;
+            },
+          },
+        }
+      : undefined;
+    for (const tool of createCodingTools(codingRoot, codingToolsOptions) as unknown as AnyAgentTool[]) {
       if (tool.name === "read") {
         if (sandboxRoot) {
           const sandboxed = createSandboxedReadTool({


### PR DESCRIPTION
Closes #96101

## What Problem This Solves

When OpenClaw's bash tool spawns child processes, there is no way for external process-level observability tools to trace those executions back to the originating OpenClaw session. This makes it difficult to build session-scoped command audit trails, resource attribution, or security monitoring for agent-driven workflows.

Claude Code already exports `CLAUDE_CODE_SESSION_ID` to all child processes (v2.1.132+), establishing a de facto pattern for agent session traceability via `/proc/<pid>/environ`.

## Why This Change Was Made

Uses the existing `BashSpawnHook` to inject `OPENCLAW_SESSION_ID` into the bash tool's spawn environment. The value comes from `options.sessionId` already available in `createOpenClawCodingTools()`. No new interfaces — only a spawnHook added in `agent-tools.ts` when `sessionId` is present.

## User Impact

- OpenClaw operators and plugin authors gain session-scoped visibility into spawned commands
- Enables third-party observability integrations (process tracers, audit daemons) to correlate execve events to OpenClaw sessions
- Aligns with the Claude Code pattern, making multi-agent environments consistently traceable

## Evidence

- `tsc --noEmit`: zero errors
- Single file changed: `src/agents/agent-tools.ts` (+13/-2)
- AI-assisted (marked per contributing guidelines)